### PR TITLE
BTreeIndex Add GroupDataSize

### DIFF
--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -97,6 +97,7 @@ namespace NKikimr::NTable::NPage {
             TPageId PageId;
             TRowId RowCount;
             ui64 DataSize;
+            ui64 GroupDataSize;
             TRowId ErasedRowCount;
 
             auto operator<=>(const TChild&) const = default;
@@ -106,11 +107,17 @@ namespace NKikimr::NTable::NPage {
             }
 
             TString ToString() const noexcept {
-                return TStringBuilder() << "PageId: " << PageId << " RowCount: " << RowCount << " DataSize: " << DataSize << " ErasedRowCount: " << ErasedRowCount;
+                TStringBuilder result;
+                result << "PageId: " << PageId << " RowCount: " << RowCount << " DataSize: " << DataSize;
+                if (GroupDataSize) {
+                    result << " GroupDataSize: " << GroupDataSize;
+                }
+                result << " ErasedRowCount: " << ErasedRowCount;
+                return result;
             }
         } Y_PACKED;
 
-        static_assert(sizeof(TChild) == 28, "Invalid TBtreeIndexNode TChild size");
+        static_assert(sizeof(TChild) == 36, "Invalid TBtreeIndexNode TChild size");
 
         static_assert(offsetof(TChild, PageId) == offsetof(TShortChild, PageId));
         static_assert(offsetof(TChild, RowCount) == offsetof(TShortChild, RowCount));

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -252,7 +252,9 @@ namespace NKikimr::NTable::NPage {
             : Raw(std::move(raw))
         {
             const auto data = NPage::TLabelWrapper().Read(Raw, EPage::BTreeIndex);
-            Y_ABORT_UNLESS(data == ECodec::Plain && data.Version == 0);
+
+            // Version = 0 didn't have GroupDataSize field
+            Y_ABORT_UNLESS(data == ECodec::Plain && data.Version == 1);
 
             Header = TDeref<const THeader>::At(data.Page.data());
             size_t offset = sizeof(THeader);

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -249,6 +249,8 @@ namespace NKikimr::NTable::NPage {
         void PlaceChild(const TChild& child) noexcept
         {
             if (IsShortChildFormat()) {
+                Y_DEBUG_ABORT_UNLESS(child.GroupDataSize == 0);
+                Y_DEBUG_ABORT_UNLESS(child.ErasedRowCount == 0);
                 Place<TShortChild>() = TShortChild{child.PageId, child.RowCount, child.DataSize};
             } else {
                 Place<TChild>() = child;
@@ -375,13 +377,14 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddShortChild(TShortChild child) {
-            AddChild(TChild{child.PageId, child.RowCount, child.DataSize, 0});
+            AddChild(TChild{child.PageId, child.RowCount, child.DataSize, 0, 0});
         }
 
         void AddChild(TChild child) {
             // aggregate in order to perform search by row id from any leaf node
             child.RowCount = (ChildRowCount += child.RowCount);
-            child.DataSize = (ChildSize += child.DataSize);
+            child.DataSize = (ChildDataSize += child.DataSize);
+            child.GroupDataSize = (ChildGroupDataSize += child.GroupDataSize);
             child.ErasedRowCount = (ChildErasedRowCount += child.ErasedRowCount);
 
             Levels[0].PushChild(child);
@@ -423,7 +426,8 @@ namespace NKikimr::NTable::NPage {
             Levels = { TLevel() };
             ChildRowCount = 0;
             ChildErasedRowCount = 0;
-            ChildSize = 0;
+            ChildDataSize = 0;
+            ChildGroupDataSize = 0;
         }
 
     private:
@@ -474,7 +478,8 @@ namespace NKikimr::NTable::NPage {
                 Levels.emplace_back();
                 Y_ABORT_UNLESS(Levels.size() < Max<ui32>(), "Levels size is out of bounds");
             }
-            Levels[levelIndex + 1].PushChild(TChild{pageId, lastChild.RowCount, lastChild.DataSize, lastChild.ErasedRowCount});
+            lastChild.PageId = pageId;
+            Levels[levelIndex + 1].PushChild(lastChild);
             if (!last) {
                 Levels[levelIndex + 1].PushKey(Levels[levelIndex].PopKey());
             }
@@ -509,7 +514,8 @@ namespace NKikimr::NTable::NPage {
 
         TRowId ChildRowCount = 0;
         TRowId ChildErasedRowCount = 0;
-        ui64 ChildSize = 0;
+        ui64 ChildDataSize = 0;
+        ui64 ChildGroupDataSize = 0;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -97,7 +97,7 @@ namespace NKikimr::NTable::NPage {
             Ptr = buf.mutable_begin();
             End = buf.end();
 
-            WriteUnaligned<TLabel>(Advance(sizeof(TLabel)), TLabel::Encode(EPage::BTreeIndex, 0, pageSize));
+            WriteUnaligned<TLabel>(Advance(sizeof(TLabel)), TLabel::Encode(EPage::BTreeIndex, 1, pageSize));
 
             auto &header = Place<THeader>();
             header.KeysCount = Keys.size();

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -84,7 +84,8 @@ void TLoader::StageParseMeta() noexcept
                 NPage::TBtreeIndexMeta converted{{
                     meta.GetRootPageId(), 
                     meta.GetRowCount(), 
-                    meta.GetDataSize(), 
+                    meta.GetDataSize(),
+                    meta.GetGroupDataSize(),
                     meta.GetErasedRowCount()}, 
                     meta.GetLevelCount(), 
                     meta.GetIndexSize()};

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -488,13 +488,14 @@ namespace NTable {
             // The first group must write the last key
             Y_ABORT_UNLESS(std::exchange(Phase, 1) == 0, "Called twice");
 
-            for (auto& g : Groups) {
-                g.Data.Flush(*this);
+            for (size_t i : xrange<size_t>(1, Groups.size())) {
+                Groups[i].Data.Flush(*this);
             }
-
             for (auto& g : Histories) {
                 g.Data.Flush(*this);
             }
+            // Main index should have correct groups data size
+            Groups[0].Data.Flush(*this);
 
             if (Current.Rows > 0) {
                 Y_ABORT_UNLESS(Phase == 2, "Missed the last Save call");

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -853,6 +853,8 @@ namespace NTable {
                 auto blob = NPage::TLabelWrapper::WrapString(plain, EPage::Opaque, 0);
                 ui64 ref = Globs.Size(); /* is the current blob index */
 
+                Current.BTreeGroupDataSize += blob.size();
+
                 return Register(row, tag, Pager.WriteLarge(std::move(blob), ref));
 
             } else if (plain.size() >= SmallEdge) {
@@ -863,6 +865,7 @@ namespace NTable {
                 FrameS.Put(row, tag, blob.size());
 
                 Current.SmallWritten += blob.size();
+                Current.BTreeGroupDataSize += blob.size();
 
                 return { ELargeObj::Outer, Pager.WriteOuter(std::move(blob)) };
 

--- a/ydb/core/tablet_flat/protos/flat_table_part.proto
+++ b/ydb/core/tablet_flat/protos/flat_table_part.proto
@@ -27,9 +27,10 @@ message TBTreeIndexMeta {
     optional uint32 RootPageId = 1;
     optional uint32 LevelCount = 2;
     optional uint64 IndexSize = 3;
-    optional uint64 DataSize = 4;
-    optional uint64 RowCount = 5; // Total number of data rows
-    optional uint64 ErasedRowCount = 6; // Total number of erased data rows
+    optional uint64 DataSize = 4; // Main pages data size
+    optional uint64 GroupDataSize = 5; // Group pages data size (includes history and external blobs)
+    optional uint64 RowCount = 6; // Total number of data rows
+    optional uint64 ErasedRowCount = 7; // Total number of erased data rows
 }
 
 message TLayout {

--- a/ydb/core/tablet_flat/protos/flat_table_part.proto
+++ b/ydb/core/tablet_flat/protos/flat_table_part.proto
@@ -28,9 +28,9 @@ message TBTreeIndexMeta {
     optional uint32 LevelCount = 2;
     optional uint64 IndexSize = 3;
     optional uint64 DataSize = 4; // Main pages data size
-    optional uint64 GroupDataSize = 5; // Group pages data size (includes history and external blobs)
-    optional uint64 RowCount = 6; // Total number of data rows
-    optional uint64 ErasedRowCount = 7; // Total number of erased data rows
+    optional uint64 RowCount = 5; // Total number of data rows
+    optional uint64 ErasedRowCount = 6; // Total number of erased data rows
+    optional uint64 GroupDataSize = 7; // Group pages data size (includes history and external blobs)
 }
 
 message TLayout {

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -184,6 +184,23 @@ namespace NTest {
             return result;
         }
 
+        inline ui64 CountDataSize(const TPart& part, TGroupId groupId) {
+            size_t result = 0;
+
+            TTestEnv env;
+            auto index = CreateIndexIter(&part, &env, groupId);
+            for (size_t i = 0; ; i++) {
+                auto ready = i == 0 ? index->Seek(0) : index->Next();
+                if (ready != EReady::Data) {
+                    Y_ABORT_UNLESS(ready != EReady::Page, "Unexpected page fault");
+                    break;
+                }
+                result += part.GetPageSize(index->GetPageId(), groupId);
+            }
+
+            return result;
+        }
+
         inline TRowId GetEndRowId(const TPart& part) {
             TTestEnv env;
             auto index = CreateIndexIter(&part, &env, { });

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -133,9 +133,10 @@ namespace NTest {
             for (bool history : {false, true}) {
                 for (const auto &meta : history ? lay.GetBTreeHistoricIndexes() : lay.GetBTreeGroupIndexes()) {
                     NPage::TBtreeIndexMeta converted{{
-                        meta.GetRootPageId(), 
-                        meta.GetRowCount(), 
-                        meta.GetDataSize(), 
+                        meta.GetRootPageId(),
+                        meta.GetRowCount(),
+                        meta.GetDataSize(),
+                        meta.GetGroupDataSize(),
                         meta.GetErasedRowCount()}, 
                         meta.GetLevelCount(), 
                         meta.GetIndexSize()};

--- a/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
@@ -731,7 +731,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 2);
 
-        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].PageId, 10, 10480, 0, 0}, 1, 1115};
+        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].PageId, 10, 10480, 0, 0}, 1, 1131};
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected, "Got " + part->IndexPages.BTreeGroups[0].ToString());
     }
 
@@ -764,7 +764,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 117);
 
-        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].PageId, 700, 733140, 0, 0}, 3, 86036};
+        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].PageId, 700, 733140, 0, 0}, 3, 87172};
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected, "Got " + part->IndexPages.BTreeGroups[0].ToString());
     }
 
@@ -798,7 +798,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 31);
 
