### PR TITLE
Add tstool and tsserver into ydb/tools

### DIFF
--- a/ydb/tools/tsserver/defs.h
+++ b/ydb/tools/tsserver/defs.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include <ydb/core/test_tablet/processor.h>
+#include <ydb/library/actors/interconnect/interconnect_stream.h>

--- a/ydb/tools/tsserver/main.cpp
+++ b/ydb/tools/tsserver/main.cpp
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <sys/epoll.h>
+#include <ydb/core/protos/test_shard.pb.h>
+#include "socket_context.h"
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        printf("Usage: %s <port>\n", argv[0]);
+        return 1;
+    }
+
+    auto server = NInterconnect::TStreamSocket::Make(AF_INET6);
+    Y_ABORT_UNLESS(*server != -1, "failed to create server socket");
+    SetNonBlock(*server);
+    SetSockOpt(*server, SOL_SOCKET, SO_REUSEADDR, 1);
+    SetSockOpt(*server, SOL_SOCKET, SO_REUSEPORT, 1);
+
+    int res = server->Bind(NInterconnect::TAddress("::", atoi(argv[1])));
+    Y_ABORT_UNLESS(!res, "failed to bind server socket: %s", strerror(-res));
+    res = server->Listen(10);
+    Y_ABORT_UNLESS(!res, "failed to listen on server socket: %s", strerror(-res));
+
+    int epfd = epoll_create(1);
+    if (epfd == -1) {
+        Y_ABORT("failed to create epoll: %s", strerror(errno));
+    }
+
+    epoll_event e;
+    e.events = EPOLLIN;
+    e.data.u64 = 0;
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, *server, &e) == -1) {
+        Y_ABORT("failed to add listening socket to epoll: %s", strerror(errno));
+    }
+
+    std::unordered_map<ui64, TSocketContext> Clients;
+    ui64 LastClientId = 0;
+
+    TProcessor processor;
+
+    for (;;) {
+        static constexpr size_t N = 64;
+        epoll_event events[N];
+        int res = epoll_wait(epfd, events, N, -1);
+        if (res == -1) {
+            if (errno == EINTR) {
+                continue;
+            } else {
+                Y_ABORT("epoll_wait failed: %s", strerror(errno));
+            }
+        }
+        for (int i = 0; i < res; ++i) {
+            epoll_event& e = events[i];
+            if (!e.data.u64) {
+                NInterconnect::TAddress addr;
+                int fd = server->Accept(addr);
+                Y_ABORT_UNLESS(fd >= 0, "failed to accept client socket: %s", strerror(-fd));
+                auto client = MakeIntrusive<NInterconnect::TStreamSocket>(fd);
+                SetNonBlock(*client);
+                SetNoDelay(*client, true);
+                const ui64 clientId = ++LastClientId;
+                auto&& [it, inserted] = Clients.try_emplace(clientId, clientId, epfd, client, processor);
+                Y_ABORT_UNLESS(inserted);
+            } else if (auto it = Clients.find(e.data.u64); it != Clients.end()) {
+                try {
+                    if (e.events & EPOLLIN) {
+                        it->second.Read();
+                    }
+                    if (e.events & EPOLLOUT) {
+                        it->second.Write();
+                    }
+                    it->second.UpdateEpoll();
+                } catch (const TExError&) {
+                    Clients.erase(it);
+                }
+            }
+        }
+    }
+
+    close(epfd);
+
+    return 0;
+}

