### PR TITLE
Merging sorted streams improvement

### DIFF
--- a/ydb/core/formats/arrow/merging_sorted_input_stream.h
+++ b/ydb/core/formats/arrow/merging_sorted_input_stream.h
@@ -41,14 +41,14 @@ private:
     std::shared_ptr<TReplaceKey> PrevKey;
 
     std::vector<TSortCursorImpl> Cursors;
-    TSortingHeap Queue;
+    TLoserTree LoserTree;
 
     void Init();
-    void FetchNextBatch(const TSortCursor& current, TSortingHeap& queue);
-    void Merge(IRowsBuffer& rowsBuffer, TSortingHeap& queue);
+    void FetchNextBatch(const TSortCursor& current, TLoserTree& tree);
+    void Merge(IRowsBuffer& rowsBuffer, TLoserTree& tree);
 
     template <bool replace, bool limit>
-    void MergeImpl(IRowsBuffer& rowsBuffer, TSortingHeap& queue);
+    void MergeImpl(IRowsBuffer& rowsBuffer, TLoserTree& tree);
 };
 
 }

--- a/ydb/core/formats/arrow/sort_cursor.h
+++ b/ydb/core/formats/arrow/sort_cursor.h
@@ -155,7 +155,7 @@ public:
         Cursors.reserve(tCursors.size());
         for (auto & cur : tCursors)
             if (!cur.Empty())
-                Cursors.emplace_back(SortCursor(&cur, not_null));
+                Cursors.emplace_back(TSortCursor(&cur, notNull));
 
         while (DataSize < Cursors.size())
             DataSize *= 2;

--- a/ydb/core/formats/arrow/sort_cursor.h
+++ b/ydb/core/formats/arrow/sort_cursor.h
@@ -165,7 +165,7 @@ public:
         Build(0);
     }
 
-    bool IsValid() const { return Tree[0] != -1; }
+    bool IsValid() const { return !Tree.empty() && Tree[0] != -1; }
     TSortCursor& Current() { return Cursors[Tree[0]]; }
 
     void Next() {
@@ -181,11 +181,13 @@ public:
     }
 
     void ReplaceTop(TSortCursor&& new_top) {
+        Y_ABORT_UNLESS(IsValid());
         Current() = new_top;
         UpdateTop();
     }
 
     void RemoveTop() {
+        Y_ABORT_UNLESS(IsValid());
         int32_t top = Tree[0];
         Tree[0] = -1;
         Update(top, -1);


### PR DESCRIPTION
### Main change:
- Replace heap with [Loser Tree](https://en.wikipedia.org/wiki/K-way_merge_algorithm#Tournament_Tree), fix [TODO](https://github.com/ydb-platform/ydb/blob/0916a1061bb8d774a39fa242eb28753f42da412c/ydb/core/formats/arrow/sort_cursor.h#L148)

### Changes in [ydb/core/formats/arrow](https://github.com/ydb-platform/ydb/blob/main/ydb/core/formats/arrow):
- sort_cursor.h: add TLoserTree (with implementation)
- merging_sorted_input_stream.cpp: replace TSortingHeap with TLoserTree, Queue with LoserTree
- merging_sorted_input_stream.h: replace TSortingHeap with TLoserTree, Queue with LoserTree