### PR TITLE
ci: change comment author in the PR-check action to github-actions bot

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -65,7 +65,6 @@ jobs:
             github.event.action == 'opened'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -76,7 +75,6 @@ jobs:
       - name: cleanup-test-label
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;


### PR DESCRIPTION
Without a personal token `actions/github-script` will utilize workflow's GITHUB_TOKEN and post a comment from the `github-actions` bot. The workflow requires write permission, which has already been configured.

An example PR comment:
<img width="928" alt="image" src="https://github.com/ydb-platform/ydb/assets/95808/58551e68-2c76-4ae2-8b1d-6c28ba843941">
