### PR TITLE
HC made storage issue RED when no bsc reply

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -547,7 +547,7 @@ public:
         RootSchemeShardId = domain->SchemeRoot;
         ConsoleId = MakeConsoleID();
         RootHiveId = domains->GetHive();
-        BsControllerId = MakeBSControllerID(); //  MakeTabletID(false, 0x9888);
+        BsControllerId = MakeBSControllerID(); // MakeTabletID(false, 0x9888);
 
         if (ConsoleId) {
             TabletRequests.TabletStates[ConsoleId].Database = DomainPath;
@@ -2126,7 +2126,7 @@ public:
                 context.UpdateMaxStatus(tabletContext.GetOverallStatus());
             }
         }
-        if (!FilterDatabase) {
+        if (!FilterDatabase && BaseConfig) {
             TDatabaseState unknownDatabase;
             for (auto& [id, pool] : StoragePoolState) {
                 Cerr << "iiiiiiiiiii check poolId" << id << " pool.Name " << pool.Name << Endl;

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -809,7 +809,7 @@ public:
     void Handle(TEvBlobStorage::TEvControllerConfigResponse::TPtr& ev) {
         TabletRequests.CompleteRequest(ev->Cookie);
         const NKikimrBlobStorage::TEvControllerConfigResponse& pbRecord(ev->Get()->Record);
-        if (pbRecord.HasResponse() && pbRecord.GetResponse().StatusSize() > 0) {
+        if (pbRecord.HasResponse() && pbRecord.GetResponse().StatusSize() > 1) {
             const NKikimrBlobStorage::TConfigResponse::TStatus& pbStatus(pbRecord.GetResponse().GetStatus(0));
             if (pbStatus.HasBaseConfig()) {
                 BaseConfig = ev->Release();
@@ -1920,7 +1920,8 @@ public:
 
     void FillStorage(TDatabaseState& databaseState, Ydb::Monitoring::StorageStatus& storageStatus, TSelfCheckContext context) {
         if (!BaseConfig) {
-            context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, "System tablet BSC didn't provide information", ETags::StorageState);
+            // it will be reported RED BSController System Tablet in this case, we don't need report RED Storage
+            context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN, "System tablet BSC didn't provide information", ETags::StorageState);
         } else if (databaseState.StoragePools.empty()) {
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, "There are no storage pools", ETags::StorageState);
         } else {

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -1427,7 +1427,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         Ctest << result.ShortDebugString() << Endl;
 
         UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::EMERGENCY);
-        UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 2);
 
         bool bscTabletIssueFoundInResult = false;
         for (const auto &issue_log : result.issue_log()) {
@@ -1438,22 +1437,17 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                 bscTabletIssueFoundInResult = true;
             }
         }
-
-        for (const auto &database_status : result.database_status()) {
-            if (!database_status.name()) {
-                UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::RED);
-
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::RED);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
-            } else if (database_status.name() == "/Root") {
-                UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::RED);
-
-                UNIT_ASSERT_VALUES_EQUAL(database_status.compute().overall(), Ydb::Monitoring::StatusFlag::RED);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::RED);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
-            }
-        }
         UNIT_ASSERT(bscTabletIssueFoundInResult);
+
+        UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
+        const auto &database_status = result.database_status(0);
+
+        UNIT_ASSERT_VALUES_EQUAL(database_status.name(), "/Root");
+        UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::RED);
+
+        UNIT_ASSERT_VALUES_EQUAL(database_status.compute().overall(), Ydb::Monitoring::StatusFlag::RED);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::RED);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
     }
 }
 }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -1446,7 +1446,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::RED);
 
         UNIT_ASSERT_VALUES_EQUAL(database_status.compute().overall(), Ydb::Monitoring::StatusFlag::RED);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::RED);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
     }
 }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -142,12 +142,16 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         auto& pbRecord = (*ev)->Get()->Record;
         auto pbConfig = pbRecord.mutable_response()->mutable_status(0)->mutable_baseconfig();
 
