### PR TITLE
tests: enable ydb-core-kqp-ut-spilling test

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -88,7 +88,7 @@ runs:
       testmo automation:run:complete --instance "$TESTMO_URL" --run-id ${{steps.th.outputs.runid}}
   - name: Upload S3
     uses: shallwefootball/s3-upload-action@master
-    if: always()
+    if: inputs.AWS_KEY_ID
     with:
       aws_key_id: ${{inputs.AWS_KEY_ID }}
       aws_secret_access_key: ${{inputs.AWS_KEY_VALUE}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -87,7 +87,7 @@ runs:
       testmo automation:run:complete --instance "$TESTMO_URL" --run-id ${{steps.th.outputs.runid}}
   - name: Upload S3
     uses: shallwefootball/s3-upload-action@master
-    if: inputs.AWS_KEY_ID
+    if: always() && inputs.AWS_KEY_ID
     with:
       aws_key_id: ${{inputs.AWS_KEY_ID }}
       aws_secret_access_key: ${{inputs.AWS_KEY_VALUE}}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -68,8 +68,7 @@ runs:
       TMPDIR=$WORKDIR/tmp GTEST_OUTPUT="xml:$TESTREPDIR/unittests/" Y_UNITTEST_OUTPUT="xml:$TESTREPDIR/unittests/" \
         ctest -j28 --timeout 1200 --force-new-ctest-process --output-on-failure \
               --output-junit $TESTREPDIR/suites/ctest_report.xml \
-              -L '${{inputs.test_label_regexp}}' \
-              -E ydb-core-kqp-ut-spilling | \
+              -L '${{inputs.test_label_regexp}}' | \
         sed -e 's/\x1b\[[0-9;]*m//g' | \
         tee >(gzip --stdout > $WORKDIR/artifacts/${{steps.init.outputs.logfilename}}) | \
         grep -E '(Test\s*#.*\*\*\*|\[FAIL\])|.*tests passed,.*tests failed out of' | \


### PR DESCRIPTION
This pull request enables the ydb-core-kqp-ut-spilling test and also adds the condition for uploading test results to S3.