### PR TITLE
YQ-2737 add TOKEN auth for YT datasource

### DIFF
--- a/ydb/core/external_sources/external_source_factory.cpp
+++ b/ydb/core/external_sources/external_source_factory.cpp
@@ -53,7 +53,7 @@ IExternalSourceFactory::TPtr CreateExternalSourceFactory(const std::vector<TStri
         },
         {
             ToString(NYql::EDatabaseType::YT),
-            CreateExternalDataSource(TString{NYql::YtProviderName}, {"NONE"}, {}, hostnamePatternsRegEx)
+            CreateExternalDataSource(TString{NYql::YtProviderName}, {"TOKEN"}, {}, hostnamePatternsRegEx)
         }
     });
 }

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -1337,6 +1337,7 @@ private:
             task.Meta.ShardId = shardId;
             shardTasks.emplace(shardId, task.Id);
 
+            FillSecureParamsFromStage(task.Meta.SecureParams, stage);
             BuildSinks(stage, task);
 
             return task;

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -830,6 +830,15 @@ protected:
 
 
 protected:
+    void FillSecureParamsFromStage(THashMap<TString, TString>& secureParams, const NKqpProto::TKqpPhyStage& stage) {
+        for (const auto& [secretName, authInfo] : stage.GetSecureParams()) {
+            const auto& structuredToken = NYql::CreateStructuredTokenParser(authInfo).ToBuilder().ReplaceReferences(SecureParams).ToJson();
+            const auto& structuredTokenParser = NYql::CreateStructuredTokenParser(structuredToken);
+            YQL_ENSURE(structuredTokenParser.HasIAMToken(), "only token authentification supported for compute tasks");
+            secureParams.emplace(secretName, structuredTokenParser.GetIAMToken());
+        }
+    }
+
     void BuildSysViewScanTasks(TStageInfo& stageInfo) {
         Y_DEBUG_ABORT_UNLESS(stageInfo.Meta.IsSysView());
 
@@ -873,6 +882,7 @@ protected:
             task.Meta.ReadInfo.Reverse = op.GetReadRange().GetReverse();
             task.Meta.Type = TTaskMeta::TTaskType::Compute;
 
+            FillSecureParamsFromStage(task.Meta.SecureParams, stage);
             BuildSinks(stage, task);
 
             LOG_D("Stage " << stageInfo.Id << " create sysview scan task: " << task.Id);
@@ -959,6 +969,7 @@ protected:
             if (structuredToken) {
                 task.Meta.SecureParams.emplace(sourceName, structuredToken);
             }
+            FillSecureParamsFromStage(task.Meta.SecureParams, stage);
 
             if (resourceSnapshot.empty()) {
                 task.Meta.Type = TTaskMeta::TTaskType::Compute;
@@ -1051,6 +1062,7 @@ protected:
                 YQL_ENSURE(!shardsResolved);
                 task.Meta.ShardId = taskLocation;
             }
+            FillSecureParamsFromStage(task.Meta.SecureParams, stage);
 
             const auto& stageSource = stage.GetSources(0);
             auto& input = task.Inputs[stageSource.GetInputIndex()];
@@ -1306,6 +1318,7 @@ protected:
             auto& task = TasksGraph.AddTask(stageInfo);
             task.Meta.Type = TTaskMeta::TTaskType::Compute;
             task.Meta.ExecuterId = SelfId();
+            FillSecureParamsFromStage(task.Meta.SecureParams, stage);
             BuildSinks(stage, task);
             LOG_D("Stage " << stageInfo.Id << " create compute task: " << task.Id);
         }
