### PR TITLE
ci: add actual merge commit sha instead of PR head in the PR commit

### DIFF
--- a/.github/workflows/build_and_test_ya.yml
+++ b/.github/workflows/build_and_test_ya.yml
@@ -76,7 +76,7 @@ jobs:
         # tricky: we are searching job with name that contains build_preset
         check_url=$(curl -s $jobs_url | jq --arg n "$BUILD_PRESET" -r '.jobs[] | select(.name | contains($n)) | .html_url')
         
-        echo "Pre-commit [check]($check_url) for ${{ github.event.pull_request.head.sha }} has started." | .github/scripts/tests/comment-pr.py --rewrite
+        echo "Pre-commit [check]($check_url) for ${{ inputs.commit_sha }} has started." | .github/scripts/tests/comment-pr.py --rewrite
     
     - name: Prepare s3cmd
       uses: ./.github/actions/s3cmd


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

* add actual merge commit sha instead of PR head in the PR commit