### PR TITLE
Ci pytest xdist

### DIFF
--- a/.github/actions/prepare_vm/action.yaml
+++ b/.github/actions/prepare_vm/action.yaml
@@ -29,7 +29,7 @@ runs:
         sudo apt-get -y install --no-install-recommends \
           python-is-python3 git cmake python3-pip ninja-build antlr3 m4 \
           clang-12 lld-12 llvm-12 libidn11-dev libaio1 libaio-dev parallel s3cmd
-        sudo pip3 install conan==1.59 pytest==7.1.3 pytest-timeout grpcio grpcio-tools PyHamcrest tornado xmltodict pyarrow
+        sudo pip3 install conan==1.59 pytest==7.1.3 pytest-timeout pytest-xdist==3.3.1 setproctitle==1.3.2 grpcio grpcio-tools PyHamcrest tornado xmltodict pyarrow
     - name: install ccache
       shell: bash
       run: |

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -233,25 +233,30 @@ runs:
       export build_root=$WORKDIR/../build/
 
       echo "[Stdout pytest log (gzip archive)](${{steps.init.outputs.logurlprefix}}/${{steps.init.outputs.pytest-logfilename}})" >> $GITHUB_STEP_SUMMARY
-      cd $WORKDIR/ydb/tests/functional/
-      bad_suites=$(grep -Eo 'ignore=[a-zA-Z_-]*' pytest.ini | sed -e 's/ignore=//g')
-      suites=""
-      for suite in $(echo */ | sed -e 's/\///g'); do
-        if [[ $(echo "$bad_suites" | grep -F -e $suite -) == '' ]]; then
-            suites+=$suite
-            suites+=$'\n'
-        fi
-      done
-      if [[ "${{inputs.test_label_regexp}}" != '' ]]; then
-        suites="${{inputs.test_label_regexp}}"
-      fi
       source $WORKDIR/ydb/tests/oss/launch/prepare.sh
-      echo -n "$suites" | parallel -j28 "pytest -o junit_logging=log -o junit_log_passing_tests=False \
-        -v --junit-xml=$PYTESTREPDIR/{}.xml {}" | \
-        sed -e 's/\x1b\[[0-9;]*m//g' | \
-        tee >(gzip --stdout > $ARTIFACTS_DIR/${{steps.init.outputs.pytest-logfilename}}) | \
-        grep -E '(FAILED|ERROR)\s*\[.*\]' | \
-        tee $WORKDIR/pytest-short.log
+      
+      rm -rf $ARTIFACTS_DIR/pytest/
+      mkdir $ARTIFACTS_DIR/pytest/
+      
+      cd $WORKDIR/ydb/tests/functional/
+      
+      pytest \
+        -p xdist -n 24 --dist worksteal \
+        --timeout_method signal \
+        -o junit_logging=log -o junit_log_passing_tests=False --junit-xml=$PYTESTREPDIR/pytest.xml \
+        -ra --tb=no --show-capture=no \
+        --github-repo $GITHUB_REPOSITORY --github-ref $GITHUB_SHA \
+        --source-root $source_root \
+        --build-root $build_root \
+        --output-dir $ARTIFACTS_DIR/pytest/ \
+        . | tee $WORKDIR/pytest-short.log
+            
+#      echo -n "$suites" | parallel -j28 "pytest -o junit_logging=log -o junit_log_passing_tests=False \
+#        -v --junit-xml=$PYTESTREPDIR/{}.xml {}" | \
+#        sed -e 's/\x1b\[[0-9;]*m//g' | \
+#        tee >(gzip --stdout > $ARTIFACTS_DIR/${{steps.init.outputs.pytest-logfilename}}) | \
+#        grep -E '(FAILED|ERROR)\s*\[.*\]' | \
+#        tee $WORKDIR/pytest-short.log
 
   - name: postprocess functional test reports
     if: always() && inputs.run_functional_tests == 'true'
