### PR TITLE
Support for temporary tokens in yql_plugin

### DIFF
--- a/ydb/library/yql/core/facade/yql_facade.cpp
+++ b/ydb/library/yql/core/facade/yql_facade.cpp
@@ -432,6 +432,8 @@ TString TProgram::TakeSessionId() {
 }
 
 void TProgram::AddCredentials(const TVector<std::pair<TString, TCredential>>& credentials) {
+    Y_ENSURE(!TypeCtx_, "TypeCtx_ already created");
+
     for (const auto& credential : credentials) {
         Credentials_->AddCredential(credential.first, credential.second);
     }
@@ -445,6 +447,8 @@ void TProgram::AddCredentials(const TVector<std::pair<TString, TCredential>>& cr
 }
 
 void TProgram::ClearCredentials() {
+    Y_ENSURE(!TypeCtx_, "TypeCtx_ already created");
+
     Credentials_ = MakeIntrusive<TCredentials>();
 
     if (auto modules = dynamic_cast<TModuleResolver*>(Modules_.get())) {

--- a/ydb/library/yql/core/facade/yql_facade.h
+++ b/ydb/library/yql/core/facade/yql_facade.h
@@ -331,6 +331,11 @@ public:
         AbortHidden_ = std::move(func);
     }
 
+    TMaybe<TSet<TString>> GetUsedClusters() {
+        CollectUsedClusters();
+        return UsedClusters_;
+    }
+
 private:
     TProgram(
         const NKikimr::NMiniKQL::IFunctionRegistry* functionRegistry,

--- a/ydb/library/yql/yt/bridge/interface.h
+++ b/ydb/library/yql/yt/bridge/interface.h
@@ -73,6 +73,15 @@ struct TBridgeQueryResult
     ssize_t YsonErrorLength = 0;
 };
 
+struct TBridgeClustersResult
+{
+    const char** Clusters = nullptr;
+    ssize_t ClusterCount = 0;
+
+    const char* YsonError = nullptr;
+    ssize_t YsonErrorLength = 0;
+};
+
 enum EQueryFileContentType
 {
     RawInlineData,
@@ -97,16 +106,25 @@ struct TBridgeAbortResult
 };
 
 using TFuncBridgeFreeQueryResult = void(TBridgeQueryResult* result);
+using TFuncBridgeFreeClustersResult = void(TBridgeClustersResult* result);
 using TFuncBridgeRun = TBridgeQueryResult*(
     TBridgeYqlPlugin* plugin,
     const char* queryId,
-    const char* impersonationUser,
+    const char* user,
+    const char* token,
     const char* queryText,
     const char* settings,
     int settingsLength,
     const TBridgeQueryFile* files,
     int fileCount,
     int executeMode);
+using TFuncBridgeGetUsedClusters = TBridgeClustersResult*(
+    TBridgeYqlPlugin* plugin,
+    const char* queryText,
+    const char* settings,
+    int settingsLength,
+    const TBridgeQueryFile* files,
+    int fileCount);
 using TFuncBridgeGetProgress = TBridgeQueryResult*(TBridgeYqlPlugin* plugin, const char* queryId);
 using TFuncBridgeAbort = TBridgeAbortResult*(TBridgeYqlPlugin* plugin, const char* queryId);
 using TFuncBridgeFreeAbortResult = void(TBridgeAbortResult* result);
@@ -118,7 +136,9 @@ using TFuncBridgeFreeAbortResult = void(TBridgeAbortResult* result);
     XX(BridgeStartYqlPlugin) \
     XX(BridgeFreeYqlPlugin) \
     XX(BridgeFreeQueryResult) \
+    XX(BridgeFreeClustersResult) \
     XX(BridgeRun) \
+    XX(BridgeGetUsedClusters) \
     XX(BridgeGetProgress) \
     XX(BridgeGetAbiVersion) \
     XX(BridgeAbort) \

--- a/ydb/library/yql/yt/dynamic/dylib.exports
+++ b/ydb/library/yql/yt/dynamic/dylib.exports
@@ -3,7 +3,9 @@ BridgeCreateYqlPlugin
 BridgeStartYqlPlugin
 BridgeFreeYqlPlugin
 BridgeFreeQueryResult
+BridgeFreeClustersResult
 BridgeRun
+BridgeGetUsedClusters
 BridgeGetProgress
 BridgeGetAbiVersion
 BridgeAbort

--- a/ydb/library/yql/yt/native/plugin.cpp
+++ b/ydb/library/yql/yt/native/plugin.cpp
@@ -332,7 +332,12 @@ public:
             if (options.YTTokenPath) {
                 TFsPath path(options.YTTokenPath);
                 YqlAgentToken_ = TIFStream(path).ReadAll();
+            } else if (!NYT::TConfig::Get()->Token.empty()) {
+                YqlAgentToken_ = NYT::TConfig::Get()->Token;
             }
+            // do not use token from .yt/token or env in queries
+            NYT::TConfig::Get()->Token = {};
+
             ProgramFactory_->AddUserDataTable(userDataTable);
             ProgramFactory_->SetCredentials(MakeIntrusive<NYql::TCredentials>());
             ProgramFactory_->SetModules(ModuleResolver_);

--- a/ydb/library/yql/yt/native/plugin.cpp
+++ b/ydb/library/yql/yt/native/plugin.cpp
@@ -589,7 +589,6 @@ public:
                 };
             }
             if (!ActiveQueriesProgress_[queryId].Compiled) {
-                ActiveQueriesProgress_.erase(queryId);
                 return TAbortResult{
                     .YsonError = MessageToYtErrorYson(Format("Query %v is not compiled", queryId)),
                 };
@@ -631,7 +630,9 @@ private:
     void RemoveQuery(TQueryId queryId)
     {
         auto guard = WriterGuard(ProgressSpinLock);
-        ActiveQueriesProgress_.erase(queryId);
+        if (ActiveQueriesProgress_.contains(queryId)) {
+            ActiveQueriesProgress_.erase(queryId);
+        }
     }
 
     static TString PatchQueryAttributes(TYsonString configAttributes, TYsonString querySettings)

--- a/ydb/library/yql/yt/plugin.h
+++ b/ydb/library/yql/yt/plugin.h
@@ -11,8 +11,6 @@
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
 
-#include <optional>
-
 namespace NYT::NYqlPlugin {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,6 +48,14 @@ struct TQueryResult
     std::optional<TString> YsonError;
 };
 
+struct TClustersResult
+{
+    std::vector<TString> Clusters;
+
+    //! YSON representation of a YT error.
+    std::optional<TString> YsonError;
+};
+
 struct TQueryFile
 {
     TStringBuf Name;
@@ -74,13 +80,20 @@ struct IYqlPlugin
 {
     virtual void Start() = 0;
 
+    virtual TClustersResult GetUsedClusters(
+        TString queryText,
+        NYson::TYsonString settings,
+        std::vector<TQueryFile> files) noexcept = 0;
+
     virtual TQueryResult Run(
         TQueryId queryId,
-        TString impersonationUser,
+        TString user,
+        TString token,
         TString queryText,
         NYson::TYsonString settings,
         std::vector<TQueryFile> files,
         int executeMode) noexcept = 0;
+
     virtual TQueryResult GetProgress(TQueryId queryId) noexcept = 0;
 
     virtual TAbortResult Abort(TQueryId queryId) noexcept = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

In this pull request, I am changing the authorization method in yql QT requests. Temporary tokens will be used instead of impersonation.

The algorithm for generating temporary tokens is:
1) We get all used clusters from the query (in yql_plugin)
2) Generating a temporary token on all clusters (in yql_agent)
3) Run the query (in yql_agent)

Unfortunately, in order to get all the clusters from a request, you must first compile it, and for this you must already have partial rights to execute it. Therefore, this step will be performed with superuser rights. (by yql_agent user)

yql_agent PR: https://github.com/ytsaurus/ytsaurus/pull/410