### PR TITLE
Fix PDisk log flush completion action use after free

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -13,27 +13,24 @@ class TLogFlushCompletionAction : public TCompletionAction {
     const ui32 EndChunkIdx;
     const ui32 EndSectorIdx;
     THolder<TLogWriter> &CommonLogger;
+    TCompletionAction* CompletionLogWrite;
 public:
     TLogFlushCompletionAction(ui32 endChunkIdx, ui32 endSectorIdx, THolder<TLogWriter> &commonLogger, TCompletionAction* completionLogWrite)
         : EndChunkIdx(endChunkIdx)
         , EndSectorIdx(endSectorIdx)
-        , CommonLogger(commonLogger) {
-            this->FlushAction = completionLogWrite;
-        }
+        , CommonLogger(commonLogger)
+        , CompletionLogWrite(completionLogWrite) { }
 
     void Exec(TActorSystem *actorSystem) override {
         CommonLogger->FirstUncommitted = TFirstUncommitted(EndChunkIdx, EndSectorIdx);
 
-        Y_DEBUG_ABORT_UNLESS(FlushAction);
-
-        // FlushAction here is a TCompletionLogWrite which will decrease owner's inflight count.
-        FlushAction->Exec(actorSystem);
+        CompletionLogWrite->Exec(actorSystem);
 
         delete this;
     }
 
     void Release(TActorSystem *actorSystem) override {
-        FlushAction->Release(actorSystem);
+        CompletionLogWrite->Release(actorSystem);
 
         delete this;
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -23,13 +23,17 @@ public:
 
     void Exec(TActorSystem *actorSystem) override {
         CommonLogger->FirstUncommitted = TFirstUncommitted(EndChunkIdx, EndSectorIdx);
-
+        
+        CompletionLogWrite->SetResult(Result);
+        CompletionLogWrite->SetErrorReason(ErrorReason);
         CompletionLogWrite->Exec(actorSystem);
 
         delete this;
     }
 
     void Release(TActorSystem *actorSystem) override {
+        CompletionLogWrite->SetResult(Result);
+        CompletionLogWrite->SetErrorReason(ErrorReason);
         CompletionLogWrite->Release(actorSystem);
 
         delete this;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
@@ -196,6 +196,7 @@ struct TOwnerData {
         CurrentFirstLsnToKeep = 0;
         LastWrittenCommitLsn = 0;
         CutLogId = TActorId();
+        LogEndPosition = TLogEndPosition(0, 0);
         WhiteboardProxyId = TActorId();
         LogRecordsInitiallyRead = 0;
         LogRecordsConsequentlyRead = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Fixes use after free in pdisk log flush wrapper 

### Changelog category <!-- remove all except one -->
* Bugfix

### Additional information
Should fix:
```
Test crashed (return code: -6)
See logs for more info
Problem thread backtrace:
Thread 1 (LWP 156277):
#0  0x00007fb31dedf00b in raise () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#1  0x00007fb31debe859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#2  0x0000000001e027c6 in __cxa_pure_virtual () at /-S/contrib/libs/cxxsupp/libcxxrt/auxhelper.cc:80
No locals.
#3  0x00000000031cdbde in NKikimr::NPDisk::TLogFlushCompletionAction::Release(NActors::TActorSystem*) () at /-S/contrib/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp:36
No locals.
```