### PR TITLE
Fix uninitialized value in log settings

### DIFF
--- a/ydb/library/actors/core/log_settings.h
+++ b/ydb/library/actors/core/log_settings.h
@@ -51,7 +51,7 @@ namespace NActors {
                     ui8 Level;
                 } X;
 
-                ui64 Data;
+                ui64 Data = 0;
             } Raw;
 
             TComponentSettings(TAtomicBase data) {


### PR DESCRIPTION
- fix uninitialized value in log settings

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix uninitialized value to calm down msan

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

