### PR TITLE
ci: put build results to cache for PR checks and fix log extraction in the transform-ya-junit script

### DIFF
--- a/.github/scripts/tests/transform-ya-junit.py
+++ b/.github/scripts/tests/transform-ya-junit.py
@@ -101,7 +101,7 @@ class YTestReportTrace:
 def filter_empty_logs(logs):
     result = {}
     for k, v in logs.items():
-        if os.stat(v).st_size == 0:
+        if not os.path.isfile(v) or os.stat(v).st_size == 0:
             continue
         result[k] = v
     return result

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -122,5 +122,5 @@ jobs:
       test_type: "unittest,py3test,py2test,pytest"
       test_threads: 52
       runner_label: auto-provisioned
-      put_build_results_to_cache: false
+      put_build_results_to_cache: true
     secrets: inherit


### PR DESCRIPTION
This pull request enables caching compilation results for PR checks and also fixes a bug in extracting logs in the transform-ya-junit script.