### PR TITLE
ci: pass extra compile flags

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,6 +7,10 @@ inputs:
   ccache_remote_path:
     required: false
     description: "ccache remote storage definition"
+  extra_compile_flags:
+    required: false
+    default: ""
+    description: "extra compile flags will be added to the end of C_FLAGS and CXX_FLAGS"
 
 runs:
   using: "composite"
@@ -24,8 +28,8 @@ runs:
       cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/ccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache \
         -DCMAKE_TOOLCHAIN_FILE=../ydb/clang.toolchain \
-        -DCMAKE_CXX_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -gsplit-dwarf -gz -fno-omit-frame-pointer -UNDEBUG" \
-        -DCMAKE_C_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -gsplit-dwarf -gz -fno-omit-frame-pointer -UNDEBUG" \
+        -DCMAKE_CXX_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -gsplit-dwarf -gz -fno-omit-frame-pointer -UNDEBUG ${{ inputs.extra_compile_flags }}" \
+        -DCMAKE_C_FLAGS="-fsanitize=${{ inputs.sanitizer }} -g -gsplit-dwarf -gz -fno-omit-frame-pointer -UNDEBUG ${{ inputs.extra_compile_flags }}" \
         ../ydb
   - name: Configure
     shell: bash
@@ -43,10 +47,10 @@ runs:
       cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/ccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache \
         -DCMAKE_TOOLCHAIN_FILE=../ydb/clang.toolchain \
-        -DCMAKE_C_FLAGS="-O2 -UNDEBUG" \
-        -DCMAKE_CXX_FLAGS="-O2 -UNDEBUG" \
-        -DCMAKE_C_FLAGS_RELEASE="-O2 -UNDEBUG" \
-        -DCMAKE_CXX_FLAGS_RELEASE="-O2 -UNDEBUG" \
+        -DCMAKE_C_FLAGS="-O2 -UNDEBUG ${{ inputs.extra_compile_flags }}" \
+        -DCMAKE_CXX_FLAGS="-O2 -UNDEBUG ${{ inputs.extra_compile_flags }}" \
+        -DCMAKE_C_FLAGS_RELEASE="-O2 -UNDEBUG ${{ inputs.extra_compile_flags }}" \
+        -DCMAKE_CXX_FLAGS_RELEASE="-O2 -UNDEBUG ${{ inputs.extra_compile_flags }}" \
         ../ydb
   - name: Build
     shell: bash

--- a/.github/workflows/build_and_test_ondemand.yml
+++ b/.github/workflows/build_and_test_ondemand.yml
@@ -13,6 +13,9 @@ on:
         type: string
         required: false
         default: fd8earpjmhevh8h6ug5o
+      extra_compile_flags:
+        required: false
+        type: string
       run_unit_tests:
         type: boolean
         default: true
@@ -31,13 +34,16 @@ on:
         type: string
         required: false
         default: fd8earpjmhevh8h6ug5o
+      extra_compile_flags:
+        required: false
+        type: string
       run_unit_tests:
         type: boolean
         default: true
       run_functional_tests:
         type: boolean
         default: true
-    
+
 jobs:
 
   provide-runner:
@@ -102,6 +108,7 @@ jobs:
       with: 
         sanitizer: ${{ inputs.sanitizer }}
         ccache_remote_path: ${{ vars.REMOTE_CACHE_URL && format('http://{0}{1}', secrets.REMOTE_CACHE_AUTH, vars.REMOTE_CACHE_URL) || ''}}
+        extra_compile_flags: ${{ inputs.extra_compile_flags }}
     - name: Run tests
       uses: ./.github/actions/test
       with:

--- a/.github/workflows/build_and_test_provisioned.yml
+++ b/.github/workflows/build_and_test_provisioned.yml
@@ -21,6 +21,9 @@ on:
       test_label_regexp:
         required: false
         type: string
+      extra_compile_flags:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       runner_label:
@@ -41,7 +44,10 @@ on:
       test_label_regexp:
         required: false
         type: string
-    
+      extra_compile_flags:
+        required: false
+        type: string
+
 jobs:
   main:
     name: Build and test
@@ -55,6 +61,7 @@ jobs:
       with: 
         sanitizer: ${{ inputs.sanitizer }}
         ccache_remote_path: ${{ vars.REMOTE_CACHE_URL && format('http://{0}{1}', secrets.REMOTE_CACHE_AUTH, vars.REMOTE_CACHE_URL) || ''}}
+        extra_compile_flags: ${{ inputs.extra_compile_flags }}
     - name: Run tests
       uses: ./.github/actions/test
       with: 

--- a/.github/workflows/nightly_run.yaml
+++ b/.github/workflows/nightly_run.yaml
@@ -30,5 +30,6 @@ jobs:
     with:
       runner_label: ARM64
       sanitizer: ${{matrix.sanitizer}}
+      extra_compile_flags: "-DMKQL_DISABLE_CODEGEN"
       test_label_regexp: ${{inputs.test_label_regexp}}
     secrets: inherit


### PR DESCRIPTION
Add ability to pass extra compile flags. This is required to pass `-DMKQL_DISABLE_CODEGEN` for ARM64 build.