### PR TITLE
ci: add "external" label for PRs made by external contributors

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -79,12 +79,21 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            let externalContributorLabel = 'external';
+            
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
+
+            github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: context.issue.number,
+                labels: [externalContributorLabel]
+            });
+
       - name: cleanup-test-label
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* Not for changelog (changelog entry is not required)

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)

### Additional information

...
