### PR TITLE
Update old actors examples

### DIFF
--- a/library/cpp/actors/examples/01_ping_pong/main.cpp
+++ b/library/cpp/actors/examples/01_ping_pong/main.cpp
@@ -54,7 +54,7 @@ public:
         Y_UNUSED(ctx);
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvents::TEvPing, Handle);
-            cFunc(TEvents::TEvWakeup::EventType, PrintStats);
+            sFunc(TEvents::TEvWakeup, PrintStats);
         }
 
         ++HandledEvents;
@@ -64,7 +64,7 @@ public:
         Y_UNUSED(ctx);
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvents::TEvPong, Handle);
-            cFunc(TEvents::TEvWakeup::EventType, PrintStats);
+            sFunc(TEvents::TEvWakeup, PrintStats);
         }
 
         ++HandledEvents;

--- a/library/cpp/actors/examples/02_discovery/lookup.cpp
+++ b/library/cpp/actors/examples/02_discovery/lookup.cpp
@@ -52,8 +52,8 @@ public:
         Y_UNUSED(ctx);
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvExample::TEvReplicaInfo, Handle);
-            cFunc(TEvents::TEvUndelivered::EventType, HandleUndelivered);
-            cFunc(TEvInterconnect::TEvNodeDisconnected::EventType, HandleUndelivered);
+            sFunc(TEvents::TEvUndelivered, HandleUndelivered);
+            sFunc(TEvInterconnect::TEvNodeDisconnected, HandleUndelivered);
         default:
             break;
         }

--- a/library/cpp/actors/examples/02_discovery/publish.cpp
+++ b/library/cpp/actors/examples/02_discovery/publish.cpp
@@ -47,9 +47,9 @@ public:
     STFUNC(StatePublish) {
         Y_UNUSED(ctx);
         switch (ev->GetTypeRewrite()) {
-            cFunc(TEvents::TEvPoison::EventType, PassAway);
-            cFunc(TEvents::TEvUndelivered::EventType, SomeSleep);
-            cFunc(TEvInterconnect::TEvNodeDisconnected::EventType, SomeSleep);
+            sFunc(TEvents::TEvPoison, PassAway);
+            sFunc(TEvents::TEvUndelivered, SomeSleep);
+            sFunc(TEvInterconnect::TEvNodeDisconnected, SomeSleep);
         default:
             break;
         }
@@ -58,8 +58,8 @@ public:
     STFUNC(StateSleep) {
         Y_UNUSED(ctx);
         switch (ev->GetTypeRewrite()) {
-            cFunc(TEvents::TEvPoison::EventType, PassAway);
-            cFunc(TEvents::TEvWakeup::EventType, Bootstrap);
+            sFunc(TEvents::TEvPoison, PassAway);
+            sFunc(TEvents::TEvWakeup, Bootstrap);
         default:
             break;
         }
@@ -101,7 +101,7 @@ public:
     STFUNC(StateWork) {
         Y_UNUSED(ctx);
         switch (ev->GetTypeRewrite()) {
-            cFunc(TEvents::TEvPoison::EventType, PassAway);
+            sFunc(TEvents::TEvPoison, PassAway);
         default:
             break;
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=ru)

There is an example: [link](https://github.com/ydb-platform/ydb/blob/main/library/cpp/actors/examples/01_ping_pong/main.cpp#L56-L57)
These lines look inconsistent. There's another API: `sFunc` which provides the same API but allows code to be consistent.