### PR TITLE
Support passing debug info from shards to grpc responses

### DIFF
--- a/ydb/core/grpc_services/rpc_commit_transaction.cpp
+++ b/ydb/core/grpc_services/rpc_commit_transaction.cpp
@@ -93,6 +93,8 @@ private:
                 FillQueryStats(*commitResult->mutable_query_stats(), kqpResponse);
             }
 
+            FillDebugInfo(*commitResult, kqpResponse);
+
             AuditContextAppend(Request_.get(), *GetProtoRequest(), *commitResult);
 
             ReplyWithResult(Ydb::StatusIds::SUCCESS, issueMessage, *commitResult, ctx);

--- a/ydb/core/grpc_services/rpc_execute_data_query.cpp
+++ b/ydb/core/grpc_services/rpc_execute_data_query.cpp
@@ -189,6 +189,7 @@ public:
                     NKqp::ConvertKqpQueryResultsToDbResult(kqpResponse, queryResult);
                 }
                 ConvertQueryStats(kqpResponse, queryResult);
+                FillDebugInfo(*queryResult, kqpResponse);
                 if (kqpResponse.HasTxMeta()) {
                     queryResult->mutable_tx_meta()->CopyFrom(kqpResponse.GetTxMeta());
                 }

--- a/ydb/core/grpc_services/rpc_execute_yql_script.cpp
+++ b/ydb/core/grpc_services/rpc_execute_yql_script.cpp
@@ -107,6 +107,8 @@ public:
             queryResult->mutable_query_stats()->set_query_plan(kqpResponse.GetQueryPlan());
         }
 
+        FillDebugInfo(*queryResult, kqpResponse);
+
         AuditContextAppend(Request_.get(), *GetProtoRequest(), *queryResult);
 
         ReplyWithResult(Ydb::StatusIds::SUCCESS, issueMessage, *queryResult, ctx);

--- a/ydb/core/grpc_services/rpc_kqp_base.h
+++ b/ydb/core/grpc_services/rpc_kqp_base.h
@@ -77,6 +77,18 @@ inline bool CheckQuery(const TString& query, NYql::TIssues& issues) {
 void FillQueryStats(Ydb::TableStats::QueryStats& queryStats, const NKqpProto::TKqpStatsQuery& kqpStats);
 void FillQueryStats(Ydb::TableStats::QueryStats& queryStats, const NKikimrKqp::TQueryResponse& kqpResponse);
 
+template<class TPublicResponse>
+void FillDebugInfo(TPublicResponse& response, const NKikimrKqp::TQueryResponse& kqpResponse) {
+    auto size = kqpResponse.DebugInfoSize();
+    if (size > 0) {
+        auto* p = response.mutable_query_stats()->mutable_debug_info();
+        p->Reserve(size);
+        for (TString debugInfo : kqpResponse.GetDebugInfo()) {
+            p->Add(std::move(debugInfo));
+        }
+    }
+}
+
 Ydb::Table::QueryStatsCollection::Mode GetCollectStatsMode(Ydb::Query::StatsMode mode);
 
 template <typename TDerived, typename TRequest>

--- a/ydb/core/grpc_services/rpc_stream_execute_scan_query.cpp
+++ b/ydb/core/grpc_services/rpc_stream_execute_scan_query.cpp
@@ -315,6 +315,8 @@ private:
                     response.mutable_result()->mutable_query_stats()->set_query_ast(kqpResponse.GetQueryAst());
                 }
 
+                FillDebugInfo(*response.mutable_result(), kqpResponse);
+
                 response.mutable_result()->set_query_full_diagnostics(kqpResponse.GetQueryDiagnostics());
 
                 Y_PROTOBUF_SUPPRESS_NODISCARD response.SerializeToString(&out);

--- a/ydb/core/grpc_services/rpc_stream_execute_yql_script.cpp
+++ b/ydb/core/grpc_services/rpc_stream_execute_yql_script.cpp
@@ -358,6 +358,8 @@ private:
                 response.mutable_result()->mutable_query_stats()->set_query_plan(kqpResponse.GetQueryPlan());
             }
 
