### PR TITLE
Fix TEvPatch behaviour

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -2,7 +2,6 @@ ydb/core/blobstorage/dsproxy/ut TBlobStorageProxySequenceTest.TestBlock42PutWith
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
 ydb/core/blobstorage/pdisk/ut TSectorMap.*
 ydb/core/blobstorage/ut_blobstorage/ut_read_only_vdisk ReadOnlyVDisk.TestStorageLoad
-ydb/core/blobstorage/ut_blobstorage BlobPatching.PatchBlock42
 ydb/core/blobstorage/ut_blobstorage CostMetricsGetBlock4Plus2.TestGet4Plus2BlockRequests10000Inflight1BlobSize1000
 ydb/core/blobstorage/ut_blobstorage Defragmentation.DoesItWork
 ydb/core/blobstorage/ut_blobstorage SpaceCheckForDiskReassign.*

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
@@ -365,7 +365,7 @@ namespace NKikimr::NPrivate {
                     (ResultSize, record.ResultSize()),
                     (ParityPart, (blobId.PartId() <= GType.DataParts() ? "no" : "yes")));
 
-            ui8 *buffer = reinterpret_cast<ui8*>(Buffer.UnsafeGetContiguousSpanMut().data());
+            ui8 *buffer = reinterpret_cast<ui8*>(Buffer.GetContiguousSpanMut().data());
             if (PatchedPartId <= GType.DataParts()) {
                 AddMark("Data part");
                 if (GType.ErasureFamily() != TErasureType::ErasureMirror) {
@@ -675,7 +675,7 @@ namespace NKikimr::NPrivate {
             }
 
             if (Buffer) {
-                ui8 *buffer = reinterpret_cast<ui8*>(Buffer.UnsafeGetContiguousSpanMut().data());
+                ui8 *buffer = reinterpret_cast<ui8*>(Buffer.GetContiguousSpanMut().data());
                 ui32 dataSize = OriginalBlobId.BlobSize();
 
                 AddMark("Apply xor diff");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix bug in TEvPatch event processing pipeline leading to probable corruption of original blob.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

TEvPatch processing sometimes involves inter-VDisk operation, which uses TSkeletonVPatchActor. This actor reads existing blobs through TEvVGet queries and operates on data received in TEvVGetResult responses. Previously they were delivered as "bytes" protobuf fields, then the logic was changed to use TRope payloads. Also, there was a change that switched internally-stored responses from TString to TRope. Thus it became possible when queries were local and blobs weren't huge that TEvVGetResult delivers rope pointing to Fresh segment of data. And usage of unsafe rope manipulators (introduced as drop-in replacement for const_cast<char*>(TString::data())) led to changing data inside the Fresh segment, instead of making on-demand copy and changing it.

For this bug to happen the following conditions needed to be met for original blob to be possibly corrupted:
1. Blob must have been written recently (still in fresh segment, not compacted to L0)
2. Blob must be small
3. Patch query must have requested blob part from process-local VDisk