### PR TITLE
feat: initial copy from ydb-k8s-operator

### DIFF
--- a/.github/workflows/build_and_test_ondemand.yml
+++ b/.github/workflows/build_and_test_ondemand.yml
@@ -119,7 +119,7 @@ jobs:
       - provide-runner # required to get output from the start-runner job
       - main # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ needs.provide-runner.result != 'skipped' }}
+    if: always()
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/build_and_test_ondemand.yml
+++ b/.github/workflows/build_and_test_ondemand.yml
@@ -52,6 +52,27 @@ jobs:
           core-fraction: 100
           zone-id: ru-central1-b
           subnet-id: ${{secrets.YC_SUBNET}}
+      - name: cleanup-test-label
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const labelToRemove = 'ok-to-test';
+            try {
+              const result = await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: labelToRemove
+              });
+            } catch(e) {
+              // ignore the 404 error that arises
+              // when the label did not exist for the
+              // organization member
+              console.log(e);
+            }
 
   prepare-vm:
     name: Prepare runner
@@ -98,7 +119,7 @@ jobs:
       - provide-runner # required to get output from the start-runner job
       - main # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ needs.provide-runner.result != 'skipped' }}
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -5,11 +5,32 @@ on:
       - 'main'
     paths-ignore:
       - 'ydb/docs/**'
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'labeled'
       
 jobs:
+  comment-if-waiting-on-ok:
+    if: |
+      (github.event.action == 'opened') &&
+       !contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+          github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: comment-if-waiting-on-ok
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
+            })
   build_and_test:
     uses: ./.github/workflows/build_and_test_ondemand.yml
-    if: github.event.review.state == 'approved'
     with:
       test_label_regexp: '(SMALL|MEDIUM)'
     secrets: inherit

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,6 +30,11 @@ jobs:
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             })
   build_and_test:
+    if: |
+      (contains(fromJSON('["opened","synchronize"]'), github.event.action) &&
+       contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+         github.event.pull_request.author_association)) ||
+       contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     uses: ./.github/workflows/build_and_test_ondemand.yml
     with:
       test_label_regexp: '(SMALL|MEDIUM)'


### PR DESCRIPTION
This PR brings a basic implementation of a pipeline from an external contributor, where the tests aren't triggered until a maintainer explicitly attaches an 'ok-to-test' label. Reference implementation is available in the [ydb-kubernetes-operator repo](https://github.com/ydb-platform/ydb-kubernetes-operator/blob/master/.github/workflows/e2e.yml)