### PR TITLE
TFederatedTopicWriteSession: use SelfContext instead of shared_ptr

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.cpp
@@ -24,11 +24,13 @@ bool DatabasesAreSame(std::shared_ptr<TDbInfo> lhs, std::shared_ptr<TDbInfo> rhs
 
 NTopic::TTopicClientSettings FromFederated(const TFederatedTopicClientSettings& settings);
 
-TFederatedWriteSession::TFederatedWriteSession(const TFederatedWriteSessionSettings& settings,
-                                             std::shared_ptr<TGRpcConnectionsImpl> connections,
-                                             const TFederatedTopicClientSettings& clientSetttings,
-                                             std::shared_ptr<TFederatedDbObserver> observer,
-                                             std::shared_ptr<std::unordered_map<NTopic::ECodec, THolder<NTopic::ICodec>>> codecs)
+TFederatedWriteSessionImpl::TFederatedWriteSessionImpl(
+    const TFederatedWriteSessionSettings& settings,
+    std::shared_ptr<TGRpcConnectionsImpl> connections,
+    const TFederatedTopicClientSettings& clientSetttings,
+    std::shared_ptr<TFederatedDbObserver> observer,
+    std::shared_ptr<std::unordered_map<NTopic::ECodec, THolder<NTopic::ICodec>>> codecs
+)
     : Settings(settings)
     , Connections(std::move(connections))
     , SubClientSetttings(FromFederated(clientSetttings))
@@ -42,11 +44,11 @@ TFederatedWriteSession::TFederatedWriteSession(const TFederatedWriteSessionSetti
 {
 }
 
-TStringBuilder TFederatedWriteSession::GetLogPrefix() const {
+TStringBuilder TFederatedWriteSessionImpl::GetLogPrefix() const {
      return TStringBuilder() << GetDatabaseLogPrefix(SubClientSetttings.Database_.GetOrElse("")) << "[" << SessionId << "] ";
 }
 
-void TFederatedWriteSession::Start() {
+void TFederatedWriteSessionImpl::Start() {
     // TODO validate settings?
     Settings.EventHandlers_.HandlersExecutor_->Start();
     with_lock(Lock) {
@@ -54,16 +56,18 @@ void TFederatedWriteSession::Start() {
         ClientHasToken = true;
     }
 
-    AsyncInit.Subscribe([self = shared_from_this()](const auto& f){
+    AsyncInit.Subscribe([selfCtx = SelfContext](const auto& f){
         Y_UNUSED(f);
-        with_lock(self->Lock) {
-            self->FederationState = self->Observer->GetState();
-            self->OnFederatedStateUpdateImpl();
+        if (auto self = selfCtx->LockShared()) {
+            with_lock(self->Lock) {
+                self->FederationState = self->Observer->GetState();
+                self->OnFederatedStateUpdateImpl();
+            }
         }
     });
 }
 
-void TFederatedWriteSession::OpenSubSessionImpl(std::shared_ptr<TDbInfo> db) {
+void TFederatedWriteSessionImpl::OpenSubSessionImpl(std::shared_ptr<TDbInfo> db) {
     if (Subsession) {
         PendingToken.Clear();
         Subsession->Close(TDuration::Zero());
@@ -77,32 +81,38 @@ void TFederatedWriteSession::OpenSubSessionImpl(std::shared_ptr<TDbInfo> db) {
 
     auto handlers = NTopic::TWriteSessionSettings::TEventHandlers()
         .HandlersExecutor(Settings.EventHandlers_.HandlersExecutor_)
-        .ReadyToAcceptHandler([self = shared_from_this()](NTopic::TWriteSessionEvent::TReadyToAcceptEvent& ev){
-            TDeferredWrite deferred(self->Subsession);
-            with_lock(self->Lock) {
-                Y_ABORT_UNLESS(self->PendingToken.Empty());
-                self->PendingToken = std::move(ev.ContinuationToken);
-                self->PrepareDeferredWrite(deferred);
-            }
-            deferred.DoWrite();
-        })
-        .AcksHandler([self = shared_from_this()](NTopic::TWriteSessionEvent::TAcksEvent& ev){
-            with_lock(self->Lock) {
-                Y_ABORT_UNLESS(ev.Acks.size() <= self->OriginalMessagesToGetAck.size());
-                for (size_t i = 0; i < ev.Acks.size(); ++i) {
-                    self->BufferFreeSpace += self->OriginalMessagesToGetAck.front().Data.size();
-                    self->OriginalMessagesToGetAck.pop_front();
+        .ReadyToAcceptHandler([selfCtx = SelfContext](NTopic::TWriteSessionEvent::TReadyToAcceptEvent& ev) {
+            if (auto self = selfCtx->LockShared()) {
+                TDeferredWrite deferred(self->Subsession);
+                with_lock(self->Lock) {
+                    Y_ABORT_UNLESS(self->PendingToken.Empty());
+                    self->PendingToken = std::move(ev.ContinuationToken);
+                    self->PrepareDeferredWrite(deferred);
                 }
-                self->ClientEventsQueue->PushEvent(std::move(ev));
-                if (self->BufferFreeSpace > 0 && !self->ClientHasToken) {
-                    self->ClientEventsQueue->PushEvent(NTopic::TWriteSessionEvent::TReadyToAcceptEvent{IssueContinuationToken()});
-                    self->ClientHasToken = true;
-                }
+                deferred.DoWrite();
             }
         })
-        .SessionClosedHandler([self = shared_from_this()](const NTopic::TSessionClosedEvent & ev){
-            with_lock(self->Lock) {
-                self->ClientEventsQueue->PushEvent(ev);
+        .AcksHandler([selfCtx = SelfContext](NTopic::TWriteSessionEvent::TAcksEvent& ev) {
+            if (auto self = selfCtx->LockShared()) {
+                with_lock(self->Lock) {
+                    Y_ABORT_UNLESS(ev.Acks.size() <= self->OriginalMessagesToGetAck.size());
+                    for (size_t i = 0; i < ev.Acks.size(); ++i) {
+                        self->BufferFreeSpace += self->OriginalMessagesToGetAck.front().Data.size();
+                        self->OriginalMessagesToGetAck.pop_front();
+                    }
+                    self->ClientEventsQueue->PushEvent(std::move(ev));
+                    if (self->BufferFreeSpace > 0 && !self->ClientHasToken) {
+                        self->ClientEventsQueue->PushEvent(NTopic::TWriteSessionEvent::TReadyToAcceptEvent{IssueContinuationToken()});
+                        self->ClientHasToken = true;
+                    }
+                }
+            }
+        })
+        .SessionClosedHandler([selfCtx = SelfContext](const NTopic::TSessionClosedEvent & ev) {
+            if (auto self = selfCtx->LockShared()) {
+                with_lock(self->Lock) {
+                    self->ClientEventsQueue->PushEvent(ev);
+                }
             }
         });
 
@@ -115,7 +125,7 @@ void TFederatedWriteSession::OpenSubSessionImpl(std::shared_ptr<TDbInfo> db) {
     CurrentDatabase = db;
 }
 
-std::shared_ptr<TDbInfo> TFederatedWriteSession::SelectDatabaseImpl() {
+std::shared_ptr<TDbInfo> TFederatedWriteSessionImpl::SelectDatabaseImpl() {
     std::vector<std::shared_ptr<TDbInfo>> availableDatabases;
     ui64 totalWeight = 0;
 
@@ -159,7 +169,7 @@ std::shared_ptr<TDbInfo> TFederatedWriteSession::SelectDatabaseImpl() {
     Y_UNREACHABLE();
 }
 
-void TFederatedWriteSession::OnFederatedStateUpdateImpl() {
+void TFederatedWriteSessionImpl::OnFederatedStateUpdateImpl() {
     if (!FederationState->Status.IsSuccess()) {
         CloseImpl(FederationState->Status.GetStatus(), NYql::TIssues(FederationState->Status.GetIssues()));
         return;
@@ -186,16 +196,18 @@ void TFederatedWriteSession::OnFederatedStateUpdateImpl() {
     ScheduleFederatedStateUpdateImpl(UPDATE_FEDERATION_STATE_DELAY);
 }
 
-void TFederatedWriteSession::ScheduleFederatedStateUpdateImpl(TDuration delay) {
+void TFederatedWriteSessionImpl::ScheduleFederatedStateUpdateImpl(TDuration delay) {
     Y_ABORT_UNLESS(Lock.IsLocked());
-    auto cb = [self = shared_from_this()](bool ok) {
+    auto cb = [selfCtx = SelfContext](bool ok) {
         if (ok) {
-            with_lock(self->Lock) {
-                if (self->Closing) {
-                    return;
+            if (auto self = selfCtx->LockShared()) {
+                with_lock(self->Lock) {
+                    if (self->Closing) {
+                        return;
+                    }
+                    self->FederationState = self->Observer->GetState();
+                    self->OnFederatedStateUpdateImpl();
                 }
-                self->FederationState = self->Observer->GetState();
-                self->OnFederatedStateUpdateImpl();
             }
         }
     };
@@ -211,24 +223,24 @@ void TFederatedWriteSession::ScheduleFederatedStateUpdateImpl(TDuration delay) {
                                   UpdateStateDelayContext);
 }
 
-NThreading::TFuture<void> TFederatedWriteSession::WaitEvent() {
+NThreading::TFuture<void> TFederatedWriteSessionImpl::WaitEvent() {
     return ClientEventsQueue->WaitEvent();
 }
 
-TVector<NTopic::TWriteSessionEvent::TEvent> TFederatedWriteSession::GetEvents(bool block, TMaybe<size_t> maxEventsCount) {
+TVector<NTopic::TWriteSessionEvent::TEvent> TFederatedWriteSessionImpl::GetEvents(bool block, TMaybe<size_t> maxEventsCount) {
     return ClientEventsQueue->GetEvents(block, maxEventsCount);
 }
 
-TMaybe<NTopic::TWriteSessionEvent::TEvent> TFederatedWriteSession::GetEvent(bool block) {
+TMaybe<NTopic::TWriteSessionEvent::TEvent> TFederatedWriteSessionImpl::GetEvent(bool block) {
     auto events = GetEvents(block, 1);
     return events.empty() ? Nothing() : TMaybe<NTopic::TWriteSessionEvent::TEvent>{std::move(events.front())};
 }
 
-NThreading::TFuture<ui64> TFederatedWriteSession::GetInitSeqNo() {
+NThreading::TFuture<ui64> TFederatedWriteSessionImpl::GetInitSeqNo() {
     return NThreading::MakeFuture<ui64>(0u);
 }
 
-void TFederatedWriteSession::Write(NTopic::TContinuationToken&& token, TStringBuf data, TMaybe<ui64> seqNo,
+void TFederatedWriteSessionImpl::Write(NTopic::TContinuationToken&& token, TStringBuf data, TMaybe<ui64> seqNo,
                                    TMaybe<TInstant> createTimestamp) {
     NTopic::TWriteMessage message{std::move(data)};
     if (seqNo.Defined())
@@ -238,11 +250,11 @@ void TFederatedWriteSession::Write(NTopic::TContinuationToken&& token, TStringBu
     return WriteInternal(std::move(token), std::move(message));
 }
 
-void TFederatedWriteSession::Write(NTopic::TContinuationToken&& token, NTopic::TWriteMessage&& message) {
+void TFederatedWriteSessionImpl::Write(NTopic::TContinuationToken&& token, NTopic::TWriteMessage&& message) {
     return WriteInternal(std::move(token), TWrappedWriteMessage(std::move(message)));
 }
 
-void TFederatedWriteSession::WriteEncoded(NTopic::TContinuationToken&& token, TStringBuf data, NTopic::ECodec codec,
+void TFederatedWriteSessionImpl::WriteEncoded(NTopic::TContinuationToken&& token, TStringBuf data, NTopic::ECodec codec,
                                           ui32 originalSize, TMaybe<ui64> seqNo, TMaybe<TInstant> createTimestamp) {
     auto message = NTopic::TWriteMessage::CompressedMessage(std::move(data), codec, originalSize);
     if (seqNo.Defined())
@@ -252,11 +264,11 @@ void TFederatedWriteSession::WriteEncoded(NTopic::TContinuationToken&& token, TS
     return WriteInternal(std::move(token), TWrappedWriteMessage(std::move(message)));
 }
 
-void TFederatedWriteSession::WriteEncoded(NTopic::TContinuationToken&& token, NTopic::TWriteMessage&& message) {
+void TFederatedWriteSessionImpl::WriteEncoded(NTopic::TContinuationToken&& token, NTopic::TWriteMessage&& message) {
     return WriteInternal(std::move(token), TWrappedWriteMessage(std::move(message)));
 }
 
-void TFederatedWriteSession::WriteInternal(NTopic::TContinuationToken&&, TWrappedWriteMessage&& wrapped) {
+void TFederatedWriteSessionImpl::WriteInternal(NTopic::TContinuationToken&&, TWrappedWriteMessage&& wrapped) {
     ClientHasToken = false;
     if (!wrapped.Message.CreateTimestamp_.Defined()) {
         wrapped.Message.CreateTimestamp_ = TInstant::Now();
@@ -278,7 +290,7 @@ void TFederatedWriteSession::WriteInternal(NTopic::TContinuationToken&&, TWrappe
     }
 }
 
-bool TFederatedWriteSession::PrepareDeferredWrite(TDeferredWrite& deferred) {
+bool TFederatedWriteSessionImpl::PrepareDeferredWrite(TDeferredWrite& deferred) {
     if (PendingToken.Empty()) {
         return false;
     }
@@ -293,7 +305,7 @@ bool TFederatedWriteSession::PrepareDeferredWrite(TDeferredWrite& deferred) {
     return true;
 }
 
-void TFederatedWriteSession::CloseImpl(EStatus statusCode, NYql::TIssues&& issues) {
+void TFederatedWriteSessionImpl::CloseImpl(EStatus statusCode, NYql::TIssues&& issues) {
     Closing = true;
     if (Subsession) {
         Subsession->Close(TDuration::Zero());
@@ -301,7 +313,7 @@ void TFederatedWriteSession::CloseImpl(EStatus statusCode, NYql::TIssues&& issue
     ClientEventsQueue->Close(TSessionClosedEvent(statusCode, std::move(issues)));
 }
 
-bool TFederatedWriteSession::Close(TDuration timeout) {
+bool TFederatedWriteSessionImpl::Close(TDuration timeout) {
     if (Subsession) {
         return Subsession->Close(timeout);
     }

--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.h
@@ -10,12 +10,52 @@
 
 namespace NYdb::NFederatedTopic {
 
-class TFederatedWriteSession : public NTopic::IWriteSession,
-                               public NTopic::TContinuationTokenIssuer,
-                               public std::enable_shared_from_this<TFederatedWriteSession> {
+class TFederatedWriteSessionImpl : public NTopic::TContinuationTokenIssuer,
+                                   public NTopic::TEnableSelfContext<TFederatedWriteSessionImpl> {
+    friend class TFederatedWriteSession;
     friend class TFederatedTopicClient::TImpl;
 
 public:
+
+    TFederatedWriteSessionImpl(const TFederatedWriteSessionSettings& settings,
+                               std::shared_ptr<TGRpcConnectionsImpl> connections,
+                               const TFederatedTopicClientSettings& clientSetttings,
+                               std::shared_ptr<TFederatedDbObserver> observer,
+                               std::shared_ptr<std::unordered_map<NTopic::ECodec, THolder<NTopic::ICodec>>> codecs);
+
+    ~TFederatedWriteSessionImpl() = default;
+
+    NThreading::TFuture<void> WaitEvent();
+    TMaybe<NTopic::TWriteSessionEvent::TEvent> GetEvent(bool block);
+    TVector<NTopic::TWriteSessionEvent::TEvent> GetEvents(bool block, TMaybe<size_t> maxEventsCount);
+
+    NThreading::TFuture<ui64> GetInitSeqNo();
+
+    void Write(NTopic::TContinuationToken&& continuationToken, NTopic::TWriteMessage&& message);
+
+    void WriteEncoded(NTopic::TContinuationToken&& continuationToken, NTopic::TWriteMessage&& params);
+
+    void Write(NTopic::TContinuationToken&&, TStringBuf, TMaybe<ui64> seqNo = Nothing(),
+                       TMaybe<TInstant> createTimestamp = Nothing());
+
+    void WriteEncoded(NTopic::TContinuationToken&&, TStringBuf, NTopic::ECodec, ui32,
+                              TMaybe<ui64> seqNo = Nothing(), TMaybe<TInstant> createTimestamp = Nothing());
+
+    bool Close(TDuration timeout);
+
+private:
+
+    struct TWrappedWriteMessage {
+        const TString Data;
+        NTopic::TWriteMessage Message;
+        TWrappedWriteMessage(NTopic::TWriteMessage&& message)
+            : Data(message.Data)
+            , Message(std::move(message))
+        {
+            Message.Data = Data;
+        }
+    };
+
     struct TDeferredWrite {
         explicit TDeferredWrite(std::shared_ptr<NTopic::IWriteSession> writer)
             : Writer(std::move(writer)) {
@@ -33,48 +73,6 @@ public:
         TMaybe<NTopic::TContinuationToken> Token;
         TMaybe<NTopic::TWriteMessage> Message;
     };
-
-    TFederatedWriteSession(const TFederatedWriteSessionSettings& settings,
-                          std::shared_ptr<TGRpcConnectionsImpl> connections,
-                          const TFederatedTopicClientSettings& clientSetttings,
-                          std::shared_ptr<TFederatedDbObserver> observer,
-                          std::shared_ptr<std::unordered_map<NTopic::ECodec, THolder<NTopic::ICodec>>> codecs);
-
-    ~TFederatedWriteSession() = default;
-
-    NThreading::TFuture<void> WaitEvent() override;
-    TMaybe<NTopic::TWriteSessionEvent::TEvent> GetEvent(bool block) override;
-    TVector<NTopic::TWriteSessionEvent::TEvent> GetEvents(bool block, TMaybe<size_t> maxEventsCount) override;
-
-    virtual NThreading::TFuture<ui64> GetInitSeqNo() override;
-
-    virtual void Write(NTopic::TContinuationToken&& continuationToken, NTopic::TWriteMessage&& message) override;
-
-    virtual void WriteEncoded(NTopic::TContinuationToken&& continuationToken, NTopic::TWriteMessage&& params) override;
-
-    virtual void Write(NTopic::TContinuationToken&&, TStringBuf, TMaybe<ui64> seqNo = Nothing(),
-                       TMaybe<TInstant> createTimestamp = Nothing()) override;
-
-    virtual void WriteEncoded(NTopic::TContinuationToken&&, TStringBuf, NTopic::ECodec, ui32,
-                              TMaybe<ui64> seqNo = Nothing(), TMaybe<TInstant> createTimestamp = Nothing()) override;
-
-    bool Close(TDuration timeout) override;
-
-    inline NTopic::TWriterCounters::TPtr GetCounters() override {Y_ABORT("Unimplemented"); } //ToDo - unimplemented;
-
-private:
-
-    class TWrappedWriteMessage {
-    public:
-        const TString Data;
-        NTopic::TWriteMessage Message;
-        TWrappedWriteMessage(NTopic::TWriteMessage&& message)
-            : Data(message.Data)
-            , Message(std::move(message))
-        {
-            Message.Data = Data;
-        }
-    };    
 
 private:
     void Start();
@@ -125,6 +123,58 @@ private:
 
     // Exiting.
     bool Closing = false;
+};
+
+class TFederatedWriteSession : public NTopic::IWriteSession,
+                               public NTopic::TContextOwner<TFederatedWriteSessionImpl> {
+    friend class TFederatedTopicClient::TImpl;
+
+public:
+
+    TFederatedWriteSession(const TFederatedWriteSessionSettings& settings,
+                           std::shared_ptr<TGRpcConnectionsImpl> connections,
+                           const TFederatedTopicClientSettings& clientSettings,
+                           std::shared_ptr<TFederatedDbObserver> observer,
+                           std::shared_ptr<std::unordered_map<NTopic::ECodec, THolder<NTopic::ICodec>>> codecs)
+        : TContextOwner(settings, std::move(connections), clientSettings, std::move(observer), codecs) {}
+
+    NThreading::TFuture<void> WaitEvent() override {
+        return TryGetImpl()->WaitEvent();
+    }
+    TMaybe<NTopic::TWriteSessionEvent::TEvent> GetEvent(bool block) override {
+        return TryGetImpl()->GetEvent(block);
+    }
+    TVector<NTopic::TWriteSessionEvent::TEvent> GetEvents(bool block, TMaybe<size_t> maxEventsCount) override {
+        return TryGetImpl()->GetEvents(block, maxEventsCount);
+    }
+    NThreading::TFuture<ui64> GetInitSeqNo() override {
+        return TryGetImpl()->GetInitSeqNo();
+    }
+    void Write(NTopic::TContinuationToken&& continuationToken, NTopic::TWriteMessage&& message) override {
+        TryGetImpl()->Write(std::move(continuationToken), std::move(message));
+    }
+    void WriteEncoded(NTopic::TContinuationToken&& continuationToken, NTopic::TWriteMessage&& params) override {
+        TryGetImpl()->WriteEncoded(std::move(continuationToken), std::move(params));
+    }
+    void Write(NTopic::TContinuationToken&& continuationToken, TStringBuf data, TMaybe<ui64> seqNo = Nothing(),
+                       TMaybe<TInstant> createTimestamp = Nothing()) override {
+        TryGetImpl()->Write(std::move(continuationToken), data, seqNo, createTimestamp);
+    }
+    void WriteEncoded(NTopic::TContinuationToken&& continuationToken, TStringBuf data, NTopic::ECodec codec, ui32 originalSize,
+                      TMaybe<ui64> seqNo = Nothing(), TMaybe<TInstant> createTimestamp = Nothing()) override {
+        TryGetImpl()->WriteEncoded(std::move(continuationToken), data, codec, originalSize, seqNo, createTimestamp);
+    }
+    bool Close(TDuration timeout) override {
+        return TryGetImpl()->Close(timeout);
+    }
+
+    inline NTopic::TWriterCounters::TPtr GetCounters() override {Y_ABORT("Unimplemented"); } //ToDo - unimplemented;
+
+private:
+
+    void Start() {
+        TryGetImpl()->Start();
+    }
 };
 
 } // namespace NYdb::NFederatedTopic

--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.h
@@ -86,7 +86,8 @@ private:
     void WriteInternal(NTopic::TContinuationToken&&, TWrappedWriteMessage&& message);
     bool PrepareDeferredWrite(TDeferredWrite& deferred);
 
-    void CloseImpl(EStatus statusCode, NYql::TIssues&& issues);
+    void CloseImpl(EStatus statusCode, NYql::TIssues&& issues, TDuration timeout = TDuration::Zero());
+    void CloseImpl(NTopic::TSessionClosedEvent const& ev, TDuration timeout = TDuration::Zero());
 
     TStringBuilder GetLogPrefix() const;
 


### PR DESCRIPTION
Otherwise it deadlocks and prevents the session to die.