### PR TITLE
ci: fix ya-transform when no logs in the trace

### DIFF
--- a/.github/scripts/tests/transform-ya-junit.py
+++ b/.github/scripts/tests/transform-ya-junit.py
@@ -83,7 +83,7 @@ class YTestReportTrace:
     def get_logs(self, cls, name):
         trace = self.traces.get((cls, name))
 
-        if not trace:
+        if not trace or 'logs' not in trace:
             return {}
 
         logs = trace["logs"]


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Fix postprocessing error on traces without logs