### PR TITLE
Make `docker-compose`-based tests more isolated

### DIFF
--- a/ydb/core/kqp/ut/federated_query/generic/docker-compose.yml
+++ b/ydb/core/kqp/ut/federated_query/generic/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '3.4'
+version: '3.7'
 services:
   postgresql:
     image: postgres:15-bullseye@sha256:3411b9f2e5239cd7867f34fcf22fe964230f7d447a71d63c283e3593d3f84085
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}-postgresql
     environment:
       POSTGRES_DB: db
       POSTGRES_USER: user
@@ -10,6 +11,7 @@ services:
       - 15432:5432
   clickhouse:
     image: clickhouse/clickhouse-server:23-alpine@sha256:b078c1cd294632afa2aeba3530e7ba2e568513da23304354f455a25fab575c06
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}-clickhouse
     environment:
       CLICKHOUSE_DB: db
       CLICKHOUSE_USER: user
@@ -19,7 +21,8 @@ services:
       - 19000:9000
       - 18123:8123
   fq-connector-go:
-    image: ghcr.io/ydb-platform/fq-connector-go:v0.0.6-rc.8@sha256:74ebae0530d916c1842a7fddfbddc6c018763a0401f2f627a44e8829692fe41f
+    image: ghcr.io/ydb-platform/fq-connector-go:v0.1.1@sha256:47e24df143aee31a83d4a4cd0acc20b4cab8c03a9c63e81a6e99cb017a31f916
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}-fq-connector-go
     ports:
       - 50051:50051
     network_mode: host

--- a/ydb/core/kqp/ut/federated_query/generic/ya.make
+++ b/ydb/core/kqp/ut/federated_query/generic/ya.make
@@ -38,6 +38,7 @@ PEERDIR(
     ydb/library/yql/sql/pg_dummy
 )
 
+ENV(COMPOSE_PROJECT_NAME=core-kqp-ut-federated_query-generic)
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 # Including of docker_compose/recipe.inc automatically converts these tests into LARGE, 

--- a/ydb/core/kqp/ut/federated_query/generic/ya.make
+++ b/ydb/core/kqp/ut/federated_query/generic/ya.make
@@ -48,6 +48,9 @@ IF (OPENSOURCE)
     SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
+    TAG(
+        ya:docker_compose
+    )
 ENDIF()
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/library/yql/providers/generic/connector/tests/docker-compose.yml
+++ b/ydb/library/yql/providers/generic/connector/tests/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.4'
+version: '3.7'
 services:
   postgresql:
     image: postgres:15-bullseye@sha256:3411b9f2e5239cd7867f34fcf22fe964230f7d447a71d63c283e3593d3f84085
-    container_name: ${USER}_connector-integration-tests-postgresql
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}-postgresql
     environment:
       POSTGRES_DB: db
       POSTGRES_USER: user
@@ -11,7 +11,7 @@ services:
       - 5432
   clickhouse:
     image: clickhouse/clickhouse-server:23-alpine@sha256:b078c1cd294632afa2aeba3530e7ba2e568513da23304354f455a25fab575c06
-    container_name: ${USER}_connector-integration-tests-clickhouse
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}-clickhouse
     environment:
       CLICKHOUSE_DB: db
       CLICKHOUSE_USER: user
@@ -21,7 +21,7 @@ services:
       - 9000
       - 8123
   fq-connector-go:
-    container_name: ${USER}_connector-integration-tests-fq-connector-go
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}-fq-connector-go
     image: ghcr.io/ydb-platform/fq-connector-go:v0.1.1@sha256:47e24df143aee31a83d4a4cd0acc20b4cab8c03a9c63e81a6e99cb017a31f916
     ports:
       - 50051

--- a/ydb/library/yql/providers/generic/connector/tests/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/ya.make
@@ -30,6 +30,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_PROJECT_NAME=library-yql-providers-generic-connector-tests)
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 # Including of docker_compose/recipe.inc automatically converts these tests into LARGE, 

--- a/ydb/library/yql/providers/generic/connector/tests/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/ya.make
@@ -1,3 +1,8 @@
+OWNER(
+    vitalyisaev
+    g:yq
+)
+
 PY3TEST()
 
 STYLE_PYTHON()
@@ -35,6 +40,9 @@ IF (OPENSOURCE)
     SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
+    TAG(
+        ya:docker_compose
+    )
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/tests/fq/generic/docker-compose.yml
+++ b/ydb/tests/fq/generic/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '3.4'
+version: '3.7'
 services:
   postgresql:
     image: "postgres:15-bullseye@sha256:3411b9f2e5239cd7867f34fcf22fe964230f7d447a71d63c283e3593d3f84085"
     # to be able to run tests by different users on the same machine we set prefix to ${USER}
-    container_name: ${USER}_ydb_tests_fq_generic_postgresql
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}_postgresql
     environment:
       POSTGRES_DB: db
       POSTGRES_USER: user
@@ -13,7 +13,7 @@ services:
     command: -p 6432
   clickhouse:
     image: "clickhouse/clickhouse-server:23-alpine@sha256:b078c1cd294632afa2aeba3530e7ba2e568513da23304354f455a25fab575c06"
-    container_name: ${USER}_ydb_tests_fq_generic_clickhouse
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}_clickhouse
     environment:
       CLICKHOUSE_DB: db
       CLICKHOUSE_USER: user
@@ -23,6 +23,6 @@ services:
       - ./clickhouse:/docker-entrypoint-initdb.d
   connector:
     image: "ghcr.io/ydb-platform/fq-connector-go:v0.1.1-rc.2@sha256:e5c2d86bce9cb43420eed0ed534afe760fb90ad41229dbbf34af28023b219af3"
-    container_name: ${USER}_ydb_tests_fq_generic_connector
+    container_name: ${USER}_${COMPOSE_PROJECT_NAME}_fq-connector-go
     ports:
       - '50051'

--- a/ydb/tests/fq/generic/ya.make
+++ b/ydb/tests/fq/generic/ya.make
@@ -21,6 +21,7 @@ IF (AUTOCHECK)
 
 ENDIF()
 
+ENV(COMPOSE_PROJECT_NAME=tests-fq-generic)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/mdb_mock/recipe.inc)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/token_accessor_mock/recipe.inc)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/fq_runner/ydb_runner_with_datastreams.inc)

--- a/ydb/tests/fq/generic/ya.make
+++ b/ydb/tests/fq/generic/ya.make
@@ -5,17 +5,21 @@ PY3TEST()
 STYLE_PYTHON()
 NO_CHECK_IMPORTS()
 
-TAG(
-    ya:external
-    ya:force_sandbox
-    ya:fat
-)
+IF (AUTOCHECK) 
 
-REQUIREMENTS(
-    container:4467981730
-    cpu:all
-    dns:dns64
-)
+    TAG(
+        ya:external
+        ya:force_sandbox
+        ya:fat
+    )
+
+    REQUIREMENTS(
+        container:4467981730
+        cpu:all
+        dns:dns64
+    )
+
+ENDIF()
 
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/mdb_mock/recipe.inc)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/token_accessor_mock/recipe.inc)
@@ -30,6 +34,9 @@ IF (OPENSOURCE)
     SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
+    TAG(
+        ya:docker_compose
+    )
 ENDIF()
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry 

* Tag all `docker-compose` based tests with a single tag
* Make separate COMPOSE_PROJECT_NAME files for docker-compose based tests

### Changelog category 

* Not for changelog (changelog entry is not required)

### Additional information

...
