### PR TITLE
use splitter for abstract data chunks. not columns only

### DIFF
--- a/ydb/core/tx/columnshard/blob.h
+++ b/ydb/core/tx/columnshard/blob.h
@@ -288,6 +288,10 @@ struct TBlobRange {
         return BlobId;
     }
 
+    bool IsValid() const {
+        return BlobId.IsValid() && Size && Offset + Size <= BlobId.BlobSize();
+    }
+
     ui32 GetBlobSize() const {
         return Size;
     }

--- a/ydb/core/tx/columnshard/columnshard_schema.cpp
+++ b/ydb/core/tx/columnshard/columnshard_schema.cpp
@@ -2,31 +2,6 @@
 
 namespace NKikimr::NColumnShard {
 
-bool Schema::IndexColumns_Load(NIceDb::TNiceDb& db, const IBlobGroupSelector* dsGroupSelector, const std::function<void(const NOlap::TPortionInfo&, const NOlap::TColumnChunkLoadContext&)>& callback) {
-    auto rowset = db.Table<IndexColumns>().Prefix(0).Select();
-    if (!rowset.IsReady()) {
-        return false;
-    }
-
-    while (!rowset.EndOfSet()) {
-        NOlap::TPortionInfo portion = NOlap::TPortionInfo::BuildEmpty();
-        portion.SetPathId(rowset.GetValue<IndexColumns::PathId>());
-        portion.SetMinSnapshot(rowset.GetValue<IndexColumns::PlanStep>(), rowset.GetValue<IndexColumns::TxId>());
-        portion.SetPortion(rowset.GetValue<IndexColumns::Portion>());
-        portion.SetDeprecatedGranuleId(rowset.GetValue<IndexColumns::Granule>());
-
-        NOlap::TColumnChunkLoadContext chunkLoadContext(rowset, dsGroupSelector);
-
-        portion.SetRemoveSnapshot(rowset.GetValue<IndexColumns::XPlanStep>(), rowset.GetValue<IndexColumns::XTxId>());
-
-        callback(portion, chunkLoadContext);
-
-        if (!rowset.Next())
-            return false;
-    }
-    return true;
-}
-
 bool Schema::InsertTable_Load(NIceDb::TNiceDb& db, const IBlobGroupSelector* dsGroupSelector, NOlap::TInsertTableAccessor& insertTable, const TInstant& /*loadTime*/) {
     auto rowset = db.Table<InsertTable>().GreaterOrEqual(0, 0, 0, 0, "").Select();
     if (!rowset.IsReady()) {

--- a/ydb/core/tx/columnshard/columnshard_schema.h
+++ b/ydb/core/tx/columnshard/columnshard_schema.h
@@ -508,34 +508,6 @@ struct Schema : NIceDb::Schema {
                                  NOlap::TInsertTableAccessor& insertTable,
                                  const TInstant& loadTime);
 
-    // IndexColumns activities
-
-    static void IndexColumns_Write(NIceDb::TNiceDb& db, const NOlap::TPortionInfo& portion, const TColumnRecord& row) {
-        auto proto = portion.GetMeta().SerializeToProto(row.ColumnId, row.Chunk);
-        auto rowProto = row.GetMeta().SerializeToProto();
-        if (proto) {
-            *rowProto.MutablePortionMeta() = std::move(*proto);
-        }
-        db.Table<IndexColumns>().Key(0, portion.GetDeprecatedGranuleId(), row.ColumnId,
-            portion.GetMinSnapshot().GetPlanStep(), portion.GetMinSnapshot().GetTxId(), portion.GetPortion(), row.Chunk).Update(
-                NIceDb::TUpdate<IndexColumns::XPlanStep>(portion.GetRemoveSnapshot().GetPlanStep()),
-                NIceDb::TUpdate<IndexColumns::XTxId>(portion.GetRemoveSnapshot().GetTxId()),
-                NIceDb::TUpdate<IndexColumns::Blob>(row.SerializedBlobId()),
-                NIceDb::TUpdate<IndexColumns::Metadata>(rowProto.SerializeAsString()),
-                NIceDb::TUpdate<IndexColumns::Offset>(row.BlobRange.Offset),
-                NIceDb::TUpdate<IndexColumns::Size>(row.BlobRange.Size),
-                NIceDb::TUpdate<IndexColumns::PathId>(portion.GetPathId())
-            );
-    }
-
-    static void IndexColumns_Erase(NIceDb::TNiceDb& db, const NOlap::TPortionInfo& portion, const TColumnRecord& row) {
-        db.Table<IndexColumns>().Key(0, portion.GetDeprecatedGranuleId(), row.ColumnId,
-            portion.GetMinSnapshot().GetPlanStep(), portion.GetMinSnapshot().GetTxId(), portion.GetPortion(), row.Chunk).Delete();
-    }
-
-    static bool IndexColumns_Load(NIceDb::TNiceDb& db, const IBlobGroupSelector* dsGroupSelector,
-        const std::function<void(const NOlap::TPortionInfo&, const NOlap::TColumnChunkLoadContext&)>& callback);
-
     // IndexCounters
 
     static void IndexCounters_Write(NIceDb::TNiceDb& db, ui32 counterId, ui64 value) {

--- a/ydb/core/tx/columnshard/engines/changes/abstract/abstract.h
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/abstract.h
@@ -2,7 +2,6 @@
 #include "settings.h"
 #include <ydb/core/tx/columnshard/blobs_action/abstract/action.h>
 #include <ydb/core/tx/columnshard/counters/indexation.h>
-#include <ydb/core/tx/columnshard/engines/columns_table.h>
 #include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
 #include <ydb/core/tx/columnshard/engines/portions/with_blobs.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/task.h>

--- a/ydb/core/tx/columnshard/engines/changes/cleanup.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/cleanup.cpp
@@ -39,9 +39,7 @@ bool TCleanupColumnEngineChanges::DoApplyChanges(TColumnEngineForLogs& self, TAp
             AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "Cannot erase portion")("portion", portionInfo.DebugString());
             continue;
         }
-        for (auto& record : portionInfo.Records) {
-            context.DB.EraseColumn(portionInfo, record);
-        }
+        portionInfo.RemoveFromDatabase(context.DB);
     }
 
     return true;

--- a/ydb/core/tx/columnshard/engines/changes/compaction/column_cursor.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/column_cursor.cpp
@@ -63,7 +63,7 @@ bool TPortionColumnCursor::NextChunk() {
         ChunkRecordIndexStartPosition += CurrentChunkRecordsCount;
         CurrentBlobChunk = BlobChunks[ChunkIdx];
         CurrentColumnChunk = ColumnChunks[ChunkIdx];
-        CurrentChunkRecordsCount = CurrentBlobChunk->GetRecordsCount();
+        CurrentChunkRecordsCount = CurrentBlobChunk->GetRecordsCountVerified();
         return true;
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/column_portion_chunk.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/column_portion_chunk.cpp
@@ -5,16 +5,15 @@
 
 namespace NKikimr::NOlap::NCompaction {
 
-std::vector<NKikimr::NOlap::IPortionColumnChunk::TPtr> TChunkPreparation::DoInternalSplit(const TColumnSaver& saver, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const std::vector<ui64>& splitSizes) const {
+std::vector<std::shared_ptr<IPortionDataChunk>> TChunkPreparation::DoInternalSplitImpl(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const {
     auto loader = SchemaInfo->GetColumnLoaderVerified(Record.ColumnId);
     auto rb = NArrow::TStatusValidator::GetValid(loader->Apply(Data));
 
     auto chunks = TSimpleSplitter(saver, counters).SplitBySizes(rb, Data, splitSizes);
-    std::vector<IPortionColumnChunk::TPtr> newChunks;
+    std::vector<std::shared_ptr<IPortionDataChunk>> newChunks;
     for (auto&& i : chunks) {
         Y_ABORT_UNLESS(i.GetSlicedBatch()->num_columns() == 1);
-        newChunks.emplace_back(std::make_shared<TChunkPreparation>(
-            saver.Apply(i.GetSlicedBatch()), i.GetSlicedBatch()->column(0), ColumnId, SchemaInfo));
+        newChunks.emplace_back(std::make_shared<TChunkPreparation>(saver.Apply(i.GetSlicedBatch()), i.GetSlicedBatch()->column(0), GetColumnId(), SchemaInfo));
     }
     return newChunks;
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/column_portion_chunk.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/column_portion_chunk.h
@@ -19,11 +19,11 @@ private:
     std::shared_ptr<arrow::Scalar> First;
     std::shared_ptr<arrow::Scalar> Last;
 protected:
-    virtual std::vector<IPortionColumnChunk::TPtr> DoInternalSplit(const TColumnSaver& saver, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const std::vector<ui64>& splitSizes) const override;
+    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoInternalSplitImpl(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const override;
     virtual const TString& DoGetData() const override {
         return Data;
     }
-    virtual ui32 DoGetRecordsCount() const override {
+    virtual ui32 DoGetRecordsCountImpl() const override {
         return Record.GetMeta().GetNumRowsVerified();
     }
     virtual TString DoDebugString() const override {
@@ -70,14 +70,15 @@ private:
     const ui32 RecordsCount;
     TString Data;
 protected:
-    virtual std::vector<IPortionColumnChunk::TPtr> DoInternalSplit(const TColumnSaver& /*saver*/, std::shared_ptr<NColumnShard::TSplitterCounters> /*counters*/, const std::vector<ui64>& /*splitSizes*/) const override {
+    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoInternalSplitImpl(const TColumnSaver& /*saver*/, const std::shared_ptr<NColumnShard::TSplitterCounters>& /*counters*/,
+                                                                                const std::vector<ui64>& /*splitSizes*/) const override {
         AFL_VERIFY(false);
         return {};
     }
     virtual const TString& DoGetData() const override {
         return Data;
     }
-    virtual ui32 DoGetRecordsCount() const override {
+    virtual ui32 DoGetRecordsCountImpl() const override {
         return RecordsCount;
     }
     virtual TString DoDebugString() const override {
@@ -107,7 +108,7 @@ public:
 
 class TColumnPortionResult {
 protected:
-    std::vector<std::shared_ptr<IPortionColumnChunk>> Chunks;
+    std::vector<std::shared_ptr<IPortionDataChunk>> Chunks;
     ui64 CurrentPortionRecords = 0;
     const ui32 ColumnId;
     ui64 PackedSize = 0;
@@ -121,7 +122,7 @@ public:
 
     }
 
-    const std::vector<std::shared_ptr<IPortionColumnChunk>>& GetChunks() const {
+    const std::vector<std::shared_ptr<IPortionDataChunk>>& GetChunks() const {
         return Chunks;
     }
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction/merged_column.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/merged_column.cpp
@@ -29,7 +29,7 @@ void TMergedColumn::AppendSlice(const std::shared_ptr<arrow::Array>& data, const
     }
 }
 
-std::vector<NKikimr::NOlap::NCompaction::TColumnPortionResult> TMergedColumn::BuildResult() {
+std::vector<TColumnPortionResult> TMergedColumn::BuildResult() {
     std::vector<TColumnPortionResult> result;
     if (Portions.size()) {
         Portions.back().FlushBuffer();

--- a/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
@@ -220,7 +220,7 @@ TConclusionStatus TGeneralCompactColumnEngineChanges::DoConstructBlobs(TConstruc
     NChanges::TGeneralCompactionCounters::OnPortionsKind(insertedPortionsSize, compactedPortionsSize, otherPortionsSize);
     NChanges::TGeneralCompactionCounters::OnRepackPortions(portionsCount, portionsSize);
 
-    if (AppDataVerified().ColumnShardConfig.GetUseChunkedMergeOnCompaction()) {
+    if (!HasAppData() || AppDataVerified().ColumnShardConfig.GetUseChunkedMergeOnCompaction()) {
         BuildAppendedPortionsByChunks(context);
     } else {
         BuildAppendedPortionsByFullBatches(context);

--- a/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
@@ -189,13 +189,13 @@ void TGeneralCompactColumnEngineChanges::BuildAppendedPortionsByChunks(TConstruc
         ui32 recordIdx = 0;
         for (auto&& i : packs) {
             TGeneralSerializedSlice slice(std::move(i));
-            auto b = batchResult->Slice(recordIdx, slice.GetRecordsCountVerified());
+            auto b = batchResult->Slice(recordIdx, slice.GetRecordsCount());
             std::vector<std::vector<std::shared_ptr<IPortionDataChunk>>> chunksByBlobs = slice.GroupChunksByBlobs();
             AppendedPortions.emplace_back(TPortionInfoWithBlobs::BuildByBlobs(chunksByBlobs, nullptr, GranuleMeta->GetPathId(), resultSchema->GetSnapshot(), SaverContext.GetStorageOperator()));
             NArrow::TFirstLastSpecialKeys primaryKeys(slice.GetFirstLastPKBatch(resultSchema->GetIndexInfo().GetReplaceKey()));
             NArrow::TMinMaxSpecialKeys snapshotKeys(b, TIndexInfo::ArrowSchemaSnapshot());
             AppendedPortions.back().GetPortionInfo().AddMetadata(*resultSchema, primaryKeys, snapshotKeys, SaverContext.GetTierName());
-            recordIdx += slice.GetRecordsCountVerified();
+            recordIdx += slice.GetRecordsCount();
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/db_wrapper.cpp
+++ b/ydb/core/tx/columnshard/engines/db_wrapper.cpp
@@ -93,7 +93,6 @@ bool TDbWrapper::LoadColumns(const std::function<void(const NOlap::TPortionInfo&
     }
     return true;
 }
-}
 
 void TDbWrapper::WriteCounter(ui32 counterId, ui64 value) {
     NIceDb::TNiceDb db(Database);

--- a/ydb/core/tx/columnshard/engines/db_wrapper.cpp
+++ b/ydb/core/tx/columnshard/engines/db_wrapper.cpp
@@ -42,17 +42,57 @@ bool TDbWrapper::Load(TInsertTableAccessor& insertTable,
 
 void TDbWrapper::WriteColumn(const NOlap::TPortionInfo& portion, const TColumnRecord& row) {
     NIceDb::TNiceDb db(Database);
-    NColumnShard::Schema::IndexColumns_Write(db, portion, row);
+    auto proto = portion.GetMeta().SerializeToProto(row.ColumnId, row.Chunk);
+    auto rowProto = row.GetMeta().SerializeToProto();
+    if (proto) {
+        *rowProto.MutablePortionMeta() = std::move(*proto);
+    }
+    using IndexColumns = NColumnShard::Schema::IndexColumns;
+    db.Table<IndexColumns>().Key(0, portion.GetDeprecatedGranuleId(), row.ColumnId,
+        portion.GetMinSnapshot().GetPlanStep(), portion.GetMinSnapshot().GetTxId(), portion.GetPortion(), row.Chunk).Update(
+            NIceDb::TUpdate<IndexColumns::XPlanStep>(portion.GetRemoveSnapshot().GetPlanStep()),
+            NIceDb::TUpdate<IndexColumns::XTxId>(portion.GetRemoveSnapshot().GetTxId()),
+            NIceDb::TUpdate<IndexColumns::Blob>(row.SerializedBlobId()),
+            NIceDb::TUpdate<IndexColumns::Metadata>(rowProto.SerializeAsString()),
+            NIceDb::TUpdate<IndexColumns::Offset>(row.BlobRange.Offset),
+            NIceDb::TUpdate<IndexColumns::Size>(row.BlobRange.Size),
+            NIceDb::TUpdate<IndexColumns::PathId>(portion.GetPathId())
+        );
 }
 
 void TDbWrapper::EraseColumn(const NOlap::TPortionInfo& portion, const TColumnRecord& row) {
     NIceDb::TNiceDb db(Database);
-    NColumnShard::Schema::IndexColumns_Erase(db, portion, row);
+    using IndexColumns = NColumnShard::Schema::IndexColumns;
+    db.Table<IndexColumns>().Key(0, portion.GetDeprecatedGranuleId(), row.ColumnId,
+        portion.GetMinSnapshot().GetPlanStep(), portion.GetMinSnapshot().GetTxId(), portion.GetPortion(), row.Chunk).Delete();
 }
 
 bool TDbWrapper::LoadColumns(const std::function<void(const NOlap::TPortionInfo&, const TColumnChunkLoadContext&)>& callback) {
     NIceDb::TNiceDb db(Database);
-    return NColumnShard::Schema::IndexColumns_Load(db, DsGroupSelector, callback);
+    using IndexColumns = NColumnShard::Schema::IndexColumns;
+    auto rowset = db.Table<IndexColumns>().Prefix(0).Select();
+    if (!rowset.IsReady()) {
+        return false;
+    }
+
+    while (!rowset.EndOfSet()) {
+        NOlap::TPortionInfo portion = NOlap::TPortionInfo::BuildEmpty();
+        portion.SetPathId(rowset.GetValue<IndexColumns::PathId>());
+        portion.SetMinSnapshot(rowset.GetValue<IndexColumns::PlanStep>(), rowset.GetValue<IndexColumns::TxId>());
+        portion.SetPortion(rowset.GetValue<IndexColumns::Portion>());
+        portion.SetDeprecatedGranuleId(rowset.GetValue<IndexColumns::Granule>());
+
+        NOlap::TColumnChunkLoadContext chunkLoadContext(rowset, DsGroupSelector);
+
+        portion.SetRemoveSnapshot(rowset.GetValue<IndexColumns::XPlanStep>(), rowset.GetValue<IndexColumns::XTxId>());
+
+        callback(portion, chunkLoadContext);
+
+        if (!rowset.Next())
+            return false;
+    }
+    return true;
+}
 }
 
 void TDbWrapper::WriteCounter(ui32 counterId, ui64 value) {

--- a/ydb/core/tx/columnshard/engines/portions/column_record.h
+++ b/ydb/core/tx/columnshard/engines/portions/column_record.h
@@ -155,10 +155,11 @@ protected:
     virtual const TString& DoGetData() const override {
         return Data;
     }
-    virtual ui32 DoGetRecordsCount() const override {
+    virtual ui32 DoGetRecordsCountImpl() const override {
         return ColumnRecord.GetMeta().GetNumRowsVerified();
     }
-    virtual std::vector<IPortionColumnChunk::TPtr> DoInternalSplit(const TColumnSaver& /*saver*/, std::shared_ptr<NColumnShard::TSplitterCounters> /*counters*/, const std::vector<ui64>& /*splitSizes*/) const override {
+    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoInternalSplitImpl(const TColumnSaver& /*saver*/, const std::shared_ptr<NColumnShard::TSplitterCounters>& /*counters*/,
+                                                                                const std::vector<ui64>& /*splitSizes*/) const override {
         Y_ABORT_UNLESS(false);
         return {};
     }
@@ -173,10 +174,9 @@ protected:
     }
 public:
     TSimpleOrderedColumnChunk(const TColumnRecord& cRecord, const TString& data)
-        : TBase(cRecord.ColumnId)
+        : TBase(cRecord.ColumnId, cRecord.Chunk)
         , ColumnRecord(cRecord)
         , Data(data) {
-        ChunkIdx = cRecord.Chunk;
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/portions/column_record.h
+++ b/ydb/core/tx/columnshard/engines/portions/column_record.h
@@ -57,6 +57,12 @@ public:
     ui16 Chunk = 0;
     TBlobRange BlobRange;
 
+
+    void RegisterBlobId(const TUnifiedBlobId& blobId) {
+//        AFL_VERIFY(!BlobRange.BlobId.GetTabletId())("original", BlobRange.BlobId.ToStringNew())("new", blobId.ToStringNew());
+        BlobRange.BlobId = blobId;
+    }
+
     TColumnRecord(const TChunkAddress& address, const TBlobRange& range, TChunkMeta&& meta)
         : Meta(std::move(meta))
         , ColumnId(address.GetColumnId())

--- a/ydb/core/tx/columnshard/engines/portions/portion_info.h
+++ b/ydb/core/tx/columnshard/engines/portions/portion_info.h
@@ -34,8 +34,7 @@ public:
         bool found = false;
         for (auto it = Records.begin(); it != Records.end(); ++it) {
             if (it->ColumnId == address.GetEntityId() && it->Chunk == address.GetChunkIdx()) {
-                AFL_VERIFY(!it->BlobRange.BlobId.IsValid());
-                it->BlobRange.BlobId = blobId;
+                it->RegisterBlobId(blobId);
                 found = true;
                 break;
             }

--- a/ydb/core/tx/columnshard/engines/portions/portion_info.h
+++ b/ydb/core/tx/columnshard/engines/portions/portion_info.h
@@ -11,6 +11,7 @@
 namespace NKikimr::NOlap {
 
 struct TIndexInfo;
+class IDbWrapper;
 
 class TPortionInfo {
 private:
@@ -28,6 +29,23 @@ public:
     ui64 GetPathId() const {
         return PathId;
     }
+
+    void RegisterBlobId(const TChunkAddress& address, const TUnifiedBlobId& blobId) {
+        bool found = false;
+        for (auto it = Records.begin(); it != Records.end(); ++it) {
+            if (it->ColumnId == address.GetEntityId() && it->Chunk == address.GetChunkIdx()) {
+                AFL_VERIFY(!it->BlobRange.BlobId.IsValid());
+                it->BlobRange.BlobId = blobId;
+                found = true;
+                break;
+            }
+        }
+        AFL_VERIFY(found)("address", address.DebugString());
+    }
+
+    void RemoveFromDatabase(IDbWrapper& db) const;
+
+    void SaveToDatabase(IDbWrapper& db) const;
 
     bool OlderThen(const TPortionInfo& info) const {
         return RecordSnapshotMin() < info.RecordSnapshotMin();

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
@@ -22,9 +22,8 @@ static std::vector<TString> NamesOnly(const std::vector<TNameTypeInfo>& columns)
     return out;
 }
 
-TIndexInfo::TIndexInfo(const TString& name, ui32 id)
+TIndexInfo::TIndexInfo(const TString& name)
     : NTable::TScheme::TTableSchema()
-    , Id(id)
     , Name(name)
 {}
 
@@ -326,6 +325,12 @@ TColumnSaver TIndexInfo::GetColumnSaver(const ui32 columnId, const TSaverContext
     }
 }
 
+std::shared_ptr<TColumnLoader> TIndexInfo::GetColumnLoaderVerified(const ui32 columnId) const {
+    auto result = GetColumnLoaderOptional(columnId);
+    AFL_VERIFY(result);
+    return result;
+}
+
 std::shared_ptr<TColumnLoader> TIndexInfo::GetColumnLoaderOptional(const ui32 columnId) const {
     auto it = ColumnFeatures.find(columnId);
     if (it == ColumnFeatures.end()) {
@@ -451,7 +456,7 @@ std::vector<TNameTypeInfo> GetColumns(const NTable::TScheme::TTableSchema& table
 }
 
 std::optional<TIndexInfo> TIndexInfo::BuildFromProto(const NKikimrSchemeOp::TColumnTableSchema& schema) {
-    TIndexInfo result("", 0);
+    TIndexInfo result("");
     if (!result.DeserializeFromProto(schema)) {
         return std::nullopt;
     }

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.h
@@ -34,7 +34,7 @@ struct TIndexInfo : public NTable::TScheme::TTableSchema {
 private:
     THashMap<ui32, TColumnFeatures> ColumnFeatures;
     THashMap<ui32, std::shared_ptr<arrow::Field>> ArrowColumnByColumnIdCache;
-    TIndexInfo(const TString& name, ui32 id);
+    TIndexInfo(const TString& name);
     bool DeserializeFromProto(const NKikimrSchemeOp::TColumnTableSchema& schema);
     TColumnFeatures& GetOrCreateColumnFeatures(const ui32 columnId) const;
     void BuildSchemaWithSpecials();
@@ -54,7 +54,6 @@ public:
     TString DebugString() const {
         TStringBuilder sb;
         sb << "("
-            << "id=" << Id << ";"
             << "version=" << Version << ";"
             << "name=" << Name << ";"
             << ")";
@@ -92,16 +91,11 @@ public:
 
 public:
     static TIndexInfo BuildDefault() {
-        TIndexInfo result("dummy", 0);
+        TIndexInfo result("dummy");
         return result;
     }
 
     static std::optional<TIndexInfo> BuildFromProto(const NKikimrSchemeOp::TColumnTableSchema& schema);
-
-    /// Returns id of the index.
-    ui32 GetId() const noexcept {
-        return Id;
-    }
 
     static const std::vector<std::string>& SnapshotColumnNames() {
         static std::vector<std::string> result = {SPEC_COL_PLAN_STEP, SPEC_COL_TX_ID};
@@ -206,7 +200,6 @@ public:
     bool CheckCompatible(const TIndexInfo& other) const;
 
 private:
-    ui32 Id;
     ui64 Version = 0;
     TString Name;
     std::shared_ptr<arrow::Schema> Schema;

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.h
@@ -108,6 +108,7 @@ public:
     std::shared_ptr<arrow::Schema> GetColumnsSchema(const std::set<ui32>& columnIds) const;
     TColumnSaver GetColumnSaver(const ui32 columnId, const TSaverContext& context) const;
     std::shared_ptr<TColumnLoader> GetColumnLoaderOptional(const ui32 columnId) const;
+    std::shared_ptr<TColumnLoader> GetColumnLoaderVerified(const ui32 columnId) const;
 
     /// Returns an id of the column located by name. The name should exists in the schema.
     ui32 GetColumnId(const std::string& name) const;

--- a/ydb/core/tx/columnshard/engines/storage/granule.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/granule.cpp
@@ -56,12 +56,12 @@ void TGranuleMeta::AddColumnRecord(const TIndexInfo& indexInfo, const TPortionIn
     if (it == Portions.end()) {
         Y_ABORT_UNLESS(portion.Records.empty());
         auto portionNew = std::make_shared<TPortionInfo>(portion);
-        portionNew->AddRecord(indexInfo, rec, portionMeta);
         it = Portions.emplace(portion.GetPortion(), portionNew).first;
     } else {
         AFL_VERIFY(it->second->IsEqualWithSnapshots(portion))("self", it->second->DebugString())("item", portion.DebugString());
-        it->second->AddRecord(indexInfo, rec, portionMeta);
     }
+    it->second->AddRecord(indexInfo, rec, portionMeta);
+
     if (portionMeta) {
         it->second->InitOperator(Owner->GetStoragesManager()->InitializePortionOperator(*it->second), false);
     }

--- a/ydb/core/tx/columnshard/splitter/batch_slice.cpp
+++ b/ydb/core/tx/columnshard/splitter/batch_slice.cpp
@@ -4,9 +4,9 @@
 namespace NKikimr::NOlap {
 
 bool TGeneralSerializedSlice::GroupBlobs(std::vector<TSplittedBlob>& blobs) {
-    std::vector<IPortionColumnChunk::TPtr> chunksInProgress;
-    std::sort(Columns.begin(), Columns.end());
-    for (auto&& i : Columns) {
+    std::vector<std::shared_ptr<IPortionDataChunk>> chunksInProgress;
+    std::sort(Data.begin(), Data.end());
+    for (auto&& i : Data) {
         for (auto&& p : i.GetChunks()) {
             chunksInProgress.emplace_back(p);
         }
@@ -49,12 +49,12 @@ bool TGeneralSerializedSlice::GroupBlobs(std::vector<TSplittedBlob>& blobs) {
                         Y_ABORT_UNLESS((i64)chunksInProgress[i]->GetPackedSize() > Settings.GetMinBlobSize() - partSize);
                         Y_ABORT_UNLESS(otherSize - (Settings.GetMinBlobSize() - partSize) >= Settings.GetMinBlobSize());
 
-                        std::vector<IPortionColumnChunk::TPtr> newChunks;
-                        const bool splittable = chunksInProgress[i]->GetRecordsCount() > 1;
+                        std::vector<std::shared_ptr<IPortionDataChunk>> newChunks;
+                        const bool splittable = chunksInProgress[i]->IsSplittable();
                         if (splittable) {
                             Counters->BySizeSplitter.OnTrashSerialized(chunksInProgress[i]->GetPackedSize());
                             const std::vector<ui64> sizes = {(ui64)(Settings.GetMinBlobSize() - partSize)};
-                            newChunks = chunksInProgress[i]->InternalSplit(Schema->GetColumnSaver(chunksInProgress[i]->GetColumnId()), Counters, sizes);
+                            newChunks = chunksInProgress[i]->InternalSplit(Schema->GetColumnSaver(chunksInProgress[i]->GetEntityId()), Counters, sizes);
                             chunksInProgress.erase(chunksInProgress.begin() + i);
                             chunksInProgress.insert(chunksInProgress.begin() + i, newChunks.begin(), newChunks.end());
                         }
@@ -81,10 +81,10 @@ bool TGeneralSerializedSlice::GroupBlobs(std::vector<TSplittedBlob>& blobs) {
     ui32 currentChunkIdx = 0;
     for (auto&& i : result) {
         for (auto&& c : i.GetChunks()) {
-            Y_ABORT_UNLESS(c->GetColumnId());
-            if (!lastColumnId || *lastColumnId != c->GetColumnId()) {
-                Y_ABORT_UNLESS(columnIds.emplace(c->GetColumnId()).second);
-                lastColumnId = c->GetColumnId();
+            Y_ABORT_UNLESS(c->GetEntityId());
+            if (!lastColumnId || *lastColumnId != c->GetEntityId()) {
+                Y_ABORT_UNLESS(columnIds.emplace(c->GetEntityId()).second);
+                lastColumnId = c->GetEntityId();
                 currentChunkIdx = 0;
             }
             c->SetChunkIdx(currentChunkIdx++);
@@ -94,27 +94,27 @@ bool TGeneralSerializedSlice::GroupBlobs(std::vector<TSplittedBlob>& blobs) {
     return true;
 }
 
-TGeneralSerializedSlice::TGeneralSerializedSlice(const std::map<ui32, std::vector<IPortionColumnChunk::TPtr>>& data,
-    ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const TSplitSettings& settings)
+TGeneralSerializedSlice::TGeneralSerializedSlice(const std::map<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters,
+                                                 const TSplitSettings& settings)
     : Schema(schema)
     , Counters(counters)
     , Settings(settings) {
-
     std::optional<ui32> recordsCount;
-    for (auto&& [columnId, chunks] : data) {
-        auto f = schema->GetField(columnId);
-        TSplittedColumn column(f, columnId);
-        column.AddChunks(chunks);
-        if (!recordsCount) {
-            recordsCount = column.GetRecordsCount();
-        } else {
-            AFL_VERIFY(*recordsCount == column.GetRecordsCount())("records_count", *recordsCount)("column", column.GetRecordsCount());
+    for (auto&& [entityId, chunks] : data) {
+        TSplittedEntity entity(entityId);
+        entity.SetChunks(chunks);
+        if (!!entity.GetRecordsCount()) {
+            if (!recordsCount) {
+                recordsCount = entity.GetRecordsCount();
+            } else {
+                AFL_VERIFY(*recordsCount == entity.GetRecordsCount())("records_count", *recordsCount)("column", entity.GetRecordsCount());
+            }
         }
-        Size += column.GetSize();
-        Columns.emplace_back(std::move(column));
+        Size += entity.GetSize();
+        Data.emplace_back(std::move(entity));
     }
     Y_ABORT_UNLESS(recordsCount);
-    RecordsCount = *recordsCount;
+    RecordsCount = recordsCount;
 }
 
 TGeneralSerializedSlice::TGeneralSerializedSlice(ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const TSplitSettings& settings)
@@ -130,24 +130,22 @@ TBatchSerializedSlice::TBatchSerializedSlice(std::shared_ptr<arrow::RecordBatch>
 {
     Y_ABORT_UNLESS(batch);
     RecordsCount = batch->num_rows();
-    Columns.reserve(batch->num_columns());
+    Data.reserve(batch->num_columns());
     for (auto&& i : batch->schema()->fields()) {
-        TSplittedColumn c(i, schema->GetColumnId(i->name()));
-        Columns.emplace_back(std::move(c));
+        TSplittedEntity c(schema->GetColumnId(i->name()));
+        Data.emplace_back(std::move(c));
     }
 
     ui32 idx = 0;
     for (auto&& i : batch->columns()) {
-        auto& c = Columns[idx];
-        auto columnSaver = schema->GetColumnSaver(c.GetColumnId());
-        auto stats = schema->GetColumnSerializationStats(c.GetColumnId());
+        auto& c = Data[idx];
+        auto columnSaver = schema->GetColumnSaver(c.GetEntityId());
+        auto stats = schema->GetColumnSerializationStats(c.GetEntityId());
         TSimpleSplitter splitter(columnSaver, Counters);
-        if (stats) {
-            splitter.SetStats(*stats);
-        }
-        std::vector<IPortionColumnChunk::TPtr> chunks;
-        for (auto&& i : splitter.Split(i, c.GetField(), Settings.GetMaxBlobSize())) {
-            chunks.emplace_back(std::make_shared<TSplittedColumnChunk>(c.GetColumnId(), i, Schema));
+        splitter.SetStats(stats);
+        std::vector<std::shared_ptr<IPortionDataChunk>> chunks;
+        for (auto&& i : splitter.Split(i, Schema->GetField(c.GetEntityId()), Settings.GetMaxBlobSize())) {
+            chunks.emplace_back(std::make_shared<TSplittedColumnChunk>(c.GetEntityId(), i, Schema));
         }
         c.SetChunks(chunks);
         Size += c.GetSize();
@@ -156,11 +154,15 @@ TBatchSerializedSlice::TBatchSerializedSlice(std::shared_ptr<arrow::RecordBatch>
 }
 
 void TGeneralSerializedSlice::MergeSlice(TGeneralSerializedSlice&& slice) {
-    Y_ABORT_UNLESS(Columns.size() == slice.Columns.size());
-    RecordsCount += slice.GetRecordsCount();
-    for (ui32 i = 0; i < Columns.size(); ++i) {
-        Size += slice.Columns[i].GetSize();
-        Columns[i].Merge(std::move(slice.Columns[i]));
+    Y_ABORT_UNLESS(Data.size() == slice.Data.size());
+    if (!RecordsCount) {
+        RecordsCount = slice.GetRecordsCountVerified();
+    } else {
+        *RecordsCount += slice.GetRecordsCountVerified();
+    }
+    for (ui32 i = 0; i < Data.size(); ++i) {
+        Size += slice.Data[i].GetSize();
+        Data[i].Merge(std::move(slice.Data[i]));
     }
 }
 

--- a/ydb/core/tx/columnshard/splitter/batch_slice.h
+++ b/ydb/core/tx/columnshard/splitter/batch_slice.h
@@ -87,10 +87,11 @@ public:
 };
 
 class TGeneralSerializedSlice {
+private:
+    YDB_READONLY(ui32, RecordsCount, 0);
 protected:
     std::vector<TSplittedEntity> Data;
     ui64 Size = 0;
-    std::optional<ui32> RecordsCount;
     ISchemaDetailInfo::TPtr Schema;
     std::shared_ptr<NColumnShard::TSplitterCounters> Counters;
     TSplitSettings Settings;
@@ -123,15 +124,6 @@ public:
         return Size;
     }
 
-    ui32 GetRecordsCountVerified() const {
-        AFL_VERIFY(RecordsCount);
-        return *RecordsCount;
-    }
-
-    std::optional<ui32> GetRecordsCount() const {
-        return RecordsCount;
-    }
-
     std::vector<std::vector<std::shared_ptr<IPortionDataChunk>>> GroupChunksByBlobs() {
         std::vector<std::vector<std::shared_ptr<IPortionDataChunk>>> result;
         std::vector<TSplittedBlob> blobs;
@@ -150,7 +142,7 @@ public:
         }
     }
     TGeneralSerializedSlice(const std::map<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const TSplitSettings& settings);
-    TGeneralSerializedSlice(ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const TSplitSettings& settings);
+    TGeneralSerializedSlice(const ui32 recordsCount, ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const TSplitSettings& settings);
 
     void MergeSlice(TGeneralSerializedSlice&& slice);
 
@@ -166,10 +158,9 @@ private:
     using TBase = TGeneralSerializedSlice;
     YDB_READONLY_DEF(std::shared_ptr<arrow::RecordBatch>, Batch);
 public:
-    TBatchSerializedSlice(std::shared_ptr<arrow::RecordBatch> batch, ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const TSplitSettings& settings);
+    TBatchSerializedSlice(const std::shared_ptr<arrow::RecordBatch>& batch, ISchemaDetailInfo::TPtr schema, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const TSplitSettings& settings);
 
-    explicit TBatchSerializedSlice(TVectorView<TBatchSerializedSlice>&& objects)
-    {
+    explicit TBatchSerializedSlice(TVectorView<TBatchSerializedSlice>&& objects) {
         Y_ABORT_UNLESS(objects.size());
         std::swap(*this, objects.front());
         for (ui32 i = 1; i < objects.size(); ++i) {

--- a/ydb/core/tx/columnshard/splitter/blob_info.cpp
+++ b/ydb/core/tx/columnshard/splitter/blob_info.cpp
@@ -2,9 +2,8 @@
 
 namespace NKikimr::NOlap {
 
-void TSplittedBlob::Take(const IPortionColumnChunk::TPtr& chunk) {
+void TSplittedBlob::Take(const std::shared_ptr<IPortionDataChunk>& chunk) {
     Chunks.emplace_back(chunk);
     Size += chunk->GetPackedSize();
 }
-
 }

--- a/ydb/core/tx/columnshard/splitter/blob_info.h
+++ b/ydb/core/tx/columnshard/splitter/blob_info.h
@@ -7,9 +7,10 @@ namespace NKikimr::NOlap {
 class TSplittedBlob {
 private:
     YDB_READONLY(i64, Size, 0);
-    YDB_READONLY_DEF(std::vector<IPortionColumnChunk::TPtr>, Chunks);
+    YDB_READONLY_DEF(std::vector<std::shared_ptr<IPortionDataChunk>>, Chunks);
+
 public:
-    void Take(const IPortionColumnChunk::TPtr& chunk);
+    void Take(const std::shared_ptr<IPortionDataChunk>& chunk);
     bool operator<(const TSplittedBlob& item) const {
         return Size > item.Size;
     }

--- a/ydb/core/tx/columnshard/splitter/chunks.cpp
+++ b/ydb/core/tx/columnshard/splitter/chunks.cpp
@@ -1,8 +1,10 @@
 #include "chunks.h"
+#include <ydb/core/tx/columnshard/engines/portions/column_record.h>
+#include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
 
 namespace NKikimr::NOlap {
 
-std::vector<NKikimr::NOlap::IPortionColumnChunk::TPtr> IPortionColumnChunk::InternalSplit(const TColumnSaver& saver, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const std::vector<ui64>& splitSizes) const {
+std::vector<std::shared_ptr<IPortionDataChunk>> IPortionColumnChunk::DoInternalSplit(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const {
     ui64 sumSize = 0;
     for (auto&& i : splitSizes) {
         sumSize += i;
@@ -13,13 +15,18 @@ std::vector<NKikimr::NOlap::IPortionColumnChunk::TPtr> IPortionColumnChunk::Inte
     } else {
         Y_ABORT_UNLESS(GetRecordsCount() >= splitSizes.size());
     }
-    auto result = DoInternalSplit(saver, counters, splitSizes);
+    auto result = DoInternalSplitImpl(saver, counters, splitSizes);
     if (sumSize == GetPackedSize()) {
         Y_ABORT_UNLESS(result.size() == splitSizes.size());
     } else {
         Y_ABORT_UNLESS(result.size() == splitSizes.size() + 1);
     }
     return result;
+}
+
+void IPortionColumnChunk::DoAddIntoPortion(const TBlobRange& bRange, TPortionInfo& portionInfo) const {
+    TColumnRecord rec(GetChunkAddress(), bRange, BuildSimpleChunkMeta());
+    portionInfo.AppendOneChunkColumn(std::move(rec));
 }
 
 }

--- a/ydb/core/tx/columnshard/splitter/chunks.h
+++ b/ydb/core/tx/columnshard/splitter/chunks.h
@@ -1,38 +1,75 @@
 #pragma once
 #include "chunk_meta.h"
-#include <ydb/core/tx/columnshard/engines/scheme/column_features.h>
+
 #include <ydb/core/tx/columnshard/counters/splitter.h>
 #include <ydb/core/tx/columnshard/engines/portions/common.h>
+#include <ydb/core/tx/columnshard/engines/scheme/column_features.h>
 
 namespace NKikimr::NOlap {
 
-class IPortionColumnChunk {
-public:
-    using TPtr = std::shared_ptr<IPortionColumnChunk>;
+class IPortionDataChunk {
+private:
+    YDB_READONLY(ui32, EntityId, 0);
+
+    std::optional<ui32> ChunkIdx;
+
 protected:
-    ui32 ColumnId = 0;
-    ui16 ChunkIdx = 0;
-    virtual std::vector<IPortionColumnChunk::TPtr> DoInternalSplit(const TColumnSaver& saver, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const std::vector<ui64>& splitSizes) const = 0;
-    virtual ui64 DoGetPackedSize() const {
+    ui64 DoGetPackedSize() const {
         return GetData().size();
     }
     virtual const TString& DoGetData() const = 0;
-    virtual ui32 DoGetRecordsCount() const = 0;
     virtual TString DoDebugString() const = 0;
-    virtual TSimpleChunkMeta DoBuildSimpleChunkMeta() const = 0;
+    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoInternalSplit(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const = 0;
+    virtual bool DoIsSplittable() const = 0;
+    virtual std::optional<ui32> DoGetRecordsCount() const = 0;
     virtual std::shared_ptr<arrow::Scalar> DoGetFirstScalar() const = 0;
     virtual std::shared_ptr<arrow::Scalar> DoGetLastScalar() const = 0;
-
+    virtual void DoAddIntoPortion(const TBlobRange& bRange, TPortionInfo& portionInfo) const = 0;
 public:
-    IPortionColumnChunk(const ui32 columnId)
-        : ColumnId(columnId)
-    {
-
+    IPortionDataChunk(const ui32 entityId, const std::optional<ui16>& chunkIdx = {})
+        : EntityId(entityId)
+        , ChunkIdx(chunkIdx) {
     }
-    virtual ~IPortionColumnChunk() = default;
 
-    TChunkAddress GetChunkAddress() const {
-        return TChunkAddress(ColumnId, ChunkIdx);
+    virtual ~IPortionDataChunk() = default;
+
+    TString DebugString() const {
+        return DoDebugString();
+    }
+
+    const TString& GetData() const {
+        return DoGetData();
+    }
+
+    ui64 GetPackedSize() const {
+        return DoGetPackedSize();
+    }
+
+    std::optional<ui32> GetRecordsCount() const {
+        return DoGetRecordsCount();
+    }
+
+    ui32 GetRecordsCountVerified() const {
+        auto result = DoGetRecordsCount();
+        AFL_VERIFY(result);
+        return *result;
+    }
+
+    std::vector<std::shared_ptr<IPortionDataChunk>> InternalSplit(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const {
+        return DoInternalSplit(saver, counters, splitSizes);
+    }
+
+    bool IsSplittable() const {
+        return DoIsSplittable();
+    }
+
+    ui16 GetChunkIdx() const {
+        AFL_VERIFY(!!ChunkIdx);
+        return *ChunkIdx;
+    }
+
+    void SetChunkIdx(const ui16 value) {
+        ChunkIdx = value;
     }
 
     std::shared_ptr<arrow::Scalar> GetFirstScalar() const {
@@ -46,38 +83,136 @@ public:
         return result;
     }
 
+    TChunkAddress GetChunkAddress() const {
+        return TChunkAddress(GetEntityId(), GetChunkIdx());
+    }
+
+    void AddIntoPortion(const TBlobRange& bRange, TPortionInfo& portionInfo) const {
+        return DoAddIntoPortion(bRange, portionInfo);
+    }
+};
+
+class IPortionColumnChunk : public IPortionDataChunk {
+private:
+    using TBase = IPortionDataChunk;
+
+protected:
+    virtual TSimpleChunkMeta DoBuildSimpleChunkMeta() const = 0;
+    virtual ui32 DoGetRecordsCountImpl() const = 0;
+    virtual std::optional<ui32> DoGetRecordsCount() const override final {
+        return DoGetRecordsCountImpl();
+    }
+
+    virtual void DoAddIntoPortion(const TBlobRange& bRange, TPortionInfo& portionInfo) const override;
+
+    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoInternalSplitImpl(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const = 0;
+    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoInternalSplit(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const override;
+    virtual bool DoIsSplittable() const override {
+        return GetRecordsCount() > 1;
+    }
+
+public:
+    IPortionColumnChunk(const ui32 entityId, const std::optional<ui16>& chunkIdx = {})
+        : TBase(entityId, chunkIdx) {
+    }
+    virtual ~IPortionColumnChunk() = default;
+
     TSimpleChunkMeta BuildSimpleChunkMeta() const {
         return DoBuildSimpleChunkMeta();
     }
 
     ui32 GetColumnId() const {
-        return ColumnId;
+        return GetEntityId();
     }
-
-    ui16 GetChunkIdx() const {
-        return ChunkIdx;
-    }
-
-    void SetChunkIdx(const ui16 value) {
-        ChunkIdx = value;
-    }
-
-    TString DebugString() const {
-        return DoDebugString();
-    }
-
-    ui32 GetRecordsCount() const {
-        return DoGetRecordsCount();
-    }
-
-    const TString& GetData() const {
-        return DoGetData();
-    }
-
-    ui64 GetPackedSize() const {
-        return DoGetPackedSize();
-    }
-
-    std::vector<IPortionColumnChunk::TPtr> InternalSplit(const TColumnSaver& saver, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const std::vector<ui64>& splitSizes) const;
 };
+
+class TChunkedColumnReader {
+private:
+    std::vector<std::shared_ptr<IPortionDataChunk>> Chunks;
+    std::shared_ptr<TColumnLoader> Loader;
+
+    std::shared_ptr<arrow::Array> CurrentChunk;
+    ui32 CurrentChunkIndex = 0;
+    ui32 CurrentRecordIndex = 0;
+public:
+    TChunkedColumnReader(const std::vector<std::shared_ptr<IPortionDataChunk>>& chunks, const std::shared_ptr<TColumnLoader>& loader)
+        : Chunks(chunks) 
+        , Loader(loader)
+    {
+        if (Chunks.size()) {
+            CurrentChunk = Loader->ApplyVerifiedColumn(Chunks.front()->GetData());
+        }
+    }
+
+    const std::shared_ptr<arrow::Array>& GetCurrentChunk() const {
+        return CurrentChunk;
+    }
+
+    ui32 GetCurrentRecordIndex() const {
+        return CurrentRecordIndex;
+    }
+
+    bool IsCorrect() const {
+        return !!CurrentChunk;
+    }
+
+    bool ReadNext() {
+        AFL_VERIFY(!!CurrentChunk);
+        if (++CurrentRecordIndex < CurrentChunk->length()) {
+            return true;
+        } 
+        while (++CurrentChunkIndex < Chunks.size()) {
+            CurrentChunk = Loader->ApplyVerifiedColumn(Chunks[CurrentChunkIndex]->GetData());
+            CurrentRecordIndex = 0;
+            if (CurrentRecordIndex < CurrentChunk->length()) {
+                return true;
+            }
+        }
+        CurrentChunk = nullptr;
+        return false;
+    }
+};
+
+class TChunkedBatchReader {
+private:
+    std::vector<TChunkedColumnReader> Columns;
+    bool IsCorrectFlag = true;
+public:
+    TChunkedBatchReader(const std::vector<TChunkedColumnReader>& columnReaders)
+        : Columns(columnReaders)
+    {
+        AFL_VERIFY(Columns.size());
+        for (auto&& i : Columns) {
+            AFL_VERIFY(i.IsCorrect());
+        }
+    }
+
+    bool IsCorrect() const {
+        return IsCorrectFlag;
+    }
+
+    bool ReadNext() {
+        std::optional<bool> result;
+        for (auto&& i : Columns) {
+            if (!result) {
+                result = i.ReadNext();
+            } else {
+                AFL_VERIFY(*result == i.ReadNext());
+            }
+        }
+        if (!*result) {
+            IsCorrectFlag = false;
+        }
+        return *result;
+    }
+
+    std::vector<TChunkedColumnReader>::const_iterator begin() const {
+        return Columns.begin();
+    }
+
+    std::vector<TChunkedColumnReader>::const_iterator end() const {
+        return Columns.end();
+    }
+};
+
 }

--- a/ydb/core/tx/columnshard/splitter/column_info.h
+++ b/ydb/core/tx/columnshard/splitter/column_info.h
@@ -7,14 +7,31 @@
 
 namespace NKikimr::NOlap {
 
-class TSplittedColumn {
+class TSplittedEntity {
 private:
+    YDB_READONLY(ui32, EntityId, 0);
     YDB_READONLY(ui64, Size, 0);
-    YDB_READONLY(ui32, ColumnId, 0);
-    YDB_READONLY(ui32, RecordsCount, 0);
-    YDB_READONLY_DEF(std::shared_ptr<arrow::Field>, Field);
-    YDB_READONLY_DEF(std::vector<IPortionColumnChunk::TPtr>, Chunks);
+    YDB_READONLY_DEF(std::vector<std::shared_ptr<IPortionDataChunk>>, Chunks);
+    YDB_READONLY_DEF(std::optional<ui32>, RecordsCount);
+
+protected:
+    template <class T>
+    const T& GetChunkAs(const ui32 idx) const {
+        AFL_VERIFY(idx < Chunks.size());
+        auto result = std::dynamic_pointer_cast<T>(Chunks[idx]);
+        AFL_VERIFY(result);
+        return *result;
+    }
+
 public:
+    TSplittedEntity(const ui32 entityId)
+        : EntityId(entityId) {
+        AFL_VERIFY(EntityId);
+    }
+
+    bool operator<(const TSplittedEntity& item) const {
+        return Size > item.Size;
+    }
 
     std::shared_ptr<arrow::Scalar> GetFirstScalar() const {
         Y_ABORT_UNLESS(Chunks.size());
@@ -26,46 +43,40 @@ public:
         return Chunks.back()->GetLastScalar();
     }
 
-    void Merge(TSplittedColumn&& c) {
+    void Merge(TSplittedEntity&& c) {
         Size += c.Size;
-        Y_ABORT_UNLESS(Field->name() == c.Field->name());
-        Y_DEBUG_ABORT_UNLESS(Field->Equals(c.Field));
-        Y_ABORT_UNLESS(ColumnId == c.ColumnId);
-        Y_ABORT_UNLESS(ColumnId);
-        RecordsCount += c.RecordsCount;
+        AFL_VERIFY(!!RecordsCount == !!c.RecordsCount);
+        if (RecordsCount) {
+            *RecordsCount += *c.RecordsCount;
+        }
+        AFL_VERIFY(EntityId == c.EntityId)("self", EntityId)("c", c.EntityId);
+        Y_ABORT_UNLESS(c.EntityId);
         for (auto&& i : c.Chunks) {
             Chunks.emplace_back(std::move(i));
         }
     }
 
-    void SetChunks(const std::vector<IPortionColumnChunk::TPtr>& data) {
+    void SetChunks(const std::vector<std::shared_ptr<IPortionDataChunk>>& data) {
         Y_ABORT_UNLESS(Chunks.empty());
+        std::optional<bool> hasRecords;
         for (auto&& i : data) {
-            Y_ABORT_UNLESS(i->GetColumnId() == ColumnId);
+            Y_ABORT_UNLESS(i->GetEntityId() == EntityId);
             Size += i->GetPackedSize();
-            RecordsCount += i->GetRecordsCount();
             Chunks.emplace_back(i);
+            auto rc = i->GetRecordsCount();
+            if (!hasRecords) {
+                hasRecords = !!rc;
+            }
+            AFL_VERIFY(*hasRecords == !!rc);
+            if (!rc) {
+                continue;
+            }
+            if (!RecordsCount) {
+                RecordsCount = rc;
+            } else {
+                *RecordsCount += *rc;
+            }
         }
-    }
-
-    void AddChunks(const std::vector<IPortionColumnChunk::TPtr>& data) {
-        for (auto&& i : data) {
-            Y_ABORT_UNLESS(i->GetColumnId() == ColumnId);
-            Size += i->GetPackedSize();
-            RecordsCount += i->GetRecordsCount();
-            Chunks.emplace_back(i);
-        }
-    }
-
-    TSplittedColumn(std::shared_ptr<arrow::Field> f, const ui32 id)
-        : ColumnId(id)
-        , Field(f)
-    {
-
-    }
-
-    bool operator<(const TSplittedColumn& item) const {
-        return Size > item.Size;
     }
 };
 }

--- a/ydb/core/tx/columnshard/splitter/rb_splitter.cpp
+++ b/ydb/core/tx/columnshard/splitter/rb_splitter.cpp
@@ -34,7 +34,7 @@ TRBSplitLimiter::TRBSplitLimiter(std::shared_ptr<NColumnShard::TSplitterCounters
     Y_ABORT_UNLESS(chunkStartPosition == slices.size());
     ui32 recordsCountCheck = 0;
     for (auto&& i : Slices) {
-        recordsCountCheck += i.GetRecordsCountVerified();
+        recordsCountCheck += i.GetRecordsCount();
     }
     Y_ABORT_UNLESS(recordsCountCheck == batch->num_rows());
 }

--- a/ydb/core/tx/columnshard/splitter/rb_splitter.cpp
+++ b/ydb/core/tx/columnshard/splitter/rb_splitter.cpp
@@ -34,18 +34,18 @@ TRBSplitLimiter::TRBSplitLimiter(std::shared_ptr<NColumnShard::TSplitterCounters
     Y_ABORT_UNLESS(chunkStartPosition == slices.size());
     ui32 recordsCountCheck = 0;
     for (auto&& i : Slices) {
-        recordsCountCheck += i.GetRecordsCount();
+        recordsCountCheck += i.GetRecordsCountVerified();
     }
     Y_ABORT_UNLESS(recordsCountCheck == batch->num_rows());
 }
 
-bool TRBSplitLimiter::Next(std::vector<std::vector<IPortionColumnChunk::TPtr>>& portionBlobs, std::shared_ptr<arrow::RecordBatch>& batch) {
+bool TRBSplitLimiter::Next(std::vector<std::vector<std::shared_ptr<IPortionDataChunk>>>& portionBlobs, std::shared_ptr<arrow::RecordBatch>& batch) {
     if (!Slices.size()) {
         return false;
     }
     std::vector<TSplittedBlob> blobs;
     Slices.front().GroupBlobs(blobs);
-    std::vector<std::vector<IPortionColumnChunk::TPtr>> result;
+    std::vector<std::vector<std::shared_ptr<IPortionDataChunk>>> result;
     std::map<ui32, ui32> columnChunks;
     for (auto&& i : blobs) {
         if (blobs.size() == 1) {
@@ -60,5 +60,4 @@ bool TRBSplitLimiter::Next(std::vector<std::vector<IPortionColumnChunk::TPtr>>& 
     Slices.pop_front();
     return true;
 }
-
 }

--- a/ydb/core/tx/columnshard/splitter/rb_splitter.h
+++ b/ydb/core/tx/columnshard/splitter/rb_splitter.h
@@ -56,7 +56,7 @@ public:
     TRBSplitLimiter(std::shared_ptr<NColumnShard::TSplitterCounters> counters,
         ISchemaDetailInfo::TPtr schemaInfo, const std::shared_ptr<arrow::RecordBatch> batch, const TSplitSettings& settings);
 
-    bool Next(std::vector<std::vector<IPortionColumnChunk::TPtr>>& portionBlobs, std::shared_ptr<arrow::RecordBatch>& batch);
+    bool Next(std::vector<std::vector<std::shared_ptr<IPortionDataChunk>>>& portionBlobs, std::shared_ptr<arrow::RecordBatch>& batch);
 };
 
 }

--- a/ydb/core/tx/columnshard/splitter/simple.h
+++ b/ydb/core/tx/columnshard/splitter/simple.h
@@ -140,7 +140,7 @@ public:
         return TLinearSplitInfo(countPacksMax, stepPackMin, objectsCount);
     }
 
-    std::vector<TSaverSplittedChunk> Split(const std::shared_ptr<arrow::Array>& data, std::shared_ptr<arrow::Field> field, const ui32 maxBlobSize) const;
+    std::vector<TSaverSplittedChunk> Split(const std::shared_ptr<arrow::Array>& data, const std::shared_ptr<arrow::Field>& field, const ui32 maxBlobSize) const;
     std::vector<TSaverSplittedChunk> Split(const std::shared_ptr<arrow::RecordBatch>& data, const ui32 maxBlobSize) const;
     std::vector<TSaverSplittedChunk> SplitByRecordsCount(std::shared_ptr<arrow::RecordBatch> data, const std::vector<ui64>& recordsCount) const;
     std::vector<TSaverSplittedChunk> SplitBySizes(std::shared_ptr<arrow::RecordBatch> data, const TString& dataSerialization, const std::vector<ui64>& splitPartSizesExt) const;
@@ -152,18 +152,18 @@ private:
     TSaverSplittedChunk Data;
     ISchemaDetailInfo::TPtr SchemaInfo;
 protected:
-    virtual std::vector<IPortionColumnChunk::TPtr> DoInternalSplit(const TColumnSaver& saver, std::shared_ptr<NColumnShard::TSplitterCounters> counters, const std::vector<ui64>& splitSizes) const override;
+    virtual std::vector<std::shared_ptr<IPortionDataChunk>> DoInternalSplitImpl(const TColumnSaver& saver, const std::shared_ptr<NColumnShard::TSplitterCounters>& counters, const std::vector<ui64>& splitSizes) const override;
     virtual const TString& DoGetData() const override {
         return Data.GetSerializedChunk();
     }
-    virtual ui32 DoGetRecordsCount() const override {
+    virtual ui32 DoGetRecordsCountImpl() const override {
         return Data.GetRecordsCount();
     }
 
     virtual TString DoDebugString() const override;
 
     virtual TSimpleChunkMeta DoBuildSimpleChunkMeta() const override {
-        return TSimpleChunkMeta(Data.GetColumn(), SchemaInfo->NeedMinMaxForColumn(ColumnId), SchemaInfo->IsSortedColumn(ColumnId));
+        return TSimpleChunkMeta(Data.GetColumn(), SchemaInfo->NeedMinMaxForColumn(GetColumnId()), SchemaInfo->IsSortedColumn(GetColumnId()));
     }
 
     virtual std::shared_ptr<arrow::Scalar> DoGetFirstScalar() const override {

--- a/ydb/core/tx/columnshard/splitter/ut/ut_splitter.cpp
+++ b/ydb/core/tx/columnshard/splitter/ut/ut_splitter.cpp
@@ -74,7 +74,7 @@ Y_UNIT_TEST_SUITE(Splitter) {
         void Execute(std::shared_ptr<arrow::RecordBatch> batch) {
             NKikimr::NColumnShard::TIndexationCounters counters("test");
             NKikimr::NOlap::TRBSplitLimiter limiter(counters.SplitterCounters, Schema, batch, NKikimr::NOlap::TSplitSettings());
-            std::vector<std::vector<NKikimr::NOlap::IPortionColumnChunk::TPtr>> chunksForBlob;
+            std::vector<std::vector<std::shared_ptr<NKikimr::NOlap::IPortionDataChunk>>> chunksForBlob;
             std::map<std::string, std::vector<std::shared_ptr<arrow::RecordBatch>>> restoredBatch;
             std::vector<i64> blobsSize;
             bool hasMultiSplit = false;
@@ -91,7 +91,9 @@ Y_UNIT_TEST_SUITE(Splitter) {
                     ui64 blobSize = 0;
                     sb << "[";
                     std::set<ui32> blobColumnChunks;
-                    for (auto&& i : chunks) {
+                    for (auto&& iData : chunks) {
+                        auto i = dynamic_pointer_cast<IPortionColumnChunk>(iData);
+                        AFL_VERIFY(i);
                         ++chunksCount;
                         const ui32 columnId = i->GetColumnId();
                         recordsCountByColumn[columnId] += i->GetRecordsCount();

--- a/ydb/core/tx/columnshard/splitter/ut/ut_splitter.cpp
+++ b/ydb/core/tx/columnshard/splitter/ut/ut_splitter.cpp
@@ -92,11 +92,11 @@ Y_UNIT_TEST_SUITE(Splitter) {
                     sb << "[";
                     std::set<ui32> blobColumnChunks;
                     for (auto&& iData : chunks) {
-                        auto i = dynamic_pointer_cast<IPortionColumnChunk>(iData);
+                        auto i = dynamic_pointer_cast<NKikimr::NOlap::IPortionColumnChunk>(iData);
                         AFL_VERIFY(i);
                         ++chunksCount;
                         const ui32 columnId = i->GetColumnId();
-                        recordsCountByColumn[columnId] += i->GetRecordsCount();
+                        recordsCountByColumn[columnId] += i->GetRecordsCountVerified();
                         restoredBatch[Schema->GetColumnName(columnId)].emplace_back(*Schema->GetColumnLoader(columnId).Apply(i->GetData()));
                         blobSize += i->GetData().size();
                         if (i->GetRecordsCount() != NKikimr::NOlap::TSplitSettings().GetMinRecordsCount() && !blobColumnChunks.emplace(columnId).second) {

--- a/ydb/library/accessor/validator.cpp
+++ b/ydb/library/accessor/validator.cpp
@@ -1,0 +1,1 @@
+#include "validator.h"

--- a/ydb/library/accessor/validator.h
+++ b/ydb/library/accessor/validator.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <ydb/library/actors/core/log.h>
+
+class TValidator {
+public:
+    template <class T>
+    static const T& CheckNotNull(const T& object) {
+        AFL_VERIFY(!!object);
+        return object;
+    }
+};

--- a/ydb/library/accessor/ya.make
+++ b/ydb/library/accessor/ya.make
@@ -1,10 +1,12 @@
 LIBRARY()
 
 PEERDIR(
+    ydb/library/actors/core
 )
 
 SRCS(
     accessor.cpp
+    validator.cpp
 )
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

in past, we used splitter for normalize blobs (control size) for columns only. but remove these specialities for another entities too in future (indexes, for example).

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
