### PR TITLE
Add missing includes when _LIBCPP_REMOVE_TRANSITIVE_INCLUDES enabled

### DIFF
--- a/ydb/library/arrow_clickhouse/Common/Allocator.h
+++ b/ydb/library/arrow_clickhouse/Common/Allocator.h
@@ -21,7 +21,7 @@
 
 #include <cstdlib>
 #include <algorithm>
-
+#include <stdexcept>
 
 #include <common/mremap.h>
 //#include <common/getPageSize.h>

--- a/ydb/library/arrow_parquet/result_set_parquet_printer.h
+++ b/ydb/library/arrow_parquet/result_set_parquet_printer.h
@@ -2,6 +2,7 @@
 
 #include <util/system/types.h>
 
+#include <memory>
 #include <string>
 
 namespace NYdb {

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
After defining `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` in libc++, some of the transitive includes will disappear.
Therefore, we have to include them explicitly.