### PR TITLE
Fix aligned allocation for experimental/test SIMD code

### DIFF
--- a/ydb/library/yql/utils/simd/exec/pack_tuple/main.cpp
+++ b/ydb/library/yql/utils/simd/exec/pack_tuple/main.cpp
@@ -1,6 +1,7 @@
 #include <util/generic/ptr.h>
 #include <util/system/cpu_id.h>
 #include <util/system/types.h>
+#include <new>
 
 #include <ydb/library/yql/utils/simd/simd.h>
 
@@ -32,8 +33,8 @@ struct TPerfomancer {
             const ui64 NTuples = 32 << 18;
             const ui64 TupleSize =  sizeof(ui32) + sizeof(ui64);
 
-            ui32 *arrUi32 __attribute__((aligned(32))) = new ui32[NTuples];
-            ui64 *arrUi64 __attribute__((aligned(32))) = new ui64[NTuples];
+            ui32* arrUi32 = new (std::align_val_t(TTraits::Size)) ui32[NTuples];
+            ui64* arrUi64 = new (std::align_val_t(TTraits::Size)) ui64[NTuples];
 
             for (ui32 i = 0; i < NTuples; i++) {
                 arrUi32[i] = 2 * i;
@@ -143,8 +144,8 @@ struct TPerfomancer {
                     << " MB/sec" << Endl;
                 Cerr << Endl;
             }
-            delete[] arrUi32;
-            delete[] arrUi64;
+            operator delete[](arrUi64, std::align_val_t(TTraits::Size));
+            operator delete[](arrUi32, std::align_val_t(TTraits::Size));
 
             return 1;
         }

--- a/ydb/library/yql/utils/simd/exec/pack_tuple/main.cpp
+++ b/ydb/library/yql/utils/simd/exec/pack_tuple/main.cpp
@@ -19,8 +19,8 @@ struct TPerfomancer {
         using TSimd = typename TTraits::template TSimd8<T>;
         TWorker() = default;
 
-        ui8* ShuffleMask(ui32 v[8]) {
-            ui8* det = new ui8[32];
+        TSimd<ui8> ShuffleMask(ui32 v[8]) {
+            ui8 det[32];
             for (size_t i = 0; i < 32; i += 1) {
                 det[i] = v[i / 4] == ui32(-1) ? ui8(-1) : 4 * v[i / 4] + i % 4;
             }

--- a/ydb/library/yql/utils/simd/exec/stream_store/main.cpp
+++ b/ydb/library/yql/utils/simd/exec/stream_store/main.cpp
@@ -1,6 +1,7 @@
 #include <util/generic/ptr.h>
 #include <util/system/cpu_id.h>
 #include <util/system/types.h>
+#include <new>
 
 #include <ydb/library/yql/utils/simd/simd.h>
 
@@ -43,7 +44,7 @@ struct TPerfomancer {
             const size_t size = (32LL << 21);
             const size_t arrSize = size / 8;
 
-            i64* buf __attribute__((aligned(32))) = new i64[arrSize];
+            i64* buf = new (std::align_val_t(TTraits::Size)) i64[arrSize];
 
             for (size_t i = 0; i < arrSize; i += 1) {
                 buf[i] = 0;
@@ -94,6 +95,7 @@ struct TPerfomancer {
                         << " MB/sec" << Endl;
                 Cerr << Endl;
             }
+            operator delete[](buf, std::align_val_t(TTraits::Size));
             return is_ok;
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=en)

`__attribute__((aligned))` aligns *pointer*, not the memory it points to. Changes into c++17 aligned `new`.
(Note that aligned `new` requires paired aligned `delete`).

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixup experimental SIMD code

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

1) this affects only currently-unused (and unfinished?) experimental code;
2) largely, no-op: for SSE* only 16-byte alignment required and `operator new` in practice returns 16-byte aligned memory (... but this is not mandated by standard and not portable), and for AVX alignment requirements was relaxed
3) compile-tested only (... but, again, code is unused)