### PR TITLE
time difference lines2

### DIFF
--- a/ydb/core/tablet/node_whiteboard.cpp
+++ b/ydb/core/tablet/node_whiteboard.cpp
@@ -969,6 +969,11 @@ protected:
     }
 
     void Handle(TEvPrivate::TEvUpdateClockSkew::TPtr &, const TActorContext &ctx) {
+        auto group = NKikimr::GetServiceCounters(NKikimr::AppData()->Counters, "utils")
+            ->GetSubgroup("subsystem", "whiteboard");
+        group->GetCounter("MaxClockSkewWithPeerUs")->Set(MaxClockSkewWithPeerUs);
+        group->GetCounter("MaxClockSkewPeerId")->Set(MaxClockSkewPeerId);
+
         SystemStateInfo.SetMaxClockSkewWithPeerUs(MaxClockSkewWithPeerUs);
         SystemStateInfo.SetMaxClockSkewPeerId(MaxClockSkewPeerId);
         MaxClockSkewWithPeerUs = 0;

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -142,6 +142,14 @@ protected:
         SendRequestToPipe(pipeClient, request.Release());
     }
 
+    void RequestBSControllerConfigWithStoragePools() {
+        TActorId pipeClient = ConnectTabletPipe(GetBSControllerId());
+        THolder<TEvBlobStorage::TEvControllerConfigRequest> request = MakeHolder<TEvBlobStorage::TEvControllerConfigRequest>();
+        request->Record.MutableRequest()->AddCommand()->MutableQueryBaseConfig();
+        request->Record.MutableRequest()->AddCommand()->MutableReadStoragePool()->SetBoxId(Max<ui64>());
+        SendRequestToPipe(pipeClient, request.Release());
+    }
+
     void RequestBSControllerInfo() {
         TActorId pipeClient = ConnectTabletPipe(GetBSControllerId());
         THolder<TEvBlobStorage::TEvRequestControllerInfo> request = MakeHolder<TEvBlobStorage::TEvRequestControllerInfo>();

--- a/ydb/core/viewer/json_storage.h
+++ b/ydb/core/viewer/json_storage.h
@@ -20,6 +20,7 @@ class TJsonStorage : public TJsonStorageBase {
     enum class EGroupSort {
         PoolName,
         Kind,
+        MediaType,
         Erasure,
         Degraded,
         Usage,
@@ -46,6 +47,7 @@ class TJsonStorage : public TJsonStorageBase {
         TString PoolName;
         TString GroupId;
         TString Kind;
+        TString MediaType;
         TString Erasure;
         ui32 Degraded;
         float Usage;
@@ -100,6 +102,8 @@ public:
                 GroupSort = EGroupSort::PoolName;
             } else if (sort == "Kind") {
                 GroupSort = EGroupSort::Kind;
+            } else if (sort == "MediaType") {
+                GroupSort = EGroupSort::MediaType;
             } else if (sort == "Erasure") {
                 GroupSort = EGroupSort::Erasure;
             } else if (sort == "Degraded") {
@@ -142,6 +146,7 @@ public:
             const auto& groupRow = GroupRowsByGroupId[groupId];
             json << "\"PoolName\":\"" << groupRow.PoolName << "\",";
             json << "\"Kind\":\"" << groupRow.Kind << "\",";
+            json << "\"MediaType\":\"" << groupRow.MediaType << "\",";
             json << "\"Erasure\":\"" << groupRow.Erasure << "\",";
             json << "\"Degraded\":\"" << groupRow.Degraded << "\",";
             json << "\"Usage\":\"" << groupRow.Usage << "\",";
@@ -310,6 +315,7 @@ public:
                 row.PoolName = poolName;
                 row.GroupId = groupId;
                 row.Kind = poolInfo.Kind;
+                row.MediaType = poolInfo.MediaType;
                 auto ib = BSGroupIndex.find(groupId);
                 if (ib != BSGroupIndex.end()) {
                     row.Erasure = ib->second.GetErasureSpecies();
@@ -390,6 +396,9 @@ public:
                     break;
                 case EGroupSort::Kind:
                     SortCollection(GroupRows, [](const TGroupRow& node) { return node.Kind;}, ReverseSort);
+                    break;
+                case EGroupSort::MediaType:
+                    SortCollection(GroupRows, [](const TGroupRow& node) { return node.MediaType;}, ReverseSort);
                     break;
                 case EGroupSort::Erasure:
                     SortCollection(GroupRows, [](const TGroupRow& node) { return node.Erasure;}, ReverseSort);
@@ -494,7 +503,7 @@ struct TJsonRequestParameters<TJsonStorage> {
                       {"name":"version","in":"query","description":"query version (v1, v2)","required":false,"type":"string"},
                       {"name":"usage_pace","in":"query","description":"bucket size as a percentage","required":false,"type":"integer","default":5},
                       {"name":"usage_buckets","in":"query","description":"filter groups by usage buckets","required":false,"type":"integer"},
-                      {"name":"sort","in":"query","description":"sort by (PoolName,Type,Erasure,Degraded,Usage,GroupId,Used,Limit,Read,Write)","required":false,"type":"string"},
+                      {"name":"sort","in":"query","description":"sort by (PoolName,Kind,MediaType,Erasure,Degraded,Usage,GroupId,Used,Limit,Read,Write)","required":false,"type":"string"},
                       {"name":"offset","in":"query","description":"skip N nodes","required":false,"type":"integer"},
                       {"name":"limit","in":"query","description":"limit to N nodes","required":false,"type":"integer"},
                       {"name":"timeout","in":"query","description":"timeout in ms","required":false,"type":"integer"}])___";

--- a/ydb/core/viewer/json_storage.h
+++ b/ydb/core/viewer/json_storage.h
@@ -355,6 +355,7 @@ public:
                 ++foundGroups;
                 if (Version == EVersion::v1) {
                     pool->AddGroups()->SetGroupId(groupId);
+                    pool->SetMediaType(poolInfo.MediaType);
                 } else if (Version == EVersion::v2) {
                     if (!UsageBuckets.empty() && !BinarySearch(UsageBuckets.begin(), UsageBuckets.end(), (ui32)(row.Usage * 100) / UsagePace)) {
                         continue;

--- a/ydb/core/viewer/json_storage_base.h
+++ b/ydb/core/viewer/json_storage_base.h
@@ -221,7 +221,7 @@ public:
     void Handle(TEvBlobStorage::TEvControllerConfigResponse::TPtr& ev) {
         const NKikimrBlobStorage::TEvControllerConfigResponse& pbRecord(ev->Get()->Record);
 
-        if (pbRecord.HasResponse() && pbRecord.GetResponse().StatusSize() > 0) {
+        if (pbRecord.HasResponse() && pbRecord.GetResponse().StatusSize() > 1) {
             const NKikimrBlobStorage::TConfigResponse::TStatus& pbStatus(pbRecord.GetResponse().GetStatus(0));
             if (pbStatus.HasBaseConfig()) {
                 BaseConfig = ev->Release();
@@ -244,9 +244,10 @@ public:
                         SendNodeRequests(nodeId);
                     }
                 }
-                for (const NKikimrBlobStorage::TDefineStoragePool& pool : pbStatus.GetStoragePool()) {
-                    StoragePoolInfo[pool.GetName()].MediaType = GetMediaType(pool);
-                }
+            }
+            const NKikimrBlobStorage::TConfigResponse::TStatus& spStatus(pbRecord.GetResponse().GetStatus(1));
+            for (const NKikimrBlobStorage::TDefineStoragePool& pool : spStatus.GetStoragePool()) {
+                StoragePoolInfo[pool.GetName()].MediaType = GetMediaType(pool);
             }
         }
         RequestDone();

--- a/ydb/core/viewer/json_storage_base.h
+++ b/ydb/core/viewer/json_storage_base.h
@@ -174,7 +174,7 @@ public:
             return;
         }
 
-        RequestBSControllerConfig();
+        RequestBSControllerConfigWithStoragePools();
 
         TBase::Become(&TThis::StateWork);
         Schedule(TDuration::MilliSeconds(Timeout / 100 * 70), new TEvents::TEvWakeup(TimeoutBSC)); // 70% timeout (for bsc)

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -402,6 +402,7 @@ message TStoragePoolInfo {
     float MaximumIOPS = 9;
     uint64 MaximumThroughput = 10;
     uint64 MaximumSize = 11;
+    string MediaType = 12;
 }
 
 message TStorageInfo {


### PR DESCRIPTION
- fix incorrect tests implementation (#2212)
- Base transaction class for all propose operations (#2208)
- Fix TzTimestamp wrong encoding (YQL-17920) (#2222)
- [PG Syntax] Added ydb pragma support (#2225)
- Test for ALTER TABLE RENAME TO (doesn't work yet) (#2228)
- Pass VDisk burst threshold in config, fix TBucketQuoter bug (#2165)
- YT YQL plugin; Fix configs parsing (#2093)
- Add shared thread logic to harmonizer (#1767)
- parquet DateTime insert has been supported YQ-2570 (#1410)
- YQ-2786 partly unmute tests fq s3 (#2143)
- Handle NOT Ready GetOperationResponse for Scripts (#1479)
- LOGBROKER-8953: change 400 to 503 status for Unavailable in http_proxy (#2130)
- Dynamic listing mass fix (#1913)
- VERIFY that created ingress is not empty (#2233)
- Added database to request discriminator (#2221)
- Implemented tracing for bulk row upsert (#2218)
- fixes #2201: remove obsolete ENSURE (#2216)
- ci: run relwithdebinfo and debug with build-preset labels too (#2245)
- Reading with a guarantee in case of autoscaling (#2128)
- Fix missing ToFlow in dict join (#2189)
- REST Monitoring API Support for CPU Load Control (#2229)
- Base flow for EvWrite with locks (#2234)
- Implemented tracing sampling by db (#2220)
- persqueue: add WRITE_ERROR_PARTITION_INACTIVE status code (#2241)
- KIKIMR-20543: ddl+dml in query service (#1444)
- Volatile transaction support in EvWrite (#2196)
- persqueue: extract common ut code, rename to autoscaling (#2255)
- New volatile EvWrite tests (#2253)
- Add TMPDIR to reducer and mapper enviroment (#2248)
- change large serializable test configuration (#2244)
- BTreeIndex Stats Visit top nodes only (#2177)
- add fullscan metric (#2192)
- resolves #1917: fix, add, unmute pgwire tests (#2213)
- YQ-2862 Add partition id to log (#2251)
- support search_path in SET too (#2261)
- YQ-2068 extract TTypeBuilder from TProgramBuilder to get rid of dependency on IFunctionRegistry (#2224)
- Fix partition helpers (#2281)
- KIKIMR-20109 Direct write without partition ID for ydb_topic (#2185)
- purebench tool (#2287)
- Application name into translation settings (#2235)
- clean useless metadata from memory (#2280)
- YQ-2068 delete Y_YQL_DQ_NO_PROGRAM_BUILDER_FOR_TRANSFORM (#2272)
- BTreeIndex Stats Visit top nodes only fix max type (#2295)
- Revert "KIKIMR-20580: enable stream lookup (#1676)" (#2290)
- Disable PROTOC_TRANSITIVE_HEADERS to speed up build (#1784)
- Disable log batching for kv tablet (#2263)
- Dont return shared nodes for serverless KIKIMR-21128 (#2264)
- BTreeIndex Stats Visit top nodes only fix negative epochs (#2297)
- [CLI] double output fixed (#2301)
- Some PgAdmin fixes (#2294)
- Enable PreparedDDL by default. (#2293)
- [yt provider] Ignore resolve errors when reading symlink attributes (#2319)
- Move UserDb to TExecuteWriteUnit (#2282)
- Extract ydb init to separate classes (#2064)
- Removed redundant wilson uploader parameter (#2270)
- Tracing scope to tracing rule rename (#2268)
- Delete single keys, move table in first place, colorise table name (#2330)
- Test TPQTabletTests::DropTablet_Before_Write (#2306)
- add base_port_offset parameter to local_ydb (#2323)
- Check for ChangeQueue overflow in EvWrite (#2324)
- LOGBROKER-8935: return error for compression.type config in Kafka API (#2262)
- config for the service partition (#1807)
- TEvProposeTransaction handler (#1963)
- Revert "Disable log batching for kv tablet" (#2328)
- use different storages per columns (#2274)
- Add OAuth support #2311 (#2312)
- Workload read without consumer and metrics fixes (#1792)
- ydb workload kv init: add --max-partitions arg (#2085)
- tests: mute ydb/services/ydb/table_split_ut, chunk [5/7] (#2320)
- Fix stale read of some acknowledged writes after a table split (#2286)
- schemeboard: pass describe-result as an opaque payload (#2083)
- Removed unnecessary field (#2338)
- Removed outdated comment (#2339)
- Move grpc actor client from Yandex specific library (#2351)
- Better handling for mediator time jumps in datashard (#2342)
- Fix predicate pushdown prompt (#2348)
- fix backward compatibility on useless data cleaning (#2357)
- [pg] support of table row (#2350)
- Bring back NoArgument for syslog option (#2349)
- fix sortness of table in tests (#2362)
- dont rebuild s3 client in case same config (#2352)
- EvWrite OverloadSubscribe (#2341)
- YDB-1470 added database filter for time difference (#2217)
- negative response from KQP (#2345)
- Preserve original join node (#2372)
- Preserve original join node if ForceSortedMerge=true (#2373)
- Improove tablet generation value in Topic protocol (#2375)
- Mute OperationLog.ConcurrentWrites test (#2381)
- Print backtrace on unhandled exception (#2379)
- Support YDB in YQL Generic Provider (YQv1) (#2300)
- Support of nulls first/last (#2365)
- Remove TraceId from EvWrite tests (#2384)
- Disable CBO for unsupported link settings (#2385)
- fix windows build (#2389)
- add query replay tool to oss (#2392)
- implemented syscache RELNAMENSP (#2387)
- Remove support for multiple domains, remove support for state storage groups (#2275)
- Add deduplication options checks (#2254)
- YQL-17935 delete non deterministic test (#2344)
- Fix muted tests and adjust tablet ids (#2406)
- Refactoring of pqconfig.proto - extract message Consumer instead of separeted arrays of ReadRules (#2347)
- Fixed iterator invalidation in graph shard (#2395)
- Temporary mute kv tests (#2408)
- Disable LogBatching for already existed kv tablets (#2303)
- Add MySQL and MS SQL Server to the list of external data sources (#2407)
- YQ-2885 fix issue script execution is canceled (#2106)
- Links instead of full blobid (#2400)
- YQ-2898 fix query failed with unknown uncommitted upload issue (#2240)
- statistics for columnshard (#2396)
- YQ-2549 Checkpointing in match_recognize (#1860)
- trace raw queries (#2410)
- Added stage id to JSON plan (#2420)
- Temporary mute kv tests 2 (#2419)
- add media type filed
- added RequestBSControllerConfigWithStoragePools
- added second status
- fixed for v1
- time-difference-lines

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Additional information

...
