### PR TITLE
[ratelimiter] fix not_allowed message if no admins on cluster in configuration

### DIFF
--- a/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
+++ b/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
@@ -67,7 +67,7 @@ public:
         if (resource.has_metering_config()) {
             auto self = static_cast<TDerived*>(this);
             const auto& userTokenStr = self->Request_->GetSerializedToken();
-            bool allowed = false;
+            bool allowed = AppData()->AdministrationAllowedSIDs.empty();
             if (userTokenStr) {
                 NACLib::TUserToken userToken(userTokenStr);
                 for (auto &sid : AppData()->AdministrationAllowedSIDs) {


### PR DESCRIPTION
Fixed case when no administrators are configured via `administration_allowed_sids` option.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->
* Bugfix 

### Additional information

...