-        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].PageId, 1000, 22098, 0, 143}, 2, 1380};
+        TBtreeIndexMeta expected{{part->IndexPages.BTreeGroups[0].PageId, 1000, 22098, 0, 143}, 2, 1668};
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected, "Got " + part->IndexPages.BTreeGroups[0].ToString());
     }
 
@@ -832,10 +832,10 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 334);
 
-        TBtreeIndexMeta expected0{{part->IndexPages.BTreeGroups[0].PageId, 1000, 16680, 32680, 0}, 3, 15246};
+        TBtreeIndexMeta expected0{{part->IndexPages.BTreeGroups[0].PageId, 1000, 16680, 21890, 0}, 3, 18430};
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected0, "Got " + part->IndexPages.BTreeGroups[0].ToString());
 
-        TBtreeIndexMeta expected1{{part->IndexPages.BTreeGroups[1].PageId, 1000, 21890, 42890, 0}, 3, 6497};
+        TBtreeIndexMeta expected1{{part->IndexPages.BTreeGroups[1].PageId, 1000, 21890, 0, 0}, 3, 6497};
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[1], expected1, "Got " + part->IndexPages.BTreeGroups[1].ToString());
     }
 
@@ -871,7 +871,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPart) {
         auto pages = IndexTools::CountMainPages(*part);
         UNIT_ASSERT_VALUES_EQUAL(pages, 334);
 
-        TBtreeIndexMeta expected0{{part->IndexPages.BTreeGroups[0].PageId, 1000, 32680, 64000, 0}, 3, 15246};
+        TBtreeIndexMeta expected0{{part->IndexPages.BTreeGroups[0].PageId, 1000, 32680, 22889+77340+45780, 0}, 3, 18430};
         UNIT_ASSERT_EQUAL_C(part->IndexPages.BTreeGroups[0], expected0, "Got " + part->IndexPages.BTreeGroups[0].ToString());
 
         TBtreeIndexMeta expected1{{part->IndexPages.BTreeGroups[1].PageId, 1000, 22889, 0, 0}, 3, 6497};

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -183,65 +183,65 @@ Y_UNIT_TEST_SUITE(BuildStats) {
     Y_UNIT_TEST(Single_BTreeIndex)
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2106439, 41220);
+        Check(*subset, 24000, 2106439, 49449);
     }
 
     Y_UNIT_TEST(Single_Slices_BTreeIndex)
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 12816, 1121048, 41220);
+        Check(*subset, 12816, 1121048, 49449);
     }
 
     Y_UNIT_TEST(Single_Groups_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2460139, 20485);
