### PR TITLE
Do not start idle check after forwarding event for streaming session.

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -863,7 +863,7 @@ public:
         }
 
         const TKqpSessionInfo* info = LocalSessions->FindPtr(proxyRequest->SessionId);
-        if (info) {
+        if (info && !info->AttachedRpcId) {
             LocalSessions->StartIdleCheck(info, GetSessionIdleDuration());
         }
 


### PR DESCRIPTION

Lifetime of streaming session is controlled by grpc stream.


### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
