### PR TITLE
KIKIMR-20009: fix race condition on blobs removing

### DIFF
--- a/ydb/core/tx/columnshard/blob_manager.cpp
+++ b/ydb/core/tx/columnshard/blob_manager.cpp
@@ -346,12 +346,15 @@ void TBlobManager::DoSaveBlobBatch(TBlobBatch&& blobBatch, IBlobManagerDb& db) {
     blobBatch.BatchInfo->GenStepRef.Reset();
 }
 
-void TBlobManager::DeleteBlob(const TUnifiedBlobId& blobId, IBlobManagerDb& db) {
-    ++CountersUpdate.BlobsDeleted;
-
+void TBlobManager::DeleteBlobOnExecute(const TUnifiedBlobId& blobId, IBlobManagerDb& db) {
     // Persist deletion intent
     db.AddBlobToDelete(blobId);
-    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("to_delete", blobId);
+    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("to_delete_on_execute", blobId);
+}
+
+void TBlobManager::DeleteBlobOnComplete(const TUnifiedBlobId& blobId) {
+    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("to_delete_on_complete", blobId);
+    ++CountersUpdate.BlobsDeleted;
 
     // Check if the deletion needs to be delayed until the blob is no longer
     // used by in-flight requests

--- a/ydb/core/tx/columnshard/blob_manager.h
+++ b/ydb/core/tx/columnshard/blob_manager.h
@@ -90,7 +90,8 @@ public:
     }
 
     // Deletes the blob that was previously permanently saved
-    virtual void DeleteBlob(const TUnifiedBlobId& blobId, IBlobManagerDb& db) = 0;
+    virtual void DeleteBlobOnExecute(const TUnifiedBlobId& blobId, IBlobManagerDb& db) = 0;
+    virtual void DeleteBlobOnComplete(const TUnifiedBlobId& blobId) = 0;
 };
 
 // An interface for exporting and caching exported blobs out of ColumnShard index to external storages like S3.
@@ -218,7 +219,8 @@ public:
 
     // Implementation of IBlobManager interface
     TBlobBatch StartBlobBatch(ui32 channel = BLOB_CHANNEL) override;
-    void DeleteBlob(const TUnifiedBlobId& blobId, IBlobManagerDb& db) override;
+    void DeleteBlobOnExecute(const TUnifiedBlobId& blobId, IBlobManagerDb& db) override;
+    void DeleteBlobOnComplete(const TUnifiedBlobId& blobId) override;
 private:
     TGenStep FindNewGCBarrier();
 

--- a/ydb/core/tx/columnshard/blobs_action/abstract/action.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/action.h
@@ -64,12 +64,12 @@ public:
         }
     }
 
-    void OnCompleteTxAfterAction(NColumnShard::TColumnShard& self) {
+    void OnCompleteTxAfterAction(NColumnShard::TColumnShard& self, const bool success) {
         if (Removing) {
-            Removing->OnCompleteTxAfterRemoving(self);
+            Removing->OnCompleteTxAfterRemoving(self, success);
         }
         if (Writing) {
-            Writing->OnCompleteTxAfterWrite(self);
+            Writing->OnCompleteTxAfterWrite(self, success);
         }
     }
 };
@@ -150,9 +150,9 @@ public:
         }
     }
 
-    void OnCompleteTxAfterAction(NColumnShard::TColumnShard& self) {
+    void OnCompleteTxAfterAction(NColumnShard::TColumnShard& self, const bool success) {
         for (auto&& i : StorageActions) {
-            i.second.OnCompleteTxAfterAction(self);
+            i.second.OnCompleteTxAfterAction(self, success);
         }
     }
 

--- a/ydb/core/tx/columnshard/blobs_action/abstract/remove.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/remove.h
@@ -20,7 +20,7 @@ private:
 protected:
     virtual void DoDeclareRemove(const TUnifiedBlobId& blobId) = 0;
     virtual void DoOnExecuteTxAfterRemoving(NColumnShard::TColumnShard& self, NColumnShard::TBlobManagerDb& dbBlobs, const bool success) = 0;
-    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& self) = 0;
+    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& self, const bool success) = 0;
 public:
     IBlobsDeclareRemovingAction(const TString& storageId)
         : TBase(storageId)
