### PR TITLE
Mute Burst Detection tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -2,6 +2,7 @@ ydb/core/blobstorage/dsproxy/ut TBlobStorageProxySequenceTest.TestBlock42PutWith
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
 ydb/core/blobstorage/ut_blobstorage CostMetricsGetBlock4Plus2.TestGet4Plus2BlockRequests10000Inflight1BlobSize1000
 ydb/core/blobstorage/ut_blobstorage CostMetricsPatchMirror3dc.*
+ydb/core/blobstorage/ut_blobstorage BurstDetection.*
 ydb/core/client/ut TClientTest.PromoteFollower
 ydb/core/client/ut TClientTest.ReadFromFollower
 ydb/core/client/ut TFlatTest.AutoSplitMergeQueue


### PR DESCRIPTION
- Moved sampler and throttler tests to jaeger_tracing folder (#1572)
- Update StorageLoad docs, YDBDOCS-583 (#1530)
- Coverity fix in TPutRecordsActorBase (#1580)
- Mute some flaky tests (#1579)
- Improve TSectorMap performance tests (#1526)
- Add stable release 23.3.17 to documentation (#1588)
- init (#1598)
- init (#1594)
- Handle bad http headers in requests to YDB (#1542)
- Consider inflight in full result writer (fix large memory consumption) YQL-17720 (#1590)
- kcat fixes (#1586)
- Fix kafka lock partition delay and balance test (#1600)
- Fix crash during run s3 backup. (#1596)
- Reintroduce light indicator for bursts to BsCostModel, #1336 (#1477)
- YQL-17755 fix drying input up (#1604)
- YQL-17542 split stat (#1553)
- Fix iterator (#1612)
- Made tvm url optional (#1591)
- Use std::atomic in shared data header (#1584)
- Remove obsolete controllers (#1577)
- Add separate lower and upper bounds for time deviation (#1614)
- BuildCompleted (#1613)
- [YQ-2800] Fixed path pruning for large amount of files (#1597)
- Fix GetColumnSerializationStats and ResourceSubscriber task name (#1618)
- YQL-17476 check for cycle during evaluation of file args (#1608)
- [YQL-17625] Fix ORDER BY by column missing in projections (#1617)
- Prepare common library for locks (#1605)
- YQL-9517: Over BlockExpandChunked (#1366)
- YQL-17542 remove transition guards (#1610)
- [yt provider] Remove aux columns in PushDownYtMapOverSortedMerge optimizer (YQL-17715) (#1616)
- additional validation and correct case with empty array (#1627)
- correct libraries for use in future (#1628)
- YQL-15941 llvm14 for LLVM_BC (#1245)
- [YQL-17776] Canonize test (#1638)
- Removed required fields from tracing configs (#1636)
- BTreeIndex Charge History (#1593)
- graceful tiering stop (#1632)
- fix filter apply and serializer usage (#1629)
- snapshot serialization (#1630)
- YQL-17542 get rid of std::any in handling sources state (#1635)
- YQL-17755 ut for TComputeActorAsyncInputHelperTest::PollAsyncInput (#1626)
- YQL-17284: Sort output for several tests (#1624)
- YQ-2734 added retries for internal queries (#1457)
- Fix flaky TestDeleteReadRulesAfterAbortBySystem (#1070)
- Fix scrubbing and flapping unittest (#1640)
- add initialization for pool stats (#1644)
- Fix build and behavior with SSA runtime < 4 (#1634)
- Memory control and search fix (#1649)
- Fix leaking blobs via using patching (#1639)
- Add force io pool threads (#1523)
- Add patching to keyvalue (#1549)
- Add decimal128 type support with big precision (#1607)
- Update github.com/ydb-platform/fq-connector-go to v0.1.3 (#1651)
- YQL-17542 move TaskRunner dependent Execute to TDqSyncComputeActorBase (#1599)
- YQL-17711: Fix backtrace (#1619)
- Removed aborts in service initialization (#1652)
- fix tests (#1653)
- YQ-2549 Move yds integration tests to github  (#1592)
- KIKIMR-20539: pure pg_catalog selects (#950)
- YQL-17284: Add hybtrid run for sql tests (#1602)
- Optimized DPccp (#1563)
- Local table writer tests KIKIMR-20902 (#1656)
- use only thread for async s3 interaction (#1668)
- Generate single JSON with all types of plans in the server (#1606)
- add strip port for ssl outgoing connection (#1665)
- Add CMS request priorities KIKIMR-9024 (#1620)
- remove direct indexes in vectors from debug output (#1648)
- YQL-17057: Fix escaping (#1664)
- init (#1667)
- init (#1660)
- Pg patches (#1587)
- Fix mistype in YQL plugin (#1631)
- KIKIMR-20539: resolve static information_schema tables (#1675)
- YQL-17284: Fixed test due to PR conflict (#1686)
- YQL-17542 move TaskRunner dependent Execute to TDqSyncComputeActorBase (#1666)
- YQ-2803 Exception checking in checkpoint storages (#1540)
- KqpRun add results into clear execution (#1661)
- Some BlobDepot hardening checks (#1692)
- fix tierings db usage (#1691)
- YQL-17790: Fix symbolizer ut (#1696)
- don't parametrize default values for columns (#1679)
- Support returning list in delete statements (#1684)
- Fix TEvPatch interface and remove unnecessary patching-related output in KV tablet (#1693)
- [yt provider] Less restrictions for BypassMerge optimizer (YQL-17618) (#1695)
- Fix autoconfig's compute cpu table (#1669)
- Revert "Support returning list in delete statements (#1684)" (#1705)
- Make UTs reachable KIKIMR-20902 (#1700)
- Fix skip for Tz* types (#1697)
- Implement converter yt join tree -> optimizer join tree YQL-17437 (#1671)
- [YQL-17174] added spilling library for compute actors (#1544)
- parallel for (#1650)
- Support KV patching in TestShard (#1699)
- Support temp tables in yql (#1589)
- Convert mismatched types of arg/sequence when applying optimization of ShuffleByKeys to empty sequence (#1568)
- Adjust cost bucket capacity dynamically (#1681)
- Fix plugins path (#1719)
- YQ-2634: S3 runtime file listing (#925)
- Add cmake check workflow (#1725)
- Forbid new required fields in config (#1710)
- Fix cmake postcommit (#1739)
- Split TPayloadHelper to TPayloadReader & TPayloadWriter (#1702)
- Make UTs reachable (attempt 2) KIKIMR-20902 (#1715)
- Enable DDL in ExecuteScript. Allow not to specify TxControl in QueryService queries (#1603)
- NBS-4415: changed log level for ReasonPill (#1736)
- Implement cbo join tree -> yt join tree converter (#1730)
- Cmake sync script (#1743)
- Pushdown Timestamp ctor. (#1726)
- Create sync_cmakebuild.yml (#1747)
- init (#1711)
- init (#1709)
- Fix race between callback and destructor (#1745)
- [*] конструкторы TPartitionId (#1740)
- [YQL-16903] Change default value for EmitAggApply and dq.EnableDqReplicate if BlockEngine is enabled (#1748)
- Don't make lookups on predicate pushdown stage (#1560)
- Reapply "Support returning list in delete statements (#1684)" (#1705) (#1706)
- Make stopping result/notification sending dependent on operation type KIKIMR-21014 (#1680)
- Mute Burst Detection tests
