### PR TITLE
Initial implementation of attach session call

### DIFF
--- a/ydb/core/grpc_services/query/rpc_attach_session.cpp
+++ b/ydb/core/grpc_services/query/rpc_attach_session.cpp
@@ -12,16 +12,6 @@ namespace NKikimr::NGRpcService {
 
 namespace {
 
-//TODO move to common
-bool CheckSession(const TString& sessionId, IRequestCtxBase* ctx) {
-    if (sessionId.empty()) {
-        ctx->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, "Empty session id"));
-        return false;
-    }
-
-    return true;
-}
-
 using TEvAttachSessionRequest = TGrpcRequestNoOperationCall<Ydb::Query::AttachSessionRequest,
     Ydb::Query::SessionState>;
 

--- a/ydb/core/grpc_services/query/rpc_attach_session.cpp
+++ b/ydb/core/grpc_services/query/rpc_attach_session.cpp
@@ -1,11 +1,154 @@
 #include "service_query.h"
 #include <ydb/core/grpc_services/base/base.h>
 
+#include <ydb/core/grpc_services/query/service_query.h>
+#include <ydb/core/grpc_services/rpc_common/rpc_common.h>
+
+#include <ydb/core/kqp/common/events/events.h>
+#include <ydb/core/kqp/common/simple/services.h>
+
+
 namespace NKikimr::NGRpcService {
+
+namespace {
+
+//TODO move to common
+bool CheckSession(const TString& sessionId, IRequestCtxBase* ctx) {
+    if (sessionId.empty()) {
+        ctx->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, "Empty session id"));
+        return false;
+    }
+
+    return true;
+}
+
+using TEvAttachSessionRequest = TGrpcRequestNoOperationCall<Ydb::Query::AttachSessionRequest,
+    Ydb::Query::SessionState>;
+
+class TAttachSessionRPC : public TActorBootstrapped<TAttachSessionRPC> {
+public:
+    TAttachSessionRPC(std::unique_ptr<IRequestNoOpCtx> request)
+        : Request(std::move(request))
+    {}
+
+    void Bootstrap() {
+        Become(&TAttachSessionRPC::AttachingState);
+        DoAttach();
+    }
+
+    void AttachingState(TAutoPtr<IEventHandle>& ev) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NKqp::TEvKqp::TEvPingSessionResponse, HandleAttachin);
+            hFunc(NKqp::TEvKqp::TEvProcessResponse, HandleAttachin);
+        }
+    }
+
+    void ReadyState(TAutoPtr<IEventHandle>& ev) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvents::TEvWakeup, HandleReady);
+        }
+    }
+
+private:
+   void SubscribeClientLost() {
+        auto selfId = this->SelfId();
+        auto as = TActivationContext::ActorSystem();
+
+        Request->SetFinishAction([selfId, as]() {
+            as->Send(selfId, new TEvents::TEvWakeup());
+        });
+   }
+
+   void DoAbortTx() {
+       auto ev = std::make_unique<NKqp::TEvKqp::TEvCloseSessionRequest>();
+       ev->Record.MutableRequest()->SetSessionId(SessionId);
+       Send(NKqp::MakeKqpProxyID(SelfId().NodeId()), ev.release());
+   }
+
+    void DoAttach() {
+        auto ev = std::make_unique<NKqp::TEvKqp::TEvPingSessionRequest>();
+        auto req = dynamic_cast<TEvAttachSessionRequest*>(Request.get());
+        Y_VERIFY(req, "unexpected request type");
+
+        const auto sessionId = req->GetProtoRequest()->session_id();
+
+        if (CheckSession(sessionId, req)) {
+            ev->Record.MutableRequest()->SetSessionId(sessionId);
+            SessionId = sessionId;
+        } else {
+            return ReplyFinishStream(Ydb::StatusIds::BAD_REQUEST);
+        }
+
+        Send(NKqp::MakeKqpProxyID(SelfId().NodeId()), ev.release());
+    }
+
+    void HandleReady(TEvents::TEvWakeup::TPtr&) {
+        DoAbortTx();
+        ReplyFinishStream(Ydb::StatusIds::INTERNAL_ERROR);
+    }
+
+    void HandleAttachin(NKqp::TEvKqp::TEvPingSessionResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+        // Do not try to attach to closing session
+        const bool sessionExpired = record.GetWorkerIsClosing();
+        if (sessionExpired) {
+            return ReplyFinishStream(Ydb::StatusIds::NOT_FOUND);
+        }
+
+        SubscribeClientLost();
+
+        SendAttachResult(record.GetStatus());
+
+        Become(&TAttachSessionRPC::ReadyState);
+    }
+
+    void SendAttachResult(Ydb::StatusIds::StatusCode status) {
+        Ydb::Query::SessionState resp;
+        resp.set_status(status);
+
+        TString out;
+        Y_PROTOBUF_SUPPRESS_NODISCARD resp.SerializeToString(&out);
+
+        Request->SendSerializedResult(std::move(out), status);
+    }
+
+    template<typename TResp>
+    void ReplyResponseError(const TResp& kqpResponse) {
+        if (kqpResponse.HasError()) {
+            Request->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, kqpResponse.GetError()));
+        }
+        return ReplyFinishStream(kqpResponse.GetYdbStatus());
+    }
+
+    void HandleAttachin(NKqp::TEvKqp::TEvProcessResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+        if (record.GetYdbStatus() == Ydb::StatusIds::SUCCESS) {
+            // KQP should not send TEvProcessResponse with SUCCESS for CreateSession rpc.
+            // We expect TEvKqp::TEvPingSessionResponse instead.
+            static const TString err = "Unexpected TEvProcessResponse with success status for PingSession request";
+            Request->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, err));
+            ReplyFinishStream(Ydb::StatusIds::INTERNAL_ERROR);
+        } else {
+            return ReplyResponseError(record);
+        }
+    }
+
+    void ReplyFinishStream(Ydb::StatusIds::StatusCode status) {
+        Request->ReplyWithYdbStatus(status);
+        Request->FinishStream();
+        this->PassAway();
+    }
+
+    std::unique_ptr<IRequestNoOpCtx> Request;
+    TString SessionId;
+};
+
+}
+
 namespace NQuery {
 
-void DoAttachSession(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider&) {
-    p->ReplyWithRpcStatus(grpc::StatusCode::UNIMPLEMENTED);
+void DoAttachSession(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider& provider) {
+    provider.RegisterActor(new TAttachSessionRPC(std::move(p)));
 }
 
 }

--- a/ydb/core/grpc_services/query/rpc_attach_session.cpp
+++ b/ydb/core/grpc_services/query/rpc_attach_session.cpp
@@ -28,7 +28,7 @@ public:
 
     void AttachingState(TAutoPtr<IEventHandle>& ev) {
         switch (ev->GetTypeRewrite()) {
-            hFunc(NKqp::TEvKqp::TEvPingSessionResponse, HandleAttachin);
+            hFunc(NKqp::TEvKqp::TEvPingSessionResponse, HandleAttaching);
             hFunc(NKqp::TEvKqp::TEvProcessResponse, HandleAttachin);
         }
     }
@@ -77,7 +77,7 @@ private:
         ReplyFinishStream(Ydb::StatusIds::INTERNAL_ERROR);
     }
 
