### PR TITLE
BTreeIndex Bugfix load indexes in scan

### DIFF
--- a/ydb/core/tablet_flat/flat_scan_feed.h
+++ b/ydb/core/tablet_flat/flat_scan_feed.h
@@ -359,12 +359,16 @@ namespace NTable {
         bool LoadIndexes() noexcept
         {
             bool ready = true;
-            for (const auto& partView : Subset.Flatten) {
-                for (auto indexPageId : partView->IndexPages.Groups) {
-                    ready &= bool(CurrentEnv->TryGetPage(partView.Part.Get(), indexPageId));
-                }
-                for (auto indexPageId : partView->IndexPages.Historic) {
-                    ready &= bool(CurrentEnv->TryGetPage(partView.Part.Get(), indexPageId));
+            if (Levels) {
+                for (const auto &run: *Levels) {
+                    for (const auto &item : run) {
+                        for (auto indexPageId : item.Part->IndexPages.Groups) {
+                            ready &= bool(CurrentEnv->TryGetPage(item.Part.Get(), indexPageId));
+                        }
+                        for (auto indexPageId : item.Part->IndexPages.Historic) {
+                            ready &= bool(CurrentEnv->TryGetPage(item.Part.Get(), indexPageId));
+                        }
+                    }
                 }
             }
             return ready;


### PR DESCRIPTION
[PrepareBoots](https://github.com/ydb-platform/ydb/blob/35177af0d5ad0049b77927f4830a5648134283d9/ydb/core/tablet_flat/flat_scan_feed.h#L377) может использовать LoadedParts, и на основе них создавать итераторы Boots, поэтому нужно загружать индексы по ним 