### PR TITLE
Forward cache handle page faults

### DIFF
--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -60,10 +60,6 @@ namespace NFwd {
             DoNext,
             Exhausted
         };
-        struct TBinarySearchState {
-            TPageId PageId;
-            TRowId BeginRowId, EndRowId;
-        };
 
     public:
         using TGroupId = NPage::TGroupId;

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -4,7 +4,6 @@
 #include "flat_fwd_iface.h"
 #include "flat_fwd_misc.h"
 #include "flat_fwd_page.h"
-#include "flat_part_index_iter.h"
 #include "flat_part_index_iter_iface.h"
 #include "flat_table_part.h"
 #include "flat_part_slice.h"
@@ -61,7 +60,7 @@ namespace NFwd {
         TCache() = delete;
 
         TCache(const TPart* part, IPages* env, TGroupId groupId, const TIntrusiveConstPtr<TSlices>& bounds = nullptr)
-            : Index(MakeHolder<TPartIndexIt>(part, env, groupId)) // TODO: use CreateIndexIter(part, env, groupId)
+            : Index(CreateIndexIter(part, env, groupId))
         { 
             if (bounds && !bounds->empty()) {
                 BeginRowId = bounds->front().BeginRowId();

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -208,7 +208,7 @@ namespace NFwd {
                     return false;
                 }
                 ContinueNext = false;
-                Y_ABORT_UNLESS(Index->GetRowId() < EndRowId, "Requested page is outside of slices");
+                Y_DEBUG_ABORT_UNLESS(Index->GetRowId() < EndRowId, "Requested page is outside of slices");
             }
 
             Y_ABORT_UNLESS(Index->IsValid(), "Requested page doesn't belong to the part");

--- a/ydb/core/tablet_flat/flat_scan_feed.h
+++ b/ydb/core/tablet_flat/flat_scan_feed.h
@@ -334,7 +334,7 @@ namespace NTable {
             }
 
             PrepareBoots();
-            SeekState = ESeekState::LoadIndexes;
+            SeekState = ESeekState::SeekBoots;
             return true;
         }
 
@@ -354,24 +354,6 @@ namespace NTable {
             }
 
             return LoadingParts == 0;
-        }
-
-        bool LoadIndexes() noexcept
-        {
-            bool ready = true;
-            if (Levels) {
-                for (const auto &run: *Levels) {
-                    for (const auto &item : run) {
-                        for (auto indexPageId : item.Part->IndexPages.Groups) {
-                            ready &= bool(CurrentEnv->TryGetPage(item.Part.Get(), indexPageId));
-                        }
-                        for (auto indexPageId : item.Part->IndexPages.Historic) {
-                            ready &= bool(CurrentEnv->TryGetPage(item.Part.Get(), indexPageId));
-                        }
-                    }
-                }
-            }
-            return ready;
         }
 
         void PrepareBoots() noexcept