@@ -36,8 +36,8 @@ public:
     void OnExecuteTxAfterRemoving(NColumnShard::TColumnShard& self, NColumnShard::TBlobManagerDb& dbBlobs, const bool success) {
         return DoOnExecuteTxAfterRemoving(self, dbBlobs, success);
     }
-    void OnCompleteTxAfterRemoving(NColumnShard::TColumnShard& self) {
-        return DoOnCompleteTxAfterRemoving(self);
+    void OnCompleteTxAfterRemoving(NColumnShard::TColumnShard& self, const bool success) {
+        return DoOnCompleteTxAfterRemoving(self, success);
     }
 };
 

--- a/ydb/core/tx/columnshard/blobs_action/abstract/write.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/write.h
@@ -31,7 +31,7 @@ protected:
     virtual void DoOnBlobWriteResult(const TUnifiedBlobId& blobId, const NKikimrProto::EReplyStatus status) = 0;
 
     virtual void DoOnExecuteTxAfterWrite(NColumnShard::TColumnShard& self, NColumnShard::TBlobManagerDb& dbBlobs, const bool success) = 0;
-    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self) = 0;
+    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, const bool success) = 0;
 
     virtual TUnifiedBlobId AllocateNextBlobId(const TString& data) = 0;
 public:
@@ -79,8 +79,8 @@ public:
         return DoOnExecuteTxAfterWrite(self, dbBlobs, success);
     }
 
-    void OnCompleteTxAfterWrite(NColumnShard::TColumnShard& self) {
-        return DoOnCompleteTxAfterWrite(self);
+    void OnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, const bool success) {
+        return DoOnCompleteTxAfterWrite(self, success);
     }
 
     void SendWriteBlobRequest(const TString& data, const TUnifiedBlobId& blobId);

--- a/ydb/core/tx/columnshard/blobs_action/bs/remove.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/remove.h
@@ -18,12 +18,16 @@ protected:
     virtual void DoOnExecuteTxAfterRemoving(NColumnShard::TColumnShard& /*self*/, NColumnShard::TBlobManagerDb& dbBlobs, const bool success) {
         if (success) {
             for (auto&& i : GetDeclaredBlobs()) {
-                Manager->DeleteBlob(i, dbBlobs);
+                Manager->DeleteBlobOnExecute(i, dbBlobs);
             }
         }
     }
-    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& /*self*/) {
-
+    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& /*self*/, const bool success) {
+        if (success) {
+            for (auto&& i : GetDeclaredBlobs()) {
+                Manager->DeleteBlobOnComplete(i);
+            }
+        }
     }
 public:
     TDeclareRemovingAction(const TString& storageId, NColumnShard::TBlobManager& manager)

--- a/ydb/core/tx/columnshard/blobs_action/bs/write.h
+++ b/ydb/core/tx/columnshard/blobs_action/bs/write.h
@@ -29,7 +29,7 @@ protected:
     }
 
     virtual void DoOnExecuteTxAfterWrite(NColumnShard::TColumnShard& self, NColumnShard::TBlobManagerDb& dbBlobs, const bool success) override;
-    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& /*self*/) override {
+    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& /*self*/, const bool /*success*/) override {
 
     }
 public:

--- a/ydb/core/tx/columnshard/blobs_action/memory.h
+++ b/ydb/core/tx/columnshard/blobs_action/memory.h
@@ -71,7 +71,7 @@ protected:
     virtual void DoOnExecuteTxAfterWrite(NColumnShard::TColumnShard& /*self*/, NColumnShard::TBlobManagerDb& /*dbBlobs*/, const bool /*success*/) override {
 
     }
-    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& /*self*/) override {
+    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& /*self*/, const bool /*success*/) override {
 
     }
 public:
