### PR TITLE
Fix scrubbing and flapping unittest

### DIFF
--- a/ydb/core/blobstorage/backpressure/queue.h
+++ b/ydb/core/blobstorage/backpressure/queue.h
@@ -180,6 +180,10 @@ public:
         return Queues.InFlight.size();
     }
 
+    ui64 GetInFlightCost() const {
+        return InFlightCost;
+    }
+
     void UpdateCostModel(TInstant now, const NKikimrBlobStorage::TVDiskCostSettings& settings,
             const TBlobStorageGroupType& type);
     void InvalidateCosts();

--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
@@ -365,7 +365,11 @@ private:
                         << " msgId# " << msgId << " sequenceId# " << sequenceId
                         << " expectedMsgId# " << expectedMsgId << " expectedSequenceId# " << expectedSequenceId
                         << " status# " << NKikimrProto::EReplyStatus_Name(status)
-                        << " ws# " << NKikimrBlobStorage::TWindowFeedback_EStatus_Name(ws));
+                        << " ws# " << NKikimrBlobStorage::TWindowFeedback_EStatus_Name(ws)
+                        << " InFlightCost# " << Queue.GetInFlightCost()
+                        << " InFlightCount# " << Queue.InFlightCount()
+                        << " ItemsWaiting# " << Queue.GetItemsWaiting()
+                        << " BytesWaiting# " << Queue.GetBytesWaiting());
 
                     switch (ws) {
                         case NKikimrBlobStorage::TWindowFeedback::IncorrectMsgId:

--- a/ydb/core/blobstorage/backpressure/queue_backpressure_server.h
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_server.h
@@ -196,9 +196,7 @@ namespace NKikimr {
                     }
                 }
 
