### PR TITLE
Implement CREATE/DROP EXTERNAL DATA SOURCE/EXTERNAL TABLE in QueryService. Without IF NOT EXISTS/IF EXISTS support yet

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/kqp/session_actor/kqp_worker_common.h>
 #include <ydb/core/tx/schemeshard/schemeshard_build_index.h>
+#include <ydb/services/metadata/abstract/kqp_common.h>
 
 namespace NKikimr::NKqp {
 
@@ -49,7 +50,7 @@ public:
         return NKikimrServices::TActivity::KQP_EXECUTER_ACTOR;
     }
 
-    TKqpSchemeExecuter(TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, const TActorId& target, const TMaybe<TString>& requestType, 
+    TKqpSchemeExecuter(TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, const TActorId& target, const TMaybe<TString>& requestType,
         const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken,
         bool temporary, TString sessionId, TIntrusivePtr<TUserRequestContext> ctx)
         : PhyTx(phyTx)
@@ -69,13 +70,11 @@ public:
     }
 
     void StartBuildOperation() {
-        const auto& schemeOp = PhyTx->GetSchemeOperation();
-        auto buildOp = schemeOp.GetBuildOperation();
         Send(MakeTxProxyID(), new TEvTxUserProxy::TEvAllocateTxId);
-        Become(&TKqpSchemeExecuter::ExecuteState);    
+        Become(&TKqpSchemeExecuter::ExecuteState);
     }
 
-    void Bootstrap() {
+    void MakeSchemeOperationRequest() {
         using TRequest = TEvTxUserProxy::TEvProposeTransaction;
 
         auto ev = MakeHolder<TRequest>();
@@ -124,30 +123,44 @@ public:
             }
 
             case NKqpProto::TKqpSchemeOperation::kAlterTable: {
-                auto modifyScheme = schemeOp.GetAlterTable();
+                const auto& modifyScheme = schemeOp.GetAlterTable();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kBuildOperation: {
-                auto buildOp = schemeOp.GetBuildOperation();
                 return StartBuildOperation();
             }
 
             case NKqpProto::TKqpSchemeOperation::kCreateUser: {
-                auto modifyScheme = schemeOp.GetCreateUser();
+                const auto& modifyScheme = schemeOp.GetCreateUser();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kAlterUser: {
-                auto modifyScheme = schemeOp.GetAlterUser();
+                const auto& modifyScheme = schemeOp.GetAlterUser();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kDropUser: {
-                auto modifyScheme = schemeOp.GetDropUser();
+                const auto& modifyScheme = schemeOp.GetDropUser();
+                ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
+                break;
+            }
+            case NKqpProto::TKqpSchemeOperation::kCreateExternalTable: {
+                const auto& modifyScheme = schemeOp.GetCreateExternalTable();
+                ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
+                break;
+            }
+            case NKqpProto::TKqpSchemeOperation::kAlterExternalTable: {
+                const auto& modifyScheme = schemeOp.GetAlterExternalTable();
+                ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
+                break;
+            }
+            case NKqpProto::TKqpSchemeOperation::kDropExternalTable: {
+                const auto& modifyScheme = schemeOp.GetDropExternalTable();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
                 break;
             }
@@ -191,7 +204,7 @@ public:
         auto promise = NewPromise<IKqpGateway::TGenericResult>();
 
         bool successOnNotExist = false;
-        bool failedOnAlreadyExists = false;        
+        bool failedOnAlreadyExists = false;
         // exists/not exists semantics supported only in the query service.
         if (IsQueryService()) {
             successOnNotExist = ev->Record.GetTransaction().GetModifyScheme().GetSuccessOnNotExist();
@@ -218,6 +231,57 @@ public:
         Become(&TKqpSchemeExecuter::ExecuteState);
     }
 
+    void MakeObjectRequest() {
+        const auto& schemeOp = PhyTx->GetSchemeOperation();
+        NMetadata::IClassBehaviour::TPtr cBehaviour(NMetadata::IClassBehaviour::TFactory::Construct(schemeOp.GetObjectType()));
+        if (!cBehaviour) {
+            InternalError(TStringBuilder() << "Unsupported object type: \"" << schemeOp.GetObjectType() << "\"");
+            return;
+        }
+
+        if (!cBehaviour->GetOperationsManager()) {
+            InternalError(TStringBuilder() << "Object type \"" << schemeOp.GetObjectType() << "\" does not have manager for operations");
+        }
+
+        auto* actorSystem = TActivationContext::ActorSystem();
+        auto selfId = SelfId();
+
+        NMetadata::NModifications::IOperationsManager::TExternalModificationContext context;
+        context.SetDatabase(Database);
+        context.SetActorSystem(actorSystem);
+        if (UserToken) {
+            context.SetUserToken(*UserToken);
+        }
+
+        auto resultFuture = cBehaviour->GetOperationsManager()->ExecutePrepared(schemeOp, cBehaviour, context);
+
+        using TResultFuture = NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus>;
+        resultFuture.Subscribe([actorSystem, selfId](const TResultFuture& f) {
+            const auto& status = f.GetValue();
+            auto ev = MakeHolder<TEvPrivate::TEvResult>();
+            if (status.Ok()) {
+                ev->Result.SetSuccess();
+            } else {
+                ev->Result.SetStatus(status.GetStatus());
+                if (TString message = status.GetErrorMessage()) {
+                    ev->Result.AddIssue(NYql::TIssue{message});
+                }
+            }
+            actorSystem->Send(selfId, ev.Release());
+        });
+
+        Become(&TKqpSchemeExecuter::ObjectExecuteState);
+    }
+
+    void Bootstrap() {
+        const auto& schemeOp = PhyTx->GetSchemeOperation();
+        if (schemeOp.GetObjectType()) {
+            MakeObjectRequest();
+        } else {
+            MakeSchemeOperationRequest();
+        }
+    }
+
 public:
     STATEFN(ExecuteState) {
         try {
@@ -240,6 +304,19 @@ public:
         }
     }
 
+    STATEFN(ObjectExecuteState) {
+        try {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvPrivate::TEvResult, HandleExecute);
+                hFunc(TEvKqp::TEvAbortExecution, HandleAbortExecution);
+                default:
+                    UnexpectedEvent("ObjectExecuteState", ev->GetTypeRewrite());
+            }
+        } catch (const yexception& e) {
+            InternalError(e.what());
+        }
+    }
+
 
     void Handle(TEvTxUserProxy::TEvAllocateTxIdResult::TPtr& ev) {
         const auto* msg = ev->Get();
@@ -250,7 +327,7 @@ public:
 
     void Navigate(const TActorId& schemeCache) {
         const auto& schemeOp = PhyTx->GetSchemeOperation();
-        auto buildOp = schemeOp.GetBuildOperation();
+        const auto& buildOp = schemeOp.GetBuildOperation();
         const auto& path = buildOp.source_path();
 
         const auto paths = NKikimr::SplitPath(path);
@@ -258,10 +335,10 @@ public:
             TString error = TStringBuilder() << "Failed to split table path " << path;
             return ReplyErrorAndDie(Ydb::StatusIds::BAD_REQUEST, NYql::TIssue(error));
         }
-    
+
         auto request = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
 
-        request->DatabaseName = Database;    
+        request->DatabaseName = Database;
         auto& entry = request->ResultSet.emplace_back();
         entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
         entry.Path = ::NKikimr::SplitPath(path);
@@ -312,7 +389,7 @@ public:
         }
 
         const auto& schemeOp = PhyTx->GetSchemeOperation();
-        auto buildOp = schemeOp.GetBuildOperation();
+        const auto& buildOp = schemeOp.GetBuildOperation();
         SetSchemeShardId(domainInfo->ExtractSchemeShard());
         auto req = std::make_unique<NSchemeShard::TEvIndexBuilder::TEvCreateRequest>(TxId, Database, buildOp);
         ForwardToSchemeShard(std::move(req));

--- a/ydb/core/kqp/executer_actor/ut/kqp_executer_ut.cpp
+++ b/ydb/core/kqp/executer_actor/ut/kqp_executer_ut.cpp
@@ -20,7 +20,7 @@ namespace {
 
 [[maybe_unused]]
 NKqpProto::TKqpPhyTx BuildTxPlan(const TString& sql, TIntrusivePtr<IKqpGateway> gateway,
-    const TKikimrConfiguration::TPtr& config)
+    const TKikimrConfiguration::TPtr& config, NActors::TActorId* actorSystem)
 {
     auto cluster = TString(DefaultKikimrClusterName);
 
@@ -28,7 +28,7 @@ NKqpProto::TKqpPhyTx BuildTxPlan(const TString& sql, TIntrusivePtr<IKqpGateway> 
     IModuleResolver::TPtr moduleResolver;
     UNIT_ASSERT(GetYqlDefaultModuleResolver(moduleCtx, moduleResolver));
 
-    auto qp = CreateKqpHost(gateway, cluster, "/Root", config, moduleResolver, NYql::IHTTPGateway::Make());
+    auto qp = CreateKqpHost(gateway, cluster, "/Root", config, moduleResolver, NYql::IHTTPGateway::Make(), nullptr, false, false, nullptr, actorSystem);
     auto result = qp->SyncPrepareDataQuery(sql, IKqpHost::TPrepareSettings());
     result.Issues().PrintTo(Cerr);
     UNIT_ASSERT(result.Success());
@@ -97,7 +97,7 @@ Y_UNIT_TEST_SUITE(KqpExecuter) {
 
             UPSERT INTO [Root/EightShard]
             SELECT * FROM $itemsSource;
-        )", gateway, ctx);
+        )", gateway, ctx, kikimr.GetTestServer().GetRuntime()->GetAnyNodeActorSystem());
 
         LogTxPlan(kikimr, tx);
 

--- a/ydb/core/kqp/executer_actor/ya.make
+++ b/ydb/core/kqp/executer_actor/ya.make
@@ -33,6 +33,7 @@ PEERDIR(
     ydb/core/protos
     ydb/core/tx/long_tx_service/public
     ydb/core/ydb_convert
+    ydb/services/metadata/abstract
     ydb/library/mkql_proto
     ydb/library/mkql_proto/protos
     ydb/library/yql/dq/actors/compute

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -3,10 +3,10 @@
 
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/kqp/gateway/actors/scheme.h>
+#include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/kqp/provider/yql_kikimr_gateway.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/feature_flags.h>
-#include <ydb/core/kqp/provider/yql_kikimr_gateway.h>
 
 #include <util/string/type.h>
 
@@ -17,6 +17,17 @@ namespace {
 TString GetOrEmpty(const NYql::TCreateObjectSettings& container, const TString& key) {
     auto fValue = container.GetFeaturesExtractor().Extract(key);
     return fValue ? *fValue : TString{};
+}
+
+void CheckFeatureFlag(TExternalDataSourceManager::TInternalModificationContext& context) {
+    auto* actorSystem = context.GetExternalData().GetActorSystem();
+    if (!actorSystem) {
+        ythrow yexception() << "This place needs an actor system. Please contact internal support";
+    }
+
+    if (!AppData(actorSystem)->FeatureFlags.GetEnableExternalDataSources()) {
+        throw std::runtime_error("External data sources are disabled. Please contact your system administrator to enable it");
+    }
 }
 
 void FillCreateExternalDataSourceDesc(NKikimrSchemeOp::TExternalDataSourceDescription& externaDataSourceDesc,
@@ -72,6 +83,44 @@ void FillCreateExternalDataSourceDesc(NKikimrSchemeOp::TExternalDataSourceDescri
     }
 }
 
+void FillCreateExternalDataSourceCommand(NKikimrSchemeOp::TModifyScheme& modifyScheme, const NYql::TObjectSettingsImpl& settings,
+                                         TExternalDataSourceManager::TInternalModificationContext& context) {
+    CheckFeatureFlag(context);
+
+    std::pair<TString, TString> pathPair;
+    {
+        TString error;
+        if (!TrySplitPathByDb(settings.GetObjectId(), context.GetExternalData().GetDatabase(), pathPair, error)) {
+            throw std::runtime_error(error.c_str());
+        }
+    }
+
+    modifyScheme.SetWorkingDir(pathPair.first);
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateExternalDataSource);
+
+    NKikimrSchemeOp::TExternalDataSourceDescription& dataSourceDesc = *modifyScheme.MutableCreateExternalDataSource();
+    FillCreateExternalDataSourceDesc(dataSourceDesc, pathPair.second, settings);
+}
+
+void FillDropExternalDataSourceCommand(NKikimrSchemeOp::TModifyScheme& modifyScheme, const NYql::TObjectSettingsImpl& settings,
+                                       TExternalDataSourceManager::TInternalModificationContext& context) {
+    CheckFeatureFlag(context);
+
+    std::pair<TString, TString> pathPair;
+    {
+        TString error;
+        if (!NSchemeHelpers::TrySplitTablePath(settings.GetObjectId(), pathPair, error)) {
+            throw std::runtime_error(error.c_str());
+        }
+    }
+
+    modifyScheme.SetWorkingDir(pathPair.first);
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpDropExternalDataSource);
+
+    NKikimrSchemeOp::TDrop& drop = *modifyScheme.MutableDrop();
+    drop.SetName(pathPair.second);
+}
+
 NThreading::TFuture<TExternalDataSourceManager::TYqlConclusionStatus> SendSchemeRequest(TEvTxUserProxy::TEvProposeTransaction* request, TActorSystem* actorSystem, bool failedOnAlreadyExists = false)
 {
     auto promiseScheme = NThreading::NewPromise<NKqp::TSchemeOpRequestHandler::TResult>();
@@ -91,9 +140,10 @@ NThreading::TFuture<TExternalDataSourceManager::TYqlConclusionStatus> SendScheme
 
 NThreading::TFuture<TExternalDataSourceManager::TYqlConclusionStatus> TExternalDataSourceManager::DoModify(const NYql::TObjectSettingsImpl& settings,
                                                                                                            const ui32 nodeId,
-                                                                                                           NMetadata::IClassBehaviour::TPtr manager,
+                                                                                                           const NMetadata::IClassBehaviour::TPtr& manager,
                                                                                                            TInternalModificationContext& context) const {
-        Y_UNUSED(nodeId, manager, settings);
+    Y_UNUSED(nodeId, manager, settings);
+    try {
         switch (context.GetActivityType()) {
             case EActivityType::Upsert:
             case EActivityType::Undefined:
@@ -104,85 +154,105 @@ NThreading::TFuture<TExternalDataSourceManager::TYqlConclusionStatus> TExternalD
             case EActivityType::Drop:
                 return DropExternalDataSource(settings, context);
         }
+    } catch (...) {
+        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(CurrentExceptionMessage()));
+    }
 }
 
 NThreading::TFuture<TExternalDataSourceManager::TYqlConclusionStatus> TExternalDataSourceManager::CreateExternalDataSource(const NYql::TObjectSettingsImpl& settings,
                                                                                                                            TInternalModificationContext& context) const {
     using TRequest = TEvTxUserProxy::TEvProposeTransaction;
 
-    try {
-        auto* actorSystem = context.GetExternalData().GetActorSystem();
-        if (!actorSystem) {
-            return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("This place needs an actor system. Please contact internal support"));
-        }
-
-        if (!AppData(actorSystem)->FeatureFlags.GetEnableExternalDataSources()) {
-            return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("External data sources are disabled. Please contact your system administrator to enable it"));
-        }
-
-        std::pair<TString, TString> pathPair;
-        {
-            TString error;
-            if (!TrySplitPathByDb(settings.GetObjectId(), context.GetExternalData().GetDatabase(), pathPair, error)) {
-                return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(error));
-            }
-        }
-
-        auto ev = MakeHolder<TRequest>();
-        ev->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
-        if (context.GetExternalData().GetUserToken()) {
-            ev->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
-        }
-        auto& schemeTx = *ev->Record.MutableTransaction()->MutableModifyScheme();
-        schemeTx.SetWorkingDir(pathPair.first);
-        schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateExternalDataSource);
-
-        NKikimrSchemeOp::TExternalDataSourceDescription& dataSourceDesc = *schemeTx.MutableCreateExternalDataSource();
-        FillCreateExternalDataSourceDesc(dataSourceDesc, pathPair.second, settings);
-        return SendSchemeRequest(ev.Release(), actorSystem, true);
-    } catch (...) {
-        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(CurrentExceptionMessage()));
+    auto ev = MakeHolder<TRequest>();
+    ev->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
+    if (context.GetExternalData().GetUserToken()) {
+        ev->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
     }