-    void HandleAttachin(NKqp::TEvKqp::TEvPingSessionResponse::TPtr& ev) {
+    void HandleAttaching(NKqp::TEvKqp::TEvPingSessionResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
         // Do not try to attach to closing session
         const bool sessionExpired = record.GetWorkerIsClosing();

--- a/ydb/core/grpc_services/rpc_begin_transaction.cpp
+++ b/ydb/core/grpc_services/rpc_begin_transaction.cpp
@@ -52,11 +52,10 @@ private:
         SetAuthToken(ev, *Request_);
         SetDatabase(ev, *Request_);
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         if (traceId) {

--- a/ydb/core/grpc_services/rpc_commit_transaction.cpp
+++ b/ydb/core/grpc_services/rpc_commit_transaction.cpp
@@ -50,11 +50,10 @@ private:
         SetAuthToken(ev, *Request_);
         SetDatabase(ev, *Request_);
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         if (traceId) {

--- a/ydb/core/grpc_services/rpc_common/rpc_common.h
+++ b/ydb/core/grpc_services/rpc_common/rpc_common.h
@@ -50,5 +50,25 @@ inline void SetPeerName(TEvTxUserProxy::TEvProposeTransaction* ev, const IReques
     ev->Record.SetPeerName(ctx.GetPeerName());
 }
 
+inline bool CheckSession(const TString& sessionId, IRequestCtxBase* ctx) {
+    static const auto err = TString("Empty session id");
+    if (sessionId.empty()) {
+        ctx->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, err));
+        return false;
+    }
+
+    return true;
+}
+
+inline bool CheckQuery(const TString& query, IRequestCtxBase* ctx) {
+    static const auto err = TString("Empty query text");
+    if (query.empty()) {
+        ctx->RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, err));
+        return false;
+    }
+
+    return true;
+}
+
 } // namespace NGRpcService
 } // namespace NKikimr

