### PR TITLE
Refactoting to forbid call unsafe bistream methods.

### DIFF
--- a/ydb/core/grpc_services/audit_dml_operations.h
+++ b/ydb/core/grpc_services/audit_dml_operations.h
@@ -30,8 +30,7 @@ class ExecuteScriptRequest;
 
 namespace NKikimr::NGRpcService {
 
-class IRequestCtxBase;
-class IRequestCtx;
+class IAuditCtx;
 
 // RPC requests audit info collection methods.
 //
@@ -39,46 +38,46 @@ class IRequestCtx;
 // AuditContextAppend() specializations extract specific info from request (and result) protos.
 //
 
-void AuditContextStart(IRequestCtxBase* ctx, const TString& database, const TString& userSID, const std::vector<std::pair<TString, TString>>& databaseAttrs);
-void AuditContextEnd(IRequestCtxBase* ctx);
+void AuditContextStart(IAuditCtx* ctx, const TString& database, const TString& userSID, const std::vector<std::pair<TString, TString>>& databaseAttrs);
+void AuditContextEnd(IAuditCtx* ctx);
 
 template <class TProtoRequest>
-void AuditContextAppend(IRequestCtx* /*ctx*/, const TProtoRequest& /*request*/) {
+void AuditContextAppend(IAuditCtx* /*ctx*/, const TProtoRequest& /*request*/) {
     // do nothing by default
 }
 
 template <class TProtoRequest, class TProtoResult>
-void AuditContextAppend(IRequestCtx* /*ctx*/, const TProtoRequest& /*request*/, const TProtoResult& /*result*/) {
+void AuditContextAppend(IAuditCtx* /*ctx*/, const TProtoRequest& /*request*/, const TProtoResult& /*result*/) {
     // do nothing by default
 }
 
 // ExecuteDataQuery
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::ExecuteDataQueryRequest& request);
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::ExecuteDataQueryRequest& request, const Ydb::Table::ExecuteQueryResult& result);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::ExecuteDataQueryRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::ExecuteDataQueryRequest& request, const Ydb::Table::ExecuteQueryResult& result);
 
 // PrepareDataQuery
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::PrepareDataQueryRequest& request);
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::PrepareDataQueryRequest& request, const Ydb::Table::PrepareQueryResult& result);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::PrepareDataQueryRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::PrepareDataQueryRequest& request, const Ydb::Table::PrepareQueryResult& result);
 
 // BeginTransaction
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::BeginTransactionRequest& request, const Ydb::Table::BeginTransactionResult& result);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::BeginTransactionRequest& request, const Ydb::Table::BeginTransactionResult& result);
 
 // CommitTransaction
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::CommitTransactionRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::CommitTransactionRequest& request);
 
 // RollbackTransaction
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::RollbackTransactionRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::RollbackTransactionRequest& request);
 
 // BulkUpsert
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Table::BulkUpsertRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Table::BulkUpsertRequest& request);
 
 // ExecuteYqlScript, StreamExecuteYqlScript
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Scripting::ExecuteYqlRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Scripting::ExecuteYqlRequest& request);
 
 // ExecuteQuery
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Query::ExecuteQueryRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Query::ExecuteQueryRequest& request);
 
 // ExecuteSrcipt
