### PR TITLE
Reintroduce test_helpers for ut_blobstorage

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,8 +1,7 @@
 ydb/core/blobstorage/dsproxy/ut TBlobStorageProxySequenceTest.TestBlock42PutWithChangingSlowDisk
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
-ydb/core/blobstorage/ut_blobstorage CostMetricsGetBlock4Plus2.TestGet4Plus2BlockRequests10000Inflight1BlobSize1000
-ydb/core/blobstorage/ut_blobstorage CostMetricsPatchMirror3dc.*
 ydb/core/blobstorage/ut_blobstorage BurstDetection.*
+ydb/core/blobstorage/ut_blobstorage CostMetrics*
 ydb/core/client/ut TClientTest.PromoteFollower
 ydb/core/client/ut TClientTest.ReadFromFollower
 ydb/core/client/ut TFlatTest.AutoSplitMergeQueue

--- a/ydb/core/blobstorage/ut_blobstorage/monitoring.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/monitoring.cpp
@@ -1,5 +1,6 @@
 #include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
+#include "ut_helpers.h"
 
 constexpr bool VERBOSE = false;
 
@@ -10,72 +11,6 @@ TString MakeData(ui32 dataSize) {
     }
     return data;
 }
-
-template <typename TDerived>
-class TInflightActor : public TActorBootstrapped<TDerived> {
-public:
-    struct TSettings {
-        ui32 Requests;
-        ui32 MaxInFlight;
-        TDuration Delay = TDuration::Zero();
-    };
-
-public:
-    TInflightActor(TSettings settings)
-        : RequestsToSend(settings.Requests)
-        , RequestInFlight(settings.MaxInFlight)
-        , Settings(settings)
-    {}
-
-    virtual ~TInflightActor() = default;
-
-    void SetGroupId(ui32 groupId) {
-        GroupId = groupId;
-    }
-    void Bootstrap(const TActorContext &ctx) {
-        BootstrapImpl(ctx);
-    }
-
-protected:
-    void ScheduleRequests() {
-        while (RequestInFlight > 0 && RequestsToSend > 0) {
-            TMonotonic now = TMonotonic::Now();
-            TDuration timePassed = now - LastTs;
-            if (timePassed >= Settings.Delay) {
-                LastTs = now;
-                RequestInFlight--;
-                RequestsToSend--;
-                SendRequest();
-            } else {
-                TActorBootstrapped<TDerived>::Schedule(Settings.Delay - timePassed, new TEvents::TEvWakeup);
-            }
-        }
-    }
-
-    void HandleReply(NKikimrProto::EReplyStatus status) {
-        if (status == NKikimrProto::OK) {
-            OKs++;
-        } else {
-            Fails++;
-        }
-        ++RequestInFlight;
-        ScheduleRequests();
-    }
-
-    virtual void BootstrapImpl(const TActorContext &ctx) = 0;
-    virtual void SendRequest() = 0;
-
-protected:
-    ui32 RequestsToSend;
-    ui32 RequestInFlight;
-    ui32 GroupId;
-    TMonotonic LastTs;
-    TSettings Settings;
-
-public:
-    ui32 OKs = 0;
-    ui32 Fails = 0;
-};
 
 ui64 AggregateVDiskCounters(std::unique_ptr<TEnvironmentSetup>& env, const NKikimrBlobStorage::TBaseConfig& baseConfig,
         TString storagePool, ui32 groupSize, ui32 groupId, const std::vector<ui32>& pdiskLayout, TString subsystem,
@@ -168,8 +103,8 @@ void TestDSProxyAndVDiskEqualCost(const TBlobStorageGroupInfo::TTopology& topolo
     TStringStream str;
     double proportion = 1. * dsproxyCost / vdiskCost;
     i64 diff = (i64)dsproxyCost - vdiskCost;
-    str << "OKs# " << actor->OKs << ", Fails# " << actor->Fails << ", Cost on dsproxy# "
-            << dsproxyCost << ", Cost on vdisks# " << vdiskCost << ", proportion# " << proportion
+    str << "OKs# " << actor->ResponsesByStatus[NKikimrProto::OK] << ", Errors# " << actor->ResponsesByStatus[NKikimrProto::ERROR]
+            << ", Cost on dsproxy# " << dsproxyCost << ", Cost on vdisks# " << vdiskCost << ", proportion# " << proportion
             << " diff# " << diff;
 
     if constexpr(VERBOSE) {
@@ -178,43 +113,6 @@ void TestDSProxyAndVDiskEqualCost(const TBlobStorageGroupInfo::TTopology& topolo
     }
     UNIT_ASSERT_VALUES_EQUAL_C(dsproxyCost, vdiskCost, str.Str());
 }
-
-class TInflightActorPut : public TInflightActor<TInflightActorPut> {
-public:
-    TInflightActorPut(TSettings settings, ui32 dataSize = 1024)
-        : TInflightActor(settings)
-        , DataSize(dataSize)
-    {}
-
-    STRICT_STFUNC(StateWork,
-        cFunc(TEvBlobStorage::TEvStatusResult::EventType, ScheduleRequests);
-        cFunc(TEvents::TEvWakeup::EventType, ScheduleRequests);
-        hFunc(TEvBlobStorage::TEvPutResult, Handle);
-    )
-
-    virtual void BootstrapImpl(const TActorContext&/* ctx*/) override {
-        // dummy request to establish the session
-        auto ev = new TEvBlobStorage::TEvStatus(TInstant::Max());
-        SendToBSProxy(SelfId(), GroupId, ev, 0);
-        Become(&TInflightActorPut::StateWork);
-    }
-
-protected:
-    virtual void SendRequest() override {
-        TString data = MakeData(DataSize);
-        auto ev = new TEvBlobStorage::TEvPut(TLogoBlobID(1, 1, 1, 10, DataSize, RequestsToSend + 1),
-                data, TInstant::Max(), NKikimrBlobStorage::UserData);
-        SendToBSProxy(SelfId(), GroupId, ev, 0);
-    }
-
-    void Handle(TEvBlobStorage::TEvPutResult::TPtr res) {
-        HandleReply(res->Get()->Status);
-    }
-
-private:
-    std::string Data;
-    ui32 DataSize;
-};
 
 #define MAKE_TEST(erasure, requestType, requests, inflight)                         \
 Y_UNIT_TEST(Test##requestType##erasure##Requests##requests##Inflight##inflight) {   \
@@ -235,99 +133,6 @@ Y_UNIT_TEST(Test##requestType##erasure##Requests##requests##Inflight##inflight##
     auto actor = new TInflightActor##requestType({requests, inflight}, dataSize);                       \
     TestDSProxyAndVDiskEqualCost(topology, actor);                                                      \
 }
-
-class TInflightActorGet : public TInflightActor<TInflightActorGet> {
-public:
-    TInflightActorGet(TSettings settings, ui32 dataSize = 1024)
-        : TInflightActor(settings)
-        , DataSize(dataSize)
-    {}
-
-    STRICT_STFUNC(StateWork,
-        cFunc(TEvBlobStorage::TEvPutResult::EventType, ScheduleRequests);
-        cFunc(TEvents::TEvWakeup::EventType, ScheduleRequests);
-        hFunc(TEvBlobStorage::TEvGetResult, Handle);
-    )
-
-    virtual void BootstrapImpl(const TActorContext&/* ctx*/) override {
-        TString data = MakeData(DataSize);
-        BlobId = TLogoBlobID(1, 1, 1, 10, DataSize, 1);
-        auto ev = new TEvBlobStorage::TEvPut(BlobId, data, TInstant::Max());
-        SendToBSProxy(SelfId(), GroupId, ev, 0);
-        Become(&TInflightActorGet::StateWork);
-    }
-
-protected:
-    virtual void SendRequest() override {
-        auto ev = new TEvBlobStorage::TEvGet(BlobId, 0, 10, TInstant::Max(), NKikimrBlobStorage::EGetHandleClass::FastRead);
-        SendToBSProxy(SelfId(), GroupId, ev, 0);
-    }
-
-    void Handle(TEvBlobStorage::TEvGetResult::TPtr res) {
-        HandleReply(res->Get()->Status);
-    }
-
-private:
-    TLogoBlobID BlobId;
-    std::string Data;
-    ui32 DataSize;
-};
-
-class TInflightActorPatch : public TInflightActor<TInflightActorPatch> {
-public:
-    TInflightActorPatch(TSettings settings, ui32 dataSize = 1024)
-        : TInflightActor(settings)
-        , DataSize(dataSize)
-    {}
-
-    STRICT_STFUNC(StateWork,
-        hFunc(TEvBlobStorage::TEvPatchResult, Handle);
-        hFunc(TEvBlobStorage::TEvPutResult, Handle);
-    )
-
-    virtual void BootstrapImpl(const TActorContext&/* ctx*/) override {
-        TString data = MakeData(DataSize);
-        for (ui32 i = 0; i < RequestInFlight; ++i) {
-            TLogoBlobID blobId(1, 1, 1, 10, DataSize, 1 + i);
-            auto ev = new TEvBlobStorage::TEvPut(blobId, data, TInstant::Max());
-            SendToBSProxy(SelfId(), GroupId, ev, 0);
-        }
-        Become(&TInflightActorPatch::StateWork);
-    }
-
-protected:
-    virtual void SendRequest() override {
-        TLogoBlobID oldId = Blobs.front();
-        Blobs.pop_front();
-        TLogoBlobID newId(1, 1, oldId.Step() + 1, 10, DataSize, oldId.Cookie());
-        Y_ABORT_UNLESS(TEvBlobStorage::TEvPatch::GetBlobIdWithSamePlacement(oldId, &newId, BlobIdMask, GroupId, GroupId));
-        TArrayHolder<TEvBlobStorage::TEvPatch::TDiff> diffs(new TEvBlobStorage::TEvPatch::TDiff[1]);
-        char c = 'a' + RequestsToSend % 26;
-        diffs[0].Set(TString(DataSize, c), 0);
-        auto ev = new TEvBlobStorage::TEvPatch(GroupId, oldId, newId, BlobIdMask, std::move(diffs), 1, TInstant::Max());
-        SendToBSProxy(SelfId(), GroupId, ev, 0);
-    }
-
-
-    void Handle(TEvBlobStorage::TEvPatchResult::TPtr res) {
-        Blobs.push_back(res->Get()->Id);
-        HandleReply(res->Get()->Status);
-    }
-
-    void Handle(TEvBlobStorage::TEvPutResult::TPtr res) {
-        Blobs.push_back(res->Get()->Id);
-        if (++BlobsWritten == RequestInFlight) {
-            ScheduleRequests();
-        }
-    }
-
-protected:
-    std::deque<TLogoBlobID> Blobs;
-    ui32 BlobIdMask = TLogoBlobID::MaxCookie & 0xfffff000;
-    ui32 BlobsWritten = 0;
-    std::string Data;
-    ui32 DataSize;
-};
 
 Y_UNIT_TEST_SUITE(CostMetricsPutMirror3dc) {
     MAKE_TEST_W_DATASIZE(Mirror3dc, Put, 1, 1, 1000);

--- a/ydb/core/blobstorage/ut_blobstorage/ut_helpers.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_helpers.cpp
@@ -1,0 +1,15 @@
+#include "ut_helpers.h"
+
+namespace NKikimr {
+
+TString MakeData(ui32 dataSize) {
+    TString data(dataSize, '\0');
+    for (ui32 i = 0; i < dataSize; ++i) {
+        data[i] = 'A' + (i % 26);
+    }
+    return data;
+}
+
+ui64 TInflightActor::Cookie = 1;
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
@@ -46,7 +46,6 @@ protected:
                 RequestInFlight--;
                 RequestsToSend--;
                 RequestsSent++;
-                Y_ABORT_UNLESS(RequestsSent < 200);
                 SendRequest();
             } else if (!WakeupScheduled) {
                 Schedule(Settings.Delay - timePassed, new TEvents::TEvWakeup);

--- a/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <ydb/core/util/hp_timer_helpers.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+
+namespace NKikimr {
+
+TString MakeData(ui32 dataSize);
+
+class TInflightActor : public TActorBootstrapped<TInflightActor> {
+public:
+    struct TSettings {
+        ui32 Requests;
+        ui32 MaxInFlight;
+        TDuration Delay = TDuration::Zero();
+        ui32 GroupId = 0;
+        ui32 GroupGeneration = 1;
+    };
+
+public:
+    TInflightActor(TSettings settings)
+        : RequestsToSend(settings.Requests)
+        , RequestInFlight(settings.MaxInFlight)
+        , GroupId(settings.GroupId)
+        , Settings(settings)
+    {}
+
+    virtual ~TInflightActor() = default;
+
+    void SetGroupId(ui32 groupId) {
+        GroupId = groupId;
+    }
+
+    void Bootstrap(const TActorContext &ctx) {
+        LastTs = TAppData::TimeProvider->Now();
+        BootstrapImpl(ctx);
+    }
+
+protected:
+    void ScheduleRequests() {
+        while (RequestInFlight > 0 && RequestsToSend > 0) {
+            TInstant now = TAppData::TimeProvider->Now();
+            TDuration timePassed = now - LastTs;
+            if (timePassed >= Settings.Delay) {
+                LastTs = now;
+                RequestInFlight--;
+                RequestsToSend--;
+                RequestsSent++;
+                Y_ABORT_UNLESS(RequestsSent < 200);
+                SendRequest();
+            } else if (!WakeupScheduled) {
+                Schedule(Settings.Delay - timePassed, new TEvents::TEvWakeup);
+                WakeupScheduled = true;
+                break;
+            }
+        }
+    }
+
+    void WakeupAndSchedule() {
+        WakeupScheduled = false;
+        ScheduleRequests();
+    }
+
+    void HandleReply(NKikimrProto::EReplyStatus status) {
+        ResponsesByStatus[status]++;
+        ++RequestInFlight;
+        ScheduleRequests();
+    }
+
+    virtual void BootstrapImpl(const TActorContext &ctx) = 0;
+    virtual void SendRequest() = 0;
+
+protected:
+    ui32 RequestsToSend;
+    ui32 RequestInFlight;
+    ui32 GroupId;
+    TInstant LastTs;
+    TSettings Settings;
+    bool WakeupScheduled = false;
+
+public:
+    std::unordered_map<NKikimrProto::EReplyStatus, ui32> ResponsesByStatus;
+    ui32 RequestsSent = 0;
+
+protected:
+    static ui64 Cookie;
+};
+
+/////////////////////////////////// TInflightActorPut ///////////////////////////////////
+
+class TInflightActorPut : public TInflightActor {
+public:
+    TInflightActorPut(TSettings settings, ui32 dataSize = 1024)
+        : TInflightActor(settings)
+        , DataSize(dataSize)
+    {}
+
+    STRICT_STFUNC(StateWork,
+        cFunc(TEvBlobStorage::TEvStatusResult::EventType, ScheduleRequests);
+        cFunc(TEvents::TEvWakeup::EventType, WakeupAndSchedule);
+        hFunc(TEvBlobStorage::TEvPutResult, Handle);
+    )
+
+    virtual void BootstrapImpl(const TActorContext&/* ctx*/) override {
+        // dummy request to establish the session
+        auto ev = new TEvBlobStorage::TEvStatus(TInstant::Max());
+        SendToBSProxy(SelfId(), GroupId, ev, 0);
+        Become(&TInflightActorPut::StateWork);
+    }
+
+protected:
+    virtual void SendRequest() override {
+        TString data = MakeData(DataSize);
+        auto ev = new TEvBlobStorage::TEvPut(TLogoBlobID(1, 1, 1, 10, DataSize, Cookie++),
+                data, TInstant::Max(), NKikimrBlobStorage::UserData);
+        SendToBSProxy(SelfId(), GroupId, ev, 0);
+    }
+
+    void Handle(TEvBlobStorage::TEvPutResult::TPtr res) {
+        HandleReply(res->Get()->Status);
+    }
+
+private:
+    std::string Data;
+    ui32 DataSize;
+};
+
+/////////////////////////////////// TInflightActorGet ///////////////////////////////////
+
+class TInflightActorGet : public TInflightActor {
+public:
+    TInflightActorGet(TSettings settings, ui32 dataSize = 1024)
+        : TInflightActor(settings)
+        , DataSize(dataSize)
+    {}
+
+    STRICT_STFUNC(StateWork,
+        cFunc(TEvBlobStorage::TEvPutResult::EventType, ScheduleRequests);
+        cFunc(TEvents::TEvWakeup::EventType, WakeupAndSchedule);
+        hFunc(TEvBlobStorage::TEvGetResult, Handle);
+    )
+
+    virtual void BootstrapImpl(const TActorContext&/* ctx*/) override {
+        TString data = MakeData(DataSize);
+        BlobId = TLogoBlobID(1, 1, 1, 10, DataSize, Cookie++);
+        auto ev = new TEvBlobStorage::TEvPut(BlobId, data, TInstant::Max());
+        SendToBSProxy(SelfId(), GroupId, ev, 0);
+        Become(&TInflightActorGet::StateWork);
+    }
+
+protected:
+    virtual void SendRequest() override {
+        auto ev = new TEvBlobStorage::TEvGet(BlobId, 0, 10, TInstant::Max(), NKikimrBlobStorage::EGetHandleClass::FastRead);
+        SendToBSProxy(SelfId(), GroupId, ev, 0);
+    }
+
+    void Handle(TEvBlobStorage::TEvGetResult::TPtr res) {
+        HandleReply(res->Get()->Status);
+    }
+
+private:
+    TLogoBlobID BlobId;
+    std::string Data;
+    ui32 DataSize;
+};
+
+/////////////////////////////////// TInflightActorPatch ///////////////////////////////////
+
+class TInflightActorPatch : public TInflightActor {
+public:
+    TInflightActorPatch(TSettings settings, ui32 dataSize = 1024)
+        : TInflightActor(settings)
+        , DataSize(dataSize)
+    {}
+
+    STRICT_STFUNC(StateWork,
+        cFunc(TEvents::TEvWakeup::EventType, WakeupAndSchedule);
+        hFunc(TEvBlobStorage::TEvPatchResult, Handle);
+        hFunc(TEvBlobStorage::TEvPutResult, Handle);
+    )
+
+    virtual void BootstrapImpl(const TActorContext&/* ctx*/) override {
+        TString data = MakeData(DataSize);
+        for (ui32 i = 0; i < RequestInFlight; ++i) {
+            TLogoBlobID blobId(1, 1, 1, 10, DataSize, Cookie++);
+            auto ev = new TEvBlobStorage::TEvPut(blobId, data, TInstant::Max());
+            SendToBSProxy(SelfId(), GroupId, ev, 0);
+        }
+        Become(&TInflightActorPatch::StateWork);
+    }
+
+protected:
+    virtual void SendRequest() override {
+        TLogoBlobID oldId = Blobs.front();
+        Blobs.pop_front();
+        TLogoBlobID newId(1, 1, oldId.Step() + 1, 10, DataSize, oldId.Cookie());
+        Y_ABORT_UNLESS(TEvBlobStorage::TEvPatch::GetBlobIdWithSamePlacement(oldId, &newId, BlobIdMask, GroupId, GroupId));
+        TArrayHolder<TEvBlobStorage::TEvPatch::TDiff> diffs(new TEvBlobStorage::TEvPatch::TDiff[1]);
+        char c = 'a' + RequestsToSend % 26;
+        diffs[0].Set(TString(DataSize, c), 0);
+        auto ev = new TEvBlobStorage::TEvPatch(GroupId, oldId, newId, BlobIdMask, std::move(diffs), 1, TInstant::Max());
+        SendToBSProxy(SelfId(), GroupId, ev, 0);
+    }
+
+
+    void Handle(TEvBlobStorage::TEvPatchResult::TPtr res) {
+        Blobs.push_back(res->Get()->Id);
+        HandleReply(res->Get()->Status);
+    }
+
+    void Handle(TEvBlobStorage::TEvPutResult::TPtr res) {
+        Blobs.push_back(res->Get()->Id);
+        if (++BlobsWritten == RequestInFlight) {
+            ScheduleRequests();
+        }
+    }
+
+protected:
+    std::deque<TLogoBlobID> Blobs;
+    ui32 BlobIdMask = TLogoBlobID::MaxCookie & 0xfffff000;
+    ui32 BlobsWritten = 0;
+    std::string Data;
+    ui32 DataSize;
+};
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
@@ -47,11 +47,12 @@ protected:
                 RequestsToSend--;
                 RequestsSent++;
                 SendRequest();
+                continue;
             } else if (!WakeupScheduled) {
                 Schedule(Settings.Delay - timePassed, new TEvents::TEvWakeup);
                 WakeupScheduled = true;
-                break;
             }
+            break;
         }
     }
 

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -37,6 +37,7 @@ SRCS(
     snapshots.cpp
     space_check.cpp
     sync.cpp
+    ut_helpers.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
- Moved sampler and throttler tests to jaeger_tracing folder (#1572)
- Update StorageLoad docs, YDBDOCS-583 (#1530)
- Coverity fix in TPutRecordsActorBase (#1580)
- Mute some flaky tests (#1579)
- Improve TSectorMap performance tests (#1526)
- Add stable release 23.3.17 to documentation (#1588)
- init (#1598)
- init (#1594)
- Handle bad http headers in requests to YDB (#1542)
- Consider inflight in full result writer (fix large memory consumption) YQL-17720 (#1590)
- kcat fixes (#1586)
- Fix kafka lock partition delay and balance test (#1600)
- Fix crash during run s3 backup. (#1596)
- Reintroduce light indicator for bursts to BsCostModel, #1336 (#1477)
- YQL-17755 fix drying input up (#1604)
- YQL-17542 split stat (#1553)
- Fix iterator (#1612)
- Made tvm url optional (#1591)
- Use std::atomic in shared data header (#1584)
- Remove obsolete controllers (#1577)
- Add separate lower and upper bounds for time deviation (#1614)
- BuildCompleted (#1613)
- [YQ-2800] Fixed path pruning for large amount of files (#1597)
- Fix GetColumnSerializationStats and ResourceSubscriber task name (#1618)
- YQL-17476 check for cycle during evaluation of file args (#1608)
- [YQL-17625] Fix ORDER BY by column missing in projections (#1617)
- Prepare common library for locks (#1605)
- YQL-9517: Over BlockExpandChunked (#1366)
- YQL-17542 remove transition guards (#1610)
- [yt provider] Remove aux columns in PushDownYtMapOverSortedMerge optimizer (YQL-17715) (#1616)
- additional validation and correct case with empty array (#1627)
- correct libraries for use in future (#1628)
- YQL-15941 llvm14 for LLVM_BC (#1245)
- [YQL-17776] Canonize test (#1638)
- Removed required fields from tracing configs (#1636)
- BTreeIndex Charge History (#1593)
- graceful tiering stop (#1632)
- fix filter apply and serializer usage (#1629)
- snapshot serialization (#1630)
- YQL-17542 get rid of std::any in handling sources state (#1635)
- YQL-17755 ut for TComputeActorAsyncInputHelperTest::PollAsyncInput (#1626)
- YQL-17284: Sort output for several tests (#1624)
- YQ-2734 added retries for internal queries (#1457)
- Fix flaky TestDeleteReadRulesAfterAbortBySystem (#1070)
- Fix scrubbing and flapping unittest (#1640)
- add initialization for pool stats (#1644)
- Fix build and behavior with SSA runtime < 4 (#1634)
- Memory control and search fix (#1649)
- Fix leaking blobs via using patching (#1639)
- Add force io pool threads (#1523)
- Add patching to keyvalue (#1549)
- Add decimal128 type support with big precision (#1607)
- Update github.com/ydb-platform/fq-connector-go to v0.1.3 (#1651)
- YQL-17542 move TaskRunner dependent Execute to TDqSyncComputeActorBase (#1599)
- YQL-17711: Fix backtrace (#1619)
- Removed aborts in service initialization (#1652)
- fix tests (#1653)
- YQ-2549 Move yds integration tests to github  (#1592)
- KIKIMR-20539: pure pg_catalog selects (#950)
- YQL-17284: Add hybtrid run for sql tests (#1602)
- Optimized DPccp (#1563)
- Local table writer tests KIKIMR-20902 (#1656)
- use only thread for async s3 interaction (#1668)
- Generate single JSON with all types of plans in the server (#1606)
- add strip port for ssl outgoing connection (#1665)
- Add CMS request priorities KIKIMR-9024 (#1620)
- remove direct indexes in vectors from debug output (#1648)
- YQL-17057: Fix escaping (#1664)
- init (#1667)
- init (#1660)
- Pg patches (#1587)
- Fix mistype in YQL plugin (#1631)
- KIKIMR-20539: resolve static information_schema tables (#1675)
- YQL-17284: Fixed test due to PR conflict (#1686)
- YQL-17542 move TaskRunner dependent Execute to TDqSyncComputeActorBase (#1666)
- YQ-2803 Exception checking in checkpoint storages (#1540)
- KqpRun add results into clear execution (#1661)
- Some BlobDepot hardening checks (#1692)
- fix tierings db usage (#1691)
- YQL-17790: Fix symbolizer ut (#1696)
- don't parametrize default values for columns (#1679)
- Support returning list in delete statements (#1684)
- Fix TEvPatch interface and remove unnecessary patching-related output in KV tablet (#1693)
- [yt provider] Less restrictions for BypassMerge optimizer (YQL-17618) (#1695)
- Fix autoconfig's compute cpu table (#1669)
- Revert "Support returning list in delete statements (#1684)" (#1705)
- Make UTs reachable KIKIMR-20902 (#1700)
- Fix skip for Tz* types (#1697)
- Implement converter yt join tree -> optimizer join tree YQL-17437 (#1671)
- [YQL-17174] added spilling library for compute actors (#1544)
- parallel for (#1650)
- Support KV patching in TestShard (#1699)
- Support temp tables in yql (#1589)
- Convert mismatched types of arg/sequence when applying optimization of ShuffleByKeys to empty sequence (#1568)
- Adjust cost bucket capacity dynamically (#1681)
- Fix plugins path (#1719)
- YQ-2634: S3 runtime file listing (#925)
- Add cmake check workflow (#1725)
- Forbid new required fields in config (#1710)
- Fix cmake postcommit (#1739)
- Split TPayloadHelper to TPayloadReader & TPayloadWriter (#1702)
- Make UTs reachable (attempt 2) KIKIMR-20902 (#1715)
- Enable DDL in ExecuteScript. Allow not to specify TxControl in QueryService queries (#1603)
- NBS-4415: changed log level for ReasonPill (#1736)
- Implement cbo join tree -> yt join tree converter (#1730)
- Cmake sync script (#1743)
- Pushdown Timestamp ctor. (#1726)
- Create sync_cmakebuild.yml (#1747)
- init (#1711)
- init (#1709)
- Fix race between callback and destructor (#1745)
- [*] конструкторы TPartitionId (#1740)
- [YQL-16903] Change default value for EmitAggApply and dq.EnableDqReplicate if BlockEngine is enabled (#1748)
- Don't make lookups on predicate pushdown stage (#1560)
- Reapply "Support returning list in delete statements (#1684)" (#1705) (#1706)
- Make stopping result/notification sending dependent on operation type KIKIMR-21014 (#1680)
- Mute Burst Detection tests (#1763)
- BTreeIndex Bugfix partially-loaded tree (#1674)
- Fix pq writer and few renames (#1757)
- LOGBROKER-8783 bugfix (#1713)
- Moved optimizers from providers/dq to dq (#1758)
- Return back dq_arrow_helpers (#1762)
- LOGBROKER-8792 remove redundant checks (#1417)
- Fix win build (#1760)
- Add option to disable SSL for IAM endpoint (make possible to mock IAM endpoint in tests) (#780)
- add testcases for PgConvertNumericDecimal128Big (#1751)
- Move Inflight actors to ut_helpers (#1759)
- [yt provider] Raise error on invalid poller_interval value (#1771)
- CMake regeneration workflow (#1774)
- support cast in default values (#1754)
- Allow arithmetic operations and operator* for const iterators (#1663)
- Update sync_cmakebuild.yml (#1776)
- Fix fail with pydebug in tf (old)
- Add target and extra_targets, remove unused Targets_, recanonize tests
- Intermediate changes
- External build system generator release 76
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Intermediate changes
- sprintf -> snprintf as it is deprecated on macOS..
- Fix sprintf deprecation warnings on newer macOS SDK
- Fix deprecated pod type in llvm / libcxxabi
- Intermediate changes
- Remove targets, use target/extra_targets
- Automatic release build for ya_bin3, os_ya, ya_bin, test_tool, os_test_tool_3, test_tool3
- 
- Mark methods as const
- Intermediate changes
- cc contrib/grpc: unify one of the patches with how upstream fixed the issue
- Intermediate changes
- 
- Artifacts from bucket and some refactoring
- YDB Import 559
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Intermediate changes
- Remove empty glibtop headers resolving
- Fix reimport for contrib/libs/cxxsupp/libcxxrt
- Move android sysincls to where they belong
- Get rid of empty cuda/include resolving
- check lifetime bounds of  values returned from String's c_str(), data() methods
- 
- Move macOS-specific sysincls to where they belong
- Remove empty resolving for X11/ includes
- Remove empty resolving for Eigen/Array
- Intermediate changes
- TMaybe Monadic operations
- Intermediate changes
- Update contrib/libs/libidn to 1.42
- Add glfw 3.3.9 to contrib
- Bump CUDA -> 11.4 and cuDNN -> 8.0.5
- Intermediate changes
- Update vendor/go.opentelemetry.io/otel to 1.22.0
- Update contrib/libs/libunwind to 18.1.0-rc1
- Intermediate changes
- Update boost/asio and boost/process to 1.70.0
- Fix: add input file as MAIN_DEPENDENCY in Cython call..
- Update contrib/python/MarkupSafe/py3 to 2.1.4
- Intermediate changes
- Fix bug after rXXXXXX
- Disable non-existing macOS include
- yamaker: Disable tr1/ and ext/ includes by default
- Update contrib/libs/re2 to 2024-02-01
- Move macOS-specific sysincls to where they belong
- Disable ext/ and tr1/ headers resolving
- Remove empty resolving of tr1/ and ext/ includes
- Intermediate changes
- Support nonstandard 'ar' versions
- Intermediate changes
- Update contrib/restricted/boost/asio to 1.71.0
- Disable empty doc/ includes resolving
- Remove windows-specific headers resolving from unsorted.yml
- Disable empty resolving of zzip-[1-5].h headers
- Disable empty resolving of libgit2-specific includes
- Remove empty math_constants.h resolving from unsorted.yml
- Clarify wrl headers resolution
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Remove unused -ish.h headers resolving
- Move windows-specific sysincls to windows.yml
- Intermediate changes
- Remove various unused sysincls from unsorted.yml
- 
- Automatic release build for ymake, os_ymake
- Intermediate changes
- Remove unused MX_FORMULAS() macro support
- Update contrib/libs/nghttp2 to 1.59.0
- Intermediate changes
- 
- PR from branch users/prettyboy/release-ya-bin-after-fix-mapping
- Intermediate changes
- TThread::SetName sets thread name on android
- Intermediate changes
- Update yfm-docs for ya make to Build time: 9.706ms
- Intermediate changes
- Upload new jdk-21.0.2+13 + tzdata 2024a
- Update contrib/libs/lzma to 5.4.6
- Intermediate changes
- fix prometheus_decoder ConsumeCounter
- Disable QNX-specific includes in contrib/libs/lzma
- Intermediate changes
- Remove empty resolving of QNX-specific headers
- Intermediate changes
- Upload new jdk-17.0.10+7 + tzdata 2024a
- Update yfm-docs for ya make to Build time: 9.883ms
- Disable non-existing include in contrib/libs/openldap
- Update tzinfo 2024a
- Intermediate changes
- Update yfm-docs for ya make to Build time: 10.003ms
- Intermediate changes
- llvm16 targets
- Update libcxxrt to 2024-02-04 39f76d286ffa70e15ae45632fe3fa5ea96cd46e4
- contrib/restricted/boost: Remove empty resolving of auld stl headers
- Intermediate changes
- Update Python 3 to 3.11.8
- Intermediate changes
- Update contrib/python/types-protobuf to 4.24.0.20240129
- Intermediate changes
- Disable non-existing include in contrib/libs/lzma
- Intermediate changes
- Always return string for cuda architectures
- Remove all remaining checks of auto CUDA support for PPC64 / MacOS
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Intermediate changes
- Disable empty resolving of contrib/libs/curl related headers
- Disable auld stl headers #include
- 
- feat(conf): move nots from internal
- Make #include <random> work in nvcc -std=c++17 mode
- Intermediate changes
- 
- Intermediate changes
- Update contrib/libs/cxxsupp/libcxxrt to 2024-02-06
- Intermediate changes
- Update `ya tool python 3` to 3.11.8
- Intermediate changes
- Add USE_LOCAL_PYTHON setting
- [devtools/ya/test] Removed unused PyTestScriptSuite
- Intermediate changes
- Backport https://github.com/ydb-platform/ydb/pull/1688/files
- Intermediate changes
- 
- Intermediate changes
- fix namespace for DOCS_SRCS
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- Rework joinpath for importlib.resources
- Fix threading for gevent in Python 3.11.8
- baseline per project для дефолтного ktlint
- Add nvml.h sysincl
- nots: Оптимизация в расчете integrity
- Intermediate changes
- Try to allow PEERDIR between resource libraries
- Update rightlib sha
- Added 'FQ_CONNECTOR_ENDPOINT' env variable to `local_ydb` (#1769)
- Add proto plugin for config processing (#1750)
- Change numeric.c according to postgres 14 (#1753)
- [YQL-17637] Revive merging PERCENTILE/MEDIAN aggregation traits for same column (#1775)
- hive ui fixes after tablet availability feature (#1779)
- Break deps from core/grpc_services to core/fq/libs/actors (#1781)
- Mark mutable_id for YT writes (#1744)
- store history of changes made to hive via http (#1637)
- Return skiff from dq (#1765)
- improve base stats propagation logic (#1741)
- Cannonized two plans (#1773)
- KIKIMR-20580: enable stream lookup (#1676)
- YQL-17502 Bigdate from/to string conversions (#1447)
- fix segfault (#1799)
- Revert "Move Inflight actors to ut_helpers" (#1802)
- docs: fix presentation url (#1816)
- Use six's 'urllib.parse' in 'PY23_LIBRARY' modules (#1833)
- Do not move protobuf from TValue during BulkUpsert execution. (#1809)
- Manage releases docs (#1351)
- runtime dispatching (fixed) (#1847)
- ci: fix Embedded UI refresh workflow (#1780)
- Сhange keys format for service partitions (#1569)
- Support of database sys cache (#1817)
- Expose a factory for new native cbo YQL-17437 (#1855)
- YQL-17250: Add stats for hybrid skip checks (#1670)
- Fixed missing PEERDIR in ydb/public/tools/lib/cmds (#1856)
- Test supported types KIKIMR-20902 (#1865)
- Do not call TypeName for trace in tablet transactions if no trace exists (#1867)
- [Configs Refactor] Split protobufs (#1863)
- Add unit tests for EvaluateExpr in VIEWs (#1488)
- LOGBROKER-8894 enable minSeqNo save in partition (iter3) (#1768)
- quick fix for column name of select version() (#1801)
- YDBDOCS-596: extra clarifications to upgrade.md (#1874)
- Remove duplicated defines (#1788)
- Create a submenu for changelog to enable includes into the overlay docs (#1880)
- bring simple queue tool to oss (#1879)
- YQ-2417 show ast in case of compilation error (#1353)
- [Configs Refactor] Deprecate old yaml_config_parser (#1876)
- Forbid query execution on explicit session without attach (#1870)
- Unmute some flaky tests (#1889)
- Logging & tagging KIKIMR-21006 (#1881)
- Fix git workflow documentation (#1685)
- Improve some headers (#1877)
- Move Inflight actors to ut_helpers
- Mute patch tests
- Remove unused assert
