### PR TITLE
Fix partial distributed commit of uncommitted changes during shard restart race

### DIFF
--- a/ydb/core/tx/datashard/datashard_dep_tracker.cpp
+++ b/ydb/core/tx/datashard/datashard_dep_tracker.cpp
@@ -673,11 +673,13 @@ void TDependencyTracker::TMvccDependencyTrackingLogic::AddOperation(const TOpera
 
                     if (lock) {
                         lock->SetLastOpId(op->GetTxId());
-                        if (locksCache.Locks.contains(lockTxId) && lock->IsPersistent()) {
+                        if (locksCache.Locks.contains(lockTxId) && lock->IsPersistent() && !lock->IsFrozen()) {
                             // This lock was cached before, and since we know
                             // it's persistent, we know it was also frozen
                             // during that lock caching. Restore the frozen
                             // flag for this lock.
+                            // Note: this code path is only for older shards
+                            // which didn't persist the frozen flag.
                             lock->SetFrozen();
                         }
                     }

--- a/ydb/core/tx/datashard/datashard_ut_common_kqp.h
+++ b/ydb/core/tx/datashard/datashard_ut_common_kqp.h
@@ -146,7 +146,17 @@ namespace NKqpHelpers {
         if (result.result_sets_size() == 0) {
             return "<empty>";
         }
-        return FormatResult(result.result_sets(0));
+        if (result.result_sets_size() == 1) {
+            return FormatResult(result.result_sets(0));
+        }
+        TStringBuilder sb;
+        for (int i = 0; i < result.result_sets_size(); ++i) {
+            if (i != 0) {
+                sb << "\n";
+            }
+            sb << FormatResult(result.result_sets(i));
+        }
+        return sb;
     }
 
     inline TString FormatResult(const Ydb::Table::ExecuteDataQueryResponse& response) {

--- a/ydb/core/tx/datashard/store_and_send_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/store_and_send_out_rs_unit.cpp
@@ -1,6 +1,7 @@
 #include "datashard_impl.h"
 #include "datashard_pipeline.h"
 #include "execution_unit_ctors.h"
+#include "datashard_locks_db.h"
 
 namespace NKikimr {
 namespace NDataShard {
@@ -62,7 +63,8 @@ EExecutionStatus TStoreAndSendOutRSUnit::Execute(TOperation::TPtr op,
             ui64 lockId = pr.first;
             auto lock = DataShard.SysLocksTable().GetRawLock(lockId, TRowVersion::Min());
             if (lock && lock->IsPersistent()) {
-                lock->SetFrozen();
+                TDataShardLocksDb locksDb(DataShard, txc);
+                lock->SetFrozen(&locksDb);
             }
         }
         tx->MarkLocksStored();

--- a/ydb/core/tx/datashard/store_and_send_write_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/store_and_send_write_out_rs_unit.cpp
@@ -1,6 +1,7 @@
 #include "datashard_impl.h"
 #include "datashard_pipeline.h"
 #include "execution_unit_ctors.h"
+#include "datashard_locks_db.h"
 
 namespace NKikimr {
 namespace NDataShard {
@@ -62,7 +63,8 @@ EExecutionStatus TStoreAndSendWriteOutRSUnit::Execute(TOperation::TPtr op,
             ui64 lockId = pr.first;
             auto lock = DataShard.SysLocksTable().GetRawLock(lockId, TRowVersion::Min());
             if (lock && lock->IsPersistent()) {
-                lock->SetFrozen();
+                TDataShardLocksDb locksDb(DataShard, txc);
+                lock->SetFrozen(&locksDb);
             }
         }
         writeOp->MarkLocksStored();

--- a/ydb/core/tx/locks/locks_db.h
+++ b/ydb/core/tx/locks/locks_db.h
@@ -133,6 +133,14 @@ public:
         HasChanges_ = true;
     }
 
+    void PersistLockFlags(ui64 lockId, ui64 flags) override {
+        using Schema = TSchemaDescription;
+        NIceDb::TNiceDb db(DB);
+        db.Table<typename Schema::Locks>().Key(lockId).Update(
+            NIceDb::TUpdate<typename Schema::Locks::Flags>(flags));
+        HasChanges_ = true;
+    }
+
     // Persist adding/removing info on locked ranges
     void PersistAddRange(ui64 lockId, ui64 rangeId, const TPathId& tableId, ui64 flags = 0, const TString& data = {}) override {
         using Schema = TSchemaDescription;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix partial distributed commit of uncommitted changes during shard restart race.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

A rare G0 anomaly was detected with Jepsen, which corresponded to a partial commit of accumulated changes when using persistent distributed transactions. Investigation showed that the `Frozen` lock flag was not persisted (this flag is set for write locks when they are validated and outgoing readsets are generated, and used to protect lock changes until transaction decides to commit or abort based on other participant decisions), and there was a window after a given shard restarts and before it fully restores the pipeline dependencies (including `Frozen` flag for locks validated in previous generations). During this time window lock subscription may report lock as unavailable or expired (e.g. when transaction is fully removed from a KQP session, either due to implicit rollback also failing quickly due to shard unavailability, or node restarting and losing all state). This in turn rolled back (previously frozen) lock changes, when they should have been committed instead.

Fixes KIKIMR-21088.