### PR TITLE
Make test actorsystem actor id globally unique #1087

### DIFF
--- a/ydb/core/util/testactorsys.h
+++ b/ydb/core/util/testactorsys.h
@@ -102,12 +102,12 @@ class TTestActorSystem {
 
     struct TMailboxInfo {
         TMailboxHeader Header{TMailboxType::Simple};
-        ui64 ActorLocalId = 1;
     };
 
     const ui32 MaxNodeId;
     std::map<TInstant, std::deque<TScheduleItem>> ScheduleQ;
     TInstant Clock = TInstant::Zero();
+    ui64 ActorLocalId = 1;
     std::unordered_map<TMailboxId, TMailboxInfo, THash<std::tuple<ui32, ui32, ui32>>> Mailboxes;
     TProgramShouldContinue ProgramShouldContinue;
     TAppData AppData;
@@ -473,11 +473,11 @@ public:
         // register actor in mailbox
         const auto& it = Mailboxes.try_emplace(TMailboxId(nodeId, poolId, mboxId)).first;
         TMailboxInfo& mbox = it->second;
-        mbox.Header.AttachActor(mbox.ActorLocalId, actor);
+        mbox.Header.AttachActor(ActorLocalId, actor);
 
         // generate actor id
-        const TActorId actorId(nodeId, poolId, mbox.ActorLocalId, mboxId);
-        ++mbox.ActorLocalId;
+        const TActorId actorId(nodeId, poolId, ActorLocalId, mboxId);
+        ++ActorLocalId;
         if (OwnLogPriority >= NActors::NLog::EPrio::Info) {
             *LogStream << "[TestActorSystem] Register actor \"" << name << "\" with id " << actorId.ToString() << Endl;
             RegisterActorName(actorId, name);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
For now in prod actor system actor ids generating globally unique, but in test actor system after node restart old actor ids of this will be reused. This commit makes allocation of actor ids in test actor system globally unique
...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