@@ -287,13 +292,13 @@ runs:
     run: |
       testmo automation:run:complete --instance "$TESTMO_URL" --run-id ${{steps.th.outputs.runid}}
 
-  - name: sync test results to s3
-    if: always() && inputs.run_functional_tests == 'true'
-    shell: bash
-    run: |
-      echo "::group::s3-sync"
-      s3cmd sync -P --no-progress --stats --no-check-md5 -P $ARTIFACTS_DIR/ $S3_BUCKET_PATH
-      echo "::endgroup::"
+#  - name: sync test results to s3
+#    if: always() && inputs.run_functional_tests == 'true'
+#    shell: bash
+#    run: |
+#      echo "::group::s3-sync"
+#      s3cmd sync -P --no-progress --stats --no-check-md5 -P $ARTIFACTS_DIR/ $S3_BUCKET_PATH
+#      echo "::endgroup::"
 
   - name: finish
     shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -249,6 +249,7 @@ runs:
         --source-root $source_root \
         --build-root $build_root \
         --output-dir $ARTIFACTS_DIR/pytest/ \
+        --artifacts-dir $ARTIFACTS_DIR/artifacts/ \
         . | tee $WORKDIR/pytest-short.log
             
 #      echo -n "$suites" | parallel -j28 "pytest -o junit_logging=log -o junit_log_passing_tests=False \

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -55,7 +55,6 @@ runs:
       echo "testfilterfile=$(pwd)/.github/config/muted_test.txt" >> $GITHUB_OUTPUT
       echo "testshardfilterfile=$(pwd)/.github/config/muted_shard.txt" >> $GITHUB_OUTPUT
       echo "functestfilterfile=$(pwd)/.github/config/muted_functest.txt" >> $GITHUB_OUTPUT
-      echo "logurlprefix=${{inputs.aws_endpoint}}/${{inputs.aws_bucket}}/${{ github.repository }}/${{github.workflow}}/${{github.run_id}}" >> $GITHUB_OUTPUT
       echo "pytest-logfilename=${{inputs.log_suffix}}-pytest-stdout.gz" >> $GITHUB_OUTPUT
 
   - name: configure s3cmd
@@ -69,8 +68,9 @@ runs:
       host_base = storage.yandexcloud.net
       host_bucket = %(bucket)s.storage.yandexcloud.net
       EOF
-      echo "S3CMD_CONFIG=$TPMDIR/s3cfg" >> $GITHUB_ENV
+      echo "S3CMD_CONFIG=$TMPDIR/s3cfg" >> $GITHUB_ENV
       echo "S3_BUCKET_PATH=s3://${{ inputs.aws_bucket }}/${{ github.repository }}/${{github.workflow}}/${{ github.run_id }}/" >> $GITHUB_ENV
+      echo "S3_URL_PREFIX=${{inputs.aws_endpoint}}/${{inputs.aws_bucket}}/${{ github.repository }}/${{github.workflow}}/${{github.run_id}}" >> $GITHUB_ENV
     env:
       aws_key_id: ${{inputs.AWS_KEY_ID }}
       aws_secret_access_key: ${{inputs.AWS_KEY_VALUE}}
@@ -131,7 +131,7 @@ runs:
     run: |
       cd $WORKDIR/../build/ydb
 
-      echo "[Stdout unittest/ctest log (gzip archive)](${{steps.init.outputs.logurlprefix}}/${{steps.init.outputs.logfilename}})" >> $GITHUB_STEP_SUMMARY
+      echo "[Stdout unittest/ctest log (gzip archive)]($S3_URL_PREFIX/${{steps.init.outputs.logfilename}})" >> $GITHUB_STEP_SUMMARY
 
       # Sed removes coloring from the output
       
@@ -157,7 +157,7 @@ runs:
     run: |
       tar -C $TESTREPDIR/ -czf $ARTIFACTS_DIR/reports.tar.gz .
       ls -la $ARTIFACTS_DIR/reports.tar.gz
