### PR TITLE
External contributor pipeline

### DIFF
--- a/.github/workflows/build_and_test_ondemand.yml
+++ b/.github/workflows/build_and_test_ondemand.yml
@@ -119,7 +119,7 @@ jobs:
       - provide-runner # required to get output from the start-runner job
       - main # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ needs.provide-runner.result != 'skipped' }}
+    if: always()
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/build_and_test_ondemand.yml
+++ b/.github/workflows/build_and_test_ondemand.yml
@@ -52,6 +52,27 @@ jobs:
           core-fraction: 100
           zone-id: ru-central1-b
           subnet-id: ${{secrets.YC_SUBNET}}
+      - name: cleanup-test-label
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const labelToRemove = 'ok-to-test';
+            try {
+              const result = await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: labelToRemove
+              });
+            } catch(e) {
+              // ignore the 404 error that arises
+              // when the label did not exist for the
+              // organization member
+              console.log(e);
+            }
 
   prepare-vm:
     name: Prepare runner
@@ -98,7 +119,7 @@ jobs:
       - provide-runner # required to get output from the start-runner job
       - main # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ needs.provide-runner.result != 'skipped' }}
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,9 +10,9 @@ on:
       - 'synchronize'
       - 'reopened'
       - 'labeled'
-
       
 jobs:
+
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:
@@ -23,12 +23,12 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            # const response = await github.rest.orgs.checkMembershipForUser({
-            #   org: context.payload.organization.login,
-            #   username: context.payload.pull_request.user.login
-            # });
-            # // How to interpret status code: 
-            # // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            //const response = await github.rest.orgs.checkMembershipForUser({
+            //  org: context.payload.organization.login,
+            //  username: context.payload.pull_request.user.login
+            //});
+            //// How to interpret status code: 
+            //// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
             return 'true'
       - name: comment-if-waiting-on-ok
         if: steps.check-if-org-member.outputs.result == 'false'
@@ -41,7 +41,6 @@ jobs:
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
-
   build_and_test:
     needs:
       - check-running-allowed

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -5,11 +5,32 @@ on:
       - 'main'
     paths-ignore:
       - 'ydb/docs/**'
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'labeled'
       
 jobs:
+  comment-if-waiting-on-ok:
+    if: |
+      (github.event.action == 'opened') &&
+       !contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+          github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: comment-if-waiting-on-ok
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
+            })
   build_and_test:
     uses: ./.github/workflows/build_and_test_ondemand.yml
-    if: github.event.review.state == 'approved'
     with:
       test_label_regexp: '(SMALL|MEDIUM)'
     secrets: inherit

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -29,6 +29,7 @@ jobs:
               return true;
             }
 
+
             const response = await github.rest.orgs.checkMembershipForUser({
               org: context.payload.organization.login,
               username: userLogin,

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -12,7 +12,6 @@ on:
       - 'labeled'
       
 jobs:
-
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -13,36 +13,39 @@ on:
 
       
 jobs:
-  debug:
+  check-running-allowed:
     runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.check-if-org-member.outputs.result }}
     steps:
-      - name: logging
-        run: |
-          echo '${{ toJSON(github) }}'
-  comment-if-waiting-on-ok:
-    if: |
-      (github.event.action == 'opened') &&
-       !contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR", "OWNER"]'),
-          github.event.pull_request.author_association)
-    runs-on: ubuntu-latest
-    steps:
-      - name: comment-if-waiting-on-ok
+      - id: check-if-org-member
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const response = await github.rest.orgs.checkMembershipForUser({
+              org: context.payload.organization.login,
+              username: context.payload.pull_request.user.login
+            });
+            // How to interpret status code: 
+            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            return response.status == '204'
+      - name: comment-if-waiting-on-ok
+        if: steps.check-if-org-member.outputs.result == 'false'
+        uses: actions/github-script@v6
+        with:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
-            })
+            });
+
   build_and_test:
