### PR TITLE
YQL-18027: Add block implementation for STRING_UDF

### DIFF
--- a/ydb/library/yql/tests/sql/dq_file/part13/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part13/canondata/result.json
@@ -2701,9 +2701,9 @@
     ],
     "test.test[view-system_udf--Debug]": [
         {
-            "checksum": "4c89feecc12bb761d7c286cd68f0a0d9",
-            "size": 1913,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql_patched"
+            "checksum": "713d145392bd9acad8aa842dea972c3c",
+            "size": 1926,
+            "uri": "https://{canondata_backend}/1903885/2da0f73cb9a37f1ac161dd6dc86492d6ea33f7da/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-system_udf--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part17/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part17/canondata/result.json
@@ -671,9 +671,9 @@
     ],
     "test.test[csee-yql-7237--Debug]": [
         {
-            "checksum": "b767adfc92f688e5a8de2beda8281abf",
-            "size": 5164,
-            "uri": "https://{canondata_backend}/1814674/596b6881e4e692acb2f60c77f02abe1dfca443e9/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql_patched"
+            "checksum": "5f2e95bf587ba9783b26f8c764c55343",
+            "size": 5177,
+            "uri": "https://{canondata_backend}/1937367/7b7d3406bd73e757a0d1fdeafae5df9757f3a7bc/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql_patched"
         }
     ],
     "test.test[csee-yql-7237--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part6/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part6/canondata/result.json
@@ -2775,9 +2775,9 @@
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Debug]": [
         {
-            "checksum": "a600c5cb3146df18222057da6013ff57",
-            "size": 3303,
-            "uri": "https://{canondata_backend}/1784826/fd4cc2f7af6fc79fb1fbaf0c17095673db944f7a/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql_patched"
+            "checksum": "671affd56e33dd6cac828a299255b11e",
+            "size": 3316,
+            "uri": "https://{canondata_backend}/1924537/c5db08849456fd743b1ee29541c5e4a60ede833f/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
@@ -617,9 +617,9 @@
     ],
     "test.test[csee-yql-7237--Debug]": [
         {
-            "checksum": "bafe318973c66327c44e0fe1a4297b63",
-            "size": 10675,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql_patched"
+            "checksum": "d41f93842f4edd4c9fc31395ffe70838",
+            "size": 10688,
+            "uri": "https://{canondata_backend}/1777230/216d4e6d62fea8f58776a41a12ef7ca23fab393c/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql_patched"
         }
     ],
     "test.test[csee-yql-7237--Plan]": [
@@ -2731,9 +2731,9 @@
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Debug]": [
         {
-            "checksum": "255119b18c8fc481cc8ac4797c43eeaa",
-            "size": 4387,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql_patched"
+            "checksum": "64a3b7027319e8dcc7a09ed4dcc533a0",
+            "size": 4400,
+            "uri": "https://{canondata_backend}/1777230/216d4e6d62fea8f58776a41a12ef7ca23fab393c/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part2/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part2/canondata/result.json
@@ -2647,9 +2647,9 @@
     ],
     "test.test[view-system_udf--Debug]": [
         {
-            "checksum": "5d2d6012880259ee1ec3ec07a648e71c",
-            "size": 2647,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql_patched"
+            "checksum": "1adbe5bf7421b8a95bf7be16d29a10f0",
+            "size": 2660,
+            "uri": "https://{canondata_backend}/1889210/2dae1c5fad742ec810acd62ae7ea2470f7db3f6e/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-system_udf--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part13/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part13/canondata/result.json
@@ -2682,9 +2682,9 @@
     ],
     "test.test[view-system_udf--Debug]": [
         {
-            "checksum": "54856668ae61fbe9841230f05cac3785",
-            "size": 1995,
-            "uri": "https://{canondata_backend}/212715/e1bc1d6e31fa656365a738e65224a7c3f774bae6/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql"
+            "checksum": "34a45459b156d0fec9414209c6f96d5f",
+            "size": 2008,
+            "uri": "https://{canondata_backend}/1937367/2da4c4972d9611e6d436df6f08563470944ebfa6/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql"
         }
     ],
     "test.test[view-system_udf--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part17/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part17/canondata/result.json
@@ -627,9 +627,9 @@
     ],
     "test.test[csee-yql-7237--Debug]": [
         {
-            "checksum": "6475d5d6a1a57e719cf52732c721ab9c",
-            "size": 9449,
-            "uri": "https://{canondata_backend}/1942173/13ba7b5baedaca7ddec0432ccede2666d8739ef4/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql"
+            "checksum": "3265bb2200dbebd0c5ed5f2b67ca4062",
+            "size": 9462,
+            "uri": "https://{canondata_backend}/1777230/396a1d533b924a50e79a9801559f809bbe35c7d0/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql"
         }
     ],
     "test.test[csee-yql-7237--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part6/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part6/canondata/result.json
