### PR TITLE
Do not initiate IC session upon receiving TEvUnsubscribe

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -63,6 +63,11 @@ namespace NActors {
     void TInterconnectProxyTCP::RequestNodeInfo(STATEFN_SIG) {
         ICPROXY_PROFILED;
 
+        if (ev->GetTypeRewrite() == TEvents::TSystem::Unsubscribe) {
+            // do not initiate new session upon receiving this event
+            return;
+        }
+
         Y_ABORT_UNLESS(!IncomingHandshakeActor && !OutgoingHandshakeActor && !PendingIncomingHandshakeEvents && !PendingSessionEvents);
         EnqueueSessionEvent(ev);
         StartConfiguring();

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -177,7 +177,7 @@ namespace NActors {
 
     void TInterconnectSessionTCP::Unsubscribe(STATEFN_SIG) {
         LOG_DEBUG_IC_SESSION("ICS05", "unsubscribe for session state for %s", ev->Sender.ToString().data());
-        Proxy->Metrics->SubSubscribersCount( Subscribers.erase(ev->Sender));
+        Proxy->Metrics->SubSubscribersCount(Subscribers.erase(ev->Sender));
     }
 
     THolder<TEvHandshakeAck> TInterconnectSessionTCP::ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Do not initiate IC session upon receiving TEvUnsubscribe

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Previously TEvUnsubscribe to proxy in "pending activation" state led to initiating new connection and forwarding this event to session actor. This commit removes this incorrect behaviour, now TEvUnsubscribe on non-established session is just dropped as it's expected to be.
