### PR TITLE
ci: fix C_FLAGS for prewarm ccache docker images

### DIFF
--- a/.github/prewarm/build.sh
+++ b/.github/prewarm/build.sh
@@ -13,8 +13,8 @@ echo "::group::cmake"
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
 -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/ccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache \
 -DCMAKE_TOOLCHAIN_FILE=../ydb/clang.toolchain \
--DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -UNDEBUG" \
--DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -UNDEBUG" \
+-DCMAKE_C_FLAGS_RELEASE="-O2 -UNDEBUG" \
+-DCMAKE_CXX_FLAGS_RELEASE="-O2 -UNDEBUG" \
 ../ydb
 echo "::endgroup::"
 


### PR DESCRIPTION
This PR fixes incorrect flag setting name for C_FLAGS and CXX_FLAGS.