-    if: |
-      (contains(fromJSON('["opened","synchronize"]'), github.event.action) &&
-       contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
-         github.event.pull_request.author_association)) ||
-       contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    needs:
+      - check-running-allowed
+    if: needs.check-running-allowed.outputs.result == 'true'
     uses: ./.github/workflows/build_and_test_ondemand.yml
     with:
       test_label_regexp: '(SMALL|MEDIUM)'

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,6 +10,7 @@ on:
       - 'synchronize'
       - 'reopened'
       - 'labeled'
+
       
 jobs:
   comment-if-waiting-on-ok:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -11,7 +11,6 @@ on:
       - 'reopened'
       - 'labeled'
 
-      
 jobs:
   check-running-allowed:
     runs-on: ubuntu-latest
@@ -46,14 +45,6 @@ jobs:
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
-  debug:
-    runs-on: ubuntu-latest
-    needs:
-      - check-running-allowed
-    steps:
-      - id: abc
-        run: |
-          echo '${{ toJSON(needs) }}'
   build_and_test:
     needs:
       - check-running-allowed

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -16,7 +16,7 @@ jobs:
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:
-      result: ${{ steps.check-ownership-membership.outputs.result }}
+      result: steps.check-ownership-membership.outputs.result
     steps:
       - id: check-ownership-membership
         uses: actions/github-script@v6
@@ -24,12 +24,12 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             const userLogin = context.payload.pull_request.user.login;
-            if context.payload.organization.owner.login == userLogin {
+            if (context.payload.organization.owner.login == userLogin) {
               return true;
             }
             const response = await github.rest.orgs.checkMembershipForUser({
               org: context.payload.organization.login,
-              username: userLogin
+              username: userLogin,
             });
             // How to interpret status code: 
             // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,7 +30,6 @@ jobs:
               return true;
             }
 
