### PR TITLE
Enable quoting disk space usage by storage pool kind

### DIFF
--- a/ydb/core/cms/console/console_ut_tenants.cpp
+++ b/ydb/core/cms/console/console_ut_tenants.cpp
@@ -90,6 +90,20 @@ TTenantTestConfig DefaultConsoleTestConfig()
     return res;
 }
 
+TString DefaultDatabaseQuotas() {
+    return R"(
+        data_size_hard_quota: 3000
+        storage_quotas {
+            unit_kind: "hdd"
+            data_size_hard_quota: 2000
+        }
+        storage_quotas {
+            unit_kind: "hdd-1"
+            data_size_hard_quota: 1000
+        }
+    )";
+}
+
 void CheckAlterTenantSlots(TTenantTestRuntime &runtime, const TString &path,
                            ui64 generation, Ydb::StatusIds::StatusCode code,
                            TVector<TSlotRequest> add,
@@ -2026,6 +2040,58 @@ Y_UNIT_TEST_SUITE(TConsoleTests) {
     Y_UNIT_TEST(TestAlterTenantTooManyStorageResourcesForRunningExtSubdomain) {
         TTenantTestRuntime runtime(DefaultConsoleTestConfig(), {}, true);
         RunTestAlterTenantTooManyStorageResourcesForRunning(runtime);
+    }
+
+    void RunTestDatabaseQuotas(TTenantTestRuntime& runtime, const TString& quotas, bool shared = false) {
+        using EType = TCreateTenantRequest::EType;
+
+        CheckCreateTenant(runtime, Ydb::StatusIds::SUCCESS,
+            TCreateTenantRequest(TENANT1_1_NAME, shared ? EType::Shared : EType::Common)
+                .WithPools({{"hdd", 1}, {"hdd-1", 1}})
+                .WithDatabaseQuotas(quotas)
+        );
+
+        RestartTenantPool(runtime);
+
+        CheckTenantStatus(runtime, TENANT1_1_NAME, shared, Ydb::StatusIds::SUCCESS,
+                          Ydb::Cms::GetDatabaseStatusResult::RUNNING,
+                          {{"hdd", 1, 1}, {"hdd-1", 1, 1}}, {});
+    }
+
+    Y_UNIT_TEST(TestDatabaseQuotas) {
+        TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+        RunTestDatabaseQuotas(runtime, DefaultDatabaseQuotas());
+    }
+
+    Y_UNIT_TEST(TestDatabaseQuotasBadOverallQuota) {
+        TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+
+        CheckCreateTenant(runtime, Ydb::StatusIds::BAD_REQUEST,
+            TCreateTenantRequest(TENANT1_1_NAME, TCreateTenantRequest::EType::Common)
+                .WithPools({{"hdd", 1}})
+                .WithDatabaseQuotas(R"(
+                        data_size_hard_quota: 1
+                        data_size_soft_quota: 1000
+                    )"
+                )
+        );
+    }
+
+    Y_UNIT_TEST(TestDatabaseQuotasBadStorageQuota) {
+        TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+
+        CheckCreateTenant(runtime, Ydb::StatusIds::BAD_REQUEST,
+            TCreateTenantRequest(TENANT1_1_NAME, TCreateTenantRequest::EType::Common)
+                .WithPools({{"hdd", 1}})
+                .WithDatabaseQuotas(R"(
+                        storage_quotas {
+                            unit_kind: "hdd"
+                            data_size_hard_quota: 1
+                            data_size_soft_quota: 1000
+                        }
+                    )"
+                )
+        );
     }
 }
 

--- a/ydb/core/protos/subdomains.proto
+++ b/ydb/core/protos/subdomains.proto
@@ -61,8 +61,17 @@ message TDiskSpaceUsage {
         optional uint64 UsedReserveSize = 4;
     }
 
+    message TStoragePoolUsage {
+        // in bytes
+        optional string PoolKind = 1;
+        optional uint64 TotalSize = 2;
+        optional uint64 DataSize = 3;
+        optional uint64 IndexSize = 4;
+    }
+
     optional TTables Tables = 1;
     optional TTopics Topics = 2;
