### PR TITLE
Add _cluster_name field to yql_statistics part of YT query progress

### DIFF
--- a/ydb/library/yql/providers/yt/gateway/native/yql_yt_exec_ctx.h
+++ b/ydb/library/yql/providers/yt/gateway/native/yql_yt_exec_ctx.h
@@ -126,7 +126,7 @@ protected:
     static TString GetSpecImpl(const TVector<TTableType>& tables, size_t beginIdx, size_t endIdx, NYT::TNode initialOutSpec, bool ensureOldTypesOnly, ui64 nativeTypeCompatibilityFlags, bool intermediateInput);
 
     NThreading::TFuture<void> MakeOperationWaiter(const NYT::IOperationPtr& op, const TMaybe<ui32>& publicId) const {
-        return Session_->OpTracker_->MakeOperationWaiter(op, publicId, YtServer_, Session_->ProgressWriter_, Session_->StatWriter_);
+        return Session_->OpTracker_->MakeOperationWaiter(op, publicId, YtServer_, Cluster_, Session_->ProgressWriter_, Session_->StatWriter_);
     }
 
     TString GetAuth(const TYtSettings::TConstPtr& config) const;

--- a/ydb/library/yql/providers/yt/gateway/native/yql_yt_op_tracker.h
+++ b/ydb/library/yql/providers/yt/gateway/native/yql_yt_op_tracker.h
@@ -30,7 +30,7 @@ public:
     void Stop();
 
     NThreading::TFuture<void> MakeOperationWaiter(const NYT::IOperationPtr& operation, TMaybe<ui32> publicId,
-        const TString& ytServer, const TOperationProgressWriter& writer, const TStatWriter& statWriter);
+        const TString& ytServer, const TString& ytClusterName, const TOperationProgressWriter& writer, const TStatWriter& statWriter);
 
 private:
     static void* Tracker(void* param);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Adding `_cluster_name` field near to `_cluster` field in YQL yql_statistics response so UI can use it to create links to YT operations

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Ytsaurus issue: https://github.com/ytsaurus/ytsaurus/issues/425

Currently, YQL doesn't save cluster_name for YT operations. Instead, it stores URL which it used to make YT calls. 
Query Tracker UI parses these URLs and extracts cluster names out of it, in order to make links to YT operations
This logic works bad for YT clusters on kubernetes, since remoteId may not have cluster_name in it.

Here I add `_cluster_name` field near to `_cluster` field so UI can use it