### PR TITLE
YQL-15717  Flush queue and send Final message immidiately on full result writer error

### DIFF
--- a/ydb/library/yql/providers/dq/actors/result_actor_base.h
+++ b/ydb/library/yql/providers/dq/actors/result_actor_base.h
@@ -212,6 +212,8 @@ namespace NYql::NDqs::NExecutionHelpers {
             if (ev->Get()->Record.IssuesSize() == 0) {  // weird way used by writer to acknowledge it's death
                 DoFinish();
             } else {
+                WaitingAckFromFRW = false;
+                WriteQueue.clear();
                 Y_ABORT_UNLESS(ev->Get()->Record.GetStatusCode() != NYql::NDqProto::StatusIds::SUCCESS);
                 TBase::Send(ExecuterID, ev->Release().Release());
             }


### PR DESCRIPTION
We cannot wait for WaitingAckFromFRW in that case because FullResultWriter is in fail state.