### PR TITLE
Remove TActiveTransaction from datashard_kqp.h

### DIFF
--- a/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
@@ -100,7 +100,7 @@ EExecutionStatus TBuildKqpDataTxOutRSUnit::Execute(TOperation::TPtr op, TTransac
         dataTx->SetReadVersion(DataShard.GetReadWriteVersions(tx).ReadVersion);
 
         if (dataTx->GetKqpComputeCtx().HasPersistentChannels()) {
-            auto result = KqpRunTransaction(ctx, op->GetTxId(), kqpLocks, useGenericReadSets, tasksRunner);
+            auto result = KqpRunTransaction(ctx, op->GetTxId(), useGenericReadSets, tasksRunner);
 
             Y_VERIFY_S(!dataTx->GetKqpComputeCtx().HadInconsistentReads(),
                 "Unexpected inconsistent reads in operation " << *op << " when preparing persistent channels");

--- a/ydb/core/tx/datashard/datashard__engine_host.cpp
+++ b/ydb/core/tx/datashard/datashard__engine_host.cpp
@@ -276,7 +276,7 @@ public:
         return UserDb.GetChangeCollector(tableId);
     }
 
-    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) {
+    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) override {
         UserDb.CommitChanges(tableId, lockId, writeVersion);
     }
 
@@ -605,13 +605,6 @@ void TEngineBay::SetIsRepeatableSnapshot() {
 
     auto* host = static_cast<TDataShardEngineHost*>(EngineHost.Get());
     host->SetIsRepeatableSnapshot();
-}
-
-void TEngineBay::CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) {
-    Y_ABORT_UNLESS(EngineHost);
-
-    auto* host = static_cast<TDataShardEngineHost*>(EngineHost.Get());
-    host->CommitChanges(tableId, lockId, writeVersion);
 }
 
 TVector<IDataShardChangeCollector::TChange> TEngineBay::GetCollectedChanges() const {

--- a/ydb/core/tx/datashard/datashard__engine_host.h
+++ b/ydb/core/tx/datashard/datashard__engine_host.h
@@ -103,8 +103,6 @@ public:
     void SetIsImmediateTx();
     void SetIsRepeatableSnapshot();
 
-    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion);
-
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const;
     void ResetCollectedChanges();
 

--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -206,6 +206,13 @@ TValidatedDataTx::~TValidatedDataTx() {
     NActors::NMemory::TLabel<MemoryLabelValidatedDataTx>::Sub(TxSize);
 }
 
+TDataShardUserDb& TValidatedDataTx::GetUserDb() {
+    return EngineBay.GetUserDb();
+}
+const TDataShardUserDb& TValidatedDataTx::GetUserDb() const {
+    return EngineBay.GetUserDb();
+}
+
 ui32 TValidatedDataTx::ExtractKeys(bool allowErrors)
 {
     using EResult = NMiniKQL::IEngineFlat::EResult;

--- a/ydb/core/tx/datashard/datashard_active_transaction.h
+++ b/ydb/core/tx/datashard/datashard_active_transaction.h
@@ -23,6 +23,7 @@ using NTabletFlatExecutor::TTransactionContext;
 using NTabletFlatExecutor::TTableSnapshotContext;
 
 class TDataShard;
+class TDataShardUserDb;
 class TSysLocks;
 struct TReadSetKey;
 class TActiveTransaction;
@@ -173,16 +174,15 @@ public:
     const NMiniKQL::TEngineHostCounters& GetCounters() { return EngineBay.GetCounters(); }
     void ResetCounters() { EngineBay.ResetCounters(); }
 
+    TDataShardUserDb& GetUserDb();
+    const TDataShardUserDb& GetUserDb() const;
+
     bool CanCancel();
     bool CheckCancelled(ui64 tabletId);
 
     void SetWriteVersion(TRowVersion writeVersion) { EngineBay.SetWriteVersion(writeVersion); }
     void SetReadVersion(TRowVersion readVersion) { EngineBay.SetReadVersion(readVersion); }
     void SetVolatileTxId(ui64 txId) { EngineBay.SetVolatileTxId(txId); }
-
-    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) {
-        EngineBay.CommitChanges(tableId, lockId, writeVersion);
-    }
 
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const { return EngineBay.GetCollectedChanges(); }
     void ResetCollectedChanges() { EngineBay.ResetCollectedChanges(); }

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "datashard.h"
-#include "datashard_active_transaction.h"
+
+#include "operation.h"
+#include "key_validator.h"
+#include "datashard_locks.h"
+#include "datashard_user_db.h"
 
 #include <ydb/core/engine/minikql/minikql_engine_host.h>
 #include <ydb/core/kqp/runtime/kqp_tasks_runner.h>