-
             const response = await github.rest.orgs.checkMembershipForUser({
               org: context.payload.organization.login,
               username: userLogin,

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -29,7 +29,7 @@ jobs:
             //});
             //// How to interpret status code: 
             //// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            return 'true'
+            return true
       - name: comment-if-waiting-on-ok
         if: steps.check-if-org-member.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,22 +23,23 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            // This is used primarily in forks. Repository owner 
-            // should be allowed to run anything. 
-            const userLogin = context.payload.pull_request.user.login;
-            if (context.payload.repository.owner.login == userLogin) {
-              return true;
-            }
+            // // This is used primarily in forks. Repository owner 
+            // // should be allowed to run anything. 
+            // const userLogin = context.payload.pull_request.user.login;
+            // if (context.payload.repository.owner.login == userLogin) {
+            //   return true;
+            // }
 
-            const response = await github.rest.orgs.checkMembershipForUser({
-              org: context.payload.organization.login,
-              username: userLogin,
-            });
-            // How to interpret membership status code: 
-            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            if (response.status == '204') {
-              return true;
-            }
+            // const response = await github.rest.orgs.checkMembershipForUser({
+            //   org: context.payload.organization.login,
+            //   username: userLogin,
+            // });
+
+            // // How to interpret membership status code: 
+            // // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            // if (response.status == '204') {
+            //   return true;  
+            // }
 
             const labels = context.payload.pull_request.labels;
             const okToTestLabel = labels.find(

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,18 +23,17 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            console.log(context.payload);
-            // const userLogin = context.payload.pull_request.user.login;
-            // if (context.payload.organization.owner.login == userLogin) {
-            //   return true;
-            // }
-            // const response = await github.rest.orgs.checkMembershipForUser({
-            //   org: context.payload.organization.login,
-            //   username: userLogin,
-            // });
-            // // How to interpret status code: 
-            // // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            // return response.status == '204'
+            const userLogin = context.payload.pull_request.user.login;
+            if (context.payload.repository.owner.login == userLogin) {
+              return true;
+            }
+            const response = await github.rest.orgs.checkMembershipForUser({
+              org: context.payload.organization.login,
+              username: userLogin,
+            });
+            // How to interpret status code: 
+            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            return response.status == '204'
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,17 +23,18 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            const userLogin = context.payload.pull_request.user.login;
-            if (context.payload.organization.owner.login == userLogin) {
-              return true;
-            }
-            const response = await github.rest.orgs.checkMembershipForUser({
-              org: context.payload.organization.login,
-              username: userLogin,
-            });
-            // How to interpret status code: 
-            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            return response.status == '204'
+            console.log(context.payload);
+            // const userLogin = context.payload.pull_request.user.login;
+            // if (context.payload.organization.owner.login == userLogin) {
+            //   return true;
+            // }
+            // const response = await github.rest.orgs.checkMembershipForUser({
+            //   org: context.payload.organization.login,
+            //   username: userLogin,
+            // });
+            // // How to interpret status code: 
+            // // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            // return response.status == '204'
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -16,22 +16,26 @@ jobs:
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:
-      result: ${{ steps.check-if-org-member.outputs.result }}
+      result: ${{ steps.check-ownership-membership.outputs.result }}
     steps:
-      - id: check-if-org-member
+      - id: check-ownership-membership
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            //const response = await github.rest.orgs.checkMembershipForUser({
-            //  org: context.payload.organization.login,
-            //  username: context.payload.pull_request.user.login
-            //});
-            //// How to interpret status code: 
-            //// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            return true
+            const userLogin = context.payload.pull_request.user.login;
+            if context.payload.organization.owner.login == userLogin {
+              return true;
+            }
+            const response = await github.rest.orgs.checkMembershipForUser({
+              org: context.payload.organization.login,
+              username: userLogin
+            });
+            // How to interpret status code: 
+            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            return response.status == '204'
       - name: comment-if-waiting-on-ok
-        if: steps.check-if-org-member.outputs.result == 'false'
+        if: steps.check-ownership-membership.outputs.result == 'false'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,18 +23,19 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            const userLogin = context.payload.pull_request.user.login;
-            console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
-            if (context.payload.repository.owner.login == userLogin) {
-              return true;
-            }
-            const response = await github.rest.orgs.checkMembershipForUser({
-              org: context.payload.organization.login,
-              username: userLogin,
-            });
-            // How to interpret status code: 
-            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            return response.status == '204'
+            // const userLogin = context.payload.pull_request.user.login;
+            // console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
+            // if (context.payload.repository.owner.login == userLogin) {
+            //   return true;
+            // }
+            // const response = await github.rest.orgs.checkMembershipForUser({
+            //   org: context.payload.organization.login,
+            //   username: userLogin,
+            // });
+            // // How to interpret status code: 
+            // // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            // return response.status == '204'
+            return false;
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
+<<<<<<< Updated upstream
             // const userLogin = context.payload.pull_request.user.login;
             // console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
             // if (context.payload.repository.owner.login == userLogin) {
@@ -36,6 +37,30 @@ jobs:
             // // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
             // return response.status == '204'
             return false;
+=======
+            // This is used primarily in forks. Repository owner 
+            // should be allowed to run anything. 
+            const userLogin = context.payload.pull_request.user.login;
+            if (context.payload.repository.owner.login == userLogin) {
+              return true;
+            }
+
+            const response = await github.rest.orgs.checkMembershipForUser({
+              org: context.payload.organization.login,
+              username: userLogin,
+            });
+            // How to interpret membership status code: 
+            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            if (response.status == '204') {
+              return true;
+            }
+
+            const labels = context.payload.pull_request.labels;
+            const okToTestLabel = labels.find(
+              label => label.name == 'ok-to-test'
+            );
+            return okToTestLabel !== undefined;
+>>>>>>> Stashed changes
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -16,7 +16,7 @@ jobs:
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:
-      result: steps.check-ownership-membership.outputs.result
+      result: ${{ steps.check-ownership-membership.outputs.result }}
     steps:
       - id: check-ownership-membership
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,7 +10,6 @@ on:
       - 'synchronize'
       - 'reopened'
       - 'labeled'
-
 jobs:
   check-running-allowed:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,13 +23,13 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            const response = await github.rest.orgs.checkMembershipForUser({
-              org: context.payload.organization.login,
-              username: context.payload.pull_request.user.login
-            });
-            // How to interpret status code: 
-            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            return response.status == '204'
+            # const response = await github.rest.orgs.checkMembershipForUser({
+            #   org: context.payload.organization.login,
+            #   username: context.payload.pull_request.user.login
+            # });
+            # // How to interpret status code: 
+            # // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            return 'true'
       - name: comment-if-waiting-on-ok
         if: steps.check-if-org-member.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,6 +30,11 @@ jobs:
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             })
   build_and_test:
+    if: |
+      (contains(fromJSON('["opened","synchronize"]'), github.event.action) &&
+       contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+         github.event.pull_request.author_association)) ||
+       contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     uses: ./.github/workflows/build_and_test_ondemand.yml
     with:
       test_label_regexp: '(SMALL|MEDIUM)'

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -12,6 +12,7 @@ on:
       - 'labeled'
       
 jobs:
