### PR TITLE
do schema snapshots after a reassign

### DIFF
--- a/ydb/core/protos/scheme_log.proto
+++ b/ydb/core/protos/scheme_log.proto
@@ -73,5 +73,7 @@ message TAlterRecord {
 
 message TSchemeChanges {
     repeated TAlterRecord Delta = 1;
-    optional bool Rewrite = 2 [default = false]; // If set, we are allowed to forget all scheme changes before this
+    // If the flag bellow is set, delete all scheme blobs before this
+    // Note that an old version will ignore the flag and will not delete anything
+    optional bool Rewrite = 2 [default = false];
 };

--- a/ydb/core/protos/scheme_log.proto
+++ b/ydb/core/protos/scheme_log.proto
@@ -73,4 +73,5 @@ message TAlterRecord {
 
 message TSchemeChanges {
     repeated TAlterRecord Delta = 1;
+    optional bool Rewrite = 2 [default = false]; // If set, we are allowed to forget all scheme changes before this
 };

--- a/ydb/core/tablet_flat/flat_boot_snap.h
+++ b/ydb/core/tablet_flat/flat_boot_snap.h
@@ -142,8 +142,18 @@ namespace NBoot {
 
             blobs.reserve(Proto.SchemeInfoBodiesSize());
 
-            for (const auto &one : Proto.GetSchemeInfoBodies())
+            ui32 fromGeneration = 0;
+            const auto* systemChannel = Logic->Info->ChannelInfo(0);
+            if (systemChannel) {
+                fromGeneration = systemChannel->LatestEntry()->FromGeneration;
+            }
+
+            for (const auto &one : Proto.GetSchemeInfoBodies()) {
                 blobs.emplace_back(LogoBlobIDFromLogoBlobID(one));
+                if (blobs.back().Generation() < fromGeneration) {
+                    Logic->Result().ShouldSnapshotScheme = true;
+                }
+            }
 
             NPageCollection::TGroupBlobsByCookie chop(blobs);
 

--- a/ydb/core/tablet_flat/flat_boot_snap.h
+++ b/ydb/core/tablet_flat/flat_boot_snap.h
@@ -142,15 +142,11 @@ namespace NBoot {
 
             blobs.reserve(Proto.SchemeInfoBodiesSize());
 
-            ui32 fromGeneration = 0;
-            const auto* systemChannel = Logic->Info->ChannelInfo(0);
-            if (systemChannel) {
-                fromGeneration = systemChannel->LatestEntry()->FromGeneration;
-            }
-
             for (const auto &one : Proto.GetSchemeInfoBodies()) {
                 blobs.emplace_back(LogoBlobIDFromLogoBlobID(one));
-                if (blobs.back().Generation() < fromGeneration) {
+                const auto& blob = blobs.back();
+                const auto* channel = Logic->Info->ChannelInfo(blob.Channel());
+                if (channel && blob.Generation() < channel->LatestEntry()->FromGeneration) {
                     Logic->Result().ShouldSnapshotScheme = true;
                 }
             }

--- a/ydb/core/tablet_flat/flat_dbase_scheme.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.cpp
@@ -318,9 +318,6 @@ TAlter& TAlter::SetEraseCache(ui32 tableId, bool enabled, ui32 minRows, ui32 max
 TAlter& TAlter::SetRewrite()
 {
     Log.SetRewrite(true);
-    if (Sink) {
-        Sink->SetRewriteScheme();
-    }
     return *this;
 }
 

--- a/ydb/core/tablet_flat/flat_dbase_scheme.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.cpp
@@ -58,7 +58,6 @@ TAutoPtr<TSchemeChanges> TScheme::GetSnapshot() const {
     delta.SetExecutorLogFlushPeriod(Executor.LogFlushPeriod);
     delta.SetExecutorResourceProfile(Executor.ResourceProfile);
     delta.SetExecutorFastLogPolicy(Executor.LogFastTactic);
-
     return delta.Flush();
 }
 
@@ -316,6 +315,15 @@ TAlter& TAlter::SetEraseCache(ui32 tableId, bool enabled, ui32 minRows, ui32 max
     return ApplyLastRecord();
 }
 
+TAlter& TAlter::SetRewrite()
+{
+    Log.SetRewrite(true);
+    if (Sink) {
+        Sink->SetRewriteScheme();
+    }
+    return *this;
+}
+
 TAlter::operator bool() const noexcept
 {
     return Log.DeltaSize() > 0;
@@ -324,7 +332,7 @@ TAlter::operator bool() const noexcept
 TAutoPtr<TSchemeChanges> TAlter::Flush()
 {
     TAutoPtr<TSchemeChanges> log(new TSchemeChanges);
-    log->MutableDelta()->Swap(Log.MutableDelta());
+    log->Swap(&Log);
     return log;
 }
 

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -217,8 +217,6 @@ public:
      * is true the record is deemed useful, otherwise it is discarded.
      */
     virtual bool ApplyAlterRecord(const TAlterRecord& record) = 0;
-
-    virtual void SetRewriteScheme() {};
 };
 
 // scheme delta

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -217,6 +217,8 @@ public:
      * is true the record is deemed useful, otherwise it is discarded.
      */
     virtual bool ApplyAlterRecord(const TAlterRecord& record) = 0;
+
+    virtual void SetRewriteScheme() {};
 };
 
 // scheme delta
@@ -259,6 +261,7 @@ public:
     TAlter& SetByKeyFilter(ui32 tableId, bool enabled);
     TAlter& SetColdBorrow(ui32 tableId, bool enabled);
     TAlter& SetEraseCache(ui32 tableId, bool enabled, ui32 minRows, ui32 maxBytes);
+    TAlter& SetRewrite();
 
     TAutoPtr<TSchemeChanges> Flush();
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -486,6 +486,18 @@ void TExecutor::Active(const TActorContext &ctx) {
 
     MakeLogSnapshot();
 
+    if (loadedState->ShouldSnapshotScheme) {
+        TTxStamp stamp = Stamp();
+        auto alter = Database->GetScheme().GetSnapshot();
+        alter->SetRewrite(true);
+        auto change = alter->SerializeAsString();
+        Database->RollUp(stamp, change, {}, {});
+        auto commit = CommitManager->Begin(true, ECommit::Misc, {});
+        LogicAlter->Clear();
+        LogicAlter->WriteLog(*commit, std::move(change));
+        CommitManager->Commit(commit);
+    }
+
     if (auto error = CheckBorrowConsistency()) {
         if (auto logl = Logger->Log(ELnLev::Crit))
             logl << NFmt::Do(*this) << " Borrow consistency failed: " << error;
@@ -497,18 +509,6 @@ void TExecutor::Active(const TActorContext &ctx) {
     Owner->ActivateExecutor(OwnerCtx());
 
     UpdateCounters(ctx);
-
-    if (loadedState->ShouldSnapshotScheme) {
-        TTxStamp stamp = Stamp();
-        auto alter = Database->GetScheme().GetSnapshot();
-        alter->SetRewrite(true);
-        auto change = alter->SerializeAsString();
-        auto commit = CommitManager->Begin(true, ECommit::Misc, {});
-        Database->RollUp(stamp, change, {}, {});
-        LogicAlter->Clear();
-        LogicAlter->WriteLog(*commit, std::move(change));
-        CommitManager->Commit(commit);
-    }
 }
 
 void TExecutor::TranscriptBootOpResult(ui32 res, const TActorContext &ctx) {

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.h
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.h
@@ -37,6 +37,7 @@ namespace NBoot {
         THashMap<ui32, NTable::TRowVersionRanges> RemovedRowVersions;
 
         TVector<TIntrusivePtr<TPrivatePageCache::TInfo>> PageCaches;
+        bool ShouldSnapshotScheme = false;
     };
 }
 

--- a/ydb/core/tablet_flat/logic_alter_main.h
+++ b/ydb/core/tablet_flat/logic_alter_main.h
@@ -36,6 +36,12 @@ namespace NTabletFlatExecutor {
             auto items = snap.MutableSchemeInfoBodies();
             for (const auto &logo : Log)
                 LogoBlobIDFromLogoBlobID(logo, items->Add());
+
+            auto deleted = snap.MutableGcSnapLeft();
+            for (const auto &logo : ObsoleteLog) {
+                LogoBlobIDFromLogoBlobID(logo, deleted->Add());
+            }
+            ObsoleteLog.clear();
         }
 
         void WriteLog(TLogCommit &commit, TString alter) noexcept
@@ -50,11 +56,18 @@ namespace NTabletFlatExecutor {
             }
         }
 
+        void Clear() noexcept
+        {
+            ObsoleteLog.splice(ObsoleteLog.end(), Log);
+            Bytes = 0;
+        }
+
     protected:
         TAutoPtr<NPageCollection::TSteppedCookieAllocator> Cookies;
         NPageCollection::TSlicer Slicer;
         ui64 Bytes = 0;
         TList<TLogoBlobID> Log;
+        TList<TLogoBlobID> ObsoleteLog;
     };
 
 }

--- a/ydb/core/tablet_flat/logic_alter_main.h
+++ b/ydb/core/tablet_flat/logic_alter_main.h
@@ -41,7 +41,6 @@ namespace NTabletFlatExecutor {
             for (const auto &logo : ObsoleteLog) {
                 LogoBlobIDFromLogoBlobID(logo, deleted->Add());
             }
-            ObsoleteLog.clear();
         }
 
         void WriteLog(TLogCommit &commit, TString alter) noexcept

--- a/ydb/core/tablet_flat/test/libs/exec/helper.h
+++ b/ydb/core/tablet_flat/test/libs/exec/helper.h
@@ -21,7 +21,7 @@ namespace NFake {
             return new NFake::TOwner(user, retry, info, setup, followerId);
         }
 
-        static TStorageInfo* MakeTabletInfo(ui64 tablet) noexcept
+        virtual TStorageInfo* MakeTabletInfo(ui64 tablet) noexcept
         {
             const auto none = TErasureType::ErasureNone;
 

--- a/ydb/core/tablet_flat/test/libs/exec/runner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/runner.h
@@ -66,11 +66,15 @@ namespace NFake {
             return &Env;
         }
 
-        void FireTablet(TActorId user, ui32 tablet, TStarter::TMake make, ui32 followerId = 0)
+        void FireTablet(TActorId user, ui32 tablet, TStarter::TMake make, ui32 followerId = 0, TStarter *starter = nullptr)
         {
             const auto mbx =  EMail::Simple;
+            TStarter defaultStarter;
+            if (starter == nullptr) {
+                starter = &defaultStarter;
+            }
 
-            RunOn(7, { }, TStarter().Do(user, 1, tablet, std::move(make), followerId), mbx);
+            RunOn(7, { }, starter->Do(user, 1, tablet, std::move(make), followerId), mbx);
         }
 
         void FireFollower(TActorId user, ui32 tablet, TStarter::TMake make, ui32 followerId)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Schema data in tablet log is now rewritten after a reassign to another storage group, allowing to eventually free space used by old schema changes.

### Changelog category <!-- remove all except one -->


* Improvement


### Additional information

...