+
+    auto& schemeTx = *ev->Record.MutableTransaction()->MutableModifyScheme();
+    FillCreateExternalDataSourceCommand(schemeTx, settings, context);
+
+    return SendSchemeRequest(ev.Release(), context.GetExternalData().GetActorSystem(), true);
 }
 
 NThreading::TFuture<TExternalDataSourceManager::TYqlConclusionStatus> TExternalDataSourceManager::DropExternalDataSource(const NYql::TObjectSettingsImpl& settings,
                                                                                                                          TInternalModificationContext& context) const {
     using TRequest = TEvTxUserProxy::TEvProposeTransaction;
 
+    auto ev = MakeHolder<TRequest>();
+    ev->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
+    if (context.GetExternalData().GetUserToken()) {
+        ev->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
+    }
+
+    auto& schemeTx = *ev->Record.MutableTransaction()->MutableModifyScheme();
+    FillDropExternalDataSourceCommand(schemeTx, settings, context);
+
+    return SendSchemeRequest(ev.Release(), context.GetExternalData().GetActorSystem());
+}
+
+TExternalDataSourceManager::TYqlConclusionStatus TExternalDataSourceManager::DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+    const NMetadata::IClassBehaviour::TPtr& manager, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& context) const {
+    Y_UNUSED(manager);
+
     try {
-        auto* actorSystem = context.GetExternalData().GetActorSystem();
-        if (!actorSystem) {
-            return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("This place needs an actor system. Please contact internal support"));
+        switch (context.GetActivityType()) {
+            case EActivityType::Undefined:
+                return TYqlConclusionStatus::Fail("Undefined operation for EXTERNAL_DATA_SOURCE object");
+            case EActivityType::Upsert:
+                return TYqlConclusionStatus::Fail("Upsert operation for EXTERNAL_DATA_SOURCE objects is not implemented");
+            case EActivityType::Alter:
+                return TYqlConclusionStatus::Fail("Alter operation for EXTERNAL_DATA_SOURCE objects is not implemented");
+            case EActivityType::Create:
+                PrepareCreateExternalDataSource(schemeOperation, settings, context);
+                break;
+            case EActivityType::Drop:
+                PrepareDropExternalDataSource(schemeOperation, settings, context);
+                break;
         }
-
-        if (!AppData(actorSystem)->FeatureFlags.GetEnableExternalDataSources()) {
-            return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("External data sources are disabled. Please contact your system administrator to enable it"));
-        }
-
-        std::pair<TString, TString> pathPair;
-        {
-            TString error;
-            if (!NYql::IKikimrGateway::TrySplitTablePath(settings.GetObjectId(), pathPair, error)) {
-                return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(error));
-            }
-        }
-
-        auto ev = MakeHolder<TRequest>();
-        ev->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
-        if (context.GetExternalData().GetUserToken()) {
-            ev->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
-        }
-        auto& schemeTx = *ev->Record.MutableTransaction()->MutableModifyScheme();
-        schemeTx.SetWorkingDir(pathPair.first);
-        schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpDropExternalDataSource);
-
-        NKikimrSchemeOp::TDrop& drop = *schemeTx.MutableDrop();
-        drop.SetName(pathPair.second);
-        return SendSchemeRequest(ev.Release(), actorSystem);
+        return TYqlConclusionStatus::Success();
+    } catch (...) {
+        return TYqlConclusionStatus::Fail(CurrentExceptionMessage());
     }