+    repeated TStoragePoolUsage StoragePoolsUsage = 3;
 }
 
 message TDomainState {

--- a/ydb/core/protos/table_stats.proto
+++ b/ydb/core/protos/table_stats.proto
@@ -16,6 +16,15 @@ message TChannelStats {
     optional uint64 IndexSize = 3;
 }
 
+message TStoragePoolsStats {
+    message TPoolUsage {
+        optional string PoolKind = 1;
+        optional uint64 DataSize = 2;
+        optional uint64 IndexSize = 3;
+    }
+    repeated TPoolUsage PoolsUsage = 1;
+}
+
 message TTableStats {
     optional uint64 DataSize = 1; // both inMem and ondisk
     optional uint64 RowCount = 2; // both inMem and ondisk
@@ -55,4 +64,6 @@ message TTableStats {
     optional bool HasLoanedParts = 29;
 
     repeated TChannelStats Channels = 30;
+
+    optional TStoragePoolsStats StoragePools = 31;
 }

--- a/ydb/core/testlib/tenant_helpers.h
+++ b/ydb/core/testlib/tenant_helpers.h
@@ -96,6 +96,7 @@ struct TCreateTenantRequest {
     TString Path;
     EType Type;
     TAttrsCont Attrs;
+    Ydb::Cms::DatabaseQuotas DatabaseQuotas;
     // Common & Shared
     TPoolsCont Pools;
     TSlotsCont Slots;
@@ -113,6 +114,18 @@ struct TCreateTenantRequest {
 
     TSelf& WithAttrs(const TAttrsCont& attrs) {
         Attrs = attrs;
+        return *this;
+    }
+
+    TSelf& WithDatabaseQuotas(const Ydb::Cms::DatabaseQuotas& quotas) {
+        DatabaseQuotas = quotas;
+        return *this;
+    }
+
+    TSelf& WithDatabaseQuotas(const TString& quotas) {
+        Ydb::Cms::DatabaseQuotas parsedQuotas;
+        UNIT_ASSERT_C(NProtoBuf::TextFormat::ParseFromString(quotas, &parsedQuotas), quotas);
+        DatabaseQuotas = std::move(parsedQuotas);
         return *this;
     }
 
@@ -340,6 +353,8 @@ inline void CheckCreateTenant(TTenantTestRuntime &runtime,
     if (request.PlanResolution) {
         event->Record.MutableRequest()->mutable_options()->set_plan_resolution(request.PlanResolution);
     }
+    
+    event->Record.MutableRequest()->mutable_database_quotas()->CopyFrom(request.DatabaseQuotas);
 
     TAutoPtr<IEventHandle> handle;
     runtime.SendToConsole(event);
@@ -347,7 +362,7 @@ inline void CheckCreateTenant(TTenantTestRuntime &runtime,
     auto &operation = reply->Record.GetResponse().operation();
 
     if (operation.ready()) {
-        UNIT_ASSERT_VALUES_EQUAL(operation.status(), code);
+        UNIT_ASSERT_VALUES_EQUAL_C(operation.status(), code, operation.DebugString());
     } else {
         TString id = operation.id();
         auto *request = new NConsole::TEvConsole::TEvNotifyOperationCompletionRequest;

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -1831,7 +1831,12 @@ void ExecSQL(Tests::TServer::TPtr server,
     auto request = MakeSQLRequest(sql, dml);
     runtime.Send(new IEventHandle(NKqp::MakeKqpProxyID(runtime.GetNodeId()), sender, request.Release(), 0, 0, nullptr));
     auto ev = runtime.GrabEdgeEventRethrow<NKqp::TEvKqp::TEvQueryResponse>(sender);
-    UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetRef().GetYdbStatus(), code);
+    auto& response = ev->Get()->Record.GetRef();
+    auto& issues = response.GetResponse().GetQueryIssues();
+    UNIT_ASSERT_VALUES_EQUAL_C(response.GetYdbStatus(),
+                               code,
+                               issues.empty() ? response.DebugString() : issues.Get(0).DebugString()
+    );
 }
 
 std::unique_ptr<NEvents::TDataEvents::TEvWrite> MakeWriteRequest(ui64 txId, NKikimrDataEvents::TEvWrite::ETxMode txMode, NKikimrDataEvents::TEvWrite_TOperation::EOperationType operationType, const TTableId& tableId, const TVector<TShardedTableOptions::TColumn>& columns, ui32 rowCount, ui64 seed) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
@@ -258,6 +258,16 @@ VerifyParams(TParamsDelta* delta, const TPathId pathId, const TSubDomainInfo::TP
             }
         }
 
+        // storage pools quotas check
+        TString error;
+        if (const auto& effectivePools = requestedPools.empty()
+                ? actualPools
+                : requestedPools;
+            !CheckStorageQuotasKinds(input.GetDatabaseQuotas(), effectivePools, pathId.ToString(), error)
+        ) {
+            return paramError(error);
+        }
+
         std::set_difference(requestedPools.begin(), requestedPools.end(),
                             actualPools.begin(), actualPools.end(),
                             std::back_inserter(storagePoolsAdded));

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
@@ -287,6 +287,14 @@ public:
         }
 
         if (settings.HasDatabaseQuotas()) {
+            if (const auto& effectivePools = requestedPools.empty()
+                    ? actualPools
+                    : requestedPools;
+                !CheckStorageQuotasKinds(settings.GetDatabaseQuotas(), effectivePools, path.PathString(), errStr)
+            ) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                return result;
+            }
             alterData->SetDatabaseQuotas(settings.GetDatabaseQuotas());
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
@@ -295,6 +295,12 @@ public:
         }
 
         if (settings.HasDatabaseQuotas()) {
+            if (!requestedStoragePools.empty()
+                    && !CheckStorageQuotasKinds(settings.GetDatabaseQuotas(), requestedStoragePools, dstPath.PathString(), errStr)
+            ) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                return result;
+            }
             alter->SetDatabaseQuotas(settings.GetDatabaseQuotas());
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -515,11 +515,11 @@ void TSchemeShard::Handle(TEvDataShard::TEvPeriodicTableStats::TPtr& ev, const T
                                                      << " rowCount " << rowCount
                                                      << " cpuUsage " << tabletMetrics.GetCPU()/10000.0);
 
-    LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+    LOG_TRACE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                 "Got periodic table stats at tablet " << TabletID()
                                                      << " from shard " << datashardId
                                                      << " pathId " << pathId
-                                                     << " raw table stats:\n" << tableStats.DebugString());
+                                                     << " raw table stats:\n" << tableStats.ShortDebugString());
 
     TStatsId statsId(pathId, datashardId);
 

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -5,6 +5,32 @@
 #include <ydb/core/base/cputime.h>
 #include <ydb/core/protos/sys_view.pb.h>
 
+namespace {
+
+THashMap<ui32, TString> MapChannelsToStoragePoolKinds(const NActors::TActorContext& ctx,
+                                                      const NKikimr::TStoragePools& pools,
+                                                      const NKikimr::TChannelsBindings& bindings
+) {
+    THashMap<TString, TString> nameToKindMap(pools.size());
+    for (const auto& pool : pools) {
+        nameToKindMap.emplace(pool.GetName(), pool.GetKind());
+    }
+    THashMap<ui32, TString> channelsMapping(bindings.size());
+    for (ui32 channel = 0u; channel < bindings.size(); ++channel) {
+        if (const auto* poolKind = nameToKindMap.FindPtr(bindings[channel].GetStoragePoolName())) {
+            channelsMapping.emplace(channel, *poolKind);
+        } else {
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                        "MapChannelsToStoragePoolKinds: the subdomain has no info about the storage pool named "
+                            << bindings[channel].GetStoragePoolName()
+            );
+        }
+    }
+    return channelsMapping;
+}
+
+}
+
 namespace NKikimr {
 namespace NSchemeShard {
 
@@ -93,7 +119,7 @@ public:
     void ScheduleNextBatch(const TActorContext& ctx) override;
 
     template <typename T>
-    TPartitionStats PrepareStats(const TActorContext& ctx, const T& rec) const;
+    TPartitionStats PrepareStats(const TActorContext& ctx, const T& rec, const THashMap<ui32, TString>& channelsMapping = {}) const;
 };
 
 
@@ -125,7 +151,10 @@ THolder<TProposeRequest> MergeRequest(
 }
 
 template <typename T>
-TPartitionStats TTxStoreTableStats::PrepareStats(const TActorContext& ctx, const T& rec) const {
+TPartitionStats TTxStoreTableStats::PrepareStats(const TActorContext& ctx,
+                                                 const T& rec,
+                                                 const THashMap<ui32, TString>& channelsMapping
+) const {
     const auto& tableStats = rec.GetTableStats();
     const auto& tabletMetrics = rec.GetTabletMetrics();
 
@@ -137,6 +166,18 @@ TPartitionStats TTxStoreTableStats::PrepareStats(const TActorContext& ctx, const
     newStats.IndexSize = tableStats.GetIndexSize();
     newStats.LastAccessTime = TInstant::MilliSeconds(tableStats.GetLastAccessTime());
     newStats.LastUpdateTime = TInstant::MilliSeconds(tableStats.GetLastUpdateTime());
+    for (const auto& channelStats : tableStats.GetChannels()) {
+        if (const auto* poolKind = channelsMapping.FindPtr(channelStats.GetChannel())) {
+            auto& [dataSize, indexSize] = newStats.StoragePoolsStats[*poolKind];
+            dataSize += channelStats.GetDataSize();
+            indexSize += channelStats.GetIndexSize();
+        } else {
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                        "PrepareStats: the subdomain has no info about the datashard's channel "
+                            << channelStats.GetChannel()
+            );
+        }
+    }
 
     newStats.ImmediateTxCompleted = tableStats.GetImmediateTxCompleted();
     newStats.PlannedTxCompleted = tableStats.GetPlannedTxCompleted();
@@ -205,6 +246,12 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     }
 
     TShardIdx shardIdx = Self->TabletIdToShardIdx[datashardId];
+    const auto* shardInfo = Self->ShardInfos.FindPtr(shardIdx);
+    Y_ABORT_UNLESS(shardInfo, "ShardInfos does not know about the shardIdx returned by TabletIdToShardIdx.");
+    auto subDomainInfo = Self->ResolveDomainInfo(pathId);
+    const auto channelsMapping = MapChannelsToStoragePoolKinds(ctx,
+                                                               subDomainInfo->EffectiveStoragePools(),
+                                                               shardInfo->BindedChannels);
 
     LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                 "TTxStoreTableStats.PersistSingleStats: main stats from"
@@ -212,7 +259,7 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
                     << ", pathId: " << pathId << ", pathId map=" << Self->PathsById[pathId]->Name
                     << ", is column=" << isColumnTable << ", is olap=" << isOlapStore);
 
-    const TPartitionStats newStats = PrepareStats(ctx, rec);
+    const TPartitionStats newStats = PrepareStats(ctx, rec, channelsMapping);
 
     LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                "Add stats from shard with datashardId(TabletID)=" << datashardId << ", pathId " << pathId.LocalPathId
@@ -290,7 +337,6 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
 
     if (updateSubdomainInfo) {
         auto subDomainId = Self->ResolvePathIdForDomain(pathId);
-        auto subDomainInfo = Self->ResolveDomainInfo(pathId);
         subDomainInfo->AggrDiskSpaceUsage(Self, newAggrStats, oldAggrStats);
         if (subDomainInfo->CheckDiskSpaceQuotas(Self)) {
             Self->PersistSubDomainState(db, subDomainId, *subDomainInfo);
@@ -468,6 +514,12 @@ void TSchemeShard::Handle(TEvDataShard::TEvPeriodicTableStats::TPtr& ev, const T
                                                      << " dataSize " << dataSize
                                                      << " rowCount " << rowCount
                                                      << " cpuUsage " << tabletMetrics.GetCPU()/10000.0);
+
+    LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "Got periodic table stats at tablet " << TabletID()
+                                                     << " from shard " << datashardId
+                                                     << " pathId " << pathId
+                                                     << " raw table stats:\n" << tableStats.DebugString());
 
     TStatsId statsId(pathId, datashardId);
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -19,6 +19,40 @@
 
 #include <util/generic/algorithm.h>
 
+namespace {
+
+using TDiskSpaceQuotas = NKikimr::NSchemeShard::TSubDomainInfo::TDiskSpaceQuotas;
+using TQuotasPair = TDiskSpaceQuotas::TQuotasPair;
+using TStoragePoolUsage = NKikimr::NSchemeShard::TSubDomainInfo::TDiskSpaceUsage::TStoragePoolUsage;
+
+enum class EDiskUsageStatus {
+    AboveHardQuota,
+    InBetween,
+    BelowSoftQuota,
+};
+
+EDiskUsageStatus CheckStoragePoolsQuotas(const THashMap<TString, TStoragePoolUsage>& storagePoolsUsage,
+                                         const THashMap<TString, TQuotasPair>& storagePoolsQuotas
+) {
+    bool softQuotaExceeded = false;
+    for (const auto& [poolKind, usage] : storagePoolsUsage) {
+        if (const auto* quota = storagePoolsQuotas.FindPtr(poolKind)) {
+            const auto totalSize = usage.DataSize + usage.IndexSize;
+            if (quota->HardQuota && totalSize > quota->HardQuota) {
+                return EDiskUsageStatus::AboveHardQuota;
+            }
+            if (quota->SoftQuota && totalSize >= quota->SoftQuota) {
+                softQuotaExceeded = true;
+            }
+        }
+    }
+    return softQuotaExceeded
+            ? EDiskUsageStatus::InBetween
+            : EDiskUsageStatus::BelowSoftQuota;
+}
+
+}
+
 namespace NKikimr {
 namespace NSchemeShard {
 
@@ -44,6 +78,117 @@ void TSubDomainInfo::ApplyAuditSettings(const TSubDomainInfo::TMaybeAuditSetting
             AuditSettings = input;
         }
     }
+}
+
+TDiskSpaceQuotas TSubDomainInfo::GetDiskSpaceQuotas() const {
+    if (!DatabaseQuotas) {
+        return {};
+    }
+
+    ui64 hardQuota = DatabaseQuotas->data_size_hard_quota();
+    ui64 softQuota = DatabaseQuotas->data_size_soft_quota();
+
+    if (!softQuota) {
+        softQuota = hardQuota;
+    } else if (!hardQuota) {
+        hardQuota = softQuota;
+    }
+
+    THashMap<TString, TQuotasPair> storagePoolsQuotas;
+    for (const auto& storageQuota : DatabaseQuotas->storage_quotas()) {
+        ui64 unitHardQuota = storageQuota.data_size_hard_quota();
+        ui64 unitSoftQuota = storageQuota.data_size_soft_quota();
+
+        if (!unitSoftQuota) {
+            unitSoftQuota = unitHardQuota;
+        } else if (!unitHardQuota) {
+            unitHardQuota = unitSoftQuota;
+        }
+
+        storagePoolsQuotas.emplace(storageQuota.unit_kind(), TQuotasPair{
+                .HardQuota = unitHardQuota,
+                .SoftQuota = unitSoftQuota
+            }
+        );
+    }
+
+    return TDiskSpaceQuotas{hardQuota, softQuota, std::move(storagePoolsQuotas)};
+}
+
+bool TSubDomainInfo::CheckDiskSpaceQuotas(IQuotaCounters* counters) {
+    const auto changeSubdomainState = [&](EDiskUsageStatus diskUsage) {
+        if (diskUsage == EDiskUsageStatus::AboveHardQuota && !DiskQuotaExceeded) {
+            counters->ChangeDiskSpaceQuotaExceeded(+1);
+            DiskQuotaExceeded = true;
+            ++DomainStateVersion;
+            return true;
+        }
+        if (diskUsage == EDiskUsageStatus::BelowSoftQuota && DiskQuotaExceeded) {
+            counters->ChangeDiskSpaceQuotaExceeded(-1);
+            DiskQuotaExceeded = false;
+            ++DomainStateVersion;
+            return true;
+        }
+        return false;
+    };
+
+    auto quotas = GetDiskSpaceQuotas();
+    if (!quotas) {
+        return changeSubdomainState(EDiskUsageStatus::BelowSoftQuota);
+    }
+
+    ui64 totalUsage = TotalDiskSpaceUsage();
+    const auto storagePoolsUsageStatus = CheckStoragePoolsQuotas(DiskSpaceUsage.StoragePoolsUsage, quotas.StoragePoolsQuotas);
+
+    // Quota being equal to zero is treated as if there is no limit set on disk space usage.
+    const bool overallHardQuotaIsExceeded = quotas.HardQuota && totalUsage > quotas.HardQuota;
+    const bool someStoragePoolHardQuotaIsExceeded = !quotas.StoragePoolsQuotas.empty()
+                                                        && storagePoolsUsageStatus == EDiskUsageStatus::AboveHardQuota;
+    if (overallHardQuotaIsExceeded || someStoragePoolHardQuotaIsExceeded) {
+        return changeSubdomainState(EDiskUsageStatus::AboveHardQuota);
+    }
+
+    const bool totalUsageIsBelowOverallSoftQuota = !quotas.SoftQuota || totalUsage < quotas.SoftQuota;
+    const bool allStoragePoolsUsageIsBelowSoftQuota = quotas.StoragePoolsQuotas.empty()
+                                                          || storagePoolsUsageStatus == EDiskUsageStatus::BelowSoftQuota;
+    if (totalUsageIsBelowOverallSoftQuota && allStoragePoolsUsageIsBelowSoftQuota) {
+        return changeSubdomainState(EDiskUsageStatus::BelowSoftQuota);
+    }
+
+    return false;
+}
+
+void TSubDomainInfo::AggrDiskSpaceUsage(IQuotaCounters* counters, const TPartitionStats& newAggr, const TPartitionStats& oldAggr) {
+    DiskSpaceUsage.Tables.DataSize += (newAggr.DataSize - oldAggr.DataSize);
+    counters->ChangeDiskSpaceTablesDataBytes(newAggr.DataSize - oldAggr.DataSize);
+
+    DiskSpaceUsage.Tables.IndexSize += (newAggr.IndexSize - oldAggr.IndexSize);
+    counters->ChangeDiskSpaceTablesIndexBytes(newAggr.IndexSize - oldAggr.IndexSize);
+
+    i64 oldTotalBytes = DiskSpaceUsage.Tables.TotalSize;
+    DiskSpaceUsage.Tables.TotalSize = DiskSpaceUsage.Tables.DataSize + DiskSpaceUsage.Tables.IndexSize;
+    i64 newTotalBytes = DiskSpaceUsage.Tables.TotalSize;
+    counters->ChangeDiskSpaceTablesTotalBytes(newTotalBytes - oldTotalBytes);
+
+    for (const auto& [poolKind, newStoragePoolStats] : newAggr.StoragePoolsStats) {
+        const auto* oldStats = oldAggr.StoragePoolsStats.FindPtr(poolKind);
+        auto& storagePoolUsage = DiskSpaceUsage.StoragePoolsUsage[poolKind];
+        storagePoolUsage.DataSize += newStoragePoolStats.DataSize - (oldStats ? oldStats->DataSize : 0u);
+        storagePoolUsage.IndexSize += newStoragePoolStats.IndexSize - (oldStats ? oldStats->IndexSize : 0u);
+    }
+    for (const auto& [poolKind, oldStoragePoolStats] : oldAggr.StoragePoolsStats) {
+        if (const auto* newStats = newAggr.StoragePoolsStats.FindPtr(poolKind); !newStats) {
+            auto& storagePoolUsage = DiskSpaceUsage.StoragePoolsUsage[poolKind];
+            storagePoolUsage.DataSize -= oldStoragePoolStats.DataSize;
+            storagePoolUsage.IndexSize -= oldStoragePoolStats.IndexSize;
+        }
+    }
+}
+
+void TSubDomainInfo::AggrDiskSpaceUsage(const TTopicStats& newAggr, const TTopicStats& oldAggr) {
+    auto& topics = DiskSpaceUsage.Topics;
+    topics.DataSize += (newAggr.DataSize - oldAggr.DataSize);
+    topics.UsedReserveSize += (newAggr.UsedReserveSize - oldAggr.UsedReserveSize);
 }
 
 TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
@@ -1356,6 +1501,11 @@ void TTableInfo::SetPartitioning(TVector<TTableShardInfo>&& newPartitioning) {
         newAggregatedStats.RowCount += newStats.RowCount;
         newAggregatedStats.DataSize += newStats.DataSize;
         newAggregatedStats.IndexSize += newStats.IndexSize;
+        for (const auto& [poolKind, newStoragePoolStats] : newStats.StoragePoolsStats) {
+            auto& aggregatedStoragePoolStats = newAggregatedStats.StoragePoolsStats[poolKind];
+            aggregatedStoragePoolStats.DataSize += newStoragePoolStats.DataSize;
+            aggregatedStoragePoolStats.IndexSize += newStoragePoolStats.IndexSize;
+        }
         newAggregatedStats.InFlightTxCount += newStats.InFlightTxCount;
         cpuTotal += newStats.GetCurrentRawCpuUsage();
         newAggregatedStats.Memory += newStats.Memory;
@@ -1436,6 +1586,30 @@ void TAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartition
     Aggregated.RowCount += (newStats.RowCount - oldStats.RowCount);
     Aggregated.DataSize += (newStats.DataSize - oldStats.DataSize);
     Aggregated.IndexSize += (newStats.IndexSize - oldStats.IndexSize);
+    for (const auto& [poolKind, newStoragePoolStats] : newStats.StoragePoolsStats) {
+        auto* aggregatedStoragePoolStats = Aggregated.StoragePoolsStats.FindPtr(poolKind);
+        if (aggregatedStoragePoolStats) {
+            const auto* oldStoragePoolStats = oldStats.StoragePoolsStats.FindPtr(poolKind);
+
+            // Missing old stats for a particular storage pool are interpreted as if this data
+            // has just been written to the datashard and we need to increment the aggregate by the entire new stats' sizes.
+            aggregatedStoragePoolStats->DataSize += newStoragePoolStats.DataSize - (oldStoragePoolStats ? oldStoragePoolStats->DataSize : 0u);
+            aggregatedStoragePoolStats->IndexSize += newStoragePoolStats.IndexSize - (oldStoragePoolStats ? oldStoragePoolStats->IndexSize : 0u);
+        } else {
+            Aggregated.StoragePoolsStats.emplace(poolKind, newStoragePoolStats);
+        }
+    }
+    for (const auto& [poolKind, oldStoragePoolStats] : oldStats.StoragePoolsStats) {
+        if (const auto* newStoragePoolStats = newStats.StoragePoolsStats.FindPtr(poolKind); !newStoragePoolStats) {
+            auto* aggregatedStoragePoolStats = Aggregated.StoragePoolsStats.FindPtr(poolKind);
+            Y_ABORT_UNLESS(aggregatedStoragePoolStats, "Old stats are present, but they haven't been aggregated.");
+
+            // Missing new stats for a particular storage pool are interpreted as if this data
+            // has been removed from the datashard and we need to subtract the old stats' sizes from the aggregate.
+            aggregatedStoragePoolStats->DataSize -= oldStoragePoolStats.DataSize;
+            aggregatedStoragePoolStats->IndexSize -= oldStoragePoolStats.IndexSize;
+        }
+    }
     Aggregated.LastAccessTime = Max(Aggregated.LastAccessTime, newStats.LastAccessTime);
     Aggregated.LastUpdateTime = Max(Aggregated.LastUpdateTime, newStats.LastUpdateTime);
     Aggregated.ImmediateTxCompleted += (newStats.ImmediateTxCompleted - oldStats.ImmediateTxCompleted);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -226,6 +226,12 @@ struct TPartitionStats {
     ui64 DataSize = 0;
     ui64 IndexSize = 0;
 
+    struct TStoragePoolStats {
+        ui64 DataSize = 0;
+        ui64 IndexSize = 0;
+    };
+    THashMap<TString, TStoragePoolStats> StoragePoolsStats;
+
     TInstant LastAccessTime;
     TInstant LastUpdateTime;
     TDuration TxCompleteLag;
@@ -1452,14 +1458,29 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
             ui64 DataSize = 0;
             ui64 UsedReserveSize = 0;
         } Topics;
+
+        struct TStoragePoolUsage {
+            ui64 DataSize = 0;
+            ui64 IndexSize = 0;
+        };
+        THashMap<TString, TStoragePoolUsage> StoragePoolsUsage;
     };
 
     struct TDiskSpaceQuotas {
         ui64 HardQuota;
         ui64 SoftQuota;
 
+        struct TQuotasPair {
+            ui64 HardQuota;
+            ui64 SoftQuota;
+        };
+        THashMap<TString, TQuotasPair> StoragePoolsQuotas;
+
         explicit operator bool() const {
-            return HardQuota || SoftQuota;
+            return HardQuota || SoftQuota || AnyOf(StoragePoolsQuotas, [](const auto& storagePoolQuota) {
+                    return storagePoolQuota.second.HardQuota || storagePoolQuota.second.SoftQuota;
+                }
+            );
         }
     };
 
@@ -1744,21 +1765,6 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         return TDuration::Seconds(DatabaseQuotas->ttl_min_run_internal_seconds());
     }
 
-    TDiskSpaceQuotas GetDiskSpaceQuotas() const {
-        ui64 hardQuota = DatabaseQuotas ? DatabaseQuotas->data_size_hard_quota() : 0;
-        ui64 softQuota = DatabaseQuotas ? DatabaseQuotas->data_size_soft_quota() : 0;
-
-        if (hardQuota || softQuota) {
-            if (!softQuota) {
-                softQuota = hardQuota;
-            } else if (!hardQuota) {
-                hardQuota = softQuota;
-            }
-        }
-
-        return TDiskSpaceQuotas{ hardQuota, softQuota };
-    }
-
     static void CountDiskSpaceQuotas(IQuotaCounters* counters, const TDiskSpaceQuotas& quotas) {
         if (quotas.HardQuota != 0) {
             counters->ChangeDiskSpaceHardQuotaBytes(quotas.HardQuota);
@@ -1795,48 +1801,13 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         counters->ChangeStreamReservedStorageQuota(next - prev);
     }
 
+    TDiskSpaceQuotas GetDiskSpaceQuotas() const;
 
-    /**
-     * Checks current disk usage against disk quotas
-     *
-     * Returns true when DiskQuotaExceeded value has changed and needs to be
-     * persisted and pushed to scheme board.
-     */
-    bool CheckDiskSpaceQuotas(IQuotaCounters* counters) {
-        auto quotas = GetDiskSpaceQuotas();
-        if (!quotas) {
-            if (DiskQuotaExceeded) {
-                counters->ChangeDiskSpaceQuotaExceeded(-1);
-                DiskQuotaExceeded = false;
-                ++DomainStateVersion;
-                return true;
-            }
-            return false;
-        }
-
-        ui64 totalUsage = TotalDiskSpaceUsage();
-        if (totalUsage > quotas.HardQuota) {
-            if (!DiskQuotaExceeded) {
-                counters->ChangeDiskSpaceQuotaExceeded(+1);
-                DiskQuotaExceeded = true;
-                ++DomainStateVersion;
-                return true;
-            }
-            return false;
-        }
-
-        if (totalUsage < quotas.SoftQuota) {
-            if (DiskQuotaExceeded) {
-                counters->ChangeDiskSpaceQuotaExceeded(-1);
-                DiskQuotaExceeded = false;
-                ++DomainStateVersion;
-                return true;
-            }
-            return false;
-        }
-
-        return false;
-    }
+    /*
+    Checks current disk usage against disk quotas.
+    Returns true when DiskQuotaExceeded value has changed and needs to be persisted and pushed to scheme board.
+    */
+    bool CheckDiskSpaceQuotas(IQuotaCounters* counters);
 
     ui64 TotalDiskSpaceUsage() {
         return DiskSpaceUsage.Tables.TotalSize + (AppData()->FeatureFlags.GetEnableTopicDiskSubDomainQuota() ? GetPQAccountStorage() : 0);
@@ -2000,24 +1971,9 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         CoordinatorSelector = new TCoordinators(ProcessingParams);
     }
 
-    void AggrDiskSpaceUsage(IQuotaCounters* counters, const TPartitionStats& newAggr, const TPartitionStats& oldAggr = {}) {
-        DiskSpaceUsage.Tables.DataSize += (newAggr.DataSize - oldAggr.DataSize);
-        counters->ChangeDiskSpaceTablesDataBytes(newAggr.DataSize - oldAggr.DataSize);
+    void AggrDiskSpaceUsage(IQuotaCounters* counters, const TPartitionStats& newAggr, const TPartitionStats& oldAggr = {});
 
-        DiskSpaceUsage.Tables.IndexSize += (newAggr.IndexSize - oldAggr.IndexSize);
-        counters->ChangeDiskSpaceTablesIndexBytes(newAggr.IndexSize - oldAggr.IndexSize);
-
-        i64 oldTotalBytes = DiskSpaceUsage.Tables.TotalSize;
-        DiskSpaceUsage.Tables.TotalSize = DiskSpaceUsage.Tables.DataSize + DiskSpaceUsage.Tables.IndexSize;
-        i64 newTotalBytes = DiskSpaceUsage.Tables.TotalSize;
-        counters->ChangeDiskSpaceTablesTotalBytes(newTotalBytes - oldTotalBytes);
-    }
-
-    void AggrDiskSpaceUsage(const TTopicStats& newAggr, const TTopicStats& oldAggr = {}) {
-        auto& topics = DiskSpaceUsage.Topics;
-        topics.DataSize += (newAggr.DataSize - oldAggr.DataSize);
-        topics.UsedReserveSize += (newAggr.UsedReserveSize - oldAggr.UsedReserveSize);
-    }
+    void AggrDiskSpaceUsage(const TTopicStats& newAggr, const TTopicStats& oldAggr = {});
 
     const TDiskSpaceUsage& GetDiskSpaceUsage() const {
         return DiskSpaceUsage;

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -31,6 +31,14 @@ static void FillTableStats(NKikimrTableStats::TTableStats* stats, const TPartiti
     stats->SetRangeReadRows(tableStats.RangeReadRows);
 
     stats->SetPartCount(tableStats.PartCount);
+
+    auto* storagePoolsStats = stats->MutableStoragePools()->MutablePoolsUsage();
+    for (const auto& [poolKind, stats] : tableStats.StoragePoolsStats) {
+        auto* storagePoolStats = storagePoolsStats->Add();
+        storagePoolStats->SetPoolKind(poolKind);
+        storagePoolStats->SetDataSize(stats.DataSize);
+        storagePoolStats->SetIndexSize(stats.IndexSize);
+    }
 }
 
 static void FillTableMetrics(NKikimrTabletBase::TMetrics* metrics, const TPartitionStats& tableStats) {
@@ -707,6 +715,14 @@ void TPathDescriber::DescribeDomainRoot(TPathElement::TPtr pathEl) {
     diskSpaceUsage->MutableTopics()->SetAccountSize(subDomainInfo->GetPQAccountStorage());
     diskSpaceUsage->MutableTopics()->SetDataSize(subDomainInfo->GetDiskSpaceUsage().Topics.DataSize);
     diskSpaceUsage->MutableTopics()->SetUsedReserveSize(subDomainInfo->GetDiskSpaceUsage().Topics.UsedReserveSize);
+    auto* storagePoolsUsage = diskSpaceUsage->MutableStoragePoolsUsage();
+    for (const auto& [poolKind, usage] : subDomainInfo->GetDiskSpaceUsage().StoragePoolsUsage) {
+        auto* storagePoolUsage = storagePoolsUsage->Add();
+        storagePoolUsage->SetPoolKind(poolKind);
+        storagePoolUsage->SetDataSize(usage.DataSize);
+        storagePoolUsage->SetIndexSize(usage.IndexSize);
+        storagePoolUsage->SetTotalSize(usage.DataSize + usage.IndexSize);
+    }
 
     if (subDomainInfo->GetDeclaredSchemeQuotas()) {
         entry->MutableDeclaredSchemeQuotas()->CopyFrom(*subDomainInfo->GetDeclaredSchemeQuotas());

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -368,6 +368,9 @@ struct Schema : NIceDb::Schema {
 
         // PartCount, PartOwners & ShardState are volatile data
 
+        // Represented by NKikimrTableStats::TStoragePoolsStats.
+        struct StoragePoolsStats : Column<33, NScheme::NTypeIds::String> { using Type = TString; };
+
         using TKey = TableKey<TableOwnerId, TableLocalId, PartitionId>;
         using TColumns = TableColumns<
             TableOwnerId,
@@ -401,7 +404,8 @@ struct Schema : NIceDb::Schema {
             WriteIops,
             SearchHeight,
             FullCompactionTs,
-            MemDataSize
+            MemDataSize,
+            StoragePoolsStats
         >;
     };
 

--- a/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
+++ b/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 #include <ydb/core/protos/table_stats.pb.h>
 
 using namespace NKikimr;
@@ -124,6 +125,39 @@ void WaitAndCheckStatPersisted(
     eventAction = TTestActorRuntime::EEventAction::PROCESS;
 }
 
+void SetStatsObserver(TTestActorRuntime& runtime, const std::function<TTestActorRuntime::EEventAction()>& statsObserver) {
+    // capture original observer func by setting a dummy one
+    auto originalObserver = runtime.SetObserverFunc([](TAutoPtr<IEventHandle>&) {
+        return TTestActorRuntime::EEventAction::PROCESS;
+    });
+    // now set a custom observer backed up by the original
+    runtime.SetObserverFunc([originalObserver, statsObserver](TAutoPtr<IEventHandle>& ev) {
+        switch (ev->GetTypeRewrite()) {
+        case TEvDataShard::EvPeriodicTableStats:
+            return statsObserver();
+        default:
+            return originalObserver(ev);
+        }
+    });
+}
+
+TVector<ui64> GetTableShards(TTestActorRuntime& runtime,
+                             const TString& path
+) {
+    TVector<ui64> shards;
+    auto tableDescription = DescribePath(runtime, path, true);
+    for (const auto& part : tableDescription.GetPathDescription().GetTablePartitions()) {
+        shards.emplace_back(part.GetDatashardId());
+    }
+
+    return shards;
+}
+
+TTableId ResolveTableId(TTestActorRuntime& runtime, const TString& path) {
+    auto response = Navigate(runtime, path);
+    return response->ResultSet.at(0).TableId;
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TSchemeshardStatsBatchingTest) {
@@ -149,21 +183,10 @@ Y_UNIT_TEST_SUITE(TSchemeshardStatsBatchingTest) {
         GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
 
         auto eventAction = TTestActorRuntime::EEventAction::PROCESS;
-
-        // capture original observer func by setting dummy one
-        auto originalObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>&) {
-            return TTestActorRuntime::EEventAction::PROCESS;
-        });
-        // now set our observer backed up by original
-        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
-            switch (ev->GetTypeRewrite()) {
-            case TEvDataShard::EvPeriodicTableStats: {
+        SetStatsObserver(runtime, [&]() {
                 return eventAction;
             }
-            default:
-                return originalObserver(ev);
-            }
-        });
+        );
 
         ui64 txId = 1000;
 
@@ -197,22 +220,11 @@ Y_UNIT_TEST_SUITE(TSchemeshardStatsBatchingTest) {
 
         auto eventAction = TTestActorRuntime::EEventAction::PROCESS;
         ui64 statsCount = 0;
-
-        // capture original observer func by setting dummy one
-        auto originalObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>&) {
-            return TTestActorRuntime::EEventAction::PROCESS;
-        });
-        // now set our observer backed up by original
-        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
-            switch (ev->GetTypeRewrite()) {
-            case TEvDataShard::EvPeriodicTableStats: {
+        SetStatsObserver(runtime, [&]() {
                 ++statsCount;
                 return eventAction;
             }
-            default:
-                return originalObserver(ev);
-            }
-        });
+        );
 
         ui64 txId = 1000;
 
@@ -269,21 +281,10 @@ Y_UNIT_TEST_SUITE(TSchemeshardStatsBatchingTest) {
         GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
 
         auto eventAction = TTestActorRuntime::EEventAction::PROCESS;
-
-        // capture original observer func by setting dummy one
-        auto originalObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>&) {
-            return TTestActorRuntime::EEventAction::PROCESS;
-        });
-        // now set our observer backed up by original
-        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
-            switch (ev->GetTypeRewrite()) {
-            case TEvDataShard::EvPeriodicTableStats: {
+        SetStatsObserver(runtime, [&]() {
                 return eventAction;
             }
-            default:
-                return originalObserver(ev);
-            }
-        });
+        );
 
         ui64 txId = 1000;
 
@@ -594,3 +595,117 @@ Y_UNIT_TEST_SUITE(TSchemeshardStatsBatchingTest) {
     }
 
 };
+
+Y_UNIT_TEST_SUITE(TStoragePoolsStatsPersistence) {
+    Y_UNIT_TEST(SameAggregatedStatsAfterRestart) {
+        TTestBasicRuntime runtime;
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_DEBUG);
+
+        TTestEnvOptions opts;
+        opts.DisableStatsBatching(true);
+        opts.EnablePersistentPartitionStats(true);
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        
+        NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
+        NDataShard::gDbStatsDataSizeResolution = 1;
+        NDataShard::gDbStatsRowCountResolution = 1;
+
+        ui64 txId = 100;
+
+        TVector<TString> poolsKinds;
+        {
+            auto databaseDescription = DescribePath(runtime, "/MyRoot").GetPathDescription().GetDomainDescription();
+            UNIT_ASSERT_GE_C(databaseDescription.StoragePoolsSize(), 2u, databaseDescription.DebugString());
+            for (const auto& pool : databaseDescription.GetStoragePools()) {
+                poolsKinds.emplace_back(pool.GetKind());
+            }
+        }
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+                    Name: "SomeTable"
+                    Columns { Name: "key"   Type: "Uint32" FamilyName: "default"}
+                    Columns { Name: "value" Type: "Utf8"   FamilyName: "alternative"}
+                    KeyColumnNames: ["key"]
+                    PartitionConfig {
+                        ColumnFamilies {
+                            Name: "default"
+                            StorageConfig {
+                                SysLog { PreferredPoolKind: "%s" }
+                                Log { PreferredPoolKind: "%s" }
+                                Data { PreferredPoolKind: "%s" }
+                            }
+                        }
+                        ColumnFamilies {
+                            Name: "alternative"
+                            StorageConfig {
+                                Data { PreferredPoolKind: "%s" }
+                            }
+                        }
+                    }
+                )", poolsKinds[0].c_str(), poolsKinds[0].c_str(), poolsKinds[0].c_str(), poolsKinds[1].c_str()
+            )
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        auto shards = GetTableShards(runtime, "/MyRoot/SomeTable");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1);
+        auto& datashard = shards[0];
+        constexpr ui32 rowsCount = 100u;
+        for (ui32 i = 0u; i < rowsCount; ++i) {
+            UpdateRow(runtime, "SomeTable", i, "meaningless_value", datashard);
+        }
+
+        // compaction is necessary for storage pools' stats to appear in the periodic messages from datashards
+        UNIT_ASSERT_VALUES_EQUAL(NKikimr::CompactTable(runtime, datashard, ResolveTableId(runtime, "/MyRoot/SomeTable")).GetStatus(),
+                                 NKikimrTxDataShard::TEvCompactTableResult::OK
+        );
+        // we wait for at least 1 part count, because it means that the table has been compacted
+        WaitTableStats(runtime, datashard, 1, rowsCount).GetTableStats();
+
+        auto checkUsage = [&poolsKinds](ui64 totalUsage, const auto& poolUsage) {
+            if (IsIn(poolsKinds, poolUsage.GetPoolKind())) {
+                UNIT_ASSERT_GT_C(totalUsage, 0, poolUsage.DebugString());
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL_C(totalUsage, 0, poolUsage.DebugString());
+            }
+        };
+        const auto expectedTableStats = DescribePath(runtime, "/MyRoot/SomeTable").GetPathDescription().GetTableStats();
+        UNIT_ASSERT_GT_C(expectedTableStats.GetStoragePools().PoolsUsageSize(), 0, expectedTableStats.DebugString());
+        for (const auto& poolUsage : expectedTableStats.GetStoragePools().GetPoolsUsage()) {
+            checkUsage(poolUsage.GetDataSize() + poolUsage.GetIndexSize(), poolUsage);
+        }
+        const auto expectedDatabaseStats = DescribePath(runtime, "/MyRoot").GetPathDescription().GetDomainDescription().GetDiskSpaceUsage();
+        UNIT_ASSERT_GT_C(expectedDatabaseStats.StoragePoolsUsageSize(), 0, expectedDatabaseStats.DebugString());
+        for (const auto& poolUsage : expectedDatabaseStats.GetStoragePoolsUsage()) {
+            checkUsage(poolUsage.GetTotalSize(), poolUsage);
+        }
+
+        // will be used to turn off table stats processing in SchemeShard
+        auto statsEventAction = TTestActorRuntime::EEventAction::PROCESS;
+        SetStatsObserver(runtime, [&]() {
+                return statsEventAction;
+            }
+        );
+
+        // drop any further stat updates and restart SS
+        // the only way for SS to know proper stat is to read it from localDB
+        statsEventAction = TTestActorRuntime::EEventAction::DROP;
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        auto tableStats = DescribePath(runtime, "/MyRoot/SomeTable").GetPathDescription().GetTableStats();
+        auto databaseStats = DescribePath(runtime, "/MyRoot").GetPathDescription().GetDomainDescription().GetDiskSpaceUsage();
+
+        using google::protobuf::util::MessageDifferencer;
+        MessageDifferencer differencer;
+        TString diff;
+        differencer.ReportDifferencesToString(&diff);
+        differencer.set_repeated_field_comparison(MessageDifferencer::RepeatedFieldComparison::AS_SET);
+        UNIT_ASSERT_C(differencer.Compare(tableStats.GetStoragePools(), expectedTableStats.GetStoragePools()), diff);
+        UNIT_ASSERT_C(differencer.Compare(databaseStats, expectedDatabaseStats), diff);
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_stats/ya.make
+++ b/ydb/core/tx/schemeshard/ut_stats/ya.make
@@ -19,6 +19,7 @@ PEERDIR(
     ydb/core/cms
     ydb/core/testlib/default
     ydb/core/tx
+    ydb/core/tx/datashard/ut_common
     ydb/core/tx/schemeshard/ut_helpers
     ydb/core/wrappers/ut_helpers
 )

