### PR TITLE
Always assume default YT cluster will be used in YQL query

### DIFF
--- a/ydb/library/yql/yt/native/plugin.cpp
+++ b/ydb/library/yql/yt/native/plugin.cpp
@@ -400,7 +400,12 @@ public:
             };
         }
 
+        if (DefaultCluster_ && !usedClusters->contains(*DefaultCluster_)) {
+            usedClusters->insert(*DefaultCluster_);
+        }
+
         std::vector<TString> clustersList(usedClusters->begin(), usedClusters->end());
+
         return TClustersResult{
             .Clusters = clustersList,
         };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Not for changelog. Please remove

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Adding DefaultCluster to the list of used clusters

YQL can't give us all clusters that will be used during execution, but we need this information in order to create and pass yt tokens

YQL team said that they can't give us something like `GetClustersForWhichYQLWillUseTokens` because YQL can add new clusters during execution

In a simple example with python udf
```
$script = @@#py
def foo():
    """
       ()->String

       foo function description
    """
    return b"bar"
@@;

$udf = Python3::foo($script);
SELECT $udf(); -- bar
```
We see an error 'Client is missing credentials'
Because YQL did not return default cluster as used one, but used it during execution
