### PR TITLE
Optimize TSpan methods to prevent unneeded object construction KIKIMR-15449

### DIFF
--- a/ydb/core/blobstorage/backpressure/queue.cpp
+++ b/ydb/core/blobstorage/backpressure/queue.cpp
@@ -203,9 +203,9 @@ void TBlobStorageQueue::SendToVDisk(const TActorContext& ctx, const TActorId& re
         ++*QueueItemsSent;
 
         // send item
-        item.Span.Event("SendToVDisk", {{
+        item.Span && item.Span.Event("SendToVDisk", {
             {"VDiskOrderNumber", vdiskOrderNumber}
-        }});
+        });
         item.Event.SendToVDisk(ctx, remoteVDisk, item.QueueCookie, item.MsgId, item.SequenceId, sendMeCostSettings,
             item.Span.GetTraceId(), ClientId, item.ProcessingTimer);
 

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
@@ -193,7 +193,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
                             "Writer: bootstrap: id# %s chunkId# %u offset# %u storedBlobSize# %u "
                             "writtenSize# %u", HugeSlot.ToString().data(), chunkId, offset,
                             storedBlobSize, writtenSize));
-            Span.Event("Send_TEvChunkWrite", NWilson::TKeyValueList{{{"ChunkId", chunkId}, {"Offset", offset}, {"WrittenSize", writtenSize}}});
+            Span && Span.Event("Send_TEvChunkWrite", {{"ChunkId", chunkId}, {"Offset", offset}, {"WrittenSize", writtenSize}});
             auto ev = std::make_unique<NPDisk::TEvChunkWrite>(HugeKeeperCtx->PDiskCtx->Dsk->Owner,
                         HugeKeeperCtx->PDiskCtx->Dsk->OwnerRound, chunkId, offset,
                         partsPtr, Cookie, true, GetWritePriority(), false);

--- a/ydb/core/tablet_flat/flat_executor_txloglogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_txloglogic.cpp
@@ -188,8 +188,9 @@ TLogicRedo::TCommitRWTransactionResult TLogicRedo::CommitRWTransaction(
 
             Batch->Commit->FirstTx->TxSpan.Attribute("BatchSize", batchSize);
 
-            seat->TxSpan.Attribute("Batched", true);
-            seat->TxSpan.Link(Batch->Commit->FirstTx->GetTxTraceId(), {});
+            seat->TxSpan
+                .Attribute("Batched", true)
+                .Link(Batch->Commit->FirstTx->GetTxTraceId());
         }
         
         Batch->Commit->PushTx(seat.Get());