@@ -106,7 +106,7 @@ protected:
             Storage->DeclareDataForRemove(i);
         }
     }
-    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& /*self*/) {
+    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& /*self*/, const bool /*success*/) {
 
     }
 public:

--- a/ydb/core/tx/columnshard/blobs_action/tier/remove.h
+++ b/ydb/core/tx/columnshard/blobs_action/tier/remove.h
@@ -20,6 +20,12 @@ protected:
         if (success) {
             for (auto&& i : GetDeclaredBlobs()) {
                 dbBlobs.AddTierBlobToDelete(GetStorageId(), i);
+            }
+        }
+    }
+    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& /*self*/, const bool success) {
+        if (success) {
+            for (auto&& i : GetDeclaredBlobs()) {
                 if (GCInfo->IsBlobInUsage(i)) {
                     Y_ABORT_UNLESS(GCInfo->MutableBlobsToDeleteInFuture().emplace(i).second);
                 } else {
@@ -27,9 +33,6 @@ protected:
                 }
             }
         }
-    }
-    virtual void DoOnCompleteTxAfterRemoving(NColumnShard::TColumnShard& /*self*/) {
-
     }
 public:
     TDeclareRemovingAction(const TString& storageId, const std::shared_ptr<TGCInfo>& gcInfo)

--- a/ydb/core/tx/columnshard/blobs_action/tier/write.h
+++ b/ydb/core/tx/columnshard/blobs_action/tier/write.h
@@ -27,7 +27,7 @@ protected:
     }
 
     virtual void DoOnExecuteTxAfterWrite(NColumnShard::TColumnShard& self, NColumnShard::TBlobManagerDb& dbBlobs, const bool success) override;
-    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& /*self*/) override {
+    virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& /*self*/, const bool /*success*/) override {
 
     }
 public:

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_gc_insert_table.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_gc_insert_table.cpp
@@ -21,7 +21,7 @@ bool TTxInsertTableCleanup::Execute(TTransactionContext& txc, const TActorContex
 }
 void TTxInsertTableCleanup::Complete(const TActorContext& /*ctx*/) {
     Y_ABORT_UNLESS(BlobsAction);
-    BlobsAction->OnCompleteTxAfterRemoving(*Self);
+    BlobsAction->OnCompleteTxAfterRemoving(*Self, true);
     Self->EnqueueBackgroundActivities();
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
@@ -102,10 +102,10 @@ void TTxWrite::Complete(const TActorContext& ctx) {
     const auto now = TMonotonic::Now();
     const NOlap::TWritingBuffer& buffer = PutBlobResult->Get()->MutableWritesBuffer();
     for (auto&& i : buffer.GetAddActions()) {
-        i->OnCompleteTxAfterWrite(*Self);
+        i->OnCompleteTxAfterWrite(*Self, true);
     }
     for (auto&& i : buffer.GetRemoveActions()) {
-        i->OnCompleteTxAfterRemoving(*Self);
+        i->OnCompleteTxAfterRemoving(*Self, true);
     }
     AFL_VERIFY(buffer.GetAggregations().size() == Results.size());
     for (ui32 i = 0; i < buffer.GetAggregations().size(); ++i) {

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_write_index.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_write_index.cpp
@@ -64,7 +64,7 @@ void TTxWriteIndex::Complete(const TActorContext& ctx) {
         Self->EnqueueBackgroundActivities(false, TriggerActivity);
     }
 
-    changes->MutableBlobsAction().OnCompleteTxAfterAction(*Self);
+    changes->MutableBlobsAction().OnCompleteTxAfterAction(*Self, Ev->Get()->GetPutStatus() == NKikimrProto::OK);
     NYDBTest::TControllers::GetColumnShardController()->OnWriteIndexComplete(Self->TabletID(), changes->TypeString());
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

split actions:
on execute we have to write into db only
on complete we have to write to memory storage
in other way we have problem in case execution not finished, but gc finished before and if binary killed in this time, we have problem with meta withno blobs

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
