### PR TITLE
YQL-18053: Add block implementation for AddMember callable 

### DIFF
--- a/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
+++ b/ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.cpp
@@ -5570,7 +5570,7 @@ bool CollectBlockRewrites(const TMultiExprType* multiInputType, bool keepInputCo
         std::string_view arrowFunctionName;
         const bool rewriteAsIs = node->IsCallable({"AssumeStrict", "AssumeNonStrict", "Likely"});
         if (node->IsList() || rewriteAsIs ||
-            node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "Exists", "If", "Just", "Member", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
+            node->IsCallable({"And", "Or", "Xor", "Not", "Coalesce", "Exists", "If", "Just", "AddMember", "Member", "Nth", "ToPg", "FromPg", "PgResolvedCall", "PgResolvedOp"}))
         {
             if (node->IsCallable() && !IsSupportedAsBlockType(node->Pos(), *node->GetTypeAnn(), ctx, types)) {
                 return true;

--- a/ydb/library/yql/core/type_ann/type_ann_blocks.h
+++ b/ydb/library/yql/core/type_ann/type_ann_blocks.h
@@ -20,6 +20,7 @@ namespace NTypeAnnImpl {
     IGraphTransformer::TStatus BlockJustWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockAsTupleWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockNthWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
+    IGraphTransformer::TStatus BlockAddMemberWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockMemberWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockToPgWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);
     IGraphTransformer::TStatus BlockFromPgWrapper(const TExprNode::TPtr& input, TExprNode::TPtr& output, TContext& ctx);

--- a/ydb/library/yql/core/type_ann/type_ann_core.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_core.cpp
@@ -12288,6 +12288,7 @@ template <NKikimr::NUdf::EDataSlot DataSlot>
         Functions["BlockJust"] = &BlockJustWrapper;
         Functions["BlockAsTuple"] = &BlockAsTupleWrapper;
         Functions["BlockMember"] = &BlockMemberWrapper;
+        Functions["BlockAddMember"] = &BlockAddMemberWrapper;
         Functions["BlockNth"] = &BlockNthWrapper;
         Functions["BlockToPg"] = &BlockToPgWrapper;
         Functions["BlockFromPg"] = &BlockFromPgWrapper;

--- a/ydb/library/yql/core/yql_opt_utils.cpp
+++ b/ydb/library/yql/core/yql_opt_utils.cpp
@@ -1048,8 +1048,13 @@ TExprNode::TPtr ExpandDivePrefixMembers(const TExprNode::TPtr& node, TExprContex
     return ret;
 }
 
+// Expand AddMember over AsStruct.
+// (AddMember (AsStruct '('...)) <member> <value>) ==> (AsStruct '('...) '('<member> <value>))
 TExprNode::TPtr ExpandAddMember(const TExprNode::TPtr& node, TExprContext& ctx) {
     TExprNode::TListType members;
+    if (node->Child(0)->IsCallable("AsStruct")) {
+        return node;
+    }
     UpdateStructMembers(ctx, node->ChildPtr(0), "AddMember", members);
     members.push_back(ctx.NewList(node->Pos(), { node->ChildPtr(1), node->ChildPtr(2) }));
     return ctx.NewCallable(node->Pos(), "AsStruct", std::move(members));

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_addmember.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_addmember.cpp
@@ -1,0 +1,129 @@
+#include "mkql_block_addmember.h"
+
+#include <ydb/library/yql/minikql/computation/mkql_block_impl.h>
+#include <ydb/library/yql/minikql/mkql_node_cast.h>
+#include <ydb/library/yql/minikql/mkql_node_builder.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+namespace {
+
+class TBlockAddMemberExec {
+public:
+    TBlockAddMemberExec(const std::shared_ptr<arrow::DataType>& returnArrowType, ui32 index,
+        const TType* structType, const TType* memberType)
+        : ReturnArrowType(returnArrowType)
+        , StructType(structType)
+        , MemberType(memberType)
+        , Index(index)
+    {}
+
+    arrow::Status Exec(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) const {
+        arrow::Datum structDatum = batch.values[0];
+        arrow::Datum valueDatum = batch.values[1];
+        if (structDatum.is_scalar() && valueDatum.is_scalar()) {
+            const auto& obj = arrow::internal::checked_cast<const arrow::StructScalar&>(*structDatum.scalar());
+
+            std::vector<std::shared_ptr<arrow::Scalar>> arrowValue;
+            for (ui32 i = 0; i < Index; i++) {
+                arrowValue.push_back(obj.value[i]);
+            }
+
+            arrowValue.push_back(valueDatum.scalar());
+
+            for (ui32 i = Index; i < obj.value.size(); i++) {
+                arrowValue.push_back(obj.value[i]);
+            }
+
+            *res = arrow::Datum(std::make_shared<arrow::StructScalar>(arrowValue, ReturnArrowType));
+        } else if (structDatum.is_scalar()) {
+            const auto& obj = arrow::internal::checked_cast<const arrow::StructScalar&>(*structDatum.scalar());
+            const size_t blockSize = valueDatum.array()->length;
+            auto resArrayData = arrow::ArrayData::Make(ReturnArrowType, blockSize, { std::shared_ptr<arrow::Buffer>{} });
+
+            for (ui32 i = 0; i < Index; i++) {
+                const TType* memberType = AS_TYPE(TStructType, StructType)->GetMemberType(i);
+                const auto value = MakeArrayFromScalar(*obj.value[i], blockSize, memberType, *ctx->memory_pool());
+                resArrayData->child_data.push_back(value.array());
+            }
+
+            resArrayData->child_data.push_back(valueDatum.array());
+
+            for (ui32 i = Index; i < obj.value.size(); i++) {
+                const TType* memberType = AS_TYPE(TStructType, StructType)->GetMemberType(i);
+                const auto value = MakeArrayFromScalar(*obj.value[i], blockSize, memberType, *ctx->memory_pool());
+                resArrayData->child_data.push_back(value.array());
+            }
+
+            *res = arrow::Datum(resArrayData);
+        } else {
+            const auto& arr = *structDatum.array();
+            auto resArrayData = arrow::ArrayData::Make(ReturnArrowType, arr.length, { std::shared_ptr<arrow::Buffer>{} });
+
+            for (ui32 i = 0; i < Index; i++) {
+                resArrayData->child_data.push_back(arr.child_data[i]);
+            }
+
+            if (valueDatum.is_scalar()) {
+                const auto& vobj = *valueDatum.scalar();
+                const auto value = MakeArrayFromScalar(vobj, arr.length, MemberType, *ctx->memory_pool());
+                resArrayData->child_data.push_back(value.array());
+            } else {
+                const auto& varr = *valueDatum.array();
+                MKQL_ENSURE(varr.length == arr.length, "Datum arrays must be the same size");
+                resArrayData->child_data.push_back(varr.child_data[0]);
+            }
+
+            for (ui32 i = Index; i < arr.child_data.size(); i++) {
+                resArrayData->child_data.push_back(arr.child_data[i]);
+            }
+
+            *res = arrow::Datum(resArrayData);
+        }
+        return arrow::Status::OK();
+    }
+
+private:
+    const std::shared_ptr<arrow::DataType> ReturnArrowType;
+    const TType* StructType;
+    const TType* MemberType;
+    const ui32 Index;
+};
+
+
+std::shared_ptr<arrow::compute::ScalarKernel> MakeBlockAddMemberKernel(const TVector<TType*>& argTypes, TType* resultType, ui32 index) {
+    std::shared_ptr<arrow::DataType> returnArrowType;
+    MKQL_ENSURE(ConvertArrowType(AS_TYPE(TBlockType, resultType)->GetItemType(), returnArrowType), "Unsupported arrow type");
+    auto structType = AS_TYPE(TBlockType, argTypes[0])->GetItemType();
+    auto memberType = AS_TYPE(TBlockType, argTypes[1])->GetItemType();
+    auto exec = std::make_shared<TBlockAddMemberExec>(returnArrowType, index, structType, memberType);
+    auto kernel = std::make_shared<arrow::compute::ScalarKernel>(ConvertToInputTypes(argTypes), ConvertToOutputType(resultType),
+        [exec](arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
+        return exec->Exec(ctx, batch, res);
+    });
+
+    kernel->null_handling = arrow::compute::NullHandling::COMPUTED_NO_PREALLOCATE;
+    return kernel;
+}
+
+} // namespace
+
+IComputationNode* WrapBlockAddMember(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    MKQL_ENSURE(callable.GetInputsCount() == 3, "Expected three args.");
+    auto structType = AS_TYPE(TBlockType, callable.GetInput(0).GetStaticType());
+    auto valueType = AS_TYPE(TBlockType, callable.GetInput(1).GetStaticType());
+    auto memberIndex = AS_VALUE(TDataLiteral, callable.GetInput(2));
+    auto index = memberIndex->AsValue().Get<ui32>();
+
+    auto structNode = LocateNode(ctx.NodeLocator, callable, 0);
+    auto valueNode = LocateNode(ctx.NodeLocator, callable, 1);
+
+    TComputationNodePtrVector argsNodes = { structNode, valueNode };
+    TVector<TType*> argsTypes = { structType, valueType };
+    auto kernel = MakeBlockAddMemberKernel(argsTypes, callable.GetType()->GetReturnType(), index);
+    return new TBlockFuncNode(ctx.Mutables, callable.GetType()->GetName(), std::move(argsNodes), argsTypes, *kernel, kernel);
+}
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_addmember.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_addmember.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <ydb/library/yql/minikql/computation/mkql_computation_node.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+IComputationNode* WrapBlockAddMember(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
@@ -7,6 +7,7 @@
 #include "mkql_block_func.h"
 #include "mkql_blocks.h"
 #include "mkql_block_agg.h"
+#include "mkql_block_addmember.h"
 #include "mkql_block_coalesce.h"
 #include "mkql_block_exists.h"
 #include "mkql_block_getelem.h"
@@ -298,6 +299,7 @@ struct TCallableComputationNodeBuilderFuncMapFiller {
         {"BlockJust", &WrapBlockJust},
         {"BlockCompress", &WrapBlockCompress},
         {"BlockAsTuple", &WrapBlockAsTuple},
+        {"BlockAddMember", &WrapBlockAddMember},
         {"BlockMember", &WrapBlockMember},
         {"BlockNth", &WrapBlockNth},
         {"BlockExpandChunked", &WrapBlockExpandChunked},

--- a/ydb/library/yql/minikql/comp_nodes/ya.make.inc
+++ b/ydb/library/yql/minikql/comp_nodes/ya.make.inc
@@ -8,6 +8,7 @@ SET(ORIG_SOURCES
     mkql_aggrcount.cpp
     mkql_append.cpp
     mkql_apply.cpp
+    mkql_block_addmember.cpp
     mkql_block_agg.cpp
     mkql_block_agg_count.cpp
     mkql_block_agg_factory.cpp

--- a/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
@@ -141,7 +141,7 @@ arrow::Datum ConvertScalar(TType* type, const NUdf::TBlockItem& value, arrow::Me
     return DoConvertScalar(type, value, pool);
 }
 
-arrow::Datum MakeArrayFromScalar(const arrow::Scalar& scalar, size_t len, TType* type, arrow::MemoryPool& pool) {
+arrow::Datum MakeArrayFromScalar(const arrow::Scalar& scalar, size_t len, const TType* type, arrow::MemoryPool& pool) {
     MKQL_ENSURE(len > 0, "Invalid block size");
     auto reader = MakeBlockReader(TTypeInfoHelper(), type);
     auto builder = MakeArrayBuilder(TTypeInfoHelper(), type, pool, len, nullptr);

--- a/ydb/library/yql/minikql/computation/mkql_block_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_block_impl.h
@@ -19,7 +19,7 @@ namespace NKikimr::NMiniKQL {
 
 arrow::Datum ConvertScalar(TType* type, const NUdf::TUnboxedValuePod& value, arrow::MemoryPool& pool);
 arrow::Datum ConvertScalar(TType* type, const NUdf::TBlockItem& value, arrow::MemoryPool& pool);
-arrow::Datum MakeArrayFromScalar(const arrow::Scalar& scalar, size_t len, TType* type, arrow::MemoryPool& pool);
+arrow::Datum MakeArrayFromScalar(const arrow::Scalar& scalar, size_t len, const TType* type, arrow::MemoryPool& pool);
 
 arrow::ValueDescr ToValueDescr(TType* type);
 std::vector<arrow::ValueDescr> ToValueDescr(const TVector<TType*>& types);

--- a/ydb/library/yql/minikql/mkql_program_builder.h
+++ b/ydb/library/yql/minikql/mkql_program_builder.h
@@ -238,6 +238,7 @@ public:
     TRuntimeNode BlockCoalesce(TRuntimeNode first, TRuntimeNode second);
     TRuntimeNode BlockExists(TRuntimeNode data);
     TRuntimeNode BlockMember(TRuntimeNode structure, const std::string_view& memberName);
+    TRuntimeNode BlockAddMember(TRuntimeNode structObj, const std::string_view& memberName, TRuntimeNode memberValue);
     TRuntimeNode BlockNth(TRuntimeNode tuple, ui32 index);
     TRuntimeNode BlockAsTuple(const TArrayRef<const TRuntimeNode>& args);
     TRuntimeNode BlockToPg(TRuntimeNode input, TType* returnType);

--- a/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
+++ b/ydb/library/yql/providers/common/mkql/yql_provider_mkql.cpp
@@ -2731,6 +2731,13 @@ TMkqlCommonCallableCompiler::TShared::TShared() {
         return ctx.ProgramBuilder.BlockMember(structObj, name);
     });
 
+    AddCallable("BlockAddMember", [](const TExprNode& node, TMkqlBuildContext& ctx) {
+        const auto structObj = MkqlBuildExpr(node.Head(), ctx);
+        const auto memberName = node.Child(1)->Content();
+        const auto value = MkqlBuildExpr(node.Tail(), ctx);
+        return ctx.ProgramBuilder.BlockAddMember(structObj, memberName, value);
+    });
+
     AddCallable("BlockNth", [](const TExprNode& node, TMkqlBuildContext& ctx) {
         const auto tupleObj = MkqlBuildExpr(node.Head(), ctx);
         const auto index = FromString<ui32>(node.Tail().Content());

--- a/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
@@ -535,23 +535,23 @@
     "test.test[blocks-filter_direct_col--Results]": [],
     "test.test[blocks-member--Analyze]": [
         {
-            "checksum": "b08274fd137c1878d90520c832f06fd3",
-            "size": 3676,
-            "uri": "https://{canondata_backend}/1889210/75a1d72834c0a9de8b328ec130be934f6cc6cea0/resource.tar.gz#test.test_blocks-member--Analyze_/plan.txt"
+            "checksum": "4d80733bb5655340645b981057ba9910",
+            "size": 3703,
+            "uri": "https://{canondata_backend}/1871182/b7efc92d550d9075cc9bd0a0b8c67f46b2d09684/resource.tar.gz#test.test_blocks-member--Analyze_/plan.txt"
         }
     ],
     "test.test[blocks-member--Debug]": [
         {
-            "checksum": "a30b76ba380ee4f694dc731aa2771fed",
-            "size": 1467,
-            "uri": "https://{canondata_backend}/1937027/96028d31f8e29253c9276a86f02284e2a71add76/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
+            "checksum": "e416cc9ad0b581661db6c3a98c7ac4cb",
+            "size": 1686,
+            "uri": "https://{canondata_backend}/1871182/b7efc92d550d9075cc9bd0a0b8c67f46b2d09684/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-member--Plan]": [
         {
-            "checksum": "b08274fd137c1878d90520c832f06fd3",
-            "size": 3676,
-            "uri": "https://{canondata_backend}/1889210/75a1d72834c0a9de8b328ec130be934f6cc6cea0/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
+            "checksum": "4d80733bb5655340645b981057ba9910",
+            "size": 3703,
+            "uri": "https://{canondata_backend}/1871182/b7efc92d550d9075cc9bd0a0b8c67f46b2d09684/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-member--Results]": [],

--- a/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
@@ -673,16 +673,16 @@
     ],
     "test.test[blocks-member--Debug]": [
         {
-            "checksum": "49012dc14c1d467d864bc5079aa4542f",
-            "size": 1982,
-            "uri": "https://{canondata_backend}/1597364/2a4f282ea286021ee8f9098fb8207324c7ebe684/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
+            "checksum": "a5011d36a2f7ce3f9d14de94e0eba166",
+            "size": 2388,
+            "uri": "https://{canondata_backend}/1946324/38b1bbd25512f9d7059f4529d180a8a18b996e72/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-member--Plan]": [
         {
-            "checksum": "794e5e7aaffc457f9e8f888953e1c89e",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/1597364/07eb39555ae99a903261332d5998f32599b281fe/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
+            "checksum": "dd2dd3d0cedb748dd1909eb4bfb6cfc5",
+            "size": 4072,
+            "uri": "https://{canondata_backend}/1946324/38b1bbd25512f9d7059f4529d180a8a18b996e72/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-minmax_strings--Debug]": [

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -3578,9 +3578,9 @@
     ],
     "test_sql2yql.test[blocks-member]": [
         {
-            "checksum": "88c9131d7ea3c80ecc268cb7f458fc86",
-            "size": 1230,
-            "uri": "https://{canondata_backend}/1937027/f015781f1ee8e2e10d049f80211c1f81b56abfb9/resource.tar.gz#test_sql2yql.test_blocks-member_/sql.yql"
+            "checksum": "189edcc3118d838508b104a023c16ec1",
+            "size": 1414,
+            "uri": "https://{canondata_backend}/1946324/ce138e32034f531ac6592d07562b8c5abb6f4130/resource.tar.gz#test_sql2yql.test_blocks-member_/sql.yql"
         }
     ],
     "test_sql2yql.test[blocks-minmax_strings]": [
@@ -21904,9 +21904,9 @@
     ],
     "test_sql_format.test[blocks-member]": [
         {
-            "checksum": "7fcb44569c4f84aee80ea32b5961e0ed",
-            "size": 146,
-            "uri": "https://{canondata_backend}/1937027/f015781f1ee8e2e10d049f80211c1f81b56abfb9/resource.tar.gz#test_sql_format.test_blocks-member_/formatted.sql"
+            "checksum": "e0e2ef484c763d309bc64463c754767f",
+            "size": 183,
+            "uri": "https://{canondata_backend}/1946324/ce138e32034f531ac6592d07562b8c5abb6f4130/resource.tar.gz#test_sql_format.test_blocks-member_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-minmax_strings]": [

--- a/ydb/library/yql/tests/sql/suites/blocks/member.sql
+++ b/ydb/library/yql/tests/sql/suites/blocks/member.sql
@@ -4,4 +4,5 @@ pragma UseBlocks;
 
 SELECT
     val.a as a,
+    AddMember(val, "c", key) as wic,
 FROM Input;

--- a/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
@@ -550,30 +550,30 @@
     ],
     "test.test[blocks-member--Debug]": [
         {
-            "checksum": "bc4498c90892a7f1e023ac57dbcbc16d",
-            "size": 1459,
-            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql"
+            "checksum": "5575417e475bed29b393bce9ae99aac5",
+            "size": 1801,
+            "uri": "https://{canondata_backend}/1937429/f859bf457f712f3de26260d35df69450f3a784f1/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql"
         }
     ],
     "test.test[blocks-member--Peephole]": [
         {
-            "checksum": "b4c9c617dd8d2fa940d076319eb8928d",
-            "size": 1343,
-            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Peephole_/opt.yql"
+            "checksum": "9334feb48c2ec27f2aa5ac320e25df8f",
+            "size": 1724,
+            "uri": "https://{canondata_backend}/1937429/f859bf457f712f3de26260d35df69450f3a784f1/resource.tar.gz#test.test_blocks-member--Peephole_/opt.yql"
         }
     ],
     "test.test[blocks-member--Plan]": [
         {
-            "checksum": "082fc363e364c6bd7e557a48f4a982e4",
-            "size": 4537,
-            "uri": "https://{canondata_backend}/1937424/677956b7b1d51ac69cbef1b401a74f8916d215bb/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
+            "checksum": "4875e8f0e36c185dc7d584edda9f815e",
+            "size": 4852,
+            "uri": "https://{canondata_backend}/1937429/f859bf457f712f3de26260d35df69450f3a784f1/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-member--Results]": [
         {
-            "checksum": "2cbf207655f2d864cbcbda63073d76f5",
-            "size": 1282,
-            "uri": "https://{canondata_backend}/1597364/82c77c5ee80726b7fecf97522a463a7edce9a1be/resource.tar.gz#test.test_blocks-member--Results_/results.txt"
+            "checksum": "cc594be96311181e4215ac6fd7325c0e",
+            "size": 5129,
+            "uri": "https://{canondata_backend}/1937429/f859bf457f712f3de26260d35df69450f3a784f1/resource.tar.gz#test.test_blocks-member--Results_/results.txt"
         }
     ],
     "test.test[blocks-pg_to_dates--Debug]": [


### PR DESCRIPTION
Since `AddMember` callable always expands to `AsStruct`, there is no need to implement its block implementation (at least until lazy structures are implemented). All the related tests are moved to #3485.