### PR TITLE
disable warmup for root hive

### DIFF
--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -4163,7 +4163,9 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         static const int NUM_TABLETS = NUM_NODES * TABLETS_PER_NODE;
 
         TTestBasicRuntime runtime(NUM_NODES, false);
-        Setup(runtime, true);
+        Setup(runtime, true, 1, [](TAppPrepare& app) {
+            app.HiveConfig.SetWarmUpEnabled(true);
+        });
         const int nodeBase = runtime.GetNodeId(0);
         TActorId senderA = runtime.AllocateEdgeActor();
         const ui64 hiveTablet = MakeDefaultHiveID(0);

--- a/ydb/core/mind/hive/tx__load_everything.cpp
+++ b/ydb/core/mind/hive/tx__load_everything.cpp
@@ -181,7 +181,11 @@ public:
         }
 
         Self->BuildCurrentConfig();
-        Self->WarmUp = Self->CurrentConfig.GetWarmUpEnabled();
+        if (Self->CurrentConfig.HasWarmUpEnabled()) {
+            Self->WarmUp = Self->CurrentConfig.GetWarmUpEnabled();
+        } else {
+            Self->WarmUp = Self->CurrentConfig.GetWarmUpEnabled() && !Self->AreWeRootHive();
+        }
 
         Self->DefaultResourceMetricsAggregates.MaximumCPU.SetWindowSize(TDuration::MilliSeconds(Self->GetMetricsWindowSize()));
         Self->DefaultResourceMetricsAggregates.MaximumMemory.SetWindowSize(TDuration::MilliSeconds(Self->GetMetricsWindowSize()));


### PR DESCRIPTION
Some unit tests are failing now (e. g. see KIKIMR-20753, KIKIMR-20710), because root hive warm-up became unexpectedly long. In those tests there is a pause between the start of static and dynamic nodes, which makes the recently added adaptive timeout become as large as that pause. A simple solution is disabling warm-up for root hives by default - we do not actually need it, we only need warm-up for tenant hives.