### PR TITLE
CREATE / DROP VIEW queries support

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/view/behaviour.cpp
+++ b/ydb/core/kqp/gateway/behaviour/view/behaviour.cpp
@@ -1,0 +1,24 @@
+#include "behaviour.h"
+#include "manager.h"
+
+namespace NKikimr::NKqp {
+
+TViewBehaviour::TFactory::TRegistrator<TViewBehaviour> TViewBehaviour::Registrator(TViewConfig::GetTypeId());
+
+NMetadata::NInitializer::IInitializationBehaviour::TPtr TViewBehaviour::ConstructInitializer() const {
+    return nullptr;
+}
+
+NMetadata::NModifications::IOperationsManager::TPtr TViewBehaviour::ConstructOperationsManager() const {
+    return std::make_shared<TViewManager>();
+}
+
+TString TViewBehaviour::GetInternalStorageTablePath() const {
+    return TViewConfig::GetTypeId();
+}
+
+TString TViewBehaviour::GetTypeId() const {
+    return TViewConfig::GetTypeId();
+}
+
+}

--- a/ydb/core/kqp/gateway/behaviour/view/behaviour.h
+++ b/ydb/core/kqp/gateway/behaviour/view/behaviour.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <ydb/services/metadata/abstract/kqp_common.h>
+#include <ydb/services/metadata/abstract/initialization.h>
+
+namespace NKikimr::NKqp {
+
+struct TViewConfig {
+    static TString GetTypeId() {
+        return "VIEW";
+    }
+};
+
+class TViewBehaviour: public NMetadata::TClassBehaviour<TViewConfig> {
+private:
+    static TFactory::TRegistrator<TViewBehaviour> Registrator;
+
+protected:
+    std::shared_ptr<NMetadata::NInitializer::IInitializationBehaviour> ConstructInitializer() const override;
+    std::shared_ptr<NMetadata::NModifications::IOperationsManager> ConstructOperationsManager() const override;
+
+    TString GetInternalStorageTablePath() const override;
+    TString GetTypeId() const override;
+};
+
+}

