### PR TITLE
Fix NodeWarden caching error

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -286,7 +286,7 @@ void TNodeWarden::HandleGone(STATEFN_SIG) {
 }
 
 void TNodeWarden::ApplyStaticServiceSet(const NKikimrBlobStorage::TNodeWardenServiceSet& ss) {
-    ApplyServiceSet(ss, true, false, true);
+    ApplyServiceSet(ss, true, false, false);
 }
 
 void TNodeWarden::HandleIncrHugeInit(NIncrHuge::TEvIncrHugeInit::TPtr ev) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix NodeWarden caching error

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fix NodeWarden caching error leading to impossibility to use configuration caching mechanism allowing storage operation without immediate BSC availability.
