### PR TITLE
report hc node location

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -1125,10 +1125,18 @@ public:
         }
     }
 
-    Ydb::Monitoring::StatusFlag::Status FillSystemTablets(TSelfCheckContext context) {
+    Ydb::Monitoring::StatusFlag::Status FillSystemTablets(TDatabaseState& databaseState, TSelfCheckContext context) {
         TString databaseId = context.Location.database().name();
         for (auto& [tabletId, tablet] : TabletRequests.TabletStates) {
             if (tablet.Database == databaseId) {
+                auto tabletIt = databaseState.MergedTabletState.find(std::make_pair(tabletId, 0));
+                if (tabletIt != databaseState.MergedTabletState.end()) {
+                    auto nodeId = tabletIt->second->GetNodeID();
+                    if (nodeId) {
+                        FillNodeInfo(nodeId, context.Location.mutable_node());
+                    }
+                }
+
                 context.Location.mutable_compute()->clear_tablet();
                 auto& protoTablet = *context.Location.mutable_compute()->mutable_tablet();
                 auto timeoutMs = Timeout.MilliSeconds();
@@ -1164,6 +1172,7 @@ public:
                 if (count.Count > 0) {
                     TSelfCheckContext tabletContext(&tabletsContext, "TABLET");
                     auto& protoTablet = *tabletContext.Location.mutable_compute()->mutable_tablet();
+                    FillNodeInfo(nodeId, tabletContext.Location.mutable_node());
                     protoTablet.set_type(TTabletTypes::EType_Name(count.Type));
                     protoTablet.set_count(count.Count);
                     if (!count.Identifiers.empty()) {
@@ -1287,7 +1296,7 @@ public:
         if (computeNodeIds->empty()) {
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, "There are no compute nodes", ETags::ComputeState);
         } else {
-            Ydb::Monitoring::StatusFlag::Status systemStatus = FillSystemTablets({&context, "SYSTEM_TABLET"});
+            Ydb::Monitoring::StatusFlag::Status systemStatus = FillSystemTablets(databaseState, {&context, "SYSTEM_TABLET"});
             if (systemStatus != Ydb::Monitoring::StatusFlag::GREEN && systemStatus != Ydb::Monitoring::StatusFlag::GREY) {
                 context.ReportStatus(systemStatus, "Compute has issues with system tablets", ETags::ComputeState, {ETags::SystemTabletState});
             }
@@ -2087,7 +2096,8 @@ public:
             tabletContext.Location.mutable_database()->set_name(DomainPath);
             databaseStatus.set_name(DomainPath);
             {
-                FillSystemTablets({&tabletContext, "SYSTEM_TABLET"});
+                TDatabaseState databaseState;
+                FillSystemTablets(databaseState, {&tabletContext, "SYSTEM_TABLET"});
                 context.UpdateMaxStatus(tabletContext.GetOverallStatus());
             }
         }
@@ -2162,6 +2172,8 @@ public:
 
         FillResult({&result});
         RemoveUnrequestedEntries(result, Request->Request);
+
+        FillNodeInfo(SelfId().NodeId(), result.mutable_location());
 
         auto byteSize = result.ByteSizeLong();
         auto byteLimit = 50_MB - 1_KB; // 1_KB - for HEALTHCHECK STATUS issue going last

--- a/ydb/public/api/protos/ydb_monitoring.proto
+++ b/ydb/public/api/protos/ydb_monitoring.proto
@@ -202,4 +202,5 @@ message SelfCheckResult {
     SelfCheck.Result self_check_result = 1;
     repeated IssueLog issue_log = 2;
     repeated DatabaseStatus database_status = 3;
+    LocationNode location = 4;
 }


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/2250
added hc reporting node location for better diagnostic

example issue
```
    {
      "id": "RED-1c0c-c138-SchemeShard",
      "status": "RED",
      "message": "System tablet is unresponsive",
      "location": {
        "compute": {
          "tablet": {
            "type": "SchemeShard",
            "id": [
              "72075186224037889"
            ]
          }
        },
        "database": {
          "name": "/slice/db"
        },
        "node": {
          "id": 50006,
          "host": "man0-0026.ydb-dev.nemax.nebiuscloud.net",
          "port": 31003
        }
      },
      "type": "SYSTEM_TABLET",
      "level": 3
    },
```

example reply
```
{
  "self_check_result": "GOOD",
  "location": {
    "id": 1,
    "host": "man0-0024.ydb-dev.nemax.nebiuscloud.net",
    "port": 19001
  }
}
```