### PR TITLE
Fix bugs/flaws in harness library

### DIFF
--- a/ydb/tests/library/harness/kikimr_cluster.py
+++ b/ydb/tests/library/harness/kikimr_cluster.py
@@ -88,10 +88,14 @@ class ExternalKiKiMRCluster(KiKiMRClusterInterface):
     def _run_on(instances, *funcs):
         with futures.ThreadPoolExecutor(8) as executor:
             for func in funcs:
-                executor.map(
+                results = executor.map(
                     func,
                     instances.values()
                 )
+                # raising exceptions here if they occured
+                # also ensure that funcs[0] finished before func[1]
+                for _ in results:
+                    pass
 
     def _deploy_secrets(self):
         self._run_on(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Several fixes and flaws were fixed in harness library

### Changelog category <!-- remove all except one -->

* Improvement
* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information:
- use scp with same options as ssh
- don't ignore exceptions in  parallel execution (see `_run_on` function)
- trace process'es output as string not as binary (`process output` instead of `b'process output'`)
- don't show stack traces in case of `raise_on_error=False`
- Use `LogLevel=ERROR` in order to show less spam in logs from ssh/scp