### PR TITLE
Convert mismatched types of arg/sequence when applying optimization of ShuffleByKeys/PartitionsByKeys to empty sequence

### DIFF
--- a/ydb/library/yql/core/common_opt/yql_co_simple1.cpp
+++ b/ydb/library/yql/core/common_opt/yql_co_simple1.cpp
@@ -6299,13 +6299,8 @@ void RegisterCoSimpleCallables1(TCallableOptimizerMap& map) {
 
             auto& lambdaArg = node->Tail().Head().Head();
 
-            TExprNode::TPtr sequence = node->HeadPtr();
-            auto* sequenceType = sequence->GetTypeAnn();
-            YQL_ENSURE(sequenceType, "No argument type for sequence in " << node->Content());
-
-            if (sequenceType->GetKind() != ETypeAnnotationKind::Stream) {
-                sequence = ctx.NewCallable(sequence->Pos(), "ToStream", { sequence });
-            }
+            TExprNode::TPtr sequence = node->HeadPtr(); // param (list)
+            sequence = ctx.NewCallable(sequence->Pos(), "ToStream", { sequence }); // lambda accepts stream, but we have list type
             sequence = KeepConstraints(sequence, lambdaArg, ctx);
 
             auto lambdaResult = ctx.Builder(node->Pos()).Apply(node->Tail()).With(0, sequence).Seal().Build();

--- a/ydb/library/yql/core/type_ann/type_ann_list.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_list.cpp
@@ -1915,18 +1915,14 @@ namespace {
     }
 
     IGraphTransformer::TStatus ForwardListWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx) {
+        Y_UNUSED(output);
         if (!EnsureArgsCount(*input, 1, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
         }
 
         const TTypeAnnotationNode* itemType = nullptr;
-        if (!EnsureNewSeqType<false, true>(input->Head(), ctx.Expr, &itemType)) {
+        if (!EnsureNewSeqType<false, false>(input->Head(), ctx.Expr, &itemType)) {
             return IGraphTransformer::TStatus::Error;
-        }
-
-        if (input->Head().GetTypeAnn()->GetKind() == ETypeAnnotationKind::List) { // Already a list, remove ForwardList
-            output = input->HeadPtr();
-            return IGraphTransformer::TStatus::Repeat;
         }
 
         input->SetTypeAnn(ctx.Expr.MakeType<TListExprType>(itemType));

--- a/ydb/library/yql/core/type_ann/type_ann_list.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_list.cpp
@@ -1915,14 +1915,18 @@ namespace {
     }
 
     IGraphTransformer::TStatus ForwardListWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx) {
-        Y_UNUSED(output);
         if (!EnsureArgsCount(*input, 1, ctx.Expr)) {
             return IGraphTransformer::TStatus::Error;
         }
 
         const TTypeAnnotationNode* itemType = nullptr;
-        if (!EnsureNewSeqType<false, false>(input->Head(), ctx.Expr, &itemType)) {
+        if (!EnsureNewSeqType<false, true>(input->Head(), ctx.Expr, &itemType)) {
             return IGraphTransformer::TStatus::Error;
+        }
+
+        if (input->Head().GetTypeAnn()->GetKind() == ETypeAnnotationKind::List) { // Already a list, remove ForwardList
+            output = input->HeadPtr();
+            return IGraphTransformer::TStatus::Repeat;
         }
 
         input->SetTypeAnn(ctx.Expr.MakeType<TListExprType>(itemType));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
