### PR TITLE
#1497: treat missing JSON values as NULLs for import

### DIFF
--- a/ydb/public/lib/json_value/ydb_json_value.cpp
+++ b/ydb/public/lib/json_value/ydb_json_value.cpp
@@ -745,11 +745,15 @@ namespace {
                     const TString& memberName = TypeParser.GetMemberName();
                     const auto it = jsonMap.find(memberName);
                     if (it == jsonMap.end()) {
-                        ThrowFatalError(TStringBuilder() << "No member \"" << memberName
-                            << "\" in the map in json string for YDB struct type");
+                        // missing JSON value is treated as NULL on input
+                        ValueBuilder.AddMember(memberName);
+                        TypeParser.OpenOptional();
+                        ValueBuilder.EmptyOptional(GetType());
+                        TypeParser.CloseOptional();
+                    } else {
+                        ValueBuilder.AddMember(memberName);
+                        ParseValue(it->second);
                     }
-                    ValueBuilder.AddMember(memberName);
-                    ParseValue(it->second);
                 }
 
                 ValueBuilder.EndStruct();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

YDB CLI now treats missing JSON values as NULLs for `ydb import file json` command.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
