### PR TITLE
#2856 avoid non-initialized data in ares_options

### DIFF
--- a/contrib/libs/curl/lib/asyn-ares.c
+++ b/contrib/libs/curl/lib/asyn-ares.c
@@ -171,7 +171,7 @@ static void sock_state_cb(void *data, ares_socket_t socket_fd,
 CURLcode Curl_resolver_init(struct Curl_easy *easy, void **resolver)
 {
   int status;
-  struct ares_options options;
+  struct ares_options options = { 0 };
   int optmask = ARES_OPT_SOCK_STATE_CB;
   options.sock_state_cb = sock_state_cb;
   options.sock_state_cb_data = easy;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

`Curl_resolver_init()` function does not properly initialize the `ares_options` structure before passing it to `ares_init_options()`

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

See https://github.com/ydb-platform/ydb/issues/2856

...
