### PR TITLE
YQL-18053: Add block implementation for Member callable

### DIFF
--- a/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
+++ b/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
@@ -5468,7 +5468,7 @@ bool CollectBlockRewrites(const TMultiExprType* multiInputType, bool keepInputCo
 
         TExprNode::TListType funcArgs;
         std::string_view arrowFunctionName;
-        if (node->IsList() || node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "Exists", "If", "Just", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
+        if (node->IsList() || node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "Exists", "If", "Just", "Member", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
         {
             if (node->IsCallable() && !IsSupportedAsBlockType(node->Pos(), *node->GetTypeAnn(), ctx, types)) {
                 return true;

--- a/ydb/library/yql/core/type_ann/type_ann_blocks.h
+++ b/ydb/library/yql/core/type_ann/type_ann_blocks.h
@@ -20,6 +20,7 @@ namespace NTypeAnnImpl {
     IGraphTransformer::TStatus BlockJustWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockAsTupleWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockNthWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
+    IGraphTransformer::TStatus BlockMemberWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockToPgWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockFromPgWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockFuncWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TExtContext& ctx);

--- a/ydb/library/yql/core/type_ann/type_ann_core.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_core.cpp
@@ -12239,6 +12239,7 @@ template <NKikimr::NUdf::EDataSlot DataSlot>
         Functions["BlockIf"] = &BlockIfWrapper;
         Functions["BlockJust"] = &BlockJustWrapper;
         Functions["BlockAsTuple"] = &BlockAsTupleWrapper;
+        Functions["BlockMember"] = &BlockMemberWrapper;
         Functions["BlockNth"] = &BlockNthWrapper;
         Functions["BlockToPg"] = &BlockToPgWrapper;
         Functions["BlockFromPg"] = &BlockFromPgWrapper;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.cpp
@@ -1,0 +1,110 @@
+#include "mkql_block_getelem.h"
+
+#include <ydb/library/yql/minikql/computation/mkql_block_impl.h>
+#include <ydb/library/yql/minikql/mkql_node_cast.h>
+#include <ydb/library/yql/minikql/mkql_node_builder.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+namespace {
+
+class TBlockGetElementExec {
+public:
+    TBlockGetElementExec(const std::shared_ptr<arrow::DataType>& returnArrowType, ui32 index, bool isOptional, bool needExternalOptional)
+        : ReturnArrowType(returnArrowType)
+        , Index(index)
+        , IsOptional(isOptional)
+        , NeedExternalOptional(needExternalOptional)
+    {}
+
+    arrow::Status Exec(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) const {
+        arrow::Datum inputDatum = batch.values[0];
+        if (inputDatum.is_scalar()) {
+            if (inputDatum.scalar()->is_valid) {
+                const auto& structScalar = arrow::internal::checked_cast<const arrow::StructScalar&>(*inputDatum.scalar());
+                *res = arrow::Datum(structScalar.value[Index]);
+            } else {
+                *res = arrow::Datum(arrow::MakeNullScalar(ReturnArrowType));
+            }
+        } else {
+            const auto& array = inputDatum.array();
+            auto child = array->child_data[Index];
+            if (NeedExternalOptional) {
+                auto newArrayData = arrow::ArrayData::Make(ReturnArrowType, array->length, { array->buffers[0] });
+                newArrayData->child_data.push_back(child);
+                *res = arrow::Datum(newArrayData);
+            } else if (!IsOptional || !array->buffers[0]) {
+                *res = arrow::Datum(child);
+            } else {
+                auto newArrayData = child->Copy();
+                if (!newArrayData->buffers[0]) {
+                    newArrayData->buffers[0] = array->buffers[0];
+                } else {
+                    auto buffer = AllocateBitmapWithReserve(array->length + array->offset, ctx->memory_pool());
+                    arrow::internal::BitmapAnd(child->GetValues<uint8_t>(0, 0), child->offset, array->GetValues<uint8_t>(0, 0), array->offset, array->length, array->offset, buffer->mutable_data());
+                    newArrayData->buffers[0] = buffer;
+                }
+
+                newArrayData->SetNullCount(arrow::kUnknownNullCount);
+                *res = arrow::Datum(newArrayData);
+            }
+        }
+
+        return arrow::Status::OK();
+    }
+
+private:
+    const std::shared_ptr<arrow::DataType> ReturnArrowType;
+    const ui32 Index;
+    const bool IsOptional;
+    const bool NeedExternalOptional;
+};
+
+std::shared_ptr<arrow::compute::ScalarKernel> MakeBlockGetElementKernel(const TVector<TType*>& argTypes, TType* resultType,
+    ui32 index, bool isOptional, bool needExternalOptional) {
+    std::shared_ptr<arrow::DataType> returnArrowType;
+    MKQL_ENSURE(ConvertArrowType(AS_TYPE(TBlockType, resultType)->GetItemType(), returnArrowType), "Unsupported arrow type");
+    auto exec = std::make_shared<TBlockGetElementExec>(returnArrowType, index, isOptional, needExternalOptional);
+    auto kernel = std::make_shared<arrow::compute::ScalarKernel>(ConvertToInputTypes(argTypes), ConvertToOutputType(resultType),
+        [exec](arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
+        return exec->Exec(ctx, batch, res);
+    });
+
+    kernel->null_handling = arrow::compute::NullHandling::COMPUTED_NO_PREALLOCATE;
+    return kernel;
+}
+
+TType* GetElementType(const TTupleType* tupleType, ui32 index) {
+    MKQL_ENSURE(index < tupleType->GetElementsCount(), "Bad tuple index");
+    return tupleType->GetElementType(index);
+}
+
+template<typename ObjectType>
+IComputationNode* WrapBlockGetElement(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    MKQL_ENSURE(callable.GetInputsCount() == 2, "Expected two args.");
+    auto inputObject = callable.GetInput(0);
+    auto blockType = AS_TYPE(TBlockType, inputObject.GetStaticType());
+    bool isOptional;
+    auto objectType = AS_TYPE(ObjectType, UnpackOptional(blockType->GetItemType(), isOptional));
+    auto indexData = AS_VALUE(TDataLiteral, callable.GetInput(1));
+    auto index = indexData->AsValue().Get<ui32>();
+    auto childType = GetElementType(objectType, index);
+    bool needExternalOptional = isOptional && childType->IsVariant();
+
+    auto objectNode = LocateNode(ctx.NodeLocator, callable, 0);
+
+    TComputationNodePtrVector argsNodes = { objectNode };
+    TVector<TType*> argsTypes = { blockType };
+    auto kernel = MakeBlockGetElementKernel(argsTypes, callable.GetType()->GetReturnType(), index, isOptional, needExternalOptional);
+    return new TBlockFuncNode(ctx.Mutables, callable.GetType()->GetName(), std::move(argsNodes), argsTypes, *kernel, kernel);
+}
+
+} // namespace
+
+IComputationNode* WrapBlockNth(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    return WrapBlockGetElement<TTupleType>(callable, ctx);
+}
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.cpp
@@ -75,6 +75,11 @@ std::shared_ptr<arrow::compute::ScalarKernel> MakeBlockGetElementKernel(const TV
     return kernel;
 }
 
+TType* GetElementType(const TStructType* structType, ui32 index) {
+    MKQL_ENSURE(index < structType->GetMembersCount(), "Bad member index");
+    return structType->GetMemberType(index);
+}
+
 TType* GetElementType(const TTupleType* tupleType, ui32 index) {
     MKQL_ENSURE(index < tupleType->GetElementsCount(), "Bad tuple index");
     return tupleType->GetElementType(index);
@@ -101,6 +106,10 @@ IComputationNode* WrapBlockGetElement(TCallable& callable, const TComputationNod
 }
 
 } // namespace
+
+IComputationNode* WrapBlockMember(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    return WrapBlockGetElement<TStructType>(callable, ctx);
+}
 
 IComputationNode* WrapBlockNth(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
     return WrapBlockGetElement<TTupleType>(callable, ctx);

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.h
@@ -4,6 +4,7 @@
 namespace NKikimr {
 namespace NMiniKQL {
 
+IComputationNode* WrapBlockMember(TCallable& callable, const TComputationNodeFactoryContext& ctx);
 IComputationNode* WrapBlockNth(TCallable& callable, const TComputationNodeFactoryContext& ctx);
 
 } // namespace NMiniKQL

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_getelem.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <ydb/library/yql/minikql/computation/mkql_computation_node.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+IComputationNode* WrapBlockNth(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_tuple.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_tuple.h
@@ -5,7 +5,6 @@ namespace NKikimr {
 namespace NMiniKQL {
 
 IComputationNode* WrapBlockAsTuple(TCallable& callable, const TComputationNodeFactoryContext& ctx);
-IComputationNode* WrapBlockNth(TCallable& callable, const TComputationNodeFactoryContext& ctx);
 
 }
 }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
@@ -9,6 +9,7 @@
 #include "mkql_block_agg.h"
 #include "mkql_block_coalesce.h"
 #include "mkql_block_exists.h"
+#include "mkql_block_getelem.h"
 #include "mkql_block_if.h"
 #include "mkql_block_just.h"
 #include "mkql_block_logical.h"

--- a/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
@@ -298,6 +298,7 @@ struct TCallableComputationNodeBuilderFuncMapFiller {
         {"BlockJust", &WrapBlockJust},
         {"BlockCompress", &WrapBlockCompress},
         {"BlockAsTuple", &WrapBlockAsTuple},
+        {"BlockMember", &WrapBlockMember},
         {"BlockNth", &WrapBlockNth},
         {"BlockExpandChunked", &WrapBlockExpandChunked},
         {"BlockCombineAll", &WrapBlockCombineAll},

--- a/ydb/library/yql/minikql/comp_nodes/ya.make.inc
+++ b/ydb/library/yql/minikql/comp_nodes/ya.make.inc
@@ -16,6 +16,7 @@ SET(ORIG_SOURCES
     mkql_block_agg_sum.cpp
     mkql_block_coalesce.cpp
     mkql_block_exists.cpp
+    mkql_block_getelem.cpp
     mkql_block_if.cpp
     mkql_block_just.cpp
     mkql_block_logical.cpp

--- a/ydb/library/yql/minikql/mkql_program_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_program_builder.cpp
@@ -1620,6 +1620,24 @@ TRuntimeNode TProgramBuilder::BlockExists(TRuntimeNode data) {
     return TRuntimeNode(callableBuilder.Build(), false);
 }
 
+TRuntimeNode TProgramBuilder::BlockMember(TRuntimeNode structObj, const std::string_view& memberName) {
+    auto blockType = AS_TYPE(TBlockType, structObj.GetStaticType());
+    bool isOptional;
+    const auto type = AS_TYPE(TStructType, UnpackOptional(blockType->GetItemType(), isOptional));
+
+    const auto memberIndex = type->GetMemberIndex(memberName);
+    auto memberType = type->GetMemberType(memberIndex);
+    if (isOptional && !memberType->IsOptional() && !memberType->IsNull() && !memberType->IsPg()) {
+        memberType = NewOptionalType(memberType);
+    }
+
+    auto returnType = NewBlockType(memberType, blockType->GetShape());
+    TCallableBuilder callableBuilder(Env, __func__, returnType);
+    callableBuilder.Add(structObj);
+    callableBuilder.Add(NewDataLiteral<ui32>(memberIndex));
+    return TRuntimeNode(callableBuilder.Build(), false);
+}
+
 TRuntimeNode TProgramBuilder::BlockNth(TRuntimeNode tuple, ui32 index) {
     auto blockType = AS_TYPE(TBlockType, tuple.GetStaticType());
     bool isOptional;

--- a/ydb/library/yql/minikql/mkql_program_builder.h
+++ b/ydb/library/yql/minikql/mkql_program_builder.h
@@ -237,6 +237,7 @@ public:
     TRuntimeNode BlockExpandChunked(TRuntimeNode flow);
     TRuntimeNode BlockCoalesce(TRuntimeNode first, TRuntimeNode second);
     TRuntimeNode BlockExists(TRuntimeNode data);
+    TRuntimeNode BlockMember(TRuntimeNode structure, const std::string_view& memberName);
     TRuntimeNode BlockNth(TRuntimeNode tuple, ui32 index);
     TRuntimeNode BlockAsTuple(const TArrayRef<const TRuntimeNode>& args);
     TRuntimeNode BlockToPg(TRuntimeNode input, TType* returnType);

--- a/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
+++ b/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
@@ -2725,6 +2725,12 @@ TMkqlCommonCallableCompiler::TShared::TShared() {
         return ctx.ProgramBuilder.BlockBitCast(arg, targetType);
     });
 
+    AddCallable("BlockMember", [](const TExprNode& node, TMkqlBuildContext& ctx) {
+        const auto structObj = MkqlBuildExpr(node.Head(), ctx);
+        const auto name = node.Tail().Content();
+        return ctx.ProgramBuilder.BlockMember(structObj, name);
+    });
+
     AddCallable("BlockNth", [](const TExprNode& node, TMkqlBuildContext& ctx) {
         const auto tupleObj = MkqlBuildExpr(node.Head(), ctx);
         const auto index = FromString<ui32>(node.Tail().Content());

--- a/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
@@ -533,6 +533,28 @@
         }
     ],
     "test.test[blocks-filter_direct_col--Results]": [],
+    "test.test[blocks-member--Analyze]": [
+        {
+            "checksum": "b08274fd137c1878d90520c832f06fd3",
+            "size": 3676,
+            "uri": "https://{canondata_backend}/1889210/75a1d72834c0a9de8b328ec130be934f6cc6cea0/resource.tar.gz#test.test_blocks-member--Analyze_/plan.txt"
+        }
+    ],
+    "test.test[blocks-member--Debug]": [
+        {
+            "checksum": "a30b76ba380ee4f694dc731aa2771fed",
+            "size": 1467,
+            "uri": "https://{canondata_backend}/1937027/96028d31f8e29253c9276a86f02284e2a71add76/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-member--Plan]": [
+        {
+            "checksum": "b08274fd137c1878d90520c832f06fd3",
+            "size": 3676,
+            "uri": "https://{canondata_backend}/1889210/75a1d72834c0a9de8b328ec130be934f6cc6cea0/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-member--Results]": [],
     "test.test[blocks-pg_to_dates--Analyze]": [
         {
             "checksum": "2a21c8668a5f5f9b4304777c6aa3c3ca",

--- a/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
@@ -671,6 +671,20 @@
             "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_blocks-finalize_hashed_keys--Plan_/plan.txt"
         }
     ],
+    "test.test[blocks-member--Debug]": [
+        {
+            "checksum": "49012dc14c1d467d864bc5079aa4542f",
+            "size": 1982,
+            "uri": "https://{canondata_backend}/1597364/2a4f282ea286021ee8f9098fb8207324c7ebe684/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-member--Plan]": [
+        {
+            "checksum": "794e5e7aaffc457f9e8f888953e1c89e",
+            "size": 4045,
+            "uri": "https://{canondata_backend}/1597364/07eb39555ae99a903261332d5998f32599b281fe/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
+        }
+    ],
     "test.test[blocks-minmax_strings--Debug]": [
         {
             "checksum": "f17fd002ee0286a709010b0cb6a5805e",

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -3569,6 +3569,13 @@
             "uri": "https://{canondata_backend}/1917492/bf361ba6aca9974e26535026fb228b74d0ff24ef/resource.tar.gz#test_sql2yql.test_blocks-if_/sql.yql"
         }
     ],
+    "test_sql2yql.test[blocks-member]": [
+        {
+            "checksum": "88c9131d7ea3c80ecc268cb7f458fc86",
+            "size": 1230,
+            "uri": "https://{canondata_backend}/1937027/f015781f1ee8e2e10d049f80211c1f81b56abfb9/resource.tar.gz#test_sql2yql.test_blocks-member_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[blocks-minmax_strings]": [
         {
             "checksum": "a73aaced3247f72c7a4ddda05dbc53e0",
@@ -21809,6 +21816,13 @@
             "checksum": "b649410c2a4dbec4627225e51894b5fe",
             "size": 532,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_blocks-if_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-member]": [
+        {
+            "checksum": "7fcb44569c4f84aee80ea32b5961e0ed",
+            "size": 146,
+            "uri": "https://{canondata_backend}/1937027/f015781f1ee8e2e10d049f80211c1f81b56abfb9/resource.tar.gz#test_sql_format.test_blocks-member_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-minmax_strings]": [

--- a/ydb/library/yql/tests/sql/suites/blocks/member.cfg
+++ b/ydb/library/yql/tests/sql/suites/blocks/member.cfg
@@ -1,0 +1,1 @@
+in Input input_struct.txt

--- a/ydb/library/yql/tests/sql/suites/blocks/member.sql
+++ b/ydb/library/yql/tests/sql/suites/blocks/member.sql
@@ -1,0 +1,7 @@
+USE plato;
+/* XXX: Enable UseBlocks pragma and provide input to trigger block execution. */
+pragma UseBlocks;
+
+SELECT
+    val.a as a,
+FROM Input;

--- a/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
@@ -548,6 +548,34 @@
             "uri": "https://{canondata_backend}/1689644/8bfa47b4b6b4d6f6543bfef6c07a8937dfb0470d/resource.tar.gz#test.test_blocks-filter_direct_col--Results_/results.txt"
         }
     ],
+    "test.test[blocks-member--Debug]": [
+        {
+            "checksum": "bc4498c90892a7f1e023ac57dbcbc16d",
+            "size": 1459,
+            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-member--Peephole]": [
+        {
+            "checksum": "b4c9c617dd8d2fa940d076319eb8928d",
+            "size": 1343,
+            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-member--Plan]": [
+        {
+            "checksum": "082fc363e364c6bd7e557a48f4a982e4",
+            "size": 4537,
+            "uri": "https://{canondata_backend}/1937424/677956b7b1d51ac69cbef1b401a74f8916d215bb/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-member--Results]": [
+        {
+            "checksum": "2cbf207655f2d864cbcbda63073d76f5",
+            "size": 1282,
+            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Results_/results.txt"
+        }
+    ],
     "test.test[blocks-pg_to_dates--Debug]": [
         {
             "checksum": "93f519572585eb5003ddbd5d67797b48",


### PR DESCRIPTION
This patchset introduces block implementation for `Member` callable. The semantics of this callable differs from `Nth` callable only in the type of the object being processed (structure vs tuple). Hence, the first patch of the series turns `Nth` callable block implementation into generic `GetElem` helper, so the last patch only introduce its specialization for the Struct type.

### Changelog category

* Improvement