--- a/ydb/core/kqp/gateway/behaviour/view/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/view/manager.cpp
@@ -1,0 +1,207 @@
+#include "manager.h"
+
+#include <ydb/core/base/path.h>
+#include <ydb/core/kqp/gateway/actors/scheme.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+using TYqlConclusionStatus = TViewManager::TYqlConclusionStatus;
+using TInternalModificationContext = TViewManager::TInternalModificationContext;
+
+TString GetByKeyOrDefault(const NYql::TCreateObjectSettings& container, const TString& key) {
+    const auto value = container.GetFeaturesExtractor().Extract(key);
+    return value ? *value : TString{};
+}
+
+void CheckFeatureFlag(TInternalModificationContext& context) {
+    auto* const actorSystem = context.GetExternalData().GetActorSystem();
+    if (!actorSystem) {
+        ythrow TSystemError() << "This place needs an actor system. Please contact internal support";
+    }
+    if (!AppData(actorSystem)->FeatureFlags.GetEnableViews()) {
+        ythrow TSystemError() << "Views are disabled. Please contact your system administrator to enable it";
+    }
+}
+
+void FillCreateViewProposal(NKikimrSchemeOp::TModifyScheme& modifyScheme,
+                           const NYql::TCreateObjectSettings& settings,
+                           TInternalModificationContext& context) {
+
+    std::pair<TString, TString> pathPair;
+    {
+        TString error;
+        if (!TrySplitPathByDb(settings.GetObjectId(), context.GetExternalData().GetDatabase(), pathPair, error)) {
+            ythrow TBadArgumentException() << error;
+        }
+    }
+    modifyScheme.SetWorkingDir(pathPair.first);
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateView);
+
+    auto& viewDesc = *modifyScheme.MutableCreateView();
+    viewDesc.SetName(pathPair.second);
+    viewDesc.SetQueryText(GetByKeyOrDefault(settings, "query_text"));
+
+    if (!settings.GetFeaturesExtractor().IsFinished()) {
+        ythrow TBadArgumentException() << "Unknown property: " << settings.GetFeaturesExtractor().GetRemainedParamsString();
+    }
+}
+
+void FillDropViewProposal(NKikimrSchemeOp::TModifyScheme& modifyScheme,
+                         const NYql::TDropObjectSettings& settings,
+                         TInternalModificationContext& context) {
+
+    std::pair<TString, TString> pathPair;
+    {
+        TString error;
+        if (!TrySplitPathByDb(settings.GetObjectId(), context.GetExternalData().GetDatabase(), pathPair, error)) {
+            ythrow TBadArgumentException() << error;
+        }
+    }
+    modifyScheme.SetWorkingDir(pathPair.first);
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpDropView);
+
+    auto& drop = *modifyScheme.MutableDrop();
+    drop.SetName(pathPair.second);
+}
+
+NThreading::TFuture<TYqlConclusionStatus> SendSchemeRequest(TEvTxUserProxy::TEvProposeTransaction* request,
+                                                            TActorSystem* actorSystem,
+                                                            bool failOnAlreadyExists) {
+    const auto promiseScheme = NThreading::NewPromise<NKqp::TSchemeOpRequestHandler::TResult>();
+    IActor* const requestHandler = new TSchemeOpRequestHandler(request, promiseScheme, failOnAlreadyExists);
+    actorSystem->Register(requestHandler);
+    return promiseScheme.GetFuture().Apply([](const NThreading::TFuture<NKqp::TSchemeOpRequestHandler::TResult>& opResult) {
+        if (opResult.HasValue()) {
+            if (!opResult.HasException() && opResult.GetValue().Success()) {
+                return TYqlConclusionStatus::Success();
+            }
+            return TYqlConclusionStatus::Fail(opResult.GetValue().Status(), opResult.GetValue().Issues().ToString());
+        }
+        return TYqlConclusionStatus::Fail("no value in result");
+    });
+}
+
+NThreading::TFuture<TYqlConclusionStatus> CreateView(const NYql::TCreateObjectSettings& settings,
+                                                     TInternalModificationContext& context) {
+    auto proposal = MakeHolder<TEvTxUserProxy::TEvProposeTransaction>();
+    proposal->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
+    if (context.GetExternalData().GetUserToken()) {
+        proposal->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
+    }
+    auto& schemeTx = *proposal->Record.MutableTransaction()->MutableModifyScheme();
+    FillCreateViewProposal(schemeTx, settings, context);
+
+    return SendSchemeRequest(proposal.Release(), context.GetExternalData().GetActorSystem(), true);
+}
+
+NThreading::TFuture<TYqlConclusionStatus> DropView(const NYql::TDropObjectSettings& settings,
+                                                   TInternalModificationContext& context) {
+    auto proposal = MakeHolder<TEvTxUserProxy::TEvProposeTransaction>();
+    proposal->Record.SetDatabaseName(context.GetExternalData().GetDatabase());
+    if (context.GetExternalData().GetUserToken()) {
+        proposal->Record.SetUserToken(context.GetExternalData().GetUserToken()->GetSerializedToken());
+    }
+    auto& schemeTx = *proposal->Record.MutableTransaction()->MutableModifyScheme();
+    FillDropViewProposal(schemeTx, settings, context);
+
+    return SendSchemeRequest(proposal.Release(), context.GetExternalData().GetActorSystem(), false);
+}
+
+void PrepareCreateView(NKqpProto::TKqpSchemeOperation& schemeOperation,
+                       const NYql::TObjectSettingsImpl& settings,
+                       TInternalModificationContext& context) {
+    FillCreateViewProposal(*schemeOperation.MutableCreateView(), settings, context);
+}
+
+void PrepareDropView(NKqpProto::TKqpSchemeOperation& schemeOperation,
+                     const NYql::TObjectSettingsImpl& settings,
+                     TInternalModificationContext& context) {
+    FillDropViewProposal(*schemeOperation.MutableDropView(), settings, context);
+}
+
+}
+
+NThreading::TFuture<TYqlConclusionStatus> TViewManager::DoModify(const NYql::TObjectSettingsImpl& settings,
+                                                                 const ui32 nodeId,
+                                                                 const NMetadata::IClassBehaviour::TPtr& manager,
+                                                                 TInternalModificationContext& context) const {
+    Y_UNUSED(nodeId, manager);
+
+    try {
+        CheckFeatureFlag(context);
+        switch (context.GetActivityType()) {
+            case EActivityType::Alter:
+            case EActivityType::Upsert:
+            case EActivityType::Undefined:
+                ythrow TBadArgumentException() << "not implemented";
+            case EActivityType::Create:
+                return CreateView(settings, context);
+            case EActivityType::Drop:
+                return DropView(settings, context);
+        }
+    } catch (...) {
+        return NThreading::MakeFuture<TYqlConclusionStatus>(TYqlConclusionStatus::Fail(CurrentExceptionMessage()));
+    }
+}
+
+TViewManager::TYqlConclusionStatus TViewManager::DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation,
+                                                           const NYql::TObjectSettingsImpl& settings,
+                                                           const NMetadata::IClassBehaviour::TPtr& manager,
+                                                           TInternalModificationContext& context) const {
+    Y_UNUSED(manager);
+    
+    try {
+        CheckFeatureFlag(context);
+        switch (context.GetActivityType()) {
+            case EActivityType::Undefined:
+                ythrow TBadArgumentException() << "Undefined operation for a VIEW object";
+            case EActivityType::Upsert:
+                ythrow TBadArgumentException() << "Upsert operation for VIEW objects is not implemented";
+            case EActivityType::Alter:
+                ythrow TBadArgumentException() << "Alter operation for VIEW objects is not implemented";
+            case EActivityType::Create:
+                PrepareCreateView(schemeOperation, settings, context);
+                break;
+            case EActivityType::Drop:
+                PrepareDropView(schemeOperation, settings, context);
+                break;
+        }
+    } catch (...) {
+        return TYqlConclusionStatus::Fail(CurrentExceptionMessage());
+    }
+    return TYqlConclusionStatus::Success();
+}
+
+NThreading::TFuture<TYqlConclusionStatus> TViewManager::ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+                                                                        const NMetadata::IClassBehaviour::TPtr& manager,
+                                                                        const TExternalModificationContext& context) const {
+    Y_UNUSED(manager);
+
+    auto proposal = MakeHolder<TEvTxUserProxy::TEvProposeTransaction>();
+    proposal->Record.SetDatabaseName(context.GetDatabase());
+    if (context.GetUserToken()) {
+        proposal->Record.SetUserToken(context.GetUserToken()->GetSerializedToken());
+    }
+
+    auto& schemeTx = *proposal->Record.MutableTransaction()->MutableModifyScheme();
+    switch (schemeOperation.GetOperationCase()) {
+        case NKqpProto::TKqpSchemeOperation::kCreateView:
+            schemeTx.CopyFrom(schemeOperation.GetCreateView());
+            return SendSchemeRequest(proposal.Release(), context.GetActorSystem(), true);
+        case NKqpProto::TKqpSchemeOperation::kDropView:
+            schemeTx.CopyFrom(schemeOperation.GetDropView());
+            return SendSchemeRequest(proposal.Release(), context.GetActorSystem(), false);
+        default:
+            return NThreading::MakeFuture(TYqlConclusionStatus::Fail(
+                    TStringBuilder()
+                        << "Execution of prepare operation for a VIEW object, unsupported operation: "
+                        << int(schemeOperation.GetOperationCase())
+                )
+            );
+    }
+}
+
+}

