### PR TITLE
Fix docker self hosted example. Use explciit protocol.

### DIFF
--- a/ydb/docs/en/core/getting_started/self_hosted/_includes/ydb_docker/04_request.md
+++ b/ydb/docs/en/core/getting_started/self_hosted/_includes/ydb_docker/04_request.md
@@ -15,7 +15,7 @@ ydb -e grpcs://localhost:2135 --ca-file ydb_certs/ca.pem -d /local scheme ls
 A precompiled version of the [YDB CLI](../../../../reference/ydb-cli/index.md) is also available within the image:
 
 ```bash
-docker exec <container_id> /ydb -e localhost:2136 -d /local scheme ls
+docker exec <container_id> /ydb -e grpc://localhost:2136 -d /local scheme ls
 ```
 
 , where

--- a/ydb/docs/ru/core/getting_started/self_hosted/_includes/ydb_docker/04_request.md
+++ b/ydb/docs/ru/core/getting_started/self_hosted/_includes/ydb_docker/04_request.md
@@ -15,7 +15,7 @@ ydb -e grpcs://localhost:2135 --ca-file ydb_certs/ca.pem -d /local scheme ls
 Предсобранная версия [YDB CLI](../../../../reference/ydb-cli/index.md) также доступа внутри образа:
 
 ```bash
-docker exec <container_id> /ydb -e localhost:2136 -d /local scheme ls
+docker exec <container_id> /ydb -e grpc://localhost:2136 -d /local scheme ls
 ```
 
 , где


### PR DESCRIPTION
Doc fix on docker getting started self hosted guide.
When running a precompiled version of ydb in a container protocol defaults to grpcs.
But example is for non TLS connection. So one should explicitly use grpc protocol.