### PR TITLE
[YQL-17709] [channel] split spilling into actor and non-actor parts

### DIFF
--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -983,7 +983,7 @@ public:
         return {};
     }
 
-    NDq::IDqChannelStorage::TPtr CreateChannelStorage(ui64 /* channelId */, bool /* withSpilling */, TActorSystem* /* actorSystem */, bool /*isConcurrent*/) const override {
+    NDq::IDqChannelStorage::TPtr CreateChannelStorage(ui64 /* channelId */, bool /* withSpilling */, TActorSystem* /* actorSystem */) const override {
         return {};
     }
 

--- a/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.cpp
@@ -13,12 +13,12 @@ TDqTaskRunnerExecutionContext::TDqTaskRunnerExecutionContext(TTxId txId, IDqChan
 }
 
 IDqChannelStorage::TPtr TDqTaskRunnerExecutionContext::CreateChannelStorage(ui64 channelId, bool withSpilling) const {
-    return CreateChannelStorage(channelId, withSpilling, nullptr, false);
+    return CreateChannelStorage(channelId, withSpilling, NActors::TlsActivationContext->ActorSystem());
 }
 
-IDqChannelStorage::TPtr TDqTaskRunnerExecutionContext::CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem, bool isConcurrent) const {
+IDqChannelStorage::TPtr TDqTaskRunnerExecutionContext::CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem) const {
     if (withSpilling) {
-        return CreateDqChannelStorage(TxId_, channelId, WakeUp_, actorSystem, isConcurrent);
+        return CreateDqChannelStorage(TxId_, channelId, WakeUp_, actorSystem);
     } else {
         return nullptr;
     }

--- a/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.h
+++ b/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.h
@@ -12,7 +12,7 @@ public:
     TDqTaskRunnerExecutionContext(TTxId txId, IDqChannelStorage::TWakeUpCallback&& wakeUp);
 
     IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling) const override;
-    IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem, bool isConcurrent) const override;
+    IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem) const override;
 
     std::function<void()> GetWakeupCallback() const override;
 