@@ -20,12 +24,10 @@ void KqpSetTxKeys(ui64 tabletId, ui64 taskId, const TUserTable* tableInfo,
 
 void KqpSetTxLocksKeys(const NKikimrDataEvents::TKqpLocks& locks, const TSysLocks& sysLocks, TKeyValidator& keyValidator);
 
-NYql::NDq::ERunStatus KqpRunTransaction(const TActorContext& ctx, ui64 txId,
-    const NKikimrDataEvents::TKqpLocks& kqpLocks, bool useGenericReadSets, NKqp::TKqpTasksRunner& tasksRunner);
+NYql::NDq::ERunStatus KqpRunTransaction(const TActorContext& ctx, ui64 txId, bool useGenericReadSets, NKqp::TKqpTasksRunner& tasksRunner);
 
 THolder<TEvDataShard::TEvProposeTransactionResult> KqpCompleteTransaction(const TActorContext& ctx,
-    ui64 origin, ui64 txId, const TInputOpData::TInReadSets* inReadSets,
-    const NKikimrDataEvents::TKqpLocks& kqpLocks, bool useGenericReadSets, NKqp::TKqpTasksRunner& tasksRunner,
+    ui64 tabletId, ui64 txId, const TInputOpData::TInReadSets* inReadSets, bool useGenericReadSets, NKqp::TKqpTasksRunner& tasksRunner,
     const NMiniKQL::TKqpDatashardComputeContext& computeCtx);
 
 void KqpFillOutReadSets(TOutputOpData::TOutReadSets& outReadSets, const NKikimrDataEvents::TKqpLocks& kqpLocks, 
@@ -35,11 +37,14 @@ void KqpFillOutReadSets(TOutputOpData::TOutReadSets& outReadSets, const NKikimrD
 void KqpPrepareInReadsets(TInputOpData::TInReadSets& inReadSets,
     const NKikimrDataEvents::TKqpLocks& kqpLocks, const NKqp::TKqpTasksRunner& tasksRunner, ui64 tabletId);
 
-bool KqpValidateLocks(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks);
-bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks);
+std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateLocks(ui64 tabletId, TSysLocks& sysLocks, 
+    const NKikimrDataEvents::TKqpLocks* kqpLocks, bool useGenericReadSets, const TInputOpData::TInReadSets& inReadSets);
+std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 tabletId, TSysLocks& sysLocks, 
+    const NKikimrDataEvents::TKqpLocks* kqpLocks, bool useGenericReadSets, ui64 txId, const TVector<NKikimrTx::TEvReadSet>& delayedInReadSets, 
+    TInputOpData::TAwaitingDecisions& awaitingDecisions, TOutputOpData::TOutReadSets& outReadSets);
 
-void KqpEraseLocks(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks);
-void KqpCommitLocks(ui64 origin, TActiveTransaction* tx, const TRowVersion& writeVersion, TDataShard& dataShard);
+void KqpEraseLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks);
+void KqpCommitLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, const TRowVersion& writeVersion, IDataShardUserDb& userDb);
 
 void KqpUpdateDataShardStatCounters(TDataShard& dataShard, const NMiniKQL::TEngineHostCounters& counters);
 

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -32,7 +32,12 @@ public:
 
     virtual void EraseRow(
             const TTableId& tableId,
-            const TArrayRef<const TRawTypeValue> key) = 0;            
+            const TArrayRef<const TRawTypeValue> key) = 0;
+
+    virtual void CommitChanges(
+            const TTableId& tableId,
+            ui64 lockId,
+            const TRowVersion& writeVersion) = 0;
 };
 
 class IDataShardConflictChecker {
@@ -89,6 +94,11 @@ public:
             const TTableId& tableId,
             const TArrayRef<const TRawTypeValue> key) override;
 
