### PR TITLE
Write flat index last key setting

### DIFF
--- a/ydb/core/tablet_flat/flat_page_conf.h
+++ b/ydb/core/tablet_flat/flat_page_conf.h
@@ -84,6 +84,7 @@ namespace NPage {
         bool Final = true;
         bool CutIndexKeys = true;
         bool WriteBTreeIndex = false;
+        bool WriteLastFlatIndexKey = true;       /* for UTs */
         ui32 MaxLargeBlob = 8 * 1024 * 1024 - 8; /* Maximum large blob size */
         ui32 LargeEdge = Max<ui32>();   /* External blob edge size      */
         ui32 SmallEdge = Max<ui32>();   /* Outer blobs edge bytes limit */

--- a/ydb/core/tablet_flat/flat_page_writer.h
+++ b/ydb/core/tablet_flat/flat_page_writer.h
@@ -559,7 +559,7 @@ namespace NPage {
             , MinSize(conf.Groups[groupId.Index].IndexMin)
             , GroupId(groupId)
             , GroupInfo(Scheme->GetLayout(groupId))
-            , DataPageBuilder(EPage::Index, groupId.IsMain() ? 3 : 2, false, 0 /* no extra data before block */)
+            , DataPageBuilder(EPage::Index, groupId.IsMain() && conf.WriteLastFlatIndexKey ? 3 : 2, false, 0 /* no extra data before block */)
         {
 
         }

--- a/ydb/core/tablet_flat/flat_part_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter.h
@@ -161,7 +161,7 @@ private:
         auto page = Env->TryGetPage(Part, pageId);
         if (page) {
             Index = TIndex(*page);
-            Y_VERIFY_DEBUG_S(EndRowId == Index->GetEndRowId(), "EndRowId mismatch " << EndRowId << " != " << Index->GetEndRowId() << " (group " << GroupId.Historic << "/" << GroupId.Index <<")");
+            Y_VERIFY_DEBUG_S(EndRowId == Index->GetEndRowId() || Index->GetEndRowId() == Max<TRowId>(), "EndRowId mismatch " << EndRowId << " != " << Index->GetEndRowId() << " (group " << GroupId.Historic << "/" << GroupId.Index <<")");
             return &*Index;
         }
         return { };

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -43,6 +43,7 @@ namespace NTable {
             : Final(conf.Final)
             , CutIndexKeys(conf.CutIndexKeys)
             , WriteBTreeIndex(conf.WriteBTreeIndex)
+            , WriteLastFlatIndexKey(conf.WriteLastFlatIndexKey)
             , SmallEdge(conf.SmallEdge)
             , LargeEdge(conf.LargeEdge)
             , MaxLargeBlob(conf.MaxLargeBlob)
@@ -815,8 +816,10 @@ namespace NTable {
                     SaveSlice(lastRowId, TSerializedCellVec(Key));
 
                     if (Phase == 1) {
-                        Y_DEBUG_ABORT_UNLESS(g.Index.CalcSize(Key) == g.LastKeyIndexSize);
-                        g.Index.Add(g.LastKeyIndexSize, Key, lastRowId, page);
+                        if (WriteLastFlatIndexKey) {
+                            Y_DEBUG_ABORT_UNLESS(g.Index.CalcSize(Key) == g.LastKeyIndexSize);
+                            g.Index.Add(g.LastKeyIndexSize, Key, lastRowId, page);
+                        }
                         Y_ABORT_UNLESS(std::exchange(Phase, 2) == 1);
                         PrevPageLastKey.clear(); // new index will be started
                         PrevPageData = { };
@@ -961,7 +964,7 @@ namespace NTable {
                 auto &prevCell = PrevPageLastKey[it];
                 auto &cell = Key[it];
 
-                Y_ABORT_UNLESS(!cell.IsNull(), "Keys should be in ascendic order");
+                Y_ABORT_UNLESS(!cell.IsNull(), "Keys should be in ascending order");
 
                 size_t index;
                 for (index = 0; index < Min(prevCell.Size(), cell.Size()); index++) {
@@ -1024,6 +1027,7 @@ namespace NTable {
         const bool Final = false;
         const bool CutIndexKeys;
         const bool WriteBTreeIndex;
+        const bool WriteLastFlatIndexKey;
         const ui32 SmallEdge;
         const ui32 LargeEdge;
         const ui32 MaxLargeBlob;

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -1208,7 +1208,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         NPage::TConf conf{ true, 8192 };
         conf.Group(0).PageRows = 3;
 
-        UNIT_ASSERT_VALUES_EQUAL_C(conf.WriteLastFlatIndexKey, true, "Should be true by default");
+        UNIT_ASSERT_C(conf.WriteLastFlatIndexKey, "Should be true by default");
 
         TPartCook cook(lay, conf);
 

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -1196,6 +1196,70 @@ Y_UNIT_TEST_SUITE(TPart) {
             "abc😖😖😖", // \xF0\x9F\x98\x96
             "abc😖");
     }
+
+    Y_UNIT_TEST(WriteLastFlatIndexKey_True)
+    {
+        TLayoutCook lay;
+
+        lay
+            .Col(0, 0,  NScheme::NTypeIds::Uint32)
+            .Key({0});
+
+        NPage::TConf conf{ true, 8192 };
+        conf.Group(0).PageRows = 3;
+
+        UNIT_ASSERT_VALUES_EQUAL_C(conf.WriteLastFlatIndexKey, true, "Should be true by default");
+
+        TPartCook cook(lay, conf);
+
+        for (ui32 k : xrange(8)) {
+            cook.Add(*TSchemedCookRow(*lay).Col(k));
+        }
+
+        auto eggs = cook.Finish();
+        auto part = *eggs.Lone();
+        
+        Cerr << DumpPart(part, 3) << Endl;
+
+        auto index = NPage::TIndex(*TTestEnv().TryGetPage(&part, part.IndexPages.Groups[0], { }));
+        
+        UNIT_ASSERT_VALUES_EQUAL(index->Count, 3);
+        UNIT_ASSERT_VALUES_EQUAL(index.Rows(), 8);
+        UNIT_ASSERT_VALUES_EQUAL(index.GetEndRowId(), 8);
+        UNIT_ASSERT(index.GetLastKeyRecord() != nullptr);
+    }
+
+    Y_UNIT_TEST(WriteLastFlatIndexKey_False)
+    {
+        TLayoutCook lay;
+
+        lay
+            .Col(0, 0,  NScheme::NTypeIds::Uint32)
+            .Key({0});
+
+        NPage::TConf conf{ true, 8192 };
+        conf.Group(0).PageRows = 3;
+
+        conf.WriteLastFlatIndexKey = false;
+
+        TPartCook cook(lay, conf);
+
+        for (ui32 k : xrange(8)) {
+            cook.Add(*TSchemedCookRow(*lay).Col(k));
+        }
+
+        auto eggs = cook.Finish();
+        auto part = *eggs.Lone();
+        
+        Cerr << DumpPart(part, 3) << Endl;
+
+        auto index = NPage::TIndex(*TTestEnv().TryGetPage(&part, part.IndexPages.Groups[0], { }));
+        
+        UNIT_ASSERT_VALUES_EQUAL(index->Count, 3);
+        UNIT_ASSERT_VALUES_EQUAL(index.Rows(), 8);
+        UNIT_ASSERT_VALUES_EQUAL(index.GetEndRowId(), Max<TRowId>());
+        UNIT_ASSERT(index.GetLastKeyRecord() == nullptr);
+    }
 }
 
 }


### PR DESCRIPTION
This new `WriteLastFlatIndexKey` setting is needed for comparison of Precharge logic: B-tree index doesn't have the last key, so it can't be used when we precharge some range [k1, k2] where k1 > the last key