### PR TITLE
Support result set extract from TDataQueryResult

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_table/table.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.cpp
@@ -2084,6 +2084,10 @@ const TVector<TResultSet>& TDataQueryResult::GetResultSets() const {
     return ResultSets_;
 }
 
+TVector<TResultSet> TDataQueryResult::ExtractResultSets() && {
+    return std::move(ResultSets_);
+}
+
 TResultSet TDataQueryResult::GetResultSet(size_t resultIndex) const {
     if (resultIndex >= ResultSets_.size()) {
         RaiseError(TString("Requested index out of range\n"));

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -1818,6 +1818,7 @@ public:
         const TMaybe<TDataQuery>& dataQuery, bool fromCache, const TMaybe<TQueryStats>& queryStats);
 
     const TVector<TResultSet>& GetResultSets() const;
+    TVector<TResultSet> ExtractResultSets() &&;
     TResultSet GetResultSet(size_t resultIndex) const;
 
     TResultSetParser GetResultSetParser(size_t resultIndex) const;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

add method `ExtractResultSets` in `TDataQueryResult` to extract results to avoid a long period of `TSession` life and release it

### Additional information

...
