### PR TITLE
Added mini-function

### DIFF
--- a/ydb/library/yql/utils/simd/simd_avx2.h
+++ b/ydb/library/yql/utils/simd/simd_avx2.h
@@ -78,6 +78,10 @@ struct TSimd8 {
         return crc;
     }
 
+    inline void Add64(const TSimd8<T>& another) {
+        Value = _mm256_add_epi64(Value, another.Value);
+    }
+
     inline int ToBitMask() const {
         return _mm256_movemask_epi8(this->Value);
     }


### PR DESCRIPTION
- YQ-2068 refactoring, get rid of macro in BuildConnections (#883)
- LOGBROKER-8860 Implement CreatePartitions Kafka API endpoint (#866)
- KIKIMR-20635: pg types in TQueryPlan (#853)
- Test sorting on indexation (#920)
- Mark NYT::TFuture as [[nodiscard]] (#919)
- Revert "Remove devtools folder (#895)" (#922)
- Get right TraceId in SessionActor (#908)
- Add shared executor thread, KIKIMR-18440 (#903)
- Add YT pragmas for `description` and `started_by` (#918)
- support optional list in ListIndexOf (#902)
- TRowVersion -> TSnapshot (#921)
- Enable distconf by default and fix race issue KIKIMR-19031 (#875)
- Fixes clang-format usage (#929)
- YDBDOCS-188: fix a title that was missed during translation (#904)
- Introduce InitialAllocation option for storage load actor, KIKIMR-20619 (#806)
- return up-to-date node stats KIKIMR-20697 (#910)
- Remove change senders upon DROP TABLE KIKIMR-20678 (#901)
- Fixed forget operation failure (#781)
- Add shared executor pool, KIKIMR-18440 (#933)
- Fix datashard read traces (#913)
- Add operation estimations for HDD devices, KIKIMR-17759 (#909)
- Fix Coordinator::RestoreTenantConfiguration test KIKIMR-20710 (#938)
- added references (#924)
- YQL-15844 fix getting view by symlink (#928)
- Introduce blobsan (#941)
- Fix persqueue ut (#940)
- Allow UPDATE ON, UPSERT with partial set of input... (#894)
- Library import 7 (#937)
- Unsupported database type (DataStreams) by 403 http error (#930)
- Remove TEvColumnShard::TEvRead (#927)
- fix upsert overwriting non-default values (#926)
- fix missed check for usedIndexes. (#947)
- Mute some flaky tests (#949)
- Forgotten OwnerId in EvWrite (#945)
- Tests: Replace EvProposeTransaction with EvWrite (#932)
- Run OnTieringModified only once on tablet initialization (#951)
- add missing backtick (#959)
- TTableId fix (#958)
- Fix for full join when keys for both sides are identical (#948)
- ci: build docker local-ydb docker image using ya make (#934)
- Mute some flaky tests (#962)
- sprintf -> snprintf replacement inside ydb code (#952)
- Create CODEOWNERS (#943)
- make it possible to stop Hive subactors through web ui KIKIMR-20645 (#810)
- Add forgotten file (#969)
- Return --global to git authorship guideline (#963)
- lock for different client versions usage (#961)
- basic statistics bugfixes KIKIMR-18323 (#915)
- cancel previous Build Documentation on the same PR (#967)
- Copy locks in observer & SingleObserver (#973)
- alter table request for metadata modifications (#974)
- added article about goose into docs (#811)
- update roadmap
- Report correct status on overloaded errors in read table KIKIMR-17778 (#946)
- Fixed cardinality estimation bug in CBO (#975)
- cleanup portions store (#971)
- EOperationKind::WriteTx (#976)
- Explicitely restict TCL statements in QueryService. (KIKIMR-16294) (#980)
- usage chunked merge by optional and usage full-batches-merge for norm… (#972)
- Auto stash before merge of "main" and "origin/main" (#985)
- Fix python test style (#867)
- Cancel previous jobs on re-push changes from PR branch (#983)
- Fix a misprint
- Scale screenshot images in goose article (#982)
- Fix StageDurationUs (#984)
- Mute some flaky tests (#994)
- KIKIMR-20714 Удаляем LongTxService в тестах (#970)
- fix test withno appdata (#991)
- Kv tracing ut (#992)
- added function
