### PR TITLE
Explicitly specify clang version to compile llvm bytecode

### DIFF
--- a/ydb/library/yql/minikql/codegen/llvm14/ut/ya.make
+++ b/ydb/library/yql/minikql/codegen/llvm14/ut/ya.make
@@ -17,7 +17,7 @@ IF (OS_LINUX)
     )
 ENDIF()
 
-
+USE_LLVM_BC14()
 SET(LLVM_VER 14)
 
 INCLUDE(../../ut/ya.make.inc)


### PR DESCRIPTION
This change is needed [here](https://a.yandex-team.ru/review/5585234/details)

### Changelog category

* Not for changelog (changelog entry is not required)
