### PR TITLE
ci: change postprocess script run order

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -162,6 +162,22 @@ runs:
     if: inputs.run_unit_tests == 'true'
     shell: bash
     run: |
+      echo "::group::extract-logs"
+
+      mkdir $ARTIFACTS_DIR/logs/
+
+      .github/scripts/tests/attach-logs.py \
+        --url-prefix ${{steps.init.outputs.logurlprefix}}/logs/ \
+        --filter-shard-file ${{steps.init.outputs.testshardfilterfile}} \
+        --filter-test-file ${{steps.init.outputs.testfilterfile}} \
+        --ctest-report $TESTREPDIR/suites/ctest_report.xml \
+        --junit-reports-path $TESTREPDIR/unittests/ \
+        --decompress \
+        $ARTIFACTS_DIR/${{steps.init.outputs.logfilename}} \
+        $ARTIFACTS_DIR/logs/
+
+      echo "::endgroup::"
+
       echo "::group::junit-postprocess"
       
       .github/scripts/tests/junit-postprocess.py \
@@ -177,22 +193,6 @@ runs:
         --decompress \
         $ARTIFACTS_DIR/${{steps.init.outputs.logfilename}} \
         $TESTREPDIR/suites/ctest_report.xml
-
-      echo "::endgroup::"
-
-      echo "::group::extract-logs"
-
-      mkdir $ARTIFACTS_DIR/logs/
-
-      .github/scripts/tests/attach-logs.py \
-        --url-prefix ${{steps.init.outputs.logurlprefix}}/logs/ \
-        --filter-shard-file ${{steps.init.outputs.testshardfilterfile}} \
-        --filter-test-file ${{steps.init.outputs.testfilterfile}} \
-        --ctest-report $TESTREPDIR/suites/ctest_report.xml \
-        --junit-reports-path $TESTREPDIR/unittests/ \
-        --decompress \
-        $ARTIFACTS_DIR/${{steps.init.outputs.logfilename}} \
-        $ARTIFACTS_DIR/logs/
 
       echo "::endgroup::"
 

--- a/.github/scripts/tests/attach-logs.py
+++ b/.github/scripts/tests/attach-logs.py
@@ -120,6 +120,7 @@ def attach_to_unittests(ctest_log: CTestLog, unit_path):
             continue
 
         fn = f"_{shard}_not_found.xml"
+        print(f"create {fn}")
         testcases = [create_error_testcase(t.shard.name, t.classname, t.method, t.fn, t.url) for t in extra_logs]
 
         testsuite = create_error_testsuite(testcases)

--- a/.github/scripts/tests/junit_utils.py
+++ b/.github/scripts/tests/junit_utils.py
@@ -34,8 +34,11 @@ def get_property_value(testcase, name):
 
 def create_error_testsuite(testcases):
     n = str(len(testcases))
-    root = ET.Element("testsuite", dict(tests=n, failures=n))
-    root.extend(testcases)
+    suite = ET.Element("testsuite", dict(tests=n, errors=n))
+    suite.extend(testcases)
+
+    root = ET.Element("testsuites", dict(tests=n, errors=n))
+    root.append(suite)
     return ET.ElementTree(root)
 
 

--- a/.github/scripts/tests/mute_utils.py
+++ b/.github/scripts/tests/mute_utils.py
@@ -60,7 +60,13 @@ def mute_target(node, node_name="failure"):
     if failure is None:
         return False
 
-    skipped = ET.Element("skipped", {"message": failure.attrib["message"]})
+    msg = failure.get("message")
+
+    skipped = ET.Element("skipped")
+
+    if msg:
+        skipped.set('message', msg)
+
     skipped.text = failure.text
 
     node.remove(failure)


### PR DESCRIPTION
This PR add test muting for test without XML reports (reports were generated after parsing ctest log)