### PR TITLE
Fix update token interval calculation.

### DIFF
--- a/ydb/public/sdk/cpp/client/iam/common/iam.cpp
+++ b/ydb/public/sdk/cpp/client/iam/common/iam.cpp
@@ -56,7 +56,7 @@ private:
             if (auto it = respMap.find("expires_in"); it == respMap.end())
                 ythrow yexception() << "Result doesn't contain expires_in";
             else {
-                const TDuration expiresIn = TDuration::Seconds(it->second.GetUInteger());
+                const TDuration expiresIn = TDuration::Seconds(it->second.GetUInteger()) / 2;
 
                 const auto interval = std::max(std::min(expiresIn, RefreshPeriod_), TDuration::MilliSeconds(100));
 

--- a/ydb/public/sdk/cpp/client/iam/common/iam.cpp
+++ b/ydb/public/sdk/cpp/client/iam/common/iam.cpp
@@ -58,7 +58,9 @@ private:
             else {
                 const TDuration expiresIn = TDuration::Seconds(it->second.GetUInteger());
 
-                NextTicketUpdate_ = TInstant::Now() + std::max(expiresIn, RefreshPeriod_);
+                const auto interval = std::max(std::min(expiresIn, RefreshPeriod_), TDuration::MilliSeconds(100));
+
+                NextTicketUpdate_ = TInstant::Now() + interval;
             }
         } catch (...) {
         }


### PR DESCRIPTION
We should chouse min value from expiresIn and RefreshPeriod_, not max one


### Changelog category <!-- remove all except one -->


* Bugfix 

### Additional information

...