+        Check(*subset, 24000, 2460139, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 10440, 1060798, 20485);
+        Check(*subset, 10440, 1060798, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_History_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0.3);   
-        Check(*subset, 24000, 4054050, 29710);
+        Check(*subset, 24000, 4054050, 34837);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 13570, 2277890, 29710);
+        Check(*subset, 13570, 2277890, 34837);
     }
 
     Y_UNIT_TEST(Mixed_BTreeIndex)
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 4, TMixerRnd(4));
-        Check(*subset, 24000, 2106459, 40950);
+        Check(*subset, 24000, 2106459, 49449);
     }
 
     Y_UNIT_TEST(Mixed_Groups_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 4, TMixerRnd(4));
-        Check(*subset, 24000, 2460219, 20394);
+        Check(*subset, 24000, 2460219, 23555);
     }
 
     Y_UNIT_TEST(Mixed_Groups_History_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 4, TMixerRnd(4), 0.3);
-        Check(*subset, 24000, 4054270, 29619);
+        Check(*subset, 24000, 4054270, 34579);
     }
 
     Y_UNIT_TEST(Serial_BTreeIndex)
     {
         TMixerSeq mixer(4, Mass0.Saved.Size());
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 4, mixer);
-        Check(*subset, 24000, 2106459, 40950);
+        Check(*subset, 24000, 2106459, 49502);
     }
 
     Y_UNIT_TEST(Serial_Groups_BTreeIndex)
