### PR TITLE
Added 'FQ_CONNECTOR_ENDPOINT' env variable to `local_ydb`

### DIFF
--- a/ydb/public/tools/lib/cmds/ut/test.py
+++ b/ydb/public/tools/lib/cmds/ut/test.py
@@ -5,7 +5,7 @@ from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericC
 
 
 def test_kikimr_config_generator_generic_connector_config():
-    os.environ["FQ_CONNECTOR_ENDPOINT"] = "localhost:50051"
+    os.environ["FQ_CONNECTOR_ENDPOINT"] = "grpc://localhost:50051"
 
     expected = TGenericConnectorConfig()
     expected.Endpoint.host = "localhost"
@@ -13,5 +13,14 @@ def test_kikimr_config_generator_generic_connector_config():
     expected.UseSsl = False
 
     actual = generic_connector_config()
+    assert actual == expected
 
-    assert (actual == expected)
+    os.environ["FQ_CONNECTOR_ENDPOINT"] = "grpcs://localhost:50051"
+
+    expected = TGenericConnectorConfig()
+    expected.Endpoint.host = "localhost"
+    expected.Endpoint.port = 50051
+    expected.UseSsl = True
+
+    actual = generic_connector_config()
+    assert actual == expected

--- a/ydb/public/tools/lib/cmds/ut/test.py
+++ b/ydb/public/tools/lib/cmds/ut/test.py
@@ -1,0 +1,17 @@
+import os
+
+from ydb.public.tools.lib.cmds import generic_connector_config
+from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
+
+
+def test_kikimr_config_generator_generic_connector_config():
+    os.environ["FQ_CONNECTOR_ENDPOINT"] = "localhost:50051"
+
+    expected = TGenericConnectorConfig()
+    expected.Endpoint.host = "localhost"
+    expected.Endpoint.port = 50051
+    expected.UseSsl = False
+
+    actual = generic_connector_config()
+
+    assert (actual == expected)

--- a/ydb/public/tools/lib/cmds/ut/ya.make
+++ b/ydb/public/tools/lib/cmds/ut/ya.make
@@ -1,0 +1,12 @@
+PY3TEST()
+
+PEERDIR(
+    ydb/public/tools/lib/cmds
+    ydb/library/yql/providers/common/proto
+)
+
+TEST_SRCS(
+    test.py
+)
+
+END()

--- a/ydb/public/tools/lib/cmds/ya.make
+++ b/ydb/public/tools/lib/cmds/ya.make
@@ -9,3 +9,5 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(ut)

--- a/ydb/public/tools/local_ydb/__main__.py
+++ b/ydb/public/tools/local_ydb/__main__.py
@@ -9,7 +9,7 @@ if __name__ == '__main__':
 \033[94m
 To deploy the local YDB cluster:
 
-   {prog} deploy --ydb-working-dir /absolute/path/to/working/directory --ydb-binary-path /path/to/kikimr/driver
+  {prog} deploy --ydb-working-dir /absolute/path/to/working/directory --ydb-binary-path /path/to/kikimr/driver
 
 To cleanup the deployed YDB cluster (this includes removal of working directory, all configuration files, disks and so on):
 

--- a/ydb/public/tools/local_ydb/ya.make
+++ b/ydb/public/tools/local_ydb/ya.make
@@ -3,6 +3,7 @@ PY3_PROGRAM(local_ydb)
 PY_SRCS(__main__.py)
 
 PEERDIR(
+    ydb/library/yql/providers/common/proto
     ydb/public/tools/lib/cmds
 )
 

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -161,6 +161,7 @@ class KikimrConfigGenerator(object):
             enforce_user_token_requirement=False,
             default_user_sid=None,
             pg_compatible_expirement=False,
+            generic_connector_config=None,  # typing.Optional[TGenericConnectorConfig]
     ):
         if extra_feature_flags is None:
             extra_feature_flags = []
@@ -384,6 +385,23 @@ class KikimrConfigGenerator(object):
             self.yaml_config["table_service_config"]["index_auto_choose_mode"] = 'max_used_prefix'
             self.yaml_config["feature_flags"]['enable_temp_tables'] = True
             self.yaml_config["feature_flags"]['enable_table_pg_types'] = True
