### PR TITLE
disable batching for existed tablets

### DIFF
--- a/ydb/core/keyvalue/keyvalue_flat_impl.h
+++ b/ydb/core/keyvalue/keyvalue_flat_impl.h
@@ -85,8 +85,8 @@ protected:
                     return true;
                 }
                 Self.State.UpdateResourceMetrics(ctx);
-                // auto &alter = txc.DB.Alter();
-                // ApplyLogBatching(ctx, alter);
+                auto &alter = txc.DB.Alter();
+                ApplyLogBatching(ctx, alter);
             }
             Self.State.InitExecute(Self.TabletID(), KeyValueActorId, txc.Generation, db, ctx, Self.Info());
             LOG_DEBUG_S(ctx, NKikimrServices::KEYVALUE, "KeyValue# " << txc.Tablet


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

In the main branch, batching of the tablet log is already disabled for new tablets, but for those that have already been created, batching remains unchanged. This commit disables batching for the existing tablets as well.


### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

...
