### PR TITLE
ci: add concurrency group for pr_check and allow only one simultaneous run

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -13,8 +13,10 @@ on:
       - 'synchronize'
       - 'reopened'
       - 'labeled'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
-
   check-running-allowed:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
This PR adds a concurrency group name for the pr_check workflow. It'll cancel previous PR check runs when a new commit arrives.