### PR TITLE
fix TExportToS3Tests.CorruptedDyNumber unit test

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -28,7 +28,6 @@ ydb/core/tx/columnshard/ut_schema TColumnShardTestSchema.RebootForgetAfterFail
 ydb/core/tx/columnshard/engines/ut *
 ydb/core/tx/coordinator/ut Coordinator.RestoreTenantConfiguration
 ydb/core/tx/datashard/ut_change_exchange Cdc.InitialScanDebezium
-ydb/core/tx/schemeshard/ut_export TExportToS3Tests.CorruptedDyNumber
 ydb/core/tx/schemeshard/ut_restore TImportTests.ShouldSucceedOnManyTables
 ydb/core/tx/schemeshard/ut_split_merge TSchemeShardSplitBySizeTest.Merge1KShards
 ydb/core/tx/tx_proxy/ut_ext_tenant TExtSubDomainTest.CreateTableInsideAndAlterDomainAndTable-AlterDatabaseCreateHiveFirst*

--- a/ydb/core/wrappers/ut_helpers/s3_mock.cpp
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.cpp
@@ -20,13 +20,13 @@ TS3Mock::TSettings::TSettings()
 }
 
 TS3Mock::TSettings::TSettings(ui16 port)
-    : HttpOptions(TOptions(port).SetThreads(1))
+    : HttpOptions(THttpServer::TOptions(port).SetThreads(1))
     , CorruptETags(false)
     , RejectUploadParts(false)
 {
 }
 
-TS3Mock::TSettings& TS3Mock::TSettings::WithHttpOptions(const TOptions& opts) {
+TS3Mock::TSettings& TS3Mock::TSettings::WithHttpOptions(const THttpServer::TOptions& opts) {
     HttpOptions = opts;
     return *this;
 }
@@ -388,23 +388,27 @@ bool TS3Mock::TRequest::DoReply(const TReplyParams& params) {
     }
 }
 
+bool TS3Mock::Start() {
+    return HttpServer.Start();
+}
+
 TS3Mock::TS3Mock(const TSettings& settings)
-    : THttpServer(this, settings.HttpOptions)
-    , Settings(settings)
+    : Settings(settings)
+    , HttpServer(this, settings.HttpOptions)
 {
 }
 
 TS3Mock::TS3Mock(THashMap<TString, TString>&& data, const TSettings& settings)
-    : THttpServer(this, settings.HttpOptions)
-    , Settings(settings)
+    : Settings(settings)
     , Data(std::move(data))
+    , HttpServer(this, settings.HttpOptions)
 {
 }
 
 TS3Mock::TS3Mock(const THashMap<TString, TString>& data, const TSettings& settings)
-    : THttpServer(this, settings.HttpOptions)
-    , Settings(settings)
+    : Settings(settings)
     , Data(data)
+    , HttpServer(this, settings.HttpOptions)
 {
 }
 

--- a/ydb/core/wrappers/ut_helpers/s3_mock.h
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.h
@@ -11,17 +11,17 @@ namespace NKikimr {
 namespace NWrappers {
 namespace NTestHelpers {
 
-class TS3Mock: public THttpServer, public THttpServer::ICallBack {
+class TS3Mock: public THttpServer::ICallBack {
 public:
     struct TSettings {
-        TOptions HttpOptions;
+        THttpServer::TOptions HttpOptions;
         bool CorruptETags;
         bool RejectUploadParts;
 
         TSettings();
         explicit TSettings(ui16 port);
 
-        TSettings& WithHttpOptions(const TOptions& opts);
+        TSettings& WithHttpOptions(const THttpServer::TOptions& opts);
         TSettings& WithCorruptETags(bool value);
         TSettings& WithRejectUploadParts(bool value);
 
@@ -65,7 +65,8 @@ public:
     explicit TS3Mock(THashMap<TString, TString>&& data, const TSettings& settings = {});
     explicit TS3Mock(const THashMap<TString, TString>& data, const TSettings& settings = {});
 
-    TClientRequest* CreateClient() override;
+    TClientRequest* CreateClient();
+    bool Start();
 
     const THashMap<TString, TString>& GetData() const { return Data; }
 
@@ -75,6 +76,7 @@ private:
 
     int NextUploadId = 1;
     THashMap<std::pair<TString, TString>, TVector<TString>> MultipartUploads;
+    THttpServer HttpServer;
 
 }; // TS3Mock
 


### PR DESCRIPTION
### Changelog entry

Fixed flaky TExportToS3Tests.CorruptedDyNumber unit test. After the destruction of S3Mock object, there could be access to the S3Mock class data in HttpServer handlers. To exclude this, replaced inheritance to aggregation.

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

