### PR TITLE
Fixed a problem with plans in PG ut

### DIFF
--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -1881,9 +1881,13 @@ void BuildPlanIndex(NJson::TJsonValue& plan, THashMap<int, NJson::TJsonValue>& p
 
         auto pos = precomputeName.find("precompute");
         if (pos != TString::npos) {
-            precomputes[precomputeName.substr(pos)] = plan;
+            if (!precomputes.contains(precomputeName.substr(pos))) {
+                precomputes[precomputeName.substr(pos)] = plan;
+            }
         } else if (precomputeName.size()>=4 && precomputeName.find("CTE ") != TString::npos) {
-            precomputes[precomputeName.substr(4)] = plan;
+            if (!precomputes.contains(precomputeName.substr(4))) {
+                precomputes[precomputeName.substr(4)] = plan;
+            }
         }
     }
 


### PR DESCRIPTION
- [cfg-test] Move experimental features to separate config (YQL-17455) (#805)
- statistic requests fix (#813)
- fix tests (#820)
- Implement returning list for KiWrite/UpdateTable KIKIMR-18531
- KIKIMR-20530 Datashard tracing enhancements (#746)
- ci: warn if no tests reports found (#807)
- Added stage and local inputs for JSON plans (#699)
- Fix rebase in docs (#825)
- Fix literal rewrite rule for predicate pushdown (#809)
- Fix OLAP stats (#766)
- KIKIMR-20380: min max portion keys validation (#822)
- add compatibility for old upsert nodes (#826)
- fix http tests to wait for port binding (#835)
- [YQL-17389] Normalize dq_file tests
- add pg types to TQueryPlan (#828)
- improve normalization (#827)
- YDB-1713/hotkeys (#830)
- suppress unnecessaryVERIFY which could rise on downgrade scenario (#840)
- Remove deps on non existing folder (#844)
- YQL-16896: Common type inferring for SELECT combinators (#843)
- Library import 5, delete go dependencies (#832)
- Fix flake8 violation in tests/functional/sqs/merge_split_common_table/test.py (#834)
- Support DDL operations (including IF EXISTS/IF NOT EXISTS) for objects with type secret (#838)
- Support DDL in QueryService for SECRET_ACCESS objects (#845)
- recover setting of hostname (#847)
- correctly set roles for a node (#848)
- trace(kqp): add tracing ro read actors (#841)
- Support DDL in QueryService for TIER & TIERING_RULE objects (#846)
- LOGBROKER-8859 Improvements in OffsetFetch endpoint in Kafka API (#803)
- YQL-16896: Fixed BuildProjectionLambda when emitPgStar is true (#849)
- Revert "add pg types to TQueryPlan (#828)" (#850)
- Workaround capture structured binding issue for clang14 (#851)
- Update cmake generation script to use ya, add platforms and ignored errors, add --keep-going (#857)
- Fixed pg_like canonization (#852)
- Added all known join types to CBO (#858)
- Fix opt rules for generic queries. (KIKIMR-16294) (#860)
- Update build_and_test_provisioned.yml
- Update build_and_test_provisioned.yml
- Get rid of lambdas in logging macros (#855)
- YQL-16241: [pg-make-test] Remove empty testcases from the resulting testsuite (#863)
- Move epilogue.cmake after sqlparser (#869)
- [yql] Fix test result diff (YQL-17489) (#877)
- YQ-2068 remove unused var (#837)
- Publish full rl api to oss (#808)
- Hack ydb/library/yql/providers/generic/connector/tests to make them MEDIUM, not LARGE (#876)
- allow fieldsubset optimizer with multiusage input (#862)
- add different metrics to graph service (#871)
- Coalesce pushdown (#744)
- Fix references to protoc compiler (#870)
- Delete go project files from the root (#868)
- Add unary kernels. (#859)
- Fix error in doc build. (#886)
- fix ut link (#887)
- [yql] Refresh file storage state at fork (YQL-17461) (#878)
- Storage Balancer KIKIMR-20636 (#770)
- feature(kqp): enable stream lookup for data query (#611)
- YDBOPS-8928: make connector tests MEDIUM, not LARGE (for OSS ya only) (#892)
- use counter as the resource for spread-neighbours balancer (#891)
- Library import 6 (#888)
- [YQL-17103] Support StartsWith with pg types in extract_predicate library (#854)
- refactor thread ctx (#897)
- fix trivial batch modification detector (#896)
- Disabled import from s3 directory feature on windows (#899)
- EvWrite counters (#874)
- Kafka protocol offset commit, request units and fixes (#831)
- Fixed a problem with cardinality estimation for PK joins (#907)
- YQL-17391: Make inmem_with_set_key* tests results deterministic (#880)
- movable TEventObserverHolder
- Remove devtools folder (#895)
- Fixed minor problems with plan represtation (#889)
- YQ-2068 refactoring, get rid of macro in BuildConnections (#883)
- LOGBROKER-8860 Implement CreatePartitions Kafka API endpoint (#866)
- KIKIMR-20635: pg types in TQueryPlan (#853)
- Test sorting on indexation (#920)
- Mark NYT::TFuture as [[nodiscard]] (#919)
- Revert "Remove devtools folder (#895)" (#922)
- Get right TraceId in SessionActor (#908)
- Add shared executor thread, KIKIMR-18440 (#903)
- Add YT pragmas for `description` and `started_by` (#918)
- support optional list in ListIndexOf (#902)
- TRowVersion -> TSnapshot (#921)
- Enable distconf by default and fix race issue KIKIMR-19031 (#875)
- Fixes clang-format usage (#929)
- YDBDOCS-188: fix a title that was missed during translation (#904)
- Introduce InitialAllocation option for storage load actor, KIKIMR-20619 (#806)
- return up-to-date node stats KIKIMR-20697 (#910)
- Remove change senders upon DROP TABLE KIKIMR-20678 (#901)
- Fixed forget operation failure (#781)
- Add shared executor pool, KIKIMR-18440 (#933)
- Fix datashard read traces (#913)
- Add operation estimations for HDD devices, KIKIMR-17759 (#909)
- Fix Coordinator::RestoreTenantConfiguration test KIKIMR-20710 (#938)
- added references (#924)
- YQL-15844 fix getting view by symlink (#928)
- Introduce blobsan (#941)
- Fix persqueue ut (#940)
- Allow UPDATE ON, UPSERT with partial set of input... (#894)
- Library import 7 (#937)
- Unsupported database type (DataStreams) by 403 http error (#930)
- Remove TEvColumnShard::TEvRead (#927)
- fix upsert overwriting non-default values (#926)
- fix missed check for usedIndexes. (#947)
- Mute some flaky tests (#949)
- Forgotten OwnerId in EvWrite (#945)
- Tests: Replace EvProposeTransaction with EvWrite (#932)
- Run OnTieringModified only once on tablet initialization (#951)
- add missing backtick (#959)
- TTableId fix (#958)
- Fix for full join when keys for both sides are identical (#948)
- ci: build docker local-ydb docker image using ya make (#934)
- Mute some flaky tests (#962)
- sprintf -> snprintf replacement inside ydb code (#952)
- Create CODEOWNERS (#943)
- make it possible to stop Hive subactors through web ui KIKIMR-20645 (#810)
- Add forgotten file (#969)
- Return --global to git authorship guideline (#963)
- lock for different client versions usage (#961)
- basic statistics bugfixes KIKIMR-18323 (#915)
- cancel previous Build Documentation on the same PR (#967)
- Copy locks in observer & SingleObserver (#973)
- alter table request for metadata modifications (#974)
- added article about goose into docs (#811)
- update roadmap
- Report correct status on overloaded errors in read table KIKIMR-17778 (#946)
- Fixed cardinality estimation bug in CBO (#975)
- cleanup portions store (#971)
- EOperationKind::WriteTx (#976)
- Explicitely restict TCL statements in QueryService. (KIKIMR-16294) (#980)
- usage chunked merge by optional and usage full-batches-merge for norm… (#972)
- Auto stash before merge of "main" and "origin/main" (#985)
- Fix python test style (#867)
- Cancel previous jobs on re-push changes from PR branch (#983)
- Fix a misprint
- Scale screenshot images in goose article (#982)
- Fix StageDurationUs (#984)
- Mute some flaky tests (#994)
- KIKIMR-20714 Удаляем LongTxService в тестах (#970)
- fix test withno appdata (#991)
- Kv tracing ut (#992)
- YQL-17388: fix use-after-free bug in TPgResolvedMultiCall::TListValue::TIterator (#955)
- Mute flaky KqpOlapScheme.TenThousandColumns (#1002)
- enable FieldSubsetEnableMultiusage in experimental config (#1003)
- add colors in cli and fix minor bugs (#1007)
- KIKIMR-20727: Распозновать, как запакован JsonDocument при BulkUpsert (#1008)
- Bugfix: Remove TActiveTransaction from TExecutionUnit.OpsInFly on cancel (#935)
- use iostream instead of printf (#977)
- disable warmup for root hive (#954)
- fix statestorage link (#953)
- Fix WITH statement for INDEX (#1010)
- Create PULL_REQUEST_TEMPLATE.md (#999)
- [docs] Add kafka-api global version (#702)
- Disable coordinator if no ingress tasks (#472)
- Pushdown some unary operators. (#957)
- Mute some flaky tests (#1031)
- add test for describe table store (#1030)
- fix test KIKIMR-20747 (#1020)
- Enable volatile transactions by default KIKIMR-20731 (#993)
- support basic stats for column tables (#1014)
- fix case removed column for stats usage (#1025)
- YQL-17430: Fix dependencies for hybrid (#1021)
- update feature flags for postgres docker (#1040)
- Fix plan tests & improve plan signatures for sources/sinks (#1041)
- rewrite upsert for columns with defaults (#1035)
- Added keyvalue load actor config example (#1045)
- YQ Connector: YQ-2768 fix integration tests (#1028)
- [yql] Don't compare pg-type sort with yt. Enable result check (YQL-17399, YQL-17381) (#1039)
- Set default values for InitialAllocation parameteres (#1012)
- Can read date32 as PostgreSQL date from arrow (#1046)
- Added a link to embedded ui roadmap (#1017)
- remove pdisk -> pg_parser dependency (#1036)
- YQ-2730: use docker-compose random port mapping in connector integration tests (#978)
- YQL-16252, YQL-16623: Support search_path (#788)
- YDB-966 tls incomplete transfer (#1024)
- YDBDOCS-557: add a missing redirect (#592)
- Fix uninitialized value in log settings (#1048)
- [docs] YDBDOCS-98: mention Sentinel in selfheal.md (#434)
- fix double lock (#483)
- [docs] YDBDOCS-230: update primitive types restrictions (#435)
- YDBDOCS-223: add missing backticks to "config.md" (#1072)
- Create pr_labels.yaml (#1033)
- ci: add more details to PR comment about build and tests (#1054)
- Change token in pr_labels.yaml workflow (#1080)
- Revert "Disable coordinator if no ingress tasks (#472)" (#1083)
- More strict DqReplicateType ann. Fix pushing LMap/HasItems to stage (#1057)
- SplitStageOnDqReplicate -> false (#1068)
- Unified test cases naming schema for ydb/library/yql/providers/generic/connector/tests (#1058)
- Safe topic reader KIKIMR-20673 (#1078)
- fix build (#1082)
- fix stats for splitting (#1079)
- Make test actorsystem actor id globaly unique (#1081)
- fix(kqp): pass right table filter through stream index lookup join (#1034)
- test commit (#996)
- KIKIMR-19522 BTreeIndex Iter Remove single run optimization (#995)
- general steps for data fetching (#1088)
- Mute some flaky tests (#1101)
- YQ-2744: add tpc bucket option for ydb workload tpch (#1098)
- Allow partial column set in case of insert (#1056)
- refactor(kqp): remove unused pragmas (#1052)
- YQL-17493: Wrap returned YQL-typed columns with ToPg (#1059)
- add limits for simultaneous compaction (#1096)
- Add block reader over file (#1097)
- Fix possible node crash in case of unavaliable response (#1107)
- Implemented RemoteTopicReader KIKIMR-20306 (#1093)
- Library import 8 (#1074)
- Enchanced VDisk & PDisk traces (#864)
- Fix typo in TPC-DS query (#1125)
- Skip empty description in pr_labels.yaml workflow (#1117)
- YQ-2630: fix and support detalization for v1 (#1016)
- KIKIMR-20009: fix race condition on blobs removing (#1118)
- Add result checking function in arrow_ut.cpp (#1109)
- YDB-2321 Refactor IP UDF to use supported ipmath library (#618)
- Add GLOBAL for udf service files (#1106)
- (refactoring) Move TSchemeCacheHelpers to core/tx/scheme_cache KIKIMR-20673 (#1123)
- YQL-16252, YQL-16623: fix set_config (#1121)
- Report status for static group (#1116)
- KIKIMR-20714: Удаляем LongTxService grpc (#1124)
- fix namings (#1131)
- fix use-after-free in TDummySnapshotContext IGNIETFERRO-2059 (#667)
- [YQL-17474] Expand PartitionByKeys with constant keys via YtMap. Do not fuse ops with JobCount setting (#1122)
- YDB-1060 viewer nodes handler add missing sort (#1134)
- KIKIMR-18397 HC node restarts issue (#1111)
- Fix dates in TPC-DS/YQL-syntax (#1138)
- Add missing includes (#986)
- fix format (#987)
- Fix rebinding allocator (#1023)
- YQL-17553: Fix RPC reader data loss (#1114)
- KIKIMR-19671 Refactoring of IWorkloadQueryGenerator and TWorkloadFactory (#1103)
- YQL-16218 tests dict in tables for sqlin (#1075)
- KIKIMR-20778: Тест на лаг обновления данных через bulk_upsert  (#1143)
- Enable remote cache client decompression (#1141)
- Release notes ydb cli 2 8 0 (#1050)
- Make MVCC always enabled and no longer optional KIKIMR-20802 (#1127)
- Unify test case naming in ydb/library/yql/providers/generic/connector/tests (#1110)
- Improve checkResult fun in arrow_ut.cpp (#1135)
- Accounted for HullHugeBlobChunkAllocator in canondata (#1146)
- (refactoring) IChangeRecord KIKIMR-20673 (#1142)
- S3 storage class workaround for minio (#1148)
- Rename values of ServerlessComputeResourcesMode enum KIKIMR-20642 (#1094)
- fix missing breaks (#1139)
- make storage balancer automatically triggered KIKIMR-20672 (#1018)
- use policies for memory prediction on compaction (#1130)
- YQL-17542 not initially acqured mode in TScopedAlloc (#1099)
- YQ-2356: integration tests for yq through generic provider (#988)
- remove unnecesary sleep in tests (#1092)
- Enable SELECT from views (#795)
- KIKIMR-20378: Enable IAM BulkAuthorization (#911)
- use splitter for abstract data chunks. not columns only (#1147)
- external table content has been decoded for viewer (#1055)
- [YQL-17474] Limit supported operation settings in hybrid execution (#1132)
- Fix bulk upsert writing to freshly indexed table due to a race KIKIMR-20765 (#1160)
- (refactoring) Split TEvChangeExchange into two parts: common & DS KIKIMR-20673 (#1152)
- ydb/tests/tools: change PY23_LIBRARY -> PY3_LIBRARY (#1171)
- Unittest for mirror-3-dc IndexRestoreGet (#1159)
- add sensors for metadata cache KIKIMR-20775 (#1104)
- Avoid failure of pr_comment procedure when called outside PR context, e.g. in the Postcommit checks (#1172)
- Library update 9 (#1163)
- fix(kqp): disable stream lookup for data query (#1168)
- Fix build on clang14 (#1167)
- Cherry-pick commits from right lib (#1176)
- [YQL-17552] Predicatable test output (#1177)
- YQL-16026: Remove PG tests char.sql and varchar.sql from ignored (#1178)
- scheme tests have been fixed (#1182)
- Move first key validation logic out of engines (#1161)
-  YDBD binary args: added database quotas limits (#496)
- YQL-17567: Added patches to workaround unsupported INSERT without column list & updated passing regression tests (#1185)
- Session actor perf (again) (#873)
- Fix ShardHint for read actor
- docs: fix typo (#1170)
- YQL code owners (#1188)
- Add faster data generation to Storage Load Actor, #1156 (#1157)
- Fix build KIKIMR-20673 (#1192)
- replace into olap table (#1164)
- Revert "external table content has been decoded for viewer (#1055)"  (#1190)
- Simplify error handling (#1181)
- ALTER syntax for EXTERNAL DATA SOURCE/EXTERNAL TABLE (#998)
- Scheme correction for indexes usage (#1180)
- refactor CreatePartitions endpoint of Kafka API to use TUpdateSchemeActor (#1005)
- KIKIMR-19521 BTreeIndex Keep B-TreeIndex in cache after compactions (#1165)
- S3 add switch for virtual style addressing (#1150)
- Add missing <cstddef> include (#1145)
- Fix build for clang14 compiler (#1197)
- YQL-17624: oid columns are now right-aligned in pgrun table output (#1199)
- Add more information to VERIFY message, YDBREQUESTS-2898 (#1155)
- YQL-17542 remove function with confusing name CreateKqpTaskRunner (#1183)
- YQL-17542 clarify send stats condition in compute actor (#1015)
- DebugString methods for debug prints (#1198)
- Mute some flaky tests (#1187)
- Fix 404 and fix files names. (#1032)
- Move TBaseChangeSender to ydb/core/change_exchange KIKIMR-20673 (#1207)
- [YQL-17298] Fix data race on ICompare::TPtr (#1213)
- fox coverity (#1206)
- fix allow single partition optimization (#1212)
- Fix typo leading to false VERIFY (#1220)
- YQL-17250: Fix operation name at fallback message (#1194)
- Use fallthrough and fix holder initialization (#1221)
- Remove inaccessible code from TCompatibilityInfo::CheckCompatibility, #1208 (#1209)
- add waiting for resources snapshot (#1154)
- Fix malloc size (#1211)
- KIKIMR-19522 BTreeIndex Charge Keys (#1102)
- Fix external dep on opentelemetry (#1216)
- fix ListUniqStable not working on optional arguments (#1195)
- Fixed unit tests fq/s3 + generic (#1120)
- Make ydb_root_common use only stderr to avoid command output pollution (#1218)
- LocalTableWriter skeleton KIKIMR-20673 (#1214)
- not null constraint fix for column addition (#1137)
- Add use local self heal option to ds tool (#1191)
- Correct cleanup policy. Split writeIds list (#1205)
- Move ReValidateKeys to TKeyValidator (#1217)
- YQL-17615: Fixed floats & numerics formatting in pgrun (#1230)
- Remove yt specific alloc monitoring. Ytalloc is not used. (#1202)
- Add sleep for metering tests (#1235)
- Choose partition for topic split/merge (#1038)
- YQL-17542 Ensure one allocator in TDqTaskRunner (#1210)
- fix counters (#1237)
- Fix set but unused varibles to fix -Wunused-but-set-variable (#1175)
- Add missing <cstddef> include (#1233)
- Revert "Choose partition for topic split/merge" (#1243)
- remove useless call (#1201)
- fix break (#1226)
- improve switch (#1228)
- improve switch (#1232)
- fix column build with indexed table (#1239)
- Check types for pushdown on OLAP level. (#1144)
- YQL-15941 switch to llvm14 (#1241)
- YQL-17542 remove unused abstraction (#1184)
- move ReportLatencyCounters to common call (#1193)
- Add shared logic to executor pool (#1236)
- add missing break in formatting code (#1229)
- ci: run pr checks on a merge commit instead of the PR head, add rebase-and-check label support (#1244)
- CheckCellValue after MakeCell (#1252)
- Remove support for non-scan read columns requests (#1240)
- Add range read border to key sampler KIKIMR-20859 (#1253)
- Remove navi_serializable feature
- Added point to msku_uploader to trace skus
- automation of go yamake update
- YDB Import 546
- update taxitool rev. 13268634
- 
- Update contrib/python/types-protobuf to 4.24.0.20240106
- Update build documentations for rXXXXXX
- 
- 
- Automatic release build for ymake, os_ymake
- Fix error in TArrayRef constructor for a container: Elements with a different size should not be accepted even if they are convertible to TArrayRef value type.
- Specialize iterator_traits for TIpAddressRange iterator
- [domscheme] Move runtime.h into a separate library
- Enable SA1019 rule for psp namespace
- - Release new version of ytyndexer
- Use `CUDA_ARCHITECTURES` flag to prune architectures
- Update link to GTEST macro documentation
- YDB Import 548
- fix bank-applications: remove bank-forms usage
- Update ytyndexer to sbr:5704224018
- Stop using svn in canonization tests
- Add GEN_FBS
- bug contrib/grpc: fix races between retries and cancellation
- New version of the tld SKIP_CHECK SKIP_REVIEW
- add x/image/draw to arcadia
- Fix separator in CUDA_ARCHITECTURES
- update taxitool rev. 13288386
- Flake8 migrations clean up
- YDB Import 550
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- Update gdb
- Update contrib/libs/zlib to 1.3.1
- Update library sha
- Show exclusive nodes in embedded ui KIKIMR-20675 (#1149)
- Update sha in the library import increment script (#1261)
- YQL-17502 Date32 from/to string conversion (#960)
- refresh embedded ui (#1247)
- Cell maker lib & parsing from json KIKIMR-20673 (#1255)
- Muted tests (#1265)
- DS proxy mirror-3-dc restoration strategy test (#1238)
- [-] the UseDeduplication flag was reset in the TPartitionWriter options (#1256)
- ci: comment actual merge commit sha instead of PR head (#1264)
- Fixed a minor bug in simplified plan JSON generation (#1257)
- Fixing muted SQS tests (#1234)
- YQL-16720: Skip hybrid for desc sort (#1267)
- KIKIMR-19719: Lookup for simple PgSelect (#839)
- Mute some flaky tests (#1273)
- Json change record & serialization to TEvApplyReplicationChanges::TChange KIKIMR-20673 (#1270)
- Remove second read stage during uniq index update (#1258)
- Make separate app data for different nodes in test actor system (#1231)
- YQL-17371: Fix bytea output in pgrun (#1248)
- fix (#1274)
- YQ-2790 fixed uncaught exception in TS3FileWriteActor (#1242)
- init (#1275)
- YQL-17646 Canonize weak_field-weak_field_list_type-default.txt (#1277)
- Choose partition for topic split/merge  (#1268)
- KeyValue tracing sampling (#1047)
- limit for recycled requests (#1286)
- YQ-2715 add ydb data source (#753)
- Refactor GroupDiskRequests and remove unused stuff (#1272)
- Add inflight for garbage collection requests for Storage Load Actor, KIKIMR-20593 (#666)
- KIKIMR-20740: QueryCache with temp tables (#1053)
- Mute some flaky tests (#1289)
- Add ExecuteMode to YQL plugin for YT. Support validate and explain modes (#1219)
- Remove unused but set variable (#1285)
- Revert "Add ExecuteMode to YQL plugin for YT. Support validate and explain modes" (#1295)
- ci: don't override old PR build status comment on every build (#1284)
- KIKIMR-20877: internal indexes processing (#1276)
- Fix delete table (#1283)
- Move to trace (#1297)
- Mute some flaky tests (#1293)
- validate & lineage modes in dqrun (#1290)
- YDB-2321 Add subnet operations in IP UDF (#981)
- Add ExecuteMode to YQL plugin for YT. Support validate and explain modes (#1219) (#1296)
- KIKIMR-19522 BTreeIndex Charge Groups (#1224)
- Mute some flaky tests (#1309)
- YQL-17345, YQL-17359, YQL-17340: pg_description, pg_am, pg_namespace implementation (#1262)
- Add Federated Query team to CODEOWNERS (#1316)
- YQL-17644: fix ydb/library/yql/minikql/mkql_type_ops_ut build on windows (#1320)
- YQL-17661: fix pg_wrapper win build (#1324)
- Mute some flaky tests (#1323)
- Support table changes observer KIKIMR-20853 (#1310)
- Fix style in test_dlq_mechanics_in_cloud test (#1330)
- [docs] remove odd comment in topic.md and changelog-cli.md (#1332)
- Reduce benchmark params count so it can be run (#1319)
- refactoring the transaction processing cycle (#1196)
- Mute some flaky tests (#1334)
- fix (#1315)
- Table partition writer skeleton KIKIMR-20673 (#1322)
- messages for shadow partition (#1084)
- Support of Merge along with Extend (#1307)
- init (#1327)
- KIKIMR-20846 Fix args order bug (#1280)
- Move functionality to UserDb (#1251)
- DATA() resources
- Fix typo in Storage LoadTest (#1341)
- YQL-17615: fixed formatting of float4 in pgrun (#1339)
- Checking  "not found" status has been added to Stopper (#1263)
- s3 arrow converters have been added (#1249)
- Implemented unit tests for TSampler and TThrottler (#1076)
- Add arithmetic kernels for float & double. (#1291)
- Fix get return type for binary arithmetic. (#1313)
- Make sure out-of-order volatile commits are not visible on followers KIKIMR-20853 (#1344)
- Fix consistency check complaining about borrowed tx status parts KIKIMR-20903 (#1349)
- YQL-17542 move allocator ownership from TDqTaskRunner to actors (#1335)
- init (#1348)
- TEvWriteResult STATUS_SCHEME_CHANGED (#1345)
- KIKIMR-18707: Add switching of use builtin domain authorization (#1254)
- indexes construction on first compaction stage (from insert table to … (#1343)
- Update sha
- YDB Import 551 KIKIMR-1
- update taxitool rev. 13295145
- feat yamake: add ruff wrapper and ya make macro
- Update contrib/python/Jinja2/py3 to 3.1.3
- erm: Add new version for `@yatool/prebuilder`: `0.5.1` and set `0.5.1` as default
- add fff-team poject to list of isolated projects
- feat(nots-bootstrap): take v10 build resources into use
- YDB Import 552
- Intermediate changes
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Introduce TEnumIndexedArray as a refurbished version of TEnumIndexedVector
- Get rid of go 1.20 support
- Update contrib/restricted/abseil-cpp to 20240116.0
- Intermediate changes
- Fill ENVIRONMENT for CMake projects from ENV() macroses
- Intermediate changes
- Update gdb pretty printers
- Intermediate changes
- Update libcxx to 02 June 2023 185b81e034ba60081023b6e59504dfffb560f3e3 (llvmorg-16.0.5)
- Automatic release build for ya_bin3, os_ya, ya_bin, test_tool, os_test_tool_3, test_tool3
- Update contrib/libs/opentelemetry-proto to 1.1.0
- Intermediate changes
- [util] TSystemError: print raw error code along with the message
- Intermediate changes
- Update golang to 1.21.6
- Update sha
- YQL-17371: fix ASCII-compatibe bytea output in pgrun (#1356)
- init (#1354)
- YQL-17583: DELETE with alias crash fix (#1360)
- Add marker module for python sdk v3 new behaviour (#1363)
- KIKIMR-20842: make error non-retryable again (#1364)
- fix test for indexes (#1367)
- Forbid writing/reading directly to external data source (#1204)
- YQL-17542 Introduce TDqSyncComputeActorBase (#1361)
- Add TxOperators (#1365)
- Drop coalesce crutch. (#1362)
- Enable real arithmetic. (#1352)
- Fix optimizer and return back KQP peephole type check. (#842)
- YQL-17087: Enable output channel spilling only if task has two or more outputs (#1043)
- YQ-2708 add IAM credentials to protobuf (#1340)
- Support --test-param for specifying logging level in KQP tests (#1373)
- build: add a CI flow for Embedded UI refresh (#1321)
- Check empty stats (#1259)
- Fix counter for granules normalizer (#1368)
- Mute some flaky tests (#1372)
- Use runtime grpc event dispatching instead of legacy one for PQ scheme events (#1326)
- KIKIMR-20842: fix broken test (#1370)
- Fix kafka metadata actor for Topics.size() == 0 and fix read by short topic name (#1287)
- resolves #1346 (#1347)
- Fix PDisk log flush completion action use after free (#1359)
- KIKIMR-20939: mute red test (#1380)
- YQL-17388: fix generate_series zero step (#1358)
- Fix linker (#1378)
- init (#1375)
- [dq] Don't return future with exception from ExecPlan call (YQL-17677) (#1374)
- [YQL-16903] Support BlockEngine=auto/force/disable (peephole + channels) (#1379)
- sys view and drop method for indexes (#1371)
- Mute some flaky tests (#1387)
- Improved handling of empty cells in CSV YQ-2727 (#796)
- fix warnings for pg_wrapper (#1383)
- Support result set extract from TDataQueryResult (#1388)
- fix pg sql warnings (#1395)
- Use the same constants in both tpc-ds version (yql and pg) (#1399)
- (refactoring) UT helpers lib KIKIMR-20902 (#1391)
- Mute some flaky tests (#1400)
- YQL-17343 information_schema.table_constraints (#1397)
- init (#1394)
- Fix nbs tests (#1398)
- Fixes for replace select (#1333)
- JsonDocument support added YQL-17658 (#1306)
- Do not lock already locked node KIKIMR-20904 (#1401)
- YQL-17542 helpers for compute actor async intputs (#1390)
- [YQ-1997] OR REPLACE grammar support for EXTERNAL DATA SOURCE and EXTERNAL TABLE (#1318)
- Mute some flaky tests (#1407)
- Mute some flaky tests (#1413)
- Fix empty yaml config handling in ydb cli (#1409)
- Use EnableForceFollowers in some datashard tests (#1381)
- Blocks for first stages (#1404)
- Topic split/merge for write  (#1386)
- EnableExternalDataSources by default true (#1408)
- Health check for exclusive dynamic nodes KIKIMR-20818 (#1223)
- create statistics aggregator tablet during migration (#1393)
- [YQ-1997] Refactor create external data source / external table schemeshard operations (#1119)
- значение по умолчанию для флага EnablePQConfigTransactionsAtSchemeShard (#1420)
- Enabled multiple join implementations in CBO (#1396)
- fix (#1419)
- win build has been fixed (#1411)
- Temporary disable mixed column/row tables transactions (#1412)
- Remove outdated ydbd serverconfig option (#1422)
- Finsh grpc stream without extra empty message for query service. (#1415)
- Mute some flaky tests (#1421)
- YQL-17348 pg_auth_members, YQL-17351 pg_roles (#1418)
- Revert "the default value for the EnablePQConfigTransactionsAtSchemeShard flag" (#1434)
- Move signals yql lib in os (#1435)
- Mute some flaky tests (#1430)
- Limit v2 compute load by CPU (#861)
- Remove outdated ydbd server options (#1433)
- Change max size of DP table (#1423)
- [YQL-17697] Disable core dumps for udf_resolver (#1439)
- fix memory prediction calculator (#1432)
- init (#1437)
- YQL-17542 move PrepareTaskRunner to TDqSyncComputeActorBase (#1416)
- YQL-17542 pass allocator from ComputeActor to TaskRunnerActor (#1445)
- Increase subprocess timeout to fix test (#1424)
- Add light indicator for bursts to BsCostModel, #1336 (#1337)
- LOGBROKER-8783 propose api (#537)
- Extra test for patching logic (#1446)
- schemeshard: fix copy-tables memory hog (#1442)
- Move yql dq job core in os (#1440)
- Revert "Add light indicator for bursts to BsCostModel, #1336 (#1337)" (#1458)
- Mute some flaky tests (#1456)
- Revert "Move yql dq job core in os (#1440)" (#1461)
- fix columns set algebra (#1450)
- YQL-17706 fixed deallocation size (#1449)
- Mute red test (#1465)
- Update library increment script
- Intermediate changes
- Switch -w to -Wno-everything on C with GNU compilers
- Support wide strings (and string_views) in Out<> / IOutputStream
- remove -Wno-unused-but-set-variable
- Intermediate changes
- Drop TEnumIndexedVector
- Intermediate changes
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Intermediate changes
- Automatic release build for ymake, os_ymake
- Export module headers to cmake
- Fix bugs in CUDA libs pruning
- Move enum_indexed_array from misc to containers
- Intermediate changes
- Enum serialization cmake build fix
- Update vendor/github.com/envoyproxy/go-control-plane to 0.12.0
- Extract log4j version to a variable
- remove -Wno-implicit-int
- [library/cpp/yt] fix peerdir
- Set -mno-outline-atomics for modern versions of CLang and GCC to avoid unresolved symbols linking errors on arm64.,. Fix #2527
- Remove trailing whitespace
- Set conan os.version setting from CMAKE_OSX_DEPLOYMENT_TARGET..
- Intermediate changes
- Add missed #include <type_traits>
- Fix boost asio config
- Intermediate changes
- Update libcxxrt to 2023-10-11 03c83f5a57be8c5b1a29a68de5638744f17d28ba
- Update library sha
- Fix TEvPatch behaviour (#1469)
- Mute some flaky tests (#1466)
- KIKIMR-20100: Add background cleaning (#513)
- Remote topic reader tests KIKIMR-20902 (#1451)
- Make option yaml-config singular for ydbd (#1448)
- fix sink test (#1468)
- Fix param name (#1414)
- init (#1478)
- use cache for fetched data compiled result (#1463)
- Add cost estimator for NVME disks (#1443)
- Fix cdc heartbeats reporting unconfirmed volatile transactions as resolved KIKIMR-20962 (#1473)
- YQ-2744: fix row mode in workload tpch init (#1266)
- storage balancer info in hive ui & sensors KIKIMR-2190 (#1200)
- Fixed clang14 problem with lambda capture (#1475)
- [YQ-1997] Support for ReplaceIfExists flag in SchemeShard for External Data Source and External Table (#1431)
- Mute some flaky tests (#1481)
- KIKIMR-19522 BTreeIndex Charge Items Limit (#1338)
- Temporarily mute SchemeShard's schema test (#1490)
- Method to reply, finish stream and rpc actor. (#1429)
- Add cost estimator for SSD (#1480)
- Do not call TypeName if trace is not used. (#1487)
- Fix scheme_tests canondata (#1493)
- Fix tpcds query text (#1482)
- Move yql dq job core in os (#1464)
- Yql 17542 simplify alloc in compute actor (#1452)
- YQL-17542 move SaveState LoadState (#1474)
- Remove dependncy on <ydb/library/yql/dq/runtime/dq_arrow_helpers.h> (#1476)
- Remove TActiveTransaction from datashard_kqp (#1454)
- type TPartitionId (#1472)
- init (#1511)
- Mute some flaky tests (#1512)
- Mute flaky kv tests (#1516)
- Document proto bytes field decoding with a test (#1509)
- Initialize fields needed for CA (preps for WA removing) (#1513)
- [yql] Plan: add InputSections (YQL-17549) (#1517)
- YQL-17714: Support key ranges (#1520)
- serializer as interface for make new locally (#1496)
- optimizer predicates usage on fetching (#1505)
- Profiling [perf] entry in YQL logs for RewriteReadFromView function (#1495)
- random shuffle has been fixed (#1499)
- Added decimal128 type support with small precision (#1428)
- KIKIMR-20082: TableStore/ColumnTable with QueryService (#1377)
- fix(kqp): use ReadTableRange instead LookupTable (#1140)
- Fix yaml-config requirement (#1524)
- Update build_and_test_provisioned.yml
- Enable cmake workflow to build a specified target (#1533)
- YQL-17703 always use sized allocator in CA (#1522)
- Fix Defragmentation::DoesItWork unit test (#1531)
- Init yt dq jobs (#1460)
- ci: fix Embedded UI Refresh workflow (#1514)
- init (#1534)
- KIKIMR-20931: Fix set_config (#1521)
- Unmute working tests (#1543)
- Remove broken optimizer YQL-17555 (#1376)
- ignore set escape_string_warning (#1518)
- YQL-17646 Fix dqrun/yqlrun difference in bigdate tests (#1503)
- YQL-17725 unicode string literals (#1528)
- Add yaml config support to ydbd_slice (#1406)
- add settings and downsample algorithms (#1425)
- Unmute read-only VDisk unittest (#1545)
- BTreeIndex Charge Bytes Limit (#1489)
- [YQ-1997] Extra tests
- Fix YT yql plugin build (#1548)
- Add UT to test encryption keys obtaining (#1552)
- YQL-17725 docs for unicode literals (#1547)
- add restricting tablet availability to hive ui KIKIMR-20617 (#1288)
- improving potential bottleneck in grpc layer of the query service (#1278)
- Fix pg tpc-ds query texts (#1557)
- YQL-17542 split FillIoMaps (#1537)
- init (#1559)
- Fix compilation of tpc-ds queries in yql syntax (#1562)
- support trailing generic query responses (#1441)
- Document locks and change visibility in datashard YDBDOCS-430 YDBDOCS-431 (#912)
- Fix for unequal nulls bitmap size YQL-17564 (#1570)
- Implemented first version of dynamic jaeger tracing configuration (#1484)
- YQL-17704 switch GWM ut to CA (#1567)
- [-] ссылка на идентификатор партиции (#1550)
- KQP locks in EvWrite (#1551)
- [YQL-16903] Change default value for dq.UseBlockReader and yt.UseRPCReaderInDQ if BlockEngine is enabled (#1564)
- Update github.com/ydb-platform/fq-connector-go image to v0.1.2 (#1574)
- init (#1561)
- fix coverity issues: evaluation order violations (#1556)
- Fix some unnecessary copies reported by coverity (#1578)
- Make coordination session ping period dependent on session timeout KIKIMR-20993 (#1575)
- Add missing <exception> include (#1500)
- Fix the processing of incorrect SourceId (#1555)
- Use now for CreateTime by default (#1573)
- Moved sampler and throttler tests to jaeger_tracing folder (#1572)
- Update StorageLoad docs, YDBDOCS-583 (#1530)
- Coverity fix in TPutRecordsActorBase (#1580)
- Mute some flaky tests (#1579)
- Improve TSectorMap performance tests (#1526)
- Add stable release 23.3.17 to documentation (#1588)
- init (#1598)
- init (#1594)
- Handle bad http headers in requests to YDB (#1542)
- Consider inflight in full result writer (fix large memory consumption) YQL-17720 (#1590)
- kcat fixes (#1586)
- Fix kafka lock partition delay and balance test (#1600)
- Fix crash during run s3 backup. (#1596)
- Reintroduce light indicator for bursts to BsCostModel, #1336 (#1477)
- YQL-17755 fix drying input up (#1604)
- YQL-17542 split stat (#1553)
- Fix iterator (#1612)
- Made tvm url optional (#1591)
- Use std::atomic in shared data header (#1584)
- Remove obsolete controllers (#1577)
- Add separate lower and upper bounds for time deviation (#1614)
- BuildCompleted (#1613)
- [YQ-2800] Fixed path pruning for large amount of files (#1597)
- Fix GetColumnSerializationStats and ResourceSubscriber task name (#1618)
- YQL-17476 check for cycle during evaluation of file args (#1608)
- [YQL-17625] Fix ORDER BY by column missing in projections (#1617)
- Prepare common library for locks (#1605)
- YQL-9517: Over BlockExpandChunked (#1366)
- YQL-17542 remove transition guards (#1610)
- [yt provider] Remove aux columns in PushDownYtMapOverSortedMerge optimizer (YQL-17715) (#1616)
- additional validation and correct case with empty array (#1627)
- correct libraries for use in future (#1628)
- YQL-15941 llvm14 for LLVM_BC (#1245)
- [YQL-17776] Canonize test (#1638)
- Removed required fields from tracing configs (#1636)
- BTreeIndex Charge History (#1593)
- graceful tiering stop (#1632)
- fix filter apply and serializer usage (#1629)
- snapshot serialization (#1630)
- YQL-17542 get rid of std::any in handling sources state (#1635)
- YQL-17755 ut for TComputeActorAsyncInputHelperTest::PollAsyncInput (#1626)
- YQL-17284: Sort output for several tests (#1624)
- YQ-2734 added retries for internal queries (#1457)
- Fix flaky TestDeleteReadRulesAfterAbortBySystem (#1070)
- Fix scrubbing and flapping unittest (#1640)
- add initialization for pool stats (#1644)
- Fix build and behavior with SSA runtime < 4 (#1634)
- Memory control and search fix (#1649)
- Fix leaking blobs via using patching (#1639)
- Add force io pool threads (#1523)
- Add patching to keyvalue (#1549)
- Add decimal128 type support with big precision (#1607)
- Update github.com/ydb-platform/fq-connector-go to v0.1.3 (#1651)
- YQL-17542 move TaskRunner dependent Execute to TDqSyncComputeActorBase (#1599)
- YQL-17711: Fix backtrace (#1619)
- Removed aborts in service initialization (#1652)
- fix tests (#1653)
- YQ-2549 Move yds integration tests to github  (#1592)
- KIKIMR-20539: pure pg_catalog selects (#950)
- YQL-17284: Add hybtrid run for sql tests (#1602)
- Optimized DPccp (#1563)
- Local table writer tests KIKIMR-20902 (#1656)
- use only thread for async s3 interaction (#1668)
- Generate single JSON with all types of plans in the server (#1606)
- add strip port for ssl outgoing connection (#1665)
- Add CMS request priorities KIKIMR-9024 (#1620)
- remove direct indexes in vectors from debug output (#1648)
- YQL-17057: Fix escaping (#1664)
- init (#1667)
- init (#1660)
- Pg patches (#1587)
- Fix mistype in YQL plugin (#1631)
- KIKIMR-20539: resolve static information_schema tables (#1675)
- YQL-17284: Fixed test due to PR conflict (#1686)
- YQL-17542 move TaskRunner dependent Execute to TDqSyncComputeActorBase (#1666)
- YQ-2803 Exception checking in checkpoint storages (#1540)
- KqpRun add results into clear execution (#1661)
- Some BlobDepot hardening checks (#1692)
- fix tierings db usage (#1691)
- YQL-17790: Fix symbolizer ut (#1696)
- don't parametrize default values for columns (#1679)
- Support returning list in delete statements (#1684)
- Fix TEvPatch interface and remove unnecessary patching-related output in KV tablet (#1693)
- [yt provider] Less restrictions for BypassMerge optimizer (YQL-17618) (#1695)
- Fix autoconfig's compute cpu table (#1669)
- Revert "Support returning list in delete statements (#1684)" (#1705)
- Make UTs reachable KIKIMR-20902 (#1700)
- Fix skip for Tz* types (#1697)
- Implement converter yt join tree -> optimizer join tree YQL-17437 (#1671)
- [YQL-17174] added spilling library for compute actors (#1544)
- parallel for (#1650)
- Support KV patching in TestShard (#1699)
- Support temp tables in yql (#1589)
- Convert mismatched types of arg/sequence when applying optimization of ShuffleByKeys to empty sequence (#1568)
- Adjust cost bucket capacity dynamically (#1681)
- Fix plugins path (#1719)
- YQ-2634: S3 runtime file listing (#925)
- Add cmake check workflow (#1725)
- Forbid new required fields in config (#1710)
- Fix cmake postcommit (#1739)
- Split TPayloadHelper to TPayloadReader & TPayloadWriter (#1702)
- Make UTs reachable (attempt 2) KIKIMR-20902 (#1715)
- Enable DDL in ExecuteScript. Allow not to specify TxControl in QueryService queries (#1603)
- NBS-4415: changed log level for ReasonPill (#1736)
- Implement cbo join tree -> yt join tree converter (#1730)
- Cmake sync script (#1743)
- Pushdown Timestamp ctor. (#1726)
- Create sync_cmakebuild.yml (#1747)
- init (#1711)
- init (#1709)
- Fix race between callback and destructor (#1745)
- [*] конструкторы TPartitionId (#1740)
- [YQL-16903] Change default value for EmitAggApply and dq.EnableDqReplicate if BlockEngine is enabled (#1748)
- Don't make lookups on predicate pushdown stage (#1560)
- Reapply "Support returning list in delete statements (#1684)" (#1705) (#1706)
- Make stopping result/notification sending dependent on operation type KIKIMR-21014 (#1680)
- Mute Burst Detection tests (#1763)
- BTreeIndex Bugfix partially-loaded tree (#1674)
- Fix pq writer and few renames (#1757)
- LOGBROKER-8783 bugfix (#1713)
- Moved optimizers from providers/dq to dq (#1758)
- Return back dq_arrow_helpers (#1762)
- LOGBROKER-8792 remove redundant checks (#1417)
- Fix win build (#1760)
- Add option to disable SSL for IAM endpoint (make possible to mock IAM endpoint in tests) (#780)
- add testcases for PgConvertNumericDecimal128Big (#1751)
- Move Inflight actors to ut_helpers (#1759)
- [yt provider] Raise error on invalid poller_interval value (#1771)
- CMake regeneration workflow (#1774)
- support cast in default values (#1754)
- Allow arithmetic operations and operator* for const iterators (#1663)
- Update sync_cmakebuild.yml (#1776)
- Fix fail with pydebug in tf (old)
- Add target and extra_targets, remove unused Targets_, recanonize tests
- Intermediate changes
- External build system generator release 76
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Intermediate changes
- sprintf -> snprintf as it is deprecated on macOS..
- Fix sprintf deprecation warnings on newer macOS SDK
- Fix deprecated pod type in llvm / libcxxabi
- Intermediate changes
- Remove targets, use target/extra_targets
- Automatic release build for ya_bin3, os_ya, ya_bin, test_tool, os_test_tool_3, test_tool3
- 
- Mark methods as const
- Intermediate changes
- cc contrib/grpc: unify one of the patches with how upstream fixed the issue
- Intermediate changes
- 
- Artifacts from bucket and some refactoring
- YDB Import 559
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Intermediate changes
- Remove empty glibtop headers resolving
- Fix reimport for contrib/libs/cxxsupp/libcxxrt
- Move android sysincls to where they belong
- Get rid of empty cuda/include resolving
- check lifetime bounds of  values returned from String's c_str(), data() methods
- 
- Move macOS-specific sysincls to where they belong
- Remove empty resolving for X11/ includes
- Remove empty resolving for Eigen/Array
- Intermediate changes
- TMaybe Monadic operations
- Intermediate changes
- Update contrib/libs/libidn to 1.42
- Add glfw 3.3.9 to contrib
- Bump CUDA -> 11.4 and cuDNN -> 8.0.5
- Intermediate changes
- Update vendor/go.opentelemetry.io/otel to 1.22.0
- Update contrib/libs/libunwind to 18.1.0-rc1
- Intermediate changes
- Update boost/asio and boost/process to 1.70.0
- Fix: add input file as MAIN_DEPENDENCY in Cython call..
- Update contrib/python/MarkupSafe/py3 to 2.1.4
- Intermediate changes
- Fix bug after rXXXXXX
- Disable non-existing macOS include
- yamaker: Disable tr1/ and ext/ includes by default
- Update contrib/libs/re2 to 2024-02-01
- Move macOS-specific sysincls to where they belong
- Disable ext/ and tr1/ headers resolving
- Remove empty resolving of tr1/ and ext/ includes
- Intermediate changes
- Support nonstandard 'ar' versions
- Intermediate changes
- Update contrib/restricted/boost/asio to 1.71.0
- Disable empty doc/ includes resolving
- Remove windows-specific headers resolving from unsorted.yml
- Disable empty resolving of zzip-[1-5].h headers
- Disable empty resolving of libgit2-specific includes
- Remove empty math_constants.h resolving from unsorted.yml
- Clarify wrl headers resolution
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Remove unused -ish.h headers resolving
- Move windows-specific sysincls to windows.yml
- Intermediate changes
- Remove various unused sysincls from unsorted.yml
- 
- Automatic release build for ymake, os_ymake
- Intermediate changes
- Remove unused MX_FORMULAS() macro support
- Update contrib/libs/nghttp2 to 1.59.0
- Intermediate changes
- 
- PR from branch users/prettyboy/release-ya-bin-after-fix-mapping
- Intermediate changes
- TThread::SetName sets thread name on android
- Intermediate changes
- Update yfm-docs for ya make to Build time: 9.706ms
- Intermediate changes
- Upload new jdk-21.0.2+13 + tzdata 2024a
- Update contrib/libs/lzma to 5.4.6
- Intermediate changes
- fix prometheus_decoder ConsumeCounter
- Disable QNX-specific includes in contrib/libs/lzma
- Intermediate changes
- Remove empty resolving of QNX-specific headers
- Intermediate changes
- Upload new jdk-17.0.10+7 + tzdata 2024a
- Update yfm-docs for ya make to Build time: 9.883ms
- Disable non-existing include in contrib/libs/openldap
- Update tzinfo 2024a
- Intermediate changes
- Update yfm-docs for ya make to Build time: 10.003ms
- Intermediate changes
- llvm16 targets
- Update libcxxrt to 2024-02-04 39f76d286ffa70e15ae45632fe3fa5ea96cd46e4
- contrib/restricted/boost: Remove empty resolving of auld stl headers
- Intermediate changes
- Update Python 3 to 3.11.8
- Intermediate changes
- Update contrib/python/types-protobuf to 4.24.0.20240129
- Intermediate changes
- Disable non-existing include in contrib/libs/lzma
- Intermediate changes
- Always return string for cuda architectures
- Remove all remaining checks of auto CUDA support for PPC64 / MacOS
- New version of the tld SKIP_CHECK SKIP_REVIEW
- Intermediate changes
- Disable empty resolving of contrib/libs/curl related headers
- Disable auld stl headers #include
- 
- feat(conf): move nots from internal
- Make #include <random> work in nvcc -std=c++17 mode
- Intermediate changes
- 
- Intermediate changes
- Update contrib/libs/cxxsupp/libcxxrt to 2024-02-06
- Intermediate changes
- Update `ya tool python 3` to 3.11.8
- Intermediate changes
- Add USE_LOCAL_PYTHON setting
- [devtools/ya/test] Removed unused PyTestScriptSuite
- Intermediate changes
- Backport https://github.com/ydb-platform/ydb/pull/1688/files
- Intermediate changes
- 
- Intermediate changes
- fix namespace for DOCS_SRCS
- Automatic release build for ya_bin3, ya_bin, os_ya, test_tool, os_test_tool_3, test_tool3
- Rework joinpath for importlib.resources
- Fix threading for gevent in Python 3.11.8
- baseline per project для дефолтного ktlint
- Add nvml.h sysincl
- nots: Оптимизация в расчете integrity
- Intermediate changes
- Try to allow PEERDIR between resource libraries
- Update rightlib sha
- Added 'FQ_CONNECTOR_ENDPOINT' env variable to `local_ydb` (#1769)
- Add proto plugin for config processing (#1750)
- Change numeric.c according to postgres 14 (#1753)
- [YQL-17637] Revive merging PERCENTILE/MEDIAN aggregation traits for same column (#1775)
- hive ui fixes after tablet availability feature (#1779)
- Break deps from core/grpc_services to core/fq/libs/actors (#1781)
- Mark mutable_id for YT writes (#1744)
- store history of changes made to hive via http (#1637)
- Return skiff from dq (#1765)
- improve base stats propagation logic (#1741)
- Cannonized two plans (#1773)
- KIKIMR-20580: enable stream lookup (#1676)
- YQL-17502 Bigdate from/to string conversions (#1447)
- fix segfault (#1799)
- Revert "Move Inflight actors to ut_helpers" (#1802)
- docs: fix presentation url (#1816)
- Use six's 'urllib.parse' in 'PY23_LIBRARY' modules (#1833)
- Do not move protobuf from TValue during BulkUpsert execution. (#1809)
- Manage releases docs (#1351)
- runtime dispatching (fixed) (#1847)
- ci: fix Embedded UI refresh workflow (#1780)
- Сhange keys format for service partitions (#1569)
- Support of database sys cache (#1817)
- Expose a factory for new native cbo YQL-17437 (#1855)
- YQL-17250: Add stats for hybrid skip checks (#1670)
- Fixed missing PEERDIR in ydb/public/tools/lib/cmds (#1856)
- Test supported types KIKIMR-20902 (#1865)
- Do not call TypeName for trace in tablet transactions if no trace exists (#1867)
- [Configs Refactor] Split protobufs (#1863)
- Add unit tests for EvaluateExpr in VIEWs (#1488)
- LOGBROKER-8894 enable minSeqNo save in partition (iter3) (#1768)
- quick fix for column name of select version() (#1801)
- YDBDOCS-596: extra clarifications to upgrade.md (#1874)
- Remove duplicated defines (#1788)
- Create a submenu for changelog to enable includes into the overlay docs (#1880)
- bring simple queue tool to oss (#1879)
- YQ-2417 show ast in case of compilation error (#1353)
- [Configs Refactor] Deprecate old yaml_config_parser (#1876)
- Forbid query execution on explicit session without attach (#1870)
- Unmute some flaky tests (#1889)
- Logging & tagging KIKIMR-21006 (#1881)
- Fix git workflow documentation (#1685)
- Improve some headers (#1877)
- YQ 2786 fix test fq restarts (#1810)
- YQL-17439: block implementation of From/IntervalFrom/To Datetime UDF functions (#1755)
- [yt provider] Fix table sort keys usage collection (#1886)
- KIKIMR-21038: Remove column UID from ticket parser html page (#1770)
- KIKIMR-20234: Add access right for topic commit offset (#1558)
- save the WriteId + PartitionId (#1037)
- Use uid as idempotency key KIKIMR-21059 (#1887)
- Fix TBootstrap usage in cfg tool (#1901)
- YDB-1065 added proxying for render handler (#1872)
- Some minor KeyValue tablet improvements (#1900)
- Improve dstool (#1898)
- Add ErrorReason field to EvVGet query (#1897)
- fixes for TxWriteIndex volume control, policies of exceptions on searching, eviction tasks for portions usage (#1894)
- Refactor config transformations (#1787)
- Remove MvccTestOutOfOrderRestartLocksSingleWithoutBarrier (#1905)
- Early validate json path. (#1896)
- [YQL-17789] Fix WideToBlocks over WideFromBlocks optimizer. Introduce ReplicateScalars (#1903)
- Case insensivity for pg_catalog tables/cluster, columns. Support of pg_class:relam, and some columns in pg_database & pg_namespace (#1893)
- YQ-2704 Use ActorSystem() instead of AsActorContext() (#1892)
- Switch yt provider to new CBO api YQL-17437 (#1868)
- CODEOWNERS: treat root *.md files as docs (#1909)
- EvWrite Prepare (#1658)
- [Configs Refactor] Replace macro with template in driver_lib (#1908)
- Fixed a problem with simplified plan JSONs (#1878)
- [YQL-17709] [compute] split spilling into actor and non-actor parts (#1761)
- Reintroduce test_helpers for ut_blobstorage (#1890)
- DqOptimizeEquiJoinWithCosts uses abstract CBO API YQL-17437 (#1912)
- Cover IS NULL query in the secondary index ut. (#1899)
- pg wire bypasses rpc layer and doesn't perform attach call (#1916)
- Added a fix for the unit test failure

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Additional information

...
