### PR TITLE
Do not move protobuf from TValue during BulkUpsert execution.

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_table/impl/table_client.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/table_client.cpp
@@ -923,7 +923,7 @@ TAsyncBulkUpsertResult TTableClient::TImpl::BulkUpsert(const TString& table, TVa
     auto request = MakeOperationRequest<Ydb::Table::BulkUpsertRequest>(settings);
     request.set_table(table);
     *request.mutable_rows()->mutable_type() = TProtoAccessor::GetProto(rows.GetType());
-    *request.mutable_rows()->mutable_value() = std::move(rows.GetProto());
+    *request.mutable_rows()->mutable_value() = rows.GetProto();
 
     auto promise = NewPromise<TBulkUpsertResult>();
 


### PR DESCRIPTION
TValue just wrapper over shared_ptr<TImpl> and has no deep copy ctor, it causes common mistake with retry case.

### Changelog category 
* Bugfix 