--- a/ydb/library/yql/dq/actors/spilling/channel_storage.cpp
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage.cpp
@@ -20,62 +20,109 @@ using namespace NActors;
 
 namespace {
 
+
+constexpr ui32 MAX_INFLIGHT_BLOBS_COUNT = 10;
+constexpr ui64 MAX_INFLIGHT_BLOBS_SIZE = 50_MB;
+
 class TDqChannelStorage : public IDqChannelStorage {
+    struct TWritingBlobInfo {
+        ui64 BlobSize_;
+        NThreading::TFuture<void> IsBlobWrittenFuture_;
+    };
 public:
-    TDqChannelStorage(TTxId txId, ui64 channelId, TWakeUpCallback&& wakeUp, TActorSystem* actorSystem, bool isConcurrent)
+    TDqChannelStorage(TTxId txId, ui64 channelId, TWakeUpCallback&& wakeUp, TActorSystem* actorSystem)
     : ActorSystem_(actorSystem)
     {
-        if (isConcurrent) {
-            SelfActor_ = CreateConcurrentDqChannelStorageActor(txId, channelId, std::move(wakeUp), actorSystem);
-        } else {
-            SelfActor_ = CreateDqChannelStorageActor(txId, channelId, std::move(wakeUp), actorSystem);
-        }
-        SelfActorId_ = TlsActivationContext->AsActorContext().RegisterWithSameMailbox(SelfActor_->GetActor());
-        SelfId_ = TlsActivationContext->AsActorContext().SelfID;
+        ChannelStorageActor_ = CreateDqChannelStorageActor(txId, channelId, std::move(wakeUp), actorSystem);
+        ChannelStorageActorId_ = ActorSystem_->Register(ChannelStorageActor_->GetActor());
     }
 
     ~TDqChannelStorage() {
-        if (ActorSystem_) {
-            ActorSystem_->Send(
-            new IEventHandle(
-                SelfActorId_,
-                SelfId_,
-                new TEvents::TEvPoison,
-                /*flags=*/0,
-                /*cookie=*/0));
-        } else {
-            TlsActivationContext->AsActorContext().Send(SelfActorId_, new TEvents::TEvPoison);
-        }
+        ActorSystem_->Send(ChannelStorageActorId_, new TEvents::TEvPoison);
     }
 
-    bool IsEmpty() const override {
-        return SelfActor_->IsEmpty();
+    bool IsEmpty() override {
+        UpdateWriteStatus();
+
+        return WritingBlobs_.empty() && StoredBlobsCount_ == 0 && LoadingBlobs_.empty();
     }
 
-    bool IsFull() const override {
-        return SelfActor_->IsFull();
+    bool IsFull() override {
+        UpdateWriteStatus();
+
+        return WritingBlobs_.size() > MAX_INFLIGHT_BLOBS_COUNT || WritingBlobsTotalSize_ > MAX_INFLIGHT_BLOBS_SIZE;
     }
 
     void Put(ui64 blobId, TRope&& blob, ui64 cookie = 0) override {
-        SelfActor_->Put(blobId, std::move(blob), cookie);
+        UpdateWriteStatus();
+
+        auto promise = NThreading::NewPromise<void>();
+        auto future = promise.GetFuture();
+
+        ui64 blobSize = blob.size();
+
+        ActorSystem_->Send(ChannelStorageActorId_, new TEvDqChannelSpilling::TEvPut(blobId, std::move(blob), std::move(promise)), /*flags*/0, cookie);
+
+        WritingBlobs_.emplace(blobId, TWritingBlobInfo(blobSize, std::move(future)));
+        WritingBlobsTotalSize_ += blobSize;
     }
 
     bool Get(ui64 blobId, TBuffer& blob, ui64 cookie = 0) override {
-        return SelfActor_->Get(blobId, blob, cookie);
+        UpdateWriteStatus();
+
+        const auto it = LoadingBlobs_.find(blobId);
+        // If we didn't request loading blob from spilling -> request it
+        if (it == LoadingBlobs_.end()) {
+            auto promise = NThreading::NewPromise<TBuffer>();
+            auto future = promise.GetFuture();
+            ActorSystem_->Send(ChannelStorageActorId_, new TEvDqChannelSpilling::TEvGet(blobId, std::move(promise)), /*flags*/0, cookie);
+
+            LoadingBlobs_.emplace(blobId, std::move(future));
+            return false;
+        }
+        // If we requested loading blob, but it's not loaded -> wait
+        if (!it->second.HasValue()) return false;
+
+        blob = std::move(it->second.ExtractValue());
+        LoadingBlobs_.erase(it);
+        --StoredBlobsCount_;
+
+        return true;
     }
 
 private:
-    IDqChannelStorageActor* SelfActor_;
-    TActorId SelfActorId_;
-    TActorId SelfId_;
+    void UpdateWriteStatus() {
+        TVector<THashMap<ui64, TWritingBlobInfo>::iterator> itersToRemove;
+        for (auto it = WritingBlobs_.begin(); it != WritingBlobs_.end();) {
+            if (it->second.IsBlobWrittenFuture_.HasValue()) {
+                WritingBlobsTotalSize_ -= it->second.BlobSize_;
+                ++StoredBlobsCount_;
+                WritingBlobs_.erase(it++);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+private:
+    IDqChannelStorageActor* ChannelStorageActor_;
+    TActorId ChannelStorageActorId_;
     TActorSystem *ActorSystem_;
+
+    // BlobId -> future with requested blob
+    THashMap<ui64, NThreading::TFuture<TBuffer>> LoadingBlobs_;
+    // BlobId -> future with some additional info
+    THashMap<ui64, TWritingBlobInfo> WritingBlobs_;
+    ui64 WritingBlobsTotalSize_ = 0;
+
+    ui64 StoredBlobsCount_ = 0;
 };
 
 } // anonymous namespace
 
-IDqChannelStorage::TPtr CreateDqChannelStorage(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback wakeUp, TActorSystem* actorSystem, bool isConcurrent)
+IDqChannelStorage::TPtr CreateDqChannelStorage(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback wakeUp, TActorSystem* actorSystem)
 {
-    return new TDqChannelStorage(txId, channelId, std::move(wakeUp), actorSystem, isConcurrent);
+    return new TDqChannelStorage(txId, channelId, std::move(wakeUp), actorSystem);
 }
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/spilling/channel_storage.cpp
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage.cpp
@@ -96,7 +96,7 @@ private:
             if (it->second.IsBlobWrittenFuture_.HasValue()) {
                 WritingBlobsTotalSize_ -= it->second.BlobSize_;
                 ++StoredBlobsCount_;
-                WritingBlobs_.erase(it++);
+                it = WritingBlobs_.erase(it);
             } else {
                 ++it;
             }
@@ -109,9 +109,9 @@ private:
     TActorSystem *ActorSystem_;
 
     // BlobId -> future with requested blob
-    THashMap<ui64, NThreading::TFuture<TBuffer>> LoadingBlobs_;
+    std::unordered_map<ui64, NThreading::TFuture<TBuffer>> LoadingBlobs_;
     // BlobId -> future with some additional info
-    THashMap<ui64, TWritingBlobInfo> WritingBlobs_;
+    std::unordered_map<ui64, TWritingBlobInfo> WritingBlobs_;
     ui64 WritingBlobsTotalSize_ = 0;
 
     ui64 StoredBlobsCount_ = 0;

--- a/ydb/library/yql/dq/actors/spilling/channel_storage.cpp
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage.cpp
@@ -92,7 +92,6 @@ public:
 
 private:
     void UpdateWriteStatus() {
-        TVector<THashMap<ui64, TWritingBlobInfo>::iterator> itersToRemove;
         for (auto it = WritingBlobs_.begin(); it != WritingBlobs_.end();) {
             if (it->second.IsBlobWrittenFuture_.HasValue()) {
                 WritingBlobsTotalSize_ -= it->second.BlobSize_;

--- a/ydb/library/yql/dq/actors/spilling/channel_storage.h
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage.h
@@ -11,6 +11,6 @@ namespace NActors {
 namespace NYql::NDq {
 
 IDqChannelStorage::TPtr CreateDqChannelStorage(TTxId txId, ui64 channelId,
-    IDqChannelStorage::TWakeUpCallback wakeUpCb, NActors::TActorSystem* actorSystem, bool isConcurrent);
+    IDqChannelStorage::TWakeUpCallback wakeUpCb, NActors::TActorSystem* actorSystem);
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
@@ -156,10 +156,10 @@ private:
     TActorId SpillingActorId_;
 
     // BlobId -> promise that blob is saved
-    THashMap<ui64, NThreading::TPromise<void>> WritingBlobs_;
+    std::unordered_map<ui64, NThreading::TPromise<void>> WritingBlobs_;
     
     // BlobId -> promise with requested blob
-    THashMap<ui64, NThreading::TPromise<TBuffer>> LoadingBlobs_;
+    std::unordered_map<ui64, NThreading::TPromise<TBuffer>> LoadingBlobs_;
     TMaybe<TString> Error_;
 
     TActorSystem* ActorSystem_;

--- a/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
@@ -18,168 +18,35 @@ using namespace NActors;
 
 namespace {
 
-#define LOG_D(s) { \
-    if (ActorSystem_) { \
-        LOG_DEBUG_S(*ActorSystem_, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s); \
-    } else { \
-        LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s); \
-    } \
-}
+#define LOG_D(s) \
+    LOG_DEBUG_S(*ActorSystem_, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s);
 
-#define LOG_I(s) { \
-    if (ActorSystem_) { \
-        LOG_INFO_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s); \
-    } else { \
-        LOG_INFO_S(*TlsActivationContext,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s); \
-    } \
-}
+#define LOG_I(s) \
+    LOG_INFO_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s);
 
-#define LOG_E(s) { \
-    if (ActorSystem_) { \
-        LOG_ERROR_S(*ActorSystem_, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s); \
-    } else { \
-        LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s); \
-    } \
-}
+#define LOG_E(s) \
+    LOG_ERROR_S(*ActorSystem_, NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s);
 
-#define LOG_C(s) { \
-    if (ActorSystem_) { \
-        LOG_CRIT_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s); \
-    } else { \
-        LOG_CRIT_S(*TlsActivationContext,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s); \
-    } \
-}
+#define LOG_C(s) \
+    LOG_CRIT_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s);
 
