### PR TITLE
fix prewarm cache and docker build, also add ubuntu-toolchain-r/test …

### DIFF
--- a/.github/actions/prepare_vm/action.yaml
+++ b/.github/actions/prepare_vm/action.yaml
@@ -10,6 +10,12 @@ runs:
       run: |
         echo "distro_name=$(lsb_release -si)" | tee -a $GITHUB_OUTPUT
         echo "distro_release=$(lsb_release -sr)" | tee -a $GITHUB_OUTPUT
+    - name: Add ubuntu toolchain PPA for 18.04
+      shell: bash
+      if: steps.init.outputs.distro_name == 'Ubuntu' && steps.init.outputs.distro_release == '18.04'
+      run: |
+        apt-get install -y --no-install-recommends software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
     - name: Add cmake
       shell: bash
       if: steps.init.outputs.distro_name == 'Ubuntu' && contains(fromJSON('["18.04", "20.04"]'), steps.init.outputs.distro_release)

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV TZ=Etc/UTC
 RUN apt-get update \
     && apt-get install -y sudo wget gnupg lsb-release curl xz-utils tzdata \
     cmake python3-pip ninja-build antlr3 m4 clang-14 lld-14 libidn11-dev libaio1 libaio-dev llvm-14 make \
-    && pip3 install conan==1.59 \
+    && pip3 install conan==1.59 grpcio-tools \
     && (V=4.8.1; curl -L https://github.com/ccache/ccache/releases/download/v${V}/ccache-${V}-linux-x86_64.tar.xz | \
          tar -xJ -C /usr/local/bin/ --strip-components=1 --no-same-owner ccache-${V}-linux-x86_64/ccache)
 

--- a/.github/prewarm/ubuntu-1804.dockerfile
+++ b/.github/prewarm/ubuntu-1804.dockerfile
@@ -6,15 +6,16 @@ ENV TZ=Etc/UTC
 
 ## prepare system
 RUN apt-get update \
-    && apt-get install -y wget gnupg lsb-release curl xz-utils tzdata \
+    && apt-get install -y wget gnupg lsb-release curl xz-utils tzdata software-properties-common \
     && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - \
-    && echo "deb http://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && echo "deb http://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/kitware.list \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" | tee /etc/apt/sources.list.d/llvm.list >/dev/null \
+    && echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" > /etc/apt/sources.list.d/llvm.list \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
     && apt-get update
 
 
 RUN apt-get install -y git cmake python3-pip ninja-build antlr3 m4 clang-14 lld-14 libidn11-dev libaio1 libaio-dev llvm-14 make \
-    && pip3 install conan==1.59 \
+    && pip3 install conan==1.59 grpcio-tools\
     && (V=4.8.1; curl -L https://github.com/ccache/ccache/releases/download/v${V}/ccache-${V}-linux-x86_64.tar.xz | \
      tar -xJ -C /usr/local/bin/ --strip-components=1 --no-same-owner ccache-${V}-linux-x86_64/ccache)

--- a/.github/prewarm/ubuntu-2004.dockerfile
+++ b/.github/prewarm/ubuntu-2004.dockerfile
@@ -15,6 +15,6 @@ RUN apt-get update \
 
 
 RUN apt-get install -y git cmake python3-pip ninja-build antlr3 m4 clang-14 lld-14 libidn11-dev libaio1 libaio-dev llvm-14 \
-    && pip3 install conan==1.59 \
+    && pip3 install conan==1.59 grpcio-tools \
     && (V=4.8.1; curl -L https://github.com/ccache/ccache/releases/download/v${V}/ccache-${V}-linux-x86_64.tar.xz | \
      tar -xJ -C /usr/local/bin/ --strip-components=1 --no-same-owner ccache-${V}-linux-x86_64/ccache)

--- a/.github/prewarm/ubuntu-2204.dockerfile
+++ b/.github/prewarm/ubuntu-2204.dockerfile
@@ -9,6 +9,6 @@ RUN apt-get update && apt-get install -y wget gnupg lsb-release curl xz-utils tz
 
 
 RUN apt-get install -y git cmake python3-pip ninja-build antlr3 m4 clang-14 lld-14 libidn11-dev libaio1 libaio-dev llvm-14 make \
-    && pip3 install conan==1.59 \
+    && pip3 install conan==1.59 grpcio-tools \
     && (V=4.8.1; curl -L https://github.com/ccache/ccache/releases/download/v${V}/ccache-${V}-linux-x86_64.tar.xz | \
      tar -xJ -C /usr/local/bin/ --strip-components=1 --no-same-owner ccache-${V}-linux-x86_64/ccache)


### PR DESCRIPTION
this PR fixes docker builds due to lack of grpcio-tools pythjon package, and also fixes broken prewarm build on ubuntu 18, and fixes local-ydb docker build