### PR TITLE
Fix SqlParsingOnly.AlterTableAddIndexWithIsNotSupported

### DIFF
--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -2482,7 +2482,7 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
 
     Y_UNIT_TEST(AlterTableAddIndexWithIsNotSupported) {
         ExpectFailWithError("USE plato; ALTER TABLE table ADD INDEX idx LOCAL WITH (a=b, c=d, e=f) ON (col)",
-            "<main>:1:40: Error: local: alternative is not implemented yet: 717:7: local_index\n");
+            "<main>:1:40: Error: local: alternative is not implemented yet: 719:7: local_index\n");
     }
 
     Y_UNIT_TEST(OptionalAliases) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)
