### PR TITLE
Remove functionality out of EngineBay

### DIFF
--- a/ydb/core/engine/minikql/flat_local_minikql_host.h
+++ b/ydb/core/engine/minikql/flat_local_minikql_host.h
@@ -18,6 +18,11 @@ public:
     {}
 
 private:
+    std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys() const override
+    {
+        return {NMiniKQL::IEngineFlat::EResult::Ok, ""};
+    } 
+    
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const override
     {
         Y_UNUSED(row);

--- a/ydb/core/engine/minikql/flat_local_minikql_host.h
+++ b/ydb/core/engine/minikql/flat_local_minikql_host.h
@@ -18,11 +18,12 @@ public:
     {}
 
 private:
-    std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys() const override
+    std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys(const NMiniKQL::IEngineFlat::TValidationInfo& validationInfo) const override
     {
+        Y_UNUSED(validationInfo);
         return {NMiniKQL::IEngineFlat::EResult::Ok, ""};
-    } 
-    
+    }
+
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const override
     {
         Y_UNUSED(row);

--- a/ydb/core/engine/minikql/flat_local_tx_minikql.h
+++ b/ydb/core/engine/minikql/flat_local_tx_minikql.h
@@ -305,7 +305,7 @@ class TFlatLocalMiniKQL : public NTabletFlatExecutor::ITransaction {
                     return MakeResponse(engine.Get(), ctx);
 
                 IEngineFlat::TValidationInfo validationInfo;
-                EngineResultStatusCode = engine->Validate(validationInfo);
+                EngineResultStatusCode = engine->ExtractKeys(validationInfo);
                 if (EngineResultStatusCode != IEngineFlat::EResult::Ok)
                     return MakeResponse(engine.Get(), ctx);
 

--- a/ydb/core/engine/minikql/minikql_engine_host.cpp
+++ b/ydb/core/engine/minikql/minikql_engine_host.cpp
@@ -72,8 +72,7 @@ bool TEngineHost::IsReadonly() const {
 }
 
 
-bool TEngineHost::IsValidKey(TKeyDesc& key, std::pair<ui64, ui64>& maxSnapshotTime) const {
-    Y_UNUSED(maxSnapshotTime);
+bool TEngineHost::IsValidKey(TKeyDesc& key) const {
     ui64 localTableId = LocalTableId(key.TableId);
     return Scheme.IsValidKey(localTableId, key);
 }

--- a/ydb/core/engine/minikql/minikql_engine_host.h
+++ b/ydb/core/engine/minikql/minikql_engine_host.h
@@ -203,4 +203,7 @@ NUdf::TUnboxedValue CreateSelectRangeLazyRowsList(NTable::TDatabase& db, const N
 void ConvertTableKeys(const NTable::TScheme& scheme, const NTable::TScheme::TTableInfo* tableInfo,
     const TArrayRef<const TCell>& row, TSmallVec<TRawTypeValue>& key, ui64* keyDataBytes);
 
+void ConvertTableValues(const NTable::TScheme& scheme, const NTable::TScheme::TTableInfo* tableInfo,
+    const TArrayRef<const IEngineFlatHost::TUpdateCommand>& commands,  TSmallVec<NTable::TUpdateOp>& ops, ui64* valueBytes);
+
 }}

--- a/ydb/core/engine/minikql/minikql_engine_host.h
+++ b/ydb/core/engine/minikql/minikql_engine_host.h
@@ -99,7 +99,7 @@ public:
     ui64 GetShardId() const override;
     const TScheme::TTableInfo* GetTableInfo(const TTableId& tableId) const override;
     bool IsReadonly() const override;
-    bool IsValidKey(TKeyDesc& key, std::pair<ui64, ui64>& maxSnapshotTime) const override;
+    bool IsValidKey(TKeyDesc& key) const override;
     ui64 CalculateReadSize(const TVector<const TKeyDesc*>& keys) const override;
     ui64 CalculateResultSize(const TKeyDesc& key) const override;
     void PinPages(const TVector<THolder<TKeyDesc>>& keys, ui64 pageFaultCount) override;
@@ -120,7 +120,7 @@ public:
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const override;
     ui64 GetTableSchemaVersion(const TTableId&) const override;
 
-    virtual std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys() const = 0;
+    virtual std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys(const NMiniKQL::IEngineFlat::TValidationInfo& validationInfo) const = 0;
 
     void SetPeriodicCallback(TPeriodicCallback&& callback) override;
     void ExecPeriodicCallback() { if (PeriodicCallback) { PeriodicCallback();} }

--- a/ydb/core/engine/minikql/minikql_engine_host.h
+++ b/ydb/core/engine/minikql/minikql_engine_host.h
@@ -7,6 +7,7 @@
 #include <ydb/library/yql/minikql/mkql_function_registry.h>
 #include <ydb/library/yql/minikql/mkql_node_cast.h>
 #include <ydb/library/yql/minikql/mkql_program_builder.h>
+#include <ydb/core/engine/mkql_engine_flat.h>
 #include <ydb/core/engine/mkql_engine_flat_host.h>
 
 namespace NKikimr {
@@ -118,6 +119,8 @@ public:
     bool IsPathErased(const TTableId& tableId) const override;
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const override;
     ui64 GetTableSchemaVersion(const TTableId&) const override;
+
+    virtual std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys() const = 0;
 
     void SetPeriodicCallback(TPeriodicCallback&& callback) override;
     void ExecPeriodicCallback() { if (PeriodicCallback) { PeriodicCallback();} }

--- a/ydb/core/engine/mkql_engine_flat.cpp
+++ b/ydb/core/engine/mkql_engine_flat.cpp
@@ -1043,7 +1043,7 @@ public:
         }
 
         if (Y_LIKELY(result == EResult::Ok)) {
-            validationInfo.Loaded = true;
+            validationInfo.SetLoaded();
         }
 
         IsProgramValidated = true;
@@ -2176,7 +2176,7 @@ void NKikimr::NMiniKQL::IEngineFlat::TValidationInfo::AddReadRange(const TTableI
 
     Keys.emplace_back(TValidatedKey(std::move(desc), /* isWrite */ false));
     ++ReadsCount;
-    Loaded = true;
+    SetLoaded();
 }
 
 void NKikimr::NMiniKQL::IEngineFlat::TValidationInfo::AddWriteRange(const TTableId& tableId, const TTableRange& range, const TVector<NScheme::TTypeInfo>& keyTypes, const TVector<TColumnWriteMeta>& columns, const NScheme::TTypeRegistry& typeRegistry, bool isPureEraseOp)
@@ -2201,5 +2201,5 @@ void NKikimr::NMiniKQL::IEngineFlat::TValidationInfo::AddWriteRange(const TTable
     if (!range.Point) {
         ++DynKeysCount;
     }
-    Loaded = true;
+    SetLoaded();
 }

--- a/ydb/core/engine/mkql_engine_flat.cpp
+++ b/ydb/core/engine/mkql_engine_flat.cpp
@@ -758,14 +758,13 @@ public:
         return EResult::Ok;
     }
 
-    EResult ValidateKeys(TValidationInfo& validationInfo) override {
+    EResult ValidateKeys(const TValidationInfo& validationInfo) const override {
         EResult result = EResult::Ok;
 
-        std::pair<ui64, ui64> maxSnapshotTime = {0,0}; // unused for now
-        for (auto& validKey : validationInfo.Keys) {
+        for (const auto& validKey : validationInfo.Keys) {
             TKeyDesc * key = validKey.Key.get();
 
-            bool valid = Settings.Host->IsValidKey(*key, maxSnapshotTime);
+            bool valid = Settings.Host->IsValidKey(*key);
 
             if (valid) {
                 auto curSchemaVersion = Settings.Host->GetTableSchemaVersion(key->TableId);
@@ -800,7 +799,7 @@ public:
         return result;
     }
 
-    EResult Validate(TValidationInfo& validationInfo) override {
+    EResult ExtractKeys(TValidationInfo& validationInfo) override {
         Y_ABORT_UNLESS(!IsProgramValidated, "Validate is already called");
         Y_ABORT_UNLESS(ProgramPerOrigin.size() == 1, "One program must be added to engine");
         Y_ABORT_UNLESS(Settings.Host, "Host is not set");

--- a/ydb/core/engine/mkql_engine_flat.h
+++ b/ydb/core/engine/mkql_engine_flat.h
@@ -229,8 +229,8 @@ public:
 
     //-- datashard interface
     virtual EResult AddProgram(ui64 origin, const TStringBuf& program, bool readOnly = false) noexcept = 0;
-    virtual EResult ValidateKeys(TValidationInfo& validationInfo) = 0;
-    virtual EResult Validate(TValidationInfo& validationInfo) = 0;
+    virtual EResult ValidateKeys(const TValidationInfo& validationInfo) const = 0;
+    virtual EResult ExtractKeys(TValidationInfo& validationInfo) = 0;
 
     virtual EResult PrepareOutgoingReadsets() = 0;
     virtual ui32 GetOutgoingReadsetsCount() const noexcept = 0;

--- a/ydb/core/engine/mkql_engine_flat.h
+++ b/ydb/core/engine/mkql_engine_flat.h
@@ -7,6 +7,7 @@
 #include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
 #include <ydb/library/mkql_proto/protos/minikql.pb.h>
 #include <ydb/core/protos/minikql_engine.pb.h>
+#include "ydb/core/tablet_flat/flat_table_column.h"
 #include <library/cpp/random_provider/random_provider.h>
 #include <library/cpp/time_provider/time_provider.h>
 
@@ -185,6 +186,21 @@ public:
             HasInReadsets = false;
             Loaded = false;
         }
+
+        void SetLoaded() {
+            Loaded = true;
+        }
+
+        struct TColumnWriteMeta {
+            NTable::TColumn Column;
+            ui32 MaxValueSizeBytes = 0;
+        };
+
+        void AddReadRange(const TTableId& tableId, const TVector<NTable::TColumn>& columns,
+            const TTableRange& range, const TVector<NScheme::TTypeInfo>& keyTypes, const NScheme::TTypeRegistry& typeRegistry, ui64 itemsLimit = 0, bool reverse = false);
+        void AddWriteRange(const TTableId& tableId, const TTableRange& range,
+            const TVector<NScheme::TTypeInfo>& keyTypes, const TVector<TColumnWriteMeta>& columns, const NScheme::TTypeRegistry& typeRegistry, bool isPureEraseOp);
+
     };
 
     //-- error reporting

--- a/ydb/core/engine/mkql_engine_flat_host.h
+++ b/ydb/core/engine/mkql_engine_flat_host.h
@@ -30,7 +30,7 @@ public:
     virtual bool IsReadonly() const = 0;
 
     // Validate key and fill status into it.
-    virtual bool IsValidKey(TKeyDesc& key, std::pair<ui64, ui64>& maxSnapshotTime) const = 0;
+    virtual bool IsValidKey(TKeyDesc& key) const = 0;
 
     // Calculate the whole size of data that needs to be read into memory
     virtual ui64 CalculateReadSize(const TVector<const TKeyDesc*>& keys) const = 0;

--- a/ydb/core/tablet_flat/flat_dbase_scheme.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.cpp
@@ -3,6 +3,68 @@
 namespace NKikimr {
 namespace NTable {
 
+bool TScheme::IsValidKey(ui64 localTableId, TKeyDesc& key) const {
+    auto* tableInfo = GetTableInfo(localTableId);
+    Y_ABORT_UNLESS(tableInfo);
+    
+#define EH_VALIDATE(cond, err_status)                   \
+    do {                                                \
+        if (!(cond)) {                                  \
+            key.Status = TKeyDesc::EStatus::err_status; \
+            return false;                               \
+        }                                               \
+    } while (false) /**/
+
+    EH_VALIDATE(tableInfo, NotExists);  // Table does not exist
+    EH_VALIDATE(key.KeyColumnTypes.size() <= tableInfo->KeyColumns.size(), TypeCheckFailed);
+
+    // Specified keys types should be valid for any operation
+    for (size_t keyIdx = 0; keyIdx < key.KeyColumnTypes.size(); keyIdx++) {
+        ui32 keyCol = tableInfo->KeyColumns[keyIdx];
+        auto vtype = GetColumnInfo(tableInfo, keyCol)->PType;
+        EH_VALIDATE(key.KeyColumnTypes[keyIdx] == vtype, TypeCheckFailed);
+    }
+
+    if (key.RowOperation == TKeyDesc::ERowOperation::Read) {
+        if (key.Range.Point) {
+            EH_VALIDATE(key.KeyColumnTypes.size() == tableInfo->KeyColumns.size(), TypeCheckFailed);
+        } else {
+            EH_VALIDATE(key.KeyColumnTypes.size() <= tableInfo->KeyColumns.size(), TypeCheckFailed);
+        }
+
+        for (size_t i = 0; i < key.Columns.size(); i++) {
+            const TKeyDesc::TColumnOp& cop = key.Columns[i];
+            if (IsSystemColumn(cop.Column)) {
+                continue;
+            }
+            auto* cinfo = GetColumnInfo(tableInfo, cop.Column);
+            EH_VALIDATE(cinfo, TypeCheckFailed);  // Unknown column
+            auto vtype = cinfo->PType;
+            EH_VALIDATE(cop.ExpectedType == vtype, TypeCheckFailed);
+            EH_VALIDATE(cop.Operation == TKeyDesc::EColumnOperation::Read, OperationNotSupported);
+        }
+    } else if (key.RowOperation == TKeyDesc::ERowOperation::Update) {
+        EH_VALIDATE(key.KeyColumnTypes.size() == tableInfo->KeyColumns.size(), TypeCheckFailed);  // Key must be full for updates
+        for (size_t i = 0; i < key.Columns.size(); i++) {
+            const TKeyDesc::TColumnOp& cop = key.Columns[i];
+            auto* cinfo = GetColumnInfo(tableInfo, cop.Column);
+            EH_VALIDATE(cinfo, TypeCheckFailed);  // Unknown column
+            auto vtype = cinfo->PType;
+            EH_VALIDATE(cop.ExpectedType.GetTypeId() == 0 || cop.ExpectedType == vtype, TypeCheckFailed);
+            EH_VALIDATE(cop.Operation == TKeyDesc::EColumnOperation::Set, OperationNotSupported);  // TODO[serxa]: support inplace operations in IsValidKey
+        }
+    } else if (key.RowOperation == TKeyDesc::ERowOperation::Erase) {
+        EH_VALIDATE(key.KeyColumnTypes.size() == tableInfo->KeyColumns.size(), TypeCheckFailed);
+    } else {
+        EH_VALIDATE(false, OperationNotSupported);
+    }
+
+#undef EH_VALIDATE
+
+    key.Status = TKeyDesc::EStatus::Ok;
+    return true;
+}
+
 TAutoPtr<TSchemeChanges> TScheme::GetSnapshot() const {
     TAlter delta;
 

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -5,6 +5,7 @@
 #include "util_basics.h"
 
 #include <ydb/core/base/localdb.h>
+#include "ydb/core/scheme/scheme_tabledefs.h"
 #include <ydb/core/protos/scheme_log.pb.h>
 
 #include <util/generic/map.h>
@@ -151,6 +152,8 @@ public:
     bool IsEmpty() const {
         return Tables.empty();
     }
+
+    bool IsValidKey(ui64 localTableId, TKeyDesc& key) const;
 
     const TRoom* DefaultRoomFor(ui32 id) const noexcept
     {

--- a/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
@@ -103,8 +103,9 @@ public:
         condition->Prepare(txc.DB.GetRowScheme(tableInfo.LocalTid), 0);
 
         const auto tags = MakeTags(condition->Tags(), eraseTx->GetIndexColumnIds());
+        auto now = TAppData::TimeProvider->Now();
         auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(tx);
-        TDataShardUserDb userDb(DataShard, txc.DB, readVersion, writeVersion);
+        TDataShardUserDb userDb(DataShard, txc.DB, op->GetStepOrder(), readVersion, writeVersion, now);
         bool pageFault = false;
 
         TDynBitMap confirmedRows;

--- a/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
@@ -103,8 +103,8 @@ public:
         condition->Prepare(txc.DB.GetRowScheme(tableInfo.LocalTid), 0);
 
         const auto tags = MakeTags(condition->Tags(), eraseTx->GetIndexColumnIds());
-        auto readVersion = DataShard.GetReadWriteVersions(tx).ReadVersion;
-        TDataShardUserDb userDb(DataShard, txc.DB, readVersion);
+        auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(tx);
+        TDataShardUserDb userDb(DataShard, txc.DB, readVersion, writeVersion);
         bool pageFault = false;
 
         TDynBitMap confirmedRows;

--- a/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
@@ -155,7 +155,7 @@ EExecutionStatus TBuildKqpDataTxOutRSUnit::OnTabletNotReady(TActiveTransaction& 
     DataShard.IncCounter(COUNTER_TX_TABLET_NOT_READY);
 
     ui64 pageFaultCount = tx.IncrementPageFaultCount();
-    dataTx.GetKqpComputeCtx().PinPages(dataTx.TxInfo().Keys, pageFaultCount);
+    dataTx.GetKqpComputeCtx().PinPages(dataTx.GetValidationInfo().Keys, pageFaultCount);
 
     tx.ReleaseTxData(txc, ctx);
     return EExecutionStatus::Restart;

--- a/ydb/core/tx/datashard/check_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/check_data_tx_unit.cpp
@@ -162,7 +162,7 @@ EExecutionStatus TCheckDataTxUnit::Execute(TOperation::TPtr op,
             return EExecutionStatus::Executed;
         }
 
-        for (const auto& key : dataTx->TxInfo().Keys) {
+        for (const auto& key : dataTx->GetValidationInfo().Keys) {
             if (key.IsWrite && DataShard.IsUserTable(key.Key->TableId)) {
                 ui64 keySize = 0;
                 for (const auto& cell : key.Key->Range.From) {

--- a/ydb/core/tx/datashard/check_write_unit.cpp
+++ b/ydb/core/tx/datashard/check_write_unit.cpp
@@ -64,7 +64,7 @@ EExecutionStatus TCheckWriteUnit::Execute(TOperation::TPtr op,
 
         DataShard.IncCounter(COUNTER_WRITE_OUT_OF_SPACE);
 
-        writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, err, DataShard.TabletID());
+        writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, err);
         op->Abort(EExecutionUnitKind::FinishProposeWrite);
 
         LOG_LOG_S_THROTTLE(DataShard.GetLogThrottler(TDataShard::ELogThrottlerType::CheckWriteUnit_Execute), ctx, NActors::NLog::PRI_ERROR, NKikimrServices::TX_DATASHARD, err);
@@ -73,7 +73,7 @@ EExecutionStatus TCheckWriteUnit::Execute(TOperation::TPtr op,
     }
 
     {
-        for (const auto& key : writeTx->TxInfo().Keys) {
+        for (const auto& key : writeTx->GetValidationInfo().Keys) {
             if (key.IsWrite && DataShard.IsUserTable(key.Key->TableId)) {
                 if (DataShard.IsSubDomainOutOfSpace()) {
                     switch (key.Key->RowOperation) {
@@ -88,7 +88,7 @@ EExecutionStatus TCheckWriteUnit::Execute(TOperation::TPtr op,
 
                             DataShard.IncCounter(COUNTER_WRITE_OUT_OF_SPACE);
 
-                            writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, err, DataShard.TabletID());
+                            writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, err);
                             op->Abort(EExecutionUnitKind::FinishProposeWrite);
 
                             LOG_LOG_S_THROTTLE(DataShard.GetLogThrottler(TDataShard::ELogThrottlerType::CheckWriteUnit_Execute), ctx, NActors::NLog::PRI_ERROR, NKikimrServices::TX_DATASHARD, err);
@@ -105,7 +105,7 @@ EExecutionStatus TCheckWriteUnit::Execute(TOperation::TPtr op,
         if (!Pipeline.AssignPlanInterval(op)) {
             TString err = TStringBuilder() << "Can't propose tx " << op->GetTxId() << " at blocked shard " << DataShard.TabletID();
 
-            writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, err, DataShard.TabletID());
+            writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, err);
             op->Abort(EExecutionUnitKind::FinishProposeWrite);
 
             LOG_NOTICE_S(ctx, NKikimrServices::TX_DATASHARD, err);

--- a/ydb/core/tx/datashard/datashard__engine_host.cpp
+++ b/ydb/core/tx/datashard/datashard__engine_host.cpp
@@ -295,10 +295,12 @@ public:
 
     bool IsValidKey(TKeyDesc& key, std::pair<ui64, ui64>& maxSnapshotTime) const override {
         Y_UNUSED(maxSnapshotTime);
-        if (TSysTables::IsSystemTable(key.TableId))
-            return DataShardSysTable(key.TableId).IsValidKey(key);
 
         return UserDb.IsValidKey(key);
+    }
+
+    std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys() const override {
+        return UserDb.ValidateKeys();
     }
 
     NUdf::TUnboxedValue SelectRow(const TTableId& tableId, const TArrayRef<const TCell>& row,
@@ -388,14 +390,10 @@ public:
 
     // Returns whether row belong this shard.
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const override {
-        if (TSysTables::IsSystemTable(tableId))
-            return DataShardSysTable(tableId).IsMyKey(row);
         return UserDb.IsMyKey(tableId, row);
     }
 
     bool IsPathErased(const TTableId& tableId) const override {
-        if (TSysTables::IsSystemTable(tableId))
-            return false;
         return UserDb.IsPathErased(tableId);
     }
 
@@ -404,8 +402,6 @@ public:
     }
 
     ui64 GetTableSchemaVersion(const TTableId& tableId) const override {
-        if (TSysTables::IsSystemTable(tableId))
-            return 0;
         return UserDb.GetTableSchemaVersion(tableId);
     }
 

--- a/ydb/core/tx/datashard/datashard__engine_host.cpp
+++ b/ydb/core/tx/datashard/datashard__engine_host.cpp
@@ -527,6 +527,12 @@ public:
         }
     }
 
+    void UpdateRow(const TTableId& tableId, NTable::TRawVals key, TArrayRef<const NIceDb::TUpdateOp> ops) override {
+        Y_UNUSED(tableId);
+        Y_UNUSED(key);
+        Y_UNUSED(ops);
+    }
+
     void EraseRow(const TTableId& tableId, const TArrayRef<const TCell>& row) override {
         if (TSysTables::IsSystemTable(tableId)) {
             DataShardSysTable(tableId).EraseRow(row);

--- a/ydb/core/tx/datashard/datashard__engine_host.h
+++ b/ydb/core/tx/datashard/datashard__engine_host.h
@@ -29,7 +29,6 @@ class TLockedWriteLimitException : public yexception {};
 ///
 class TEngineBay : TNonCopyable {
 public:
-    using TValidationInfo = NMiniKQL::IEngineFlat::TValidationInfo;
     using TValidatedKey = NMiniKQL::IEngineFlat::TValidatedKey;
     using EResult = NMiniKQL::IEngineFlat::EResult;
     using TEngineHostCounters = NMiniKQL::TEngineHostCounters;
@@ -51,17 +50,17 @@ public:
     void SetLockTxId(ui64 lockTxId, ui32 lockNodeId);
     void SetUseLlvmRuntime(bool llvmRuntime) { EngineSettings->LlvmRuntime = llvmRuntime; }
 
-    EResult Validate() {
-        if (TxInfo().Loaded)
+    EResult ExtractKeys(NMiniKQL::IEngineFlat::TValidationInfo& validationInfo) {
+        if (validationInfo.Loaded)
             return EResult::Ok;
         Y_ABORT_UNLESS(Engine);
-        return Engine->Validate(TxInfo());
+        return Engine->ExtractKeys(validationInfo);
     }
 
-    EResult ReValidateKeys() {
-        Y_ABORT_UNLESS(TxInfo().Loaded);
+    EResult ValidateKeys(const NMiniKQL::IEngineFlat::TValidationInfo& validationInfo) {
+        Y_ABORT_UNLESS(validationInfo.Loaded);
         Y_ABORT_UNLESS(Engine);
-        return Engine->ValidateKeys(TxInfo());
+        return Engine->ValidateKeys(validationInfo);
     }
 
     /// @note it expects TValidationInfo keys are materialized outsize of engine's allocs
@@ -81,9 +80,7 @@ public:
         EngineHost.Reset();
     }
 
-    TValidationInfo& TxInfo();
-    const TValidationInfo& TxInfo() const;
-    TEngineBay::TSizes CalcSizes(bool needsTotalKeysSize) const;
+    TEngineBay::TSizes CalcSizes(const NMiniKQL::IEngineFlat::TValidationInfo& validationInfo, bool needsTotalKeysSize) const;
 
     void SetWriteVersion(TRowVersion writeVersion);
     void SetReadVersion(TRowVersion readVersion);

--- a/ydb/core/tx/datashard/datashard__kqp_scan.cpp
+++ b/ydb/core/tx/datashard/datashard__kqp_scan.cpp
@@ -1,11 +1,11 @@
 #include "datashard_impl.h"
-#include "range_ops.h"
 #include <util/string/vector.h>
 
 #include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
 #include <ydb/core/formats/arrow/size_calcer.h>
 #include <ydb/core/kqp/compute_actor/kqp_compute_events.h>
+#include <ydb/core/tx/datashard/range_ops.h>
 #include <ydb/core/tablet_flat/flat_row_celled.h>
 
 #include <ydb/library/chunks_limiter/chunks_limiter.h>

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -1498,7 +1498,7 @@ public:
             PrepareValidationInfo(ctx, state);
         } else {
             // There should be no keys when reading sysm tables
-            ValidationInfo.Loaded = true;
+            ValidationInfo.SetLoaded();
         }
     }
 
@@ -1797,7 +1797,7 @@ private:
             }
         }
 
-        ValidationInfo.Loaded = true;
+        ValidationInfo.SetLoaded();
     }
 
     void AcquireLock(TReadIteratorState& state, const TActorContext& ctx) {

--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -227,7 +227,7 @@ bool TValidatedDataTx::ReValidateKeys()
     using EResult = NMiniKQL::IEngineFlat::EResult;
 
     if (IsKqpTx()) {
-        auto [result, error] = EngineBay.GetKqpComputeCtx().ValidateKeys(EngineBay.TxInfo());
+        auto [result, error] = EngineBay.GetKqpComputeCtx().ValidateKeys();
         if (result != EResult::Ok) {
             ErrStr = std::move(error);
             ErrCode = ConvertErrCode(result);

--- a/ydb/core/tx/datashard/datashard_active_transaction.h
+++ b/ydb/core/tx/datashard/datashard_active_transaction.h
@@ -158,17 +158,14 @@ public:
     TEngineBay::TSizes CalcReadSizes(bool needsTotalKeysSize) const { return EngineBay.CalcSizes(needsTotalKeysSize); }
 
     ui64 GetMemoryAllocated() const {
-        if (!IsKqpDataTx()) {
-            const NMiniKQL::IEngineFlat * engine = EngineBay.GetEngine();
-            if (engine) {
-                return EngineBay.GetEngine()->GetMemoryAllocated();
-            }
-        }
+        if (!IsKqpDataTx() && GetEngine())
+            return GetEngine()->GetMemoryAllocated();
 
         return 0;
     }
 
     NMiniKQL::IEngineFlat *GetEngine() { return EngineBay.GetEngine(); }
+    const NMiniKQL::IEngineFlat *GetEngine() const { return EngineBay.GetEngine(); }
     void DestroyEngine() { EngineBay.DestroyEngine(); }
     const NMiniKQL::TEngineHostCounters& GetCounters() { return EngineBay.GetCounters(); }
     void ResetCounters() { EngineBay.ResetCounters(); }

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -63,7 +63,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         self->SysLocksTable().HasWriteLocks(fullTableId) ||
         self->GetVolatileTxManager().GetTxMap());
 
-    TDataShardUserDb userDb(*self, txc.DB, readVersion);
+    TDataShardUserDb userDb(*self, txc.DB, readVersion, writeVersion);
     TDataShardChangeGroupProvider groupProvider(*self, txc.DB);
 
     if (CollectChanges) {

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -63,7 +63,8 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         self->SysLocksTable().HasWriteLocks(fullTableId) ||
         self->GetVolatileTxManager().GetTxMap());
 
-    TDataShardUserDb userDb(*self, txc.DB, readVersion, writeVersion);
+    auto now = TAppData::TimeProvider->Now();
+    TDataShardUserDb userDb(*self, txc.DB, TStepOrder(0, 0), readVersion, writeVersion, now);
     TDataShardChangeGroupProvider groupProvider(*self, txc.DB);
 
     if (CollectChanges) {
@@ -242,7 +243,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             self->GetConflictsCache().GetTableCache(writeTableId).AddUncommittedWrite(keyCells.GetCells(), globalTxId, txc.DB);
             if (!commitAdded) {
                 // Make sure we see our own changes on further iterations
-                userDb.AddCommitTxId(globalTxId, writeVersion);
+                userDb.AddCommitTxId(fullTableId, globalTxId, writeVersion);
                 commitAdded = true;
             }
         } else {

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -69,7 +69,7 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             condition->Prepare(params.Txc->DB.GetRowScheme(localTableId), 0);
         }
 
-        userDb.emplace(*self, params.Txc->DB, params.ReadVersion);
+        userDb.emplace(*self, params.Txc->DB, params.ReadVersion, params.WriteVersion);
         groupProvider.emplace(*self, params.Txc->DB);
         params.Tx->ChangeCollector.Reset(CreateChangeCollector(*self, *userDb, *groupProvider, params.Txc->DB, tableInfo));
     }

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -69,7 +69,8 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             condition->Prepare(params.Txc->DB.GetRowScheme(localTableId), 0);
         }
 
-        userDb.emplace(*self, params.Txc->DB, params.ReadVersion, params.WriteVersion);
+        auto now = TAppData::TimeProvider->Now();
+        userDb.emplace(*self, params.Txc->DB, TStepOrder(0,0), params.ReadVersion, params.WriteVersion, now);
         groupProvider.emplace(*self, params.Txc->DB);
         params.Tx->ChangeCollector.Reset(CreateChangeCollector(*self, *userDb, *groupProvider, params.Txc->DB, tableInfo));
     }
@@ -178,7 +179,7 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             self->GetConflictsCache().GetTableCache(localTableId).AddUncommittedWrite(keyCells.GetCells(), params.GlobalTxId, params.Txc->DB);
             if (!commitAdded && userDb) {
                 // Make sure we see our own changes on further iterations
-                userDb->AddCommitTxId(params.GlobalTxId, params.WriteVersion);
+                userDb->AddCommitTxId(fullTableId, params.GlobalTxId, params.WriteVersion);
                 commitAdded = true;
             }
         } else {

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -18,7 +18,7 @@ void KqpSetTxKeys(ui64 tabletId, ui64 taskId, const TUserTable* tableInfo,
     const NKikimrTxDataShard::TKqpTransaction_TDataTaskMeta& meta, const NScheme::TTypeRegistry& typeRegistry,
     const TActorContext& ctx, TEngineBay& engineBay);
 
-void KqpSetTxLocksKeys(const NKikimrDataEvents::TKqpLocks& locks, const TSysLocks& sysLocks, TEngineBay& engineBay);
+void KqpSetTxLocksKeys(const NKikimrDataEvents::TKqpLocks& locks, const TSysLocks& sysLocks, const NScheme::TTypeRegistry& typeRegistry, TEngineBay& engineBay);
 
 NYql::NDq::ERunStatus KqpRunTransaction(const TActorContext& ctx, ui64 txId,
     const NKikimrDataEvents::TKqpLocks& kqpLocks, bool useGenericReadSets, NKqp::TKqpTasksRunner& tasksRunner);

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -16,9 +16,9 @@ bool KqpValidateTransaction(const ::google::protobuf::RepeatedPtrField<::NYql::N
 
 void KqpSetTxKeys(ui64 tabletId, ui64 taskId, const TUserTable* tableInfo,
     const NKikimrTxDataShard::TKqpTransaction_TDataTaskMeta& meta, const NScheme::TTypeRegistry& typeRegistry,
-    const TActorContext& ctx, TEngineBay& engineBay);
+    const TActorContext& ctx, NMiniKQL::IEngineFlat::TValidationInfo& validationInfo);
 
-void KqpSetTxLocksKeys(const NKikimrDataEvents::TKqpLocks& locks, const TSysLocks& sysLocks, const NScheme::TTypeRegistry& typeRegistry, TEngineBay& engineBay);
+void KqpSetTxLocksKeys(const NKikimrDataEvents::TKqpLocks& locks, const TSysLocks& sysLocks, const NScheme::TTypeRegistry& typeRegistry, NMiniKQL::IEngineFlat::TValidationInfo& validationInfo);
 
 NYql::NDq::ERunStatus KqpRunTransaction(const TActorContext& ctx, ui64 txId,
     const NKikimrDataEvents::TKqpLocks& kqpLocks, bool useGenericReadSets, NKqp::TKqpTasksRunner& tasksRunner);

--- a/ydb/core/tx/datashard/datashard_kqp_compute.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.cpp
@@ -281,9 +281,9 @@ bool TKqpDatashardComputeContext::PinPages(const TVector<IEngineFlat::TValidated
     return ret;
 }
 
-std::tuple<IEngineFlat::EResult, TString> TKqpDatashardComputeContext::ValidateKeys()
+std::tuple<IEngineFlat::EResult, TString> TKqpDatashardComputeContext::ValidateKeys(const NMiniKQL::IEngineFlat::TValidationInfo& validationInfo) const
 {
-    return EngineHost.ValidateKeys();
+    return EngineHost.ValidateKeys(validationInfo);
 }
 
 static void BuildRowImpl(const TDbTupleRef& dbTuple, const THolderFactory& holderFactory,

--- a/ydb/core/tx/datashard/datashard_kqp_compute.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.cpp
@@ -1,9 +1,9 @@
 #include "datashard_kqp_compute.h"
-#include "range_ops.h"
 
 #include <ydb/core/kqp/runtime/kqp_transport.h>
 #include <ydb/core/kqp/runtime/kqp_read_table.h>
 #include <ydb/core/kqp/runtime/kqp_scan_data.h>
+#include <ydb/core/tx/datashard/range_ops.h>
 #include <ydb/core/tx/datashard/datashard_impl.h>
 
 #include <ydb/library/yql/minikql/mkql_node.h>

--- a/ydb/core/tx/datashard/datashard_kqp_compute.h
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.h
@@ -53,7 +53,7 @@ public:
     TEngineHostCounters& GetTaskCounters(ui64 taskId) { return TaskCounters[taskId]; }
     TEngineHostCounters& GetDatashardCounters() { return EngineHost.GetCounters(); }
 
-    std::tuple<IEngineFlat::EResult, TString> ValidateKeys();
+    std::tuple<IEngineFlat::EResult, TString> ValidateKeys(const NMiniKQL::IEngineFlat::TValidationInfo& validationInfo) const;
 
     bool IsTabletNotReady() const { return TabletNotReady; }
 

--- a/ydb/core/tx/datashard/datashard_kqp_compute.h
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.h
@@ -53,7 +53,7 @@ public:
     TEngineHostCounters& GetTaskCounters(ui64 taskId) { return TaskCounters[taskId]; }
     TEngineHostCounters& GetDatashardCounters() { return EngineHost.GetCounters(); }
 
-    std::pair<IEngineFlat::EResult, TString> ValidateKeys(const IEngineFlat::TValidationInfo& validationInfo);
+    std::tuple<IEngineFlat::EResult, TString> ValidateKeys();
 
     bool IsTabletNotReady() const { return TabletNotReady; }
 

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -1584,7 +1584,7 @@ TOperation::TPtr TPipeline::BuildOperation(NEvents::TDataEvents::TEvWrite::TPtr&
     Y_ABORT_UNLESS(writeTx);
 
     auto badRequest = [&](const TString& error) {
-        writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, TStringBuilder() << error << " at tablet# " << Self->TabletID(), Self->TabletID());
+        writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, TStringBuilder() << error << " at tablet# " << Self->TabletID());
         LOG_ERROR_S(TActivationContext::AsActorContext(), NKikimrServices::TX_DATASHARD, error);
     };
 
@@ -1593,7 +1593,7 @@ TOperation::TPtr TPipeline::BuildOperation(NEvents::TDataEvents::TEvWrite::TPtr&
         return writeOp;
     }
 
-    writeTx->ExtractKeys(true);
+    writeTx->ExtractKeys();
 
     if (!writeTx->Ready() && !writeTx->RequirePrepare()) {
         badRequest(TStringBuilder() << "Cannot extract keys tx " << writeOp->GetTxId() << ". " << writeOp->GetWriteTx()->GetErrCode() << ": " << writeOp->GetWriteTx()->GetErrStr());

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -1595,6 +1595,11 @@ TOperation::TPtr TPipeline::BuildOperation(NEvents::TDataEvents::TEvWrite::TPtr&
 
     writeTx->ExtractKeys(true);
 
+    if (!writeTx->Ready() && !writeTx->RequirePrepare()) {
+        badRequest(TStringBuilder() << "Cannot extract keys tx " << writeOp->GetTxId() << ". " << writeOp->GetWriteTx()->GetErrCode() << ": " << writeOp->GetWriteTx()->GetErrStr());
+        return writeOp;
+    }
+
     switch (rec.txmode()) {
         case NKikimrDataEvents::TEvWrite::MODE_PREPARE:
             break;

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -2,6 +2,19 @@
 
 namespace NKikimr::NDataShard {
 
+TDataShardUserDb::TDataShardUserDb(TDataShard& self, NTable::TDatabase& db, const TStepOrder& stepTxId, const TRowVersion& readVersion, const TRowVersion& writeVersion, TInstant now)
+    : Self(self)
+    , Db(db)
+    , ChangeGroupProvider(self, db)
+    , StepTxId(stepTxId)
+    , LockTxId(0)
+    , LockNodeId(0)
+    , ReadVersion(readVersion)
+    , WriteVersion(writeVersion)
+    , Now(now)
+{
+}
+
 NTable::EReady TDataShardUserDb::SelectRow(
         const TTableId& tableId,
         TArrayRef<const TRawTypeValue> key,
@@ -15,8 +28,8 @@ NTable::EReady TDataShardUserDb::SelectRow(
 
     return Db.Select(localTableId, key, tags, row, stats, /* readFlags */ 0,
         readVersion.GetOrElse(ReadVersion),
-        GetReadTxMap(),
-        GetReadTxObserver());
+        GetReadTxMap(tableId),
+        GetReadTxObserver(tableId));
 }
 
 NTable::EReady TDataShardUserDb::SelectRow(
@@ -32,81 +45,189 @@ NTable::EReady TDataShardUserDb::SelectRow(
 
 void TDataShardUserDb::UpdateRow(
     const TTableId& tableId,
-    NTable::TRawVals key,
-    TArrayRef<const NIceDb::TUpdateOp> ops)
+    const TArrayRef<const TRawTypeValue>& key,
+    const TArrayRef<const NIceDb::TUpdateOp>& ops)
 {
     auto localTableId = Self.GetLocalTableId(tableId);
     Y_ABORT_UNLESS(localTableId != 0, "Unexpected UpdateRow for an unknown table");
 
     auto* collector = GetChangeCollector(tableId);
 
-    const ui64 writeTxId = GetWriteTxId(tableId);
-    if (writeTxId == 0) {
+    if (LockTxId == 0) {
         if (collector && !collector->OnUpdate(tableId, localTableId, NTable::ERowOp::Upsert, key, ops, WriteVersion))
             throw TNotReadyTabletException();
 
         Db.Update(localTableId, NTable::ERowOp::Upsert, key, ops, WriteVersion);
     } else {
-        if (collector && !collector->OnUpdateTx(tableId, localTableId, NTable::ERowOp::Upsert, key, ops, writeTxId))
+        if (collector && !collector->OnUpdateTx(tableId, localTableId, NTable::ERowOp::Upsert, key, ops, LockTxId))
             throw TNotReadyTabletException();
 
-        Db.UpdateTx(localTableId, NTable::ERowOp::Upsert, key, ops, writeTxId);
+        Db.UpdateTx(localTableId, NTable::ERowOp::Upsert, key, ops, LockTxId);
     }
 }
 
-void TDataShardUserDb::AddCommitTxId(ui64 txId, const TRowVersion& commitVersion) {
-    if (!DynamicTxMap) {
-        DynamicTxMap = new NTable::TDynamicTransactionMap(Self.GetVolatileTxManager().GetTxMap());
-        TxMap = DynamicTxMap;
-    }
-    DynamicTxMap->Add(txId, commitVersion);
+void TDataShardUserDb::AddCommitTxId(const TTableId& tableId, ui64 txId, const TRowVersion& commitVersion) {
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected AddCommitTxId for an unknown table");
+
+    auto baseTxMap = Self.GetVolatileTxManager().GetTxMap();
+    auto& txMap = TxMaps[tableId.PathId];
+    if (!txMap)
+        txMap = new NTable::TDynamicTransactionMap(baseTxMap);
+    txMap->Add(txId, commitVersion);
 }
 
-NTable::ITransactionMapPtr& TDataShardUserDb::GetReadTxMap() {
-    if (!TxMap) {
-        auto baseTxMap = Self.GetVolatileTxManager().GetTxMap();
-        if (baseTxMap) {
-            DynamicTxMap = new NTable::TDynamicTransactionMap(baseTxMap);
-            TxMap = DynamicTxMap;
+ui64 TDataShardUserDb::GetTableSchemaVersion(const TTableId& tableId) const {
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected GetTableSchemaVersion for an unknown table");
+
+    const auto& userTables = Self.GetUserTables();
+    auto it = userTables.find(tableId.PathId.LocalPathId);
+    if (it == userTables.end()) {
+        Y_FAIL_S("DatshardEngineHost (tablet id: " << Self.TabletID() << " state: " << Self.GetState() << ") unables to find given table with id: " << tableId);
+        return 0;
+    } else {
+        return it->second->GetTableSchemaVersion();
+    }
+}
+
+ui64 TDataShardUserDb::GetWriteTxId(const TTableId& tableId) {
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected GetWriteTxId for an unknown table");
+
+    if (VolatileTxId) {
+        Y_ABORT_UNLESS(!LockTxId);
+        if (VolatileCommitTxIds.insert(VolatileTxId).second) {
+            // Update TxMap to include the new commit
+            auto it = TxMaps.find(tableId.PathId);
+            if (it != TxMaps.end()) {
+                it->second->Add(VolatileTxId, WriteVersion);
+            }
+        }
+        return VolatileTxId;
+    }
+
+    return LockTxId;
+}
+
+NTable::ITransactionMapPtr TDataShardUserDb::GetReadTxMap(const TTableId& tableId) {
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected GetReadTxMap for an unknown table");
+
+    auto baseTxMap = Self.GetVolatileTxManager().GetTxMap();
+
+    bool needTxMap = (
+        // We need tx map when there are waiting volatile transactions
+        baseTxMap ||
+        // We need tx map to see committed volatile tx changes
+        VolatileTxId && !VolatileCommitTxIds.empty() ||
+        // We need tx map when current lock has uncommitted changes
+        LockTxId && Self.SysLocksTable().HasCurrentWriteLock(tableId)
+    );
+
+    if (!needTxMap) {
+        // We don't need tx map
+        return nullptr;
+    }
+
+    auto& txMap = TxMaps[tableId.PathId];
+    if (!txMap) {
+        txMap = new NTable::TDynamicTransactionMap(baseTxMap);
+        if (LockTxId) {
+            // Uncommitted changes are visible in all possible snapshots
+            txMap->Add(LockTxId, TRowVersion::Min());
+        } else if (VolatileTxId) {
+            // We want committed volatile changes to be visible at the write version
+            for (ui64 commitTxId : VolatileCommitTxIds) {
+                txMap->Add(commitTxId, WriteVersion);
+            }
         }
     }
-    return TxMap;
+
+    return txMap;
+}
+
+bool TDataShardUserDb::IsValidKey(TKeyDesc& key) const {
+    ui64 localTableId = Self.GetLocalTableId(key.TableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected IsValidKey for an unknown table");
+
+    if (GetLockTxId()) {
+        // Prevent updates/erases with LockTxId set, unless it's allowed for immediate mvcc txs
+        if (key.RowOperation != TKeyDesc::ERowOperation::Read &&
+            (!Self.GetEnableLockedWrites() || !IsImmediateTx || !IsRepeatableSnapshot || !LockNodeId))
+        {
+            key.Status = TKeyDesc::EStatus::OperationNotSupported;
+            return false;
+        }
+    } else if (IsRepeatableSnapshot) {
+        // Prevent updates/erases in repeatable mvcc txs
+        if (key.RowOperation != TKeyDesc::ERowOperation::Read) {
+            key.Status = TKeyDesc::EStatus::OperationNotSupported;
+            return false;
+        }
+    }
+
+    return Db.GetScheme().IsValidKey(localTableId, key);
+}
+
+// Returns whether row belong this shard.
+bool TDataShardUserDb::IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const {
+    ui64 localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected IsMyKey for an unknown table");
+
+    auto iter = Self.FindUserTable(tableId.PathId);
+    if (!iter) {
+        // TODO: can this happen?
+        Y_VERIFY_DEBUG(false);
+        return false;
+    }
+
+    // Check row against range
+    const TUserTable& info = *iter;
+    return (ComparePointAndRange(row, info.GetTableRange(), info.KeyColumnTypes, info.KeyColumnTypes) == 0);
+}
+bool TDataShardUserDb::IsPathErased(const TTableId& tableId) const {
+    ui64 localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected IsPathErased for an unknown table");
+
+    return Self.GetLocalTableId(tableId) == 0;
+}
+
+bool TDataShardUserDb::HasRemovedTx(ui32 table, ui64 txId) const {
+    return Db.HasRemovedTx(table, txId);
+}
+
+NMiniKQL::IEngineFlat::TValidationInfo& TDataShardUserDb::GetTxInfo() {
+    return TxInfo;
 }
 
 const NMiniKQL::IEngineFlat::TValidationInfo& TDataShardUserDb::GetTxInfo() const {
     return TxInfo;
 }
 
-void TDataShardUserDb::SetIsImmediateTx() {
-    IsImmediateTx = true;
+ui64 TDataShardUserDb::GetStep() const {
+    return StepTxId.Step;
 }
-
-void TDataShardUserDb::SetLockTxId(ui64 lockTxId, ui32 lockNodeId) {
-    LockTxId = lockTxId;
-    LockNodeId = lockNodeId;
-}
-
-ui64 TDataShardUserDb::GetWriteTxId(const TTableId& tableId) {
-    if (TSysTables::IsSystemTable(tableId))
-        return 0;
-
-    return LockTxId;
-}
-
-void TDataShardUserDb::SetVolatileTxId(ui64 txId) {
-    VolatileTxId = txId;
+ui64 TDataShardUserDb::GetTxId() const {
+    return StepTxId.TxId;
 }
 
 void TDataShardUserDb::SetWriteVersion(TRowVersion writeVersion) {
     WriteVersion = writeVersion;
-};
+}
+
+TRowVersion TDataShardUserDb::GetWriteVersion() const {
+    Y_ABORT_UNLESS(!WriteVersion.IsMax(), "Cannot perform writes without WriteVersion set");
+    return WriteVersion;
+}
 
 void TDataShardUserDb::SetReadVersion(TRowVersion readVersion) {
     ReadVersion = readVersion;
-};
+}
 
-void TDataShardUserDb::MarkTxLoaded() {
-    TxInfo.Loaded = true;
+TRowVersion TDataShardUserDb::GetReadVersion() const {
+    Y_ABORT_UNLESS(!ReadVersion.IsMin(), "Cannot perform reads without ReadVersion set");
+    return ReadVersion;
 }
 
 IDataShardChangeCollector* TDataShardUserDb::GetChangeCollector(const TTableId& tableId) {
@@ -128,6 +249,49 @@ IDataShardChangeCollector* TDataShardUserDb::GetChangeCollector(const TTableId& 
         tableId.PathId.LocalPathId
     ));
     return it->second.Get();
+}
+
+void TDataShardUserDb::CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) {
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected CommitChanges for an unknown table");
+
+    if (!Db.HasOpenTx(localTableId, lockId)) {
+        return;
+    }
+
+    if (auto lock = Self.SysLocksTable().GetRawLock(lockId, TRowVersion::Min()); lock && !VolatileCommitOrdered) {
+        lock->ForAllVolatileDependencies([this](ui64 txId) {
+            auto* info = Self.GetVolatileTxManager().FindByCommitTxId(txId);
+            if (info && info->State != EVolatileTxState::Aborting) {
+                if (VolatileDependencies.insert(txId).second && !VolatileTxId) {
+                    VolatileTxId = GetTxId();
+                }
+            }
+        });
+    }
+
+    if (VolatileTxId) {
+        LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Scheduling commit of lockId# " << lockId << " in localTableId# " << localTableId << " shard# " << Self.TabletID());
+        if (VolatileCommitTxIds.insert(lockId).second) {
+            // Update TxMap to include the new commit
+            auto it = TxMaps.find(tableId.PathId);
+            if (it != TxMaps.end()) {
+                it->second->Add(lockId, WriteVersion);
+            }
+        }
+        return;
+    }
+
+    LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Committing changes lockId# " << lockId << " in localTableId# " << localTableId << " shard# " << Self.TabletID());
+    Db.CommitTx(localTableId, lockId, writeVersion);
+    Self.GetConflictsCache().GetTableCache(localTableId).RemoveUncommittedWrites(lockId, Db);
+
+    if (!CommittedLockChanges.contains(lockId) && Self.HasLockChangeRecords(lockId)) {
+        if (auto* collector = GetChangeCollector(tableId)) {
+            collector->CommitLockChanges(lockId, WriteVersion);
+            CommittedLockChanges.insert(lockId);
+        }
+    }
 }
 
 TVector<IDataShardChangeCollector::TChange> TDataShardUserDb::GetCollectedChanges() const {
@@ -153,23 +317,62 @@ void TDataShardUserDb::ResetCollectedChanges() {
     }
 }
 
-std::optional<ui64> TDataShardUserDb::GetCurrentChangeGroup() const {
-    return ChangeGroup;
-}
+TVector<ui64> TDataShardUserDb::GetVolatileCommitTxIds() const {
+    TVector<ui64> commitTxIds;
 
-ui64 TDataShardUserDb::GetChangeGroup() {
-    if (!ChangeGroup) {
-        if (IsImmediateTx) {
-            NIceDb::TNiceDb db(Db);
-            ChangeGroup = Self.AllocateChangeRecordGroup(db);
-        } else {
-            // Distributed transactions have their group set to zero
-            ChangeGroup = 0;
+    if (!VolatileCommitTxIds.empty()) {
+        commitTxIds.reserve(VolatileCommitTxIds.size());
+        for (ui64 commitTxId : VolatileCommitTxIds) {
+            commitTxIds.push_back(commitTxId);
         }
     }
 
-    return *ChangeGroup;
+    return commitTxIds;
 }
+
+std::optional<ui64> TDataShardUserDb::GetCurrentChangeGroup() const {
+    return ChangeGroupProvider.GetCurrentChangeGroup();
+}
+
+ui64 TDataShardUserDb::GetChangeGroup() {
+    // Distributed transactions have their group set to zero
+    if (!IsImmediateTx)
+        return 0;
+
+    return ChangeGroupProvider.GetChangeGroup();
+}
+
+class TLockedReadTxObserver: public NTable::ITransactionObserver {
+public:
+    TLockedReadTxObserver(TDataShardUserDb& userDb)
+        : UserDb(userDb)
+    {
+    }
+
+    void OnSkipUncommitted(ui64 txId) override {
+        UserDb.AddReadConflict(txId);
+    }
+
+    void OnSkipCommitted(const TRowVersion&) override {
+        // We already use InvisibleRowSkips for these
+    }
+
+    void OnSkipCommitted(const TRowVersion&, ui64) override {
+        // We already use InvisibleRowSkips for these
+    }
+
+    void OnApplyCommitted(const TRowVersion& rowVersion) override {
+        UserDb.CheckReadConflict(rowVersion);
+    }
+
+    void OnApplyCommitted(const TRowVersion& rowVersion, ui64 txId) override {
+        UserDb.CheckReadConflict(rowVersion);
+        UserDb.CheckReadDependency(txId);
+    }
+
+private:
+    TDataShardUserDb& UserDb;
+};
 
 class TDataShardUserDb::TReadTxObserver : public NTable::ITransactionObserver {
 public:
@@ -178,7 +381,140 @@ public:
     { }
 
     void OnSkipUncommitted(ui64) override {
-        // nothing
+        // We don't care about uncommitted changes
+        // Any future commit is supposed to be above our read version
+    }
+
+    void OnSkipCommitted(const TRowVersion&) override {
+        // We already use InvisibleRowSkips for these
+    }
+
+    void OnSkipCommitted(const TRowVersion&, ui64) override {
+        // We already use InvisibleRowSkips for these
+    }
+
+    void OnApplyCommitted(const TRowVersion&) override {
+        // Not needed
+    }
+
+    void OnApplyCommitted(const TRowVersion&, ui64 txId) override {
+        UserDb.CheckReadDependency(txId);
+    }
+
+private:
+    TDataShardUserDb& UserDb;
+};
+
+NTable::ITransactionObserverPtr TDataShardUserDb::GetReadTxObserver(const TTableId& tableId) {
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected GetReadTxObserver for an unknown table");
+
+    bool needObserver = (
+        // We need observer when there are waiting changes in the tx map
+        Self.GetVolatileTxManager().GetTxMap() ||
+        // We need observer for locked reads when there are active write locks
+        LockTxId && Self.SysLocksTable().HasWriteLocks(tableId)
+    );
+
+    if (!needObserver) {
+        // We don't need tx observer
+        return nullptr;
+    }
+
+    auto& ptr = TxObservers[tableId.PathId];
+    if (!ptr) {
+        if (LockTxId) {
+            ptr = new TLockedReadTxObserver(*this);
+        } else {
+            ptr = new TReadTxObserver(*this);
+        }
+    }
+
+    return ptr;
+}
+
+void TDataShardUserDb::AddReadConflict(ui64 txId) const {
+    Y_ABORT_UNLESS(LockTxId);
+
+    // We have detected uncommitted changes in txId that could affect
+    // our read result. We arrange a conflict that breaks our lock
+    // when txId commits.
+    Self.SysLocksTable().AddReadConflict(txId);
+}
+
+void TDataShardUserDb::CheckReadConflict(const TRowVersion& rowVersion) const {
+    Y_ABORT_UNLESS(LockTxId);
+
+    if (rowVersion > ReadVersion) {
+        // We are reading from snapshot at ReadVersion and should not normally
+        // observe changes with a version above that. However, if we have an
+        // uncommitted change, that we fake as committed for our own changes
+        // visibility, we might shadow some change that happened after a
+        // snapshot. This is a clear indication of a conflict between read
+        // and that future conflict, hence we must break locks and abort.
+        Self.SysLocksTable().BreakSetLocks();
+    }
+}
+
+void TDataShardUserDb::CheckReadDependency(ui64 txId) {
+    if (auto* info = Self.GetVolatileTxManager().FindByCommitTxId(txId)) {
+        switch (info->State) {
+            case EVolatileTxState::Waiting:
+                // We are reading undecided changes and need to wait until they are resolved
+                VolatileReadDependencies.insert(info->TxId);
+                break;
+            case EVolatileTxState::Committed:
+                // Committed changes are immediately visible and don't need a dependency
+                break;
+            case EVolatileTxState::Aborting:
+                // We just read something that we know is aborting, we would have to retry later
+                VolatileReadDependencies.insert(info->TxId);
+                break;
+        }
+    }
+}
+
+bool TDataShardUserDb::NeedToReadBeforeWrite(const TTableId& tableId) {
+    if (Self.GetVolatileTxManager().GetTxMap()) {
+        return true;
+    }
+
+    if (Self.SysLocksTable().HasWriteLocks(tableId)) {
+        return true;
+    }
+
+    if (auto* collector = GetChangeCollector(tableId)) {
+        if (collector->NeedToReadKeys()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+class TLockedWriteTxObserver: public NTable::ITransactionObserver {
+public:
+    TLockedWriteTxObserver(TDataShardUserDb& userDb, ui64 txId, ui64& skipCount, ui32 localTableId)
+        : UserDb(userDb)
+        , SelfTxId(txId)
+        , SkipCount(skipCount)
+        , LocalTid(localTableId)
+    {
+    }
+
+    void OnSkipUncommitted(ui64 txId) override {
+        // Note: all active volatile transactions will be uncommitted
+        // without a tx map, and will be handled by AddWriteConflict.
+        if (!UserDb.HasRemovedTx(LocalTid, txId)) {
+            ++SkipCount;
+            if (!SelfFound) {
+                if (txId != SelfTxId) {
+                    UserDb.AddWriteConflict(txId);
+                } else {
+                    SelfFound = true;
+                }
+            }
+        }
     }
 
     void OnSkipCommitted(const TRowVersion&) override {
@@ -193,36 +529,157 @@ public:
         // nothing
     }
 
-    void OnApplyCommitted(const TRowVersion&, ui64 txId) override {
-        UserDb.CheckReadDependency(txId);
+    void OnApplyCommitted(const TRowVersion&, ui64) override {
+        // nothing
+    }
+
+private:
+    TDataShardUserDb& UserDb;
+    const ui64 SelfTxId;
+    ui64& SkipCount;
+    const ui32 LocalTid;
+    bool SelfFound = false;
+};
+
+class TWriteTxObserver: public NTable::ITransactionObserver {
+public:
+    TWriteTxObserver(TDataShardUserDb& userDb)
+        : UserDb(userDb)
+    {
+    }
+
+    void OnSkipUncommitted(ui64 txId) override {
+        // Note: all active volatile transactions will be uncommitted
+        // without a tx map, and will be handled by BreakWriteConflict.
+        UserDb.BreakWriteConflict(txId);
+    }
+
+    void OnSkipCommitted(const TRowVersion&) override {
+        // nothing
+    }
+
+    void OnSkipCommitted(const TRowVersion&, ui64) override {
+        // nothing
+    }
+
+    void OnApplyCommitted(const TRowVersion&) override {
+        // nothing
+    }
+
+    void OnApplyCommitted(const TRowVersion&, ui64) override {
+        // nothing
     }
 
 private:
     TDataShardUserDb& UserDb;
 };
 
-NTable::ITransactionObserverPtr& TDataShardUserDb::GetReadTxObserver() {
-    if (!TxObserver) {
-        auto baseTxMap = Self.GetVolatileTxManager().GetTxMap();
-        if (baseTxMap) {
-            TxObserver = new TReadTxObserver(*this);
+void TDataShardUserDb::CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) {
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected CheckWriteConflicts for an unknown table");
+
+    // When there are uncommitted changes (write locks) we must find which
+    // locks would break upon commit.
+    bool mustFindConflicts = Self.SysLocksTable().HasWriteLocks(tableId);
+
+    // When there are volatile changes (tx map) we try to find precise
+    // dependencies, but we may switch to total order on page faults.
+    const bool tryFindConflicts = mustFindConflicts ||
+                                  (!VolatileCommitOrdered && Self.GetVolatileTxManager().GetTxMap());
+
+    if (!tryFindConflicts) {
+        // We don't need to find conflicts
+        return;
+    }
+
+    ui64 skipCount = 0;
+
+    NTable::ITransactionObserverPtr txObserver;
+    if (LockTxId) {
+        // We cannot use cached conflicts since we need to find skip count
+        txObserver = new TLockedWriteTxObserver(*this, LockTxId, skipCount, localTableId);
+        // Locked writes are immediate, increased latency is not critical
+        mustFindConflicts = true;
+    } else if (auto* cached = Self.GetConflictsCache().GetTableCache(localTableId).FindUncommittedWrites(keyCells)) {
+        for (ui64 txId : *cached) {
+            BreakWriteConflict(txId);
+        }
+        return;
+    } else {
+        txObserver = new TWriteTxObserver(*this);
+        // Prefer precise conflicts for non-distributed transactions
+        if (IsImmediateTx) {
+            mustFindConflicts = true;
         }
     }
-    return TxObserver;
+
+    // We are not actually interested in the row version, we only need to
+    // detect uncommitted transaction skips on the path to that version.
+    auto res = Db.SelectRowVersion(
+        localTableId, keyCells, /* readFlags */ 0,
+        nullptr, txObserver
+    );
+
+    if (res.Ready == NTable::EReady::Page) {
+        if (mustFindConflicts || LockTxId) {
+            // We must gather all conflicts
+            throw TNotReadyTabletException();
+        }
+
+        // Upgrade to volatile ordered commit and ignore the page fault
+        if (!VolatileCommitOrdered) {
+            if (!VolatileTxId) {
+                VolatileTxId = GetTxId();
+            }
+            VolatileCommitOrdered = true;
+            VolatileDependencies.clear();
+        }
+        return;
+    }
+
+    if (LockTxId || VolatileTxId) {
+        ui64 skipLimit = Self.GetMaxLockedWritesPerKey();
+        if (skipLimit > 0 && skipCount >= skipLimit) {
+            throw TLockedWriteLimitException();
+        }
+    }
 }
 
-void TDataShardUserDb::CheckReadDependency(ui64 txId) {
+void TDataShardUserDb::AddWriteConflict(ui64 txId) const {
     if (auto* info = Self.GetVolatileTxManager().FindByCommitTxId(txId)) {
-        switch (info->State) {
-            case EVolatileTxState::Waiting:
-                VolatileReadDependencies.insert(info->TxId);
-                break;
-            case EVolatileTxState::Committed:
-                break;
-            case EVolatileTxState::Aborting:
-                VolatileReadDependencies.insert(info->TxId);
-                break;
+        if (info->State != EVolatileTxState::Aborting) {
+            Self.SysLocksTable().AddVolatileDependency(info->TxId);
         }
+    } else {
+        Self.SysLocksTable().AddWriteConflict(txId);
+    }
+}
+
+void TDataShardUserDb::BreakWriteConflict(ui64 txId) {
+    if (VolatileCommitTxIds.contains(txId)) {
+        // Skip our own commits
+    } else if (auto* info = Self.GetVolatileTxManager().FindByCommitTxId(txId)) {
+        // We must not overwrite uncommitted changes that may become committed
+        // later, so we need to add a dependency that will force us to wait
+        // until it is persistently committed. We may ignore aborting changes
+        // even though they may not be persistent yet, since this tx will
+        // also perform writes, and either it fails, or future generation
+        // could not have possibly committed it already.
+        if (info->State != EVolatileTxState::Aborting && !VolatileCommitOrdered) {
+            if (!VolatileTxId) {
+                // All further writes will use this VolatileTxId and will
+                // add it to VolatileCommitTxIds, forcing it to be committed
+                // like a volatile transaction. Note that this does not make
+                // it into a real volatile transaction, it works as usual in
+                // every sense, only persistent commit order is affected by
+                // a dependency below.
+                VolatileTxId = GetTxId();
+            }
+            VolatileDependencies.insert(info->TxId);
+        }
+    } else {
+        // Break uncommitted locks
+        Self.SysLocksTable().BreakLock(txId);
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -10,10 +10,10 @@ NTable::EReady TDataShardUserDb::SelectRow(
         NTable::TSelectStats& stats,
         const TMaybe<TRowVersion>& readVersion)
 {
-    auto tid = Self.GetLocalTableId(tableId);
-    Y_ABORT_UNLESS(tid != 0, "Unexpected SelectRow for an unknown table");
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected SelectRow for an unknown table");
 
-    return Db.Select(tid, key, tags, row, stats, /* readFlags */ 0,
+    return Db.Select(localTableId, key, tags, row, stats, /* readFlags */ 0,
         readVersion.GetOrElse(ReadVersion),
         GetReadTxMap(),
         GetReadTxObserver());
@@ -28,6 +28,30 @@ NTable::EReady TDataShardUserDb::SelectRow(
 {
     NTable::TSelectStats stats;
     return SelectRow(tableId, key, tags, row, stats, readVersion);
+}
+
+void TDataShardUserDb::UpdateRow(
+    const TTableId& tableId,
+    NTable::TRawVals key,
+    TArrayRef<const NIceDb::TUpdateOp> ops)
+{
+    auto localTableId = Self.GetLocalTableId(tableId);
+    Y_ABORT_UNLESS(localTableId != 0, "Unexpected UpdateRow for an unknown table");
+
+    auto* collector = GetChangeCollector(tableId);
+
+    const ui64 writeTxId = GetWriteTxId(tableId);
+    if (writeTxId == 0) {
+        if (collector && !collector->OnUpdate(tableId, localTableId, NTable::ERowOp::Upsert, key, ops, WriteVersion))
+            throw TNotReadyTabletException();
+
+        Db.Update(localTableId, NTable::ERowOp::Upsert, key, ops, WriteVersion);
+    } else {
+        if (collector && !collector->OnUpdateTx(tableId, localTableId, NTable::ERowOp::Upsert, key, ops, writeTxId))
+            throw TNotReadyTabletException();
+
+        Db.UpdateTx(localTableId, NTable::ERowOp::Upsert, key, ops, writeTxId);
+    }
 }
 
 void TDataShardUserDb::AddCommitTxId(ui64 txId, const TRowVersion& commitVersion) {
@@ -47,6 +71,104 @@ NTable::ITransactionMapPtr& TDataShardUserDb::GetReadTxMap() {
         }
     }
     return TxMap;
+}
+
+const NMiniKQL::IEngineFlat::TValidationInfo& TDataShardUserDb::GetTxInfo() const {
+    return TxInfo;
+}
+
+void TDataShardUserDb::SetIsImmediateTx() {
+    IsImmediateTx = true;
+}
+
+void TDataShardUserDb::SetLockTxId(ui64 lockTxId, ui32 lockNodeId) {
+    LockTxId = lockTxId;
+    LockNodeId = lockNodeId;
+}
+
+ui64 TDataShardUserDb::GetWriteTxId(const TTableId& tableId) {
+    if (TSysTables::IsSystemTable(tableId))
+        return 0;
+
+    return LockTxId;
+}
+
+void TDataShardUserDb::SetVolatileTxId(ui64 txId) {
+    VolatileTxId = txId;
+}
+
+void TDataShardUserDb::SetWriteVersion(TRowVersion writeVersion) {
+    WriteVersion = writeVersion;
+};
+
+void TDataShardUserDb::SetReadVersion(TRowVersion readVersion) {
+    ReadVersion = readVersion;
+};
+
+void TDataShardUserDb::MarkTxLoaded() {
+    TxInfo.Loaded = true;
+}
+
+IDataShardChangeCollector* TDataShardUserDb::GetChangeCollector(const TTableId& tableId) {
+    auto it = ChangeCollectors.find(tableId.PathId);
+    if (it != ChangeCollectors.end()) {
+        return it->second.Get();
+    }
+
+    it = ChangeCollectors.emplace(tableId.PathId, nullptr).first;
+    if (!Self.IsUserTable(tableId)) {
+        return it->second.Get();
+    }
+
+    it->second.Reset(CreateChangeCollector(
+        Self,
+        *const_cast<TDataShardUserDb*>(this),
+        *const_cast<TDataShardUserDb*>(this),
+        Db,
+        tableId.PathId.LocalPathId
+    ));
+    return it->second.Get();
+}
+
+TVector<IDataShardChangeCollector::TChange> TDataShardUserDb::GetCollectedChanges() const {
+    TVector<IDataShardChangeCollector::TChange> total;
+
+    for (auto& [_, collector] : ChangeCollectors) {
+        if (!collector) {
+            continue;
+        }
+
+        auto collected = std::move(collector->GetCollected());
+        std::move(collected.begin(), collected.end(), std::back_inserter(total));
+    }
+
+    return total;
+}
+
+void TDataShardUserDb::ResetCollectedChanges() {
+    for (auto& pr : ChangeCollectors) {
+        if (pr.second) {
+            pr.second->OnRestart();
+        }
+    }
+}
+
+std::optional<ui64> TDataShardUserDb::GetCurrentChangeGroup() const {
+    return ChangeGroup;
+}
+
+ui64 TDataShardUserDb::GetChangeGroup() {
+    if (!ChangeGroup) {
+        if (IsImmediateTx) {
+            NIceDb::TNiceDb db(Db);
+            ChangeGroup = Self.AllocateChangeRecordGroup(db);
+        } else {
+            // Distributed transactions have their group set to zero
+            ChangeGroup = 0;
+        }
+    }
+
+    return *ChangeGroup;
 }
 
 class TDataShardUserDb::TReadTxObserver : public NTable::ITransactionObserver {

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -255,9 +255,9 @@ bool TDataShardUserDb::IsValidKey(TKeyDesc& key) const {
     return Db.GetScheme().IsValidKey(localTableId, key);
 }
 
-std::tuple<NMiniKQL::IEngineFlat::EResult, TString> TDataShardUserDb::ValidateKeys() const 
+std::tuple<NMiniKQL::IEngineFlat::EResult, TString> TDataShardUserDb::ValidateKeys(const NMiniKQL::IEngineFlat::TValidationInfo& txInfo) const 
 {
-    for (auto& validKey : TxInfo.Keys) {
+    for (const auto& validKey : txInfo.Keys) {
         TKeyDesc* key = validKey.Key.get();
 
         bool valid = IsValidKey(*key);
@@ -319,14 +319,6 @@ bool TDataShardUserDb::IsPathErased(const TTableId& tableId) const {
 
 bool TDataShardUserDb::HasRemovedTx(ui32 table, ui64 txId) const {
     return Db.HasRemovedTx(table, txId);
-}
-
-NMiniKQL::IEngineFlat::TValidationInfo& TDataShardUserDb::GetTxInfo() {
-    return TxInfo;
-}
-
-const NMiniKQL::IEngineFlat::TValidationInfo& TDataShardUserDb::GetTxInfo() const {
-    return TxInfo;
 }
 
 ui64 TDataShardUserDb::GetStep() const {

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -76,6 +76,7 @@ public:
     bool HasRemovedTx(ui32 table, ui64 txId) const;
 
     bool IsValidKey(TKeyDesc& key) const;
+    std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys() const;
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const;
     bool IsPathErased(const TTableId& tableId) const;
 private:

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -76,7 +76,7 @@ public:
     bool HasRemovedTx(ui32 table, ui64 txId) const;
 
     bool IsValidKey(TKeyDesc& key) const;
-    std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys() const;
+    std::tuple<NMiniKQL::IEngineFlat::EResult, TString> ValidateKeys(const NMiniKQL::IEngineFlat::TValidationInfo& txInfo) const;
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const;
     bool IsPathErased(const TTableId& tableId) const;
 private:
@@ -115,7 +115,6 @@ public:
 private:
     class TReadTxObserver;
 
-
     absl::flat_hash_set<ui64> CommittedLockChanges;
     absl::flat_hash_map<TPathId, TIntrusivePtr<NTable::TDynamicTransactionMap>> TxMaps;
     absl::flat_hash_map<TPathId, NTable::ITransactionObserverPtr> TxObservers;
@@ -125,8 +124,6 @@ private:
     YDB_ACCESSOR_DEF(bool, VolatileCommitOrdered);
 
 public:
-    NMiniKQL::IEngineFlat::TValidationInfo& GetTxInfo();
-    const NMiniKQL::IEngineFlat::TValidationInfo& GetTxInfo() const;
     ui64 GetStep() const;
     ui64 GetTxId() const;
     void SetWriteVersion(TRowVersion writeVersion);
@@ -139,7 +136,6 @@ private:
     NTable::TDatabase& Db;
 
     TDataShardChangeGroupProvider ChangeGroupProvider;
-    NMiniKQL::IEngineFlat::TValidationInfo TxInfo;
     YDB_READONLY(TStepOrder, StepTxId, TStepOrder(0, 0));
     YDB_ACCESSOR_DEF(ui64, LockTxId);
     YDB_ACCESSOR_DEF(ui32, LockNodeId);

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -78,6 +78,16 @@ public:
     bool IsValidKey(TKeyDesc& key) const;
     bool IsMyKey(const TTableId& tableId, const TArrayRef<const TCell>& row) const;
     bool IsPathErased(const TTableId& tableId) const;
+private:
+    static TSmallVec<TCell> ConvertTableKeys(const TArrayRef<const TRawTypeValue>& key);
+
+    void UpdateRowInt(
+        const TTableId& tableId,
+        ui64 localTableId,
+        const TArrayRef<const TRawTypeValue>& key,
+        const TArrayRef<const NIceDb::TUpdateOp>& ops
+    );
+
 public:    
     IDataShardChangeCollector* GetChangeCollector(const TTableId& tableId);
 

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -24,15 +24,28 @@ public:
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
             const TMaybe<TRowVersion>& readVersion = {}) = 0;
+
+    virtual void UpdateRow(
+            const TTableId& tableId,
+            NTable::TRawVals key,
+            TArrayRef<const NIceDb::TUpdateOp> ops) = 0;
+
 };
 
-class TDataShardUserDb final : public IDataShardUserDb {
+class TDataShardUserDb final
+    : public IDataShardUserDb
+    , public IDataShardChangeGroupProvider
+{
 public:
-    TDataShardUserDb(TDataShard& self, NTable::TDatabase& db, const TRowVersion& readVersion)
+    TDataShardUserDb(TDataShard& self, NTable::TDatabase& db, const TRowVersion& readVersion, const TRowVersion& writeVersion)
         : Self(self)
         , Db(db)
+        , LockTxId(0)
+        , LockNodeId(0)
         , ReadVersion(readVersion)
-    { }
+        , WriteVersion(writeVersion)
+    {
+    }
 
     NTable::EReady SelectRow(
             const TTableId& tableId,
@@ -49,11 +62,33 @@ public:
             NTable::TRowState& row,
             const TMaybe<TRowVersion>& readVersion = {}) override;
 
+    void UpdateRow(
+            const TTableId& tableId,
+            NTable::TRawVals key,
+            TArrayRef<const NIceDb::TUpdateOp> ops) override;
+
     void AddCommitTxId(ui64 txId, const TRowVersion& commitVersion);
 
     absl::flat_hash_set<ui64>& GetVolatileReadDependencies() {
         return VolatileReadDependencies;
     }
+
+    const NMiniKQL::IEngineFlat::TValidationInfo& GetTxInfo() const;
+    void SetIsImmediateTx();
+    void SetLockTxId(ui64 lockTxId, ui32 lockNodeId);
+    ui64 GetWriteTxId(const TTableId& tableId);
+    void SetVolatileTxId(ui64 txId);
+    void SetWriteVersion(TRowVersion writeVersion);
+    void SetReadVersion(TRowVersion readVersion);
+    void MarkTxLoaded();
+    
+    std::optional<ui64> GetCurrentChangeGroup() const override;
+    ui64 GetChangeGroup() override;
+    IDataShardChangeCollector* GetChangeCollector(const TTableId& tableId);
+
+    TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const;
+    void ResetCollectedChanges();
+    
 
 private:
     class TReadTxObserver;
@@ -64,11 +99,19 @@ private:
 private:
     TDataShard& Self;
     NTable::TDatabase& Db;
+    NMiniKQL::IEngineFlat::TValidationInfo TxInfo;
+    ui64 LockTxId;
+    ui32 LockNodeId;
+    ui64 VolatileTxId = 0;
+    bool IsImmediateTx = false;
     TRowVersion ReadVersion;
+    TRowVersion WriteVersion;
+    absl::flat_hash_map<TPathId, THolder<IDataShardChangeCollector>> ChangeCollectors;
     NTable::ITransactionMapPtr TxMap;
     TIntrusivePtr<NTable::TDynamicTransactionMap> DynamicTxMap;
     NTable::ITransactionObserverPtr TxObserver;
     absl::flat_hash_set<ui64> VolatileReadDependencies;
+    std::optional<ui64> ChangeGroup = std::nullopt;
 };
 
 } // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/datashard_ut_range_ops.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_range_ops.cpp
@@ -1,4 +1,4 @@
-//#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 
 #include <ydb/core/tx/datashard/range_ops.h>
 

--- a/ydb/core/tx/datashard/datashard_ut_range_ops.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_range_ops.cpp
@@ -1,4 +1,4 @@
-#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+//#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 
 #include <ydb/core/tx/datashard/range_ops.h>
 

--- a/ydb/core/tx/datashard/datashard_write_operation.h
+++ b/ydb/core/tx/datashard/datashard_write_operation.h
@@ -92,6 +92,10 @@ public:
         UserDb.SetVolatileTxId(txId);
     }
 
+    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) {
+        UserDb.CommitChanges(tableId, lockId, writeVersion);
+    }
+
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const {
         return UserDb.GetCollectedChanges();
     }
@@ -140,7 +144,6 @@ private:
 
     YDB_ACCESSOR_DEF(TActorId, Source);
 
-    YDB_READONLY(TStepOrder, StepTxId, TStepOrder(0, 0));
     YDB_READONLY_DEF(TTableId, TableId);
     YDB_READONLY_DEF(TSerializedCellMatrix, Matrix);
     YDB_READONLY_DEF(TInstant, ReceivedAt);

--- a/ydb/core/tx/datashard/execute_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_data_tx_unit.cpp
@@ -104,7 +104,7 @@ EExecutionStatus TExecuteDataTxUnit::Execute(TOperation::TPtr op,
     IEngineFlat* engine = tx->GetDataTx()->GetEngine();
     Y_VERIFY_S(engine, "missing engine for " << *op << " at " << DataShard.TabletID());
 
-    if (op->IsImmediate() && !tx->ReValidateKeys()) {
+    if (op->IsImmediate() && !tx->ValidateKeys()) {
         // Immediate transactions may be reordered with schema changes and become invalid
         const auto& dataTx = tx->GetDataTx();
         Y_ABORT_UNLESS(!dataTx->Ready());

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -45,7 +45,8 @@ public:
         auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(op.Get());
 
         if (eraseTx->HasDependents()) {
-            TDataShardUserDb userDb(DataShard, txc.DB, readVersion, writeVersion);
+            auto now = TAppData::TimeProvider->Now();
+            TDataShardUserDb userDb(DataShard, txc.DB, op->GetStepOrder(), readVersion, writeVersion, now);
             TDataShardChangeGroupProvider groupProvider(DataShard, txc.DB, /* distributed tx group */ 0);
             THolder<IDataShardChangeCollector> changeCollector{CreateChangeCollector(DataShard, userDb, groupProvider, txc.DB, request.GetTableId())};
 
@@ -191,7 +192,7 @@ public:
                 DataShard.GetConflictsCache().GetTableCache(tableInfo.LocalTid).AddUncommittedWrite(keyCells.GetCells(), globalTxId, txc.DB);
                 if (!commitAdded && userDb) {
                     // Make sure we see our own changes on further iterations
-                    userDb->AddCommitTxId(globalTxId, writeVersion);
+                    userDb->AddCommitTxId(fullTableId, globalTxId, writeVersion);
                     commitAdded = true;
                 }
             } else {

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -45,7 +45,7 @@ public:
         auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(op.Get());
 
         if (eraseTx->HasDependents()) {
-            TDataShardUserDb userDb(DataShard, txc.DB, readVersion);
+            TDataShardUserDb userDb(DataShard, txc.DB, readVersion, writeVersion);
             TDataShardChangeGroupProvider groupProvider(DataShard, txc.DB, /* distributed tx group */ 0);
             THolder<IDataShardChangeCollector> changeCollector{CreateChangeCollector(DataShard, userDb, groupProvider, txc.DB, request.GetTableId())};
 

--- a/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
@@ -106,7 +106,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
     ui64 tabletId = DataShard.TabletID();
     const TValidatedDataTx::TPtr& dataTx = tx->GetDataTx();
 
-    if (op->IsImmediate() && !dataTx->ReValidateKeys()) {
+    if (op->IsImmediate() && !dataTx->ValidateKeys()) {
         // Immediate transactions may be reordered with schema changes and become invalid
         Y_ABORT_UNLESS(!dataTx->Ready());
         op->SetAbortedFlag();
@@ -467,7 +467,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::OnTabletNotReady(TActiveTransaction& tx,
     dataTx.ResetCollectedChanges();
 
     ui64 pageFaultCount = tx.IncrementPageFaultCount();
-    dataTx.GetKqpComputeCtx().PinPages(dataTx.TxInfo().Keys, pageFaultCount);
+    dataTx.GetKqpComputeCtx().PinPages(dataTx.GetValidationInfo().Keys, pageFaultCount);
 
     tx.ReleaseTxData(txc, ctx);
     return EExecutionStatus::Restart;

--- a/ydb/core/tx/datashard/write_unit.cpp
+++ b/ydb/core/tx/datashard/write_unit.cpp
@@ -46,7 +46,7 @@ public:
         const TTableId fullTableId(self->GetPathOwnerId(), tableId);
         const ui64 localTableId = self->GetLocalTableId(fullTableId);
         if (localTableId == 0) {
-            writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, TStringBuilder() << "Unknown table id " << tableId, self->TabletID());
+            writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, TStringBuilder() << "Unknown table id " << tableId);
             return;
         }
         const ui64 shadowTableId = self->GetShadowTableId(fullTableId);

--- a/ydb/core/tx/datashard/write_unit.cpp
+++ b/ydb/core/tx/datashard/write_unit.cpp
@@ -38,6 +38,8 @@ public:
     }
 
     void DoExecute(TDataShard* self, TWriteOperation* writeOp, TTransactionContext& txc, const TActorContext& ctx) {
+        Y_UNUSED(txc);
+
         TValidatedWriteTx::TPtr& writeTx = writeOp->GetWriteTx();
 
         const ui64 tableId = writeTx->GetTableId().PathId.LocalPathId;
@@ -53,40 +55,46 @@ public:
         Y_ABORT_UNLESS(TableInfo_.LocalTid == localTableId);
         Y_ABORT_UNLESS(TableInfo_.ShadowTid == shadowTableId);
 
+        const NTable::TScheme& scheme = txc.DB.GetScheme();
+        const NTable::TScheme::TTableInfo* tableInfo = scheme.GetTableInfo(localTableId);
+
         auto [readVersion, writeVersion] = self->GetReadWriteVersions(writeOp);
         writeTx->SetReadVersion(readVersion);
         writeTx->SetWriteVersion(writeVersion);
 
-        TDataShardUserDb userDb(*self, txc.DB, readVersion);
-        TDataShardChangeGroupProvider groupProvider(*self, txc.DB);
-
-        TVector<TCell> keyCells;
-        TVector<NMiniKQL::IEngineFlatHost::TUpdateCommand> commands;
+        TSmallVec<TRawTypeValue> key;
+        TSmallVec<NTable::TUpdateOp> ops;
 
         const TSerializedCellMatrix& matrix = writeTx->GetMatrix();
 
         for (ui32 rowIdx = 0; rowIdx < matrix.GetRowCount(); ++rowIdx)
         {
-            keyCells.clear();
-            keyCells.reserve(TableInfo_.KeyColumnIds.size());
+            key.clear();
+            key.reserve(TableInfo_.KeyColumnIds.size());
             for (ui16 keyColIdx = 0; keyColIdx < TableInfo_.KeyColumnIds.size(); ++keyColIdx) {
                 const TCell& cell = matrix.GetCell(rowIdx, keyColIdx);
-                keyCells.emplace_back(cell);
+                ui32 keyCol = tableInfo->KeyColumns[keyColIdx];
+                if (cell.IsNull()) {
+                    key.emplace_back();
+                } else {
+                    NScheme::TTypeInfo vtypeInfo = scheme.GetColumnInfo(tableInfo, keyCol)->PType;
+                    key.emplace_back(cell.Data(), cell.Size(), vtypeInfo);
+                }
             }
 
-            commands.clear();
+            ops.clear();
             Y_ABORT_UNLESS(matrix.GetColCount() >= TableInfo_.KeyColumnIds.size());
-            commands.reserve(matrix.GetColCount() - TableInfo_.KeyColumnIds.size());
+            ops.reserve(matrix.GetColCount() - TableInfo_.KeyColumnIds.size());
 
             for (ui16 valueColIdx = TableInfo_.KeyColumnIds.size(); valueColIdx < matrix.GetColCount(); ++valueColIdx) {
                 ui32 columnTag = writeTx->RecordOperation().GetColumnIds(valueColIdx);
                 const TCell& cell = matrix.GetCell(rowIdx, valueColIdx);
 
-                NMiniKQL::IEngineFlatHost::TUpdateCommand command = {columnTag, TKeyDesc::EColumnOperation::Set, {}, cell};
-                commands.emplace_back(std::move(command));
+                NScheme::TTypeInfo vtypeInfo = scheme.GetColumnInfo(tableInfo, columnTag)->PType;
+                ops.emplace_back(columnTag, NTable::ECellOp::Set, cell.IsNull() ? TRawTypeValue() : TRawTypeValue(cell.Data(), cell.Size(), vtypeInfo));
             }
 
-            writeTx->GetEngineHost()->UpdateRow(fullTableId, keyCells, commands);
+            writeTx->GetUserDb()->UpdateRow(fullTableId, key, ops);
         }
         
         self->IncCounter(COUNTER_WRITE_ROWS, matrix.GetRowCount());


### PR DESCRIPTION
1. [Move TValidationInfo from TEngineBay to operations](https://github.com/ydb-platform/ydb/pull/1004/files#diff-9c89b4dea8b21192bba2c5eee614c3db7b030f6b4631ad4e3677438d2e280b84L132)
2. [TValidatedDataTx uses TValidationInfo](https://github.com/ydb-platform/ydb/pull/1004/files#diff-ab79ab220fe891f11f21ca224e5b508afd74a1e0e04c31ceb39dd8eb1900bd64R295)
3. [TWriteOperation uses TDataShardUserDb and TValidationInfo , but no TEngineBay](https://github.com/ydb-platform/ydb/pull/1004/files#diff-4fe1307ca2b1aa4c14d17c3123633982a1977f920c55f067903ebf7041d20f76R138)
4. [Move a lot of functionality from TDataShardEngineHost to TDataShardUserDb](https://github.com/ydb-platform/ydb/pull/1004/files#diff-83d9c4bd06332c19bff3bf967ac7271212473b0c5d56c8623c8c5cf867c85689)
