### PR TITLE
ci: debug info compression for sanitizers and increase memory for the VM

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,8 +24,8 @@ runs:
       cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/ccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache \
         -DCMAKE_TOOLCHAIN_FILE=../ydb/clang.toolchain \
-        -DCMAKE_CXX_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -fno-omit-frame-pointer -UNDEBUG" \
-        -DCMAKE_C_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -fno-omit-frame-pointer -UNDEBUG" \
+        -DCMAKE_CXX_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -gsplit-dwarf -gz -fno-omit-frame-pointer -UNDEBUG" \
+        -DCMAKE_C_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -gsplit-dwarf -gz -fno-omit-frame-pointer -UNDEBUG" \
         ../ydb
   - name: Configure
     shell: bash

--- a/.github/workflows/build_and_test_ondemand.yml
+++ b/.github/workflows/build_and_test_ondemand.yml
@@ -60,7 +60,7 @@ jobs:
           disk-size: ${{vars.DISK_SIZE && vars.DISK_SIZE || '1023GB'}}
           disk-type: network-ssd-nonreplicated
           cores: 32
-          memory: 64GB
+          memory: 128GB
           core-fraction: 100
           zone-id: ru-central1-b
           subnet-id: ${{secrets.YC_SUBNET}}


### PR DESCRIPTION
This pull request increases memory for on-demand VM to 128 GB and enables compression for debug sections. It also enables split-dwarf to reduce the total size of the object files processed by the linker.