### PR TITLE
[docs] remove odd comment in topic.md and changelog-cli.md

### DIFF
--- a/ydb/docs/en/core/changelog-cli.md
+++ b/ydb/docs/en/core/changelog-cli.md
@@ -1,5 +1,3 @@
-<!-- This file is not tracked by the automatic translation system. Edits to the RU-version must be made yourself. -->
-
 # {{ ydb-short-name }} CLI changelog
 
 ## Version 2.8.0 {#2-8-0}

--- a/ydb/docs/en/core/reference/ydb-sdk/topic.md
+++ b/ydb/docs/en/core/reference/ydb-sdk/topic.md
@@ -1,4 +1,3 @@
-<!-- This file is not tracked by the automatic translation system. Edits to the RU-version must be made yourself. -->
 # Working with topics
 
 This article provides examples of how to use the {{ ydb-short-name }} SDK to work with [topics](../../concepts/topic.md).


### PR DESCRIPTION
It also causes incorrect margin on page rendering:
![Screenshot 2024-01-26 at 15 29 54](https://github.com/ydb-platform/ydb/assets/623861/56bef463-3e3e-4e00-85c5-8a16aa82d236)


### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)

