### PR TITLE
Fix static group status calculation logic

### DIFF
--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -554,6 +554,7 @@ void TBlobStorageController::OnWardenDisconnected(TNodeId nodeId, TActorId serve
     }
     for (auto it = StaticVSlots.lower_bound(startingId); it != StaticVSlots.end() && it->first.NodeId == nodeId; ++it) {
         it->second.VDiskStatus = NKikimrBlobStorage::EVDiskStatus::ERROR;
+        it->second.ReadySince = TMonotonic::Max();
     }
     if (sh->VDiskStatusUpdate) {
         Send(SelfHealId, sh.Release());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix static group status calculation logic

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Correct handling of node disconnection while calculating static group status.