--- a/ydb/tools/tsserver/socket_context.h
+++ b/ydb/tools/tsserver/socket_context.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "defs.h"
+#include "types.h"
+
+using TProcessor = NKikimr::NTestShard::TProcessor;
+
+class TSocketContext {
+    const ui64 ClientId;
+    const int EpollFd;
+    TIntrusivePtr<NInterconnect::TStreamSocket> Socket;
+    TProcessor& Processor;
+
+    enum class EReadStep {
+        LEN,
+        DATA,
+    } ReadStep = EReadStep::LEN;
+    TString ReadBuffer = TString::Uninitialized(sizeof(ui32));
+    char *ReadBegin = ReadBuffer.Detach(), *ReadEnd = ReadBegin + ReadBuffer.size();
+
+    std::deque<TString> OutQ;
+    size_t WriteOffset = 0;
+
+    std::optional<ui32> StoredEvents;
+    ui32 Events = 0;
+
+public:
+    TSocketContext(ui64 clientId, int epollFd, TIntrusivePtr<NInterconnect::TStreamSocket> socket, TProcessor& processor)
+        : ClientId(clientId)
+        , EpollFd(epollFd)
+        , Socket(std::move(socket))
+        , Processor(processor)
+    {
+        printf("[%" PRIu64 "] created\n", ClientId);
+        Read();
+        Write();
+        UpdateEpoll();
+    }
+
+    ~TSocketContext() {
+        if (StoredEvents) {
+            Epoll(EPOLL_CTL_DEL, 0);
+        }
+    }
+
+    void Epoll(int op, ui32 events) {
+        epoll_event e;
+        e.events = events;
+        e.data.u64 = ClientId;
+        if (epoll_ctl(EpollFd, op, *Socket, &e) == -1) {
+            Y_ABORT("epoll_ctl failed: %s", strerror(errno));
+        }
+    }
+
+    void UpdateEpoll() {
+        std::optional<int> mode = !StoredEvents ? std::make_optional(EPOLL_CTL_ADD) :
+            *StoredEvents != Events ? std::make_optional(EPOLL_CTL_MOD) : std::nullopt;
+        if (mode) {
+            Epoll(*mode, Events);
+        }
+        StoredEvents = Events;
+    }
+
+    void Read() {
+        for (;;) {
+            ssize_t n = Socket->Recv(ReadBegin, ReadEnd - ReadBegin);
+            if (n > 0) {
+                ReadBegin += n;
+                if (ReadBegin == ReadEnd) {
+                    switch (ReadStep) {
+                        case EReadStep::LEN: {
+                            ui32 n;
+                            Y_ABORT_UNLESS(ReadBuffer.size() == sizeof(n));
+                            memcpy(&n, ReadBuffer.data(), ReadBuffer.size()); // strict aliasing
+                            Y_ABORT_UNLESS(n <= 64 * 1024 * 1024);
+                            ReadBuffer = TString::Uninitialized(n);
+                            ReadStep = EReadStep::DATA;
+                            break;
+                        }
+
+                        case EReadStep::DATA:
+                            ProcessReadBuffer();
+                            ReadBuffer = TString::Uninitialized(sizeof(ui32));
+                            ReadStep = EReadStep::LEN;
+                            break;
+                    }
+                    ReadBegin = ReadBuffer.Detach();
+                    ReadEnd = ReadBegin + ReadBuffer.size();
+                }
+            } else if (-n == EAGAIN || -n == EWOULDBLOCK) {
+                Events |= EPOLLIN;
+                break;
+            } else if (-n == EINTR) {
+                continue;
+            } else {
+                printf("[%" PRIu64 "] failed to receive data: %s\n", ClientId, strerror(-n));
+                throw TExError();
+            }
+        }
+    }
+
+    void ProcessReadBuffer() {
+        ::NTestShard::TStateServer::TRequest request;
+        if (!request.ParseFromString(ReadBuffer)) {
+            throw TExError();
+        }
+        auto send = [this](const auto& proto) {
+            TString buffer;
+            const bool success = proto.SerializeToString(&buffer);
+            Y_ABORT_UNLESS(success);
+            Y_ABORT_UNLESS(buffer.size() <= 64 * 1024 * 1024);
+            ui32 len = buffer.size();
+            TString w = TString::Uninitialized(sizeof(ui32) + len);
+            char *p = w.Detach();
+            memcpy(p, &len, sizeof(len));
+            memcpy(p + sizeof(len), buffer.data(), buffer.size());
+            OutQ.push_back(std::move(w));
+            Write();
+        };
+        switch (request.GetCommandCase()) {
+            case ::NTestShard::TStateServer::TRequest::kWrite:
+                send(Processor.Execute(request.GetWrite()));
+                break;
+
+            case ::NTestShard::TStateServer::TRequest::kRead:
+                send(Processor.Execute(request.GetRead()));
+                break;
+
+            case ::NTestShard::TStateServer::TRequest::kTabletInfo:
+            case ::NTestShard::TStateServer::TRequest::COMMAND_NOT_SET:
+                printf("[%" PRIu64 "] incorrect request received\n", ClientId);
+                throw TExError();
+        }
+    }
+
+    void Write() {
+        while (!OutQ.empty()) {
+            auto& buffer = OutQ.front();
+            if (WriteOffset == buffer.size()) {
+                OutQ.pop_front();
+                WriteOffset = 0;
+                continue;
+            }
+            ssize_t n = Socket->Send(buffer.data() + WriteOffset, buffer.size() - WriteOffset);
+            if (n > 0) {
+                WriteOffset += n;
+            } else if (-n == EWOULDBLOCK || -n == EAGAIN) {
+                break;
+            } else if (-n == EINTR) {
+                continue;
+            } else {
+                printf("[%" PRIu64 "] failed to send data: %s\n", ClientId, strerror(-n));
+            }
+        }
+        if (OutQ.empty()) {
+            Events &= ~EPOLLOUT;
+        } else {
+            Events |= EPOLLOUT;
+        }
+    }
+};

