### PR TITLE
LOGBROKER-8935: return error for compression.type config in Kafka API

### DIFF
--- a/ydb/core/kafka_proxy/actors/control_plane_common.h
+++ b/ydb/core/kafka_proxy/actors/control_plane_common.h
@@ -95,6 +95,20 @@ inline TStringBuilder InputLogMessage(
     return stringBuilder;
 }
 
+inline std::optional<THolder<TEvKafka::TEvTopicModificationResponse>> ValidateTopicConfigName(TString configName) {
+    if (configName == COMPRESSION_TYPE) {
+        auto result = MakeHolder<TEvKafka::TEvTopicModificationResponse>();
+        result->Status = EKafkaErrors::INVALID_REQUEST;
+        result->Message = TStringBuilder()
+            << "Topic-level config '"
+            << COMPRESSION_TYPE
+            << "' is not allowed.";
+        return result;
+    } else {
+        return std::optional<THolder<TEvKafka::TEvTopicModificationResponse>>();
+    }
+} 
+
 template<class T>
 inline std::unordered_set<TString> ExtractDuplicates(
         std::vector<T>& source,

--- a/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
@@ -164,12 +164,23 @@ void TKafkaCreateTopicsActor::Bootstrap(const NActors::TActorContext& ctx) {
         std::optional<TString> retentionMs;
         std::optional<TString> retentionBytes;
 
+        std::optional<THolder<TEvKafka::TEvTopicModificationResponse>> unsupportedConfigResponse;
+
         for (auto& config : topic.Configs) {
+            unsupportedConfigResponse = ValidateTopicConfigName(config.Name.value());
+            if (unsupportedConfigResponse.has_value()) {
+                break;
+            }
             if (config.Name.value() == RETENTION_MS_CONFIG_NAME) {
                 retentionMs = config.Value;
             } else if (config.Name.value() == RETENTION_BYTES_CONFIG_NAME) {
                 retentionBytes = config.Value;
             }
+        }
+
+        if (unsupportedConfigResponse.has_value()) {
+            this->TopicNamesToResponses[topicName] = unsupportedConfigResponse.value();
+            continue;
         }
 
         TRetentionsConversionResult convertedRetentions = ConvertRetentions(retentionMs, retentionBytes);


### PR DESCRIPTION
We should not allow the user to provide `compression.type` config.