+        Cerr << "iiiiiiiiiii bsc group size " << pbConfig->group_size() << Endl;
         auto groupSample = pbConfig->group(0);
         auto vslotSample = pbConfig->vslot(0);
         auto vslotIdSample = pbConfig->group(0).vslotid(0);
+        pbConfig->mutable_group(0)->set_storagepoolid(0);
         Cerr << "iiiiiiiiiii bsc group size " << pbConfig->group_size() << Endl;
         for (auto& group: *pbConfig->mutable_group()) {
             group.set_operatingstatus(groupStatus);
+            Cerr << "iiiiiiiiiii bsc group id " << group.groupid() << Endl;
+            Cerr << "iiiiiiiiiii bsc group id " << group.storagepoolid() << Endl;
  //           group.set_storagepoolid(1);
         }
         for (auto& pdisk: *pbConfig->mutable_pdisk()) {
@@ -185,10 +189,13 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         }
 
         auto spStatus = pbRecord.mutable_response()->mutable_status(1);
+        Cerr << "iiiiiiiiiii bsc pool size " << spStatus->storagepool_size() << Endl;
         spStatus->clear_storagepool();
+        Cerr << "iiiiiiiiiii bsc pool size " << spStatus->storagepool_size() << Endl;
         auto sPool = spStatus->add_storagepool();
         sPool->set_storagepoolid(1);
         sPool->set_name(STORAGE_POOL_NAME);
+        Cerr << "iiiiiiiiiii bsc pool size " << spStatus->storagepool_size() << Endl;
     };
 
     void AddVSlotInVDiskStateResponse(TEvWhiteboard::TEvVDiskStateResponse::TPtr* ev, int groupCount, int vslotCount) {
@@ -363,17 +370,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         UNIT_ASSERT_VALUES_EQUAL(issuesCount, total);
     }
 
-    void ChangeUsageDescribeSchemeResult(TEvSchemeShard::TEvDescribeSchemeResult::TPtr* ev, ui64 size, ui64 quota) {
-        auto record = (*ev)->Get()->MutableRecord();
-        auto pool = record->mutable_pathdescription()->mutable_domaindescription()->add_storagepools();
-        pool->set_name("/Root:test");
-        pool->set_kind("kind");
-
-        auto domain = record->mutable_pathdescription()->mutable_domaindescription();
-        domain->mutable_diskspaceusage()->mutable_tables()->set_totalsize(size);
-        domain->mutable_databasequotas()->set_data_stream_reserved_storage_quota(quota);
-    }
-
      void StorageTest(ui64 usage, ui64 quota, ui64 storageIssuesNumber, Ydb::Monitoring::StatusFlag::Status status = Ydb::Monitoring::StatusFlag::GREEN) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
@@ -527,15 +523,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
             }
         }
     }
-
-    // void AddSharedGroupInControllerSelectGroupsResult(TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr* ev) {
-    //     auto& pbRecord = (*ev)->Get()->Record;
-    //     auto pbMatchGroups = pbRecord.add_matchinggroups();
-
-    //     auto group = pbMatchGroups->add_groups();
-    //     group->set_groupid(GROUP_START_ID);
-    //     group->set_storagepoolname(STORAGE_POOL_NAME);
-    // }
 
     void ChangeNavigateKeyResultServerless(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr* ev,
         NKikimrSubDomains::EServerlessComputeResourcesMode serverlessComputeResourcesMode,
@@ -710,11 +697,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                //     AddSharedGroupInControllerSelectGroupsResult(x);
-                //     break;
-                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -812,11 +794,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                //     AddSharedGroupInControllerSelectGroupsResult(x);
-                //     break;
-                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -903,11 +880,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                //     AddSharedGroupInControllerSelectGroupsResult(x);
-                //     break;
-                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -987,11 +959,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                //     AddSharedGroupInControllerSelectGroupsResult(x);
-                //     break;
-                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -1089,11 +1056,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                //     AddSharedGroupInControllerSelectGroupsResult(x);
-                //     break;
-                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -1116,8 +1078,10 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
         auto *request = new NHealthCheck::TEvSelfCheckRequest;
         request->Request.set_return_verbose_status(true);
+        Cerr << "AAAAAAAAAa 1" << Endl;
         runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
         const auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
+        Cerr << "AAAAAAAAAa 2" << Endl;
 
         Cerr << "iiiiiiiiiiiiii result " << result.ShortDebugString() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::EMERGENCY);
