### PR TITLE
Fix volatile result sent before it is fully committed (24-1)

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2006,20 +2006,65 @@ private:
                                     TTopicTabletTxs& topicTxs) {
         TDatashardTxs datashardTxs;
 
-        std::vector<ui64> affectedShardsSet;
-        affectedShardsSet.reserve(datashardTasks.size());
-
         for (auto& [shardId, tasks]: datashardTasks) {
             auto [it, success] = datashardTxs.emplace(
                 shardId,
                 TasksGraph.GetMeta().Allocate<NKikimrTxDataShard::TKqpTransaction>());
 
             YQL_ENSURE(success, "unexpected duplicates in datashard transactions");
-            affectedShardsSet.emplace_back(shardId);
             NKikimrTxDataShard::TKqpTransaction* dsTxs = it->second;
             dsTxs->MutableTasks()->Reserve(tasks.size());
             for (auto& task: tasks) {
                 dsTxs->AddTasks()->Swap(task);
+            }
+        }
+
+        // Note: when locks map is present it will be mutated to avoid copying data
+        auto& locksMap = Request.DataShardLocks;
+        if (!locksMap.empty()) {
+            YQL_ENSURE(Request.LocksOp == ELocksOp::Commit || Request.LocksOp == ELocksOp::Rollback);
+        }
+
+        // Materialize (possibly empty) txs for all shards with locks (either commit or rollback)
+        for (auto& [shardId, locksList] : locksMap) {
+            YQL_ENSURE(!locksList.empty(), "unexpected empty locks list in DataShardLocks");
+
+            auto it = datashardTxs.find(shardId);
+            if (it == datashardTxs.end()) {
+                auto [emplaced, success] = datashardTxs.emplace(
+                    shardId,
+                    TasksGraph.GetMeta().Allocate<NKikimrTxDataShard::TKqpTransaction>());
+
+                YQL_ENSURE(success, "unexpected failure to emplace a datashard transaction");
+                it = emplaced;
+            }
+
+            NKikimrTxDataShard::TKqpTransaction* tx = it->second;
+            switch (Request.LocksOp) {
+                case ELocksOp::Commit:
+                    tx->MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+                    break;
+                case ELocksOp::Rollback:
+                    tx->MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Rollback);
+                    break;
+                case ELocksOp::Unspecified:
+                    break;
+            }
+
+            // Move lock descriptions to the datashard tx
+            auto* protoLocks = tx->MutableLocks()->MutableLocks();
+            protoLocks->Reserve(locksList.size());
+            bool hasWrites = false;
+            for (auto& lock : locksList) {
+                hasWrites = hasWrites || lock.GetHasWrites();
+                protoLocks->Add(std::move(lock));
+            }
+            locksList.clear();
+
+            // When locks with writes are committed this commits accumulated effects
+            if (Request.LocksOp == ELocksOp::Commit && hasWrites) {
+                ShardsWithEffects.insert(shardId);
+                YQL_ENSURE(!ReadOnlyTx);
             }
         }
 
@@ -2042,7 +2087,7 @@ private:
             // TODO: add support in the future
             topicTxs.empty() &&
             // We only want to use volatile transactions for multiple shards
-            (affectedShardsSet.size() + topicTxs.size()) > 1 &&
+            (datashardTxs.size() + topicTxs.size()) > 1 &&
             // We cannot use volatile transactions with persistent channels
             // Note: currently persistent channels are never used
             !HasPersistentChannels);
@@ -2055,30 +2100,29 @@ private:
             // Transactions with topics must always use generic readsets
             !topicTxs.empty());
 