--- a/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/persqueue/events/internal.h>
 
 #include <ydb/core/protos/blockstore_config.pb.h>
+#include <ydb/core/protos/table_stats.pb.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -73,11 +74,176 @@ NLs::TCheckFunc LsCheckSubDomainParamsInMassiveCase(const TString name = "",
     };
 }
 
-NLs::TCheckFunc LsCheckDiskQuotaExceeded(bool value = true, TString msg = TString()) {
+NLs::TCheckFunc LsCheckDiskQuotaExceeded(
+    bool expectExceeded = true,
+    const TString& debugHint = ""
+) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
         auto& desc = record.GetPathDescription().GetDomainDescription();
-        UNIT_ASSERT_VALUES_EQUAL_C(desc.GetDomainState().GetDiskQuotaExceeded(), value, msg);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            desc.GetDomainState().GetDiskQuotaExceeded(),
+            expectExceeded,
+            debugHint << ", subdomain's disk space usage:\n" << desc.GetDiskSpaceUsage().DebugString()
+        );
     };
+}
+
+enum class EDiskUsageStatus {
+    AboveHardQuota,
+    InBetween,
+    BelowSoftQuota,
+};
+
+template <>
+void Out<EDiskUsageStatus>(IOutputStream& o, EDiskUsageStatus status) {
+    o << static_cast<int>(status);
+}
+
+struct TQuotasPair {
+    ui64 HardQuota = 0;
+    ui64 SoftQuota = 0;
+};
+
+TMap<TString, EDiskUsageStatus> CheckStoragePoolsQuotas(const THashMap<TString, ui64>& storagePoolsUsage,
+                                                        const THashMap<TString, TQuotasPair>& storagePoolsQuotas
+) {
+    TMap<TString, EDiskUsageStatus> exceeders;
+    for (const auto& [poolKind, totalSize] : storagePoolsUsage) {
+        if (const auto* quota = storagePoolsQuotas.FindPtr(poolKind)) {
+            if (quota->HardQuota && totalSize > quota->HardQuota) {
+                exceeders.emplace(poolKind, EDiskUsageStatus::AboveHardQuota);
+            } else if (quota->SoftQuota && totalSize >= quota->SoftQuota) {
+                exceeders.emplace(poolKind, EDiskUsageStatus::InBetween);
+            }
+        }
+    }
+    return exceeders;
+}
+
+ui64 GetTotalDiskUsage(const NKikimrSubDomains::TDiskSpaceUsage& usage) {
+    const auto& tables = usage.GetTables();
+    const auto& topics = usage.GetTopics();
+    return tables.GetTotalSize() + topics.GetAccountSize();
+}
+
+constexpr const char* EntireDatabaseTag = "entire_database";
+
+NLs::TCheckFunc LsCheckDiskQuotaExceeded(
+    const TMap<TString, EDiskUsageStatus>& expectedExceeders,
+    const TString& debugHint = ""
+) {
+    return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
+        auto& desc = record.GetPathDescription().GetDomainDescription();
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            desc.GetDomainState().GetDiskQuotaExceeded(),
+            !expectedExceeders.empty(),
+            debugHint << ", subdomain's disk space usage:\n" << desc.GetDiskSpaceUsage().DebugString()
+        );
+
+        if (!expectedExceeders.empty()) {
+            const auto& receivedUsage = desc.GetDiskSpaceUsage();
+            THashMap<TString, ui64> parsedUsage;
+            for (const auto& poolUsage : receivedUsage.GetStoragePoolsUsage()) {
+                parsedUsage.emplace(poolUsage.GetPoolKind(),
+                                    poolUsage.GetDataSize() + poolUsage.GetIndexSize()
+                );
+            }
+            UNIT_ASSERT_C(!parsedUsage.contains(EntireDatabaseTag), EntireDatabaseTag << " is reserved");
+            parsedUsage.emplace(EntireDatabaseTag, GetTotalDiskUsage(receivedUsage));
+
+            const auto& receivedQuotas = desc.GetDatabaseQuotas();
+            THashMap<TString, TQuotasPair> parsedQuotas;
+            for (const auto& poolQuotas : receivedQuotas.storage_quotas()) {
+                parsedQuotas.emplace(poolQuotas.unit_kind(),
+                                     TQuotasPair{poolQuotas.data_size_hard_quota(),
+                                                 poolQuotas.data_size_soft_quota()
+                                     }
+                );
+            }
+            UNIT_ASSERT_C(!parsedQuotas.contains(EntireDatabaseTag), EntireDatabaseTag << " is reserved");
+            parsedQuotas.emplace(EntireDatabaseTag,
+                                 TQuotasPair{receivedQuotas.data_size_hard_quota(),
+                                             receivedQuotas.data_size_soft_quota()
+                                 }
+            );
+            
+            TMap<TString, EDiskUsageStatus> exceeders = CheckStoragePoolsQuotas(parsedUsage, parsedQuotas);
+            UNIT_ASSERT_VALUES_EQUAL_C(exceeders, expectedExceeders,
+                debugHint << ", subdomain's disk space usage:\n" << desc.GetDiskSpaceUsage().DebugString()
+            );
+        }
+    };
+}
+
+void CheckQuotaExceedance(TTestActorRuntime& runtime,
+                          ui64 schemeShard,
+                          const TString& pathToSubdomain,
+                          bool expectExceeded,
+                          const TString& debugHint = ""
+) {
+    TestDescribeResult(DescribePath(runtime, schemeShard, pathToSubdomain),
+                       { LsCheckDiskQuotaExceeded(expectExceeded, debugHint) }
+    );
+}
+
+void CheckQuotaExceedance(TTestActorRuntime& runtime,
+                          ui64 schemeShard,
+                          const TString& pathToSubdomain,
+                          const TMap<TString, EDiskUsageStatus>& expectedExceeders,
+                          const TString& debugHint = ""
+) {
+    TestDescribeResult(DescribePath(runtime, schemeShard, pathToSubdomain),
+                       { LsCheckDiskQuotaExceeded(expectedExceeders, debugHint) }
+    );
+}
+
+TVector<ui64> GetTableShards(TTestActorRuntime& runtime,
+                             ui64 schemeShard,
+                             const TString& path
+) {
+    TVector<ui64> shards;
+    const auto tableDescription = DescribePath(runtime, schemeShard, path, true);
+    for (const auto& part : tableDescription.GetPathDescription().GetTablePartitions()) {
+        shards.emplace_back(part.GetDatashardId());
+    }
+
+    return shards;
+}
+
+TTableId ResolveTableId(TTestActorRuntime& runtime, const TString& path) {
+    const auto response = Navigate(runtime, path);
+    return response->ResultSet.at(0).TableId;
+}
+
+NKikimrTxDataShard::TEvPeriodicTableStats WaitTableStats(TTestActorRuntime& runtime, ui64 datashardId, ui64 minPartCount = 0) {
+    NKikimrTxDataShard::TEvPeriodicTableStats stats;
+    bool captured = false;
+
+    auto observer = runtime.AddObserver<TEvDataShard::TEvPeriodicTableStats>([&](const auto& event) {
+            const auto& record = event->Get()->Record;
+            if (record.GetDatashardId() == datashardId && record.GetTableStats().GetPartCount() >= minPartCount) {
+                stats = record;
+                captured = true;
+            }
+        }
+    );
+
+    for (int i = 0; i < 5 && !captured; ++i) {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() { return captured; };
+        runtime.DispatchEvents(options, TDuration::Seconds(5));
+    }
+
+    observer.Remove();
+
+    UNIT_ASSERT(captured);
+
+    return stats;
+}
+
+void CompactTableAndCheckResult(TTestActorRuntime& runtime, ui64 shardId, const TTableId& tableId) {
+    const auto compactionResult = CompactTable(runtime, shardId, tableId);
+    UNIT_ASSERT_VALUES_EQUAL(compactionResult.GetStatus(), NKikimrTxDataShard::TEvCompactTableResult::OK);
 }
 
 Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
