### PR TITLE
Fix Defragmentation::DoesItWork unit test

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -3,7 +3,6 @@ ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestD
 ydb/core/blobstorage/pdisk/ut TSectorMap.*
 ydb/core/blobstorage/ut_blobstorage/ut_read_only_vdisk ReadOnlyVDisk.TestStorageLoad
 ydb/core/blobstorage/ut_blobstorage CostMetricsGetBlock4Plus2.TestGet4Plus2BlockRequests10000Inflight1BlobSize1000
-ydb/core/blobstorage/ut_blobstorage Defragmentation.DoesItWork
 ydb/core/blobstorage/ut_blobstorage SpaceCheckForDiskReassign.*
 ydb/core/blobstorage/ut_blobstorage ScrubFast.SingleBlob
 ydb/core/blobstorage/ut_blobstorage VDiskAssimilation.Test

--- a/ydb/core/blobstorage/ut_blobstorage/defrag.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/defrag.cpp
@@ -24,13 +24,7 @@ static TIntrusivePtr<TBlobStorageGroupInfo> PrepareEnv(TEnvironmentSetup& env, T
 
     for (;;) {
         const TLogoBlobID id(1, 1, index /*step*/, 0, data.size(), 0);
-        const ui32 hash = id.FullID().Hash();
-        if (!info->GetTopology().BelongsToSubgroup(vdiskId, hash)) {
-            continue;
-        }
-        const ui32 idxInSubgroup = info->GetTopology().GetIdxInSubgroup(vdiskId, hash);
-        const ui32 partIdx = idxInSubgroup & 1; // 0 1 0 1 01 01 01 01 possible layouts; this fits them
-        env.PutBlob(vdiskId, TLogoBlobID(id, partIdx + 1), data);
+        env.PutBlob(vdiskId, TLogoBlobID(id, 1), data);
         ++index;
 
         env.Sim();
@@ -67,13 +61,6 @@ static TIntrusivePtr<TBlobStorageGroupInfo> PrepareEnv(TEnvironmentSetup& env, T
 
     // wait for sync
     env.Sim(TDuration::Seconds(3));
-
-    // partition
-    for (const ui32 node : env.Runtime->GetNodes()) {
-        env.StopNode(node);
-    }
-    env.StartNode(actorId.NodeId());
-    env.Sim(TDuration::Seconds(20));
 
     for (;;) {
         // trigger compaction
@@ -115,8 +102,8 @@ static TIntrusivePtr<TBlobStorageGroupInfo> PrepareEnv(TEnvironmentSetup& env, T
 Y_UNIT_TEST_SUITE(Defragmentation) {
     Y_UNIT_TEST(DoesItWork) {
         TEnvironmentSetup env(TEnvironmentSetup::TSettings{
-            .NodeCount = 8,
-            .Erasure = TBlobStorageGroupType::ErasureMirror3of4,
+            .NodeCount = 1,
+            .Erasure = TBlobStorageGroupType::ErasureNone,
         });
 
         TVector<TLogoBlobID> keep;
@@ -150,8 +137,8 @@ Y_UNIT_TEST_SUITE(Defragmentation) {
 
     Y_UNIT_TEST(DefragCompactionRace) {
         TEnvironmentSetup env(TEnvironmentSetup::TSettings{
-            .NodeCount = 8,
-            .Erasure = TBlobStorageGroupType::ErasureMirror3of4,
+            .NodeCount = 1,
+            .Erasure = TBlobStorageGroupType::ErasureNone,
         });
 
         TVector<TLogoBlobID> keep;
@@ -177,13 +164,6 @@ Y_UNIT_TEST_SUITE(Defragmentation) {
 
         while (!caughtPut) {
             env.Sim(TDuration::Minutes(1));
-        }
-
-        // unpartition
-        for (const ui32 node : env.Runtime->GetNodes()) {
-            if (node != actorId.NodeId()) {
-                env.StartNode(node);
-            }
         }
 
         // issue collect garbage command


### PR DESCRIPTION
### Changelog entry

Fix and unmute Defragmentation::DoesItWork unit test

### Changelog category

* Not for changelog

### Additional information

False-positive test failure was fixed. It occured due to incorrect expectation of partitioned VDisk behaviour, which was
reasonably changed in commit 50167f67480c8969d5b6fa49f878b356fab83cce.