-    catch (...) {
-        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(CurrentExceptionMessage()));
+}
+
+void TExternalDataSourceManager::PrepareCreateExternalDataSource(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+                                                                                                             TInternalModificationContext& context) const {
+    FillCreateExternalDataSourceCommand(*schemeOperation.MutableCreateExternalDataSource(), settings, context);
+}
+
+void TExternalDataSourceManager::PrepareDropExternalDataSource(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+                                                                                                           TInternalModificationContext& context) const {
+    FillDropExternalDataSourceCommand(*schemeOperation.MutableDropExternalDataSource(), settings, context);
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TExternalDataSourceManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& context) const {
+    using TRequest = TEvTxUserProxy::TEvProposeTransaction;
+
+    auto ev = MakeHolder<TRequest>();
+    ev->Record.SetDatabaseName(context.GetDatabase());
+    if (context.GetUserToken()) {
+        ev->Record.SetUserToken(context.GetUserToken()->GetSerializedToken());
     }
+
+    auto& schemeTx = *ev->Record.MutableTransaction()->MutableModifyScheme();
+    switch (schemeOperation.GetOperationCase()) {
+        case NKqpProto::TKqpSchemeOperation::kCreateExternalDataSource:
+            schemeTx.CopyFrom(schemeOperation.GetCreateExternalDataSource());
+            break;
+        case NKqpProto::TKqpSchemeOperation::kAlterExternalDataSource:
+            schemeTx.CopyFrom(schemeOperation.GetAlterExternalDataSource());
+            break;
+        case NKqpProto::TKqpSchemeOperation::kDropExternalDataSource:
+            schemeTx.CopyFrom(schemeOperation.GetDropExternalDataSource());
+            break;
+        default:
+            return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+                TStringBuilder() << "Execution of prepare operation for EXTERNAL_DATA_SOURCE object: unsupported operation: " << int(schemeOperation.GetOperationCase())));
+    }
+
+    return SendSchemeRequest(ev.Release(), context.GetActorSystem(), true);
 }
 
 }

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.h
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.h
@@ -11,11 +11,23 @@ class TExternalDataSourceManager: public NMetadata::NModifications::IOperationsM
     NThreading::TFuture<TYqlConclusionStatus> DropExternalDataSource(const NYql::TObjectSettingsImpl& settings,
                                                                      TInternalModificationContext& context) const;
 
+    void PrepareCreateExternalDataSource(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+                                         TInternalModificationContext& context) const;
+
+    void PrepareDropExternalDataSource(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+                                       TInternalModificationContext& context) const;
+
 protected:
     NThreading::TFuture<TYqlConclusionStatus> DoModify(const NYql::TObjectSettingsImpl& settings,
                                                        const ui32 nodeId,
-                                                       NMetadata::IClassBehaviour::TPtr manager,
+                                                       const NMetadata::IClassBehaviour::TPtr& manager,
                                                        TInternalModificationContext& context) const override;
+
+    IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
 
 public:
     using NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus;

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
     ydb/services/metadata/initializer
     ydb/services/metadata/abstract
     ydb/core/kqp/gateway/actors
+    ydb/core/kqp/gateway/utils
     ydb/core/kqp/gateway/behaviour/tablestore/operations
 )
 

--- a/ydb/core/kqp/gateway/behaviour/tablestore/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/tablestore/manager.cpp
@@ -12,63 +12,74 @@
 namespace NKikimr::NKqp {
 
 NThreading::TFuture<TTableStoreManager::TYqlConclusionStatus> TTableStoreManager::DoModify(const NYql::TObjectSettingsImpl& settings, const ui32 nodeId,
-        NMetadata::IClassBehaviour::TPtr manager, TInternalModificationContext& context) const {
-            Y_UNUSED(nodeId);
-            Y_UNUSED(manager);
-        auto promise = NThreading::NewPromise<TYqlConclusionStatus>();
-        auto result = promise.GetFuture();
+        const NMetadata::IClassBehaviour::TPtr& manager, TInternalModificationContext& context) const {
+    Y_UNUSED(nodeId);
+    Y_UNUSED(manager);
+    auto promise = NThreading::NewPromise<TYqlConclusionStatus>();
+    auto result = promise.GetFuture();
 
-        auto* actorSystem = context.GetExternalData().GetActorSystem();
-        if (!actorSystem) {
-            return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("This place needs an actor system. Please contact internal support"));
-        }
+    auto* actorSystem = context.GetExternalData().GetActorSystem();
+    if (!actorSystem) {
+        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("This place needs an actor system. Please contact internal support"));
+    }
 
-        switch (context.GetActivityType()) {
-            case EActivityType::Create:
-            case EActivityType::Upsert:
-            case EActivityType::Drop:
-            case EActivityType::Undefined:
-                return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("not implemented"));
-            case EActivityType::Alter:
-            try {
-                auto actionName = settings.GetFeaturesExtractor().Extract("ACTION");
-                if (!actionName) {
-                    return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("can't find ACTION parameter"));
-                }
-                ITableStoreOperation::TPtr operation(ITableStoreOperation::TFactory::Construct(*actionName));
-                if (!operation) {
-                    return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("invalid ACTION: " + *actionName));
-                }
-                {
-                    auto parsingResult = operation->Deserialize(settings);
-                    if (!parsingResult) {
-                        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(parsingResult.GetErrorMessage()));
-                    }
-                }
-                auto ev = MakeHolder<TEvTxUserProxy::TEvProposeTransaction>();
-                ev->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
-                if (context.GetExternalData().GetUserToken()) {
-                    ev->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
-                }
-                auto& schemeTx = *ev->Record.MutableTransaction()->MutableModifyScheme();
-                operation->SerializeScheme(schemeTx, IsStandalone);
-
-                auto promiseScheme = NThreading::NewPromise<NKqp::TSchemeOpRequestHandler::TResult>();
-                actorSystem->Register(new NKqp::TSchemeOpRequestHandler(ev.Release(), promiseScheme, false));
-                return promiseScheme.GetFuture().Apply([](const NThreading::TFuture<NKqp::TSchemeOpRequestHandler::TResult>& f) {
-                    if (f.HasValue() && !f.HasException() && f.GetValue().Success()) {
-                        return TYqlConclusionStatus::Success();
-                    } else if (f.HasValue()) {
-                        return TYqlConclusionStatus::Fail(f.GetValue().Status(), f.GetValue().Issues().ToString());
-                    }
-                    return TYqlConclusionStatus::Fail("no value in result");
-                });
-            } catch (yexception& e) {
-                return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(e.what()));
+    switch (context.GetActivityType()) {
+        case EActivityType::Create:
+        case EActivityType::Upsert:
+        case EActivityType::Drop:
+        case EActivityType::Undefined:
+            return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("not implemented"));
+        case EActivityType::Alter:
+        try {
+            auto actionName = settings.GetFeaturesExtractor().Extract("ACTION");
+            if (!actionName) {
+                return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("can't find ACTION parameter"));
             }
+            ITableStoreOperation::TPtr operation(ITableStoreOperation::TFactory::Construct(*actionName));
+            if (!operation) {
+                return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("invalid ACTION: " + *actionName));
+            }
+            {
+                auto parsingResult = operation->Deserialize(settings);
+                if (!parsingResult) {
+                    return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(parsingResult.GetErrorMessage()));
+                }
+            }
+            auto ev = MakeHolder<TEvTxUserProxy::TEvProposeTransaction>();
+            ev->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
+            if (context.GetExternalData().GetUserToken()) {
+                ev->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
+            }
+            auto& schemeTx = *ev->Record.MutableTransaction()->MutableModifyScheme();
+            operation->SerializeScheme(schemeTx, IsStandalone);
+
+            auto promiseScheme = NThreading::NewPromise<NKqp::TSchemeOpRequestHandler::TResult>();
+            actorSystem->Register(new NKqp::TSchemeOpRequestHandler(ev.Release(), promiseScheme, false));
+            return promiseScheme.GetFuture().Apply([](const NThreading::TFuture<NKqp::TSchemeOpRequestHandler::TResult>& f) {
+                if (f.HasValue() && !f.HasException() && f.GetValue().Success()) {
+                    return TYqlConclusionStatus::Success();
+                } else if (f.HasValue()) {
+                    return TYqlConclusionStatus::Fail(f.GetValue().Status(), f.GetValue().Issues().ToString());
+                }
+                return TYqlConclusionStatus::Fail("no value in result");
+            });
+        } catch (yexception& e) {
+            return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(e.what()));
         }
