### PR TITLE
Return end iterator in TRope::Erase

### DIFF
--- a/ydb/library/actors/util/rope.h
+++ b/ydb/library/actors/util/rope.h
@@ -494,8 +494,8 @@ public:
     TConstIterator begin() const { return Begin(); }
     TConstIterator end() const { return End(); }
 
-    void Erase(TIterator begin, TIterator end) {
-        Cut(begin, end, nullptr);
+    TIterator Erase(TIterator begin, TIterator end) {
+        return Cut(begin, end, nullptr);
     }
 
     TRope Extract(TIterator begin, TIterator end) {
@@ -844,16 +844,17 @@ public:
     friend bool operator> (const TRcBuf& x, const TRope& y) { return Compare(x.GetContiguousSpan(), y) >  0; }
     friend bool operator>=(const TRcBuf& x, const TRope& y) { return Compare(x.GetContiguousSpan(), y) >= 0; }
 
-
 private:
-    void Cut(TIterator begin, TIterator end, TRope *target) {
+    TIterator Cut(TIterator begin, TIterator end, TRope *target) {
         // ensure all iterators are belong to us
         Y_DEBUG_ABORT_UNLESS(this == begin.Rope && this == end.Rope);
+        begin.CheckValid();
+        end.CheckValid();
 
         // if begin and end are equal, we do nothing -- checking this case allows us to find out that begin does not
         // point to End(), for example
         if (begin == end) {
-            return;
+            return end;
         }
 
         auto addBlock = [&](const TRcBuf& from, const char *begin, const char *end) {
@@ -872,7 +873,7 @@ private:
             const char *firstChunkBegin = begin.PointsToChunkMiddle() ? begin->Begin : nullptr;
             begin->Begin = end.Ptr; // this affects both begin and end iterator pointed values
             if (firstChunkBegin) {
-                Chain.InsertBefore(begin.Iter, TRcBuf::Piece, firstChunkBegin, begin.Ptr, chunkToSplit);
+                end.Iter = ++Chain.InsertBefore(begin.Iter, TRcBuf::Piece, firstChunkBegin, begin.Ptr, chunkToSplit);
             }
         } else {
             // check the first iterator -- if it starts not from the begin of the block, we have to adjust end of the
@@ -907,6 +908,7 @@ private:
         }
 
         InvalidateIterators();
+        return {this, end.Iter, end.Ptr};
     }
 };
 

--- a/ydb/library/actors/util/rope_ut.cpp
+++ b/ydb/library/actors/util/rope_ut.cpp
@@ -234,6 +234,27 @@ Y_UNIT_TEST_SUITE(TRope) {
         }
     }
 
+    Y_UNIT_TEST(EraseThenInsert) {
+        TRope text = CreateRope(Text, 10);
+        for (size_t begin = 0; begin < Text.size(); ++begin) {
+            for (size_t end = begin; end <= Text.size(); ++end) {
+                for (size_t offset = 0; offset < Text.size(); offset += 11) {
+                    for (size_t endOffset = offset; endOffset <= Min(offset + 20, Text.size()); ++endOffset) {
+                        TRope rope = text;
+                        const auto beginIt = rope.Position(begin);
+                        const auto endIt = rope.Position(end);
+                        const auto insertIt = rope.Erase(beginIt, endIt);
+                        rope.Insert(insertIt, {text.Position(offset), text.Position(endOffset)});
+                        TString reference = Text;
+                        reference.erase(reference.begin() + begin, reference.begin() + end);
+                        reference.insert(reference.begin() + begin, Text.begin() + offset, Text.begin() + endOffset);
+                        UNIT_ASSERT_VALUES_EQUAL(RopeToString(rope), reference);
+                    }
+                }
+            }
+        }
+    }
+
     Y_UNIT_TEST(Extract) {
         for (size_t begin = 0; begin < Text.size(); ++begin) {
             for (size_t end = begin; end <= Text.size(); ++end) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Return end iterator in TRope::Erase

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Added return iterator in TRope::Erase/Cut methods to avoid extra calcuations when replacing parts of rope with another one.