+
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -26,7 +26,7 @@ jobs:
             const userLogin = context.payload.pull_request.user.login;
             console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
             if (context.payload.repository.owner.login == userLogin) {
-              return 'true';
+              return true;
             }
             const response = await github.rest.orgs.checkMembershipForUser({
               org: context.payload.organization.login,

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,6 +10,7 @@ on:
       - 'synchronize'
       - 'reopened'
       - 'labeled'
+
       
 jobs:
   check-running-allowed:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -40,7 +40,6 @@ jobs:
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
-
   build_and_test:
     needs:
       - check-running-allowed

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,11 +30,21 @@ jobs:
               org: context.payload.organization.login,
               username: userLogin,
             });
-            // How to interpret status code: 
+
+            // How to interpret membership status code: 
             // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            return response.status == '204'
+            if (response.status == '204') {
+              return true;  
+            }
+
+            const labels = context.payload.pull_request.labels;
+            const okToTestLabel = labels.find(
+              label => label.name == 'ok-to-test'
+            );
+            return okToTestLabel !== undefined;
       - name: comment-if-waiting-on-ok
-        if: steps.check-ownership-membership.outputs.result == 'false'
+        if: steps.check-ownership-membership.outputs.result == 'false' &&
+            github.event.action == 'opened'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,7 +10,6 @@ on:
       - 'synchronize'
       - 'reopened'
       - 'labeled'
-
       
 jobs:
   comment-if-waiting-on-ok:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -24,6 +24,7 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             const userLogin = context.payload.pull_request.user.login;
+            console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
             if (context.payload.repository.owner.login == userLogin) {
               return true;
             }
@@ -45,6 +46,17 @@ jobs:
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
+  debug:
+    runs-on: ubuntu-latest
+    needs:
+      - check-running-allowed
+    steps:
+      - id: abc
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            console.log(context);
   build_and_test:
     needs:
       - check-running-allowed

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -17,24 +17,24 @@ jobs:
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result }}
     steps:
-      - id: check-ownership-membership
+      - name: Check if running tests is allowed
+        id: check-ownership-membership
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-            // const userLogin = context.payload.pull_request.user.login;
-            // console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
-            // if (context.payload.repository.owner.login == userLogin) {
-            //   return true;
-            // }
-            // const response = await github.rest.orgs.checkMembershipForUser({
-            //   org: context.payload.organization.login,
-            //   username: userLogin,
-            // });
-            // // How to interpret status code: 
-            // // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            // return response.status == '204'
-            return false;
+            const userLogin = context.payload.pull_request.user.login;
+            console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
+            if (context.payload.repository.owner.login == userLogin) {
+              return true;
+            }
+            const response = await github.rest.orgs.checkMembershipForUser({
+              org: context.payload.organization.login,
+              username: userLogin,
+            });
+            // How to interpret status code: 
+            // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+            return response.status == '204'
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -11,6 +11,7 @@ on:
       - 'reopened'
       - 'labeled'
 jobs:
