### PR TITLE
Remove unused varibles to fix -Wunused-but-set-variable (v2)

### DIFF
--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_sequence_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_sequence_ut.cpp
@@ -225,9 +225,7 @@ void SetPredictedDelaysForAllQueues(const THashMap<TVDiskID, ui32> &latencies) {
             }
         }
     }
-    ui64 changedCount = 0;
     for (auto &[vDiskId, latency] : latencies) {
-        changedCount++;
         TGroupQueues::TVDisk &vDisk = DSProxyEnv.GroupQueues->FailDomains[vDiskId.FailDomain].VDisks[vDiskId.VDisk];
         ui32 begin = NKikimrBlobStorage::EVDiskQueueId::Begin;
         ui32 end = NKikimrBlobStorage::EVDiskQueueId::End;

--- a/ydb/core/tx/columnshard/splitter/ut/ut_splitter.cpp
+++ b/ydb/core/tx/columnshard/splitter/ut/ut_splitter.cpp
@@ -79,7 +79,6 @@ Y_UNIT_TEST_SUITE(Splitter) {
             bool hasMultiSplit = false;
             ui32 blobsCount = 0;
             ui32 slicesCount = 0;
-            ui32 chunksCount = 0;
             std::shared_ptr<arrow::RecordBatch> sliceBatch;
             while (limiter.Next(chunksForBlob, sliceBatch)) {
                 ++slicesCount;
@@ -93,7 +92,6 @@ Y_UNIT_TEST_SUITE(Splitter) {
                     for (auto&& iData : chunks) {
                         auto i = dynamic_pointer_cast<NKikimr::NOlap::IPortionColumnChunk>(iData);
                         AFL_VERIFY(i);
-                        ++chunksCount;
                         const ui32 columnId = i->GetColumnId();
                         recordsCountByColumn[columnId] += i->GetRecordsCountVerified();
                         restoredBatch[Schema->GetColumnName(columnId)].emplace_back(*Schema->GetColumnLoader(columnId).Apply(i->GetData()));

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -4561,7 +4561,6 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         StreamingWriteClientMessage clientMessage;
         auto* writeRequest = clientMessage.mutable_write_request();
         auto sequenceNumber = 1;
-        auto messageCount = 0;
         const auto message = NUnitTest::RandomString(250_KB, std::rand());
         auto compress = [](TString data, i32 codecID) {
             Y_UNUSED(codecID);
@@ -4581,7 +4580,6 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             writeRequest->add_blocks_uncompressed_sizes(message.size());
             writeRequest->add_blocks_headers(TString(1, codecID));
             writeRequest->add_blocks_data(compressedMessage);
-            ++messageCount;
         }
         auto session = setup.InitWriteSession();
 

--- a/ydb/services/ydb/sdk_sessions_ut/sdk_sessions_ut.cpp
+++ b/ydb/services/ydb/sdk_sessions_ut/sdk_sessions_ut.cpp
@@ -353,19 +353,12 @@ Y_UNIT_TEST_SUITE(YdbSdkSessions) {
         }
         for (auto& r : results) {
             if (!r.empty()) {
-                int ok = 0;
-                int bad = 0;
                 for (auto& asyncStatus : r) {
                     auto res = asyncStatus.GetValue();
-                    if (res.IsSuccess()) {
-                        ok++;
-                    } else {
+                    if (!res.IsSuccess()) {
                         UNIT_ASSERT_VALUES_EQUAL(res.GetStatus(), EStatus::SESSION_BUSY);
-                        bad++;
                     }
                 }
-                //UNIT_ASSERT_VALUES_EQUAL(ok, 1);
-                //UNIT_ASSERT_VALUES_EQUAL(bad, nRequests - 1);
             }
         }
         UNIT_ASSERT_VALUES_EQUAL(client.GetActiveSessionCount(), maxActiveSessions);


### PR DESCRIPTION
When compiling with -Wunused-but-set-variable there are some warnings (errors) in YDB. To be able to compile with -Wunused-but-set-variable in the near future we should fix those warnings