### PR TITLE
ci: change github-token for yc-github-runner

### DIFF
--- a/.github/workflows/build_and_test_ondemand.yml
+++ b/.github/workflows/build_and_test_ondemand.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           mode: start
           yc-sa-json-credentials: ${{ secrets.YC_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           folder-id: ${{secrets.YC_FOLDER}}
           image-id: ${{inputs.image}}
           disk-size: ${{vars.DISK_SIZE && vars.DISK_SIZE || '1023GB'}}
@@ -129,7 +129,7 @@ jobs:
         with:
           mode: stop
           yc-sa-json-credentials: ${{ secrets.YC_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           label: ${{ needs.provide-runner.outputs.label }}
           instance-id: ${{ needs.provide-runner.outputs.instance-id }}
           

--- a/.github/workflows/prewarm-ccache.yml
+++ b/.github/workflows/prewarm-ccache.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           mode: start
           yc-sa-json-credentials: ${{ secrets.YC_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           folder-id: ${{ secrets.YC_FOLDER }}
           image-id: fd8earpjmhevh8h6ug5o # TODO: create constant
           disk-size: ${{ vars.DISK_SIZE && vars.DISK_SIZE || '279GB' }}
@@ -80,6 +80,6 @@ jobs:
         with:
           mode: stop
           yc-sa-json-credentials: ${{ secrets.YC_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           label: ${{ needs.provide-runner.outputs.label }}
           instance-id: ${{ needs.provide-runner.outputs.instance-id }}


### PR DESCRIPTION
This PR partially reverts #297 and revert the github-token in yc-github-runer steps.