### PR TITLE
Allow arithmetic operations and operator* for const iterators

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_sort.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_sort.cpp
@@ -100,7 +100,7 @@ public:
 
     TGatherIterator(const TGatherIterator&) = default;
     TGatherIterator& operator=(const TGatherIterator&) = default;
-    TGatherIteratorRef operator*() {
+    TGatherIteratorRef operator*() const& {
         return TGatherIteratorRef(*First, *Second);
     }
 
@@ -142,18 +142,18 @@ public:
         return *this;
     }
 
-    ptrdiff_t operator - (TGatherIterator& rhs) {
+    ptrdiff_t operator - const& (TGatherIterator& rhs) {
         return First - rhs.First;
     }
 
-    TGatherIterator operator + (ptrdiff_t n) {
+    TGatherIterator operator + const& (ptrdiff_t n) {
         TGatherIterator tmp(*this);
         tmp.First += n;
         tmp.Second += n;
         return tmp;
     }
 
-    TGatherIterator operator - (ptrdiff_t n) {
+    TGatherIterator operator - (ptrdiff_t n) const& {
         TGatherIterator tmp(*this);
         tmp.First -= n;
         tmp.Second -= n;
@@ -168,19 +168,19 @@ public:
         return First != rhs.First;
     }
 
-    bool operator<(TGatherIterator& rhs) {
+    bool operator<(TGatherIterator& rhs) const& {
         return First < rhs.First;
     }
 
-    bool operator<=(TGatherIterator& rhs) {
+    bool operator<=(TGatherIterator& rhs) const& {
         return First <= rhs.First;
     }
 
-    bool operator>(TGatherIterator& rhs) {
+    bool operator>(TGatherIterator& rhs) const& {
         return First > rhs.First;
     }
 
-    bool operator>=(TGatherIterator& rhs) {
+    bool operator>=(TGatherIterator& rhs) const& {
         return First >= rhs.First;
     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_sort.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_sort.cpp
@@ -142,11 +142,11 @@ public:
         return *this;
     }
 
-    ptrdiff_t operator - const& (TGatherIterator& rhs) {
+    ptrdiff_t operator - (TGatherIterator& rhs) const& {
         return First - rhs.First;
     }
 
-    TGatherIterator operator + const& (ptrdiff_t n) {
+    TGatherIterator operator + (ptrdiff_t n) const& {
         TGatherIterator tmp(*this);
         tmp.First += n;
         tmp.Second += n;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Avoid
```
$(SOURCE_ROOT)/contrib/libs/cxxsupp/libcxx/include/__algorithm/sort.h:289:52: error: invalid operands to binary expression ('const NKikimr::NMiniKQL::(anonymous namespace)::TGatherIterator' and 'difference_type' (aka 'long'))
  const _RandomAccessIterator __leftmost = __first - difference_type(1); (void)__leftmost; // can be unused when assertions are disabled
  ```

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