-        return result;
+    }
+    return result;
+}
+
+NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus TTableStoreManager::DoPrepare(NKqpProto::TKqpSchemeOperation& /*schemeOperation*/, const NYql::TObjectSettingsImpl& /*settings*/,
+    const NMetadata::IClassBehaviour::TPtr& /*manager*/, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& /*context*/) const {
+    return NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Prepare operations for TABLE objects are not supported");
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TTableStoreManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& /*schemeOperation*/,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& /*context*/) const {
+    return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Execution of prepare operations for TABLE objects is not supported"));
 }
 
 }
-

--- a/ydb/core/kqp/gateway/behaviour/tablestore/manager.h
+++ b/ydb/core/kqp/gateway/behaviour/tablestore/manager.h
@@ -11,7 +11,13 @@ class TTableStoreManager: public NMetadata::NModifications::IOperationsManager {
     bool IsStandalone = false;
 protected:
     NThreading::TFuture<TYqlConclusionStatus> DoModify(const NYql::TObjectSettingsImpl& settings, const ui32 nodeId,
-        NMetadata::IClassBehaviour::TPtr manager, TInternalModificationContext& context) const override;
+        const NMetadata::IClassBehaviour::TPtr& manager, TInternalModificationContext& context) const override;
+
+    IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
 public:
     TTableStoreManager(bool isStandalone)
         : IsStandalone(isStandalone)

--- a/ydb/core/kqp/gateway/behaviour/tablestore/operations/abstract.cpp
+++ b/ydb/core/kqp/gateway/behaviour/tablestore/operations/abstract.cpp
@@ -1,4 +1,5 @@
 #include "abstract.h"
+#include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/kqp/provider/yql_kikimr_gateway.h>
 
 namespace NKikimr::NKqp {
@@ -7,7 +8,7 @@ TConclusionStatus ITableStoreOperation::Deserialize(const NYql::TObjectSettingsI
     std::pair<TString, TString> pathPair;
     {
         TString error;
-        if (!NYql::IKikimrGateway::TrySplitTablePath(settings.GetObjectId(), pathPair, error)) {
+        if (!NSchemeHelpers::TrySplitTablePath(settings.GetObjectId(), pathPair, error)) {
             return TConclusionStatus::Fail(error);
         }
         WorkingDir = pathPair.first;

--- a/ydb/core/kqp/gateway/behaviour/tablestore/operations/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/tablestore/operations/ya.make
@@ -10,6 +10,7 @@ SRCS(
 PEERDIR(
     ydb/services/metadata/manager
     ydb/core/formats/arrow/compression
+    ydb/core/kqp/gateway/utils
     ydb/core/protos
 )
 

--- a/ydb/core/kqp/gateway/behaviour/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/ya.make
@@ -1,0 +1,5 @@
+RECURSE(
+    external_data_source
+    table
+    tablestore
+)

--- a/ydb/core/kqp/gateway/kqp_gateway.h
+++ b/ydb/core/kqp/gateway/kqp_gateway.h
@@ -207,12 +207,6 @@ TIntrusivePtr<IKqpGateway> CreateKikimrIcGateway(const TString& cluster, NKikimr
     std::shared_ptr<IKqpGateway::IKqpTableMetadataLoader>&& metadataLoader, NActors::TActorSystem* actorSystem,
     ui32 nodeId, TKqpRequestCounters::TPtr counters, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig = NKikimrConfig::TQueryServiceConfig());
 
-bool SplitTablePath(const TString& tableName, const TString& database, std::pair<TString, TString>& pathPair,
-    TString& error, bool createDir);
-
-bool SetDatabaseForLoginOperation(TString& result, bool getDomainLoginOnly, TMaybe<TString> domainName,
-    const TString& database);
-
 } // namespace NKikimr::NKqp
 
 template<>

--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -12,6 +12,7 @@
 #include <ydb/core/engine/mkql_proto.h>
 #include <ydb/core/kqp/common/kqp.h>
 #include <ydb/core/kqp/executer_actor/kqp_executer.h>
+#include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/kqp/rm_service/kqp_snapshot_manager.h>
 #include <ydb/core/protos/external_sources.pb.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
@@ -653,7 +654,7 @@ private:
 
 template<typename TResult>
 TFuture<TResult> InvalidCluster(const TString& cluster) {
-    return MakeFuture(ResultFromError<TResult>("Invalid cluster:" + cluster));
+    return MakeFuture(ResultFromError<TResult>("Invalid cluster: " + cluster));
 }
 
 void KqpResponseToQueryResult(const NKikimrKqp::TEvQueryResponse& response, IKqpGateway::TQueryResult& queryResult) {
@@ -1212,7 +1213,7 @@ public:
             schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateExternalTable);
 
             NKikimrSchemeOp::TExternalTableDescription& externalTableDesc = *schemeTx.MutableCreateExternalTable();
-            FillCreateExternalTableColumnDesc(externalTableDesc, pathPair.second, settings);
+            NSchemeHelpers::FillCreateExternalTableColumnDesc(externalTableDesc, pathPair.second, settings);
             return SendSchemeRequest(ev.Release(), true);
         }
         catch (yexception& e) {
@@ -2300,13 +2301,13 @@ private:
     }
 
     bool GetDatabaseForLoginOperation(TString& database) {
-        return SetDatabaseForLoginOperation(database, GetDomainLoginOnly(), GetDomainName(), GetDatabase());
+        return NSchemeHelpers::SetDatabaseForLoginOperation(database, GetDomainLoginOnly(), GetDomainName(), GetDatabase());
     }
 
     bool GetPathPair(const TString& tableName, std::pair<TString, TString>& pathPair,
         TString& error, bool createDir)
     {
-        return SplitTablePath(tableName, Database, pathPair, error, createDir);
+        return NSchemeHelpers::SplitTablePath(tableName, Database, pathPair, error, createDir);
     }
 
 private:
@@ -2355,33 +2356,6 @@ private:
         }
 
         schema.SetEngine(NKikimrSchemeOp::EColumnTableEngine::COLUMN_ENGINE_REPLACING_TIMESERIES);
-    }
-
-    static void FillCreateExternalTableColumnDesc(NKikimrSchemeOp::TExternalTableDescription& externalTableDesc,
-                                                  const TString& name,
-                                                  const NYql::TCreateExternalTableSettings& settings)
-    {
-        externalTableDesc.SetName(name);
-        externalTableDesc.SetDataSourcePath(settings.DataSourcePath);
-        externalTableDesc.SetLocation(settings.Location);
-        externalTableDesc.SetSourceType("General");
-
-        Y_ENSURE(settings.ColumnOrder.size() == settings.Columns.size());
-        for (const auto& name : settings.ColumnOrder) {
-            auto columnIt = settings.Columns.find(name);
-            Y_ENSURE(columnIt != settings.Columns.end());
-
-            TColumnDescription& columnDesc = *externalTableDesc.AddColumns();
-            columnDesc.SetName(columnIt->second.Name);
-            columnDesc.SetType(columnIt->second.Type);
-            columnDesc.SetNotNull(columnIt->second.NotNull);
-        }
-        NKikimrExternalSources::TGeneral general;
-        auto& attributes = *general.mutable_attributes();
-        for (const auto& [key, value]: settings.SourceTypeParameters) {
-            attributes.insert({key, value});
-        }
-        externalTableDesc.SetContent(general.SerializeAsString());
     }
 
     static void FillParameters(TQueryData::TPtr params, ::google::protobuf::Map<TBasicString<char>, Ydb::TypedValue>* output) {
@@ -2468,27 +2442,6 @@ TIntrusivePtr<IKqpGateway> CreateKikimrIcGateway(const TString& cluster, NKikimr
     return MakeIntrusive<TKikimrIcGateway>(cluster, queryType, database, std::move(metadataLoader), actorSystem, nodeId,
         counters, queryServiceConfig);
 }
-
-bool SplitTablePath(const TString& tableName, const TString& database, std::pair<TString, TString>& pathPair,
-    TString& error, bool createDir)
-{
-    if (createDir) {
-        return TrySplitPathByDb(tableName, database, pathPair, error);
-    } else {
-        return IKqpGateway::TrySplitTablePath(tableName, pathPair, error);
-    }
-}
-
-bool SetDatabaseForLoginOperation(TString& result, bool getDomainLoginOnly, TMaybe<TString> domainName,
-    const TString& database)
-{
-    if (getDomainLoginOnly && !domainName) {
-        return false;
-    }
-    result = domainName ? "/" + *domainName : database;
-    return true;
-}
-
 
 } // namespace NKqp
 } // namespace NKikimr

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -3,6 +3,7 @@
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/kqp/federated_query/kqp_federated_query_actors.h>
+#include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/statistics/stat_service.h>
 
