### PR TITLE
Update security-changelog.md

### DIFF
--- a/ydb/docs/en/core/security-changelog.md
+++ b/ydb/docs/en/core/security-changelog.md
@@ -9,3 +9,13 @@ Out-of-bounds read was discovered in YDB server. An attacker could construct a q
 Link to CVE: [https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28228).
 
 Credits: Maxim Arnold.
+
+## Fixed in YDB Go SDK v3.53.3, 17.10.2023 2023-10-17 {#17-10-2023}
+
+### CVE-2023-45825 {#cve-2023-45825}
+
+Token in custom credentials object can leak through logs.
+
+Link to CVE: [https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28228](https://nvd.nist.gov/vuln/detail/CVE-2023-45825).
+
+Credits: Sergey Foster.

--- a/ydb/docs/ru/core/security-changelog.md
+++ b/ydb/docs/ru/core/security-changelog.md
@@ -9,3 +9,13 @@
 Ссылка на CVE: [https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28228).
 
 Обнаружено благодаря Максиму Арнольду.
+
+## Исправлено в YDB Go SDK v3.53.3, 17.10.2023 2023-10-17 {#17-10-2023}
+
+### CVE-2023-45825 {#cve-2023-45825}
+
+Токен авторизации может утекать через логи
+
+Link to CVE: [https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28228](https://nvd.nist.gov/vuln/detail/CVE-2023-45825).
+
+Обнаружено благодаря Сергею Фостер.


### PR DESCRIPTION
## Fixed in YDB Go SDK v3.53.3, 17.10.2023 2023-10-17 {#17-10-2023}

### CVE-2023-45825 {#cve-2023-45825}

Token in custom credentials object can leak through logs.

Link to CVE: [https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28228](https://nvd.nist.gov/vuln/detail/CVE-2023-45825).

Credits: Sergey Foster.
