### PR TITLE
YQL-18027: Add block implementation for String::CollapseText

### DIFF
--- a/ydb/library/yql/tests/sql/dq_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part8/canondata/result.json
@@ -2986,9 +2986,9 @@
     ],
     "test.test[udf-automap_null--Debug]": [
         {
-            "checksum": "41101539ab28736cf80f3c0674180af3",
-            "size": 708,
-            "uri": "https://{canondata_backend}/1936842/982183b1f97cbe0bb25f4212b8e60d3d566d4b6c/resource.tar.gz#test.test_udf-automap_null--Debug_/opt.yql_patched"
+            "checksum": "608a3ea16a6ad6b6fb652b751ba5735a",
+            "size": 721,
+            "uri": "https://{canondata_backend}/212715/964d05b7001c3fa8cca6a512b2a887e7ad4280e4/resource.tar.gz#test.test_udf-automap_null--Debug_/opt.yql_patched"
         }
     ],
     "test.test[udf-automap_null--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
@@ -2633,9 +2633,9 @@
     ],
     "test.test[udf-automap_null--Debug]": [
         {
-            "checksum": "5e716a54e0c86c0f54e79a47bfbacc8e",
-            "size": 707,
-            "uri": "https://{canondata_backend}/1889210/796baf28896eb5aaad8828a0b6000e7d17563447/resource.tar.gz#test.test_udf-automap_null--Debug_/opt.yql_patched"
+            "checksum": "da359b3f98f262bd990bc1c032362f97",
+            "size": 720,
+            "uri": "https://{canondata_backend}/212715/e5225633107910b9706a50590b4aaaf5be080f7a/resource.tar.gz#test.test_udf-automap_null--Debug_/opt.yql_patched"
         }
     ],
     "test.test[udf-automap_null--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part8/canondata/result.json
@@ -2711,9 +2711,9 @@
     ],
     "test.test[udf-automap_null--Debug]": [
         {
-            "checksum": "c70d23c5b49a78d7a91095e48f5ae528",
-            "size": 637,
-            "uri": "https://{canondata_backend}/1847551/236011fa303dc9c115378482df01b6a80777a84f/resource.tar.gz#test.test_udf-automap_null--Debug_/opt.yql"
+            "checksum": "75fbfff4eae73732d850d5c8cc24f6fc",
+            "size": 650,
+            "uri": "https://{canondata_backend}/1031349/561c62f6383de6722bda744949d64145b04f4939/resource.tar.gz#test.test_udf-automap_null--Debug_/opt.yql"
         }
     ],
     "test.test[udf-automap_null--Plan]": [

--- a/ydb/library/yql/udfs/common/string/string_udf.cpp
+++ b/ydb/library/yql/udfs/common/string/string_udf.cpp
@@ -353,12 +353,28 @@ namespace {
     XX(HumanReadableQuantity, SF_QUANTITY)       \
     XX(HumanReadableBytes, SF_BYTES)
 
-    SIMPLE_STRICT_UDF(TCollapseText, char*(TAutoMap<char*>, ui64)) {
+
+    BEGIN_SIMPLE_STRICT_ARROW_UDF(TCollapseText, char*(TAutoMap<char*>, ui64)) {
         TString input(args[0].AsStringRef());
         ui64 maxLength = args[1].Get<ui64>();
         CollapseText(input, maxLength);
         return valueBuilder->NewString(input);
     }
+
+    struct TCollapseTextKernelExec
+        : public TBinaryKernelExec<TCollapseTextKernelExec>
+    {
+        template <typename TSink>
+        static void Process(TBlockItem arg1, TBlockItem arg2, const TSink& sink) {
+            TString input(arg1.AsStringRef());
+            ui64 maxLength = arg2.Get<ui64>();
+            CollapseText(input, maxLength);
+            return sink(TBlockItem(input));
+        }
+    };
+
+    END_SIMPLE_ARROW_UDF(TCollapseText, TCollapseTextKernelExec::Do);
+
 
     BEGIN_SIMPLE_STRICT_ARROW_UDF(TContains, bool(TOptional<char*>, char*)) {
         Y_UNUSED(valueBuilder);

--- a/ydb/library/yql/udfs/common/string/test/canondata/test.test_BlockStringUDF_/results.txt
+++ b/ydb/library/yql/udfs/common/string/test/canondata/test.test_BlockStringUDF_/results.txt
@@ -90,6 +90,13 @@
                                     "DataType";
                                     "String"
                                 ]
+                            ];
+                            [
+                                "clpst";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
                             ]
                         ]
                     ]
@@ -107,7 +114,8 @@
                         "+++!qwe+rty+++uiop+%5B+%5D$";
                         "   !qwe rty   uiop [ ]$";
                         " !qwe rty uiop [ ]$";
