### PR TITLE
Fix crash during  s3 backup.

### DIFF
--- a/contrib/libs/curl/CMakeLists.darwin-x86_64.txt
+++ b/contrib/libs/curl/CMakeLists.darwin-x86_64.txt
@@ -21,7 +21,6 @@ target_include_directories(contrib-libs-curl PUBLIC
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/include
 )
 target_include_directories(contrib-libs-curl PRIVATE
-  ${CMAKE_SOURCE_DIR}/contrib/libs/c-ares/include
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/lib
 )
 target_link_libraries(contrib-libs-curl PUBLIC

--- a/contrib/libs/curl/CMakeLists.linux-aarch64.txt
+++ b/contrib/libs/curl/CMakeLists.linux-aarch64.txt
@@ -21,7 +21,6 @@ target_include_directories(contrib-libs-curl PUBLIC
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/include
 )
 target_include_directories(contrib-libs-curl PRIVATE
-  ${CMAKE_SOURCE_DIR}/contrib/libs/c-ares/include
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/lib
 )
 target_link_libraries(contrib-libs-curl PUBLIC

--- a/contrib/libs/curl/CMakeLists.linux-x86_64.txt
+++ b/contrib/libs/curl/CMakeLists.linux-x86_64.txt
@@ -21,7 +21,6 @@ target_include_directories(contrib-libs-curl PUBLIC
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/include
 )
 target_include_directories(contrib-libs-curl PRIVATE
-  ${CMAKE_SOURCE_DIR}/contrib/libs/c-ares/include
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/lib
 )
 target_link_libraries(contrib-libs-curl PUBLIC

--- a/contrib/libs/curl/CMakeLists.windows-x86_64.txt
+++ b/contrib/libs/curl/CMakeLists.windows-x86_64.txt
@@ -21,7 +21,6 @@ target_include_directories(contrib-libs-curl PUBLIC
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/include
 )
 target_include_directories(contrib-libs-curl PRIVATE
-  ${CMAKE_SOURCE_DIR}/contrib/libs/c-ares/include
   ${CMAKE_SOURCE_DIR}/contrib/libs/curl/lib
 )
 target_link_libraries(contrib-libs-curl PUBLIC

--- a/contrib/libs/curl/ya.make
+++ b/contrib/libs/curl/ya.make
@@ -21,9 +21,14 @@ PEERDIR(
     contrib/libs/zlib
 )
 
+IF (NOT EXPORT_CMAKE)
+    ADDINCL(
+        contrib/libs/c-ares/include
+    )
+ENDIF()
+
 ADDINCL(
     GLOBAL contrib/libs/curl/include
-    contrib/libs/c-ares/include
     contrib/libs/curl/lib
 )
 


### PR DESCRIPTION
AWS uses libcurl which uses patched version of c-ares header which binary incompatible with c-ares from conan.

### Changelog category 

* Bugfix 
