### PR TITLE
Fix unknown type name 'size_t' in actors/core/buffer

### DIFF
--- a/ydb/library/actors/core/buffer.h
+++ b/ydb/library/actors/core/buffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <limits>
 
 class TConstBuffer;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Avoid this type of errors on upcoming libcxx update since some transitive includes have been removed.

```
In file included from $(SOURCE_ROOT)/ydb/library/actors/core/buffer.cpp:1:
$(SOURCE_ROOT)/ydb/library/actors/core/buffer.h:10:5: error: unknown type name 'size_t'
    size_t GetSize() const noexcept;
```

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
