### PR TITLE
Disable volatile transactions KIKIMR-21060

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -97,7 +97,7 @@ message TFeatureFlags {
     optional bool EnableAlterDatabaseCreateHiveFirst = 82 [default = false];
     reserved 83; // EnableKqpDataQuerySourceRead
     optional bool EnableSmallDiskOptimization = 84 [default = true];
-    optional bool EnableDataShardVolatileTransactions = 85 [default = true];
+    optional bool EnableDataShardVolatileTransactions = 85 [default = false];
     optional bool EnableTopicServiceTx = 86 [default = false];
     optional bool EnableLLVMCache = 87 [default = false];
     optional bool EnableExternalDataSources = 88 [default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Disabling volatile transactions as not yet ready for production.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

A critical issue was observed during internal testing. Disabling volatile transactions until problem is investigated and fixed.