+            FillDebugInfo(*response.mutable_result(), kqpResponse);
+
             AuditContextAppend(Request_.get(), *GetProtoRequest(), response);
 
             Y_PROTOBUF_SUPPRESS_NODISCARD response.SerializeToString(&out);

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -1025,6 +1025,10 @@ public:
             BrokenLocks.push_back(lock);
         }
 
+        for (const auto& debugInfo : record.GetDebugInfo()) {
+            DebugInfo.push_back(debugInfo);
+        }
+
         CA_LOG_D("Taken " << Locks.size() << " locks");
         Reads[id].SerializedContinuationToken = record.GetContinuationToken();
 
@@ -1421,6 +1425,16 @@ public:
         for (auto& lock : BrokenLocks) {
             resultInfo.AddLocks()->CopyFrom(lock);
         }
+
+        if (!DebugInfo.empty()) {
+            auto* debugInfos = resultInfo.MutableDebugInfo();
+            debugInfos->Reserve(DebugInfo.size());
+            for (auto& debugInfo : DebugInfo) {
+                debugInfos->Add(std::move(debugInfo));
+            }
+            DebugInfo.clear();
+        }
+
         result.PackFrom(resultInfo);
         return result;
     }
@@ -1481,6 +1495,7 @@ private:
 
     TVector<NKikimrDataEvents::TLock> Locks;
     TVector<NKikimrDataEvents::TLock> BrokenLocks;
+    TVector<TString> DebugInfo;
 
     IKqpGateway::TKqpSnapshot Snapshot;
 

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -212,6 +212,15 @@ private:
             resultInfo.AddLocks()->CopyFrom(lock);
         }
 
+        if (!DebugInfo.empty()) {
+            auto* debugInfos = resultInfo.MutableDebugInfo();
+            debugInfos->Reserve(DebugInfo.size());
+            for (auto& debugInfo : DebugInfo) {
+                debugInfos->Add(std::move(debugInfo));
+            }
+            DebugInfo.clear();
+        }
+
         result.PackFrom(resultInfo);
         return result;
     }
@@ -272,6 +281,10 @@ private:
 
         for (auto& lock : record.GetTxLocks()) {
             Locks.push_back(lock);
+        }
+
+        for (const auto& debugInfo : record.GetDebugInfo()) {
+            DebugInfo.push_back(debugInfo);
         }
 
         if (!Snapshot.IsValid()) {
@@ -513,6 +526,7 @@ private:
     NActors::TActorId SchemeCacheRequestTimeoutTimer;
     TVector<NKikimrDataEvents::TLock> Locks;
     TVector<NKikimrDataEvents::TLock> BrokenLocks;
+    TVector<TString> DebugInfo;
     std::unique_ptr<TKqpStreamLookupWorker> StreamLookupWorker;
     ui64 ReadId = 0;
 

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -100,6 +100,7 @@ public:
     TInstant StartTime;
     NYql::TKikimrQueryDeadlines QueryDeadlines;
     TKqpQueryStats QueryStats;
+    TVector<TString> DebugInfo;
     bool KeepSession = false;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     NActors::TMonotonic StartedAt;

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1394,6 +1394,10 @@ public:
             QueryState->QueryStats.Executions.back().Swap(executerResults.MutableStats());
         }
 
+        for (const auto& debugInfo : executerResults.GetDebugInfo()) {
+            QueryState->DebugInfo.push_back(debugInfo);
+        }
+
         if (!response->GetIssues().empty()){
             NYql::IssuesFromMessage(response->GetIssues(), QueryState->Issues);
         }
@@ -1640,6 +1644,15 @@ public:
         }
 
         response->SetQueryDiagnostics(QueryState->ReplayMessage);
