### PR TITLE
Fixed missing PEERDIR in ydb/public/tools/lib/cmds

### DIFF
--- a/ydb/public/tools/lib/cmds/ya.make
+++ b/ydb/public/tools/lib/cmds/ya.make
@@ -4,8 +4,9 @@ PY_SRCS(
 )
 
 PEERDIR(
-    ydb/tests/library
+    contrib/python/six
     library/python/testing/recipe
+    ydb/tests/library
 )
 
 END()


### PR DESCRIPTION
### Changelog entry 

* Fixed missing PEERDIR in ydb/public/tools/lib/cmds

### Changelog category 

* Not for changelog

