### PR TITLE
Support skipping blob header in TDiskBlob

### DIFF
--- a/ydb/core/blobstorage/ut_vdisk/lib/test_repl.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_repl.cpp
@@ -203,6 +203,7 @@ private:
 
         ReplCtx = std::make_shared<TReplCtx>(
                 VCtx,
+                nullptr,
                 nullptr, // PDiskCtx
                 nullptr, // HugeBlobCtx
                 nullptr,

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_cost_tracker.h
@@ -232,7 +232,7 @@ public:
         const NKikimrBlobStorage::EPutHandleClass handleClass = record.GetHandleClass();
         const ui64 size = record.HasBuffer() ? record.GetBuffer().size() : ev.GetPayload(0).GetSize();
 
-        NPriPut::EHandleType handleType = NPriPut::HandleType(HugeBlobSize, handleClass, size);
+        NPriPut::EHandleType handleType = NPriPut::HandleType(HugeBlobSize, handleClass, size, true);
         if (handleType == NPriPut::Log) {
             return WriteCost(size);
         } else {
@@ -247,7 +247,7 @@ public:
 
         for (ui64 idx = 0; idx < record.ItemsSize(); ++idx) {
             const ui64 size = ev.GetBufferBytes(idx);
-            NPriPut::EHandleType handleType = NPriPut::HandleType(HugeBlobSize, handleClass, size);
+            NPriPut::EHandleType handleType = NPriPut::HandleType(HugeBlobSize, handleClass, size, true);
             if (handleType == NPriPut::Log) {
                 cost += WriteCost(size);
             } else {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
@@ -45,6 +45,7 @@ namespace NKikimr {
         HullCompMaxInFlightReads = 20;
         HullCompReadBatchEfficiencyThreshold = 0.5;  // don't issue reads if there are more gaps than the useful data
         AnubisOsirisMaxInFly = 1000;
+        AddHeader = true;
 
         RecoveryLogCutterFirstDuration = TDuration::Seconds(10);
         RecoveryLogCutterRegularDuration = TDuration::Seconds(30);

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -128,6 +128,7 @@ namespace NKikimr {
         ui32 HullCompMaxInFlightReads;
         double HullCompReadBatchEfficiencyThreshold;
         ui64 AnubisOsirisMaxInFly;
+        bool AddHeader;
 
         //////////////// LOG CUTTER SETTINGS ////////////////
         TDuration RecoveryLogCutterFirstDuration;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_costmodel.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_costmodel.cpp
@@ -180,7 +180,7 @@ namespace NKikimr {
         const NKikimrBlobStorage::EPutHandleClass handleClass = record.GetHandleClass();
         const ui64 bufSize = record.HasBuffer() ? record.GetBuffer().size() : ev.GetPayload(0).GetSize();
 
-        NPriPut::EHandleType handleType = NPriPut::HandleType(MinREALHugeBlobInBytes, handleClass, bufSize);
+        NPriPut::EHandleType handleType = NPriPut::HandleType(MinREALHugeBlobInBytes, handleClass, bufSize, true);
         if (handleType == NPriPut::Log) {
             *logPutInternalQueue = true;
             return SmallWriteCost(bufSize);
@@ -197,7 +197,7 @@ namespace NKikimr {
         ui64 cost = 0;
         for (ui64 idx = 0; idx < record.ItemsSize(); ++idx) {
             const ui64 size = ev.GetBufferBytes(idx);
-            NPriPut::EHandleType handleType = NPriPut::HandleType(MinREALHugeBlobInBytes, handleClass, size);
+            NPriPut::EHandleType handleType = NPriPut::HandleType(MinREALHugeBlobInBytes, handleClass, size, true);
             if (handleType == NPriPut::Log) {
                 cost += SmallWriteCost(size);
             } else {
@@ -264,7 +264,7 @@ namespace NKikimr {
             cost += MovedPatchCostBySize(essence.MovedPatchBlobSize);
         }
         for (ui64 size : essence.PutBufferSizes) {
-            NPriPut::EHandleType handleType = NPriPut::HandleType(MinREALHugeBlobInBytes, essence.HandleClass, size);
+            NPriPut::EHandleType handleType = NPriPut::HandleType(MinREALHugeBlobInBytes, essence.HandleClass, size, true);
             if (handleType == NPriPut::Log) {
                 cost += SmallWriteCost(size);
             } else {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_handle_class.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_handle_class.cpp
@@ -9,9 +9,9 @@ namespace NKikimr {
     namespace NPriPut {
 
         EHandleType HandleType(const ui32 minREALHugeBlobSize, NKikimrBlobStorage::EPutHandleClass handleClass,
-                               ui32 originalBufSizeWithoutOverhead) {
+                               ui32 originalBufSizeWithoutOverhead, bool addHeader) {
             // what size of huge blob it would be, if it huge
-            const ui64 hugeBlobSize = TDiskBlob::HugeBlobOverhead + originalBufSizeWithoutOverhead;
+            const ui64 hugeBlobSize = (addHeader ? TDiskBlob::HeaderSize : 0) + originalBufSizeWithoutOverhead;
 
             switch (handleClass) {
                 case NKikimrBlobStorage::TabletLog:
@@ -23,14 +23,6 @@ namespace NKikimr {
                 default:
                     Y_ABORT("Unexpected case");
             }
-        }
-
-        bool IsHandleTypeLog(const ui32 minREALHugeBlobSize, NKikimrBlobStorage::EPutHandleClass handleClass,
-                             ui32 originalBufSizeWithoutOverhead) {
-            const NPriPut::EHandleType handleType = NPriPut::HandleType(minREALHugeBlobSize, handleClass,
-                                                                        originalBufSizeWithoutOverhead);
-            const bool isHandleTypeLog = handleType == NPriPut::Log;
-            return isHandleTypeLog;
         }
 
     } // NPriPut

--- a/ydb/core/blobstorage/vdisk/common/vdisk_handle_class.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_handle_class.h
@@ -18,10 +18,8 @@ namespace NKikimr {
         };
 
         EHandleType HandleType(const ui32 minREALHugeBlobSize, NKikimrBlobStorage::EPutHandleClass handleClass,
-                               ui32 originalBufSizeWithoutOverhead);
+                               ui32 originalBufSizeWithoutOverhead, bool addHeader);
 
-        bool IsHandleTypeLog(const ui32 minREALHugeBlobSize, NKikimrBlobStorage::EPutHandleClass handleClass,
-                             ui32 originalBufSizeWithoutOverhead);
     } // NPriPut
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.cpp
@@ -43,7 +43,7 @@ namespace NKikimr {
 
     // check whether this blob is huge one; userPartSize doesn't include any metadata stored along with blob
     bool THugeBlobCtx::IsHugeBlob(TBlobStorageGroupType gtype, const TLogoBlobID& fullId) const {
-        return gtype.MaxPartSize(fullId) + TDiskBlob::HugeBlobOverhead >= MinREALHugeBlobInBytes;
+        return gtype.MaxPartSize(fullId) + (AddHeader ? TDiskBlob::HeaderSize : 0) >= MinREALHugeBlobInBytes;
     }
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.h
@@ -66,13 +66,15 @@ namespace NKikimr {
         // this value is multiply of AppendBlockSize and is calculated from Config->MinHugeBlobSize
         const ui32 MinREALHugeBlobInBytes;
         const std::shared_ptr<const THugeSlotsMap> HugeSlotsMap;
+        const bool AddHeader;
 
-        // check whether this blob is huge one; userPartSize doesn't include any metadata stored along with blob
+        // check whether this NEW blob is huge one; userPartSize doesn't include any metadata stored along with blob
         bool IsHugeBlob(TBlobStorageGroupType gtype, const TLogoBlobID& fullId) const;
 
-        THugeBlobCtx(ui32 minREALHugeBlobInBytes, const std::shared_ptr<const THugeSlotsMap> &hugeSlotsMap)
+        THugeBlobCtx(ui32 minREALHugeBlobInBytes, const std::shared_ptr<const THugeSlotsMap> &hugeSlotsMap, bool addHeader)
             : MinREALHugeBlobInBytes(minREALHugeBlobInBytes)
             , HugeSlotsMap(hugeSlotsMap)
+            , AddHeader(addHeader)
         {}
     };
 

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
@@ -131,18 +131,25 @@ namespace NKikimr {
             Y_ABORT_UNLESS(partId);
 
             TRcBuf data = msg->Data.ToString();
-            Y_ABORT_UNLESS(data.size() == TDiskBlob::HeaderSize + gtype.PartSize(rec.LogoBlobId));
-            const char *header = data.data();
+            Y_ABORT_UNLESS(data.size() == TDiskBlob::HeaderSize + gtype.PartSize(rec.LogoBlobId) ||
+                data.size() == gtype.PartSize(rec.LogoBlobId));
 
-            ui32 fullDataSize;
-            memcpy(&fullDataSize, header, sizeof(fullDataSize));
-            header += sizeof(fullDataSize);
-            Y_ABORT_UNLESS(fullDataSize == rec.LogoBlobId.BlobSize());
-
-            Y_ABORT_UNLESS(NMatrix::TVectorType::MakeOneHot(partId - 1, gtype.TotalPartCount()).Raw() == static_cast<ui8>(*header));
+            ui32 trim = 0;
+            if (data.size() == TDiskBlob::HeaderSize + gtype.PartSize(rec.LogoBlobId)) {
+                const char *header = data.data();
+                ui32 fullDataSize;
+                memcpy(&fullDataSize, header, sizeof(fullDataSize));
+                header += sizeof(fullDataSize);
+                Y_ABORT_UNLESS(fullDataSize == rec.LogoBlobId.BlobSize());
+                Y_ABORT_UNLESS(NMatrix::TVectorType::MakeOneHot(partId - 1, gtype.TotalPartCount()).Raw() == static_cast<ui8>(*header));
+                trim += TDiskBlob::HeaderSize;
+            }
 
             TRope rope(std::move(data));
-            rope.EraseFront(TDiskBlob::HeaderSize);
+            if (trim) {
+                rope.EraseFront(trim);
+            }
+            Y_ABORT_UNLESS(rope.size() == gtype.PartSize(rec.LogoBlobId));
 
             auto writeEvent = std::make_unique<TEvBlobStorage::TEvVPut>(rec.LogoBlobId, std::move(rope),
                     SelfVDiskId, true, nullptr, TInstant::Max(), NKikimrBlobStorage::EPutHandleClass::AsyncBlob);

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ctx_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ctx_ut.cpp
@@ -36,7 +36,8 @@ namespace NKikimr {
 
             return std::make_shared<THugeBlobCtx>(
                     repairedHuge->GetMinREALHugeBlobInBytes(),
-                    repairedHuge->Heap->BuildHugeSlotsMap());
+                    repairedHuge->Heap->BuildHugeSlotsMap(),
+                    true);
         }
 
 

--- a/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_blob_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_blob_ut.cpp
@@ -14,162 +14,179 @@ namespace NKikimr {
     Y_UNIT_TEST_SUITE(TBlobStorageDiskBlob) {
 
         Y_UNIT_TEST(CreateFromDistinctParts) {
-            const ui8 totalParts = MaxTotalPartCount;
-            const ui32 partSize = 6;
-            const ui64 fullDataSize = partSize * totalParts / 2;
-            const char *data[totalParts] = {
-                "111111",
-                "222222",
-                "333333",
-                "444444",
-                "555555",
-                "666666",
-                "777777",
-            };
+            for (bool addHeader1 : {true, false}) {
+                for (bool addHeader2 : {true, false}) {
+                    const ui8 totalParts = MaxTotalPartCount;
+                    const ui32 partSize = 6;
+                    const ui64 fullDataSize = partSize;
+                    const char *data[totalParts] = {
+                        "111111",
+                        "222222",
+                        "333333",
+                        "444444",
+                        "555555",
+                        "666666",
+                        "777777",
+                    };
 
-            for (ui32 mask = 1; mask < (1 << totalParts); ++mask) {
-                std::array<TRope, MaxTotalPartCount> partsData;
-                ui32 numParts = 0;
-                NMatrix::TVectorType parts(0, totalParts);
-                for (ui8 i = 0; i < totalParts; ++i) {
-                    if (mask >> i & 1) {
-                        partsData[numParts++] = TRope(TString(data[i], partSize));
-                        parts.Set(i);
+                    for (ui32 mask = 1; mask < (1 << totalParts); ++mask) {
+                        std::array<TRope, MaxTotalPartCount> partsData;
+                        ui32 numParts = 0;
+                        NMatrix::TVectorType parts(0, totalParts);
+                        for (ui8 i = 0; i < totalParts; ++i) {
+                            if (mask >> i & 1) {
+                                partsData[numParts++] = TRope(TString(data[i], partSize));
+                                parts.Set(i);
+                            }
+                        }
+
+                        TRope buffer = TDiskBlob::CreateFromDistinctParts(partsData.begin(), partsData.begin() + numParts, parts, fullDataSize, Arena, addHeader1);
+
+                        TDiskBlobMerger m;
+                        for (ui8 i = 0; i < totalParts; ++i) {
+                            if (mask >> i & 1) {
+                                const ui8 partId = i + 1;
+                                TRope blobBuffer = TDiskBlob::Create(fullDataSize, partId, totalParts, TRope(TString(data[i], partSize)), Arena, addHeader2);
+                                TDiskBlob blob(&blobBuffer, NMatrix::TVectorType::MakeOneHot(i, totalParts), GType, TLogoBlobID(0, 0, 0, 0, fullDataSize, 0));
+                                m.Add(blob);
+                            }
+                        }
+
+                        UNIT_ASSERT_EQUAL(buffer, m.CreateDiskBlob(Arena, addHeader1));
                     }
                 }
-
-                TRope buffer = TDiskBlob::CreateFromDistinctParts(partsData.begin(), partsData.begin() + numParts, parts, fullDataSize, Arena);
-
-                TDiskBlobMerger m;
-                for (ui8 i = 0; i < totalParts; ++i) {
-                    if (mask >> i & 1) {
-                        const ui8 partId = i + 1;
-                        TRope blobBuffer = TDiskBlob::Create(fullDataSize, partId, totalParts, TRope(TString(data[i], partSize)), Arena);
-                        TDiskBlob blob(&blobBuffer, NMatrix::TVectorType::MakeOneHot(i, totalParts), GType, TLogoBlobID(0, 0, 0, 0, partSize, 0));
-                        m.Add(blob);
-                    }
-                }
-
-                UNIT_ASSERT_EQUAL(buffer, m.CreateDiskBlob(Arena));
             }
         }
 
         Y_UNIT_TEST(CreateIterate) {
-            ui8 partId = 2;
-            TString data("abcdefgh");
-            TRope buf = TDiskBlob::Create(16, partId, 3, TRope(data), Arena);
-            NMatrix::TVectorType localParts(0, 3);
-            localParts.Set(partId - 1);
-            TDiskBlob blob(&buf, localParts, GType, TLogoBlobID(0, 0, 0, 0, data.size(), 0));
-            for (TDiskBlob::TPartIterator it = blob.begin(), e = blob.end(); it != e; ++it) {
-                UNIT_ASSERT(it.GetPartId() == partId);
-                UNIT_ASSERT(it.GetPart().ConvertToString() == data);
+            for (bool addHeader : {true, false}) {
+                ui8 partId = 2;
+                TString data("abcdefgh");
+                TRope buf = TDiskBlob::Create(16, partId, 3, TRope(data), Arena, addHeader);
+                NMatrix::TVectorType localParts(0, 3);
+                localParts.Set(partId - 1);
+                TDiskBlob blob(&buf, localParts, GType, TLogoBlobID(0, 0, 0, 0, data.size(), 0));
+                for (TDiskBlob::TPartIterator it = blob.begin(), e = blob.end(); it != e; ++it) {
+                    UNIT_ASSERT(it.GetPartId() == partId);
+                    UNIT_ASSERT(it.GetPart().ConvertToString() == data);
+                }
             }
         }
 
         Y_UNIT_TEST(Merge) {
             TString data("abcdefgh");
 
-            // blob1
-            ui8 partId1 = 1;
-            TRope buf1 = TDiskBlob::Create(16, partId1, 8, TRope(data), Arena);
-            NMatrix::TVectorType localParts1(0, 3);
-            localParts1.Set(partId1 - 1);
-            TDiskBlob blob1(&buf1, localParts1, GType, TLogoBlobID(0, 0, 0, 0, data.size(), 0));
+            for (bool addHeader1 : {true, false}) {
+                for (bool addHeader2 : {true, false}) {
+                    // blob1
+                    ui8 partId1 = 1;
+                    const TLogoBlobID id(0, 0, 0, 0, data.size(), 0);
+                    TRope buf1 = TDiskBlob::Create(GType.PartSize(TLogoBlobID(id, partId1)), partId1, 8, TRope(data), Arena, addHeader1);
+                    NMatrix::TVectorType localParts1(0, 3);
+                    localParts1.Set(partId1 - 1);
+                    TDiskBlob blob1(&buf1, localParts1, GType, id);
 
-            // blob2
-            ui8 partId2 = 3;
-            TRope buf2 = TDiskBlob::Create(16, partId2, 8, TRope(data), Arena);
-            NMatrix::TVectorType localParts2(0, 3);
-            localParts2.Set(partId2 - 1);
-            TDiskBlob blob2(&buf2, localParts2, GType, TLogoBlobID(0, 0, 0, 0, data.size(), 0));
+                    // blob2
+                    ui8 partId2 = 3;
+                    TRope buf2 = TDiskBlob::Create(GType.PartSize(TLogoBlobID(id, partId2)), partId2, 8, TRope(data), Arena, addHeader2);
+                    NMatrix::TVectorType localParts2(0, 3);
+                    localParts2.Set(partId2 - 1);
+                    TDiskBlob blob2(&buf2, localParts2, GType, id);
 
-            // merge vars
-            TDiskBlobMerger merger;
-            TVector<ui8> ppp;
-            TVector<ui8> resPpp;
-            resPpp.push_back(1);
-            resPpp.push_back(3);
-            NMatrix::TVectorType resParts(0, 3);
-            resParts.Set(partId1 - 1);
-            resParts.Set(partId2 - 1);
+                    // merge vars
+                    TDiskBlobMerger merger;
+                    TVector<ui8> ppp;
+                    TVector<ui8> resPpp;
+                    resPpp.push_back(1);
+                    resPpp.push_back(3);
+                    NMatrix::TVectorType resParts(0, 3);
+                    resParts.Set(partId1 - 1);
+                    resParts.Set(partId2 - 1);
 
-            // merge 1 (natural order)
-            {
-                UNIT_ASSERT(merger.Empty());
-                merger.Add(blob1);
-                UNIT_ASSERT(!merger.Empty());
-                merger.Add(blob2);
-                UNIT_ASSERT(!merger.Empty());
-                const TDiskBlob& blob = merger.GetDiskBlob();
-                UNIT_ASSERT(resParts == blob.GetParts());
-                for (TDiskBlob::TPartIterator it = blob.begin(), e = blob.end(); it != e; ++it) {
-                    ppp.push_back(it.GetPartId());
-                    UNIT_ASSERT_VALUES_EQUAL(blob.GetPartSize(it.GetPartId() - 1), data.size());
-                    UNIT_ASSERT(it.GetPart().ConvertToString() == data);
+                    // merge 1 (natural order)
+                    {
+                        UNIT_ASSERT(merger.Empty());
+                        merger.Add(blob1);
+                        UNIT_ASSERT(!merger.Empty());
+                        merger.Add(blob2);
+                        UNIT_ASSERT(!merger.Empty());
+                        const TDiskBlob& blob = merger.GetDiskBlob();
+                        UNIT_ASSERT(resParts == blob.GetParts());
+                        for (TDiskBlob::TPartIterator it = blob.begin(), e = blob.end(); it != e; ++it) {
+                            ppp.push_back(it.GetPartId());
+                            UNIT_ASSERT_VALUES_EQUAL(blob.GetPartSize(it.GetPartId() - 1), data.size());
+                            UNIT_ASSERT(it.GetPart().ConvertToString() == data);
+                        }
+                        UNIT_ASSERT(ppp == resPpp);
+                    }
+
+                    // clear
+                    merger.Clear();
+                    ppp.clear();
+
+                    // merge 2 (reverse order)
+                    {
+                        UNIT_ASSERT(merger.Empty());
+                        merger.Add(blob2);
+                        UNIT_ASSERT(!merger.Empty());
+                        merger.Add(blob1);
+                        UNIT_ASSERT(!merger.Empty());
+                        const TDiskBlob& blob = merger.GetDiskBlob();
+                        UNIT_ASSERT(resParts == blob.GetParts());
+                        for (TDiskBlob::TPartIterator it = blob.begin(), e = blob.end(); it != e; ++it) {
+                            ppp.push_back(it.GetPartId());
+                            UNIT_ASSERT(blob.GetPartSize(it.GetPartId() - 1) == data.size());
+                            UNIT_ASSERT(it.GetPart().ConvertToString() == data);
+                        }
+                        UNIT_ASSERT(ppp == resPpp);
+                    }
                 }
-                UNIT_ASSERT(ppp == resPpp);
-            }
-
-            // clear
-            merger.Clear();
-            ppp.clear();
-
-            // merge 2 (reverse order)
-            {
-                UNIT_ASSERT(merger.Empty());
-                merger.Add(blob2);
-                UNIT_ASSERT(!merger.Empty());
-                merger.Add(blob1);
-                UNIT_ASSERT(!merger.Empty());
-                const TDiskBlob& blob = merger.GetDiskBlob();
-                UNIT_ASSERT(resParts == blob.GetParts());
-                for (TDiskBlob::TPartIterator it = blob.begin(), e = blob.end(); it != e; ++it) {
-                    ppp.push_back(it.GetPartId());
-                    UNIT_ASSERT(blob.GetPartSize(it.GetPartId() - 1) == data.size());
-                    UNIT_ASSERT(it.GetPart().ConvertToString() == data);
-                }
-                UNIT_ASSERT(ppp == resPpp);
             }
         }
 
         Y_UNIT_TEST(FilterMask) {
-            const ui8 numParts = 6;
-            for (ui32 mask1 = 1; mask1 < (1 << numParts); ++mask1) {
-                for (ui32 mask2 = 1; mask2 < (1 << numParts); ++mask2) {
-                    if (!(mask1 & mask2)) {
-                        continue;
-                    }
+            for (bool addHeader1 : {true, false}) {
+                for (bool addHeader2 : {true, false}) {
+                    for (bool addHeader3 : {true, false}) {
+                        const ui8 numParts = 6;
+                        for (ui32 mask1 = 1; mask1 < (1 << numParts); ++mask1) {
+                            for (ui32 mask2 = 1; mask2 < (1 << numParts); ++mask2) {
+                                if (!(mask1 & mask2)) {
+                                    continue;
+                                }
 
-                    NMatrix::TVectorType partsToStore(0, numParts);
-                    for (ui8 i = 0; i < numParts; ++i) {
-                        if (mask2 >> i & 1) {
-                            partsToStore.Set(i);
+                                NMatrix::TVectorType partsToStore(0, numParts);
+                                for (ui8 i = 0; i < numParts; ++i) {
+                                    if (mask2 >> i & 1) {
+                                        partsToStore.Set(i);
+                                    }
+                                }
+
+                                TDiskBlobMergerWithMask m;
+                                m.SetFilterMask(partsToStore);
+                                for (ui8 i = 0; i < numParts; ++i) {
+                                    if (mask1 >> i & 1) {
+                                        NMatrix::TVectorType v(0, numParts);
+                                        v.Set(i);
+                                        TRope buffer = TDiskBlob::Create(8, i + 1, numParts, TRope(Sprintf("%08x", i)), Arena, addHeader1);
+                                        m.Add(TDiskBlob(&buffer, v, GType, TLogoBlobID(0, 0, 0, 0, 8, 0)));
+                                    }
+                                }
+
+                                TDiskBlobMerger m2;
+                                for (ui8 i = 0; i < numParts; ++i) {
+                                    if ((mask1 & mask2) >> i & 1) {
+                                        NMatrix::TVectorType v(0, numParts);
+                                        v.Set(i);
+                                        TRope buffer = TDiskBlob::Create(8, i + 1, numParts, TRope(Sprintf("%08x", i)), Arena, addHeader2);
+                                        m2.Add(TDiskBlob(&buffer, v, GType, TLogoBlobID(0, 0, 0, 0, 8, 0)));
+                                    }
+                                }
+
+                                UNIT_ASSERT_EQUAL(m.CreateDiskBlob(Arena, addHeader3), m2.CreateDiskBlob(Arena, addHeader3));
+                            }
                         }
                     }
-
-                    TDiskBlobMergerWithMask m;
-                    m.SetFilterMask(partsToStore);
-                    for (ui8 i = 0; i < numParts; ++i) {
-                        if (mask1 >> i & 1) {
-                            NMatrix::TVectorType v(0, numParts);
-                            v.Set(i);
-                            TRope buffer = TDiskBlob::Create(100, i + 1, numParts, TRope(Sprintf("%08x", i)), Arena);
-                            m.Add(TDiskBlob(&buffer, v, GType, TLogoBlobID(0, 0, 0, 0, 8, 0)));
-                        }
-                    }
-
-                    TDiskBlobMerger m2;
-                    for (ui8 i = 0; i < numParts; ++i) {
-                        if ((mask1 & mask2) >> i & 1) {
-                            NMatrix::TVectorType v(0, numParts);
-                            v.Set(i);
-                            TRope buffer = TDiskBlob::Create(100, i + 1, numParts, TRope(Sprintf("%08x", i)), Arena);
-                            m2.Add(TDiskBlob(&buffer, v, GType, TLogoBlobID(0, 0, 0, 0, 8, 0)));
-                        }
-                    }
-
-                    UNIT_ASSERT_EQUAL(m.CreateDiskBlob(Arena), m2.CreateDiskBlob(Arena));
                 }
             }
         }

--- a/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.cpp
@@ -89,7 +89,7 @@ namespace NKikimr {
             bool gcOnlySynced, bool allowKeepFlags, bool barrierValidation, ui32 hullSstSizeInChunksFresh,
             ui32 hullSstSizeInChunksLevel, double hullCompFreeSpaceThreshold, ui32 freshCompMaxInFlightWrites,
             ui32 hullCompMaxInFlightWrites, ui32 hullCompMaxInFlightReads, double hullCompReadBatchEfficiencyThreshold,
-            TDuration hullCompStorageRatioCalcPeriod, TDuration hullCompStorageRatioMaxCalcDuration)
+            TDuration hullCompStorageRatioCalcPeriod, TDuration hullCompStorageRatioMaxCalcDuration, bool addHeader)
         : VCtx(std::move(vctx))
         , IngressCache(TIngressCache::Create(VCtx->Top, VCtx->ShortSelfVDisk))
         , ChunkSize(chunkSize)
@@ -107,6 +107,7 @@ namespace NKikimr {
         , HullCompReadBatchEfficiencyThreshold(hullCompReadBatchEfficiencyThreshold)
         , HullCompStorageRatioCalcPeriod(hullCompStorageRatioCalcPeriod)
         , HullCompStorageRatioMaxCalcDuration(hullCompStorageRatioMaxCalcDuration)
+        , AddHeader(addHeader)
         , LsmHullGroup(VCtx->VDiskCounters, "subsystem", "lsmhull")
         , LsmHullSpaceGroup(VCtx->VDiskCounters, "subsystem", "outofspace")
     {}

--- a/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hulldefs.h
@@ -137,6 +137,7 @@ namespace NKikimr {
         const double HullCompReadBatchEfficiencyThreshold;
         const TDuration HullCompStorageRatioCalcPeriod;
         const TDuration HullCompStorageRatioMaxCalcDuration;
+        const bool AddHeader;
 
         NMonGroup::TLsmHullGroup LsmHullGroup;
         NMonGroup::TLsmHullSpaceGroup LsmHullSpaceGroup;
@@ -157,7 +158,8 @@ namespace NKikimr {
                 ui32 hullCompMaxInFlightReads,
                 double hullCompReadBatchEfficiencyThreshold,
                 TDuration hullCompStorageRatioCalcPeriod,
-                TDuration hullCompStorageRatioMaxCalcDuration);
+                TDuration hullCompStorageRatioMaxCalcDuration,
+                bool addHeader);
 
         void UpdateSpaceCounters(const NHullComp::TSstRatio& prev, const NHullComp::TSstRatio& current);
     };

--- a/ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h
@@ -31,7 +31,8 @@ namespace NKikimr {
                         20,     // HullCompMaxInFlightReads
                         0.5,
                         TDuration::Minutes(5),
-                        TDuration::Seconds(1)))
+                        TDuration::Seconds(1),
+                        true))  // AddHeader
             , LevelIndexSettings(
                 HullCtx,
                 8u,                         // Level0MaxSstsAtOnce

--- a/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment_impl.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment_impl.h
@@ -204,7 +204,8 @@ namespace NKikimr {
         buffer = TRope::CopySpaceOptimized(std::move(buffer), 128, *Arena);
         const ui64 fullDataSize = key.LogoBlobID().BlobSize();
         const size_t delta = buffer.size();
-        TRope blob = TDiskBlob::Create(fullDataSize, partId, HullCtx->VCtx->Top->GType.TotalPartCount(), std::move(buffer), *Arena);
+        TRope blob = TDiskBlob::Create(fullDataSize, partId, HullCtx->VCtx->Top->GType.TotalPartCount(), std::move(buffer), *Arena,
+            HullCtx->AddHeader);
         FreshDataMemConsumer.Add(delta);
         const ui32 blobSize = blob.GetSize();
 

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hulldatamerger.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hulldatamerger.h
@@ -46,9 +46,9 @@ namespace NKikimr {
             }
         }
 
-        ui32 GetInplacedSize() const {
+        ui32 GetInplacedSize(bool addHeader) const {
             Y_DEBUG_ABORT_UNLESS(HugeBlobMerger.Empty() || DiskBlobMerger.Empty());
-            return HugeBlobMerger.Empty() ? DiskBlobMerger.GetDiskBlob().GetSize() : 0;
+            return HugeBlobMerger.Empty() ? DiskBlobMerger.GetDiskBlob().GetBlobSize(addHeader) : 0;
         }
 
         void AddHugeBlob(const TDiskPart *begin, const TDiskPart *end, const NMatrix::TVectorType &parts,
@@ -80,9 +80,9 @@ namespace NKikimr {
             return !DiskBlobMerger.Empty();
         }
 
-        ui32 GetDiskBlobRawSize() const {
+        ui32 GetDiskBlobRawSize(bool addHeader) const {
             Y_DEBUG_ABORT_UNLESS(!DiskBlobMerger.Empty());
-            return DiskBlobMerger.GetDiskBlob().GetSize();
+            return DiskBlobMerger.GetDiskBlob().GetBlobSize(addHeader);
         }
 
         const TDiskBlobMerger &GetDiskBlobMerger() const {

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullrecmerger.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullrecmerger.h
@@ -123,11 +123,12 @@ namespace NKikimr {
         };
 
     public:
-        TCompactRecordMergerBase(const TBlobStorageGroupType &gtype)
+        TCompactRecordMergerBase(const TBlobStorageGroupType &gtype, bool addHeader)
             : TBase(gtype, true)
             , MemRecs()
             , ProducingSmallBlob(false)
             , NeedToLoadData(ELoadData::NotSet)
+            , AddHeader(addHeader)
         {}
 
         void Clear() {
@@ -235,7 +236,7 @@ namespace NKikimr {
             // in case when we keep data and disk merger contains small blobs, we set up small blob record -- this logic
             // is used in replication and in fresh compaction
             if (NeedToLoadData == ELoadData::LoadData && DataMerger.HasSmallBlobs()) {
-                TDiskPart addr(0, 0, DataMerger.GetDiskBlobRawSize());
+                TDiskPart addr(0, 0, DataMerger.GetDiskBlobRawSize(AddHeader));
                 MemRec.SetDiskBlob(addr);
             }
 
@@ -258,6 +259,7 @@ namespace NKikimr {
         bool ProducingSmallBlob;
         ELoadData NeedToLoadData;
         TDataMerger DataMerger;
+        const bool AddHeader;
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -276,8 +278,8 @@ namespace NKikimr {
         using TBase::MemRec;
 
     public:
-        TCompactRecordMergerIndexPass(const TBlobStorageGroupType &gtype)
-            : TBase(gtype)
+        TCompactRecordMergerIndexPass(const TBlobStorageGroupType &gtype, bool addHeader)
+            : TBase(gtype, addHeader)
         {}
 
         void Finish() {
@@ -314,8 +316,8 @@ namespace NKikimr {
         using TBase::SetLoadDataMode;
 
     public:
-        TCompactRecordMergerDataPass(const TBlobStorageGroupType &gtype)
-            : TBase(gtype)
+        TCompactRecordMergerDataPass(const TBlobStorageGroupType &gtype, bool addHeader)
+            : TBase(gtype, addHeader)
         {
             SetLoadDataMode(true);
         }

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hullwritesst_ut.cpp
@@ -75,7 +75,7 @@ namespace NKikimr {
                 , AppendBlockSize(appendBlockSize)
                 , WriteBlockSize(writeBlockSize)
                 , WriterPtr(new TWriter(TestCtx.GetVCtx(), EWriterDataType::Fresh, ChunksToUse, Owner, OwnerRound,
-                        ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena))
+                        ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena, true))
                 , Arena(&TRopeArenaBackend::Allocate)
                 , ReservedChunks()
                 , Stat()
@@ -156,7 +156,7 @@ namespace NKikimr {
 
         template <>
         void TTest<TKeyLogoBlob, TMemRecLogoBlob, TWriterLogoBlob>::Test(ui32 maxStep, const TString &data) {
-            TTLogoBlobCompactRecordMerger merger(TBlobStorageGroupType::ErasureMirror3);
+            TTLogoBlobCompactRecordMerger merger(TBlobStorageGroupType::ErasureMirror3, true);
 
             for (ui32 step = 0; step < maxStep; step++) {
                 TLogoBlobID id(1, 1, step, 0, 0, 0);
@@ -167,7 +167,7 @@ namespace NKikimr {
                 TMemRecLogoBlob memRec(ingress);
 
 
-                TRope blobBuf = TDiskBlob::Create(data.size(), 1, 3, TRope(data), Arena);
+                TRope blobBuf = TDiskBlob::Create(data.size(), 1, 3, TRope(data), Arena, true);
 
                 memRec.SetDiskBlob(TDiskPart(0, 0, data.size()));
                 merger.Clear();
@@ -179,7 +179,8 @@ namespace NKikimr {
                 if (!pushRes) {
                     Finish(step);
                     WriterPtr = std::make_unique<TWriterLogoBlob>(TestCtx.GetVCtx(), EWriterDataType::Fresh, ChunksToUse,
-                        Owner, OwnerRound, ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena);
+                        Owner, OwnerRound, ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena,
+                        true);
                     pushRes = WriterPtr->Push(key, memRec, merger.GetDataMerger());
                     Y_ABORT_UNLESS(pushRes);
                 }
@@ -193,7 +194,7 @@ namespace NKikimr {
 
         template <>
         void TTest<TKeyLogoBlob, TMemRecLogoBlob, TWriterLogoBlob>::TestOutbound(ui32 maxStep) {
-            TTLogoBlobCompactRecordMerger merger(TBlobStorageGroupType::ErasureMirror3);
+            TTLogoBlobCompactRecordMerger merger(TBlobStorageGroupType::ErasureMirror3, true);
 
             for (ui32 step = 0; step < maxStep; step++) {
                 TLogoBlobID id(1, 1, step, 0, 0, 0);
@@ -221,7 +222,8 @@ namespace NKikimr {
                     Finish(step);
 
                     WriterPtr = std::make_unique<TWriterLogoBlob>(TestCtx.GetVCtx(), EWriterDataType::Fresh, ChunksToUse,
-                        Owner, OwnerRound, ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena);
+                        Owner, OwnerRound, ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena,
+                        true);
                     pushRes = WriterPtr->Push(key, merger.GetMemRec(), merger.GetDataMerger());
                     Y_ABORT_UNLESS(pushRes);
                 }
@@ -235,7 +237,7 @@ namespace NKikimr {
 
         template <>
         void TTest<TKeyBlock, TMemRecBlock, TWriterBlock>::Test(ui32 maxGen) {
-            TBlockCompactRecordMerger merger(TBlobStorageGroupType::ErasureMirror3);
+            TBlockCompactRecordMerger merger(TBlobStorageGroupType::ErasureMirror3, true);
 
             for (ui32 gen = 0; gen < maxGen; gen++) {
                 TKeyBlock key(34 + gen);
@@ -250,7 +252,8 @@ namespace NKikimr {
                     Finish(gen);
 
                     WriterPtr = std::make_unique<TWriterBlock>(TestCtx.GetVCtx(), EWriterDataType::Fresh, ChunksToUse,
-                        Owner, OwnerRound, ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena);
+                        Owner, OwnerRound, ChunkSize, AppendBlockSize, WriteBlockSize, 0, false, ReservedChunks, Arena,
+                        true);
                     pushRes = WriterPtr->Push(key, memRec, merger.GetDataMerger());
                     Y_ABORT_UNLESS(pushRes);
                 }

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactdeferredqueue.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactdeferredqueue.h
@@ -34,11 +34,13 @@ namespace NKikimr {
         bool Started = false;
         TRopeArena& Arena;
         const TBlobStorageGroupType GType;
+        const bool AddHeader;
 
     public:
-        TDeferredItemQueueBase(TRopeArena& arena, TBlobStorageGroupType gtype)
+        TDeferredItemQueueBase(TRopeArena& arena, TBlobStorageGroupType gtype, bool addHeader)
             : Arena(arena)
             , GType(gtype)
+            , AddHeader(addHeader)
         {}
 
         template<typename... TArgs>
@@ -91,7 +93,8 @@ namespace NKikimr {
             Y_ABORT_UNLESS(item.Merger.GetDiskBlob().GetParts() == item.PartsToStore);
 
             // get newly generated blob raw content and put it into writer queue
-            static_cast<TDerived&>(*this).ProcessItemImpl(item.PreallocatedLocation, item.Merger.CreateDiskBlob(Arena));
+            static_cast<TDerived&>(*this).ProcessItemImpl(item.PreallocatedLocation, item.Merger.CreateDiskBlob(Arena,
+                AddHeader));
         }
     };
 

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactdeferredqueue_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcompactdeferredqueue_ut.cpp
@@ -40,7 +40,7 @@ public:
     TVector<size_t> Results;
 
     TTestDeferredQueue(TRopeArena& arena)
-        : TDeferredItemQueueBase<TTestDeferredQueue>(arena, ::GType)
+        : TDeferredItemQueueBase<TTestDeferredQueue>(arena, ::GType, true)
     {}
 };
 
@@ -80,7 +80,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageHullCompactDeferredQueueTest) {
             // create initial memory merger
             for (ui8 i = 0; i < 6; ++i) {
                 if (mem >> i & 1) {
-                    TRope buf = TDiskBlob::Create(fullDataSize, i + 1, 6, TRope(parts[i]), arena);
+                    TRope buf = TDiskBlob::Create(fullDataSize, i + 1, 6, TRope(parts[i]), arena, true);
                     TDiskBlob blob(&buf, NMatrix::TVectorType::MakeOneHot(i, 6), GType, TLogoBlobID(0, 0, 0, 0, parts[i].GetSize(), 0));
                     expm.Add(blob);
                 }
@@ -90,7 +90,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageHullCompactDeferredQueueTest) {
             if (expm.Empty()) {
                 item.BlobId = -1;
             } else {
-                item.BlobId = GetResMapId(expm.CreateDiskBlob(arena));
+                item.BlobId = GetResMapId(expm.CreateDiskBlob(arena, true));
             }
             item.BlobParts = expm.GetDiskBlob().GetParts();
 
@@ -104,14 +104,14 @@ Y_UNIT_TEST_SUITE(TBlobStorageHullCompactDeferredQueueTest) {
                 TDiskBlobMerger m;
                 for (ui8 i = 0; i < 6; ++i) {
                     if (mask >> i & 1) {
-                        TRope buf = TDiskBlob::Create(fullDataSize, i + 1, 6, TRope(parts[i]), arena);
+                        TRope buf = TDiskBlob::Create(fullDataSize, i + 1, 6, TRope(parts[i]), arena, true);
                         TDiskBlob blob(&buf, NMatrix::TVectorType::MakeOneHot(i, 6), GType, TLogoBlobID(0, 0, 0, 0, parts[i].GetSize(), 0));
                         m.Add(blob);
                         expm.Add(blob);
                     }
                 }
 
-                TRope buf = m.CreateDiskBlob(arena);
+                TRope buf = m.CreateDiskBlob(arena, true);
                 Y_ABORT_UNLESS(buf);
                 item.DiskData.emplace_back(GetResMapId(buf), m.GetDiskBlob().GetParts());
 
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageHullCompactDeferredQueueTest) {
                     TDiskBlobMergerWithMask mx;
                     mx.SetFilterMask(v);
                     mx.Add(expm.GetDiskBlob());
-                    item.Expected = GetResMapId(mx.CreateDiskBlob(arena));
+                    item.Expected = GetResMapId(mx.CreateDiskBlob(arena, true));
 
                     items.push_back(item);
                 }

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -449,7 +449,8 @@ namespace NKikimr {
             }
             HugeBlobCtx = std::make_shared<THugeBlobCtx>(
                     LocRecCtx->RepairedHuge->GetMinREALHugeBlobInBytes(),
-                    LocRecCtx->RepairedHuge->Heap->BuildHugeSlotsMap());
+                    LocRecCtx->RepairedHuge->Heap->BuildHugeSlotsMap(),
+                    Config->AddHeader);
             HugeKeeperInitialized = true;
             return true;
         }
@@ -499,7 +500,8 @@ namespace NKikimr {
                         Config->HullCompMaxInFlightReads,
                         Config->HullCompReadBatchEfficiencyThreshold,
                         Config->HullCompStorageRatioCalcPeriod,
-                        Config->HullCompStorageRatioMaxCalcDuration);
+                        Config->HullCompStorageRatioMaxCalcDuration,
+                        Config->AddHeader);
 
                 // create THullDbRecovery, which creates THullDs
                 LocRecCtx->HullDbRecovery = std::make_shared<THullDbRecovery>(hullCtx);

--- a/ydb/core/blobstorage/vdisk/query/query_readbatch.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_readbatch.cpp
@@ -44,10 +44,23 @@ namespace NKikimr {
         if (QueryPartId && !parts.Get(QueryPartId - 1)) {
             return; // we have no requested part here
         }
-        ui32 partOffs = data.Offset + TDiskBlob::HeaderSize; // current part offset in the data chunk
+
+        const auto& gtype = Ctx->VCtx->Top->GType;
+        ui32 blobSize = 0;
+        for (ui8 i = parts.FirstPosition(); i != parts.GetSize(); i = parts.NextPosition(i)) {
+            blobSize += gtype.PartSize(TLogoBlobID(CurID, i + 1));
+        }
+
+        ui32 partOffs = data.Offset;
+        if (data.Size == TDiskBlob::HeaderSize + blobSize) { // skip the header, if it is present
+            partOffs += TDiskBlob::HeaderSize;
+        } else {
+            Y_ABORT_UNLESS(blobSize == data.Size);
+        }
+
         for (ui8 i = parts.FirstPosition(); i != parts.GetSize(); i = parts.NextPosition(i)) {
             const TLogoBlobID partId(CurID, i + 1);
-            const ui32 partSize = Ctx->VCtx->Top->GType.PartSize(partId);
+            const ui32 partSize = gtype.PartSize(partId);
             if (QueryPartId == 0 || QueryPartId == i + 1) {
                 FoundAnything = true;
                 auto& tmpItem = TmpItems[i];

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst.h
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst.h
@@ -137,7 +137,7 @@ namespace NKikimr {
             Writer = std::make_unique<TWriter>(ReplCtx->VCtx, EWriterDataType::Replication, 1, ReplCtx->PDiskCtx->Dsk->Owner,
                 ReplCtx->PDiskCtx->Dsk->OwnerRound, ReplCtx->PDiskCtx->Dsk->ChunkSize,
                 ReplCtx->PDiskCtx->Dsk->AppendBlockSize, ReplCtx->PDiskCtx->Dsk->BulkWriteBlockSize,
-                HullDs->LogoBlobs->AllocSstId(), true, ReservedChunks, Arena);
+                HullDs->LogoBlobs->AllocSstId(), true, ReservedChunks, Arena, ReplCtx->GetAddHeader());
 
             // start collecting blobs
             State = EState::COLLECT;
@@ -157,7 +157,7 @@ namespace NKikimr {
 
             // create memory record for disk blob with correct length
             TMemRecLogoBlob memRec(ingress);
-            memRec.SetDiskBlob(TDiskPart(0, 0, Merger.GetDiskBlobRawSize()));
+            memRec.SetDiskBlob(TDiskPart(0, 0, Merger.GetDiskBlobRawSize(ReplCtx->GetAddHeader())));
 
             const bool success = Writer->Push(record.Id, memRec, &Merger);
             if (success) {

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
@@ -14,11 +14,12 @@ std::shared_ptr<TReplCtx> CreateReplCtx(TVector<TVDiskID>& vdisks, const TIntrus
     auto counters = MakeIntrusive<::NMonitoring::TDynamicCounters>();
     auto vctx = MakeIntrusive<TVDiskContext>(TActorId(), info->PickTopology(), counters, TVDiskID(0, 1, 0, 0, 0),
         nullptr, NPDisk::DEVICE_TYPE_UNKNOWN);
-    auto hugeBlobCtx = std::make_shared<THugeBlobCtx>(512u << 10u, nullptr);
+    auto hugeBlobCtx = std::make_shared<THugeBlobCtx>(512u << 10u, nullptr, true);
     auto dsk = MakeIntrusive<TPDiskParams>(ui8(1), 1u, 128u << 20, 4096u, 0u, 1000000000u, 1000000000u, 65536u, 65536u, 65536u);
     auto pdiskCtx = std::make_shared<TPDiskCtx>(dsk, TActorId(), TString());
     auto replCtx = std::make_shared<TReplCtx>(
         vctx,
+        nullptr,
         pdiskCtx,
         hugeBlobCtx,
         nullptr,
@@ -36,7 +37,7 @@ TVDiskContextPtr CreateVDiskContext(const TBlobStorageGroupInfo& info) {
 
 TIntrusivePtr<THullCtx> CreateHullCtx(const TBlobStorageGroupInfo& info, ui32 chunkSize, ui32 compWorthReadSize) {
     return MakeIntrusive<THullCtx>(CreateVDiskContext(info), chunkSize, compWorthReadSize, true, true, true, true, 1u,
-        1u, 2.0, 10u, 10u, 20u, 0.5, TDuration::Minutes(5), TDuration::Seconds(1));
+        1u, 2.0, 10u, 10u, 20u, 0.5, TDuration::Minutes(5), TDuration::Seconds(1), true);
 }
 
 TIntrusivePtr<THullDs> CreateHullDs(const TBlobStorageGroupInfo& info) {
@@ -111,7 +112,7 @@ Y_UNIT_TEST_SUITE(HullReplWriteSst) {
                         if (TIngress::CreateIngressWithLocal(&groupInfo->GetTopology(), replCtx->VCtx->ShortSelfVDisk,
                                 TLogoBlobID(id, partIdx + 1))) {
                             vec.Set(partIdx);
-                            rope = TDiskBlob::Create(size, partIdx + 1, vec.GetSize(), TRope(std::move(data)), arena);
+                            rope = TDiskBlob::Create(size, partIdx + 1, vec.GetSize(), TRope(std::move(data)), arena, true);
                             break;
                         }
                     }

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_replctx.h
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_replctx.h
@@ -12,6 +12,7 @@ namespace NKikimr {
     class TReplCtx {
     public:
         TIntrusivePtr<TVDiskContext> VCtx;
+        TIntrusivePtr<THullCtx> HullCtx;
         TPDiskCtxPtr PDiskCtx;
         std::shared_ptr<THugeBlobCtx> HugeBlobCtx;
         TIntrusivePtr<THullDs> HullDs;
@@ -26,6 +27,7 @@ namespace NKikimr {
 
         TReplCtx(
                 TIntrusivePtr<TVDiskContext> vctx,
+                TIntrusivePtr<THullCtx> hullCtx,
                 TPDiskCtxPtr pdiskCtx,
                 std::shared_ptr<THugeBlobCtx> hugeBlobCtx,
                 TIntrusivePtr<THullDs> hullDs,
@@ -35,6 +37,7 @@ namespace NKikimr {
                 std::shared_ptr<std::atomic_uint64_t> pdiskWriteBytes,
                 bool pausedAtStart = false)
             : VCtx(std::move(vctx))
+            , HullCtx(std::move(hullCtx))
             , PDiskCtx(std::move(pdiskCtx))
             , HugeBlobCtx(std::move(hugeBlobCtx))
             , HullDs(std::move(hullDs))
@@ -45,6 +48,8 @@ namespace NKikimr {
             , PDiskWriteBytes(std::move(pdiskWriteBytes))
             , PausedAtStart(pausedAtStart)
         {}
+
+        bool GetAddHeader() const { return !HullCtx || HullCtx->AddHeader; }
     };
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_replrecoverymachine.h
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_replrecoverymachine.h
@@ -205,8 +205,8 @@ namespace NKikimr {
                             TRope& data = item.Parts[i];
                             Y_ABORT_UNLESS(data.GetSize() == partSize);
                             if (ReplCtx->HugeBlobCtx->IsHugeBlob(groupType, id)) {
-                                AddBlobToQueue(partId, TDiskBlob::Create(id.BlobSize(), i + 1,
-                                    groupType.TotalPartCount(), std::move(data), Arena), {}, true, rbq);
+                                AddBlobToQueue(partId, TDiskBlob::Create(id.BlobSize(), i + 1, groupType.TotalPartCount(),
+                                    std::move(data), Arena, ReplCtx->GetAddHeader()), {}, true, rbq);
                                 ++numHuge;
                             } else {
                                 partData[numSmallParts++] = std::move(data);
@@ -217,7 +217,7 @@ namespace NKikimr {
                         if (numSmallParts) {
                             // fill in disk blob buffer
                             AddBlobToQueue(id, TDiskBlob::CreateFromDistinctParts(&partData[0], &partData[numSmallParts],
-                                small, id.BlobSize(), Arena), small, false, rbq);
+                                small, id.BlobSize(), Arena, ReplCtx->GetAddHeader()), small, false, rbq);
                         }
 
                         ReplInfo->LogoBlobsRecovered += !!numSmallParts;
@@ -369,7 +369,7 @@ namespace NKikimr {
                     merger.Add(TDiskBlob(&last.Data, last.LocalParts, ReplCtx->VCtx->Top->GType, id));
                     merger.Add(TDiskBlob(&blob, parts, ReplCtx->VCtx->Top->GType, id));
                     last.LocalParts = merger.GetDiskBlob().GetParts();
-                    last.Data = merger.CreateDiskBlob(Arena);
+                    last.Data = merger.CreateDiskBlob(Arena, ReplCtx->GetAddHeader());
                 } else {
                     rbq.emplace(id, std::move(blob), isHugeBlob, parts);
                 }
@@ -392,7 +392,7 @@ namespace NKikimr {
                         const NMatrix::TVectorType parts = NMatrix::TVectorType::MakeOneHot(id.PartId() - 1,
                             gtype.TotalPartCount());
                         AddBlobToQueue(id.FullID(), TDiskBlob::Create(id.BlobSize(), parts, TRope(),
-                            Arena), parts, isHugeBlob, rbq);
+                            Arena, ReplCtx->GetAddHeader()), parts, isHugeBlob, rbq);
                     }
                     ++ReplInfo->MetadataBlobs;
                 }

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_replrecoverymachine_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_replrecoverymachine_ut.cpp
@@ -66,9 +66,10 @@ namespace NKikimr {
             auto counters = MakeIntrusive<::NMonitoring::TDynamicCounters>();
             auto vctx = MakeIntrusive<TVDiskContext>(TActorId(), info->PickTopology(), counters, TVDiskID(0, 1, 0, 0, 0),
                 nullptr, NPDisk::DEVICE_TYPE_UNKNOWN);
-            auto hugeBlobCtx = std::make_shared<THugeBlobCtx>(512u << 10u, nullptr);
+            auto hugeBlobCtx = std::make_shared<THugeBlobCtx>(512u << 10u, nullptr, true);
             auto replCtx = std::make_shared<TReplCtx>(
                 vctx,
+                nullptr, // HullCtx
                 nullptr, // PDiskCtx
                 hugeBlobCtx,
                 nullptr,
@@ -172,7 +173,7 @@ namespace NKikimr {
                 auto& item = rbq.front();
                 UNIT_ASSERT_EQUAL(item.Id, id);
 
-                TRope buf = TDiskBlob::Create(id.BlobSize(), partIndex + 1, groupInfo->Type.TotalPartCount(), TRope(v[0]), arena);
+                TRope buf = TDiskBlob::Create(id.BlobSize(), partIndex + 1, groupInfo->Type.TotalPartCount(), TRope(v[0]), arena, true);
 
                 UNIT_ASSERT_EQUAL(item.Data, buf);
             }

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -410,7 +410,7 @@ namespace NKikimr {
         {
             Y_DEBUG_ABORT_UNLESS(info.HullStatus.Status == NKikimrProto::OK);
             info.Buffer = TDiskBlob::Create(info.BlobId.BlobSize(), info.BlobId.PartId(), Db->GType.TotalPartCount(),
-                std::move(info.Buffer), *Arena);
+                std::move(info.Buffer), *Arena, HullCtx->AddHeader);
             UpdatePDiskWriteBytes(info.Buffer.GetSize());
             return std::make_unique<TEvHullWriteHugeBlob>(sender, cookie, info.BlobId, info.Ingress,
                     std::move(info.Buffer), ignoreBlock, handleClass, std::move(res), &info.ExtraBlockChecks);
@@ -1964,8 +1964,8 @@ namespace NKikimr {
                 DbBirthLsn = ev->Get()->DbBirthLsn;
                 SkeletonIsUpAndRunning(ctx, Config->RunRepl);
                 if (Config->RunRepl) {
-                    auto replCtx = std::make_shared<TReplCtx>(VCtx, PDiskCtx, HugeBlobCtx, Hull->GetHullDs(), GInfo,
-                        SelfId(), Config, PDiskWriteBytes, Config->ReplPausedAtStart);
+                    auto replCtx = std::make_shared<TReplCtx>(VCtx, HullCtx, PDiskCtx, HugeBlobCtx, Hull->GetHullDs(),
+                        GInfo, SelfId(), Config, PDiskWriteBytes, Config->ReplPausedAtStart);
                     Db->ReplID.Set(ctx.Register(CreateReplActor(replCtx)));
                     ActiveActors.Insert(Db->ReplID, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE); // keep forever
                     if (CommenceRepl) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support skipping blob header in TDiskBlob

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

A support for headerless TDiskBlob has been added, allowing to remove 5-byte header and fix blob alignment.
