### PR TITLE
 YQL-18053: Add block implementation for RemoveMember callable 

### DIFF
--- a/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
+++ b/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
@@ -5570,7 +5570,7 @@ bool CollectBlockRewrites(const TMultiExprType* multiInputType, bool keepInputCo
         std::string_view arrowFunctionName;
         const bool rewriteAsIs = node->IsCallable({"AssumeStrict", "AssumeNonStrict", "Likely"});
         if (node->IsList() || rewriteAsIs ||
-            node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "Exists", "If", "Just", "Member", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
+            node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "Exists", "If", "Just", "RemoveMember", "Member", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
         {
             if (node->IsCallable() && !IsSupportedAsBlockType(node->Pos(), *node->GetTypeAnn(), ctx, types)) {
                 return true;

--- a/ydb/library/yql/core/type_ann/type_ann_blocks.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_blocks.cpp
@@ -430,6 +430,44 @@ IGraphTransformer::TStatus BlockAsTupleWrapper(const TExprNode::TPtr& input, TEx
     return IGraphTransformer::TStatus::Ok;
 }
 
+IGraphTransformer::TStatus BlockRemoveMemberWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx) {
+    Y_UNUSED(output);
+    if (!EnsureArgsCount(*input, 2, ctx.Expr)) {
+        return IGraphTransformer::TStatus::Error;
+    }
+
+    auto& structNode = *input->Child(0);
+    if (!EnsureBlockOrScalarType(structNode, ctx.Expr)) {
+        return IGraphTransformer::TStatus::Error;
+    }
+
+    bool isStructScalar;
+    const TTypeAnnotationNode* structBlockItemType = GetBlockItemType(*structNode.GetTypeAnn(), isStructScalar);
+
+    if (!EnsureStructType(structNode.Pos(), *structBlockItemType, ctx.Expr)) {
+        return IGraphTransformer::TStatus::Error;
+    }
+
+    auto& nameNode = *input->Child(1);
+    if (!EnsureAtom(nameNode, ctx.Expr)) {
+        return IGraphTransformer::TStatus::Error;
+    }
+
+    auto newItems = structBlockItemType->Cast<TStructExprType>()->GetItems();
+    EraseIf(newItems, [&](const auto& item) { return item->GetName() == nameNode.Content(); });
+
+    const TTypeAnnotationNode* resultType = ctx.Expr.MakeType<TStructExprType>(newItems);
+
+    if (isStructScalar) {
+        resultType = ctx.Expr.MakeType<TScalarExprType>(resultType);
+    } else {
+        resultType = ctx.Expr.MakeType<TBlockExprType>(resultType);
+    }
+
+    input->SetTypeAnn(resultType);
+    return IGraphTransformer::TStatus::Ok;
+}
+
 IGraphTransformer::TStatus BlockMemberWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx) {
     Y_UNUSED(output);
     if (!EnsureArgsCount(*input, 2, ctx.Expr)) {

--- a/ydb/library/yql/core/type_ann/type_ann_blocks.h
+++ b/ydb/library/yql/core/type_ann/type_ann_blocks.h
@@ -20,6 +20,7 @@ namespace NTypeAnnImpl {
     IGraphTransformer::TStatus BlockJustWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockAsTupleWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockNthWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
+    IGraphTransformer::TStatus BlockRemoveMemberWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockMemberWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockToPgWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockFromPgWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);

--- a/ydb/library/yql/core/type_ann/type_ann_core.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_core.cpp
@@ -12288,6 +12288,7 @@ template <NKikimr::NUdf::EDataSlot DataSlot>
         Functions["BlockJust"] = &BlockJustWrapper;
         Functions["BlockAsTuple"] = &BlockAsTupleWrapper;
         Functions["BlockMember"] = &BlockMemberWrapper;
+        Functions["BlockRemoveMember"] = &BlockRemoveMemberWrapper;
         Functions["BlockNth"] = &BlockNthWrapper;
         Functions["BlockToPg"] = &BlockToPgWrapper;
         Functions["BlockFromPg"] = &BlockFromPgWrapper;

--- a/ydb/library/yql/core/yql_opt_utils.cpp
+++ b/ydb/library/yql/core/yql_opt_utils.cpp
@@ -793,7 +793,12 @@ bool UpdateStructMembers(TExprContext& ctx, const TExprNode::TPtr& node, const T
     return filtered;
 }
 
+// Expand RemoveMember over AsStruct.
+// (RemoveMember (AsStruct '('...) '('<member> <value>))) <member>) ==> (AsStruct '('...))
 TExprNode::TPtr ExpandRemoveMember(const TExprNode::TPtr& node, TExprContext& ctx) {
+    if (node->Child(0)->IsCallable("AsStruct")) {
+        return node;
+    }
     const bool force = node->Content() == "ForceRemoveMember";
     const auto& removeMemberName = node->Child(1)->Content();
     MemberUpdaterFunc removeFunc = [&removeMemberName](TString& memberName, const TTypeAnnotationNode*) {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_removemember.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_removemember.cpp
@@ -1,0 +1,82 @@
+#include "mkql_block_removemember.h"
+
+#include <ydb/library/yql/minikql/computation/mkql_block_impl.h>
+#include <ydb/library/yql/minikql/mkql_node_cast.h>
+#include <ydb/library/yql/minikql/mkql_node_builder.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+namespace {
+
+class TBlockRemoveMemberExec {
+public:
+    TBlockRemoveMemberExec(const std::shared_ptr<arrow::DataType>& returnArrowType, const ui32 index)
+        : ReturnArrowType(returnArrowType)
+        , Index(index)
+    {}
+
+    arrow::Status Exec(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) const {
+        Y_UNUSED(ctx);
+        arrow::Datum structDatum = batch.values[0];
+        if (structDatum.is_scalar()) {
+            const auto& obj = arrow::internal::checked_cast<const arrow::StructScalar&>(*structDatum.scalar());
+            std::vector<std::shared_ptr<arrow::Scalar>> arrowValue;
+            for (ui32 i = 0; i < Index; i++) {
+                arrowValue.push_back(obj.value[i]);
+            }
+            for (ui32 i = Index + 1; i < obj.value.size(); i++) {
+                arrowValue.push_back(obj.value[i]);
+            }
+            *res = arrow::Datum(std::make_shared<arrow::StructScalar>(arrowValue, ReturnArrowType));
+        } else {
+            const auto& arr = *structDatum.array();
+            auto resArrayData = arrow::ArrayData::Make(ReturnArrowType, arr.length, { arr.buffers[0] });
+            for (ui32 i = 0; i < Index; i++) {
+                resArrayData->child_data.push_back(arr.child_data[i]);
+            }
+            for (ui32 i = Index + 1; i < arr.child_data.size(); i++) {
+                resArrayData->child_data.push_back(arr.child_data[i]);
+            }
+            *res = arrow::Datum(resArrayData);
+        }
+        return arrow::Status::OK();
+    }
+
+private:
+    const std::shared_ptr<arrow::DataType> ReturnArrowType;
+    const ui32 Index;
+};
+
+
+std::shared_ptr<arrow::compute::ScalarKernel> MakeBlockRemoveMemberKernel(const TVector<TType*>& argTypes, TType* resultType, const ui32 index) {
+    std::shared_ptr<arrow::DataType> returnArrowType;
+    MKQL_ENSURE(ConvertArrowType(AS_TYPE(TBlockType, resultType)->GetItemType(), returnArrowType), "Unsupported arrow type");
+    auto exec = std::make_shared<TBlockRemoveMemberExec>(returnArrowType, index);
+    auto kernel = std::make_shared<arrow::compute::ScalarKernel>(ConvertToInputTypes(argTypes), ConvertToOutputType(resultType),
+        [exec](arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
+        return exec->Exec(ctx, batch, res);
+    });
+
+    kernel->null_handling = arrow::compute::NullHandling::COMPUTED_NO_PREALLOCATE;
+    return kernel;
+}
+
+} // namespace
+
+IComputationNode* WrapBlockRemoveMember(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    MKQL_ENSURE(callable.GetInputsCount() == 2, "Expected two args.");
+    auto structType = AS_TYPE(TBlockType, callable.GetInput(0).GetStaticType());
+    auto memberName = AS_VALUE(TDataLiteral, callable.GetInput(1));
+    const ui32 index = memberName->AsValue().Get<ui32>();
+
+    auto structNode = LocateNode(ctx.NodeLocator, callable, 0);
+
+    TComputationNodePtrVector argsNodes = { structNode };
+    TVector<TType*> argsTypes = { structType };
+    auto kernel = MakeBlockRemoveMemberKernel(argsTypes, callable.GetType()->GetReturnType(), index);
+    return new TBlockFuncNode(ctx.Mutables, callable.GetType()->GetName(), std::move(argsNodes), argsTypes, *kernel, kernel);
+}
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_removemember.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_removemember.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <ydb/library/yql/minikql/computation/mkql_computation_node.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+IComputationNode* WrapBlockRemoveMember(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
@@ -7,6 +7,7 @@
 #include "mkql_block_func.h"
 #include "mkql_blocks.h"
 #include "mkql_block_agg.h"
+#include "mkql_block_removemember.h"
 #include "mkql_block_coalesce.h"
 #include "mkql_block_exists.h"
 #include "mkql_block_getelem.h"
@@ -298,6 +299,7 @@ struct TCallableComputationNodeBuilderFuncMapFiller {
         {"BlockJust", &WrapBlockJust},
         {"BlockCompress", &WrapBlockCompress},
         {"BlockAsTuple", &WrapBlockAsTuple},
+        {"BlockRemoveMember", &WrapBlockRemoveMember},
         {"BlockMember", &WrapBlockMember},
         {"BlockNth", &WrapBlockNth},
         {"BlockExpandChunked", &WrapBlockExpandChunked},

--- a/ydb/library/yql/minikql/comp_nodes/ya.make.inc
+++ b/ydb/library/yql/minikql/comp_nodes/ya.make.inc
@@ -22,6 +22,7 @@ SET(ORIG_SOURCES
     mkql_block_logical.cpp
     mkql_block_compress.cpp
     mkql_block_func.cpp
+    mkql_block_removemember.cpp
     mkql_block_skiptake.cpp
     mkql_block_top.cpp
     mkql_block_tuple.cpp

--- a/ydb/library/yql/minikql/mkql_program_builder.h
+++ b/ydb/library/yql/minikql/mkql_program_builder.h
@@ -238,6 +238,7 @@ public:
     TRuntimeNode BlockCoalesce(TRuntimeNode first, TRuntimeNode second);
     TRuntimeNode BlockExists(TRuntimeNode data);
     TRuntimeNode BlockMember(TRuntimeNode structure, const std::string_view& memberName);
+    TRuntimeNode BlockRemoveMember(TRuntimeNode structObj, const std::string_view& memberName);
     TRuntimeNode BlockNth(TRuntimeNode tuple, ui32 index);
     TRuntimeNode BlockAsTuple(const TArrayRef<const TRuntimeNode>& args);
     TRuntimeNode BlockToPg(TRuntimeNode input, TType* returnType);

--- a/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
+++ b/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
@@ -2731,6 +2731,12 @@ TMkqlCommonCallableCompiler::TShared::TShared() {
         return ctx.ProgramBuilder.BlockMember(structObj, name);
     });
 
+    AddCallable("BlockRemoveMember", [](const TExprNode& node, TMkqlBuildContext& ctx) {
+        const auto structObj = MkqlBuildExpr(node.Head(), ctx);
+        const auto memberName = node.Tail().Content();
+        return ctx.ProgramBuilder.BlockRemoveMember(structObj, memberName);
+    });
+
     AddCallable("BlockNth", [](const TExprNode& node, TMkqlBuildContext& ctx) {
         const auto tupleObj = MkqlBuildExpr(node.Head(), ctx);
         const auto index = FromString<ui32>(node.Tail().Content());

--- a/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
@@ -542,9 +542,9 @@
     ],
     "test.test[blocks-member--Debug]": [
         {
-            "checksum": "a30b76ba380ee4f694dc731aa2771fed",
-            "size": 1467,
-            "uri": "https://{canondata_backend}/1937027/96028d31f8e29253c9276a86f02284e2a71add76/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
+            "checksum": "e39cd2e466a9d415e3c4fba4f28415a4",
+            "size": 1589,
+            "uri": "https://{canondata_backend}/1946324/555b4e0876ace77a95b11767b21d4d2fe26b344f/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-member--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
@@ -673,9 +673,9 @@
     ],
     "test.test[blocks-member--Debug]": [
         {
-            "checksum": "49012dc14c1d467d864bc5079aa4542f",
-            "size": 1982,
-            "uri": "https://{canondata_backend}/1597364/2a4f282ea286021ee8f9098fb8207324c7ebe684/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
+            "checksum": "504b3cb893db5dcb87dc96252a088a61",
+            "size": 2237,
+            "uri": "https://{canondata_backend}/1689644/7ba6bd80669bb2d323eeefa277743d2d7647e1ec/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-member--Plan]": [

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -3578,9 +3578,9 @@
     ],
     "test_sql2yql.test[blocks-member]": [
         {
-            "checksum": "88c9131d7ea3c80ecc268cb7f458fc86",
-            "size": 1230,
-            "uri": "https://{canondata_backend}/1937027/f015781f1ee8e2e10d049f80211c1f81b56abfb9/resource.tar.gz#test_sql2yql.test_blocks-member_/sql.yql"
+            "checksum": "0a0e67e01c3b0c85339d497f9eaa53d1",
+            "size": 1397,
+            "uri": "https://{canondata_backend}/1881367/bd245a6444d8c07714284c53db004239c2a935a1/resource.tar.gz#test_sql2yql.test_blocks-member_/sql.yql"
         }
     ],
     "test_sql2yql.test[blocks-minmax_strings]": [
@@ -21904,9 +21904,9 @@
     ],
     "test_sql_format.test[blocks-member]": [
         {
-            "checksum": "7fcb44569c4f84aee80ea32b5961e0ed",
-            "size": 146,
-            "uri": "https://{canondata_backend}/1937027/f015781f1ee8e2e10d049f80211c1f81b56abfb9/resource.tar.gz#test_sql_format.test_blocks-member_/formatted.sql"
+            "checksum": "d117463db21a985f49a896921ed229af",
+            "size": 181,
+            "uri": "https://{canondata_backend}/1881367/bd245a6444d8c07714284c53db004239c2a935a1/resource.tar.gz#test_sql_format.test_blocks-member_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-minmax_strings]": [

--- a/ydb/library/yql/tests/sql/suites/blocks/member.sql
+++ b/ydb/library/yql/tests/sql/suites/blocks/member.sql
@@ -4,4 +4,5 @@ pragma UseBlocks;
 
 SELECT
     val.a as a,
+    RemoveMember(val, "x") as wox,
 FROM Input;

--- a/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
@@ -550,16 +550,16 @@
     ],
     "test.test[blocks-member--Debug]": [
         {
-            "checksum": "bc4498c90892a7f1e023ac57dbcbc16d",
-            "size": 1459,
-            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql"
+            "checksum": "e63a9cc248c4db5521f1f34b7c33a00b",
+            "size": 1670,
+            "uri": "https://{canondata_backend}/995452/0b64fa49ca5e1784b3a97911055c9b1481ceeb62/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql"
         }
     ],
     "test.test[blocks-member--Peephole]": [
         {
-            "checksum": "b4c9c617dd8d2fa940d076319eb8928d",
-            "size": 1343,
-            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Peephole_/opt.yql"
+            "checksum": "ac10eecc85df385106fd733275e8bc7c",
+            "size": 1554,
+            "uri": "https://{canondata_backend}/995452/0b64fa49ca5e1784b3a97911055c9b1481ceeb62/resource.tar.gz#test.test_blocks-member--Peephole_/opt.yql"
         }
     ],
     "test.test[blocks-member--Plan]": [
@@ -571,9 +571,9 @@
     ],
     "test.test[blocks-member--Results]": [
         {
-            "checksum": "2cbf207655f2d864cbcbda63073d76f5",
-            "size": 1282,
-            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Results_/results.txt"
+            "checksum": "e674d6cac9a79b2860c27a9755f3b190",
+            "size": 3824,
+            "uri": "https://{canondata_backend}/995452/0b64fa49ca5e1784b3a97911055c9b1481ceeb62/resource.tar.gz#test.test_blocks-member--Results_/results.txt"
         }
     ],
     "test.test[blocks-pg_to_dates--Debug]": [


### PR DESCRIPTION
Since `RemoveMember` callable always expands to `AsStruct`, there is no need to implement its block implementation (at least until lazy structures are implemented). All the related tests are moved to #3485.