### PR TITLE
Add default copy assignment operator to TVDiskAvailabilityTiming

### DIFF
--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1901,6 +1901,7 @@ private:
 
         TVDiskAvailabilityTiming() = default;
         TVDiskAvailabilityTiming(const TVDiskAvailabilityTiming&) = default;
+        TVDiskAvailabilityTiming& operator=(const TVDiskAvailabilityTiming&) = default;
 
         TVDiskAvailabilityTiming(const TVSlotInfo& vslot)
             : VSlotId(vslot.VSlotId)


### PR DESCRIPTION
Just add default copy assignment operator in order to avoid `-Wdeprecated-copy` warn on the upcoming libcxx update.

> The implicit definition of a copy constructor as defaulted is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor. The implicit definition of a copy assignment operator as defaulted is deprecated if the class has a user-declared copy constructor or a user-declared destructor.
