### PR TITLE
BTreeIndex Charge Bytes Limit

### DIFF
--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -82,7 +82,7 @@ public:
         TVector<TNodeState> level, nextLevel(::Reserve(3));
         TPageId key1PageId = key1 ? meta.PageId : Max<TPageId>();
         TPageId key2PageId = key2 ? meta.PageId : Max<TPageId>();
-        ui64 prevKey1Items = 0, prevKey1Bytes = 0, key1Items = 0, key1Bytes = 0;
+        ui64 key1Items = 0, key1Bytes = 0, prevKey1Items = 0, prevKey1Bytes = 0;
 
         const auto iterateLevel = [&](const auto& tryHandleChild) {
             // tryHandleChild may update them, copy for simplicity
@@ -122,7 +122,6 @@ public:
                             }
                             if (bytesLimit) {
                                 ui64 bytes = child->DataSize - firstChild->DataSize;
-                                Cerr << child->RowCount << " " << bytes << Endl;
                                 if (LimitExceeded(bytes, bytesLimit)) {
                                     overshot = false;
                                     return;

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -507,14 +507,20 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
                         DoChargeKeys(part, limitedCharge, limitedEnv, key1, { }, 0, bytesLimit, reverse, *keyDefaults, message);
                         DoChargeKeys(part, unlimitedCharge, unlimitedEnv, key1, { }, 0, 0, reverse, *keyDefaults, message);
                         
-                        for (const auto& [groupId, unlimitedLoaded] : unlimitedEnv.Loaded) {
+                        TSet<TGroupId> groupIds;
+                        for (const auto &c : {limitedEnv.Loaded, unlimitedEnv.Loaded}) {
+                            for (const auto &g : c) {
+                                groupIds.insert(g.first);
+                            }
+                        }
+                        for (auto groupId : groupIds) {
                             ui64 size = 0;
                             TSet<TPageId> expected, loaded;
-                            TVector<TPageId> unlimitedLoadedList(unlimitedLoaded.begin(), unlimitedLoaded.end());
+                            TVector<TPageId> unlimitedLoaded(unlimitedEnv.Loaded[groupId].begin(), unlimitedEnv.Loaded[groupId].end());
                             if (reverse) {
-                                std::reverse(unlimitedLoadedList.begin(), unlimitedLoadedList.end());
+                                std::reverse(unlimitedLoaded.begin(), unlimitedLoaded.end());
                             }
-                            for (auto pageId : unlimitedLoadedList) {
+                            for (auto pageId : unlimitedLoaded) {
                                 if (part.GetPageType(pageId, groupId) == EPage::DataPage) {
                                     if (expected || !groupId.IsMain()) {
                                         // do not count first main page


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Support bytes limit in `TChargeBTreeIndex`: stop iteration when we touched enough data pages.

Do not apply bytes limit on the first touched page because begin row or first key position may vary.

Limit each additional column family separately to simplify the process.

Part of KIKIMR-19522, #1483
