### PR TITLE
Hack ydb/library/yql/providers/generic/connector/tests to make them MEDIUM, not LARGE

### DIFF
--- a/ydb/library/yql/providers/generic/connector/tests/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/ya.make
@@ -3,8 +3,6 @@ PY3TEST()
 STYLE_PYTHON()
 NO_CHECK_IMPORTS()
 
-SIZE(MEDIUM)
-
 IF (AUTOCHECK) 
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
@@ -26,6 +24,16 @@ IF (AUTOCHECK)
 ENDIF()
 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
+
+# Including of docker_compose/recipe.inc automatically converts these tests into LARGE, 
+# which makes it impossible to run them during precommit checks on Github CI. 
+# Next several lines forces these tests to be MEDIUM. To see discussion, visit YDBOPS-8928.
+SIZE(MEDIUM)
+
+IF (OPENSOURCE)
+    SET(TEST_TAGS_VALUE)
+    SET(TEST_REQUIREMENTS_VALUE)
+ENDIF()
 
 TEST_SRCS(
     conftest.py


### PR DESCRIPTION
* LARGE tests are running only nightly, but we want these tests to run on every PR