### PR TITLE
YQL-18009: fix WalkFolders inside Evaluate context

### DIFF
--- a/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
@@ -717,6 +717,10 @@ private:
                 auto nextState = parsedKey.GetWalkFolderImplArgs()->UserStateExpr;
                 walkFoldersStatus = walkFoldersImpl.GetNextStateExpr(ctx, std::move(parsedKey.GetWalkFolderImplArgs().GetRef()), nextState);
 
+                if (walkFoldersStatus == TStatus::Error) {
+                    return {};
+                }
+
                 if (walkFoldersImpl.IsFinished()) {
                     YQL_CLOG(INFO, ProviderYt) << "Building result expr for WalkFolders with key: " << instanceKey;
                     PendingWalkFolders_.erase(currImplKey);

--- a/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
@@ -537,7 +537,7 @@ public:
         CanonizeFuture_ = {};
         CanonizationRangesFoldersFuture_ = {};
 
-        if (!PendingWalkFolders_.empty() && !State_->Types->EvaluationInProgress) {
+        if (!PendingWalkFolders_.empty()) {
             const auto walkFoldersStatus = RewriteWalkFoldersOnAsyncOrEvalChanges(output, ctx);
             if (walkFoldersStatus != TStatus::Ok) {
                 return walkFoldersStatus;
@@ -663,18 +663,18 @@ private:
     [[nodiscard]]
     TExprNode::TPtr InitializeWalkFolders(TYtKey&& key, const TString& cluster, TPosition pos, TExprContext& ctx) {
         auto& args = key.GetWalkFolderArgs().GetRef();
-        const auto instanceKey = args.StateKey;
 
         TWalkFoldersImpl walkFolders {State_->SessionId, cluster, State_->Configuration->Snapshot(), 
                          pos, std::move(args), State_->Gateway};
         YQL_CLOG(INFO, ProviderYt) << "Initialized WalkFolders from " << cluster << ".`" 
             << args.InitialFolder.Prefix << "`" << " with root attributes cnt: " 
             << args.InitialFolder.Attributes.size();
+        const auto instanceKey = ctx.NextUniqueId;
         PendingWalkFolders_.emplace(instanceKey, std::move(walkFolders));
 
         auto walkFoldersImplNode = Build<TYtWalkFoldersImpl>(ctx, key.GetNode()->Pos())
             .ProcessStateKey()
-                .Value(args.StateKey)
+                .Value(instanceKey)
             .Build()
             .PickledUserState(args.PickledUserState)
             .UserStateType(args.UserStateType)
@@ -688,9 +688,10 @@ private:
     TStatus RewriteWalkFoldersOnAsyncOrEvalChanges(TExprNode::TPtr& output, TExprContext& ctx) {
         Y_ENSURE(!PendingWalkFolders_.empty());
 
-        auto currImplKey = PendingWalkFolders_.begin()->first;
+        const auto currImplKey = PendingWalkFolders_.begin()->first;
+        TStatus walkFoldersStatus = IGraphTransformer::TStatus::Ok;
 
-        auto status = VisitInputKeys(output, ctx, [this, &ctx, currImplKey] (TYtRead readNode, TYtInputKeys&& keys) -> TExprNode::TPtr {
+        auto status = VisitInputKeys(output, ctx, [this, &ctx, currImplKey, &walkFoldersStatus] (TYtRead readNode, TYtInputKeys&& keys) -> TExprNode::TPtr {
             if (keys.GetType() == TYtKey::EType::WalkFoldersImpl) {
                 YQL_CLOG(INFO, ProviderYt) << "YtIODiscovery - DoApplyAsyncChanges WalkFoldersImpl handling start";
 
@@ -713,8 +714,9 @@ private:
                 Y_ENSURE(walkFoldersImpl.GetAnyOpFuture().HasValue(), 
                     "Called RewriteWalkFoldersOnAsyncChanges, but impl future is not ready");
 
-                auto userState = 
-                    walkFoldersImpl.GetNextStateExpr(ctx, std::move(parsedKey.GetWalkFolderImplArgs().GetRef()));
+                auto nextState = parsedKey.GetWalkFolderImplArgs()->UserStateExpr;
+                walkFoldersStatus = walkFoldersImpl.GetNextStateExpr(ctx, std::move(parsedKey.GetWalkFolderImplArgs().GetRef()), nextState);
+
                 if (walkFoldersImpl.IsFinished()) {
                     YQL_CLOG(INFO, ProviderYt) << "Building result expr for WalkFolders with key: " << instanceKey;
                     PendingWalkFolders_.erase(currImplKey);
@@ -740,7 +742,7 @@ private:
                                     .Add<TCoAtom>()
                                         .Value("State")
                                     .Build()
-                                    .Add(userState)
+                                    .Add(nextState)
                                 .Build()
                             .Build()
                         .Build()
@@ -760,30 +762,25 @@ private:
                     .Ptr();
                 }
 
-                if (userState == parsedKey.GetWalkFolderImplArgs()->UserStateExpr) {
+                if (nextState == parsedKey.GetWalkFolderImplArgs()->UserStateExpr) {
                     return readNode.Ptr();
                 }
 
-                YQL_CLOG(DEBUG, ProviderYt) << "State expr ast: " << ConvertToAst(*userState, ctx, {}).Root->ToString();
+                YQL_CLOG(DEBUG, ProviderYt) << "State expr ast: " << ConvertToAst(*nextState, ctx, {}).Root->ToString();
 
-                auto walkFoldersImplNode = ctx.ChangeChild(*parsedKey.GetNode(), 0, std::move(userState));
+                auto walkFoldersImplNode = ctx.ChangeChild(*parsedKey.GetNode(), 0, std::move(nextState));
                 return ctx.ChangeChild(readNode.Ref(), 2, std::move(walkFoldersImplNode));
-
-                return readNode.Ptr();
             }
             return readNode.Ptr();
         });
         
-        if (status != TStatus::Error && !PendingWalkFolders_.empty()) {
-            YQL_CLOG(INFO, ProviderYt) << "Has pending WalkFolders, repeating. ";
-            status = TStatus::Repeat;
-        } else {
-            YQL_CLOG(INFO, ProviderYt) << "All WalkFolders instances are finished. ";
-            status = TStatus::Ok;
+        if (status == TStatus::Error) {
+            YQL_CLOG(ERROR, ProviderYt) << "WalkFolders error transforming";
+            return status;
         }
 
-        YQL_CLOG(INFO, ProviderYt) << "WalkFolders next status: " << (TStatus::ELevel)status.Level;
-        return status;
+        YQL_CLOG(INFO, ProviderYt) << "WalkFolders next status: " << walkFoldersStatus;
+        return walkFoldersStatus;
     }
     
     IGraphTransformer::TStatus VisitInputKeys(TExprNode::TPtr& output,

--- a/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery_walk_folders.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery_walk_folders.cpp
@@ -444,7 +444,7 @@ IGraphTransformer::TStatus TWalkFoldersImpl::HandleAfterResolveFuture(TExprConte
     YQL_CLOG(INFO, ProviderYt) << "After resolve future result";
 
     if (!BatchResolveFuture_) {
-        YQL_CLOG(ERROR, ProviderYt) << "Resolve future not set";
+        ctx.AddError(TIssue(Pos_, TStringBuilder() << "Resolve future not set for WalkFolders in: " << folder.Folder.Prefix));
         return IGraphTransformer::TStatus::Error;
     }
     if (!BatchResolveFuture_->HasValue() && !BatchResolveFuture_->HasException()) {

--- a/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery_walk_folders.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery_walk_folders.cpp
@@ -119,40 +119,41 @@ TWalkFoldersImpl::TWalkFoldersImpl(const TString& sessionId, const TString& clus
     DoFolderListOperation({folder});
 }
 
-TExprNode::TPtr TWalkFoldersImpl::GetNextStateExpr(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args) {
+IGraphTransformer::TStatus TWalkFoldersImpl::GetNextStateExpr(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& state) {
     YQL_CLOG(INFO, ProviderYt) << "Current processing state: " << int(ProcessingState_);
     switch (ProcessingState_) {
         case WaitingListFolderOp: {
-            return AfterListFolderOp(ctx, args);
+            return AfterListFolderOp(ctx, args, state);
         }
         case PreHandling: {
-            return PreHandleVisitedInSingleFolder(ctx, args, ProcessFoldersQueue_.front());
+            return PreHandleVisitedInSingleFolder(ctx, args, ProcessFoldersQueue_.front(), state);
         }
         case ResolveHandling: {
-            return ResolveHandleInSingleFolder(ctx, args, ProcessFoldersQueue_.front());
+            return ResolveHandleInSingleFolder(ctx, args, ProcessFoldersQueue_.front(), state);
         }
         case AfterResolveHandling: {
-            return AfterResolveHandle(ctx, args, ProcessFoldersQueue_.front());
+            return AfterResolveHandle(ctx, args, ProcessFoldersQueue_.front(), state);
         }
         case WaitingResolveLinkOp: {
-            return HandleAfterResolveFuture(ctx, args, ProcessFoldersQueue_.front());
+            return HandleAfterResolveFuture(ctx, args, ProcessFoldersQueue_.front(), state);
         }
         case DiveHandling: {
-            return DiveHandleInSingleFolder(ctx, args, ProcessFoldersQueue_.front());
+            return DiveHandleInSingleFolder(ctx, args, ProcessFoldersQueue_.front(), state);
         }
         case AfterDiveHandling: {
-            return AfterDiveHandle(ctx, args, ProcessFoldersQueue_.front());
+            return AfterDiveHandle(ctx, args, ProcessFoldersQueue_.front(), state);
         }
         case PostHandling: {
-            return PostHandleVisitedInSingleFolder(ctx, args, ProcessFoldersQueue_.front());
+            return PostHandleVisitedInSingleFolder(ctx, args, ProcessFoldersQueue_.front(), state);
         }
         case FinishingHandling: {
-            return BuildFinishedState(ctx, args);
+            return BuildFinishedState(ctx, args, state);
         }
         case FinishedHandling: {
+            return IGraphTransformer::TStatus::Ok;
         }
     }
-    return args.UserStateExpr;
+    return IGraphTransformer::TStatus::Ok;
 }
 
 void TWalkFoldersImpl::DoFolderListOperation(TVector<IYtGateway::TBatchFolderOptions::TFolderPrefixAttrs>&& folders) {
@@ -165,8 +166,7 @@ void TWalkFoldersImpl::DoFolderListOperation(TVector<IYtGateway::TBatchFolderOpt
     BatchFolderListFuture_ = Gateway_->GetFolders(std::move(options));
 }
 
-TExprNode::TPtr TWalkFoldersImpl::EvaluateNextUserStateExpr(TExprContext& ctx, const TExprNode::TPtr& userStateType, const TExprNode::TPtr userStateExpr, std::function<TExprNode::TPtr(const NNodes::TExprBase&)> nextStateFunc) {
-
+IGraphTransformer::TStatus TWalkFoldersImpl::EvaluateNextUserStateExpr(TExprContext& ctx, const TExprNode::TPtr& userStateType, const TExprNode::TPtr userStateExpr, std::function<TExprNode::TPtr(const NNodes::TExprBase&)> nextStateFunc, TExprNode::TPtr& state) {
     const auto userStateUnpickled = Build<TCoUnpickle>(ctx, PosHandle_)
         .Type(userStateType)
         .Buffer(userStateExpr)
@@ -182,22 +182,23 @@ TExprNode::TPtr TWalkFoldersImpl::EvaluateNextUserStateExpr(TExprContext& ctx, c
 
     YQL_CLOG(TRACE, ProviderYt) << "WalkFolders - next evaluate ast: " << ConvertToAst(*nextUserStatePickled, ctx, {}).Root->ToString();
 
-    return ctx.Builder(PosHandle_)
+    state = ctx.Builder(PosHandle_)
         .Callable("EvaluateExpr")
             .Add(0, nextUserStatePickled)
         .Seal()
         .Build();
+    return IGraphTransformer::TStatus::Ok;
 }
 
-TExprNode::TPtr TWalkFoldersImpl::AfterListFolderOp(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args) {
+IGraphTransformer::TStatus TWalkFoldersImpl::AfterListFolderOp(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& state) {
     if (!BatchFolderListFuture_) {
         YQL_CLOG(INFO, ProviderYt) << "Folder queue is empty, finishing WalkFolders with key: " << args.StateKey;
         ProcessingState_ = FinishingHandling;
-        return GetNextStateExpr(ctx, args);
+        return GetNextStateExpr(ctx, args, state);
     } else {
         if (!BatchFolderListFuture_->HasValue()) {
             YQL_CLOG(INFO, ProviderYt) << "Batch list future is not ready";
-            return args.UserStateExpr;
+            return IGraphTransformer::TStatus::Repeat;
         }
 
         Y_ENSURE(!ProcessFoldersQueue_.empty(), "Got future result for Yt List but no folder in queue");
@@ -214,24 +215,24 @@ TExprNode::TPtr TWalkFoldersImpl::AfterListFolderOp(TExprContext& ctx, const TYt
 
         BatchFolderListFuture_ = Nothing();
     }
-    return PreHandleVisitedInSingleFolder(ctx, args, ProcessFoldersQueue_.front());
+    return PreHandleVisitedInSingleFolder(ctx, args, ProcessFoldersQueue_.front(), state);
 }
 
-TExprNode::TPtr TWalkFoldersImpl::PreHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder) {
+IGraphTransformer::TStatus TWalkFoldersImpl::PreHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state) {
     YQL_CLOG(INFO, ProviderYt) << "Processing preHandler at " << folder.Folder.Prefix
                                << " for WalkFolders with key: " << args.StateKey;
 
     if (!folder.PreHandleItemsFetched) {
         YQL_CLOG(INFO, ProviderYt) << "Waiting for folder list: `" << folder.Folder.Prefix << "`";
         ProcessingState_ = WaitingListFolderOp;
-        return GetNextStateExpr(ctx, args);
+        return GetNextStateExpr(ctx, args, state);
     }
 
     if (folder.ItemsToPreHandle.empty()) {
         YQL_CLOG(INFO, ProviderYt) << "Items to preHandle are empty, skipping " << folder.Folder.Prefix;
         ProcessFoldersQueue_.pop_front();
         ProcessingState_ = WaitingListFolderOp;
-        return GetNextStateExpr(ctx, args);
+        return GetNextStateExpr(ctx, args, state);
     }
 
     TVector<TExprBase> folderListItems;
@@ -254,7 +255,7 @@ TExprNode::TPtr TWalkFoldersImpl::PreHandleVisitedInSingleFolder(TExprContext& c
     if (!PreHandler_) {
         YQL_CLOG(INFO, ProviderYt) << "No preHandler defined, skipping for WalkFolders with key: " << args.StateKey;
         ProcessingState_ = ResolveHandling;
-        return GetNextStateExpr(ctx, args);
+        return GetNextStateExpr(ctx, args, state);
     }
 
     const auto folderListExpr = BuildFolderListExpr(ctx, PosHandle_, folderListItems);
@@ -277,18 +278,18 @@ TExprNode::TPtr TWalkFoldersImpl::PreHandleVisitedInSingleFolder(TExprContext& c
     };
 
     ProcessingState_ = ResolveHandling;
-    return EvaluateNextUserStateExpr(ctx, args.UserStateType, args.UserStateExpr, makeNextUserState);
+    return EvaluateNextUserStateExpr(ctx, args.UserStateType, args.UserStateExpr, makeNextUserState, state);
 }
 
-TExprNode::TPtr TWalkFoldersImpl::ResolveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args,  TFolderQueueItem& folder) {
+IGraphTransformer::TStatus TWalkFoldersImpl::ResolveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state) {
     YQL_CLOG(INFO, ProviderYt) << "Processing resolveHandler at " << folder.Folder.Prefix
                                << "for WalkFolders with key: " << args.StateKey;
     ProcessingState_ = AfterResolveHandling;
-    return BuildDiveOrResolveHandlerEval(ctx, args, ResolveHandler_.GetRef(), folder.LinksToResolveHandle, folder.Folder.Attributes, folder.Level);
+    return BuildDiveOrResolveHandlerEval(ctx, args, ResolveHandler_.GetRef(), folder.LinksToResolveHandle, folder.Folder.Attributes, folder.Level, state);
 }
 
-TExprNode::TPtr TWalkFoldersImpl::BuildDiveOrResolveHandlerEval(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& handler,
-                                              const TVector<IYtGateway::TBatchFolderResult::TFolderItem>& res, const TVector<TString>& attributes, ui64 level) {
+IGraphTransformer::TStatus TWalkFoldersImpl::BuildDiveOrResolveHandlerEval(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& handler, 
+    const TVector<IYtGateway::TBatchFolderResult::TFolderItem>& res, const TVector<TString>& attributes, ui64 level, TExprNode::TPtr& state) {
     using namespace NNodes;
 
     TVector<TExprBase> items;
@@ -335,7 +336,7 @@ TExprNode::TPtr TWalkFoldersImpl::BuildDiveOrResolveHandlerEval(TExprContext& ct
     .Value()
     .Ptr();
     
-    auto resolveHandlerResPickled = ctx.Builder(PosHandle_)
+    const auto resolveHandlerResPickled = ctx.Builder(PosHandle_)
         .Callable("StaticMap")
             .Add(0, handlerResult)
             .Lambda(1)
@@ -348,11 +349,12 @@ TExprNode::TPtr TWalkFoldersImpl::BuildDiveOrResolveHandlerEval(TExprContext& ct
         .Build();
 
     ctx.Step.Repeat(TExprStep::ExprEval);
-    return ctx.Builder(PosHandle_)
+    state = ctx.Builder(PosHandle_)
         .Callable("EvaluateExpr")
             .Add(0, resolveHandlerResPickled)
         .Seal()
         .Build();
+    return IGraphTransformer::TStatus::Ok;
 }
 
 void ParseNameAttributesPickledList(TStringBuf pickledTupleList, std::function<void(TString&&, TSet<TString>)> handleParsedNameAndAttrs) {
@@ -391,7 +393,7 @@ void ParseNameAttributesPickledList(TStringBuf pickledTupleList, std::function<v
     }
 }
 
-TExprNode::TPtr TWalkFoldersImpl::AfterResolveHandle(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder) {
+IGraphTransformer::TStatus TWalkFoldersImpl::AfterResolveHandle(TExprContext& ctx, TYtKey::TWalkFoldersImplArgs args, TFolderQueueItem& folder, TExprNode::TPtr& state) {
     EnsureTupleSize(*args.UserStateExpr, 2, ctx);
     YQL_CLOG(INFO, ProviderYt) << "After resolveHandler EvaluateExpr";
 
@@ -419,8 +421,11 @@ TExprNode::TPtr TWalkFoldersImpl::AfterResolveHandle(TExprContext& ctx, const TY
 
     if (links.empty()) {
         YQL_CLOG(INFO, ProviderYt) << "Links to visit are empty";
+        args.UserStateExpr = args.UserStateExpr->Child(1);
+        state = args.UserStateExpr;
+
         ProcessingState_ = DiveHandling;
-        return GetNextStateExpr(ctx, {.UserStateExpr = args.UserStateExpr->Child(1), .UserStateType = args.UserStateType, .StateKey = args.StateKey});
+        return GetNextStateExpr(ctx, args, state);
     }
 
     ProcessingState_ = WaitingResolveLinkOp;
@@ -431,19 +436,20 @@ TExprNode::TPtr TWalkFoldersImpl::AfterResolveHandle(TExprContext& ctx, const TY
         .Items(links);
     BatchResolveFuture_ = Gateway_->ResolveLinks(std::move(options));
 
-    return args.UserStateExpr->Child(1);
+    state = args.UserStateExpr->Child(1);
+    return IGraphTransformer::TStatus::Repeat;
 }
 
-TExprNode::TPtr TWalkFoldersImpl::HandleAfterResolveFuture(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder) {
+IGraphTransformer::TStatus TWalkFoldersImpl::HandleAfterResolveFuture(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state) {
     YQL_CLOG(INFO, ProviderYt) << "After resolve future result";
 
     if (!BatchResolveFuture_) {
-        YQL_CLOG(WARN, ProviderYt) << "Resolve future not set";
-        return nullptr;
+        YQL_CLOG(ERROR, ProviderYt) << "Resolve future not set";
+        return IGraphTransformer::TStatus::Error;
     }
     if (!BatchResolveFuture_->HasValue() && !BatchResolveFuture_->HasException()) {
         YQL_CLOG(INFO, ProviderYt) << "Batch resolve future is not ready";
-        return args.UserStateExpr;
+        return IGraphTransformer::TStatus::Repeat;
     }
 
     auto res = BatchResolveFuture_->ExtractValue();
@@ -459,17 +465,17 @@ TExprNode::TPtr TWalkFoldersImpl::HandleAfterResolveFuture(TExprContext& ctx, co
     }
 
     ProcessingState_ = DiveHandling;
-    return GetNextStateExpr(ctx, args);
+    return GetNextStateExpr(ctx, args, state);
 }
 
-TExprNode::TPtr TWalkFoldersImpl::DiveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args,  TFolderQueueItem& folder) {
+IGraphTransformer::TStatus TWalkFoldersImpl::DiveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state) {
     YQL_CLOG(INFO, ProviderYt) << "Processing diveHandler at " << folder.Folder.Prefix
                                << " for WalkFolders with key: " << args.StateKey;
     ProcessingState_ = AfterDiveHandling;
-    return BuildDiveOrResolveHandlerEval(ctx, args, DiveHandler_.GetRef(), folder.ItemsToDiveHandle, folder.Folder.Attributes, folder.Level);
+    return BuildDiveOrResolveHandlerEval(ctx, args, DiveHandler_.GetRef(), folder.ItemsToDiveHandle, folder.Folder.Attributes, folder.Level, state);
 }
 
-TExprNode::TPtr TWalkFoldersImpl::AfterDiveHandle(TExprContext& ctx, TYtKey::TWalkFoldersImplArgs args, TFolderQueueItem& folder) {
+IGraphTransformer::TStatus TWalkFoldersImpl::AfterDiveHandle(TExprContext& ctx, TYtKey::TWalkFoldersImplArgs args, TFolderQueueItem& folder, TExprNode::TPtr& state) {
     using namespace NKikimr::NMiniKQL;
 
     EnsureTupleSize(*args.UserStateExpr, 2, ctx);
@@ -493,11 +499,12 @@ TExprNode::TPtr TWalkFoldersImpl::AfterDiveHandle(TExprContext& ctx, TYtKey::TWa
     folder.ItemsToDiveHandle.clear();
     
     args.UserStateExpr = args.UserStateExpr->Child(1);
+    state = args.UserStateExpr;
     ProcessingState_ = PostHandling;
 
     if (diveItems.empty()) {
         YQL_CLOG(INFO, ProviderYt) << "Nodes to dive are empty";
-        return GetNextStateExpr(ctx, args);
+        return GetNextStateExpr(ctx, args, state);
     }
 
     auto options = IYtGateway::TBatchFolderOptions(SessionId_)
@@ -508,14 +515,14 @@ TExprNode::TPtr TWalkFoldersImpl::AfterDiveHandle(TExprContext& ctx, TYtKey::TWa
     Y_ENSURE(!BatchFolderListFuture_, "Single inflight batch folder request allowed");
     BatchFolderListFuture_ = Gateway_->GetFolders(std::move(options));
 
-    return GetNextStateExpr(ctx, args);
+    return GetNextStateExpr(ctx, args, state);
 }
 
-TExprNode::TPtr TWalkFoldersImpl::PostHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder) {
+IGraphTransformer::TStatus TWalkFoldersImpl::PostHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state) {
     if (!PostHandler_) {
         YQL_CLOG(INFO, ProviderYt) << "No postHandler defined, skipping for WalkFolders with key: " << args.StateKey;
         ProcessingState_ = WaitingListFolderOp;
-        return args.UserStateExpr;
+        return IGraphTransformer::TStatus::Repeat;
     }
 
     YQL_CLOG(INFO, ProviderYt) << "Processing postHandler at " << folder.Folder.Prefix
@@ -554,11 +561,10 @@ TExprNode::TPtr TWalkFoldersImpl::PostHandleVisitedInSingleFolder(TExprContext& 
     ProcessingState_ = WaitingListFolderOp;
 
     ProcessFoldersQueue_.pop_front();
-    return EvaluateNextUserStateExpr(ctx, args.UserStateType, args.UserStateExpr, makeNextUserState);
+    return EvaluateNextUserStateExpr(ctx, args.UserStateType, args.UserStateExpr, makeNextUserState, state);
 }
 
-
-TExprNode::TPtr TWalkFoldersImpl::BuildFinishedState(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args) {
+IGraphTransformer::TStatus TWalkFoldersImpl::BuildFinishedState(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& state) {
     // TODO: Dump large user state to file
     // const auto dataLen = args.UserStateExpr->IsCallable("String") 
     //     ? TCoString(args.UserStateExpr).Literal().StringValue().Size()
@@ -573,10 +579,11 @@ TExprNode::TPtr TWalkFoldersImpl::BuildFinishedState(TExprContext& ctx, const TY
     ctx.Step.Repeat(TExprStep::ExprEval);
     ProcessingState_ = FinishedHandling;
 
-    return ctx.Builder(PosHandle_)
+    state = ctx.Builder(PosHandle_)
         .Callable("EvaluateExpr")
             .Add(0, userStateUnpickled)
         .Seal()
         .Build();
+    return IGraphTransformer::TStatus::Ok;
 }
 } // namespace NYql

--- a/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery_walk_folders.h
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery_walk_folders.h
@@ -22,7 +22,7 @@ public:
     TWalkFoldersImpl(const TString& sessionId, const TString& cluster, TYtSettings::TConstPtr config, 
                      TPosition pos, TYtKey::TWalkFoldersArgs&& args, const IYtGateway::TPtr gateway);
 
-    TExprNode::TPtr GetNextStateExpr(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args);
+    IGraphTransformer::TStatus GetNextStateExpr(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& state);
 
     enum EProcessingState {
         WaitingListFolderOp,
@@ -100,27 +100,27 @@ private:
 
     void DoFolderListOperation(TVector<IYtGateway::TBatchFolderOptions::TFolderPrefixAttrs>&& folders);
 
-    TExprNode::TPtr EvaluateNextUserStateExpr(TExprContext& ctx, const TExprNode::TPtr& userStateType, const TExprNode::TPtr userStateExpr, std::function<TExprNode::TPtr(const NNodes::TExprBase&)> nextStateFunc);
-    
-    TExprNode::TPtr AfterListFolderOp(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args);
+    IGraphTransformer::TStatus EvaluateNextUserStateExpr(TExprContext& ctx, const TExprNode::TPtr& userStateType, const TExprNode::TPtr userStateExpr, std::function<TExprNode::TPtr(const NNodes::TExprBase&)> nextStateFunc, TExprNode::TPtr& state);
 
-    TExprNode::TPtr PreHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder);
-    
-    TExprNode::TPtr ResolveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args,  TFolderQueueItem& folder);
+    IGraphTransformer::TStatus AfterListFolderOp(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& state);
 
-    TExprNode::TPtr BuildDiveOrResolveHandlerEval(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& handler,
-                                                  const TVector<IYtGateway::TBatchFolderResult::TFolderItem>& res, const TVector<TString>& attributes, ui64 level);
+    IGraphTransformer::TStatus PreHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state);
 
-    TExprNode::TPtr AfterResolveHandle(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder);
+    IGraphTransformer::TStatus ResolveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args,  TFolderQueueItem& folder, TExprNode::TPtr& state);
 
-    TExprNode::TPtr HandleAfterResolveFuture(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder);
+    IGraphTransformer::TStatus BuildDiveOrResolveHandlerEval(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& handler,
+                                                  const TVector<IYtGateway::TBatchFolderResult::TFolderItem>& res, const TVector<TString>& attributes, ui64 level, TExprNode::TPtr& state);
 
-    TExprNode::TPtr DiveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args,  TFolderQueueItem& folder);
+    IGraphTransformer::TStatus AfterResolveHandle(TExprContext& ctx, TYtKey::TWalkFoldersImplArgs args, TFolderQueueItem& folder, TExprNode::TPtr& state);
 
-    TExprNode::TPtr AfterDiveHandle(TExprContext& ctx, TYtKey::TWalkFoldersImplArgs args, TFolderQueueItem& folder);
+    IGraphTransformer::TStatus HandleAfterResolveFuture(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state);
 
-    TExprNode::TPtr PostHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder);
+    IGraphTransformer::TStatus DiveHandleInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args,  TFolderQueueItem& folder, TExprNode::TPtr& state);
 
-    TExprNode::TPtr BuildFinishedState(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args); 
+    IGraphTransformer::TStatus AfterDiveHandle(TExprContext& ctx, TYtKey::TWalkFoldersImplArgs args, TFolderQueueItem& folder, TExprNode::TPtr& state);
+
+    IGraphTransformer::TStatus PostHandleVisitedInSingleFolder(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TFolderQueueItem& folder, TExprNode::TPtr& state);
+
+    IGraphTransformer::TStatus BuildFinishedState(TExprContext& ctx, const TYtKey::TWalkFoldersImplArgs& args, TExprNode::TPtr& state);
 };
 } // namespace NYql

--- a/ydb/library/yql/providers/yt/provider/yql_yt_key.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_key.cpp
@@ -84,7 +84,6 @@ bool TYtKey::Parse(const TExprNode& key, TExprContext& ctx, bool isOutput) {
             .ResolveHandler = walkFolders.ResolveHandler().Ptr(),
             .DiveHandler = walkFolders.DiveHandler().Ptr(),
             .PostHandler = walkFolders.PostHandler().Ptr(),
-            .StateKey = walkFolders.Ref().UniqueId(),
         });
         
         return true;

--- a/ydb/library/yql/providers/yt/provider/yql_yt_key.h
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_key.h
@@ -57,8 +57,6 @@ public:
         TExprNode::TPtr ResolveHandler;
         TExprNode::TPtr DiveHandler;
         TExprNode::TPtr PostHandler;
-
-        ui64 StateKey;
     };
 
     struct TWalkFoldersImplArgs {


### PR DESCRIPTION
Fixes crash in following query:
```sql
USE hahn;

$postHandler = ($nodes, $state, $level) -> {
    $tables = ListFilter($nodes, ($x)->($x.Type = "table"));
    return ListExtend($state, ListExtract($tables, "Path"));
};

$a= SELECT ListLength(State) FROM WalkFolders('//home', $postHandler AS PostHandler);

EVALUATE IF $a != 0 DO BEGIN
    INSERT INTO @a
    SELECT 'a';
    COMMIT;
END DO;

SELECT * FROM @a;
```
Tests are added in `yql/tests/custom`
