### PR TITLE
docs -> yql -> types -> optional : typo

### DIFF
--- a/ydb/docs/en/core/yql/reference/yql-core/types/_includes/optional.md
+++ b/ydb/docs/en/core/yql/reference/yql-core/types/_includes/optional.md
@@ -32,7 +32,7 @@ Result:
 
 ```text
 # column0
-0 null
+null
 ```
 
 ## Logical and arithmetic operations with NULL {#null_expr}

--- a/ydb/docs/ru/core/yql/reference/yql-core/types/_includes/optional.md
+++ b/ydb/docs/ru/core/yql/reference/yql-core/types/_includes/optional.md
@@ -32,7 +32,7 @@ select if($found is not null, unwrap($found), -1);
 
 ```text
 # column0
-0 null
+null
 ```
 
 ## Логические и арифметические операции с NULL {#null_expr}


### PR DESCRIPTION
I have found those zeros confusing, checked the code snippet in the current version of ydb, and got a different result (that makes more sense).

I hereby agree to the terms of the CLA available at:  https://yandex.ru/legal/cla/?lang=en