@@ -2458,9 +2458,9 @@
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Debug]": [
         {
-            "checksum": "d5f2a3cb61003a4a54a1d627ee73b686",
-            "size": 3619,
-            "uri": "https://{canondata_backend}/1781765/c6c4741c6e6726e0705a9922b386a839af2165b7/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql"
+            "checksum": "05bd52192722ac8eab58b43a3c3b45e5",
+            "size": 3632,
+            "uri": "https://{canondata_backend}/1903885/c538922f8562634bbdc4a4aaa3f4496e1b9331b5/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql"
         }
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Plan]": [

--- a/ydb/library/yql/udfs/common/string/test/canondata/result.json
+++ b/ydb/library/yql/udfs/common/string/test/canondata/result.json
@@ -14,6 +14,11 @@
             "uri": "file://test.test_BlockFind_/results.txt"
         }
     ],
+    "test.test[BlockStringUDF]": [
+        {
+            "uri": "file://test.test_BlockStringUDF_/results.txt"
+        }
+    ],
     "test.test[ExtendAndTake]": [
         {
             "uri": "file://test.test_ExtendAndTake_/results.txt"
@@ -52,6 +57,11 @@
     "test.test[StreamFormat]": [
         {
             "uri": "file://test.test_StreamFormat_/results.txt"
+        }
+    ],
+    "test.test[StringUDF]": [
+        {
+            "uri": "file://test.test_StringUDF_/results.txt"
         }
     ],
     "test.test[To]": [

--- a/ydb/library/yql/udfs/common/string/test/canondata/test.test_BlockStringUDF_/results.txt
+++ b/ydb/library/yql/udfs/common/string/test/canondata/test.test_BlockStringUDF_/results.txt
@@ -1,0 +1,158 @@
+[
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "b32enc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "b64enc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "b64encu";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cunesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "xenc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "henc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "hdec";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cgesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cgunesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "clps";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "strp";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        "EAQCAILRO5SSA4TUPEQCAIDVNFXXAIC3EBOSI===";
+                        "ICAgIXF3ZSBydHkgICB1aW9wIFsgXSQ=";
+                        "ICAgIXF3ZSBydHkgICB1aW9wIFsgXSQ,";
+                        "   !qwe rty   uiop [ ]$";
+                        "   !qwe rty   uiop [ ]$";
+                        "202020217177652072747920202075696F70205B205D24";
+                        "   !qwe rty   uiop [ ]$";
+                        "   !qwe rty   uiop [ ]$";
+                        "+++!qwe+rty+++uiop+%5B+%5D$";
+                        "   !qwe rty   uiop [ ]$";
+                        " !qwe rty uiop [ ]$";
+                        "!qwe rty   uiop [ ]$"
+                    ];
+                    [
+                        "IBQXGIBAEAQCAIBAMRTGO2BANJVWYXDOHMTSKIBA";
+                        "QGFzICAgICAgIGRmZ2ggamtsXG47JyUgIA==";
+                        "QGFzICAgICAgIGRmZ2ggamtsXG47JyUgIA,,";
+                        "@as       dfgh jkl\\\\n;'%  ";
+                        "@as       dfgh jkl\n;'%  ";
+                        "4061732020202020202064666768206A6B6C5C6E3B27252020";
+                        "@as       dfgh jkl\\n;&#39;%  ";
+                        "@as       dfgh jkl\\n;'%  ";
+                        "@as+++++++dfgh+jkl%5Cn;%27%25++";
+                        "@as       dfgh jkl\\n;'%  ";
+                        "@as dfgh jkl\\n;'% ";
+                        "@as       dfgh jkl\\n;'%"
+                    ];
+                    [
+                        "EAQCAI32PBRQS5TCNYQASCQIEBWSYLRPH5PCAIBA";
+                        "ICAgI3p4Ywl2Ym4gCQoIIG0sLi8/XiAgIA==";
+                        "ICAgI3p4Ywl2Ym4gCQoIIG0sLi8_XiAgIA,,";
+                        "   #zxc\\tvbn \\t\\n\\x08 m,./?^   ";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        "202020237A78630976626E20090A08206D2C2E2F3F5E202020";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        "+++%23zxc%09vbn+%09%0A%08+m%2C./%3F%5E+++";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        " #zxc vbn \x08 m,./?^ ";
+                        "#zxc\tvbn \t\n\x08 m,./?^"
+                    ];
+                    [
+                        "GEQTEQBTEM2CINJFGZPDOJRYFI4SQMBJFVPT2KZMHQXD4===";
+                        "MSEyQDMjNCQ1JTZeNyY4KjkoMCktXz0rLDwuPg==";
+                        "MSEyQDMjNCQ1JTZeNyY4KjkoMCktXz0rLDwuPg,,";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "31213240332334243525365E3726382A392830292D5F3D2B2C3C2E3E";
+                        "1!2@3#4$5%6^7&amp;8*9(0)-_=+,&lt;.&gt;";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@3%234$5%256%5E7%268*9%280%29-_%3D%2B%2C%3C.%3E";
+                        "1!2@3#4$5%6^7&8*9(0)-_= ,<.>";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>"
+                    ]
+                ]
+            }
+        ]
+    }
+]

