### PR TITLE
BTreeIndex Stats iterator interface

### DIFF
--- a/ydb/core/tablet_flat/flat_part_btree_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_btree_index_iter.h
@@ -264,7 +264,7 @@ public:
         return State.back().EndRowId;
     }
 
-    TPos HasKeyCells() const override {
+    TPos GetKeyCellsCount() const override {
         Y_ABORT_UNLESS(IsLeaf());
         return State.back().BeginKey.Count();
     }

--- a/ydb/core/tablet_flat/flat_part_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter.h
@@ -4,12 +4,13 @@
 #include "flat_page_index.h"
 #include "flat_part_index_iter_iface.h"
 #include "flat_table_part.h"
+#include "flat_stat_part_group_iter_iface.h"
 #include <ydb/library/yverify_stream/yverify_stream.h>
 
 
 namespace NKikimr::NTable {
 
-class TPartIndexIt : public IIndexIter {
+class TPartIndexIt : public IIndexIter, public IStatsPartGroupIterator {
 public:
     using TCells = NPage::TCells;
     using TRecord = NPage::TIndex::TRecord;
@@ -26,6 +27,10 @@ public:
         , EndRowId(groupId.IsMain() && part->Stat.Rows ? part->Stat.Rows : Max<TRowId>())
     { }
     
+    EReady Start() override {
+        return Seek(0);
+    }
+
     EReady Seek(TRowId rowId) override {
         auto index = TryGetIndex();
         if (!index) {
@@ -123,10 +128,10 @@ public:
             : EndRowId;
     }
 
-    bool HasKeyCells() const override {
+    TPos HasKeyCells() const override {
         Y_ABORT_UNLESS(Index);
         Y_ABORT_UNLESS(Iter);
-        return true;
+        return GroupInfo.KeyTypes.size();
     }
 
     TCell GetKeyCell(TPos index) const override {

--- a/ydb/core/tablet_flat/flat_part_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter.h
@@ -128,7 +128,7 @@ public:
             : EndRowId;
     }
 
-    TPos HasKeyCells() const override {
+    TPos GetKeyCellsCount() const override {
         Y_ABORT_UNLESS(Index);
         Y_ABORT_UNLESS(Iter);
         return GroupInfo.KeyTypes.size();

--- a/ydb/core/tablet_flat/flat_part_index_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_iface.h
@@ -22,7 +22,7 @@ namespace NKikimr::NTable {
         virtual TRowId GetRowId() const = 0;
         virtual TRowId GetNextRowId() const = 0;
 
-        virtual bool HasKeyCells() const = 0;
+        virtual TPos HasKeyCells() const = 0;
         virtual TCell GetKeyCell(TPos index) const = 0;
 
         virtual ~IIndexIter() = default;

--- a/ydb/core/tablet_flat/flat_part_index_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_iface.h
@@ -22,7 +22,7 @@ namespace NKikimr::NTable {
         virtual TRowId GetRowId() const = 0;
         virtual TRowId GetNextRowId() const = 0;
 
-        virtual TPos HasKeyCells() const = 0;
+        virtual TPos GetKeyCellsCount() const = 0;
         virtual TCell GetKeyCell(TPos index) const = 0;
 
         virtual ~IIndexIter() = default;

--- a/ydb/core/tablet_flat/flat_part_iter_multi.h
+++ b/ydb/core/tablet_flat/flat_part_iter_multi.h
@@ -544,8 +544,8 @@ namespace NTable {
                                 return Exhausted();
                             };
                             case EReady::Data: {
-                                Y_DEBUG_ABORT_UNLESS(Index.HasKeyCells(), "Non-first page is expected to have key cells");
-                                if (Index.HasKeyCells()) {
+                                Y_DEBUG_ABORT_UNLESS(Index.GetKeyCellsCount(), "Non-first page is expected to have key cells");
+                                if (Index.GetKeyCellsCount()) {
                                     if (!checkIndex()) {
                                         // First row for the next RowId
                                         MaxVersion = TRowVersion::Max();
@@ -632,8 +632,8 @@ namespace NTable {
             }
 
             // We need exact match on rowId, bail on larger values
-            Y_DEBUG_ABORT_UNLESS(Index.GetRowId() == 0 || Index.HasKeyCells(), "Non-first page is expected to have key cells");
-            if (Index.HasKeyCells()) {
+            Y_DEBUG_ABORT_UNLESS(Index.GetRowId() == 0 || Index.GetKeyCellsCount(), "Non-first page is expected to have key cells");
+            if (Index.GetKeyCellsCount()) {
                 TRowId indexRowId = Index.GetKeyCell(0).AsValue<TRowId>();
                 if (rowId < indexRowId) {
                     // We cannot compute MaxVersion anyway as indexRowId row may be presented on the previous page
@@ -675,8 +675,8 @@ namespace NTable {
                 return Terminate(ready);
             }
 
-            Y_DEBUG_ABORT_UNLESS(Index.HasKeyCells(), "Non-first page is expected to have key cells");
-            if (Y_LIKELY(Index.HasKeyCells())) {
+            Y_DEBUG_ABORT_UNLESS(Index.GetKeyCellsCount(), "Non-first page is expected to have key cells");
+            if (Y_LIKELY(Index.GetKeyCellsCount())) {
                 if (!checkIndex()) {
                     // First row for the nextRowId
                     MaxVersion = TRowVersion::Max();
@@ -706,7 +706,7 @@ namespace NTable {
             Data = Page->Begin();
             Y_ABORT_UNLESS(Data);
 
-            if (Index.HasKeyCells()) {
+            if (Index.GetKeyCellsCount()) {
                 // Must have rowId as we have checked index
                 Y_ABORT_UNLESS(checkData() && RowVersion <= rowVersion, "Index and Data are out of sync");
 

--- a/ydb/core/tablet_flat/flat_stat_part.h
+++ b/ydb/core/tablet_flat/flat_stat_part.h
@@ -113,9 +113,8 @@ public:
         }
 
         if (HistoricGroups) {
-            const auto& historyScheme = Part->Scheme->HistoryGroup;
-            Y_DEBUG_ABORT_UNLESS(historyScheme.ColsKeyIdx.size() == 3);
-            while (HistoricGroups[0]->IsValid() && (!HistoricGroups[0]->HasKeyCells() || HistoricGroups[0]->GetKeyCell(0).AsValue<TRowId>() < nextRowId)) {
+            Y_DEBUG_ABORT_UNLESS(Part->Scheme->HistoryGroup.ColsKeyIdx.size() == 3);
+            while (HistoricGroups[0]->IsValid() && (!HistoricGroups[0]->GetKeyCellsCount() || HistoricGroups[0]->GetKeyCell(0).AsValue<TRowId>() < nextRowId)) {
                 // eagerly include all history up to the next row id
                 if (rowCount) {
                     AddPageSize(stats.DataSize, HistoricGroups[0]->GetPageId(), TGroupId(0, true));
@@ -190,7 +189,7 @@ private:
 
         ui32 keyIdx = 0;
         // Add columns that are present in the part
-        if (ui32 keyCellsCount = Groups[0]->HasKeyCells()) {
+        if (ui32 keyCellsCount = Groups[0]->GetKeyCellsCount()) {
             for (;keyIdx < keyCellsCount; ++keyIdx) {
                 CurrentKey.push_back(Groups[0]->GetKeyCell(keyIdx));
             }

--- a/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
@@ -132,7 +132,7 @@ public:
         return State.back().BeginRowId;
     }
 
-    TPos HasKeyCells() const override {
+    TPos GetKeyCellsCount() const override {
         Y_ABORT_UNLESS(IsLeaf());
         return State.back().BeginKey.Count();
     }

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_create.cpp
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_create.cpp
@@ -1,0 +1,16 @@
+#include "flat_stat_part_group_iter_iface.h"
+#include "flat_stat_part_group_btree_index.h"
+#include "flat_part_index_iter.h"
+
+namespace NKikimr::NTable {
+
+THolder<IStatsPartGroupIterator> CreateStatsPartGroupIter(const TPart* part, IPages* env, NPage::TGroupId groupId)
+{
+    if (groupId.Index < (groupId.IsHistoric() ? part->IndexPages.BTreeHistoric : part->IndexPages.BTreeGroups).size()) {
+        return MakeHolder<TStatsPartGroupBtreeIndexIterator>(part, env, groupId);
+    } else {
+        return MakeHolder<TPartIndexIt>(part, env, groupId);
+    }
+}
+
+}

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_create.cpp
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_create.cpp
@@ -4,7 +4,7 @@
 
 namespace NKikimr::NTable {
 
-THolder<IStatsPartGroupIterator> CreateStatsPartGroupIter(const TPart* part, IPages* env, NPage::TGroupId groupId)
+THolder<IStatsPartGroupIterator> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId)
 {
     if (groupId.Index < (groupId.IsHistoric() ? part->IndexPages.BTreeHistoric : part->IndexPages.BTreeGroups).size()) {
         return MakeHolder<TStatsPartGroupBtreeIndexIterator>(part, env, groupId);

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
@@ -15,7 +15,7 @@ namespace NKikimr::NTable {
         virtual TPageId GetPageId() const = 0;
         virtual TRowId GetRowId() const = 0;
 
-        virtual TPos HasKeyCells() const = 0;
+        virtual TPos GetKeyCellsCount() const = 0;
         virtual TCell GetKeyCell(TPos index) const = 0;
 
         virtual ~IStatsPartGroupIterator() = default;

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "flat_part_iface.h"
+#include "ydb/core/scheme/scheme_tablecell.h"
+
+namespace NKikimr::NTable {
+    
+    struct IStatsPartGroupIterator {
+        virtual EReady Start() = 0;
+        virtual EReady Next() = 0;
+
+        virtual bool IsValid() const = 0;
+
+        virtual TRowId GetEndRowId() const = 0;
+        virtual TPageId GetPageId() const = 0;
+        virtual TRowId GetRowId() const = 0;
+
+        virtual TPos HasKeyCells() const = 0;
+        virtual TCell GetKeyCell(TPos index) const = 0;
+
+        virtual ~IStatsPartGroupIterator() = default;
+    };
+
+    THolder<IStatsPartGroupIterator> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId);
+    
+}

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -14,9 +14,9 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
 
     // Make index iterators for all parts
     bool started = true;
-    for (auto& pi : subset.Flatten) {
-        stats.IndexSize.Add(pi->IndexesRawSize, pi->Label.Channel());
-        TAutoPtr<TScreenedPartIndexIterator> iter = new TScreenedPartIndexIterator(pi, env, subset.Scheme->Keys, pi->Small, pi->Large);
+    for (auto& part : subset.Flatten) {
+        stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
+        TAutoPtr<TScreenedPartIndexIterator> iter = new TScreenedPartIndexIterator(part, env, subset.Scheme->Keys, part->Small, part->Large);
         auto ready = iter->Start();
         if (ready == EReady::Page) {
             started = false;

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -9,19 +9,19 @@ namespace NTable {
 bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env) {
     stats.Clear();
 
-    TPartDataStats stIterStats = { };
-    TStatsIterator stIter(subset.Scheme->Keys);
+    TPartDataStats iteratorStats = { };
+    TStatsIterator statsIterator(subset.Scheme->Keys);
 
     // Make index iterators for all parts
     bool started = true;
-    for (auto& part : subset.Flatten) {
+    for (const auto& part : subset.Flatten) {
         stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
-        TAutoPtr<TScreenedPartIndexIterator> iter = new TScreenedPartIndexIterator(part, env, subset.Scheme->Keys, part->Small, part->Large);
+        TAutoPtr<TStatsScreenedPartIterator> iter = new TStatsScreenedPartIterator(part, env, subset.Scheme->Keys, part->Small, part->Large);
         auto ready = iter->Start();
         if (ready == EReady::Page) {
             started = false;
         } else if (ready == EReady::Data) {
-            stIter.Add(iter);
+            statsIterator.Add(iter);
         }
     }
     if (!started) {
@@ -31,35 +31,35 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
     ui64 prevRows = 0;
     ui64 prevSize = 0;
     while (true) {
-        auto ready = stIter.Next(stIterStats);
+        auto ready = statsIterator.Next(iteratorStats);
         if (ready == EReady::Page) {
             return false;
         } else if (ready == EReady::Gone) {
             break;
         }
 
-        const bool nextRowsBucket = (stIterStats.RowCount >= prevRows + rowCountResolution);
-        const bool nextSizeBucket = (stIterStats.DataSize.Size >= prevSize + dataSizeResolution);
+        const bool nextRowsBucket = (iteratorStats.RowCount >= prevRows + rowCountResolution);
+        const bool nextSizeBucket = (iteratorStats.DataSize.Size >= prevSize + dataSizeResolution);
 
         if (!nextRowsBucket && !nextSizeBucket)
             continue;
 
-        TDbTupleRef currentKey = stIter.GetCurrentKey();
+        TDbTupleRef currentKey = statsIterator.GetCurrentKey();
         TString serializedKey = TSerializedCellVec::Serialize(TConstArrayRef<TCell>(currentKey.Columns, currentKey.ColumnCount));
 
         if (nextRowsBucket) {
-            prevRows = stIterStats.RowCount;
+            prevRows = iteratorStats.RowCount;
             stats.RowCountHistogram.push_back({serializedKey, prevRows});
         }
 
         if (nextSizeBucket) {
-            prevSize = stIterStats.DataSize.Size;
+            prevSize = iteratorStats.DataSize.Size;
             stats.DataSizeHistogram.push_back({serializedKey, prevSize});
         }
     }
 
-    stats.RowCount = stIterStats.RowCount;
-    stats.DataSize = std::move(stIterStats.DataSize);
+    stats.RowCount = iteratorStats.RowCount;
+    stats.DataSize = std::move(iteratorStats.DataSize);
 
     return true;
 }

--- a/ydb/core/tablet_flat/flat_stat_table.h
+++ b/ydb/core/tablet_flat/flat_stat_table.h
@@ -14,16 +14,16 @@ namespace NTable {
 // Iterates over all parts and maintains total row count and data size
 class TStatsIterator {
 public:
-    explicit TStatsIterator(TIntrusiveConstPtr<TKeyCellDefaults> keyColumns)
-        : KeyColumns(keyColumns)
+    explicit TStatsIterator(TIntrusiveConstPtr<TKeyCellDefaults> keyDefaults)
+        : KeyDefaults(keyDefaults)
         , Heap(TIterKeyGreater{ this })
     {}
 
-    void Add(THolder<TScreenedPartIndexIterator> pi) {
-        Y_ABORT_UNLESS(pi->IsValid());
-        Iterators.PushBack(std::move(pi));
-        TScreenedPartIndexIterator* it = Iterators.back();
-        Heap.push(it);
+    void Add(THolder<TStatsScreenedPartIterator> iterator) {
+        Y_ABORT_UNLESS(iterator->IsValid());
+        Iterators.PushBack(std::move(iterator));
+        TStatsScreenedPartIterator* iteratorPtr = Iterators.back();
+        Heap.push(iteratorPtr);
     }
 
     EReady Next(TPartDataStats& stats) {
@@ -33,12 +33,12 @@ public:
         TCellsStorage cellsStorage;
 
         while (!Heap.empty()) {
-            TScreenedPartIndexIterator* it = Heap.top();
+            TStatsScreenedPartIterator* it = Heap.top();
             Heap.pop();
 
             // makes key copy
             cellsStorage.Reset({it->GetCurrentKey().Columns, it->GetCurrentKey().ColumnCount});
-            TDbTupleRef key(KeyColumns->BasicTypes().data(), cellsStorage.GetCells().data(), cellsStorage.GetCells().size());
+            TDbTupleRef key(KeyDefaults->BasicTypes().data(), cellsStorage.GetCells().data(), cellsStorage.GetCells().size());
 
             auto ready = it->Next(stats);
             if (ready == EReady::Page) {
@@ -75,20 +75,20 @@ public:
 
 private:
     int CompareKeys(const TDbTupleRef& a, const TDbTupleRef& b) const noexcept {
-        return ComparePartKeys(a.Cells(), b.Cells(), *KeyColumns);
+        return ComparePartKeys(a.Cells(), b.Cells(), *KeyDefaults);
     }
 
     struct TIterKeyGreater {
         const TStatsIterator* Self;
 
-        bool operator ()(const TScreenedPartIndexIterator* a, const TScreenedPartIndexIterator* b) const {
+        bool operator ()(const TStatsScreenedPartIterator* a, const TStatsScreenedPartIterator* b) const {
             return Self->CompareKeys(a->GetCurrentKey(), b->GetCurrentKey()) > 0;
         }
     };
 
-    TIntrusiveConstPtr<TKeyCellDefaults> KeyColumns;
-    THolderVector<TScreenedPartIndexIterator> Iterators;
-    TPriorityQueue<TScreenedPartIndexIterator*, TSmallVec<TScreenedPartIndexIterator*>, TIterKeyGreater> Heap;
+    TIntrusiveConstPtr<TKeyCellDefaults> KeyDefaults;
+    THolderVector<TStatsScreenedPartIterator> Iterators;
+    TPriorityQueue<TStatsScreenedPartIterator*, TSmallVec<TStatsScreenedPartIterator*>, TIterKeyGreater> Heap;
 };
 
 struct TBucket {

--- a/ydb/core/tablet_flat/flat_stat_table.h
+++ b/ydb/core/tablet_flat/flat_stat_table.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "flat_part_laid.h"
 #include "flat_stat_part.h"
 #include "flat_table_subset.h"
 

--- a/ydb/core/tablet_flat/flat_table_part_ut.cpp
+++ b/ydb/core/tablet_flat/flat_table_part_ut.cpp
@@ -78,7 +78,7 @@ Y_UNIT_TEST_SUITE(TLegacy) {
             TPartDataStats stats = { };
             TTestEnv env;
             // TScreenedPartIndexIterator without screen previously was TPartIndexIterator
-            TScreenedPartIndexIterator idxIter(TPartView{part, nullptr, nullptr}, &env, scheme->Keys, nullptr, nullptr);
+            TStatsScreenedPartIterator idxIter(TPartView{part, nullptr, nullptr}, &env, scheme->Keys, nullptr, nullptr);
             sizes.clear();
 
             UNIT_ASSERT_VALUES_EQUAL(idxIter.Start(), EReady::Data);
@@ -147,7 +147,7 @@ Y_UNIT_TEST_SUITE(TLegacy) {
                             TIntrusiveConstPtr<TRowScheme> scheme, TIntrusiveConstPtr<NPage::TFrames> frames) -> std::pair<ui64, ui64> {
             TPartDataStats stats = { };
             TTestEnv env;
-            TScreenedPartIndexIterator idxIter(TPartView{part, screen, nullptr}, &env, scheme->Keys, std::move(frames), nullptr);
+            TStatsScreenedPartIterator idxIter(TPartView{part, screen, nullptr}, &env, scheme->Keys, std::move(frames), nullptr);
 
             UNIT_ASSERT_VALUES_EQUAL(idxIter.Start(), EReady::Data);
             while (idxIter.IsValid()) {
@@ -308,8 +308,8 @@ Y_UNIT_TEST_SUITE(TLegacy) {
         TTestEnv env;
         TStatsIterator stIter(lay2.RowScheme()->Keys);
         {
-            auto it1 = MakeHolder<TScreenedPartIndexIterator>(TPartView{eggs2.At(0), screen2, nullptr}, &env, lay2.RowScheme()->Keys, nullptr, nullptr);
-            auto it2 = MakeHolder<TScreenedPartIndexIterator>(TPartView{eggs1.At(0), screen1, nullptr}, &env, lay2.RowScheme()->Keys, nullptr, nullptr);
+            auto it1 = MakeHolder<TStatsScreenedPartIterator>(TPartView{eggs2.At(0), screen2, nullptr}, &env, lay2.RowScheme()->Keys, nullptr, nullptr);
+            auto it2 = MakeHolder<TStatsScreenedPartIterator>(TPartView{eggs1.At(0), screen1, nullptr}, &env, lay2.RowScheme()->Keys, nullptr, nullptr);
             UNIT_ASSERT_VALUES_EQUAL(it1->Start(), EReady::Data);
             UNIT_ASSERT_VALUES_EQUAL(it2->Start(), EReady::Data);
             stIter.Add(std::move(it1));

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "test_pretty.h"
 #include "test_part.h"
 
 #include <ydb/core/tablet_flat/test/libs/rows/cook.h>
@@ -74,8 +73,14 @@ namespace NTest {
             TEpoch epoch = TEpoch(root.GetEpoch());
 
             size_t indexesRawSize = 0;
-            for (auto indexPage : eggs.GroupIndexes) {
-                indexesRawSize += Store->GetPageSize(0, indexPage);
+            if (eggs.BTreeGroupIndexes) {
+                for (const auto &meta : eggs.BTreeGroupIndexes) {
+                    indexesRawSize += meta.IndexSize;
+                }
+            } else {
+                for (auto indexPage : eggs.GroupIndexes) {
+                    indexesRawSize += Store->GetPageSize(0, indexPage);
+                }
             }
 
             return

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -13,8 +13,9 @@ namespace {
     struct TTouchEnv : public NTest::TTestEnv {
         const TSharedData* TryGetPage(const TPart *part, TPageId id, TGroupId groupId) override
         {
-            UNIT_ASSERT_C(part->GetPageType(id) == EPage::Index, "Shouldn't request non-index pages");
-            if (!Touched[groupId].insert(id).second) {
+            UNIT_ASSERT_C(part->GetPageType(id) == EPage::Index || part->GetPageType(id) == EPage::BTreeIndex, "Shouldn't request non-index pages");
+            // TODO: charge b-tree index
+            if (!Touched[groupId].insert(id).second || part->GetPageType(id) == EPage::BTreeIndex) {
                 return NTest::TTestEnv::TryGetPage(part, id, groupId);
             }
             return nullptr;

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -56,6 +56,7 @@ SRCS(
     flat_stat_part.h
     flat_stat_table.h
     flat_stat_table.cpp
+    flat_stat_part_group_iter_create.cpp
     flat_store_hotdog.cpp
     flat_table.cpp
     flat_table.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Added `IStatsPartGroupIterator` interface for further development

Now `TStatsPartGroupBtreeIndexIterator` almost copies `TPartBtreeIndexIt`, but later it will only touch top B-Tree index nodes

Although PR also contains a lot of renames, there is no any logic changes, so you may not pay much attention to these changes
