### PR TITLE
Remove unnecessary abort when periodic table stats are received from "deleted" shard

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -247,7 +247,13 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
 
     TShardIdx shardIdx = Self->TabletIdToShardIdx[datashardId];
     const auto* shardInfo = Self->ShardInfos.FindPtr(shardIdx);
-    Y_ABORT_UNLESS(shardInfo, "ShardInfos does not know about the shardIdx returned by TabletIdToShardIdx.");
+    if (!shardInfo) {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "No ShardInfo by shardIdx " << shardIdx << " of shard " << datashardId;
+        );
+        return true;
+    }
+
     auto subDomainInfo = Self->ResolveDomainInfo(pathId);
     const auto channelsMapping = MapChannelsToStoragePoolKinds(ctx,
                                                                subDomainInfo->EffectiveStoragePools(),


### PR DESCRIPTION
It turned out to be very possible for SchemeShard to receive TEvPeriodicTableStats from a datashard that has been removed (i.e. ShardInfos has been erased by the shardIdx). TabletIdToShardIdx entry for a shard is not erased, when the shard is being deleted. Moreover, it seems that entries in TabletIdToShardIdx are never erased, unless by .clear(), when the SchemeShard dies.