@@ -545,7 +546,7 @@ NThreading::TFuture<TTableMetadataResult> TKqpTableMetadataLoader::LoadIndexMeta
 
     for (size_t i = 0; i < indexesCount; i++) {
         const auto& index = tableMetadata->Indexes[i];
-        auto indexTablePath = NYql::IKikimrGateway::CreateIndexTablePath(tableName, index.Name);
+        auto indexTablePath = NSchemeHelpers::CreateIndexTablePath(tableName, index.Name);
 
         if (!index.SchemaVersion) {
             LOG_DEBUG_S(*ActorSystem, NKikimrServices::KQP_GATEWAY, "Load index metadata without schema version check index: " << index.Name);

--- a/ydb/core/kqp/gateway/utils/scheme_helpers.cpp
+++ b/ydb/core/kqp/gateway/utils/scheme_helpers.cpp
@@ -1,0 +1,89 @@
+#include "scheme_helpers.h"
+
+#include <ydb/core/base/path.h>
+#include <ydb/core/protos/external_sources.pb.h>
+
+namespace NKikimr::NKqp::NSchemeHelpers {
+
+using namespace NKikimrSchemeOp;
+using namespace NKikimrExternalSources;
+
+TString CanonizePath(const TString& path) {
+    if (path.empty()) {
+        return "/";
+    }
+
+    if (path[0] != '/') {
+        return "/" + path;
+    }
+
+    return path;
+}
+
+bool TrySplitTablePath(const TString& path, std::pair<TString, TString>& result, TString& error) {
+    auto parts = NKikimr::SplitPath(path);
+
+    if (parts.size() < 2) {
+        error = TString("Missing scheme root in table path: ") + path;
+        return false;
+    }
+
+    result = std::make_pair(
+        CombinePath(parts.begin(), parts.end() - 1),
+        parts.back());
+
+    return true;
+}
+
+bool SplitTablePath(const TString& tableName, const TString& database, std::pair<TString, TString>& pathPair,
+    TString& error, bool createDir)
+{
+    if (createDir) {
+        return TrySplitPathByDb(tableName, database, pathPair, error);
+    } else {
+        return TrySplitTablePath(tableName, pathPair, error);
+    }
+}
+
+TString CreateIndexTablePath(const TString& tableName, const TString& indexName) {
+    return tableName + "/" + indexName + "/indexImplTable";
+}
+
+bool SetDatabaseForLoginOperation(TString& result, bool getDomainLoginOnly, TMaybe<TString> domainName,
+    const TString& database)
+{
+    if (getDomainLoginOnly && !domainName) {
+        return false;
+    }
+    result = domainName ? "/" + *domainName : database;
+    return true;
+}
+
+void FillCreateExternalTableColumnDesc(NKikimrSchemeOp::TExternalTableDescription& externalTableDesc,
+                                       const TString& name,
+                                       const NYql::TCreateExternalTableSettings& settings)
+{
+    externalTableDesc.SetName(name);
+    externalTableDesc.SetDataSourcePath(settings.DataSourcePath);
+    externalTableDesc.SetLocation(settings.Location);
+    externalTableDesc.SetSourceType("General");
+
+    Y_ENSURE(settings.ColumnOrder.size() == settings.Columns.size());
+    for (const auto& name : settings.ColumnOrder) {
+        auto columnIt = settings.Columns.find(name);
+        Y_ENSURE(columnIt != settings.Columns.end());
+
+        TColumnDescription& columnDesc = *externalTableDesc.AddColumns();
+        columnDesc.SetName(columnIt->second.Name);
+        columnDesc.SetType(columnIt->second.Type);
+        columnDesc.SetNotNull(columnIt->second.NotNull);
+    }
+    NKikimrExternalSources::TGeneral general;
+    auto& attributes = *general.mutable_attributes();
+    for (const auto& [key, value]: settings.SourceTypeParameters) {
+        attributes.insert({key, value});
+    }
+    externalTableDesc.SetContent(general.SerializeAsString());
+}
+
+} // namespace NKikimr::NKqp::NSchemeHelpers

--- a/ydb/core/kqp/gateway/utils/scheme_helpers.h
+++ b/ydb/core/kqp/gateway/utils/scheme_helpers.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <ydb/core/kqp/provider/yql_kikimr_gateway.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
+#include <util/generic/string.h>
+#include <util/string/join.h>
+
+namespace NKikimr::NKqp::NSchemeHelpers {
+
+TString CanonizePath(const TString& path);
+
+template <typename TIter>
+TString CombinePath(TIter begin, TIter end, bool canonize = true) {
+    auto path = JoinRange("/", begin, end);
+    return canonize
+        ? CanonizePath(path)
+        : path;
+}
+
+bool TrySplitTablePath(const TString& path, std::pair<TString, TString>& result, TString& error);
+
+bool SplitTablePath(const TString& tableName, const TString& database, std::pair<TString, TString>& pathPair,
+    TString& error, bool createDir);
+
+TString CreateIndexTablePath(const TString& tableName, const TString& indexName);
+
+bool SetDatabaseForLoginOperation(TString& result, bool getDomainLoginOnly, TMaybe<TString> domainName,
+    const TString& database);
+
+void FillCreateExternalTableColumnDesc(NKikimrSchemeOp::TExternalTableDescription& externalTableDesc,
+                                       const TString& name,
+                                       const NYql::TCreateExternalTableSettings& settings);
+
+} // namespace NKikimr::NKqp::NSchemeHelpers

--- a/ydb/core/kqp/gateway/utils/ya.make
+++ b/ydb/core/kqp/gateway/utils/ya.make
@@ -1,0 +1,15 @@
+LIBRARY()
+
+SRCS(
+    scheme_helpers.cpp
+)
+
+PEERDIR(
+    ydb/core/base
+    ydb/core/kqp/provider
+    ydb/core/protos
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/gateway/ya.make
+++ b/ydb/core/kqp/gateway/ya.make
@@ -17,9 +17,17 @@ PEERDIR(
     ydb/core/kqp/gateway/behaviour/tablestore
     ydb/core/kqp/gateway/behaviour/table
     ydb/core/kqp/gateway/behaviour/external_data_source
+    ydb/core/kqp/gateway/utils
     ydb/library/yql/providers/result/expr_nodes
 )
 
 YQL_LAST_ABI_VERSION()
 
 END()
+
+RECURSE(
+    actors
+    behaviour
+    local_rpc
+    utils
+)

--- a/ydb/core/kqp/host/kqp_host.h
+++ b/ydb/core/kqp/host/kqp_host.h
@@ -7,6 +7,10 @@
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 #include <ydb/library/yql/providers/common/token_accessor/client/factory.h>
 
+namespace NActors {
+class TActorSystem;
+} // namespace NActors
+
 namespace NKikimr {
 namespace NKqp {
 
@@ -105,7 +109,8 @@ public:
 TIntrusivePtr<IKqpHost> CreateKqpHost(TIntrusivePtr<IKqpGateway> gateway,
     const TString& cluster, const TString& database, NYql::TKikimrConfiguration::TPtr config, NYql::IModuleResolver::TPtr moduleResolver,
     std::optional<TKqpFederatedQuerySetup> federatedQuerySetup, const NKikimr::NMiniKQL::IFunctionRegistry* funcRegistry = nullptr,
-    bool keepConfigChanges = false, bool isInternalCall = false, TKqpTempTablesState::TConstPtr tempTablesState = nullptr);
+    bool keepConfigChanges = false, bool isInternalCall = false, TKqpTempTablesState::TConstPtr tempTablesState = nullptr,
+    NActors::TActorSystem* actorSystem = nullptr /*take from TLS by default*/);
 
 } // namespace NKqp
 } // namespace NKikimr

--- a/ydb/core/kqp/host/kqp_host_impl.h
+++ b/ydb/core/kqp/host/kqp_host_impl.h
@@ -257,7 +257,7 @@ TAutoPtr<NYql::IGraphTransformer> CreateKqpTypeAnnotationTransformer(const TStri
 TAutoPtr<NYql::IGraphTransformer> CreateKqpCheckQueryTransformer();
 
 TIntrusivePtr<NYql::IKikimrGateway> CreateKqpGatewayProxy(const TIntrusivePtr<IKqpGateway>& gateway,
-    const TIntrusivePtr<NYql::TKikimrSessionContext>& sessionCtx);
+    const TIntrusivePtr<NYql::TKikimrSessionContext>& sessionCtx, TActorSystem* actorSystem);
 
 } // namespace NKqp
 } // namespace NKikimr

--- a/ydb/core/kqp/host/ya.make
+++ b/ydb/core/kqp/host/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/kqp/common
     ydb/core/kqp/federated_query
+    ydb/core/kqp/gateway/utils
     ydb/core/kqp/opt
     ydb/core/kqp/provider
     ydb/core/tx/long_tx_service/public

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -850,23 +850,7 @@ public:
 public:
     using TCreateDirFunc = std::function<void(const TString&, const TString&, NThreading::TPromise<TGenericResult>)>;
 
-    static TString CanonizePath(const TString& path);
-
-    template <typename TIter>
-    static TString CombinePath(TIter begin, TIter end, bool canonize = true) {
-        auto path = JoinRange("/", begin, end);
-        return canonize
-            ? CanonizePath(path)
-            : path;
-    }
-
-    static TVector<TString> SplitPath(const TString& path);
-
-    static bool TrySplitTablePath(const TString& path, std::pair<TString, TString>& result, TString& error);
-
     static NThreading::TFuture<TGenericResult> CreatePath(const TString& path, TCreateDirFunc createDir);
