### PR TITLE
24-1: Fix missing locks on read iterator empty result elision. Fixes #2765.

### DIFF
--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -665,6 +665,10 @@ public:
             }
         }
 
+        if (record.TxLocksSize() > 0 || record.BrokenTxLocksSize() > 0) {
+            useful = true;
+        }
+
         Self->IncCounter(COUNTER_READ_ITERATOR_ROWS_READ, RowsRead);
         if (!isKeysRequest) {
             Self->IncCounter(COUNTER_ENGINE_HOST_SELECT_RANGE_ROW_SKIPS, DeletedRowSkips);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix missing locks on read iterator empty result elision.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Jepsen showed incompatible-order failures when batching multiple operations into a single query. This was tracked to a read iterator improvement, where it tries to avoid repeating work on page faults by continuing in a new localdb transaction from the last observed key. Since it may produce internal continuations with empty intermediate results those are elided as "not useful". Unfortunately, in some cases, those results may contain information about acquired locks, which need to be passed to kqp. As a result of incorrect empty result elision transactions failed to detect serialization conflicts with other transactions, and successfully committed.

Merge from #2825.