### PR TITLE
Fix BlobDepot interaction with group mapper in mirror-3-dc mode

### DIFF
--- a/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_blobmap.cpp
+++ b/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_blobmap.cpp
@@ -165,12 +165,14 @@ namespace NKikimr {
             TMirror3dcMapper(const TBlobStorageGroupInfo::TTopology *topology)
                 : Topology(topology)
                 , NumFailRealms(Topology->FailRealms.size())
-                , NumFailDomainsPerFailRealm(Topology->FailRealms[0].FailDomains.size())
-                , NumVDisksPerFailDomain(Topology->FailRealms[0].FailDomains[0].VDisks.size())
+                , NumFailDomainsPerFailRealm(NumFailRealms ? Topology->FailRealms[0].FailDomains.size() : 0)
+                , NumVDisksPerFailDomain(NumFailDomainsPerFailRealm ? Topology->FailRealms[0].FailDomains[0].VDisks.size() : 0)
             {
-                Y_ABORT_UNLESS(NumFailRealms >= NumFailRealmsInSubgroup &&
-                        NumFailDomainsPerFailRealm >= NumFailDomainsPerFailRealmInSubgroup,
-                        "mirror-3-dc group tolopogy is invalid: %s", topology->ToString().data());
+                if (NumFailRealms && NumFailDomainsPerFailRealm && NumVDisksPerFailDomain) {
+                    Y_ABORT_UNLESS(NumFailRealms >= NumFailRealmsInSubgroup &&
+                            NumFailDomainsPerFailRealm >= NumFailDomainsPerFailRealmInSubgroup,
+                            "mirror-3-dc group tolopogy is invalid: %s", topology->ToString().data());
+                }
             }
 
             void PickSubgroup(ui32 hash, TBlobStorageGroupInfo::TOrderNums &orderNums) override final {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix BlobDepot interaction with group mapper in mirror-3-dc mode

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fix BlobDepot interaction with group mapper in mirror-3-dc mode leading to assertion failure.
