### PR TITLE
Fix offset processing in DecompressToSparseBitmap

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_exists_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_exists_ut.cpp
@@ -12,25 +12,25 @@ void DoBlockExistsOffset(size_t length, size_t offset) {
     TSetup<false> setup;
     TProgramBuilder& pb = *setup.PgmBuilder;
 
-    const auto i32Type    = pb.NewDataType(NUdf::TDataType<i32>::Id);
-    const auto opti32Type = pb.NewOptionalType(i32Type);
+    const auto ui64Type    = pb.NewDataType(NUdf::TDataType<ui64>::Id);
+    const auto optui64Type = pb.NewOptionalType(ui64Type);
     const auto boolType   = pb.NewDataType(NUdf::TDataType<bool>::Id);
 
-    const auto inputTupleType  = pb.NewTupleType({i32Type, opti32Type, opti32Type, opti32Type});
-    const auto outputTupleType = pb.NewTupleType({i32Type, boolType, boolType, boolType});
+    const auto inputTupleType  = pb.NewTupleType({ui64Type, optui64Type, optui64Type, optui64Type});
+    const auto outputTupleType = pb.NewTupleType({ui64Type, boolType, boolType, boolType});
 
     TRuntimeNode::TList input;
     static_assert(MaxBlockSizeInBytes % 4 == 0);
 
     for (size_t i = 0; i < length; i++) {
-        const auto maybeNull = (i % 2) ? pb.NewOptional(pb.NewDataLiteral<i32>(i / 2))
-                                       : pb.NewEmptyOptionalDataLiteral(NUdf::TDataType<i32>::Id);
+        const auto maybeNull = (i % 2) ? pb.NewOptional(pb.NewDataLiteral<ui64>(i / 2))
+                                       : pb.NewEmptyOptionalDataLiteral(NUdf::TDataType<ui64>::Id);
 
         const auto inputTuple = pb.NewTuple(inputTupleType, {
-            pb.NewDataLiteral<i32>(i),
+            pb.NewDataLiteral<ui64>(i),
             maybeNull,
-            pb.NewEmptyOptionalDataLiteral(NUdf::TDataType<i32>::Id),
-            pb.NewOptional(pb.NewDataLiteral<i32>(i))
+            pb.NewEmptyOptionalDataLiteral(NUdf::TDataType<ui64>::Id),
+            pb.NewOptional(pb.NewDataLiteral<ui64>(i))
         });
 
         input.push_back(inputTuple);
@@ -76,7 +76,7 @@ void DoBlockExistsOffset(size_t length, size_t offset) {
 
         NUdf::TUnboxedValue outputTuple;
         UNIT_ASSERT(iterator.Next(outputTuple));
-        const i32 key = outputTuple.GetElement(0).Get<i32>();
+        const ui32 key = outputTuple.GetElement(0).Get<ui64>();
         const bool maybeNull = outputTuple.GetElement(1).Get<bool>();
         const bool alwaysNull = outputTuple.GetElement(2).Get<bool>();
         const bool neverNull = outputTuple.GetElement(3).Get<bool>();

--- a/ydb/library/yql/public/udf/arrow/bit_util.h
+++ b/ydb/library/yql/public/udf/arrow/bit_util.h
@@ -16,14 +16,16 @@ inline ui8* CompressAsSparseBitmap(const ui8* src, size_t srcOffset, const ui8* 
 }
 
 inline ui8* DecompressToSparseBitmap(ui8* dstSparse, const ui8* src, size_t srcOffset, size_t count) {
-    if (srcOffset % 8 != 0) {
+    if (srcOffset != 0) {
         size_t offsetBytes = srcOffset >> 3;
         size_t offsetTail = srcOffset & 7;
         src += offsetBytes;
-        for (ui8 i = offsetTail; count > 0 && i < 8; i++, count--) {
-            *dstSparse++ = (*src >> i) & 1u;
+        if (offsetTail != 0) {
+            for (ui8 i = offsetTail; count > 0 && i < 8; i++, count--) {
+                *dstSparse++ = (*src >> i) & 1u;
+            }
+            src++;
         }
-        src++;
     }
     while (count >= 8) {
         ui8 slot = *src++;


### PR DESCRIPTION
There is a bug in `DecompressToSparseBitmap` routine, when the given `offset` is a multiple of 8, and the head of the batch to be skipped is processed by the main loop.

Unfortunately, the test input uses odd slots for non-null data and even slots for null data, hence the resulting output verification covered the bug in the aforementioned routine, when the given `offset` is a multiple of 8. The randomization, that is introduced to the test in the second commit, provides less structured data to finally reproduce and fix the misbehaviour.

Furthermore, `GenRand` function from `IRandomProvider` yields unsigned 64-bit integers, so all the signed 32-bit integer values are converted to unsigned 64-bit ones to prepare the test for `IRandomProvider` use in the following patch.

Follows up #3400

### Changelog category

* Bugfix