### PR TITLE
[docs] add extra mkdir to quickstart

### DIFF
--- a/ydb/docs/en/core/getting_started/quickstart.md
+++ b/ydb/docs/en/core/getting_started/quickstart.md
@@ -77,6 +77,8 @@ Normally, {{ ydb-short-name }} stores data on multiple SSD/NVMe or HDD raw disk 
 
       ```bash
       mkdir ~/ydbd && cd ~/ydbd
+      mkdir ydb_data
+      mkdir ydb_certs
       ```
    2. Pull the current version of the Docker image:
 

--- a/ydb/docs/ru/core/getting_started/quickstart.md
+++ b/ydb/docs/ru/core/getting_started/quickstart.md
@@ -76,6 +76,8 @@
 
       ```bash
       mkdir ~/ydbd && cd ~/ydbd
+      mkdir ydb_data
+      mkdir ydb_certs
       ```
    2. Загрузите текущую версию Docker образа:
 


### PR DESCRIPTION
Otherwise it fails with:
```
docker: Error response from daemon: error while creating mount source path '/Users/blinkov/ydbd/ydb_certs': chown /Users/blinkov/ydbd/ydb_certs: permission denied.
```
(Mac OS x86_64)