-                TWindowStatus *Processed(bool checkMsgId, const TMessageId &msgId, ui64 cost, TWindowStatus *opStatus) {
-                    Y_UNUSED(checkMsgId);
-                    Y_UNUSED(msgId);
+                TWindowStatus *Processed(bool /*checkMsgId*/, const TMessageId& /*msgId*/, ui64 cost, TWindowStatus *opStatus) {
                     Y_ABORT_UNLESS(Cost >= cost);
                     Cost -= cost;
                     --InFlight;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.cpp
@@ -293,12 +293,13 @@ void TGetImpl::PrepareRequests(TLogContext &logCtx, TDeque<std::unique_ptr<TEvBl
             msg->SetId(ReaderTabletData->Id);
             msg->SetGeneration(ReaderTabletData->Generation);
         }
-        R_LOG_DEBUG_SX(logCtx, "BPG14", "Send get to orderNumber# " << get.OrderNumber
-            << " vget# " << vget->ToString());
     }
 
     for (auto& vget : gets) {
         if (vget) {
+            R_LOG_DEBUG_SX(logCtx, "BPG14", "Send get to orderNumber# "
+                << Info->GetTopology().GetOrderNumber(VDiskIDFromVDiskID(vget->Record.GetVDiskID()))
+                << " vget# " << vget->ToString());
             outVGets.push_back(std::move(vget));
             ++RequestIndex;
         }

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -209,6 +209,11 @@ struct TPDiskMockState::TImpl {
         }
     }
 
+    bool HasCorruptedArea(ui32 chunkIdx, ui32 begin, ui32 end) {
+        const ui64 chunkBegin = ui64(chunkIdx) * ChunkSize;
+        return static_cast<bool>(Corrupted & TIntervalSet{chunkBegin + begin, chunkBegin + end});
+    }
+
     std::set<ui32> GetChunks() {
         std::set<ui32> res;
         for (auto& [ownerId, owner] : Owners) {
@@ -291,6 +296,10 @@ TPDiskMockState::~TPDiskMockState()
 
 void TPDiskMockState::SetCorruptedArea(ui32 chunkIdx, ui32 begin, ui32 end, bool enabled) {
     Impl->SetCorruptedArea(chunkIdx, begin, end, enabled);
+}
+
+bool TPDiskMockState::HasCorruptedArea(ui32 chunkIdx, ui32 begin, ui32 end) {
+    return Impl->HasCorruptedArea(chunkIdx, begin, end);
 }
 
 std::set<ui32> TPDiskMockState::GetChunks() {

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
@@ -27,6 +27,7 @@ namespace NKikimr {
         ~TPDiskMockState();
 
         void SetCorruptedArea(ui32 chunkIdx, ui32 begin, ui32 end, bool enabled);
+        bool HasCorruptedArea(ui32 chunkIdx, ui32 begin, ui32 end);
         std::set<ui32> GetChunks();
         TMaybe<NPDisk::TOwnerRound> GetOwnerRound(const TVDiskID& vDiskId) const;
         ui32 GetChunkSize() const;

--- a/ydb/core/blobstorage/ut_blobstorage/scrub_fast.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/scrub_fast.cpp
@@ -16,60 +16,125 @@ void Test() {
 
     TString data = TString::Uninitialized(8_MB);
     memset(data.Detach(), 'X', data.size());
-    TLogoBlobID id(1, 1, 1, 0, data.size(), 0);
 
-    { // write data to group
-        TActorId sender = runtime->AllocateEdgeActor(1);
-        runtime->WrapInActorContext(sender, [&] {
-            SendToBSProxy(sender, info->GroupID, new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
-        });
-        auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
-    }
+    for (ui32 step = 1; step < 100; ++step) {
+        TLogoBlobID id(1, 1, step, 0, data.size(), 0);
 
-    auto checkReadable = [&](NKikimrProto::EReplyStatus status) {
-        TActorId sender = runtime->AllocateEdgeActor(1);
-        runtime->WrapInActorContext(sender, [&] {
-            SendToBSProxy(sender, info->GroupID, new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(),
-                NKikimrBlobStorage::EGetHandleClass::FastRead));
-        });
-        auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
-        UNIT_ASSERT_VALUES_EQUAL(res->Get()->ResponseSz, 1);
-        auto& r = res->Get()->Responses[0];
-        UNIT_ASSERT_VALUES_EQUAL(r.Status, status);
-        if (status == NKikimrProto::OK) {
+        { // write data to group
+            TActorId sender = runtime->AllocateEdgeActor(1);
+            runtime->WrapInActorContext(sender, [&] {
+                SendToBSProxy(sender, info->GroupID, new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
+            });
+            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+        }
+
+        auto checkReadable = [&] {
+            TActorId sender = runtime->AllocateEdgeActor(1);
+            runtime->WrapInActorContext(sender, [&] {
+                SendToBSProxy(sender, info->GroupID, new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(),
+                    NKikimrBlobStorage::EGetHandleClass::FastRead));
+            });
+            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender);
+            UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
+            UNIT_ASSERT_VALUES_EQUAL(res->Get()->ResponseSz, 1);
+            auto& r = res->Get()->Responses[0];
+            UNIT_ASSERT_VALUES_EQUAL(r.Status, NKikimrProto::OK);
             UNIT_ASSERT_VALUES_EQUAL(r.Buffer.ConvertToString(), data);
-        }
-    };
 
-    checkReadable(NKikimrProto::OK);
-
-    for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
-        const TActorId vdiskActorId = info->GetActorId(i);
-
-        ui32 nodeId, pdiskId;
-        std::tie(nodeId, pdiskId, std::ignore) = DecomposeVDiskServiceId(vdiskActorId);
-        auto it = env.PDiskMockStates.find(std::make_pair(nodeId, pdiskId));
-        Y_ABORT_UNLESS(it != env.PDiskMockStates.end());
-
-        const TActorId sender = runtime->AllocateEdgeActor(vdiskActorId.NodeId());
-        env.Runtime->Send(new IEventHandle(vdiskActorId, sender, new TEvBlobStorage::TEvCaptureVDiskLayout), sender.NodeId());
-        auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvCaptureVDiskLayoutResult>(sender);
-
-        for (auto& item : res->Get()->Layout) {
-            using T = TEvBlobStorage::TEvCaptureVDiskLayoutResult;
-            if (item.Database == T::EDatabase::LogoBlobs && item.RecordType == T::ERecordType::HugeBlob) {
-                const TDiskPart& part = item.Location;
-                it->second->SetCorruptedArea(part.ChunkIdx, part.Offset, part.Offset + part.Size, true);
-                break;
+            ui32 partsMask = 0;
+            for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
+                const TVDiskID& vdiskId = info->GetVDiskId(i);
+                env.WithQueueId(vdiskId, NKikimrBlobStorage::EVDiskQueueId::GetFastRead, [&](TActorId queueId) {
+                    const TActorId sender = runtime->AllocateEdgeActor(1);
+                    auto ev = TEvBlobStorage::TEvVGet::CreateExtremeDataQuery(vdiskId, TInstant::Max(),
+                        NKikimrBlobStorage::EGetHandleClass::FastRead);
+                    ev->AddExtremeQuery(id, 0, 0);
+                    runtime->Send(new IEventHandle(queueId, sender, ev.release()), sender.NodeId());
+                    auto reply = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVGetResult>(sender);
+                    auto& record = reply->Get()->Record;
+                    UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrProto::OK);
+                    UNIT_ASSERT_VALUES_EQUAL(record.ResultSize(), 1);
+                    for (const auto& result : record.GetResult()) {
+                        if (result.GetStatus() == NKikimrProto::OK) {
+                            const TLogoBlobID& id = LogoBlobIDFromLogoBlobID(result.GetBlobID());
+                            UNIT_ASSERT(id.PartId());
+                            const ui32 partIdx = id.PartId() - 1;
+                            const ui32 mask = 1 << partIdx;
+                            UNIT_ASSERT(!(partsMask & mask));
+                            partsMask |= mask;
+                        } else {
+                            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NKikimrProto::NODATA);
+                        }
+                    }
+                });
             }
+            UNIT_ASSERT_VALUES_EQUAL(partsMask, (1 << info->Type.TotalPartCount()) - 1);
+        };
+
+        checkReadable();
+
+        ui32 mask = 0;
+
+        for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
+            const TActorId vdiskActorId = info->GetActorId(i);
+
+            ui32 nodeId, pdiskId;
+            std::tie(nodeId, pdiskId, std::ignore) = DecomposeVDiskServiceId(vdiskActorId);
+            auto it = env.PDiskMockStates.find(std::make_pair(nodeId, pdiskId));
+            Y_ABORT_UNLESS(it != env.PDiskMockStates.end());
+
+            const TActorId sender = runtime->AllocateEdgeActor(vdiskActorId.NodeId());
+            env.Runtime->Send(new IEventHandle(vdiskActorId, sender, new TEvBlobStorage::TEvCaptureVDiskLayout), sender.NodeId());
+            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvCaptureVDiskLayoutResult>(sender);
+
+            for (auto& item : res->Get()->Layout) {
+                using T = TEvBlobStorage::TEvCaptureVDiskLayoutResult;
+                if (item.Database == T::EDatabase::LogoBlobs && item.RecordType == T::ERecordType::HugeBlob && item.BlobId.FullID() == id) {
+                    const TDiskPart& part = item.Location;
+                    mask |= 1 << i;
+                    it->second->SetCorruptedArea(part.ChunkIdx, part.Offset, part.Offset + 1 + RandomNumber(part.Size), true);
+                    break;
+                }
+            }
+
+            checkReadable();
         }
 
-        checkReadable(NKikimrProto::OK);
-    }
+        env.Sim(TDuration::Seconds(60));
 
-    env.Sim(TDuration::Seconds(60));
+        for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
+            if (~mask >> i & 1) {
+                continue;
+            }
+
+            const TActorId vdiskActorId = info->GetActorId(i);
+
+            ui32 nodeId, pdiskId;
+            std::tie(nodeId, pdiskId, std::ignore) = DecomposeVDiskServiceId(vdiskActorId);
+            auto it = env.PDiskMockStates.find(std::make_pair(nodeId, pdiskId));
+            Y_ABORT_UNLESS(it != env.PDiskMockStates.end());
+
+            const TActorId sender = runtime->AllocateEdgeActor(vdiskActorId.NodeId());
+            env.Runtime->Send(new IEventHandle(vdiskActorId, sender, new TEvBlobStorage::TEvCaptureVDiskLayout), sender.NodeId());
+            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvCaptureVDiskLayoutResult>(sender);
+
+            bool anyPartReadable = false;
+
+            for (auto& item : res->Get()->Layout) {
+                using T = TEvBlobStorage::TEvCaptureVDiskLayoutResult;
+                if (item.Database == T::EDatabase::LogoBlobs && item.RecordType == T::ERecordType::HugeBlob && item.BlobId.FullID() == id) {
+                    const TDiskPart& part = item.Location;
+                    anyPartReadable = !it->second->HasCorruptedArea(part.ChunkIdx, part.Offset, part.Offset + part.Size);
+                    if (anyPartReadable) {
+                        break;
+                    }
+                }
+            }
+
+            UNIT_ASSERT(anyPartReadable);
+        }
+    }
 }
 
 Y_UNIT_TEST_SUITE(ScrubFast) {
@@ -77,3 +142,4 @@ Y_UNIT_TEST_SUITE(ScrubFast) {
         Test();
     }
 }
