### PR TITLE
Add range read border to key sampler KIKIMR-20859

### DIFF
--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -364,6 +364,16 @@ public:
         iterRange.MaxInclusive = toInclusive;
         const bool reverse = State.Reverse;
 
+        if (TArrayRef<const TCell> cells = keyFromCells.GetCells()) {
+            if (!fromInclusive || cells.size() >= TableInfo.KeyColumnTypes.size()) {
+                Self->GetKeyAccessSampler()->AddSample(TableId, cells);
+            } else {
+                TVector<TCell> extended(cells.begin(), cells.end());
+                extended.resize(TableInfo.KeyColumnTypes.size());
+                Self->GetKeyAccessSampler()->AddSample(TableId, extended);
+            }
+        }
+
         EReadStatus result;
         if (!reverse) {
             auto iter = txc.DB.IterateRange(TableInfo.LocalTid, iterRange, State.Columns, State.ReadVersion, GetReadTxMap(), GetReadTxObserver());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add range read border to key sampler.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Previously range reads that result in zero rows didn't add any keys to the key sampler, and split by load didn't have any access patterns to base split by load decisions on.