@@ -261,40 +261,40 @@ Y_UNIT_TEST_SUITE(BuildStats) {
     Y_UNIT_TEST(Single_LowResolution_BTreeIndex)
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2106439, 56610, 5310, 531050);
+        Check(*subset, 24000, 2106439, 66674, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Slices_LowResolution_BTreeIndex)
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 12816, 1121048, 56610, 5310, 531050);
+        Check(*subset, 12816, 1121048, 66674, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_LowResolution_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2460139, 29557, 5310, 531050);
+        Check(*subset, 24000, 2460139, 33541, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices_LowResolution_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 10440, 1060798, 29557, 5310, 531050);
+        Check(*subset, 10440, 1060798, 33541, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_History_LowResolution_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0.3);   
-        Check(*subset, 24000, 4054050, 42292, 5310, 531050);
+        Check(*subset, 24000, 4054050, 48540, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices_LowResolution_BTreeIndex)
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 13570, 2114857 /* ~2277890 */, 42292, 5310, 531050);
+        Check(*subset, 13570, 2114857 /* ~2277890 */, 48540, 5310, 531050);
     }
 }
 

--- a/ydb/core/tablet_flat/ut_large/ut_btree_index_large.cpp
+++ b/ydb/core/tablet_flat/ut_large/ut_btree_index_large.cpp
@@ -58,7 +58,7 @@ Y_UNIT_TEST_SUITE(TBtreeIndexTPartLarge) {
         TPartCook cook(lay, conf);
         
         for (ui32 i = 0; cook.GetDataBytes(0) < 1ull*1024*1024*1024; i++) {
-            cook.Add(*TSchemedCookRow(*lay).Col(0u, TString(120, 'x') + std::to_string(i)));
+            cook.Add(*TSchemedCookRow(*lay).Col(0u, TString(110, 'x') + std::to_string(i)));
         }
 
         TPartEggs eggs = cook.Finish();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Store group data size in B-Tree index in order to build stats easier

Breaks compatibility but I don't expect anyone to use this functionality