### PR TITLE
Fix UB: runtime error: 1.79769e+308 is outside the range of represent…

### DIFF
--- a/ydb/core/sys_view/service/ext_counters.cpp
+++ b/ydb/core/sys_view/service/ext_counters.cpp
@@ -154,7 +154,8 @@ private:
                 ExecuteLatencyMsValues[n] = diff;
                 ExecuteLatencyMsPrevValues[n] = value;
                 if (ExecuteLatencyMsBounds[n] == 0) {
-                    ExecuteLatencyMsBounds[n] = std::min<double>(snapshot->UpperBound(n), Max<ui64>());
+                    NMonitoring::TBucketBound bound = snapshot->UpperBound(n);
+                    ExecuteLatencyMsBounds[n] = bound == Max<NMonitoring::TBucketBound>() ? Max<ui64>() : bound;
                 }
             }
             metrics->AddMetric("queries.requests", total);

--- a/ydb/core/sys_view/service/ext_counters.cpp
+++ b/ydb/core/sys_view/service/ext_counters.cpp
@@ -154,7 +154,7 @@ private:
                 ExecuteLatencyMsValues[n] = diff;
                 ExecuteLatencyMsPrevValues[n] = value;
                 if (ExecuteLatencyMsBounds[n] == 0) {
-                    ExecuteLatencyMsBounds[n] = snapshot->UpperBound(n);
+                    ExecuteLatencyMsBounds[n] = std::min<double>(snapshot->UpperBound(n), Max<ui64>());
                 }
             }
             metrics->AddMetric("queries.requests", total);
@@ -183,4 +183,3 @@ IActor* CreateExtCountersUpdater(TExtCountersConfig&& config) {
 
 }
 }
-


### PR DESCRIPTION
…able values of type 'unsigned long'

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

```Last bound is Max<double>()=1.79769e+308 that great then Max<ui64>.```
