### PR TITLE
Fix partial distributed commit of uncommitted changes during shard restart race

### DIFF
--- a/ydb/core/tx/datashard/datashard_dep_tracker.cpp
+++ b/ydb/core/tx/datashard/datashard_dep_tracker.cpp
@@ -673,11 +673,13 @@ void TDependencyTracker::TMvccDependencyTrackingLogic::AddOperation(const TOpera
 
                     if (lock) {
                         lock->SetLastOpId(op->GetTxId());
-                        if (locksCache.Locks.contains(lockTxId) && lock->IsPersistent()) {
+                        if (locksCache.Locks.contains(lockTxId) && lock->IsPersistent() && !lock->IsFrozen()) {
                             // This lock was cached before, and since we know
                             // it's persistent, we know it was also frozen
                             // during that lock caching. Restore the frozen
                             // flag for this lock.
+                            // Note: this code path is only for older shards
+                            // which didn't persist the frozen flag.
                             lock->SetFrozen();
                         }
                     }

--- a/ydb/core/tx/datashard/datashard_locks.cpp
+++ b/ydb/core/tx/datashard/datashard_locks.cpp
@@ -44,16 +44,17 @@ TLockInfo::TLockInfo(TLockLocker * locker, ui64 lockId, ui32 lockNodeId)
     , CreationTime(TAppData::TimeProvider->Now())
 {}
 
-TLockInfo::TLockInfo(TLockLocker * locker, ui64 lockId, ui32 lockNodeId, ui32 generation, ui64 counter, TInstant createTs)
+TLockInfo::TLockInfo(TLockLocker * locker, const ILocksDb::TLockRow& row)
     : Locker(locker)
-    , LockId(lockId)
-    , LockNodeId(lockNodeId)
-    , Generation(generation)
-    , Counter(counter)
-    , CreationTime(createTs)
+    , LockId(row.LockId)
+    , LockNodeId(row.LockNodeId)
+    , Generation(row.Generation)
+    , Counter(row.Counter)
+    , CreationTime(TInstant::MicroSeconds(row.CreateTs))
+    , Flags(ELockFlags(row.Flags))
     , Persistent(true)
 {
-    if (counter == Max<ui64>()) {
+    if (Counter == Max<ui64>()) {
         BreakVersion.emplace(TRowVersion::Min());
     }
 }
@@ -145,7 +146,7 @@ void TLockInfo::OnRemoved() {
 void TLockInfo::PersistLock(ILocksDb* db) {
     Y_ABORT_UNLESS(!IsPersistent());
     Y_ABORT_UNLESS(db, "Cannot persist lock without a db");
-    db->PersistAddLock(LockId, LockNodeId, Generation, Counter, CreationTime.MicroSeconds());
+    db->PersistAddLock(LockId, LockNodeId, Generation, Counter, CreationTime.MicroSeconds(), ui64(Flags));
     Persistent = true;
 
     PersistRanges(db);
@@ -298,11 +299,11 @@ void TLockInfo::CleanupConflicts() {
     }
 }
 
-void TLockInfo::RestorePersistentRange(ui64 rangeId, const TPathId& tableId, ELockRangeFlags flags) {
+void TLockInfo::RestorePersistentRange(const ILocksDb::TLockRange& rangeRow) {
     auto& range = PersistentRanges.emplace_back();
-    range.Id = rangeId;
-    range.TableId = tableId;
-    range.Flags = flags;
+    range.Id = rangeRow.RangeId;
+    range.TableId = rangeRow.TableId;
+    range.Flags = ELockRangeFlags(rangeRow.Flags);
 
     if (!!(range.Flags & ELockRangeFlags::Read)) {
         if (ReadTables.insert(range.TableId).second) {
@@ -332,6 +333,14 @@ void TLockInfo::RestorePersistentVolatileDependency(ui64 txId) {
     Y_ABORT_UNLESS(IsPersistent());
 
     VolatileDependencies.insert(txId);
+}
+
+void TLockInfo::SetFrozen(ILocksDb* db) {
+    Y_ABORT_UNLESS(IsPersistent());
+    Flags |= ELockFlags::Frozen;
+    if (db) {
+        db->PersistLockFlags(LockId, ui64(Flags));
+    }
 }
 
 // TTableLocks
@@ -550,14 +559,14 @@ TLockInfo::TPtr TLockLocker::GetOrAddLock(ui64 lockId, ui32 lockNodeId) {
     return lock;
 }
 
-TLockInfo::TPtr TLockLocker::AddLock(ui64 lockId, ui32 lockNodeId, ui32 generation, ui64 counter, TInstant createTs) {
-    Y_ABORT_UNLESS(Locks.find(lockId) == Locks.end());
+TLockInfo::TPtr TLockLocker::AddLock(const ILocksDb::TLockRow& row) {
+    Y_ABORT_UNLESS(Locks.find(row.LockId) == Locks.end());
 
-    TLockInfo::TPtr lock(new TLockInfo(this, lockId, lockNodeId, generation, counter, createTs));
+    TLockInfo::TPtr lock(new TLockInfo(this, row));
     Y_ABORT_UNLESS(lock->IsPersistent());
-    Locks[lockId] = lock;
-    if (lockNodeId) {
-        PendingSubscribeLocks.emplace_back(lockId, lockNodeId);
+    Locks[row.LockId] = lock;
+    if (row.LockNodeId) {
+        PendingSubscribeLocks.emplace_back(row.LockId, row.LockNodeId);
     }
     return lock;
 }
@@ -1171,9 +1180,9 @@ bool TSysLocks::Load(ILocksDb& db) {
     Locker.Clear();
 
     for (auto& lockRow : rows) {
-        TLockInfo::TPtr lock = Locker.AddLock(lockRow.LockId, lockRow.LockNodeId, lockRow.Generation, lockRow.Counter, TInstant::MicroSeconds(lockRow.CreateTs));
+        TLockInfo::TPtr lock = Locker.AddLock(lockRow);
         for (auto& rangeRow : lockRow.Ranges) {
-            lock->RestorePersistentRange(rangeRow.RangeId, rangeRow.TableId, ELockRangeFlags(rangeRow.Flags));
+            lock->RestorePersistentRange(rangeRow);
         }
     }
 

--- a/ydb/core/tx/datashard/datashard_locks.h
+++ b/ydb/core/tx/datashard/datashard_locks.h
@@ -57,6 +57,7 @@ public:
     // Persist adding/removing a lock info
     virtual void PersistAddLock(ui64 lockId, ui32 lockNodeId, ui32 generation, ui64 counter, ui64 createTs, ui64 flags = 0) = 0;
     virtual void PersistLockCounter(ui64 lockId, ui64 counter) = 0;
+    virtual void PersistLockFlags(ui64 lockId, ui64 flags) = 0;
     virtual void PersistRemoveLock(ui64 lockId) = 0;
 
     // Persist adding/removing info on locked ranges
@@ -206,6 +207,23 @@ struct TPendingSubscribeLock {
     }
 };
 
+// ELockFlags type safe enum
+
+enum class ELockFlags : ui64 {
+    None = 0,
+    Frozen = 1,
+};
+
+using ELockFlagsRaw = std::underlying_type<ELockFlags>::type;
+
+inline ELockFlags operator|(ELockFlags a, ELockFlags b) { return ELockFlags(ELockFlagsRaw(a) | ELockFlagsRaw(b)); }
+inline ELockFlags operator&(ELockFlags a, ELockFlags b) { return ELockFlags(ELockFlagsRaw(a) & ELockFlagsRaw(b)); }
+inline ELockFlags& operator|=(ELockFlags& a, ELockFlags b) { return a = a | b; }
+inline ELockFlags& operator&=(ELockFlags& a, ELockFlags b) { return a = a & b; }
+inline bool operator!(ELockFlags c) { return ELockFlagsRaw(c) == 0; }
+
+// ELockConflictFlags type safe enum
+
 enum class ELockConflictFlags : ui8 {
     None = 0,
     BreakThemOnOurCommit = 1,
@@ -219,6 +237,8 @@ inline ELockConflictFlags operator&(ELockConflictFlags a, ELockConflictFlags b) 
 inline ELockConflictFlags& operator|=(ELockConflictFlags& a, ELockConflictFlags b) { return a = a | b; }
 inline ELockConflictFlags& operator&=(ELockConflictFlags& a, ELockConflictFlags b) { return a = a & b; }
 inline bool operator!(ELockConflictFlags c) { return ELockConflictFlagsRaw(c) == 0; }
+
+// ELockRangeFlags type safe enum
 
 enum class ELockRangeFlags : ui8 {
     None = 0,
@@ -262,7 +282,7 @@ public:
     using TPtr = TIntrusivePtr<TLockInfo>;
 
     TLockInfo(TLockLocker * locker, ui64 lockId, ui32 lockNodeId);
-    TLockInfo(TLockLocker * locker, ui64 lockId, ui32 lockNodeId, ui32 generation, ui64 counter, TInstant createTs);
+    TLockInfo(TLockLocker * locker, const ILocksDb::TLockRow& row);
     ~TLockInfo();
 
     bool Empty() const {
@@ -303,6 +323,9 @@ public:
     ui32 GetLockNodeId() const { return LockNodeId; }
 
     TInstant GetCreationTime() const { return CreationTime; }
+
+    ELockFlags GetFlags() const { return Flags; }
+
     const THashSet<TPathId>& GetReadTables() const { return ReadTables; }
     const THashSet<TPathId>& GetWriteTables() const { return WriteTables; }
 
@@ -320,7 +343,7 @@ public:
     void PersistConflicts(ILocksDb* db);
     void CleanupConflicts();
 
-    void RestorePersistentRange(ui64 rangeId, const TPathId& tableId, ELockRangeFlags flags);
+    void RestorePersistentRange(const ILocksDb::TLockRange& rangeRow);
     void RestorePersistentConflict(TLockInfo* otherLock);
     void RestorePersistentVolatileDependency(ui64 txId);
 
@@ -341,8 +364,8 @@ public:
     ui64 GetLastOpId() const { return LastOpId; }
     void SetLastOpId(ui64 opId) { LastOpId = opId; }
 
-    bool IsFrozen() const { return Frozen; }
-    void SetFrozen() { Frozen = true; }
+    bool IsFrozen() const { return !!(Flags & ELockFlags::Frozen); }
+    void SetFrozen(ILocksDb* db = nullptr);
 
 private:
     void MakeShardLock();
@@ -369,6 +392,7 @@ private:
     ui32 Generation;
     ui64 Counter;
     TInstant CreationTime;
+    ELockFlags Flags = ELockFlags::None;
     THashSet<TPathId> ReadTables;
     THashSet<TPathId> WriteTables;
     TVector<TPointKey> Points;
@@ -386,7 +410,6 @@ private:
     TVector<TPersistentRange> PersistentRanges;
 
     ui64 LastOpId = 0;
-    bool Frozen = false;
 };
 
 struct TTableLocksReadListTag {};
@@ -641,7 +664,7 @@ private:
     void RemoveBrokenRanges();
 
     TLockInfo::TPtr GetOrAddLock(ui64 lockId, ui32 lockNodeId);
-    TLockInfo::TPtr AddLock(ui64 lockId, ui32 lockNodeId, ui32 generation, ui64 counter, TInstant createTs);
+    TLockInfo::TPtr AddLock(const ILocksDb::TLockRow& row);
     void RemoveOneLock(ui64 lockId, ILocksDb* db = nullptr);
 
     void SaveBrokenPersistentLocks(ILocksDb* db);

--- a/ydb/core/tx/datashard/datashard_locks_db.cpp
+++ b/ydb/core/tx/datashard/datashard_locks_db.cpp
@@ -129,6 +129,14 @@ void TDataShardLocksDb::PersistLockCounter(ui64 lockId, ui64 counter) {
     HasChanges_ = true;
 }
 
+void TDataShardLocksDb::PersistLockFlags(ui64 lockId, ui64 flags) {
+    using Schema = TDataShard::Schema;
+    NIceDb::TNiceDb db(DB);
+    db.Table<Schema::Locks>().Key(lockId).Update(
+        NIceDb::TUpdate<Schema::Locks::Flags>(flags));
+    HasChanges_ = true;
+}
+
 void TDataShardLocksDb::PersistRemoveLock(ui64 lockId) {
     // We remove lock changes unless it's managed by volatile tx manager
     bool isVolatile = Self.GetVolatileTxManager().FindByCommitTxId(lockId);

--- a/ydb/core/tx/datashard/datashard_locks_db.h
+++ b/ydb/core/tx/datashard/datashard_locks_db.h
@@ -23,6 +23,7 @@ public:
     // Persist adding/removing a lock info
     void PersistAddLock(ui64 lockId, ui32 lockNodeId, ui32 generation, ui64 counter, ui64 createTs, ui64 flags = 0) override;
     void PersistLockCounter(ui64 lockId, ui64 counter) override;
+    void PersistLockFlags(ui64 lockId, ui64 flags) override;
     void PersistRemoveLock(ui64 lockId) override;
 
     // Persist adding/removing info on locked ranges

--- a/ydb/core/tx/datashard/datashard_ut_common_kqp.h
+++ b/ydb/core/tx/datashard/datashard_ut_common_kqp.h
@@ -146,7 +146,17 @@ namespace NKqpHelpers {
         if (result.result_sets_size() == 0) {
             return "<empty>";
         }
-        return FormatResult(result.result_sets(0));
+        if (result.result_sets_size() == 1) {
+            return FormatResult(result.result_sets(0));
+        }
+        TStringBuilder sb;
+        for (int i = 0; i < result.result_sets_size(); ++i) {
+            if (i != 0) {
+                sb << "\n";
+            }
+            sb << FormatResult(result.result_sets(i));
+        }
+        return sb;
     }
 
     inline TString FormatResult(const Ydb::Table::ExecuteDataQueryResponse& response) {

--- a/ydb/core/tx/datashard/store_and_send_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/store_and_send_out_rs_unit.cpp
@@ -1,6 +1,7 @@
 #include "datashard_impl.h"
 #include "datashard_pipeline.h"
 #include "execution_unit_ctors.h"
+#include "datashard_locks_db.h"
 
 namespace NKikimr {
 namespace NDataShard {
@@ -62,7 +63,8 @@ EExecutionStatus TStoreAndSendOutRSUnit::Execute(TOperation::TPtr op,
             ui64 lockId = pr.first;
             auto lock = DataShard.SysLocksTable().GetRawLock(lockId, TRowVersion::Min());
             if (lock && lock->IsPersistent()) {
-                lock->SetFrozen();
+                TDataShardLocksDb locksDb(DataShard, txc);
+                lock->SetFrozen(&locksDb);
             }
         }
         tx->MarkLocksStored();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix partial distributed commit of uncommitted changes during shard restart race.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

A rare G0 anomaly was detected with Jepsen, which corresponded to a partial commit of accumulated changes when using persistent distributed transactions. Investigation showed that the `Frozen` lock flag was not persisted (this flag is set for write locks when they are validated and outgoing readsets are generated, and used to protect lock changes until transaction decides to commit or abort based on other participant decisions), and there was a window after a given shard restarts and before it fully restores the pipeline dependencies (including `Frozen` flag for locks validated in previous generations). During this time window lock subscription may report lock as unavailable or expired (e.g. when transaction is fully removed from a KQP session, either due to implicit rollback also failing quickly due to shard unavailability, or node restarting and losing all state). This in turn rolled back (previously frozen) lock changes, when they should have been committed instead.

Fixes KIKIMR-21088. Ported to 24-1 from #2148.