-      echo "[Unittest/CTest XML reports archive](${{steps.init.outputs.logurlprefix}}/reports.tar.gz)" >> $GITHUB_STEP_SUMMARY
+      echo "[Unittest/CTest XML reports archive]($S3_URL_PREFIX/reports.tar.gz)" >> $GITHUB_STEP_SUMMARY
 
   - name: postprocess xml reports
     if: inputs.run_unit_tests == 'true'
@@ -168,7 +168,7 @@ runs:
       mkdir $ARTIFACTS_DIR/logs/
 
       .github/scripts/tests/attach-logs.py \
-        --url-prefix ${{steps.init.outputs.logurlprefix}}/logs/ \
+        --url-prefix $S3_URL_PREFIX/logs/ \
         --filter-shard-file ${{steps.init.outputs.testshardfilterfile}} \
         --filter-test-file ${{steps.init.outputs.testfilterfile}} \
         --ctest-report $TESTREPDIR/suites/ctest_report.xml \
@@ -233,7 +233,7 @@ runs:
       export source_root=$WORKDIR
       export build_root=$WORKDIR/../build/
 
-      echo "[Stdout pytest log (gzip archive)](${{steps.init.outputs.logurlprefix}}/${{steps.init.outputs.pytest-logfilename}})" >> $GITHUB_STEP_SUMMARY
+      echo "[Stdout pytest log (gzip archive)]($S3_URL_PREFIX/${{steps.init.outputs.pytest-logfilename}})" >> $GITHUB_STEP_SUMMARY
       source $WORKDIR/ydb/tests/oss/launch/prepare.sh
       
       rm -rf $ARTIFACTS_DIR/pytest/
@@ -250,9 +250,11 @@ runs:
         --source-root $source_root \
         --build-root $build_root \
         --output-dir $TMPDIR/pytest/ \
-        --artifacts-dir $ARTIFACTS_DIR/artifacts/ \
         . | tee $WORKDIR/pytest-short.log
-            
+
+#        --artifacts-dir $ARTIFACTS_DIR/pytest/ \
+#        --artifacts-url $S3_URL_PREFIX/pytest/ \
+
 #      echo -n "$suites" | parallel -j28 "pytest -o junit_logging=log -o junit_log_passing_tests=False \
 #        -v --junit-xml=$PYTESTREPDIR/{}.xml {}" | \
 #        sed -e 's/\x1b\[[0-9;]*m//g' | \
@@ -294,13 +296,13 @@ runs:
     run: |
       testmo automation:run:complete --instance "$TESTMO_URL" --run-id ${{steps.th.outputs.runid}}
 
-#  - name: sync test results to s3
-#    if: always() && inputs.run_functional_tests == 'true'
-#    shell: bash
-#    run: |
-#      echo "::group::s3-sync"
-#      s3cmd sync -P --no-progress --stats --no-check-md5 -P $ARTIFACTS_DIR/ $S3_BUCKET_PATH
-#      echo "::endgroup::"
+  - name: sync test results to s3
+    if: always() && inputs.run_functional_tests == 'true'
+    shell: bash
+    run: |
+      echo "::group::s3-sync"
+      s3cmd sync -P --no-progress --stats --no-check-md5 -P $ARTIFACTS_DIR/ $S3_BUCKET_PATH
+      echo "::endgroup::"
 
   - name: finish
     shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -255,13 +255,6 @@ runs:
 #        --artifacts-dir $ARTIFACTS_DIR/pytest/ \
 #        --artifacts-url $S3_URL_PREFIX/pytest/ \
 
