### PR TITLE
Finsh grpc stream without extra empty message for query service.

### DIFF
--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -407,8 +407,8 @@ class IRequestCtx
     , public virtual IRequestCtxBase
 {
     friend class TProtoResponseHelper;
-
 public:
+    using EStreamCtrl = NYdbGrpc::IRequestContextBase::EStreamCtrl;
     virtual google::protobuf::Message* GetRequestMut() = 0;
 
     virtual void SetRuHeader(ui64 ru) = 0;
@@ -418,7 +418,7 @@ public:
     virtual void SetStreamingNotify(NYdbGrpc::IRequestContextBase::TOnNextReply&& cb) = 0;
     virtual void FinishStream(ui32 status) = 0;
 
-    virtual void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status) = 0;
+    virtual void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status, EStreamCtrl flag = EStreamCtrl::CONT) = 0;
 
     virtual void Reply(NProtoBuf::Message* resp, ui32 status = 0) = 0;
 
@@ -1193,7 +1193,7 @@ public:
         return GetPeerMetaValues(NYdb::YDB_REQUEST_TYPE_HEADER);
     }
 
-    void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status) override {
+    void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status, IRequestCtx::EStreamCtrl flag = IRequestCtx::EStreamCtrl::CONT) override {
         // res->data() pointer is used inside grpc code.
         // So this object should be destroyed during grpc_slice destroying routine
         auto res = new TString;
@@ -1208,7 +1208,7 @@ public:
                     (void*)(res->data()), res->size(), freeResult, res);
         grpc::Slice sl = grpc::Slice(slice, grpc::Slice::STEAL_REF);
         auto data = grpc::ByteBuffer(&sl, 1);
-        Ctx_->Reply(&data, status);
+        Ctx_->Reply(&data, status, flag);
     }
 
     void SetCostInfo(float consumed_units) override {

--- a/ydb/core/grpc_services/local_rpc/local_rpc.h
+++ b/ydb/core/grpc_services/local_rpc/local_rpc.h
@@ -183,7 +183,7 @@ public:
         Y_ABORT("Unimplemented for local rpc");
     }
 
-    virtual void SendSerializedResult(TString&&, Ydb::StatusIds::StatusCode) override {
+    virtual void SendSerializedResult(TString&&, Ydb::StatusIds::StatusCode, EStreamCtrl) override {
         Y_ABORT("Unimplemented for local rpc");
     }
 

--- a/ydb/core/grpc_services/query/rpc_execute_query.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_query.cpp
@@ -359,10 +359,10 @@ private:
     void Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext&) {
         auto& record = ev->Get()->Record.GetRef();
 
-        NYql::TIssues issues;
         const auto& issueMessage = record.GetResponse().GetQueryIssues();
-        NYql::IssuesFromMessage(issueMessage, issues);
 
+        bool hasTrailingMessage = false;
+ 
         if (record.GetYdbStatus() == Ydb::StatusIds::SUCCESS) {
             Request_->SetRuHeader(record.GetConsumedRu());
 
@@ -371,8 +371,6 @@ private:
             Ydb::Query::ExecuteQueryResponsePart response;
 
             AuditContextAppend(Request_.get(), *Request_->GetProtoRequest(), response);
-
-            bool hasTrailingMessage = false;
 
             if (kqpResponse.HasTxMeta()) {
                 hasTrailingMessage = true;
@@ -386,13 +384,20 @@ private:
 
             if (hasTrailingMessage) {
                 response.set_status(Ydb::StatusIds::SUCCESS);
+                response.mutable_issues()->CopyFrom(issueMessage);
                 TString out;
                 Y_PROTOBUF_SUPPRESS_NODISCARD response.SerializeToString(&out);
-                Request_->SendSerializedResult(std::move(out), record.GetYdbStatus());
+                const auto finishStreamFlag = NYdbGrpc::IRequestContextBase::EStreamCtrl::FINISH;
+                Request_->SendSerializedResult(std::move(out), record.GetYdbStatus(), finishStreamFlag);
+                this->PassAway();
             }
         }
 
-        ReplyFinishStream(record.GetYdbStatus(), issues);
+        if (!hasTrailingMessage) {
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(issueMessage, issues);
+            ReplyFinishStream(record.GetYdbStatus(), issueMessage);
+        }
     }
 
 private:
@@ -437,10 +442,11 @@ private:
             response.set_status(status);
             response.mutable_issues()->CopyFrom(message);
             Y_PROTOBUF_SUPPRESS_NODISCARD response.SerializeToString(&out);
-            Request_->SendSerializedResult(std::move(out), status);
+            const auto finishStreamFlag = NYdbGrpc::IRequestContextBase::EStreamCtrl::FINISH;
+            Request_->SendSerializedResult(std::move(out), status, finishStreamFlag);
+        } else {
+            Request_->FinishStream(status);
         }
