### PR TITLE
BTreeIndex Stats Load index nodes

### DIFF
--- a/ydb/core/tablet_flat/flat_part_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter.h
@@ -97,6 +97,15 @@ public:
         return bool(Iter);
     }
 
+    void AddLastDeltaDataSize(TChanneledDataSize& dataSize) override {
+        Y_DEBUG_ABORT_UNLESS(Index);
+        Y_DEBUG_ABORT_UNLESS(Iter.Off());
+        TPageId pageId = (Iter - 1)->GetPageId();
+        ui64 delta = Part->GetPageSize(pageId, GroupId);
+        ui8 channel = Part->GetGroupChannel(GroupId);
+        dataSize.Add(delta, channel);
+    }
+
     // for precharge and TForward only
     TIndex* TryLoadRaw() {
         return TryGetIndex();

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -85,9 +85,8 @@ public:
         return EPage(PageCollections[groupId.Index]->PageCollection->Page(id).Type);
     }
 
-    ui8 GetPageChannel(NPage::TPageId id, NPage::TGroupId groupId) const override
+    ui8 GetPageChannel(NPage::TGroupId groupId) const override
     {
-        Y_UNUSED(id);
         Y_ABORT_UNLESS(groupId.Index < PageCollections.size());
         return PageCollections[groupId.Index]->Id.Channel();
     }

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -85,7 +85,7 @@ public:
         return EPage(PageCollections[groupId.Index]->PageCollection->Page(id).Type);
     }
 
