### PR TITLE
YQL-17642: Support packaged datetime2 libary for YQL binary receipe.

### DIFF
--- a/ydb/library/yql/udfs/common/datetime2/ya.make
+++ b/ydb/library/yql/udfs/common/datetime2/ya.make
@@ -2,7 +2,7 @@ IF (YQL_PACKAGED)
     PACKAGE()
 
     FROM_SANDBOX(
-        FILE 5703764078 OUT_NOAUTO
+        FILE {FILE_RESOURCE_ID} OUT_NOAUTO
             libdatetime2_udf.so
     )
 

--- a/ydb/library/yql/udfs/common/datetime2/ya.make
+++ b/ydb/library/yql/udfs/common/datetime2/ya.make
@@ -1,24 +1,32 @@
-YQL_UDF_YDB(datetime2_udf)
+IF (YQL_PACKAGED)
+    PACKAGE()
 
-YQL_ABI_VERSION(
-    2
-    35
-    0
-)
+    FROM_SANDBOX(
+        FILE 5703764078 OUT_NOAUTO
+            libdatetime2_udf.so
+            EXECUTABLE
+    )
 
-SRCS(
-    datetime_udf.cpp
-)
-
-PEERDIR(
-    util/draft
-    ydb/library/yql/public/udf/arrow
-    ydb/library/yql/minikql
-    ydb/library/yql/minikql/datetime
-    ydb/library/yql/public/udf/tz
-)
-
-END()
+    END()
+ELSE()
+    YQL_UDF_YDB(datetime2_udf)
+    YQL_ABI_VERSION(
+        2
+        35
+        0
+    )
+    SRCS(
+        datetime_udf.cpp
+    )
+    PEERDIR(
+        util/draft
+        ydb/library/yql/public/udf/arrow
+        ydb/library/yql/minikql
+        ydb/library/yql/minikql/datetime
+        ydb/library/yql/public/udf/tz
+    )
+    END()
+ENDIF()
 
 RECURSE_FOR_TESTS(
     test

--- a/ydb/library/yql/udfs/common/datetime2/ya.make
+++ b/ydb/library/yql/udfs/common/datetime2/ya.make
@@ -4,7 +4,6 @@ IF (YQL_PACKAGED)
     FROM_SANDBOX(
         FILE 5703764078 OUT_NOAUTO
             libdatetime2_udf.so
-            EXECUTABLE
     )
 
     END()


### PR DESCRIPTION
This change does not affect production as it places under flag `YQL_PACKAGED`. In future this flag will be turned ON by default.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
