### PR TITLE
YQL-18051: Add block implementation for Exists callable 

### DIFF
--- a/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
+++ b/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
@@ -5468,7 +5468,7 @@ bool CollectBlockRewrites(const TMultiExprType* multiInputType, bool keepInputCo
 
         TExprNode::TListType funcArgs;
         std::string_view arrowFunctionName;
-        if (node->IsList() || node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "If", "Just", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
+        if (node->IsList() || node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "Exists", "If", "Just", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
         {
             if (node->IsCallable() && !IsSupportedAsBlockType(node->Pos(), *node->GetTypeAnn(), ctx, types)) {
                 return true;

--- a/ydb/library/yql/core/type_ann/type_ann_blocks.h
+++ b/ydb/library/yql/core/type_ann/type_ann_blocks.h
@@ -12,6 +12,7 @@ namespace NTypeAnnImpl {
     IGraphTransformer::TStatus ReplicateScalarWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus ReplicateScalarsWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockCompressWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
+    IGraphTransformer::TStatus BlockExistsWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockExpandChunkedWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockCoalesceWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockLogicalWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);

--- a/ydb/library/yql/core/type_ann/type_ann_core.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_core.cpp
@@ -11866,6 +11866,7 @@ template <NKikimr::NUdf::EDataSlot DataSlot>
         Functions["Nanvl"] = &NanvlWrapper;
         Functions["Unwrap"] = &UnwrapWrapper;
         Functions["Exists"] = &ExistsWrapper;
+        Functions["BlockExists"] = &BlockExistsWrapper;
         Functions["Just"] = &JustWrapper;
         Functions["Optional"] = &OptionalWrapper;
         Functions["OptionalIf"] = &OptionalIfWrapper;

--- a/ydb/library/yql/minikql/arrow/arrow_util.h
+++ b/ydb/library/yql/minikql/arrow/arrow_util.h
@@ -9,6 +9,7 @@
 #include <arrow/util/bitmap.h>
 
 #include <ydb/library/yql/minikql/mkql_node.h>
+#include <ydb/library/yql/minikql/arrow/mkql_bit_utils.h>
 #include <ydb/library/yql/public/udf/arrow/util.h>
 
 namespace NKikimr::NMiniKQL {
@@ -51,6 +52,12 @@ inline arrow::Datum MakeFalseArray(arrow::MemoryPool* pool, int64_t len) {
 
 inline arrow::Datum MakeTrueArray(arrow::MemoryPool* pool, int64_t len) {
     return MakeUint8Array(pool, 1, len);
+}
+
+inline arrow::Datum MakeBitmapArray(arrow::MemoryPool* pool, int64_t len, int64_t offset, const ui8* bitmap) {
+    std::shared_ptr<arrow::Buffer> data = ARROW_RESULT(arrow::AllocateBuffer(len, pool));
+    DecompressToSparseBitmap(data->mutable_data(), bitmap, offset, len);
+    return arrow::ArrayData::Make(arrow::uint8(), len, { std::shared_ptr<arrow::Buffer>{}, data });
 }
 
 template<typename T>

--- a/ydb/library/yql/minikql/arrow/arrow_util.h
+++ b/ydb/library/yql/minikql/arrow/arrow_util.h
@@ -39,6 +39,20 @@ inline std::string_view GetStringScalarValue(const arrow::Scalar& scalar) {
     return std::string_view{reinterpret_cast<const char*>(base.value->data()), static_cast<size_t>(base.value->size())};
 }
 
+inline arrow::Datum MakeUint8Array(arrow::MemoryPool* pool, ui8 value, int64_t len) {
+    std::shared_ptr<arrow::Buffer> data = ARROW_RESULT(arrow::AllocateBuffer(len, pool));
+    std::memset(data->mutable_data(), value, len);
+    return arrow::ArrayData::Make(arrow::uint8(), len, { std::shared_ptr<arrow::Buffer>{}, data });
+}
+
+inline arrow::Datum MakeFalseArray(arrow::MemoryPool* pool, int64_t len) {
+    return MakeUint8Array(pool, 0, len);
+}
+
+inline arrow::Datum MakeTrueArray(arrow::MemoryPool* pool, int64_t len) {
+    return MakeUint8Array(pool, 1, len);
+}
+
 template<typename T>
 struct TPrimitiveDataType;
 

--- a/ydb/library/yql/minikql/arrow/mkql_bit_utils.h
+++ b/ydb/library/yql/minikql/arrow/mkql_bit_utils.h
@@ -157,6 +157,7 @@ inline size_t CompressBitmap(const ui8* src, size_t srcOffset,
 
 using NYql::NUdf::CompressAsSparseBitmap;
 using NYql::NUdf::CompressArray;
+using NYql::NUdf::DecompressToSparseBitmap;
 
 } // namespace NMiniKQL
 } // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_exists.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_exists.cpp
@@ -1,0 +1,58 @@
+#include "mkql_exists.h"
+#include <ydb/library/yql/minikql/arrow/arrow_util.h>
+#include <ydb/library/yql/minikql/computation/mkql_block_impl.h>
+#include <ydb/library/yql/minikql/mkql_node_cast.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+namespace {
+
+class TBlockExistsExec {
+public:
+    arrow::Status Exec(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) const {
+        const auto& input = batch.values[0];
+        MKQL_ENSURE(input.is_array(), "Expected array");
+        const auto& arr = *input.array();
+
+        auto nullCount = arr.GetNullCount();
+        if (nullCount == arr.length) {
+            *res = MakeFalseArray(ctx->memory_pool(), arr.length);
+        } else if (nullCount == 0) {
+            *res = MakeTrueArray(ctx->memory_pool(), arr.length);
+        } else {
+            *res = MakeBitmapArray(ctx->memory_pool(), arr.length, arr.offset,
+                arr.buffers[0]->data());
+        }
+
+        return arrow::Status::OK();
+    }
+};
+
+std::shared_ptr<arrow::compute::ScalarKernel> MakeBlockExistsKernel(const TVector<TType*>& argTypes, TType* resultType) {
+    std::shared_ptr<arrow::DataType> returnArrowType;
+    MKQL_ENSURE(ConvertArrowType(AS_TYPE(TBlockType, resultType)->GetItemType(), returnArrowType), "Unsupported arrow type");
+    // Ensure the result Arrow type (i.e. boolean) is Arrow UInt8Type.
+    Y_DEBUG_ABORT_UNLESS(returnArrowType == arrow::uint8());
+    auto exec = std::make_shared<TBlockExistsExec>();
+    auto kernel = std::make_shared<arrow::compute::ScalarKernel>(ConvertToInputTypes(argTypes), ConvertToOutputType(resultType),
+        [exec](arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
+        return exec->Exec(ctx, batch, res);
+    });
+    kernel->null_handling = arrow::compute::NullHandling::OUTPUT_NOT_NULL;
+    return kernel;
+}
+
+} // namespace
+
+IComputationNode* WrapBlockExists(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    MKQL_ENSURE(callable.GetInputsCount() == 1, "Expected 1 arg");
+    auto compute = LocateNode(ctx.NodeLocator, callable, 0);
+    TComputationNodePtrVector argsNodes = { compute };
+    TVector<TType*> argsTypes = { callable.GetInput(0).GetStaticType() };
+    auto kernel = MakeBlockExistsKernel(argsTypes, callable.GetType()->GetReturnType());
+    return new TBlockFuncNode(ctx.Mutables, "Exists", std::move(argsNodes), argsTypes, *kernel, kernel);
+}
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_exists.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_exists.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <ydb/library/yql/minikql/computation/mkql_computation_node.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+IComputationNode* WrapBlockExists(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_logical.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_logical.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/library/yql/minikql/arrow/arrow_defs.h>
 #include <ydb/library/yql/minikql/arrow/mkql_bit_utils.h>
+#include <ydb/library/yql/minikql/arrow/arrow_util.h>
 #include <ydb/library/yql/minikql/mkql_type_builder.h>
 #include <ydb/library/yql/minikql/computation/mkql_block_impl.h>
 #include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
@@ -38,18 +39,6 @@ std::shared_ptr<arrow::Buffer> CopySparseBitmap(arrow::MemoryPool* pool, const s
         std::memcpy(result->mutable_data(), bitmap->data() + offset, len);
     }
     return result;
-}
-
-arrow::Datum MakeFalseArray(arrow::MemoryPool* pool, int64_t len) {
-    std::shared_ptr<arrow::Buffer> data = ARROW_RESULT(arrow::AllocateBuffer(len, pool));
-    std::memset(data->mutable_data(), 0, len);
-    return arrow::ArrayData::Make(arrow::uint8(), len, { std::shared_ptr<arrow::Buffer>{}, data });
-}
-
-arrow::Datum MakeTrueArray(arrow::MemoryPool* pool, int64_t len) {
-    std::shared_ptr<arrow::Buffer> data = ARROW_RESULT(arrow::AllocateBuffer(len, pool));
-    std::memset(data->mutable_data(), 1, len);
-    return arrow::ArrayData::Make(arrow::uint8(), len, { std::shared_ptr<arrow::Buffer>{}, data });
 }
 
 arrow::Datum MakeNullArray(arrow::MemoryPool* pool, int64_t len) {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
@@ -8,6 +8,7 @@
 #include "mkql_blocks.h"
 #include "mkql_block_agg.h"
 #include "mkql_block_coalesce.h"
+#include "mkql_block_exists.h"
 #include "mkql_block_if.h"
 #include "mkql_block_just.h"
 #include "mkql_block_logical.h"
@@ -287,6 +288,7 @@ struct TCallableComputationNodeBuilderFuncMapFiller {
         {"AsScalar", &WrapAsScalar},
         {"ReplicateScalar", &WrapReplicateScalar},
         {"BlockCoalesce", &WrapBlockCoalesce},
+        {"BlockExists", &WrapBlockExists},
         {"BlockIf", &WrapBlockIf},
         {"BlockAnd", &WrapBlockAnd},
         {"BlockOr", &WrapBlockOr},

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_exists_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_exists_ut.cpp
@@ -1,0 +1,109 @@
+#include "mkql_computation_node_ut.h"
+
+#include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
+#include <ydb/library/yql/minikql/computation/mkql_block_builder.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+namespace {
+
+void DoBlockExistsOffset(size_t length, size_t offset) {
+    TSetup<false> setup;
+    TProgramBuilder& pb = *setup.PgmBuilder;
+
+    const auto i32Type    = pb.NewDataType(NUdf::TDataType<i32>::Id);
+    const auto opti32Type = pb.NewOptionalType(i32Type);
+    const auto boolType   = pb.NewDataType(NUdf::TDataType<bool>::Id);
+
+    const auto inputTupleType  = pb.NewTupleType({i32Type, opti32Type, opti32Type, opti32Type});
+    const auto outputTupleType = pb.NewTupleType({i32Type, boolType, boolType, boolType});
+
+    TRuntimeNode::TList input;
+    static_assert(MaxBlockSizeInBytes % 4 == 0);
+
+    for (size_t i = 0; i < length; i++) {
+        const auto maybeNull = (i % 2) ? pb.NewOptional(pb.NewDataLiteral<i32>(i / 2))
+                                       : pb.NewEmptyOptionalDataLiteral(NUdf::TDataType<i32>::Id);
+
+        const auto inputTuple = pb.NewTuple(inputTupleType, {
+            pb.NewDataLiteral<i32>(i),
+            maybeNull,
+            pb.NewEmptyOptionalDataLiteral(NUdf::TDataType<i32>::Id),
+            pb.NewOptional(pb.NewDataLiteral<i32>(i))
+        });
+
+        input.push_back(inputTuple);
+    }
+
+    const auto list = pb.NewList(inputTupleType, std::move(input));
+
+    auto node = pb.ToFlow(list);
+    node = pb.ExpandMap(node, [&](TRuntimeNode item) -> TRuntimeNode::TList {
+        return {
+            pb.Nth(item, 0),
+            pb.Nth(item, 1),
+            pb.Nth(item, 2),
+            pb.Nth(item, 3)
+        };
+    });
+    node = pb.WideToBlocks(node);
+    if (offset > 0) {
+        node = pb.WideSkipBlocks(node, pb.NewDataLiteral<ui64>(offset));
+    }
+    node = pb.WideMap(node, [&](TRuntimeNode::TList items) -> TRuntimeNode::TList {
+        return {
+            items[0],
+            pb.BlockExists(items[1]),
+            pb.BlockExists(items[2]),
+            pb.BlockExists(items[3]),
+            items[4],
+        };
+    });
+    node = pb.WideFromBlocks(node);
+    node = pb.NarrowMap(node, [&](TRuntimeNode::TList items) -> TRuntimeNode {
+        return pb.NewTuple(outputTupleType, {items[0], items[1], items[2], items[3]});
+    });
+
+    const auto pgmReturn = pb.Collect(node);
+    const auto graph = setup.BuildGraph(pgmReturn);
+    const auto iterator = graph->GetValue().GetListIterator();
+
+    for (size_t i = 0; i < length; i++) {
+        if (i < offset) {
+            continue;
+        }
+
+        NUdf::TUnboxedValue outputTuple;
+        UNIT_ASSERT(iterator.Next(outputTuple));
+        const i32 key = outputTuple.GetElement(0).Get<i32>();
+        const bool maybeNull = outputTuple.GetElement(1).Get<bool>();
+        const bool alwaysNull = outputTuple.GetElement(2).Get<bool>();
+        const bool neverNull = outputTuple.GetElement(3).Get<bool>();
+
+        UNIT_ASSERT_VALUES_EQUAL(key, i);
+        UNIT_ASSERT_VALUES_EQUAL(maybeNull, (i % 2) ? true : false);
+        UNIT_ASSERT_VALUES_EQUAL(alwaysNull, false);
+        UNIT_ASSERT_VALUES_EQUAL(neverNull, true);
+    }
+
+    NUdf::TUnboxedValue outputTuple;
+    UNIT_ASSERT(!iterator.Next(outputTuple));
+    UNIT_ASSERT(!iterator.Next(outputTuple));
+}
+
+} //namespace
+
+Y_UNIT_TEST_SUITE(TMiniKQLBlockExistsTest) {
+
+Y_UNIT_TEST(ExistsWithOffset) {
+    const size_t length = 20;
+    for (size_t offset = 0; offset < length; offset++) {
+        DoBlockExistsOffset(length, offset);
+    }
+}
+
+} // Y_UNIT_TEST_SUITE
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/ut/ya.make.inc
+++ b/ydb/library/yql/minikql/comp_nodes/ut/ya.make.inc
@@ -24,6 +24,7 @@ SET(ORIG_SOURCES
     mkql_test_factory.cpp
     mkql_bit_utils_ut.cpp
     mkql_block_compress_ut.cpp
+    mkql_block_exists_ut.cpp
     mkql_block_skiptake_ut.cpp
     mkql_block_top_sort_ut.cpp
     mkql_blocks_ut.cpp

--- a/ydb/library/yql/minikql/comp_nodes/ya.make.inc
+++ b/ydb/library/yql/minikql/comp_nodes/ya.make.inc
@@ -15,6 +15,7 @@ SET(ORIG_SOURCES
     mkql_block_agg_some.cpp
     mkql_block_agg_sum.cpp
     mkql_block_coalesce.cpp
+    mkql_block_exists.cpp
     mkql_block_if.cpp
     mkql_block_just.cpp
     mkql_block_logical.cpp

--- a/ydb/library/yql/minikql/mkql_program_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_program_builder.cpp
@@ -1611,6 +1611,15 @@ TRuntimeNode TProgramBuilder::BlockCoalesce(TRuntimeNode first, TRuntimeNode sec
     return TRuntimeNode(callableBuilder.Build(), false);
 }
 
+TRuntimeNode TProgramBuilder::BlockExists(TRuntimeNode data) {
+    auto dataType = AS_TYPE(TBlockType, data.GetStaticType());
+    auto outputType = NewBlockType(NewDataType(NUdf::TDataType<bool>::Id), dataType->GetShape());
+
+    TCallableBuilder callableBuilder(Env, __func__, outputType);
+    callableBuilder.Add(data);
+    return TRuntimeNode(callableBuilder.Build(), false);
+}
+
 TRuntimeNode TProgramBuilder::BlockNth(TRuntimeNode tuple, ui32 index) {
     auto blockType = AS_TYPE(TBlockType, tuple.GetStaticType());
     bool isOptional;

--- a/ydb/library/yql/minikql/mkql_program_builder.h
+++ b/ydb/library/yql/minikql/mkql_program_builder.h
@@ -236,6 +236,7 @@ public:
     TRuntimeNode BlockCompress(TRuntimeNode flow, ui32 bitmapIndex);
     TRuntimeNode BlockExpandChunked(TRuntimeNode flow);
     TRuntimeNode BlockCoalesce(TRuntimeNode first, TRuntimeNode second);
+    TRuntimeNode BlockExists(TRuntimeNode data);
     TRuntimeNode BlockNth(TRuntimeNode tuple, ui32 index);
     TRuntimeNode BlockAsTuple(const TArrayRef<const TRuntimeNode>& args);
     TRuntimeNode BlockToPg(TRuntimeNode input, TType* returnType);

--- a/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
+++ b/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
@@ -452,6 +452,7 @@ TMkqlCommonCallableCompiler::TShared::TShared() {
 
         {"Just", &TProgramBuilder::NewOptional},
         {"Exists", &TProgramBuilder::Exists},
+        {"BlockExists", &TProgramBuilder::BlockExists},
 
         {"Pickle", &TProgramBuilder::Pickle},
         {"StablePickle", &TProgramBuilder::StablePickle},

--- a/ydb/library/yql/public/udf/arrow/bit_util.h
+++ b/ydb/library/yql/public/udf/arrow/bit_util.h
@@ -15,6 +15,34 @@ inline ui8* CompressAsSparseBitmap(const ui8* src, size_t srcOffset, const ui8* 
     return dst;
 }
 
+inline ui8* DecompressToSparseBitmap(ui8* dstSparse, const ui8* src, size_t srcOffset, size_t count) {
+    if (srcOffset % 8 != 0) {
+        size_t offsetBytes = srcOffset >> 3;
+        size_t offsetTail = srcOffset & 7;
+        src += offsetBytes;
+        for (ui8 i = offsetTail; count > 0 && i < 8; i++, count--) {
+            *dstSparse++ = (*src >> i) & 1u;
+        }
+        src++;
+    }
+    while (count >= 8) {
+        ui8 slot = *src++;
+        *dstSparse++ = (slot >> 0) & 1u;
+        *dstSparse++ = (slot >> 1) & 1u;
+        *dstSparse++ = (slot >> 2) & 1u;
+        *dstSparse++ = (slot >> 3) & 1u;
+        *dstSparse++ = (slot >> 4) & 1u;
+        *dstSparse++ = (slot >> 5) & 1u;
+        *dstSparse++ = (slot >> 6) & 1u;
+        *dstSparse++ = (slot >> 7) & 1u;
+        count -= 8;
+    }
+    for (ui8 i = 0; i < count; i++) {
+        *dstSparse++ = (*src >> i) & 1u;
+    }
+    return dstSparse;
+}
+
 template<bool Negate>
 inline void CompressSparseImpl(ui8* dst, const ui8* srcSparse, size_t len) {
     while (len >= 8) {

--- a/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
@@ -601,6 +601,28 @@
         }
     ],
     "test.test[blocks-distinct_mixed_all--Results]": [],
+    "test.test[blocks-exists--Analyze]": [
+        {
+            "checksum": "4af0c5208aa6a331e8f85d88e603561b",
+            "size": 4383,
+            "uri": "https://{canondata_backend}/1942278/27f048235a34a7ab00d12b077c36559ae4e154d0/resource.tar.gz#test.test_blocks-exists--Analyze_/plan.txt"
+        }
+    ],
+    "test.test[blocks-exists--Debug]": [
+        {
+            "checksum": "b7a3014430e4ff9ad07839997a78fc58",
+            "size": 2034,
+            "uri": "https://{canondata_backend}/1942278/27f048235a34a7ab00d12b077c36559ae4e154d0/resource.tar.gz#test.test_blocks-exists--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-exists--Plan]": [
+        {
+            "checksum": "4af0c5208aa6a331e8f85d88e603561b",
+            "size": 4383,
+            "uri": "https://{canondata_backend}/1942278/27f048235a34a7ab00d12b077c36559ae4e154d0/resource.tar.gz#test.test_blocks-exists--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-exists--Results]": [],
     "test.test[blocks-mul_uint64_opt2--Analyze]": [
         {
             "checksum": "5670e60dfd13457111e1f9a99808aaf7",

--- a/ydb/library/yql/tests/sql/hybrid_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part5/canondata/result.json
@@ -629,6 +629,20 @@
             "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_blocks-div_uint64--Plan_/plan.txt"
         }
     ],
+    "test.test[blocks-exists--Debug]": [
+        {
+            "checksum": "d21bb39d49e91937226bd22fb5f7e656",
+            "size": 3752,
+            "uri": "https://{canondata_backend}/1923547/74cae215200c318886a1a7a2cef83da244653515/resource.tar.gz#test.test_blocks-exists--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-exists--Plan]": [
+        {
+            "checksum": "ffea96c2256a3abd858ffebcff78556f",
+            "size": 6274,
+            "uri": "https://{canondata_backend}/1923547/74cae215200c318886a1a7a2cef83da244653515/resource.tar.gz#test.test_blocks-exists--Plan_/plan.txt"
+        }
+    ],
     "test.test[blocks-filter_by_column_with_drop--Debug]": [
         {
             "checksum": "d269aa92d26087b5b0eb4360f97181d5",

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -3492,6 +3492,13 @@
             "uri": "https://{canondata_backend}/1936997/00f46808be87e2ae2d4ac3ac45675b659c5ace45/resource.tar.gz#test_sql2yql.test_blocks-div_uint64_opt2_/sql.yql"
         }
     ],
+    "test_sql2yql.test[blocks-exists]": [
+        {
+            "checksum": "404395a71b7504a31422ca6d0ce2ea9d",
+            "size": 1798,
+            "uri": "https://{canondata_backend}/1889210/03e6a8498319adef50839c34d4faa63ef49818e6/resource.tar.gz#test_sql2yql.test_blocks-exists_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[blocks-filter_by_column_with_drop]": [
         {
             "checksum": "d04dbc2c8b1f0c6eb7b66c3eb0f5fae0",
@@ -21662,6 +21669,13 @@
             "checksum": "4214195f930af57c80f286fb09db5e52",
             "size": 102,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_blocks-div_uint64_opt2_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-exists]": [
+        {
+            "checksum": "ebc750377bec015897569898a70538af",
+            "size": 281,
+            "uri": "https://{canondata_backend}/1889210/03e6a8498319adef50839c34d4faa63ef49818e6/resource.tar.gz#test_sql_format.test_blocks-exists_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-filter_by_column_with_drop]": [

--- a/ydb/library/yql/tests/sql/suites/blocks/exists.cfg
+++ b/ydb/library/yql/tests/sql/suites/blocks/exists.cfg
@@ -1,0 +1,1 @@
+in Input input_exists.txt

--- a/ydb/library/yql/tests/sql/suites/blocks/exists.sql
+++ b/ydb/library/yql/tests/sql/suites/blocks/exists.sql
@@ -1,0 +1,11 @@
+USE plato;
+/* XXX: Enable UseBlocks pragma and provide input to trigger block execution. */
+PRAGMA UseBlocks;
+
+SELECT
+    key,
+    maybe_null is NULL as is_maybe_null,
+    always_null is NULL as is_always_null,
+    never_null is NULL as is_never_null,
+FROM Input
+ORDER BY key;

--- a/ydb/library/yql/tests/sql/suites/blocks/input_exists.txt
+++ b/ydb/library/yql/tests/sql/suites/blocks/input_exists.txt
@@ -1,0 +1,9 @@
+{"key"=1;"always_null"=#;"never_null"=11;"maybe_null"=11;};
+{"key"=2;"always_null"=#;"never_null"=22;"maybe_null"=22;};
+{"key"=3;"always_null"=#;"never_null"=33;"maybe_null"=33;};
+{"key"=4;"always_null"=#;"never_null"=44;"maybe_null"=#; };
+{"key"=5;"always_null"=#;"never_null"=55;"maybe_null"=55;};
+{"key"=6;"always_null"=#;"never_null"=66;"maybe_null"=#; };
+{"key"=7;"always_null"=#;"never_null"=77;"maybe_null"=#; };
+{"key"=8;"always_null"=#;"never_null"=88;"maybe_null"=88;};
+{"key"=9;"always_null"=#;"never_null"=99;"maybe_null"=#; };

--- a/ydb/library/yql/tests/sql/suites/blocks/input_exists.txt.attr
+++ b/ydb/library/yql/tests/sql/suites/blocks/input_exists.txt.attr
@@ -1,0 +1,8 @@
+{"_yql_row_spec"={
+    "Type"=["StructType";[
+        ["key";["DataType";"Int32"]];
+        ["always_null";["OptionalType";["DataType";"Int32"]]];
+        ["never_null";["OptionalType";["DataType";"Int32"]]];
+        ["maybe_null";["OptionalType";["DataType";"Int32"]]];
+    ]];
+}}

--- a/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
@@ -561,6 +561,34 @@
             "uri": "https://{canondata_backend}/1775059/093c5591aafe8470d91f685024bc819018711cfb/resource.tar.gz#test.test_blocks-distinct_mixed_all--Results_/results.txt"
         }
     ],
+    "test.test[blocks-exists--Debug]": [
+        {
+            "checksum": "56c5ed97b2964d69a15b013a0e4eeac5",
+            "size": 2331,
+            "uri": "https://{canondata_backend}/1881367/286560089b1a47b5c1edb33ed7618ecb02fe722c/resource.tar.gz#test.test_blocks-exists--Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-exists--Peephole]": [
+        {
+            "checksum": "7869ea432d2e0944e7ce2b58f787beb1",
+            "size": 2011,
+            "uri": "https://{canondata_backend}/1881367/286560089b1a47b5c1edb33ed7618ecb02fe722c/resource.tar.gz#test.test_blocks-exists--Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-exists--Plan]": [
+        {
+            "checksum": "a16701a0748542c47a6be1a51c844a7c",
+            "size": 5603,
+            "uri": "https://{canondata_backend}/1881367/286560089b1a47b5c1edb33ed7618ecb02fe722c/resource.tar.gz#test.test_blocks-exists--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-exists--Results]": [
+        {
+            "checksum": "d4457e004f315207faf2b4dd9da5df7d",
+            "size": 2904,
+            "uri": "https://{canondata_backend}/1881367/286560089b1a47b5c1edb33ed7618ecb02fe722c/resource.tar.gz#test.test_blocks-exists--Results_/results.txt"
+        }
+    ],
     "test.test[blocks-mul_uint64_opt2--Debug]": [
         {
             "checksum": "383fb41627c2b0ca7fda9eea536c065a",


### PR DESCRIPTION
This patchset supports block implementation for `Exists` callable. All the phases implements quite similar transformations and checks to the scalar analogue. And still there is block specific optimization in kernel for the cases when all values in the batch and are invalid (i.e. `NULL`) or valid (i.e. `NOT NULL`). In this case the data buffer in the resulting array is filled by 0 or 1 respectively.

Apart from the main changeset, several helpers are introduced (or moved to the common headers) within the series.

### Changelog category

* Improvement