-
-        Request_->FinishStream(status);
         this->PassAway();
     }
 

--- a/ydb/core/kafka_proxy/actors/kafka_create_partitions_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_partitions_actor.cpp
@@ -153,7 +153,7 @@ public:
         Y_UNUSED(status);
     };
 
-    void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status) override {
+    void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status, EStreamCtrl) override {
         Y_UNUSED(in);
         Y_UNUSED(status);
     };

--- a/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
@@ -151,9 +151,10 @@ public:
         Y_UNUSED(status);
     };
 
-    void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status) override {
+    void SendSerializedResult(TString&& in, Ydb::StatusIds::StatusCode status, EStreamCtrl flag) override {
         Y_UNUSED(in);
         Y_UNUSED(status);
+        Y_UNUSED(flag);
     };
 
     void Reply(NProtoBuf::Message* resp, ui32 status = 0) override {

--- a/ydb/core/public_http/grpc_request_context_wrapper.cpp
+++ b/ydb/core/public_http/grpc_request_context_wrapper.cpp
@@ -34,9 +34,10 @@ namespace NKikimr::NPublicHttp {
         ReplySender(RequestContext, JsonSettings, resp, status);
     }
 
-    void TGrpcRequestContextWrapper::Reply(grpc::ByteBuffer* resp, ui32 status) {
+    void TGrpcRequestContextWrapper::Reply(grpc::ByteBuffer* resp, ui32 status, EStreamCtrl ctrl) {
         Y_UNUSED(resp);
         Y_UNUSED(status);
+        Y_UNUSED(ctrl);
         Y_ABORT_UNLESS(false, "TGrpcRequestContextWrapper::Reply");
     }
 

--- a/ydb/core/public_http/grpc_request_context_wrapper.h
+++ b/ydb/core/public_http/grpc_request_context_wrapper.h
@@ -27,7 +27,7 @@ public:
     virtual NProtoBuf::Message* GetRequestMut();
     virtual NYdbGrpc::TAuthState& GetAuthState();
     virtual void Reply(NProtoBuf::Message* resp, ui32 status = 0);
-    virtual void Reply(grpc::ByteBuffer* resp, ui32 status = 0);
+    virtual void Reply(grpc::ByteBuffer* resp, ui32 status = 0, EStreamCtrl ctrl = EStreamCtrl::CONT);
     virtual void ReplyUnauthenticated(const TString& in);
     virtual void ReplyError(grpc::StatusCode code, const TString& msg, const TString& details);
     virtual TInstant Deadline() const;

--- a/ydb/library/grpc/server/grpc_request_base.h
+++ b/ydb/library/grpc/server/grpc_request_base.h
@@ -46,6 +46,11 @@ public:
         ERROR,
         CANCEL
     };
+    enum class EStreamCtrl {
+        CONT = 0,   // Continue stream
+        FINISH = 1, // Finish stream just after this reply
+    };
+
     using TAsyncFinishResult = NThreading::TFuture<EFinishStatus>;
 
     using TOnNextReply = std::function<void (size_t left)>;
@@ -65,7 +70,9 @@ public:
 
     //! Send serialised response (The request shoult be created for bytes response type)
     //! Implementation can swap ByteBuffer
-    virtual void Reply(grpc::ByteBuffer* resp, ui32 status = 0) = 0;
+
+    //! ctrl - controll stream behaviour. Ignored in case of unary call
+    virtual void Reply(grpc::ByteBuffer* resp, ui32 status = 0, EStreamCtrl ctrl = EStreamCtrl::CONT) = 0;
 
     //! Send grpc UNAUTHENTICATED status
     virtual void ReplyUnauthenticated(const TString& in) = 0;


### PR DESCRIPTION
### Changelog entry 

grpc allows to finish stream just without sending extra messages. This patch adds this in to query service.

https://github.com/ydb-platform/ydb/issues/1314

### Changelog category 

* Improvement


