### PR TITLE
README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,8 @@ For development purposes we test that YDB could be built and run under latest ve
 We are glad to welcome new contributors!
 
 1. Please read [contributor's guide](CONTRIBUTING.md).
-2. We can accept your work to YDB after you have read contributor's license agreement (aka CLA).
+2. We can accept your work to YDB after you have signed contributor's license agreement (aka CLA).
 3. Please don't forget to add a note to your pull request, that you agree to the terms of the CLA.
-
-More information can be found in [CONTRIBUTING](CONTRIBUTING) file.
 
 ## Success Stories
 


### PR DESCRIPTION
Remove second broken link to contributing guide - it was broken after adding .md extension. Why have it two times in such small section?
Require signing of CLA not just reading it - require only reading the CLA without any signs and obligations would be cool.