@@ -1411,60 +1375,60 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
     }
 
-    Y_UNIT_TEST(NoBscConfigResponse) {
-        TPortManager tp;
-        ui16 port = tp.GetPort(2134);
-        ui16 grpcPort = tp.GetPort(2135);
-        auto settings = TServerSettings(port)
-                .SetNodeCount(1)
-                .SetDynamicNodeCount(1)
-                .SetUseRealThreads(false)
-                .SetDomainName("Root");
-        TServer server(settings);
-        server.EnableGRpc(grpcPort);
-        TClient client(settings);
-        TTestActorRuntime& runtime = *server.GetRuntime();
+    // Y_UNIT_TEST(NoBscConfigResponse) {
+    //     TPortManager tp;
+    //     ui16 port = tp.GetPort(2134);
+    //     ui16 grpcPort = tp.GetPort(2135);
+    //     auto settings = TServerSettings(port)
+    //             .SetNodeCount(1)
+    //             .SetDynamicNodeCount(1)
+    //             .SetUseRealThreads(false)
+    //             .SetDomainName("Root");
+    //     TServer server(settings);
+    //     server.EnableGRpc(grpcPort);
+    //     TClient client(settings);
+    //     TTestActorRuntime& runtime = *server.GetRuntime();
 
-        auto &dynamicNameserviceConfig = runtime.GetAppData().DynamicNameserviceConfig;
-        dynamicNameserviceConfig->MaxStaticNodeId = runtime.GetNodeId(server.StaticNodes() - 1);
-        dynamicNameserviceConfig->MinDynamicNodeId = runtime.GetNodeId(server.StaticNodes());
-        dynamicNameserviceConfig->MaxDynamicNodeId = runtime.GetNodeId(server.StaticNodes() + server.DynamicNodes() - 1);
+    //     auto &dynamicNameserviceConfig = runtime.GetAppData().DynamicNameserviceConfig;
+    //     dynamicNameserviceConfig->MaxStaticNodeId = runtime.GetNodeId(server.StaticNodes() - 1);
+    //     dynamicNameserviceConfig->MinDynamicNodeId = runtime.GetNodeId(server.StaticNodes());
+    //     dynamicNameserviceConfig->MaxDynamicNodeId = runtime.GetNodeId(server.StaticNodes() + server.DynamicNodes() - 1);
 
-        ui32 dynNodeId = runtime.GetNodeId(1);
+    //     ui32 dynNodeId = runtime.GetNodeId(1);
 
-        // const TPathId SUBDOMAIN_KEY = {7000000000, 1};
+    //     // const TPathId SUBDOMAIN_KEY = {7000000000, 1};
 
-        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
-            if (ev->GetTypeRewrite() == TEvBlobStorage::EvControllerConfigResponse) {
-                return TTestActorRuntime::EEventAction::DROP;
-            }
+    //     auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+    //         if (ev->GetTypeRewrite() == TEvBlobStorage::EvControllerConfigResponse) {
+    //             return TTestActorRuntime::EEventAction::DROP;
+    //         }
 
-            return TTestActorRuntime::EEventAction::PROCESS;
-        };
-        runtime.SetObserverFunc(observerFunc);
+    //         return TTestActorRuntime::EEventAction::PROCESS;
+    //     };
+    //     runtime.SetObserverFunc(observerFunc);
 
-        TActorId sender = runtime.AllocateEdgeActor();
-        TAutoPtr<IEventHandle> handle;
+    //     TActorId sender = runtime.AllocateEdgeActor();
+    //     TAutoPtr<IEventHandle> handle;
 
-        auto *request = new NHealthCheck::TEvSelfCheckRequest;
-        request->Request.set_return_verbose_status(true);
-        runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
-        const auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
+    //     auto *request = new NHealthCheck::TEvSelfCheckRequest;
+    //     request->Request.set_return_verbose_status(true);
+    //     runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
+    //     const auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
 
