### PR TITLE
add pumpkin mode and improve downsampling

### DIFF
--- a/ydb/core/graph/shard/tx_monitoring.cpp
+++ b/ydb/core/graph/shard/tx_monitoring.cpp
@@ -51,7 +51,8 @@ public:
         html << "<tr><td>Memory.RecordsSize</td><td>" << Self->MemoryBackend.MetricsValues.size() << "</td></tr>";
 
         html << "<tr><td>Local.MetricsSize</td><td>" << Self->LocalBackend.MetricsIndex.size() << "</td></tr>";
-        html << "<tr><td>Local.StartTimestamp</td><td>" << Self->StartTimestamp << "</td></tr>";
+        html << "<tr><td>StartTimestamp</td><td>" << Self->StartTimestamp << "</td></tr>";
+        html << "<tr><td>ClearTimestamp</td><td>" << Self->ClearTimestamp << "</td></tr>";
 
         html << "</table>";
         html << "</html>";


### PR DESCRIPTION
pumpkin mode helps spend less resources when graphs are not enabled on a database.
downsampling was improved to allow process timeseries with different time-deltas. for example, when part of the series was already downsampled before.