### PR TITLE
24-1: Cancel waiting volatile transactions on split and schema changes. Fixes #3084.

### DIFF
--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -978,4 +978,25 @@ bool TActiveTransaction::OnStopping(TDataShard& self, const TActorContext& ctx) 
     }
 }
 
+void TActiveTransaction::OnCleanup(TDataShard& self, std::vector<std::unique_ptr<IEventHandle>>& replies) {
+    if (!IsImmediate() && GetTarget() && !HasCompletedFlag()) {
+        auto kind = static_cast<NKikimrTxDataShard::ETransactionKind>(GetKind());
+        auto status = NKikimrTxDataShard::TEvProposeTransactionResult::ABORTED;
+        auto result = std::make_unique<TEvDataShard::TEvProposeTransactionResult>(
+            kind, self.TabletID(), GetTxId(), status);
+
+        if (self.State == TShardState::SplitSrcWaitForNoTxInFlight) {
+            result->AddError(NKikimrTxDataShard::TError::WRONG_SHARD_STATE, TStringBuilder()
+                << "DataShard " << self.TabletID() << " is splitting");
+        } else if (self.Pipeline.HasWaitingSchemeOps()) {
+            result->AddError(NKikimrTxDataShard::TError::SHARD_IS_BLOCKED, TStringBuilder()
+                << "DataShard " << self.TabletID() << " is blocked by a schema operation");
+        } else {
+            result->AddError(NKikimrTxDataShard::TError::EXECUTION_CANCELLED, "Transaction was cleaned up");
+        }
+
+        replies.push_back(std::make_unique<IEventHandle>(GetTarget(), self.SelfId(), result.release(), 0, GetCookie()));
+    }
+}
+
 }}

--- a/ydb/core/tx/datashard/datashard_active_transaction.h
+++ b/ydb/core/tx/datashard/datashard_active_transaction.h
@@ -604,6 +604,7 @@ public:
     }
 
     bool OnStopping(TDataShard& self, const TActorContext& ctx) override;