-        Cerr << "iiiiiiiiiii " << result.ShortDebugString() << Endl;
+    //     Cerr << "iiiiiiiiiii " << result.ShortDebugString() << Endl;
 
-        UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::EMERGENCY);
-        UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
-        const auto &database_status = result.database_status(0);
-        // UNIT_ASSERT_VALUES_EQUAL(database_status.name(),  "/Root/database");
-        UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::RED);
+    //     UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::EMERGENCY);
+    //     UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
+    //     const auto &database_status = result.database_status(0);
+    //     // UNIT_ASSERT_VALUES_EQUAL(database_status.name(),  "/Root/database");
+    //     UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::RED);
 
-        UNIT_ASSERT_VALUES_EQUAL(database_status.compute().overall(), Ydb::Monitoring::StatusFlag::RED);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.compute().nodes().size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.compute().nodes()[0].id(), ToString(dynNodeId));
+    //     UNIT_ASSERT_VALUES_EQUAL(database_status.compute().overall(), Ydb::Monitoring::StatusFlag::RED);
+    //     UNIT_ASSERT_VALUES_EQUAL(database_status.compute().nodes().size(), 1);
+    //     UNIT_ASSERT_VALUES_EQUAL(database_status.compute().nodes()[0].id(), ToString(dynNodeId));
 
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::YELLOW);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
-    }
+    //     UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::YELLOW);
+    //     UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
+    // }
 }
 }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -56,8 +56,12 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         BasicTest(new NHealthCheck::TEvNodeCheckRequest());
     }
 
-    int const GROUP_START_ID = 1200;
-    int const VCARD_START_ID = 55;
+    const int GROUP_START_ID = 1200;
+    const int VCARD_START_ID = 55;
+
+    const TPathId SERVERLESS_DOMAIN_KEY = {7000000000, 2};
+    const TPathId SHARED_DOMAIN_KEY = {7000000000, 1};
+    const TString STORAGE_POOL_NAME = "/Root:test";
 
     void ChangeDescribeSchemeResult(TEvSchemeShard::TEvDescribeSchemeResult::TPtr* ev, ui64 size = 20000000, ui64 quota = 90000000) {
         auto record = (*ev)->Get()->MutableRecord();
@@ -132,49 +136,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         }
     };
 
