### PR TITLE
YQL-17646 Fix dqrun/yqlrun difference in bigdate tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -53,7 +53,6 @@ ydb/library/actors/http/ut sole*
 ydb/library/yql/providers/generic/connector/tests sole*
 ydb/library/yql/providers/generic/connector/tests test.py.*
 ydb/library/yql/sql/pg/ut PgSqlParsingAutoparam.AutoParamValues_DifferentTypes
-ydb/library/yql/tests/sql/dq_file/part* *
 ydb/public/sdk/cpp/client/ydb_federated_topic/ut BasicUsage.SimpleHandlers
 ydb/public/sdk/cpp/client/ydb_persqueue_core/ut/with_offset_ranges_mode_ut RetryPolicy.RetryWithBatching
 ydb/public/sdk/cpp/client/ydb_topic/ut BasicUsage.ConflictingWrites

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_pack.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_pack.cpp
@@ -300,6 +300,7 @@ NUdf::TUnboxedValue UnpackFromChunkedBuffer(const TType* type, TChunkedInputBuff
         case NUdf::EDataSlot::Uint16:
             return NUdf::TUnboxedValuePod(UnpackData<Fast, ui16>(buf));
         case NUdf::EDataSlot::Int32:
+        case NUdf::EDataSlot::Date32:
             return NUdf::TUnboxedValuePod(UnpackData<Fast, i32>(buf));
         case NUdf::EDataSlot::Uint32:
             return NUdf::TUnboxedValuePod(UnpackData<Fast, ui32>(buf));
@@ -599,6 +600,7 @@ void PackImpl(const TType* type, TBuf& buffer, const NUdf::TUnboxedValuePod& val
             PackData<Fast>(value.Get<ui16>(), buffer);
             break;
         case NUdf::EDataSlot::Int32:
+        case NUdf::EDataSlot::Date32:
             PackData<Fast>(value.Get<i32>(), buffer);
             break;
         case NUdf::EDataSlot::Uint32:


### PR DESCRIPTION
ydb/library/yql/tests/sql/dq_file/part6 test.py.test[bigdate-input_date32-default.txt-Results] was broken