### PR TITLE
fix use-after-free in TDummySnapshotContext IGNIETFERRO-2059

### DIFF
--- a/ydb/core/tablet_flat/test/libs/exec/dummy.h
+++ b/ydb/core/tablet_flat/test/libs/exec/dummy.h
@@ -87,9 +87,9 @@ namespace NFake {
 
         void Enqueue(TEventHandlePtr &eh) override
         {
-            const auto *name = eh->GetTypeName().c_str();
+            const auto &name = eh->GetTypeName();
 
-            Y_ABORT("Got unexpected event %s on tablet booting", name);
+            Y_ABORT("Got unexpected event %s on tablet booting", name.c_str());
         }
 
         void DefaultSignalTabletActive(const TActorContext&) override


### PR DESCRIPTION
Fix problem detected by clang's lifetime bound static analyzer.