+    void CommitChanges(
+            const TTableId& tableId, 
+            ui64 lockId, 
+            const TRowVersion& writeVersion) override;
+
 //IDataShardChangeGroupProvider
 public:  
     std::optional<ui64> GetCurrentChangeGroup() const override;
@@ -110,7 +120,6 @@ public:
     void ResetCollectedChanges();
 
 public:
-    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion);
     bool NeedToReadBeforeWrite(const TTableId& tableId);
     void AddCommitTxId(const TTableId& tableId, ui64 txId, const TRowVersion& commitVersion);
     ui64 GetWriteTxId(const TTableId& tableId);

--- a/ydb/core/tx/datashard/datashard_write_operation.h
+++ b/ydb/core/tx/datashard/datashard_write_operation.h
@@ -103,10 +103,6 @@ public:
         UserDb.SetVolatileTxId(txId);
     }
 
-    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) {
-        UserDb.CommitChanges(tableId, lockId, writeVersion);
-    }
-
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const {
         return UserDb.GetCollectedChanges();
     }

--- a/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
@@ -4,6 +4,7 @@
 #include "execution_unit_ctors.h"
 #include "setup_sys_locks.h"
 #include "datashard_locks_db.h"
+#include "datashard_user_db.h"
 #include "probes.h"
 
 #include <ydb/core/engine/minikql/minikql_engine_host.h>