-#define LOG_W(s) { \
-    if (ActorSystem_) { \
-        LOG_WARN_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s); \
-    } else { \
-        LOG_WARN_S(*TlsActivationContext,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s); \
-    } \
-}
+#define LOG_W(s) \
+    LOG_WARN_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId << ", channelId: " << ChannelId << ". " << s);
 
-#define LOG_T(s) { \
-    if (ActorSystem_) { \
-        LOG_TRACE_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s); \
-    } else { \
-        LOG_TRACE_S(*TlsActivationContext,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s); \
-    } \
-}
+#define LOG_T(s) \
+    LOG_TRACE_S(*ActorSystem_,  NKikimrServices::KQP_COMPUTE, "TxId: " << TxId_ << ", channelId: " << ChannelId_ << ". " << s); 
 
-constexpr ui32 MAX_INFLIGHT_BLOBS_COUNT = 10;
-constexpr ui64 MAX_INFLIGHT_BLOBS_SIZE = 50_MB;
-
-class TDqChannelStorageActorBase : public IDqChannelStorageActor
-{
-public:
-    ~TDqChannelStorageActorBase() = default;
-
-    TDqChannelStorageActorBase(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, TActorSystem* actorSystem)
-        : TxId_(txId)
-        , ChannelId_(channelId)
-        , WakeUp_(std::move(wakeUp))
-        , ActorSystem_(actorSystem)
-    {}
-
-    bool IsEmpty() override {
-        return WritingBlobs_.empty() && StoredBlobsCount_ == 0 && LoadedBlobs_.empty();
-    }
-
-    bool IsFull() override {
-        return WritingBlobs_.size() > MAX_INFLIGHT_BLOBS_COUNT || WritingBlobsSize_ > MAX_INFLIGHT_BLOBS_SIZE;
-    }
-
-    [[nodiscard]]
-    const TMaybe<TString>& GetError() const {
-        return Error_;
-    }
-
-protected:
-
-    void PutInternal(ui64 blobId, TRope&& blob, TActorIdentity selfActorId, ui64 cookie) {
-        FailOnError();
-
-        // TODO: timeout
-        // TODO: limit inflight events
-
-        ui64 size = blob.size();
-
-        SendEvent(new TEvDqSpilling::TEvWrite(blobId, std::move(blob)), selfActorId, cookie);
-
-        WritingBlobs_.emplace(blobId, size);
-        WritingBlobsSize_ += size;
-    }
-
-    bool GetInternal(ui64 blobId, TBuffer& blob, TActorIdentity selfActorId, ui64 cookie) {
-        FailOnError();
-
-        auto loadedIt = LoadedBlobs_.find(blobId);
-        if (loadedIt != LoadedBlobs_.end()) {
-            YQL_ENSURE(loadedIt->second.size() != 0);
-            blob.Swap(loadedIt->second);
-            LoadedBlobs_.erase(loadedIt);
-            return true;
-        }
-
-        auto result = LoadingBlobs_.emplace(blobId);
-        if (result.second) {
-            SendEvent(new TEvDqSpilling::TEvRead(blobId, true), selfActorId, cookie);
-        }
-
-        return false;
-    }
-
-    void FailOnError() {
-        if (Error_) {
-            LOG_E("Error: " << *Error_);
-            ythrow TDqChannelStorageException() << "TxId: " << TxId_ << ", channelId: " << ChannelId_
-                << ", error: " << *Error_;
-        }
-    }
-
-    template<typename T> void SendEvent(T* event, TActorIdentity selfActorId, ui64 cookie) {
-        if (ActorSystem_) {
-            ActorSystem_->Send(
-                new IEventHandle(
-                    SpillingActorId_,
-                    selfActorId,
-                    event,
-                    /*flags=*/0,
-                    cookie
-                )
-            );
-        } else {
-            selfActorId.Send(SpillingActorId_, event);
-        }
-    }
-
-protected:
-    const TTxId TxId_;
-    const ui64 ChannelId_;
-    IDqChannelStorage::TWakeUpCallback WakeUp_;
-    TActorId SpillingActorId_;
-
-    TMap<ui64, ui64> WritingBlobs_; // blobId -> blobSize
-    ui64 WritingBlobsSize_ = 0;
-
-    ui32 StoredBlobsCount_ = 0;
-    ui64 StoredBlobsSize_ = 0;
-
-    TSet<ui64> LoadingBlobs_;
-    TMap<ui64, TBuffer> LoadedBlobs_;
-
-    TMaybe<TString> Error_;
-
-    TActorSystem* ActorSystem_;
-};
-
-class TDqChannelStorageActor : public TDqChannelStorageActorBase,
+class TDqChannelStorageActor : public IDqChannelStorageActor,
                                public NActors::TActorBootstrapped<TDqChannelStorageActor>
 {
     using TBase = TActorBootstrapped<TDqChannelStorageActor>;
 public:
-    TDqChannelStorageActor(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, NActors::TActorSystem* actorSystem)
-        : TDqChannelStorageActorBase(txId, channelId, std::move(wakeUp), actorSystem)
+
+    TDqChannelStorageActor(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, TActorSystem* actorSystem)
+        : TxId_(txId)
+        , ChannelId_(channelId)
+        , WakeUp_(std::move(wakeUp))
+        , ActorSystem_(actorSystem)
     {}
 
     void Bootstrap() {
@@ -195,26 +62,15 @@ public:
         return this;
     }
 
-    void Put(ui64 blobId, TRope&& blob, ui64 cookie) override {
-        TDqChannelStorageActorBase::PutInternal(blobId, std::move(blob), SelfId(), cookie);
-    }
-
-    bool Get(ui64 blobId, TBuffer& blob, ui64 cookie) override {
-        return TDqChannelStorageActorBase::GetInternal(blobId, blob, SelfId(), cookie);
-    }
-
-protected:
-    void PassAway() override {
-        Send(SpillingActorId_, new TEvents::TEvPoison);
-        TBase::PassAway();
-    }
-
 private:
+
     STATEFN(WorkState) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvDqSpilling::TEvWriteResult, HandleWork);
             hFunc(TEvDqSpilling::TEvReadResult, HandleWork);
             hFunc(TEvDqSpilling::TEvError, HandleWork);