-    ui8 GetPageChannel(NPage::TGroupId groupId) const override
+    ui8 GetGroupChannel(NPage::TGroupId groupId) const override
     {
         Y_ABORT_UNLESS(groupId.Index < PageCollections.size());
         return PageCollections[groupId.Index]->Id.Channel();

--- a/ydb/core/tablet_flat/flat_stat_part.h
+++ b/ydb/core/tablet_flat/flat_stat_part.h
@@ -177,7 +177,7 @@ private:
     void AddPageSize(TPartDataSize& stats, TPageId pageId, TGroupId groupId) const {
         // TODO: move to IStatsPartGroupIterator
         ui64 size = Part->GetPageSize(pageId, groupId);
-        ui8 channel = Part->GetPageChannel(pageId, groupId);
+        ui8 channel = Part->GetPageChannel(groupId);
         stats.Add(size, channel);
     }
 

--- a/ydb/core/tablet_flat/flat_stat_part.h
+++ b/ydb/core/tablet_flat/flat_stat_part.h
@@ -11,24 +11,6 @@
 namespace NKikimr {
 namespace NTable {
 
-struct TPartDataSize {
-    ui64 Size = 0;
-    TVector<ui64> ByChannel = { };
-
-    void Add(ui64 size, ui8 channel) {
-        Size += size;
-        if (!(channel < ByChannel.size())) {
-            ByChannel.resize(channel + 1);
-        }
-        ByChannel[channel] += size;
-    }
-};
-
-struct TPartDataStats {
-    ui64 RowCount = 0;
-    TPartDataSize DataSize = { };
-};
-
 // Iterates over part index and calculates total row count and data size
 // This iterator skips pages that are screened. Currently the logic is simple:
 // if page start key is screened then we assume that the whole previous page is screened
@@ -82,7 +64,7 @@ public:
         return Groups[0]->IsValid();
     }
 
-    EReady Next(TPartDataStats& stats) {
+    EReady Next(TDataStats& stats) {
         Y_ABORT_UNLESS(IsValid());
 
         auto curPageId = Groups[0]->GetPageId();
@@ -174,7 +156,7 @@ private:
         return LastRowId;
     }
 
-    void AddPageSize(TPartDataSize& stats, TPageId pageId, TGroupId groupId) const {
+    void AddPageSize(TChanneledDataSize& stats, TPageId pageId, TGroupId groupId) const {
         // TODO: move to IStatsPartGroupIterator
         ui64 size = Part->GetPageSize(pageId, groupId);
         ui8 channel = Part->GetPageChannel(groupId);
@@ -229,7 +211,7 @@ private:
         return rowCount;
     }
 
-    void AddBlobsSize(TPartDataSize& stats, const TFrames* frames, ELargeObj lob, ui32 &prevPage) noexcept {
+    void AddBlobsSize(TChanneledDataSize& stats, const TFrames* frames, ELargeObj lob, ui32 &prevPage) noexcept {
         const auto row = GetLastRowId();
         const auto end = GetCurrentRowId();
 

--- a/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
@@ -22,48 +22,16 @@ class TStatsPartGroupBtreeIndexIterator : public IStatsPartGroupIterator {
         TRowId BeginRowId;
         TRowId EndRowId;
         TCellsIterable BeginKey;
-        TCellsIterable EndKey;
-        std::optional<TBtreeIndexNode> Node;
-        std::optional<TRecIdx> Pos;
         ui64 DataSize;
 
-        TNodeState(TPageId pageId, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, TCellsIterable endKey, ui64 dataSize)
+        TNodeState(TPageId pageId, TRowId beginRowId, TRowId endRowId, TCellsIterable beginKey, ui64 dataSize)
             : PageId(pageId)
             , BeginRowId(beginRowId)
             , EndRowId(endRowId)
             , BeginKey(beginKey)
-            , EndKey(endKey)
             , DataSize(dataSize)
         {
         }
-
-        bool IsLastPos() const noexcept {
-            Y_ABORT_UNLESS(Node);
-            Y_ABORT_UNLESS(Pos);
-            return *Pos == Node->GetKeysCount();
-        }
-
-        bool IsFirstPos() const noexcept {
-            Y_ABORT_UNLESS(Node);
-            Y_ABORT_UNLESS(Pos);
-            return *Pos == 0;
-        }
-    };
-
-    struct TSeekRowId {
-        TSeekRowId(TRowId rowId)
-            : RowId(rowId)
-        {}
-
-        bool BelongsTo(const TNodeState& state) const noexcept {
-            return TBtreeIndexNode::Has(RowId, state.BeginRowId, state.EndRowId);
-        }
-
-        TRecIdx Do(const TNodeState& state) const noexcept {
-            return state.Node->Seek(RowId, state.Pos);
-        }
-
-        const TRowId RowId;
     };
 
 public:
@@ -73,55 +41,65 @@ public:
         , GroupId(groupId)
         , GroupInfo(part->Scheme->GetLayout(groupId))
         , Meta(groupId.IsHistoric() ? part->IndexPages.BTreeHistoric[groupId.Index] : part->IndexPages.BTreeGroups[groupId.Index])
-        , State(Reserve(Meta.LevelCount + 1))
         , GroupChannel(Part->GetGroupChannel(GroupId))
+        , NodeIndex(0)
         , PrevDataSize(0)
         , PrevPrevDataSize(0)
     {
-        const static TCellsIterable EmptyKey(static_cast<const char*>(nullptr), TColumns());
-        State.emplace_back(Meta.PageId, 0, GetEndRowId(), EmptyKey, EmptyKey, Meta.DataSize);
     }
     
     EReady Start() override {
-        return DoSeek<TSeekRowId>({0});
+        const static TCellsIterable EmptyKey(static_cast<const char*>(nullptr), TColumns());
+
+        bool ready = true;
+        TVector<TNodeState> nextNodes;
+        Nodes.emplace_back(Meta.PageId, 0, GetEndRowId(), EmptyKey, Meta.DataSize);
+
+        for (ui32 height = 0; height < Meta.LevelCount; height++) {
+            for (auto &nodeState : Nodes) {
+                auto page = Env->TryGetPage(Part, nodeState.PageId);
+                if (!page) {
+                    ready = false;
+                    continue;
+                }
+                TBtreeIndexNode node(*page);
+
+                for (TRecIdx pos : xrange<TRecIdx>(0, node.GetChildrenCount())) {
+                    auto& child = node.GetShortChild(pos);
+
+                    TRowId beginRowId = pos ? node.GetShortChild(pos - 1).RowCount : nodeState.BeginRowId;
+                    TRowId endRowId = child.RowCount;
+                    TCellsIterable beginKey = pos ? node.GetKeyCellsIterable(pos - 1, GroupInfo.ColsKeyIdx) : nodeState.BeginKey;
+                    ui64 dataSize = child.DataSize;
+
+                    nextNodes.emplace_back(child.PageId, beginRowId, endRowId, beginKey, dataSize);
+                }
+            }
+
+            Nodes.swap(nextNodes);
+            nextNodes.clear();
+        }
+
+        if (!ready) {
+            Nodes.clear(); // some invalid subset
+            return EReady::Page;
+        }
+
+        return DataOrGone();
     }
 
     EReady Next() override {
-        Y_ABORT_UNLESS(!IsExhausted());
+        Y_ABORT_UNLESS(IsValid());
 
         PrevPrevDataSize = PrevDataSize;
-        PrevDataSize = State.back().DataSize;
+        PrevDataSize = GetCurrentNode().DataSize;
 
-        if (Meta.LevelCount == 0) {
-            return Exhaust();
-        }
+        NodeIndex++;
 
-        if (IsLeaf()) {
-            do {
-                State.pop_back();
-            } while (State.size() > 1 && State.back().IsLastPos());
-            if (State.back().IsLastPos()) {
-                return Exhaust();
-            }
-            PushNextState(*State.back().Pos + 1);
-        }
-
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
-            if (!TryLoad(State[level])) {
-                // exiting with an intermediate state
-                Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
-                return EReady::Page;
-            }
-            PushNextState(0);
-        }
-
-        // State.back() points to the target data page
-        Y_ABORT_UNLESS(IsLeaf());
-        return EReady::Data;
+        return DataOrGone();
     }
 
     void AddLastDeltaDataSize(TChanneledDataSize& dataSize) override {
-        Y_ABORT_UNLESS(IsExhausted() || IsLeaf());
         Y_DEBUG_ABORT_UNLESS(PrevDataSize >= PrevPrevDataSize);
         ui64 delta = PrevDataSize - PrevPrevDataSize;
         dataSize.Add(delta, GroupChannel);
@@ -129,8 +107,7 @@ public:
 
 public:
     bool IsValid() const override {
-        Y_DEBUG_ABORT_UNLESS(IsLeaf() || IsExhausted());
-        return IsLeaf();
+        return NodeIndex < Nodes.size();
     }
 
     TRowId GetEndRowId() const override {
@@ -138,107 +115,29 @@ public:
     }
 
     TPageId GetPageId() const override {
-        Y_ABORT_UNLESS(IsLeaf());
-        return State.back().PageId;
+        return GetCurrentNode().PageId;
     }
 
     TRowId GetRowId() const override {
-        Y_ABORT_UNLESS(IsLeaf());
-        return State.back().BeginRowId;
+        return GetCurrentNode().BeginRowId;
     }
 
     TPos GetKeyCellsCount() const override {
-        Y_ABORT_UNLESS(IsLeaf());
-        return State.back().BeginKey.Count();
+        return GetCurrentNode().BeginKey.Count();
     }
 
     TCell GetKeyCell(TPos index) const override {
-        Y_ABORT_UNLESS(IsLeaf());
-        return State.back().BeginKey.Iter().At(index);
+        return GetCurrentNode().BeginKey.Iter().At(index);
     }
 
 private:
-    template<typename TSeek>
-    EReady DoSeek(TSeek seek) {
-        while (State.size() > 1 && !seek.BelongsTo(State.back())) {
-            State.pop_back();
-        }
-
-        if (IsExhausted()) {
-            // don't use exhausted state as an initial one
-            State[0].Pos = { };
-        }
-
-        for (ui32 level : xrange<ui32>(State.size() - 1, Meta.LevelCount)) {
-            auto &state = State[level];
-            Y_DEBUG_ABORT_UNLESS(seek.BelongsTo(state));
-            if (!TryLoad(state)) {
-                // exiting with an intermediate state
-                Y_DEBUG_ABORT_UNLESS(!IsLeaf() && !IsExhausted());
-                return EReady::Page;
-            }
-            auto pos = seek.Do(state);
-            
-            PushNextState(pos);
-        }
-
-        // State.back() points to the target data page
-        Y_ABORT_UNLESS(IsLeaf());
-        Y_DEBUG_ABORT_UNLESS(seek.BelongsTo(State.back()));
-        return EReady::Data;
+    EReady DataOrGone() const {
+        return IsValid() ? EReady::Data : EReady::Gone;
     }
 
-    bool IsRoot() const noexcept {
-        return State.size() == 1;
-    }
-    
-    bool IsExhausted() const noexcept {
-        return State[0].Pos == Max<TRecIdx>();
-    }
-
-    bool IsLeaf() const noexcept {
-        // Note: it is possible to have 0 levels in B-Tree
-        // so we may have exhausted state with leaf (data) node
-        return State.size() == Meta.LevelCount + 1 && !IsExhausted();
-    }
-
-    EReady Exhaust() {
-        while (State.size() > 1) {
-            State.pop_back();
-        }
-        State[0].Pos = Max<TRecIdx>();
-        return EReady::Gone;
-    }
-
-    void PushNextState(TRecIdx pos) {
-        TNodeState& current = State.back();
-        Y_ABORT_UNLESS(pos < current.Node->GetChildrenCount(), "Should point to some child");
-        current.Pos.emplace(pos);
-
-        auto& child = current.Node->GetShortChild(pos);
-
-        TRowId beginRowId = pos ? current.Node->GetShortChild(pos - 1).RowCount : current.BeginRowId;
-        TRowId endRowId = child.RowCount;
-        
-        TCellsIterable beginKey = pos ? current.Node->GetKeyCellsIterable(pos - 1, GroupInfo.ColsKeyIdx) : current.BeginKey;
-        TCellsIterable endKey = pos < current.Node->GetKeysCount() ? current.Node->GetKeyCellsIterable(pos, GroupInfo.ColsKeyIdx) : current.EndKey;
-        
-        ui64 dataSize = child.DataSize;
-
-        State.emplace_back(child.PageId, beginRowId, endRowId, beginKey, endKey, dataSize);
-    }
-
-    bool TryLoad(TNodeState& state) {
-        if (state.Node) {
-            return true;
-        }
-
-        auto page = Env->TryGetPage(Part, state.PageId);
-        if (page) {
-            state.Node.emplace(*page);
-            return true;
-        }
-        return false;
+    const TNodeState& GetCurrentNode() const {
+        Y_ABORT_UNLESS(IsValid());
+        return Nodes[NodeIndex];
     }
 
 private:
@@ -247,8 +146,9 @@ private:
     const TGroupId GroupId;
     const TPartScheme::TGroupInfo& GroupInfo;
     const TBtreeIndexMeta Meta;
-    TVector<TNodeState> State;
     ui8 GroupChannel;
+    ui32 NodeIndex;
+    TVector<TNodeState> Nodes;
     ui64 PrevDataSize, PrevPrevDataSize;
 };
 

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
@@ -26,6 +26,7 @@ struct TDataStats {
 struct IStatsPartGroupIterator {
     virtual EReady Start() = 0;
     virtual EReady Next() = 0;
+    virtual void AddLastDeltaDataSize(TChanneledDataSize& dataSize) = 0;
 
     virtual bool IsValid() const = 0;
 

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
@@ -4,23 +4,41 @@
 #include "ydb/core/scheme/scheme_tablecell.h"
 
 namespace NKikimr::NTable {
-    
-    struct IStatsPartGroupIterator {
-        virtual EReady Start() = 0;
-        virtual EReady Next() = 0;
 
-        virtual bool IsValid() const = 0;
+struct TChanneledDataSize {
+    ui64 Size = 0;
+    TVector<ui64> ByChannel = { };
 
-        virtual TRowId GetEndRowId() const = 0;
-        virtual TPageId GetPageId() const = 0;
-        virtual TRowId GetRowId() const = 0;
+    void Add(ui64 size, ui8 channel) {
+        Size += size;
+        if (!(channel < ByChannel.size())) {
+            ByChannel.resize(channel + 1);
+        }
+        ByChannel[channel] += size;
+    }
+};
 
-        virtual TPos GetKeyCellsCount() const = 0;
-        virtual TCell GetKeyCell(TPos index) const = 0;
+struct TDataStats {
+    ui64 RowCount = 0;
+    TChanneledDataSize DataSize = { };
+};
 
-        virtual ~IStatsPartGroupIterator() = default;
-    };
+struct IStatsPartGroupIterator {
+    virtual EReady Start() = 0;
+    virtual EReady Next() = 0;
 
-    THolder<IStatsPartGroupIterator> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId);
+    virtual bool IsValid() const = 0;
+
+    virtual TRowId GetEndRowId() const = 0;
+    virtual TPageId GetPageId() const = 0;
+    virtual TRowId GetRowId() const = 0;
+
+    virtual TPos GetKeyCellsCount() const = 0;
+    virtual TCell GetKeyCell(TPos index) const = 0;
+
+    virtual ~IStatsPartGroupIterator() = default;
+};
+
+THolder<IStatsPartGroupIterator> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId);
     
 }

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -9,7 +9,7 @@ namespace NTable {
 bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env) {
     stats.Clear();
 
-    TPartDataStats iteratorStats = { };
+    TDataStats iteratorStats = { };
     TStatsIterator statsIterator(subset.Scheme->Keys);
 
     // Make index iterators for all parts

--- a/ydb/core/tablet_flat/flat_stat_table.h
+++ b/ydb/core/tablet_flat/flat_stat_table.h
@@ -26,7 +26,7 @@ public:
         Heap.push(iteratorPtr);
     }
 
-    EReady Next(TPartDataStats& stats) {
+    EReady Next(TDataStats& stats) {
         ui64 lastRowCount = stats.RowCount;
         ui64 lastDataSize = stats.DataSize.Size;
 
@@ -100,8 +100,8 @@ using THistogram = TVector<TBucket>;
 
 struct TStats {
     ui64 RowCount = 0;
-    TPartDataSize DataSize = { };
-    TPartDataSize IndexSize = { };
+    TChanneledDataSize DataSize = { };
+    TChanneledDataSize IndexSize = { };
     THistogram RowCountHistogram;
     THistogram DataSizeHistogram;
 

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -129,7 +129,7 @@ namespace NTable {
         virtual ui64 BackingSize() const = 0;
         virtual ui64 GetPageSize(NPage::TPageId id, NPage::TGroupId groupId = { }) const = 0;
         virtual NPage::EPage GetPageType(NPage::TPageId id, NPage::TGroupId groupId = { }) const = 0;
-        virtual ui8 GetPageChannel(NPage::TPageId id, NPage::TGroupId groupId = { }) const = 0;
+        virtual ui8 GetPageChannel(NPage::TGroupId groupId = { }) const = 0;
         virtual ui8 GetPageChannel(ELargeObj lob, ui64 ref) const = 0;
 
     protected:

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -129,7 +129,7 @@ namespace NTable {
         virtual ui64 BackingSize() const = 0;
         virtual ui64 GetPageSize(NPage::TPageId id, NPage::TGroupId groupId = { }) const = 0;
         virtual NPage::EPage GetPageType(NPage::TPageId id, NPage::TGroupId groupId = { }) const = 0;
-        virtual ui8 GetPageChannel(NPage::TGroupId groupId = { }) const = 0;
+        virtual ui8 GetGroupChannel(NPage::TGroupId groupId = { }) const = 0;
         virtual ui8 GetPageChannel(ELargeObj lob, ui64 ref) const = 0;
 
     protected:

--- a/ydb/core/tablet_flat/flat_table_part_ut.cpp
+++ b/ydb/core/tablet_flat/flat_table_part_ut.cpp
@@ -75,7 +75,7 @@ Y_UNIT_TEST_SUITE(TLegacy) {
                 TIntrusiveConstPtr<TRowScheme> scheme,
                 std::vector<ui64>& sizes)
         {
-            TPartDataStats stats = { };
+            TDataStats stats = { };
             TTestEnv env;
             // TScreenedPartIndexIterator without screen previously was TPartIndexIterator
             TStatsScreenedPartIterator idxIter(TPartView{part, nullptr, nullptr}, &env, scheme->Keys, nullptr, nullptr);
@@ -145,7 +145,7 @@ Y_UNIT_TEST_SUITE(TLegacy) {
 
         auto fnIterate = [&dbgOut, &typeRegistry] (TIntrusiveConstPtr<TPartStore> part, TIntrusiveConstPtr<TScreen> screen,
                             TIntrusiveConstPtr<TRowScheme> scheme, TIntrusiveConstPtr<NPage::TFrames> frames) -> std::pair<ui64, ui64> {
-            TPartDataStats stats = { };
+            TDataStats stats = { };
             TTestEnv env;
             TStatsScreenedPartIterator idxIter(TPartView{part, screen, nullptr}, &env, scheme->Keys, std::move(frames), nullptr);
 
@@ -304,7 +304,7 @@ Y_UNIT_TEST_SUITE(TLegacy) {
                 TScreen::THole(4200, 100000)
                 });
 
-        TPartDataStats stats = { };
+        TDataStats stats = { };
         TTestEnv env;
         TStatsIterator stIter(lay2.RowScheme()->Keys);
         {

--- a/ydb/core/tablet_flat/test/libs/table/test_make.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_make.h
@@ -88,7 +88,7 @@ namespace NTest {
             return cook.Add(Saved.begin(), Saved.end()).Finish();
         }
 
-        TAutoPtr<TSubset> Mixed(ui32 frozen, ui32 flatten, THash hash, float history = 0)
+        TAutoPtr<TSubset> Mixed(ui32 frozen, ui32 flatten, THash hash, float addHistory = 0, ui32 addSlices = 1)
         {
             TMersenne<ui64> rnd(0);
             TDeque<TAutoPtr<IBand>> bands;
@@ -104,12 +104,12 @@ namespace NTest {
             if (const auto slots = bands.size()) {
                 for (auto &row: Saved) {
                     auto &band = bands[hash(row) % slots];
-                    if (history) {
+                    if (addHistory) {
                         for (ui64 txId = 10; txId; txId--) {
                             band->Ver({0, txId});
                             // FIXME: change row data?
                             band->Add(row);
-                            if (rnd.GenRandReal4() > history) {
+                            if (rnd.GenRandReal4() > addHistory) {
                                 // each row will have from 1 to 10 versions
                                 break;
                             }
@@ -121,6 +121,7 @@ namespace NTest {
             }
 
             TAutoPtr<TSubset> subset = new TSubset(TEpoch::FromIndex(bands.size()), Scheme);
+            rnd = {0};
 
             for (auto &one: bands) {
                 if (auto *mem = dynamic_cast<TMem*>(one.Get())) {
@@ -131,13 +132,23 @@ namespace NTest {
                     subset->Frozen.emplace_back(std::move(table), table->Immediate());
                 } else if (auto *part_ = dynamic_cast<TPart*>(one.Get())) {
                     auto eggs = part_->Cook.Finish();
-
-                    if (eggs.Parts.size() != 1) {
-                        Y_Fail("Unexpected " << eggs.Parts.size() << " parts");
+                    auto part = eggs.Lone();
+                    TVector<TSlice> slices = *part->Slices;
+                    if (addSlices > 1) {
+                        slices.clear();
+                        auto pages = IndexTools::CountMainPages(*part);
+                        TSet<TRowId> points;
+                        while (points.size() < addSlices * 2) {
+                            points.insert(rnd.GenRand() % pages);
+                        }
+                        for (auto it = points.begin(); it != points.end(); std::advance(it, 2)) {
+                            slices.push_back(IndexTools::MakeSlice(*part, *it, *next(it) + 1));
+                        }
                     }
-
-                    subset->Flatten.push_back(
-                                { eggs.At(0), nullptr, eggs.At(0)->Slices });
+                    auto slices_ = MakeIntrusive<TSlices>(slices);
+                    TPartView partView(part, slices_->ToScreen(), slices_);
+                    TOverlay{partView.Screen, partView.Slices}.Validate();
+                    subset->Flatten.push_back(partView);
                 } else {
                     Y_ABORT("Unknown IBand writer type, internal error");
                 }

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -177,6 +177,30 @@ namespace NTest {
             return index.GetLastRecord();
         }
 
+        inline TRowId GetRowId(const TPart& part, ui32 pageIndex) {
+            TTestEnv env;
+            TPartIndexIt index(&part, &env, { });
+
+            Y_ABORT_UNLESS(index.Seek(0) == EReady::Data);
+            for (TPageId p = 0; p < pageIndex; p++) {
+                Y_ABORT_UNLESS(index.Next() == EReady::Data);
+            }
+
+            return index.GetRowId();
+        }
+
+        inline TRowId GetRowId(const TPart& part, ui32 pageIndex) {
+            TTestEnv env;
+            TPartIndexIt index(&part, &env, { });
+
+            Y_ABORT_UNLESS(index.Seek(0) == EReady::Data);
+            for (TPageId p = 0; p < pageIndex; p++) {
+                Y_ABORT_UNLESS(index.Next() == EReady::Data);
+            }
+
+            return index.GetRowId();
+        }
+
         inline const TPartIndexIt::TRecord * GetRecord(const TPart& part, ui32 pageIndex) {
             TTestEnv env;
             TPartIndexIt index(&part, &env, { });
@@ -201,6 +225,33 @@ namespace NTest {
             TPartIndexIt index(&part, &env, groupId);
             index.Seek(index.GetEndRowId() - 1);
             return index.GetPageId();
+        }
+
+        inline TSlice MakeSlice(const TPartStore& part, ui32 pageIndex1Inclusive, ui32 pageIndex2Exclusive) {
+            auto mainPagesCount = CountMainPages(part);
+            Y_ABORT_UNLESS(pageIndex1Inclusive < pageIndex2Exclusive);
+            Y_ABORT_UNLESS(pageIndex2Exclusive <= mainPagesCount);
+            auto getKey = [&] (const NPage::TIndex::TRecord* record) {
+                TSmallVec<TCell> key;
+                for (const auto& info : part.Scheme->Groups[0].ColsKeyIdx) {
+                    key.push_back(record->Cell(info));
+                }
+                return TSerializedCellVec(key);
+            };
+            TSlice slice;
+            slice.FirstInclusive = true;
+            slice.FirstRowId = IndexTools::GetRowId(part, pageIndex1Inclusive);
+            slice.FirstKey = pageIndex1Inclusive > 0 
+                ? getKey(IndexTools::GetRecord(part, pageIndex1Inclusive)) 
+                : part.Slices->begin()->FirstKey;
+            slice.LastInclusive = false;
+            slice.LastRowId = pageIndex2Exclusive < mainPagesCount 
+                ? IndexTools::GetRowId(part, pageIndex2Exclusive)
+                : part.Stat.Rows;
+            slice.LastKey = pageIndex2Exclusive < mainPagesCount 
+                ? getKey(IndexTools::GetRecord(part, pageIndex2Exclusive)) 
+                : part.Slices->rbegin()->LastKey;
+            return slice;
         }
     }
 

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -189,18 +189,6 @@ namespace NTest {
             return index.GetRowId();
         }
 
-        inline TRowId GetRowId(const TPart& part, ui32 pageIndex) {
-            TTestEnv env;
-            TPartIndexIt index(&part, &env, { });
-
-            Y_ABORT_UNLESS(index.Seek(0) == EReady::Data);
-            for (TPageId p = 0; p < pageIndex; p++) {
-                Y_ABORT_UNLESS(index.Next() == EReady::Data);
-            }
-
-            return index.GetRowId();
-        }
-
         inline const TPartIndexIt::TRecord * GetRecord(const TPart& part, ui32 pageIndex) {
             TTestEnv env;
             TPartIndexIt index(&part, &env, { });

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -56,9 +56,8 @@ namespace NTest {
             return Store->GetPageType(groupId.Index, id);
         }
 
-        ui8 GetPageChannel(NPage::TPageId id, NPage::TGroupId groupId) const override
+        ui8 GetPageChannel(NPage::TGroupId groupId) const override
         {
-            Y_UNUSED(id);
             Y_UNUSED(groupId);
             return 0;
         }

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -56,7 +56,7 @@ namespace NTest {
             return Store->GetPageType(groupId.Index, id);
         }
 
-        ui8 GetPageChannel(NPage::TGroupId groupId) const override
+        ui8 GetGroupChannel(NPage::TGroupId groupId) const override
         {
             Y_UNUSED(groupId);
             return 0;

--- a/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ydb/core/tablet_flat/flat_part_overlay.h"
 #include <ydb/core/tablet_flat/flat_table_subset.h>
 #include <ydb/core/tablet_flat/flat_iterator.h>
 #include <ydb/core/tablet_flat/flat_row_scheme.h>
@@ -26,7 +27,7 @@ namespace NTest {
             for (auto &partView: Flatten) {
                 Y_ABORT_UNLESS(partView.Part, "Creating TWrapIter without a part");
                 Y_ABORT_UNLESS(partView.Slices, "Creating TWrapIter without slices");
-                Y_ABORT_UNLESS(!partView.Screen, "Creating TWrapIter with a screen");
+                TOverlay{partView.Screen, partView.Slices}.Validate();
                 parts.push_back(&partView);
             }
             std::sort(parts.begin(), parts.end(),

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -158,23 +158,8 @@ namespace {
         if (params.Slices) {
             TSlices slices;
             auto partSlices = (TSlices*)part.Slices.Get();
-
-            auto getKey = [&] (const NPage::TIndex::TRecord* record) {
-                TSmallVec<TCell> key;
-                for (const auto& info : part.Scheme->Groups[0].ColsKeyIdx) {
-                    key.push_back(record->Cell(info));
-                }
-                return TSerializedCellVec(key);
-            };
-            auto add = [&](ui32 pageIndex1 /*inclusive*/, ui32 pageIndex2 /*exclusive*/) {
-                TSlice slice;
-                slice.FirstInclusive = true;
-                slice.FirstRowId = pageIndex1 * 2;
-                slice.FirstKey = pageIndex1 > 0 ? getKey(IndexTools::GetRecord(part, pageIndex1)) : partSlices->begin()->FirstKey;
-                slice.LastInclusive = false;
-                slice.LastRowId = pageIndex2 * 2;
-                slice.LastKey = pageIndex2 < 20 ? getKey(IndexTools::GetRecord(part, pageIndex2)) : partSlices->begin()->LastKey;
-                slices.push_back(slice);
+            auto add = [&](ui32 pageIndex1Inclusive, ui32 pageIndex2Exclusive) {
+                slices.push_back(IndexTools::MakeSlice(part, pageIndex1Inclusive, pageIndex2Exclusive));
             };
             add(0, 2);
             add(3, 4);

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -98,16 +98,37 @@ Y_UNIT_TEST_SUITE(BuildStats) {
         Check(*subset, 24000, 2106439, 25272);
     }
 
+    Y_UNIT_TEST(Single_Slices)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        Check(*subset, 12816, 1121048, 25272);
+    }
+
     Y_UNIT_TEST(Single_Groups)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ });   
         Check(*subset, 24000, 2460139, 13170);
     }
 
+    Y_UNIT_TEST(Single_Groups_Slices)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        Check(*subset, 10440, 1060798, 13170);
+    }
+
     Y_UNIT_TEST(Single_Groups_History)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0.3);   
         Check(*subset, 24000, 4054050, 18810);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_Slices)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        Check(*subset, 13570, 2277890, 18810);
     }
 
     Y_UNIT_TEST(Mixed)

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -14,8 +14,7 @@ namespace {
         const TSharedData* TryGetPage(const TPart *part, TPageId id, TGroupId groupId) override
         {
             UNIT_ASSERT_C(part->GetPageType(id) == EPage::Index || part->GetPageType(id) == EPage::BTreeIndex, "Shouldn't request non-index pages");
-            // TODO: charge b-tree index
-            if (!Touched[groupId].insert(id).second || part->GetPageType(id) == EPage::BTreeIndex) {
+            if (!Touched[groupId].insert(id).second) {
                 return NTest::TTestEnv::TryGetPage(part, id, groupId);
             }
             return nullptr;

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -176,16 +176,37 @@ Y_UNIT_TEST_SUITE(BuildStats) {
         Check(*subset, 24000, 2106439, 41220);
     }
 
+    Y_UNIT_TEST(Single_Slices_BTreeIndex)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        Check(*subset, 12816, 1121048, 41220);
+    }
+
     Y_UNIT_TEST(Single_Groups_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ });   
         Check(*subset, 24000, 2460139, 20485);
     }
 
+    Y_UNIT_TEST(Single_Groups_Slices_BTreeIndex)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        Check(*subset, 10440, 1060798, 20485);
+    }
+
     Y_UNIT_TEST(Single_Groups_History_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0.3);   
         Check(*subset, 24000, 4054050, 29710);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_Slices_BTreeIndex)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        Check(*subset, 13570, 2277890, 29710);
     }
 
     Y_UNIT_TEST(Mixed_BTreeIndex)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Implement `TStatsPartGroupBtreeIndexIterator.Start` method that loads all (for now) B-Tree nodes

Also store all index nodes in a list to iterate through them easily on Next calls (without up/down moves)

Test `BuildStats` with screen (slices)