@@ -1441,6 +1454,7 @@ protected:
         THashMap<ui64, ui64>& assignedShardsCount,
         const bool sorted, const bool isOlapScan)
     {
+        const auto& stage = stageInfo.Meta.GetStage(stageInfo.Id);
         ui64 nodeId = ShardIdToNodeId.at(shardId);
         if (stageInfo.Meta.IsOlap() && sorted) {
             auto& task = TasksGraph.AddTask(stageInfo);
@@ -1448,6 +1462,7 @@ protected:
             task.Meta.NodeId = nodeId;
             task.Meta.ScanTask = true;
             task.Meta.Type = TTaskMeta::TTaskType::Scan;
+            FillSecureParamsFromStage(task.Meta.SecureParams, stage);
             return task;
         }
 
@@ -1459,6 +1474,7 @@ protected:
             task.Meta.NodeId = nodeId;
             task.Meta.ScanTask = true;
             task.Meta.Type = TTaskMeta::TTaskType::Scan;
+            FillSecureParamsFromStage(task.Meta.SecureParams, stage);
             tasks.push_back(task.Id);
             ++cnt;
             return task;
@@ -1552,6 +1568,7 @@ protected:
                         task.Meta.ScanTask = true;
                         task.Meta.Type = TTaskMeta::TTaskType::Scan;
                         task.SetMetaId(metaGlueingId);
+                        FillSecureParamsFromStage(task.Meta.SecureParams, stage);
                         BuildSinks(stage, task);
                     }
                 }

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -61,6 +61,9 @@ void FillCreateExternalDataSourceDesc(NKikimrSchemeOp::TExternalDataSourceDescri
         aws.SetAwsAccessKeyIdSecretName(GetOrEmpty(settings, "aws_access_key_id_secret_name"));
         aws.SetAwsSecretAccessKeySecretName(GetOrEmpty(settings, "aws_secret_access_key_secret_name"));
         aws.SetAwsRegion(GetOrEmpty(settings, "aws_region"));
+    } else if (authMethod == "TOKEN") {
+        auto& token = *externaDataSourceDesc.MutableAuth()->MutableToken();
+        token.SetTokenSecretName(GetOrEmpty(settings, "token_secret_name"));
     } else {
         ythrow yexception() << "Internal error. Unknown auth method: " << authMethod;
     }

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -450,6 +450,14 @@ void UpdateExternalDataSourceSecretsValue(TTableMetadataResult& externalDataSour
                 externalDataSourceMetadata.Metadata->ExternalSource.AwsSecretAccessKey = objectDescription.SecretValues[1];
                 return;
             }
+            case NKikimrSchemeOp::TAuth::kToken: {
+                if (objectDescription.SecretValues.size() != 1) {
+                    SetError(externalDataSourceMetadata, TStringBuilder{} << "Token auth contains invalid count of secrets: " << objectDescription.SecretValues.size() << " instead of 1");
+                    return;
+                }
+                externalDataSourceMetadata.Metadata->ExternalSource.Token = objectDescription.SecretValues[0];
+                return;
+            }
             case NKikimrSchemeOp::TAuth::IDENTITY_NOT_SET: {
                 SetError(externalDataSourceMetadata, "identity case is not specified in case of update external data source secrets");
                 return;
@@ -491,6 +499,13 @@ NThreading::TFuture<TEvDescribeSecretsResponse::TDescription> LoadExternalDataSo
             const TString& awsAccessKeyKeySecretId = authDescription.GetAws().GetAwsSecretAccessKeySecretName();
             auto promise = NewPromise<TEvDescribeSecretsResponse::TDescription>();
             actorSystem->Register(CreateDescribeSecretsActor(userToken ? userToken->GetUserSID() : "", {awsAccessKeyIdSecretId, awsAccessKeyKeySecretId}, promise, maximalSecretsSnapshotWaitTime));
+            return promise.GetFuture();
+        }
+
+        case NKikimrSchemeOp::TAuth::kToken: {
+            const TString& tokenSecretId = authDescription.GetToken().GetTokenSecretName();
+            auto promise = NewPromise<TEvDescribeSecretsResponse::TDescription>();
+            actorSystem->Register(CreateDescribeSecretsActor(userToken ? userToken->GetUserSID() : "", {tokenSecretId}, promise, maximalSecretsSnapshotWaitTime));
             return promise.GetFuture();
         }
 