-                        "!qwe rty   uiop [ ]$"
+                        "!qwe rty   uiop [ ]$";
+                        "!qwe ..."
                     ];
                     [
                         "IBQXGIBAEAQCAIBAMRTGO2BANJVWYXDOHMTSKIBA";
@@ -121,7 +129,8 @@
                         "@as+++++++dfgh+jkl%5Cn;%27%25++";
                         "@as       dfgh jkl\\n;'%  ";
                         "@as dfgh jkl\\n;'% ";
-                        "@as       dfgh jkl\\n;'%"
+                        "@as       dfgh jkl\\n;'%";
+                        "@as ..."
                     ];
                     [
                         "EAQCAI32PBRQS5TCNYQASCQIEBWSYLRPH5PCAIBA";
@@ -135,7 +144,8 @@
                         "+++%23zxc%09vbn+%09%0A%08+m%2C./%3F%5E+++";
                         "   #zxc\tvbn \t\n\x08 m,./?^   ";
                         " #zxc vbn \x08 m,./?^ ";
-                        "#zxc\tvbn \t\n\x08 m,./?^"
+                        "#zxc\tvbn \t\n\x08 m,./?^";
+                        "#zxc ..."
                     ];
                     [
                         "GEQTEQBTEM2CINJFGZPDOJRYFI4SQMBJFVPT2KZMHQXD4===";
@@ -149,7 +159,8 @@
                         "1!2@3%234$5%256%5E7%268*9%280%29-_%3D%2B%2C%3C.%3E";
                         "1!2@3#4$5%6^7&8*9(0)-_= ,<.>";
                         "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
-                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>"
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@ ..."
                     ]
                 ]
             }

--- a/ydb/library/yql/udfs/common/string/test/canondata/test.test_StringUDF_/results.txt
+++ b/ydb/library/yql/udfs/common/string/test/canondata/test.test_StringUDF_/results.txt
@@ -90,6 +90,13 @@
                                     "DataType";
                                     "String"
                                 ]
+                            ];
+                            [
+                                "clpst";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
                             ]
                         ]
                     ]
@@ -107,7 +114,8 @@
                         "+++!qwe+rty+++uiop+%5B+%5D$";
                         "   !qwe rty   uiop [ ]$";
                         " !qwe rty uiop [ ]$";
-                        "!qwe rty   uiop [ ]$"
+                        "!qwe rty   uiop [ ]$";
+                        "!qwe ..."
                     ];
                     [
                         "IBQXGIBAEAQCAIBAMRTGO2BANJVWYXDOHMTSKIBA";
@@ -121,7 +129,8 @@
                         "@as+++++++dfgh+jkl%5Cn;%27%25++";
                         "@as       dfgh jkl\\n;'%  ";
                         "@as dfgh jkl\\n;'% ";
-                        "@as       dfgh jkl\\n;'%"
+                        "@as       dfgh jkl\\n;'%";
+                        "@as ..."
                     ];
                     [
                         "EAQCAI32PBRQS5TCNYQASCQIEBWSYLRPH5PCAIBA";
@@ -135,7 +144,8 @@
                         "+++%23zxc%09vbn+%09%0A%08+m%2C./%3F%5E+++";
                         "   #zxc\tvbn \t\n\x08 m,./?^   ";
                         " #zxc vbn \x08 m,./?^ ";
-                        "#zxc\tvbn \t\n\x08 m,./?^"
+                        "#zxc\tvbn \t\n\x08 m,./?^";
+                        "#zxc ..."
                     ];
                     [
                         "GEQTEQBTEM2CINJFGZPDOJRYFI4SQMBJFVPT2KZMHQXD4===";
@@ -149,7 +159,8 @@
                         "1!2@3%234$5%256%5E7%268*9%280%29-_%3D%2B%2C%3C.%3E";
                         "1!2@3#4$5%6^7&8*9(0)-_= ,<.>";
                         "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
-                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>"
+                        "1!2@3#4$5%6^7&8*9(0)-_=+,<.>";
+                        "1!2@ ..."
                     ]
                 ]
             }

--- a/ydb/library/yql/udfs/common/string/test/cases/BlockStringUDF.sql
+++ b/ydb/library/yql/udfs/common/string/test/cases/BlockStringUDF.sql
@@ -14,4 +14,5 @@ SELECT
     String::CgiUnescape(value) as cgunesc,
     String::Collapse(value) as clps,
     String::Strip(value) as strp,
+    String::CollapseText(value, 9) as clpst,
 FROM Input

--- a/ydb/library/yql/udfs/common/string/test/cases/StringUDF.sql
+++ b/ydb/library/yql/udfs/common/string/test/cases/StringUDF.sql
@@ -11,4 +11,5 @@ SELECT
     String::CgiUnescape(value) as cgunesc,
     String::Collapse(value) as clps,
     String::Strip(value) as strp,
+    String::CollapseText(value, 9) as clpst,
 FROM Input


### PR DESCRIPTION
Within this changeset `String::CollapseText` UDF is rewritten to provide both scalar and block implementations.

### Changelog category

* Improvement