### PR TITLE
Fix lost coordinator steps during mediator reconnect race (#2037)

### DIFF
--- a/ydb/core/tx/coordinator/mediator_queue.cpp
+++ b/ydb/core/tx/coordinator/mediator_queue.cpp
@@ -284,6 +284,7 @@ public:
 
     STFUNC(StateSync) {
         switch (ev->GetTypeRewrite()) {
+            HFunc(TEvMediatorQueueStep, Handle);
             HFunc(TEvTxProcessing::TEvPlanStepAck, Handle);
             HFunc(TEvTxCoordinator::TEvCoordinatorSyncResult, Handle);
             HFunc(TEvTabletPipe::TEvClientConnected, Handle);
@@ -294,8 +295,8 @@ public:
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(TEvTxProcessing::TEvPlanStepAck, Handle);
             HFunc(TEvMediatorQueueStep, Handle);
+            HFunc(TEvTxProcessing::TEvPlanStepAck, Handle);
             HFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
             CFunc(TEvents::TSystem::PoisonPill, Die)
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix lost coordinator steps during mediator reconnect race.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Coordinator's mediator queues were changed in 24-1 to support efficient planning of volatile transactions. Unfortunately mediator queue actor didn't handle mediator steps during mediator reconnect (never needed to, since old code was reloading the full queue from disk on every reconnect), and in rare failure modes this could cause entire planned steps to be lost at some mediators. The fix is to handle mediator steps during re-sync. Fixes KIKIMR-21077.