+            hFunc(TEvDqChannelSpilling::TEvGet, HandleWork);
+            hFunc(TEvDqChannelSpilling::TEvPut, HandleWork);
             cFunc(TEvents::TEvPoison::EventType, PassAway);
             default:
                 Y_ABORT("TDqChannelStorageActor::WorkState unexpected event type: %" PRIx32 " event: %s",
@@ -223,11 +79,29 @@ private:
         }
     }
 
+    void HandleWork(TEvDqChannelSpilling::TEvGet::TPtr& ev) {
+        auto& msg = *ev->Get();
+        LOG_T("[TEvGet] blobId: " << msg.BlobId_);
+ 
+        LoadingBlobs_.emplace(msg.BlobId_, std::move(msg.Promise_));
+
+        Send(SpillingActorId_, new TEvDqSpilling::TEvRead(msg.BlobId_));
+    }
+
+    void HandleWork(TEvDqChannelSpilling::TEvPut::TPtr& ev) {
+        auto& msg = *ev->Get();
+        LOG_T("[TEvPut] blobId: " << msg.BlobId_);
+
+        WritingBlobs_.emplace(msg.BlobId_, std::move(msg.Promise_));
+
+        Send(SpillingActorId_, new TEvDqSpilling::TEvWrite(msg.BlobId_, std::move(msg.Blob_)));
+    }
+
     void HandleWork(TEvDqSpilling::TEvWriteResult::TPtr& ev) {
         auto& msg = *ev->Get();
         LOG_T("[TEvWriteResult] blobId: " << msg.BlobId);
 
-        auto it = WritingBlobs_.find(msg.BlobId);
+        const auto it = WritingBlobs_.find(msg.BlobId);
         if (it == WritingBlobs_.end()) {
             LOG_E("Got unexpected TEvWriteResult, blobId: " << msg.BlobId);
 
@@ -237,110 +111,18 @@ private:
             return;
         }
 
-        ui64 size = it->second;
-        WritingBlobsSize_ -= size;
+        // Complete the future
+        it->second.SetValue();
         WritingBlobs_.erase(it);
-
-        StoredBlobsCount_++;
-        StoredBlobsSize_ += size;
     }
 
     void HandleWork(TEvDqSpilling::TEvReadResult::TPtr& ev) {
         auto& msg = *ev->Get();
         LOG_T("[TEvReadResult] blobId: " << msg.BlobId << ", size: " << msg.Blob.size());
 
-        if (LoadingBlobs_.erase(msg.BlobId) != 1) {
-            LOG_E("[TEvReadResult] unexpected, blobId: " << msg.BlobId << ", size: " << msg.Blob.size());
-            return;
-        }
-
-        LoadedBlobs_[msg.BlobId].Swap(msg.Blob);
-        YQL_ENSURE(LoadedBlobs_[msg.BlobId].size() != 0);
-
-        if (LoadedBlobs_.size() == 1) {
-            WakeUp_();
-        }
-    }
-
-    void HandleWork(TEvDqSpilling::TEvError::TPtr& ev) {
-        auto& msg = *ev->Get();
-        LOG_D("[TEvError] " << msg.Message);
-
-        Error_.ConstructInPlace(msg.Message);
-    }
-};
-
-class TConcurrentDqChannelStorageActor : public TDqChannelStorageActorBase,
-                               public NActors::TActorBootstrapped<TConcurrentDqChannelStorageActor>
-{
-    using TBase = TActorBootstrapped<TConcurrentDqChannelStorageActor>;
-public:
-    TConcurrentDqChannelStorageActor(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, NActors::TActorSystem* actorSystem)
-        : TDqChannelStorageActorBase(txId, channelId, std::move(wakeUp), actorSystem)
-    {}
-
-
-    void Bootstrap() {
-        auto spillingActor = CreateDqLocalFileSpillingActor(TxId_, TStringBuilder() << "ChannelId: " << ChannelId_,
-            SelfId(), true);
-        SpillingActorId_ = Register(spillingActor);
-        Become(&TConcurrentDqChannelStorageActor::WorkState);
-    }
-
-    static constexpr char ActorName[] = "DQ_CONCURRENT_CHANNEL_STORAGE";
-
-    IActor* GetActor() override {
-        return this;
-    }
-
-    bool IsEmpty() override {
-        std::lock_guard lock(Mutex_);
-        return TDqChannelStorageActorBase::IsEmpty();
-    }
-
-    bool IsFull() override {
-        std::lock_guard lock(Mutex_);
-        return TDqChannelStorageActorBase::IsFull();
-    }
-
-    void Put(ui64 blobId, TRope&& blob, ui64 cookie) override {
-        std::lock_guard lock(Mutex_);
-        TDqChannelStorageActorBase::PutInternal(blobId, std::move(blob), SelfId(), cookie);
-    }
-
-    bool Get(ui64 blobId, TBuffer& blob, ui64 cookie) override {
-        std::lock_guard lock(Mutex_);
-        return TDqChannelStorageActorBase::GetInternal(blobId, blob, SelfId(), cookie);
-    }
-
-protected:
-    void PassAway() override {
-        Send(SpillingActorId_, new TEvents::TEvPoison);
-        TBase::PassAway();
-    }
-
-private:
-    STATEFN(WorkState) {
-        switch (ev->GetTypeRewrite()) {
-            hFunc(TEvDqSpilling::TEvWriteResult, HandleWork);
-            hFunc(TEvDqSpilling::TEvReadResult, HandleWork);
-            hFunc(TEvDqSpilling::TEvError, HandleWork);
-            cFunc(TEvents::TEvPoison::EventType, PassAway);
-            default:
-                Y_ABORT("TDqChannelStorageActor::WorkState unexpected event type: %" PRIx32 " event: %s",
-                    ev->GetTypeRewrite(),
-                    ev->ToString().data());
-        }
-    }
-
-    void HandleWork(TEvDqSpilling::TEvWriteResult::TPtr& ev) {
-        auto& msg = *ev->Get();
-        LOG_T("[TEvWriteResult] blobId: " << msg.BlobId);
-
-        std::lock_guard lock(Mutex_);
-        auto it = WritingBlobs_.find(msg.BlobId);
-        if (it == WritingBlobs_.end()) {
-            LOG_E("Got unexpected TEvWriteResult, blobId: " << msg.BlobId);
+        const auto it = LoadingBlobs_.find(msg.BlobId);
+        if (it == LoadingBlobs_.end()) {
+            LOG_E("Got unexpected TEvReadResult, blobId: " << msg.BlobId);
 
             Error_ = "Internal error";
 
@@ -348,30 +130,10 @@ private:
             return;
         }
 
-        ui64 size = it->second;
-        WritingBlobsSize_ -= size;
-        WritingBlobs_.erase(it);
+        it->second.SetValue(std::move(msg.Blob));
+        LoadingBlobs_.erase(it);
 
-        StoredBlobsCount_++;
-        StoredBlobsSize_ += size;
-    }
-
-    void HandleWork(TEvDqSpilling::TEvReadResult::TPtr& ev) {
-        auto& msg = *ev->Get();
-        LOG_T("[TEvReadResult] blobId: " << msg.BlobId << ", size: " << msg.Blob.size());
-
-        std::lock_guard lock(Mutex_);
-        if (LoadingBlobs_.erase(msg.BlobId) != 1) {
-            LOG_E("[TEvReadResult] unexpected, blobId: " << msg.BlobId << ", size: " << msg.Blob.size());
-            return;
-        }
-
-        LoadedBlobs_[msg.BlobId].Swap(msg.Blob);
-        YQL_ENSURE(LoadedBlobs_[msg.BlobId].size() != 0);
-
-        if (LoadedBlobs_.size() == 1) {
-            WakeUp_();
-        }
+        WakeUp_();
     }
 
     void HandleWork(TEvDqSpilling::TEvError::TPtr& ev) {
@@ -381,18 +143,32 @@ private:
         Error_.ConstructInPlace(msg.Message);
     }
 
+    void PassAway() override {
+        Send(SpillingActorId_, new TEvents::TEvPoison);
+        TBase::PassAway();
+    }
+
+
 private:
-    std::mutex Mutex_;
+    const TTxId TxId_;
+    const ui64 ChannelId_;
+    IDqChannelStorage::TWakeUpCallback WakeUp_;
+    TActorId SpillingActorId_;
+
+    // BlobId -> promise that blob is saved
+    THashMap<ui64, NThreading::TPromise<void>> WritingBlobs_;
+    
+    // BlobId -> promise with requested blob
+    THashMap<ui64, NThreading::TPromise<TBuffer>> LoadingBlobs_;
+    TMaybe<TString> Error_;
+
+    TActorSystem* ActorSystem_;
 };
 
 } // anonymous namespace
 
 IDqChannelStorageActor* CreateDqChannelStorageActor(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, NActors::TActorSystem* actorSystem) {
     return new TDqChannelStorageActor(txId, channelId, std::move(wakeUp), actorSystem);
-}
-
-IDqChannelStorageActor* CreateConcurrentDqChannelStorageActor(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, NActors::TActorSystem* actorSystem) {
-    return new TConcurrentDqChannelStorageActor(txId, channelId, std::move(wakeUp), actorSystem);
 }
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/spilling/channel_storage_actor.h
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage_actor.h
@@ -5,6 +5,39 @@
 
 namespace NYql::NDq {
 
+struct TDqChannelStorageActorEvents {
+    enum {
+        EvPut = EventSpaceBegin(NActors::TEvents::EEventSpace::ES_USERSPACE) + 30100,
+        EvGet
+    };
+};
+
+struct TEvDqChannelSpilling {
+    struct TEvPut : NActors::TEventLocal<TEvPut, TDqChannelStorageActorEvents::EvPut> {
+        TEvPut(ui64 blobId, TRope&& blob, NThreading::TPromise<void>&& promise)
+            : BlobId_(blobId)
+            , Blob_(std::move(blob))
+            , Promise_(std::move(promise))
+        {
+        }
+
+        ui64 BlobId_;
+        TRope Blob_;
+        NThreading::TPromise<void> Promise_;
+    };
+
+    struct TEvGet : NActors::TEventLocal<TEvGet, TDqChannelStorageActorEvents::EvGet> {
+        TEvGet(ui64 blobId, NThreading::TPromise<TBuffer>&& promise)
+            : BlobId_(blobId)
+            , Promise_(std::move(promise))
+        {
+        }
+
+        ui64 BlobId_;
+        NThreading::TPromise<TBuffer> Promise_;
+    };
+};
+
 class IDqChannelStorageActor
 {
 public:
@@ -14,23 +47,8 @@ public:
     virtual ~IDqChannelStorageActor() = default;
 
     virtual NActors::IActor* GetActor() = 0;
-
-    virtual bool IsEmpty() = 0;
-    virtual bool IsFull() = 0;
-
-    // methods Put/Get can throw `TDqChannelStorageException`
-
-    // Data should be owned by `blob` argument since the Put() call is actually asynchronous
-    virtual void Put(ui64 blobId, TRope&& blob, ui64 cookie = 0) = 0;
-
-    // TODO: there is no way for client to delete blob.
-    // It is better to replace Get() with Pull() which will delete blob after read
-    // (current clients read each blob exactly once)
-    // Get() will return false if data is not ready yet. Client should repeat Get() in this case
-    virtual bool Get(ui64 blobId, TBuffer& data, ui64 cookie = 0)  = 0;
 };
 
 IDqChannelStorageActor* CreateDqChannelStorageActor(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, NActors::TActorSystem* actorSystem);
-IDqChannelStorageActor* CreateConcurrentDqChannelStorageActor(TTxId txId, ui64 channelId, IDqChannelStorage::TWakeUpCallback&& wakeUp, NActors::TActorSystem* actorSystem);
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/runtime/dq_channel_storage.h
+++ b/ydb/library/yql/dq/runtime/dq_channel_storage.h
@@ -20,8 +20,8 @@ public:
 public:
     virtual ~IDqChannelStorage() = default;
 
-    virtual bool IsEmpty() const = 0;
-    virtual bool IsFull() const = 0;
+    virtual bool IsEmpty() = 0;
+    virtual bool IsFull() = 0;
 
     // methods Put/Get can throw `TDqChannelStorageException`
 

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.h
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.h
@@ -136,7 +136,7 @@ public:
         TVector<IDqOutput::TPtr>&& outputs) const = 0;
 
     virtual IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling) const = 0;