+
+        if generic_connector_config:
+            if "query_service_config" not in self.yaml_config:
+                self.yaml_config["query_service_config"] = {}
+
+            self.yaml_config["query_service_config"]["generic"] = {
+                "connector": {
+                    "endpoint": {
+                        "host": generic_connector_config.Endpoint.host,
+                        "port": generic_connector_config.Endpoint.port,
+                    },
+                    "use_ssl": generic_connector_config.UseSsl
+                }
+            }
+
+            self.yaml_config["feature_flags"]["enable_external_data_sources"] = True
+            self.yaml_config["feature_flags"]["enable_script_execution_operations"] = True
 
     @property
     def pdisks_info(self):

--- a/ydb/tests/library/ut/kikimr_config.py
+++ b/ydb/tests/library/ut/kikimr_config.py
@@ -12,8 +12,8 @@ def test_kikimr_config_generator_generic_connector_config():
     cfg_gen = KikimrConfigGenerator(generic_connector_config=generic_connector_config)
     yaml_config = cfg_gen.yaml_config
 
-    assert (yaml_config["query_service_config"]["generic"]["connector"]["endpoint"]["host"] == generic_connector_config.Endpoint.host)
-    assert (yaml_config["query_service_config"]["generic"]["connector"]["endpoint"]["port"] == generic_connector_config.Endpoint.port)
-    assert (yaml_config["query_service_config"]["generic"]["connector"]["use_ssl"] == generic_connector_config.UseSsl)
-    assert (yaml_config["feature_flags"]["enable_external_data_sources"] is True)
-    assert (yaml_config["feature_flags"]["enable_script_execution_operations"] is True)
+    assert yaml_config["query_service_config"]["generic"]["connector"]["endpoint"]["host"] == generic_connector_config.Endpoint.host
+    assert yaml_config["query_service_config"]["generic"]["connector"]["endpoint"]["port"] == generic_connector_config.Endpoint.port
+    assert yaml_config["query_service_config"]["generic"]["connector"]["use_ssl"] == generic_connector_config.UseSsl
+    assert yaml_config["feature_flags"]["enable_external_data_sources"] is True
+    assert yaml_config["feature_flags"]["enable_script_execution_operations"] is True

--- a/ydb/tests/library/ut/kikimr_config.py
+++ b/ydb/tests/library/ut/kikimr_config.py
@@ -1,0 +1,19 @@
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+
+from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
+
+
+def test_kikimr_config_generator_generic_connector_config():
+    generic_connector_config = TGenericConnectorConfig()
+    generic_connector_config.Endpoint.host = "localhost"
+    generic_connector_config.Endpoint.port = 50051
+    generic_connector_config.UseSsl = False
+
+    cfg_gen = KikimrConfigGenerator(generic_connector_config=generic_connector_config)
+    yaml_config = cfg_gen.yaml_config
+
+    assert (yaml_config["query_service_config"]["generic"]["connector"]["endpoint"]["host"] == generic_connector_config.Endpoint.host)
+    assert (yaml_config["query_service_config"]["generic"]["connector"]["endpoint"]["port"] == generic_connector_config.Endpoint.port)
+    assert (yaml_config["query_service_config"]["generic"]["connector"]["use_ssl"] == generic_connector_config.UseSsl)
+    assert (yaml_config["feature_flags"]["enable_external_data_sources"] is True)
+    assert (yaml_config["feature_flags"]["enable_script_execution_operations"] is True)

--- a/ydb/tests/library/ut/ya.make
+++ b/ydb/tests/library/ut/ya.make
@@ -1,0 +1,12 @@
+PY3TEST()
+
+PEERDIR(
+    ydb/tests/library
+    ydb/library/yql/providers/common/proto
+)
+
+TEST_SRCS(
+    kikimr_config.py
+)
+
+END()

--- a/ydb/tests/library/ya.make
+++ b/ydb/tests/library/ya.make
@@ -95,6 +95,7 @@ PEERDIR(
     library/python/svn_version
     library/python/testing/yatest_common
     ydb/core/protos
+    ydb/library/yql/providers/common/proto
     ydb/public/api/grpc
     ydb/public/api/grpc/draft
     ydb/public/api/protos
@@ -103,3 +104,5 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(ut)


### PR DESCRIPTION
### Changelog entry 

Added 'FQ_CONNECTOR_ENDPOINT' env variable to `local_ydb`. It configures `query_service_config` section in order to enable YDB's Federated Query features. This option will be used by OSS YDB users for joint YDB + FQ Connector deployments.

### Changelog category

* New feature