-
-    static TString CreateIndexTablePath(const TString& tableName, const TString& indexName);
 
     static void BuildIndexMetadata(TTableMetadataResult& loadTableMetadataResult);
 };

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -1,6 +1,7 @@
 #include "yql_kikimr_provider_impl.h"
 #include "yql_kikimr_gateway.h"
 
+#include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <ydb/library/yql/core/yql_opt_utils.h>
 #include <ydb/library/yql/utils/log/log.h>
 #include <ydb/library/yql/providers/result/expr_nodes/yql_res_expr_nodes.h>
@@ -126,7 +127,7 @@ struct TKiExploreTxResults {
         auto view = key.GetView();
         if (view && view->Name) {
             const auto& indexName = view->Name;
-            const auto indexTablePath = IKikimrGateway::CreateIndexTablePath(tableMeta->Name, indexName);
+            const auto indexTablePath = NKikimr::NKqp::NSchemeHelpers::CreateIndexTablePath(tableMeta->Name, indexName);
 
             auto indexIt = std::find_if(tableMeta->Indexes.begin(), tableMeta->Indexes.end(), [&indexName](const auto& index){
                 return index.Name == indexName;
@@ -176,7 +177,7 @@ struct TKiExploreTxResults {
                 continue;
             }
 
-            const auto indexTable = IKikimrGateway::CreateIndexTablePath(tableMeta->Name, index.Name);
+            const auto indexTable = NKikimr::NKqp::NSchemeHelpers::CreateIndexTablePath(tableMeta->Name, index.Name);
 
             ops[tableMeta->Name] |= TPrimitiveYdbOperation::Read;
             ops[indexTable] = TPrimitiveYdbOperation::Write;
@@ -198,7 +199,7 @@ struct TKiExploreTxResults {
                 continue;
             }
 
-            const auto indexTable = IKikimrGateway::CreateIndexTablePath(tableMeta->Name, index.Name);
+            const auto indexTable = NKikimr::NKqp::NSchemeHelpers::CreateIndexTablePath(tableMeta->Name, index.Name);
             for (const auto& column : index.KeyColumns) {
                 if (updateColumns.contains(column)) {
                     // delete old index values and upsert rows into index table

--- a/ydb/core/kqp/provider/yql_kikimr_provider.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.h
@@ -480,8 +480,16 @@ public:
         UserName = userName;
     }
 
+    TString GetCluster() const {
+        return Cluster;
+    }
+
     TString GetDatabase() const {
         return Database;
+    }
+
+    void SetCluster(const TString& cluster) {
+        Cluster = cluster;
     }
 
     void SetDatabase(const TString& database) {
@@ -512,6 +520,7 @@ public:
 
 private:
     TString UserName;
+    TString Cluster;
     TString Database;
     TKikimrConfiguration::TPtr Configuration;
     TIntrusivePtr<TKikimrTablesData> TablesData;

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -25,21 +25,25 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableExternalDataSources(true);
         featureFlags.SetEnableScriptExecutionOperations(true);
+        if (!appConfig) {
+            appConfig.emplace();
+        }
+        appConfig->MutableTableServiceConfig()->SetEnablePreparedDdl(true);
 
         auto federatedQuerySetupFactory = std::make_shared<TKqpFederatedQuerySetupFactoryMock>(
             httpGateway,
             connectorClient,
             nullptr,
             databaseAsyncResolver,
-            appConfig ? appConfig->GetQueryServiceConfig().GetS3() : NYql::TS3GatewayConfig(),
-            appConfig ? appConfig->GetQueryServiceConfig().GetGeneric() : NYql::TGenericGatewayConfig());
+            appConfig->GetQueryServiceConfig().GetS3(),
+            appConfig->GetQueryServiceConfig().GetGeneric());
 
         auto settings = TKikimrSettings()
                             .SetFeatureFlags(featureFlags)
                             .SetFederatedQuerySetupFactory(federatedQuerySetupFactory)
                             .SetKqpSettings({});
 
-        settings = appConfig ? settings.SetAppConfig(appConfig.value()) : settings.SetAppConfig({});
+        settings = settings.SetAppConfig(appConfig.value());
 
         return std::make_shared<TKikimrRunner>(settings);
     }

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_scheme_ut.cpp
@@ -1,0 +1,150 @@
+#include "s3_recipe_ut_helpers.h"
+
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/kqp/ut/federated_query/common/common.h>
+#include <ydb/core/kqp/federated_query/kqp_federated_query_helpers.h>
+#include <ydb/library/yql/utils/log/log.h>
+#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
+
+#include <fmt/format.h>
+
+namespace NKikimr::NKqp {
+
+using namespace NYdb;
+using namespace NYdb::NQuery;
+using namespace NKikimr::NKqp::NFederatedQueryTest;
+using namespace NTestUtils;
+using namespace fmt::literals;
+
+Y_UNIT_TEST_SUITE(KqpFederatedSchemeTest) {
+    Y_UNIT_TEST(CreateExternalTable) {
+        enum EEx {
+            Empty,
+            IfExists,
+            IfNotExists,
+        };
+
+        CreateBucketWithObject("CreateExternalDataSourceBucket", "obj", TEST_CONTENT);
+
+        auto kikimr = MakeKikimrRunner(NYql::IHTTPGateway::Make());
+
+        auto queryClient = kikimr->GetQueryClient();
+
+        auto logSql = [](const TString& sql, bool expectSuccess) {
+            Cerr << "Execute sql in test (expect " << (expectSuccess ? "success" : "fail") << "):\n"
+                 << sql << Endl;
+        };
+
+        auto checkCreate = [&](bool expectSuccess, EEx exMode, int nameSuffix) {
+            UNIT_ASSERT_UNEQUAL(exMode, EEx::IfExists);
+            const TString ifNotExistsStatement = exMode == EEx::IfNotExists ? "IF NOT EXISTS" : "";
+            const TString sql = fmt::format(R"sql(
+                CREATE EXTERNAL DATA SOURCE {if_not_exists} test_data_source_{name_suffix} WITH (
+                    SOURCE_TYPE="ObjectStorage",
+                    LOCATION="{location}",
+                    AUTH_METHOD="NONE"
+                );
+
+                CREATE EXTERNAL TABLE {if_not_exists} test_table_{name_suffix} (
+                    key Utf8 NOT NULL,
+                    value Utf8 NOT NULL
+                ) WITH (
+                    DATA_SOURCE="test_data_source_{name_suffix}",
+                    LOCATION="obj",
+                    FORMAT="json_each_row"
+                );
+                )sql",
+                "location"_a = GetBucketLocation("CreateExternalDataSourceBucket"),
+                "name_suffix"_a = nameSuffix,
+                "if_not_exists"_a = ifNotExistsStatement
+            );
+            logSql(sql, expectSuccess);
+            auto result = queryClient.ExecuteQuery(
+                sql,
+                TTxControl::NoTx()).GetValueSync();
+
+            if (expectSuccess) {
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            } else {
+                UNIT_ASSERT(!result.IsSuccess());
+            }
+        };
+
+        auto checkTableExists = [&](bool expectSuccess, int nameSuffix) {
+            // Check that we can use created external table
+            const TString sql = fmt::format(R"sql(
+                SELECT * FROM test_table_{name_suffix};
+                )sql",
+                "name_suffix"_a = nameSuffix
+            );
+            logSql(sql, expectSuccess);
+            auto result = queryClient.ExecuteQuery(
+                sql,
+                TTxControl::BeginTx().CommitTx()).GetValueSync();
+
+            if (expectSuccess) {
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+                auto resultSet = result.GetResultSetParser(0);
+                UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 2);
+            } else {
+                UNIT_ASSERT(!result.IsSuccess());
+            }
+        };
+
+        auto checkDrop = [&](bool expectSuccess, EEx exMode, int nameSuffix) {
+            UNIT_ASSERT_UNEQUAL(exMode, EEx::IfNotExists);
+            const TString ifExistsStatement = exMode == EEx::IfExists ? "IF EXISTS" : "";
+            const TString sql = fmt::format(R"sql(
+                DROP EXTERNAL TABLE {if_exists} test_table_{name_suffix};
+                DROP EXTERNAL DATA SOURCE {if_exists} test_data_source_{name_suffix};
+                )sql",
+                "name_suffix"_a = nameSuffix,
+                "if_exists"_a = ifExistsStatement,
+                "name_suffix"_a = nameSuffix
+            );
+            logSql(sql, expectSuccess);
+            auto result = queryClient.ExecuteQuery(
+                sql,
+                TTxControl::NoTx()).GetValueSync();
+
+            if (expectSuccess) {
+                UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            } else {
+                UNIT_ASSERT(!result.IsSuccess());
+            }
+        };
+
+        // usual create
+        checkCreate(true, EEx::Empty, 0);
+        checkTableExists(true, 0);
+
+        // create already existing table
+        checkCreate(false, EEx::Empty, 0); // already
+        //checkCreate(true, EEx::IfNotExists, 0);
+        checkTableExists(true, 0);
+
+        // usual drop
+        checkDrop(true, EEx::Empty, 0);
+        checkTableExists(false, 0);
+        checkDrop(false, EEx::Empty, 0); // no such table
+
+        // drop if exists
+        //checkDrop(true, EEx::IfExists, 0);
+        checkTableExists(false, 0);
+
+        // failed attempt to drop nonexisting table
+        checkDrop(false, EEx::Empty, 0);
+
+        // create with if not exists
+        //checkCreate(true, EEx::IfNotExists, 1); // real creation
+        //checkTableExists(true, 1);
+        //checkCreate(true, EEx::IfNotExists, 1);
+
+        // drop if exists
+        //checkDrop(true, EEx::IfExists, 1); // real drop
+        //checkTableExists(false, 1);
+        //checkDrop(true, EEx::IfExists, 1);
+    }
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/federated_query/s3/ya.make
+++ b/ydb/core/kqp/ut/federated_query/s3/ya.make
@@ -11,6 +11,7 @@ ENDIF()
 
 SRCS(
     kqp_federated_query_ut.cpp
+    kqp_federated_scheme_ut.cpp
     kqp_s3_plan_ut.cpp
     s3_recipe_ut_helpers.cpp
 )

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -381,6 +381,11 @@ message TKqpSchemeOperation {
         FLAG_IF_NOT_EXISTS = 2; // set if IF_NOT_EXISTS modificator present
     };
 
+    // If the object is modified, this field is not empty
+    // and in that case modification will be through
+    // NMetadata::IClassBehaviour way
+    string ObjectType = 100;
+
     oneof Operation {
         NKikimrSchemeOp.TModifyScheme CreateTable = 1;
         NKikimrSchemeOp.TModifyScheme DropTable = 2;
@@ -394,6 +399,12 @@ message TKqpSchemeOperation {
         NKikimrSchemeOp.TModifyScheme RemoveGroupMembership = 10;
         NKikimrSchemeOp.TModifyScheme DropGroup = 11;
         NKikimrSchemeOp.TModifyScheme RenameGroup = 12;
+        NKikimrSchemeOp.TModifyScheme CreateExternalDataSource = 13;
+        NKikimrSchemeOp.TModifyScheme AlterExternalDataSource = 14;
+        NKikimrSchemeOp.TModifyScheme DropExternalDataSource = 15;
+        NKikimrSchemeOp.TModifyScheme CreateExternalTable = 16;
+        NKikimrSchemeOp.TModifyScheme AlterExternalTable = 17;
+        NKikimrSchemeOp.TModifyScheme DropExternalTable = 18;
     }
 }
 

--- a/ydb/core/tx/tiering/rule/manager.cpp
+++ b/ydb/core/tx/tiering/rule/manager.cpp
@@ -30,4 +30,16 @@ NMetadata::NModifications::TOperationParsingResult TTieringRulesManager::DoBuild
     return result;
 }
 
+NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus TTieringRulesManager::DoPrepare(NKqpProto::TKqpSchemeOperation& /*schemeOperation*/, const NYql::TObjectSettingsImpl& /*settings*/,
+    const NMetadata::IClassBehaviour::TPtr& /*manager*/, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& /*context*/) const {
+    return NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Prepare operations for TIERING_RULE objects are not supported");
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TTieringRulesManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& /*schemeOperation*/,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& /*context*/) const {
+    return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Execution of prepare operations for TIERING_RULE objects is not supported"));
+}
+
 }

