### PR TITLE
ydb_topic: split write messages on different codecs

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/basic_usage_ut.cpp
@@ -698,6 +698,115 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         UNIT_ASSERT_VALUES_EQUAL(stats->GetEndOffset(), count);
 
     }
+
+    Y_UNIT_TEST(TWriteSession_WriteEncoded) {
+        // This test was adapted from ydb_persqueue tests.
+        // It writes 4 messages: 2 with default codec, 1 with explicitly set GZIP codec, 1 with RAW codec.
+        // The last message MUST be sent in a separate WriteRequest, as it has a codec field applied for all messages in the request.
+        // This separation currently happens in TWriteSessionImpl::SendImpl method.
+
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        auto client = setup->MakeClient();
+        auto settings = TWriteSessionSettings()
+            .Path(TEST_TOPIC)
+            .MessageGroupId(TEST_MESSAGE_GROUP_ID);
+
+        size_t batchSize = 100000000;
+        settings.BatchFlushInterval(TDuration::Seconds(1000)); // Batch on size, not on time.
+        settings.BatchFlushSizeBytes(batchSize);
+        auto writer = client.CreateWriteSession(settings);
+        TString message = "message";
+        TString packed;
+        {
+            TStringOutput so(packed);
+            TZLibCompress oss(&so, ZLib::GZip, 6);
+            oss << message;
+        }
+
+        Cerr << message << " " << packed << "\n";
+
+        {
+            auto event = *writer->GetEvent(true);
+            UNIT_ASSERT(!writer->WaitEvent().Wait(TDuration::Seconds(1)));
+            auto ev = writer->WaitEvent();
+            UNIT_ASSERT(std::holds_alternative<TWriteSessionEvent::TReadyToAcceptEvent>(event));
+            auto continueToken = std::move(std::get<TWriteSessionEvent::TReadyToAcceptEvent>(event).ContinuationToken);
+            writer->Write(std::move(continueToken), message);
+            UNIT_ASSERT(ev.Wait(TDuration::Seconds(1)));
+        }
+        {
+            auto event = *writer->GetEvent(true);
+            UNIT_ASSERT(std::holds_alternative<TWriteSessionEvent::TReadyToAcceptEvent>(event));
+            auto continueToken = std::move(std::get<TWriteSessionEvent::TReadyToAcceptEvent>(event).ContinuationToken);
+            writer->Write(std::move(continueToken), "");
+        }
+        {
+            auto event = *writer->GetEvent(true);
+            UNIT_ASSERT(std::holds_alternative<TWriteSessionEvent::TReadyToAcceptEvent>(event));
+            auto continueToken = std::move(std::get<TWriteSessionEvent::TReadyToAcceptEvent>(event).ContinuationToken);
+            writer->WriteEncoded(std::move(continueToken), packed, ECodec::GZIP, message.size());
+        }
+
+        ui32 acks = 0, tokens = 0;
+        while(acks < 4 || tokens < 2)  {
+            auto event = *writer->GetEvent(true);
+            if (std::holds_alternative<TWriteSessionEvent::TAcksEvent>(event)) {
+                acks += std::get<TWriteSessionEvent::TAcksEvent>(event).Acks.size();
+            }
+            if (std::holds_alternative<TWriteSessionEvent::TReadyToAcceptEvent>(event)) {
+                if (tokens == 0) {
+                    auto continueToken = std::move(std::get<TWriteSessionEvent::TReadyToAcceptEvent>(event).ContinuationToken);
+                    writer->WriteEncoded(std::move(continueToken), "", ECodec::RAW, 0);
+                }
+                ++tokens;
+            }
+            Cerr << "GOT EVENT " << acks << " " << tokens << "\n";
+        }
+        UNIT_ASSERT(!writer->WaitEvent().Wait(TDuration::Seconds(5)));
+
+        UNIT_ASSERT_VALUES_EQUAL(acks, 4);
+        UNIT_ASSERT_VALUES_EQUAL(tokens, 2);
+
+        auto readSettings = TReadSessionSettings()
+            .ConsumerName(TEST_CONSUMER)
+            .AppendTopics(TEST_TOPIC);
+        std::shared_ptr<IReadSession> readSession = client.CreateReadSession(readSettings);
+        ui32 readMessageCount = 0;
+        while (readMessageCount < 4) {
+            Cerr << "Get event on client\n";
+            auto event = *readSession->GetEvent(true);
+            std::visit(TOverloaded {
+                [&](TReadSessionEvent::TDataReceivedEvent& event) {
+                    for (auto& message: event.GetMessages()) {
+                        TString sourceId = message.GetMessageGroupId();
+                        ui32 seqNo = message.GetSeqNo();
+                        UNIT_ASSERT_VALUES_EQUAL(readMessageCount + 1, seqNo);
+                        ++readMessageCount;
+                        UNIT_ASSERT_VALUES_EQUAL(message.GetData(), (seqNo % 2) == 1 ? "message" : "");
+                    }
+                },
+                [&](TReadSessionEvent::TCommitOffsetAcknowledgementEvent&) {
+                    UNIT_FAIL("no commits in test");
+                },
+                [&](TReadSessionEvent::TStartPartitionSessionEvent& event) {
+                    event.Confirm();
+                },
+                [&](TReadSessionEvent::TStopPartitionSessionEvent& event) {
+                    event.Confirm();
+                },
+                [&](TReadSessionEvent::TPartitionSessionStatusEvent&) {
+                    UNIT_FAIL("Test does not support lock sessions yet");
+                },
+                [&](TReadSessionEvent::TPartitionSessionClosedEvent&) {
+                    UNIT_FAIL("Test does not support lock sessions yet");
+                },
+                [&](TSessionClosedEvent&) {
+                    UNIT_FAIL("Session closed");
+                }
+
+            }, event);
+        }
+    }
 } // Y_UNIT_TEST_SUITE(BasicUsage)
 
 Y_UNIT_TEST_SUITE(TSettingsValidation) {


### PR DESCRIPTION
There should only be messages encoded with the same codec in the WriteRequest.