@@ -126,9 +127,14 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
     }
 
     try {
-        auto& kqpLocks = dataTx->GetKqpLocks();
+        const ui64 txId = tx->GetTxId();
+        const auto* kqpLocks = tx->GetDataTx()->HasKqpLocks() ? &tx->GetDataTx()->GetKqpLocks() : nullptr;
+        const auto& inReadSets = op->InReadSets();
+        auto& awaitingDecisions = tx->AwaitingDecisions();
+        auto& outReadSets = tx->OutReadSets();
         bool useGenericReadSets = dataTx->GetUseGenericReadSets();
         auto& tasksRunner = dataTx->GetKqpTasksRunner();
+        TSysLocks& sysLocks = DataShard.SysLocksTable();
 
         ui64 consumedMemory = dataTx->GetTxSize() + tasksRunner.GetAllocatedMemory();
         if (MaybeRequestMoreTxMemory(consumedMemory, txc)) {
@@ -177,18 +183,30 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
             // We need to clear OutReadSets and AwaitingDecisions for
             // volatile transactions, except when we commit them.
             if (!keepOutReadSets) {
-                tx->OutReadSets().clear();
-                tx->AwaitingDecisions().clear();
+                outReadSets.clear();
+                awaitingDecisions.clear();
             }
         };
 
-        const bool validated = op->HasVolatilePrepareFlag()
-            ? KqpValidateVolatileTx(tabletId, tx, DataShard.SysLocksTable())
-            : KqpValidateLocks(tabletId, tx, DataShard.SysLocksTable());
+        auto [validated, brokenLocks] = op->HasVolatilePrepareFlag()
+            ? KqpValidateVolatileTx(tabletId, sysLocks, kqpLocks, useGenericReadSets, 
+                txId, tx->DelayedInReadSets(), awaitingDecisions, outReadSets)
+            : KqpValidateLocks(tabletId, sysLocks, kqpLocks, useGenericReadSets, inReadSets);
 
         if (!validated) {
-            KqpEraseLocks(tabletId, tx, DataShard.SysLocksTable());
-            DataShard.SysLocksTable().ApplyLocks();
+            tx->Result() = MakeHolder<TEvDataShard::TEvProposeTransactionResult>(
+                NKikimrTxDataShard::TX_KIND_DATA,
+                tabletId,
+                txId,
+                NKikimrTxDataShard::TEvProposeTransactionResult::LOCKS_BROKEN
+            );
+
+            for (auto& brokenLock : brokenLocks) {
+                tx->Result()->Record.MutableTxLocks()->Add()->Swap(&brokenLock);
+            }
+
+            KqpEraseLocks(tabletId, kqpLocks, sysLocks);
+            sysLocks.ApplyLocks();
             DataShard.SubscribeNewLocks(ctx);
             if (locksDb.HasChanges()) {
                 op->SetWaitCompletionFlag(true);
@@ -203,10 +221,10 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
         req.MemoryPool = NKqp::NRm::EKqpMemoryPool::DataQuery;
         req.Memory = txc.GetMemoryLimit();
         ui64 taskId = dataTx->GetFirstKqpTaskId();
-        NKqp::GetKqpResourceManager()->NotifyExternalResourcesAllocated(tx->GetTxId(), taskId, req);
+        NKqp::GetKqpResourceManager()->NotifyExternalResourcesAllocated(txId, taskId, req);
 
         Y_DEFER {
-            NKqp::GetKqpResourceManager()->NotifyExternalResourcesFreed(tx->GetTxId(), taskId);
+            NKqp::GetKqpResourceManager()->NotifyExternalResourcesFreed(txId, taskId);
         };
 
         LOG_T("Operation " << *op << " (execute_kqp_data_tx) at " << tabletId
@@ -220,17 +238,17 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
         dataTx->SetWriteVersion(writeVersion);
 
         if (op->HasVolatilePrepareFlag()) {
-            dataTx->SetVolatileTxId(tx->GetTxId());
+            dataTx->SetVolatileTxId(txId);
         }
 
         LWTRACK(ProposeTransactionKqpDataExecute, op->Orbit);
 
-        KqpCommitLocks(tabletId, tx, writeVersion, DataShard);
+        KqpCommitLocks(tabletId, kqpLocks, sysLocks, writeVersion, tx->GetDataTx()->GetUserDb());
 
         auto& computeCtx = tx->GetDataTx()->GetKqpComputeCtx();
 
         auto result = KqpCompleteTransaction(ctx, tabletId, op->GetTxId(),
-            op->HasKqpAttachedRSFlag() ? nullptr : &op->InReadSets(), kqpLocks, useGenericReadSets, tasksRunner, computeCtx);
+            op->HasKqpAttachedRSFlag() ? nullptr : &op->InReadSets(), useGenericReadSets, tasksRunner, computeCtx);
 
         if (!result && computeCtx.HadInconsistentReads()) {
             LOG_T("Operation " << *op << " (execute_kqp_data_tx) at " << tabletId
@@ -319,16 +337,16 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
         op->SetKqpAttachedRSFlag();
 
         if (dataTx->GetCounters().InvisibleRowSkips && op->LockTxId()) {
-            DataShard.SysLocksTable().BreakSetLocks();
+            sysLocks.BreakSetLocks();
         }
 
         // Note: any transaction (e.g. immediate or non-volatile) may decide to commit as volatile due to dependencies
         // Such transactions would have no participants and become immediately committed
         auto commitTxIds = dataTx->GetVolatileCommitTxIds();
         if (commitTxIds) {
-            TVector<ui64> participants(tx->AwaitingDecisions().begin(), tx->AwaitingDecisions().end());
+            TVector<ui64> participants(awaitingDecisions.begin(), awaitingDecisions.end());
             DataShard.GetVolatileTxManager().PersistAddVolatileTx(
-                tx->GetTxId(),
+                txId,
                 writeVersion,
                 commitTxIds,
                 dataTx->GetVolatileDependencies(),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The dependency of the KQP Locks on TActiveTransaction has been removed.
This is a necessary preliminary step to support KQP locks in EvWrite event.
...

### Changelog category <!-- remove all except one -->

* Improvement

...
