### PR TITLE
Introduce blobsan

### DIFF
--- a/ydb/tools/blobsan/main.cpp
+++ b/ydb/tools/blobsan/main.cpp
@@ -1,0 +1,614 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_partlayout.h>
+#include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_sets.h>
+#include <ydb/core/blobstorage/vdisk/query/query_stream.h>
+#include <library/cpp/containers/absl_flat_hash/flat_hash_map.h>
+#include <library/cpp/streams/bzip2/bzip2.h>
+#include <library/cpp/pop_count/popcount.h>
+#include <util/generic/buffer.h>
+#include <util/generic/hash.h>
+#include <util/stream/buffer.h>
+#include <util/stream/input.h>
+#include <util/stream/output.h>
+#include <util/stream/str.h>
+#include <util/string/builder.h>
+#include <util/system/thread.h>
+#include <util/system/mutex.h>
+#include <util/system/condvar.h>
+#include <deque>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <list>
+
+using namespace NKikimr;
+
+ui32 TotalPartCount = 0;
+ui32 BlobSubgroupSize = 0;
+
+bool OutputCout = true;
+
+struct TRecordHeader {
+    ui32 GroupId;
+    ui32 Index;
+    ui32 Length;
+};
+
+using TStreamId = std::tuple<ui32, ui32>;
+
+struct TParseState {
+    std::optional<TString> ActorId;
+    ui64 SequenceId = 1;
+};
+
+std::unordered_map<TStreamId, TParseState, THash<TStreamId>> ParseState;
+
+using TBarrierKey = std::tuple<ui64, ui32>; // tablet:channel
+
+struct TBarrierRecord {
+    bool Hard = false;
+    ui32 CollectGen = 0;
+    ui32 CollectStep = 0;
+    ui32 Ingress = 0;
+};
+
+struct TBarrierInfo {
+    std::map<std::tuple<ui32, ui32>, TBarrierRecord> Records;
+    std::tuple<ui32, ui32> SoftKey, HardKey;
+    std::optional<std::tuple<ui32, ui32>> Soft, Hard;
+
+    TString ToString(ui32 blobGen, ui32 blobStep, bool hasKeepFlag) const {
+        TStringStream str;
+        if (Soft) {
+            auto [rec, ctr] = SoftKey;
+            auto [gen, step] = *Soft;
+            str << "soft[" << rec << ":" << ctr << "=>" << gen << ":" << step << "]";
+            if (std::make_tuple(blobGen, blobStep) <= std::make_tuple(gen, step)) {
+                str << "(collect)";
+                if (hasKeepFlag) {
+                    str << "(keep)";
+                }
+            }
+        }
+        if (Hard) {
+            if (Soft) {
+                str << " ";
+            }
+            auto [rec, ctr] = HardKey;
+            auto [gen, step] = *Hard;
+            str << "hard[" << rec << ":" << ctr << "=>" << gen << ":" << step << "]";
+            if (std::make_tuple(blobGen, blobStep) <= std::make_tuple(gen, step)) {
+                str << "(collect)";
+            }
+        }
+        return str.Str();
+    }
+};
+
+enum EKeepMode {
+    DEFAULT,
+    KEEP,
+    DO_NOT_KEEP,
+};
+
+struct TBlobInfo {
+    EKeepMode KeepMode = DEFAULT;
+    ui32 Nodes = 0;
+    TSubgroupPartLayout Layout;
+    TSubgroupPartLayout LocalLayout;
+    TSubgroupPartLayout ReflectionLayout;
+
+    void Merge(const TBlobInfo& other, const TBlobStorageGroupType& type) {
+        KeepMode = Max(KeepMode, other.KeepMode);
+        Nodes |= other.Nodes;
+        Layout.Merge(other.Layout, type);
+        LocalLayout.Merge(other.LocalLayout, type);
+        ReflectionLayout.Merge(other.ReflectionLayout, type);
+    }
+};
+
+struct TVDiskState {
+    THashMap<TBarrierKey, TBarrierInfo> Barriers;
+    std::unordered_map<TLogoBlobID, TBlobInfo> Blobs;
+};
+
+struct TGroupState {
+    std::unordered_map<ui32, TVDiskState> States;
+};
+
+std::unordered_map<ui32, TGroupState> Groups;
+
+void ParseBlock(TBuffer& buffer, TVDiskState& vs, const TBlobStorageGroupInfo& info) {
+    TBufferInput stream(buffer);
+    TRecordHeader header;
+    const size_t read = stream.Load(&header, sizeof(header));
+    Y_ABORT_UNLESS(read == sizeof(header));
+    TBZipDecompress y(&stream);
+
+    const TStreamId streamId(header.GroupId, header.Index);
+    TParseState& ps = ParseState[streamId];
+
+    ui64 rawX1, rawX2, sequenceId, numBlocks;
+    Load(&y, rawX1);
+    Load(&y, rawX2);
+    Load(&y, sequenceId);
+    Load(&y, numBlocks);
+
+    if (sequenceId == 1) {
+        vs = {};
+        ps = {};
+    }
+
+    const TString actorId(TStringBuilder() << rawX1 << "," << rawX2);
+    Y_ABORT_UNLESS(actorId == ps.ActorId.value_or(actorId));
+    Y_ABORT_UNLESS(sequenceId == ps.SequenceId, "SequenceId# %" PRIu64 " Expected# %" PRIu64, sequenceId, ps.SequenceId);
+    ps.ActorId = actorId;
+    ++ps.SequenceId;
+
+    TLevelIndexStreamActor::TOutputBlockHeader blockHeader;
+
+    const auto& topology = info.GetTopology();
+    const auto& vdiskId = topology.GetVDiskId(header.Index);
+    auto ingressCache = TIngressCache::Create(info.PickTopology(), vdiskId);
+
+    TBufferedOutput lines(&Cout, 1_MB);
+
+    while (const size_t read = y.Load(&blockHeader, sizeof(blockHeader))) {
+        Y_ABORT_UNLESS(read == sizeof(blockHeader));
+
+        TString linePrefix;
+        if (OutputCout) {
+            linePrefix = TStringBuilder() << header.GroupId << " " << header.Index << " " << static_cast<char>('A' + blockHeader.Database) << " ";
+            TStringOutput pfx(linePrefix);
+            switch (blockHeader.TableType) {
+                case static_cast<ui32>(TLevelIndexStreamActor::ETableType::FCUR):
+                    pfx << "FCur ";
+                    break;
+
+                case static_cast<ui32>(TLevelIndexStreamActor::ETableType::FDREG):
+                    pfx << "FDreg ";
+                    break;
+
+                case static_cast<ui32>(TLevelIndexStreamActor::ETableType::FOLD):
+                    pfx << "FOld ";
+                    break;
+
+                case static_cast<ui32>(TLevelIndexStreamActor::ETableType::LEVEL):
+                    pfx << "L" << blockHeader.Level << " ID# " << blockHeader.SstId << " ";
+                    break;
+
+                default:
+                    Y_ABORT();
+            }
+        }
+
+        auto processLogoBlob = [&](const TLevelIndexStreamActor::TOutputLogoBlob& record) {
+            const TLogoBlobID& blobId = record.Key.LogoBlobID();
+            const TIngress ingress(record.Ingress);
+            if (OutputCout) {
+                lines << "Key# " << blobId << " Ingress# " << ingress.ToString(&topology, vdiskId, blobId);
+            }
+
+            EKeepMode keepMode;
+            switch (ingress.GetCollectMode(TIngress::IngressMode(info.Type))) {
+                case CollectModeDefault:
+                    keepMode = DEFAULT;
+                    break;
+
+                case CollectModeKeep:
+                    keepMode = KEEP;
+                    break;
+
+                case CollectModeDoNotKeep:
+                case CollectModeDoNotKeep | CollectModeKeep:
+                    keepMode = DO_NOT_KEEP;
+                    break;
+            }
+
+            const ui32 nodeId = topology.GetIdxInSubgroup(vdiskId, blobId.Hash());
+
+            const auto layout = TSubgroupPartLayout::CreateFromIngress(ingress, info.Type);
+            TSubgroupPartLayout localLayout;
+            const auto& local = ingress.LocalParts(info.Type);
+            for (ui32 i = local.FirstPosition(); i != local.GetSize(); i = local.NextPosition(i)) {
+                localLayout.AddItem(nodeId, i, info.Type);
+            }
+
+            TSubgroupPartLayout reflectionLayout = layout;
+            for (ui32 i = 0; i < TotalPartCount; ++i) {
+                reflectionLayout.Mask(i, 1 << nodeId);
+            }
+
+            const TBlobInfo blob{
+                .KeepMode = keepMode,
+                .Nodes = (ui32)1 << nodeId,
+                .Layout = layout,
+                .LocalLayout = localLayout,
+                .ReflectionLayout = reflectionLayout,
+            };
+            vs.Blobs[blobId].Merge(blob, info.Type);
+        };
+
+        auto processBlock = [&](const TLevelIndexStreamActor::TOutputBlock& record) {
+            if (OutputCout) {
+                lines << "Key# " << record.Key.ToString() << " MemRec# " << record.MemRec.ToString(ingressCache.Get());
+            }
+        };
+
+        auto processBarrier = [&](const TLevelIndexStreamActor::TOutputBarrier& record) {
+            if (OutputCout) {
+                lines << "Key# " << record.Key.ToString() << " MemRec# " << record.MemRec.ToString(ingressCache.Get());
+            }
+
+            auto& barrier = vs.Barriers[TBarrierKey(record.Key.TabletId, record.Key.Channel)];
+
+            const auto [it, inserted] = barrier.Records.try_emplace({record.Key.Gen, record.Key.GenCounter});
+            auto& r = it->second;
+            if (inserted) {
+                r = {
+                    .Hard = static_cast<bool>(record.Key.Hard),
+                    .CollectGen = record.MemRec.CollectGen,
+                    .CollectStep = record.MemRec.CollectStep,
+                    .Ingress = record.MemRec.Ingress.Raw(),
+                };
+            } else {
+                Y_ABORT_UNLESS(r.Hard == record.Key.Hard);
+                Y_ABORT_UNLESS(r.CollectGen == record.MemRec.CollectGen);
+                Y_ABORT_UNLESS(r.CollectStep == record.MemRec.CollectStep);
+                r.Ingress |= record.MemRec.Ingress.Raw();
+            }
+
+            auto ingress = TBarrierIngress::CreateFromRaw(r.Ingress);
+            if (ingress.IsQuorum(ingressCache.Get())) {
+                auto& key = r.Hard ? barrier.HardKey : barrier.SoftKey;
+                auto& value = r.Hard ? barrier.Hard : barrier.Soft;
+                if (!value || key < it->first) { // newer barrier with quorum wins
+                    key = it->first;
+                    value.emplace(r.CollectGen, r.CollectStep);
+                }
+            }
+        };
+
+        auto processRecord = [&](auto& record, const auto& callback) {
+            if (OutputCout) {
+                lines << linePrefix;
+            }
+            callback(record);
+            if (OutputCout) {
+                lines << Endl;
+            }
+        };
+
+        auto processRecordArray = [&](const auto& v, const auto& callback) {
+            using T = std::decay_t<decltype(v)>;
+            for (ui32 i = 0; i < blockHeader.NumRecs; ++i) {
+                T record;
+                const size_t n = y.Load(&record, sizeof(record));
+                Y_ABORT_UNLESS(n == sizeof(record));
+                processRecord(record, callback);
+            }
+        };
+
+        switch (blockHeader.Database) {
+            case static_cast<ui32>(TLevelIndexStreamActor::EDatabase::LOGOBLOBS):
+                processRecordArray(TLevelIndexStreamActor::TOutputLogoBlob(), processLogoBlob);
+                break;
+
+            case static_cast<ui32>(TLevelIndexStreamActor::EDatabase::BLOCKS):
+                processRecordArray(TLevelIndexStreamActor::TOutputBlock(), processBlock);
+                break;
+
+            case static_cast<ui32>(TLevelIndexStreamActor::EDatabase::BARRIERS):
+                processRecordArray(TLevelIndexStreamActor::TOutputBarrier(), processBarrier);
+                break;
+
+            default:
+                Y_ABORT();
+        }
+    }
+}
+
+void PushBlock(TStreamId streamId, TBuffer&& buffer, const TBlobStorageGroupInfo& info) {
+    auto [groupId, index] = streamId;
+    ParseBlock(buffer, Groups[groupId].States[index], info);
+}
+
+TString FormatBitMask(ui64 mask, ui32 numBits) {
+    TStringStream str;
+    for (ui32 i = 0; i < numBits; ++i) {
+        str << (mask >> i & 1);
+    }
+    return str.Str();
+}
+
+TString FormatLayout(const TSubgroupPartLayout& layout, TBlobStorageGroupType type) {
+    TStringStream s;
+    bool first = true;
+    s << "{";
+
+    switch (type.GetErasure()) {
+        case TBlobStorageGroupType::ErasureMirror3dc:
+            for (ui32 realm = 0; realm < 3; ++realm) {
+                for (ui32 domain = 0; domain < 3; ++domain) {
+                    const ui32 nodeId = realm + domain * 3;
+                    ui32 parts = 0;
+                    for (ui32 i = 0; i < TotalPartCount; ++i) {
+                        if (layout.GetDisksWithPart(i) >> nodeId & 1) {
+                            parts |= 1 << i;
+                        }
+                    }
+                    if (parts) {
+                        s << (std::exchange(first, false) ? "" : " ") << "R" << realm << "D" << domain;
+                        if (parts != (1 << realm)) {
+                            s << "!";
+                            for (ui32 i = 0; parts; ++i, parts >>= 1) {
+                                if (parts & 1) {
+                                    if (i == nodeId % 3) {
+                                        s << "+";
+                                    } else {
+                                        s << (i + 1);
+                                    }
+                                } else if (i == nodeId % 3) {
+                                    s << "?";
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            break;
+
+        default:
+            return layout.ToString(type);
+    }
+
+    s << "}";
+    return s.Str();
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        Cerr << "usage: " << argv[0] << " <erasure>" << Endl;
+        return 1;
+    }
+
+    char link[256];
+    ssize_t rv = readlink("/proc/self/fd/1", link, sizeof(link));
+    if (rv == 9 && strncmp(link, "/dev/null", rv) == 0) {
+        OutputCout = false;
+    }
+
+    TBlobStorageGroupType type(TBlobStorageGroupType::ErasureSpeciesByName(argv[1]));
+    TotalPartCount = type.TotalPartCount();
+    BlobSubgroupSize = type.BlobSubgroupSize();
+
+    const ui32 numRealms = type.GetErasure() == TBlobStorageGroupType::ErasureMirror3dc ? 3 : 1;
+    const ui32 numDomains = type.GetErasure() == TBlobStorageGroupType::ErasureMirror3dc ? 3 : BlobSubgroupSize;
+    TBlobStorageGroupInfo info(type, 1, numDomains, numRealms);
+    auto& checker = info.GetQuorumChecker();
+    const TBlobStorageGroupInfo::TSubgroupVDisks failed(&info.GetTopology());
+    ui64 trashSize = 0;
+
+    IInputStream& stream = Cin;
+    for (;;) {
+        TRecordHeader header;
+        if (const size_t read = stream.Load(&header, sizeof(header))) {
+            Y_ABORT_UNLESS(read == sizeof(header));
+            TBuffer buffer(read + header.Length);
+            buffer.Append((const char*)&header, sizeof(header));
+            const size_t n = stream.Load(buffer.Pos(), header.Length);
+            buffer.Advance(n);
+            Y_ABORT_UNLESS(n == header.Length);
+            PushBlock(TStreamId(header.GroupId, header.Index), std::move(buffer), info);
+        } else {
+            break;
+        }
+    }
+
+    TBufferedOutput err(&Cerr, 1_MB);
+
+    for (auto& [groupId, group] : Groups) {
+        struct TBlobRecord {
+            TBlobInfo Info;
+            bool Hard = false;
+            ui32 UnderBarrierMask = 0;
+            ui32 DiscardMask = 0;
+            ui32 KeepMask = 0;
+            ui32 DoNotKeepMask = 0;
+            std::vector<TBlobInfo> PerIndexInfo;
+        };
+
+        std::vector<ui32> indexes;
+        for (const auto& [index, vdisk] : group.States) {
+            indexes.push_back(index);
+        }
+        std::sort(indexes.begin(), indexes.end());
+
+        for (;;) {
+            TLogoBlobID blobId;
+
+            // collect record information from the disks of the group
+            TBlobRecord record;
+            for (auto& [index, vdisk] : group.States) {
+                auto it = blobId == TLogoBlobID() ? vdisk.Blobs.begin() : vdisk.Blobs.find(blobId);
+                if (it == vdisk.Blobs.end()) {
+                    continue;
+                }
+                auto nh = vdisk.Blobs.extract(it);
+                blobId = nh.key();
+                TBlobInfo& blob = nh.mapped();
+
+                bool underBarrier = false;
+                bool hard = false;
+                bool discard = false;
+
+                const auto& barrierKey = std::make_tuple(blobId.TabletID(), blobId.Channel());
+                if (const auto barrierIt = vdisk.Barriers.find(barrierKey); barrierIt != vdisk.Barriers.end()) {
+                    const auto& barrier = barrierIt->second;
+                    const auto& blobBarrierKey = std::make_tuple(blobId.Generation(), blobId.Step());
+                    if (barrier.Hard && blobBarrierKey <= *barrier.Hard) {
+                        underBarrier = true;
+                        discard = true;
+                        hard = true;
+                    } else if (barrier.Soft && blobBarrierKey <= *barrier.Soft) {
+                        underBarrier = true;
+                        discard = blob.KeepMode != KEEP;
+                        hard = false;
+                    }
+                }
+
+                if (discard) { // no local data
+                    blob.LocalLayout = {};
+                }
+
+                record.Info.Merge(blob, type);
+                record.Hard |= hard;
+                if (underBarrier) {
+                    record.UnderBarrierMask |= blob.Nodes;
+                }
+                if (discard) {
+                    record.DiscardMask |= blob.Nodes;
+                }
+                if (blob.KeepMode == KEEP) {
+                    record.KeepMask |= blob.Nodes;
+                } else if (blob.KeepMode == DO_NOT_KEEP) {
+                    record.DoNotKeepMask |= blob.Nodes;
+                }
+
+                if (record.PerIndexInfo.empty()) {
+                    record.PerIndexInfo.resize(BlobSubgroupSize);
+                }
+                record.PerIndexInfo[index].Merge(blob, type);
+            }
+            if (blobId == TLogoBlobID()) {
+                break;
+            }
+
+            // process the blob
+            TBlobRecord& blob = record;
+            TBlobStorageGroupInfo::TOrderNums nums;
+            info.GetTopology().PickSubgroup(blobId.Hash(), nums);
+
+            auto originalLocalLayout = blob.Info.LocalLayout;
+
+            for (ui32 i = 0; i < BlobSubgroupSize; ++i) {
+                if (!group.States.contains(nums[i])) {
+                    TSubgroupPartLayout temp = blob.Info.Layout;
+                    for (ui32 j = 0; j < TotalPartCount; ++j) {
+                        temp.Mask(j, 1 << i);
+                    }
+                    blob.Info.LocalLayout.Merge(temp, type);
+                    blob.Info.ReflectionLayout.Merge(temp, type);
+                }
+            }
+
+            auto getNumParts = [&](const TSubgroupPartLayout& layout) {
+                ui32 res = 0;
+                for (ui32 i = 0; i < TotalPartCount; ++i) {
+                    res += layout.GetDisksWithPart(i) != 0;
+                }
+                return res;
+            };
+
+            const ui32 numParts = getNumParts(blob.Info.Layout);
+            const ui32 numLocalParts = getNumParts(blob.Info.LocalLayout);
+            const ui32 numNodes = PopCount(blob.Info.Nodes);
+
+            auto isFull = [&](const TSubgroupPartLayout& layout) {
+                return checker.GetBlobState(layout, failed) == TBlobStorageGroupInfo::EBS_FULL;
+            };
+
+            bool misplacedParts = false;
+            if (type.GetErasure() == TBlobStorageGroupType::ErasureMirror3dc) {
+                for (ui32 partId = 0; partId < TotalPartCount; ++partId) {
+                    const ui32 disks = blob.Info.Layout.GetDisksWithPart(partId) | blob.Info.LocalLayout.GetDisksWithPart(partId);
+                    if ((disks & (0b001001001 << partId)) != disks) {
+                        for (ui32 nodeId = 0; nodeId < BlobSubgroupSize; ++nodeId) {
+                            if (disks >> nodeId & 1 && nodeId % 3 != partId) {
+                                trashSize += blobId.BlobSize();
+                                misplacedParts = true;
+                            }
+                        }
+                    }
+                    // mask out misplaced parts
+                    blob.Info.LocalLayout.Mask(partId, 0b001001001 << partId);
+                }
+            }
+
+            if (!blob.UnderBarrierMask || blob.Hard || blob.Info.KeepMode != KEEP ||
+                    (isFull(blob.Info.Layout) && isFull(blob.Info.ReflectionLayout) && isFull(blob.Info.LocalLayout))) {
+                // looks like correct blob -- either it is not under barrier (and may be being written right now), or
+                // it is with keep flags and fully written with correct ingress bits on every disk
+                continue;
+            }
+
+            ui32 seenDisks = 0;
+            for (ui32 i = 0; i < BlobSubgroupSize; ++i) {
+                if (group.States.contains(nums[i])) {
+                    seenDisks |= 1 << i;
+                }
+            }
+
+            const bool phantomLike = seenDisks != blob.Info.Nodes;
+
+            if (phantomLike || numParts < type.MinimalRestorablePartCount() || numLocalParts < type.MinimalRestorablePartCount() ||
+                    !info.GetQuorumChecker().CheckFailModelForSubgroup(~TBlobStorageGroupInfo::TSubgroupVDisks::CreateFromMask(
+                    &info.GetTopology(), blob.Info.Nodes))) {
+                // looks like phantom blob -- count found parts as trash
+                for (ui32 partIdx = 0; partIdx < TotalPartCount; ++partIdx) {
+                    if (const ui32 disks = blob.Info.LocalLayout.GetDisksWithPart(partIdx)) {
+                        trashSize += type.PartSize(blobId) * PopCount(disks);
+                    }
+                }
+                continue;
+            }
+
+            TString keepMode;
+            switch (blob.Info.KeepMode) {
+                case DEFAULT: keepMode = "default"; break;
+                case KEEP: keepMode = "keep"; break;
+                case DO_NOT_KEEP: keepMode = "doNotKeep"; break;
+            }
+
+            err << "GroupId# " << groupId << " BlobId# " << blobId
+                << "\n\tOrderNums#          " << FormatList(nums)
+                << "\n\tKeepMode#           " << keepMode
+                << "\n\tLayout#             " << FormatLayout(blob.Info.Layout, type)
+                << "\n\tLocalLayout#        " << FormatLayout(blob.Info.LocalLayout, type)
+                << "\n\tOrigLocalLayout#    " << FormatLayout(originalLocalLayout, type)
+                << "\n\tReflectionLayout#   " << FormatLayout(blob.Info.ReflectionLayout, type)
+                << "\n\tNumParts#           " << numParts
+                << "\n\tNumLocalParts#      " << numLocalParts
+                << "\n\tNumReflectionParts# " << getNumParts(blob.Info.ReflectionLayout)
+                << "\n\tNumNodes#           " << numNodes
+                << "\n\tNodes#              " << FormatBitMask(blob.Info.Nodes, BlobSubgroupSize)
+                << "\n\tSeenDisks#          " << FormatBitMask(seenDisks, BlobSubgroupSize)
+                << "\n\tNumUnderBarrier#    " << PopCount(blob.UnderBarrierMask)
+                << "\n\tUnderBarrierMask#   " << FormatBitMask(blob.UnderBarrierMask, BlobSubgroupSize)
+                << "\n\tNumDiscard#         " << PopCount(blob.DiscardMask)
+                << "\n\tDiscardMask#        " << FormatBitMask(blob.DiscardMask, BlobSubgroupSize)
+                << "\n\tKeepMask#           " << FormatBitMask(blob.KeepMask, BlobSubgroupSize)
+                << "\n\tDoNotKeepMask#      " << FormatBitMask(blob.DoNotKeepMask, BlobSubgroupSize)
+                << "\n\tMisplaced#          " << (misplacedParts ? "true" : "false");
+
+            for (const ui32 index : indexes) {
+                const auto& vdisk = group.States.at(index);
+                const auto& k = std::make_tuple(blobId.TabletID(), blobId.Channel());
+                if (const auto it = vdisk.Barriers.find(k); it != vdisk.Barriers.end()) {
+                    const bool keep = blob.KeepMask >> index & 1;
+                    err << "\n\tBarrier[" << index << "]#         " << it->second.ToString(blobId.Generation(), blobId.Channel(), keep);
+                }
+            }
+
+            err << Endl;
+        }
+    }
+
+    if (trashSize) {
+        err << "TrashSize# " << trashSize << Endl;
+    }
+
+    return 0;
+}

--- a/ydb/tools/blobsan/ya.make
+++ b/ydb/tools/blobsan/ya.make
@@ -1,0 +1,15 @@
+PROGRAM()
+
+SRCS(
+    main.cpp
+)
+
+PEERDIR(
+    library/cpp/pop_count
+    library/cpp/streams/bzip2
+    ydb/core/blobstorage
+    ydb/core/blobstorage/groupinfo
+    ydb/core/blobstorage/vdisk/query
+)
+
+END()


### PR DESCRIPTION
- Removed unneccessy file from docs folder
- Use AggrAdd for Limit.
- Fix any join absence after key columns cast
- Remove unused fields from TKqpSchemeOperation
- Added support for optional for predicate selectivity
- Better use AggrAdd for limits.
- Intermediate changes
- Canonization fix.
- YQL-16196 Add FileOptions pragma and bypass_artifact_cache option for MR job spec
- Add host_os.ya.make.inc files to piglet-sync
- Fix bug KIKIMR-11082
- KIKIMR-20451: Pass TTLSettings on column table create
- ci: add missing ydb/ci sync
- pg-make-test saves stderr
- Prepare to rename py3_flake8 tests to flake8
- Intermediate changes
- add attribute to detect lifetime bound errors
- Handle long-lasting Put queries in DS proxy correctly -- part 2 KIKIMR-9016
- Handle RaiseError calls in OffsetFetchActor
- Не работает ResourceManager.resource_filename вместе с Y_PYTHON_SOURCE_ROOT
- Intermediate changes
- Fix inconsistency in rpc protocol
- , YT-18091: Do not schedule pollable shutdown in finalizer invoker
- Update contrib/python/traitlets/py3 to 5.14.0
- Intermediate changes
- Update contrib/python/ipython/py3 to 8.18.1
- YT-20658: add two fields to Bundle Controller API
- Moved cmake files to generator dir and updated generator.toml
- Update doc content
- [dq] Refactor dq gateway session handling
- Disable data validation in opensource
- unknown data source has been fixed
- Removed wrong copy
- add kms's symmetric_crypto_service for nbs
- KIKIMR-19831: exclude right columns from left only stream join result
- YQL-17080 fix win build + adjust bounds
- YQL-17117: optimize PgCast unknown->text
- Fix verify requirement \!PipeToBalancer failed
- Y_DECLARE_OUT_SPEC for NKikimrDataEvents
- YQL-17346 more columns in pg_type
- Traffic agg task metrics + YQ public metrics
- ci: cache tests results
- Update contrib/python/s3transfer/py3 to 0.8.0
- Intermediate changes
- KIKIMR-19861: fix compaction task volume limit
- YQL-16196 Add docs for FileOption pragma
- Rewrite switching pools for executor thread, KIKIMR-18440
- Create postcommit.yml
- Consider used columns in index chooser
- YQL-17352 YQL-17356 YQL-17347 more pg_catalog tables
- Fix build problem KIKIMR-9016
- fix typo in port number section + add note on ports for multiple dynnodes per server
- Add build support for cortex-m23 platform
- Support override `distutils` from `setuptools`
- YQ Connector: prepare code base for S3 integration
- Test for duplicate data in anyjoin
- Intermediate changes
- Introduce convenient _B literal for bytes
- Support std::filesystem::path in TFile and TFileHandle
- feat setuptools: revert/fix UnionProvider
- ci: don't fail to fast on test run, add POST suffix for push checks
- Update Python 3 to 3.11.7
- Add GO_MOCKGEN_CONTRIB_FROM macro to generate mockgens from contribs
- Support Python 3.12 for `future`
- Intermediate changes
- Support Python 3.12 for `cffi`
- drop unused MaxDPccpDPTableSize
- fix return code UNSUPPORTED to UNAVILABLE
- updated roadmap for 2024
- not found behaviour has been changed for get script execution
- Support Python 3.12 for `tornado-4`
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- YT-20686: Fix TResponseKeeper
- ci: quote log file path
- Pass DiscoveryEndpoint in to DiscoveryMutator
- Intermediate changes
- KIKIMR-20179: remove deprecated reader from tests
- serial execution in simple write session
- ci: testmo-proxy use RequestException instead of ConnectionError
- Handle long-lasting Put queries in DS proxy correctly -- part 3
- add a whitelist for pooltrees pragma
- ci: use ya from repo, fix memory sanitizer run, always try generate summary
- Intermediate changes
- Remove excessive EOL spaces in blobstorage code
- Intermediate changes
- Better relational operators for TStrongTypedef
- [yql] test auto partition
- YQL-16196 Move internal link into internal docs (PRAGMA FileOptions)
- KIKIMR-20482: Remove duplicates on schema versions
- Print time in shutdown logging
- Fix comparison key
- Intermediate changes
- Fix fluky test. We can get CLIENT_CANCELED status at driver shutdown.…
- RowCount/ColCount should be used in move/parse
- KIKIMR-20042 Wilson uploader fix
- ,allow optional timestamp in insert into monitoring
- YT-20425: Optional offset in pull_consumer
- primary keys naming unification
- fix stream-write refresh-token rights
- support default values in create table for pg syntax KIKIMR-20022
- PR from branch users/nsofya/KIKIMR-19564
- Fix build, KIKIMR-18440
- fix codestyle: remove semicolon
- finer check of lifetimebound attribute support
- Use generic node count, not datashards only
- [yql] extend dq_file test parts
- Fix _an attribute list cannot appear here_ from clang-cl16
- Fix modernize-use-emplace reported by clang-tidy16
- FS_TOOLS to python3
- [yql] extend yt_native_file test parts
- Update contrib/restricted/nlohmann_json to 3.11.3
- Intermediate changes
- Stricter platform check for prebuilt protoc-gen-go
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- Update COPY_FILE macro
- Replace rep.erase with rep.erase_one in THashSet::erase
- fix typo in public method name
- Move ApplyJitter impl to inl file
- Add fake PDisk key to kikimr_cfg, KIKIMR-20141
- Allow using std::filesystem::path when constructing TFileInput / TFileOutput
- Switch windows builds to clang16
- Remote development
- KIKIMR-19521 BTreeIndex Loader & Dump
- KIKIMR-19521 BTreeIndex Charge Interface
- Intermediate changes
- KIKIMR-20432, KIKIMR-20431: support pg and not null types for stream lookup join
- KIKIMR-19512 Push down binary arithmetic operations and use YQL kernels.
- Split postcommits in two workflows
- TEvWriteResult Origin
- YQL-17353 YQL-17355 YQL-17357 YQL-17358 YQL-17360 YQL-17361 YQL-17362 more tables (mostly empty)
- PR from branch users/zverevgeny/YQL-17279_mr_permute
- KIKIMR-20538: background processes disabling
- KIKIMR-20009:dont remove blobs in case failed main data writing
- External build system generator release 69
- KIKIMR-19900 switch arcadia to python ydb sdk from contrib
- SpillingEngine pragma propagation to resource allocator.
- Intermediate changes
- KIKIMR-20484: switch required fields to optional in generic config
- KIKIMR-18888 query classic schema when not found
- YT-20123: make proto config && check it on const values Bundle Controller API
- Fix WriteTableToStream in pgrun
- Attempt to fix CloseSessionsWithLoad test. KIKIMR-20405
- KIKIMR-19512 Add 'Coalesce' kernel.
- UT for dq actors (initial)
- Use clang-tidy via RESOURCE_LIBRARY
- ,allow optional timestamp in insert into monitoring, add tests
- Continue with test on build fail
- Revert "YT-20123: make proto config && check it on const values Bundle Controller API"
- Reorder a bit and remove unneeded var
- Fix names of + and - in json.
- Switch to use object attributes for consumer
- Refactor OutputChannel reads in task_runner_actor
- Correct v1/v2 totals
- Update contrib/libs/backtrace to 2023-11-30
- YT: Introduce schema for TYsonStruct
- Rename py3_flake8 to flake8
- Move fyamlcpp and yaml_config to NKikimr namespace
- [yql] Common zero-sampling optimizer for both yt/dq providers
- federated topic write
- Enable COPY_FILE with text context for UNION and PACKAGE
- Better follback in ranges multiplier
- YT-16482: Fix GROUP BY
- Fix channel garbage collection issue KIKIMR-20525
- Intermediate changes
- Simplify AddOperation
- Add UT for consequent major updates, KIKIMR-20283
- Intermediate changes
- skip empty metrics KIKIMR-20270
- YT-19944: Add key filter metrics
- Intermediate changes
- KIKIMR-19452: Pg insert from selection by column order
- timeout logs have been moved to error
- detect dangling references in MapFindPtr and utility helpers
- Intermediate changes
- detect dangling references to temporary TStringBuilder object
- Remove TCoordinatorInfo::TabletId
- Intermediate changes
- 
- pg varchar as primary key
- YQL-17378 simple obfuscation of SQL query
- Intermediate changes
- Finalizing full result write via writing queue to avoid early finish
- YQL-17276: Fix hybrid for TopSort case
- Do not update index record in case of upsert with value equal to already present one
- Fix double hard gc KIKIMR-20525
- Remove more old patches
- Intermediate changes
- Use dynamic vendored libs when put in cache
- DataShard EvWrite Immediate
- Fix yson parsing in yql_agent
- KIKIMR-19512 Set combiner limit from mkql heavy limit.
- Intermediate changes
- detect dangling references in TMaybe object
- Update contrib/python/clickhouse-connect to 0.6.22
- Intermediate changes
- for darwin-arm64
- Static libs
- Run checks switches
- Support \pset null in pgrun
- Offload "annotations" attribute handling
- Use aggregate for Sequoia replicas
- Update contrib/restricted/boost/predef to 1.84.0
- Update contrib/restricted/boost/config to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/variant to 1.84.0
- Update contrib/restricted/boost/mp11 to 1.84.0
- Update contrib/restricted/boost/math to 1.84.0
- Update contrib/restricted/boost/conversion to 1.84.0
- infly metrics have been fixed
- Update contrib/restricted/boost/core to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/utility to 1.84.0
- Intermediate changes
- Update contrib/restricted/boost/any to 1.84.0
- Update contrib/restricted/boost/winapi to 1.84.0
- Update contrib/restricted/boost/endian to 1.84.0
- Update contrib/python/fonttools to 4.46.0
- Fix crash caused by StdNormalRandom producing a value out of expected range
- Root CMakeLists.txt generation with jinja
- Release opensource ya & test_tool
- Reset tests cache
- Intermediate changes
- Fix SCHEME_ERROR from DS KIKIMR-20297
- Update contrib/restricted/boost/atomic to 1.84.0
- Update contrib/restricted/boost/bind to 1.84.0
- USE_OPENSOURCE_TEST_TOOL=yes
- re-enable clang::reinitialized attribute for non-CUDA target platforms
- Update contrib/restricted/boost/ratio to 1.84.0
- Checks switch fix
- Update contrib/restricted/boost/smart_ptr to 1.84.0
- Update contrib/restricted/boost/function to 1.84.0
- Update contrib/restricted/boost/tuple to 1.84.0
- Update contrib/restricted/boost/array to 1.84.0
- Update contrib/restricted/boost/thread to 1.84.0
- Update contrib/restricted/boost/optional to 1.84.0
- fix tests after
- Add KDevelop (#495)
- do not use adaptive thread pool (#536)
- add uniq node id validation to ydb cfg (#538)
- ci: add defalut for put_build_results_to_cache (#546)
- Enhance error message (#539)
- support api proto files in go (#543)
- Test error delivery in result receiver (#548)
- Refactor DQ Channel Storage to accept external actor system (#547)
- Do not include data_events/events.h in do datashard.h. Ydb import fix. (#552)
- YQL-17145: fix autoparametrization of null values and refactor settings (#555)
- YQL-17393: Fix dq tests (#551)
- KIKIMR-20042 Wilson enchancements (#540)
- Add tstool and tsserver into ydb/tools (#545)
- KIKIMR-20079: create/alter/drop group (#501)
- ci: put build results to cache for PR checks and fix log extraction in the transform-ya-junit script (#561)
- Remove unused include (#559)
- KIKIMR-20042 KeyValue tablet toplevel tracing (#526)
- GetSubmatrix (#556)
- Refactored CBO interface for DQ (#558)
- Fix plans and cannonize tests with aggr functions. (#550)
- Fix missed subscription for non local request cancelation. (#527)
- Optimize TString creation in TSpan ctor (#568)
- Optimize heartbeats emission KIKIMR-20392 (#557)
- Report nodeId with create session response. (#562)
- Optimize TSpan methods to prevent unneeded object construction KIKIMR-15449 (#575)
- KIKIMR-20042 Enchanced VDisk tracing (#571)
- Mote YT plugin to ydb/library/yql (#573)
- KIKIMR-20042 Added table with statistics to LoadActor html report (#565)
- fix sequence requests lost and add debugging tools to sequence proxy (#570)
- added GetOpenTelemetryTraceParent() to IRequestCtxBaseMtSafe (#577)
- KIKIMR-16087 Replace Y_ABORT_UNLESS (#569)
- Update pr_check.yml (#583)
- ci: start testmo run before starting tests (#580)
- ci: run CheckAllowedDirs on all branches (#581)
- YQL-17393: Fix Dq tests (#560)
- TaskRunnerActor accepts unknown events (#576)
- Flush queue and end Final message immidiately on full result writer error (#582)
- Disable YQL YT plugin under non-linux platforms (#588)
- Implement CREATE/DROP EXTERNAL DATA SOURCE/EXTERNAL TABLE in QueryService. Without IF NOT EXISTS/IF EXISTS support yet (#524)
- YQL-17087: Move DqChannelStorage to separate file and use interface (#591)
- [dq] Peephole integration + some transform helpers (YQL-17386) (#572)
- YQL-9853: add documentation for WalkFolders (#585)
- Mutetests1 (#578)
- YQL-17434 Ignore TEvStatistics (#598)
- Update README.md (#602)
- YQ-2323: YQ Connector:  use Connector docker image for YQL Generic provider integration tests  (#604)
- Add grpc request proxy wilson span and trace id on the request context. (#606)
- KIKIMR-20081: add grant/revoke permissions to query service (#522)
- KIKIMR-20533 Implemented conversion from OTEL header to traceId (#607)
- Replace Y_ABORT_UNLESS #2 (#603)
- KIKIMR-20533 TraceId parser unittests (#617)
- KIKIMR-20217 Initial datashard tracing (#530)
- init (#610)
- Fix ui.sh, add missing mounts.txt (#614)
- Add dynamic config cli (#615)
- YQL-17250: Add operation information into hybrid statistics (#597)
- [dq] Integrate YT peephole transforms into DQ integration (YQL-17386) (#605)
- Out<NYql::TIssues> (#626)
- Import libs 1 (#590)
- Use user provided otel header to start grpc proxy tracing. (#628)
- Moved csv parsing in import file cmd to YDB CLI and supported pg-types (only row tables) (#514)
- added vscode (#636)
- add talks/presentations to the docs (#528)
- KIKIMR-20321 viewer tests asan fix (#525)
- First 25 queries of TPC-DS (#632)
- CheckWriteUnit & FinishProposeWriteUnit (#631)
- Add schema example for TPC-DS (#613)
- Move iam auth actors out of IO pool (#648)
- fix (#654)
- [YQL-16903] Introduce BlockEngine pragma (parser/config provider part) (#616)
- Second 25 queries of TPC-DS (#660)
- Third 25 queries of TPC-DS (#662)
- cgi parameters have been sorted YQ-2558 (#619)
- [yql] Fix join-anyjoin_common_dup test (#651)
- UpdateRow & WriteRow (#663)
- Fix Unique/Distinct constraints from nested filtering FlatMap. (#584)
- YQ Connector: fix integration tests style (#640)
- [dq] Separate setting SplitStageOnDqReplicate (YQL-17382) (#664)
- KIKIMR-19521 BTreeIndex Test (#653)
- KIKIMR-19139 Bugfix load indexes (#657)
- add StarvingInRowForNotEnoughCpu for tcp sessions (#625)
- Fix metric PotentialMaxThreadCount (#629)
- Last 25 queries of TPC-DS (#668)
- YQ-2628: add connections option for streaming queries (#579)
- KIKIMR-19521 BTreeIndex Bugfix index size (#671)
- WriteRow out of space (#665)
- YQL-17087: Add channel spilling to dq pipe communication (#612)
- KIKIMR-20521: Add UseVDisksBalancing feature flag (#523)
- KIKIMR-20522: Tests for vdisks balancing (#531)
- Library import 2 (#639)
- Revert "Workload TPC-C init" (#529)
- Consistent debug (#652)
- YQL-17250: Add operation name in fallback message (#627)
- Moved TSpan::Link(TraceId) implementation to .cpp (#674)
- [yql] Fix result diff in dq_file tests (YQL-17386, YQL-17404, YQL-17402, YQL-17405) (#676)
- Add BsCostTracker and advanced cost metrics, KIKIMR-17759 (#600)
- Import libs 3 (#679)
- added tests (#647)
- Refactoring - optimize parameters of CreatePartitionWriter (#669)
- YQL-15941 avoid llvm version pinning where possible (#677)
- Ignore empty metrics in in-progress stats. Try-catch in-progress stats conversion. (#633)
- KIKIMR-19521 BTreeIndex Fix SchemeShard Verify (#655)
- CREATE / DROP VIEW queries support (#656)
- Mute postgresql* tests (#675)
- KIKIMR-20042 Fix of TSpan abort outside of actor system (#630)
- [YQL-17338] disable cast warning from integral types to float types (#690)
- Fix constrains after expand PartitionsByKeys. (#685)
- KIKIMR-20533 Forward traceparent header to KV-tablet (#689)
- Add TPC-DS Q56 (#692)
- YQ-2628: Print stats on final status log (#563)
- get status polling has been fixed YQ-2667 (#620)
- YDB_ACCESSORs (#672)
- Remove TabletId from TValidatedDataTx (#683)
- Removed useless includes (#621)
- YQ-2560: add YDB data_source (#693)
- YQL-9517: RPC Arrow reader YT column converters (#599)
- [yql] gateway extension contains only additional settings (#700)
- Update cost model (#697)
- Use Source Name as name, drop unused index (#701)
- Revert "KIKIMR-20522: Tests for vdisks balancing (#531)" (#706)
- Refuse empty query text (#708)
- KIKIMR-19671 Add RemovePathRecursive function (#680)
- buffered writing for columnshards (#686)
- KIKIMR-20042 Partially implemented PDisk tracing (#574)
- Rename op -> writeOp (#715)
- KIKIMR-19522 BTreeIndex Precharge Simplification (#682)
- YQL-15941 no_llvm versions of purecalc and embedded (#707)
- YQ-2670 switch generic tests to docker compose (#691)
- Start tablets in object domain KIKIMR-20271 (#705)
- KIKIMR-20150: fix and improve flaky test (#713)
- ActorSystem fix typo (#638)
- KQP computation pattern cache serialized program (#634)
- ActorSystem should continue use std atomic (#643)
- ActorSystem memlog use std atomic (#644)
- ActorSystem interrupter use std atomic (#645)
- ActorSystem cpu load log use std atomic (#646)
- Add QueryService coverage for kqp_perf_ut.(KIKIMR-16294) (#721)
- fix tests TopicPeriodicStat* (#717)
- use adaptive timeouts and persistent node count in hive warmup KIKIMR-20551 (#624)
- [YQL-17103] Basic support of pg types in predicate extractor library (#709)
- Add discovery mutator for underlay (#566)
- YQ-2628: add RECURSE_FOR_TESTS (#718)
- YQ-2704 TCheckpointStorage failed on log (#594)
- Keep Issue fields after censorship (#714)
- KIKIMR-20150: remove the test from the mute list (#726)
- Ability for ydb-cli to write request results as arrow parquet (#673)
- YQL-17385 fix tests (#730)
- (refactoring) Inline TChangeRecordBuilder's methods (#734)
- fix broken pg autoparam unit test
- remove a hard error in formatter when CASE wih no ELSE (#723)
- fix (#736)
- fix tests (#735)
- Add PG provider to pgrun (#732)
- use statistics aggregator for basic statistics KIKIMR-18323 (#623)
- YQL-17286: Fix sublink in projection, which has no external deps (#684)
- init (#738)
- generic query for load actor (#512)
- Switch ticket_parser auth clients to HTSwap mailbox type (#670)
- Remove msgbus trace service (deprecated and unused) (#687)
- Remove node identifier (deprecated) (#688)
- Session actor perf (#724)
- YDB-2345 HC time difference message (#741)
- YQ-2651 use ChildPtr instead of ChildRef (#488)
- ut_read_iterator + EvWrite (#742)
- Fixed TItem in-place creation under clang14 (#752)
- Common TChangeRecord in ydb/core/change_exchange (#737)
- Add library increment script (#760)
- Added import s3 to directory (#678)
- Support IF NOT EXISTS/IF EXISTS for tables, external tables and external data sources (#694)
- normalize test (#759)
- Import libs 4 (#758)
- Incremented YDB CLI version to 2.8.0 (#762)
- [yt provider] Don't omit YtMerge with KeepSorted setting (YQL-17413) (#755)
- YDBDOCS-559 add parquet format to docs (#761)
- style has been fixed (#763)
- add monitoring info for tables_manager (#764)
- to change the configuration, skip the step CALCULATING (#743)
- Add ring activation queue (#695)
- Fix poller compatibility mode KIKIMR-20604 (#765)
- ci: new config for ya tests muting (#601)
- Move size checks to the parse phase (#767)
- Add TPC-DS Queries (Postgres variant) (#771)
- YQL-17087. Fix work with actor system in case of async compute actors. (#757)
- Implement double/int -> pg numeric conversion YQL-16767 (#727)
- YQ Connector: YQ-2323: remove Golang implementaion from YDB (#772)
- Untie Keep/DoNotKeep flags from blackboard KIKIMR-20527 (#773)
- graph backend KIKIMR-18277 (#745)
- Predictable test: order select result YQL-17397 (#776)
- [yql] Fix query cache for UDFs (YQL-17478) (#778)
- KIKIMR-20522: Tests for vdisks balancing 2 (#751)
- Revert "Session actor perf (#724)" (#782)
- Enable APPLE_LOCAL_SDK, disable USE_OPENSOURCE_TEST_TOOL (#777)
- [hybrid] Substitute prev operation tables in peephole. Move FillSecureParams after peephole (YQL-17473) (#769)
- EvWrite locks (#774)
- Fix missed root/ya on library import (#784)
- unused-but-set-variable fix (#789)
- Russian translation for GitHub dev docs (#790)
- Introduce strategy test KIKIMR-20527 (#779)
- Revert "KQP computation pattern cache serialized program (#634)" (#750)
- self holder has been added YQ-2588 (#783)
- Use optimize_for = CODE_SIZE in sql protobuf (#794)
- Fail when reading parquets with complex types (#785)
- Predictable test: order dicts YQL-17384 (#793)
- Sys view full for columnshards (#786)
- Add docs for fluent-bit (#541)
- Do not skip index update if index has non equatable types as data column. (#787)
- Sync config documentation with implementation (#797)
- Enhance monitoring for serverless tenants in Hive KIKIMR-19289 (#710)
- Add feature flag for exclusive dynamic nodes KIKIMR-20562 (#748)
- Add default copy assignment operator (#733)
- LOGBROKER-8840: add CreateTopics endpoint to KafkaAPI (#747)
- Better test result normalization YQL-17397 (#804)
- Exclude google.proto.Struct from validator (#800)
- additional memory monitoring (#798)
- YQL-16218 fix SqlIn for tuples (#801)
- YDB-2101 storage handler added check usage when out-of-space filter (#658)
- Prepare Development section for override in customized docs (#814)
- symlinks (#816)
- KIKIMR-19522 BTreeIndex Precharge RowId (#754)
- YQL-17485 initial version of splitter for generated pb files from grammar (#791)
- fix DqReplicate expansion (#818)
- KIKIMR-20597 Implemented tvm authentication for wilson uploader (#768)
- [cfg-test] Move experimental features to separate config (YQL-17455) (#805)
- statistic requests fix (#813)
- fix tests (#820)
- Implement returning list for KiWrite/UpdateTable KIKIMR-18531
- KIKIMR-20530 Datashard tracing enhancements (#746)
- ci: warn if no tests reports found (#807)
- Added stage and local inputs for JSON plans (#699)
- Fix rebase in docs (#825)
- Fix literal rewrite rule for predicate pushdown (#809)
- Fix OLAP stats (#766)
- KIKIMR-20380: min max portion keys validation (#822)
- add compatibility for old upsert nodes (#826)
- fix http tests to wait for port binding (#835)
- [YQL-17389] Normalize dq_file tests
- add pg types to TQueryPlan (#828)
- improve normalization (#827)
- YDB-1713/hotkeys (#830)
- suppress unnecessaryVERIFY which could rise on downgrade scenario (#840)
- Remove deps on non existing folder (#844)
- YQL-16896: Common type inferring for SELECT combinators (#843)
- Library import 5, delete go dependencies (#832)
- Fix flake8 violation in tests/functional/sqs/merge_split_common_table/test.py (#834)
- Support DDL operations (including IF EXISTS/IF NOT EXISTS) for objects with type secret (#838)
- Support DDL in QueryService for SECRET_ACCESS objects (#845)
- recover setting of hostname (#847)
- correctly set roles for a node (#848)
- trace(kqp): add tracing ro read actors (#841)
- Support DDL in QueryService for TIER & TIERING_RULE objects (#846)
- LOGBROKER-8859 Improvements in OffsetFetch endpoint in Kafka API (#803)
- YQL-16896: Fixed BuildProjectionLambda when emitPgStar is true (#849)
- Revert "add pg types to TQueryPlan (#828)" (#850)
- Workaround capture structured binding issue for clang14 (#851)
- Update cmake generation script to use ya, add platforms and ignored errors, add --keep-going (#857)
- Fixed pg_like canonization (#852)
- Added all known join types to CBO (#858)
- Fix opt rules for generic queries. (KIKIMR-16294) (#860)
- Update build_and_test_provisioned.yml
- Update build_and_test_provisioned.yml
- Get rid of lambdas in logging macros (#855)
- YQL-16241: [pg-make-test] Remove empty testcases from the resulting testsuite (#863)
- Move epilogue.cmake after sqlparser (#869)
- [yql] Fix test result diff (YQL-17489) (#877)
- YQ-2068 remove unused var (#837)
- Publish full rl api to oss (#808)
- Hack ydb/library/yql/providers/generic/connector/tests to make them MEDIUM, not LARGE (#876)
- allow fieldsubset optimizer with multiusage input (#862)
- add different metrics to graph service (#871)
- Coalesce pushdown (#744)
- Fix references to protoc compiler (#870)
- Delete go project files from the root (#868)
- Add unary kernels. (#859)
- Fix error in doc build. (#886)
- fix ut link (#887)
- [yql] Refresh file storage state at fork (YQL-17461) (#878)
- Storage Balancer KIKIMR-20636 (#770)
- feature(kqp): enable stream lookup for data query (#611)
- YDBOPS-8928: make connector tests MEDIUM, not LARGE (for OSS ya only) (#892)
- use counter as the resource for spread-neighbours balancer (#891)
- Library import 6 (#888)
- [YQL-17103] Support StartsWith with pg types in extract_predicate library (#854)
- refactor thread ctx (#897)
- fix trivial batch modification detector (#896)
- Disabled import from s3 directory feature on windows (#899)
- EvWrite counters (#874)
- Kafka protocol offset commit, request units and fixes (#831)
- Fixed a problem with cardinality estimation for PK joins (#907)
- YQL-17391: Make inmem_with_set_key* tests results deterministic (#880)
- movable TEventObserverHolder
- Remove devtools folder (#895)
- Fixed minor problems with plan represtation (#889)
- YQ-2068 refactoring, get rid of macro in BuildConnections (#883)
- LOGBROKER-8860 Implement CreatePartitions Kafka API endpoint (#866)
- KIKIMR-20635: pg types in TQueryPlan (#853)
- Test sorting on indexation (#920)
- Mark NYT::TFuture as [[nodiscard]] (#919)
- Revert "Remove devtools folder (#895)" (#922)
- Get right TraceId in SessionActor (#908)
- Add shared executor thread, KIKIMR-18440 (#903)
- Add YT pragmas for `description` and `started_by` (#918)
- support optional list in ListIndexOf (#902)
- TRowVersion -> TSnapshot (#921)
- Enable distconf by default and fix race issue KIKIMR-19031 (#875)
- Fixes clang-format usage (#929)
- YDBDOCS-188: fix a title that was missed during translation (#904)
- Introduce blobsan
