### PR TITLE
Call ProposeQueue.Ack for canceled txs

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -2952,13 +2952,13 @@ void TDataShard::Handle(TEvPrivate::TEvDelayedProposeTransaction::TPtr &ev, cons
                     kind, TabletID(), txId,
                     NKikimrTxDataShard::TEvProposeTransactionResult::CANCELLED);
                 ctx.Send(target, result, 0, cookie);
-                return;
+                break;
             }
             case NEvents::TDataEvents::TEvWrite::EventType: {
                 auto* msg = item.Event->Get<NEvents::TDataEvents::TEvWrite>();
                 auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), msg->GetTxId(), NKikimrDataEvents::TEvWriteResult::STATUS_CANCELLED, "Canceled");
                 ctx.Send(target, result.release(), 0, cookie);
-                return;
+                break;
             }
             default:
                 Y_FAIL_S("Unexpected event type " << item.Event->GetTypeRewrite());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

`return`  prevented call `ProposeQueue.Ack(ctx);`. 
So the ProposeQueue grows infinitely for canceled immediate transactions.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