@@ -3192,3 +3358,343 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
     }
 }
 
+Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
+
+#define DEBUG_HINT (TStringBuilder() << "at line " << __LINE__)
+
+    Y_UNIT_TEST_FLAG(DisableWritesToDatabase, IsExternalSubdomain) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+
+        TTestEnvOptions opts;
+        opts.DisableStatsBatching(true);
+        opts.EnablePersistentPartitionStats(true);
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        
+        NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
+        NDataShard::gDbStatsDataSizeResolution = 1;
+        NDataShard::gDbStatsRowCountResolution = 1;
+
+        ui64 txId = 100;
+
+        // step 1: create a subdomain with a quoted storage pool
+        constexpr const char* databaseDescription = R"(
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+            StoragePools {
+                Name: "unquoted_storage_pool"
+                Kind: "unquoted_storage_pool_kind"
+            }
+            StoragePools {
+                Name: "quoted_storage_pool"
+                Kind: "quoted_storage_pool_kind"
+            }
+            DatabaseQuotas {
+                storage_quotas {
+                    unit_kind: "quoted_storage_pool_kind"
+                    data_size_hard_quota: 1
+                }
+            }
+        )";
+        if (IsExternalSubdomain) {
+            TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
+                    Name: "SomeDatabase"
+                )"
+            );
+            TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", TStringBuilder() << R"(
+                    Name: "SomeDatabase"
+                    ExternalSchemeShard: true
+                )" << databaseDescription
+            );
+        } else {
+            TestCreateSubDomain(runtime, ++txId,  "/MyRoot", TStringBuilder() << R"(
+                    Name: "SomeDatabase"
+                )" << databaseDescription
+            );
+        }
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/SomeDatabase"), {
+                NLs::PathExist,
+                IsExternalSubdomain ? NLs::IsExternalSubDomain("SomeDatabase") : NLs::IsSubDomain("SomeDatabase"),
+                LsCheckDiskQuotaExceeded(false, DEBUG_HINT)
+            }
+        );
+        ui64 tenantSchemeShard = TTestTxConfig::SchemeShard;
+        if (IsExternalSubdomain) {
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/SomeDatabase"), {
+                    NLs::ExtractTenantSchemeshard(&tenantSchemeShard)
+                }
+            );
+        }
+
+        // step 2: create a table inside the subdomain
+        TestCreateTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/SomeDatabase", R"(
+                Name: "SomeTable"
+                Columns { Name: "key"   Type: "Uint32" FamilyName: "default"}
+                Columns { Name: "value" Type: "Utf8"   FamilyName: "quoted_family"}
+                KeyColumnNames: ["key"]
+                PartitionConfig {
+                    ColumnFamilies {
+                        Name: "default"
+                        StorageConfig {
+                            SysLog { PreferredPoolKind: "unquoted_storage_pool_kind" }
+                            Log { PreferredPoolKind: "unquoted_storage_pool_kind" }
+                            Data { PreferredPoolKind: "unquoted_storage_pool_kind" }
+                        }
+                    }
+                    ColumnFamilies {
+                        Name: "quoted_family"
+                        StorageConfig {
+                            Data { PreferredPoolKind: "quoted_storage_pool_kind" }
+                        }
+                    }
+                }
+            )"
+        );
+        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
+        CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", false, DEBUG_HINT);
+
+        // step 3: insert data into the table
+        const auto shards = GetTableShards(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase/SomeTable");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1);
+        UpdateRow(runtime, "SomeTable", 1, "some_value_for_the_key", shards[0]);
+        {
+            const auto tableStats = WaitTableStats(runtime, shards[0]).GetTableStats();
+            // channels' usage statistics appears only after a table compaction 
+            UNIT_ASSERT_VALUES_EQUAL_C(tableStats.ChannelsSize(), 0, tableStats.DebugString());
+        }
+        CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", false, DEBUG_HINT);
+
+        // step 4: compact the table (statistics by channels does not appear in the messages from datashards otherwise)
+        const auto tableId = ResolveTableId(runtime, "/MyRoot/SomeDatabase/SomeTable");
+        CompactTableAndCheckResult(runtime, shards[0], tableId);
+        {
+            const auto tableStats = WaitTableStats(runtime, shards[0]).GetTableStats();
+            UNIT_ASSERT_GT_C(tableStats.ChannelsSize(), 0, tableStats.DebugString());
+        }
+        CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", true, DEBUG_HINT);
+
+        // step 5: drop the table
+        TestDropTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/SomeDatabase", "SomeTable");
+        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
+        CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", false, DEBUG_HINT);
+    }
+
+    Y_UNIT_TEST_FLAG(QuoteNonexistentPool, IsExternalSubdomain) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+
+        TTestEnvOptions opts;
+        TTestEnv env(runtime, opts);
+        
+        ui64 txId = 100;
+
+        constexpr const char* databaseDescription = R"(
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+            DatabaseQuotas {
+                storage_quotas {
+                    unit_kind: "nonexistent_storage_kind"
+                    data_size_hard_quota: 1
+                }
+            }
+        )";
+        if (IsExternalSubdomain) {
+            TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
+                    Name: "SomeDatabase"
+                )"
+            );
+            TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", TStringBuilder() << R"(
+                    Name: "SomeDatabase"
+                    ExternalSchemeShard: true
+                )" << databaseDescription,
+                {{ NKikimrScheme::StatusInvalidParameter }}
+            );
+        } else {
+            TestCreateSubDomain(runtime, ++txId,  "/MyRoot", R"(
+                    Name: "SomeDatabase"
+                )"
+            );
+            TestAlterSubDomain(runtime, ++txId,  "/MyRoot", TStringBuilder() << R"(
+                    Name: "SomeDatabase"
+                )" << databaseDescription,
+                {{ NKikimrScheme::StatusInvalidParameter }}
+            );
+        }
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+    }
+
+    // This test might start failing, because disk space usage of the created table might change
+    // due to changes in the storage implementation.
+    // To fix the test you need to update canonical quotas and / or batch sizes.
+    Y_UNIT_TEST_FLAG(DifferentQuotasInteraction, IsExternalSubdomain) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+
+        TTestEnvOptions opts;
+        opts.DisableStatsBatching(true);
+        opts.EnablePersistentPartitionStats(true);
+        opts.EnableBackgroundCompaction(false);
+        TTestEnv env(runtime, opts);
+        
+        NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
+        NDataShard::gDbStatsDataSizeResolution = 1;
+        NDataShard::gDbStatsRowCountResolution = 1;
+
+        ui64 txId = 100;
+
+        // Warning: calculated empirically, might need an update if the test fails.
+        // Test scenario that expects these particular quotas is described in the comments below.
+        const TString canonicalQuotas = Sprintf(R"(
+                DatabaseQuotas {
+                    data_size_hard_quota: %d
+                    data_size_soft_quota: %d
+                    storage_quotas {
+                        unit_kind: "fast_kind"
+                        data_size_hard_quota: %d
+                        data_size_soft_quota: %d
+                    }
+                    storage_quotas {
+                        unit_kind: "large_kind"
+                        data_size_hard_quota: %d
+                        data_size_soft_quota: %d
+                    }
+                }
+            )", 2800, 2200, 600, 500, 2200, 1700
+        );
+
+        // step 1: create a subdomain with a quoted storage pool
+        const TString databaseDescription = TStringBuilder() << R"(
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+            StoragePools {
+                Name: "fast"
+                Kind: "fast_kind"
+            }
+            StoragePools {
+                Name: "large"
+                Kind: "large_kind"
+            }
+        )" << canonicalQuotas;
+
+        if (IsExternalSubdomain) {
+            TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
+                    Name: "SomeDatabase"
+                )"
+            );
+            TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", TStringBuilder() << R"(
+                    Name: "SomeDatabase"
+                    ExternalSchemeShard: true
+                )" << databaseDescription
+            );
+        } else {
+            TestCreateSubDomain(runtime, ++txId,  "/MyRoot", TStringBuilder() << R"(
+                    Name: "SomeDatabase"
+                )" << databaseDescription
+            );
+        }
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/SomeDatabase"), {
+                NLs::PathExist,
+                IsExternalSubdomain ? NLs::IsExternalSubDomain("SomeDatabase") : NLs::IsSubDomain("SomeDatabase"),
+                LsCheckDiskQuotaExceeded(false, DEBUG_HINT)
+            }
+        );
+        ui64 tenantSchemeShard = TTestTxConfig::SchemeShard;
+        if (IsExternalSubdomain) {
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/SomeDatabase"), {
+                    NLs::ExtractTenantSchemeshard(&tenantSchemeShard)
+                }
+            );
+        }
+
+        // step 2: create a table inside the subdomain
+        TestCreateTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/SomeDatabase", R"(
+                Name: "SomeTable"
+                Columns { Name: "key"   Type: "Uint32" FamilyName: "default"}
+                Columns { Name: "value" Type: "Utf8"   FamilyName: "large"}
+                KeyColumnNames: ["key"]
+                PartitionConfig {
+                    ColumnFamilies {
+                        Name: "default"
+                        StorageConfig {
+                            SysLog { PreferredPoolKind: "fast_kind" }
+                            Log { PreferredPoolKind: "fast_kind" }
+                            Data { PreferredPoolKind: "fast_kind" }
+                        }
+                    }
+                    ColumnFamilies {
+                        Name: "large"
+                        StorageConfig {
+                            Data { PreferredPoolKind: "large_kind" }
+                        }
+                    }
+                }
+            )"
+        );
+        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
+        CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", false, DEBUG_HINT);
+
+        // step 3: insert data into the table in several batches
+        const auto shards = GetTableShards(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase/SomeTable");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1);
+        const auto tableId = ResolveTableId(runtime, "/MyRoot/SomeDatabase/SomeTable");
+
+        const auto updateAndCheck = [&](ui32 rowsToUpdate,
+                                        const TString& value,
+                                        bool compact,
+                                        const TMap<TString, EDiskUsageStatus>& expectedExceeders,
+                                        const TString& debugHint = ""
+        ) {
+            for (ui32 i = 0; i < rowsToUpdate; ++i) {
+                UpdateRow(runtime, "SomeTable", i, value, shards[0]);
+            }
+            if (compact) {
+                CompactTableAndCheckResult(runtime, shards[0], tableId);
+            }
+            WaitTableStats(runtime, shards[0]);
+            CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", expectedExceeders, debugHint);
+        };
+
+        // Warning: calculated empirically, might need an update if the test fails.
+        // The logic of the test expects:
+        // batchSizes[0] <= batchSizes[1] <= batchSizes[2],
+        // because rows are never deleted, only updated.
+        constexpr std::array<ui32, 3> batchSizes = {25, 35, 50};
+
+        constexpr const char* longText = "this_text_is_very_long_and_takes_a_lot_of_disk_space";
+        constexpr const char* middleLengthText = "this_text_is_significantly_shorter";
+
+        // Test scenario:
+        // 1) break only the entire database hard quota, don't break others,
+        updateAndCheck(batchSizes[0], longText, false, {{EntireDatabaseTag, EDiskUsageStatus::AboveHardQuota}}, DEBUG_HINT);
+        updateAndCheck(0, "", true, {}, DEBUG_HINT);
+
+        // 2) break only the large_kind hard quota, don't break other hard quotas,
+        updateAndCheck(batchSizes[1], longText, true,
+            {{"large_kind", EDiskUsageStatus::AboveHardQuota}, {EntireDatabaseTag, EDiskUsageStatus::InBetween}}, DEBUG_HINT
+        );
+        updateAndCheck(batchSizes[1], middleLengthText, true, {{"large_kind", EDiskUsageStatus::InBetween}}, DEBUG_HINT);
+        updateAndCheck(batchSizes[1], "extra_short_text", true, {}, DEBUG_HINT);
+
+        // 3) break only the fast_kind hard quota, don't break others.
+        updateAndCheck(batchSizes[2], "shortest", true, {{"fast_kind", EDiskUsageStatus::AboveHardQuota}}, DEBUG_HINT);
+
+        // step 4: drop the table
+        TestDropTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/SomeDatabase", "SomeTable");
+        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
+        CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", false, DEBUG_HINT);
+    }
+
+#undef DEBUG_HINT
+
+}