--- a/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
@@ -105,6 +105,12 @@ TString FillAuthProperties(THashMap<TString, TString>& properties, const TExtern
             properties["awsRegion"] = externalSource.DataSourceAuth.GetAws().GetAwsRegion();
             return {};
 
+        case NKikimrSchemeOp::TAuth::kToken:
+            properties["authMethod"] = "TOKEN";
+            properties["token"] = externalSource.Token;
+            properties["tokenReference"] = externalSource.DataSourceAuth.GetToken().GetTokenSecretName();
+            return {};
+
         case NKikimrSchemeOp::TAuth::IDENTITY_NOT_SET:
             return {"Identity case is not specified"};
     }

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -386,6 +386,7 @@ struct TExternalSource {
     TString Password;
     TString AwsAccessKeyId;
     TString AwsSecretAccessKey;
+    TString Token;
     NKikimrSchemeOp::TAuth DataSourceAuth;
     NKikimrSchemeOp::TExternalDataSourceProperties Properties;
 };

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1863,6 +1863,10 @@ message TBasic {
     optional string PasswordSecretName = 2;
 }
 
+message TToken {
+    optional string TokenSecretName = 2;
+}
+
 message TAuth {
     oneof identity {
         TNoneAuth None = 3;
@@ -1870,6 +1874,7 @@ message TAuth {
         TBasic Basic = 5;
         TMdbBasic MdbBasic = 6;
         TAws Aws = 7;
+        TToken Token = 8;
     }
 }
 

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -373,6 +373,7 @@ message TKqpPhyStage {
     repeated TKqpSource Sources = 9;
     bool IsSinglePartition = 10;
     repeated TKqpSink Sinks = 11;
+    map<string, string> SecureParams = 12;
 }
 
 message TKqpPhyResult {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
@@ -74,6 +74,8 @@ bool ValidateAuth(const NKikimrSchemeOp::TAuth& auth,
             return CheckAuth("BASIC", availableAuthMethods, errStr);
         case NKikimrSchemeOp::TAuth::kAws:
             return CheckAuth("AWS", availableAuthMethods, errStr);
+        case NKikimrSchemeOp::TAuth::kToken:
+            return CheckAuth("TOKEN", availableAuthMethods, errStr);
         case NKikimrSchemeOp::TAuth::kNone:
             return CheckAuth("NONE", availableAuthMethods, errStr);
     }

--- a/ydb/library/yql/providers/common/structured_token/yql_token_builder.h
+++ b/ydb/library/yql/providers/common/structured_token/yql_token_builder.h
@@ -16,6 +16,7 @@ public:
     TStructuredTokenBuilder& SetServiceAccountIdAuthWithSecret(const TString& accountId, const TString& accountIdSignatureReference, const TString& accountIdSignature);
     TStructuredTokenBuilder& SetBasicAuth(const TString& login, const TString& password);
     TStructuredTokenBuilder& SetBasicAuthWithSecret(const TString& login, const TString& passwordReference);
+    TStructuredTokenBuilder& SetTokenAuthWithSecret(const TString& tokenReference, const TString& token);
     TStructuredTokenBuilder& SetIAMToken(const TString& token);
     TStructuredTokenBuilder& SetNoAuth();
     TStructuredTokenBuilder& ReplaceReferences(const std::map<TString, TString>& secrets);
@@ -51,4 +52,5 @@ TStructuredTokenParser CreateStructuredTokenParser(const TString& content);
 TString ComposeStructuredTokenJsonForServiceAccount(const TString& serviceAccountId, const TString& serviceAccountIdSignature, const TString& token);
 TString ComposeStructuredTokenJsonForServiceAccountWithSecret(const TString& serviceAccountId, const TString& serviceAccountIdSignatureSecretName, const TString& serviceAccountIdSignature);
 TString ComposeStructuredTokenJsonForBasicAuthWithSecret(const TString& login, const TString& passwordSecretName, const TString& password);
+TString ComposeStructuredTokenJsonForTokenAuthWithSecret(const TString& tokenSecretName, const TString& token);
 }

--- a/ydb/library/yql/providers/yt/provider/ya.make
+++ b/ydb/library/yql/providers/yt/provider/ya.make
@@ -75,6 +75,7 @@ PEERDIR(
     ydb/library/yql/providers/common/activation
     ydb/library/yql/providers/common/provider
     ydb/library/yql/providers/common/schema/expr
+    ydb/library/yql/providers/common/structured_token
     ydb/library/yql/providers/common/transform
     ydb/library/yql/providers/dq/common
     ydb/library/yql/providers/dq/expr_nodes

--- a/ydb/library/yql/providers/yt/provider/yql_yt_datasource.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_datasource.cpp
@@ -6,6 +6,7 @@
 #include "yql_yt_dq_integration.h"
 #include "yql_yt_dq_optimize.h"
 
+#include <ydb/library/yql/providers/common/structured_token/yql_token_builder.h>
 #include <ydb/library/yql/providers/yt/expr_nodes/yql_yt_expr_nodes.h>
 #include <ydb/library/yql/providers/result/expr_nodes/yql_res_expr_nodes.h>
 #include <ydb/library/yql/providers/yt/common/yql_names.h>
@@ -95,11 +96,15 @@ public:
     }
 
     void AddCluster(const TString& name, const THashMap<TString, TString>& properties) override {
+        const TString& token = properties.Value("token", "");
+
         State_->Configuration->AddValidCluster(name);
+        State_->Configuration->Tokens[name] = ComposeStructuredTokenJsonForTokenAuthWithSecret(properties.Value("tokenReference", ""), token);
 
         TYtClusterConfig cluster;
         cluster.SetName(name);
         cluster.SetCluster(properties.Value("location", ""));
+        cluster.SetYTToken(token);
         State_->Gateway->AddCluster(cluster);
     }
 

--- a/ydb/library/yql/providers/yt/provider/yql_yt_dq_integration.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_dq_integration.cpp
@@ -506,8 +506,8 @@ public:
     TExprNode::TPtr WrapRead(const TDqSettings&, const TExprNode::TPtr& read, TExprContext& ctx) override {
         if (auto maybeYtReadTable = TMaybeNode<TYtReadTable>(read)) {
             TMaybeNode<TCoSecureParam> secParams;
-            if (State_->Configuration->Auth.Get().GetOrElse(TString())) {
-                const auto cluster = maybeYtReadTable.Cast().DataSource().Cluster();
+            const auto cluster = maybeYtReadTable.Cast().DataSource().Cluster();
+            if (State_->Configuration->Auth.Get().GetOrElse(TString()) || State_->Configuration->Tokens.contains(cluster)) {
                 secParams = Build<TCoSecureParam>(ctx, read->Pos()).Name().Build(TString("cluster:default_").append(cluster)).Done();
             }
             return Build<TDqReadWrap>(ctx, read->Pos())

--- a/ydb/library/yql/sql/v1/sql_translation.cpp
+++ b/ydb/library/yql/sql/v1/sql_translation.cpp
@@ -4453,14 +4453,16 @@ bool TSqlTranslation::ValidateAuthMethod(const std::map<TString, TDeferredAtom>&
         "password_secret_name",
         "aws_access_key_id_secret_name",
         "aws_secret_access_key_secret_name",
-        "aws_region"
+        "aws_region",
+        "token_secret_name"
     };
     const static TMap<TStringBuf, TSet<TStringBuf>> authMethodFields{
         {"NONE", {}},
         {"SERVICE_ACCOUNT", {"service_account_id", "service_account_secret_name"}},
         {"BASIC", {"login", "password_secret_name"}},
         {"AWS", {"aws_access_key_id_secret_name", "aws_secret_access_key_secret_name", "aws_region"}},
-        {"MDB_BASIC", {"service_account_id", "service_account_secret_name", "login", "password_secret_name"}}
+        {"MDB_BASIC", {"service_account_id", "service_account_secret_name", "login", "password_secret_name"}},
+        {"TOKEN", {"token_secret_name"}}
     };
     auto authMethodIt = result.find("auth_method");
     if (authMethodIt == result.end() || authMethodIt->second.GetLiteral() == nullptr) {

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -21,7 +21,7 @@ struct TExecutionOptions {
     bool ClearExecution = false;
     NKikimrKqp::EQueryAction ScriptQueryAction = NKikimrKqp::QUERY_ACTION_EXECUTE;
 
-    TString ScriptTraceId = "kqprun";
+    TString TraceId = "kqprun";
 
     bool HasResults() const {
         return ScriptQuery && ScriptQueryAction == NKikimrKqp::QUERY_ACTION_EXECUTE;
@@ -37,7 +37,7 @@ void RunScript(const TExecutionOptions& executionOptions, const NKqpRun::TRunner
 
     if (executionOptions.SchemeQuery) {
         Cout << colors.Yellow() << "Executing scheme query..." << colors.Default() << Endl;
-        if (!runner.ExecuteSchemeQuery(executionOptions.SchemeQuery)) {
+        if (!runner.ExecuteSchemeQuery(executionOptions.SchemeQuery, executionOptions.TraceId)) {
             ythrow yexception() << "Scheme query execution failed";
         }
     }
@@ -45,14 +45,14 @@ void RunScript(const TExecutionOptions& executionOptions, const NKqpRun::TRunner
     if (executionOptions.ScriptQuery) {
         Cout << colors.Yellow() << "Executing script..." << colors.Default() << Endl;
         if (!executionOptions.ClearExecution) {
-            if (!runner.ExecuteScript(executionOptions.ScriptQuery, executionOptions.ScriptQueryAction, executionOptions.ScriptTraceId)) {
+            if (!runner.ExecuteScript(executionOptions.ScriptQuery, executionOptions.ScriptQueryAction, executionOptions.TraceId)) {
                 ythrow yexception() << "Script execution failed";
             }
             if (!runner.FetchScriptResults()) {
                 ythrow yexception() << "Fetch script results failed";
             }
         } else {
-            if (!runner.ExecuteQuery(executionOptions.ScriptQuery, executionOptions.ScriptQueryAction, executionOptions.ScriptTraceId)) {
+            if (!runner.ExecuteQuery(executionOptions.ScriptQuery, executionOptions.ScriptQueryAction, executionOptions.TraceId)) {
                 ythrow yexception() << "Query execution failed";
             }
         }
@@ -73,6 +73,15 @@ THolder<TFileOutput> SetupDefaultFileOutput(const TString& filePath, IOutputStre
         stream = fileHolder.Get();
     }
     return fileHolder;
+}
+
+
+void ReplaceTemplate(const TString& variableName, const TString& variableValue, TString& query) {
+    TString variableTemplate = TStringBuilder() << "${" << variableName << "}";
+    for (size_t position = query.find(variableTemplate); position != TString::npos; position = query.find(variableTemplate, position)) {
+        query.replace(position, variableTemplate.size(), variableValue);
+        position += variableValue.size();
+    }
 }
 
 
@@ -190,6 +199,10 @@ void RunMain(int argc, const char* argv[]) {
 
     NLastGetopt::TOptsParseResult parsedOptions(&options, argc, argv);
 
+    // Environment variables
+
+    const TString& yqlToken = GetEnv(NKqpRun::YQL_TOKEN_VARIABLE);
+
     // Execution options
 
     if (!schemeQueryFile && !scriptQueryFile) {
@@ -197,6 +210,7 @@ void RunMain(int argc, const char* argv[]) {
     }
     if (schemeQueryFile) {
         executionOptions.SchemeQuery = TFileInput(schemeQueryFile).ReadAll();
+        ReplaceTemplate(NKqpRun::YQL_TOKEN_VARIABLE, yqlToken, executionOptions.SchemeQuery);
     }
     if (scriptQueryFile) {
         executionOptions.ScriptQuery = TFileInput(scriptQueryFile).ReadAll();
@@ -240,7 +254,7 @@ void RunMain(int argc, const char* argv[]) {
         std::remove(logFile.c_str());
     }
 
-    runnerOptions.YdbSettings.YqlToken = GetEnv("YQL_TOKEN");
+    runnerOptions.YdbSettings.YqlToken = yqlToken;
     runnerOptions.YdbSettings.FunctionRegistry = CreateFunctionRegistry(udfsDirectory, udfsPaths).Get();
 
     TString appConfigData = TFileInput(appConfigFile).ReadAll();

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -9,6 +9,8 @@
 
 namespace NKqpRun {
 
+constexpr char YQL_TOKEN_VARIABLE[] = "YQL_TOKEN";
+
 struct TYdbSetupSettings {
     TString DomainName = "Root";
 

--- a/ydb/tests/tools/kqprun/src/kqp_runner.cpp
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.cpp
@@ -20,11 +20,11 @@ public:
         , CoutColors_(NColorizer::AutoColors(Cout))
     {}
 
-    bool ExecuteSchemeQuery(const TString& query) const {
+    bool ExecuteSchemeQuery(const TString& query, const TString& traceId) const {
         StartSchemeTraceOpt();
 
         TSchemeMeta meta;
-        TRequestResult status = YdbSetup_.SchemeQueryRequest(query, meta);
+        TRequestResult status = YdbSetup_.SchemeQueryRequest(query, traceId, meta);
         TYdbSetup::StopTraceOpt();
 
         PrintSchemeQueryAst(meta.Ast);
@@ -199,8 +199,8 @@ TKqpRunner::TKqpRunner(const TRunnerOptions& options)
     : Impl_(new TImpl(options))
 {}
 
-bool TKqpRunner::ExecuteSchemeQuery(const TString& query) const {
-    return Impl_->ExecuteSchemeQuery(query);
+bool TKqpRunner::ExecuteSchemeQuery(const TString& query, const TString& traceId) const {
+    return Impl_->ExecuteSchemeQuery(query, traceId);
 }
 
 bool TKqpRunner::ExecuteScript(const TString& script, NKikimrKqp::EQueryAction action, const TString& traceId) const {

--- a/ydb/tests/tools/kqprun/src/kqp_runner.h
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.h
@@ -10,7 +10,7 @@ class TKqpRunner {
 public:
     explicit TKqpRunner(const TRunnerOptions& options);
 
-    bool ExecuteSchemeQuery(const TString& query) const;
+    bool ExecuteSchemeQuery(const TString& query, const TString& traceId) const;
 
     bool ExecuteScript(const TString& script, NKikimrKqp::EQueryAction action, const TString& traceId) const;
 

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -170,9 +170,9 @@ public:
         InitializeServer();
     }
 
-    NKikimr::NKqp::TEvKqp::TEvQueryResponse::TPtr SchemeQueryRequest(const TString& query) const {
+    NKikimr::NKqp::TEvKqp::TEvQueryResponse::TPtr SchemeQueryRequest(const TString& query, const TString& traceId) const {
         auto event = MakeHolder<NKikimr::NKqp::TEvKqp::TEvQueryRequest>();
-        FillSchemeRequest(query, *event->Record.MutableRequest());
+        FillSchemeRequest(query, traceId, event->Record);
 
         return RunKqpProxyRequest<NKikimr::NKqp::TEvKqp::TEvQueryRequest, NKikimr::NKqp::TEvKqp::TEvQueryResponse>(std::move(event));
     }
@@ -243,30 +243,30 @@ private:
     }
 
 private:
-    void FillSchemeRequest(const TString& query, NKikimrKqp::TQueryRequest& request) const {
-        request.SetType(NKikimrKqp::QUERY_TYPE_SQL_DDL);
-        request.SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);
-        request.SetCollectStats(Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL);
+    void FillQueryRequest(const TString& query, NKikimrKqp::EQueryType type, NKikimrKqp::EQueryAction action, const TString& traceId, NKikimrKqp::TEvQueryRequest& event) const {
+        event.SetTraceId(traceId);
+        event.SetUserToken(NACLib::TUserToken(Settings_.YqlToken, BUILTIN_ACL_ROOT, {}).SerializeAsString());
 
-        request.SetDatabase(Settings_.DomainName);
-        request.SetQuery(query);
+        auto request = event.MutableRequest();
+        request->SetQuery(query);
+        request->SetType(type);
+        request->SetAction(action);
+        request->SetCollectStats(Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL);
+        request->SetDatabase(Settings_.DomainName);
+    }
+
+    void FillSchemeRequest(const TString& query, const TString& traceId, NKikimrKqp::TEvQueryRequest& event) const {
+        FillQueryRequest(query, NKikimrKqp::QUERY_TYPE_SQL_DDL, NKikimrKqp::QUERY_ACTION_EXECUTE, traceId, event);
     }
 
     void FillScriptRequest(const TString& script, NKikimrKqp::EQueryAction action, const TString& traceId, NKikimrKqp::TEvQueryRequest& event) const {
-        event.SetTraceId(traceId);
-        
+        FillQueryRequest(script, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, action, traceId, event);
+
         auto request = event.MutableRequest();
         if (action == NKikimrKqp::QUERY_ACTION_EXECUTE) {
             request->MutableTxControl()->mutable_begin_tx()->mutable_serializable_read_write();
             request->MutableTxControl()->set_commit_tx(true);
         }
-
-        request->SetType(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT);
-        request->SetAction(action);
-        request->SetCollectStats(Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL);
-
-        request->SetDatabase(Settings_.DomainName);
-        request->SetQuery(script);
     }
 
 private:
@@ -304,8 +304,8 @@ TYdbSetup::TYdbSetup(const TYdbSetupSettings& settings)
     : Impl_(new TImpl(settings))
 {}
 
-TRequestResult TYdbSetup::SchemeQueryRequest(const TString& query, TSchemeMeta& meta) const {
-    auto schemeQueryOperationResponse = Impl_->SchemeQueryRequest(query)->Get()->Record.GetRef();
+TRequestResult TYdbSetup::SchemeQueryRequest(const TString& query, const TString& traceId, TSchemeMeta& meta) const {
+    auto schemeQueryOperationResponse = Impl_->SchemeQueryRequest(query, traceId)->Get()->Record.GetRef();
 
     meta.Ast = schemeQueryOperationResponse.GetResponse().GetQueryAst();
 

--- a/ydb/tests/tools/kqprun/src/ydb_setup.h
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.h
@@ -47,7 +47,7 @@ class TYdbSetup {
 public:
     explicit TYdbSetup(const TYdbSetupSettings& settings);
 
-    TRequestResult SchemeQueryRequest(const TString& query, TSchemeMeta& meta) const;
+    TRequestResult SchemeQueryRequest(const TString& query, const TString& traceId, TSchemeMeta& meta) const;
 
     TRequestResult ScriptRequest(const TString& script, NKikimrKqp::EQueryAction action, const TString& traceId, TString& operation) const;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Supported TOKEN auth for YT datasource

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

- Added new auth method `TOKEN`
- Added auth for YT datasource
- Passed secure params from Stage.Program to task.Meta