### PR TITLE
Fix rebinding an allocator to the same type should result in the original allocator

### DIFF
--- a/ydb/library/yql/minikql/mkql_alloc.h
+++ b/ydb/library/yql/minikql/mkql_alloc.h
@@ -378,15 +378,15 @@ inline void* MKQLAllocWithSize(size_t sz, const EMemorySubPool mPool) {
 }
 
 inline void MKQLFreeWithSize(const void* mem, size_t sz, const EMemorySubPool mPool) noexcept {
-    return MKQLFreeFastWithSize(mem, sz, TlsAllocState, mPool);
+    MKQLFreeFastWithSize(mem, sz, TlsAllocState, mPool);
 }
 
 inline void MKQLRegisterObject(NUdf::TBoxedValue* value) noexcept {
-    return value->Link(TlsAllocState->GetRoot());
+    value->Link(TlsAllocState->GetRoot());
 }
 
 inline void MKQLUnregisterObject(NUdf::TBoxedValue* value) noexcept {
-    return value->Unlink();
+    value->Unlink();
 }
 
 template <const EMemorySubPool MemoryPoolExt = EMemorySubPool::Default>
@@ -426,7 +426,7 @@ T* AllocateOn(TAllocState* state, Args&&... args)
     static_assert(std::is_base_of<TWithMiniKQLAlloc<T::MemoryPool>, T>::value, "Class must inherit TWithMiniKQLAlloc.");
 }
 
-template <typename Type, enum EMemorySubPool MemoryPool = EMemorySubPool::Default>
+template <typename Type, EMemorySubPool MemoryPool = EMemorySubPool::Default>
 struct TMKQLAllocator
 {
     typedef Type value_type;
@@ -440,10 +440,10 @@ struct TMKQLAllocator
     TMKQLAllocator() noexcept = default;
     ~TMKQLAllocator() noexcept = default;
 
-    template<typename U> TMKQLAllocator(const TMKQLAllocator<U>&) noexcept {}
-    template<typename U> struct rebind { typedef TMKQLAllocator<U> other; };
-    template<typename U> bool operator==(const TMKQLAllocator<U>&) const { return true; }
-    template<typename U> bool operator!=(const TMKQLAllocator<U>&) const { return false; }
+    template<typename U> TMKQLAllocator(const TMKQLAllocator<U, MemoryPool>&) noexcept {}
+    template<typename U> struct rebind { typedef TMKQLAllocator<U, MemoryPool> other; };
+    template<typename U> bool operator==(const TMKQLAllocator<U, MemoryPool>&) const { return true; }
+    template<typename U> bool operator!=(const TMKQLAllocator<U, MemoryPool>&) const { return false; }
 
     static pointer allocate(size_type n, const void* = nullptr)
     {
@@ -452,7 +452,7 @@ struct TMKQLAllocator
 
     static void deallocate(const_pointer p, size_type n) noexcept
     {
-        return MKQLFreeWithSize(p, n * sizeof(value_type), MemoryPool);
+        MKQLFreeWithSize(p, n * sizeof(value_type), MemoryPool);
     }
 };
 
@@ -683,7 +683,7 @@ private:
 
 inline void TBoxedValueWithFree::operator delete(void *mem) noexcept {
     auto size = ((TMkqlPAllocHeader*)mem)->Size + sizeof(TMkqlPAllocHeader);
-    return MKQLFreeWithSize(mem, size, EMemorySubPool::Default);
+    MKQLFreeWithSize(mem, size, EMemorySubPool::Default);
 }
 
 } // NMiniKQL


### PR DESCRIPTION
1. This patch https://lists.llvm.org/pipermail/libcxx-commits/2022-October/045949.html introduces `static_assert` with the additional requirement on allocator — rebinding an allocator to the same type should result in the original allocator.

On the upcoming libcxx update I have got the following error:
```
/home/hiddenpath/ydb/contrib/libs/cxxsupp/libcxx/include/vector:367:5: error: static assertion failed due to requirement 'is_same<NKikimr::NMiniKQL::TMKQLAllocator<NYql::NUdf::TUnboxedValue, NKikimr::NMiniKQL::EMemorySubPool::Temporary>, NKikimr::NMiniKQL::TMKQLAllocator<NYql::NUdf::TUnboxedValue, NKikimr::NMiniKQL::EMemorySubPool::Default>>::value': [allocator.requirements] states that rebinding an allocator to the same type should result in the original allocator
    static_assert(is_same<allocator_type, __rebind_alloc<__alloc_traits, value_type> >::value,
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hiddenpath/ydb/library/yql/minikql/computation/mkql_computation_node_holders.cpp:235:91: note: in instantiation of template class 'std::vector<NYql::NUdf::TUnboxedValue, NKikimr::NMiniKQL::TMKQLAllocator<NYql::NUdf::TUnboxedValue, NKikimr::NMiniKQL::EMemorySubPool::Temporary>>' requested here
class TVectorHolderBase: public TComputationValue<TVectorHolderBase<TBaseVector>>, public TBaseVector {
                                                                                          ^
```

2. I have found some mistaken `return` keywords in various functions (since they have a void return type we have to get rid of them) as well.