--- a/ydb/public/api/protos/ydb_cms.proto
+++ b/ydb/public/api/protos/ydb_cms.proto
@@ -94,6 +94,14 @@ message DatabaseQuotas {
     // A minimum value of `TtlSettings.run_interval_seconds` that can be specified.
     // Default is 1800 (15 minutes).
     uint32 ttl_min_run_internal_seconds = 4;
+    
+    message StorageQuotas {
+        // in theory an arbitrary string, but in practice HDD or SSD
+        string unit_kind = 1;
+        uint64 data_size_hard_quota = 2;
+        uint64 data_size_soft_quota = 3;
+    }
+    repeated StorageQuotas storage_quotas = 6;
 }
 
 // Request to create a new database. For successfull creation

--- a/ydb/public/api/protos/ydb_cms.proto
+++ b/ydb/public/api/protos/ydb_cms.proto
@@ -96,7 +96,7 @@ message DatabaseQuotas {
     uint32 ttl_min_run_internal_seconds = 4;
     
     message StorageQuotas {
-        // in theory an arbitrary string, but in practice HDD or SSD
+        // in theory an arbitrary string, but in practice "hdd" or "ssd"
         string unit_kind = 1;
         uint64 data_size_hard_quota = 2;
         uint64 data_size_soft_quota = 3;

--- a/ydb/services/ydb/ut/ya.make
+++ b/ydb/services/ydb/ut/ya.make
@@ -38,6 +38,7 @@ PEERDIR(
     library/cpp/svnversion
     ydb/core/kqp/ut/common
     ydb/core/testlib/default
+    ydb/core/tx/datashard/ut_common
     ydb/core/grpc_services/base
     ydb/core/testlib
     ydb/library/yql/minikql/dom

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -5,9 +5,11 @@
 #include <grpc++/create_channel.h>
 
 #include <ydb/core/base/storage_pools.h>
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/testlib/test_client.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 
 #include <ydb/public/api/grpc/ydb_scheme_v1.grpc.pb.h>
 #include <ydb/public/api/grpc/ydb_operation_v1.grpc.pb.h>
@@ -5443,6 +5445,210 @@ Y_UNIT_TEST(LocksFromAnotherTenants) {
                                        << " Issues: " << result.GetIssues().ToString());
     }
 }
+}
+
+Y_UNIT_TEST_SUITE(TDatabaseQuotas) {
+
+NKikimrConfig::TStoragePolicy CreateDefaultStoragePolicy(const TString& poolKind) {
+    NKikimrSchemeOp::TStorageConfig config;
+    config.MutableSysLog()->SetPreferredPoolKind(poolKind);
+    config.MutableLog()->SetPreferredPoolKind(poolKind);
+    config.MutableData()->SetPreferredPoolKind(poolKind);
+
+    NKikimrConfig::TStoragePolicy policy;
+    auto* family = policy.AddColumnFamilies();
+    *family->MutableStorageConfig() = std::move(config);
+
+    return policy;
+}
+
+NKikimrConfig::TTableProfilesConfig CreateDefaultTableProfilesConfig(const TString& poolKind) {
+    constexpr const char* name = "default";
+    NKikimrConfig::TTableProfilesConfig profiles;
+    {
+        auto* policy = profiles.AddStoragePolicies();
+        *policy = CreateDefaultStoragePolicy(poolKind);
+        policy->SetName(name);
+    }
+    {
+        auto* profile = profiles.AddTableProfiles();
+        profile->SetName(name);
+        profile->SetStoragePolicy(name);
+    }
+
+    return profiles;
+}
+
+void CompactTableAndCheckResult(TTestActorRuntime& runtime, ui64 shardId, const TTableId& tableId) {
+    auto compactionResult = CompactTable(runtime, shardId, tableId);
+    UNIT_ASSERT_VALUES_EQUAL(compactionResult.GetStatus(), NKikimrTxDataShard::TEvCompactTableResult::OK);
+}
+
+ui64 RunSchemeTx(
+        TTestActorRuntimeBase& runtime,
+        THolder<TEvTxUserProxy::TEvProposeTransaction>&& request,
+        TActorId sender = {},
+        bool viaActorSystem = false,
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus expectedStatus
+            = TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress
+) {
+    if (!sender) {
+        sender = runtime.AllocateEdgeActor();
+    }
+
+    runtime.Send(new IEventHandle(MakeTxProxyID(), sender, request.Release()), 0, viaActorSystem);
+    auto ev = runtime.GrabEdgeEventRethrow<TEvTxUserProxy::TEvProposeTransactionStatus>(sender);
+    UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetStatus(), expectedStatus);
+
+    return ev->Get()->Record.GetTxId();
+}
+
+THolder<TEvTxUserProxy::TEvProposeTransaction> SchemeTxTemplate(
+        NKikimrSchemeOp::EOperationType type,
+        const TString& workingDir
+) {
+    auto request = MakeHolder<TEvTxUserProxy::TEvProposeTransaction>();
+    request->Record.SetExecTimeoutPeriod(Max<ui64>());
+
+    auto& tx = *request->Record.MutableTransaction()->MutableModifyScheme();
+    tx.SetOperationType(type);
+    tx.SetWorkingDir(workingDir);
+
+    return request;
+}
+
+void WaitTxNotification(TServer::TPtr server, TActorId sender, ui64 txId) {
+    auto& runtime = *server->GetRuntime();
+    auto& settings = server->GetSettings();
+
+    auto request = MakeHolder<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletion>();
+    request->Record.SetTxId(txId);
+    auto tid = ChangeStateStorage(SchemeRoot, settings.Domain);
+    runtime.SendToPipe(tid, sender, request.Release(), 0, GetPipeConfigWithRetries());
+    runtime.GrabEdgeEventRethrow<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult>(sender);
+}
+
+void CreateSubdomain(TServer::TPtr server,
+                     TActorId sender,
+                     const TString& workingDir,
+                     const NKikimrSubDomains::TSubDomainSettings& settings
+) {
+    auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpCreateSubDomain, workingDir);
+
+    auto& tx = *request->Record.MutableTransaction()->MutableModifyScheme();
+    *tx.MutableSubDomain() = settings;
+
+    WaitTxNotification(server, sender, RunSchemeTx(*server->GetRuntime(), std::move(request), sender));
+}
+
+void AlterSubdomain(TServer::TPtr server,
+                    TActorId sender,
+                    const TString& workingDir,
+                    const NKikimrSubDomains::TSubDomainSettings& settings
+) {
+    auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpAlterSubDomain, workingDir);
+
+    auto& tx = *request->Record.MutableTransaction()->MutableModifyScheme();
+    *tx.MutableSubDomain() = settings;
+
+    // Don't wait for completion. It won't happen until the resources (i. e. dynamic nodes) are provided.
+    RunSchemeTx(*server->GetRuntime(), std::move(request), sender);
+}
+
+Y_UNIT_TEST(DisableWritesToDatabase) {
+    TPortManager portManager;
+    ui16 mbusPort = portManager.GetPort();
+    TServerSettings serverSettings(mbusPort);
+    serverSettings
+        .SetUseRealThreads(false)
+        .SetDynamicNodeCount(1)
+        .SetDomainName("Root");
+
+    TStoragePools storagePools = {{"/Root:ssd", "ssd"}, {"/Root:hdd", "hdd"}};
+    for (const auto& pool : storagePools) {
+        serverSettings.AddStoragePool(pool.GetKind(), pool.GetName());
+    }
+    NKikimrConfig::TAppConfig appConfig;
+    // default table profile with a storage policy is needed to be able to create a table with families
+    *appConfig.MutableTableProfilesConfig() = CreateDefaultTableProfilesConfig(storagePools[0].GetKind());
+    serverSettings.SetAppConfig(appConfig);
+
+    TServer::TPtr server = new TServer(serverSettings);
+    auto& runtime = *server->GetRuntime();
+    auto sender = runtime.AllocateEdgeActor();
+    InitRoot(server, sender);
+
+    runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+    NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
+    NDataShard::gDbStatsDataSizeResolution = 1;
+    NDataShard::gDbStatsRowCountResolution = 1;
+
+    TString tenant = "tenant";
+    TString tenantPath = Sprintf("/Root/%s", tenant.c_str());
+
+    CreateSubdomain(server, sender, "/Root", GetSubDomainDeclarationSetting(tenant));
+
+    auto subdomainSettings = GetSubDomainDefaultSetting(tenant, storagePools);
+    auto* parsedQuotas = subdomainSettings.MutableDatabaseQuotas();
+    constexpr const char* quotas = R"(
+        storage_quotas {
+            unit_kind: "hdd"
+            data_size_hard_quota: 1
+        }
+    )";
+    UNIT_ASSERT_C(NProtoBuf::TextFormat::ParseFromString(quotas, parsedQuotas), quotas);
+    AlterSubdomain(server, sender, "/Root", subdomainSettings);
+
+    TTenants tenants(server);
+    tenants.Run(tenantPath, 1);
+    
+    TString table = Sprintf("%s/table", tenantPath.c_str());
+    ExecSQL(server, sender, Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Utf8 FAMILY hdd,
+                    PRIMARY KEY (Key),
+                    FAMILY default (
+                        DATA = "ssd",
+                        COMPRESSION = "off"
+                    ),
+                    FAMILY hdd (
+                        DATA = "hdd",
+                        COMPRESSION = "lz4"
+                    )
+                );
+            )", table.c_str()
+        ), false
+    );
+
+    ExecSQL(server, sender, Sprintf(R"(
+                UPSERT INTO `%s` (Key, Value) VALUES (1u, "Foo");
+            )", table.c_str()
+        )
+    );
+
+    auto shards = GetTableShards(server, sender, table);
+    UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1);
+    auto& datashard = shards[0];
+    auto tableId = ResolveTableId(server, sender, table);
+
+    // Compaction is a must. Table stats are missing channels usage statistics until the table is compacted at least once.
+    CompactTableAndCheckResult(runtime, datashard, tableId);
+    WaitTableStats(runtime, datashard, 1);
+
+    ExecSQL(server, sender, Sprintf(R"(
+                UPSERT INTO `%s` (Key, Value) VALUES (2u, "Bar");
+            )", table.c_str()
+        ), true, Ydb::StatusIds::UNAVAILABLE
+    );
+    auto schemeEntry = Navigate(runtime, sender, tenantPath, NSchemeCache::TSchemeCacheNavigate::EOp::OpPath)->ResultSet.at(0);
+    UNIT_ASSERT_C(schemeEntry.DomainDescription, schemeEntry.ToString());
+    auto& domainDescription = schemeEntry.DomainDescription->Description;
+    UNIT_ASSERT_C(domainDescription.HasDomainState(), domainDescription.DebugString());
+    bool quotaExceeded = domainDescription.GetDomainState().GetDiskQuotaExceeded();
+    UNIT_ASSERT_C(quotaExceeded, domainDescription.DebugString());
+}
+
 }
 
 } // namespace NKikimr

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -6787,6 +6787,11 @@
                 "ColumnId": 32,
                 "ColumnName": "MemDataSize",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 33,
