### PR TITLE
BTreeIndex Bugfix partially-loaded tree

### DIFF
--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -112,7 +112,6 @@ public:
                     auto childState = BuildChildState(node, child, prevChild);
                     if (LimitExceeded(firstChild.Items, childState.PrevItems, itemsLimit) || LimitExceeded(firstChild.Bytes, childState.PrevBytes, bytesLimit)) {
                         endRowId = Min(endRowId, childState.BeginRowId);
-                        overshot = false;
                         return;
                     }
                     ready &= tryHandleChild(childState);
@@ -264,7 +263,6 @@ public:
                     auto childState = BuildChildState(node, child, prevChild);
                     if (LimitExceeded(childState.Items, lastChild.PrevItems, itemsLimit) || LimitExceeded(childState.Bytes, lastChild.PrevBytes, bytesLimit)) {
                         beginRowId = Max(beginRowId, childState.EndRowId);
-                        overshot = false;
                         return;
                     }
                     ready &= tryHandleChild(childState);
@@ -797,10 +795,6 @@ private:
             prevChild ? prevChild->RowCount : parent.BeginRowId, child.RowCount,
             prevChild ? prevChild->RowCount : parent.BeginRowId, child.RowCount,
             prevChild ? prevChild->DataSize : parent.PrevBytes, child.DataSize);
-    }
-
-    bool LimitExceeded(ui64 value, ui64 limit) const noexcept {
-        return limit && value > limit;
     }
 
     bool LimitExceeded(ui64 prev, ui64 current, ui64 limit) const noexcept {

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -566,7 +566,12 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
                                     }
                                     if (!groupId.IsMain() && !loaded.contains(pageId)) {
                                         // only check that we loaded consecutive pages
-                                        break;
+                                        if (params.StickSomePages) {
+                                            // extra pages may appear after the bytes limit is applied on main pages
+                                            continue;
+                                        } else {
+                                            break;
+                                        }
                                     }
                                     expected.insert(pageId);
                                     if (size > bytesLimit) {

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -99,7 +99,7 @@ namespace {
         const bool History = false;
         const bool Slices = false;
         const ui32 Rows = 40;
-        const bool StickSomePages = true;
+        const bool StickSomePages = false;
     };
 
     TPartEggs MakePart(TTestParams params) {
@@ -330,7 +330,7 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
     }
 
     void CheckSeekKey(const TPartStore& part, const TKeyCellDefaults *keyDefaults) {
-        for (bool reverse : {false}) {
+        for (bool reverse : {false, true}) {
             for (ESeek seek : {ESeek::Exact, ESeek::Lower, ESeek::Upper}) {
                 for (ui32 firstCell : xrange<ui32>(0, part.Stat.Rows / 7 + 1)) {
                     for (ui32 secondCell : xrange<ui32>(0, 14)) {
@@ -642,8 +642,16 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
         CheckPart({.Levels = 3, .History = true});
     }
 
+    Y_UNIT_TEST(FewNodes_Sticky) {
+        CheckPart({.Levels = 3, .StickSomePages = true});
+    }
+
     Y_UNIT_TEST(FewNodes_Groups_History) {
         CheckPart({.Levels = 3, .Groups = true, .History = true});
+    }
+
+    Y_UNIT_TEST(FewNodes_Groups_History_Sticky) {
+        CheckPart({.Levels = 3, .Groups = true, .History = true, .StickSomePages = true});
     }
 }
 
@@ -849,6 +857,10 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIteration) {
         CheckPart({.Levels = 3, .History = true});
     }
 
+    Y_UNIT_TEST(FewNodes_Sticky) {
+        CheckPart({.Levels = 3, .StickSomePages = true});
+    }
+
     Y_UNIT_TEST(FewNodes_Slices) {
         CheckPart({.Levels = 3, .Slices = true});
     }
@@ -863,6 +875,10 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIteration) {
 
     Y_UNIT_TEST(FewNodes_Groups_History_Slices) {
         CheckPart({.Levels = 3, .Groups = true, .History = true, .Slices = true});
+    }
+
+    Y_UNIT_TEST(FewNodes_Groups_History_Slices_Sticky) {
+        CheckPart({.Levels = 3, .Groups = true, .History = true, .Slices = true, .StickSomePages = true});
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -425,7 +425,7 @@ Y_UNIT_TEST_SUITE(TChargeBTreeIndex) {
     }
 
     void DoChargeRowId(ICharge& charge, TTouchEnv& env, const TRowId row1, const TRowId row2, ui64 itemsLimit, ui64 bytesLimit,
-            bool reverse, const TKeyCellDefaults &keyDefaults, const TString& message, ui32 failsAllowed = 10) {
+            bool reverse, const TKeyCellDefaults &keyDefaults, const TString& message, ui32 failsAllowed = 15) {
         while (true) {
             bool ready = reverse
                 ? charge.DoReverse(row2, row1, keyDefaults, itemsLimit, bytesLimit)

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -18,8 +18,12 @@ namespace {
     struct TTouchEnv : public NTest::TTestEnv {
         const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
         {
+            if (Sticky[groupId].contains(pageId)) {
+                Loaded[groupId].insert(pageId);
+            }
+
             Touched[groupId].insert(pageId);
-            if (Loaded[groupId].contains(pageId) || Sticky[groupId].contains(pageId)) {
+            if (Loaded[groupId].contains(pageId)) {
                 return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             }
             return nullptr;
@@ -47,6 +51,7 @@ namespace {
 
     void AssertLoadedTheSame(const TPartStore& part, const TTouchEnv& bTree, const TTouchEnv& flat, const TString& message, 
             bool allowAdditionalFirstLastPartPages = false, bool allowAdditionalFirstLoadedPage = false, bool allowLastLoadedPageDifference = false) {
+
         TSet<TGroupId> groupIds;
         for (const auto &c : {bTree.Loaded, flat.Loaded}) {
             for (const auto &g : c) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Previous version has a bug, that if we have some (but not all) pages, it passes wrong bounds to groups/history precharge.

For example: 

- 3-leveled tree 
  - level0: node00: rows [0..40)
  - level1: node10: rows [0..20); node11: rows [20..40)
  - level2: node20: rows [0..10); node20: rows [10..20); ...
- in memory we have all the nodes except node11
- precharge **keys** range [5..15]

We will reach and stop on level 1, and have beginRowId = 0. And will call `DoGroupsAndHistory(0, 10)` instead of `DoGroupsAndHistory(5, 10)`.

So instead of stopping as soon as we have unloaded node on current level, we should continue the process and search for exact begin/end bounds.

Also, it was really hard to track limits in previous version because we don't have enough information about nodes sizes and items (and skip unneeded nodes easily).

We may also consider 'Deep First Search' instead of current 'Breadth First Search' and do not store all level node states, but I expect that usually level will consist of two or three nodes.