### PR DESCRIPTION
- Removed unneccessy file from docs folder
- Use AggrAdd for Limit.
- Fix any join absence after key columns cast
- Remove unused fields from TKqpSchemeOperation
- Added support for optional for predicate selectivity
- Better use AggrAdd for limits.
- Intermediate changes
- Canonization fix.
- YQL-16196 Add FileOptions pragma and bypass_artifact_cache option for MR job spec
- Add host_os.ya.make.inc files to piglet-sync
- Fix bug KIKIMR-11082
- KIKIMR-20451: Pass TTLSettings on column table create
- ci: add missing ydb/ci sync
- pg-make-test saves stderr
- Prepare to rename py3_flake8 tests to flake8
- Intermediate changes
- add attribute to detect lifetime bound errors
- Handle long-lasting Put queries in DS proxy correctly -- part 2 KIKIMR-9016
- Handle RaiseError calls in OffsetFetchActor
- Не работает ResourceManager.resource_filename вместе с Y_PYTHON_SOURCE_ROOT
- Intermediate changes
- Fix inconsistency in rpc protocol
- , YT-18091: Do not schedule pollable shutdown in finalizer invoker
- Update contrib/python/traitlets/py3 to 5.14.0
- Intermediate changes
- Update contrib/python/ipython/py3 to 8.18.1
- YT-20658: add two fields to Bundle Controller API
- Moved cmake files to generator dir and updated generator.toml
- Update doc content
- [dq] Refactor dq gateway session handling
- Disable data validation in opensource
- unknown data source has been fixed
- Removed wrong copy
- add kms's symmetric_crypto_service for nbs
- KIKIMR-19831: exclude right columns from left only stream join result
- YQL-17080 fix win build + adjust bounds
- YQL-17117: optimize PgCast unknown->text
- Fix verify requirement \!PipeToBalancer failed
- Y_DECLARE_OUT_SPEC for NKikimrDataEvents
- YQL-17346 more columns in pg_type
- Traffic agg task metrics + YQ public metrics
- ci: cache tests results
- Update contrib/python/s3transfer/py3 to 0.8.0
- Intermediate changes
- KIKIMR-19861: fix compaction task volume limit
- YQL-16196 Add docs for FileOption pragma
- Rewrite switching pools for executor thread, KIKIMR-18440
- Create postcommit.yml
- Consider used columns in index chooser
- YQL-17352 YQL-17356 YQL-17347 more pg_catalog tables
- Fix build problem KIKIMR-9016
- fix typo in port number section + add note on ports for multiple dynnodes per server
- Add build support for cortex-m23 platform
- Support override `distutils` from `setuptools`
- YQ Connector: prepare code base for S3 integration
- Test for duplicate data in anyjoin
- Intermediate changes
- Introduce convenient _B literal for bytes
- Support std::filesystem::path in TFile and TFileHandle
- feat setuptools: revert/fix UnionProvider
- ci: don't fail to fast on test run, add POST suffix for push checks
- Update Python 3 to 3.11.7
- Add GO_MOCKGEN_CONTRIB_FROM macro to generate mockgens from contribs
- Support Python 3.12 for `future`
- Intermediate changes
- Support Python 3.12 for `cffi`
- drop unused MaxDPccpDPTableSize
- fix return code UNSUPPORTED to UNAVILABLE
- updated roadmap for 2024
- not found behaviour has been changed for get script execution
- Support Python 3.12 for `tornado-4`
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- YT-20686: Fix TResponseKeeper
- ci: quote log file path
- Pass DiscoveryEndpoint in to DiscoveryMutator
- Intermediate changes
- KIKIMR-20179: remove deprecated reader from tests
- serial execution in simple write session
- ci: testmo-proxy use RequestException instead of ConnectionError
- Handle long-lasting Put queries in DS proxy correctly -- part 3
- add a whitelist for pooltrees pragma
- ci: use ya from repo, fix memory sanitizer run, always try generate summary
- Intermediate changes
- Remove excessive EOL spaces in blobstorage code
- Intermediate changes
- Better relational operators for TStrongTypedef
- [yql] test auto partition
- YQL-16196 Move internal link into internal docs (PRAGMA FileOptions)
- KIKIMR-20482: Remove duplicates on schema versions
- Print time in shutdown logging
- Fix comparison key
- Intermediate changes
- Fix fluky test. We can get CLIENT_CANCELED status at driver shutdown.…
- RowCount/ColCount should be used in move/parse
- KIKIMR-20042 Wilson uploader fix
- ,allow optional timestamp in insert into monitoring
- YT-20425: Optional offset in pull_consumer
- primary keys naming unification
- fix stream-write refresh-token rights
- support default values in create table for pg syntax KIKIMR-20022
- PR from branch users/nsofya/KIKIMR-19564
- Fix build, KIKIMR-18440
- fix codestyle: remove semicolon
- finer check of lifetimebound attribute support
- Use generic node count, not datashards only
- [yql] extend dq_file test parts
- Fix _an attribute list cannot appear here_ from clang-cl16
- Fix modernize-use-emplace reported by clang-tidy16
- FS_TOOLS to python3
- [yql] extend yt_native_file test parts
- Update contrib/restricted/nlohmann_json to 3.11.3
- Intermediate changes
- Stricter platform check for prebuilt protoc-gen-go
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- Update COPY_FILE macro
- Replace rep.erase with rep.erase_one in THashSet::erase
- fix typo in public method name
- Move ApplyJitter impl to inl file
- Add fake PDisk key to kikimr_cfg, KIKIMR-20141
- Allow using std::filesystem::path when constructing TFileInput / TFileOutput
- Switch windows builds to clang16
- Remote development
- KIKIMR-19521 BTreeIndex Loader & Dump
- KIKIMR-19521 BTreeIndex Charge Interface
- Intermediate changes
- KIKIMR-20432, KIKIMR-20431: support pg and not null types for stream lookup join
- KIKIMR-19512 Push down binary arithmetic operations and use YQL kernels.
- Split postcommits in two workflows
- TEvWriteResult Origin
- YQL-17353 YQL-17355 YQL-17357 YQL-17358 YQL-17360 YQL-17361 YQL-17362 more tables (mostly empty)
- PR from branch users/zverevgeny/YQL-17279_mr_permute
- KIKIMR-20538: background processes disabling
- KIKIMR-20009:dont remove blobs in case failed main data writing
- External build system generator release 69
- KIKIMR-19900 switch arcadia to python ydb sdk from contrib
- SpillingEngine pragma propagation to resource allocator.
- Intermediate changes
- KIKIMR-20484: switch required fields to optional in generic config
- KIKIMR-18888 query classic schema when not found
- YT-20123: make proto config && check it on const values Bundle Controller API
- Fix WriteTableToStream in pgrun
- Attempt to fix CloseSessionsWithLoad test. KIKIMR-20405
- KIKIMR-19512 Add 'Coalesce' kernel.
- UT for dq actors (initial)
- Use clang-tidy via RESOURCE_LIBRARY
- ,allow optional timestamp in insert into monitoring, add tests
- Continue with test on build fail
- Revert "YT-20123: make proto config && check it on const values Bundle Controller API"
- Reorder a bit and remove unneeded var
- Fix names of + and - in json.
- Switch to use object attributes for consumer
- Refactor OutputChannel reads in task_runner_actor
- Correct v1/v2 totals
- Update contrib/libs/backtrace to 2023-11-30
- YT: Introduce schema for TYsonStruct
- Rename py3_flake8 to flake8
- Move fyamlcpp and yaml_config to NKikimr namespace
- [yql] Common zero-sampling optimizer for both yt/dq providers
- federated topic write
- Enable COPY_FILE with text context for UNION and PACKAGE
- Better follback in ranges multiplier
- YT-16482: Fix GROUP BY
- Fix channel garbage collection issue KIKIMR-20525
- Intermediate changes
- Simplify AddOperation
- Add UT for consequent major updates, KIKIMR-20283
- Intermediate changes
- skip empty metrics KIKIMR-20270
- YT-19944: Add key filter metrics
- Intermediate changes
- KIKIMR-19452: Pg insert from selection by column order
- timeout logs have been moved to error
- detect dangling references in MapFindPtr and utility helpers
- Intermediate changes
- detect dangling references to temporary TStringBuilder object
- Remove TCoordinatorInfo::TabletId
- Intermediate changes
- 
- pg varchar as primary key
- YQL-17378 simple obfuscation of SQL query
- Intermediate changes
- Finalizing full result write via writing queue to avoid early finish
- YQL-17276: Fix hybrid for TopSort case
- Do not update index record in case of upsert with value equal to already present one
- Fix double hard gc KIKIMR-20525
- Remove more old patches
- Intermediate changes
- Use dynamic vendored libs when put in cache
- DataShard EvWrite Immediate
- Fix yson parsing in yql_agent
- KIKIMR-19512 Set combiner limit from mkql heavy limit.
- Intermediate changes
- detect dangling references in TMaybe object
- Update contrib/python/clickhouse-connect to 0.6.22
- Intermediate changes
- for darwin-arm64
- Static libs
- Run checks switches
- Support \pset null in pgrun
- Offload "annotations" attribute handling
- Use aggregate for Sequoia replicas
- Update contrib/restricted/boost/predef to 1.84.0
- Update contrib/restricted/boost/config to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/variant to 1.84.0
- Update contrib/restricted/boost/mp11 to 1.84.0
- Update contrib/restricted/boost/math to 1.84.0
- Update contrib/restricted/boost/conversion to 1.84.0
- infly metrics have been fixed
- Update contrib/restricted/boost/core to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/utility to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/any to 1.84.0
- Update contrib/restricted/boost/winapi to 1.84.0
- Update contrib/restricted/boost/endian to 1.84.0
- Update contrib/python/fonttools to 4.46.0
- Fix crash caused by StdNormalRandom producing a value out of expected range
- Root CMakeLists.txt generation with jinja
- Release opensource ya & test_tool
- Reset tests cache
- Intermediate changes
- Fix SCHEME_ERROR from DS KIKIMR-20297
- Update contrib/restricted/boost/atomic to 1.84.0
- Update contrib/restricted/boost/bind to 1.84.0
- USE_OPENSOURCE_TEST_TOOL=yes
- re-enable clang::reinitialized attribute for non-CUDA target platforms
- Update contrib/restricted/boost/ratio to 1.84.0
- Checks switch fix
- Update contrib/restricted/boost/smart_ptr to 1.84.0
- Update contrib/restricted/boost/function to 1.84.0
- Update contrib/restricted/boost/tuple to 1.84.0
- Update contrib/restricted/boost/array to 1.84.0
- Update contrib/restricted/boost/thread to 1.84.0
- Update contrib/restricted/boost/optional to 1.84.0
- fix tests after
- Add KDevelop (#495)
- do not use adaptive thread pool (#536)
- add uniq node id validation to ydb cfg (#538)
- ci: add defalut for put_build_results_to_cache (#546)
- Enhance error message (#539)
- support api proto files in go (#543)
- Test error delivery in result receiver (#548)
- Refactor DQ Channel Storage to accept external actor system (#547)
- Do not include data_events/events.h in do datashard.h. Ydb import fix. (#552)
- YQL-17145: fix autoparametrization of null values and refactor settings (#555)
- YQL-17393: Fix dq tests (#551)
- KIKIMR-20042 Wilson enchancements (#540)
- Add tstool and tsserver into ydb/tools (#545)
- KIKIMR-20079: create/alter/drop group (#501)
- ci: put build results to cache for PR checks and fix log extraction in the transform-ya-junit script (#561)
- Remove unused include (#559)
- KIKIMR-20042 KeyValue tablet toplevel tracing (#526)
- GetSubmatrix (#556)
- Refactored CBO interface for DQ (#558)
- Fix plans and cannonize tests with aggr functions. (#550)
- Fix missed subscription for non local request cancelation. (#527)
- Optimize TString creation in TSpan ctor (#568)
- Optimize TSpan methods to prevent unneeded object construction KIKIMR-15449
