### PR TITLE
Fix race condition between callback and destructor in TS3ExternalStorage

### DIFF
--- a/ydb/core/wrappers/s3_storage.h
+++ b/ydb/core/wrappers/s3_storage.h
@@ -67,9 +67,7 @@ private:
                 Y_DEFER {
                     std::unique_lock guard(RunningQueriesMutex);
                     --RunningQueriesCount;
-                    bool needNotify = (RunningQueriesCount == 0);
-                    guard.unlock();
-                    if (needNotify) {
+                    if (RunningQueriesCount == 0) {
                         RunningQueriesNotifier.notify_all();
                     }
                 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Access the conditional variable `RunningQueriesNotifier` in the callback under the mutex to prevent a race condition between this access and the TS3ExternalStorage destruction.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
The race is reproducible with `./ya make -ttt ydb/core/tx/schemeshard/ut_export -F=TExportToS3Tests::CorruptedDyNumber --sanitize=thread`