### PR TITLE
YQL-17493: Wrap returned YQL-typed columns with ToPg

### DIFF
--- a/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
+++ b/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
@@ -348,7 +348,7 @@ Y_UNIT_TEST_SUITE(KqpQueryService) {
             auto db = kikimr.GetTableClient();
             auto session = db.CreateSession().GetValueSync().GetSession();
             auto result = session.ExecuteSchemeQuery(R"(
-                CREATE TABLE test (id int8,PRIMARY KEY (id)))"
+                CREATE TABLE test (id int16,PRIMARY KEY (id)))"
             ).GetValueSync();
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());

--- a/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
@@ -2210,6 +2210,28 @@
         }
     ],
     "test.test[pg-select_win_count-default.txt-Results]": [],
+    "test.test[pg-select_yql_type--Analyze]": [
+        {
+            "checksum": "8ff95379719438cd7e637f0c2b6945c5",
+            "size": 7622,
+            "uri": "https://{canondata_backend}/1031349/1e1ff3377d9e6463687741aa3509395b92a00445/resource.tar.gz#test.test_pg-select_yql_type--Analyze_/plan.txt"
+        }
+    ],
+    "test.test[pg-select_yql_type--Debug]": [
+        {
+            "checksum": "3dde0f6689824d0af2cae2e11a23fe80",
+            "size": 2702,
+            "uri": "https://{canondata_backend}/1031349/1e1ff3377d9e6463687741aa3509395b92a00445/resource.tar.gz#test.test_pg-select_yql_type--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[pg-select_yql_type--Plan]": [
+        {
+            "checksum": "8ff95379719438cd7e637f0c2b6945c5",
+            "size": 7622,
+            "uri": "https://{canondata_backend}/1031349/1e1ff3377d9e6463687741aa3509395b92a00445/resource.tar.gz#test.test_pg-select_yql_type--Plan_/plan.txt"
+        }
+    ],
+    "test.test[pg-select_yql_type--Results]": [],
     "test.test[pg-str_lookup_pg-default.txt-Analyze]": [
         {
             "checksum": "a48ccc9922567dfee1170d2c2df45b6e",

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -12046,6 +12046,13 @@
             "uri": "https://{canondata_backend}/1599023/af9c2f81df0601cf266a0926b5ce73b6101b9115/resource.tar.gz#test_sql2yql.test_pg-select_win_sum_null_/sql.yql"
         }
     ],
+    "test_sql2yql.test[pg-select_yql_type]": [
+        {
+            "checksum": "7447752d11b2fc790e27004b7112fe31",
+            "size": 1975,
+            "uri": "https://{canondata_backend}/1937367/379ba745ff59ebd29c817a5b281c005a67df3be4/resource.tar.gz#test_sql2yql.test_pg-select_yql_type_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[pg-set_of_as_records]": [
         {
             "checksum": "439ee1feaf9750daf11386fe54adbc05",

--- a/ydb/library/yql/tests/sql/suites/pg/select_yql_type.cfg
+++ b/ydb/library/yql/tests/sql/suites/pg/select_yql_type.cfg
@@ -1,0 +1,1 @@
+in Input input_name.txt

--- a/ydb/library/yql/tests/sql/suites/pg/select_yql_type.sql
+++ b/ydb/library/yql/tests/sql/suites/pg/select_yql_type.sql
@@ -1,5 +1,15 @@
 --!syntax_pg
 SELECT
-    key, index
+    key, index, index + 1
 FROM plato."Input"
+ORDER BY index;
+
+SELECT
+    *
+FROM plato."Input"
+ORDER BY index;
+
+SELECT
+    t.*
+FROM plato."Input" as t
 ORDER BY index;

--- a/ydb/library/yql/tests/sql/suites/pg/select_yql_type.sql
+++ b/ydb/library/yql/tests/sql/suites/pg/select_yql_type.sql
@@ -1,0 +1,5 @@
+--!syntax_pg
+SELECT
+    key, index
+FROM plato."Input"
+ORDER BY index;

--- a/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
@@ -2075,6 +2075,27 @@
             "uri": "https://{canondata_backend}/1773845/f8e51a5dd98665ee7534cca6737c91ce5a753b8e/resource.tar.gz#test.test_pg-select_win_count-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[pg-select_yql_type--Debug]": [
+        {
+            "checksum": "f94603a4a31fd031cd1be6adf9bde1fd",
+            "size": 3816,
+            "uri": "https://{canondata_backend}/1031349/2368626953942b3adafcb76228785c3ee4e852f5/resource.tar.gz#test.test_pg-select_yql_type--Debug_/opt.yql"
+        }
+    ],
+    "test.test[pg-select_yql_type--Plan]": [
+        {
+            "checksum": "5889de5da2fd54b7327aaf12f536e2d9",
+            "size": 6736,
+            "uri": "https://{canondata_backend}/1031349/2368626953942b3adafcb76228785c3ee4e852f5/resource.tar.gz#test.test_pg-select_yql_type--Plan_/plan.txt"
+        }
+    ],
+    "test.test[pg-select_yql_type--Results]": [
+        {
+            "checksum": "aa4c3b838298a4c407b27345733a5fa1",
+            "size": 3812,
+            "uri": "https://{canondata_backend}/1031349/2368626953942b3adafcb76228785c3ee4e852f5/resource.tar.gz#test.test_pg-select_yql_type--Results_/results.txt"
+        }
+    ],
     "test.test[pg-str_lookup_pg-default.txt-Debug]": [
         {
             "checksum": "66a86824b404ec795db5472f15e7ef6d",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
PG's common type algorithm for columns returned from combined SELECTs (UNION et al) operates on PG types only. This patch adds convertion of YQL-typed columns to PG types before PG's common type algorithm processes them.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

No