-    void AddGroupVSlotInControllerConfigResponse(TEvBlobStorage::TEvControllerConfigResponse::TPtr* ev, const NKikimrBlobStorage::TGroupStatus::E groupStatus, const TVector<NKikimrBlobStorage::EVDiskStatus>& vdiskStatuses) {
-        auto& pbRecord = (*ev)->Get()->Record;
-        auto pbConfig = pbRecord.mutable_response()->mutable_status(0)->mutable_baseconfig();
-
-        auto groupSample = pbConfig->group(0);
-        auto vslotSample = pbConfig->vslot(0);
-        auto vslotIdSample = pbConfig->group(0).vslotid(0);
-        pbConfig->clear_group();
-        pbConfig->clear_vslot();
-        for (auto& pdisk: *pbConfig->mutable_pdisk()) {
-            pdisk.mutable_pdiskmetrics()->set_state(NKikimrBlobStorage::TPDiskState::Normal);
-        }
-
-        auto groupId = GROUP_START_ID;
-
-        auto group = pbConfig->add_group();
-        group->CopyFrom(groupSample);
-        group->set_groupid(groupId);
-        group->set_operatingstatus(groupStatus);
-        group->set_erasurespecies(NHealthCheck::TSelfCheckRequest::BLOCK_4_2);
-
-        group->clear_vslotid();
-        auto vslotId = VCARD_START_ID;
-
-        for (auto status: vdiskStatuses) {
-            auto vslot = pbConfig->add_vslot();
-            vslot->CopyFrom(vslotSample);
-            vslot->set_vdiskidx(vslotId);
-            vslot->set_groupid(groupId);
-            vslot->set_failrealmidx(vslotId);
-            vslot->mutable_vslotid()->set_vslotid(vslotId);
-
-            auto slotId = group->add_vslotid();
-            slotId->CopyFrom(vslotIdSample);
-            slotId->set_vslotid(vslotId);
-
-            const auto *descriptor = NKikimrBlobStorage::EVDiskStatus_descriptor();
-            vslot->set_status(descriptor->FindValueByNumber(status)->name());
-
-            vslotId++;
-        }
-    };
-
     void AddGroupVSlotInControllerConfigResponseWithStaticGroup(TEvBlobStorage::TEvControllerConfigResponse::TPtr* ev,
         const NKikimrBlobStorage::TGroupStatus::E groupStatus, const TVector<NKikimrBlobStorage::EVDiskStatus>& vdiskStatuses)
     {
@@ -184,8 +145,10 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         auto groupSample = pbConfig->group(0);
         auto vslotSample = pbConfig->vslot(0);
         auto vslotIdSample = pbConfig->group(0).vslotid(0);
+        Cerr << "iiiiiiiiiii bsc group size " << pbConfig->group_size() << Endl;
         for (auto& group: *pbConfig->mutable_group()) {
             group.set_operatingstatus(groupStatus);
+ //           group.set_storagepoolid(1);
         }
         for (auto& pdisk: *pbConfig->mutable_pdisk()) {
             pdisk.mutable_pdiskmetrics()->set_state(NKikimrBlobStorage::TPDiskState::Normal);
@@ -196,6 +159,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         auto group = pbConfig->add_group();
         group->CopyFrom(groupSample);
         group->set_groupid(groupId);
+        group->set_storagepoolid(1);
         group->set_operatingstatus(groupStatus);
         group->set_erasurespecies(NHealthCheck::TSelfCheckRequest::BLOCK_4_2);
 
@@ -219,6 +183,12 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
             vslotId++;
         }
+
+        auto spStatus = pbRecord.mutable_response()->mutable_status(1);
+        spStatus->clear_storagepool();
+        auto sPool = spStatus->add_storagepool();
+        sPool->set_storagepoolid(1);
+        sPool->set_name(STORAGE_POOL_NAME);
     };
 
     void AddVSlotInVDiskStateResponse(TEvWhiteboard::TEvVDiskStateResponse::TPtr* ev, int groupCount, int vslotCount) {
@@ -367,7 +337,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                 }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
-                    AddGroupVSlotInControllerConfigResponse(x, groupStatus, vdiskStatuses);
+                    AddGroupVSlotInControllerConfigResponseWithStaticGroup(x, groupStatus, vdiskStatuses);
                     break;
                 }
             }
@@ -558,18 +528,14 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         }
     }
 
-    const TPathId SERVERLESS_DOMAIN_KEY = {7000000000, 2};
-    const TPathId SHARED_DOMAIN_KEY = {7000000000, 1};
-    const TString SHARED_STORAGE_POOL_NAME = "/Root/shared:test";
+    // void AddSharedGroupInControllerSelectGroupsResult(TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr* ev) {
+    //     auto& pbRecord = (*ev)->Get()->Record;
+    //     auto pbMatchGroups = pbRecord.add_matchinggroups();
 
-    void AddSharedGroupInControllerSelectGroupsResult(TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr* ev) {
-        auto& pbRecord = (*ev)->Get()->Record;
-        auto pbMatchGroups = pbRecord.add_matchinggroups();
-
-        auto group = pbMatchGroups->add_groups();
-        group->set_groupid(GROUP_START_ID);
-        group->set_storagepoolname(SHARED_STORAGE_POOL_NAME);
-    }
+    //     auto group = pbMatchGroups->add_groups();
+    //     group->set_groupid(GROUP_START_ID);
+    //     group->set_storagepoolname(STORAGE_POOL_NAME);
+    // }
 
     void ChangeNavigateKeyResultServerless(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr* ev,
         NKikimrSubDomains::EServerlessComputeResourcesMode serverlessComputeResourcesMode,
@@ -599,7 +565,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         if (record->path() == "/Root/serverless" || record->path() == "/Root/shared") {
             record->set_status(NKikimrScheme::StatusSuccess);
             auto pool = record->mutable_pathdescription()->mutable_domaindescription()->add_storagepools();
-            pool->set_name(SHARED_STORAGE_POOL_NAME);
+            pool->set_name(STORAGE_POOL_NAME);
             pool->set_kind("kind");
         }
     }