-    virtual IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem, bool isConcurrent) const = 0;
+    virtual IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem) const = 0;
 
     virtual std::function<void()> GetWakeupCallback() const = 0;
 };
@@ -156,7 +156,7 @@ public:
         return {};
     };
 
-    IDqChannelStorage::TPtr CreateChannelStorage(ui64 /*channelId*/, bool /*withSpilling*/, NActors::TActorSystem* /*actorSystem*/, bool /*isConcurrent*/) const override {
+    IDqChannelStorage::TPtr CreateChannelStorage(ui64 /*channelId*/, bool /*withSpilling*/, NActors::TActorSystem* /*actorSystem*/) const override {
         return {};
     };
 

--- a/ydb/library/yql/dq/runtime/ut/ut_helper.h
+++ b/ydb/library/yql/dq/runtime/ut/ut_helper.h
@@ -12,11 +12,11 @@ public:
     TMockChannelStorage(ui64 capacity)
         : Capacity(capacity) {}
 
-    bool IsEmpty() const override {
+    bool IsEmpty() override {
         return Blobs.empty();
     }
 
-    bool IsFull() const override {
+    bool IsFull() override {
         return Capacity <= UsedSpace;
     }
 

--- a/ydb/library/yql/providers/dq/task_runner_actor/task_runner_actor.cpp
+++ b/ydb/library/yql/providers/dq/task_runner_actor/task_runner_actor.cpp
@@ -726,7 +726,7 @@ private:
 
     void CreateSpillingStorage(ui64 channelId, TActorSystem* actorSystem, bool enableSpilling) {
         TSpillingStorageInfo::TPtr spillingStorageInfo = nullptr;
-        auto channelStorage = ExecCtx->CreateChannelStorage(channelId, enableSpilling, actorSystem, true /*isConcurrent*/);
+        auto channelStorage = ExecCtx->CreateChannelStorage(channelId, enableSpilling, actorSystem);
 
         if (channelStorage) {
             auto spillingIt = SpillingStoragesInfos.find(channelId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Removed direct calls of actors. Splitted channel spiller into actor and non-actor parts and replaced calls with events sending.

### Changelog category <!-- remove all except one -->


* Improvement


### Additional information

Arcadia PR with tests: https://a.yandex-team.ru/review/5620461/details

...
