### PR TITLE
Enable DDL in ExecuteScript. Allow not to specify TxControl in QueryService queries (#1603)

### DIFF
--- a/ydb/core/grpc_services/query/rpc_execute_script.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_script.cpp
@@ -59,10 +59,6 @@ std::tuple<Ydb::StatusIds::StatusCode, NYql::TIssues> FillKqpRequest(
     kqpRequest.MutableRequest()->SetType(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT);
     kqpRequest.MutableRequest()->SetKeepSession(false);
 
-    // TODO: Avoid explicit tx_control for script queries.
-    kqpRequest.MutableRequest()->MutableTxControl()->mutable_begin_tx()->mutable_serializable_read_write();
-    kqpRequest.MutableRequest()->MutableTxControl()->set_commit_tx(true);
-
     kqpRequest.MutableRequest()->SetCancelAfterMs(GetDuration(req.operation_params().cancel_after()).MilliSeconds());
     kqpRequest.MutableRequest()->SetTimeoutMs(GetDuration(req.operation_params().operation_timeout()).MilliSeconds());
 

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -362,6 +362,8 @@ public:
         return RequestEv->HasTxControl();
     }
 
+    bool HasImpliedTx() const; // (only for QueryService API) user has not specified TxControl in the request. In this case we behave like Begin/Commit was specified.
+
     const ::Ydb::Table::TransactionControl& GetTxControl() const {
         return RequestEv->GetTxControl();
     }

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -636,9 +636,21 @@ public:
         Counters->ReportBeginTransaction(Settings.DbCounters, Transactions.EvictedTx, Transactions.Size(), Transactions.ToBeAbortedSize());
     }
 
+    static const Ydb::Table::TransactionControl& GetImpliedTxControl() {
+        auto create = []() -> Ydb::Table::TransactionControl {
+            Ydb::Table::TransactionControl control;
+            control.mutable_begin_tx()->mutable_serializable_read_write();
+            control.set_commit_tx(true);
+            return control;
+        };
+        static const Ydb::Table::TransactionControl control = create();
+        return control;
+    }
+
     bool PrepareQueryTransaction() {
-        if (QueryState->HasTxControl()) {
-            const auto& txControl = QueryState->GetTxControl();
+        const bool hasTxControl = QueryState->HasTxControl();
+        if (hasTxControl || QueryState->HasImpliedTx()) {
+            const auto& txControl = hasTxControl ? QueryState->GetTxControl() : GetImpliedTxControl();
 
             QueryState->Commit = txControl.commit_tx();
             switch (txControl.tx_selector_case()) {
@@ -941,7 +953,7 @@ public:
                 case NKqpProto::TKqpPhyTx::TYPE_SCHEME:
                     YQL_ENSURE(tx->StagesSize() == 0);
 
-                    if (QueryState->TxCtx->EffectiveIsolationLevel != NKikimrKqp::ISOLATION_LEVEL_UNDEFINED) {
+                    if (QueryState->HasTxControl() && QueryState->TxCtx->EffectiveIsolationLevel != NKikimrKqp::ISOLATION_LEVEL_UNDEFINED) {
                         ReplyQueryError(Ydb::StatusIds::PRECONDITION_FAILED,
                             "Scheme operations cannot be executed inside transaction");
                         return true;

--- a/ydb/core/kqp/ut/service/kqp_qs_scripts_ut.cpp
+++ b/ydb/core/kqp/ut/service/kqp_qs_scripts_ut.cpp
@@ -203,7 +203,7 @@ Y_UNIT_TEST_SUITE(KqpQueryServiceScripts) {
     }
 
 
-    void ExecuteScriptWithStatsMode (Ydb::Query::StatsMode statsMode) {
+    void ExecuteScriptWithStatsMode(Ydb::Query::StatsMode statsMode) {
         auto kikimr = DefaultKikimrRunner();
         auto db = kikimr.GetQueryClient();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* Enable DDL in ExecuteScript
* Allow not to specify TxControl in QueryService queries

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