@@ -663,41 +629,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
         auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
-                case NConsole::TEvConsole::EvGetTenantStatusResponse: {
-                    auto *x = reinterpret_cast<NConsole::TEvConsole::TEvGetTenantStatusResponse::TPtr*>(&ev);
-                    ChangeGetTenantStatusResponse(x, "/Root/serverless");
-                    break;
-                }
-                case TEvTxProxySchemeCache::EvNavigateKeySetResult: {
-                    auto *x = reinterpret_cast<TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr*>(&ev);
-                    ChangeNavigateKeyResultServerless(x, NKikimrSubDomains::EServerlessComputeResourcesModeShared, runtime);
-                    break;
-                }
-                case TEvHive::EvResponseHiveNodeStats: {
-                    auto *x = reinterpret_cast<TEvHive::TEvResponseHiveNodeStats::TPtr*>(&ev);
-                    ChangeResponseHiveNodeStats(x, sharedDynNodeId);
-                    break;
-                }
-                case TEvSchemeShard::EvDescribeSchemeResult: {
-                    auto *x = reinterpret_cast<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr*>(&ev);
-                    ChangeDescribeSchemeResultServerless(x);
-                    break;
-                }
-                case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                    auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                    AddSharedGroupInControllerSelectGroupsResult(x);
-                    break;
-                }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
                     AddGroupVSlotInControllerConfigResponseWithStaticGroup(x, NKikimrBlobStorage::TGroupStatus::FULL, vdiskStatuses);
-                    break;
-                }
-                case TEvWhiteboard::EvSystemStateResponse: {
-                    auto *x = reinterpret_cast<TEvWhiteboard::TEvSystemStateResponse::TPtr*>(&ev);
-                    ClearLoadAverage(x);
-                    break;
+                    return TTestActorRuntime::EEventAction::PROCESS;
                 }
             }
 
@@ -727,7 +663,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
     }
 
     Y_UNIT_TEST(SpecificServerlessWithExclusiveNodes) {
@@ -774,11 +710,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                    auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                    AddSharedGroupInControllerSelectGroupsResult(x);
-                    break;
-                }
+                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
+                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
+                //     AddSharedGroupInControllerSelectGroupsResult(x);
+                //     break;
+                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -819,7 +755,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
     }
 
     Y_UNIT_TEST(IgnoreServerlessWhenNotSpecific) {
@@ -876,11 +812,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                    auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                    AddSharedGroupInControllerSelectGroupsResult(x);
-                    break;
-                }
+                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
+                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
+                //     AddSharedGroupInControllerSelectGroupsResult(x);
+                //     break;
+                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -967,11 +903,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                    auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                    AddSharedGroupInControllerSelectGroupsResult(x);
-                    break;
-                }
+                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
+                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
+                //     AddSharedGroupInControllerSelectGroupsResult(x);
+                //     break;
+                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -1012,7 +948,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
             }
         }
         UNIT_ASSERT(databaseFoundInResult);
@@ -1051,11 +987,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                    auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                    AddSharedGroupInControllerSelectGroupsResult(x);
-                    break;
-                }
+                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
+                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
+                //     AddSharedGroupInControllerSelectGroupsResult(x);
+                //     break;
+                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -1095,7 +1031,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
     }
 
     Y_UNIT_TEST(ServerlessWithExclusiveNodesWhenTroublesWithSharedNodes) {
@@ -1153,11 +1089,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                    auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                    AddSharedGroupInControllerSelectGroupsResult(x);
-                    break;
-                }
+                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
+                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
+                //     AddSharedGroupInControllerSelectGroupsResult(x);
+                //     break;
+                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -1183,7 +1119,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
         const auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
 
-        Ctest << result.ShortDebugString();
+        Cerr << "iiiiiiiiiiiiii result " << result.ShortDebugString() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::EMERGENCY);
 
         bool serverlessDatabaseFoundInResult = false;
