### PR TITLE
Make sure out-of-order volatile commits are not visible on followers …

### DIFF
--- a/ydb/core/tablet/tablet_resolver.cpp
+++ b/ydb/core/tablet/tablet_resolver.cpp
@@ -649,8 +649,9 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
                     if (!(entry.KnownLeaderTablet == msg->CurrentLeaderTablet || !entry.KnownLeaderTablet)) {
                         DropEntry(tabletId, entry, ctx); // got info but not full, occurs on transitional cluster states
                     } else {
-                        entry.KnownLeaderTablet = msg->CurrentLeaderTablet;
                         entry.State = TEntry::StProblemPing;
+                        entry.KnownLeaderTablet = msg->CurrentLeaderTablet;
+                        entry.KnownFollowers = std::move(msg->Followers);
                         SendPing(tabletId, entry, ctx);
                     }
                 } else {

--- a/ydb/core/tx/datashard/datashard_ut_volatile.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_volatile.cpp
@@ -1992,6 +1992,127 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         UNIT_ASSERT(splitLatency < TDuration::Seconds(5));
     }
 
+    Y_UNIT_TEST(DistributedOutOfOrderFollowerConsistency) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false)
+            .SetEnableDataShardVolatileTransactions(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::TABLET_RESOLVER, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::STATESTORAGE, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        auto opts = TShardedTableOptions()
+                        .Shards(1)
+                        .Followers(1);
+        CreateShardedTable(server, sender, "/Root", "table-1", opts);
+        CreateShardedTable(server, sender, "/Root", "table-2", opts);
+
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        for (ui64 shard : GetTableShards(server, sender, "/Root/table-1")) {
+            InvalidateTabletResolverCache(runtime, shard);
+        }
+        for (ui64 shard : GetTableShards(server, sender, "/Root/table-2")) {
+            InvalidateTabletResolverCache(runtime, shard);
+        }
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 1);");
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table-2` (key, value) VALUES (2, 2);");
+
+        // Let followers catch up
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Block readset exchange
+        std::vector<std::unique_ptr<IEventHandle>> readSets;
+        auto blockReadSets = runtime.AddObserver<TEvTxProcessing::TEvReadSet>([&](TEvTxProcessing::TEvReadSet::TPtr& ev) {
+            readSets.emplace_back(ev.Release());
+        });
+
+        // Start a distributed write to both tables
+        TString sessionId = CreateSessionRPC(runtime, "/Root");
+        auto upsertResult = SendRequest(
+            runtime,
+            MakeSimpleRequestRPC(R"(
+                UPSERT INTO `/Root/table-1` (key, value) VALUES (3, 3);
+                UPSERT INTO `/Root/table-2` (key, value) VALUES (4, 4);
+                )", sessionId, /* txId */ "", /* commitTx */ true),
+            "/Root");
+        WaitFor(runtime, [&]{ return readSets.size() >= 4; }, "readsets");
+
+        // Stop blocking further readsets
+        blockReadSets.Remove();
+
+        // Start another distributed write to both tables, it should succeed
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table-1` (key, value) VALUES (5, 5);
+            UPSERT INTO `/Root/table-2` (key, value) VALUES (6, 6);
+        )");
+
+        // Let followers catch up
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        for (ui64 shard : GetTableShards(server, sender, "/Root/table-1")) {
+            InvalidateTabletResolverCache(runtime, shard);
+        }
+        for (ui64 shard : GetTableShards(server, sender, "/Root/table-2")) {
+            InvalidateTabletResolverCache(runtime, shard);
+        }
+
+        // Check tables, they shouldn't see inconsistent results with the latest write
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleStaleRoExec(runtime, Q_(R"(
+                SELECT key, value
+                FROM `/Root/table-1`
+                ORDER BY key
+                )"), "/Root"),
+            "{ items { uint32_value: 1 } items { uint32_value: 1 } }");
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleStaleRoExec(runtime, Q_(R"(
+                SELECT key, value
+                FROM `/Root/table-2`
+                ORDER BY key
+                )"), "/Root"),
+            "{ items { uint32_value: 2 } items { uint32_value: 2 } }");
+
+        // Unblock readsets
+        for (auto& ev : readSets) {
+            ui32 nodeIndex = ev->GetRecipientRewrite().NodeId() - runtime.GetNodeId(0);
+            runtime.Send(ev.release(), nodeIndex, true);
+        }
+        readSets.clear();
+
+        // Let followers catch up
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // Check tables again, they should have all rows visible now
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleStaleRoExec(runtime, Q_(R"(
+                SELECT key, value
+                FROM `/Root/table-1`
+                ORDER BY key
+                )")),
+            "{ items { uint32_value: 1 } items { uint32_value: 1 } }, "
+            "{ items { uint32_value: 3 } items { uint32_value: 3 } }, "
+            "{ items { uint32_value: 5 } items { uint32_value: 5 } }");
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleStaleRoExec(runtime, Q_(R"(
+                SELECT key, value
+                FROM `/Root/table-2`
+                ORDER BY key
+                )")),
+            "{ items { uint32_value: 2 } items { uint32_value: 2 } }, "
+            "{ items { uint32_value: 4 } items { uint32_value: 4 } }, "
+            "{ items { uint32_value: 6 } items { uint32_value: 6 } }");
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardVolatile)
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/volatile_tx.h
+++ b/ydb/core/tx/datashard/volatile_tx.h
@@ -197,6 +197,14 @@ namespace NKikimr::NDataShard {
             return !VolatileTxByVersion.empty() && (*VolatileTxByVersion.begin())->Version <= snapshot;
         }
 
+        TRowVersion GetMinUncertainVersion() const {
+            if (!VolatileTxByVersion.empty()) {
+                return (*VolatileTxByVersion.begin())->Version;
+            } else {
+                return TRowVersion::Max();
+            }
+        }
+
         void PersistAddVolatileTx(
             ui64 txId, const TRowVersion& version,
             TConstArrayRef<ui64> commitTxIds,


### PR DESCRIPTION
…KIKIMR-20853

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make sure out-of-order volatile commits are not visible on followers.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

It was possible for out-of-order volatile transaction commits to become visible on followers, before earlier transactions are decided, which caused observable results inconsistent with the global commit order.