+

--- a/ydb/core/blobstorage/vdisk/scrub/blob_recovery_impl.h
+++ b/ydb/core/blobstorage/vdisk/scrub/blob_recovery_impl.h
@@ -99,15 +99,15 @@ namespace NKikimr {
 
         // a map to fill upon receiving VGet result
         struct TPerBlobInfo {
-            const TInstant Deadline;
             std::weak_ptr<TInFlightContext> Context;
             TEvRecoverBlobResult::TItem *Item; // item to update
             ui32 BlobReplyCounter = 0; // number of unreplied queries for this blob
         };
         std::unordered_multimap<TLogoBlobID, TPerBlobInfo, THash<TLogoBlobID>> VGetResultMap;
+        std::set<std::tuple<TVDiskIdShort, TLogoBlobID>> GetsInFlight;
 
         void AddBlobQuery(const TLogoBlobID& id, NMatrix::TVectorType needed, const std::shared_ptr<TInFlightContext>& context, TEvRecoverBlobResult::TItem *item);
-        void AddExtremeQuery(const TVDiskID& vdiskId, const TLogoBlobID& id, TInstant deadline, ui32 worstReplySize);
+        void AddExtremeQuery(const TVDiskID& vdiskId, const TLogoBlobID& id, TInstant deadline, ui32 idxInSubgroup);
         void SendPendingQueries();
         void Handle(TEvBlobStorage::TEvVGetResult::TPtr ev);
         NKikimrProto::EReplyStatus ProcessItemData(TEvRecoverBlobResult::TItem& item);

--- a/ydb/core/blobstorage/vdisk/scrub/blob_recovery_request.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/blob_recovery_request.cpp
@@ -49,14 +49,9 @@ namespace NKikimr {
         }
         InFlight.erase(InFlight.begin(), it);
 
-        TInstant deadline = TInstant::Max(); // next deadline
-        if (it != InFlight.end()) {
-            deadline = it->first;
-        }
-
         // reschedule timer
-        if (deadline != TInstant::Max()) {
-            Schedule(deadline, new TEvents::TEvWakeup);
+        if (it != InFlight.end()) {
+            Schedule(it->first, new TEvents::TEvWakeup);
         } else {
             WakeupScheduled = false;
         }

--- a/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.cpp
@@ -196,6 +196,8 @@ namespace NKikimr {
         }
 
         void IssueQuery() {
+            STLOG(PRI_DEBUG, BS_VDISK_SCRUB, VDS00, VDISKP(LogPrefix, "IssueQuery"), (SelfId, SelfId()));
+
             std::unique_ptr<TEvRecoverBlob> ev;
             for (size_t i = 0; i < Items.size(); ++i) {
                 const auto& item = Items[i];
@@ -205,6 +207,8 @@ namespace NKikimr {
                         ev->Deadline = Deadline;
                     }
                     ev->Items.emplace_back(item.BlobId, TStackVec<TRope, 8>(item.Parts), item.PartsMask, item.Needed, TDiskPart(), i);
+                    STLOG(PRI_DEBUG, BS_VDISK_SCRUB, VDS17, VDISKP(LogPrefix, "IssueQuery item"), (SelfId, SelfId()),
+                        (BlobId, item.BlobId), (PartsMask, item.PartsMask), (Needed, item.Needed));
                 }
             }
             if (ev) {
@@ -222,6 +226,8 @@ namespace NKikimr {
         }
 
         void Handle(TEvRecoverBlobResult::TPtr ev) {
+            STLOG(PRI_DEBUG, BS_VDISK_SCRUB, VDS24, VDISKP(LogPrefix, "Handle(TEvRecoverBlobResult)"), (SelfId, SelfId()));
+
             for (auto& item : ev->Get()->Items) {
                 auto& myItem = Items[item.Cookie];
                 Y_ABORT_UNLESS(myItem.Status == NKikimrProto::UNKNOWN);
@@ -233,6 +239,8 @@ namespace NKikimr {
                         IssueWrite(myItem, item.Cookie);
                     }
                 }
+                STLOG(PRI_DEBUG, BS_VDISK_SCRUB, VDS43, VDISKP(LogPrefix, "Handle(TEvRecoverBlobResult) item"),
+                    (SelfId, SelfId()), (BlobId, item.BlobId), (Status, item.Status), (PartsMask, item.PartsMask));
             }
             for (const auto& item : Items) {
                 if (item.Status == NKikimrProto::UNKNOWN) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed scrubbing logic and flapping unittest.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

There were some logic issues in blob recovery actor leading to blob read multiplication.