@@ -1203,7 +1139,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
             } else if (database_status.name() == "/Root/shared") {
                 sharedDatabaseFoundInResult = true;
 
@@ -1214,7 +1150,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
             } else if (database_status.name() == "/Root") {
                 rootDatabaseFoundInResult = true;
 
@@ -1289,11 +1225,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     ChangeDescribeSchemeResultServerless(x);
                     break;
                 }
-                case TEvBlobStorage::EvControllerSelectGroupsResult: {
-                    auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
-                    AddSharedGroupInControllerSelectGroupsResult(x);
-                    break;
-                }
+                // case TEvBlobStorage::EvControllerSelectGroupsResult: {
+                //     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerSelectGroupsResult::TPtr*>(&ev);
+                //     AddSharedGroupInControllerSelectGroupsResult(x);
+                //     break;
+                // }
                 case TEvBlobStorage::EvControllerConfigResponse: {
                     auto *x = reinterpret_cast<TEvBlobStorage::TEvControllerConfigResponse::TPtr*>(&ev);
                     TVector<NKikimrBlobStorage::EVDiskStatus> vdiskStatuses = { NKikimrBlobStorage::EVDiskStatus::READY };
@@ -1338,7 +1274,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
             } else if (database_status.name() == "/Root/shared") {
                 sharedDatabaseFoundInResult = true;
 
@@ -1350,7 +1286,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
                 UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), SHARED_STORAGE_POOL_NAME);
+                UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].id(), STORAGE_POOL_NAME);
             } else if (database_status.name() == "/Root") {
                 rootDatabaseFoundInResult = true;
 
@@ -1472,6 +1408,62 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         UNIT_ASSERT_VALUES_EQUAL(database_status.compute().nodes()[0].id(), ToString(dynNodeId));
 
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::RED);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
+    }
+
+    Y_UNIT_TEST(NoBscConfigResponse) {
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        auto settings = TServerSettings(port)
+                .SetNodeCount(1)
+                .SetDynamicNodeCount(1)
+                .SetUseRealThreads(false)
+                .SetDomainName("Root");
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        TClient client(settings);
+        TTestActorRuntime& runtime = *server.GetRuntime();
+
+        auto &dynamicNameserviceConfig = runtime.GetAppData().DynamicNameserviceConfig;
+        dynamicNameserviceConfig->MaxStaticNodeId = runtime.GetNodeId(server.StaticNodes() - 1);
+        dynamicNameserviceConfig->MinDynamicNodeId = runtime.GetNodeId(server.StaticNodes());
+        dynamicNameserviceConfig->MaxDynamicNodeId = runtime.GetNodeId(server.StaticNodes() + server.DynamicNodes() - 1);
+
+        ui32 dynNodeId = runtime.GetNodeId(1);
+
+        // const TPathId SUBDOMAIN_KEY = {7000000000, 1};
+
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::EvControllerConfigResponse) {
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        TAutoPtr<IEventHandle> handle;
+
+        auto *request = new NHealthCheck::TEvSelfCheckRequest;
+        request->Request.set_return_verbose_status(true);
+        runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
+        const auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
+
+        Cerr << "iiiiiiiiiii " << result.ShortDebugString() << Endl;
+
+        UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::EMERGENCY);
+        UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
+        const auto &database_status = result.database_status(0);
+        // UNIT_ASSERT_VALUES_EQUAL(database_status.name(),  "/Root/database");
+        UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::RED);
+
+        UNIT_ASSERT_VALUES_EQUAL(database_status.compute().overall(), Ydb::Monitoring::StatusFlag::RED);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.compute().nodes().size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(database_status.compute().nodes()[0].id(), ToString(dynNodeId));
+
+        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::YELLOW);
         UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 0);
     }
 }


### PR DESCRIPTION
- removed unnecessary fields in `TStoragePoolState`
- now identify pools by IDs instead of names in some places
- information collection now mainly based on `BSController` response
- stopped requests for storage nodes whiteboard, not needed for time difference now
- set storage to GREEN when no `BSController` info

