### PR TITLE
Revert "Remove devtools folder"

### DIFF
--- a/.github/check_dirs.sh
+++ b/.github/check_dirs.sh
@@ -17,6 +17,7 @@ declare -A top_dirs=(
     [scripts/]=1,
     [yt/]=1,
     [vendor/]=1,
+    [devtools/]=1,
 )
 
 cd $GIT_URL

--- a/devtools/ya/test/const/__init__.py
+++ b/devtools/ya/test/const/__init__.py
@@ -1,0 +1,1 @@
+from build.plugins.lib.test_const import *  # noqa: F401, F403

--- a/devtools/ya/test/const/ya.make
+++ b/devtools/ya/test/const/ya.make
@@ -1,0 +1,14 @@
+PY23_LIBRARY()
+
+PEERDIR(
+    build/plugins/lib/test_const
+)
+
+STYLE_PYTHON()
+
+PY_SRCS(
+    NAMESPACE test.const
+    __init__.py
+)
+
+END()


### PR DESCRIPTION
Reverts ydb-platform/ydb#895

As db/library/yql/providers/generic/connector/tests with docker recipe do not run.