--- a/ydb/core/grpc_services/rpc_delete_session.cpp
+++ b/ydb/core/grpc_services/rpc_delete_session.cpp
@@ -38,11 +38,10 @@ private:
 
         auto ev = MakeHolder<NKqp::TEvKqp::TEvCloseSessionRequest>();
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         ctx.Send(NKqp::MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release()); //no respose will be sended, so don't wait for anything

--- a/ydb/core/grpc_services/rpc_execute_data_query.cpp
+++ b/ydb/core/grpc_services/rpc_execute_data_query.cpp
@@ -53,10 +53,8 @@ public:
         const auto traceId = Request_->GetTraceId();
         const auto requestType = Request_->GetRequestType();
 
-        NYql::TIssues issues;
-
-        if (!CheckSession(req->session_id(), issues)) {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+        if (!CheckSession(req->session_id(), Request_.get())) {
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         if (!req->has_tx_control()) {
@@ -112,7 +110,6 @@ public:
                     NYql::TIssues issues;
                     issues.AddIssue(NYql::ExceptionToIssue(ex));
                     return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
-                    return;
                 }
 
                 queryAction = NKikimrKqp::QUERY_ACTION_EXECUTE_PREPARED;

--- a/ydb/core/grpc_services/rpc_execute_scheme_query.cpp
+++ b/ydb/core/grpc_services/rpc_execute_scheme_query.cpp
@@ -51,11 +51,10 @@ public:
         SetAuthToken(ev, *Request_);
         SetDatabase(ev, *Request_);
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         if (traceId) {
@@ -66,8 +65,8 @@ public:
             ev->Record.SetRequestType(requestType.GetRef());
         }
 
-        if (!CheckQuery(req->yql_text(), issues)) {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+        if (!CheckQuery(req->yql_text(), Request_.get())) {
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         ev->Record.MutableRequest()->SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);

--- a/ydb/core/grpc_services/rpc_explain_data_query.cpp
+++ b/ydb/core/grpc_services/rpc_explain_data_query.cpp
@@ -55,15 +55,14 @@ public:
             ev->Record.SetTraceId(traceId.GetRef());
         }
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
-        if (!CheckQuery(req->yql_text(), issues)) {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+        if (!CheckQuery(req->yql_text(), Request_.get())) {
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         ev->Record.MutableRequest()->SetAction(NKikimrKqp::QUERY_ACTION_EXPLAIN);

--- a/ydb/core/grpc_services/rpc_keep_alive.cpp
+++ b/ydb/core/grpc_services/rpc_keep_alive.cpp
@@ -48,11 +48,10 @@ private:
 
         auto ev = MakeHolder<NKqp::TEvKqp::TEvPingSessionRequest>();
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         if (traceId) {

--- a/ydb/core/grpc_services/rpc_kqp_base.h
+++ b/ydb/core/grpc_services/rpc_kqp_base.h
@@ -65,15 +65,6 @@ inline NYql::NDqProto::EDqStatsMode GetKqpStatsMode(Ydb::Table::QueryStatsCollec
     }
 }
 
-inline bool CheckSession(const TString& sessionId, NYql::TIssues& issues) {
-    if (sessionId.empty()) {
-        issues.AddIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, "Empty session id"));
-        return false;
-    }
-
-    return true;
-}
-
 inline bool CheckQuery(const TString& query, NYql::TIssues& issues) {
     if (query.empty()) {
         issues.AddIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, "Empty query text"));

--- a/ydb/core/grpc_services/rpc_prepare_data_query.cpp
+++ b/ydb/core/grpc_services/rpc_prepare_data_query.cpp
@@ -62,15 +62,14 @@ public:
             ev->Record.SetRequestType(requestType.GetRef());
         }
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
-        if (!CheckQuery(req->yql_text(), issues)) {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+        if (!CheckQuery(req->yql_text(), Request_.get())) {
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         ev->Record.MutableRequest()->SetAction(NKikimrKqp::QUERY_ACTION_PREPARE);

--- a/ydb/core/grpc_services/rpc_rollback_transaction.cpp
+++ b/ydb/core/grpc_services/rpc_rollback_transaction.cpp
@@ -50,11 +50,10 @@ private:
         SetAuthToken(ev, *Request_);
         SetDatabase(ev, *Request_);
 
-        NYql::TIssues issues;
-        if (CheckSession(req->session_id(), issues)) {
+        if (CheckSession(req->session_id(), Request_.get())) {
             ev->Record.MutableRequest()->SetSessionId(req->session_id());
         } else {
-            return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+            return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
         }
 
         if (traceId) {

--- a/ydb/services/persqueue_v1/actors/update_offsets_in_transaction_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/update_offsets_in_transaction_actor.cpp
@@ -36,11 +36,10 @@ void TUpdateOffsetsInTransactionActor::Proceed(const NActors::TActorContext& ctx
     SetAuthToken(ev, *Request_);
     SetDatabase(ev, *Request_);
 
-    NYql::TIssues issues;
-    if (CheckSession(req->tx().session(), issues)) {
+    if (CheckSession(req->tx().session(), Request_.get())) {
         ev->Record.MutableRequest()->SetSessionId(req->tx().session());
     } else {
-        return Reply(Ydb::StatusIds::BAD_REQUEST, issues, ctx);
+        return Reply(Ydb::StatusIds::BAD_REQUEST, ctx);
     }
 
     ev->Record.MutableRequest()->SetType(NKikimrKqp::QUERY_TYPE_UNDEFINED);

--- a/ydb/services/ydb/ydb_query_ut.cpp
+++ b/ydb/services/ydb/ydb_query_ut.cpp
@@ -5,56 +5,95 @@
 using namespace NYdb;
 using namespace NGrpc;
 
+namespace {
+
+TString CreateSession(const NGRpcProxy::TGRpcClientConfig& clientConfig) {
+    NGrpc::TGRpcClientLow clientLow;
+    auto connection = clientLow.CreateGRpcServiceConnection<Ydb::Query::V1::QueryService>(clientConfig);
+
+    Ydb::Query::CreateSessionRequest request;
+    TString sessionId;
+
+    NGrpc::TResponseCallback<Ydb::Query::CreateSessionResponse> responseCb =
+        [&sessionId](NGrpc::TGrpcStatus&& grpcStatus, Ydb::Query::CreateSessionResponse&& response) -> void {
+            UNIT_ASSERT(!grpcStatus.InternalError);
+            UNIT_ASSERT(grpcStatus.GRpcStatusCode == 0);
+            UNIT_ASSERT_VALUES_EQUAL(response.status(), Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT(response.session_id() != "");
+            sessionId = response.session_id();
+    };
+
+    connection->DoRequest(request, std::move(responseCb), &Ydb::Query::V1::QueryService::Stub::AsyncCreateSession);
+
+    return sessionId;
+}
+
+using TProcessor = typename NGrpc::IStreamRequestReadProcessor<Ydb::Query::SessionState>::TPtr;
+void CheckAttach(const NGRpcProxy::TGRpcClientConfig& clientConfig, const TString& id,
+    const Ydb::StatusIds::StatusCode expected, bool& allDoneOk)
+{
+    NGrpc::TGRpcClientLow clientLow;
+    auto connection = clientLow.CreateGRpcServiceConnection<Ydb::Query::V1::QueryService>(clientConfig);
+
+    Ydb::Query::AttachSessionRequest request;
+    request.set_session_id(id);
+
+    auto promise = NThreading::NewPromise<TProcessor>();
+    auto cb = [&allDoneOk, promise, expected](TGrpcStatus grpcStatus, TProcessor processor) mutable {
+        UNIT_ASSERT(grpcStatus.GRpcStatusCode == grpc::StatusCode::OK);
+        auto resp = std::make_shared<Ydb::Query::SessionState>();
+        processor->Read(resp.get(), [&allDoneOk, resp, promise, processor, expected](TGrpcStatus grpcStatus) mutable {
+            UNIT_ASSERT(grpcStatus.GRpcStatusCode == grpc::StatusCode::OK);
+            allDoneOk &= (resp->status() == expected);
+            if (!allDoneOk) {
+                Cerr << "Got attach response: " << resp->DebugString() << Endl;
+            }
+            promise.SetValue(processor);
+        });
+    };
+
+    connection->DoStreamRequest<Ydb::Query::AttachSessionRequest, Ydb::Query::SessionState>(
+        request,
+        cb,
+        &Ydb::Query::V1::QueryService::Stub::AsyncAttachSession);
+
+    auto processor = promise.GetFuture().GetValueSync();
+    processor->Cancel();
+}
+
+}
+
 Y_UNIT_TEST_SUITE(YdbQueryService) {
-    Y_UNIT_TEST(TestCreateSession) {
+    Y_UNIT_TEST(TestCreateAndAttachSession) {
         TKikimrWithGrpcAndRootSchema server;
+
         ui16 grpc = server.GetPort();
         TString location = TStringBuilder() << "localhost:" << grpc;
+
         auto clientConfig = NGRpcProxy::TGRpcClientConfig(location);
-        bool allDoneOk = false;
+        bool allDoneOk = true;
 
-        {
-            NGrpc::TGRpcClientLow clientLow;
-            auto connection = clientLow.CreateGRpcServiceConnection<Ydb::Query::V1::QueryService>(clientConfig);
+        TString sessionId = CreateSession(clientConfig);
 
-            Ydb::Query::CreateSessionRequest request;
+        UNIT_ASSERT(sessionId);
 
-            NGrpc::TResponseCallback<Ydb::Query::CreateSessionResponse> responseCb =
-                [&allDoneOk](NGrpc::TGrpcStatus&& grpcStatus, Ydb::Query::CreateSessionResponse&& response) -> void {
-                    UNIT_ASSERT(!grpcStatus.InternalError);
-                    UNIT_ASSERT(grpcStatus.GRpcStatusCode == 0);
-                    UNIT_ASSERT_VALUES_EQUAL(response.status(), Ydb::StatusIds::SUCCESS);
-                    UNIT_ASSERT(response.session_id() != "");
-                    allDoneOk = true;
-            };
-
-            connection->DoRequest(request, std::move(responseCb), &Ydb::Query::V1::QueryService::Stub::AsyncCreateSession);
+        for (const auto id : {"", "unknownSesson"}) {
+            CheckAttach(clientConfig, id, Ydb::StatusIds::BAD_REQUEST, allDoneOk);
         }
 
         UNIT_ASSERT(allDoneOk);
-        allDoneOk = false;
 
         {
-            using TProcessor = typename NGrpc::IStreamRequestReadProcessor<Ydb::Query::SessionState>::TPtr;
+            // We expect to get reply from KQP proxy
+            // and destroy session in the time of destroy stream
+            CheckAttach(clientConfig, sessionId, Ydb::StatusIds::SUCCESS, allDoneOk);
+        }
 
-            NGrpc::TGRpcClientLow clientLow;
-            auto connection = clientLow.CreateGRpcServiceConnection<Ydb::Query::V1::QueryService>(clientConfig);
+        UNIT_ASSERT(allDoneOk);
 
-            Ydb::Query::AttachSessionRequest request;
-
-            auto cb = [&allDoneOk](TGrpcStatus grpcStatus, TProcessor processor) {
-                if (grpcStatus.Ok()) {
-                    Ydb::Query::SessionState resp;
-                    processor->Read(&resp, [&allDoneOk](TGrpcStatus grpcStatus) {
-                        allDoneOk = grpcStatus.GRpcStatusCode == grpc::StatusCode::UNIMPLEMENTED;
-                    });
-                }
-            };
-
-            connection->DoStreamRequest<Ydb::Query::AttachSessionRequest, Ydb::Query::SessionState>(
-                request,
-                cb,
-                &Ydb::Query::V1::QueryService::Stub::AsyncAttachSession);
+        {
+            // We expect session has been destroyed
+            CheckAttach(clientConfig, sessionId, Ydb::StatusIds::BAD_SESSION, allDoneOk);
         }
 
         UNIT_ASSERT(allDoneOk);


### PR DESCRIPTION
Implemented client control which automatically close session in case of lost the client.

Simple implementation.
Future code must implement:
- tx control
- graceful disconnect
Nice to have:
- active session check or subscribe for session actor to notify client if session has been destroyed on the server side 