### PR TITLE
Use std::atomic in shared data header

### DIFF
--- a/ydb/library/actors/util/shared_data.cpp
+++ b/ydb/library/actors/util/shared_data.cpp
@@ -23,8 +23,7 @@ namespace NActors {
             NActors::NMemory::TLabel<MemoryLabelSharedData>::Add(allocSize);
 
             auto* header = reinterpret_cast<THeader*>(raw + PrivateHeaderSize);
-            header->RefCount = 1;
-            header->Owner = nullptr;
+            new (header) THeader(nullptr);
 
             data = raw + OverheadSize;
             NSan::Poison(data, size);
@@ -41,6 +40,7 @@ namespace NActors {
 
             auto* header = reinterpret_cast<THeader*>(raw + PrivateHeaderSize);
             Y_DEBUG_ABORT_UNLESS(header->Owner == nullptr);
+            header->~THeader();
 
             y_deallocate(raw);
         }

--- a/ydb/library/actors/util/shared_data_backtracing_owner.h
+++ b/ydb/library/actors/util/shared_data_backtracing_owner.h
@@ -30,8 +30,7 @@ public:
         TSelf* btOwner = new TSelf;
         btOwner->BackTrace.Capture();
         btOwner->Info = info;
-        header->RefCount = 1;
-        header->Owner = btOwner;
+        new (header) THeader(btOwner);
         char* data = raw + OverheadSize;
         return data;
     }
@@ -59,6 +58,8 @@ public:
 
     void Deallocate(char* data) noexcept override {
         if (!RealOwner) {
+            THeader* header = reinterpret_cast<THeader*>(data - sizeof(THeader));
+            header->~THeader();
             char* raw = data - OverheadSize;
             y_deallocate(raw);
         } else {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Use std::atomic in shared data header

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

This should fix performance issues where TSharedData is more expensive to copy than std::shared_ptr.