+
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,21 +23,6 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
-<<<<<<< Updated upstream
-            // const userLogin = context.payload.pull_request.user.login;
-            // console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
-            // if (context.payload.repository.owner.login == userLogin) {
-            //   return true;
-            // }
-            // const response = await github.rest.orgs.checkMembershipForUser({
-            //   org: context.payload.organization.login,
-            //   username: userLogin,
-            // });
-            // // How to interpret status code: 
-            // // https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-            // return response.status == '204'
-            return false;
-=======
             // This is used primarily in forks. Repository owner 
             // should be allowed to run anything. 
             const userLogin = context.payload.pull_request.user.login;
@@ -60,7 +45,6 @@ jobs:
               label => label.name == 'ok-to-test'
             );
             return okToTestLabel !== undefined;
->>>>>>> Stashed changes
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false'
         uses: actions/github-script@v6

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -47,7 +47,8 @@ jobs:
             );
             return okToTestLabel !== undefined;
       - name: comment-if-waiting-on-ok
-        if: steps.check-ownership-membership.outputs.result == 'false'
+        if: steps.check-ownership-membership.outputs.result == 'false' &&
+            github.event.action == 'opened'
         uses: actions/github-script@v6
         with:
           script: |
@@ -57,14 +58,6 @@ jobs:
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
-  debug:
-    runs-on: ubuntu-latest
-    needs:
-      - check-running-allowed
-    steps:
-      - id: abc
-        run: |
-          echo '${{ toJSON(needs) }}'
   build_and_test:
     needs:
       - check-running-allowed

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -26,7 +26,7 @@ jobs:
             const userLogin = context.payload.pull_request.user.login;
             console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
             if (context.payload.repository.owner.login == userLogin) {
-              return true;
+              return 'true';
             }
             const response = await github.rest.orgs.checkMembershipForUser({
               org: context.payload.organization.login,
@@ -52,11 +52,8 @@ jobs:
       - check-running-allowed
     steps:
       - id: abc
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          script: |
-            console.log(context);
+        run: |
+          echo '${{ toJSON(needs) }}'
   build_and_test:
     needs:
       - check-running-allowed

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -18,12 +18,11 @@ jobs:
     steps:
       - name: logging
         run: |
-          echo '${{ toJSON(github.event.pull_request) }}'
-          echo '${{ toJSON(github.event.action) }}'
+          echo '${{ toJSON(github) }}'
   comment-if-waiting-on-ok:
     if: |
       (github.event.action == 'opened') &&
-       !contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+       !contains(fromJSON('["MEMBER", "COLLABORATOR", "CONTRIBUTOR", "OWNER"]'),
           github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -13,6 +13,13 @@ on:
 
       
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: logging
+        run: |
+          echo '${{ toJSON(github.event.pull_request) }}'
+          echo '${{ toJSON(github.event.action) }}'
   comment-if-waiting-on-ok:
     if: |
       (github.event.action == 'opened') &&
@@ -23,6 +30,7 @@ jobs:
       - name: comment-if-waiting-on-ok
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -23,7 +23,6 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             const userLogin = context.payload.pull_request.user.login;
-            console.log('*', context.payload.repository.owner.login, '*', userLogin,'*');
             if (context.payload.repository.owner.login == userLogin) {
               return true;
             }


### PR DESCRIPTION
This PR brings a basic implementation of a pipeline from an external contributor, where the tests aren't triggered until a maintainer explicitly attaches an `ok-to-test` label. Reference implementation is available in the ydb-kubernetes-operator repository.