### PR TITLE
Add missing <cstddef> include

### DIFF
--- a/ydb/core/util/btree.h
+++ b/ydb/core/util/btree.h
@@ -11,6 +11,7 @@
 #include <util/system/yassert.h>
 
 #include <atomic>
+#include <cstddef>
 #include <vector>
 
 namespace NKikimr {

--- a/ydb/core/util/btree_common.h
+++ b/ydb/core/util/btree_common.h
@@ -3,6 +3,8 @@
 #include <util/generic/ylimits.h>
 #include <util/system/compiler.h>
 
+#include <cstddef>
+
 namespace NKikimr {
 
     /**


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Avoid this type of errors on upcoming libcxx update since some transitive includes have been removed.
```
In file included from $(SOURCE_ROOT)/ydb/library/actors/core/buffer.cpp:1:
$(SOURCE_ROOT)/ydb/core/util/btree_common.h:11:14: error: unknown type name 'size_t'
    template<size_t PageSize = 512>
```
and
```
In file included from $(SOURCE_ROOT)/ydb/library/actors/core/buffer.cpp:1:
$(SOURCE_ROOT)/ydb/core/util/btree_common.h:11:14: error: unknown type name 'size_t'
    template<size_t PageSize = 512>
```
...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Additional information

...
