### PR TITLE
Fix references to protoc compiler

### DIFF
--- a/ydb/library/yql/parser/proto_ast/gen/v0_proto_split/ya.make
+++ b/ydb/library/yql/parser/proto_ast/gen/v0_proto_split/ya.make
@@ -23,7 +23,7 @@ RUN_ANTLR(
 IF (USE_VANILLA_PROTOC)
     SET(PROTOC_PATH contrib/tools/protoc_std)
 ELSE()
-    SET(PROTOC_PATH contrib/tools/protoc)
+    SET(PROTOC_PATH contrib/tools/protoc/bin)
 ENDIF()
 
 

--- a/ydb/library/yql/parser/proto_ast/gen/v1_proto_split/ya.make
+++ b/ydb/library/yql/parser/proto_ast/gen/v1_proto_split/ya.make
@@ -33,7 +33,7 @@ RUN_ANTLR(
 IF (USE_VANILLA_PROTOC)
     SET(PROTOC_PATH contrib/tools/protoc_std)
 ELSE()
-    SET(PROTOC_PATH contrib/tools/protoc)
+    SET(PROTOC_PATH contrib/tools/protoc/bin)
 ENDIF()
 
 


### PR DESCRIPTION
To reference to the same place where libraries reference it, as it's not possible to compile protoc in two targets simultaneously in cmake.