### PR TITLE
Document proto bytes field decoding with a test

### DIFF
--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -943,10 +943,12 @@ namespace NKikimr::NYaml {
         return result;
     }
 
-    void Parse(const TString& data, NKikimrConfig::TAppConfig& config) {
+    void Parse(const TString& data, NKikimrConfig::TAppConfig& config, bool needsTransforming) {
         auto yamlNode = YAML::Load(data);
         NJson::TJsonValue jsonNode = Yaml2Json(yamlNode, true);
-        TransformConfig(jsonNode);
+        if (needsTransforming) {
+            TransformConfig(jsonNode);
+        }
         NProtobufJson::MergeJson2Proto(jsonNode, config, GetJsonToProtoConfig());
     }
 }

--- a/ydb/library/yaml_config/yaml_config_parser.h
+++ b/ydb/library/yaml_config/yaml_config_parser.h
@@ -19,5 +19,5 @@ namespace NKikimr::NYaml {
 
     void TransformConfig(NJson::TJsonValue& config, bool relaxed = false);
 
-    void Parse(const TString& data, NKikimrConfig::TAppConfig& config);
+    void Parse(const TString& data, NKikimrConfig::TAppConfig& config, bool needsTransforming = true);
 }

--- a/ydb/library/yaml_config/yaml_config_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_ut.cpp
@@ -1,4 +1,5 @@
 #include "yaml_config.h"
+#include "yaml_config_parser.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -1764,5 +1765,25 @@ obj: {value: 2} # comment2
 
             UNIT_ASSERT_VALUES_EQUAL(res, exp);
         }
+    }
+
+    Y_UNIT_TEST(ProtoBytesFieldDoesNotDecodeBase64) {
+    // "c2FtcGxlLXBpbgo=" -> base64 decode -> "sample-pin"
+            TString config = R"(
+pdisk_key_config:
+  keys:
+  - container_path: "/a/b/c"
+    pin: "c2FtcGxlLXBpbgo="
+    id: "sample-encryption-key"
+    version: 1
+)";
+        NKikimrConfig::TAppConfig cfg;
+        NKikimr::NYaml::Parse(config, cfg, false);
+
+        UNIT_ASSERT(cfg.has_pdiskkeyconfig());
+        auto keys = cfg.pdiskkeyconfig().GetKeys();
+        UNIT_ASSERT_VALUES_EQUAL(keys.end() - keys.begin(), 1);
+        auto key = keys.at(0);
+        UNIT_ASSERT_VALUES_EQUAL("c2FtcGxlLXBpbgo=", key.pin());
     }
 }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

When invoking `CopyFrom` method on protobufs in Python, fields with a `bytes` type are automatically and implicitly base64-encoded. I've added a test to document that YDBD binary, when reading the `config.yaml` file, DOES NOT do the decoding automatically. In other words, in the business logic after reading the config, the base64-encoded string is used.  

#### A real-world example to understand the case

This is related to `cfg` utility that is used to generate configs + proto txt files from a "cluster template yaml" file. When `cfg` is called with a template like this: 
```
pdisk_key_config:
  keys:
  - container_path: "..."
    pin: "DqQEiklOLAFz/QmV/Pr4DQ=="
    id: "..."
```

The result in generated `config.yaml` looks like this, notice the DOUBLE base-64 encoding: 

```
pdisk_key_config:
  keys:
  - {container_path: ..., id: ..., pin: RHFRRWlrbE9MQUZ6L1FtVi9QcjREUT09}
```  
