### PR TITLE
Support table changes observer KIKIMR-20853

### DIFF
--- a/ydb/core/tablet_flat/CMakeLists.darwin-arm64.txt
+++ b/ydb/core/tablet_flat/CMakeLists.darwin-arm64.txt
@@ -124,6 +124,7 @@ target_sources(ydb-core-tablet_flat PRIVATE
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_part.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_misc.cpp
+  ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_observer.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/probes.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_handle.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_sausagecache.cpp

--- a/ydb/core/tablet_flat/CMakeLists.darwin-x86_64.txt
+++ b/ydb/core/tablet_flat/CMakeLists.darwin-x86_64.txt
@@ -124,6 +124,7 @@ target_sources(ydb-core-tablet_flat PRIVATE
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_part.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_misc.cpp
+  ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_observer.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/probes.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_handle.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_sausagecache.cpp

--- a/ydb/core/tablet_flat/CMakeLists.linux-aarch64.txt
+++ b/ydb/core/tablet_flat/CMakeLists.linux-aarch64.txt
@@ -125,6 +125,7 @@ target_sources(ydb-core-tablet_flat PRIVATE
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_part.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_misc.cpp
+  ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_observer.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/probes.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_handle.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_sausagecache.cpp

--- a/ydb/core/tablet_flat/CMakeLists.linux-x86_64.txt
+++ b/ydb/core/tablet_flat/CMakeLists.linux-x86_64.txt
@@ -125,6 +125,7 @@ target_sources(ydb-core-tablet_flat PRIVATE
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_part.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_misc.cpp
+  ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_observer.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/probes.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_handle.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_sausagecache.cpp

--- a/ydb/core/tablet_flat/CMakeLists.windows-x86_64.txt
+++ b/ydb/core/tablet_flat/CMakeLists.windows-x86_64.txt
@@ -124,6 +124,7 @@ target_sources(ydb-core-tablet_flat PRIVATE
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_part.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_misc.cpp
+  ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/flat_table_observer.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/probes.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_handle.cpp
   ${CMAKE_SOURCE_DIR}/ydb/core/tablet_flat/shared_sausagecache.cpp

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -495,6 +495,11 @@ const TDbStats& TDatabase::Counters() const noexcept
     return DatabaseImpl->Stats;
 }
 
+void TDatabase::SetTableObserver(ui32 table, ITableObserverPtr ptr) noexcept
+{
+    Require(table)->SetTableObserver(std::move(ptr));
+}
+
 TDatabase::TChg TDatabase::Head(ui32 table) const noexcept
 {
     if (table == Max<ui32>()) {

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -495,7 +495,7 @@ const TDbStats& TDatabase::Counters() const noexcept
     return DatabaseImpl->Stats;
 }
 
-void TDatabase::SetTableObserver(ui32 table, ITableObserverPtr ptr) noexcept
+void TDatabase::SetTableObserver(ui32 table, TIntrusivePtr<ITableObserver> ptr) noexcept
 {
     Require(table)->SetTableObserver(std::move(ptr));
 }

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -58,7 +58,7 @@ public:
     TDatabase(TDatabaseImpl *databaseImpl = nullptr) noexcept;
     ~TDatabase();
 
-    void SetTableObserver(ui32 table, ITableObserverPtr ptr) noexcept;
+    void SetTableObserver(ui32 table, TIntrusivePtr<ITableObserver> ptr) noexcept;
 
     /* Returns durable monotonic change number for table or entire database
         on default (table = Max<ui32>()). Serial is incremented for each

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -6,6 +6,7 @@
 #include "flat_dbase_change.h"
 #include "flat_dbase_misc.h"
 #include "flat_iterator.h"
+#include "flat_table_observer.h"
 #include "util_basics.h"
 
 namespace NKikimr {
@@ -56,6 +57,8 @@ public:
     TDatabase(const TDatabase&) = delete;
     TDatabase(TDatabaseImpl *databaseImpl = nullptr) noexcept;
     ~TDatabase();
+
+    void SetTableObserver(ui32 table, ITableObserverPtr ptr) noexcept;
 
     /* Returns durable monotonic change number for table or entire database
         on default (table = Max<ui32>()). Serial is incremented for each

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -413,6 +413,8 @@ class TExecutor
     THashMap<ui64, THolder<TScanSnapshot>> ScanSnapshots;
     ui64 ScanSnapshotId = 1;
 
+    class TActiveTransactionZone;
+
     bool ActiveTransaction = false;
     bool BrokenTransaction = false;
     ui32 ActivateTransactionWaiting = 0;

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -830,6 +830,7 @@ void TTable::Update(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMemG
     }
 
     MemTable().Update(rop, key, ops, apart, rowVersion, CommittedTransactions);
+    TableObserver.OnUpdate(rop, key, ops, rowVersion);
 }
 
 void TTable::AddTxRef(ui64 txId)
@@ -863,6 +864,8 @@ void TTable::UpdateTx(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMe
     } else {
         Y_DEBUG_ABORT_UNLESS(TxRefs[txId] > 0);
     }
+
+    TableObserver.OnUpdateTx(rop, key, ops, txId);
 }
 
 void TTable::CommitTx(ui64 txId, TRowVersion rowVersion)
@@ -1336,6 +1339,11 @@ TCompactionStats TTable::GetCompactionStats() const
     stats.PartCount = Flatten.size() + ColdParts.size();
 
     return stats;
+}
+
+void TTable::SetTableObserver(ITableObserverPtr ptr) noexcept
+{
+    TableObserver = std::move(ptr);
 }
 
 void TPartStats::Add(const TPartView& partView)

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -830,7 +830,9 @@ void TTable::Update(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMemG
     }
 
     MemTable().Update(rop, key, ops, apart, rowVersion, CommittedTransactions);
-    TableObserver.OnUpdate(rop, key, ops, rowVersion);
+    if (TableObserver) {
+        TableObserver->OnUpdate(rop, key, ops, rowVersion);
+    }
 }
 
 void TTable::AddTxRef(ui64 txId)
@@ -865,7 +867,9 @@ void TTable::UpdateTx(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMe
         Y_DEBUG_ABORT_UNLESS(TxRefs[txId] > 0);
     }
 
-    TableObserver.OnUpdateTx(rop, key, ops, txId);
+    if (TableObserver) {
+        TableObserver->OnUpdateTx(rop, key, ops, txId);
+    }
 }
 
 void TTable::CommitTx(ui64 txId, TRowVersion rowVersion)
@@ -1341,7 +1345,7 @@ TCompactionStats TTable::GetCompactionStats() const
     return stats;
 }
 
-void TTable::SetTableObserver(ITableObserverPtr ptr) noexcept
+void TTable::SetTableObserver(TIntrusivePtr<ITableObserver> ptr) noexcept
 {
     TableObserver = std::move(ptr);
 }

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -13,6 +13,7 @@
 #include "flat_table_stats.h"
 #include "flat_table_subset.h"
 #include "flat_table_misc.h"
+#include "flat_table_observer.h"
 #include "flat_sausage_solid.h"
 #include "util_basics.h"
 
@@ -322,7 +323,7 @@ public:
 
     TCompactionStats GetCompactionStats() const;
 
-    void FillTxStatusCache(THashMap<TLogoBlobID, TSharedData>& cache) const noexcept;
+    void SetTableObserver(ITableObserverPtr ptr) noexcept;
 
 private:
     TMemTable& MemTable();
@@ -358,6 +359,7 @@ private:
     absl::flat_hash_set<ui64> CheckTransactions;
     TTransactionMap CommittedTransactions;
     TTransactionSet RemovedTransactions;
+    ITableObserverPtr TableObserver;
 
 private:
     struct TRollbackRemoveTxRef {

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -323,7 +323,7 @@ public:
 
     TCompactionStats GetCompactionStats() const;
 
-    void SetTableObserver(ITableObserverPtr ptr) noexcept;
+    void SetTableObserver(TIntrusivePtr<ITableObserver> ptr) noexcept;
 
 private:
     TMemTable& MemTable();
@@ -359,7 +359,7 @@ private:
     absl::flat_hash_set<ui64> CheckTransactions;
     TTransactionMap CommittedTransactions;
     TTransactionSet RemovedTransactions;
-    ITableObserverPtr TableObserver;
+    TIntrusivePtr<ITableObserver> TableObserver;
 
 private:
     struct TRollbackRemoveTxRef {

--- a/ydb/core/tablet_flat/flat_table_observer.cpp
+++ b/ydb/core/tablet_flat/flat_table_observer.cpp
@@ -1,0 +1,1 @@
+#include "flat_table_observer.h"

--- a/ydb/core/tablet_flat/flat_table_observer.h
+++ b/ydb/core/tablet_flat/flat_table_observer.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "defs.h"
+#include "flat_row_eggs.h"
+#include "flat_update_op.h"
+
+#include <util/generic/ptr.h>
+
+namespace NKikimr::NTable {
+
+    class ITableObserver : public TThrRefBase {
+    public:
+        /**
+         * Called when a new update is applied to the table
+         */
+        virtual void OnUpdate(
+            ERowOp rop,
+            TArrayRef<const TRawTypeValue> key,
+            TArrayRef<const TUpdateOp> ops,
+            TRowVersion rowVersion) = 0;
+
+        /**
+         * Called when an uncommitted update is applied to the table
+         */
+        virtual void OnUpdateTx(
+            ERowOp rop,
+            TArrayRef<const TRawTypeValue> key,
+            TArrayRef<const TUpdateOp> ops,
+            ui64 txId) = 0;
+    };
+
+    /**
+     * Smart pointer that can safely be used to call methods even when it's nullptr
+     */
+    class ITableObserverPtr : public TIntrusivePtr<ITableObserver> {
+    public:
+        using TIntrusivePtr::TIntrusivePtr;
+
+        void OnUpdate(
+                ERowOp rop,
+                TArrayRef<const TRawTypeValue> key,
+                TArrayRef<const TUpdateOp> ops,
+                TRowVersion rowVersion)
+        {
+            if (ITableObserver* p = Get()) {
+                p->OnUpdate(rop, key, ops, rowVersion);
+            }
+        }
+
+        void OnUpdateTx(
+                ERowOp rop,
+                TArrayRef<const TRawTypeValue> key,
+                TArrayRef<const TUpdateOp> ops,
+                ui64 txId)
+        {
+            if (ITableObserver* p = Get()) {
+                p->OnUpdateTx(rop, key, ops, txId);
+            }
+        }
+    };
+
+} // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/flat_table_observer.h
+++ b/ydb/core/tablet_flat/flat_table_observer.h
@@ -28,34 +28,4 @@ namespace NKikimr::NTable {
             ui64 txId) = 0;
     };
 
-    /**
-     * Smart pointer that can safely be used to call methods even when it's nullptr
-     */
-    class ITableObserverPtr : public TIntrusivePtr<ITableObserver> {
-    public:
-        using TIntrusivePtr::TIntrusivePtr;
-
-        void OnUpdate(
-                ERowOp rop,
-                TArrayRef<const TRawTypeValue> key,
-                TArrayRef<const TUpdateOp> ops,
-                TRowVersion rowVersion)
-        {
-            if (ITableObserver* p = Get()) {
-                p->OnUpdate(rop, key, ops, rowVersion);
-            }
-        }
-
-        void OnUpdateTx(
-                ERowOp rop,
-                TArrayRef<const TRawTypeValue> key,
-                TArrayRef<const TUpdateOp> ops,
-                ui64 txId)
-        {
-            if (ITableObserver* p = Get()) {
-                p->OnUpdateTx(rop, key, ops, txId);
-            }
-        }
-    };
-
 } // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/tablet_flat_executor.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executor.cpp
@@ -68,6 +68,14 @@ namespace NFlatExecutorSetup {
     void ITablet::OnFollowersCountChanged() {
         // nothing by default
     }
+
+    void ITablet::OnFollowerSchemaUpdated() {
+        // nothing by default
+    }
+
+    void ITablet::OnFollowerDataUpdated() {
+        // nothing by default
+    }
 }
 
 }}

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -505,6 +505,9 @@ namespace NFlatExecutorSetup {
 
         virtual void OnFollowersCountChanged();
 
+        virtual void OnFollowerSchemaUpdated();
+        virtual void OnFollowerDataUpdated();
+
         // create transaction?
     protected:
         ITablet(TTabletStorageInfo *info, const TActorId &tablet)

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -62,6 +62,8 @@ SRCS(
     flat_table_part.cpp
     flat_table_part.h
     flat_table_misc.cpp
+    flat_table_observer.cpp
+    flat_table_observer.h
     flat_update_op.h
     probes.cpp
     shared_handle.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support table changes observer

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

This will allow datashard followers to inspect leader changes without re-reading tables at the start of every transaction.