--- a/ydb/library/yql/udfs/common/string/test/canondata/test.test_StringUDF_/results.txt
+++ b/ydb/library/yql/udfs/common/string/test/canondata/test.test_StringUDF_/results.txt
@@ -1,0 +1,158 @@
+[
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "b32enc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "b64enc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "b64encu";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cunesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "xenc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "henc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "hdec";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cgesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "cgunesc";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "clps";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "strp";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        "EAQCAILRO5SSA4TUPEQCAIDVNFXXAIC3EBOSI===";
+                        "ICAgIXF3ZSBydHkgICB1aW9wIFsgXSQ=";
+                        "ICAgIXF3ZSBydHkgICB1aW9wIFsgXSQ,";
+                        "   !qwe rty   uiop [ ]$";
+                        "   !qwe rty   uiop [ ]$";
+                        "202020217177652072747920202075696F70205B205D24";
+                        "   !qwe rty   uiop [ ]$";
+                        "   !qwe rty   uiop [ ]$";
+                        "+++!qwe+rty+++uiop+%5B+%5D$";
+                        "   !qwe rty   uiop [ ]$";
+                        " !qwe rty uiop [ ]$";
+                        "!qwe rty   uiop [ ]$"
+                    ];
+                    [
+                        "IBQXGIBAEAQCAIBAMRTGO2BANJVWYXDOHMTSKIBA";
+                        "QGFzICAgICAgIGRmZ2ggamtsXG47JyUgIA==";
+                        "QGFzICAgICAgIGRmZ2ggamtsXG47JyUgIA,,";
+                        "@as       dfgh jkl\\\\n;'%  ";
+                        "@as       dfgh jkl\n;'%  ";
+                        "4061732020202020202064666768206A6B6C5C6E3B27252020";
+                        "@as       dfgh jkl\\n;&#39;%  ";
+                        "@as       dfgh jkl\\n;'%  ";
+                        "@as+++++++dfgh+jkl%5Cn;%27%25++";
+                        "@as       dfgh jkl\\n;'%  ";
+                        "@as dfgh jkl\\n;'% ";
+                        "@as       dfgh jkl\\n;'%"
+                    ];
+                    [
+                        "EAQCAI32PBRQS5TCNYQASCQIEBWSYLRPH5PCAIBA";
+                        "ICAgI3p4Ywl2Ym4gCQoIIG0sLi8/XiAgIA==";
+                        "ICAgI3p4Ywl2Ym4gCQoIIG0sLi8_XiAgIA,,";
+                        "   #zxc\\tvbn \\t\\n\\x08 m,./?^   ";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        "202020237A78630976626E20090A08206D2C2E2F3F5E202020";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        "+++%23zxc%09vbn+%09%0A%08+m%2C./%3F%5E+++";
+                        "   #zxc\tvbn \t\n\x08 m,./?^   ";
+                        " #zxc vbn \x08 m,./?^ ";
+                        "#zxc\tvbn \t\n\x08 m,./?^"
+                    ];
+                    [
+                        "GEQTEQBTEM2CINJFGZPDOJRYFI4SQMBJFVPT2KZMHQXD4===";
+                        "MSEyQDMjNCQ1JTZeNyY4KjkoMCktXz0rLDwuPg==";
+                        "MSEyQDMjNCQ1JTZeNyY4KjkoMCktXz0rLDwuPg,,";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "31213240332334243525365E3726382A392830292D5F3D2B2C3C2E3E";
+                        "1!2@3#4$5%6^7&amp;8*9(0)-_=+,&lt;.&gt;";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@3%234$5%256%5E7%268*9%280%29-_%3D%2B%2C%3C.%3E";
+                        "1!2@3#4$5%6^7&8*9(0)-_= ,<.>";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>"
+                    ]
+                ]
+            }
+        ]
+    }
+]