--- a/ydb/core/kqp/gateway/behaviour/view/manager.h
+++ b/ydb/core/kqp/gateway/behaviour/view/manager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <ydb/services/metadata/manager/generic_manager.h>
+
+namespace NKikimr::NKqp {
+
+class TViewManager: public NMetadata::NModifications::IOperationsManager {
+
+    NThreading::TFuture<TYqlConclusionStatus> DoModify(const NYql::TObjectSettingsImpl& settings,
+                                                       const ui32 nodeId,
+                                                       const NMetadata::IClassBehaviour::TPtr& manager,
+                                                       TInternalModificationContext& context) const override;
+
+    TYqlConclusionStatus DoPrepare(NKqpProto::TKqpSchemeOperation& schemeOperation,
+                                   const NYql::TObjectSettingsImpl& settings,
+                                   const NMetadata::IClassBehaviour::TPtr& manager,
+                                   TInternalModificationContext& context) const override;
+
+    NThreading::TFuture<TYqlConclusionStatus> ExecutePrepared(const NKqpProto::TKqpSchemeOperation& schemeOperation,
+                                                              const NMetadata::IClassBehaviour::TPtr& manager,
+                                                              const TExternalModificationContext& context) const override;
+
+public:
+    using NMetadata::NModifications::IOperationsManager::TYqlConclusionStatus;
+};
+
+}