-#      echo -n "$suites" | parallel -j28 "pytest -o junit_logging=log -o junit_log_passing_tests=False \
-#        -v --junit-xml=$PYTESTREPDIR/{}.xml {}" | \
-#        sed -e 's/\x1b\[[0-9;]*m//g' | \
-#        tee >(gzip --stdout > $ARTIFACTS_DIR/${{steps.init.outputs.pytest-logfilename}}) | \
-#        grep -E '(FAILED|ERROR)\s*\[.*\]' | \
-#        tee $WORKDIR/pytest-short.log
-
   - name: postprocess functional test reports
     if: always() && inputs.run_functional_tests == 'true'
     shell: bash
@@ -270,6 +263,7 @@ runs:
       
       .github/scripts/tests/junit-postprocess.py \
         --filter-file ${{ steps.init.outputs.functestfilterfile }} \
+        --no-attach-filename \
         $PYTESTREPDIR/
 
       echo "::endgroup::"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -42,11 +42,12 @@ runs:
     id: init
     shell: bash
     run: |
-      mkdir -p artifacts tmp test_reports
-      rm -rf artifacts/* tmp/* test_reports/*
+      rm -rf artifacts tmp test_reports
+      mkdir -p artifacts tmp/pytest test_reports/pytest
       echo "WORKDIR=$(pwd)" >> $GITHUB_ENV
       echo "TESTREPDIR=$(pwd)/test_reports" >> $GITHUB_ENV
-      echo "PYTESTREPDIR=$(pwd)/ydb/tests/functional/test-results/xml" >> $GITHUB_ENV
+      echo "TMPDIR=$(pwd)/tmp" >> $GITHUB_ENV
+      echo "PYTESTREPDIR=$(pwd)/test_reports/pytest/" >> $GITHUB_ENV
       echo "TESTMO_TOKEN=${{inputs.testman_token}}" >> $GITHUB_ENV
       echo "TESTMO_URL=${{inputs.testman_url}}" >> $GITHUB_ENV
       echo "ARTIFACTS_DIR=$(pwd)/artifacts" >> $GITHUB_ENV
@@ -60,7 +61,7 @@ runs:
   - name: configure s3cmd
     shell: bash
     run: |
-      cat <<EOF > $WORKDIR/tmp/s3cfg
+      cat <<EOF > $TMPDIR/s3cfg
       [default]
       access_key = ${aws_key_id}
       secret_key = ${aws_secret_access_key}
@@ -68,7 +69,7 @@ runs:
       host_base = storage.yandexcloud.net
       host_bucket = %(bucket)s.storage.yandexcloud.net
       EOF
-      echo "S3CMD_CONFIG=$WORKDIR/tmp/s3cfg" >> $GITHUB_ENV
+      echo "S3CMD_CONFIG=$TPMDIR/s3cfg" >> $GITHUB_ENV
       echo "S3_BUCKET_PATH=s3://${{ inputs.aws_bucket }}/${{ github.repository }}/${{github.workflow}}/${{ github.run_id }}/" >> $GITHUB_ENV
     env:
       aws_key_id: ${{inputs.AWS_KEY_ID }}
@@ -134,7 +135,7 @@ runs:
 
       # Sed removes coloring from the output
       
-      TMPDIR=$WORKDIR/tmp GTEST_OUTPUT="xml:$TESTREPDIR/unittests/" Y_UNITTEST_OUTPUT="xml:$TESTREPDIR/unittests/" \
+      GTEST_OUTPUT="xml:$TESTREPDIR/unittests/" Y_UNITTEST_OUTPUT="xml:$TESTREPDIR/unittests/" \
         ctest -j28 --timeout 1200 --force-new-ctest-process --output-on-failure \
               --output-junit $TESTREPDIR/suites/ctest_report.xml \
               -L '${{inputs.test_label_regexp}}' -E "${CTEST_SKIP_SHARDS:-}" | \
@@ -248,7 +249,7 @@ runs:
         --github-repo $GITHUB_REPOSITORY --github-ref $GITHUB_SHA \
         --source-root $source_root \
         --build-root $build_root \
-        --output-dir $ARTIFACTS_DIR/pytest/ \
+        --output-dir $TMPDIR/pytest/ \
         --artifacts-dir $ARTIFACTS_DIR/artifacts/ \
         . | tee $WORKDIR/pytest-short.log
             

--- a/.github/scripts/tests/junit-postprocess.py
+++ b/.github/scripts/tests/junit-postprocess.py
@@ -18,7 +18,7 @@ def attach_filename(testcase, filename):
     add_junit_property(testcase, "shard", shardname)
 
 
-def postprocess_junit(is_mute_test, folder, dry_run):
+def postprocess_junit(is_mute_test, folder, no_attach_filename, dry_run):
     for fn in glob.glob(os.path.join(folder, "*.xml")):
         tree = ET.parse(fn)
         root = tree.getroot()
@@ -28,7 +28,8 @@ def postprocess_junit(is_mute_test, folder, dry_run):
             fail_cnt = error_cnt = 0
 
             for case, cls, method in case_iterator(suite):
-                attach_filename(case, os.path.basename(fn))
+                if not no_attach_filename:
+                    attach_filename(case, os.path.basename(fn))
 
                 if is_mute_test(cls, method):
                     if mute_target(case):
@@ -57,6 +58,7 @@ def postprocess_junit(is_mute_test, folder, dry_run):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--filter-file", required=True)
+    parser.add_argument("--no-attach-filename", action="store_true", default=False)
     parser.add_argument("--dry-run", action="store_true", default=False)
     parser.add_argument("yunit_path")
     args = parser.parse_args()
@@ -72,7 +74,7 @@ def main():
         print("nothing to mute")
         return
 
-    postprocess_junit(is_mute_test, args.yunit_path, args.dry_run)
+    postprocess_junit(is_mute_test, args.yunit_path, args.no_attach_filename, args.dry_run)
 
 
 if __name__ == "__main__":

--- a/ydb/tests/functional/pytest.ini
+++ b/ydb/tests/functional/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 timeout = 600
+python_files = test_*.py *_tests.py
 addopts = --ignore=clickbench --ignore=dynumber --ignore=large_serializable --ignore=serializable --ignore=postgresql --ignore=rename

--- a/ydb/tests/oss/ci/ci.py
+++ b/ydb/tests/oss/ci/ci.py
@@ -1,0 +1,104 @@
+import contextlib
+import os
+
+import pytest
+
+
+def pytest_sessionstart(session):
+    def noop(*args, **kwargs):
+        pass
+
+    assert session.config.pluginmanager
+    session.config.pluginmanager._check_non_top_pytest_plugins = noop
+
+
+# noinspection PyProtectedMember
+@contextlib.contextmanager
+def patch_project_path(item):
+    from ya import pytest_config
+
+    ctx = pytest_config.ya._context
+
+    old_path = ctx["project_path"]
+
+    project_path = os.path.relpath(
+        os.path.dirname(item.fspath),
+        pytest_config.ya._source_root,
+    )
+
+    ctx["project_path"] = project_path
+
+    yield
+
+    ctx["project_path"] = old_path
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_make_collect_report(collector):
+    with patch_project_path(collector):
+        yield
+
+
+def make_github_link(repo, ref, filepath, lineno):
+    result = [f"https://github.com/{repo}/blob/{ref}/{filepath}"]
+
+    if lineno:
+        result.append(f"#L{lineno + 1}")
+
+    return "".join(result)
+
+
+# noinspection PyProtectedMember
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    from ya import pytest_config
+    import library.python.pytest.yatest_tools as tools
+
+    # class_name, test_name = tools.split_node_id(item.nodeid)
+
+    # test_dir = (
+    #     f"{tools.normalize_filename(class_name)}_{tools.normalize_filename(test_name)}"
+    # )
+
+    # out_path = os.path.join(pytest_config.option.output_dir, test_dir)
+
+    if 'PYTEST_XDIST_WORKER' in os.environ:
+        out_path = os.path.join(pytest_config.option.output_dir, os.environ['PYTEST_XDIST_WORKER'])
+    else:
+        out_path = pytest_config.option.output_dir
+
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
+    pytest_config.ya._output_dir = out_path
+
+    rel_filepath = os.path.relpath(item.path, pytest_config.ya._source_root)
+
+    junit_props = {
+        "filename": rel_filepath,
+    }
+
+    if pytest_config.option.github_repo and pytest_config.option.github_ref:
+        lineno = item.reportinfo()[1]
+        junit_props["url:testcase"] = make_github_link(
+            pytest_config.option.github_repo,
+            pytest_config.option.github_ref,
+            rel_filepath,
+            lineno,
+        )
+    else:
+        junit_props["testcase"] = item.nodeid
+
+    for k, v in junit_props.items():
+        item.user_properties.append((k, v))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    with patch_project_path(item):
+        yield
+
+
+def pytest_addoption(parser):
+    parser.addoption("--github-repo", help="junit: link files to specific github repo")
+    parser.addoption("--github-ref", help="junit: link files to specific changeset")

--- a/ydb/tests/oss/launch/prepare.sh
+++ b/ydb/tests/oss/launch/prepare.sh
@@ -2,20 +2,27 @@
 
 python ${source_root}/ydb/tests/oss/launch/compile_protos.py --source-root ${source_root} 2>/dev/null
 
-testresults=${source_root}/ydb/tests/functional/test-results
+#testresults=${source_root}/ydb/tests/functional/test-results
+#
+#mkdir ${testresults}
+#mkdir ${testresults}/xml
+#mkdir ${testresults}/py3test
+#mkdir ${testresults}/py3test/testing_out_stuff
+#
+#python ${source_root}/ydb/tests/oss/launch/generate_test_context.py --build-root ${build_root} --source-root ${source_root} --out-dir ${testresults}
 
-mkdir ${testresults}
-mkdir ${testresults}/xml
-mkdir ${testresults}/py3test
-mkdir ${testresults}/py3test/testing_out_stuff
+export PYTHONPATH=${source_root}/ydb/public/sdk/python3
+export PYTHONPATH=$PYTHONPATH:${source_root}
+export PYTHONPATH=$PYTHONPATH:${source_root}/library/python/testing/yatest_common
+export PYTHONPATH=$PYTHONPATH:${source_root}/library/python/testing
+export PYTHONPATH=$PYTHONPATH:${source_root}/library/python/pytest/plugins
+export PYTHONPATH=$PYTHONPATH:${source_root}/ydb/tests/oss/canonical
+export PYTHONPATH=$PYTHONPATH:${source_root}/ydb/tests/oss/ci
 
-python ${source_root}/ydb/tests/oss/launch/generate_test_context.py --build-root ${build_root} --source-root ${source_root} --out-dir ${testresults}
-
-export PYTHONPATH=${source_root}/ydb/public/sdk/python3:${source_root}:${source_root}/library/python/testing/yatest_common:${source_root}/library/python/testing:${source_root}/library/python/pytest/plugins:${source_root}/ydb/tests/oss/canonical
 
 export YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd"
 export YDB_CLI_BINARY="ydb/apps/ydb/ydb"
 export SQS_CLIENT_BINARY="ydb/core/ymq/client/bin/sqs"
-export PYTEST_PLUGINS=ya,conftests,canonical
-export YA_TEST_CONTEXT_FILE=${testresults}/test.context
+export PYTEST_PLUGINS=ya,ci,canonical
+#export YA_TEST_CONTEXT_FILE=${testresults}/test.context
 export YDB_OPENSOURCE=yes


### PR DESCRIPTION
This PR introduces running functional test  using the `xdist` pytest plugin. I'm running xdist with the `worksteal` scheduler, and this should reduce the total runtime of functional test to approximately 25 minutes. Also, in a future PR I think about exporting logs and artifacts for functional tests.