### PR TITLE
Fix VDisk internal tracing issues related to patching

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -1524,7 +1524,7 @@ namespace NKikimr {
         , TEventWithRelevanceTracker
     {
         mutable NLWTrace::TOrbit Orbit;
-        TVDiskSkeletonTrace *VDiskSkeletonTrace = nullptr;
+        std::shared_ptr<TVDiskSkeletonTrace> VDiskSkeletonTrace;
 
         TEvVSpecialPatchBase() = default;
 
@@ -1918,7 +1918,7 @@ namespace NKikimr {
         , TEventWithRelevanceTracker
     {
         mutable NLWTrace::TOrbit Orbit;
-        TVDiskSkeletonTrace *VDiskSkeletonTrace = nullptr;
+        std::shared_ptr<TVDiskSkeletonTrace> VDiskSkeletonTrace;
 
         TEvVPatchStart() = default;
 
@@ -2004,7 +2004,7 @@ namespace NKikimr {
         , TEventWithRelevanceTracker
     {
         mutable NLWTrace::TOrbit Orbit;
-        TVDiskSkeletonTrace *VDiskSkeletonTrace = nullptr;
+        std::shared_ptr<TVDiskSkeletonTrace> VDiskSkeletonTrace;
 
         TEvVPatchDiff() = default;
 
@@ -2079,7 +2079,7 @@ namespace NKikimr {
         , TEventWithRelevanceTracker
     {
         mutable NLWTrace::TOrbit Orbit;
-        TVDiskSkeletonTrace *VDiskSkeletonTrace = nullptr;
+        std::shared_ptr<TVDiskSkeletonTrace> VDiskSkeletonTrace;
 
         TEvVPatchXorDiff() = default;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix VDisk internal tracing issues related to patching

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fixed usage of plain pointers involved in internal VDisk tracing being invalidated too early.
