### PR TITLE
Sift PRAGMA TablePathPrefix down to the persisted query text of a view

### DIFF
--- a/ydb/core/kqp/ut/view/input/cases/multiple_tables/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_tables/create_view.sql
@@ -1,17 +1,14 @@
-CREATE VIEW `/Root/read_from_multiple_tables` WITH (security_invoker = TRUE) AS
+CREATE VIEW read_from_multiple_tables WITH (security_invoker = TRUE) AS
     SELECT
         *
-    FROM `/Root/series`
-        AS series
+    FROM series
     JOIN (
         SELECT
             seasons.title AS seasons_title,
             episodes.title AS episodes_title,
             seasons.series_id AS series_id
-        FROM `/Root/seasons`
-            AS seasons
-        JOIN `/Root/episodes`
-            AS episodes
+        FROM seasons
+        JOIN episodes
         ON seasons.series_id == episodes.series_id
     )
         AS seasons_and_episodes

--- a/ydb/core/kqp/ut/view/input/cases/multiple_tables/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_tables/drop_view.sql
@@ -1,1 +1,1 @@
-DROP VIEW `/Root/read_from_multiple_tables`;
+DROP VIEW read_from_multiple_tables;

--- a/ydb/core/kqp/ut/view/input/cases/multiple_tables/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_tables/etalon_query.sql
@@ -3,17 +3,14 @@ SELECT
 FROM (
     SELECT
         *
-    FROM `/Root/series`
-        AS series
+    FROM series
     JOIN (
         SELECT
             seasons.title AS seasons_title,
             episodes.title AS episodes_title,
             seasons.series_id AS series_id
-        FROM `/Root/seasons`
-            AS seasons
-        JOIN `/Root/episodes`
-            AS episodes
+        FROM seasons
+        JOIN episodes
         ON seasons.series_id == episodes.series_id
     )
         AS seasons_and_episodes

--- a/ydb/core/kqp/ut/view/input/cases/multiple_tables/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_tables/select_from_view.sql
@@ -1,3 +1,3 @@
 SELECT
     *
-FROM `/Root/read_from_multiple_tables`;
+FROM read_from_multiple_tables;

--- a/ydb/core/kqp/ut/view/input/cases/multiple_views/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_views/create_view.sql
@@ -1,9 +1,9 @@
-CREATE VIEW `/Root/read_from_multiple_views` WITH (security_invoker = TRUE) AS
+CREATE VIEW read_from_multiple_views WITH (security_invoker = TRUE) AS
     SELECT
         series.title AS series_title,
         seasons.title AS seasons_title
-    FROM `/Root/view_series`
+    FROM view_series
         AS series
-    JOIN `/Root/view_seasons`
+    JOIN view_seasons
         AS seasons
     ON series.series_id == seasons.series_id;

--- a/ydb/core/kqp/ut/view/input/cases/multiple_views/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_views/drop_view.sql
@@ -1,1 +1,1 @@
-DROP VIEW `/Root/read_from_multiple_views`;
+DROP VIEW read_from_multiple_views;

--- a/ydb/core/kqp/ut/view/input/cases/multiple_views/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_views/etalon_query.sql
@@ -4,9 +4,9 @@ FROM (
     SELECT
         series.title AS series_title,
         seasons.title AS seasons_title
-    FROM `/Root/view_series`
+    FROM view_series
         AS series
-    JOIN `/Root/view_seasons`
+    JOIN view_seasons
         AS seasons
     ON series.series_id == seasons.series_id
 );

--- a/ydb/core/kqp/ut/view/input/cases/multiple_views/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/multiple_views/select_from_view.sql
@@ -1,3 +1,3 @@
 SELECT
     *
-FROM `/Root/read_from_multiple_views`;
+FROM read_from_multiple_views;

--- a/ydb/core/kqp/ut/view/input/cases/one_table/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_table/create_view.sql
@@ -1,4 +1,4 @@
-CREATE VIEW `/Root/read_from_one_table` WITH (security_invoker = TRUE) AS
+CREATE VIEW read_from_one_table WITH (security_invoker = TRUE) AS
     SELECT
         *
-    FROM `/Root/series`;
+    FROM series;

--- a/ydb/core/kqp/ut/view/input/cases/one_table/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_table/drop_view.sql
@@ -1,1 +1,1 @@
-DROP VIEW `/Root/read_from_one_table`;
+DROP VIEW read_from_one_table;

--- a/ydb/core/kqp/ut/view/input/cases/one_table/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_table/etalon_query.sql
@@ -3,5 +3,5 @@ SELECT
 FROM (
     SELECT
         *
-    FROM `/Root/series`
+    FROM series
 );

--- a/ydb/core/kqp/ut/view/input/cases/one_table/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_table/select_from_view.sql
@@ -1,3 +1,3 @@
 SELECT
     *
-FROM `/Root/read_from_one_table`;
+FROM read_from_one_table;

--- a/ydb/core/kqp/ut/view/input/cases/one_view/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_view/create_view.sql
@@ -1,4 +1,4 @@
-CREATE VIEW `/Root/read_from_one_view` WITH (security_invoker = TRUE) AS
+CREATE VIEW read_from_one_view WITH (security_invoker = TRUE) AS
     SELECT
         *
-    FROM `/Root/view_series`;
+    FROM view_series;

--- a/ydb/core/kqp/ut/view/input/cases/one_view/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_view/drop_view.sql
@@ -1,1 +1,1 @@
-DROP VIEW `/Root/read_from_one_view`;
+DROP VIEW read_from_one_view;

--- a/ydb/core/kqp/ut/view/input/cases/one_view/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_view/etalon_query.sql
@@ -3,5 +3,5 @@ SELECT
 FROM (
     SELECT
         *
-    FROM `/Root/series`
+    FROM series
 );

--- a/ydb/core/kqp/ut/view/input/cases/one_view/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/one_view/select_from_view.sql
@@ -1,3 +1,3 @@
 SELECT
     *
-FROM `/Root/read_from_one_view`;
+FROM read_from_one_view;

--- a/ydb/core/kqp/ut/view/input/cases/scalar/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/scalar/create_view.sql
@@ -1,3 +1,3 @@
-CREATE VIEW `/Root/read_from_scalar` WITH (security_invoker = TRUE) AS
+CREATE VIEW read_from_scalar WITH (security_invoker = TRUE) AS
     SELECT
         1;

--- a/ydb/core/kqp/ut/view/input/cases/scalar/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/scalar/drop_view.sql
@@ -1,1 +1,1 @@
-DROP VIEW `/Root/read_from_scalar`;
+DROP VIEW read_from_scalar;

--- a/ydb/core/kqp/ut/view/input/cases/scalar/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/scalar/select_from_view.sql
@@ -1,3 +1,3 @@
 SELECT
     *
-FROM `/Root/read_from_scalar`;
+FROM read_from_scalar;

--- a/ydb/core/kqp/ut/view/input/cases/two_tables/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/two_tables/create_view.sql
@@ -1,9 +1,7 @@
-CREATE VIEW `/Root/read_from_two_tables` WITH (security_invoker = TRUE) AS
+CREATE VIEW read_from_two_tables WITH (security_invoker = TRUE) AS
     SELECT
         series.title AS series_title,
         seasons.title AS seasons_title
-    FROM `/Root/series`
-        AS series
-    JOIN `/Root/seasons`
-        AS seasons
+    FROM series
+    JOIN seasons
     ON series.series_id == seasons.series_id;

--- a/ydb/core/kqp/ut/view/input/cases/two_tables/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/two_tables/drop_view.sql
@@ -1,1 +1,1 @@
-DROP VIEW `/Root/read_from_two_tables`;
+DROP VIEW read_from_two_tables;

--- a/ydb/core/kqp/ut/view/input/cases/two_tables/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/two_tables/etalon_query.sql
@@ -4,9 +4,7 @@ FROM (
     SELECT
         series.title AS series_title,
         seasons.title AS seasons_title
-    FROM `/Root/series`
-        AS series
-    JOIN `/Root/seasons`
-        AS seasons
+    FROM series
+    JOIN seasons
     ON series.series_id == seasons.series_id
 );

--- a/ydb/core/kqp/ut/view/input/cases/two_tables/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/two_tables/select_from_view.sql
@@ -1,3 +1,3 @@
 SELECT
     *
-FROM `/Root/read_from_two_tables`;
+FROM read_from_two_tables;

--- a/ydb/core/kqp/ut/view/input/create_tables_and_secondary_views.sql
+++ b/ydb/core/kqp/ut/view/input/create_tables_and_secondary_views.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `/Root/series` (
+CREATE TABLE series (
     series_id Uint64,
     title Utf8,
     series_info Utf8,
@@ -6,7 +6,7 @@ CREATE TABLE `/Root/series` (
     PRIMARY KEY (series_id)
 );
 
-CREATE TABLE `/Root/seasons` (
+CREATE TABLE seasons (
     series_id Uint64,
     season_id Uint64,
     title Utf8,
@@ -15,7 +15,7 @@ CREATE TABLE `/Root/seasons` (
     PRIMARY KEY (series_id, season_id)
 );
 
-CREATE TABLE `/Root/episodes` (
+CREATE TABLE episodes (
     series_id Uint64,
     season_id Uint64,
     episode_id Uint64,
@@ -24,17 +24,17 @@ CREATE TABLE `/Root/episodes` (
     PRIMARY KEY (series_id, season_id, episode_id)
 );
 
-CREATE VIEW `/Root/view_series` WITH (security_invoker = TRUE) AS
+CREATE VIEW view_series WITH (security_invoker = TRUE) AS
     SELECT
         *
-    FROM `/Root/series`;
+    FROM series;
 
-CREATE VIEW `/Root/view_seasons` WITH (security_invoker = TRUE) AS
+CREATE VIEW view_seasons WITH (security_invoker = TRUE) AS
     SELECT
         *
-    FROM `/Root/seasons`;
+    FROM seasons;
 
-CREATE VIEW `/Root/view_episodes` WITH (security_invoker = TRUE) AS
+CREATE VIEW view_episodes WITH (security_invoker = TRUE) AS
     SELECT
         *
-    FROM `/Root/episodes`;
+    FROM episodes;

--- a/ydb/core/kqp/ut/view/input/fill_tables.sql
+++ b/ydb/core/kqp/ut/view/input/fill_tables.sql
@@ -1,4 +1,4 @@
-REPLACE INTO `/Root/series` (
+REPLACE INTO series (
     series_id,
     title,
     release_date,
@@ -8,7 +8,7 @@ VALUES
     (1, "IT Crowd", Date("2006-02-03"), "The IT Crowd is a British sitcom produced by Channel 4, written by Graham Linehan, produced by Ash Atalla and starring Chris O'Dowd, Richard Ayoade, Katherine Parkinson, and Matt Berry."),
     (2, "Silicon Valley", Date("2014-04-06"), "Silicon Valley is an American comedy television series created by Mike Judge, John Altschuler and Dave Krinsky. The series focuses on five young men who founded a startup company in Silicon Valley.");
 
-REPLACE INTO `/Root/seasons` (
+REPLACE INTO seasons (
     series_id,
     season_id,
     title,
@@ -26,7 +26,7 @@ VALUES
     (2, 4, "Season 4", Date("2017-04-23"), Date("2017-06-25")),
     (2, 5, "Season 5", Date("2018-03-25"), Date("2018-05-13"));
 
-REPLACE INTO `/Root/episodes` (
+REPLACE INTO episodes (
     series_id,
     season_id,
     episode_id,

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -89,7 +89,7 @@ void InitializeTablesAndSecondaryViews(TSession& session) {
 
 }
 
-Y_UNIT_TEST_SUITE(TKQPViewTest) {
+Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
 
     Y_UNIT_TEST(CheckCreatedView) {
         TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));

--- a/ydb/library/yql/sql/v1/sql_query.cpp
+++ b/ydb/library/yql/sql/v1/sql_query.cpp
@@ -1075,8 +1075,12 @@ bool TSqlQuery::Statement(TVector<TNodePtr>& blocks, const TRule_sql_stmt_core& 
             }
 
             std::map<TString, TDeferredAtom> features;
-            ParseViewOptions(features, node.GetRule_with_table_settings4());
-            ParseViewQuery(features, node.GetRule_select_stmt6());
+            if (!ParseViewOptions(features, node.GetRule_with_table_settings4())) {
+                return false;
+            }
+            if (!ParseViewQuery(features, node.GetRule_select_stmt6())) {
+                return false;
+            }
 
             const TString objectId = Id(node.GetRule_object_ref3().GetRule_id_or_at2(), *this).second;
             constexpr const char* TypeId = "VIEW";

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6275,16 +6275,16 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         );
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
 
-        TString reconstructedQuery = ToString(Tokenize(query));
+        const TString reconstructedQuery = ToString(Tokenize(query));
         TVerifyLineFunc verifyLine = [&](const TString& word, const TString& line) {
             if (word == "query_text") {
                 UNIT_ASSERT_STRING_CONTAINS(line, reconstructedQuery);
             }
         };
-        TWordCountHive elementStat = { {"Write!"} };
+        TWordCountHive elementStat = { {"query_text"} };
         VerifyProgram(res, elementStat, verifyLine);
 
-        UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
+        UNIT_ASSERT_VALUES_EQUAL(elementStat["query_text"], 1);
     }
 
     Y_UNIT_TEST(DropView) {
@@ -6310,10 +6310,10 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
 
-    Y_UNIT_TEST(CreateViewWithTablePrefix) {
+    Y_UNIT_TEST(CreateViewWithTablePathPrefix) {
         NYql::TAstParseResult res = SqlToYql(R"(
                 USE plato;
-                PRAGMA TablePathPrefix='/PathPrefix';
+                PRAGMA TablePathPrefix = "PathPrefix";
                 CREATE VIEW TheView WITH (security_invoker = TRUE) AS SELECT 1;
             )"
         );
@@ -6321,7 +6321,7 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
 
         TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
             if (word == "Write!") {
-                UNIT_ASSERT_STRING_CONTAINS(line, "/PathPrefix/TheView");
+                UNIT_ASSERT_STRING_CONTAINS(line, "PathPrefix/TheView");
                 UNIT_ASSERT_STRING_CONTAINS(line, "createObject");
             }
         };
@@ -6332,10 +6332,10 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
 
-    Y_UNIT_TEST(DropViewWithTablePrefix) {
+    Y_UNIT_TEST(DropViewWithTablePathPrefix) {
         NYql::TAstParseResult res = SqlToYql(R"(
                 USE plato;
-                PRAGMA TablePathPrefix='/PathPrefix';
+                PRAGMA TablePathPrefix = "PathPrefix";
                 DROP VIEW TheView;
             )"
         );
@@ -6343,7 +6343,7 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
 
         TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
             if (word == "Write") {
-                UNIT_ASSERT_STRING_CONTAINS(line, "/PathPrefix/TheView");
+                UNIT_ASSERT_STRING_CONTAINS(line, "PathPrefix/TheView");
                 UNIT_ASSERT_STRING_CONTAINS(line, "dropObject");
             }
         };


### PR DESCRIPTION
KIKIMR-20656

Whenever a user SELECTs from a view, we compile the persisted query text of the view in an [almost blank context](https://github.com/ydb-platform/ydb/blob/0c915e616b63e7047189c91e523a47e6476bd3df/ydb/core/kqp/provider/rewrite_io_utils.cpp#L42), which doesn't have any connection with the context in which the corresponding CREATE VIEW statement was executed. This means that the tables mentioned in the query text have to be specified by their absolute path. I believe this is very inconvinient and unexpected for users and needs to be fixed.

The solution proposed in this PR is the following: [prepend](https://github.com/ydb-platform/ydb/blob/de947bf1d784a3f88d7f848b752367e1dae98264/ydb/library/yql/sql/v1/sql_translation.cpp#L4507) the persisted query text with the PRAGMA TablePathPrefix (if it is present in the context of the CREATE VIEW statement) and save it like this. This should be transparent to the user and moreover this solution enables cross YDB installation usage of VIEWs, i.e. the VIEWs created in YDB version #X should be usable (= SELECTable from) in YDB version #Y. The alternative solution (persist to the database not the query text, but the parsed AST of the query text, which is prepared using the context of the CREATE VIEW statement) might turn out to be incompatible across different YDB versions.

In the future we might found out that some other parts of the context in which the CREATE VIEW statement was executed need to be persisted in some way for later SELECTing from that view. I would like us to agree on the way we will do this and use this PR for the discussion.