--- a/ydb/core/kqp/gateway/behaviour/view/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/view/ya.make
@@ -1,0 +1,20 @@
+LIBRARY()
+
+OWNER(g:kikimr)
+
+SRCS(
+    manager.cpp
+    GLOBAL behaviour.cpp
+)
+
+PEERDIR(
+    ydb/core/base
+    ydb/core/kqp/gateway/actors
+    ydb/core/tx/tx_proxy
+    ydb/services/metadata/abstract
+    ydb/services/metadata/manager
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/gateway/ya.make
+++ b/ydb/core/kqp/gateway/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
     ydb/core/kqp/gateway/behaviour/tablestore
     ydb/core/kqp/gateway/behaviour/table
     ydb/core/kqp/gateway/behaviour/external_data_source
+    ydb/core/kqp/gateway/behaviour/view
     ydb/core/kqp/gateway/utils
     ydb/library/yql/providers/result/expr_nodes
 )

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -128,9 +128,9 @@ private:
     }
 
     TStatus HandleCreateObject(TKiCreateObject node, TExprContext& ctx) override {
-        ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), TStringBuilder()
-            << "CreateObject is not yet implemented for intent determination transformer"));
-        return TStatus::Error;
+        Y_UNUSED(node);
+        Y_UNUSED(ctx);
+        return TStatus::Ok;
     }
 
     TStatus HandleAlterObject(TKiAlterObject node, TExprContext& ctx) override {

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -1,0 +1,171 @@
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+#include <format>
+
+using namespace NKikimr;
+using namespace NKikimr::NKqp;
+using namespace NYdb::NTable;
+
+namespace {
+
+void SetEnableViewsFeatureFlag(TKikimrRunner& kikimr) {
+    kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableViews(true);
+}
+
+NKikimrSchemeOp::TViewDescription GetViewDescription(TTestActorRuntime& runtime, const TString& path) {
+    const auto pathQueryResult = Navigate(runtime,
+                                          runtime.AllocateEdgeActor(),
+                                          path,
+                                          NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+    const auto& pathEntry = pathQueryResult->ResultSet.at(0);
+    UNIT_ASSERT_EQUAL(pathEntry.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindView);
+    UNIT_ASSERT(pathEntry.ViewInfo);
+    return pathEntry.ViewInfo->Description;
+}
+
+void ExpectUnknownEntry(TTestActorRuntime& runtime, const TString& path) {
+    const auto pathQueryResult = Navigate(runtime,
+                                          runtime.AllocateEdgeActor(),
+                                          path,
+                                          NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+    UNIT_ASSERT_EQUAL(pathQueryResult->ErrorCount, 1);
+    const auto& pathEntry = pathQueryResult->ResultSet.at(0);
+    UNIT_ASSERT_EQUAL(pathEntry.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown);
+}
+
+void ExecuteDataDefinitionQuery(TSession& session, const TString& script) {
+    const auto result = session.ExecuteSchemeQuery(script, {}).ExtractValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+}
+
+}
+
+Y_UNIT_TEST_SUITE(TKQPViewTest) {
+
+    Y_UNIT_TEST(CheckCreatedView) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        SetEnableViewsFeatureFlag(kikimr);
+        auto& runtime = *kikimr.GetTestServer().GetRuntime();
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        constexpr const char* path = "/Root/TheView";
+        constexpr const char* queryInView = "SELECT 1";
+
+        const TString creationQuery = std::format(R"(
+                CREATE VIEW `{}` WITH (security_invoker = true) AS {};
+            )",
+            path,
+            queryInView
+        );
+        ExecuteDataDefinitionQuery(session, creationQuery);
+
+        const auto viewDescription = GetViewDescription(runtime, path);
+        UNIT_ASSERT_EQUAL(viewDescription.GetQueryText(), queryInView);
+    }
+
+    Y_UNIT_TEST(ListCreatedView) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        SetEnableViewsFeatureFlag(kikimr);
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        // .sys directory is always present in the `/Root`, that's why we need a subfolder
+        constexpr const char* folder = "/Root/ThisSubfolderIsNecessary";
+        constexpr const char* viewName = "TheView";
+        const auto path = TStringBuilder() << folder << '/' << viewName;
+        constexpr const char* queryInView = "SELECT 1";
+
+        const TString creationQuery = std::format(R"(
+                CREATE VIEW `{}` WITH (security_invoker = true) AS {};
+            )",
+            path.c_str(),
+            queryInView
+        );
+        ExecuteDataDefinitionQuery(session, creationQuery);
+
+        auto schemeClient = kikimr.GetSchemeClient();
+        const auto lsResults = schemeClient.ListDirectory(folder).GetValueSync();
+        UNIT_ASSERT_C(lsResults.IsSuccess(), lsResults.GetIssues().ToString());
+
+        UNIT_ASSERT_VALUES_EQUAL(lsResults.GetChildren().size(), 1);
+        const auto& viewEntry = lsResults.GetChildren()[0];
+        UNIT_ASSERT_VALUES_EQUAL(viewEntry.Name, viewName);
+        UNIT_ASSERT_VALUES_EQUAL(viewEntry.Type, NYdb::NScheme::ESchemeEntryType::View);
+    }
+
+    Y_UNIT_TEST(CreateSameViewTwice) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        SetEnableViewsFeatureFlag(kikimr);
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        constexpr const char* path = "/Root/TheView";
+        constexpr const char* queryInView = "SELECT 1";
+
+        const TString creationQuery = std::format(R"(
+                CREATE VIEW `{}` WITH (security_invoker = true) AS {};
+            )",
+            path,
+            queryInView
+        );
+        ExecuteDataDefinitionQuery(session, creationQuery);
+        {
+            const auto creationResult = session.ExecuteSchemeQuery(creationQuery).GetValueSync();
+            UNIT_ASSERT(!creationResult.IsSuccess());
+            UNIT_ASSERT(creationResult.GetIssues().ToString().Contains("error: path exist, request accepts it"));
+        }
+    }
+
+    Y_UNIT_TEST(DropView) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        SetEnableViewsFeatureFlag(kikimr);
+        auto& runtime = *kikimr.GetTestServer().GetRuntime();
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        constexpr const char* path = "/Root/TheView";
+        constexpr const char* queryInView = "SELECT 1";
+
+        const TString creationQuery = std::format(R"(
+                CREATE VIEW `{}` WITH (security_invoker = true) AS {};
+            )",
+            path,
+            queryInView
+        );
+        ExecuteDataDefinitionQuery(session, creationQuery);
+
+        const TString dropQuery = std::format(R"(
+                DROP VIEW `{}`;
+            )",
+            path
+        );
+        ExecuteDataDefinitionQuery(session, dropQuery);
+        ExpectUnknownEntry(runtime, path);
+    }
+
+    Y_UNIT_TEST(DropSameViewTwice) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        SetEnableViewsFeatureFlag(kikimr);
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        constexpr const char* path = "/Root/TheView";
+        constexpr const char* queryInView = "SELECT 1";
+
+        const TString creationQuery = std::format(R"(
+                CREATE VIEW `{}` WITH (security_invoker = true) AS {};
+            )",
+            path,
+            queryInView
+        );
+        ExecuteDataDefinitionQuery(session, creationQuery);
+
+        const TString dropQuery = std::format(R"(
+                DROP VIEW `{}`;
+            )",
+            path
+        );
+        ExecuteDataDefinitionQuery(session, dropQuery);
+        {
+            const auto dropResult = session.ExecuteSchemeQuery(dropQuery).GetValueSync();
+            UNIT_ASSERT(!dropResult.IsSuccess());
+            UNIT_ASSERT(dropResult.GetIssues().ToString().Contains("Error: Path does not exist"));
+        }
+    }
+}

