### PR TITLE
Handle bad http headers in requests to YDB

### DIFF
--- a/ydb/library/actors/http/http.cpp
+++ b/ydb/library/actors/http/http.cpp
@@ -119,8 +119,9 @@ void THttpParser<THttpRequest, TSocketBuffer>::Advance(size_t len) {
                         } else {
                             Stage = EParseStage::Done;
                         }
-                    } else {
-                        ProcessHeader(Header);
+                    } else if (!ProcessHeader(Header)) {
+                        Stage = EParseStage::Error;
+                        break;
                     }
                     Headers = TStringBuf(Headers.data(), data.data() - Headers.data());
                 }
@@ -278,8 +279,9 @@ void THttpParser<THttpResponse, TSocketBuffer>::Advance(size_t len) {
                         } else {
                             Stage = EParseStage::Done;
                         }
-                    } else {
-                        ProcessHeader(Header);
+                    } else if (!ProcessHeader(Header)) {
+                        Stage = EParseStage::Error;
+                        break;
                     }
                     Headers = TStringBuf(Headers.data(), data.data() - Headers.data());
                 }

--- a/ydb/library/actors/http/http.h
+++ b/ydb/library/actors/http/http.h
@@ -291,16 +291,20 @@ public:
         return target.size() == size;
     }
 
-    void ProcessHeader(TStringBuf& header) {
-        TStringBuf name = header.NextTok(':');
+    bool ProcessHeader(TStringBuf& header) {
+        TStringBuf name;
+        TStringBuf value;
+        if (!header.TrySplit(':', name, value)) {
+            return false;
+        }
         TrimBegin(name, ' ');
-        TStringBuf value = header;
         Trim(value, ' ');
         auto cit = HeaderType::HeadersLocation.find(name);
         if (cit != HeaderType::HeadersLocation.end()) {
             this->*cit->second = value;
         }
         header.Clear();
+        return true;
     }
 
     size_t ParseHex(TStringBuf value) {


### PR DESCRIPTION
KIKIMR-19943

Modify THttpParser to detect headers without a colon and report an error in this case. Missing colon is detected for both THttpRequest and THttpResponse classes. For some reason, this hasn't been done before.