### PR TITLE
ci: don't override old PR build status comment on every build

### DIFF
--- a/.github/scripts/tests/comment-pr.py
+++ b/.github/scripts/tests/comment-pr.py
@@ -23,6 +23,7 @@ def main():
     elif args.fail:
         color = 'red'
 
+    run_number = int(os.environ.get("GITHUB_RUN_NUMBER"))
     build_preset = os.environ["BUILD_PRESET"]
 
     gh = Github(auth=GithubAuth.Token(os.environ["GITHUB_TOKEN"]))
@@ -30,11 +31,10 @@ def main():
     with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
         event = json.load(fp)
 
-    prnum = event.get("pull_request")
-    if not prnum is None:
-        pr = gh.create_from_raw_data(PullRequest, prnum)
-        update_pr_comment_text(pr, build_preset, color, args.text.read().rstrip(), args.rewrite)
+    pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
+    update_pr_comment_text(pr, build_preset, run_number, color, args.text.read().rstrip(), args.rewrite)
 
 
 if __name__ == "__main__":
-    main()
+    if os.environ.get('GITHUB_EVENT_NAME', '').startswith('pull_request'):
+        main()

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -347,7 +347,9 @@ def main():
         else:
             color = 'green'
 
-        update_pr_comment_text(pr, args.build_preset, color, text='\n'.join(text), rewrite=False)
+        run_number = int(os.environ.get("GITHUB_RUN_NUMBER"))
+
+        update_pr_comment_text(pr, args.build_preset, run_number, color, text='\n'.join(text), rewrite=False)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/gh_status.py
+++ b/.github/scripts/tests/gh_status.py
@@ -11,9 +11,9 @@ def get_platform_name():
     return f'{platform.system().lower()}-{platform.machine()}'
 
 
-def update_pr_comment_text(pr: PullRequest, build_preset: str, color: str, text: str, rewrite: bool):
+def update_pr_comment_text(pr: PullRequest, build_preset: str, run_number: int, color: str, text: str, rewrite: bool):
     platform_name = get_platform_name()
-    header = f"<!-- status pr={pr.number}, preset={platform_name}-{build_preset} -->"
+    header = f"<!-- status pr={pr.number}, preset={platform_name}-{build_preset}, run={run_number} -->"
 
     body = comment = None
     for c in pr.get_issue_comments():


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

ci: don't override old PR build status comment on every build
