### PR TITLE
YQL-17087. Fix work with actor system in case of async compute actors.

### DIFF
--- a/ydb/library/yql/providers/dq/task_runner_actor/task_runner_actor.cpp
+++ b/ydb/library/yql/providers/dq/task_runner_actor/task_runner_actor.cpp
@@ -106,6 +106,7 @@ private:
             }
 
             hasData = lastPop.GetResult();
+            result.HasData = result.HasData || hasData;
             dataSize = data.Size();
             isFinished = !hasData && Channel->IsFinished();
             changed = changed || hasData || (isFinished != WasFinished);
@@ -116,7 +117,6 @@ private:
         }
         result.IsFinished = isFinished;
         result.IsChanged = changed;
-        result.HasData = hasData;
         return result;
     }
 

--- a/ydb/library/yql/tools/dq/worker_node/main.cpp
+++ b/ydb/library/yql/tools/dq/worker_node/main.cpp
@@ -177,6 +177,7 @@ int main(int argc, char** argv) {
     opts.AddLongOption("disable_pipe", "Disable pipe").NoArgument();
     opts.AddLongOption("log_level", "Log Level");
     opts.AddLongOption("ipv4", "Use ipv4").NoArgument();
+    opts.AddLongOption("enable-spilling", "Enable disk spilling").NoArgument();
 
     ui32 threads = THREAD_PER_NODE;
     TString host;
@@ -405,7 +406,7 @@ int main(int argc, char** argv) {
                 })
             : NTaskRunnerActor::CreateTaskRunnerActorFactory(lwmOptions.Factory, lwmOptions.TaskRunnerInvokerFactory);
         lwmOptions.ComputeActorOwnsCounters = true;
-        lwmOptions.UseSpilling = true;
+        lwmOptions.UseSpilling = res.Has("enable-spilling");
         auto resman = NDqs::CreateLocalWorkerManager(lwmOptions);
 
         auto workerManagerActorId = actorSystem->Register(resman);


### PR DESCRIPTION
Fix response result field set for reads without spilling.
Add enable-spilling flag to worker node.