### PR TITLE
Use six's 'urllib.parse' in 'PY23_LIBRARY' modules

### DIFF
--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -8,7 +8,7 @@ import random
 import string
 import typing  # noqa: F401
 import sys
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
 from ydb.tests.library.common import yatest_common


### PR DESCRIPTION
### Changelog entry

* Fixed Python 2 broken import tests in Arcadia (dependent on `kikimr`)

### Changelog category <!-- remove all except one -->

* Bugfix 