--- a/ydb/core/kqp/ut/view/ya.make
+++ b/ydb/core/kqp/ut/view/ya.make
@@ -1,0 +1,18 @@
+UNITTEST_FOR(ydb/core/kqp)
+
+OWNER(g:kikimr)
+
+SIZE(MEDIUM)
+
+SRCS(
+    view_ut.cpp
+)
+
+PEERDIR(
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/basics/default
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/ut/view/ya.make
+++ b/ydb/core/kqp/ut/view/ya.make
@@ -10,6 +10,8 @@ SRCS(
 
 PEERDIR(
     ydb/core/kqp/ut/common
+    ydb/library/yql/sql
+
     ydb/core/testlib/basics/default
 )
 

--- a/ydb/core/kqp/ut/ya.make
+++ b/ydb/core/kqp/ut/ya.make
@@ -18,5 +18,6 @@ RECURSE_FOR_TESTS(
     spilling
     sysview
     tx
+    view
     yql
 )

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -124,4 +124,5 @@ message TFeatureFlags {
     optional bool EnableLocalDBBtreeIndex = 109 [default = false];
     optional bool EnablePDiskHighHDDInFlight = 110 [default = false];
     optional bool UseVDisksBalancing = 111 [default = false];
+    optional bool EnableViews = 112 [default = false];
 }

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -406,6 +406,9 @@ message TKqpSchemeOperation {
         NKikimrSchemeOp.TModifyScheme AlterExternalTable = 17;
         NKikimrSchemeOp.TModifyScheme DropExternalTable = 18;
         NKikimrSchemeOp.TModifyScheme ModifyPermissions = 19;
+        NKikimrSchemeOp.TModifyScheme CreateView = 20;
+        NKikimrSchemeOp.TModifyScheme AlterView = 21;
+        NKikimrSchemeOp.TModifyScheme DropView = 22;
     }
 }
 

--- a/ydb/core/tx/replication/controller/util.h
+++ b/ydb/core/tx/replication/controller/util.h
@@ -31,6 +31,7 @@ inline TMaybe<TReplication::ETargetKind> TryTargetKindFromEntryType(NYdb::NSchem
     case NYdb::NScheme::ESchemeEntryType::Topic:
     case NYdb::NScheme::ESchemeEntryType::ExternalTable:
     case NYdb::NScheme::ESchemeEntryType::ExternalDataSource:
+    case NYdb::NScheme::ESchemeEntryType::View:
         return Nothing();
     }
 }

