### PR TITLE
config for the service partition

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2661,4 +2661,9 @@ const NKikimrPQ::TPQTabletConfig::TPartition* TPartition::GetPartitionConfig(con
     return NPQ::GetPartitionConfig(config, Partition.OriginalPartitionId);
 }
 
+bool TPartition::IsSupportive() const
+{
+    return Partition.IsSupportivePartition();
+}
+
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -779,6 +779,8 @@ private:
     const NKikimrPQ::TPQTabletConfig::TPartition* GetPartitionConfig(const NKikimrPQ::TPQTabletConfig& config);
 
     bool ClosedInternalPartition = false;
+
+    bool IsSupportive() const;
 };
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -934,10 +934,9 @@ NKikimrPQ::TPQTabletConfig TPersQueue::MakeSupportivePartitionConfig() const
 
     partitionConfig.MutableReadRules()->Clear();
     partitionConfig.MutableReadFromTimestampsMs()->Clear();
-    //partitionConfig.MutableConsumerFormatVersions()->Clear();
-    //partitionConfig.MutableConsumerCodecs()->Clear();
+    partitionConfig.MutableConsumerFormatVersions()->Clear();
+    partitionConfig.MutableConsumerCodecs()->Clear();
     partitionConfig.MutableReadRuleServiceTypes()->Clear();
-    //partitionConfig.MutableCodecs()->Clear();
     partitionConfig.MutableReadRuleVersions()->Clear();
     partitionConfig.MutableReadRuleGenerations()->Clear();
 

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -937,7 +937,7 @@ NKikimrPQ::TPQTabletConfig TPersQueue::MakeSupportivePartitionConfig() const
     //partitionConfig.MutableConsumerFormatVersions()->Clear();
     //partitionConfig.MutableConsumerCodecs()->Clear();
     partitionConfig.MutableReadRuleServiceTypes()->Clear();
-    partitionConfig.MutableCodecs()->Clear();
+    //partitionConfig.MutableCodecs()->Clear();
     partitionConfig.MutableReadRuleVersions()->Clear();
     partitionConfig.MutableReadRuleGenerations()->Clear();
 

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -928,6 +928,22 @@ void TPersQueue::AddSupportivePartition(const TPartitionId& partitionId)
     NewSupportivePartitions.insert(partitionId);
 }
 
+NKikimrPQ::TPQTabletConfig TPersQueue::MakeSupportivePartitionConfig() const
+{
+    NKikimrPQ::TPQTabletConfig partitionConfig = Config;
+
+    partitionConfig.MutableReadRules()->Clear();
+    partitionConfig.MutableReadFromTimestampsMs()->Clear();
+    //partitionConfig.MutableConsumerFormatVersions()->Clear();
+    //partitionConfig.MutableConsumerCodecs()->Clear();
+    partitionConfig.MutableReadRuleServiceTypes()->Clear();
+    partitionConfig.MutableCodecs()->Clear();
+    partitionConfig.MutableReadRuleVersions()->Clear();
+    partitionConfig.MutableReadRuleGenerations()->Clear();
+
+    return partitionConfig;
+}
+
 void TPersQueue::CreateSupportivePartitionActor(const TPartitionId& partitionId,
                                                 const TActorContext& ctx)
 {
@@ -936,7 +952,7 @@ void TPersQueue::CreateSupportivePartitionActor(const TPartitionId& partitionId,
     TPartitionInfo& partition = Partitions.at(partitionId);
     partition.Actor = ctx.Register(CreatePartitionActor(partitionId,
                                                         TopicConverter,
-                                                        Config,
+                                                        MakeSupportivePartitionConfig(),
                                                         true,
                                                         ctx));
 }

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -473,7 +473,7 @@ private:
     void AddSupportivePartition(const TPartitionId& shadowPartitionId);
     void CreateSupportivePartitionActors(const TActorContext& ctx);
     void CreateSupportivePartitionActor(const TPartitionId& shadowPartitionId, const TActorContext& ctx);
-    NKikimrPQ::TPQTabletConfig MakeSupportivePartitionConfig() const;
+    static NKikimrPQ::TPQTabletConfig MakeSupportivePartitionConfig(const NKikimrPQ::TPQTabletConfig& config);
     void SubscribeWriteId(ui64 writeId, const TActorContext& ctx);
 
     bool AllOriginalPartitionsInited() const;

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -473,7 +473,7 @@ private:
     void AddSupportivePartition(const TPartitionId& shadowPartitionId);
     void CreateSupportivePartitionActors(const TActorContext& ctx);
     void CreateSupportivePartitionActor(const TPartitionId& shadowPartitionId, const TActorContext& ctx);
-    static NKikimrPQ::TPQTabletConfig MakeSupportivePartitionConfig(const NKikimrPQ::TPQTabletConfig& config);
+    NKikimrPQ::TPQTabletConfig MakeSupportivePartitionConfig() const;
     void SubscribeWriteId(ui64 writeId, const TActorContext& ctx);
 
     bool AllOriginalPartitionsInited() const;

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -473,6 +473,7 @@ private:
     void AddSupportivePartition(const TPartitionId& shadowPartitionId);
     void CreateSupportivePartitionActors(const TActorContext& ctx);
     void CreateSupportivePartitionActor(const TPartitionId& shadowPartitionId, const TActorContext& ctx);
+    NKikimrPQ::TPQTabletConfig MakeSupportivePartitionConfig() const;
     void SubscribeWriteId(ui64 writeId, const TActorContext& ctx);
 
     bool AllOriginalPartitionsInited() const;


### PR DESCRIPTION
Config for the service partition

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

1. The config for the service partition is created without any settings for reading.
2. Auxiliary method `TPartition::IsSupportive`.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