+    void OnCleanup(TDataShard& self, std::vector<std::unique_ptr<IEventHandle>>& replies) override;
 
 private:
     void TrackMemory() const;

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -1188,7 +1188,7 @@ ECleanupStatus TPipeline::CleanupOutdated(NIceDb::TNiceDb& db, const TActorConte
 {
     const ui32 OUTDATED_BATCH_SIZE = 100;
     TVector<ui64> outdatedTxs;
-    auto status = Self->TransQueue.CleanupOutdated(db, outdatedStep, OUTDATED_BATCH_SIZE, outdatedTxs, replies);
+    auto status = Self->TransQueue.CleanupOutdated(db, outdatedStep, OUTDATED_BATCH_SIZE, outdatedTxs);
     switch (status) {
         case ECleanupStatus::None:
         case ECleanupStatus::Restart:
@@ -1204,8 +1204,10 @@ ECleanupStatus TPipeline::CleanupOutdated(NIceDb::TNiceDb& db, const TActorConte
     for (ui64 txId : outdatedTxs) {
         auto op = Self->TransQueue.FindTxInFly(txId);
         if (op && !op->IsExecutionPlanFinished()) {
+            op->OnCleanup(*Self, replies);
             GetExecutionUnit(op->GetCurrentUnit()).RemoveOperation(op);
         }
+        Self->TransQueue.RemoveTxInFly(txId, &replies);
 
         ForgetTx(txId);
         LOG_INFO(ctx, NKikimrServices::TX_DATASHARD,
@@ -1221,12 +1223,14 @@ ECleanupStatus TPipeline::CleanupOutdated(NIceDb::TNiceDb& db, const TActorConte
 bool TPipeline::CleanupVolatile(ui64 txId, const TActorContext& ctx,
         std::vector<std::unique_ptr<IEventHandle>>& replies)
 {
-    if (Self->TransQueue.CleanupVolatile(txId, replies)) {
+    if (Self->TransQueue.CleanupVolatile(txId)) {
         auto op = Self->TransQueue.FindTxInFly(txId);
         if (op && !op->IsExecutionPlanFinished()) {
+            op->OnCleanup(*Self, replies);
             GetExecutionUnit(op->GetCurrentUnit()).RemoveOperation(op);
         }
-        
+        Self->TransQueue.RemoveTxInFly(txId, &replies);
+
         ForgetTx(txId);
 
         Self->CheckDelayedProposeQueue(ctx);
@@ -1244,6 +1248,25 @@ bool TPipeline::CleanupVolatile(ui64 txId, const TActorContext& ctx,
     }
 
     return false;
+}
+
+size_t TPipeline::CleanupWaitingVolatile(const TActorContext& ctx, std::vector<std::unique_ptr<IEventHandle>>& replies)
+{
+    std::vector<ui64> cleanupTxs;
+    for (const auto& pr : Self->TransQueue.GetTxsInFly()) {
+        if (pr.second->HasVolatilePrepareFlag() && !pr.second->GetStep()) {
+            cleanupTxs.push_back(pr.first);
+        }
+    }
+
+    size_t cleaned = 0;
+    for (ui64 txId : cleanupTxs) {
+        if (CleanupVolatile(txId, ctx, replies)) {
+            ++cleaned;
+        }
+    }
+
+    return cleaned;
 }
 
 ui64 TPipeline::PlannedTxInFly() const

--- a/ydb/core/tx/datashard/datashard_pipeline.h
+++ b/ydb/core/tx/datashard/datashard_pipeline.h
@@ -205,6 +205,7 @@ public:
         std::vector<std::unique_ptr<IEventHandle>>& replies);
     bool CleanupVolatile(ui64 txId, const TActorContext& ctx,
         std::vector<std::unique_ptr<IEventHandle>>& replies);
+    size_t CleanupWaitingVolatile(const TActorContext& ctx, std::vector<std::unique_ptr<IEventHandle>>& replies);
     ui64 PlannedTxInFly() const;
     const TSet<TStepOrder> &GetPlan() const;
     bool HasProposeDelayers() const;

--- a/ydb/core/tx/datashard/datashard_split_src.cpp
+++ b/ydb/core/tx/datashard/datashard_split_src.cpp
@@ -14,6 +14,8 @@ private:
     TEvDataShard::TEvSplit::TPtr Ev;
     bool SplitAlreadyFinished;
 
+    std::vector<std::unique_ptr<IEventHandle>> Replies;
+
 public:
     TTxSplit(TDataShard* ds, TEvDataShard::TEvSplit::TPtr& ev)
         : NTabletFlatExecutor::TTransactionBase<TDataShard>(ds)
@@ -53,6 +55,8 @@ public:
                 Self->Pipeline.AddCandidateOp(op);
                 Self->PlanQueue.Progress(ctx);
             }
+
+            Self->Pipeline.CleanupWaitingVolatile(ctx, Replies);
         } else {
             // Check that this is the same split request
             Y_ABORT_UNLESS(opId == Self->SrcSplitOpId,
@@ -83,6 +87,8 @@ public:
     }
 
     void Complete(const TActorContext &ctx) override {
+        Self->SendCommittedReplies(std::move(Replies));
+
         if (SplitAlreadyFinished) {
             // Send the Ack
             for (const TActorId& ackTo : Self->SrcAckSplitTo) {

--- a/ydb/core/tx/datashard/datashard_trans_queue.cpp
+++ b/ydb/core/tx/datashard/datashard_trans_queue.cpp
@@ -450,7 +450,7 @@ bool TTransQueue::CancelPropose(NIceDb::TNiceDb& db, ui64 txId, std::vector<std:
 // all planned transactions.
 // NOTE: DeadlineQueue no longer contains planned transactions.
 ECleanupStatus TTransQueue::CleanupOutdated(NIceDb::TNiceDb& db, ui64 outdatedStep, ui32 batchSize,
-        TVector<ui64>& outdatedTxs, std::vector<std::unique_ptr<IEventHandle>>& replies)
+        TVector<ui64>& outdatedTxs)
 {
     using Schema = TDataShard::Schema;
 
@@ -490,21 +490,22 @@ ECleanupStatus TTransQueue::CleanupOutdated(NIceDb::TNiceDb& db, ui64 outdatedSt
     for (const auto& pr : erasedDeadlines) {
         DeadlineQueue.erase(pr);
     }
-    for (ui64 txId : outdatedTxs) {
-        RemoveTxInFly(txId, &replies);
-    }
+
+    // We don't call RemoveTxInFly to give caller a chance to work with them
+    // Caller is expected to call RemoveTxInFly on all outdated txs
 
     Self->IncCounter(COUNTER_TX_PROGRESS_OUTDATED, outdatedTxs.size());
     return ECleanupStatus::Success;
 }
 
-bool TTransQueue::CleanupVolatile(ui64 txId, std::vector<std::unique_ptr<IEventHandle>>& replies) {
+bool TTransQueue::CleanupVolatile(ui64 txId) {
     auto it = TxsInFly.find(txId);
     if (it != TxsInFly.end() && it->second->HasVolatilePrepareFlag() && !it->second->GetStep()) {
         LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
                 "Cleaning up volatile tx " << txId << " ahead of time");
 
-        RemoveTxInFly(txId, &replies);
+        // We don't call RemoveTxInFly to give caller a chance to work with the operation
+        // Caller must call RemoveTxInFly on the transaction
 
         Self->IncCounter(COUNTER_TX_PROGRESS_OUTDATED, 1);
         return true;

--- a/ydb/core/tx/datashard/datashard_trans_queue.h
+++ b/ydb/core/tx/datashard/datashard_trans_queue.h
@@ -86,9 +86,8 @@ private: // for pipeline only
     void UpdateTxBody(NIceDb::TNiceDb& db, ui64 txId, const TStringBuf& txBody);
     void ProposeSchemaTx(NIceDb::TNiceDb& db, const TSchemaOperation& op);
     bool CancelPropose(NIceDb::TNiceDb& db, ui64 txId, std::vector<std::unique_ptr<IEventHandle>>& replies);
-    ECleanupStatus CleanupOutdated(NIceDb::TNiceDb& db, ui64 outdatedStep, ui32 batchSize,
-        TVector<ui64>& outdatedTxs, std::vector<std::unique_ptr<IEventHandle>>& replies);
-    bool CleanupVolatile(ui64 txId, std::vector<std::unique_ptr<IEventHandle>>& replies);
+    ECleanupStatus CleanupOutdated(NIceDb::TNiceDb& db, ui64 outdatedStep, ui32 batchSize, TVector<ui64>& outdatedTxs);
+    bool CleanupVolatile(ui64 txId);
 
     // Plan
 

--- a/ydb/core/tx/datashard/datashard_ut_minstep.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_minstep.cpp
@@ -66,13 +66,14 @@ TAutoPtr<IEventHandle> EjectDataPropose(TServer::TPtr server, ui64 dataShard)
 }
 
 Y_UNIT_TEST_SUITE(TDataShardMinStepTest) {
-    void TestDropTablePlanComesNotTooEarly(const TString& query, Ydb::StatusIds::StatusCode expectedStatus) {
+    void TestDropTablePlanComesNotTooEarly(const TString& query, Ydb::StatusIds::StatusCode expectedStatus, bool volatileTxs) {
         TPortManager pm;
         NKikimrConfig::TAppConfig app;
         app.MutableTableServiceConfig()->SetEnableKqpDataQuerySourceRead(false);
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
             .SetUseRealThreads(false)
+            .SetEnableDataShardVolatileTransactions(volatileTxs)
             .SetAppConfig(app);
 
         Tests::TServer::TPtr server = new TServer(serverSettings);
@@ -103,8 +104,9 @@ Y_UNIT_TEST_SUITE(TDataShardMinStepTest) {
         auto proposeEvent = EjectDataPropose(server, shard2);
 
         // drop one table while proposes are active
+        auto senderScheme = runtime.AllocateEdgeActor();
         const TInstant dropStart = runtime.GetCurrentTime();
-        ExecSQL(server, sender, "DROP TABLE `/Root/table-1`", false);
+        ExecSQL(server, senderScheme, "DROP TABLE `/Root/table-1`", false);
         WaitTabletBecomesOffline(server, shard1);
         const TInstant dropEnd = runtime.GetCurrentTime();
 
@@ -116,15 +118,18 @@ Y_UNIT_TEST_SUITE(TDataShardMinStepTest) {
             request->Record.CopyFrom(proposeEvent->Get<TEvTxProxy::TEvProposeTransaction>()->Record);
             runtime.SendToPipe(request->Record.GetCoordinatorID(), sender, request.Release());
 
-            TAutoPtr<IEventHandle> handle;
-            auto reply = runtime.GrabEdgeEventRethrow<TEvTxProxy::TEvProposeTransactionStatus>(handle);
-            UNIT_ASSERT_VALUES_EQUAL((TEvTxProxy::TEvProposeTransactionStatus::EStatus)reply->Record.GetStatus(),
-                TEvTxProxy::TEvProposeTransactionStatus::EStatus::StatusOutdated);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvTxProxy::TEvProposeTransactionStatus>(sender);
+            auto expectedPlanStatus = volatileTxs
+                // Volatile transactions abort eagerly, so plan will be accepted (but eventually fail)
+                ? TEvTxProxy::TEvProposeTransactionStatus::EStatus::StatusAccepted
+                : TEvTxProxy::TEvProposeTransactionStatus::EStatus::StatusOutdated;
+            UNIT_ASSERT_VALUES_EQUAL((TEvTxProxy::TEvProposeTransactionStatus::EStatus)ev->Get()->Record.GetStatus(),
+                expectedPlanStatus);
         }
 
         { // handle respond from unplanned data transaction because plan ejection
-            TAutoPtr<IEventHandle> handle;
-            auto reply = runtime.GrabEdgeEventRethrow<NKqp::TEvKqp::TEvQueryResponse>(handle);
+            auto ev = runtime.GrabEdgeEventRethrow<NKqp::TEvKqp::TEvQueryResponse>(sender);
+            auto* reply = ev->Get();
             NYql::TIssues issues;
             NYql::IssuesFromMessage(reply->Record.GetRef().GetResponse().GetQueryIssues(), issues);
             UNIT_ASSERT_VALUES_EQUAL_C(reply->Record.GetRef().GetYdbStatus(), expectedStatus,
@@ -137,10 +142,11 @@ Y_UNIT_TEST_SUITE(TDataShardMinStepTest) {
         WaitTabletBecomesOffline(server, shard2);
     }
 
-    Y_UNIT_TEST(TestDropTablePlanComesNotTooEarlyRW) {
+    Y_UNIT_TEST_TWIN(TestDropTablePlanComesNotTooEarlyRW, VolatileTxs) {
         TestDropTablePlanComesNotTooEarly(
             "UPSERT INTO `/Root/table-2` (key, value) SELECT key, value FROM `/Root/table-1`;",
-            Ydb::StatusIds::UNDETERMINED
+            Ydb::StatusIds::ABORTED,
+            VolatileTxs
         );
     }
 
@@ -373,13 +379,14 @@ Y_UNIT_TEST_SUITE(TDataShardMinStepTest) {
         TestAlterProposeRebootMinStep(ERebootOnPropose::SchemeShard);
     }
 
-    void TestDropTableCompletesQuickly(const TString& query, Ydb::StatusIds::StatusCode expectedStatus) {
+    void TestDropTableCompletesQuickly(const TString& query, Ydb::StatusIds::StatusCode expectedStatus, bool volatileTxs) {
         TPortManager pm;
         NKikimrConfig::TAppConfig app;
         app.MutableTableServiceConfig()->SetEnableKqpDataQuerySourceRead(false);
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
             .SetUseRealThreads(false)
+            .SetEnableDataShardVolatileTransactions(volatileTxs)
             .SetAppConfig(app);
 
         Tests::TServer::TPtr server = new TServer(serverSettings);
@@ -470,10 +477,11 @@ Y_UNIT_TEST_SUITE(TDataShardMinStepTest) {
         WaitTabletBecomesOffline(server, shard2);
     }
 
-    Y_UNIT_TEST(TestDropTableCompletesQuicklyRW) {
+    Y_UNIT_TEST_TWIN(TestDropTableCompletesQuicklyRW, VolatileTxs) {
         TestDropTableCompletesQuickly(
             "UPSERT INTO `/Root/table-2` (key, value) SELECT key, value FROM `/Root/table-1`;",
-            Ydb::StatusIds::SUCCESS
+            VolatileTxs ? Ydb::StatusIds::ABORTED : Ydb::StatusIds::SUCCESS,
+            VolatileTxs
         );
     }
 

--- a/ydb/core/tx/datashard/datashard_ut_order.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_order.cpp
@@ -2109,7 +2109,10 @@ Y_UNIT_TEST(TestPlannedTimeoutSplit) {
     // Wait for query to return an error
     {
         auto response = AwaitResponse(runtime, fWrite1);
-        UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::UNAVAILABLE);
+        UNIT_ASSERT_C(
+            response.operation().status() == Ydb::StatusIds::ABORTED ||
+            response.operation().status() == Ydb::StatusIds::UNAVAILABLE,
+            "Status: " << response.operation().status());
     }
 }
 
@@ -2247,6 +2250,7 @@ Y_UNIT_TEST(TestPlannedHalfOverloadedSplit) {
     {
         auto response = AwaitResponse(runtime, fWrite1);
         UNIT_ASSERT_C(
+            response.operation().status() == Ydb::StatusIds::ABORTED ||
             response.operation().status() == Ydb::StatusIds::OVERLOADED ||
             response.operation().status() == Ydb::StatusIds::UNAVAILABLE,
             "Status: " << response.operation().status());

--- a/ydb/core/tx/datashard/datashard_write_operation.h
+++ b/ydb/core/tx/datashard/datashard_write_operation.h
@@ -333,6 +333,8 @@ public:
     void SetError(const NKikimrDataEvents::TEvWriteResult::EStatus& status, const TString& errorMsg);
     void SetWriteResult(std::unique_ptr<NEvents::TDataEvents::TEvWriteResult>&& writeResult);
 
+    void OnCleanup(TDataShard& self, std::vector<std::unique_ptr<IEventHandle>>& replies) override;
+
 private:
     void TrackMemory() const;
     void UntrackMemory() const;

--- a/ydb/core/tx/datashard/operation.cpp
+++ b/ydb/core/tx/datashard/operation.cpp
@@ -330,5 +330,10 @@ bool TOperation::OnStopping(TDataShard&, const TActorContext&)
     return true;
 }
 
+void TOperation::OnCleanup(TDataShard&, std::vector<std::unique_ptr<IEventHandle>>&)
+{
+    // By default operation does nothing
+}
+
 } // namespace NDataShard
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/operation.h
+++ b/ydb/core/tx/datashard/operation.h
@@ -836,6 +836,16 @@ public:
      */
     virtual bool OnStopping(TDataShard& self, const TActorContext& ctx);
 
+    /**
+     * Called when operation is aborted on cleanup
+     *
+     * Distributed transaction is cleaned up when deadline is reached, and
+     * it hasn't been planned yet. Additionally volatile transactions are
+     * cleaned when shard is waiting for transaction queue to drain, and
+     * the given operation wasn't planned yet.
+     */
+    virtual void OnCleanup(TDataShard& self, std::vector<std::unique_ptr<IEventHandle>>& replies);
+
 protected:
     TOperation()
         : TOperation(TBasicOpInfo())


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Cancel waiting volatile transactions on split and schema changes.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Proposed, but not yet planned transactions currently block splits and schema changes, during which shard becomes unavailable for up to 30 seconds until those operations time out. Since volatile transactions are in-memory and don't have any obligation to other participants until they are executed, shards may cancel them at any time, which they now do after split start or schema propose. This helps with long unavailability when nodes under load are suddenly killed.

Fixes #3084.

Merge from #3136 and #3170.