### PR TITLE
Untie Keep/DoNotKeep flags from blackboard KIKIMR-20527

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.cpp
@@ -87,7 +87,7 @@ bool TBlobState::Restore(const TBlobStorageGroupInfo &info) {
 }
 
 void TBlobState::AddResponseData(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 orderNumber,
-        ui32 shift, TRope&& data, bool keep, bool doNotKeep) {
+        ui32 shift, TRope&& data) {
     // Add actual data to Parts
     Y_ABORT_UNLESS(id.PartId() != 0);
     const ui32 partIdx = id.PartId() - 1;
@@ -112,9 +112,6 @@ void TBlobState::AddResponseData(const TBlobStorageGroupInfo &info, const TLogoB
         TIntervalVec<i32> responseInterval(shift, shift + dataSize);
         diskPart.Requested.Subtract(responseInterval);
     }
-
-    Keep |= keep;
-    DoNotKeep |= doNotKeep;
 }
 
 void TBlobState::AddNoDataResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 orderNumber) {
@@ -164,8 +161,7 @@ void TBlobState::AddErrorResponse(const TBlobStorageGroupInfo &info, const TLogo
     diskPart.Requested.Clear();
 }
 
-void TBlobState::AddNotYetResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 orderNumber,
-        bool keep, bool doNotKeep) {
+void TBlobState::AddNotYetResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 orderNumber) {
     Y_ABORT_UNLESS(id.PartId() != 0);
     const ui32 partIdx = id.PartId() - 1;
     IsChanged = true;
@@ -179,9 +175,6 @@ void TBlobState::AddNotYetResponse(const TBlobStorageGroupInfo &info, const TLog
     TDiskPart &diskPart = disk.DiskParts[partIdx];
     diskPart.Situation = ESituation::Lost;
     diskPart.Requested.Clear();
-
-    Keep |= keep;
-    DoNotKeep |= doNotKeep;
 }
 
 ui64 TBlobState::GetPredictedDelayNs(const TBlobStorageGroupInfo &info, TGroupQueues &groupQueues,
@@ -377,11 +370,11 @@ void TBlackboard::AddPutOkResponse(const TLogoBlobID &id, ui32 orderNumber) {
     state.AddPutOkResponse(*Info, id, orderNumber);
 }
 
-void TBlackboard::AddResponseData(const TLogoBlobID &id, ui32 orderNumber, ui32 shift, TRope&& data, bool keep, bool doNotKeep) {
+void TBlackboard::AddResponseData(const TLogoBlobID &id, ui32 orderNumber, ui32 shift, TRope&& data) {
     Y_ABORT_UNLESS(bool(id));
     Y_ABORT_UNLESS(id.PartId() != 0);
     TBlobState &state = GetState(id);
-    state.AddResponseData(*Info, id, orderNumber, shift, std::move(data), keep, doNotKeep);
+    state.AddResponseData(*Info, id, orderNumber, shift, std::move(data));
 }
 
 void TBlackboard::AddNoDataResponse(const TLogoBlobID &id, ui32 orderNumber) {
@@ -391,11 +384,11 @@ void TBlackboard::AddNoDataResponse(const TLogoBlobID &id, ui32 orderNumber) {
     state.AddNoDataResponse(*Info, id, orderNumber);
 }
 
-void TBlackboard::AddNotYetResponse(const TLogoBlobID &id, ui32 orderNumber, bool keep, bool doNotKeep) {
+void TBlackboard::AddNotYetResponse(const TLogoBlobID &id, ui32 orderNumber) {
     Y_ABORT_UNLESS(bool(id));
     Y_ABORT_UNLESS(id.PartId() != 0);
     TBlobState &state = GetState(id);
-    state.AddNotYetResponse(*Info, id, orderNumber, keep, doNotKeep);
+    state.AddNotYetResponse(*Info, id, orderNumber);
 }
 
 void TBlackboard::AddErrorResponse(const TLogoBlobID &id, ui32 orderNumber) {

--- a/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.h
@@ -84,8 +84,6 @@ struct TBlobState {
     NKikimrProto::EReplyStatus Status = NKikimrProto::UNKNOWN;
     ui8 BlobIdx;
     bool IsChanged = false;
-    bool Keep = false;
-    bool DoNotKeep = false;
 
     void Init(const TLogoBlobID &id, const TBlobStorageGroupInfo &Info);
     void AddNeeded(ui64 begin, ui64 size);
@@ -93,12 +91,11 @@ struct TBlobState {
     void MarkBlobReadyToPut(ui8 blobIdx = 0);
     bool Restore(const TBlobStorageGroupInfo &info);
     void AddResponseData(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 diskIdxInSubring,
-            ui32 shift, TRope&& data, bool keep, bool doNotKeep);
+            ui32 shift, TRope&& data);
     void AddPutOkResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 orderNumber);
     void AddNoDataResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 diskIdxInSubring);
     void AddErrorResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 diskIdxInSubring);
-    void AddNotYetResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 diskIdxInSubring,
-            bool keep, bool doNotKeep);
+    void AddNotYetResponse(const TBlobStorageGroupInfo &info, const TLogoBlobID &id, ui32 diskIdxInSubring);
     ui64 GetPredictedDelayNs(const TBlobStorageGroupInfo &info, TGroupQueues &groupQueues,
             ui32 diskIdxInSubring, NKikimrBlobStorage::EVDiskQueueId queueId) const;
     void GetWorstPredictedDelaysNs(const TBlobStorageGroupInfo &info, TGroupQueues &groupQueues,
@@ -204,11 +201,11 @@ struct TBlackboard {
     void AddPartToPut(const TLogoBlobID &id, ui32 partIdx, TRope&& partData);
     void MarkBlobReadyToPut(const TLogoBlobID &id, ui8 blobIdx = 0);
     void MoveBlobStateToDone(const TLogoBlobID &id);
-    void AddResponseData(const TLogoBlobID &id, ui32 orderNumber, ui32 shift, TRope&& data, bool keep, bool doNotKeep);
+    void AddResponseData(const TLogoBlobID &id, ui32 orderNumber, ui32 shift, TRope&& data);
     void AddPutOkResponse(const TLogoBlobID &id, ui32 orderNumber);
     void AddNoDataResponse(const TLogoBlobID &id, ui32 orderNumber);
     void AddErrorResponse(const TLogoBlobID &id, ui32 orderNumber);
-    void AddNotYetResponse(const TLogoBlobID &id, ui32 orderNumber, bool keep, bool doNotKeep);
+    void AddNotYetResponse(const TLogoBlobID &id, ui32 orderNumber);
     EStrategyOutcome RunStrategies(TLogContext& logCtx, const TStackVec<IStrategy*, 1>& strategies,
         TBatchedVec<TBlobStates::value_type*> *finished = nullptr, const TBlobStorageGroupInfo::TGroupVDisks *expired = nullptr);
     EStrategyOutcome RunStrategy(TLogContext &logCtx, const IStrategy& s, TBatchedVec<TBlobStates::value_type*> *finished = nullptr,

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
@@ -44,11 +44,13 @@ void TGetImpl::PrepareReply(NKikimrProto::EReplyStatus status, TString errorReas
             const TBlobState &blobState = Blackboard.GetState(query.Id);
             outResponse.Id = query.Id;
             outResponse.PartMap = blobState.PartMap;
-            outResponse.Keep = blobState.Keep;
-            outResponse.DoNotKeep = blobState.DoNotKeep;
             outResponse.LooksLikePhantom = PhantomCheck
                 ? std::make_optional(blobState.WholeSituation == TBlobState::ESituation::Absent)
                 : std::nullopt;
+
+            // fill in keep/doNotKeep flags
+            const auto it = BlobFlags.find(query.Id);
+            std::tie(outResponse.Keep, outResponse.DoNotKeep) = it != BlobFlags.end() ? it->second : std::make_tuple(false, false);
 
             if (blobState.WholeSituation == TBlobState::ESituation::Absent) {
                 bool okay = true;


### PR DESCRIPTION
- Removed unneccessy file from docs folder
- Use AggrAdd for Limit.
- Fix any join absence after key columns cast
- Remove unused fields from TKqpSchemeOperation
- Added support for optional for predicate selectivity
- Better use AggrAdd for limits.
- Intermediate changes
- Canonization fix.
- YQL-16196 Add FileOptions pragma and bypass_artifact_cache option for MR job spec
- Add host_os.ya.make.inc files to piglet-sync
- Fix bug KIKIMR-11082
- KIKIMR-20451: Pass TTLSettings on column table create
- ci: add missing ydb/ci sync
- pg-make-test saves stderr
- Prepare to rename py3_flake8 tests to flake8
- Intermediate changes
- add attribute to detect lifetime bound errors
- Handle long-lasting Put queries in DS proxy correctly -- part 2 KIKIMR-9016
- Handle RaiseError calls in OffsetFetchActor
- Не работает ResourceManager.resource_filename вместе с Y_PYTHON_SOURCE_ROOT
- Intermediate changes
- Fix inconsistency in rpc protocol
- , YT-18091: Do not schedule pollable shutdown in finalizer invoker
- Update contrib/python/traitlets/py3 to 5.14.0
- Intermediate changes
- Update contrib/python/ipython/py3 to 8.18.1
- YT-20658: add two fields to Bundle Controller API
- Moved cmake files to generator dir and updated generator.toml
- Update doc content
- [dq] Refactor dq gateway session handling
- Disable data validation in opensource
- unknown data source has been fixed
- Removed wrong copy
- add kms's symmetric_crypto_service for nbs
- KIKIMR-19831: exclude right columns from left only stream join result
- YQL-17080 fix win build + adjust bounds
- YQL-17117: optimize PgCast unknown->text
- Fix verify requirement \!PipeToBalancer failed
- Y_DECLARE_OUT_SPEC for NKikimrDataEvents
- YQL-17346 more columns in pg_type
- Traffic agg task metrics + YQ public metrics
- ci: cache tests results
- Update contrib/python/s3transfer/py3 to 0.8.0
- Intermediate changes
- KIKIMR-19861: fix compaction task volume limit
- YQL-16196 Add docs for FileOption pragma
- Rewrite switching pools for executor thread, KIKIMR-18440
- Create postcommit.yml
- Consider used columns in index chooser
- YQL-17352 YQL-17356 YQL-17347 more pg_catalog tables
- Fix build problem KIKIMR-9016
- fix typo in port number section + add note on ports for multiple dynnodes per server
- Add build support for cortex-m23 platform
- Support override `distutils` from `setuptools`
- YQ Connector: prepare code base for S3 integration
- Test for duplicate data in anyjoin
- Intermediate changes
- Introduce convenient _B literal for bytes
- Support std::filesystem::path in TFile and TFileHandle
- feat setuptools: revert/fix UnionProvider
- ci: don't fail to fast on test run, add POST suffix for push checks
- Update Python 3 to 3.11.7
- Add GO_MOCKGEN_CONTRIB_FROM macro to generate mockgens from contribs
- Support Python 3.12 for `future`
- Intermediate changes
- Support Python 3.12 for `cffi`
- drop unused MaxDPccpDPTableSize
- fix return code UNSUPPORTED to UNAVILABLE
- updated roadmap for 2024
- not found behaviour has been changed for get script execution
- Support Python 3.12 for `tornado-4`
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- YT-20686: Fix TResponseKeeper
- ci: quote log file path
- Pass DiscoveryEndpoint in to DiscoveryMutator
- Intermediate changes
- KIKIMR-20179: remove deprecated reader from tests
- serial execution in simple write session
- ci: testmo-proxy use RequestException instead of ConnectionError
- Handle long-lasting Put queries in DS proxy correctly -- part 3
- add a whitelist for pooltrees pragma
- ci: use ya from repo, fix memory sanitizer run, always try generate summary
- Intermediate changes
- Remove excessive EOL spaces in blobstorage code
- Intermediate changes
- Better relational operators for TStrongTypedef
- [yql] test auto partition
- YQL-16196 Move internal link into internal docs (PRAGMA FileOptions)
- KIKIMR-20482: Remove duplicates on schema versions
- Print time in shutdown logging
- Fix comparison key
- Intermediate changes
- Fix fluky test. We can get CLIENT_CANCELED status at driver shutdown.…
- RowCount/ColCount should be used in move/parse
- KIKIMR-20042 Wilson uploader fix
- ,allow optional timestamp in insert into monitoring
- YT-20425: Optional offset in pull_consumer
- primary keys naming unification
- fix stream-write refresh-token rights
- support default values in create table for pg syntax KIKIMR-20022
- PR from branch users/nsofya/KIKIMR-19564
- Fix build, KIKIMR-18440
- fix codestyle: remove semicolon
- finer check of lifetimebound attribute support
- Use generic node count, not datashards only
- [yql] extend dq_file test parts
- Fix _an attribute list cannot appear here_ from clang-cl16
- Fix modernize-use-emplace reported by clang-tidy16
- FS_TOOLS to python3
- [yql] extend yt_native_file test parts
- Update contrib/restricted/nlohmann_json to 3.11.3
- Intermediate changes
- Stricter platform check for prebuilt protoc-gen-go
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- Update COPY_FILE macro
- Replace rep.erase with rep.erase_one in THashSet::erase
- fix typo in public method name
- Move ApplyJitter impl to inl file
- Add fake PDisk key to kikimr_cfg, KIKIMR-20141
- Allow using std::filesystem::path when constructing TFileInput / TFileOutput
- Switch windows builds to clang16
- Remote development
- KIKIMR-19521 BTreeIndex Loader & Dump
- KIKIMR-19521 BTreeIndex Charge Interface
- Intermediate changes
- KIKIMR-20432, KIKIMR-20431: support pg and not null types for stream lookup join
- KIKIMR-19512 Push down binary arithmetic operations and use YQL kernels.
- Split postcommits in two workflows
- TEvWriteResult Origin
- YQL-17353 YQL-17355 YQL-17357 YQL-17358 YQL-17360 YQL-17361 YQL-17362 more tables (mostly empty)
- PR from branch users/zverevgeny/YQL-17279_mr_permute
- KIKIMR-20538: background processes disabling
- KIKIMR-20009:dont remove blobs in case failed main data writing
- External build system generator release 69
- KIKIMR-19900 switch arcadia to python ydb sdk from contrib
- SpillingEngine pragma propagation to resource allocator.
- Intermediate changes
- KIKIMR-20484: switch required fields to optional in generic config
- KIKIMR-18888 query classic schema when not found
- YT-20123: make proto config && check it on const values Bundle Controller API
- Fix WriteTableToStream in pgrun
- Attempt to fix CloseSessionsWithLoad test. KIKIMR-20405
- KIKIMR-19512 Add 'Coalesce' kernel.
- UT for dq actors (initial)
- Use clang-tidy via RESOURCE_LIBRARY
- ,allow optional timestamp in insert into monitoring, add tests
- Continue with test on build fail
- Revert "YT-20123: make proto config && check it on const values Bundle Controller API"
- Reorder a bit and remove unneeded var
- Fix names of + and - in json.
- Switch to use object attributes for consumer
- Refactor OutputChannel reads in task_runner_actor
- Correct v1/v2 totals
- Update contrib/libs/backtrace to 2023-11-30
- YT: Introduce schema for TYsonStruct
- Rename py3_flake8 to flake8
- Move fyamlcpp and yaml_config to NKikimr namespace
- [yql] Common zero-sampling optimizer for both yt/dq providers
- federated topic write
- Enable COPY_FILE with text context for UNION and PACKAGE
- Better follback in ranges multiplier
- YT-16482: Fix GROUP BY
- Fix channel garbage collection issue KIKIMR-20525
- Intermediate changes
- Simplify AddOperation
- Add UT for consequent major updates, KIKIMR-20283
- Intermediate changes
- skip empty metrics KIKIMR-20270
- YT-19944: Add key filter metrics
- Intermediate changes
- KIKIMR-19452: Pg insert from selection by column order
- timeout logs have been moved to error
- detect dangling references in MapFindPtr and utility helpers
- Intermediate changes
- detect dangling references to temporary TStringBuilder object
- Remove TCoordinatorInfo::TabletId
- Intermediate changes
- 
- pg varchar as primary key
- YQL-17378 simple obfuscation of SQL query
- Intermediate changes
- Finalizing full result write via writing queue to avoid early finish
- YQL-17276: Fix hybrid for TopSort case
- Do not update index record in case of upsert with value equal to already present one
- Fix double hard gc KIKIMR-20525
- Remove more old patches
- Intermediate changes
- Use dynamic vendored libs when put in cache
- DataShard EvWrite Immediate
- Fix yson parsing in yql_agent
- KIKIMR-19512 Set combiner limit from mkql heavy limit.
- Intermediate changes
- detect dangling references in TMaybe object
- Update contrib/python/clickhouse-connect to 0.6.22
- Intermediate changes
- for darwin-arm64
- Static libs
- Run checks switches
- Support \pset null in pgrun
- Offload "annotations" attribute handling
- Use aggregate for Sequoia replicas
- Update contrib/restricted/boost/predef to 1.84.0
- Update contrib/restricted/boost/config to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/variant to 1.84.0
- Update contrib/restricted/boost/mp11 to 1.84.0
- Update contrib/restricted/boost/math to 1.84.0
- Update contrib/restricted/boost/conversion to 1.84.0
- infly metrics have been fixed
- Update contrib/restricted/boost/core to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/utility to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/any to 1.84.0
- Update contrib/restricted/boost/winapi to 1.84.0
- Update contrib/restricted/boost/endian to 1.84.0
- Update contrib/python/fonttools to 4.46.0
- Fix crash caused by StdNormalRandom producing a value out of expected range
- Root CMakeLists.txt generation with jinja
- Release opensource ya & test_tool
- Reset tests cache
- Intermediate changes
- Fix SCHEME_ERROR from DS KIKIMR-20297
- Update contrib/restricted/boost/atomic to 1.84.0
- Update contrib/restricted/boost/bind to 1.84.0
- USE_OPENSOURCE_TEST_TOOL=yes
- re-enable clang::reinitialized attribute for non-CUDA target platforms
- Update contrib/restricted/boost/ratio to 1.84.0
- Checks switch fix
- Update contrib/restricted/boost/smart_ptr to 1.84.0
- Update contrib/restricted/boost/function to 1.84.0
- Update contrib/restricted/boost/tuple to 1.84.0
- Update contrib/restricted/boost/array to 1.84.0
- Update contrib/restricted/boost/thread to 1.84.0
- Update contrib/restricted/boost/optional to 1.84.0
- fix tests after
- Add KDevelop (#495)
- do not use adaptive thread pool (#536)
- add uniq node id validation to ydb cfg (#538)
- ci: add defalut for put_build_results_to_cache (#546)
- Enhance error message (#539)
- support api proto files in go (#543)
- Test error delivery in result receiver (#548)
- Refactor DQ Channel Storage to accept external actor system (#547)
- Do not include data_events/events.h in do datashard.h. Ydb import fix. (#552)
- YQL-17145: fix autoparametrization of null values and refactor settings (#555)
- YQL-17393: Fix dq tests (#551)
- KIKIMR-20042 Wilson enchancements (#540)
- Add tstool and tsserver into ydb/tools (#545)
- KIKIMR-20079: create/alter/drop group (#501)
- ci: put build results to cache for PR checks and fix log extraction in the transform-ya-junit script (#561)
- Remove unused include (#559)
- KIKIMR-20042 KeyValue tablet toplevel tracing (#526)
- GetSubmatrix (#556)
- Refactored CBO interface for DQ (#558)
- Fix plans and cannonize tests with aggr functions. (#550)
- Fix missed subscription for non local request cancelation. (#527)
- Optimize TString creation in TSpan ctor (#568)
- Optimize heartbeats emission KIKIMR-20392 (#557)
- Report nodeId with create session response. (#562)
- Optimize TSpan methods to prevent unneeded object construction KIKIMR-15449 (#575)
- KIKIMR-20042 Enchanced VDisk tracing (#571)
- Mote YT plugin to ydb/library/yql (#573)
- KIKIMR-20042 Added table with statistics to LoadActor html report (#565)
- fix sequence requests lost and add debugging tools to sequence proxy (#570)
- added GetOpenTelemetryTraceParent() to IRequestCtxBaseMtSafe (#577)
- KIKIMR-16087 Replace Y_ABORT_UNLESS (#569)
- Update pr_check.yml (#583)
- ci: start testmo run before starting tests (#580)
- ci: run CheckAllowedDirs on all branches (#581)
- YQL-17393: Fix Dq tests (#560)
- TaskRunnerActor accepts unknown events (#576)
- Flush queue and end Final message immidiately on full result writer error (#582)
- Disable YQL YT plugin under non-linux platforms (#588)
- Implement CREATE/DROP EXTERNAL DATA SOURCE/EXTERNAL TABLE in QueryService. Without IF NOT EXISTS/IF EXISTS support yet (#524)
- YQL-17087: Move DqChannelStorage to separate file and use interface (#591)
- [dq] Peephole integration + some transform helpers (YQL-17386) (#572)
- YQL-9853: add documentation for WalkFolders (#585)
- Mutetests1 (#578)
- YQL-17434 Ignore TEvStatistics (#598)
- Update README.md (#602)
- YQ-2323: YQ Connector:  use Connector docker image for YQL Generic provider integration tests  (#604)
- Add grpc request proxy wilson span and trace id on the request context. (#606)
- KIKIMR-20081: add grant/revoke permissions to query service (#522)
- KIKIMR-20533 Implemented conversion from OTEL header to traceId (#607)
- Replace Y_ABORT_UNLESS #2 (#603)
- KIKIMR-20533 TraceId parser unittests (#617)
- KIKIMR-20217 Initial datashard tracing (#530)
- init (#610)
- Fix ui.sh, add missing mounts.txt (#614)
- Add dynamic config cli (#615)
- YQL-17250: Add operation information into hybrid statistics (#597)
- [dq] Integrate YT peephole transforms into DQ integration (YQL-17386) (#605)
- Out<NYql::TIssues> (#626)
- Import libs 1 (#590)
- Use user provided otel header to start grpc proxy tracing. (#628)
- Moved csv parsing in import file cmd to YDB CLI and supported pg-types (only row tables) (#514)
- added vscode (#636)
- add talks/presentations to the docs (#528)
- KIKIMR-20321 viewer tests asan fix (#525)
- First 25 queries of TPC-DS (#632)
- CheckWriteUnit & FinishProposeWriteUnit (#631)
- Add schema example for TPC-DS (#613)
- Move iam auth actors out of IO pool (#648)
- fix (#654)
- [YQL-16903] Introduce BlockEngine pragma (parser/config provider part) (#616)
- Second 25 queries of TPC-DS (#660)
- Third 25 queries of TPC-DS (#662)
- cgi parameters have been sorted YQ-2558 (#619)
- [yql] Fix join-anyjoin_common_dup test (#651)
- UpdateRow & WriteRow (#663)
- Fix Unique/Distinct constraints from nested filtering FlatMap. (#584)
- YQ Connector: fix integration tests style (#640)
- [dq] Separate setting SplitStageOnDqReplicate (YQL-17382) (#664)
- KIKIMR-19521 BTreeIndex Test (#653)
- KIKIMR-19139 Bugfix load indexes (#657)
- add StarvingInRowForNotEnoughCpu for tcp sessions (#625)
- Fix metric PotentialMaxThreadCount (#629)
- Last 25 queries of TPC-DS (#668)
- YQ-2628: add connections option for streaming queries (#579)
- KIKIMR-19521 BTreeIndex Bugfix index size (#671)
- WriteRow out of space (#665)
- YQL-17087: Add channel spilling to dq pipe communication (#612)
- KIKIMR-20521: Add UseVDisksBalancing feature flag (#523)
- KIKIMR-20522: Tests for vdisks balancing (#531)
- Library import 2 (#639)
- Revert "Workload TPC-C init" (#529)
- Consistent debug (#652)
- YQL-17250: Add operation name in fallback message (#627)
- Moved TSpan::Link(TraceId) implementation to .cpp (#674)
- [yql] Fix result diff in dq_file tests (YQL-17386, YQL-17404, YQL-17402, YQL-17405) (#676)
- Add BsCostTracker and advanced cost metrics, KIKIMR-17759 (#600)
- Import libs 3 (#679)
- added tests (#647)
- Refactoring - optimize parameters of CreatePartitionWriter (#669)
- YQL-15941 avoid llvm version pinning where possible (#677)
- Ignore empty metrics in in-progress stats. Try-catch in-progress stats conversion. (#633)
- KIKIMR-19521 BTreeIndex Fix SchemeShard Verify (#655)
- CREATE / DROP VIEW queries support (#656)
- Mute postgresql* tests (#675)
- KIKIMR-20042 Fix of TSpan abort outside of actor system (#630)
- [YQL-17338] disable cast warning from integral types to float types (#690)
- Fix constrains after expand PartitionsByKeys. (#685)
- KIKIMR-20533 Forward traceparent header to KV-tablet (#689)
- Add TPC-DS Q56 (#692)
- YQ-2628: Print stats on final status log (#563)
- get status polling has been fixed YQ-2667 (#620)
- YDB_ACCESSORs (#672)
- Remove TabletId from TValidatedDataTx (#683)
- Removed useless includes (#621)
- YQ-2560: add YDB data_source (#693)
- YQL-9517: RPC Arrow reader YT column converters (#599)
- [yql] gateway extension contains only additional settings (#700)
- Update cost model (#697)
- Use Source Name as name, drop unused index (#701)
- Revert "KIKIMR-20522: Tests for vdisks balancing (#531)" (#706)
- Refuse empty query text (#708)
- KIKIMR-19671 Add RemovePathRecursive function (#680)
- buffered writing for columnshards (#686)
- KIKIMR-20042 Partially implemented PDisk tracing (#574)
- Rename op -> writeOp (#715)
- KIKIMR-19522 BTreeIndex Precharge Simplification (#682)
- YQL-15941 no_llvm versions of purecalc and embedded (#707)
- YQ-2670 switch generic tests to docker compose (#691)
- Start tablets in object domain KIKIMR-20271 (#705)
- KIKIMR-20150: fix and improve flaky test (#713)
- ActorSystem fix typo (#638)
- KQP computation pattern cache serialized program (#634)
- ActorSystem should continue use std atomic (#643)
- ActorSystem memlog use std atomic (#644)
- ActorSystem interrupter use std atomic (#645)
- ActorSystem cpu load log use std atomic (#646)
- Add QueryService coverage for kqp_perf_ut.(KIKIMR-16294) (#721)
- fix tests TopicPeriodicStat* (#717)
- use adaptive timeouts and persistent node count in hive warmup KIKIMR-20551 (#624)
- [YQL-17103] Basic support of pg types in predicate extractor library (#709)
- Add discovery mutator for underlay (#566)
- YQ-2628: add RECURSE_FOR_TESTS (#718)
- YQ-2704 TCheckpointStorage failed on log (#594)
- Keep Issue fields after censorship (#714)
- KIKIMR-20150: remove the test from the mute list (#726)
- Ability for ydb-cli to write request results as arrow parquet (#673)
- YQL-17385 fix tests (#730)
- (refactoring) Inline TChangeRecordBuilder's methods (#734)
- fix broken pg autoparam unit test
- remove a hard error in formatter when CASE wih no ELSE (#723)
- fix (#736)
- fix tests (#735)
- Add PG provider to pgrun (#732)
- use statistics aggregator for basic statistics KIKIMR-18323 (#623)
- YQL-17286: Fix sublink in projection, which has no external deps (#684)
- init (#738)
- generic query for load actor (#512)
- Switch ticket_parser auth clients to HTSwap mailbox type (#670)
- Remove msgbus trace service (deprecated and unused) (#687)
- Remove node identifier (deprecated) (#688)
- Session actor perf (#724)
- YDB-2345 HC time difference message (#741)
- YQ-2651 use ChildPtr instead of ChildRef (#488)
- ut_read_iterator + EvWrite (#742)
- Fixed TItem in-place creation under clang14 (#752)
- Common TChangeRecord in ydb/core/change_exchange (#737)
- Add library increment script (#760)
- Added import s3 to directory (#678)
- Support IF NOT EXISTS/IF EXISTS for tables, external tables and external data sources (#694)
- normalize test (#759)
- Import libs 4 (#758)
- Incremented YDB CLI version to 2.8.0 (#762)
- Fix poller compatibility mode KIKIMR-20604
- Untie Keep/DoNotKeep flags from blackboard KIKIMR-20527
