### PR TITLE
Fix flake8 warning in arcadia tests

### DIFF
--- a/ydb/public/sdk/python/enable_v3_new_behavior/__init__.py
+++ b/ydb/public/sdk/python/enable_v3_new_behavior/__init__.py
@@ -1,2 +1,1 @@
 # MARKER MODULE
-


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix flake8 warning:
`contrib/ydb/public/sdk/python/enable_v3_new_behavior/__init__.py:2: [W391] blank line at end of file`

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