-template <> void AuditContextAppend(IRequestCtx* ctx, const Ydb::Query::ExecuteScriptRequest& request);
+template <> void AuditContextAppend(IAuditCtx* ctx, const Ydb::Query::ExecuteScriptRequest& request);
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/core/grpc_services/base/iface.h
+++ b/ydb/core/grpc_services/base/iface.h
@@ -14,6 +14,11 @@ class TUserToken;
 }
 namespace NKikimr {
 
+namespace NRpcService {
+struct  TRlPath;
+
+}
+
 namespace NGRpcService {
 
 using TAuditLogParts = TVector<std::pair<TString, TString>>;
@@ -34,6 +39,15 @@ public:
     virtual bool IsInternalCall() const {
         return false;
     }
+    // Meta value from request
+    virtual const TMaybe<TString> GetPeerMetaValues(const TString&) const = 0;
+    // Return address of the peer
+    virtual TString GetPeerName() const = 0;
+    virtual const TString& GetRequestName() const = 0;
+    // Returns path and resource for rate limiter
+    virtual TMaybe<NRpcService::TRlPath> GetRlPath() const = 0;
+    // Return deadile of request execution, calculated from client timeout by grpc
+    virtual TInstant GetDeadline() const = 0;
 };
 
 

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -23,6 +23,19 @@
 namespace NKikimr {
 namespace NGRpcService {
 
+template<typename TCtx>
+bool TGRpcRequestProxyHandleMethods::ValidateAndReplyOnError(TCtx* ctx) {
+    TString validationError;
+    if (!ctx->Validate(validationError)) {
+        const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_API_VALIDATION_ERROR, validationError);
+        ctx->RaiseIssue(issue);
+        ctx->ReplyWithYdbStatus(Ydb::StatusIds::BAD_REQUEST);
+        return false;
+    } else {
+        return true;
+    }
+}
+
 template <typename TEvent>
 class TGrpcRequestCheckActor
     : public TGRpcRequestProxyHandleMethods

--- a/ydb/core/grpc_services/grpc_request_proxy_handle_methods.h
+++ b/ydb/core/grpc_services/grpc_request_proxy_handle_methods.h
@@ -7,6 +7,8 @@ namespace NGRpcService {
 
 class TGRpcRequestProxyHandleMethods {
 protected:
+    template<typename TCtx>
+    static bool ValidateAndReplyOnError(TCtx* ctx);
     static void Handle(TEvBiStreamPingRequest::TPtr& ev, const TActorContext& ctx);
     static void Handle(TEvStreamPQWriteRequest::TPtr& ev, const TActorContext& ctx);
     static void Handle(TEvStreamPQMigrationReadRequest::TPtr& ev, const TActorContext& ctx);

--- a/ydb/core/grpc_services/local_rpc/local_rpc.h
+++ b/ydb/core/grpc_services/local_rpc/local_rpc.h
@@ -208,15 +208,8 @@ public:
         CostInfo->set_consumed_units(consumed_units);
     }
 
-    void SetDiskQuotaExceeded(bool disk) override {
-        if (!QuotaExceeded) {
-            QuotaExceeded = std::make_unique<Ydb::QuotaExceeded>();
-        }
-        QuotaExceeded->set_disk(disk);
-    }
-
     bool GetDiskQuotaExceeded() const override {
-        return QuotaExceeded ? QuotaExceeded->disk() : false;
+        return false;
     }
 
     TMaybe<NRpcService::TRlPath> GetRlPath() const override {
@@ -257,7 +250,6 @@ private:
     NYql::TIssueManager IssueManager;
     google::protobuf::Arena Arena;
     std::unique_ptr<Ydb::CostInfo> CostInfo;
-    std::unique_ptr<Ydb::QuotaExceeded> QuotaExceeded;
 };
 
 template<class TRequest>

--- a/ydb/core/grpc_services/rpc_calls.h
+++ b/ydb/core/grpc_services/rpc_calls.h
@@ -44,18 +44,6 @@ void FillYdbStatus(Draft::Dummy::PingResponse& resp, const NYql::TIssues& issues
 template <>
 void FillYdbStatus(Ydb::Coordination::SessionResponse& resp, const NYql::TIssues& issues, Ydb::StatusIds::StatusCode status);
 
-inline bool ValidateAndReplyOnError(IRequestProxyCtx* ctx) {
-    TString validationError;
-    if (!ctx->Validate(validationError)) {
-        const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_API_VALIDATION_ERROR, validationError);
-        ctx->RaiseIssue(issue);
-        ctx->ReplyWithYdbStatus(Ydb::StatusIds::BAD_REQUEST);
-        return false;
-    } else {
-        return true;
-    }
-}
-
 
 using TEvListEndpointsRequest = TGRpcRequestWrapper<TRpcServices::EvListEndpoints, Ydb::Discovery::ListEndpointsRequest, Ydb::Discovery::ListEndpointsResponse, true>;
 

--- a/ydb/core/kafka_proxy/actors/control_plane_common.h
+++ b/ydb/core/kafka_proxy/actors/control_plane_common.h
@@ -265,10 +265,6 @@ public:
         return DummyString;
     };
 
-    void SetDiskQuotaExceeded(bool disk) override {
-        Y_UNUSED(disk);
-    };
-
     bool GetDiskQuotaExceeded() const override {
         return false;
     };

--- a/ydb/core/kafka_proxy/actors/kafka_create_partitions_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_partitions_actor.cpp
@@ -114,10 +114,6 @@ public:
         return DummyString;
     };
 
-    void SetDiskQuotaExceeded(bool disk) override {
-        Y_UNUSED(disk);
-    };
-
     bool GetDiskQuotaExceeded() const override {
         return false;
     };

--- a/ydb/core/persqueue/pq_rl_helpers.h
+++ b/ydb/core/persqueue/pq_rl_helpers.h
@@ -13,7 +13,7 @@ public:
     TRlContext() {
     }
 
-    TRlContext(const NGRpcService::IRequestCtxBase* reqCtx) {
+    TRlContext(const NGRpcService::IRequestCtxBaseMtSafe* reqCtx) {
         Path.DatabaseName = reqCtx->GetDatabaseName().GetOrElse("");
         Path.Token = reqCtx->GetSerializedToken();
 

--- a/ydb/core/tx/datashard/datashard_ut_trace.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_trace.cpp
@@ -44,7 +44,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
                     return Nothing();
                 }
 
-                TMaybe<TString> GetPeerMetaValues(const TString&) const override {
+                const TMaybe<TString> GetPeerMetaValues(const TString&) const override {
                     return Nothing();
                 }
  
@@ -57,7 +57,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
                     return empty;
                 }
 
-                TMaybe<NRpcService::TRlPath> GetRlPath const override {
+                TMaybe<NRpcService::TRlPath> GetRlPath() const override {
                     return Nothing();
                 }
 

--- a/ydb/core/tx/datashard/datashard_ut_trace.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_trace.cpp
@@ -44,6 +44,27 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
                     return Nothing();
                 }
 
+                TMaybe<TString> GetPeerMetaValues(const TString&) const override {
+                    return Nothing();
+                }
+ 
+                TString GetPeerName() const override {
+                    return {};
+                }
+
+                const TString& GetRequestName() const override {
+                    static TString empty;
+                    return empty;
+                }
+
+                TMaybe<NRpcService::TRlPath> GetRlPath const override {
+                    return Nothing();
+                }
+
+                TInstant GetDeadline() const override {
+                    return TInstant::Max();
+                }
+
                 const TMaybe<TString> GetDatabaseName() const override {
                     return "";
                 }


### PR DESCRIPTION
ReplyWithYdbStatus and ReplyUnavaliable methods perform fake attach to allow grpc proxy reply with error. It is unsafe to allow call it from user code because first thing to use bidirectional stream is to perform attach rpc to actor. But multiple attach is not allowed.


