### PR TITLE
ci: run relwithdebinfo and debug with build-preset labels too

### DIFF
--- a/.github/workflows/build_and_test_ya_provisioned.yml
+++ b/.github/workflows/build_and_test_ya_provisioned.yml
@@ -101,8 +101,7 @@ jobs:
     with:
       # FIXME: always use auto-provisioned here?
       runner_label: ${{ inputs.runner_label }}
-      # naive check for -asan, -tsan, -msan
-      runner_additional_label: ${{ contains(inputs.build_preset, '-') && format('build-preset-{0}', inputs.build_preset) || '' }}
+      runner_additional_label: ${{ format('build-preset-{0}', inputs.build_preset) }}
       build_target: ${{ inputs.build_target }}
       build_preset: ${{ inputs.build_preset }}
       run_build: ${{ inputs.run_build }}


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Add `build-preset-{preset}` labels for all auto-provisioned builds.