### PR TITLE
YQ-2871 fix error broadcast is not supported

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt.cpp
@@ -76,6 +76,14 @@ ui32 GetStageOutputsCount(const TDqStageBase& stage) {
     return resultsTypeTuple->GetSize();
 }
 
+bool DqStageFirstInputIsBroadcast(const TDqStageBase& stage) {
+    if (stage.Inputs().Empty()) {
+        return false;
+    }
+
+    return TDqCnBroadcast::Match(stage.Inputs().Item(0).Raw());
+}
+
 bool IsDqPureNode(const TExprBase& node) {
     return !node.Maybe<TDqSource>() &&
            !node.Maybe<TDqConnection>() &&

--- a/ydb/library/yql/dq/opt/dq_opt.h
+++ b/ydb/library/yql/dq/opt/dq_opt.h
@@ -25,6 +25,7 @@ bool IsSingleConsumerConnection(const NNodes::TDqConnection& node, const TParent
 ui32 GetStageOutputsCount(const NNodes::TDqStageBase& stage);
 
 void FindDqConnections(const NNodes::TExprBase& node, TVector<NNodes::TDqConnection>& connections, bool& isPure);
+bool DqStageFirstInputIsBroadcast(const NNodes::TDqStageBase& stage);
 bool IsDqPureExpr(const NNodes::TExprBase& node, bool isPrecomputePure = true);
 bool IsDqSelfContainedExpr(const NNodes::TExprBase& node);
 bool IsDqDependsOnStage(const NNodes::TExprBase& node, const NNodes::TDqStageBase& stage);

--- a/ydb/library/yql/dq/opt/dq_opt_join.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join.cpp
@@ -710,6 +710,11 @@ TExprBase DqBuildPhyJoin(const TDqJoin& join, bool pushLeftStage, TExprContext& 
         if (!buildNewStage) {
             // NOTE: Do not push join to stage with multiple outputs, reduce memory footprint.
             buildNewStage = GetStageOutputsCount(leftCn.Output().Stage()) > 1;
+            if (!buildNewStage && rightBroadcast) {
+                // NOTE: Do not fuse additional input into stage which have first input `Broadcast` type.
+                // Rule described in /ydb/library/yql/dq/tasks/dq_connection_builder.h:23
+                buildNewStage = DqStageFirstInputIsBroadcast(leftCn.Output().Stage());
+            }
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed error, produced by: [`Broadcast` can not be the 1st stage input unless it's a single input](https://github.com/ydb-platform/ydb/blob/e0a15dd06e20584cd820f958c91f5eb33128647f/ydb/core/kqp/executer_actor/kqp_executer_impl.h#L1260)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

- Added `Broadcast` validation into MapJoin optimizer
