### PR TITLE
Fix burst tests, adjust cost bucket inflow dynamically

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,6 +1,5 @@
 ydb/core/blobstorage/dsproxy/ut TBlobStorageProxySequenceTest.TestBlock42PutWithChangingSlowDisk
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
-ydb/core/blobstorage/ut_blobstorage BurstDetection.*
 ydb/core/blobstorage/ut_blobstorage CostMetrics*
 ydb/core/client/ut TClientTest.PromoteFollower
 ydb/core/client/ut TClientTest.ReadFromFollower

--- a/ydb/core/blobstorage/ut_blobstorage/monitoring.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/monitoring.cpp
@@ -251,7 +251,7 @@ Y_UNIT_TEST(Test##requestType##distribution) {                                  
 
 Y_UNIT_TEST_SUITE(BurstDetection) {
     MAKE_BURST_TEST(Put, 10, 1, TDuration::Seconds(1), Evenly);
-    MAKE_BURST_TEST(Put, 10, 100, TDuration::Zero(), Burst);
+    MAKE_BURST_TEST(Put, 10, 100, TDuration::MilliSeconds(1), Burst);
 }
 
 #undef MAKE_BURST_TEST

--- a/ydb/core/blobstorage/ut_blobstorage/monitoring.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/monitoring.cpp
@@ -250,8 +250,8 @@ Y_UNIT_TEST(Test##requestType##distribution) {                                  
 }
 
 Y_UNIT_TEST_SUITE(BurstDetection) {
-    MAKE_BURST_TEST(Put, 50, 1, TDuration::MilliSeconds(100), Evenly);
-    MAKE_BURST_TEST(Put, 50, 100, TDuration::Zero(), Burst);
+    MAKE_BURST_TEST(Put, 10, 1, TDuration::Seconds(1), Evenly);
+    MAKE_BURST_TEST(Put, 10, 100, TDuration::Zero(), Burst);
 }
 
 #undef MAKE_BURST_TEST

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.cpp
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.cpp
@@ -50,7 +50,7 @@ TBsCostTracker::TBsCostTracker(const TBlobStorageGroupType& groupType, NPDisk::E
     , ScrubDiskCost(CostCounters->GetCounter("ScrubDiskCost", true))
     , DefragDiskCost(CostCounters->GetCounter("DefragDiskCost", true))
     , InternalDiskCost(CostCounters->GetCounter("InternalDiskCost", true))
-    , Bucket(&BucketInflow, &BucketCapacity, nullptr, nullptr, nullptr, nullptr, true)
+    , Bucket(&DiskTimeAvailableNs, &BucketCapacity, nullptr, nullptr, nullptr, nullptr, true)
 {
     BurstDetector.Initialize(CostCounters, "BurstDetector");
     switch (GroupType.GetErasure()) {

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
@@ -357,6 +357,7 @@ public:
     }
 
     void CountRequest(ui64 cost) {
+        Cerr << TAppData::TimeProvider->Now() << " " << Bucket.GetAvail() << " " << cost << Endl;
         Bucket.Use(cost);
         BurstDetector.Set(!Bucket.IsAvail(), SeqnoBurstDetector.fetch_add(1));
     }

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
@@ -357,7 +357,6 @@ public:
     }
 
     void CountRequest(ui64 cost) {
-        Cerr << TAppData::TimeProvider->Now() << " " << Bucket.GetAvail() << " " << cost << Endl;
         Bucket.Use(cost);
         BurstDetector.Set(!Bucket.IsAvail(), SeqnoBurstDetector.fetch_add(1));
     }

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
@@ -278,6 +278,18 @@ public:
     }
 };
 
+struct TAppDataTimerMs {
+    using TTime = TInstant;
+    static constexpr ui64 Resolution = 1000ull; // milliseconds
+    static TTime Now() {
+        Y_ABORT_UNLESS(NKikimr::TAppData::TimeProvider);
+        return NKikimr::TAppData::TimeProvider->Now();
+    }
+    static ui64 Duration(TTime from, TTime to) {
+        return (to - from).MilliSeconds();
+    }
+};
+
 using TBsCostModelErasureNone = TBsCostModelBase;
 class TBsCostModelMirror3dc;
 class TBsCostModel4Plus2Block;
@@ -296,8 +308,8 @@ private:
     ::NMonitoring::TDynamicCounters::TCounterPtr InternalDiskCost;
 
     TAtomic BucketCapacity = 1'000'000'000;  // 10^9 nsec
-    TAtomic BucketInflow = 1'000'000'000;  // 10^9 nsec
-    TBucketQuoter<i64, TSpinLock, THPTimerUs> Bucket;
+    TAtomic DiskTimeAvailableNs = 1'000'000'000;
+    TBucketQuoter<i64, TSpinLock, TAppDataTimerMs> Bucket;
     TLight BurstDetector;
     std::atomic<ui64> SeqnoBurstDetector = 0;
     static constexpr ui32 ConcurrentHugeRequestsAllowed = 3;
@@ -345,8 +357,15 @@ public:
     }
 
     void CountRequest(ui64 cost) {
+        Cerr << TAppData::TimeProvider->Now() << " " << Bucket.GetAvail() << " " << cost << Endl;
         Bucket.Use(cost);
         BurstDetector.Set(!Bucket.IsAvail(), SeqnoBurstDetector.fetch_add(1));
+    }
+
+    void SetTimeAvailable(ui32 diskTimeAvailableNSec) {
+        if (diskTimeAvailableNSec != AtomicGet(DiskTimeAvailableNs)) {
+            AtomicSet(DiskTimeAvailableNs, diskTimeAvailableNSec);
+        }
     }
 
 public:

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
@@ -362,9 +362,7 @@ public:
     }
 
     void SetTimeAvailable(ui32 diskTimeAvailableNSec) {
-        if (diskTimeAvailableNSec != AtomicGet(DiskTimeAvailableNs)) {
-            AtomicSet(DiskTimeAvailableNs, diskTimeAvailableNSec);
-        }
+        AtomicSet(DiskTimeAvailableNs, diskTimeAvailableNSec);
     }
 
 public:

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_tracker.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_tracker.cpp
@@ -92,7 +92,9 @@ namespace NKikimr {
             MonGroup.DskTotalBytes() = msg->TotalChunks * PDiskCtx->Dsk->ChunkSize;
             MonGroup.DskFreeBytes() = msg->FreeChunks * PDiskCtx->Dsk->ChunkSize;
             if (msg->NumSlots > 0) {
-                CostGroup.DiskTimeAvailableNs() = 1'000'000'000ull / msg->NumSlots;
+                ui32 timeAvailable = 1'000'000'000 / msg->NumSlots;
+                CostGroup.DiskTimeAvailableNs() = timeAvailable;
+                VCtx->CostTracker->SetTimeAvailable(timeAvailable);
             }
 
             Become(&TThis::WaitFunc);


### PR DESCRIPTION
- Adjust cost bucket inflow
- Fix inflight actor
- Fix burst tests, add TAppData::TimeProvider to CostBucket quoter