--- a/ydb/tools/tsserver/types.h
+++ b/ydb/tools/tsserver/types.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "defs.h"
+
+struct TExError : std::exception {};

--- a/ydb/tools/tsserver/ya.make
+++ b/ydb/tools/tsserver/ya.make
@@ -1,0 +1,14 @@
+PROGRAM()
+
+OWNER(alexvru)
+
+SRCS(
+    main.cpp
+)
+
+PEERDIR(
+    ydb/library/actors/interconnect
+    ydb/core/protos
+)
+
+END()

--- a/ydb/tools/tstool/testshard.txt
+++ b/ydb/tools/tstool/testshard.txt
@@ -1,0 +1,7 @@
+StorageServerPort: 35000
+MaxDataBytes: 1500000000
+MinDataBytes: 1000000000
+MaxInFlight: 5
+Sizes { Weight: 1 Min: 1 Max: 1024 Inline: true }
+Sizes { Weight: 3 Min: 10000 Max: 1000000 }
+Sizes { Weight: 7 Min: 2357120 Max: 8388608 }

--- a/ydb/tools/tstool/tstool.py
+++ b/ydb/tools/tstool/tstool.py
@@ -1,0 +1,102 @@
+from argparse import ArgumentParser, FileType
+from ydb.core.protos.grpc_pb2_grpc import TGRpcServerStub
+from ydb.core.protos.msgbus_pb2 import THiveCreateTablet, TTestShardControlRequest
+from ydb.core.protos.tablet_pb2 import TTabletTypes
+from ydb.core.protos.base_pb2 import EReplyStatus
+from google.protobuf import text_format
+import grpc
+import socket
+import sys
+import time
+import multiprocessing
+import random
+
+grpc_host = None
+grpc_port = None
+domain_uid = None
+default_tsserver_port = 35000
+
+
+def invoke_grpc(func, *params):
+    with grpc.insecure_channel('%s:%d' % (grpc_host, grpc_port), []) as channel:
+        stub = TGRpcServerStub(channel)
+        return getattr(stub, func)(*params)
+
+
+def create_tablet(owner_idx, channels, count):
+    request = THiveCreateTablet(DomainUid=domain_uid)
+    for i in range(count):
+        cmd = request.CmdCreateTablet.add(OwnerId=0, OwnerIdx=owner_idx + i, TabletType=TTabletTypes.TestShard, ChannelsProfile=0)
+        for channel in channels:
+            cmd.BindedChannels.add(StoragePoolName=channel, PhysicalGroupsOnly=False)
+
+    for _ in range(10):
+        res = invoke_grpc('HiveCreateTablet', request)
+        if res.Status == 1:
+            assert all(r.Status in [EReplyStatus.OK, EReplyStatus.ALREADY] for r in res.CreateTabletResult)
+            return [r.TabletId for r in res.CreateTabletResult]
+        else:
+            print(res, file=sys.stderr)
+            time.sleep(3)
+
+    assert False
+
+
+def init_tablet(args):
+    tablet_id, cmd = args
+    request = TTestShardControlRequest(TabletId=tablet_id, Initialize=cmd)
+
+    for _ in range(100):
+        res = invoke_grpc('TestShardControl', request)
+        if res.Status == 1:
+            return None
+        else:
+            time.sleep(random.uniform(1.0, 2.0))
+
+    return str(tablet_id) + ': ' + str(res)
+
+
+def main():
+    parser = ArgumentParser(description='YDB TestShard control tool')
+    parser.add_argument('--grpc-host', type=str, required=True, help='gRPC endpoint hostname')
+    parser.add_argument('--grpc-port', type=int, default=2135, help='gRPC endpoint port')
+    parser.add_argument('--domain-uid', type=int, default=1, help='domain UID')
+    parser.add_argument('--owner-idx', type=int, required=True, help='unique instance id for tablet creation')
+    parser.add_argument('--channels', type=str, nargs='+', required=True, help='channel storage pool names')
+    parser.add_argument('--count', type=int, default=1, help='create desired amount of tablets at once')
+
+    subparsers = parser.add_subparsers(help='Action', dest='action', required=True)
+
+    p = subparsers.add_parser('initialize', help='initialize test shard state')
+    p.add_argument('--proto-file', type=FileType(), required=True, help='path to protobuf containing TCmdInitialize')
+    p.add_argument('--tsserver', type=str, help='FQDN:port pair for tsserver')
+
+    args = parser.parse_args()
+
+    global grpc_host, grpc_port, domain_uid
+    grpc_host = args.grpc_host
+    grpc_port = args.grpc_port
+    domain_uid = args.domain_uid
+
+    tablet_ids = create_tablet(args.owner_idx, args.channels, args.count)
+    print('TabletIds# %s' % ', '.join(map(str, tablet_ids)))
+
+    if args.action == 'initialize':
+        cmd = text_format.Parse(args.proto_file.read(), TTestShardControlRequest.TCmdInitialize())
+        if args.tsserver is not None:
+            host, sep, port = args.tsserver.partition(':')
+            port = int(port) if sep else default_tsserver_port
+            sockaddr = None
+            for _, _, _, _, sockaddr in socket.getaddrinfo(host, port, socket.AF_INET6):
+                break
+            if sockaddr is None:
+                print('Failed to resolve hostname %s' % host, file=sys.stderr)
+                sys.exit(1)
+            cmd.StorageServerHost = sockaddr[0]
+        with multiprocessing.Pool(None) as p:
+            status = 0
+            for r in p.imap_unordered(init_tablet, ((tablet_id, cmd) for tablet_id in tablet_ids), 1):
+                if r is not None:
+                    sys.stderr.write(r)
+                    status = 1
+            sys.exit(status)

