### PR TITLE
Relax configuration requirements when starting `DatabaseAsyncResolver` from KQP

### DIFF
--- a/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
+++ b/ydb/core/kqp/federated_query/kqp_federated_query_helpers.cpp
@@ -120,10 +120,8 @@ namespace NKikimr::NKqp {
             YtGateway};
 
         // Init DatabaseAsyncResolver only if all requirements are met
-        if (DatabaseResolverActorId && 
-            GenericGatewaysConfig.HasMdbGateway() && 
-            GenericGatewaysConfig.HasYdbMvpEndpoint() && 
-            MdbEndpointGenerator) {
+        if (DatabaseResolverActorId && MdbEndpointGenerator &&
+            (GenericGatewaysConfig.HasMdbGateway() || GenericGatewaysConfig.HasYdbMvpEndpoint())) {
             result.DatabaseAsyncResolver = std::make_shared<NFq::TDatabaseAsyncResolverImpl>(
                 actorSystem,
                 DatabaseResolverActorId.value(),


### PR DESCRIPTION
### Changelog entry 

Relax configuration requirements when starting `DatabaseAsyncResolver` from KQP

### Changelog category <!-- remove all except one -->

* Not for changelog

