### PR TITLE
CI:  fail test log links in HTML test lists

### DIFF
--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -79,17 +79,18 @@ def render_testlist_html(rows, fn):
             has_any_log.add(t.status)
 
     for status in status_test.keys():
-        status_test[status].sort(key=attrgetter('full_name'))
+        status_test[status].sort(key=attrgetter("full_name"))
 
     status_order = [TestStatus.FAIL, TestStatus.SKIP, TestStatus.MUTE, TestStatus.PASS]
 
     # remove status group without tests
     status_order = [s for s in status_order if s in status_test]
 
-    content = env.get_template("summary.html").render(status_order=status_order, tests=status_test,
-                                                      has_any_log=has_any_log)
+    content = env.get_template("summary.html").render(
+        status_order=status_order, tests=status_test, has_any_log=has_any_log
+    )
 
-    with open(fn, 'w') as fp:
+    with open(fn, "w") as fp:
         fp.write(content)
 
 
@@ -108,7 +109,11 @@ def write_summary(lines: List[str]):
         fp.close()
 
 
-def gen_summary(summary_url_prefix, summary_out_folder, paths, ):
+def gen_summary(
+    summary_url_prefix,
+    summary_out_folder,
+    paths,
+):
     summary = [
         "|      | TESTS | PASSED | ERRORS | FAILED | SKIPPED | MUTED[^1] |",
         "| :--- | ---:  | -----: | -----: | -----: | ------: | ----: |",
@@ -142,7 +147,7 @@ def gen_summary(summary_url_prefix, summary_out_folder, paths, ):
             test_result = TestResult(classname=classname, name=name, status=status, log_url=log_url)
             test_results.append(test_result)
 
-        report_url = f'{summary_url_prefix}{html_fn}'
+        report_url = f"{summary_url_prefix}{html_fn}"
 
         render_testlist_html(test_results, os.path.join(summary_out_folder, html_fn))
 
@@ -150,18 +155,18 @@ def gen_summary(summary_url_prefix, summary_out_folder, paths, ):
             " | ".join(
                 [
                     title,
-                    render_pm(tests, f'{report_url}', 0),
-                    render_pm(passed, f'{report_url}#PASS', 0),
-                    render_pm(errors, f'{report_url}#ERROR', 0),
-                    render_pm(failed, f'{report_url}#FAIL', 0),
-                    render_pm(skipped, f'{report_url}#SKIP', 0),
-                    render_pm(muted, f'{report_url}#MUTE', 0),
+                    render_pm(tests, f"{report_url}", 0),
+                    render_pm(passed, f"{report_url}#PASS", 0),
+                    render_pm(errors, f"{report_url}#ERROR", 0),
+                    render_pm(failed, f"{report_url}#FAIL", 0),
+                    render_pm(skipped, f"{report_url}#SKIP", 0),
+                    render_pm(muted, f"{report_url}#MUTE", 0),
                 ]
             )
         )
 
-    github_srv = os.environ.get('GITHUB_SERVER_URL', 'https://github.com')
-    repo = os.environ.get('GITHUB_REPOSITORY', 'ydb-platform/ydb')
+    github_srv = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    repo = os.environ.get("GITHUB_REPOSITORY", "ydb-platform/ydb")
 
     summary.append("\n")
     summary.append(f"[^1]: All mute rules are defined [here]({github_srv}/{repo}/tree/main/.github/config).")

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -28,23 +28,41 @@
         span.test_mute {
             color: blue;
         }
+        table > tbody > tr > td:nth-child(2),
+        table > tbody > tr > td:nth-child(3) {
+            text-align: center;
+        }
     </style>
 </head>
 <body>
-{% for status, rows in test_results %}
-<h1 id="{{ status.name}}">{{ status.name }}</h1>
-<table style="width:90%;" border="1">
+{% for status in status_order %}
+<h1 id="{{ status.name}}">{{ status.name }} ({{ tests[status] | length }})</h1>
+<table style="width:100%;" border="1">
     <thead>
     <tr>
         <th>test name</th>
         <th>status</th>
+    {% if status in has_any_log %}
+        <th>LOG</th>
+    {% endif %}
     </tr>
     </thead>
     <tbody>
-    {% for t in rows %}
+    {% for t in tests[status] %}
     <tr>
         <td>{{ t.full_name }}</td>
-        <td><span class="test_status test_{{ t.status_display }}">{{ t.status_display }}</span></td>
+        <td>
+            <span class="test_status test_{{ t.status_display }}">{{ t.status_display }}</span>
+        </td>
+        {% if status in has_any_log %}
+        <td>
+            {% if t.log_url %}
+                <a href="{{ t.log_url }}">LOG</a>
+            {% else %}
+                &nbsp;
+            {% endif %}
+        </td>
+        {% endif %}
     </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
This PR adds additional column in HTML test lists for failed/muted tests with log url. 