+
+        if (!QueryState->DebugInfo.empty()) {
+            auto* debugInfos = response->MutableDebugInfo();
+            debugInfos->Reserve(QueryState->DebugInfo.size());
+            for (auto& debugInfo : QueryState->DebugInfo) {
+                debugInfos->Add(std::move(debugInfo));
+            }
+            QueryState->DebugInfo.clear();
+        }
 
         // Result for scan query is sent directly to target actor.
         Y_ABORT_UNLESS(response->GetArena());

--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -122,4 +122,8 @@ message TEvWriteResult {
 
     // Statistics
     optional NKikimrQueryStats.TTxStats TxStats = 13;
+
+    // Debug info about operation results in json format
+    // Enabled with EnableQueryDebugInfo feature flag
+    repeated string DebugInfo = 14;
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -131,4 +131,5 @@ message TFeatureFlags {
     optional bool EnableReplaceIfExistsForExternalEntities = 116 [ default = false];
     optional bool EnableCMSRequestPriorities = 117 [default = false];
     optional bool EnableKeyvalueLogBatching = 118 [default = false];
+    optional bool EnableQueryDebugInfo = 119 [default = false];
 }

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -268,6 +268,7 @@ message TQueryResponse {
     repeated Ydb.ResultSet YdbResults = 13;
     optional TTopicOperationsResponse TopicOperations = 14;
     optional string QueryDiagnostics = 15;
+    repeated string DebugInfo = 16;
 }
 
 message TEvQueryResponse {
@@ -431,6 +432,7 @@ message TExecuterTxResult {
     reserved 5; // (deprecated) Stats
     optional NYql.NDqProto.TDqExecutionStats Stats = 6;
     reserved 7;
+    repeated string DebugInfo = 8;
 };
 
 message TExecuterTxResponse {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -229,6 +229,7 @@ message TKqpTransaction {
 
 message TEvKqpInputActorResultInfo {
     repeated NKikimrDataEvents.TLock Locks = 1;
+    repeated string DebugInfo = 2;
 }
 
 message TKqpReadRangesSourceSettings {
@@ -627,6 +628,10 @@ message TEvProposeTransactionResult {
     optional bytes DataLastKey = 25; // Response data last key (for retries)
     reserved 26; // optional NKqpProto.TKqpStatsRun KqpRunStats = 26;
     optional NYql.NDqProto.TDqComputeActorStats ComputeActorStats = 27; // overall time + per-task statistics
+
+    // Debug info about operation results in json format
+    // Enabled with EnableQueryDebugInfo feature flag
+    repeated string DebugInfo = 28;
 }
 
 message TEvProposeTransactionRestart {
@@ -1708,6 +1713,10 @@ message TEvReadResult {
     optional uint64 RowCount = 12;
 
     optional uint32 NodeId = 13;
+
+    // Debug info about operation results in json format
+    // Enabled with EnableQueryDebugInfo feature flag
+    repeated string DebugInfo = 14;
 
     // Data for the possibly partial result
     oneof ReadResult {

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -719,6 +719,18 @@ public:
             record.MutableSnapshot()->SetTxId(State.ReadVersion.TxId);
         }
 
+        Self->MaybeAddDebugInfo(record, [&](NJsonWriter::TBuf& b) {
+            b.WriteKey("op").WriteString("read");
+            b.WriteKey("read_id").WriteULongLong(State.ReadId);
+            b.WriteKey("read_version").WriteString(TStringBuilder() << State.ReadVersion);
+            if (!State.IsHeadRead) {
+                b.WriteKey("snapshot_repeatable").WriteBool(true);
+            }
+            if (State.LockId) {
+                b.WriteKey("lock_tx_id").WriteULongLong(State.LockId);
+            }
+        });
+
         return useful;
     }
 

--- a/ydb/core/tx/datashard/datashard_ut_debug_info.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_debug_info.cpp
@@ -1,0 +1,75 @@
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include "datashard_ut_common_kqp.h"
+
+#include <library/cpp/json/json_reader.h>
+
+namespace NKikimr {
+
+using namespace NKikimr::NDataShard;
+using namespace NKikimr::NDataShard::NKqpHelpers;
+using namespace NSchemeShard;
+using namespace Tests;
+
+Y_UNIT_TEST_SUITE(DataShardDebugInfo) {
+
+    TVector<NJson::TJsonValue> ExtractDebugInfo(const Ydb::Table::ExecuteQueryResult& result) {
+        TVector<NJson::TJsonValue> out;
+        for (const TString& debugInfo : result.query_stats().debug_info()) {
+            NJson::ReadJsonTree(debugInfo, &out.emplace_back(), /* throwOnError */ true);
+        }
+        return out;
+    }
+
+    TVector<NJson::TJsonValue> ExtractDebugInfo(const Ydb::Table::ExecuteDataQueryResponse& response) {
+        Ydb::Table::ExecuteQueryResult result;
+        response.operation().result().UnpackTo(&result);
+        return ExtractDebugInfo(result);
+    }
+
+    Y_UNIT_TEST(ReadDebugInfo) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+        CreateShardedTable(server, sender, "/Root", "table-2", 1);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 10), (2, 20), (3, 30);");
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table-2` (key, value) VALUES (4, 40), (5, 50), (6, 60);");
+
+        runtime.GetAppData().FeatureFlags.SetEnableQueryDebugInfo(true);
+
+        TString readSessionId = CreateSessionRPC(runtime);
+        auto readFuture = SendRequest(runtime, MakeSimpleRequestRPC(Q_(R"(
+            SELECT key, value FROM `/Root/table-1`
+            UNION ALL
+            SELECT key, value FROM `/Root/table-2`
+            ORDER BY key;
+            )"), readSessionId, "", /* commit */ true));
+
+        auto readResponse = AwaitResponse(runtime, std::move(readFuture));
+        UNIT_ASSERT_VALUES_EQUAL(readResponse.operation().status(), Ydb::StatusIds::SUCCESS);
+
+        int reads = 0;
+        for (auto& debugInfo : ExtractDebugInfo(readResponse)) {
+            if (debugInfo.Has("op") && debugInfo["op"].GetString() == "read") {
+                ++reads;
+            }
+        }
+
+        UNIT_ASSERT_C(reads >= 2, "Found only " << reads << " reads");
+    }
+
+} // Y_UNIT_TEST_SUITE(DataShardDebugInfo)
+
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/ut_debug_info/ya.make
+++ b/ydb/core/tx/datashard/ut_debug_info/ya.make
@@ -1,0 +1,20 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+PEERDIR(
+    ydb/core/tx/datashard/ut_common
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/default
+    ydb/library/yql/public/udf/service/exception_policy
+    ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/client/ydb_result
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    datashard_ut_debug_info.cpp
+)
+
+REQUIREMENTS(ram:32)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -227,6 +227,7 @@ PEERDIR(
     library/cpp/digest/md5
     library/cpp/html/pcdata
     library/cpp/json
+    library/cpp/json/writer
     library/cpp/json/yson
     library/cpp/lwtrace
     library/cpp/lwtrace/mon
@@ -287,6 +288,7 @@ RECURSE_FOR_TESTS(
     ut_change_collector
     ut_change_exchange
     ut_compaction
+    ut_debug_info
     ut_erase_rows
     ut_followers
     ut_init

--- a/ydb/public/api/protos/ydb_query_stats.proto
+++ b/ydb/public/api/protos/ydb_query_stats.proto
@@ -43,4 +43,6 @@ message QueryStats {
     string query_ast = 5;
     uint64 total_duration_us = 6;
     uint64 total_cpu_time_us = 7;
+    // Optional query execution debug info (when enabled on the server)
+    repeated string debug_info = 8;
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support passing debug info from shards to grpc responses

### Changelog category <!-- remove all except one -->

* Experimental feature

### Additional information

When investigating consistency failures (e.g. with jepsen) it is necessary to gather additional info about query execution, so it can be attached to operations in the history. This patch adds a feature flag that allows shards to generate debug info in json format and pass it via kqp to grpc responses.