### PR TITLE
Disable style tests in ydb/library/yql/providers/generic/connector/tests

### DIFF
--- a/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
@@ -1,6 +1,5 @@
 PY3TEST()
 
-STYLE_PYTHON()
 NO_CHECK_IMPORTS()
 
 DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/docker-compose.yml)

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
@@ -1,6 +1,5 @@
 PY3TEST()
 
-STYLE_PYTHON()
 NO_CHECK_IMPORTS()
 
 DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/docker-compose.yml)

--- a/ydb/library/yql/providers/generic/connector/tests/join/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/join/ya.make
@@ -1,6 +1,5 @@
 PY3TEST()
 
-STYLE_PYTHON()
 NO_CHECK_IMPORTS()
 
 DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/join/docker-compose.yml)

--- a/ydb/library/yql/providers/generic/connector/tests/test_cases/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/test_cases/ya.make
@@ -1,7 +1,5 @@
 PY3_LIBRARY()
 
-STYLE_PYTHON()
-
 PY_SRCS(
     base.py
     select_missing_database.py

--- a/ydb/library/yql/providers/generic/connector/tests/utils/clients/postgresql.py
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/clients/postgresql.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 import time
 from datetime import datetime
 from typing import Tuple
-import sys
 
 import pg8000.dbapi
 
@@ -19,7 +18,7 @@ class Client:
     def __init__(self, settings: Settings.PostgreSQL):
         self.settings = settings
         self.pools = dict()
-        LOGGER.debug(f"initializing client")
+        LOGGER.debug("initializing client")
 
     @contextmanager
     def get_cursor(self, dbname: str):

--- a/ydb/library/yql/providers/generic/connector/tests/utils/clients/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/clients/ya.make
@@ -1,7 +1,5 @@
 PY3_LIBRARY()
 
-STYLE_PYTHON()
-
 PY_SRCS(
     clickhouse.py
     postgresql.py

--- a/ydb/library/yql/providers/generic/connector/tests/utils/scenario/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/scenario/ya.make
@@ -1,7 +1,5 @@
 PY3_LIBRARY()
 
-STYLE_PYTHON()
-
 PY_SRCS(
     clickhouse.py
     postgresql.py

--- a/ydb/library/yql/providers/generic/connector/tests/utils/types/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/types/ya.make
@@ -1,7 +1,5 @@
 PY3_LIBRARY()
 
-STYLE_PYTHON()
-
 PY_SRCS(
     clickhouse.py
     postgresql.py

--- a/ydb/library/yql/providers/generic/connector/tests/utils/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/ya.make
@@ -1,7 +1,5 @@
 PY3_LIBRARY()
 
-STYLE_PYTHON()
-
 PY_SRCS(
     artifacts.py
     comparator.py


### PR DESCRIPTION
### Changelog entry 

* Disable style tests in `ydb/library/yql/providers/generic/connector/tests` due to problems with Arcadia sync

### Changelog category

* Not for changelog

### Additional information

* See DEVTOOLSSUPPORT-44055 for details