--- a/ydb/core/tx/tiering/rule/manager.h
+++ b/ydb/core/tx/tiering/rule/manager.h
@@ -13,6 +13,12 @@ protected:
 
     virtual NMetadata::NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings,
         TInternalModificationContext& context) const override;
+
+    virtual IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    virtual NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
 };
 
 }

--- a/ydb/core/tx/tiering/tier/manager.cpp
+++ b/ydb/core/tx/tiering/tier/manager.cpp
@@ -67,4 +67,16 @@ void TTiersManager::DoPrepareObjectsBeforeModification(std::vector<TTierConfig>&
     TActivationContext::Register(new TTierPreparationActor(std::move(patchedObjects), controller, context));
 }
 
+NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus TTiersManager::DoPrepare(NKqpProto::TKqpSchemeOperation& /*schemeOperation*/, const NYql::TObjectSettingsImpl& /*settings*/,
+    const NMetadata::IClassBehaviour::TPtr& /*manager*/, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& /*context*/) const {
+    return NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Prepare operations for TIER objects are not supported");
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TTiersManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& /*schemeOperation*/,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& /*context*/) const {
+    return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Execution of prepare operations for TIER objects is not supported"));
+}
+
 }

--- a/ydb/core/tx/tiering/tier/manager.h
+++ b/ydb/core/tx/tiering/tier/manager.h
@@ -13,6 +13,12 @@ protected:
 
     virtual NMetadata::NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings,
         TInternalModificationContext& context) const override;
+
+    virtual IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    virtual NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
 public:
 };
 

--- a/ydb/services/ext_index/metadata/manager.cpp
+++ b/ydb/services/ext_index/metadata/manager.cpp
@@ -90,4 +90,16 @@ NModifications::TOperationParsingResult TManager::DoBuildPatchFromSettings(const
     }
 }
 
+NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus TManager::DoPrepare(NKqpProto::TKqpSchemeOperation& /*schemeOperation*/, const NYql::TObjectSettingsImpl& /*settings*/,
+    const NMetadata::IClassBehaviour::TPtr& /*manager*/, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& /*context*/) const {
+    return NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Prepare operations for CS_EXT_INDEX objects are not supported");
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& /*schemeOperation*/,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& /*context*/) const {
+    return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Execution of prepare operations for CS_EXT_INDEX objects is not supported"));
+}
+
 }

--- a/ydb/services/ext_index/metadata/manager.h
+++ b/ydb/services/ext_index/metadata/manager.h
@@ -15,6 +15,12 @@ protected:
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(
         const NYql::TObjectSettingsImpl& settings, TInternalModificationContext& context) const override;
 
+    virtual IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    virtual NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
+
 public:
 };
 

--- a/ydb/services/metadata/initializer/manager.cpp
+++ b/ydb/services/metadata/initializer/manager.cpp
@@ -17,4 +17,16 @@ NModifications::TOperationParsingResult TManager::DoBuildPatchFromSettings(
     return result;
 }
 
+NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus TManager::DoPrepare(NKqpProto::TKqpSchemeOperation& /*schemeOperation*/, const NYql::TObjectSettingsImpl& /*settings*/,
+    const NMetadata::IClassBehaviour::TPtr& /*manager*/, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& /*context*/) const {
+    return NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Prepare operations for INITIALIZATION objects are not supported");
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& /*schemeOperation*/,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& /*context*/) const {
+    return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Execution of prepare operations for INITIALIZATION objects is not supported"));
+}
+
 }

--- a/ydb/services/metadata/initializer/manager.h
+++ b/ydb/services/metadata/initializer/manager.h
@@ -20,6 +20,12 @@ protected:
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& /*settings*/,
         TInternalModificationContext& context) const override;
 
+    virtual IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    virtual NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
+
 public:
 };
 

--- a/ydb/services/metadata/manager/abstract.cpp
+++ b/ydb/services/metadata/manager/abstract.cpp
@@ -35,7 +35,7 @@ NKikimr::NMetadata::NModifications::TTableSchema& TTableSchema::AddColumn(const 
 }
 
 NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> IOperationsManager::DropObject(const NYql::TDropObjectSettings& settings,
-    const ui32 nodeId, IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const
+    const ui32 nodeId, const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const
 {
     if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
         return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("metadata provider service is disabled"));
@@ -46,7 +46,7 @@ NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> IOperationsManager
 }
 
 NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> IOperationsManager::AlterObject(const NYql::TAlterObjectSettings& settings,
-    const ui32 nodeId, IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const
+    const ui32 nodeId, const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const
 {
     if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
         return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("metadata provider service is disabled"));
@@ -57,7 +57,7 @@ NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> IOperationsManager
 }
 
 NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> IOperationsManager::CreateObject(const NYql::TCreateObjectSettings& settings,
-    const ui32 nodeId, IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const {
+    const ui32 nodeId, const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const {
     if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
         return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("metadata provider service is disabled"));
     }
@@ -67,13 +67,57 @@ NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> IOperationsManager
 }
 
 NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> IOperationsManager::UpsertObject(const NYql::TUpsertObjectSettings& settings,
-    const ui32 nodeId, IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const {
+    const ui32 nodeId, const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const {
     if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
         return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("metadata provider service is disabled"));
     }
     TInternalModificationContext internalContext(context);
     internalContext.SetActivityType(EActivityType::Upsert);
     return DoModify(settings, nodeId, manager, internalContext);
+}
+
+IOperationsManager::TYqlConclusionStatus IOperationsManager::PrepareUpsertObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+    const NYql::TUpsertObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+    const TExternalModificationContext& context) const {
+    if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
+        return TYqlConclusionStatus::Fail("metadata provider service is disabled");
+    }
+    TInternalModificationContext internalContext(context);
+    internalContext.SetActivityType(EActivityType::Upsert);
+    return DoPrepare(schemeOperation, settings, manager, internalContext);
+}
+
+IOperationsManager::TYqlConclusionStatus IOperationsManager::PrepareCreateObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+    const NYql::TCreateObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+    const TExternalModificationContext& context) const {
+    if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
+        return TYqlConclusionStatus::Fail("metadata provider service is disabled");
+    }
+    TInternalModificationContext internalContext(context);
+    internalContext.SetActivityType(EActivityType::Create);
+    return DoPrepare(schemeOperation, settings, manager, internalContext);
+}
+
+IOperationsManager::TYqlConclusionStatus IOperationsManager::PrepareAlterObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+    const NYql::TAlterObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+    const TExternalModificationContext& context) const {
+    if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
+        return TYqlConclusionStatus::Fail("metadata provider service is disabled");
+    }
+    TInternalModificationContext internalContext(context);
+    internalContext.SetActivityType(EActivityType::Alter);
+    return DoPrepare(schemeOperation, settings, manager, internalContext);
+}
+
+IOperationsManager::TYqlConclusionStatus IOperationsManager::PrepareDropObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+    const NYql::TDropObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+    const TExternalModificationContext& context) const {
+    if (!NMetadata::NProvider::TServiceOperator::IsEnabled()) {
+        return TYqlConclusionStatus::Fail("metadata provider service is disabled");
+    }
+    TInternalModificationContext internalContext(context);
+    internalContext.SetActivityType(EActivityType::Drop);
+    return DoPrepare(schemeOperation, settings, manager, internalContext);
 }
 
 }

