### PR TITLE
Remove actors.pb.h from project-wide includes

### DIFF
--- a/ydb/core/tx/tx_proxy/datareq.cpp
+++ b/ydb/core/tx/tx_proxy/datareq.cpp
@@ -30,6 +30,7 @@
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/protos/actors.pb.h>
 
 #include <util/generic/hash_set.h>
 #include <util/generic/queue.h>

--- a/ydb/library/actors/core/event.cpp
+++ b/ydb/library/actors/core/event.cpp
@@ -1,6 +1,8 @@
 #include "event.h"
 #include "event_pb.h"
 
+#include <ydb/library/actors/protos/actors.pb.h>
+
 namespace NActors {
 
     const TScopeId TScopeId::LocallyGenerated{

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -5,7 +5,6 @@
 
 #include <google/protobuf/io/zero_copy_stream.h>
 #include <google/protobuf/arena.h>
-#include <ydb/library/actors/protos/actors.pb.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 #include <util/generic/deque.h>
 #include <util/system/context.h>
@@ -17,6 +16,10 @@
 
 // enable only when patch with this macro was successfully deployed
 #define USE_EXTENDED_PAYLOAD_FORMAT 0
+
+namespace NActorsProto {
+    class TActorId;
+} // NActorsProto
 
 namespace NActors {
 
@@ -642,13 +645,7 @@ namespace NActors {
         }
     };
 
-    inline TActorId ActorIdFromProto(const NActorsProto::TActorId& actorId) {
-        return TActorId(actorId.GetRawX1(), actorId.GetRawX2());
-    }
+    TActorId ActorIdFromProto(const NActorsProto::TActorId& actorId);
+    void ActorIdToProto(const TActorId& src, NActorsProto::TActorId* dest);
 
-    inline void ActorIdToProto(const TActorId& src, NActorsProto::TActorId* dest) {
-        Y_DEBUG_ABORT_UNLESS(dest);
-        dest->SetRawX1(src.RawX1());
-        dest->SetRawX2(src.RawX2());
-    }
 }

--- a/ydb/library/actors/core/events.cpp
+++ b/ydb/library/actors/core/events.cpp
@@ -1,0 +1,17 @@
+#include "events.h"
+
+#include <ydb/library/actors/protos/actors.pb.h>
+
+namespace NActors {
+
+    TActorId ActorIdFromProto(const NActorsProto::TActorId& actorId) {
+        return TActorId(actorId.GetRawX1(), actorId.GetRawX2());
+    }
+
+    void ActorIdToProto(const TActorId& src, NActorsProto::TActorId* dest) {
+        Y_DEBUG_ABORT_UNLESS(dest);
+        dest->SetRawX1(src.RawX1());
+        dest->SetRawX2(src.RawX2());
+    }
+
+} // NActors

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -3,8 +3,12 @@
 #include "event.h"
 #include "event_pb.h"
 
-#include <ydb/library/actors/protos/actors.pb.h>
 #include <util/system/unaligned_mem.h>
+
+namespace NActorsProto {
+    class TCallbackException;
+    class TActorId;
+} // NActorsProto
 
 namespace NActors {
     struct TEvents {
@@ -190,21 +194,21 @@ namespace NActors {
             DEFINE_SIMPLE_LOCAL_EVENT(TEvFlushLog, "System: TEvFlushLog")
         };
 
-        struct TEvCallbackException: public TEventPB<TEvCallbackException,
-                                                      NActorsProto::TCallbackException,
-                                                      TSystem::CallbackException> {
-            TEvCallbackException(const TActorId& id, const TString& msg) {
-                ActorIdToProto(id, Record.MutableActorId());
-                Record.SetExceptionMessage(msg);
-            }
+        struct TEvCallbackException : TEventBase<TEvCallbackException, TSystem::CallbackException> {
+            DEFINE_SIMPLE_LOCAL_EVENT(TEvCallbackException, "System: TEvCallbackException")
+
+            const TActorId Id;
+            TString Msg;
+
+            TEvCallbackException(const TActorId& id, const TString& msg) : Id(id), Msg(msg) {}
         };
 
-        struct TEvCallbackCompletion: public TEventPB<TEvCallbackCompletion,
-                                                       NActorsProto::TActorId,
-                                                       TSystem::CallbackCompletion> {
-            TEvCallbackCompletion(const TActorId& id) {
-                ActorIdToProto(id, &Record);
-            }
+        struct TEvCallbackCompletion : TEventBase<TEvCallbackCompletion, TSystem::CallbackCompletion> {
+            DEFINE_SIMPLE_LOCAL_EVENT(TEvCallbackException, "System: TEvCallbackCompletion")
+
+            const TActorId Id;
+
+            TEvCallbackCompletion(const TActorId& id) : Id(id) {}
         };
 
         struct TEvGone: public TEventBase<TEvGone, TSystem::Gone> {

--- a/ydb/library/actors/core/mon.cpp
+++ b/ydb/library/actors/core/mon.cpp
@@ -1,0 +1,75 @@
+#include "mon.h"
+
+#include <ydb/library/actors/protos/actors.pb.h>
+
+namespace NActors::NMon {
+
+    TEvRemoteHttpInfo::TEvRemoteHttpInfo()
+    {}
+
+    TEvRemoteHttpInfo::TEvRemoteHttpInfo(const TString& query, HTTP_METHOD method)
+        : Query(query)
+        , Method(method)
+    {}
+
+    TEvRemoteHttpInfo::TEvRemoteHttpInfo(NActorsProto::TRemoteHttpInfo info)
+        : Query(MakeSerializedQuery(info))
+        , ExtendedQuery(std::make_unique<NActorsProto::TRemoteHttpInfo>(info))
+    {}
+
+    TEvRemoteHttpInfo::~TEvRemoteHttpInfo()
+    {}
+
+    TString TEvRemoteHttpInfo::MakeSerializedQuery(const NActorsProto::TRemoteHttpInfo& info) {
+        TString s(1, '\0');
+        const bool success = info.AppendToString(&s);
+        Y_ABORT_UNLESS(success);
+        return s;
+    }
+
+    TString TEvRemoteHttpInfo::PathInfo() const {
+        if (ExtendedQuery) {
+            return ExtendedQuery->GetPath();
+        } else {
+            const size_t pos = Query.find('?');
+            return (pos == TString::npos) ? TString() : Query.substr(0, pos);
+        }
+    }
+
+    TCgiParameters TEvRemoteHttpInfo::Cgi() const {
+        if (ExtendedQuery) {
+            TCgiParameters params;
+            for (const auto& kv : ExtendedQuery->GetQueryParams()) {
+                params.emplace(kv.GetKey(), kv.GetValue());
+            }
+            return params;
+        } else {
+            const size_t pos = Query.find('?');
+            return TCgiParameters((pos == TString::npos) ? TString() : Query.substr(pos + 1));
+        }
+    }
+
+    HTTP_METHOD TEvRemoteHttpInfo::GetMethod() const {
+        return ExtendedQuery ? static_cast<HTTP_METHOD>(ExtendedQuery->GetMethod()) : Method;
+    }
+
+    IEventBase* TEvRemoteHttpInfo::Load(TEventSerializedData* bufs) {
+        TString s = bufs->GetString();
+        if (s.size() && s[0] == '\0') {
+            TRope::TConstIterator iter = bufs->GetBeginIter();
+            ui64 size = bufs->GetSize();
+            iter += 1, --size; // skip '\0'
+            TRopeStream stream(iter, size);
+
+            auto res = std::make_unique<TEvRemoteHttpInfo>();
+            res->Query = s;
+            res->ExtendedQuery = std::make_unique<NActorsProto::TRemoteHttpInfo>();
+            const bool success = res->ExtendedQuery->ParseFromZeroCopyStream(&stream);
+            Y_ABORT_UNLESS(success);
+            return res.release();
+        } else {
+            return new TEvRemoteHttpInfo(s);
+        }
+    }
+
+} // NActors::NMon

--- a/ydb/library/actors/core/mon.h
+++ b/ydb/library/actors/core/mon.h
@@ -5,6 +5,10 @@
 #include <library/cpp/monlib/service/monservice.h>
 #include <library/cpp/monlib/service/pages/mon_page.h>
 
+namespace NActorsProto {
+    class TRemoteHttpInfo;
+} // NActorsProto
+
 namespace NActors {
     namespace NMon {
         enum {
@@ -80,55 +84,20 @@ namespace NActors {
         };
 
         struct TEvRemoteHttpInfo: public NActors::TEventBase<TEvRemoteHttpInfo, RemoteHttpInfo> {
-            TEvRemoteHttpInfo() = default;
+            TEvRemoteHttpInfo();
+            TEvRemoteHttpInfo(const TString& query, HTTP_METHOD method = HTTP_METHOD_UNDEFINED);
+            TEvRemoteHttpInfo(NActorsProto::TRemoteHttpInfo info);
+            ~TEvRemoteHttpInfo();
 
-            TEvRemoteHttpInfo(const TString& query, HTTP_METHOD method = HTTP_METHOD_UNDEFINED)
-                : Query(query)
-                , Method(method)
-            {
-            }
-
-            TEvRemoteHttpInfo(NActorsProto::TRemoteHttpInfo info)
-                : Query(MakeSerializedQuery(info))
-                , ExtendedQuery(std::move(info))
-            {}
-
-            static TString MakeSerializedQuery(const NActorsProto::TRemoteHttpInfo& info) {
-                TString s(1, '\0');
-                const bool success = info.AppendToString(&s);
-                Y_ABORT_UNLESS(success);
-                return s;
-            }
+            static TString MakeSerializedQuery(const NActorsProto::TRemoteHttpInfo& info);
 
             TString Query;
             HTTP_METHOD Method = HTTP_METHOD_UNDEFINED;
-            std::optional<NActorsProto::TRemoteHttpInfo> ExtendedQuery;
+            std::unique_ptr<NActorsProto::TRemoteHttpInfo> ExtendedQuery;
 
-            TString PathInfo() const {
-                if (ExtendedQuery) {
-                    return ExtendedQuery->GetPath();
-                } else {
-                    const size_t pos = Query.find('?');
-                    return (pos == TString::npos) ? TString() : Query.substr(0, pos);
-                }
-            }
-
-            TCgiParameters Cgi() const {
-                if (ExtendedQuery) {
-                    TCgiParameters params;
-                    for (const auto& kv : ExtendedQuery->GetQueryParams()) {
-                        params.emplace(kv.GetKey(), kv.GetValue());
-                    }
-                    return params;
-                } else {
-                    const size_t pos = Query.find('?');
-                    return TCgiParameters((pos == TString::npos) ? TString() : Query.substr(pos + 1));
-                }
-            }
-
-            HTTP_METHOD GetMethod() const {
-                return ExtendedQuery ? static_cast<HTTP_METHOD>(ExtendedQuery->GetMethod()) : Method;
-            }
+            TString PathInfo() const;
+            TCgiParameters Cgi() const;
+            HTTP_METHOD GetMethod() const;
 
             TString ToStringHeader() const override {
                 return "TEvRemoteHttpInfo";
@@ -146,24 +115,7 @@ namespace NActors {
                 return true;
             }
 
-            static IEventBase* Load(TEventSerializedData* bufs) {
-                TString s = bufs->GetString();
-                if (s.size() && s[0] == '\0') {
-                    TRope::TConstIterator iter = bufs->GetBeginIter();
-                    ui64 size = bufs->GetSize();
-                    iter += 1, --size; // skip '\0'
-                    TRopeStream stream(iter, size);
-
-                    auto res = std::make_unique<TEvRemoteHttpInfo>();
-                    res->Query = s;
-                    res->ExtendedQuery.emplace();
-                    const bool success = res->ExtendedQuery->ParseFromZeroCopyStream(&stream);
-                    Y_ABORT_UNLESS(success);
-                    return res.release();
-                } else {
-                    return new TEvRemoteHttpInfo(s);
-                }
-            }
+            static IEventBase* Load(TEventSerializedData* bufs);
         };
 
         struct TEvRemoteHttpInfoRes: public NActors::TEventBase<TEvRemoteHttpInfoRes, RemoteHttpInfoRes> {

--- a/ydb/library/actors/core/mon_ut.cpp
+++ b/ydb/library/actors/core/mon_ut.cpp
@@ -1,5 +1,6 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/library/actors/core/mon.h>
+#include <ydb/library/actors/protos/actors.pb.h>
 
 using namespace NActors;
 using namespace NMon;

--- a/ydb/library/actors/core/ya.make
+++ b/ydb/library/actors/core/ya.make
@@ -42,6 +42,7 @@ SRCS(
     event_local.h
     event_pb.cpp
     event_pb.h
+    events.cpp
     events.h
     events_undelivered.cpp
     executelater.h
@@ -75,6 +76,7 @@ SRCS(
     mailbox.h
     mailbox_queue_revolving.h
     mailbox_queue_simple.h
+    mon.cpp
     mon.h
     mon_stats.h
     monotonic.cpp

--- a/ydb/library/actors/protos/actors.proto
+++ b/ydb/library/actors/protos/actors.proto
@@ -11,11 +11,6 @@ message TTraceId {
     optional bytes Data = 1;
 }
 
-message TCallbackException {
-    required TActorId ActorId = 1;
-    required string ExceptionMessage = 2;
-}
-
 message TRemoteHttpInfo {
     message TQueryParam {
         optional string Key = 1;

--- a/ydb/library/actors/wilson/wilson_trace.cpp
+++ b/ydb/library/actors/wilson/wilson_trace.cpp
@@ -3,7 +3,28 @@
 #include <util/generic/algorithm.h>
 #include <util/string/hex.h>
 
+#include <ydb/library/actors/protos/actors.pb.h>
+
 namespace NWilson {
+    TTraceId::TTraceId(const NActorsProto::TTraceId& pb)
+        : TTraceId()
+    {
+        if (pb.HasData()) {
+            const auto& data = pb.GetData();
+            if (data.size() == sizeof(TSerializedTraceId)) {
+                *this = *reinterpret_cast<const TSerializedTraceId*>(data.data());
+            }
+        }
+    }
+
+    void TTraceId::Serialize(NActorsProto::TTraceId *pb) const {
+        if (*this) {
+            TSerializedTraceId data;
+            Serialize(&data);
+            pb->SetData(reinterpret_cast<const char*>(&data), sizeof(data));
+        }
+    }
+
     TTraceId TTraceId::FromTraceparentHeader(const TStringBuf header, ui8 verbosity) {
         constexpr size_t versionChars = 2; // Only version 0 is supported
         constexpr size_t versionStart = 0;

--- a/ydb/library/actors/wilson/wilson_trace.h
+++ b/ydb/library/actors/wilson/wilson_trace.h
@@ -1,13 +1,16 @@
 #pragma once
 
 #include <ydb/library/actors/core/monotonic.h>
-#include <ydb/library/actors/protos/actors.pb.h>
 
 #include <util/random/random.h>
 #include <util/random/fast.h>
 #include <util/stream/output.h>
 
 #include <array>
+
+namespace NActorsProto {
+    class TTraceId;
+} // NActorsProto
 
 namespace NWilson {
     class TTraceId {
@@ -115,16 +118,7 @@ namespace NWilson {
             Y_DEBUG_ABORT_UNLESS(p - in == sizeof(TSerializedTraceId));
         }
 
-        TTraceId(const NActorsProto::TTraceId& pb)
-            : TTraceId()
-        {
-            if (pb.HasData()) {
-                const auto& data = pb.GetData();
-                if (data.size() == sizeof(TSerializedTraceId)) {
-                    *this = *reinterpret_cast<const TSerializedTraceId*>(data.data());
-                }
-            }
-        }
+        TTraceId(const NActorsProto::TTraceId& pb);
 
         void Serialize(TSerializedTraceId *out) const {
             char *p = *out;
@@ -137,13 +131,7 @@ namespace NWilson {
             Y_DEBUG_ABORT_UNLESS(p - *out == sizeof(TSerializedTraceId));
         }
 
-        void Serialize(NActorsProto::TTraceId *pb) const {
-            if (*this) {
-                TSerializedTraceId data;
-                Serialize(&data);
-                pb->SetData(reinterpret_cast<const char*>(&data), sizeof(data));
-            }
-        }
+        void Serialize(NActorsProto::TTraceId *pb) const;
 
         TTraceId& operator=(TTraceId&& other) {
             if (this != &other) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Remove actors.pb.h from project-wide includes

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Remove actors.pb.h from project-wide includes to reduce compilation time.
