### PR TITLE
Fix unrelevant doc line on AnsiInForEmptyOrNullableItemsCollections

### DIFF
--- a/ydb/docs/en/core/yql/reference/yql-core/syntax/_includes/pragma/global.md
+++ b/ydb/docs/en/core/yql/reference/yql-core/syntax/_includes/pragma/global.md
@@ -112,7 +112,6 @@ This pragma brings the behavior of the `IN` operator in accordance with the stan
 `1 IN (2, 3, NULL) = NULL (was Just(False))`
 `NULL IN () = Just(False) (was NULL)`
 `(1, null) IN ((2, 2), (3, 3)) = Just(False) (was NULL)`
-`2147483648u IN (1, 2147483648u) = True (was False)`
 
 For more information about the `IN` behavior when operands include `NULL`s, see [here](../../expressions.md#in). You can explicitly select the old behavior by specifying the pragma `DisableAnsiInForEmptyOrNullableItemsCollections`. If no pragma is set, then a warning is issued and the old version works.
 

--- a/ydb/docs/ru/core/yql/reference/yql-core/syntax/_includes/pragma/global.md
+++ b/ydb/docs/ru/core/yql/reference/yql-core/syntax/_includes/pragma/global.md
@@ -141,7 +141,6 @@ StrictJoinKeyTypes является [scoped](#pragmascope) настройкой.
 `1 IN (2, 3, NULL) = NULL (было Just(False))`
 `NULL IN () = Just(False) (было NULL)`
 `(1, null) IN ((2, 2), (3, 3)) = Just(False) (было NULL)`
-`2147483648u IN (1, 2147483648u) = True (было False)`
 
 Подробнее про поведение `IN` при наличии `NULL`ов в операндах можно почитать [здесь](../../expressions.md#in). Явным образом выбрать старое поведение можно указав прагму `DisableAnsiInForEmptyOrNullableItemsCollections`. Если никакой прагмы не задано, то выдается предупреждение и работает старый вариант.
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix unrelevant doc line on AnsiInForEmptyOrNullableItemsCollections

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)

### Additional information

If the intent of using `2147483648u` in this case has something to do with checks for integer overflows, please let me know, I'll make necessary corrections.
