### PR TITLE
redefine ToString() for TEvSchemeShard::TEvDescribeSchemeResult

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard.h
+++ b/ydb/core/tx/schemeshard/schemeshard.h
@@ -337,6 +337,20 @@ struct TEvSchemeShard {
             Record.SetPathId(pathId.LocalPathId);
             Record.SetPathOwnerId(pathId.OwnerId);
         }
+
+        // TEventPreSerializedPB::ToString() calls TEventPreSerializedPB::GetRecord()
+        // which reconstructs full message by deserializing PreSerializedData.
+        // That could be expensive for NKikimrScheme::TEvDescribeSchemeResult (e.g.
+        // table with huge number of partitions).
+        // Override ToString() to avoid unintentional message reconstruction.
+        TString ToString() const override {
+            TStringStream str;
+            str << ToStringHeader()
+                << " PreSerializedData size# " << PreSerializedData.size()
+                << " Record# " << Record.ShortDebugString()
+            ;
+            return str.Str();
+        }
     };
 
     struct TEvDescribeSchemeResultBuilder : TEvDescribeSchemeResult {


### PR DESCRIPTION
To avoid accidental deserialization of the possibly huge message.

Closes #2672

### Changelog category

* Not for changelog
