### PR TITLE
Temporarily mute YQL Generic provider integration tests due to problems with Docker on Github CI

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -36,8 +36,7 @@ ydb/core/viewer/ut Viewer.TabletMerging
 ydb/core/viewer/ut Viewer.TabletMergingPacked
 ydb/library/actors/http/ut HttpProxy.TooLongHeader
 ydb/library/actors/http/ut sole*
-ydb/library/yql/providers/generic/connector/tests sole*
-ydb/library/yql/providers/generic/connector/tests test.py.*
+ydb/library/yql/providers/generic/connector/tests *
 ydb/public/lib/ydb_cli/topic/ut TTopicReaderTests.TestRun_ReadOneMessage
 ydb/public/sdk/cpp/client/ydb_persqueue_core/ut/with_offset_ranges_mode_ut RetryPolicy.RetryWithBatching
 ydb/public/sdk/cpp/client/ydb_persqueue_core/ut/with_offset_ranges_mode_ut RetryPolicy.TWriteSession_TestBrokenPolicy


### PR DESCRIPTION

### Changelog entry

* Temporarily mute YQL Generic provider integration tests due to problems with Docker on Github CI

### Changelog category 


* Not for changelog (changelog entry is not required)

### Additional information

...
