### PR TITLE
Fix grace join UUID encoding

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -285,6 +285,7 @@ void TGraceJoinPacker::Pack()  {
             auto str = TuplePtrs[i]->AsStringRef();
             TupleStrings[offset] = str.Data();
             TupleStrSizes[offset] = str.Size();
+            break;
         }
         case NUdf::EDataSlot::TzDate:
         {
@@ -403,6 +404,7 @@ void TGraceJoinPacker::UnPack()  {
         case NUdf::EDataSlot::Uuid:
         {
             value = MakeString(NUdf::TStringRef(TupleStrings[offset], TupleStrSizes[offset]));
+            break;
         }
         case NUdf::EDataSlot::TzDate:
         {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -280,13 +280,6 @@ void TGraceJoinPacker::Pack()  {
         case NUdf::EDataSlot::Interval64:
             WriteUnaligned<i64>(buffPtr, value.Get<i64>()); break;
 
-        case NUdf::EDataSlot::Uuid:
-        {
-            auto str = TuplePtrs[i]->AsStringRef();
-            TupleStrings[offset] = str.Data();
-            TupleStrSizes[offset] = str.Size();
-            break;
-        }
         case NUdf::EDataSlot::TzDate:
         {
             WriteUnaligned<ui16>(buffPtr, value.Get<ui16>());
@@ -401,11 +394,6 @@ void TGraceJoinPacker::UnPack()  {
             value = NUdf::TUnboxedValuePod(ReadUnaligned<i64>(buffPtr)); break;
         case NUdf::EDataSlot::Interval64:
             value = NUdf::TUnboxedValuePod(ReadUnaligned<i64>(buffPtr)); break;
-        case NUdf::EDataSlot::Uuid:
-        {
-            value = MakeString(NUdf::TStringRef(TupleStrings[offset], TupleStrSizes[offset]));
-            break;
-        }
         case NUdf::EDataSlot::TzDate:
         {
             value = NUdf::TUnboxedValuePod(ReadUnaligned<ui16>(buffPtr));

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_grace_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_grace_join_ut.cpp
@@ -988,6 +988,84 @@ Y_UNIT_TEST_SUITE(TMiniKQLGraceJoinTest) {
 
     }
 
+    Y_UNIT_TEST_LLVM(TestInnerManyKeyUuid) {
+
+        for (ui32 pass = 0; pass < 1; ++pass) {
+            TSetup<LLVM> setup;
+            TProgramBuilder& pb = *setup.PgmBuilder;
+
+            const auto key1 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("A1A1A1A1A1A1A1A1");
+            const auto key2 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("A2A2A2A2A2A2A2A2");
+            const auto key3 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("A3A3A3A3A3A3A3A3");
+            const auto key4 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("B1B1B1B1B1B1B1B1");
+            const auto key5 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("B2B2B2B2B2B2B2B2");
+            const auto key6 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("B3B3B3B3B3B3B3B3");
+
+
+            const auto payload1 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("AAAAAAAAAAAAAAAA");
+            const auto payload2 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("BBBBBBBBBBBBBBBB");
+            const auto payload3 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("CCCCCCCCCCCCCCCC");
+            const auto payload4 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("XXXXXXXXXXXXXXXX");
+            const auto payload5 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("YYYYYYYYYYYYYYYY");
+            const auto payload6 = pb.NewDataLiteral<NUdf::EDataSlot::Uuid>("ZZZZZZZZZZZZZZZZ");
+
+            const auto tupleType1 = pb.NewTupleType({
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id),
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id),
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id)
+            });
+
+            const auto tupleType2 = pb.NewTupleType({
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id),
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id),
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id)
+            });
+
+
+            const auto list1 = pb.NewList(tupleType1, {
+                pb.NewTuple({key1, key4, payload1}),
+                pb.NewTuple({key2, key5, payload2}),
+                pb.NewTuple({key3, key6, payload3})
+            });
+
+            const auto list2 = pb.NewList(tupleType2, {
+                pb.NewTuple({key4, key1, payload4}),
+                pb.NewTuple({key5, key2, payload5}),
+                pb.NewTuple({key6, key6, payload6})
+            });
+
+
+            const auto resultType = pb.NewFlowType(pb.NewMultiType({
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id),
+                pb.NewDataType(NUdf::TDataType<NUdf::TUuid>::Id)
+            }));
+
+            const auto pgmReturn = pb.Collect(pb.NarrowMap(pb.GraceJoin(
+                pb.ExpandMap(pb.ToFlow(list1), [&](TRuntimeNode item) -> TRuntimeNode::TList { return {pb.Nth(item, 0U), pb.Nth(item, 1U), pb.Nth(item, 2U)}; }),
+                pb.ExpandMap(pb.ToFlow(list2), [&](TRuntimeNode item) -> TRuntimeNode::TList { return {pb.Nth(item, 0U), pb.Nth(item, 1U), pb.Nth(item, 2U)}; }),
+                EJoinKind::Inner, {0U, 1U}, {1U, 0U}, {1U, 0U}, {2U, 1U}, resultType),
+                [&](TRuntimeNode::TList items) -> TRuntimeNode { return pb.NewTuple(items); })
+            );
+
+            const auto graph = setup.BuildGraph(pgmReturn);
+
+            const auto iterator = graph->GetValue().GetListIterator();
+
+            NUdf::TUnboxedValue tuple;
+
+            UNIT_ASSERT(iterator.Next(tuple));
+            UNBOXED_VALUE_STR_EQUAL(tuple.GetElement(0), "B2B2B2B2B2B2B2B2");
+            UNBOXED_VALUE_STR_EQUAL(tuple.GetElement(1), "YYYYYYYYYYYYYYYY");
+            UNIT_ASSERT(iterator.Next(tuple));
+            UNBOXED_VALUE_STR_EQUAL(tuple.GetElement(0), "B1B1B1B1B1B1B1B1");
+            UNBOXED_VALUE_STR_EQUAL(tuple.GetElement(1), "XXXXXXXXXXXXXXXX");
+            UNIT_ASSERT(!iterator.Next(tuple));
+
+        }
+
+
+    }
+
 
     Y_UNIT_TEST_LLVM(TestInnerStringKey1) {
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix Uuid handling in mkql_grace_join

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

I noticed something weird while reading the code: I believe there are missing `break;` statement in handling Uuid's; also note mismatch between Uuid handling and string-alike handling, this is yet another bug (mostly easily fixed by unifying string-alike and Uuid handling).
I added very crude test (just copied another and replaced strings with Uuid). It fails when applied alone, still fails with only `break` added, and passes with complete series applied.
Compile-tested, limited runtime-tested (my machine is too weak to handle even single round of compilation).