### PR TITLE
[YQL-17789] Do node type / column order checks for already annotated new nodes

### DIFF
--- a/ydb/library/yql/core/type_ann/type_ann_expr.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_expr.cpp
@@ -525,31 +525,7 @@ private:
     }
 
     void CheckExpected(const TExprNode& input, TExprContext& ctx) {
-        Y_UNUSED(ctx);
-        auto it = Types.ExpectedTypes.find(input.UniqueId());
-        if (it != Types.ExpectedTypes.end()) {
-            YQL_ENSURE(IsSameAnnotation(*input.GetTypeAnn(), *it->second),
-                "Rewrite error, type should be : " <<
-                *it->second << ", but it is: " << *input.GetTypeAnn() << " for node " << input.Content());
-        }
-
-        auto coIt = Types.ExpectedColumnOrders.find(input.UniqueId());
-        if (coIt != Types.ExpectedColumnOrders.end()) {
-            TColumnOrder oldColumnOrder = coIt->second;
-            TMaybe<TColumnOrder> newColumnOrder = Types.LookupColumnOrder(input);
-            if (!newColumnOrder) {
-                // keep column order after rewrite
-                // TODO: check if needed
-                auto status = Types.SetColumnOrder(input, oldColumnOrder, ctx);
-                YQL_ENSURE(status == IGraphTransformer::TStatus::Ok);
-            } else {
-                YQL_ENSURE(newColumnOrder == oldColumnOrder,
-                    "Rewrite error, column order should be: "
-                    << FormatColumnOrder(oldColumnOrder) << ", but it is: "
-                    << FormatColumnOrder(newColumnOrder) << " for node "
-                    << input.Content());
-            }
-        }
+        CheckExpectedTypeAndColumnOrder(input, ctx, Types);
     }
 
 private:

--- a/ydb/library/yql/core/yql_expr_type_annotation.cpp
+++ b/ydb/library/yql/core/yql_expr_type_annotation.cpp
@@ -6677,4 +6677,31 @@ TStringBuf NormalizeCallableName(TStringBuf name) {
     return name;
 }
 
+void CheckExpectedTypeAndColumnOrder(const TExprNode& node, TExprContext& ctx, TTypeAnnotationContext& typesCtx) {
+    auto it = typesCtx.ExpectedTypes.find(node.UniqueId());
+    if (it != typesCtx.ExpectedTypes.end()) {
+        YQL_ENSURE(IsSameAnnotation(*node.GetTypeAnn(), *it->second),
+            "Rewrite error, type should be : " <<
+            *it->second << ", but it is: " << *node.GetTypeAnn() << " for node " << node.Content());
+    }
+
+    auto coIt = typesCtx.ExpectedColumnOrders.find(node.UniqueId());
+    if (coIt != typesCtx.ExpectedColumnOrders.end()) {
+        TColumnOrder oldColumnOrder = coIt->second;
+        TMaybe<TColumnOrder> newColumnOrder = typesCtx.LookupColumnOrder(node);
+        if (!newColumnOrder) {
+            // keep column order after rewrite
+            // TODO: check if needed
+            auto status = typesCtx.SetColumnOrder(node, oldColumnOrder, ctx);
+            YQL_ENSURE(status == IGraphTransformer::TStatus::Ok);
+        } else {
+            YQL_ENSURE(newColumnOrder == oldColumnOrder,
+                "Rewrite error, column order should be: "
+                << FormatColumnOrder(oldColumnOrder) << ", but it is: "
+                << FormatColumnOrder(newColumnOrder) << " for node "
+                << node.Content());
+        }
+    }
+}
+
 } // NYql

--- a/ydb/library/yql/core/yql_expr_type_annotation.h
+++ b/ydb/library/yql/core/yql_expr_type_annotation.h
@@ -349,4 +349,7 @@ TExprNode::TPtr ConvertToMultiLambda(const TExprNode::TPtr& lambda, TExprContext
 const TStringBuf BlockLengthColumnName = "_yql_block_length";
 
 TStringBuf NormalizeCallableName(TStringBuf name);
+
+void CheckExpectedTypeAndColumnOrder(const TExprNode& node, TExprContext& ctx, TTypeAnnotationContext& typesCtx);
+
 }


### PR DESCRIPTION
- [YQL-17789] Do node type / column order checks for already annotated new nodes
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Improvement
* Not for changelog (changelog entry is not required)

### Additional information

...
