### PR TITLE
BTreeIndex Precharge RowId

### DIFF
--- a/ydb/core/tablet_flat/benchmark/b_part_index.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part_index.cpp
@@ -70,7 +70,7 @@ namespace {
 
             Cerr << "DataBytes = " << part->Stat.Bytes << " DataPages = " << IndexTools::CountMainPages(*part) << Endl;
             Cerr << "FlatIndexBytes = " << part->GetPageSize(part->IndexPages.Groups[groups ? 1 : 0], {}) << " BTreeIndexBytes = " << part->IndexPages.BTreeGroups[groups ? 1 : 0].IndexSize << Endl;
-            Cerr << "Levels = " << part->IndexPages.BTreeGroups[groups ? 1 : 0].LevelsCount << Endl;
+            Cerr << "Levels = " << part->IndexPages.BTreeGroups[groups ? 1 : 0].LevelCount << Endl;
 
             // 100 MB
             UNIT_ASSERT_GE(part->Stat.Bytes, 100ull*1024*1024);

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -316,7 +316,7 @@ namespace NKikimr::NTable::NPage {
             return beginRowId <= rowId && rowId < endRowId;
         }
 
-        TRecIdx Seek(TRowId rowId, std::optional<TRecIdx> on) const noexcept
+        TRecIdx Seek(TRowId rowId, std::optional<TRecIdx> on = { }) const noexcept
         {
             const TRecIdx childrenCount = GetChildrenCount();
             if (on && on >= childrenCount) {

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -464,7 +464,7 @@ namespace NKikimr::NTable::NPage {
     };
 
     struct TBtreeIndexMeta : public TBtreeIndexNode::TChild {
-        size_t LevelsCount;
+        ui32 LevelsCount;
         ui64 IndexSize;
 
         auto operator<=>(const TBtreeIndexMeta&) const = default;

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -85,7 +85,7 @@ namespace NKikimr::NTable::NPage {
 
         struct TShortChild {
             TPageId PageId;
-            TRowId Count;
+            TRowId RowsCount;
             ui64 DataSize;
 
             auto operator<=>(const TShortChild&) const = default;
@@ -95,22 +95,22 @@ namespace NKikimr::NTable::NPage {
 
         struct TChild {
             TPageId PageId;
-            TRowId Count;
+            TRowId RowsCount;
             ui64 DataSize;
-            TRowId ErasedCount;
+            TRowId ErasedRowsCount;
 
             auto operator<=>(const TChild&) const = default;
 
             TString ToString() const noexcept
             {
-                return TStringBuilder() << "PageId: " << PageId << " Count: " << Count << " DataSize: " << DataSize << " Erased: " << ErasedCount;
+                return TStringBuilder() << "PageId: " << PageId << " RowsCount: " << RowsCount << " DataSize: " << DataSize << " ErasedRowsCount: " << ErasedRowsCount;
             }
         } Y_PACKED;
 
         static_assert(sizeof(TChild) == 28, "Invalid TBtreeIndexNode TChild size");
 
         static_assert(offsetof(TChild, PageId) == offsetof(TShortChild, PageId));
-        static_assert(offsetof(TChild, Count) == offsetof(TShortChild, Count));
+        static_assert(offsetof(TChild, RowsCount) == offsetof(TShortChild, RowsCount));
         static_assert(offsetof(TChild, DataSize) == offsetof(TShortChild, DataSize));
 
 #pragma pack(pop)
@@ -306,7 +306,7 @@ namespace NKikimr::NTable::NPage {
         {
             if (Header->IsShortChildFormat) {
                 const TShortChild* const shortChild = TDeref<const TShortChild>::At(Children, pos * sizeof(TShortChild));
-                return { shortChild->PageId, shortChild->Count, shortChild->DataSize, 0 };
+                return { shortChild->PageId, shortChild->RowsCount, shortChild->DataSize, 0 };
             } else {
                 return *TDeref<const TChild>::At(Children, pos * sizeof(TChild));
             }
@@ -326,19 +326,19 @@ namespace NKikimr::NTable::NPage {
 
             auto range = xrange(0u, childrenCount);
             const auto cmp = [this](TRowId rowId, TPos pos) {
-                return rowId < GetShortChild(pos).Count;
+                return rowId < GetShortChild(pos).RowsCount;
             };
 
             TRecIdx result;
             if (!on) {
                 // Will do a full binary search on full range
-            } else if (GetShortChild(*on).Count <= rowId) {
+            } else if (GetShortChild(*on).RowsCount <= rowId) {
                 // Try a short linear search first
                 result = *on;
                 for (int linear = 0; linear < 4; ++linear) {
                     result++;
                     Y_ABORT_UNLESS(result < childrenCount, "Should always seek some child");
-                    if (GetShortChild(result).Count > rowId) {
+                    if (GetShortChild(result).RowsCount > rowId) {
                         return result;
                     }
                 }
@@ -352,7 +352,7 @@ namespace NKikimr::NTable::NPage {
                     if (result == 0) {
                         return 0;
                     }
-                    if (GetShortChild(result - 1).Count <= rowId) {
+                    if (GetShortChild(result - 1).RowsCount <= rowId) {
                         return result;
                     }
                     result--;

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -85,7 +85,7 @@ namespace NKikimr::NTable::NPage {
 
         struct TShortChild {
             TPageId PageId;
-            TRowId RowsCount;
+            TRowId RowCount;
             ui64 DataSize;
 
             auto operator<=>(const TShortChild&) const = default;
@@ -95,22 +95,22 @@ namespace NKikimr::NTable::NPage {
 
         struct TChild {
             TPageId PageId;
-            TRowId RowsCount;
+            TRowId RowCount;
             ui64 DataSize;
-            TRowId ErasedRowsCount;
+            TRowId ErasedRowCount;
 
             auto operator<=>(const TChild&) const = default;
 
             TString ToString() const noexcept
             {
-                return TStringBuilder() << "PageId: " << PageId << " RowsCount: " << RowsCount << " DataSize: " << DataSize << " ErasedRowsCount: " << ErasedRowsCount;
+                return TStringBuilder() << "PageId: " << PageId << " RowCount: " << RowCount << " DataSize: " << DataSize << " ErasedRowCount: " << ErasedRowCount;
             }
         } Y_PACKED;
 
         static_assert(sizeof(TChild) == 28, "Invalid TBtreeIndexNode TChild size");
 
         static_assert(offsetof(TChild, PageId) == offsetof(TShortChild, PageId));
-        static_assert(offsetof(TChild, RowsCount) == offsetof(TShortChild, RowsCount));
+        static_assert(offsetof(TChild, RowCount) == offsetof(TShortChild, RowCount));
         static_assert(offsetof(TChild, DataSize) == offsetof(TShortChild, DataSize));
 
 #pragma pack(pop)
@@ -306,7 +306,7 @@ namespace NKikimr::NTable::NPage {
         {
             if (Header->IsShortChildFormat) {
                 const TShortChild* const shortChild = TDeref<const TShortChild>::At(Children, pos * sizeof(TShortChild));
-                return { shortChild->PageId, shortChild->RowsCount, shortChild->DataSize, 0 };
+                return { shortChild->PageId, shortChild->RowCount, shortChild->DataSize, 0 };
             } else {
                 return *TDeref<const TChild>::At(Children, pos * sizeof(TChild));
             }
@@ -326,19 +326,19 @@ namespace NKikimr::NTable::NPage {
 
             auto range = xrange(0u, childrenCount);
             const auto cmp = [this](TRowId rowId, TPos pos) {
-                return rowId < GetShortChild(pos).RowsCount;
+                return rowId < GetShortChild(pos).RowCount;
             };
 
             TRecIdx result;
             if (!on) {
                 // Will do a full binary search on full range
-            } else if (GetShortChild(*on).RowsCount <= rowId) {
+            } else if (GetShortChild(*on).RowCount <= rowId) {
                 // Try a short linear search first
                 result = *on;
                 for (int linear = 0; linear < 4; ++linear) {
                     result++;
                     Y_ABORT_UNLESS(result < childrenCount, "Should always seek some child");
-                    if (GetShortChild(result).RowsCount > rowId) {
+                    if (GetShortChild(result).RowCount > rowId) {
                         return result;
                     }
                 }
@@ -352,7 +352,7 @@ namespace NKikimr::NTable::NPage {
                     if (result == 0) {
                         return 0;
                     }
-                    if (GetShortChild(result - 1).RowsCount <= rowId) {
+                    if (GetShortChild(result - 1).RowCount <= rowId) {
                         return result;
                     }
                     result--;
@@ -464,14 +464,14 @@ namespace NKikimr::NTable::NPage {
     };
 
     struct TBtreeIndexMeta : public TBtreeIndexNode::TChild {
-        ui32 LevelsCount;
+        ui32 LevelCount;
         ui64 IndexSize;
 
         auto operator<=>(const TBtreeIndexMeta&) const = default;
 
         TString ToString() const noexcept
         {
-            return TStringBuilder() << TBtreeIndexNode::TChild::ToString() << " LevelsCount: " << LevelsCount << " IndexSize: " << IndexSize;
+            return TStringBuilder() << TBtreeIndexNode::TChild::ToString() << " LevelCount: " << LevelCount << " IndexSize: " << IndexSize;
         }
     };
 }

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -50,7 +50,7 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddChild(TChild child) {
-            Y_ABORT_UNLESS(child.ErasedCount == 0 || !IsShortChildFormat(), "Short format can't have ErasedCount");
+            Y_ABORT_UNLESS(child.ErasedRowsCount == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowsCount");
             Children.push_back(child);
         }
 
@@ -249,7 +249,7 @@ namespace NKikimr::NTable::NPage {
         void PlaceChild(const TChild& child) noexcept
         {
             if (IsShortChildFormat()) {
-                Place<TShortChild>() = TShortChild{child.PageId, child.Count, child.DataSize};
+                Place<TShortChild>() = TShortChild{child.PageId, child.RowsCount, child.DataSize};
             } else {
                 Place<TChild>() = child;
             }
@@ -375,14 +375,14 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddShortChild(TShortChild child) {
-            AddChild(TChild{child.PageId, child.Count, child.DataSize, 0});
+            AddChild(TChild{child.PageId, child.RowsCount, child.DataSize, 0});
         }
 
         void AddChild(TChild child) {
             // aggregate in order to perform search by row id from any leaf node
-            child.Count = (ChildrenCount += child.Count);
+            child.RowsCount = (ChildrenRowsCount += child.RowsCount);
             child.DataSize = (ChildrenSize += child.DataSize);
-            child.ErasedCount = (ChildrenErasedCount += child.ErasedCount);
+            child.ErasedRowsCount = (ChildrenErasedRowsCount += child.ErasedRowsCount);
 
             Levels[0].PushChild(child);
         }
@@ -409,8 +409,8 @@ namespace NKikimr::NTable::NPage {
             IndexSize = 0;
             Writer.Reset();
             Levels = { TLevel() };
-            ChildrenCount = 0;
-            ChildrenErasedCount = 0;
+            ChildrenRowsCount = 0;
+            ChildrenErasedRowsCount = 0;
             ChildrenSize = 0;
         }
 
@@ -463,7 +463,7 @@ namespace NKikimr::NTable::NPage {
             if (levelIndex + 1 == Levels.size()) {
                 Levels.emplace_back();
             }
-            Levels[levelIndex + 1].PushChild(TChild{pageId, lastChild.Count, lastChild.DataSize, lastChild.ErasedCount});
+            Levels[levelIndex + 1].PushChild(TChild{pageId, lastChild.RowsCount, lastChild.DataSize, lastChild.ErasedRowsCount});
             if (!last) {
                 Levels[levelIndex + 1].PushKey(Levels[levelIndex].PopKey());
             }
@@ -498,8 +498,8 @@ namespace NKikimr::NTable::NPage {
         const ui32 NodeKeysMin;
         const ui32 NodeKeysMax;
 
-        TRowId ChildrenCount = 0;
-        TRowId ChildrenErasedCount = 0;
+        TRowId ChildrenRowsCount = 0;
+        TRowId ChildrenErasedRowsCount = 0;
         ui64 ChildrenSize = 0;
     };
 

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -388,7 +388,8 @@ namespace NKikimr::NTable::NPage {
         }
 
         std::optional<TBtreeIndexMeta> Flush(IPageWriter &pager, bool last) {
-            for (size_t levelIndex = 0; levelIndex < Levels.size(); levelIndex++) {
+            Y_ABORT_UNLESS(Levels.size() < Max<ui32>(), "Levels size is out of bounds");
+            for (ui32 levelIndex = 0; levelIndex < Levels.size(); levelIndex++) {
                 if (last && !Levels[levelIndex].GetKeysCount()) {
                     Y_ABORT_UNLESS(Levels[levelIndex].GetChildrenCount() == 1, "Should be root");
                     return TBtreeIndexMeta{ Levels[levelIndex].PopChild(), levelIndex, IndexSize };
@@ -414,7 +415,7 @@ namespace NKikimr::NTable::NPage {
         }
 
     private:
-        bool TryFlush(size_t levelIndex, IPageWriter &pager, bool last) {
+        bool TryFlush(ui32 levelIndex, IPageWriter &pager, bool last) {
             if (!last && Levels[levelIndex].GetKeysCount() <= 2 * NodeKeysMax) {
                 // Note: node should meet both NodeKeysMin and NodeSize restrictions for split
 

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -50,7 +50,7 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddChild(TChild child) {
-            Y_ABORT_UNLESS(child.ErasedRowsCount == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowsCount");
+            Y_ABORT_UNLESS(child.ErasedRowCount == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
             Children.push_back(child);
         }
 
@@ -249,7 +249,7 @@ namespace NKikimr::NTable::NPage {
         void PlaceChild(const TChild& child) noexcept
         {
             if (IsShortChildFormat()) {
-                Place<TShortChild>() = TShortChild{child.PageId, child.RowsCount, child.DataSize};
+                Place<TShortChild>() = TShortChild{child.PageId, child.RowCount, child.DataSize};
             } else {
                 Place<TChild>() = child;
             }
@@ -375,14 +375,14 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddShortChild(TShortChild child) {
-            AddChild(TChild{child.PageId, child.RowsCount, child.DataSize, 0});
+            AddChild(TChild{child.PageId, child.RowCount, child.DataSize, 0});
         }
 
         void AddChild(TChild child) {
             // aggregate in order to perform search by row id from any leaf node
-            child.RowsCount = (ChildrenRowsCount += child.RowsCount);
-            child.DataSize = (ChildrenSize += child.DataSize);
-            child.ErasedRowsCount = (ChildrenErasedRowsCount += child.ErasedRowsCount);
+            child.RowCount = (ChildRowCount += child.RowCount);
+            child.DataSize = (ChildSize += child.DataSize);
+            child.ErasedRowCount = (ChildErasedRowCount += child.ErasedRowCount);
 
             Levels[0].PushChild(child);
         }
@@ -409,9 +409,9 @@ namespace NKikimr::NTable::NPage {
             IndexSize = 0;
             Writer.Reset();
             Levels = { TLevel() };
-            ChildrenRowsCount = 0;
-            ChildrenErasedRowsCount = 0;
-            ChildrenSize = 0;
+            ChildRowCount = 0;
+            ChildErasedRowCount = 0;
+            ChildSize = 0;
         }
 
     private:
@@ -463,7 +463,7 @@ namespace NKikimr::NTable::NPage {
             if (levelIndex + 1 == Levels.size()) {
                 Levels.emplace_back();
             }
-            Levels[levelIndex + 1].PushChild(TChild{pageId, lastChild.RowsCount, lastChild.DataSize, lastChild.ErasedRowsCount});
+            Levels[levelIndex + 1].PushChild(TChild{pageId, lastChild.RowCount, lastChild.DataSize, lastChild.ErasedRowCount});
             if (!last) {
                 Levels[levelIndex + 1].PushKey(Levels[levelIndex].PopKey());
             }
@@ -498,9 +498,9 @@ namespace NKikimr::NTable::NPage {
         const ui32 NodeKeysMin;
         const ui32 NodeKeysMax;
 
-        TRowId ChildrenRowsCount = 0;
-        TRowId ChildrenErasedRowsCount = 0;
-        ui64 ChildrenSize = 0;
+        TRowId ChildRowCount = 0;
+        TRowId ChildErasedRowCount = 0;
+        ui64 ChildSize = 0;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_part_btree_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_btree_index_iter.h
@@ -115,7 +115,7 @@ public:
         , GroupId(groupId)
         , GroupInfo(part->Scheme->GetLayout(groupId))
         , Meta(groupId.IsHistoric() ? part->IndexPages.BTreeHistoric[groupId.Index] : part->IndexPages.BTreeGroups[groupId.Index])
-        , State(Reserve(Meta.LevelsCount + 1))
+        , State(Reserve(Meta.LevelCount + 1))
     {
         const static TCellsIterable EmptyKey(static_cast<const char*>(nullptr), TColumns());
         State.emplace_back(Meta, 0, GetEndRowId(), EmptyKey, EmptyKey);
@@ -180,7 +180,7 @@ public:
     EReady Next() override {
         Y_ABORT_UNLESS(!IsExhausted());
 
-        if (Meta.LevelsCount == 0) {
+        if (Meta.LevelCount == 0) {
             return Exhaust();
         }
 
@@ -194,7 +194,7 @@ public:
             PushNextState(*State.back().Pos + 1);
         }
 
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelsCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
             if (!TryLoad(State[level])) {
                 // exiting with an intermediate state
                 Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
@@ -211,7 +211,7 @@ public:
     EReady Prev() override {
         Y_ABORT_UNLESS(!IsExhausted());
 
-        if (Meta.LevelsCount == 0) {
+        if (Meta.LevelCount == 0) {
             return Exhaust();
         }
 
@@ -225,7 +225,7 @@ public:
             PushNextState(*State.back().Pos - 1);
         }
 
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelsCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
             if (!TryLoad(State[level])) {
                 // exiting with an intermediate state
                 Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
@@ -246,7 +246,7 @@ public:
     }
 
     TRowId GetEndRowId() const override {
-        return Meta.RowsCount;
+        return Meta.RowCount;
     }
 
     TPageId GetPageId() const override {
@@ -286,7 +286,7 @@ private:
             State[0].Pos = { };
         }
 
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelsCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
             auto &state = State[level];
             Y_DEBUG_ABORT_UNLESS(seek.BelongsTo(state));
             if (!TryLoad(state)) {
@@ -316,7 +316,7 @@ private:
     bool IsLeaf() const noexcept {
         // Note: it is possible to have 0 levels in B-Tree
         // so we may have exhausted state with leaf (data) node
-        return State.size() == Meta.LevelsCount + 1 && !IsExhausted();
+        return State.size() == Meta.LevelCount + 1 && !IsExhausted();
     }
 
     EReady Exhaust() {
@@ -334,8 +334,8 @@ private:
 
         auto child = current.Node->GetChild(pos);
 
-        TRowId beginRowId = pos ? current.Node->GetChild(pos - 1).RowsCount : current.BeginRowId;
-        TRowId endRowId = child.RowsCount;
+        TRowId beginRowId = pos ? current.Node->GetChild(pos - 1).RowCount : current.BeginRowId;
+        TRowId endRowId = child.RowCount;
         
         TCellsIterable beginKey = pos ? current.Node->GetKeyCellsIterable(pos - 1, GroupInfo.ColsKeyIdx) : current.BeginKey;
         TCellsIterable endKey = pos < current.Node->GetKeysCount() ? current.Node->GetKeyCellsIterable(pos, GroupInfo.ColsKeyIdx) : current.EndKey;

--- a/ydb/core/tablet_flat/flat_part_btree_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_btree_index_iter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "flat_part_iface.h"
-#include "flat_page_index.h"
 #include "flat_table_part.h"
 #include "flat_part_index_iter_iface.h"
 
@@ -195,7 +194,7 @@ public:
             PushNextState(*State.back().Pos + 1);
         }
 
-        for (size_t level : xrange(State.size() - 1, Meta.LevelsCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelsCount)) {
             if (!TryLoad(State[level])) {
                 // exiting with an intermediate state
                 Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
@@ -226,7 +225,7 @@ public:
             PushNextState(*State.back().Pos - 1);
         }
 
-        for (size_t level : xrange(State.size() - 1, Meta.LevelsCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelsCount)) {
             if (!TryLoad(State[level])) {
                 // exiting with an intermediate state
                 Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
@@ -287,7 +286,7 @@ private:
             State[0].Pos = { };
         }
 
-        for (size_t level : xrange(State.size() - 1, Meta.LevelsCount)) {
+        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelsCount)) {
             auto &state = State[level];
             Y_DEBUG_ABORT_UNLESS(seek.BelongsTo(state));
             if (!TryLoad(state)) {

--- a/ydb/core/tablet_flat/flat_part_btree_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_btree_index_iter.h
@@ -246,7 +246,7 @@ public:
     }
 
     TRowId GetEndRowId() const override {
-        return Meta.Count;
+        return Meta.RowsCount;
     }
 
     TPageId GetPageId() const override {
@@ -334,8 +334,8 @@ private:
 
         auto child = current.Node->GetChild(pos);
 
-        TRowId beginRowId = pos ? current.Node->GetChild(pos - 1).Count : current.BeginRowId;
-        TRowId endRowId = child.Count;
+        TRowId beginRowId = pos ? current.Node->GetChild(pos - 1).RowsCount : current.BeginRowId;
+        TRowId endRowId = child.RowsCount;
         
         TCellsIterable beginKey = pos ? current.Node->GetKeyCellsIterable(pos - 1, GroupInfo.ColsKeyIdx) : current.BeginKey;
         TCellsIterable endKey = pos < current.Node->GetKeysCount() ? current.Node->GetKeyCellsIterable(pos, GroupInfo.ColsKeyIdx) : current.EndKey;

--- a/ydb/core/tablet_flat/flat_part_charge.h
+++ b/ydb/core/tablet_flat/flat_part_charge.h
@@ -252,7 +252,7 @@ namespace NTable {
                         }
                     }
                     if (itemsLimit && prechargeCurrentFirstRowId <= prechargeCurrentLastRowId) {
-                        ui64 left = itemsLimit - items; // we count only foolprof taken rows, so here we may precharge some extra rows
+                        ui64 left = itemsLimit - items; // we count only foolproof taken rows, so here we may precharge some extra rows
                         if (prechargeCurrentLastRowId - prechargeCurrentFirstRowId > left) {
                             prechargeCurrentLastRowId = prechargeCurrentFirstRowId + left;
                         }
@@ -347,7 +347,7 @@ namespace NTable {
                     }
 
                     if (itemsLimit && prechargeCurrentFirstRowId >= prechargeCurrentLastRowId) {
-                        ui64 left = itemsLimit - items; // we count only foolprof taken rows, so here we may precharge some extra rows
+                        ui64 left = itemsLimit - items; // we count only foolproof taken rows, so here we may precharge some extra rows
                         if (prechargeCurrentFirstRowId - prechargeCurrentLastRowId > left) {
                             prechargeCurrentLastRowId = prechargeCurrentFirstRowId - left;
                         }

--- a/ydb/core/tablet_flat/flat_part_charge.h
+++ b/ydb/core/tablet_flat/flat_part_charge.h
@@ -42,7 +42,7 @@ namespace NTable {
             }
         }
 
-        TResult Do(const TCells key1, const TCells key2, const TRowId row1, const TRowId row2, 
+        TResult Do(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept override
         {
             auto index = Index.TryLoadRaw();
@@ -110,7 +110,7 @@ namespace NTable {
             return { ready, overshot };
         }
 
-        TResult DoReverse(const TCells key1, const TCells key2, const TRowId row1, const TRowId row2, 
+        TResult DoReverse(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept override
         {
             auto index = Index.TryLoadRaw();

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -24,7 +24,6 @@ public:
     TResult Do(const TCells key1, const TCells key2, const TRowId row1,
             const TRowId row2, const TKeyCellDefaults &keyDefaults, ui64 itemsLimit,
             ui64 bytesLimit) const noexcept override {
-        // TODO: implement
         Y_UNUSED(key1);
         Y_UNUSED(key2);
         Y_UNUSED(row1);

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -41,6 +41,10 @@ public:
 
         auto& meta = Part->IndexPages.BTreeGroups[0];
 
+        if (Y_UNLIKELY(row1 >= meta.Count)) {
+            return { true, true }; // already out of bounds, nothing to precharge
+        }
+
         TVector<TBtreeIndexNode> level, nextLevel(Reserve(2));
         for (ui32 high = 0; high < meta.LevelsCount && ready; high++) {
             if (high == 0) {
@@ -70,7 +74,7 @@ public:
         }
 
         if (meta.LevelsCount == 0) {
-            // TODO: no index nodes
+            ready &= HasDataPage(meta.PageId, { });
         } else {
             for (auto i : xrange(level.size())) {
                 TRecIdx begin = 0, end = level[i].GetChildrenCount();

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -33,7 +33,7 @@ public:
         Y_UNUSED(itemsLimit);
         Y_UNUSED(bytesLimit);
 
-        auto& meta = Part->IndexPages.BTreeGroups[0];
+        const auto& meta = Part->IndexPages.BTreeGroups[0];
 
         if (Y_UNLIKELY(row1 >= meta.RowsCount)) {
             return { true, true }; // already out of bounds, nothing to precharge
@@ -101,7 +101,7 @@ public:
         Y_UNUSED(itemsLimit);
         Y_UNUSED(bytesLimit);
 
-        auto& meta = Part->IndexPages.BTreeGroups[0];
+        const auto& meta = Part->IndexPages.BTreeGroups[0];
 
         if (Y_UNLIKELY(row1 >= meta.RowsCount)) {
             row1 = meta.RowsCount - 1; // start from the last row

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -35,7 +35,7 @@ public:
 
         const auto& meta = Part->IndexPages.BTreeGroups[0];
 
-        if (Y_UNLIKELY(row1 >= meta.RowsCount)) {
+        if (Y_UNLIKELY(row1 >= meta.RowCount)) {
             return { true, true }; // already out of bounds, nothing to precharge
         }
         if (Y_UNLIKELY(row1 > row2)) {
@@ -43,8 +43,8 @@ public:
         }
 
         TVector<TBtreeIndexNode> level, nextLevel(Reserve(2));
-        for (ui32 high = 0; high < meta.LevelsCount && ready; high++) {
-            if (high == 0) {
+        for (ui32 height = 0; height < meta.LevelCount && ready; height++) {
+            if (height == 0) {
                 ready &= TryLoadNode(meta.PageId, nextLevel);
             } else {
                 for (ui32 i : xrange<ui32>(level.size())) {
@@ -52,7 +52,7 @@ public:
                     if (i == 0) {
                         from = level[i].Seek(row1);
                     }
-                    if (i + 1 == level.size() && row2 < meta.RowsCount) {
+                    if (i + 1 == level.size() && row2 < meta.RowCount) {
                         to = level[i].Seek(row2);
                     }
                     for (TRecIdx j : xrange(from, to + 1)) {
@@ -70,7 +70,7 @@ public:
             return {false, false};
         }
 
-        if (meta.LevelsCount == 0) {
+        if (meta.LevelCount == 0) {
             ready &= HasDataPage(meta.PageId, { });
         } else {
             for (ui32 i : xrange<ui32>(level.size())) {
@@ -78,7 +78,7 @@ public:
                 if (i == 0) {
                     from = level[i].Seek(row1);
                 }
-                if (i + 1 == level.size() && row2 < meta.RowsCount) {
+                if (i + 1 == level.size() && row2 < meta.RowCount) {
                     to = level[i].Seek(row2);
                 }
                 for (TRecIdx j : xrange(from, to + 1)) {
@@ -103,8 +103,8 @@ public:
 
         const auto& meta = Part->IndexPages.BTreeGroups[0];
 
-        if (Y_UNLIKELY(row1 >= meta.RowsCount)) {
-            row1 = meta.RowsCount - 1; // start from the last row
+        if (Y_UNLIKELY(row1 >= meta.RowCount)) {
+            row1 = meta.RowCount - 1; // start from the last row
         }
         if (Y_UNLIKELY(row1 < row2)) {
             row2 = row1; // will not go further than row1
@@ -112,8 +112,8 @@ public:
 
         // level contains nodes in reverse order
         TVector<TBtreeIndexNode> level, nextLevel(Reserve(2));
-        for (ui32 high = 0; high < meta.LevelsCount && ready; high++) {
-            if (high == 0) {
+        for (ui32 height = 0; height < meta.LevelCount && ready; height++) {
+            if (height == 0) {
                 ready &= TryLoadNode(meta.PageId, nextLevel);
             } else {
                 for (ui32 i : xrange<ui32>(level.size())) {
@@ -121,7 +121,7 @@ public:
                     if (i == 0) {
                         from = level[i].Seek(row1);
                     }
-                    if (i + 1 == level.size() && row2 < meta.RowsCount) {
+                    if (i + 1 == level.size() && row2 < meta.RowCount) {
                         to = level[i].Seek(row2);
                     }
                     for (TRecIdx j = from + 1; j > to; j--) {
@@ -139,7 +139,7 @@ public:
             return {false, false};
         }
 
-        if (meta.LevelsCount == 0) {
+        if (meta.LevelCount == 0) {
             ready &= HasDataPage(meta.PageId, { });
         } else {
             for (ui32 i : xrange<ui32>(level.size())) {
@@ -147,7 +147,7 @@ public:
                 if (i == 0) {
                     from = level[i].Seek(row1);
                 }
-                if (i + 1 == level.size() && row2 < meta.RowsCount) {
+                if (i + 1 == level.size() && row2 < meta.RowCount) {
                     to = level[i].Seek(row2);
                 }
                 for (TRecIdx j = from + 1; j > to; j--) {

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -6,45 +6,78 @@
 
 namespace NKikimr::NTable {
 
-    class TChargeBTreeIndex : public ICharge {
-    public:
-        TChargeBTreeIndex(IPages *env, const TPart &part, TTagsRef tags, bool includeHistory = false) {
-            Y_UNUSED(env);
-            Y_UNUSED(part);
-            Y_UNUSED(tags);
-            Y_UNUSED(includeHistory);
+class TChargeBTreeIndex : public ICharge {
+    using TBtreeIndexNode = NPage::TBtreeIndexNode;
+    using TBtreeIndexMeta = NPage::TBtreeIndexMeta;
+
+public:
+    TChargeBTreeIndex(IPages *env, const TPart &part, TTagsRef tags, bool includeHistory = false)
+        : Part(&part)
+        , Env(env) {
+        Y_UNUSED(env);
+        Y_UNUSED(part);
+        Y_UNUSED(tags);
+        Y_UNUSED(includeHistory);
+    }
+
+public:
+    TResult Do(const TCells key1, const TCells key2, const TRowId row1,
+            const TRowId row2, const TKeyCellDefaults &keyDefaults, ui64 itemsLimit,
+            ui64 bytesLimit) const noexcept override {
+        // TODO: implement
+        Y_UNUSED(key1);
+        Y_UNUSED(key2);
+        Y_UNUSED(row1);
+        Y_UNUSED(row2);
+        Y_UNUSED(keyDefaults);
+        Y_UNUSED(itemsLimit);
+        Y_UNUSED(bytesLimit);
+
+        auto& meta = Part->IndexPages.BTreeGroups[0];
+
+        TVector<TBtreeIndexNode> level, nextLevel(Reserve(2));
+        for (ui32 high : xrange(meta.LevelsCount)) {
+            if (high == 0) {
+                if (!TryLoad(meta.PageId, nextLevel)) {
+                    return {false, false};
+                }
+            } else {
+                Y_ABORT_UNLESS(level);
+                
+
+            }
         }
 
-        TResult Do(const TCells key1, const TCells key2, const TRowId row1,
-                const TRowId row2, const TKeyCellDefaults &keyDefaults, ui64 itemsLimit,
-                ui64 bytesLimit) const noexcept override {
-            // TODO: implement
-            Y_UNUSED(key1);
-            Y_UNUSED(key2);
-            Y_UNUSED(row1);
-            Y_UNUSED(row2);
-            Y_UNUSED(keyDefaults);
-            Y_UNUSED(itemsLimit);
-            Y_UNUSED(bytesLimit);
-            return {true, false};
+        return {true, false};
+    }
+
+    TResult DoReverse(const TCells key1, const TCells key2, const TRowId row1,
+            const TRowId row2, const TKeyCellDefaults &keyDefaults, ui64 itemsLimit,
+            ui64 bytesLimit) const noexcept override {
+        // TODO: implement
+        Y_UNUSED(key1);
+        Y_UNUSED(key2);
+        Y_UNUSED(row1);
+        Y_UNUSED(row2);
+        Y_UNUSED(keyDefaults);
+        Y_UNUSED(itemsLimit);
+        Y_UNUSED(bytesLimit);
+        return {true, false};
+    }
+
+private:
+    bool TryLoad(TPageId pageId, TVector<TBtreeIndexNode>& level) const noexcept {
+        auto page = Env->TryGetPage(Part, pageId);
+        if (page) {
+            level.emplace_back(*page);
+            return true;
         }
+        return false;
+    }
 
-        TResult DoReverse(const TCells key1, const TCells key2, const TRowId row1,
-                const TRowId row2, const TKeyCellDefaults &keyDefaults, ui64 itemsLimit,
-                ui64 bytesLimit) const noexcept override {
-            // TODO: implement
-            Y_UNUSED(key1);
-            Y_UNUSED(key2);
-            Y_UNUSED(row1);
-            Y_UNUSED(row2);
-            Y_UNUSED(keyDefaults);
-            Y_UNUSED(itemsLimit);
-            Y_UNUSED(bytesLimit);
-            return {true, false};
-        }
-
-    private:
-
+private:
+    const TPart* const Part;
+    IPages* const Env;
 };
 
 }

--- a/ydb/core/tablet_flat/flat_part_charge_iface.h
+++ b/ydb/core/tablet_flat/flat_part_charge_iface.h
@@ -17,7 +17,7 @@ namespace NKikimr::NTable {
          *
          * Important caveat: assumes iteration won't touch any row > row2
          */
-        bool Do(const TRowId row1, const TRowId row2,
+        bool Do(TRowId row1, TRowId row2,
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept
         {
             return Do(TCells{}, TCells{}, row1, row2, 
@@ -29,7 +29,7 @@ namespace NKikimr::NTable {
          *
          * Important caveat: assumes iteration won't touch any row > row2
          */
-        bool DoReverse(const TRowId row1, const TRowId row2, 
+        bool DoReverse(TRowId row1, TRowId row2, 
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept
         {
             return DoReverse(TCells{}, TCells{}, row1, row2, 
@@ -39,13 +39,13 @@ namespace NKikimr::NTable {
         /**
          * Precharges data for rows between max(key1, row1) and min(key2, row2) inclusive
          */
-        virtual TResult Do(const TCells key1, const TCells key2, const TRowId row1, const TRowId row2, 
+        virtual TResult Do(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept = 0;
 
         /**
          * Precharges data for rows between min(key1, row1) and max(key2, row2) inclusive in reverse
          */
-        virtual TResult DoReverse(const TCells key1, const TCells key2, const TRowId row1, const TRowId row2, 
+        virtual TResult DoReverse(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
                 const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept = 0;
 
         virtual ~ICharge() = default;

--- a/ydb/core/tablet_flat/flat_part_dump.cpp
+++ b/ydb/core/tablet_flat/flat_part_dump.cpp
@@ -168,7 +168,7 @@ namespace {
     {
         if (part.IndexPages.BTreeGroups) {
             auto meta = part.IndexPages.BTreeGroups.front();
-            if (meta.LevelsCount) {
+            if (meta.LevelCount) {
                 BTreeIndexNode(part, meta);
             } else {
                 Out

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -83,9 +83,9 @@ void TLoader::StageParseMeta() noexcept
                 for (const auto &meta : history ? layout.GetBTreeHistoricIndexes() : layout.GetBTreeGroupIndexes()) {
                     NPage::TBtreeIndexMeta converted{{
                         meta.GetRootPageId(), 
-                        meta.GetCount(), 
+                        meta.GetRowsCount(), 
                         meta.GetDataSize(), 
-                        meta.GetErasedCount()}, 
+                        meta.GetErasedRowsCount()}, 
                         meta.GetLevelsCount(), 
                         meta.GetIndexSize()};
                     (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(converted);

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -83,10 +83,10 @@ void TLoader::StageParseMeta() noexcept
                 for (const auto &meta : history ? layout.GetBTreeHistoricIndexes() : layout.GetBTreeGroupIndexes()) {
                     NPage::TBtreeIndexMeta converted{{
                         meta.GetRootPageId(), 
-                        meta.GetRowsCount(), 
+                        meta.GetRowCount(), 
                         meta.GetDataSize(), 
-                        meta.GetErasedRowsCount()}, 
-                        meta.GetLevelsCount(), 
+                        meta.GetErasedRowCount()}, 
+                        meta.GetLevelCount(), 
                         meta.GetIndexSize()};
                     (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(converted);
                 }

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -669,8 +669,8 @@ namespace NTable {
                         m->SetLevelsCount(meta.LevelsCount);
                         m->SetIndexSize(meta.IndexSize);
                         m->SetDataSize(meta.DataSize);
-                        m->SetCount(meta.Count);
-                        m->SetErasedCount(meta.ErasedCount);
+                        m->SetRowsCount(meta.RowsCount);
+                        m->SetErasedRowsCount(meta.ErasedRowsCount);
                     }
                 }
 

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -666,11 +666,11 @@ namespace NTable {
                     for (auto meta : history ? Current.BTreeHistoricIndexes : Current.BTreeGroupIndexes) {
                         auto m = history ? lay->AddBTreeHistoricIndexes() : lay->AddBTreeGroupIndexes();
                         m->SetRootPageId(meta.PageId);
-                        m->SetLevelsCount(meta.LevelsCount);
+                        m->SetLevelCount(meta.LevelCount);
                         m->SetIndexSize(meta.IndexSize);
                         m->SetDataSize(meta.DataSize);
-                        m->SetRowsCount(meta.RowsCount);
-                        m->SetErasedRowsCount(meta.ErasedRowsCount);
+                        m->SetRowCount(meta.RowCount);
+                        m->SetErasedRowCount(meta.ErasedRowCount);
                     }
                 }
 

--- a/ydb/core/tablet_flat/protos/flat_table_part.proto
+++ b/ydb/core/tablet_flat/protos/flat_table_part.proto
@@ -28,8 +28,8 @@ message TBTreeIndexMeta {
     optional uint32 LevelsCount = 2;
     optional uint64 IndexSize = 3;
     optional uint64 DataSize = 4;
-    optional uint64 Count = 5; // Total number of data rows
-    optional uint64 ErasedCount = 6; // Total number of erased data rows
+    optional uint64 RowsCount = 5; // Total number of data rows
+    optional uint64 ErasedRowsCount = 6; // Total number of erased data rows
 }
 
 message TLayout {

--- a/ydb/core/tablet_flat/protos/flat_table_part.proto
+++ b/ydb/core/tablet_flat/protos/flat_table_part.proto
@@ -25,11 +25,11 @@ message TPartScheme {
 
 message TBTreeIndexMeta {
     optional uint32 RootPageId = 1;
-    optional uint32 LevelsCount = 2;
+    optional uint32 LevelCount = 2;
     optional uint64 IndexSize = 3;
     optional uint64 DataSize = 4;
-    optional uint64 RowsCount = 5; // Total number of data rows
-    optional uint64 ErasedRowsCount = 6; // Total number of erased data rows
+    optional uint64 RowCount = 5; // Total number of data rows
+    optional uint64 ErasedRowCount = 6; // Total number of erased data rows
 }
 
 message TLayout {

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -129,10 +129,10 @@ namespace NTest {
                 for (const auto &meta : history ? lay.GetBTreeHistoricIndexes() : lay.GetBTreeGroupIndexes()) {
                     NPage::TBtreeIndexMeta converted{{
                         meta.GetRootPageId(), 
-                        meta.GetRowsCount(), 
+                        meta.GetRowCount(), 
                         meta.GetDataSize(), 
-                        meta.GetErasedRowsCount()}, 
-                        meta.GetLevelsCount(), 
+                        meta.GetErasedRowCount()}, 
+                        meta.GetLevelCount(), 
                         meta.GetIndexSize()};
                     (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(converted);
                 }

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -129,9 +129,9 @@ namespace NTest {
                 for (const auto &meta : history ? lay.GetBTreeHistoricIndexes() : lay.GetBTreeGroupIndexes()) {
                     NPage::TBtreeIndexMeta converted{{
                         meta.GetRootPageId(), 
-                        meta.GetCount(), 
+                        meta.GetRowsCount(), 
                         meta.GetDataSize(), 
-                        meta.GetErasedCount()}, 
+                        meta.GetErasedRowsCount()}, 
                         meta.GetLevelsCount(), 
                         meta.GetIndexSize()};
                     (history ? BTreeHistoricIndexes : BTreeGroupIndexes).push_back(converted);

--- a/ydb/core/tablet_flat/ut/ut_btree_index.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index.cpp
@@ -1157,16 +1157,17 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
     }
 
     void AssertEqual(const TPartStore& part, const TTouchEnv& bTree, const TTouchEnv& flat, const TString& message) {
-        AssertEqual(part, bTree.Has, flat.Has, message + " Has");
-        AssertEqual(part, bTree.Touched, flat.Touched, message + " Touched");
+        AssertEqual(part, bTree.Has, flat.Has, message);
+        AssertEqual(part, bTree.Touched, flat.Touched, message);
     }
 
-    void DoChargeRowId(ICharge& charge, const TRowId row1, const TRowId row2, ui64 itemsLimit, ui64 bytesLimit,
+    void DoChargeRowId(ICharge& charge, IPages& env, const TRowId row1, const TRowId row2, ui64 itemsLimit, ui64 bytesLimit,
             const TKeyCellDefaults &keyDefaults, const TString& message, ui32 failsAllowed = 10) {
         while (true) {
             if (charge.Do(row1, row2, keyDefaults, itemsLimit, bytesLimit)) {
                 return;
             }
+            TTouchEnv::LoadTouched(env, false);
             UNIT_ASSERT_C(failsAllowed--, "Too many fails " + message);
         }
         Y_UNREACHABLE();
@@ -1180,8 +1181,8 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
                 TCharge flat(&flatEnv, part, tags, true);
 
                 TString message = TStringBuilder() << "ChargeRowId " << rowId1 << " " << rowId2;
-                DoChargeRowId(bTree, rowId1, rowId2, 0, 0, *keyDefaults, message);
-                DoChargeRowId(bTree, rowId1, rowId2, 0, 0, *keyDefaults, message);
+                DoChargeRowId(bTree, bTreeEnv, rowId1, rowId2, 0, 0, *keyDefaults, message);
+                DoChargeRowId(flat, flatEnv, rowId1, rowId2, 0, 0, *keyDefaults, message);
                 AssertEqual(part, bTreeEnv, flatEnv, message);
             }
         }

--- a/ydb/core/tablet_flat/ut/ut_btree_index.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index.cpp
@@ -17,7 +17,6 @@ namespace {
     struct TTouchEnv : public NTest::TTestEnv {
         const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
         {
-            UNIT_ASSERT_C(part->GetPageType(pageId) == EPage::BTreeIndex || part->GetPageType(pageId) == EPage::Index, "Shouldn't request non-index pages");
             Touched[groupId].insert(pageId);
             if (Has[groupId].contains(pageId)) {
                 return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
@@ -1152,7 +1151,7 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
                 }
             }
 
-            UNIT_ASSERT_VALUES_EQUAL_C(bTreeDataPages.size(), flatDataPages.size(), message);
+            UNIT_ASSERT_VALUES_EQUAL_C(flatDataPages, bTreeDataPages, message);
         }
     }
 

--- a/ydb/core/tablet_flat/ut/ut_btree_index.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index.cpp
@@ -174,7 +174,7 @@ namespace {
         UNIT_ASSERT_VALUES_EQUAL(node.GetKeysCount() + 1, children.size());
         for (TRecIdx i : xrange(node.GetKeysCount() + 1)) {
             UNIT_ASSERT_EQUAL(node.GetChild(i), children[i]);
-            TShortChild shortChild{children[i].PageId, children[i].Count, children[i].DataSize};
+            TShortChild shortChild{children[i].PageId, children[i].RowsCount, children[i].DataSize};
             UNIT_ASSERT_EQUAL(node.GetShortChild(i), shortChild);
         }
     }
@@ -314,7 +314,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
             writer.AddKey(deserialized.GetCells());
         }
         for (auto &c : children) {
-            c.ErasedCount = 0;
+            c.ErasedRowsCount = 0;
             writer.AddChild(c);
         }
 
@@ -359,7 +359,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexNode) {
             writer.AddKey(deserialized.GetCells());
         }
         for (auto &c : children) {
-            c.ErasedCount = 0;
+            c.ErasedRowsCount = 0;
             writer.AddChild(c);
         }
 
@@ -644,9 +644,9 @@ Y_UNIT_TEST_SUITE(TBtreeIndexBuilder) {
 
         TBtreeIndexMeta expected{{9, 0, 0, 0}, 3, 1550};
         for (auto c : children) {
-            expected.Count += c.Count;
+            expected.RowsCount += c.RowsCount;
             expected.DataSize += c.DataSize;
-            expected.ErasedCount += c.ErasedCount;
+            expected.ErasedRowsCount += c.ErasedRowsCount;
         }
         UNIT_ASSERT_EQUAL_C(*result, expected, "Got " + result->ToString());
     }

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -440,7 +440,7 @@ Y_UNIT_TEST_SUITE(TPart) {
 
         { /*_  Ensure that B-Tree index has enough layers */
             if (part.IndexPages.BTreeGroups.size()) {
-                UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[0].LevelsCount, 3);
+                UNIT_ASSERT_VALUES_EQUAL(part.IndexPages.BTreeGroups[0].LevelCount, 3);
             }
         }
 

--- a/ydb/core/tablet_flat/ut_large/ut_btree_index_large.cpp
+++ b/ydb/core/tablet_flat/ut_large/ut_btree_index_large.cpp
@@ -39,7 +39,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelsCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 3);
     }
 
     Y_UNIT_TEST(MiddleKeys1GB) {
@@ -69,7 +69,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelsCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 3);
     }
 
     Y_UNIT_TEST(BigKeys1GB) {
@@ -99,7 +99,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelsCount, 6);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 6);
     }
 
     Y_UNIT_TEST(CutKeys) {
@@ -131,7 +131,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelsCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[0].LevelCount, 3);
     }
 
     Y_UNIT_TEST(Group) {
@@ -162,7 +162,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[1].LevelsCount, 2);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeGroups[1].LevelCount, 2);
     }
 
     Y_UNIT_TEST(History) {
@@ -193,7 +193,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         UNIT_ASSERT_GE(part->Stat.Bytes, 1ull*1024*1024*1024);
         UNIT_ASSERT_LE(part->Stat.Bytes, 1ull*1024*1024*1024 + 100*1024*1024);
 
-        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeHistoric[0].LevelsCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(part->IndexPages.BTreeHistoric[0].LevelCount, 3);
     }
 
 }


### PR DESCRIPTION
Because the whole logic of Precharge is too complicated, let's start with a simple part that Precharges a given rows range without treating an items or a bytes limit and does not support groups nor history.

Happily, testing of the new Precharge method is quite simple: create TPart, call both (flat and b-tree) Precharge, compare sets of touched data pages. 