--- a/ydb/library/yql/sql/v1/SQLv1.g.in
+++ b/ydb/library/yql/sql/v1/SQLv1.g.in
@@ -58,6 +58,8 @@ sql_stmt_core:
   | revoke_permissions_stmt
   | alter_table_store_stmt
   | upsert_object_stmt
+  | create_view_stmt
+  | drop_view_stmt
 ;
 
 expr:
@@ -572,6 +574,13 @@ create_external_data_source_stmt: CREATE EXTERNAL DATA SOURCE object_ref
 
 drop_external_data_source_stmt: DROP EXTERNAL DATA SOURCE object_ref;
 
+create_view_stmt: CREATE VIEW object_ref
+    with_table_settings
+    AS select_stmt
+;
+
+drop_view_stmt: DROP VIEW object_ref;
+
 upsert_object_stmt: UPSERT OBJECT object_ref
     LPAREN TYPE object_type_ref RPAREN
     create_object_features?
@@ -703,6 +712,7 @@ table_setting_value:
     | integer
     | split_boundaries
     | expr ON an_id (AS (SECONDS | MILLISECONDS | MICROSECONDS | NANOSECONDS))?
+    | bool_value
 ;
 
 family_entry: FAMILY an_id family_settings;

--- a/ydb/library/yql/sql/v1/format/sql_format.cpp
+++ b/ydb/library/yql/sql/v1/format/sql_format.cpp
@@ -1390,6 +1390,18 @@ private:
         VisitAllFields(TRule_drop_external_data_source_stmt::GetDescriptor(), msg);
     }
 
+    void VisitCreateView(const TRule_create_view_stmt& msg) {
+        PosFromToken(msg.GetToken1());
+        NewLine();
+        VisitAllFields(TRule_create_view_stmt::GetDescriptor(), msg);
+    }
+
+    void VisitDropView(const TRule_drop_view_stmt& msg) {
+        PosFromToken(msg.GetToken1());
+        NewLine();
+        VisitAllFields(TRule_drop_view_stmt::GetDescriptor(), msg);
+    }
+
     void VisitCreateAsyncReplication(const TRule_create_replication_stmt& msg) {
         PosFromToken(msg.GetToken1());
         NewLine();
@@ -2581,7 +2593,9 @@ TStaticData::TStaticData()
         {TRule_drop_topic_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitDropTopic)},
         {TRule_grant_permissions_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitGrantPermissions)},
         {TRule_revoke_permissions_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitRevokePermissions)},
-        {TRule_alter_table_store_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitAlterTableStore)}
+        {TRule_alter_table_store_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitAlterTableStore)},
+        {TRule_create_view_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitCreateView)},
+        {TRule_drop_view_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitDropView)}
         })
     , ObfuscatingVisitDispatch({
         {TToken::GetDescriptor(), MakeObfuscatingFunctor(&TObfuscatingVisitor::VisitToken)},

--- a/ydb/library/yql/sql/v1/format/sql_format_ut.cpp
+++ b/ydb/library/yql/sql/v1/format/sql_format_ut.cpp
@@ -1500,4 +1500,24 @@ FROM Input MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS A);
         TSetup setup;
         setup.Run(cases, NSQLFormat::EFormatMode::Obfuscate);
     }    
