### PR TITLE
Better naming for iterators

### DIFF
--- a/ydb/core/engine/minikql/minikql_engine_host.cpp
+++ b/ydb/core/engine/minikql/minikql_engine_host.cpp
@@ -291,10 +291,10 @@ NUdf::TUnboxedValue TEngineHost::SelectRow(const TTableId& tableId, const TArray
     return std::move(rowResult);
 }
 
-template<class TTableIt>
-class TSelectRangeLazyRow : public TComputationValue<TSelectRangeLazyRow<TTableIt>> {
+template<class TTableIter>
+class TSelectRangeLazyRow : public TComputationValue<TSelectRangeLazyRow<TTableIter>> {
 private:
-    using TBase = TComputationValue<TSelectRangeLazyRow<TTableIt>>;
+    using TBase = TComputationValue<TSelectRangeLazyRow<TTableIter>>;
     NUdf::TUnboxedValue GetElement(ui32 index) const override {
         BuildValue(index);
         return GetPtr()[index];
@@ -335,7 +335,7 @@ public:
         }
     }
 
-    void OwnDb(THolder<TTableIt>&& iter) {
+    void OwnDb(THolder<TTableIter>&& iter) {
         Iter = std::move(iter);
     }
 
@@ -348,7 +348,7 @@ public:
 private:
     TSelectRangeLazyRow(const TDbTupleRef& dbData, const THolderFactory& holderFactory, ui32 maskSize,
         const TSmallVec<NTable::TTag>& systemColumnTags, ui64 shardId)
-        : TComputationValue<TSelectRangeLazyRow<TTableIt>>(&holderFactory.GetMemInfo())
+        : TComputationValue<TSelectRangeLazyRow<TTableIter>>(&holderFactory.GetMemInfo())
         , Iter()
         , DbData(dbData)
         , MaskSize(maskSize)
@@ -413,7 +413,7 @@ private:
     }
 
 private:
-    THolder<TTableIt> Iter;
+    THolder<TTableIter> Iter;
     TDbTupleRef DbData;
     ui32 MaskSize;
     TSmallVec<NTable::TTag> SystemColumnTags;
@@ -425,14 +425,14 @@ public:
     template<class>
     friend class TIterator;
 
-    template<class TTableIt>
-    class TIterator : public TComputationValue<TIterator<TTableIt>> {
+    template<class TTableIter>
+    class TIterator : public TComputationValue<TIterator<TTableIter>> {
         static const ui32 PeriodicCallbackIterations = 1000;
 
-        using TBase = TComputationValue<TIterator<TTableIt>>;
+        using TBase = TComputationValue<TIterator<TTableIter>>;
 
     public:
-        TIterator(TMemoryUsageInfo* memInfo, const TSelectRangeLazyRowsList& list, TAutoPtr<TTableIt>&& iter,
+        TIterator(TMemoryUsageInfo* memInfo, const TSelectRangeLazyRowsList& list, TAutoPtr<TTableIter>&& iter,
             const TSmallVec<NTable::TTag>& systemColumnTags, ui64 shardId)
             : TBase(memInfo)
             , List(list)
@@ -524,7 +524,7 @@ public:
                 if (HasCurrent && CurrentRowValue.UniqueBoxed()) {
                     CurrentRow()->Reuse(rowValues);
                 } else {
-                    CurrentRowValue = TSelectRangeLazyRow<TTableIt>::Create(rowValues, List.HolderFactory, SystemColumnTags, ShardId);
+                    CurrentRowValue = TSelectRangeLazyRow<TTableIter>::Create(rowValues, List.HolderFactory, SystemColumnTags, ShardId);
                 }
 
                 value = CurrentRowValue;
@@ -568,13 +568,13 @@ public:
             }
         }
 
-        TSelectRangeLazyRow<TTableIt>* CurrentRow() const {
-            return static_cast<TSelectRangeLazyRow<TTableIt>*>(CurrentRowValue.AsBoxed().Get());
+        TSelectRangeLazyRow<TTableIter>* CurrentRow() const {
+            return static_cast<TSelectRangeLazyRow<TTableIter>*>(CurrentRowValue.AsBoxed().Get());
         }
 
     private:
         const TSelectRangeLazyRowsList& List;
-        THolder<TTableIt> Iter;
+        THolder<TTableIter> Iter;
         bool HasCurrent;
         ui64 Iterations;
         ui64 Items;
@@ -631,13 +631,13 @@ public:
             auto read = Db.IterateRangeReverse(LocalTid, keyRange, Tags, EngineHost.GetReadVersion(TableId), TxMap, TxObserver);
 
             return NUdf::TUnboxedValuePod(
-                new TIterator<NTable::TTableReverseIt>(GetMemInfo(), *this, std::move(read), SystemColumnTags, ShardId)
+                new TIterator<NTable::TTableReverseIter>(GetMemInfo(), *this, std::move(read), SystemColumnTags, ShardId)
             );
         } else {
             auto read = Db.IterateRange(LocalTid, keyRange, Tags, EngineHost.GetReadVersion(TableId), TxMap, TxObserver);
 
             return NUdf::TUnboxedValuePod(
-                new TIterator<NTable::TTableIt>(GetMemInfo(), *this, std::move(read), SystemColumnTags, ShardId)
+                new TIterator<NTable::TTableIter>(GetMemInfo(), *this, std::move(read), SystemColumnTags, ShardId)
             );
         }
     }

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -97,7 +97,7 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekRowId)(benchmark::State& state) {
         THolder<IPartGroupIndexIter> iter;
 
         if (useBTree) {
-            iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
         } else {
             iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }
@@ -112,7 +112,7 @@ BENCHMARK_DEFINE_F(TPartFixture, Next)(benchmark::State& state) {
     THolder<IPartGroupIndexIter> iter;
 
     if (useBTree) {
-        iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
     } else {
         iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
@@ -133,7 +133,7 @@ BENCHMARK_DEFINE_F(TPartFixture, Prev)(benchmark::State& state) {
     THolder<IPartGroupIndexIter> iter;
 
     if (useBTree) {
-        iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
     } else {
         iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
@@ -162,7 +162,7 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekKey)(benchmark::State& state) {
         THolder<IPartGroupIndexIter> iter;
 
         if (useBTree) {
-            iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
         } else {
             iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -94,10 +94,10 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekRowId)(benchmark::State& state) {
     const bool useBTree = state.range(0);
 
     for (auto _ : state) {
-        THolder<IIndexIter> iter;
+        THolder<IPartGroupIndexIter> iter;
 
         if (useBTree) {
-            iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
         } else {
             iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }
@@ -109,10 +109,10 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekRowId)(benchmark::State& state) {
 BENCHMARK_DEFINE_F(TPartFixture, Next)(benchmark::State& state) {
     const bool useBTree = state.range(0);
 
-    THolder<IIndexIter> iter;
+    THolder<IPartGroupIndexIter> iter;
 
     if (useBTree) {
-        iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
     } else {
         iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
@@ -130,10 +130,10 @@ BENCHMARK_DEFINE_F(TPartFixture, Next)(benchmark::State& state) {
 BENCHMARK_DEFINE_F(TPartFixture, Prev)(benchmark::State& state) {
     const bool useBTree = state.range(0);
 
-    THolder<IIndexIter> iter;
+    THolder<IPartGroupIndexIter> iter;
 
     if (useBTree) {
-        iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
     } else {
         iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
@@ -159,10 +159,10 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekKey)(benchmark::State& state) {
     }
 
     for (auto _ : state) {
-        THolder<IIndexIter> iter;
+        THolder<IPartGroupIndexIter> iter;
 
         if (useBTree) {
-            iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
         } else {
             iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -26,8 +26,8 @@ namespace NKikimr::NTable {
 namespace {
     using namespace NTest;
 
-    using TCheckIt = TChecker<TWrapIter, TSubset>;
-    using TCheckReverseIt = TChecker<TWrapReverseIter, TSubset>;
+    using TCheckIter = TChecker<TWrapIter, TSubset>;
+    using TCheckReverseIter = TChecker<TWrapReverseIter, TSubset>;
 
     NPage::TConf PageConf(size_t groups, bool writeBTreeIndex) noexcept
     {
@@ -68,11 +68,11 @@ namespace {
             }
 
             if (history) {
-                Checker = new TCheckIt(*Subset, {new TTestEnv()}, TRowVersion(0, 8));
-                CheckerReverse = new TCheckReverseIt(*Subset, {new TTestEnv()}, TRowVersion(0, 8));
+                Checker = new TCheckIter(*Subset, {new TTestEnv()}, TRowVersion(0, 8));
+                CheckerReverse = new TCheckReverseIter(*Subset, {new TTestEnv()}, TRowVersion(0, 8));
             } else {
-                Checker = new TCheckIt(*Subset, {new TTestEnv()});
-                CheckerReverse = new TCheckReverseIt(*Subset, {new TTestEnv()});
+                Checker = new TCheckIter(*Subset, {new TTestEnv()});
+                CheckerReverse = new TCheckReverseIter(*Subset, {new TTestEnv()});
             }
 
             GroupId = TGroupId(groups, history);
@@ -82,8 +82,8 @@ namespace {
         TMersenne<ui64> Rnd;
         TAutoPtr<NTest::TMass> Mass;
         TAutoPtr<TSubset> Subset;
-        TAutoPtr<TCheckIt> Checker;
-        TAutoPtr<TCheckReverseIt> CheckerReverse;
+        TAutoPtr<TCheckIter> Checker;
+        TAutoPtr<TCheckReverseIter> CheckerReverse;
         TTestEnv Env;
         TGroupId GroupId;
         TPart const* Part;

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -97,7 +97,7 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekRowId)(benchmark::State& state) {
         THolder<IPartGroupIndexIter> iter;
 
         if (useBTree) {
-            iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
         } else {
             iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }
@@ -112,7 +112,7 @@ BENCHMARK_DEFINE_F(TPartFixture, Next)(benchmark::State& state) {
     THolder<IPartGroupIndexIter> iter;
 
     if (useBTree) {
-        iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
     } else {
         iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
@@ -133,7 +133,7 @@ BENCHMARK_DEFINE_F(TPartFixture, Prev)(benchmark::State& state) {
     THolder<IPartGroupIndexIter> iter;
 
     if (useBTree) {
-        iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
     } else {
         iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
@@ -162,7 +162,7 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekKey)(benchmark::State& state) {
         THolder<IPartGroupIndexIter> iter;
 
         if (useBTree) {
-            iter = MakeHolder<TPartGroupBtreeIndexIterer>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupBtreeIndexIter>(Part, &Env, GroupId);
         } else {
             iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -99,7 +99,7 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekRowId)(benchmark::State& state) {
         if (useBTree) {
             iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
         } else {
-            iter = MakeHolder<TPartIndexIt>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }
 
         iter->Seek(RandomNumber<ui32>(Part->Stat.Rows));    
@@ -114,7 +114,7 @@ BENCHMARK_DEFINE_F(TPartFixture, Next)(benchmark::State& state) {
     if (useBTree) {
         iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
     } else {
-        iter = MakeHolder<TPartIndexIt>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
 
     iter->Seek(RandomNumber<ui32>(Part->Stat.Rows));
@@ -135,7 +135,7 @@ BENCHMARK_DEFINE_F(TPartFixture, Prev)(benchmark::State& state) {
     if (useBTree) {
         iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
     } else {
-        iter = MakeHolder<TPartIndexIt>(Part, &Env, GroupId);
+        iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
     }
 
     iter->Seek(RandomNumber<ui32>(Part->Stat.Rows));
@@ -164,7 +164,7 @@ BENCHMARK_DEFINE_F(TPartFixture, SeekKey)(benchmark::State& state) {
         if (useBTree) {
             iter = MakeHolder<TPartBtreeIndexIt>(Part, &Env, GroupId);
         } else {
-            iter = MakeHolder<TPartIndexIt>(Part, &Env, GroupId);
+            iter = MakeHolder<TPartGroupFlatIndexIter>(Part, &Env, GroupId);
         }
 
         state.PauseTiming();

--- a/ydb/core/tablet_flat/flat_cxx_database.h
+++ b/ydb/core/tablet_flat/flat_cxx_database.h
@@ -843,7 +843,7 @@ struct Schema {
             }
 
             template <typename TableType>
-            using Selector = TableSelector<NTable::TTableIt, TableType, KeyColumnsTypes...>;
+            using Selector = TableSelector<NTable::TTableIter, TableType, KeyColumnsTypes...>;
             using KeyColumnsType = std::tuple<KeyColumnsTypes...>;
             using KeyValuesType = typename TableColumns<KeyColumnsTypes...>::TupleType;
             using RealKeyValuesType = typename TableColumns<KeyColumnsTypes...>::RealTupleType;
@@ -1319,11 +1319,11 @@ struct Schema {
 
             template <typename TableType, typename KeyValuesType>
             class EqualKeyIterator
-                : public KeyIterator<NTable::TTableIt, EqualKeyIterator<TableType, KeyValuesType>>
+                : public KeyIterator<NTable::TTableIter, EqualKeyIterator<TableType, KeyValuesType>>
             {
             public:
                 using KeyColumnsType = typename TableType::TKey::KeyColumnsType;
-                using Iterator = KeyIterator<NTable::TTableIt, EqualKeyIterator<TableType, KeyValuesType>>;
+                using Iterator = KeyIterator<NTable::TTableIter, EqualKeyIterator<TableType, KeyValuesType>>;
 
                 EqualKeyIterator(TToughDb& database, const KeyValuesType& key, NTable::TTagsRef columns)
                     : Iterator(MakeIterator(database, key, columns))
@@ -1336,9 +1336,9 @@ struct Schema {
                 EqualKeyIterator(EqualKeyIterator&& iterator) = default;
                 EqualKeyIterator& operator =(EqualKeyIterator&& iterator) = default;
 
-                static THolder<NTable::TTableIt> MakeIterator(TToughDb& database, const KeyValuesType& keyValues, NTable::TTagsRef columns) {
+                static THolder<NTable::TTableIter> MakeIterator(TToughDb& database, const KeyValuesType& keyValues, NTable::TTagsRef columns) {
                     TTupleToRawTypeValue<KeyValuesType, KeyColumnsType> key(keyValues);
-                    return THolder<NTable::TTableIt>(database.IterateExact(TableId, key, columns).Release());
+                    return THolder<NTable::TTableIter>(database.IterateExact(TableId, key, columns).Release());
                 }
 
                 static bool Precharge(
@@ -1355,7 +1355,7 @@ struct Schema {
                         key,
                         key,
                         columns,
-                        NTable::TTableIt::Direction,
+                        NTable::TTableIter::Direction,
                         maxRowCount,
                         maxBytes);
                 }

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -40,7 +40,7 @@ TIntrusiveConstPtr<TRowScheme> TDatabase::GetRowScheme(ui32 table) const noexcep
     return Require(table)->GetScheme();
 }
 
-TAutoPtr<TTableIt> TDatabase::Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup mode) const noexcept
+TAutoPtr<TTableIter> TDatabase::Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup mode) const noexcept
 {
     Y_ABORT_UNLESS(!NoMoreReadsFlag, "Trying to read after reads prohibited, table %u", table);
 
@@ -72,7 +72,7 @@ TAutoPtr<TTableIt> TDatabase::Iterate(ui32 table, TRawVals key, TTagsRef tags, E
     return Require(table)->Iterate(key, tags, Env, seekBy(key, mode), TRowVersion::Max());
 }
 
-TAutoPtr<TTableIt> TDatabase::IterateExact(ui32 table, TRawVals key, TTagsRef tags,
+TAutoPtr<TTableIter> TDatabase::IterateExact(ui32 table, TRawVals key, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const noexcept
@@ -126,7 +126,7 @@ namespace {
     }
 }
 
-TAutoPtr<TTableIt> TDatabase::IterateRange(ui32 table, const TKeyRange& range, TTagsRef tags,
+TAutoPtr<TTableIter> TDatabase::IterateRange(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const noexcept
@@ -155,7 +155,7 @@ TAutoPtr<TTableIt> TDatabase::IterateRange(ui32 table, const TKeyRange& range, T
     return iter;
 }
 
-TAutoPtr<TTableReverseIt> TDatabase::IterateRangeReverse(ui32 table, const TKeyRange& range, TTagsRef tags,
+TAutoPtr<TTableReverseIter> TDatabase::IterateRangeReverse(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const noexcept
@@ -185,7 +185,7 @@ TAutoPtr<TTableReverseIt> TDatabase::IterateRangeReverse(ui32 table, const TKeyR
 }
 
 template<>
-TAutoPtr<TTableIt> TDatabase::IterateRangeGeneric<TTableIt>(ui32 table, const TKeyRange& range, TTagsRef tags,
+TAutoPtr<TTableIter> TDatabase::IterateRangeGeneric<TTableIter>(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const noexcept
@@ -194,7 +194,7 @@ TAutoPtr<TTableIt> TDatabase::IterateRangeGeneric<TTableIt>(ui32 table, const TK
 }
 
 template<>
-TAutoPtr<TTableReverseIt> TDatabase::IterateRangeGeneric<TTableReverseIt>(ui32 table, const TKeyRange& range, TTagsRef tags,
+TAutoPtr<TTableReverseIter> TDatabase::IterateRangeGeneric<TTableReverseIter>(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const noexcept

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -71,16 +71,16 @@ public:
 
     /*_ Call Next() before accessing each row including the 1st row. */
 
-    TAutoPtr<TTableIt> Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup) const noexcept;
-    TAutoPtr<TTableIt> IterateExact(ui32 table, TRawVals key, TTagsRef tags,
+    TAutoPtr<TTableIter> Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup) const noexcept;
+    TAutoPtr<TTableIter> IterateExact(ui32 table, TRawVals key, TTagsRef tags,
             TRowVersion snapshot = TRowVersion::Max(),
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const noexcept;
-    TAutoPtr<TTableIt> IterateRange(ui32 table, const TKeyRange& range, TTagsRef tags,
+    TAutoPtr<TTableIter> IterateRange(ui32 table, const TKeyRange& range, TTagsRef tags,
             TRowVersion snapshot = TRowVersion::Max(),
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const noexcept;
-    TAutoPtr<TTableReverseIt> IterateRangeReverse(ui32 table, const TKeyRange& range, TTagsRef tags,
+    TAutoPtr<TTableReverseIter> IterateRangeReverse(ui32 table, const TKeyRange& range, TTagsRef tags,
             TRowVersion snapshot = TRowVersion::Max(),
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const noexcept;

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -278,7 +278,7 @@ private:
     TVector<ui32> ModifiedRefs;
     TVector<TUpdateOp> ModifiedOps;
 
-    mutable TDeque<TPartSimpleIt> TempIterators; // Keeps the last result of Select() valid
+    mutable TDeque<TPartIter> TempIterators; // Keeps the last result of Select() valid
     mutable THashSet<ui32> IteratedTables;
 
     TVector<std::function<void()>> OnCommit_;

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -265,7 +265,7 @@ namespace NFwd {
         }
 
     private:
-        THolder<IIndexIter> Index; /* Points on next to load page */
+        THolder<IPartGroupIndexIter> Index; /* Points on next to load page */
         EIndexState IndexState = DoStart;
         TRowId BeginRowId, EndRowId;
         TLoadedPagesCircularBuffer<TPart::Trace> Trace;

--- a/ydb/core/tablet_flat/flat_iterator.h
+++ b/ydb/core/tablet_flat/flat_iterator.h
@@ -252,8 +252,8 @@ public:
 
     ~TTableItBase();
 
-    void Push(TAutoPtr<TMemIt>);
-    void Push(TAutoPtr<TPartsIter>);
+    void Push(TAutoPtr<TMemIter>);
+    void Push(TAutoPtr<TRunIter>);
 
     void StopBefore(TArrayRef<const TCell> key);
     void StopAfter(TArrayRef<const TCell> key);
@@ -364,8 +364,8 @@ private:
 
     EStage Stage = EStage::Seek;
     EReady Ready = EReady::Gone;
-    THolderVector<TMemIt> MemIters;
-    THolderVector<TPartsIter> RunIters;
+    THolderVector<TMemIter> MemIters;
+    THolderVector<TRunIter> RunIters;
     TOwnedCellVec StopKey;
     bool StopKeyInclusive = true;
 
@@ -516,7 +516,7 @@ inline void TTableItBase<TIteratorOps>::AddNotReadyIterator(TIteratorId itId) {
 }
 
 template<class TIteratorOps>
-inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TMemIt> it)
+inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TMemIter> it)
 {
     if (it && it->IsValid()) {
         TIteratorId itId = { EType::Mem, IteratorIndexFromSize(MemIters.size()), it->MemTable->Epoch };
@@ -528,7 +528,7 @@ inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TMemIt> it)
 }
 
 template<class TIteratorOps>
-inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TPartsIter> it)
+inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TRunIter> it)
 {
     TIteratorId itId = { EType::Run, IteratorIndexFromSize(RunIters.size()), it->Epoch() };
 

--- a/ydb/core/tablet_flat/flat_iterator.h
+++ b/ydb/core/tablet_flat/flat_iterator.h
@@ -253,7 +253,7 @@ public:
     ~TTableItBase();
 
     void Push(TAutoPtr<TMemIt>);
-    void Push(TAutoPtr<TRunIt>);
+    void Push(TAutoPtr<TPartsIter>);
 
     void StopBefore(TArrayRef<const TCell> key);
     void StopAfter(TArrayRef<const TCell> key);
@@ -365,7 +365,7 @@ private:
     EStage Stage = EStage::Seek;
     EReady Ready = EReady::Gone;
     THolderVector<TMemIt> MemIters;
-    THolderVector<TRunIt> RunIters;
+    THolderVector<TPartsIter> RunIters;
     TOwnedCellVec StopKey;
     bool StopKeyInclusive = true;
 
@@ -528,7 +528,7 @@ inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TMemIt> it)
 }
 
 template<class TIteratorOps>
-inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TRunIt> it)
+inline void TTableItBase<TIteratorOps>::Push(TAutoPtr<TPartsIter> it)
 {
     TIteratorId itId = { EType::Run, IteratorIndexFromSize(RunIters.size()), it->Epoch() };
 

--- a/ydb/core/tablet_flat/flat_iterator.h
+++ b/ydb/core/tablet_flat/flat_iterator.h
@@ -455,23 +455,23 @@ private:
     bool SeekInternal(TArrayRef<const TCell> key, ESeek seek) noexcept;
 };
 
-class TTableIt;
-class TTableReverseIt;
+class TTableIter;
+class TTableReverseIter;
 
-class TTableIt : public TTableItBase<TTableItOps> {
+class TTableIter : public TTableItBase<TTableItOps> {
 public:
     using TTableItBase::TTableItBase;
 
-    typedef TTableReverseIt TReverseType;
+    typedef TTableReverseIter TReverseType;
 
     static constexpr EDirection Direction = EDirection::Forward;
 };
 
-class TTableReverseIt : public TTableItBase<TTableItReverseOps> {
+class TTableReverseIter : public TTableItBase<TTableItReverseOps> {
 public:
     using TTableItBase::TTableItBase;
 
-    typedef TTableIt TReverseType;
+    typedef TTableIter TReverseType;
 
     static constexpr EDirection Direction = EDirection::Reverse;
 };

--- a/ydb/core/tablet_flat/flat_iterator_ops.h
+++ b/ydb/core/tablet_flat/flat_iterator_ops.h
@@ -29,7 +29,7 @@ struct TTableItOps {
         it.Next();
     }
 
-    static inline EReady MoveNext(TRunIt& it) {
+    static inline EReady MoveNext(TPartsIter& it) {
         return it.Next();
     }
 
@@ -37,7 +37,7 @@ struct TTableItOps {
         it.Seek(key, seek);
     }
 
-    static inline EReady Seek(TRunIt& it, TArrayRef<const TCell> key, ESeek seek) {
+    static inline EReady Seek(TPartsIter& it, TArrayRef<const TCell> key, ESeek seek) {
         return it.Seek(key, seek);
     }
 
@@ -169,7 +169,7 @@ struct TTableItReverseOps {
         it.Prev();
     }
 
-    static EReady MoveNext(TRunIt& it) {
+    static EReady MoveNext(TPartsIter& it) {
         return it.Prev();
     }
 
@@ -177,7 +177,7 @@ struct TTableItReverseOps {
         it.SeekReverse(key, seek);
     }
 
-    static EReady Seek(TRunIt& it, TArrayRef<const TCell> key, ESeek seek) {
+    static EReady Seek(TPartsIter& it, TArrayRef<const TCell> key, ESeek seek) {
         return it.SeekReverse(key, seek);
     }
 

--- a/ydb/core/tablet_flat/flat_iterator_ops.h
+++ b/ydb/core/tablet_flat/flat_iterator_ops.h
@@ -25,19 +25,19 @@ struct TTableItOps {
         return 0;
     }
 
-    static inline void MoveNext(TMemIt& it) {
+    static inline void MoveNext(TMemIter& it) {
         it.Next();
     }
 
-    static inline EReady MoveNext(TPartsIter& it) {
+    static inline EReady MoveNext(TRunIter& it) {
         return it.Next();
     }
 
-    static inline void Seek(TMemIt& it, TArrayRef<const TCell> key, ESeek seek) {
+    static inline void Seek(TMemIter& it, TArrayRef<const TCell> key, ESeek seek) {
         it.Seek(key, seek);
     }
 
-    static inline EReady Seek(TPartsIter& it, TArrayRef<const TCell> key, ESeek seek) {
+    static inline EReady Seek(TRunIter& it, TArrayRef<const TCell> key, ESeek seek) {
         return it.Seek(key, seek);
     }
 
@@ -165,19 +165,19 @@ struct TTableItReverseOps {
         return -TTableItOps::CompareKeys(types, a, b);
     }
 
-    static void MoveNext(TMemIt& it) {
+    static void MoveNext(TMemIter& it) {
         it.Prev();
     }
 
-    static EReady MoveNext(TPartsIter& it) {
+    static EReady MoveNext(TRunIter& it) {
         return it.Prev();
     }
 
-    static void Seek(TMemIt& it, TArrayRef<const TCell> key, ESeek seek) {
+    static void Seek(TMemIter& it, TArrayRef<const TCell> key, ESeek seek) {
         it.SeekReverse(key, seek);
     }
 
-    static EReady Seek(TPartsIter& it, TArrayRef<const TCell> key, ESeek seek) {
+    static EReady Seek(TRunIter& it, TArrayRef<const TCell> key, ESeek seek) {
         return it.SeekReverse(key, seek);
     }
 

--- a/ydb/core/tablet_flat/flat_mem_iter.h
+++ b/ydb/core/tablet_flat/flat_mem_iter.h
@@ -15,11 +15,11 @@
 namespace NKikimr {
 namespace NTable {
 
-    class TMemIt {
+    class TMemIter {
     public:
         using TCells = TArrayRef<const TCell>;
 
-        TMemIt(const TMemTable* memTable,
+        TMemIter(const TMemTable* memTable,
                 TIntrusiveConstPtr<TKeyCellDefaults> keyDefaults,
                 const TRemap* remap,
                 IPages *env,
@@ -36,7 +36,7 @@ namespace NTable {
             Y_ABORT_UNLESS(Remap, "Remap cannot be NULL");
         }
 
-        static TAutoPtr<TMemIt> Make(
+        static TAutoPtr<TMemIter> Make(
                 const TMemTable& memTable,
                 const NMem::TTreeSnapshot& snapshot,
                 TCells key,
@@ -46,7 +46,7 @@ namespace NTable {
                 IPages *env,
                 EDirection direction = EDirection::Forward) noexcept
         {
-            auto *iter = new TMemIt(&memTable, std::move(keyDefaults), remap, env, snapshot.Iterator());
+            auto *iter = new TMemIter(&memTable, std::move(keyDefaults), remap, env, snapshot.Iterator());
 
             switch (direction) {
                 case EDirection::Forward:

--- a/ydb/core/tablet_flat/flat_mem_warm.h
+++ b/ydb/core/tablet_flat/flat_mem_warm.h
@@ -171,14 +171,14 @@ namespace NMem {
 
 } // namespace NMem
 
-    class TMemIt;
+    class TMemIter;
 
     struct TMemTableSnapshot;
 
     struct TMemTableRollbackState;
 
     class TMemTable : public TThrRefBase {
-        friend class TMemIt;
+        friend class TMemIter;
 
     public:
         struct TTxIdStat {

--- a/ydb/core/tablet_flat/flat_part_btree_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_btree_index_iter.h
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NTable {
 
-class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
+class TPartGroupBtreeIndexIterer : public IPartGroupIndexIter {
     using TCells = NPage::TCells;
     using TBtreeIndexNode = NPage::TBtreeIndexNode;
     using TGroupId = NPage::TGroupId;
@@ -109,7 +109,7 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
     };
 
 public:
-    TPartGroupBtreeIndexIter(const TPart* part, IPages* env, TGroupId groupId)
+    TPartGroupBtreeIndexIterer(const TPart* part, IPages* env, TGroupId groupId)
         : Part(part)
         , Env(env)
         , GroupId(groupId)

--- a/ydb/core/tablet_flat/flat_part_btree_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_btree_index_iter.h
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NTable {
 
-class TPartBtreeIndexIt : public IIndexIter {
+class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
     using TCells = NPage::TCells;
     using TBtreeIndexNode = NPage::TBtreeIndexNode;
     using TGroupId = NPage::TGroupId;
@@ -109,7 +109,7 @@ class TPartBtreeIndexIt : public IIndexIter {
     };
 
 public:
-    TPartBtreeIndexIt(const TPart* part, IPages* env, TGroupId groupId)
+    TPartGroupBtreeIndexIter(const TPart* part, IPages* env, TGroupId groupId)
         : Part(part)
         , Env(env)
         , GroupId(groupId)

--- a/ydb/core/tablet_flat/flat_part_btree_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_btree_index_iter.h
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NTable {
 
-class TPartGroupBtreeIndexIterer : public IPartGroupIndexIter {
+class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
     using TCells = NPage::TCells;
     using TBtreeIndexNode = NPage::TBtreeIndexNode;
     using TGroupId = NPage::TGroupId;
@@ -109,7 +109,7 @@ class TPartGroupBtreeIndexIterer : public IPartGroupIndexIter {
     };
 
 public:
-    TPartGroupBtreeIndexIterer(const TPart* part, IPages* env, TGroupId groupId)
+    TPartGroupBtreeIndexIter(const TPart* part, IPages* env, TGroupId groupId)
         : Part(part)
         , Env(env)
         , GroupId(groupId)

--- a/ydb/core/tablet_flat/flat_part_charge.h
+++ b/ydb/core/tablet_flat/flat_part_charge.h
@@ -31,10 +31,10 @@ namespace NTable {
                 if (const auto* col = Scheme.FindColumnByTag(tag)) {
                     if (col->Group != 0 && !seen.Get(col->Group)) {
                         NPage::TGroupId groupId(col->Group);
-                        Groups.emplace_back(TPartIndexIt(Part, Env, groupId), groupId);
+                        Groups.emplace_back(TPartGroupFlatIndexIter(Part, Env, groupId), groupId);
                         if (HistoryIndex) {
                             NPage::TGroupId historyGroupId(col->Group, true);
-                            HistoryGroups.emplace_back(TPartIndexIt(Part, Env, historyGroupId), historyGroupId);
+                            HistoryGroups.emplace_back(TPartGroupFlatIndexIter(Part, Env, historyGroupId), historyGroupId);
                         }
                         seen.Set(col->Group);
                     }
@@ -491,12 +491,12 @@ namespace NTable {
 
     private:
         struct TGroupState {
-            TPartIndexIt GroupIndex;
+            TPartGroupFlatIndexIter GroupIndex;
             TIter Index;
             TRowId LastRowId = Max<TRowId>();
             const NPage::TGroupId GroupId;
 
-            TGroupState(TPartIndexIt&& groupIndex, NPage::TGroupId groupId)
+            TGroupState(TPartGroupFlatIndexIter&& groupIndex, NPage::TGroupId groupId)
                 : GroupIndex(groupIndex)
                 , GroupId(groupId)
             { }
@@ -618,8 +618,8 @@ namespace NTable {
         IPages * const Env = nullptr;
         const TPart * const Part = nullptr;
         const TPartScheme &Scheme;
-        mutable TPartIndexIt Index;
-        mutable std::optional<TPartIndexIt> HistoryIndex;
+        mutable TPartGroupFlatIndexIter Index;
+        mutable std::optional<TPartGroupFlatIndexIter> HistoryIndex;
         mutable TSmallVec<TGroupState> Groups;
         mutable TSmallVec<TGroupState> HistoryGroups;
     };

--- a/ydb/core/tablet_flat/flat_part_index_iter.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter.h
@@ -10,7 +10,7 @@
 
 namespace NKikimr::NTable {
 
-class TPartIndexIt : public IIndexIter, public IStatsPartGroupIterator {
+class TPartGroupFlatIndexIter : public IPartGroupIndexIter, public IStatsPartGroupIter {
 public:
     using TCells = NPage::TCells;
     using TRecord = NPage::TIndex::TRecord;
@@ -18,7 +18,7 @@ public:
     using TIter = NPage::TIndex::TIter;
     using TGroupId = NPage::TGroupId;
 
-    TPartIndexIt(const TPart* part, IPages* env, TGroupId groupId)
+    TPartGroupFlatIndexIter(const TPart* part, IPages* env, TGroupId groupId)
         : Part(part)
         , Env(env)
         , GroupId(groupId)

--- a/ydb/core/tablet_flat/flat_part_index_iter_create.cpp
+++ b/ydb/core/tablet_flat/flat_part_index_iter_create.cpp
@@ -6,7 +6,7 @@ namespace NKikimr::NTable {
 THolder<IPartGroupIndexIter> CreateIndexIter(const TPart* part, IPages* env, NPage::TGroupId groupId)
 {
     if (part->IndexPages.HasBTree()) {
-        return MakeHolder<TPartGroupBtreeIndexIterer>(part, env, groupId);
+        return MakeHolder<TPartGroupBtreeIndexIter>(part, env, groupId);
     } else {
         return MakeHolder<TPartGroupFlatIndexIter>(part, env, groupId);
     }

--- a/ydb/core/tablet_flat/flat_part_index_iter_create.cpp
+++ b/ydb/core/tablet_flat/flat_part_index_iter_create.cpp
@@ -3,12 +3,12 @@
 
 namespace NKikimr::NTable {
 
-THolder<IIndexIter> CreateIndexIter(const TPart* part, IPages* env, NPage::TGroupId groupId)
+THolder<IPartGroupIndexIter> CreateIndexIter(const TPart* part, IPages* env, NPage::TGroupId groupId)
 {
     if (part->IndexPages.HasBTree()) {
-        return MakeHolder<TPartBtreeIndexIt>(part, env, groupId);
+        return MakeHolder<TPartGroupBtreeIndexIter>(part, env, groupId);
     } else {
-        return MakeHolder<TPartIndexIt>(part, env, groupId);
+        return MakeHolder<TPartGroupFlatIndexIter>(part, env, groupId);
     }
 }
 

--- a/ydb/core/tablet_flat/flat_part_index_iter_create.cpp
+++ b/ydb/core/tablet_flat/flat_part_index_iter_create.cpp
@@ -6,7 +6,7 @@ namespace NKikimr::NTable {
 THolder<IPartGroupIndexIter> CreateIndexIter(const TPart* part, IPages* env, NPage::TGroupId groupId)
 {
     if (part->IndexPages.HasBTree()) {
-        return MakeHolder<TPartGroupBtreeIndexIter>(part, env, groupId);
+        return MakeHolder<TPartGroupBtreeIndexIterer>(part, env, groupId);
     } else {
         return MakeHolder<TPartGroupFlatIndexIter>(part, env, groupId);
     }

--- a/ydb/core/tablet_flat/flat_part_index_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_iface.h
@@ -5,7 +5,7 @@
 
 namespace NKikimr::NTable {
     
-    struct IIndexIter {
+    struct IPartGroupIndexIter {
         using TCells = NPage::TCells;
 
         virtual EReady Seek(TRowId rowId) = 0;
@@ -25,9 +25,9 @@ namespace NKikimr::NTable {
         virtual TPos GetKeyCellsCount() const = 0;
         virtual TCell GetKeyCell(TPos index) const = 0;
 
-        virtual ~IIndexIter() = default;
+        virtual ~IPartGroupIndexIter() = default;
     };
 
-    THolder<IIndexIter> CreateIndexIter(const TPart* part, IPages* env, NPage::TGroupId groupId);
+    THolder<IPartGroupIndexIter> CreateIndexIter(const TPart* part, IPages* env, NPage::TGroupId groupId);
     
 }

--- a/ydb/core/tablet_flat/flat_part_iter_multi.cpp
+++ b/ydb/core/tablet_flat/flat_part_iter_multi.cpp
@@ -1,1 +1,0 @@
-#include "flat_part_iter_multi.h"

--- a/ydb/core/tablet_flat/flat_part_iter_multi.h
+++ b/ydb/core/tablet_flat/flat_part_iter_multi.h
@@ -1371,11 +1371,11 @@ namespace NTable {
         ui8 SkipEraseVersion : 1;
     };
 
-    class TPartsIter final {
+    class TRunIter final {
     public:
         using TCells = NPage::TCells;
 
-        TPartsIter(const TRun& run, TTagsRef tags, TIntrusiveConstPtr<TKeyCellDefaults> keyDefaults, IPages* env)
+        TRunIter(const TRun& run, TTagsRef tags, TIntrusiveConstPtr<TKeyCellDefaults> keyDefaults, IPages* env)
             : Run(run)
             , Tags(tags)
             , KeyCellDefaults(std::move(keyDefaults))

--- a/ydb/core/tablet_flat/flat_part_keys.h
+++ b/ydb/core/tablet_flat/flat_part_keys.h
@@ -226,7 +226,7 @@ namespace NTable {
         IPages* Env;
         TRowId RowId = Max<TRowId>();
         TPageId PageId = Max<TPageId>();
-        THolder<IIndexIter> Index;
+        THolder<IPartGroupIndexIter> Index;
         NPage::TDataPage Page;
         TSmallVec<TCell> Key;
     };

--- a/ydb/core/tablet_flat/flat_part_shrink.h
+++ b/ydb/core/tablet_flat/flat_part_shrink.h
@@ -43,10 +43,10 @@ namespace NTable {
                 if (!from && !to) /* [-inf, +inf) */ {
                     PartView.emplace_back(partView);
                 } else {
-                    TPartSimpleIt first(partView.Part.Get(), { }, KeyCellDefaults, Env);
+                    TPartIter first(partView.Part.Get(), { }, KeyCellDefaults, Env);
                     Skipped += EReady::Page == first.Seek(from, ESeek::Lower);
 
-                    TPartSimpleIt last(partView.Part.Get(), { }, KeyCellDefaults, Env);
+                    TPartIter last(partView.Part.Get(), { }, KeyCellDefaults, Env);
                     Skipped += EReady::Page == last.Seek(to, to ? ESeek::Lower : ESeek::Upper);
 
                     auto firstRowId = first.GetRowId();

--- a/ydb/core/tablet_flat/flat_scan_feed.h
+++ b/ydb/core/tablet_flat/flat_scan_feed.h
@@ -311,7 +311,7 @@ namespace NTable {
 
             Y_ABORT_UNLESS(Lead.Key.GetCells().size() <= keyDefaults->Size(), "TLead key is too large");
 
-            Iter = new TTableIt(Subset.Scheme.Get(), Lead.Tags, -1, SnapshotVersion, Subset.CommittedTransactions);
+            Iter = new TTableIter(Subset.Scheme.Get(), Lead.Tags, -1, SnapshotVersion, Subset.CommittedTransactions);
 
             CurrentEnv = MakeEnv();
 
@@ -507,7 +507,7 @@ namespace NTable {
         THolder<TLevels> Levels;
         TLead Lead;
         TBoots Boots;
-        TAutoPtr<TTableIt> Iter;
+        TAutoPtr<TTableIter> Iter;
         ui64 Seeks = Max<ui64>();
         ESeekState SeekState;
         bool OnPause = false;

--- a/ydb/core/tablet_flat/flat_scan_feed.h
+++ b/ydb/core/tablet_flat/flat_scan_feed.h
@@ -317,7 +317,7 @@ namespace NTable {
 
             for (auto &mem: Subset.Frozen)
                 Iter->Push(
-                    TMemIt::Make(
+                    TMemIter::Make(
                         *mem, mem.Snapshot, Lead.Key.GetCells(), Lead.Relation, keyDefaults, &Iter->Remap, CurrentEnv));
 
             if (Lead.StopKey.GetCells()) {
@@ -389,7 +389,7 @@ namespace NTable {
                 Boots.reserve(Levels->size());
                 for (auto &run: *Levels) {
                     Boots.push_back(
-                        MakeHolder<TPartsIter>(run, Lead.Tags, keyDefaults, CurrentEnv));
+                        MakeHolder<TRunIter>(run, Lead.Tags, keyDefaults, CurrentEnv));
                 }
             }
         }
@@ -497,7 +497,7 @@ namespace NTable {
         TRowVersion NextRowVersion;
 
     private:
-        using TBoots = TVector<THolder<TPartsIter>>;
+        using TBoots = TVector<THolder<TRunIter>>;
 
         IPages* CurrentEnv = nullptr;
 

--- a/ydb/core/tablet_flat/flat_scan_feed.h
+++ b/ydb/core/tablet_flat/flat_scan_feed.h
@@ -389,7 +389,7 @@ namespace NTable {
                 Boots.reserve(Levels->size());
                 for (auto &run: *Levels) {
                     Boots.push_back(
-                        MakeHolder<TRunIt>(run, Lead.Tags, keyDefaults, CurrentEnv));
+                        MakeHolder<TPartsIter>(run, Lead.Tags, keyDefaults, CurrentEnv));
                 }
             }
         }
@@ -497,7 +497,7 @@ namespace NTable {
         TRowVersion NextRowVersion;
 
     private:
-        using TBoots = TVector<THolder<TRunIt>>;
+        using TBoots = TVector<THolder<TPartsIter>>;
 
         IPages* CurrentEnv = nullptr;
 

--- a/ydb/core/tablet_flat/flat_stat_part.h
+++ b/ydb/core/tablet_flat/flat_stat_part.h
@@ -257,8 +257,8 @@ private:
     TSmallVec<TCell> CurrentKey;
     ui64 LastRowId = 0;
     
-    TVector<THolder<IStatsPartGroupIterator>> Groups;
-    TVector<THolder<IStatsPartGroupIterator>> HistoricGroups;
+    TVector<THolder<IStatsPartGroupIter>> Groups;
+    TVector<THolder<IStatsPartGroupIter>> HistoricGroups;
     TIntrusiveConstPtr<TScreen> Screen;
     TIntrusiveConstPtr<TFrames> Small;    /* Inverted index for small blobs   */
     TIntrusiveConstPtr<TFrames> Large;    /* Inverted index for large blobs   */

--- a/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NTable {
 
-class TStatsPartGroupBtreeIndexIterator : public IStatsPartGroupIterator {
+class TStatsPartGroupBtreeIndexIter : public IStatsPartGroupIter {
     using TCells = NPage::TCells;
     using TBtreeIndexNode = NPage::TBtreeIndexNode;
     using TGroupId = NPage::TGroupId;
@@ -37,7 +37,7 @@ class TStatsPartGroupBtreeIndexIterator : public IStatsPartGroupIterator {
     };
 
 public:
-    TStatsPartGroupBtreeIndexIterator(const TPart* part, IPages* env, TGroupId groupId,
+    TStatsPartGroupBtreeIndexIter(const TPart* part, IPages* env, TGroupId groupId,
             ui64 rowCountResolution, ui64 dataSizeResolution, const TVector<TRowId>& splitPoints)
         : Part(part)
         , Env(env)

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_create.cpp
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_create.cpp
@@ -4,13 +4,13 @@
 
 namespace NKikimr::NTable {
 
-THolder<IStatsPartGroupIterator> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId, 
+THolder<IStatsPartGroupIter> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId, 
     ui64 rowCountResolution, ui64 dataSizeResolution, const TVector<TRowId>& splitPoints)
 {
     if (groupId.Index < (groupId.IsHistoric() ? part->IndexPages.BTreeHistoric : part->IndexPages.BTreeGroups).size()) {
-        return MakeHolder<TStatsPartGroupBtreeIndexIterator>(part, env, groupId, rowCountResolution, dataSizeResolution, splitPoints);
+        return MakeHolder<TStatsPartGroupBtreeIndexIter>(part, env, groupId, rowCountResolution, dataSizeResolution, splitPoints);
     } else {
-        return MakeHolder<TPartIndexIt>(part, env, groupId);
+        return MakeHolder<TPartGroupFlatIndexIter>(part, env, groupId);
     }
 }
 

--- a/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_iter_iface.h
@@ -23,7 +23,7 @@ struct TDataStats {
     TChanneledDataSize DataSize = { };
 };
 
-struct IStatsPartGroupIterator {
+struct IStatsPartGroupIter {
     virtual EReady Start() = 0;
     virtual EReady Next() = 0;
     virtual void AddLastDeltaDataSize(TChanneledDataSize& dataSize) = 0;
@@ -37,10 +37,10 @@ struct IStatsPartGroupIterator {
     virtual TPos GetKeyCellsCount() const = 0;
     virtual TCell GetKeyCell(TPos index) const = 0;
 
-    virtual ~IStatsPartGroupIterator() = default;
+    virtual ~IStatsPartGroupIter() = default;
 };
 
-THolder<IStatsPartGroupIterator> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId, 
+THolder<IStatsPartGroupIter> CreateStatsPartGroupIterator(const TPart* part, IPages* env, NPage::TGroupId groupId, 
     ui64 rowCountResolution, ui64 dataSizeResolution, const TVector<TRowId>& splitPoints);
     
 }

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -972,7 +972,7 @@ TMemTable& TTable::MemTable()
     return *Mutable;
 }
 
-TAutoPtr<TTableIt> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, ESeek seek,
+TAutoPtr<TTableIter> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, ESeek seek,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const noexcept
@@ -982,7 +982,7 @@ TAutoPtr<TTableIt> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, ES
     const TCelled key(key_, *Scheme->Keys, false);
     const ui64 limit = seek == ESeek::Exact ? 1 : Max<ui64>();
 
-    TAutoPtr<TTableIt> dbIter(new TTableIt(Scheme.Get(), tags, limit, snapshot,
+    TAutoPtr<TTableIter> dbIter(new TTableIter(Scheme.Get(), tags, limit, snapshot,
             TMergedTransactionMap::Create(visible, CommittedTransactions),
             observer));
 
@@ -1019,7 +1019,7 @@ TAutoPtr<TTableIt> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, ES
     return dbIter;
 }
 
-TAutoPtr<TTableReverseIt> TTable::IterateReverse(TRawVals key_, TTagsRef tags, IPages* env, ESeek seek,
+TAutoPtr<TTableReverseIter> TTable::IterateReverse(TRawVals key_, TTagsRef tags, IPages* env, ESeek seek,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const noexcept
@@ -1029,7 +1029,7 @@ TAutoPtr<TTableReverseIt> TTable::IterateReverse(TRawVals key_, TTagsRef tags, I
     const TCelled key(key_, *Scheme->Keys, false);
     const ui64 limit = seek == ESeek::Exact ? 1 : Max<ui64>();
 
-    TAutoPtr<TTableReverseIt> dbIter(new TTableReverseIt(Scheme.Get(), tags, limit, snapshot,
+    TAutoPtr<TTableReverseIter> dbIter(new TTableReverseIter(Scheme.Get(), tags, limit, snapshot,
             TMergedTransactionMap::Create(visible, CommittedTransactions),
             observer));
 

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -145,7 +145,7 @@ public:
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const noexcept;
     EReady Select(TRawVals key, TTagsRef tags, IPages* env, TRowState& row,
-                  ui64 flg, TRowVersion snapshot, TDeque<TPartSimpleIt>& tempIterators,
+                  ui64 flg, TRowVersion snapshot, TDeque<TPartIter>& tempIterators,
                   TSelectStats& stats,
                   const ITransactionMapPtr& visible = nullptr,
                   const ITransactionObserverPtr& observer = nullptr) const noexcept;

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -136,11 +136,11 @@ public:
 
     TVector<TIntrusiveConstPtr<TMemTable>> GetMemTables() const noexcept;
 
-    TAutoPtr<TTableIt> Iterate(TRawVals key, TTagsRef tags, IPages* env, ESeek,
+    TAutoPtr<TTableIter> Iterate(TRawVals key, TTagsRef tags, IPages* env, ESeek,
             TRowVersion snapshot,
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const noexcept;
-    TAutoPtr<TTableReverseIt> IterateReverse(TRawVals key, TTagsRef tags, IPages* env, ESeek,
+    TAutoPtr<TTableReverseIter> IterateReverse(TRawVals key, TTagsRef tags, IPages* env, ESeek,
             TRowVersion snapshot,
             const ITransactionMapPtr& visible = nullptr,
             const ITransactionObserverPtr& observer = nullptr) const noexcept;

--- a/ydb/core/tablet_flat/flat_table_part_ut.cpp
+++ b/ydb/core/tablet_flat/flat_table_part_ut.cpp
@@ -77,7 +77,7 @@ Y_UNIT_TEST_SUITE(TLegacy) {
         {
             TDataStats stats = { };
             TTestEnv env;
-            // TScreenedPartIndexIterator without screen previously was TPartIndexIterator
+            // TScreenedPartIndexIterator without screen previously was TPartGroupFlatIndexItererator
             TStatsScreenedPartIterator idxIter(TPartView{part, nullptr, nullptr}, &env, scheme->Keys, nullptr, nullptr, 0, 0);
             sizes.clear();
 

--- a/ydb/core/tablet_flat/test/libs/table/misc.cpp
+++ b/ydb/core/tablet_flat/test/libs/table/misc.cpp
@@ -46,7 +46,7 @@ TString PrintRow(const TDbTupleRef& row)
     return DbgPrintTuple(row, *NTest::DbgRegistry());
 }
 
-TString PrintRow(const TMemIt& it)
+TString PrintRow(const TMemIter& it)
 {
     return PrintRowImpl(*it.Remap, it);
 }

--- a/ydb/core/tablet_flat/test/libs/table/test_curtain.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_curtain.h
@@ -64,8 +64,8 @@ namespace NTest {
         TIntrusiveConstPtr<TSlices> Cut(const TPartStore &partStore, const TScreen &screen) noexcept
         {
             TTestEnv env;
-            TPartSimpleIt first(&partStore, { }, Scheme.Keys, &env);
-            TPartSimpleIt last(&partStore, { }, Scheme.Keys, &env);
+            TPartIter first(&partStore, { }, Scheme.Keys, &env);
+            TPartIter last(&partStore, { }, Scheme.Keys, &env);
             TVector<TSlice> slices;
 
             TRowId lastEnd = 0;

--- a/ydb/core/tablet_flat/test/libs/table/test_curtain.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_curtain.h
@@ -54,7 +54,7 @@ namespace NTest {
         }
 
     private:
-        TCheckIt Wrap;
+        TCheckIter Wrap;
     };
 
 

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -148,9 +148,9 @@ namespace NTest {
     namespace IndexTools {
         using TGroupId = NPage::TGroupId;
 
-        inline const TPartIndexIt::TRecord * GetFlatRecord(const TPart& part, ui32 pageIndex) {
+        inline const TPartGroupFlatIndexIter::TRecord * GetFlatRecord(const TPart& part, ui32 pageIndex) {
             TTestEnv env;
-            TPartIndexIt index(&part, &env, { });
+            TPartGroupFlatIndexIter index(&part, &env, { });
 
             Y_ABORT_UNLESS(index.Seek(0) == EReady::Data);
             for (TPageId p = 0; p < pageIndex; p++) {
@@ -160,9 +160,9 @@ namespace NTest {
             return index.GetRecord();
         }
 
-        inline const TPartIndexIt::TRecord * GetFlatLastRecord(const TPart& part) {
+        inline const TPartGroupFlatIndexIter::TRecord * GetFlatLastRecord(const TPart& part) {
             TTestEnv env;
-            TPartIndexIt index(&part, &env, { });
+            TPartGroupFlatIndexIter index(&part, &env, { });
             Y_ABORT_UNLESS(index.SeekLast() == EReady::Data);
             return index.GetLastRecord();
         }

--- a/ydb/core/tablet_flat/test/libs/table/test_pretty.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_pretty.h
@@ -9,7 +9,7 @@ namespace NKikimr {
 namespace NTable {
 
     TString PrintRow(const TDbTupleRef& row);
-    TString PrintRow(const TMemIt&);
+    TString PrintRow(const TMemIter&);
 
 }
 }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
@@ -102,8 +102,8 @@ namespace NTest {
         TAutoPtr<TIter> Iter;
     };
 
-    using TWrapDbIter = TWrapDbIterImpl<TTableIt>;
-    using TWrapDbReverseIter = TWrapDbIterImpl<TTableReverseIt>;
+    using TWrapDbIter = TWrapDbIterImpl<TTableIter>;
+    using TWrapDbReverseIter = TWrapDbIterImpl<TTableReverseIter>;
 
 }
 }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
@@ -73,7 +73,7 @@ namespace NTest {
                         TIter::Direction));
 
             for (auto &run: Levels) {
-                auto one = MakeHolder<TRunIt>(run, Remap().Tags, KeyCellDefaults, Env);
+                auto one = MakeHolder<TPartsIter>(run, Remap().Tags, KeyCellDefaults, Env);
 
                 EReady status;
                 if constexpr (TIter::Direction == EDirection::Reverse) {

--- a/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
@@ -112,8 +112,8 @@ namespace NTest {
         TAutoPtr<TIter> Iter;
     };
 
-    using TWrapIter = TWrapIterImpl<TTableIt>;
-    using TWrapReverseIter = TWrapIterImpl<TTableReverseIt>;
+    using TWrapIter = TWrapIterImpl<TTableIter>;
+    using TWrapReverseIter = TWrapIterImpl<TTableReverseIter>;
 
 }
 }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
@@ -69,11 +69,11 @@ namespace NTest {
 
             for (auto &mem: Frozen)
                 Iter->Push(
-                    TMemIt::Make(*mem, mem.Snapshot, key, seek, KeyCellDefaults, &Iter->Remap, Env,
+                    TMemIter::Make(*mem, mem.Snapshot, key, seek, KeyCellDefaults, &Iter->Remap, Env,
                         TIter::Direction));
 
             for (auto &run: Levels) {
-                auto one = MakeHolder<TPartsIter>(run, Remap().Tags, KeyCellDefaults, Env);
+                auto one = MakeHolder<TRunIter>(run, Remap().Tags, KeyCellDefaults, Env);
 
                 EReady status;
                 if constexpr (TIter::Direction == EDirection::Reverse) {

--- a/ydb/core/tablet_flat/test/libs/table/wrap_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_part.h
@@ -200,8 +200,8 @@ namespace NTest {
     using TWrapPart = TWrapPartImpl<EDirection::Forward>;
     using TWrapReversePart = TWrapPartImpl<EDirection::Reverse>;
 
-    using TCheckIt = TChecker<TWrapPart, TPartEggs>;
-    using TCheckReverseIt = TChecker<TWrapReversePart, TPartEggs>;
+    using TCheckIter = TChecker<TWrapPart, TPartEggs>;
+    using TCheckReverseIter = TChecker<TWrapReversePart, TPartEggs>;
 }
 }
 }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_part.h
@@ -63,7 +63,7 @@ namespace NTest {
             return Iter && Iter->IsValid() && Ready == EReady::Data;
         }
 
-        TRunIt* Get() const noexcept
+        TPartsIter* Get() const noexcept
         {
             return Iter.Get();
         }
@@ -76,7 +76,7 @@ namespace NTest {
         void Make(IPages *env) noexcept
         {
             Ready = EReady::Gone;
-            Iter = MakeHolder<TRunIt>(Run, Remap_.Tags, Scheme->Keys, env);
+            Iter = MakeHolder<TPartsIter>(Run, Remap_.Tags, Scheme->Keys, env);
         }
 
         EReady Seek(TRawVals key_, ESeek seek) noexcept
@@ -193,7 +193,7 @@ namespace NTest {
         TRowState State;
         TRun Run_;
         TRun& Run;
-        THolder<TRunIt> Iter;
+        THolder<TPartsIter> Iter;
         TOwnedCellVec StopKey;
     };
 

--- a/ydb/core/tablet_flat/test/libs/table/wrap_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_part.h
@@ -63,7 +63,7 @@ namespace NTest {
             return Iter && Iter->IsValid() && Ready == EReady::Data;
         }
 
-        TPartsIter* Get() const noexcept
+        TRunIter* Get() const noexcept
         {
             return Iter.Get();
         }
@@ -76,7 +76,7 @@ namespace NTest {
         void Make(IPages *env) noexcept
         {
             Ready = EReady::Gone;
-            Iter = MakeHolder<TPartsIter>(Run, Remap_.Tags, Scheme->Keys, env);
+            Iter = MakeHolder<TRunIter>(Run, Remap_.Tags, Scheme->Keys, env);
         }
 
         EReady Seek(TRawVals key_, ESeek seek) noexcept
@@ -193,7 +193,7 @@ namespace NTest {
         TRowState State;
         TRun Run_;
         TRun& Run;
-        THolder<TPartsIter> Iter;
+        THolder<TRunIter> Iter;
         TOwnedCellVec StopKey;
     };
 

--- a/ydb/core/tablet_flat/test/libs/table/wrap_warm.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_warm.h
@@ -26,7 +26,7 @@ namespace NTest {
             return Iter && Iter->IsValid();
         }
 
-        TMemIt* Get() const noexcept
+        TMemIter* Get() const noexcept
         {
             return Iter.Get();
         }
@@ -45,7 +45,7 @@ namespace NTest {
         {
             const TCelled key(key_, *Scheme->Keys, false);
 
-            Iter = TMemIt::Make(*Table, Table->Immediate(), key, seek, Scheme->Keys, &Remap_, Env, Direction);
+            Iter = TMemIter::Make(*Table, Table->Immediate(), key, seek, Scheme->Keys, &Remap_, Env, Direction);
 
             return RollUp();
         }
@@ -96,7 +96,7 @@ namespace NTest {
     private:
         IPages *Env = nullptr;
         TRowState State;
-        TAutoPtr<TMemIt> Iter;
+        TAutoPtr<TMemIter> Iter;
     };
 
     using TWrapMemtable = TWrapMemtableImpl<EDirection::Forward>;

--- a/ydb/core/tablet_flat/test/tool/perf/do_mem.h
+++ b/ydb/core/tablet_flat/test/tool/perf/do_mem.h
@@ -35,7 +35,7 @@ namespace NPerf {
         {
             const TCelled key(key_, *Table->Scheme->Keys, false);
 
-            Iter = TMemIt::Make(*Table, Table->Immediate(), key, seek, KeyCellDefaults, &Remap, nullptr);
+            Iter = TMemIter::Make(*Table, Table->Immediate(), key, seek, KeyCellDefaults, &Remap, nullptr);
         }
 
         ui64 Scan(ui64 items, TSponge &aggr) override
@@ -72,7 +72,7 @@ namespace NPerf {
         TIntrusivePtr<TMemTable> Table;
         TIntrusiveConstPtr<TKeyCellDefaults> KeyCellDefaults;
         TRemap Remap;
-        TAutoPtr<TMemIt> Iter;
+        TAutoPtr<TMemIter> Iter;
         TRowState State;
     };
 

--- a/ydb/core/tablet_flat/ut/flat_test_db.h
+++ b/ydb/core/tablet_flat/ut/flat_test_db.h
@@ -50,10 +50,10 @@ public:
 };
 
 class TFlatDbIterator : public ITestIterator {
-    TAutoPtr<TTableIt> Iter;
+    TAutoPtr<TTableIter> Iter;
 
 public:
-    explicit TFlatDbIterator(TAutoPtr<TTableIt> iter)
+    explicit TFlatDbIterator(TAutoPtr<TTableIter> iter)
         : Iter(iter)
     {}
 

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -238,7 +238,7 @@ namespace {
 }
 
 Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
-    void AssertEqual(const TPartGroupBtreeIndexIt& bTree, EReady bTreeReady, const TPartGroupFlatIndexIter& flat, EReady flatReady, const TString& message, bool allowFirstLastPageDifference = false) {
+    void AssertEqual(const TPartGroupBtreeIndexIter& bTree, EReady bTreeReady, const TPartGroupFlatIndexIter& flat, EReady flatReady, const TString& message, bool allowFirstLastPageDifference = false) {
         // Note: it's possible that B-Tree index don't return Gone status for keys before the first page or keys after the last page
         if (allowFirstLastPageDifference && flatReady == EReady::Gone && bTreeReady == EReady::Data && 
                 (bTree.GetRowId() == 0 || bTree.GetNextRowId() == bTree.GetEndRowId())) {
@@ -291,7 +291,7 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
         for (TRowId rowId1 : xrange<TRowId>(0, part.Stat.Rows + 1)) {
             for (TRowId rowId2 : xrange<TRowId>(0, part.Stat.Rows + 1)) {
                 TTouchEnv bTreeEnv, flatEnv;
-                TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+                TPartGroupBtreeIndexIter bTree(&part, &bTreeEnv, { });
                 TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
                 // checking initial seek:
@@ -317,7 +317,7 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
 
     void CheckSeekLast(const TPartStore& part) {
         TTouchEnv bTreeEnv, flatEnv;
-        TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+        TPartGroupBtreeIndexIter bTree(&part, &bTreeEnv, { });
         TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
         TString message = TStringBuilder() << "SeekLast";
@@ -335,7 +335,7 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
                         TVector<TCell> key = MakeKey(firstCell, secondCell);
 
                         TTouchEnv bTreeEnv, flatEnv;
-                        TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+                        TPartGroupBtreeIndexIter bTree(&part, &bTreeEnv, { });
                         TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
                         TStringBuilder message = TStringBuilder() << (reverse ?  "SeekKeyReverse" : "SeekKey") << "(" << seek << ") ";
@@ -356,7 +356,7 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
         for (bool next : {true, false}) {
             for (TRowId rowId : xrange<TRowId>(0, part.Stat.Rows)) {
                 TTouchEnv bTreeEnv, flatEnv;
-                TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+                TPartGroupBtreeIndexIter bTree(&part, &bTreeEnv, { });
                 TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
                 // checking initial seek:

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -237,7 +237,7 @@ namespace {
     }
 }
 
-Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
+Y_UNIT_TEST_SUITE(TPartGroupBtreeIndexIter) {
     void AssertEqual(const TPartGroupBtreeIndexIter& bTree, EReady bTreeReady, const TPartGroupFlatIndexIter& flat, EReady flatReady, const TString& message, bool allowFirstLastPageDifference = false) {
         // Note: it's possible that B-Tree index don't return Gone status for keys before the first page or keys after the last page
         if (allowFirstLastPageDifference && flatReady == EReady::Gone && bTreeReady == EReady::Data && 

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -238,7 +238,7 @@ namespace {
 }
 
 Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
-    void AssertEqual(const TPartBtreeIndexIt& bTree, EReady bTreeReady, const TPartIndexIt& flat, EReady flatReady, const TString& message, bool allowFirstLastPageDifference = false) {
+    void AssertEqual(const TPartGroupBtreeIndexIt& bTree, EReady bTreeReady, const TPartGroupFlatIndexIter& flat, EReady flatReady, const TString& message, bool allowFirstLastPageDifference = false) {
         // Note: it's possible that B-Tree index don't return Gone status for keys before the first page or keys after the last page
         if (allowFirstLastPageDifference && flatReady == EReady::Gone && bTreeReady == EReady::Data && 
                 (bTree.GetRowId() == 0 || bTree.GetNextRowId() == bTree.GetEndRowId())) {
@@ -255,19 +255,19 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
         }
     }
 
-    EReady SeekRowId(IIndexIter& iter, TTouchEnv& env, TRowId rowId, const TString& message, ui32 failsAllowed = 10) {
+    EReady SeekRowId(IPartGroupIndexIter& iter, TTouchEnv& env, TRowId rowId, const TString& message, ui32 failsAllowed = 10) {
         return Retry([&]() {
             return iter.Seek(rowId);
         }, env, message, failsAllowed);
     }
 
-    EReady SeekLast(IIndexIter& iter, TTouchEnv& env, const TString& message, ui32 failsAllowed = 10) {
+    EReady SeekLast(IPartGroupIndexIter& iter, TTouchEnv& env, const TString& message, ui32 failsAllowed = 10) {
         return Retry([&]() {
             return iter.SeekLast();
         }, env, message, failsAllowed);
     }
 
-    EReady SeekKey(IIndexIter& iter, TTouchEnv& env, ESeek seek, bool reverse, TCells key, const TKeyCellDefaults *keyDefaults, const TString& message, ui32 failsAllowed = 10) {
+    EReady SeekKey(IPartGroupIndexIter& iter, TTouchEnv& env, ESeek seek, bool reverse, TCells key, const TKeyCellDefaults *keyDefaults, const TString& message, ui32 failsAllowed = 10) {
         return Retry([&]() {
             if (reverse) {
                 return iter.SeekReverse(seek, key, keyDefaults);
@@ -277,7 +277,7 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
         }, env, message, failsAllowed);
     }
 
-    EReady NextPrev(IIndexIter& iter, TTouchEnv& env, bool next, const TString& message, ui32 failsAllowed = 10) {
+    EReady NextPrev(IPartGroupIndexIter& iter, TTouchEnv& env, bool next, const TString& message, ui32 failsAllowed = 10) {
         return Retry([&]() {
             if (next) {
                 return iter.Next();
@@ -291,8 +291,8 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
         for (TRowId rowId1 : xrange<TRowId>(0, part.Stat.Rows + 1)) {
             for (TRowId rowId2 : xrange<TRowId>(0, part.Stat.Rows + 1)) {
                 TTouchEnv bTreeEnv, flatEnv;
-                TPartBtreeIndexIt bTree(&part, &bTreeEnv, { });
-                TPartIndexIt flat(&part, &flatEnv, { });
+                TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+                TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
                 // checking initial seek:
                 {
@@ -317,8 +317,8 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
 
     void CheckSeekLast(const TPartStore& part) {
         TTouchEnv bTreeEnv, flatEnv;
-        TPartBtreeIndexIt bTree(&part, &bTreeEnv, { });
-        TPartIndexIt flat(&part, &flatEnv, { });
+        TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+        TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
         TString message = TStringBuilder() << "SeekLast";
         EReady bTreeReady = SeekLast(bTree, bTreeEnv, message);
@@ -335,8 +335,8 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
                         TVector<TCell> key = MakeKey(firstCell, secondCell);
 
                         TTouchEnv bTreeEnv, flatEnv;
-                        TPartBtreeIndexIt bTree(&part, &bTreeEnv, { });
-                        TPartIndexIt flat(&part, &flatEnv, { });
+                        TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+                        TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
                         TStringBuilder message = TStringBuilder() << (reverse ?  "SeekKeyReverse" : "SeekKey") << "(" << seek << ") ";
                         for (auto c : key) {
@@ -356,8 +356,8 @@ Y_UNIT_TEST_SUITE(TPartBtreeIndexIt) {
         for (bool next : {true, false}) {
             for (TRowId rowId : xrange<TRowId>(0, part.Stat.Rows)) {
                 TTouchEnv bTreeEnv, flatEnv;
-                TPartBtreeIndexIt bTree(&part, &bTreeEnv, { });
-                TPartIndexIt flat(&part, &flatEnv, { });
+                TPartGroupBtreeIndexIt bTree(&part, &bTreeEnv, { });
+                TPartGroupFlatIndexIter flat(&part, &flatEnv, { });
 
                 // checking initial seek:
                 {

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -247,7 +247,7 @@ namespace {
             Y_ABORT_UNLESS(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
 
             auto sticky = GetIndexPages();
-            NTest::TCheckIt wrap(Eggs, { new TTouchEnv(false, sticky) });
+            NTest::TCheckIter wrap(Eggs, { new TTouchEnv(false, sticky) });
 
             wrap.To(CurrentStep());
             wrap.StopAfter(Tool.KeyCells(Mass.Saved[upper]));
@@ -283,7 +283,7 @@ namespace {
             Y_ABORT_UNLESS(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
 
             auto sticky = GetIndexPages();
-            NTest::TCheckReverseIt wrap(Eggs, { new TTouchEnv(false, sticky) });
+            NTest::TCheckReverseIter wrap(Eggs, { new TTouchEnv(false, sticky) });
 
             wrap.To(CurrentStep());
             wrap.StopAfter(Tool.KeyCells(Mass.Saved[upper]));

--- a/ydb/core/tablet_flat/ut/ut_compaction.cpp
+++ b/ydb/core/tablet_flat/ut/ut_compaction.cpp
@@ -22,7 +22,7 @@ Y_UNIT_TEST_SUITE(TCompaction) {
 
         auto eggs = TCompaction().Do(TMake(mass).Mem());
 
-        TCheckIt(eggs, { }).IsTheSame(mass.Saved);
+        TCheckIter(eggs, { }).IsTheSame(mass.Saved);
     }
 
     Y_UNIT_TEST(ManyParts)
@@ -34,7 +34,7 @@ Y_UNIT_TEST_SUITE(TCompaction) {
         auto subset = TMake(mass).Mixed(0, 19, NTest::TMixerRnd(19));
         auto eggs = TCompaction().Do(*subset);
 
-        TCheckIt(eggs, { }).IsTheSame(mass.Saved);
+        TCheckIter(eggs, { }).IsTheSame(mass.Saved);
     }
 
     Y_UNIT_TEST(BootAbort)
@@ -76,7 +76,7 @@ Y_UNIT_TEST_SUITE(TCompaction) {
 
             auto born = TCompaction(nullptr, { true, 7 * 1024 }).Do(eggs);
 
-            TCheckIt
+            TCheckIter
                 (born, { nullptr, 0 }, nullptr , false)
                 .To(10).Seek({ }, ESeek::Lower).Is(one)
                 .To(11).Next().IsN(2_u64, nullptr)  /* expllcit null */
@@ -88,7 +88,7 @@ Y_UNIT_TEST_SUITE(TCompaction) {
 
             auto born = TCompaction(nullptr, { true, 7 * 1024 }).Do(eggs);
 
-            TCheckIt
+            TCheckIter
                 (born, { nullptr, 0 }, nullptr, true)
                 .To(20).Seek({ }, ESeek::Lower).Is(one)
                 .To(21).Next().IsN(2_u64, nullptr)
@@ -136,7 +136,7 @@ Y_UNIT_TEST_SUITE(TCompaction) {
 
             auto born = make.Do(lower.Scheme, { &lower, &middle, &upper });
 
-            TCheckIt
+            TCheckIter
                 (born, { nullptr, 0 }, nullptr, true /* expand defaults */)
                 .To(20).Seek({ }, ESeek::Lower).Is(EReady::Data)
                 .To(21).IsOpN(ERowOp::Upsert, 1_u64, 1_u32, 1_u32)
@@ -154,7 +154,7 @@ Y_UNIT_TEST_SUITE(TCompaction) {
 
             auto born = make.Do(lower.Scheme, { &middle, &upper });
 
-            TCheckIt
+            TCheckIter
                 (born, { nullptr, 0 }, nullptr, true /* expand defaults */)
                 .To(30).Seek({ }, ESeek::Lower).Is(EReady::Data)
                 .To(31).IsOpN(ERowOp::Erase, 2_u64, ECellOp::Empty, ECellOp::Empty)

--- a/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
+++ b/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
@@ -28,7 +28,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
         UNIT_ASSERT_C(eggs.Parts.size() > 3,
             "Compaction produced " << eggs.Parts.size() << " parts");
 
-        TCheckIt(eggs, { }).IsTheSame(mass.Saved);
+        TCheckIter(eggs, { }).IsTheSame(mass.Saved);
     }
 
     void RunMainEdgeTest(
@@ -74,7 +74,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
                 UNIT_ASSERT_VALUES_EQUAL(born.Parts.size(), attempt ? 2u : 1u);
                 UNIT_ASSERT_VALUES_EQUAL(born.At(0)->Store->PageCollectionBytes(0), lastPartSize);
 
-                TCheckIt(born, { }).IsTheSame(rows).Is(EReady::Gone);
+                TCheckIter(born, { }).IsTheSame(rows).Is(EReady::Gone);
             }
 
             --conf.MainPageCollectionEdge;
@@ -89,7 +89,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
                     "Produced part with size " << lastPartSize
                     << " expected no more than " << conf.MainPageCollectionEdge);
 
-                TCheckIt(born, { }).IsTheSame(rows).Is(EReady::Gone);
+                TCheckIter(born, { }).IsTheSame(rows).Is(EReady::Gone);
 
                 // The first part must gen one less row than the last time
                 auto size = rows.end() - rows.begin();
@@ -98,10 +98,10 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
                 // The first part must get one less row than the last time
                 TPartEggs egg1{ nullptr, born.Scheme, { born.At(0) } };
                 TPartEggs egg2{ nullptr, born.Scheme, { born.At(1) } };
-                TCheckIt(egg1, { })
+                TCheckIter(egg1, { })
                     .IsTheSame(rows.begin(), rows.begin() + split)
                     .Is(EReady::Gone);
-                TCheckIt(egg2, { })
+                TCheckIter(egg2, { })
                     .IsTheSame(rows.begin() + split, rows.end())
                     .Is(EReady::Gone);
 
@@ -173,7 +173,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
                 << " maximum of " << conf.MainPageCollectionEdge << " allowed");
         }
 
-        TCheckIt(born, { }).IsTheSame(mass.Saved).Is(EReady::Gone);
+        TCheckIter(born, { }).IsTheSame(mass.Saved).Is(EReady::Gone);
     }
 
     Y_UNIT_TEST(MainPageCollectionOverflow)

--- a/ydb/core/tablet_flat/ut/ut_iterator.cpp
+++ b/ydb/core/tablet_flat/ut/ut_iterator.cpp
@@ -53,15 +53,15 @@ namespace {
     }
 }
 
-using TCheckIt = NTest::TChecker<NTest::TWrapIter, TSubset>;
-using TCheckReverseIt = NTest::TChecker<NTest::TWrapReverseIter, TSubset>;
+using TCheckIter = NTest::TChecker<NTest::TWrapIter, TSubset>;
+using TCheckReverseIter = NTest::TChecker<NTest::TWrapReverseIter, TSubset>;
 
 Y_UNIT_TEST_SUITE(TIterator) {
     using namespace NTest;
 
     Y_UNIT_TEST(Basics)
     {
-        TCheckIt wrap(*TMake(Mass0).Mixed(0, 1, TMixerOne{ }), { });
+        TCheckIter wrap(*TMake(Mass0).Mixed(0, 1, TMixerOne{ }), { });
 
         { /*_ ESeek::Exact have to give at most one row */
             wrap.To(1).Seek(Mass0.Saved[7], ESeek::Exact).Is(Mass0.Saved[7]);
@@ -81,7 +81,7 @@ Y_UNIT_TEST_SUITE(TIterator) {
 
     Y_UNIT_TEST(External)
     {
-        TCheckIt wrap(*TMake(Mass0, Conf()).Mixed(0, 1, TMixerOne{ }), { });
+        TCheckIter wrap(*TMake(Mass0, Conf()).Mixed(0, 1, TMixerOne{ }), { });
 
         UNIT_ASSERT((*wrap).Flatten.size() == 1);
 
@@ -110,31 +110,31 @@ Y_UNIT_TEST_SUITE(TIterator) {
     {
         auto subset = TMake(Mass0, Conf()).Mixed(0, 1, TMixerOne{ });
 
-        TWreck<TCheckIt, TSubset>(Mass0, 666).Do(EWreck::Cached, *subset);
+        TWreck<TCheckIter, TSubset>(Mass0, 666).Do(EWreck::Cached, *subset);
     }
 
     Y_UNIT_TEST(SingleReverse)
     {
         auto subset = TMake(Mass0, Conf()).Mixed(0, 1, TMixerOne{ });
 
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Cached, *subset);
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Cached, *subset);
     }
 
     Y_UNIT_TEST(Mixed)
     {
         auto subset = TMake(Mass0, Conf(384)).Mixed(2, 2, TMixerRnd(4));
 
-        TWreck<TCheckIt, TSubset>(Mass0, 666).Do(EWreck::Cached, *subset);
-        TWreck<TCheckIt, TSubset>(Mass0, 666).Do(EWreck::Evicted, *subset);
-        TWreck<TCheckIt, TSubset>(Mass0, 666).Do(EWreck::Forward, *subset);
+        TWreck<TCheckIter, TSubset>(Mass0, 666).Do(EWreck::Cached, *subset);
+        TWreck<TCheckIter, TSubset>(Mass0, 666).Do(EWreck::Evicted, *subset);
+        TWreck<TCheckIter, TSubset>(Mass0, 666).Do(EWreck::Forward, *subset);
     }
 
     Y_UNIT_TEST(MixedReverse)
     {
         auto subset = TMake(Mass0, Conf(384)).Mixed(2, 2, TMixerRnd(4));
 
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Cached, *subset);
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Evicted, *subset);
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Cached, *subset);
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Evicted, *subset);
     }
 
     Y_UNIT_TEST(Serial)
@@ -145,9 +145,9 @@ Y_UNIT_TEST_SUITE(TIterator) {
 
         VerifySingleLevelNonTrivial(subset);
 
-        TWreck<TCheckIt, TSubset>(Mass0, 666).Do(EWreck::Cached, *subset);
-        TWreck<TCheckIt, TSubset>(Mass0, 666).Do(EWreck::Evicted, *subset);
-        TWreck<TCheckIt, TSubset>(Mass0, 666).Do(EWreck::Forward, *subset);
+        TWreck<TCheckIter, TSubset>(Mass0, 666).Do(EWreck::Cached, *subset);
+        TWreck<TCheckIter, TSubset>(Mass0, 666).Do(EWreck::Evicted, *subset);
+        TWreck<TCheckIter, TSubset>(Mass0, 666).Do(EWreck::Forward, *subset);
     }
 
     Y_UNIT_TEST(SerialReverse)
@@ -158,8 +158,8 @@ Y_UNIT_TEST_SUITE(TIterator) {
 
         VerifySingleLevelNonTrivial(subset);
 
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Cached, *subset);
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Evicted, *subset);
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Cached, *subset);
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass0, 666).Do(EWreck::Evicted, *subset);
     }
 
     struct TFirstTimeFailEnv : public NTest::TTestEnv {
@@ -256,7 +256,7 @@ Y_UNIT_TEST_SUITE(TIterator) {
             subset.Flatten.push_back({ part, nullptr, part->Slices });
         }
 
-        TCheckIt wrap(subset, { new TFirstTimeFailEnv });
+        TCheckIter wrap(subset, { new TFirstTimeFailEnv });
 
         // Must page fault the first couple of times
         wrap.To(0).Seek({}, ESeek::Lower).Is(EReady::Page);

--- a/ydb/core/tablet_flat/ut/ut_memtable.cpp
+++ b/ydb/core/tablet_flat/ut/ut_memtable.cpp
@@ -15,8 +15,8 @@ namespace {
     const NTest::TMass Mass(new NTest::TModelStd(false), 999);
 }
 
-using TCheckIt = NTest::TChecker<NTest::TWrapMemtable, TIntrusiveConstPtr<TMemTable>>;
-using TCheckReverseIt = NTest::TChecker<NTest::TWrapReverseMemtable, TIntrusiveConstPtr<TMemTable>>;
+using TCheckIter = NTest::TChecker<NTest::TWrapMemtable, TIntrusiveConstPtr<TMemTable>>;
+using TCheckReverseIter = NTest::TChecker<NTest::TWrapReverseMemtable, TIntrusiveConstPtr<TMemTable>>;
 
 Y_UNIT_TEST_SUITE(Memtable)
 {
@@ -43,7 +43,7 @@ Y_UNIT_TEST_SUITE(Memtable)
         const auto foo = *TSchemedCookRow(*lay).Col(555_u32, "foo", 3.14, nullptr);
         const auto bar = *TSchemedCookRow(*lay).Col(777_u32, "bar", 2.72, true);
 
-        TCheckIt wrap(TCooker(lay).Add(foo).Add(bar).Unwrap(), { });
+        TCheckIter wrap(TCooker(lay).Add(foo).Add(bar).Unwrap(), { });
 
         wrap.To(10).Has(foo).Has(bar);
         wrap.To(11).NoVal(*TSchemedCookRow(*lay).Col(555_u32, "foo", 10.));
@@ -82,7 +82,7 @@ Y_UNIT_TEST_SUITE(Memtable)
         const auto foo = *TSchemedCookRow(*lay).Col(555_u32, "foo", 3.14, nullptr);
         const auto bar = *TSchemedCookRow(*lay).Col(777_u32, "bar", 2.72, true);
 
-        TCheckReverseIt wrap(TCooker(lay).Add(foo).Add(bar).Unwrap(), { });
+        TCheckReverseIter wrap(TCooker(lay).Add(foo).Add(bar).Unwrap(), { });
 
         wrap.To(10).Has(foo).Has(bar);
         wrap.To(11).NoVal(*TSchemedCookRow(*lay).Col(555_u32, "foo", 10.));
@@ -122,8 +122,8 @@ Y_UNIT_TEST_SUITE(Memtable)
 
         TCooker cooker(lay);
 
-        TCheckIt(*cooker.Add(reset, ERowOp::Upsert), { }).To(10).Has(reset);
-        TCheckIt(*cooker.Add(null, ERowOp::Upsert), { }).To(11).Has(null);
+        TCheckIter(*cooker.Add(reset, ERowOp::Upsert), { }).To(10).Has(reset);
+        TCheckIter(*cooker.Add(null, ERowOp::Upsert), { }).To(11).Has(null);
     }
 
     Y_UNIT_TEST(Overlap)
@@ -140,19 +140,19 @@ Y_UNIT_TEST_SUITE(Memtable)
 
         TCooker cooker(lay);
 
-        TCheckIt(*cooker.Add(r0W, ERowOp::Upsert), { }).To(10).Has(r0W);
-        TCheckIt(*cooker.Add(r1W, ERowOp::Upsert), { }).To(11).Has(r1W);
-        TCheckIt(*cooker.Add(r2W, ERowOp::Upsert), { }).To(12).Has(r2R);
-        TCheckIt(*cooker.Add(r3W, ERowOp::Upsert), { }).To(13).Has(r3W);
-        TCheckIt(*cooker.Add(r4W, ERowOp::Upsert), { }).To(14).Has(r4R);
-        TCheckIt(*cooker.Add(r0W, ERowOp::Erase), { }).To(19).NoKey(r0W, false);
+        TCheckIter(*cooker.Add(r0W, ERowOp::Upsert), { }).To(10).Has(r0W);
+        TCheckIter(*cooker.Add(r1W, ERowOp::Upsert), { }).To(11).Has(r1W);
+        TCheckIter(*cooker.Add(r2W, ERowOp::Upsert), { }).To(12).Has(r2R);
+        TCheckIter(*cooker.Add(r3W, ERowOp::Upsert), { }).To(13).Has(r3W);
+        TCheckIter(*cooker.Add(r4W, ERowOp::Upsert), { }).To(14).Has(r4R);
+        TCheckIter(*cooker.Add(r0W, ERowOp::Erase), { }).To(19).NoKey(r0W, false);
     }
 
     Y_UNIT_TEST(Wreck)
     {
         auto egg = *TCooker(Mass.Model->Scheme).Add(Mass.Saved, ERowOp::Upsert);
 
-        TWreck<TCheckIt, TIntrusiveConstPtr<TMemTable>>(Mass, 666).Do(EWreck::Cached, egg);
+        TWreck<TCheckIter, TIntrusiveConstPtr<TMemTable>>(Mass, 666).Do(EWreck::Cached, egg);
     }
 
     Y_UNIT_TEST(Erased)
@@ -163,7 +163,7 @@ Y_UNIT_TEST_SUITE(Memtable)
                 .Add(Mass.Holes, ERowOp::Upsert)
                 .Add(Mass.Holes, ERowOp::Erase);
 
-        TWreck<TCheckIt, TIntrusiveConstPtr<TMemTable>>(Mass, 666).Do(EWreck::Cached, egg);
+        TWreck<TCheckIter, TIntrusiveConstPtr<TMemTable>>(Mass, 666).Do(EWreck::Cached, egg);
     }
 
 }

--- a/ydb/core/tablet_flat/ut/ut_pages.cpp
+++ b/ydb/core/tablet_flat/ut/ut_pages.cpp
@@ -43,7 +43,7 @@ Y_UNIT_TEST_SUITE(NPage) {
         conf.Group(0).Codec = NPage::ECodec::LZ4;
         conf.Group(0).ForceCompression = true; /* required for this UT only */
 
-        TCheckIt wrap(TPartCook(lay, conf).Add(foo).Finish(), { });
+        TCheckIter wrap(TPartCook(lay, conf).Add(foo).Finish(), { });
 
         wrap.To(1).Has(foo).To(2).NoKey(bar);
 
@@ -76,7 +76,7 @@ Y_UNIT_TEST_SUITE(NPage) {
 
             TPartEggs eggs{ nullptr, MassZ.Model->Scheme, { std::move(part) } };
 
-            TWreck<TCheckIt, TPartEggs>(MassZ, 666).Do(EWreck::Cached, eggs);
+            TWreck<TCheckIter, TPartEggs>(MassZ, 666).Do(EWreck::Cached, eggs);
         }
     }
 

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -156,7 +156,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         const auto foo = *TSchemedCookRow(*lay).Col(555_u32, "foo", 3.14, nullptr);
         const auto bar = *TSchemedCookRow(*lay).Col(777_u32, "bar", 2.72, true);
 
-        TCheckIt wrap(TPartCook(lay, { }).Add(foo).Add(bar).Finish(), { });
+        TCheckIter wrap(TPartCook(lay, { }).Add(foo).Add(bar).Finish(), { });
 
         wrap.To(10).Has(foo).Has(bar);
         wrap.To(11).NoVal(*TSchemedCookRow(*lay).Col(555_u32, "foo", 10.));
@@ -217,7 +217,7 @@ Y_UNIT_TEST_SUITE(TPart) {
 
         UNIT_ASSERT_VALUES_EQUAL(part->GroupsCount, 3u);
 
-        TCheckIt wrap(eggs, { });
+        TCheckIter wrap(eggs, { });
 
         wrap.To(10).Has(foo).Has(bar);
     }
@@ -248,7 +248,7 @@ Y_UNIT_TEST_SUITE(TPart) {
 
         eggs.Scheme = fake.RowScheme();
 
-        TCheckIt wrap(std::move(eggs), { });
+        TCheckIter wrap(std::move(eggs), { });
 
         auto trA = *TSchemedCookRow(*fake).Col(10_u64, 3_u32, 7_u32, 77_u32);
         auto trB = *TSchemedCookRow(*fake).Col(12_u64, 3_u32, 7_u32, 44_u32);
@@ -283,7 +283,7 @@ Y_UNIT_TEST_SUITE(TPart) {
 
         const auto foo = *TSchemedCookRow(*lay).Col(7_u32, TString(128, 'x'));
 
-        TCheckIt wrap(TPartCook(lay, { true, 99, 32 }).Add(foo).Finish(), { });
+        TCheckIter wrap(TPartCook(lay, { true, 99, 32 }).Add(foo).Finish(), { });
 
         wrap.To(10).Seek(foo, ESeek::Exact).To(11).Is(foo);
 
@@ -338,7 +338,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         const auto glob = cook.PutBlob(TString(128, 'x'), 0);
         const auto foo = *TSchemedCookRow(*lay).Col(7_u32,  glob);
 
-        TCheckIt wrap(cook.Add(foo).Finish(), { });
+        TCheckIter wrap(cook.Add(foo).Finish(), { });
 
         wrap.Displace<IPages>(new TNoEnv{ true, ELargeObjNeed::No });
         wrap.To(10).Seek(foo, ESeek::Exact).To(11).Is(foo);
@@ -367,7 +367,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         const auto foo = *TSchemedCookRow(*lay).Col(7_u32, TString(24, 'x'));
         const auto bar = *TSchemedCookRow(*lay).Col(8_u32, TString(10, 'x'));
 
-        TCheckIt wrap(cook.Add(foo).Add(bar).Finish(), { });
+        TCheckIter wrap(cook.Add(foo).Add(bar).Finish(), { });
 
         wrap.To(10).Has(foo, bar);
 
@@ -459,32 +459,32 @@ Y_UNIT_TEST_SUITE(TPart) {
 
     Y_UNIT_TEST(WreckPart)
     {
-        TWreck<TCheckIt, TPartEggs>(Mass0(), 666).Do(EWreck::Cached, Eggs0());
+        TWreck<TCheckIter, TPartEggs>(Mass0(), 666).Do(EWreck::Cached, Eggs0());
     }
 
     Y_UNIT_TEST(PageFailEnv)
     {
-        TWreck<TCheckIt, TPartEggs>(Mass0(), 666).Do(EWreck::Evicted, Eggs0());
+        TWreck<TCheckIter, TPartEggs>(Mass0(), 666).Do(EWreck::Evicted, Eggs0());
     }
 
     Y_UNIT_TEST(ForwardEnv)
     {
-        TWreck<TCheckIt, TPartEggs>(Mass0(), 666).Do(EWreck::Forward, Eggs0());
+        TWreck<TCheckIter, TPartEggs>(Mass0(), 666).Do(EWreck::Forward, Eggs0());
     }
 
     Y_UNIT_TEST(WreckPartColumnGroups)
     {
-        TWreck<TCheckIt, TPartEggs>(Mass1(), 666).Do(EWreck::Cached, Eggs1());
+        TWreck<TCheckIter, TPartEggs>(Mass1(), 666).Do(EWreck::Cached, Eggs1());
     }
 
     Y_UNIT_TEST(PageFailEnvColumnGroups)
     {
-        TWreck<TCheckIt, TPartEggs>(Mass1(), 666).Do(EWreck::Evicted, Eggs1());
+        TWreck<TCheckIter, TPartEggs>(Mass1(), 666).Do(EWreck::Evicted, Eggs1());
     }
 
     Y_UNIT_TEST(ForwardEnvColumnGroups)
     {
-        TWreck<TCheckIt, TPartEggs>(Mass1(), 666).Do(EWreck::Forward, Eggs1());
+        TWreck<TCheckIter, TPartEggs>(Mass1(), 666).Do(EWreck::Forward, Eggs1());
     }
 
     Y_UNIT_TEST(Versions)
@@ -528,7 +528,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         UNIT_ASSERT_VALUES_EQUAL(part->MinRowVersion, TRowVersion(0, 99));
         UNIT_ASSERT_VALUES_EQUAL(part->MaxRowVersion, TRowVersion(5, 50));
 
-        TCheckIt wrap(eggs, { });
+        TCheckIter wrap(eggs, { });
 
         wrap.To(10).Has(hey).NoKey(foo, false).Has(bar);
 
@@ -619,7 +619,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         UNIT_ASSERT_VALUES_EQUAL(part->MinRowVersion, TRowVersion(0, 42));
         UNIT_ASSERT_VALUES_EQUAL(part->MaxRowVersion, TRowVersion(2, 1000));
 
-        TCheckIt wrap(eggs, { });
+        TCheckIter wrap(eggs, { });
 
         wrap.To(10).Has(foos[0]).Has(bars[0]);
 
@@ -713,7 +713,7 @@ Y_UNIT_TEST_SUITE(TPart) {
             cook.Add(*TSchemedCookRow(*lay).Col(r.first, r.second));
         }
 
-        TCheckIt wrap(cook.Finish(), { new TTouchEnv() });
+        TCheckIter wrap(cook.Finish(), { new TTouchEnv() });
 
         const auto part = (*wrap).Eggs.Lone();
 
@@ -776,8 +776,8 @@ Y_UNIT_TEST_SUITE(TPart) {
             fullCookR.Add(*TSchemedCookRow(*lay).Col(r.first, r.second));
         }
 
-        TCheckIt cutWrap(cutCook.Finish(), { new TTouchEnv() }), fullWrap(fullCook.Finish(), { new TTouchEnv() });
-        TCheckReverseIt cutWrapR(cutCookR.Finish(), { new TTouchEnv() }), fullWrapR(fullCookR.Finish(), { new TTouchEnv() });
+        TCheckIter cutWrap(cutCook.Finish(), { new TTouchEnv() }), fullWrap(fullCook.Finish(), { new TTouchEnv() });
+        TCheckReverseIter cutWrapR(cutCookR.Finish(), { new TTouchEnv() }), fullWrapR(fullCookR.Finish(), { new TTouchEnv() });
 
         const auto cutPart = (*cutWrap).Eggs.Lone();
         const auto fullPart = (*fullWrap).Eggs.Lone();
@@ -883,8 +883,8 @@ Y_UNIT_TEST_SUITE(TPart) {
             fullCookR.Add(*TSchemedCookRow(*lay).Col(r.first, r.second));
         }
 
-        TCheckIt cutWrap(cutCook.Finish(), { new TTouchEnv() }), fullWrap(fullCook.Finish(), { new TTouchEnv() });
-        TCheckReverseIt cutWrapR(cutCookR.Finish(), { new TTouchEnv() }), fullWrapR(fullCookR.Finish(), { new TTouchEnv() });
+        TCheckIter cutWrap(cutCook.Finish(), { new TTouchEnv() }), fullWrap(fullCook.Finish(), { new TTouchEnv() });
+        TCheckReverseIter cutWrapR(cutCookR.Finish(), { new TTouchEnv() }), fullWrapR(fullCookR.Finish(), { new TTouchEnv() });
 
         const auto cutPart = (*cutWrap).Eggs.Lone();
         const auto fullPart = (*fullWrap).Eggs.Lone();
@@ -973,7 +973,7 @@ Y_UNIT_TEST_SUITE(TPart) {
             fullCookR.Add(*TSchemedCookRow(*lay).Col(r.first, r.second));
         }
 
-        TCheckIt cutWrapTmp(cutCookTmp.Finish(), { });
+        TCheckIter cutWrapTmp(cutCookTmp.Finish(), { });
         auto cutPartTmp = (*cutWrapTmp).Eggs.Lone();
 
         TSlices slices;
@@ -996,8 +996,8 @@ Y_UNIT_TEST_SUITE(TPart) {
             }
         }
 
-        TCheckIt cutWrap(cutEggs, { new TTouchEnv() }), fullWrap(fullCook.Finish(), { new TTouchEnv() });
-        TCheckReverseIt cutWrapR(cutEggsR, { new TTouchEnv() }), fullWrapR(fullCookR.Finish(), { new TTouchEnv() });
+        TCheckIter cutWrap(cutEggs, { new TTouchEnv() }), fullWrap(fullCook.Finish(), { new TTouchEnv() });
+        TCheckReverseIter cutWrapR(cutEggsR, { new TTouchEnv() }), fullWrapR(fullCookR.Finish(), { new TTouchEnv() });
 
         auto cutPart = (*cutWrap).Eggs.Lone();
         auto fullPart = (*fullWrap).Eggs.Lone();
@@ -1072,7 +1072,7 @@ Y_UNIT_TEST_SUITE(TPart) {
             cook.Add(*TSchemedCookRow(*lay).Col(a == "<NULL>" ? nullptr : a));
             cook.Add(*TSchemedCookRow(*lay).Col(b));
 
-            TCheckIt wrap(cook.Finish(), { });
+            TCheckIter wrap(cook.Finish(), { });
 
             const auto part = (*wrap).Eggs.Lone();
 
@@ -1179,7 +1179,7 @@ Y_UNIT_TEST_SUITE(TPart) {
             cook.Add(rowA);
             cook.Add(rowB);
 
-            TCheckIt wrap(cook.Finish(), { });
+            TCheckIter wrap(cook.Finish(), { });
 
             const auto part = (*wrap).Eggs.Lone();
 

--- a/ydb/core/tablet_flat/ut/ut_part_multi.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part_multi.cpp
@@ -40,7 +40,7 @@ Y_UNIT_TEST_SUITE(TPartMulti) {
                 TPartCook(lay, { }).Add(zzz).Finish().Lone(),
             }};
 
-        TCheckIt wrap(eggs, { });
+        TCheckIter wrap(eggs, { });
 
         wrap.To(10).Has(foo).Has(bar);
         wrap.To(11).NoVal(*TSchemedCookRow(*lay).Col(555_u32, "foo", 10.));
@@ -109,7 +109,7 @@ Y_UNIT_TEST_SUITE(TPartMulti) {
                 TPartCook(lay, { }).Add(zzz).Finish().Lone(),
             }};
 
-        TCheckReverseIt wrap(eggs, { });
+        TCheckReverseIter wrap(eggs, { });
 
         wrap.To(10).Has(foo).Has(bar);
         wrap.To(11).NoVal(*TSchemedCookRow(*lay).Col(555_u32, "foo", 10.));

--- a/ydb/core/tablet_flat/ut/ut_screen.cpp
+++ b/ydb/core/tablet_flat/ut/ut_screen.cpp
@@ -103,7 +103,7 @@ Y_UNIT_TEST_SUITE(TScreen) {
                 auto slice = TSlicer(*Eggs0().Scheme).Cut(*Eggs0().Lone(), *screen);
 
                 { /*_ Check that simple screen is really working */
-                    TCheckIt iter(Eggs0(), { new TForwardEnv(1, 2), 3 }, slice);
+                    TCheckIter iter(Eggs0(), { new TForwardEnv(1, 2), 3 }, slice);
 
                     iter.To(4 + (off << 2) + (joined << 1))
                         .Seek({}, ESeek::Lower);
@@ -118,7 +118,7 @@ Y_UNIT_TEST_SUITE(TScreen) {
                 }
 
                 { /* Check working partial screening on hole edge */
-                    TCheckIt iter(Eggs0(), { new TForwardEnv(1, 2), 3 }, slice);
+                    TCheckIter iter(Eggs0(), { new TForwardEnv(1, 2), 3 }, slice);
 
                     auto it = cu.Begin + (len >> 2);
 
@@ -145,7 +145,7 @@ Y_UNIT_TEST_SUITE(TScreen) {
             auto cu = cook.Make(Mass0().Saved, rnd, 8192);
             auto slice = TSlicer(*Eggs0().Scheme).Cut(*Eggs0().Lone(), *cu.Screen);
 
-            TCheckIt iter(Eggs0(), { new TTestEnv, 0 }, slice);
+            TCheckIter iter(Eggs0(), { new TTestEnv, 0 }, slice);
 
             iter.To(4 + z);
 

--- a/ydb/core/tablet_flat/ut/ut_versions.cpp
+++ b/ydb/core/tablet_flat/ut/ut_versions.cpp
@@ -14,8 +14,8 @@ namespace NTable {
 
 using namespace NTest;
 
-using TCheckIt = TChecker<TWrapIter, TSubset>;
-using TCheckReverseIt = TChecker<TWrapReverseIter, TSubset>;
+using TCheckIter = TChecker<TWrapIter, TSubset>;
+using TCheckReverseIter = TChecker<TWrapReverseIter, TSubset>;
 
 namespace {
     NPage::TConf PageConf(size_t groups) noexcept
@@ -92,54 +92,54 @@ Y_UNIT_TEST_SUITE(TVersions) {
 
     Y_UNIT_TEST(WreckHead)
     {
-        TWreck<TCheckIt, TSubset>(Mass2(), 666).Do(EWreck::Cached, Subset());
-        TWreck<TCheckIt, TSubset>(Mass2(), 666).Do(EWreck::Evicted, Subset());
-        TWreck<TCheckIt, TSubset>(Mass2(), 666).Do(EWreck::Forward, Subset());
+        TWreck<TCheckIter, TSubset>(Mass2(), 666).Do(EWreck::Cached, Subset());
+        TWreck<TCheckIter, TSubset>(Mass2(), 666).Do(EWreck::Evicted, Subset());
+        TWreck<TCheckIter, TSubset>(Mass2(), 666).Do(EWreck::Forward, Subset());
     }
 
     Y_UNIT_TEST(WreckHeadReverse)
     {
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Cached, Subset());
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Evicted, Subset());
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Cached, Subset());
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Evicted, Subset());
     }
 
     Y_UNIT_TEST(Wreck2)
     {
-        TWreck<TCheckIt, TSubset>(Mass2(), 666).Do(EWreck::Cached, Subset(), TRowVersion(5, 50));
-        TWreck<TCheckIt, TSubset>(Mass2(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(5, 50));
-        TWreck<TCheckIt, TSubset>(Mass2(), 666).Do(EWreck::Forward, Subset(), TRowVersion(5, 50));
+        TWreck<TCheckIter, TSubset>(Mass2(), 666).Do(EWreck::Cached, Subset(), TRowVersion(5, 50));
+        TWreck<TCheckIter, TSubset>(Mass2(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(5, 50));
+        TWreck<TCheckIter, TSubset>(Mass2(), 666).Do(EWreck::Forward, Subset(), TRowVersion(5, 50));
     }
 
     Y_UNIT_TEST(Wreck2Reverse)
     {
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Cached, Subset(), TRowVersion(5, 50));
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(5, 50));
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Cached, Subset(), TRowVersion(5, 50));
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass2(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(5, 50));
     }
 
     Y_UNIT_TEST(Wreck1)
     {
-        TWreck<TCheckIt, TSubset>(Mass1(), 666).Do(EWreck::Cached, Subset(), TRowVersion(3, 30));
-        TWreck<TCheckIt, TSubset>(Mass1(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(3, 30));
-        TWreck<TCheckIt, TSubset>(Mass1(), 666).Do(EWreck::Forward, Subset(), TRowVersion(3, 30));
+        TWreck<TCheckIter, TSubset>(Mass1(), 666).Do(EWreck::Cached, Subset(), TRowVersion(3, 30));
+        TWreck<TCheckIter, TSubset>(Mass1(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(3, 30));
+        TWreck<TCheckIter, TSubset>(Mass1(), 666).Do(EWreck::Forward, Subset(), TRowVersion(3, 30));
     }
 
     Y_UNIT_TEST(Wreck1Reverse)
     {
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass1(), 666).Do(EWreck::Cached, Subset(), TRowVersion(3, 30));
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass1(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(3, 30));
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass1(), 666).Do(EWreck::Cached, Subset(), TRowVersion(3, 30));
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass1(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(3, 30));
     }
 
     Y_UNIT_TEST(Wreck0)
     {
-        TWreck<TCheckIt, TSubset>(Mass0(), 666).Do(EWreck::Cached, Subset(), TRowVersion(1, 10));
-        TWreck<TCheckIt, TSubset>(Mass0(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(1, 10));
-        TWreck<TCheckIt, TSubset>(Mass0(), 666).Do(EWreck::Forward, Subset(), TRowVersion(1, 10));
+        TWreck<TCheckIter, TSubset>(Mass0(), 666).Do(EWreck::Cached, Subset(), TRowVersion(1, 10));
+        TWreck<TCheckIter, TSubset>(Mass0(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(1, 10));
+        TWreck<TCheckIter, TSubset>(Mass0(), 666).Do(EWreck::Forward, Subset(), TRowVersion(1, 10));
     }
 
     Y_UNIT_TEST(Wreck0Reverse)
     {
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass0(), 666).Do(EWreck::Cached, Subset(), TRowVersion(1, 10));
-        TWreck<TCheckReverseIt, TSubset, EDirection::Reverse>(Mass0(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(1, 10));
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass0(), 666).Do(EWreck::Cached, Subset(), TRowVersion(1, 10));
+        TWreck<TCheckReverseIter, TSubset, EDirection::Reverse>(Mass0(), 666).Do(EWreck::Evicted, Subset(), TRowVersion(1, 10));
     }
 
 }

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -46,7 +46,6 @@ SRCS(
     flat_part_charge_range.cpp
     flat_page_label.cpp
     flat_part_dump.cpp
-    flat_part_iter_multi.cpp
     flat_part_index_iter_create.cpp
     flat_part_loader.cpp
     flat_part_overlay.cpp

--- a/ydb/core/tx/datashard/datashard_kqp_compute.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.cpp
@@ -415,7 +415,7 @@ bool TKqpDatashardComputeContext::ReadRow(const TTableId& tableId, TArrayRef<con
     return true;
 }
 
-TAutoPtr<NTable::TTableIt> TKqpDatashardComputeContext::CreateIterator(const TTableId& tableId, const TTableRange& range,
+TAutoPtr<NTable::TTableIter> TKqpDatashardComputeContext::CreateIterator(const TTableId& tableId, const TTableRange& range,
     const TSmallVec<NTable::TTag>& columnTags)
 {
     auto localTid = Shard->GetLocalTableId(tableId);
@@ -438,7 +438,7 @@ TAutoPtr<NTable::TTableIt> TKqpDatashardComputeContext::CreateIterator(const TTa
             UserDb.GetReadTxObserver(tableId));
 }
 
-TAutoPtr<NTable::TTableReverseIt> TKqpDatashardComputeContext::CreateReverseIterator(const TTableId& tableId,
+TAutoPtr<NTable::TTableReverseIter> TKqpDatashardComputeContext::CreateReverseIterator(const TTableId& tableId,
     const TTableRange& range, const TSmallVec<NTable::TTag>& columnTags)
 {
     auto localTid = Shard->GetLocalTableId(tableId);
@@ -565,28 +565,28 @@ bool TKqpDatashardComputeContext::ReadRowWideImpl(const TTableId& tableId, TRead
     return false;
 }
 
-bool TKqpDatashardComputeContext::ReadRow(const TTableId& tableId, NTable::TTableIt& iterator,
+bool TKqpDatashardComputeContext::ReadRow(const TTableId& tableId, NTable::TTableIter& iterator,
     const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
     const THolderFactory& holderFactory, NUdf::TUnboxedValue& result, TKqpTableStats& stats)
 {
     return ReadRowImpl(tableId, iterator, systemColumnTags, skipNullKeys, holderFactory, result, stats);
 }
 
-bool TKqpDatashardComputeContext::ReadRow(const TTableId& tableId, NTable::TTableReverseIt& iterator,
+bool TKqpDatashardComputeContext::ReadRow(const TTableId& tableId, NTable::TTableReverseIter& iterator,
     const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
     const THolderFactory& holderFactory, NUdf::TUnboxedValue& result, TKqpTableStats& stats)
 {
     return ReadRowImpl(tableId, iterator, systemColumnTags, skipNullKeys, holderFactory, result, stats);
 }
 
-bool TKqpDatashardComputeContext::ReadRowWide(const TTableId& tableId, NTable::TTableIt& iterator,
+bool TKqpDatashardComputeContext::ReadRowWide(const TTableId& tableId, NTable::TTableIter& iterator,
     const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
     NUdf::TUnboxedValue* const* result, TKqpTableStats& stats)
 {
     return ReadRowWideImpl(tableId, iterator, systemColumnTags, skipNullKeys,result, stats);
 }
 
-bool TKqpDatashardComputeContext::ReadRowWide(const TTableId& tableId, NTable::TTableReverseIt& iterator,
+bool TKqpDatashardComputeContext::ReadRowWide(const TTableId& tableId, NTable::TTableReverseIter& iterator,
     const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
     NUdf::TUnboxedValue* const* result, TKqpTableStats& stats)
 {

--- a/ydb/core/tx/datashard/datashard_kqp_compute.h
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.h
@@ -57,25 +57,25 @@ public:
         const TSmallVec<NTable::TTag>& systemColumnTags, const THolderFactory& holderFactory,
         NUdf::TUnboxedValue& result, TKqpTableStats& stats);
 
-    TAutoPtr<NTable::TTableIt> CreateIterator(const TTableId& tableId, const TTableRange& range,
+    TAutoPtr<NTable::TTableIter> CreateIterator(const TTableId& tableId, const TTableRange& range,
         const TSmallVec<NTable::TTag>& columnTags);
 
-    TAutoPtr<NTable::TTableReverseIt> CreateReverseIterator(const TTableId& tableId, const TTableRange& range,
+    TAutoPtr<NTable::TTableReverseIter> CreateReverseIterator(const TTableId& tableId, const TTableRange& range,
         const TSmallVec<NTable::TTag>& columnTags);
 
-    bool ReadRow(const TTableId& tableId, NTable::TTableIt& iterator,
+    bool ReadRow(const TTableId& tableId, NTable::TTableIter& iterator,
         const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
         const THolderFactory& holderFactory, NUdf::TUnboxedValue& result, TKqpTableStats& stats);
 
-    bool ReadRow(const TTableId& tableId, NTable::TTableReverseIt& iterator,
+    bool ReadRow(const TTableId& tableId, NTable::TTableReverseIter& iterator,
         const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
         const THolderFactory& holderFactory, NUdf::TUnboxedValue& result, TKqpTableStats& stats);
 
-    bool ReadRowWide(const TTableId& tableId, NTable::TTableIt& iterator,
+    bool ReadRowWide(const TTableId& tableId, NTable::TTableIter& iterator,
         const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
         NUdf::TUnboxedValue* const* result, TKqpTableStats& stats);
 
-    bool ReadRowWide(const TTableId& tableId, NTable::TTableReverseIt& iterator,
+    bool ReadRowWide(const TTableId& tableId, NTable::TTableReverseIter& iterator,
         const TSmallVec<NTable::TTag>& systemColumnTags, const TSmallVec<bool>& skipNullKeys,
         NUdf::TUnboxedValue* const* result, TKqpTableStats& stats);
 

--- a/ydb/core/tx/datashard/datashard_kqp_lookup_table.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_lookup_table.cpp
@@ -267,7 +267,7 @@ private:
     TSmallVec<TTag> SystemColumnTags;
     TKqpTableStats& ShardTableStats;
     TKqpTableStats& TaskTableStats;
-    mutable TAutoPtr<NTable::TTableIt> Iterator;
+    mutable TAutoPtr<NTable::TTableIter> Iterator;
 };
 
 IComputationNode* WrapKqpLookupTableInternal(TCallable& callable, const TComputationNodeFactoryContext& ctx,

--- a/ydb/core/tx/datashard/datashard_kqp_read_table.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_read_table.cpp
@@ -243,7 +243,7 @@ protected:
     TSmallVec<bool> SkipNullKeys;
     TKqpTableStats& ShardTableStats;
     TKqpTableStats& TaskTableStats;
-    using TTableIterator = std::conditional_t<IsReverse, NTable::TTableReverseIt, NTable::TTableIt>;
+    using TTableIterator = std::conditional_t<IsReverse, NTable::TTableReverseIter, NTable::TTableIter>;
     mutable TAutoPtr<TTableIterator> Iterator;
     mutable std::optional<ui64> Remains;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Rename iter classes:

```
// because Iter looks better than just It or Iterator:
TPartGroupRowIt -> TPartGroupRowIter
TPartGroupKeyIt -> TPartGroupKeyIter
TStatsPartGroupBtreeIndexIterator -> TStatsPartGroupBtreeIndexIter
TRunIt -> TRunIter
TMemIt -> TMemIter
TTableIt -> TTableIter
TCheckIt -> TCheckIter
TCheckReverseIt -> TCheckReverseIter

// because it works with main group history only:
TPartGroupHistoryIt -> TPartHistoryIter

// because it works with part:
TPartSimpleIt-> TPartIter

// because index iters work with specific group:
IIndexIter -> IPartGroupIndexIter
TPartBtreeIndexIt -> TPartGroupBtreeIndexIter

// because it is for flat index:
TPartIndexIt -> TPartGroupFlatIndexIter
```

File renames will go separately 