### PR TITLE
Fix typo (test -> tests)

### DIFF
--- a/ydb/library/yql/tests/common/test_framework/yql_utils.py
+++ b/ydb/library/yql/tests/common/test_framework/yql_utils.py
@@ -681,7 +681,7 @@ def get_udfs_path(extra_paths=None):
         udfs_project_path = None
 
     try:
-        ydb_udfs_project_path = yql_binary_path('ydb/library/yql/test/common/test_framework/udfs_deps')
+        ydb_udfs_project_path = yql_binary_path('ydb/library/yql/tests/common/test_framework/udfs_deps')
     except Exception:
         ydb_udfs_project_path = None
 


### PR DESCRIPTION
Fix wrong path in file:
contrib/ydb/library/yql/test/common/test_framework/udfs_deps -> contrib/ydb/library/yql/tests/common/test_framework/udfs_deps