-        if (auto locksMap = Request.DataShardLocks;
-            !locksMap.empty() ||
-            VolatileTx ||
+        if (!locksMap.empty() || VolatileTx ||
             Request.TopicOperations.HasReadOperations())
         {
             YQL_ENSURE(Request.LocksOp == ELocksOp::Commit || Request.LocksOp == ELocksOp::Rollback || VolatileTx);
 
             bool needCommit = Request.LocksOp == ELocksOp::Commit || VolatileTx;
 
-            auto locksOp = needCommit
-                ? NKikimrDataEvents::TKqpLocks::Commit
-                : NKikimrDataEvents::TKqpLocks::Rollback;
-
             absl::flat_hash_set<ui64> sendingShardsSet;
             absl::flat_hash_set<ui64> receivingShardsSet;
 
             // Gather shards that need to send/receive readsets (shards with effects)
             if (needCommit) {
-                for (auto& shardId: affectedShardsSet) {
+                for (auto& [shardId, tx] : datashardTxs) {
+                    if (tx->HasLocks()) {
+                        // Locks may be broken so shards with locks need to send readsets
+                        sendingShardsSet.insert(shardId);
+                    }
                     if (ShardsWithEffects.contains(shardId)) {
                         // Volatile transactions may abort effects, so they send readsets
                         if (VolatileTx) {
                             sendingShardsSet.insert(shardId);
                         }
+                        // Effects are only applied when all locks are valid
                         receivingShardsSet.insert(shardId);
                     }
                 }
@@ -2093,44 +2137,7 @@ private:
                 }
             }
 
-            // Gather locks that need to be committed or erased
-            for (auto& [shardId, locksList] : locksMap) {
-                NKikimrTxDataShard::TKqpTransaction* tx = nullptr;
-                auto it = datashardTxs.find(shardId);
-                if (it != datashardTxs.end()) {
-                    tx = it->second;
-                } else {
-                    auto [eIt, success] = datashardTxs.emplace(
-                        shardId,
-                        TasksGraph.GetMeta().Allocate<NKikimrTxDataShard::TKqpTransaction>());
-                    tx = eIt->second;
-                }
-
-                tx->MutableLocks()->SetOp(locksOp);
-
-                if (!locksList.empty()) {
-                    auto* protoLocks = tx->MutableLocks()->MutableLocks();
-                    protoLocks->Reserve(locksList.size());
-                    bool hasWrites = false;
-                    for (auto& lock : locksList) {
-                        hasWrites = hasWrites || lock.GetHasWrites();
-                        protoLocks->Add()->Swap(&lock);
-                    }
-
-                    if (needCommit) {
-                        // We also send the result on commit
-                        sendingShardsSet.insert(shardId);
-
-                        if (hasWrites) {
-                            // Tx with uncommitted changes can be aborted due to conflicts,
-                            // so shards with write locks should receive readsets
-                            receivingShardsSet.insert(shardId);
-                            YQL_ENSURE(!ReadOnlyTx);
-                        }
-                    }
-                }
-            }
-
+            // Encode sending/receiving shards in tx bodies
             if (needCommit) {
                 NProtoBuf::RepeatedField<ui64> sendingShards(sendingShardsSet.begin(), sendingShardsSet.end());
                 NProtoBuf::RepeatedField<ui64> receivingShards(receivingShardsSet.begin(), receivingShardsSet.end());
@@ -2139,23 +2146,13 @@ private:
                 std::sort(receivingShards.begin(), receivingShards.end());
 
                 for (auto& [shardId, shardTx] : datashardTxs) {
-                    shardTx->MutableLocks()->SetOp(locksOp);
+                    shardTx->MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
                     *shardTx->MutableLocks()->MutableSendingShards() = sendingShards;
                     *shardTx->MutableLocks()->MutableReceivingShards() = receivingShards;
                 }
 
                 for (auto& [_, tx] : topicTxs) {
-                    switch (locksOp) {
-                    case NKikimrDataEvents::TKqpLocks::Commit:
-                        tx.SetOp(NKikimrPQ::TDataTransaction::Commit);
-                        break;
-                    case NKikimrDataEvents::TKqpLocks::Rollback:
-                        tx.SetOp(NKikimrPQ::TDataTransaction::Rollback);
-                        break;
-                    case NKikimrDataEvents::TKqpLocks::Unspecified:
-                        break;
-                    }
-
+                    tx.SetOp(NKikimrPQ::TDataTransaction::Commit);
                     *tx.MutableSendingShards() = sendingShards;
                     *tx.MutableReceivingShards() = receivingShards;
                 }

--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -404,7 +404,7 @@ TValidatedDataTx::TPtr TActiveTransaction::BuildDataTx(TDataShard *self,
     if (!DataTx) {
         Y_ABORT_UNLESS(TxBody);
         DataTx = std::make_shared<TValidatedDataTx>(self, txc, ctx, GetStepOrder(),
-                                                    GetReceivedAt(), TxBody, MvccSnapshotRepeatable);
+                                                    GetReceivedAt(), TxBody, IsMvccSnapshotRepeatable());
         if (DataTx->HasStreamResponse())
             SetStreamSink(DataTx->GetSink());
     }
@@ -635,7 +635,7 @@ ERestoreDataStatus TActiveTransaction::RestoreTxData(
 
     bool extractKeys = DataTx->IsTxInfoLoaded();
     DataTx = std::make_shared<TValidatedDataTx>(self, txc, ctx, GetStepOrder(),
-                                                GetReceivedAt(), TxBody, MvccSnapshotRepeatable);
+                                                GetReceivedAt(), TxBody, IsMvccSnapshotRepeatable());
     if (DataTx->Ready() && extractKeys) {
         DataTx->ExtractKeys(true);
     }

--- a/ydb/core/tx/datashard/datashard_ut_common_kqp.h
+++ b/ydb/core/tx/datashard/datashard_ut_common_kqp.h
@@ -42,7 +42,7 @@ namespace NKqpHelpers {
     inline TString CreateSessionRPC(TTestActorRuntime& runtime, const TString& database = {}) {
         Ydb::Table::CreateSessionRequest request;
         auto future = NRpcService::DoLocalRpc<TEvCreateSessionRequest>(
-           std::move(request), database, "", /* token */ runtime.GetActorSystem(0));
+           std::move(request), database, /* token */ "", runtime.GetActorSystem(0));
         TString sessionId;
         auto response = AwaitResponse(runtime, future);
         UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::SUCCESS);
@@ -71,7 +71,7 @@ namespace NKqpHelpers {
         TTestActorRuntime& runtime, Ydb::Table::ExecuteDataQueryRequest&& request, const TString& database = {})
     {
         return NRpcService::DoLocalRpc<TEvExecuteDataQueryRequest>(
-            std::move(request), database, "" /* token */, runtime.GetActorSystem(0));
+            std::move(request), database, /* token */ "", runtime.GetActorSystem(0));
     }
 
     inline Ydb::Table::ExecuteDataQueryRequest MakeSimpleRequestRPC(
@@ -119,7 +119,7 @@ namespace NKqpHelpers {
         Ydb::Table::DeleteSessionRequest request;
         request.set_session_id(sessionId);
         auto future = NRpcService::DoLocalRpc<TEvDeleteSessionRequest>(
-            std::move(request), "", "", /* token */ runtime.GetActorSystem(0));
+            std::move(request), "", /* token */ "", runtime.GetActorSystem(0));
     }
 
     inline THolder<NKqp::TEvKqp::TEvQueryRequest> MakeStreamRequest(
@@ -168,17 +168,15 @@ namespace NKqpHelpers {
         return FormatResult(result);
     }
 
-    inline TString KqpSimpleExec(TTestActorRuntime& runtime, const TString& query, bool staleRo = false, const TString& database = {}) {
+    inline auto KqpSimpleSend(TTestActorRuntime& runtime, const TString& query, bool staleRo = false, const TString& database = {}) {
         TString sessionId = CreateSessionRPC(runtime, database);
         TString txId;
-        auto response = AwaitResponse(
-            runtime, SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, true /* commitTx */, staleRo), database));
-        if (response.operation().status() != Ydb::StatusIds::SUCCESS) {
-            return TStringBuilder() << "ERROR: " << response.operation().status();
-        }
-        Ydb::Table::ExecuteQueryResult result;
-        response.operation().result().UnpackTo(&result);
-        return FormatResult(result);
+        return SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, /* commitTx */ true, staleRo), database);
+    }
+
+    inline TString KqpSimpleExec(TTestActorRuntime& runtime, const TString& query, bool staleRo = false, const TString& database = {}) {
+        auto response = AwaitResponse(runtime, KqpSimpleSend(runtime, query, staleRo, database));
+        return FormatResult(response);
     }
 
     inline TString KqpSimpleStaleRoExec(TTestActorRuntime& runtime, const TString& query, const TString& database = {}) {

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -348,7 +348,7 @@ struct TTestHelper {
         auto &runtime = *Server->GetRuntime();
         Sender = runtime.AllocateEdgeActor();
 
-        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_NOTICE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_INFO);
 
         InitRoot(Server, Sender);
@@ -818,7 +818,11 @@ struct TTestHelper {
                     break;
                 }
                 case TEvTxProcessing::EvReadSet: {
-                    if (dropRS) {
+                    auto* msg = event->Get<TEvTxProcessing::TEvReadSet>();
+                    auto flags = msg->Record.GetFlags();
+                    auto isExpect = flags & NKikimrTx::TEvReadSet::FLAG_EXPECT_READSET;
+                    auto isNoData = flags & NKikimrTx::TEvReadSet::FLAG_NO_DATA;
+                    if (dropRS && !(isExpect && isNoData)) {
                         result.ReadSets.push_back(std::move(event));
                         return TTestActorRuntime::EEventAction::DROP;
                     }
@@ -852,7 +856,10 @@ struct TTestHelper {
             )"));
         }
 
-        waitFor([&]{ return result.ReadSets.size() == 1; }, "intercepted RS");
+        const bool usesVolatileTxs = runtime.GetAppData(0).FeatureFlags.GetEnableDataShardVolatileTransactions();
+        const size_t expectedReadSets = 1 + (finalUpserts && usesVolatileTxs ? 2 : 0);
+
+        waitFor([&]{ return result.ReadSets.size() == expectedReadSets; }, "intercepted RS");
 
         // restore original observer (note we used lambda function and stack variables)
         Server->GetRuntime()->SetObserverFunc(prevObserverFunc);
@@ -2576,7 +2583,9 @@ Y_UNIT_TEST_SUITE(DataShardReadIterator) {
         TPortManager pm;
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
-            .SetUseRealThreads(false);
+            .SetUseRealThreads(false)
+            // Blocked volatile transactions block reads, disable
+            .SetEnableDataShardVolatileTransactions(false);
 
         const ui64 shardCount = 1;
         TTestHelper helper(serverSettings, shardCount);
@@ -3600,7 +3609,7 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorPageFaults) {
         auto& runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
 
-        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_NOTICE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_INFO);
         // runtime.SetLogPriority(NKikimrServices::TABLET_EXECUTOR, NLog::PRI_DEBUG);
 

--- a/ydb/core/tx/datashard/datashard_ut_volatile.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_volatile.cpp
@@ -2283,6 +2283,120 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         UNIT_ASSERT_VALUES_EQUAL(volatileTxs, 2u);
     }
 
+    // Regression test for KIKIMR-21156
+    Y_UNIT_TEST(VolatileCommitOnBlobStorageFailure) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(1000)
+            .SetEnableDataShardVolatileTransactions(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::KQP_EXECUTER, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::KQP_SESSION, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+        CreateShardedTable(server, sender, "/Root", "table-2", 1);
+
+        // Make sure read flags are persisted by performing a snapshot read
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table-1`
+                UNION ALL
+                SELECT key, value FROM `/Root/table-2`
+                ORDER BY key
+                )"),
+            "");
+
+        // Insert initial values
+        ExecSQL(server, sender, Q_("UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 10);"));
+        ExecSQL(server, sender, Q_("UPSERT INTO `/Root/table-2` (key, value) VALUES (2, 20);"));
+
+        // Start blocking commits for table-1
+        const auto shards1 = GetTableShards(server, sender, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(shards1.size(), 1u);
+        std::deque<TEvBlobStorage::TEvPut::TPtr> blockedPuts;
+        auto blockCommits = runtime.AddObserver<TEvBlobStorage::TEvPut>([&](TEvBlobStorage::TEvPut::TPtr& ev) {
+            auto* msg = ev->Get();
+            // Drop all put requests for table-1
+            if (msg->Id.TabletID() == shards1.at(0)) {
+                Cerr << "... blocking put " << msg->Id << Endl;
+                blockedPuts.push_back(std::move(ev));
+            }
+        });
+
+        // Start an upsert to table-1, this will block further readonly localdb tx completions
+        Cerr << "... starting an upsert to table-1" << Endl;
+        auto firstUpsertFuture = KqpSimpleSend(runtime, R"(
+            UPSERT INTO `/Root/table-1` (key, value) VALUES (3, 30);
+            )");
+
+        // Wait until puts are blocked
+        WaitFor(runtime, [&]{ return blockedPuts.size() > 0; }, "blocked puts");
+        auto firstUpsertPuts = std::move(blockedPuts);
+        UNIT_ASSERT(blockedPuts.empty());
+
+        // Read from table-2 and write to table-1 based on the result
+        // This will result in a two-shard volatile tx writing to table-1
+        Cerr << "... starting distributed tx between table-1 and table-2" << Endl;
+        auto volatileFuture = KqpSimpleSend(runtime, R"(
+            UPSERT INTO `/Root/table-1`
+                SELECT key + 2u AS key, value + 2u AS value
+                FROM `/Root/table-2`;
+            )");
+
+        // Wait until it also tries to commit
+        WaitFor(runtime, [&]{ return blockedPuts.size() > 0; }, "blocked puts");
+
+        // Now unblock the first upsert puts
+        blockCommits.Remove();
+        for (auto& ev : firstUpsertPuts) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        firstUpsertPuts.clear();
+
+        // And wait for it to finish successfully
+        Cerr << "... waiting for first upsert result" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            FormatResult(AwaitResponse(runtime, std::move(firstUpsertFuture))),
+            "<empty>");
+
+        // Reply to everything previously blocked with an error, the shard will restart
+        for (auto& ev : blockedPuts) {
+            auto proxy = ev->Recipient;
+            ui32 groupId = GroupIDFromBlobStorageProxyID(proxy);
+            auto res = ev->Get()->MakeErrorResponse(NKikimrProto::ERROR, "Something went wrong", groupId);
+            runtime.Send(new IEventHandle(ev->Sender, proxy, res.release()), 0, true);
+        }
+
+        // Wait for the volatile tx result
+        Cerr << "... waiting for volatile tx result" << Endl;
+        auto result = FormatResult(AwaitResponse(runtime, std::move(volatileFuture)));
+        if (result == "<empty>") {
+            // A success result is not ok now, but in the future we might migrate state
+            // Check that the supposedly committed row actually exists
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, R"(
+                    SELECT key, value FROM `/Root/table-1` ORDER BY key;
+                    )"),
+                "{ items { uint32_value: 1 } items { uint32_value: 10 } }, "
+                "{ items { uint32_value: 3 } items { uint32_value: 30 } }, "
+                "{ items { uint32_value: 4 } items { uint32_value: 22 } }");
+        } else {
+            // Otherwise the result must be undetermined
+            UNIT_ASSERT_VALUES_EQUAL(result, "ERROR: UNDETERMINED");
+        }
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardVolatile)
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/finish_propose_unit.cpp
+++ b/ydb/core/tx/datashard/finish_propose_unit.cpp
@@ -99,8 +99,11 @@ EExecutionStatus TFinishProposeUnit::Execute(TOperation::TPtr op,
         op->SetFinishProposeTs(DataShard.ConfirmReadOnlyLease());
     }
 
-    if (!op->HasResultSentFlag() && (op->IsDirty() || op->HasVolatilePrepareFlag() || !Pipeline.WaitCompletion(op)))
+    if (!op->HasResultSentFlag() && (op->IsDirty() || op->HasVolatilePrepareFlag() || !Pipeline.WaitCompletion(op))) {
+        DataShard.IncCounter(COUNTER_PREPARE_COMPLETE);
+        op->SetProposeResultSentEarly();
         CompleteRequest(op, ctx);
+    }
 
     if (!DataShard.IsFollower())
         DataShard.PlanCleanup(ctx);
@@ -128,7 +131,7 @@ EExecutionStatus TFinishProposeUnit::Execute(TOperation::TPtr op,
 void TFinishProposeUnit::Complete(TOperation::TPtr op,
                                   const TActorContext &ctx)
 {
-    if (!op->HasResultSentFlag()) {
+    if (!op->HasResultSentFlag() && !op->IsProposeResultSentEarly()) {
         DataShard.IncCounter(COUNTER_PREPARE_COMPLETE);
 
         if (op->Result())

--- a/ydb/core/tx/datashard/finish_propose_write_unit.cpp
+++ b/ydb/core/tx/datashard/finish_propose_write_unit.cpp
@@ -97,8 +97,11 @@ EExecutionStatus TFinishProposeWriteUnit::Execute(TOperation::TPtr op,
         op->SetFinishProposeTs(DataShard.ConfirmReadOnlyLease());
     }
 
-    if (!op->HasResultSentFlag() && (op->IsDirty() || op->HasVolatilePrepareFlag() || !Pipeline.WaitCompletion(op)))
+    if (!op->HasResultSentFlag() && (op->IsDirty() || op->HasVolatilePrepareFlag() || !Pipeline.WaitCompletion(op))) {
+        DataShard.IncCounter(COUNTER_PREPARE_COMPLETE);
+        op->SetProposeResultSentEarly();
         CompleteRequest(op, ctx);
+    }
 
     if (!DataShard.IsFollower())
         DataShard.PlanCleanup(ctx);
@@ -127,7 +130,7 @@ void TFinishProposeWriteUnit::Complete(TOperation::TPtr op, const TActorContext 
 {
     TWriteOperation* writeOp = TWriteOperation::CastWriteOperation(op);
 
-    if (!op->HasResultSentFlag()) {
+    if (!op->HasResultSentFlag() && !op->IsProposeResultSentEarly()) {
         DataShard.IncCounter(COUNTER_WRITE_COMPLETE);
 
         if (writeOp->GetWriteResult())

--- a/ydb/core/tx/datashard/operation.h
+++ b/ydb/core/tx/datashard/operation.h
@@ -402,11 +402,14 @@ public:
 
     bool IsMvccSnapshotRead() const { return !MvccSnapshot.IsMax(); }
     const TRowVersion& GetMvccSnapshot() const { return MvccSnapshot; }
-    bool IsMvccSnapshotRepeatable() const { return MvccSnapshotRepeatable; }
+    bool IsMvccSnapshotRepeatable() const { return MvccSnapshotRepeatable_; }
     void SetMvccSnapshot(const TRowVersion& snapshot, bool isRepeatable = true) {
         MvccSnapshot = snapshot;
-        MvccSnapshotRepeatable = isRepeatable;
+        MvccSnapshotRepeatable_ = isRepeatable;
     }
+
+    bool IsProposeResultSentEarly() const { return ProposeResultSentEarly_; }
+    void SetProposeResultSentEarly(bool value = true) { ProposeResultSentEarly_ = value; }
 
     ///////////////////////////////////
     //     DEBUG AND MONITORING      //
@@ -429,7 +432,11 @@ protected:
 
     TSnapshotKey AcquiredSnapshotKey;
     TRowVersion MvccSnapshot = TRowVersion::Max();
-    bool MvccSnapshotRepeatable = false;
+
+private:
+    // Runtime flags
+    ui8 MvccSnapshotRepeatable_ : 1 = 0;
+    ui8 ProposeResultSentEarly_ : 1 = 0;
 };
 
 struct TRSData {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix volatile result sent before it is fully committed.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

A rare failure was detected with Jepsen when volatile transactions feature is enabled and used. Investigation showed that YDB would sometimes reply SUCCESS to a commit that has actually failed. The underlying issue is that since volatile transactions are prepared in-memory, a PREPARED reply is sent very early in the pipeline, before the (readonly) propose transaction is committed (which is expected, volatile transactions don't have storage in their critical path until they are executed). When storage is a bit slow the volatile transaction may be fast enough to plan and execute while a previous localdb transaction is still committing. When propose localdb transaction finally commits it would erroneously observe the new operation result (which optimistically has SUCCESS while it is waiting for localdb commit and other participants), and would send it thinking this is a propose phase result. The localdb commit with execution side effects may fail however, but the SUCCESS result has already been sent by that time. This is fixed by marking operations that send propose result early, and ignoring operation result on propose completion in such operations.

Fixes KIKIMR-21156. Merges #2505. Merges #2598.