--- a/ydb/services/metadata/manager/abstract.h
+++ b/ydb/services/metadata/manager/abstract.h
@@ -2,6 +2,7 @@
 #include "common.h"
 #include "table_record.h"
 
+#include <ydb/core/protos/kqp_physical.pb.h>
 #include <ydb/core/tx/datashard/sys_tables.h>
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/library/aclib/aclib.h>
@@ -80,21 +81,43 @@ private:
     YDB_ACCESSOR_DEF(std::optional<TTableSchema>, ActualSchema);
 protected:
     virtual NThreading::TFuture<TYqlConclusionStatus> DoModify(const NYql::TObjectSettingsImpl& settings, const ui32 nodeId,
-        IClassBehaviour::TPtr manager, TInternalModificationContext& context) const = 0;
+        const IClassBehaviour::TPtr& manager, TInternalModificationContext& context) const = 0;
+
+    virtual TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const IClassBehaviour::TPtr& manager, TInternalModificationContext& context) const = 0;
 public:
     virtual ~IOperationsManager() = default;
 
     NThreading::TFuture<TYqlConclusionStatus> UpsertObject(const NYql::TUpsertObjectSettings& settings, const ui32 nodeId,
-        IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const;
+        const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const;
 
     NThreading::TFuture<TYqlConclusionStatus> CreateObject(const NYql::TCreateObjectSettings& settings, const ui32 nodeId,
-        IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const;
+        const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const;
 
     NThreading::TFuture<TYqlConclusionStatus> AlterObject(const NYql::TAlterObjectSettings& settings, const ui32 nodeId,
-        IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const;
+        const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const;
 
     NThreading::TFuture<TYqlConclusionStatus> DropObject(const NYql::TDropObjectSettings& settings, const ui32 nodeId,
-        IClassBehaviour::TPtr manager, const TExternalModificationContext& context) const;
+        const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const;
+
+    TYqlConclusionStatus PrepareUpsertObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NYql::TUpsertObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+        const TExternalModificationContext& context) const;
+
+    TYqlConclusionStatus PrepareCreateObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NYql::TCreateObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+        const TExternalModificationContext& context) const;
+
+    TYqlConclusionStatus PrepareAlterObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NYql::TAlterObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+        const TExternalModificationContext& context) const;
+
+    TYqlConclusionStatus PrepareDropObjectSchemeOperation(NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NYql::TDropObjectSettings& settings, const IClassBehaviour::TPtr& manager,
+        const TExternalModificationContext& context) const;
+
+    virtual NThreading::TFuture<TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const IClassBehaviour::TPtr& manager, const TExternalModificationContext& context) const = 0;
 
     const TTableSchema& GetSchema() const {
         Y_ABORT_UNLESS(!!ActualSchema);

--- a/ydb/services/metadata/manager/alter_impl.h
+++ b/ydb/services/metadata/manager/alter_impl.h
@@ -66,7 +66,7 @@ protected:
 public:
     TModificationActorImpl(NInternal::TTableRecord&& patch,
         IAlterController::TPtr controller,
-        typename IObjectOperationsManager<TObject>::TPtr manager,
+        const typename IObjectOperationsManager<TObject>::TPtr& manager,
         const IOperationsManager::TInternalModificationContext& context)
         : ExternalController(controller)
         , Manager(manager)
@@ -75,7 +75,7 @@ public:
     }
 
     TModificationActorImpl(const NInternal::TTableRecord& patch, IAlterController::TPtr controller,
-        typename IObjectOperationsManager<TObject>::TPtr manager,
+        const typename IObjectOperationsManager<TObject>::TPtr& manager,
         const IOperationsManager::TInternalModificationContext& context)
         : ExternalController(controller)
         , Manager(manager)
@@ -84,7 +84,7 @@ public:
     }
 
     TModificationActorImpl(std::vector<NInternal::TTableRecord>&& patches, IAlterController::TPtr controller,
-        typename IObjectOperationsManager<TObject>::TPtr manager,
+        const typename IObjectOperationsManager<TObject>::TPtr& manager,
         const IOperationsManager::TInternalModificationContext& context)
         : ExternalController(controller)
         , Manager(manager)
@@ -94,7 +94,7 @@ public:
     }
 
     TModificationActorImpl(const std::vector<NInternal::TTableRecord>& patches, IAlterController::TPtr controller,
-        typename IObjectOperationsManager<TObject>::TPtr manager,
+        const typename IObjectOperationsManager<TObject>::TPtr& manager,
         const IOperationsManager::TInternalModificationContext& context)
         : ExternalController(controller)
         , Manager(manager)

--- a/ydb/services/metadata/manager/generic_manager.h
+++ b/ydb/services/metadata/manager/generic_manager.h
@@ -33,7 +33,7 @@ public:
 protected:
     virtual NThreading::TFuture<TYqlConclusionStatus> DoModify(
         const NYql::TObjectSettingsImpl& settings, const ui32 nodeId,
-        IClassBehaviour::TPtr manager, TInternalModificationContext& context) const override
+        const IClassBehaviour::TPtr& manager, TInternalModificationContext& context) const override
     {
         if (!manager) {
             return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail("modification object behaviour not initialized"));

--- a/ydb/services/metadata/secret/manager.cpp
+++ b/ydb/services/metadata/secret/manager.cpp
@@ -46,6 +46,18 @@ NModifications::TOperationParsingResult TAccessManager::DoBuildPatchFromSettings
     return result;
 }
 
+NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus TAccessManager::DoPrepare(NKqpProto::TKqpSchemeOperation& /*schemeOperation*/, const NYql::TObjectSettingsImpl& /*settings*/,
+    const NMetadata::IClassBehaviour::TPtr& /*manager*/, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& /*context*/) const {
+    return NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Prepare operations for SECRET_ACCESS objects are not supported");
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TAccessManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& /*schemeOperation*/,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& /*context*/) const {
+    return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Execution of prepare operations for SECRET_ACCESS objects is not supported"));
+}
+
 NModifications::TOperationParsingResult TSecretManager::DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings,
     TInternalModificationContext& context) const {
     static const TString ExtraPathSymbolsAllowed = "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~";
@@ -98,6 +110,18 @@ void TSecretManager::DoPrepareObjectsBeforeModification(std::vector<TSecret>&& p
         }
     }
     TActivationContext::Register(new TSecretPreparationActor(std::move(patchedObjects), controller, context));
+}
+
+NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus TSecretManager::DoPrepare(NKqpProto::TKqpSchemeOperation& /*schemeOperation*/, const NYql::TObjectSettingsImpl& /*settings*/,
+    const NMetadata::IClassBehaviour::TPtr& /*manager*/, NMetadata::NModifications::IOperationsManager::TInternalModificationContext& /*context*/) const {
+    return NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Prepare operations for SECRET objects are not supported");
+}
+
+NThreading::TFuture<NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus> TSecretManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& /*schemeOperation*/,
+        const NMetadata::IClassBehaviour::TPtr& /*manager*/, const IOperationsManager::TExternalModificationContext& /*context*/) const {
+    return NThreading::MakeFuture(NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus::Fail(
+        "Execution of prepare operations for SECRET objects is not supported"));
 }
 
 }

--- a/ydb/services/metadata/secret/manager.h
+++ b/ydb/services/metadata/secret/manager.h
@@ -15,6 +15,12 @@ protected:
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(
         const NYql::TObjectSettingsImpl& settings, TInternalModificationContext& context) const override;
 
+    virtual IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    virtual NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
+
 public:
 };
 
@@ -26,7 +32,12 @@ protected:
 
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings,
         TInternalModificationContext& context) const override;
-public:
+
+    virtual IOperationsManager::TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TObjectSettingsImpl& settings,
+        const NMetadata::IClassBehaviour::TPtr& manager, IOperationsManager::TInternalModificationContext& context) const override;
+
+    virtual NThreading::TFuture<IOperationsManager::TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+        const NMetadata::IClassBehaviour::TPtr& manager, const IOperationsManager::TExternalModificationContext& context) const override;
 };
 
 }


### PR DESCRIPTION
Implement CREATE/DROP EXTERNAL DATA SOURCE/EXTERNAL TABLE in QueryService. Without IF NOT EXISTS/IF EXISTS support yet.

Also a common mechanism for working with objects is implemented through `IClassBehaviour::TFactory`. It can be used for all types of objects in SQL