--- a/ydb/library/yql/udfs/common/string/test/cases/BlockStringUDF.in
+++ b/ydb/library/yql/udfs/common/string/test/cases/BlockStringUDF.in
@@ -1,0 +1,4 @@
+{"value"="   !qwe rty   uiop [ ]$"};
+{"value"="@as       dfgh jkl\\n;'\%  "};
+{"value"="   #zxc\tvbn \t\n\b m,./?^   "};
+{"value"="1!2@3#4$5%6^7&8*9(0)-_=+,<.>"};

--- a/ydb/library/yql/udfs/common/string/test/cases/BlockStringUDF.sql
+++ b/ydb/library/yql/udfs/common/string/test/cases/BlockStringUDF.sql
@@ -1,0 +1,17 @@
+/* XXX: Enable UseBlocks pragma and provide input to trigger block execution. */
+PRAGMA UseBlocks;
+
+SELECT
+    String::Base32Encode(value) as b32enc,
+    String::Base64Encode(value) as b64enc,
+    String::Base64EncodeUrl(value) as b64encu,
+    String::EscapeC(value) as cesc,
+    String::UnescapeC(value) as cunesc,
+    String::HexEncode(value) as xenc,
+    String::EncodeHtml(value) as henc,
+    String::DecodeHtml(value) as hdec,
+    String::CgiEscape(value) as cgesc,
+    String::CgiUnescape(value) as cgunesc,
+    String::Collapse(value) as clps,
+    String::Strip(value) as strp,
+FROM Input

--- a/ydb/library/yql/udfs/common/string/test/cases/StringUDF.in
+++ b/ydb/library/yql/udfs/common/string/test/cases/StringUDF.in
@@ -1,0 +1,4 @@
+{"value"="   !qwe rty   uiop [ ]$"};
+{"value"="@as       dfgh jkl\\n;'\%  "};
+{"value"="   #zxc\tvbn \t\n\b m,./?^   "};
+{"value"="1!2@3#4$5%6^7&8*9(0)-_=+,<.>"};

--- a/ydb/library/yql/udfs/common/string/test/cases/StringUDF.sql
+++ b/ydb/library/yql/udfs/common/string/test/cases/StringUDF.sql
@@ -1,0 +1,14 @@
+SELECT
+    String::Base32Encode(value) as b32enc,
+    String::Base64Encode(value) as b64enc,
+    String::Base64EncodeUrl(value) as b64encu,
+    String::EscapeC(value) as cesc,
+    String::UnescapeC(value) as cunesc,
+    String::HexEncode(value) as xenc,
+    String::EncodeHtml(value) as henc,
+    String::DecodeHtml(value) as hdec,
+    String::CgiEscape(value) as cgesc,
+    String::CgiUnescape(value) as cgunesc,
+    String::Collapse(value) as clps,
+    String::Strip(value) as strp,
+FROM Input


### PR DESCRIPTION
Within this patchset `<STRING_UDF>` macro, generating the particular set of UDFs (listed via `<STRING_UDF_MAP>` macro), is rewritten to generate both scalar and block implementations for these functions.

Here is the list of the aforementioned UDFs:
* `String::Base32Encode`
* `String::Base64Encode`
* `String::Base64EncodeUrl`
* `String::EscapeC`
* `String::UnescapeC`
* `String::HexEncode`
* `String::EncodeHtml`
* `String::DecodeHtml`
* `String::CgiEscape`
* `String::CgiUnescape`
* `String::Strip`
* `String::Collapse`

### Changelog category

* Improvement