--- a/ydb/tools/tstool/ya.make
+++ b/ydb/tools/tstool/ya.make
@@ -1,0 +1,16 @@
+PY3_PROGRAM(tstool)
+
+OWNER(alexvru)
+
+PY_MAIN(tstool)
+
+PY_SRCS(
+    TOP_LEVEL
+    tstool.py
+)
+
+PEERDIR(
+    ydb/core/protos
+)
+
+END()

--- a/ydb/tools/ya.make
+++ b/ydb/tools/ya.make
@@ -1,4 +1,6 @@
 RECURSE(
     cfg
     ydbd_slice
+    tsserver
+    tstool
 )


### PR DESCRIPTION
- Removed unneccessy file from docs folder
- Use AggrAdd for Limit.
- Fix any join absence after key columns cast
- Remove unused fields from TKqpSchemeOperation
- Added support for optional for predicate selectivity
- Better use AggrAdd for limits.
- Intermediate changes
- Canonization fix.
- YQL-16196 Add FileOptions pragma and bypass_artifact_cache option for MR job spec
- Add host_os.ya.make.inc files to piglet-sync
- Fix bug KIKIMR-11082
- KIKIMR-20451: Pass TTLSettings on column table create
- ci: add missing ydb/ci sync
- pg-make-test saves stderr
- Prepare to rename py3_flake8 tests to flake8
- Intermediate changes
- add attribute to detect lifetime bound errors
- Handle long-lasting Put queries in DS proxy correctly -- part 2 KIKIMR-9016
- Handle RaiseError calls in OffsetFetchActor
- Не работает ResourceManager.resource_filename вместе с Y_PYTHON_SOURCE_ROOT
- Intermediate changes
- Fix inconsistency in rpc protocol
- , YT-18091: Do not schedule pollable shutdown in finalizer invoker
- Update contrib/python/traitlets/py3 to 5.14.0
- Intermediate changes
- Update contrib/python/ipython/py3 to 8.18.1
- YT-20658: add two fields to Bundle Controller API
- Moved cmake files to generator dir and updated generator.toml
- Update doc content
- [dq] Refactor dq gateway session handling
- Disable data validation in opensource
- unknown data source has been fixed
- Removed wrong copy
- add kms's symmetric_crypto_service for nbs
- KIKIMR-19831: exclude right columns from left only stream join result
- YQL-17080 fix win build + adjust bounds
- YQL-17117: optimize PgCast unknown->text
- Fix verify requirement \!PipeToBalancer failed
- Y_DECLARE_OUT_SPEC for NKikimrDataEvents
- YQL-17346 more columns in pg_type
- Traffic agg task metrics + YQ public metrics
- ci: cache tests results
- Update contrib/python/s3transfer/py3 to 0.8.0
- Intermediate changes
- KIKIMR-19861: fix compaction task volume limit
- YQL-16196 Add docs for FileOption pragma
- Rewrite switching pools for executor thread, KIKIMR-18440
- Create postcommit.yml
- Consider used columns in index chooser
- YQL-17352 YQL-17356 YQL-17347 more pg_catalog tables
- Fix build problem KIKIMR-9016
- fix typo in port number section + add note on ports for multiple dynnodes per server
- Add build support for cortex-m23 platform
- Support override `distutils` from `setuptools`
- YQ Connector: prepare code base for S3 integration
- Test for duplicate data in anyjoin
- Intermediate changes
- Introduce convenient _B literal for bytes
- Support std::filesystem::path in TFile and TFileHandle
- feat setuptools: revert/fix UnionProvider
- ci: don't fail to fast on test run, add POST suffix for push checks
- Update Python 3 to 3.11.7
- Add GO_MOCKGEN_CONTRIB_FROM macro to generate mockgens from contribs
- Support Python 3.12 for `future`
- Intermediate changes
- Support Python 3.12 for `cffi`
- drop unused MaxDPccpDPTableSize
- fix return code UNSUPPORTED to UNAVILABLE
- updated roadmap for 2024
- not found behaviour has been changed for get script execution
- Support Python 3.12 for `tornado-4`
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- YT-20686: Fix TResponseKeeper
- ci: quote log file path
- Pass DiscoveryEndpoint in to DiscoveryMutator
- Intermediate changes
- KIKIMR-20179: remove deprecated reader from tests
- serial execution in simple write session
- ci: testmo-proxy use RequestException instead of ConnectionError
- Handle long-lasting Put queries in DS proxy correctly -- part 3
- add a whitelist for pooltrees pragma
- ci: use ya from repo, fix memory sanitizer run, always try generate summary
- Intermediate changes
- Remove excessive EOL spaces in blobstorage code
- Intermediate changes
- Better relational operators for TStrongTypedef
- [yql] test auto partition
- YQL-16196 Move internal link into internal docs (PRAGMA FileOptions)
- KIKIMR-20482: Remove duplicates on schema versions
- Print time in shutdown logging
- Fix comparison key
- Intermediate changes
- Fix fluky test. We can get CLIENT_CANCELED status at driver shutdown.…
- RowCount/ColCount should be used in move/parse
- KIKIMR-20042 Wilson uploader fix
- ,allow optional timestamp in insert into monitoring
- YT-20425: Optional offset in pull_consumer
- primary keys naming unification
- fix stream-write refresh-token rights
- support default values in create table for pg syntax KIKIMR-20022
- PR from branch users/nsofya/KIKIMR-19564
- Fix build, KIKIMR-18440
- fix codestyle: remove semicolon
- finer check of lifetimebound attribute support
- Use generic node count, not datashards only
- [yql] extend dq_file test parts
- Fix _an attribute list cannot appear here_ from clang-cl16
- Fix modernize-use-emplace reported by clang-tidy16
- FS_TOOLS to python3
- [yql] extend yt_native_file test parts
- Update contrib/restricted/nlohmann_json to 3.11.3
- Intermediate changes
- Stricter platform check for prebuilt protoc-gen-go
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- Update COPY_FILE macro
- Replace rep.erase with rep.erase_one in THashSet::erase
- fix typo in public method name
- Move ApplyJitter impl to inl file
- Add fake PDisk key to kikimr_cfg, KIKIMR-20141
- Allow using std::filesystem::path when constructing TFileInput / TFileOutput
- Switch windows builds to clang16
- Remote development
- KIKIMR-19521 BTreeIndex Loader & Dump
- KIKIMR-19521 BTreeIndex Charge Interface
- Intermediate changes
- KIKIMR-20432, KIKIMR-20431: support pg and not null types for stream lookup join
- KIKIMR-19512 Push down binary arithmetic operations and use YQL kernels.
- Split postcommits in two workflows
- TEvWriteResult Origin
- YQL-17353 YQL-17355 YQL-17357 YQL-17358 YQL-17360 YQL-17361 YQL-17362 more tables (mostly empty)
- PR from branch users/zverevgeny/YQL-17279_mr_permute
- KIKIMR-20538: background processes disabling
- KIKIMR-20009:dont remove blobs in case failed main data writing
- External build system generator release 69
- KIKIMR-19900 switch arcadia to python ydb sdk from contrib
- SpillingEngine pragma propagation to resource allocator.
- Intermediate changes
- KIKIMR-20484: switch required fields to optional in generic config
- KIKIMR-18888 query classic schema when not found
- YT-20123: make proto config && check it on const values Bundle Controller API
- Fix WriteTableToStream in pgrun
- Attempt to fix CloseSessionsWithLoad test. KIKIMR-20405
- KIKIMR-19512 Add 'Coalesce' kernel.
- UT for dq actors (initial)
- Use clang-tidy via RESOURCE_LIBRARY
- ,allow optional timestamp in insert into monitoring, add tests
- Continue with test on build fail
- Revert "YT-20123: make proto config && check it on const values Bundle Controller API"
- Reorder a bit and remove unneeded var
- Fix names of + and - in json.
- Switch to use object attributes for consumer
- Refactor OutputChannel reads in task_runner_actor
- Correct v1/v2 totals
- Update contrib/libs/backtrace to 2023-11-30
- YT: Introduce schema for TYsonStruct
- Rename py3_flake8 to flake8
- Move fyamlcpp and yaml_config to NKikimr namespace
- [yql] Common zero-sampling optimizer for both yt/dq providers
- federated topic write
- Enable COPY_FILE with text context for UNION and PACKAGE
- Better follback in ranges multiplier
- YT-16482: Fix GROUP BY
- Fix channel garbage collection issue KIKIMR-20525
- Intermediate changes
- Simplify AddOperation
- Add UT for consequent major updates, KIKIMR-20283
- Intermediate changes
- skip empty metrics KIKIMR-20270
- YT-19944: Add key filter metrics
- Intermediate changes
- KIKIMR-19452: Pg insert from selection by column order
- timeout logs have been moved to error
- detect dangling references in MapFindPtr and utility helpers
- Intermediate changes
- detect dangling references to temporary TStringBuilder object
- Remove TCoordinatorInfo::TabletId
- Intermediate changes
- 
- pg varchar as primary key
- YQL-17378 simple obfuscation of SQL query
- Intermediate changes
- Finalizing full result write via writing queue to avoid early finish
- YQL-17276: Fix hybrid for TopSort case
- Do not update index record in case of upsert with value equal to already present one
- Fix double hard gc KIKIMR-20525
- Remove more old patches
- Intermediate changes
- Use dynamic vendored libs when put in cache
- DataShard EvWrite Immediate
- Fix yson parsing in yql_agent
- KIKIMR-19512 Set combiner limit from mkql heavy limit.
- Intermediate changes
- detect dangling references in TMaybe object
- Update contrib/python/clickhouse-connect to 0.6.22
- Intermediate changes
- for darwin-arm64
- Static libs
- Run checks switches
- Support \pset null in pgrun
- Offload "annotations" attribute handling
- Use aggregate for Sequoia replicas
- Update contrib/restricted/boost/predef to 1.84.0
- Update contrib/restricted/boost/config to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/variant to 1.84.0
- Update contrib/restricted/boost/mp11 to 1.84.0
- Update contrib/restricted/boost/math to 1.84.0
- Update contrib/restricted/boost/conversion to 1.84.0
- infly metrics have been fixed
- Update contrib/restricted/boost/core to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/utility to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/any to 1.84.0
- Update contrib/restricted/boost/winapi to 1.84.0
- Update contrib/restricted/boost/endian to 1.84.0
- Update contrib/python/fonttools to 4.46.0
- Fix crash caused by StdNormalRandom producing a value out of expected range
- Root CMakeLists.txt generation with jinja
- Release opensource ya & test_tool
- Reset tests cache
- Intermediate changes
- Fix SCHEME_ERROR from DS KIKIMR-20297
- Update contrib/restricted/boost/atomic to 1.84.0
- Update contrib/restricted/boost/bind to 1.84.0
- USE_OPENSOURCE_TEST_TOOL=yes
- re-enable clang::reinitialized attribute for non-CUDA target platforms
- Update contrib/restricted/boost/ratio to 1.84.0
- Checks switch fix
- Update contrib/restricted/boost/smart_ptr to 1.84.0
- Update contrib/restricted/boost/function to 1.84.0
- Update contrib/restricted/boost/tuple to 1.84.0
- Update contrib/restricted/boost/array to 1.84.0
- Update contrib/restricted/boost/thread to 1.84.0
- Update contrib/restricted/boost/optional to 1.84.0
- fix tests after
- Add KDevelop (#495)
- do not use adaptive thread pool (#536)
- Add tstool and tsserver into ydb/tools