+                "ColumnName": "StoragePoolsStats",
+                "ColumnType": "String"
             }
         ],
         "ColumnsDropped": [],
@@ -6824,7 +6829,8 @@
                     29,
                     30,
                     31,
-                    32
+                    32,
+                    33
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
KIKIMR-18302

Users pay differently for HDD and SSD storage. They create storage pools differentiated by the underlying storage kind for their databases. Moreover, they can specify the preferred storage kind for each column in a table (see [column groups](https://ydb.tech/docs/en/yql/reference/syntax/create_table#column-family) in the docs for the CREATE TABLE statement).

However, up until this PR they didn't know, how much storage was used on each of the storage pool kinds. (And we didn't have storage pool kinds quotas to disable writes to the database, which exceeded the limit on one of its storage pools.)

We would like to provide users with an aggregate of the disk space usage of the database so they can order additional disks before the space is physically depleted. This is done by aggregating the [by channel disk space usage statistics](https://github.com/ydb-platform/ydb/blob/7a673cf01feefbe95bf5e7396d9179a5f283aeba/ydb/core/protos/table_stats.proto#L57) that the SchemeShard receives from the data shards (see [TEvPeriodicTableStats](https://github.com/ydb-platform/ydb/blob/7a673cf01feefbe95bf5e7396d9179a5f283aeba/ydb/core/protos/tx_datashard.proto#L789)). Channels are mapped to the corresponding storage pool kinds via the information that the SchemeShard has about the database (in code databases are subdomains) and the storage pools it was created with. Aggregation is done on two levels: by tables and by database. Aggregate by the table path can be seen in the UI in the path description of the table under the Describe -> PathDescription -> TableStats -> StoragePools field. Aggregate by the database can be seen in the UI in the Describe -> PathDescription -> DomainDescription -> DiskSpaceUsage -> StoragePoolsUsage field.

In addition, we implemented "storage_pools_quotas" that the user can specify in the "DatabaseQuotas" section of the config of the database that the user would like to create. There are 3 parameters in each [storage pool quota](https://github.com/jepett0/ydb/blob/a19c3b4dcc28fb1da6d04ecfb139ffdfe90c72fb/ydb/public/api/protos/ydb_cms.proto#L98):
- pool kind,
- hard quota (if any storage pool exceeds its hard quota, writes to the **whole** database (not just the storage pool that has exceeded the quota!) are restricted),
- soft quota (if all storage pools use less storage than the corresponding soft quota, then the database opens for writing again).

"storage_pools_quotas" can be used together with the existing ["data_size_hard_quota"](https://github.com/jepett0/ydb/blob/a19c3b4dcc28fb1da6d04ecfb139ffdfe90c72fb/ydb/public/api/protos/ydb_cms.proto#L82) and ["data_size_soft_quota"](https://github.com/jepett0/ydb/blob/a19c3b4dcc28fb1da6d04ecfb139ffdfe90c72fb/ydb/public/api/protos/ydb_cms.proto#L88) that do not differentiate between storage pools. Exceedance of __any__ hard quota (either the storage pool one, or the entire "data_size_hard_quota") disables writes to the database. To reenable writes, __all__ disk space usage (either the [storage pool one](https://github.com/jepett0/ydb/blob/a19c3b4dcc28fb1da6d04ecfb139ffdfe90c72fb/ydb/core/tx/schemeshard/schemeshard_info_types.h#L1460), or the aggregated [TotalSize](https://github.com/jepett0/ydb/blob/a19c3b4dcc28fb1da6d04ecfb139ffdfe90c72fb/ydb/core/tx/schemeshard/schemeshard_info_types.h#L1452)) must be below the corresponding soft quota.

One important thing to note about the storage pools usage statistics is that it is delivered to the SchemeShard with a considerable delay (about 1 minute). This means that the storage pools usage will be checked against the storage pools quotas with a delay and some data can be written above the hard limit. (And the other way around too: deleting some data to open the database for writes will be noticed by the SchemeShard with a considerable delay (about 420 seconds in my tests with a default compaction policy, I don't know where this number comes from). This is due to the fact that the new data is stored in the LSM tree (I guess) and is written to the appropriate storage pool later, after compaction.