### PR TITLE
skip metrics without name label instead of crashing KIKIMR-21198

### DIFF
--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder.cpp
@@ -370,9 +370,9 @@ namespace NMonitoring {
                 }
 
                 TMaybe<TLabel> nameLabel = MetricState_.Labels.Extract(MetricNameLabel_);
-                Y_ENSURE(nameLabel,
-                         "labels " << MetricState_.Labels <<
-                         " does not contain label '" << MetricNameLabel_ << '\'');
+                if (!nameLabel) {
+                    return;
+                }
 
                 const TString& metricName = ToString(nameLabel->Value());
                 if (MetricState_.Type != EMetricType::DSUMMARY) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

skip metrics without name label instead of crashing KIKIMR-21198

### Changelog category <!-- remove all except one -->

* Bugfix 

