### PR TITLE
return code to `ProcessRequest(TWriteMsg)`

### DIFF
--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -943,7 +943,7 @@ TPartition::EProcessResult TPartition::ProcessRequest(TWriteMsg& p, ProcessParam
 
             sourceId.Update(THeartbeat{*hbVersion, p.Msg.Data});
 
-            return EProcessResult::Continue;
+            return EProcessResult::Reply;
         }
 
         if (poffset < curOffset) { //too small offset

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -3061,8 +3061,6 @@ Y_UNIT_TEST_SUITE(Cdc) {
     }
 
     Y_UNIT_TEST(ResolvedTimestamps) {
-        return;
-
         TPortManager portManager;
         TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
             .SetUseRealThreads(false)
@@ -3187,8 +3185,6 @@ Y_UNIT_TEST_SUITE(Cdc) {
     }
 
     Y_UNIT_TEST(ResolvedTimestampsVolatileOutOfOrder) {
-        return;
-
         TPortManager portManager;
         TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
             .SetUseRealThreads(false)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The `ProcessRequest` function for `TWriteMsg` returned `Continue` instead of `Reply`. As a result, these recording operations were not stored in the KV tablet.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