+
+    Y_UNIT_TEST(CreateView) {
+        TCases cases = {
+            {"creAte vIEw TheView wiTh (security_invoker = trUE) As SELect 1",
+             "CREATE VIEW TheView WITH (security_invoker = TRUE) AS\nSELECT\n\t1;\n"},
+        };
+
+        TSetup setup;
+        setup.Run(cases);
+    }
+
+    Y_UNIT_TEST(DropView) {
+        TCases cases = {
+            {"dRop viEW theVIEW",
+             "DROP VIEW theVIEW;\n"},
+        };
+
+        TSetup setup;
+        setup.Run(cases);
+    }
 }

--- a/ydb/library/yql/sql/v1/sql_translation.h
+++ b/ydb/library/yql/sql/v1/sql_translation.h
@@ -224,6 +224,8 @@ protected:
     bool ObjectFeatureValueClause(const TRule_object_feature_value& node, TDeferredAtom& result);
     bool ParseObjectFeatures(std::map<TString, TDeferredAtom>& result, const TRule_object_features& features);
     bool ParseExternalDataSourceSettings(std::map<TString, TDeferredAtom> & result, const TRule_with_table_settings & settings);
+    bool ParseViewOptions(std::map<TString, TDeferredAtom>& features, const TRule_with_table_settings& options);
+    bool ParseViewQuery(std::map<TString, TDeferredAtom>& features, const TRule_select_stmt& query);
     bool RoleNameClause(const TRule_role_name& node, TDeferredAtom& result, bool allowSystemRoles);
     bool RoleParameters(const TRule_create_user_option& node, TRoleParameters& result);
     bool PermissionNameClause(const TRule_permission_name_target& node, TVector<TDeferredAtom>& result, bool withGrantOption);

--- a/ydb/public/api/protos/ydb_scheme.proto
+++ b/ydb/public/api/protos/ydb_scheme.proto
@@ -63,6 +63,7 @@ message Entry {
         TOPIC = 17;
         EXTERNAL_TABLE = 18;
         EXTERNAL_DATA_SOURCE = 19;
+        VIEW = 20;
     }
 
     // Name of scheme entry (dir2 of /dir1/dir2)

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -102,6 +102,8 @@ TString EntryTypeToString(NScheme::ESchemeEntryType entry) {
         return "external-data-source";
     case NScheme::ESchemeEntryType::ExternalTable:
         return "external-table";
+    case NScheme::ESchemeEntryType::View:
+        return "view";
     case NScheme::ESchemeEntryType::Unknown:
     case NScheme::ESchemeEntryType::Sequence:
     case NScheme::ESchemeEntryType::Replication:

--- a/ydb/public/sdk/cpp/client/ydb_scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_scheme/scheme.cpp
@@ -91,6 +91,8 @@ static ESchemeEntryType ConvertProtoEntryType(::Ydb::Scheme::Entry::Type entry) 
         return ESchemeEntryType::ExternalTable;
     case ::Ydb::Scheme::Entry::EXTERNAL_DATA_SOURCE:
         return ESchemeEntryType::ExternalDataSource;
+    case ::Ydb::Scheme::Entry::VIEW:
+        return ESchemeEntryType::View;
     default:
         return ESchemeEntryType::Unknown;
     }

--- a/ydb/public/sdk/cpp/client/ydb_scheme/scheme.h
+++ b/ydb/public/sdk/cpp/client/ydb_scheme/scheme.h
@@ -41,7 +41,8 @@ enum class ESchemeEntryType : i32 {
     Replication = 16,
     Topic = 17,
     ExternalTable = 18,
-    ExternalDataSource = 19
+    ExternalDataSource = 19,
+    View = 20
 };
 
 struct TVirtualTimestamp {


### PR DESCRIPTION
KIKIMR-19567

CREATE / DROP VIEW queries support

SELECTing from VIEWs is not supported yet!

- Make changes to YQL grammar to add CREATE / DROP VIEW statements.
- Save the query text specified in the CREATE VIEW statement in the VIEW object.
- Save the query AST in the view object too. It is only useful for early validation of the query stored in the view, but can be used later to list the names of the tables (and columns) the view depends on.
- Implement VIEW as a wrapped generic object: CREATE / DROP VIEW commands call Create/DropObject commands with appropriate settings (features).
- Query text is stored in the object's features.