### PR TITLE
Fix consistency check complaining about borrowed tx status parts KIKI…

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4224,6 +4224,10 @@ TString TExecutor::CheckBorrowConsistency() {
             [&](const TIntrusiveConstPtr<NTable::TColdPart>& part) {
                 knownBundles.insert(part->Label);
             });
+        Database->EnumerateTableTxStatusParts(tableId,
+            [&](const TIntrusiveConstPtr<NTable::TTxStatusPart>& part) {
+                knownBundles.insert(part->Label);
+            });
     }
     return BorrowLogic->DebugCheckBorrowConsistency(knownBundles);
 }


### PR DESCRIPTION
…MR-20903

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix consistency check complaining about borrowed tx status parts

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Change visibility caused tablet's borrow consistency check to complain about borrowed bundles that are neither garbage collected nor used by any table.