@@ -465,12 +447,6 @@ namespace NTable {
                     [[fallthrough]];
                 case ESeekState::PrepareBoots:
                     PrepareBoots();
-                    SeekState = ESeekState::LoadIndexes;
-                    [[fallthrough]];
-                case ESeekState::LoadIndexes:
-                    if (!LoadIndexes()) {
-                        return true;
-                    }
                     SeekState = ESeekState::SeekBoots;
                     [[fallthrough]];
                 case ESeekState::SeekBoots:
@@ -500,7 +476,6 @@ namespace NTable {
         enum class ESeekState {
             LoadColdParts,
             PrepareBoots,
-            LoadIndexes,
             SeekBoots,
             Finished,
         };

--- a/ydb/core/tablet_flat/flat_scan_lead.h
+++ b/ydb/core/tablet_flat/flat_scan_lead.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "flat_row_eggs.h"
-#include "flat_row_nulls.h"
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <util/generic/xrange.h>
 

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -134,26 +134,26 @@ namespace {
         TMersenne<ui64> Rnd;
     };
 
-    struct TPagesWrap : public NTest::TSteps<TPagesWrap>, protected NFwd::IPageLoadingQueue {
-        using TFrames = NPage::TFrames;
+    struct TTouchEnv : public NTest::TTestEnv {
+        const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
+        {
+            Y_ABORT_UNLESS(part->GetPageType(pageId, groupId) != EPage::DataPage, "Only index pages are allowed");
+            Y_ABORT_UNLESS(groupId.IsMain());
 
-        struct TTouchEnv : public NTest::TTestEnv {
-            const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
-            {
-                Y_ABORT_UNLESS(part->GetPageType(pageId, groupId) != EPage::DataPage, "Only index pages are allowed");
-                Y_ABORT_UNLESS(groupId.IsMain());
-
-                Touched.insert(pageId);
-                if (!Faulty || Loaded.contains(pageId)) {
-                    return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
-                }
-                return nullptr;
+            Touched.insert(pageId);
+            if (!Faulty || Loaded.contains(pageId)) {
+                return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             }
+            return nullptr;
+        }
 
-            bool Faulty = false;
-            THashSet<TPageId> Loaded;
-            TSet<TPageId> Touched;
-        };
+        bool Faulty = false;
+        THashSet<TPageId> Loaded;
+        TSet<TPageId> Touched;
+    };
+
+    struct TPagesWrap : public NTest::TSteps<TPagesWrap>, public NFwd::IPageLoadingQueue {
+        using TFrames = NPage::TFrames;
 
         TPagesWrap(const TIntrusiveConstPtr<TPartStore> part, TIntrusiveConstPtr<TSlices> run, ui64 aLo, ui64 aHi)
             : Part(std::move(part))
@@ -257,6 +257,8 @@ namespace {
     public:
         const TIntrusiveConstPtr<TPartStore> Part;
         TTouchEnv Env;
+        TAutoPtr<NFwd::IPageLoadingLogic> Cache;
+        TDeque<TPageId> Queue;
         const TIntrusiveConstPtr<TSlices> Run;
         const ui64 AheadLo;
         const ui64 AheadHi;
@@ -273,8 +275,6 @@ namespace {
         }
 
         bool Grow = false;
-        TAutoPtr<NFwd::IPageLoadingLogic> Cache;
-        TDeque<TPageId> Queue;
         TMersenne<ui64> Rnd;
     };
 }
@@ -770,7 +770,7 @@ Y_UNIT_TEST_SUITE(NFwd) {
         }
     */
 
-    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_Start)
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_DoStart)
     {
         // 20 pages, 50 bytes each
         const auto eggs = CookPart();
@@ -778,17 +778,63 @@ Y_UNIT_TEST_SUITE(NFwd) {
         TPagesWrap wrap(eggs.Lone(), 200, 350);
         wrap.UseFaultyEnv();
         
+        // IndexState = DoStart
         for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
             wrap.To(attempt).Get(1, false, false, true, 
                 {0, 0, 0, 0, 0});
             wrap.LoadTouched();
         }
         
+        // IndexState = Valid, DoNext
         wrap.To(3).Get(1, false, true, true, 
             {1, 0, 1, 0, 0});
+        wrap.To(4).Fill({1, 2},
+            {2, 2, 1, 0, 0});
     }
 
-    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_Next)
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_DoBinarySearch)
+    {
+        // 20 pages, 50 bytes each
+        const auto eggs = CookPart();
+
+        TPagesWrap wrap(eggs.Lone(), 200, 350);
+        wrap.UseFaultyEnv();
+        
+        // IndexState = Start -> BinarySearch -> Valid
+        for (ui32 attempt : xrange(7)) {
+            wrap.To(attempt).Get(4, false, false, true, 
+                {0, 0, 0, 0, 0});
+            wrap.LoadTouched();
+        }
+        wrap.To(7).Get(4, false, true, true, 
+            {1, 0, 1, 0, 0});
+
+        wrap.To(8).Fill({4, 5, 6, 7, 8, 9, 10},
+            {7, 7, 1, 0, 0});
+    }
+
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_DoBinarySearch_DoNext)
+    {
+        // 20 pages, 50 bytes each
+        const auto eggs = CookPart();
+
+        TPagesWrap wrap(eggs.Lone(), 200, 350);
+        wrap.UseFaultyEnv();
+        
+        // IndexState = Start -> BinarySearch
+        for (ui32 attempt : xrange(7)) {
+            wrap.To(attempt).Get(4, false, false, true, 
+                {0, 0, 0, 0, 0});
+            wrap.LoadTouched();
+        }
+
+        wrap.To(7).Get(5, false, true, true, 
+            {1, 0, 1, 0, 0});
+        wrap.To(8).Fill({5, 6, 7, 8, 9, 10, 11},
+            {7, 7, 1, 0, 0});
+    }
+
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_DoNext)
     {
         // 20 pages, 50 bytes each
         const auto eggs = CookPart();
@@ -796,41 +842,31 @@ Y_UNIT_TEST_SUITE(NFwd) {
         TPagesWrap wrap(eggs.Lone(), 200, 200);
         wrap.UseFaultyEnv();
         
-        // Seek(0):
-        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
-            wrap.To(attempt).Get(6, false, false, true, 
+        // IndexState = DoStart
+        for (ui32 attempt : xrange(3)) {
+            wrap.To(attempt).Get(0, false, false, true, 
                 {0, 0, 0, 0, 0});
             wrap.LoadTouched();
         }
-
-        // Next(4):
-        wrap.To(3).Get(4, false, false, true, 
-            {0, 0, 0, 0, 0});
-        wrap.LoadTouched();
-        wrap.To(4).Get(4, false, true, true, 
+        
+        // IndexState = Valid, DoNext
+        wrap.To(4).Get(1, false, true, true, 
             {1, 0, 1, 0, 0});
-    
-        wrap.To(6).Fill({4, 5},
-            {2, 2, 1, 0, 0});
-
-        // set Grow = true:
-        wrap.To(7).Get(4, true, true, true, 
-            {2, 2, 1, 0, 0});
-
-        // load {6, 7, 8} node:
-        wrap.To(8).Fill({},
-            {2, 2, 1, 0, 0});
+        wrap.To(5).Get(2, false, true, true, 
+            {2, 0, 2, 0, 1});
+        
+        wrap.To(6).Get(3, false, false, true, 
+            {2, 0, 2, 0, 2});
         wrap.LoadTouched();
-
-        // set Grow = true:
-        wrap.To(9).Get(4, true, true, true, 
-            {2, 2, 1, 0, 0});
-
-        wrap.To(10).Fill({6, 7},
-            {4, 4, 1, 0, 0});
+        
+        wrap.Queue.clear();
+        wrap.To(7).Get(3, false, true, true, 
+            {3, 0, 3, 0, 2});
+        wrap.To(8).Fill({3, 4},
+            {4, 2, 3, 0, 2});
     }
 
-    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_NextNext)
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_DoBinarySearch_DoBinarySearch)
     {
         // 20 pages, 50 bytes each
         const auto eggs = CookPart();
@@ -838,106 +874,24 @@ Y_UNIT_TEST_SUITE(NFwd) {
         TPagesWrap wrap(eggs.Lone(), 200, 350);
         wrap.UseFaultyEnv();
         
-        // Seek(0):
-        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
+        // IndexState = Start -> BinarySearch
+        for (ui32 attempt : xrange(5)) {
             wrap.To(attempt).Get(5, false, false, true, 
                 {0, 0, 0, 0, 0});
             wrap.LoadTouched();
         }
 
-        // Next(5):
-        wrap.To(3).Get(5, false, false, true, 
-            {0, 0, 0, 0, 0});
-        wrap.LoadTouched();
-        wrap.To(4).Get(5, false, true, true, 
-            {1, 0, 1, 0, 0});
-    
-        wrap.To(6).Fill({5},
-            {1, 1, 1, 0, 0});
-
-        // set Grow = true:
-        wrap.To(7).Get(5, true, true, true, 
-            {1, 1, 1, 0, 0});
-
-        // load {6, 7, 8} node:
-        wrap.To(8).Fill({},
-            {1, 1, 1, 0, 0});
-        wrap.LoadTouched();
-
-        // set Grow = true:
-        wrap.To(9).Get(5, true, true, true, 
-            {1, 1, 1, 0, 0});
-
-        wrap.To(10).Fill({6, 7, 8},
-            {4, 4, 1, 0, 0});
-    }
-
-    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_Forward)
-    {
-        // 20 pages, 50 bytes each
-        const auto eggs = CookPart();
-
-        TPagesWrap wrap(eggs.Lone(), 1000, 1000);
-        wrap.UseFaultyEnv();
-        
-        // Seek(0):
-        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
-            wrap.To(attempt).Get(0, false, false, true, 
+        for (ui32 attempt : xrange(2)) {
+            wrap.To(100 + attempt).Get(13, false, false, true, 
                 {0, 0, 0, 0, 0});
             wrap.LoadTouched();
         }
 
-        wrap.To(3).Get(0, false, true, true, 
+        wrap.To(200).Get(13, false, true, true, 
             {1, 0, 1, 0, 0});
-        wrap.To(4).Fill({0, 1, 2},
-            {3, 3, 1, 0, 0});
-
-        // ContinueNext = true but request further page
-        for (ui32 attempt : xrange(4)) {
-            wrap.To(5 + attempt).Get(9, false, false, true, 
-                {3, 3, 1, 2, 0});
-            wrap.LoadTouched();
-        }
-        wrap.To(9).Get(9, false, true, true, 
-            {4, 3, 2, 2, 0});
-
-        wrap.To(10).Fill({9, 10, 11},
-            {6, 6, 2, 2, 0});
-    }
-
-    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_Jump)
-    {
-        // 20 pages, 50 bytes each
-        const auto eggs = CookPart();
-
-        TPagesWrap wrap(eggs.Lone(), 1000, 1000);
-        wrap.UseFaultyEnv();
         
-        // Seek(0):
-        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
-            wrap.To(attempt).Get(0, false, false, true, 
-                {0, 0, 0, 0, 0});
-            wrap.LoadTouched();
-        }
-
-        wrap.To(3).Get(3, false, false, true, 
-            {1, 0, 1, 0, 0});
-        wrap.LoadTouched();
-
-        wrap.To(4).Get(7, false, false, true, 
-            {1, 0, 1, 0, 0});
-        wrap.LoadTouched();
-
-        for (ui32 attempt : xrange(3)) {
-            wrap.To(5 + attempt).Get(16, false, false, true, 
-                {1, 0, 1, 0, 0});
-            wrap.LoadTouched();
-        }
-
-        wrap.To(100).Get(16, false, true, true, 
-                {1, 0, 1, 0, 0});
-        wrap.To(101).Fill({16, 17, 18, 19},
-            {3, 3, 1, 0, 0});
+        wrap.To(201).Fill({13, 14, 15, 16, 17, 18, 19},
+            {7, 7, 1, 0, 0});
     }
 
     Y_UNIT_TEST(Pages_PageFaults_Fill)
@@ -948,7 +902,7 @@ Y_UNIT_TEST_SUITE(NFwd) {
         TPagesWrap wrap(eggs.Lone(), 500, 500);
         wrap.UseFaultyEnv();
         
-        // Seek(0):
+        // IndexState = DoStart
         for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
             wrap.To(attempt).Get(0, false, false, true, 
                 {0, 0, 0, 0, 0});
@@ -975,6 +929,63 @@ Y_UNIT_TEST_SUITE(NFwd) {
 
         wrap.To(8).Fill({3, 4, 5},
             {6, 6, 1, 0, 0});
+    }
+
+    Y_UNIT_TEST(Pages_BinarySearch) {
+        NPage::TConf conf;
+
+        conf.WriteBTreeIndex = true;
+        conf.Group(0).PageRows = 1;
+        conf.Group(0).BTreeIndexNodeKeysMin = conf.Group(0).BTreeIndexNodeKeysMax = 2;
+
+        TLayoutCook lay;
+        lay
+            .Col(0, 0,  NScheme::NTypeIds::Uint32)
+            .Col(0, 1,  NScheme::NTypeIds::Uint32)
+            .Key({0});
+        
+        TPartCook cook(lay, conf);
+
+        const ui32 count = 50;
+        for (ui32 i : xrange<ui32>(count)) {
+            cook.Add(*TSchemedCookRow(*lay).Col(i, i * 100));
+        }
+        
+        TPartEggs eggs = cook.Finish();
+        const auto& part = *eggs.Lone();
+
+        Cerr << DumpPart(*eggs.Lone(), 3) << Endl;
+
+        const ui32 attemptsLimit = 20;
+        for (ui32 pageIndex1 : xrange<ui32>(count)) {
+            auto pageId1 = IndexTools::GetPageId(part, pageIndex1);
+            for (ui32 pageIndex2 : xrange<ui32>(pageIndex1 + 1, count)) {
+                auto pageId2 = IndexTools::GetPageId(part, pageIndex2);
+
+                TPagesWrap wrap(eggs.Lone(), 100, 100);
+                wrap.UseFaultyEnv();
+
+                for (ui32 attempt : xrange(attemptsLimit + 1)) {
+                    UNIT_ASSERT_LT(attempt, attemptsLimit);
+                    wrap.Cache->Handle(&wrap, pageId1, 100);
+                    if (wrap.Queue.size() && wrap.Queue.back() == pageId1) {
+                        break; // page is found
+                    }
+                    wrap.LoadTouched();
+                }
+
+                wrap.Queue.clear();
+
+                for (ui32 attempt : xrange(attemptsLimit + 1)) {
+                    UNIT_ASSERT_LT(attempt, attemptsLimit);
+                    wrap.Cache->Handle(&wrap, pageId2, 100);
+                    if (wrap.Queue.size() && wrap.Queue.back() == pageId2) {
+                        break; // page is found
+                    }
+                    wrap.LoadTouched();
+                }
+            }
+        }
     }
 
     Y_UNIT_TEST(TLoadedPagesCircularBuffer) {

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -140,11 +140,19 @@ namespace {
         struct TTouchEnv : public NTest::TTestEnv {
             const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
             {
-                // allow index only
-                Y_ABORT_UNLESS(part->GetPageType(pageId, groupId) != EPage::DataPage);
+                Y_ABORT_UNLESS(part->GetPageType(pageId, groupId) != EPage::DataPage, "Only index pages are allowed");
+                Y_ABORT_UNLESS(groupId.IsMain());
 
-                return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
+                Touched.insert(pageId);
+                if (!Faulty || Loaded.contains(pageId)) {
+                    return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
+                }
+                return nullptr;
             }
+
+            bool Faulty = false;
+            THashSet<TPageId> Loaded;
+            TSet<TPageId> Touched;
         };
 
         TPagesWrap(const TIntrusiveConstPtr<TPartStore> part, TIntrusiveConstPtr<TSlices> run, ui64 aLo, ui64 aHi)
@@ -235,6 +243,17 @@ namespace {
             return *this;
         }
 
+        void UseFaultyEnv(bool value = true) 
+        {
+            Env.Faulty = value;
+        }
+
+        void LoadTouched()
+        {
+            Env.Loaded.insert(Env.Touched.begin(), Env.Touched.end());
+            Env.Touched.clear();
+        }
+
     public:
         const TIntrusiveConstPtr<TPartStore> Part;
         TTouchEnv Env;
@@ -284,7 +303,7 @@ Y_UNIT_TEST_SUITE(NFwd) {
 
     TPartEggs CookPart() {
         NPage::TConf conf;
-            
+
         conf.WriteBTreeIndex = true;
         conf.Group(0).PageRows = 2;
         conf.Group(0).BTreeIndexNodeKeysMin = conf.Group(0).BTreeIndexNodeKeysMax = 2;
@@ -734,6 +753,160 @@ Y_UNIT_TEST_SUITE(NFwd) {
             {7, 7, 2, 4, 0});
         wrap.To(3).Get(11, true, false, true, 
             {7, 7, 3, 4, 0});
+    }
+
+    /* B-Tree index:
+        {
+            {
+                {0, 1, 2},
+                {3, 4, 5},
+                {6, 7, 8}
+            },
+            {
+                {9, 10, 11},
+                {12, 13, 14},
+                {15, 16, 17, 18, 19}
+            }
+        }
+    */
+
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_Start)
+    {
+        // 20 pages, 50 bytes each
+        const auto eggs = CookPart();
+
+        TPagesWrap wrap(eggs.Lone(), 200, 350);
+        wrap.UseFaultyEnv();
+        
+        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
+            wrap.To(attempt).Get(1, false, false, true, 
+                {0, 0, 0, 0, 0});
+            wrap.LoadTouched();
+        }
+        
+        wrap.To(3).Get(1, false, true, true, 
+            {1, 0, 1, 0, 0});
+    }
+
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_Next)
+    {
+        // 20 pages, 50 bytes each
+        const auto eggs = CookPart();
+
+        TPagesWrap wrap(eggs.Lone(), 200, 200);
+        wrap.UseFaultyEnv();
+        
+        // Seek(0):
+        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
+            wrap.To(attempt).Get(6, false, false, true, 
+                {0, 0, 0, 0, 0});
+            wrap.LoadTouched();
+        }
+
+        // Next(4):
+        wrap.To(3).Get(4, false, false, true, 
+            {0, 0, 0, 0, 0});
+        wrap.LoadTouched();
+        wrap.To(4).Get(4, false, true, true, 
+            {1, 0, 1, 0, 0});
+    
+        wrap.To(6).Fill({4, 5},
+            {2, 2, 1, 0, 0});
+
+        // set Grow = true:
+        wrap.To(7).Get(4, true, true, true, 
+            {2, 2, 1, 0, 0});
+
+        // load {6, 7, 8} node:
+        wrap.To(8).Fill({},
+            {2, 2, 1, 0, 0});
+        wrap.LoadTouched();
+
+        // set Grow = true:
+        wrap.To(9).Get(4, true, true, true, 
+            {2, 2, 1, 0, 0});
+
+        wrap.To(10).Fill({6, 7},
+            {4, 4, 1, 0, 0});
+    }
+
+    Y_UNIT_TEST(Pages_PageFaults_SyncIndex_NextNext)
+    {
+        // 20 pages, 50 bytes each
+        const auto eggs = CookPart();
+
+        TPagesWrap wrap(eggs.Lone(), 200, 350);
+        wrap.UseFaultyEnv();
+        
+        // Seek(0):
+        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
+            wrap.To(attempt).Get(5, false, false, true, 
+                {0, 0, 0, 0, 0});
+            wrap.LoadTouched();
+        }
+
+        // Next(5):
+        wrap.To(3).Get(5, false, false, true, 
+            {0, 0, 0, 0, 0});
+        wrap.LoadTouched();
+        wrap.To(4).Get(5, false, true, true, 
+            {1, 0, 1, 0, 0});
+    
+        wrap.To(6).Fill({5},
+            {1, 1, 1, 0, 0});
+
+        // set Grow = true:
+        wrap.To(7).Get(5, true, true, true, 
+            {1, 1, 1, 0, 0});
+
+        // load {6, 7, 8} node:
+        wrap.To(8).Fill({},
+            {1, 1, 1, 0, 0});
+        wrap.LoadTouched();
+
+        // set Grow = true:
+        wrap.To(9).Get(5, true, true, true, 
+            {1, 1, 1, 0, 0});
+
+        wrap.To(10).Fill({6, 7, 8},
+            {4, 4, 1, 0, 0});
+    }
+
+    Y_UNIT_TEST(Pages_PageFaults_Fill)
+    {
+        // 20 pages, 50 bytes each
+        const auto eggs = CookPart();
+
+        TPagesWrap wrap(eggs.Lone(), 500, 500);
+        wrap.UseFaultyEnv();
+        
+        // Seek(0):
+        for (ui32 attempt : xrange(3)) { // 3-leveled B-Tree
+            wrap.To(attempt).Get(0, false, false, true, 
+                {0, 0, 0, 0, 0});
+            wrap.LoadTouched();
+        }
+
+        wrap.To(3).Get(0, false, true, true, 
+            {1, 0, 1, 0, 0});
+        wrap.To(4).Fill({0, 1, 2},
+            {3, 3, 1, 0, 0});
+
+        // set Grow = true:
+        wrap.To(5).Get(0, true, true, true, 
+            {3, 3, 1, 0, 0});
+
+        // load {3, 4, 5} node:
+        wrap.To(6).Fill({},
+            {3, 3, 1, 0, 0});
+        wrap.LoadTouched();
+
+        // set Grow = true:
+        wrap.To(7).Get(0, true, true, true, 
+            {3, 3, 1, 0, 0});
+
+        wrap.To(8).Fill({3, 4, 5},
+            {6, 6, 1, 0, 0});
     }
 
     Y_UNIT_TEST(TLoadedPagesCircularBuffer) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Remove initial indexes loading in Scan and handle page faults instead

~Optimize `SeekIndex` with binary search instead of multiple `Next` calls (complexity - O(log^2 N)). This should helps when we have some `TLead.Key` in `TKqpScan`.~

#2260
