### PR TITLE
Fixed missing peerdir in grpc_services

### DIFF
--- a/ydb/core/grpc_services/base/ya.make
+++ b/ydb/core/grpc_services/base/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/grpc_services/counters
     ydb/core/grpc_streaming
+    ydb/core/jaeger_tracing
     ydb/public/api/protos
     ydb/public/sdk/cpp/client/resources
     ydb/library/yql/public/issue


### PR DESCRIPTION
### Fixed missing peerdir in grpc_services <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
