### PR TITLE
BTreeIndex Forwad load

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_tx_env.h
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.h
@@ -40,9 +40,9 @@ namespace NTabletFlatExecutor {
         }
 
     private:
-        const TSharedData* Lookup(TPrivatePageCache::TInfo *info, TPageId id) noexcept
+        const TSharedData* Lookup(TPrivatePageCache::TInfo *info, TPageId pageId) noexcept
         {
-            return Cache.Lookup(id, info);
+            return Cache.Lookup(pageId, info);
         }
 
     public:

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -5242,7 +5242,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // no read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {1, 1};
-            queueScan->ExpectedPageFaults = 1048;
+            queueScan->ExpectedPageFaults = 1100;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5250,7 +5250,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // small read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {5*10*1024, 10*10*1024};
-            queueScan->ExpectedPageFaults = 296;
+            queueScan->ExpectedPageFaults = 174;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5258,7 +5258,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // infinite read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {Max<ui64>(), Max<ui64>()};
-            queueScan->ExpectedPageFaults = 170;
+            queueScan->ExpectedPageFaults = 5;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -5242,7 +5242,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // no read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {1, 1};
-            queueScan->ExpectedPageFaults = 1100;
+            queueScan->ExpectedPageFaults = 1172;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5250,7 +5250,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // small read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {5*10*1024, 10*10*1024};
-            queueScan->ExpectedPageFaults = 174;
+            queueScan->ExpectedPageFaults = 332;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5376,7 +5376,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // no read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount, TRowVersion(2, 0));
             queueScan->ReadAhead = {1, 1};
-            queueScan->ExpectedPageFaults = 2096;
+            queueScan->ExpectedPageFaults = 2344;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5384,7 +5384,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // small read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount, TRowVersion(2, 0));
             queueScan->ReadAhead = {5*10*1024, 10*10*1024};
-            queueScan->ExpectedPageFaults = 302;
+            queueScan->ExpectedPageFaults = 337;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5392,7 +5392,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // infinite read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount, TRowVersion(2, 0));
             queueScan->ReadAhead = {Max<ui64>(), Max<ui64>()};
-            queueScan->ExpectedPageFaults = 175;
+            queueScan->ExpectedPageFaults = 10;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5508,7 +5508,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // no read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {1, 1};
-            queueScan->ExpectedPageFaults = 1048;
+            queueScan->ExpectedPageFaults = 1172;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5516,7 +5516,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // small read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {5*10*1024, 10*10*1024};
-            queueScan->ExpectedPageFaults = 296;
+            queueScan->ExpectedPageFaults = 189;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -5242,7 +5242,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // no read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {1, 1};
-            queueScan->ExpectedPageFaults = 1172;
+            queueScan->ExpectedPageFaults = 1028;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5250,7 +5250,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // small read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {5*10*1024, 10*10*1024};
-            queueScan->ExpectedPageFaults = 332;
+            queueScan->ExpectedPageFaults = 189;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5376,7 +5376,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // no read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount, TRowVersion(2, 0));
             queueScan->ReadAhead = {1, 1};
-            queueScan->ExpectedPageFaults = 2344;
+            queueScan->ExpectedPageFaults = 2056;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5384,7 +5384,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // small read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount, TRowVersion(2, 0));
             queueScan->ReadAhead = {5*10*1024, 10*10*1024};
-            queueScan->ExpectedPageFaults = 337;
+            queueScan->ExpectedPageFaults = 194;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5508,7 +5508,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // no read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {1, 1};
-            queueScan->ExpectedPageFaults = 1172;
+            queueScan->ExpectedPageFaults = 1028;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }
@@ -5524,7 +5524,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorIndexLoading) {
         { // infinite read ahead
             auto queueScan = new TEvTestFlatTablet::TEvQueueScan(rowsCount);
             queueScan->ReadAhead = {Max<ui64>(), Max<ui64>()};
-            queueScan->ExpectedPageFaults = 170;
+            queueScan->ExpectedPageFaults = 5;
             env.SendAsync(std::move(queueScan));
             env.WaitFor<TEvTestFlatTablet::TEvScanFinished>();
         }

--- a/ydb/core/tablet_flat/flat_fwd_blobs.h
+++ b/ydb/core/tablet_flat/flat_fwd_blobs.h
@@ -3,7 +3,6 @@
 #include "flat_fwd_iface.h"
 #include "flat_fwd_page.h"
 #include "flat_fwd_misc.h"
-#include "flat_page_blobs.h"
 #include "flat_part_screen.h"
 #include "flat_part_slice.h"
 
@@ -33,7 +32,7 @@ namespace NFwd {
             for (auto &it: Pages) it.Release();
         }
 
-        TResult Handle(IPageLoadingQueue *head, ui32 ref, ui64 lower) noexcept override
+        TResult Get(IPageLoadingQueue *head, ui32 ref, EPage, ui64 lower) noexcept override
         {
             Y_ABORT_UNLESS(ref >= Lower, "Cannot handle backward blob reads");
 
@@ -55,21 +54,19 @@ namespace NFwd {
             Preload(head, upper);
         }
 
-        void Apply(TArrayRef<NPageCollection::TLoadedPage> loaded) noexcept override
+        void Fill(NPageCollection::TLoadedPage& page, EPage) noexcept override
         {
-            for (auto &one: loaded) {
-                if (!Pages || one.PageId < Pages.front().PageId) {
-                    Y_ABORT("Blobs fwd cache got page below queue");
-                } else if (one.PageId > Pages.back().PageId) {
-                    Y_ABORT("Blobs fwd cache got page above queue");
-                } else if (one.Data.size() > OnFetch) {
-                    Y_ABORT("Blobs fwd cache ahead counters is out of sync");
-                }
-
-                Stat.Saved += one.Data.size();
-                OnFetch -= one.Data.size();
-                OnHold += Lookup(one.PageId).Settle(one);
+            if (!Pages || page.PageId < Pages.front().PageId) {
+                Y_ABORT("Blobs fwd cache got page below queue");
+            } else if (page.PageId > Pages.back().PageId) {
+                Y_ABORT("Blobs fwd cache got page above queue");
+            } else if (page.Data.size() > OnFetch) {
+                Y_ABORT("Blobs fwd cache ahead counters is out of sync");
             }
+
+            Stat.Saved += page.Data.size();
+            OnFetch -= page.Data.size();
+            OnHold += Lookup(page.PageId).Settle(page);
 
             Shrink(false /* do not drop loading pages */);
         }
@@ -151,7 +148,7 @@ namespace NFwd {
                     } else if (page.Fetch == EFetch::None) {
                         auto size = head->AddToQueue(Grow, EPage::Opaque);
 
-                        Y_ABORT_UNLESS(size == page.Size, "Inconsistent page sizez");
+                        Y_ABORT_UNLESS(size == page.Size, "Inconsistent page sizes");
 
                         page.Fetch = EFetch::Wait;
                         Stat.Fetch += page.Size;

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -53,9 +53,21 @@ namespace NFwd {
     };
 
     struct ICacheLineQueue {
+        /**
+         * @brief Skips all pages before and including given @param pageId
+         */
         virtual void Advance(TPageId pageId) = 0;
+
+        /**
+         * @brief Checks whether the forward load process should be performed or continued
+         */
         virtual bool Grow(ui64 onHold, ui64 onFetch, ui64 limit) = 0;
+
+        /**
+         * @brief Returns next to load page id
+         */
         virtual TPageId Next() = 0;
+        
         virtual ~ICacheLineQueue() = default;
     };
 
@@ -149,10 +161,9 @@ namespace NFwd {
         }
 
         TPageId Next() override {
-            Y_ABORT_UNLESS(Iter);
-            auto result = Iter->GetPageId();
-            Iter++;
-            return result;
+            Y_DEBUG_ABORT_UNLESS(Iter && Iter->GetRowId() < EndRowId);
+
+            return (Iter++)->GetPageId();
         }
 
     private:

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -303,7 +303,7 @@ namespace NFwd {
 
             auto& meta = Part->IndexPages.GetBTree(groupId);
             Levels.resize(meta.LevelCount + 1);
-            Levels[0].Queue.emplace_back(meta.PageId, meta.DataSize);
+            Levels[0].Queue.push_back({meta.PageId, meta.DataSize});
             IndexPageLocator.Add(meta.PageId, GroupId, 0);
         }
 
@@ -500,7 +500,7 @@ namespace NFwd {
             Stat.Fetch += size;
 
             Y_ABORT_UNLESS(!level.Pages || level.Pages.back().PageId < pageId);
-            level.Pages.emplace_back(TPage(pageId, size, 0, Max<TPageId>()), level.Queue.front().EndDataSize);
+            level.Pages.push_back({TPage(pageId, size, 0, Max<TPageId>()), level.Queue.front().EndDataSize});
             level.Pages.back().Fetch = EFetch::Wait;
 
             level.Queue.pop_front();

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -467,7 +467,7 @@ namespace NFwd {
                     (level.Pages.empty() 
                         ? 0 
                         // Note: for simplicity consider pages as sequential
-                        : level.Pages.back().EndDataSize - level.Pages.begin()->EndDataSize + level.Pages.front().Size);
+                        : level.Pages.back().EndDataSize - level.Pages.front().EndDataSize + level.Pages.front().Size);
             } else {
                 return level.Pages.empty() 
                     ? 0 

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "flat_page_index.h"
 #include "flat_part_iface.h"
 #include "flat_fwd_iface.h"
 #include "flat_fwd_misc.h"
@@ -125,7 +124,7 @@ namespace NFwd {
         {
             if (pageId == IndexPage.PageId) {
                 if (IndexPage.Fetch == EFetch::None) {
-                    Stat.Fetch += head->AddToQueue(pageId, EPage::Index);
+                    Stat.Fetch += head->AddToQueue(pageId, EPage::FlatIndex);
                     IndexPage.Fetch = EFetch::Wait;
                 }
                 return {IndexPage.Touch(pageId, Stat), false, true};
@@ -169,7 +168,7 @@ namespace NFwd {
                 Stat.Saved += one.Data.size();
 
                 if (one.PageId == IndexPage.PageId) {
-                    Y_DEBUG_ABORT_UNLESS(Part->GetPageType(one.PageId, {}) == EPage::Index);
+                    Y_DEBUG_ABORT_UNLESS(Part->GetPageType(one.PageId, {}) == EPage::FlatIndex);
                     Index.emplace(one.Data);
                     Iter = Index->LookupRow(BeginRowId);
                     IndexPage.Settle(one);
@@ -260,8 +259,8 @@ namespace NFwd {
         TRowId BeginRowId, EndRowId;
         
         TPage IndexPage;
-        std::optional<NPage::TIndex> Index;
-        NPage::TIndex::TIter Iter;
+        std::optional<NPage::TFlatIndex> Index;
+        NPage::TFlatIndex::TIter Iter;
 
         TLoadedPagesCircularBuffer<TPart::Trace> Trace;
 

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -57,7 +57,8 @@ namespace NFwd {
         using TGroupId = NPage::TGroupId;
 
         TFlatIndexCache(const TPart* part, TGroupId groupId, const TIntrusiveConstPtr<TSlices>& slices = nullptr)
-            : IndexPage(part->IndexPages.GetFlat(groupId), part->GetPageSize(part->IndexPages.GetFlat(groupId)), 0, Max<TPageId>())
+            : Part(part)
+            , IndexPage(Part->IndexPages.GetFlat(groupId), Part->GetPageSize(Part->IndexPages.GetFlat(groupId)), 0, Max<TPageId>())
         { 
             if (slices && !slices->empty()) {
                 BeginRowId = slices->front().BeginRowId();
@@ -86,6 +87,8 @@ namespace NFwd {
                 return {IndexPage.Touch(pageId, Stat), false, true};
             }
 
+            Y_DEBUG_ABORT_UNLESS(Part->GetPageType(pageId) == EPage::DataPage);
+
             if (auto *page = Trace.Get(pageId)) {
                 return {page, false, true};
             }
@@ -206,6 +209,7 @@ namespace NFwd {
         }
 
     private:
+        const TPart* Part;
         TRowId BeginRowId, EndRowId;
         
         TPage IndexPage;
@@ -225,7 +229,8 @@ namespace NFwd {
         using TGroupId = NPage::TGroupId;
 
         TBTreeIndexCache(const TPart* part, TGroupId groupId, const TIntrusiveConstPtr<TSlices>& slices = nullptr)
-            : IndexPage(part->IndexPages.GetFlat(groupId), part->GetPageSize(part->IndexPages.GetFlat(groupId)), 0, Max<TPageId>())
+            : Part(part)
+            , IndexPage(Part->IndexPages.GetFlat(groupId), Part->GetPageSize(Part->IndexPages.GetFlat(groupId)), 0, Max<TPageId>())
         { 
             if (slices && !slices->empty()) {
                 BeginRowId = slices->front().BeginRowId();
@@ -254,6 +259,8 @@ namespace NFwd {
                 return {IndexPage.Touch(pageId, Stat), false, true};
             }
 
+            Y_DEBUG_ABORT_UNLESS(Part->GetPageType(pageId) == EPage::DataPage);
+
             if (auto *page = Trace.Get(pageId)) {
                 return {page, false, true};
             }
@@ -374,6 +381,7 @@ namespace NFwd {
         }
 
     private:
+        const TPart* Part;
         TRowId BeginRowId, EndRowId;
         
         TPage IndexPage;

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -38,6 +38,7 @@ namespace NFwd {
             Offset = (Offset + 1) % Capacity;
 
             const ui64 releasedDataSize = LoadedPages[Offset].Data.size();
+            DataSize = DataSize - releasedDataSize + page.Size;
 
             LoadedPages[Offset].Data = page.Release();
             LoadedPages[Offset].PageId = page.PageId;
@@ -47,16 +48,13 @@ namespace NFwd {
         }
 
         ui64 GetDataSize() {
-            ui64 result = 0;
-            for (const auto& page : LoadedPages) {
-                result += page.Data.size();
-            }
-            return result;
+            return DataSize;
         }
 
     private:
         std::array<NPageCollection::TLoadedPage, Capacity> LoadedPages;
         ui32 Offset = 0;
+        ui64 DataSize = 0;
         TPageId FirstUnseenPageId = 0;
     };
 

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -156,8 +156,6 @@ namespace NFwd {
 
         void Forward(IPageLoadingQueue *head, ui64 upper) noexcept override
         {
-            Y_DEBUG_ABORT_UNLESS(Iter && Iter->GetRowId() < EndRowId);
-
             while (Iter && Iter->GetRowId() < EndRowId && OnHold + OnFetch < upper) {
                 RequestNextPage(head);
             }

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -70,7 +70,7 @@ namespace NFwd {
 
     public:
         void Add(TPageId pageId, TGroupId groupId, ui32 level) {
-            Y_ABORT_UNLESS(Map.emplace(pageId, TIndexPageLocation(groupId, level)).second, "All index pages should be unique");
+            Y_ABORT_UNLESS(Map.emplace(pageId, TIndexPageLocation{groupId, level}).second, "All index pages should be unique");
         }
 
         ui32 GetLevel(TPageId pageId) const {

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -437,7 +437,7 @@ namespace NFwd {
                             continue;
                         }
                         Y_ABORT_UNLESS(!Levels[levelId + 1].Queue || Levels[levelId + 1].Queue.back().PageId < child.PageId);
-                        Levels[levelId + 1].Queue.emplace_back(child.PageId, child.DataSize);
+                        Levels[levelId + 1].Queue.push_back({child.PageId, child.DataSize});
                         if (child.RowCount >= EndRowId) {
                             break;
                         }

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -439,7 +439,7 @@ namespace NFwd {
 
         ui64 GetDataSize(TLevel& level) noexcept
         {
-            if (&level == &*Levels.rbegin()) {
+            if (&level == &Levels.back()) {
                 return 
                     level.Trace.GetDataSize() +
                     (level.Pages.empty() 
@@ -472,7 +472,8 @@ namespace NFwd {
             Y_ABORT_UNLESS(!level.Queue.empty());
             auto pageId = level.Queue.front().PageId;
 
-            auto size = head->AddToQueue(pageId, EPage::DataPage);
+            auto type = &level == &Levels.back() ? EPage::DataPage : EPage::BTreeIndex;
+            auto size = head->AddToQueue(pageId, type);
 
             Stat.Fetch += size;
 

--- a/ydb/core/tablet_flat/flat_fwd_env.h
+++ b/ydb/core/tablet_flat/flat_fwd_env.h
@@ -243,7 +243,7 @@ namespace NFwd {
 
     private:
         static bool IsIndexPage(EPage type) noexcept {
-            return type == EPage::Index || type == EPage::BTreeIndex;
+            return type == EPage::FlatIndex || type == EPage::BTreeIndex;
         }
 
         TResult Handle(TPageLoadingQueue &q, TPageId ref) noexcept

--- a/ydb/core/tablet_flat/flat_fwd_env.h
+++ b/ydb/core/tablet_flat/flat_fwd_env.h
@@ -68,7 +68,7 @@ namespace NFwd {
         using TSlot = ui32;
         using TSlotVec = TSmallVec<TSlot>;
 
-        struct TPagesLogic {
+        struct TPages {
             THolder<IPageLoadingLogic> PageLoadingLogic;
             TIntrusiveConstPtr<IPageCollection> PageCollection;
         };
@@ -297,12 +297,12 @@ namespace NFwd {
             return Queues.at(GetQueueSlot(part, room));
         }
 
-        TSlot Settle(TPagesLogic egg, ui32 slot) noexcept
+        TSlot Settle(TPages pages, ui32 slot) noexcept
         {
-            if (egg.PageLoadingLogic || egg.PageCollection) {
+            if (pages.PageLoadingLogic || pages.PageCollection) {
                 const ui64 cookie = (ui64(Queues.size()) << 32) | ui32(Salt + Epoch);
 
-                Queues.emplace_back(slot, cookie, std::move(egg.PageCollection), egg.PageLoadingLogic);
+                Queues.emplace_back(slot, cookie, std::move(pages.PageCollection), pages.PageLoadingLogic);
 
                 return Queues.size() - 1;
             } else {
@@ -310,7 +310,7 @@ namespace NFwd {
             }
         }
 
-        TPagesLogic MakeCache(const TPart *part, NPage::TGroupId groupId, TIntrusiveConstPtr<TSlices> slices) noexcept
+        TPages MakeCache(const TPart *part, NPage::TGroupId groupId, TIntrusiveConstPtr<TSlices> slices) noexcept
         {
             auto *partStore = CheckedCast<const TPartStore*>(part);
 
@@ -321,7 +321,7 @@ namespace NFwd {
             return {CreateCache(part, groupId, slices), cache->PageCollection};
         }
 
-        TPagesLogic MakeExtern(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const noexcept
+        TPages MakeExtern(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const noexcept
         {
             if (auto blobs = part->Blobs) {
                 /* Should always materialize key columns to values since
@@ -350,7 +350,7 @@ namespace NFwd {
             }
         }
 
-        TPagesLogic MakeOuter(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const noexcept
+        TPages MakeOuter(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const noexcept
         {
             if (auto small = part->Small) {
                 auto *partStore = CheckedCast<const TPartStore*>(part);

--- a/ydb/core/tablet_flat/flat_fwd_iface.h
+++ b/ydb/core/tablet_flat/flat_fwd_iface.h
@@ -7,6 +7,7 @@
 namespace NKikimr {
 namespace NTable {
     using EPage = NPage::EPage;
+    using TPageId = NPage::TPageId;
 
 namespace NFwd {
 
@@ -16,7 +17,7 @@ namespace NFwd {
     public:
         virtual ~IPageLoadingQueue() = default;
 
-        virtual ui64 AddToQueue(ui32 page, EPage type) noexcept = 0;
+        virtual ui64 AddToQueue(TPageId pageId, EPage type) noexcept = 0;
     };
 
     class IPageLoadingLogic {
@@ -29,9 +30,9 @@ namespace NFwd {
 
         virtual ~IPageLoadingLogic() = default;
 
-        virtual TResult Handle(IPageLoadingQueue *head, ui32 page, ui64 lower) noexcept = 0;
+        virtual TResult Get(IPageLoadingQueue *head, TPageId pageId, EPage type, ui64 lower) noexcept = 0;
         virtual void Forward(IPageLoadingQueue *head, ui64 upper) noexcept = 0;
-        virtual void Apply(TArrayRef<NPageCollection::TLoadedPage> loaded) noexcept = 0;
+        virtual void Fill(NPageCollection::TLoadedPage& page, EPage type) noexcept = 0;
 
         IPageLoadingQueue* Head = nullptr; /* will be set outside of IPageLoadingLogic impl */
         TStat Stat;

--- a/ydb/core/tablet_flat/flat_fwd_page.h
+++ b/ydb/core/tablet_flat/flat_fwd_page.h
@@ -22,8 +22,8 @@ namespace NFwd {
     };
 
     struct TPage {
-        TPage(TPageId id, ui64 size, ui16 tag, TPageId refer)
-            : Size(size), PageId(id), Refer(refer), Tag(tag)
+        TPage(TPageId pageId, ui64 size, ui16 tag, TPageId refer)
+            : Size(size), PageId(pageId), Refer(refer), Tag(tag)
         {
 
         }

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -3,6 +3,7 @@
 #include "flat_table_part.h"
 #include "flat_part_iface.h"
 #include "flat_part_charge_iface.h"
+#include "flat_page_data.h"
 
 namespace NKikimr::NTable {
 
@@ -707,7 +708,7 @@ private:
         ui64 result = 0;
 
         for (ui32 height = 0; height < meta.LevelCount; height++) {
-            auto page = Env->TryGetPage(Part, pageId);
+            auto page = Env->TryGetPage(Part, pageId, {});
             if (!page) {
                 return result;
             }
@@ -727,7 +728,7 @@ private:
         ui64 result = meta.DataSize;
 
         for (ui32 height = 0; height < meta.LevelCount; height++) {
-            auto page = Env->TryGetPage(Part, pageId);
+            auto page = Env->TryGetPage(Part, pageId, {});
             if (!page) {
                 return result;
             }
@@ -750,7 +751,7 @@ private:
     }
 
     bool TryLoadNode(const TChildState& child, TVector<TNodeState>& level) const noexcept {
-        auto page = Env->TryGetPage(Part, child.PageId);
+        auto page = Env->TryGetPage(Part, child.PageId, {});
         if (!page) {
             return false;
         }

--- a/ydb/core/tablet_flat/flat_part_charge_flat_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_flat_index.h
@@ -4,6 +4,7 @@
 #include "flat_part_iface.h"
 #include "flat_part_index_iter_flat_index.h"
 #include "flat_part_charge_iface.h"
+#include "flat_page_data.h"
 
 #include <util/generic/bitmap.h>
 
@@ -218,9 +219,9 @@ namespace NTable {
                     auto currentFirstRowId = current->GetRowId();
                     auto currentLastRowId = currentExt ? (currentExt->GetRowId() - 1) : Max<TRowId>();
 
-                    auto page = Env->TryGetPage(Part, current->GetPageId());
+                    auto page = Env->TryGetPage(Part, current->GetPageId(), {});
                     if (bytesLimit) {
-                        bytes += Part->GetPageSize(current->GetPageId());
+                        bytes += Part->GetPageSize(current->GetPageId(), {});
                     }
                     ready &= bool(page);
 
@@ -316,9 +317,9 @@ namespace NTable {
                     auto currentFirstRowId = currentExt ? (currentExt->GetRowId() - 1) : Max<TRowId>();
                     auto currentLastRowId = current->GetRowId();
 
-                    auto page = Env->TryGetPage(Part, current->GetPageId());
+                    auto page = Env->TryGetPage(Part, current->GetPageId(), {});
                     if (bytesLimit) {
-                        bytes += Part->GetPageSize(current->GetPageId());
+                        bytes += Part->GetPageSize(current->GetPageId(), {});
                     }
                     ready &= bool(page);
 

--- a/ydb/core/tablet_flat/flat_part_dump.cpp
+++ b/ydb/core/tablet_flat/flat_part_dump.cpp
@@ -120,8 +120,8 @@ namespace {
         auto label = index.Label();
 
         Out
-            << " + Index{" << (ui16)label.Type << " rev "
-            << label.Format << ", " << label.Size << "b}"
+            << " + Index{" << indexPageId << "}" 
+            << " Label{" << (ui16)label.Type << " rev " << label.Format << ", " << label.Size << "b}"
             << " " << index->Count + (index.GetLastKeyRecord() ? 1 : 0) << " rec" << Endl
             << " |  Page     Row    Bytes  (";
 
@@ -323,10 +323,8 @@ namespace {
 
         Out
             << intend
-            << " + BTreeIndex{"
-            << meta.ToString() << ", "
-            << (ui16)label.Type << " rev " << label.Format << ", " 
-            << label.Size << "b}"
+            << " + BTreeIndex{" << meta.ToString() << "}"
+            << " Label{" << (ui16)label.Type << " rev " << label.Format << ", " << label.Size << "b}"
             << Endl;
 
         dumpChild(node.GetChild(0));

--- a/ydb/core/tablet_flat/flat_part_dump.cpp
+++ b/ydb/core/tablet_flat/flat_part_dump.cpp
@@ -2,7 +2,6 @@
 #include "flat_part_iface.h"
 #include "flat_part_index_iter_iface.h"
 #include "flat_page_data.h"
-#include "flat_page_index.h"
 #include "flat_page_frames.h"
 #include "flat_page_blobs.h"
 #include "flat_page_bloom.h"
@@ -111,7 +110,7 @@ namespace {
 
         if (!indexPage) {
             Out
-                << " + Index{unload}"
+                << " + FlatIndex{unload}"
                 << Endl
                 << " |  Page     Row    Bytes  (";
             return;
@@ -121,7 +120,7 @@ namespace {
         auto label = index.Label();
 
         Out
-            << " + Index{" << indexPageId << "}" 
+            << " + FlatIndex{" << indexPageId << "}" 
             << " Label{" << (ui16)label.Type << " rev " << label.Format << ", " << label.Size << "b}"
             << " " << index->Count + (index.GetLastKeyRecord() ? 1 : 0) << " rec" << Endl
             << " |  Page     Row    Bytes  (";

--- a/ydb/core/tablet_flat/flat_part_iface.h
+++ b/ydb/core/tablet_flat/flat_part_iface.h
@@ -68,7 +68,7 @@ namespace NTable {
 
         virtual TResult Locate(const TMemTable*, ui64 ref, ui32 tag) noexcept = 0;
         virtual TResult Locate(const TPart*, ui64 ref, ELargeObj lob) noexcept = 0;
-        virtual const TSharedData* TryGetPage(const TPart* part, TPageId id, TGroupId groupId = { }) = 0;
+        virtual const TSharedData* TryGetPage(const TPart* part, TPageId pageId, TGroupId groupId) = 0;
 
         /**
          * Hook for cleaning up env on DB.RollbackChanges()

--- a/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
@@ -348,7 +348,7 @@ private:
             return true;
         }
 
-        auto page = Env->TryGetPage(Part, state.PageId);
+        auto page = Env->TryGetPage(Part, state.PageId, {});
         if (page) {
             state.Node.emplace(*page);
             return true;

--- a/ydb/core/tablet_flat/flat_part_index_iter_flat_index.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_flat_index.h
@@ -172,7 +172,7 @@ private:
             return &*Index;
         }
         auto pageId = Part->IndexPages.GetFlat(GroupId);
-        auto page = Env->TryGetPage(Part, pageId);
+        auto page = Env->TryGetPage(Part, pageId, {});
         if (page) {
             Index = TIndex(*page);
             Y_VERIFY_DEBUG_S(EndRowId == Index->GetEndRowId(), "EndRowId mismatch " << EndRowId << " != " << Index->GetEndRowId() << " (group " << GroupId.Historic << "/" << GroupId.Index <<")");

--- a/ydb/core/tablet_flat/flat_part_iter.h
+++ b/ydb/core/tablet_flat/flat_part_iter.h
@@ -8,6 +8,7 @@
 #include "flat_part_pinout.h"
 #include "flat_part_slice.h"
 #include "flat_table_committed.h"
+#include "flat_page_data.h"
 
 namespace NKikimr {
 namespace NTable {

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -73,16 +73,16 @@ public:
         return BackingSize() - IndexesRawSize;
     }
 
-    ui64 GetPageSize(NPage::TPageId id, NPage::TGroupId groupId) const override
+    ui64 GetPageSize(NPage::TPageId pageId, NPage::TGroupId groupId) const override
     {
         Y_ABORT_UNLESS(groupId.Index < PageCollections.size());
-        return PageCollections[groupId.Index]->PageCollection->Page(id).Size;
+        return PageCollections[groupId.Index]->PageCollection->Page(pageId).Size;
     }
 
-    NPage::EPage GetPageType(NPage::TPageId id, NPage::TGroupId groupId) const override
+    NPage::EPage GetPageType(NPage::TPageId pageId, NPage::TGroupId groupId) const override
     {
         Y_ABORT_UNLESS(groupId.Index < PageCollections.size());
-        return EPage(PageCollections[groupId.Index]->PageCollection->Page(id).Type);
+        return EPage(PageCollections[groupId.Index]->PageCollection->Page(pageId).Type);
     }
 
     ui8 GetGroupChannel(NPage::TGroupId groupId) const override

--- a/ydb/core/tablet_flat/flat_sausage_gut.h
+++ b/ydb/core/tablet_flat/flat_sausage_gut.h
@@ -2,7 +2,6 @@
 
 #include "flat_sausage_misc.h"
 #include "flat_sausage_solid.h"
-#include "util_basics.h"
 
 namespace NKikimr {
 namespace NPageCollection {

--- a/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
@@ -76,7 +76,7 @@ public:
                     continue; // don't go deeper
                 }
 
-                auto page = Env->TryGetPage(Part, nodeState.PageId);
+                auto page = Env->TryGetPage(Part, nodeState.PageId, {});
                 if (!page) {
                     ready = false;
                     continue; // continue requesting other nodes

--- a/ydb/core/tablet_flat/flat_table_part.cpp
+++ b/ydb/core/tablet_flat/flat_table_part.cpp
@@ -1,7 +1,7 @@
 #include "flat_page_label.h"
 #include "flat_part_iface.h"
 #include "flat_page_data.h"
-#include "flat_page_index.h"
+#include "flat_page_flat_index.h"
 
 #include <ydb/core/util/pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>

--- a/ydb/core/tablet_flat/flat_table_part.cpp
+++ b/ydb/core/tablet_flat/flat_table_part.cpp
@@ -1,7 +1,7 @@
 #include "flat_page_label.h"
 #include "flat_part_iface.h"
-#include "flat_table_part.h"
-#include "util_basics.h"
+#include "flat_page_data.h"
+#include "flat_page_index.h"
 
 #include <ydb/core/util/pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -11,7 +11,6 @@
 #include "flat_page_gstat.h"
 #include "flat_page_txidstat.h"
 #include "flat_page_txstatus.h"
-#include "util_basics.h"
 
 namespace NKikimr {
 namespace NTable {
@@ -156,9 +155,9 @@ namespace NTable {
 
         virtual ui64 DataSize() const = 0;
         virtual ui64 BackingSize() const = 0;
-        virtual ui64 GetPageSize(NPage::TPageId id, NPage::TGroupId groupId = { }) const = 0;
-        virtual NPage::EPage GetPageType(NPage::TPageId id, NPage::TGroupId groupId = { }) const = 0;
-        virtual ui8 GetGroupChannel(NPage::TGroupId groupId = { }) const = 0;
+        virtual ui64 GetPageSize(NPage::TPageId pageId, NPage::TGroupId groupId) const = 0;
+        virtual NPage::EPage GetPageType(NPage::TPageId pageId, NPage::TGroupId groupId) const = 0;
+        virtual ui8 GetGroupChannel(NPage::TGroupId groupId) const = 0;
         virtual ui8 GetPageChannel(ELargeObj lob, ui64 ref) const = 0;
 
     protected:

--- a/ydb/core/tablet_flat/test/libs/table/test_envs.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_envs.h
@@ -252,12 +252,8 @@ namespace NTest {
 
             Y_ABORT_UNLESS(groupId.Index < partStore->Store->GetGroupCount());
 
-            if (part->GetPageType(pageId, groupId) == EPage::FlatIndex || part->GetPageType(pageId, groupId) == EPage::BTreeIndex) {
-                return partStore->Store->GetPage(groupId.Index, pageId);
-            } else {
-                ui32 room = (groupId.Historic ? partStore->Store->GetRoomCount() : 0) + groupId.Index;
-                return Get(part, room).DoLoad(pageId, AheadLo, AheadHi).Page;
-            }
+            ui32 room = (groupId.Historic ? partStore->Store->GetRoomCount() : 0) + groupId.Index;
+            return Get(part, room).DoLoad(pageId, AheadLo, AheadHi).Page;
         }
 
     private:

--- a/ydb/core/tablet_flat/test/libs/table/test_envs.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_envs.h
@@ -275,7 +275,7 @@ namespace NTest {
                 for (ui32 room : xrange(partStore->Store->GetRoomCount())) {
                     if (room < partStore->Store->GetGroupCount()) {
                         NPage::TGroupId groupId(room);
-                        auto *cache = new NFwd::TCache(part, this, groupId);
+                        auto *cache = new NFwd::TCache(part, groupId);
                         slots.push_back(Settle(partStore, room, cache));
                     } else if (room == partStore->Store->GetOuterRoom()) {
                         slots.push_back(Settle(partStore, room, MakeOuter(partStore)));
@@ -287,7 +287,7 @@ namespace NTest {
                 }
                 for (ui32 group : xrange(part->HistoricGroupsCount)) {
                     NPage::TGroupId groupId(group, true);
-                    auto *cache = new NFwd::TCache(part, this, groupId);
+                    auto *cache = new NFwd::TCache(part, groupId);
                     slots.push_back(Settle(partStore, group, cache));
                 }
             }

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -47,14 +47,14 @@ namespace NTest {
             return Store->PageCollectionBytes(0) + Store->PageCollectionBytes(Store->GetOuterRoom());
         }
 
-        ui64 GetPageSize(NPage::TPageId id, NPage::TGroupId groupId) const override
+        ui64 GetPageSize(NPage::TPageId pageId, NPage::TGroupId groupId) const override
         {
-            return Store->GetPageSize(groupId.Index, id);
+            return Store->GetPageSize(groupId.Index, pageId);
         }
 
-        NPage::EPage GetPageType(NPage::TPageId id, NPage::TGroupId groupId) const override
+        NPage::EPage GetPageType(NPage::TPageId pageId, NPage::TGroupId groupId) const override
         {
-            return Store->GetPageType(groupId.Index, id);
+            return Store->GetPageType(groupId.Index, pageId);
         }
 
         ui8 GetGroupChannel(NPage::TGroupId groupId) const override

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -101,9 +101,9 @@ namespace NTest {
             return { true, Get(part, room, ref) };
         }
 
-        const TSharedData* TryGetPage(const TPart *part, TPageId ref, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
         {
-            return Get(part, groupId.Index, ref);
+            return Get(part, groupId.Index, pageId);
         }
 
     private:

--- a/ydb/core/tablet_flat/test/libs/table/test_store.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_store.h
@@ -270,11 +270,13 @@ namespace NTest {
         {
             Y_ABORT_UNLESS(!Finished, "This store is already finished");
 
-            auto& pages = PageCollections[GetExternRoom()];
+            auto room = GetExternRoom();
+            TPageId pageId = PageCollections[room].size();
 
-            pages.emplace_back(std::move(data));
+            PageCollections[room].emplace_back(std::move(data));
+            PageTypes[room].push_back(EPage::Opaque);
 
-            return GlobForBlob(pages.size() - 1);
+            return GlobForBlob(pageId);
         }
 
         void Finish() noexcept

--- a/ydb/core/tablet_flat/test/libs/table/test_store.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_store.h
@@ -210,24 +210,26 @@ namespace NTest {
         {
             Y_ABORT_UNLESS(!Finished, "This store is already finished");
 
-            auto& pages = PageCollections[GetOuterRoom()];
+            auto room = GetOuterRoom();
+            TPageId pageId = PageCollections[room].size();
 
-            pages.emplace_back(std::move(page));
+            PageCollections[room].emplace_back(std::move(page));
+            PageTypes[room].push_back(EPage::Opaque);
 
-            return pages.size() - 1;
+            return pageId;
         }
 
         TPageId Write(TSharedData page, EPage type, ui32 group) noexcept
         {
             Y_ABORT_UNLESS(group < PageCollections.size() - 1, "Invalid column group");
             Y_ABORT_UNLESS(!Finished, "This store is already finished");
-            NPageCollection::Checksum(page); /* will catch uninitialised values */
+            NPageCollection::Checksum(page); /* will catch uninitialized values */
 
             if (type == EPage::DataPage) {
                 DataBytes[group] += page.size();
             }
             TPageId pageId = PageCollections[group].size();
-            PageCollections[group].push_back(std::move(page));
+            PageCollections[group].emplace_back(std::move(page));
             PageTypes[group].push_back(type);
 
             if (group == 0) {

--- a/ydb/core/tablet_flat/test/libs/table/test_store.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_store.h
@@ -226,35 +226,35 @@ namespace NTest {
             if (type == EPage::DataPage) {
                 DataBytes[group] += page.size();
             }
-            TPageId id = PageCollections[group].size();
+            TPageId pageId = PageCollections[group].size();
             PageCollections[group].push_back(std::move(page));
             PageTypes[group].push_back(type);
 
             if (group == 0) {
                 switch (type) {
                     case EPage::FlatIndex:
-                        Indexes.push_back(id);
+                        Indexes.push_back(pageId);
                         break;
                     case EPage::Frames:
-                        Large = id;
+                        Large = pageId;
                         break;
                     case EPage::Globs:
-                        Globs = id;
+                        Globs = pageId;
                         break;
                     case EPage::Scheme:
                     case EPage::Schem2:
-                        Scheme = id;
+                        Scheme = pageId;
                         Rooted = (type == EPage::Schem2);
                         break;
                     case EPage::Bloom:
-                        ByKey = id;
+                        ByKey = pageId;
                         break;
                     default:
                         break;
                 }
             }
 
-            return id;
+            return pageId;
         }
 
         void WriteInplace(TPageId page, TArrayRef<const char> body) noexcept

--- a/ydb/core/tablet_flat/test/libs/table/test_wreck.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_wreck.h
@@ -110,7 +110,7 @@ namespace NTest {
 
             /*_ 5x_xxx +inf lookups logic. It could seem test has lack of it
                 but inf logic completely implemented in key cmp functions and
-                isn't related to iterators. Each key cmp functon should have
+                isn't related to iterators. Each key cmp function should have
                 special tests for its +inf.
              */
         }
@@ -120,7 +120,15 @@ namespace NTest {
             auto originEnv = wrap.template Displace<IPages>(make());
 
             { /*_ 60_000 Full sequence scan of all saved records */
-                wrap.To(60000).Seek({}, ESeek::Lower);
+                wrap.To(60000);
+
+                // load index
+                for (ui32 attempt = 0; attempt < 20; attempt++) {
+                    wrap.Seek({}, ESeek::Lower);
+                    if (wrap.GetReady() != EReady::Page) {
+                        break;
+                    }
+                }
 
                 if constexpr (Direction == EDirection::Reverse) {
                     auto it = Mass.Saved.end();
@@ -128,13 +136,15 @@ namespace NTest {
                         wrap.Is(*--it).Next();
                     }
                 } else {
-                    for (auto &row: Mass.Saved) wrap.Is(row).Next();
+                    for (auto i : xrange(Mass.Saved.Size())) {
+                        wrap.Is(Mass.Saved[i]).Next();
+                    }
                 }
 
                 wrap.Is(EReady::Gone); /* should have no more rows */
             }
 
-            /*_ 61_xxx Sequentional reads with random starts   */
+            /*_ 61_xxx Sequential reads with random starts   */
 
             if (rnd) wrap.template Displace<IPages>(make());
 
@@ -144,7 +154,15 @@ namespace NTest {
                 ui64 len = Rnd.Uniform(256, 999);
                 auto it = Mass.Saved.Any(Rnd);
 
-                wrap.To(61000 + seq).Seek(*it, ESeek::Lower);
+                wrap.To(61000 + seq);
+
+                // load index
+                for (ui32 attempt = 0; attempt < 20; attempt++) {
+                    wrap.Seek(*it, ESeek::Lower);
+                    if (wrap.GetReady() != EReady::Page) {
+                        break;
+                    }
+                }
 
                 if constexpr (Direction == EDirection::Reverse) {
                     while (len-- > 0) {

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -53,15 +53,15 @@ namespace {
             , Sticky(std::move(sticky))
             { }
 
-        const TSharedData* TryGetPage(const TPart *part, TPageId id, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
         {
-            Touched[groupId].insert(id);
+            Touched[groupId].insert(pageId);
             
-            if (!Fail || Sticky.contains({groupId, id})) {
-                return NTest::TTestEnv::TryGetPage(part, id, groupId);
+            if (!Fail || Sticky.contains({groupId, pageId})) {
+                return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             }
 
-            ToLoad[groupId].insert(id);
+            ToLoad[groupId].insert(pageId);
             return nullptr;
         }
 

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -543,11 +543,15 @@ Y_UNIT_TEST_SUITE(NFwd_TLoadedPagesCircularBuffer){
             UNIT_ASSERT_VALUES_EQUAL(result, pageId >= 5 ? (pageId - 5) * 10 + 1 : 0);
 
             // has trace
-            for (ui32 i = 0; i < Min(5u, pageId); i++) {
+            ui64 totalSize = 0;
+            for (ui32 i = 0; i < Min(5u, pageId + 1); i++) {
                 auto got = buffer.Get(pageId - i);
                 UNIT_ASSERT_VALUES_UNEQUAL(got, nullptr);
                 UNIT_ASSERT_VALUES_EQUAL(got->size(), (pageId - i) * 10 + 1);
+                totalSize += got->size();
             }
+            UNIT_ASSERT_VALUES_EQUAL(totalSize, buffer.GetDataSize());
+
             // doesn't have next
             UNIT_ASSERT_VALUES_EQUAL(buffer.Get(pageId + 1), nullptr);
         }

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -146,8 +146,10 @@ namespace {
         {
         }
 
-        ui64 AddToQueue(TPageId pageId, EPage) noexcept override
+        ui64 AddToQueue(TPageId pageId, EPage type) noexcept override
         {
+            Y_ABORT_UNLESS(type == Part->GetPageType(pageId, { }));
+
             Queue.push_back(pageId);
 
             return Part->GetPageSize(pageId, { });

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -525,6 +525,7 @@ Y_UNIT_TEST_SUITE(NFwd_TCache) {
         NPage::TConf conf;
 
         conf.WriteBTreeIndex = bTreeIndex;
+        conf.WriteFlatIndex = !bTreeIndex;
         conf.Group(0).PageRows = 2;
         conf.Group(0).BTreeIndexNodeKeysMin = conf.Group(0).BTreeIndexNodeKeysMax = 2;
 
@@ -592,13 +593,25 @@ Y_UNIT_TEST_SUITE(NFwd_TCache) {
 
         TCacheWrap wrap(eggs.Lone(), 201, 350);
         
-        // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
-            {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
-            {453, 453, 453, 0, 0});
-        wrap.To(2).Get(20, true, false, true, 
-            {453, 453, 453, 0, 0});
+        // level 0:
+        wrap.To(0).Get(28, false, false, true, 
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28}, 
+            {98, 98, 98, 0, 0});
+        wrap.To(2).Get(28, true, false, true, 
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(3).Get(23, false, true, true, 
+            {241, 98, 241, 0, 0});
+        wrap.To(4).Fill({23, 27}, 
+            {384, 384, 241, 0, 0});
+        wrap.To(5).Get(23, true, false, true, 
+            {384, 384, 241, 0, 0});
+        wrap.To(6).Get(27, true, false, true, 
+            {384, 384, 384, 0, 0});
+
+        return;
 
         wrap.To(3).Get(0, false, true, true, 
             {503, 453, 503, 0, 0});

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -54,7 +54,7 @@ namespace {
 
         TBlobsWrap& Get(ui32 page, bool has, bool grow, bool need)
         {
-            auto got = Cache->Handle(this, page, AheadLo);
+            auto got = Cache->Get(this, page, EPage::Opaque, AheadLo);
 
             if (has != bool(got.Page) || grow != got.Grow || need != got.Need){
                 Log()
@@ -113,7 +113,9 @@ namespace {
 
             Shuffle(load.begin(), load.end(), Rnd);
 
-            Cache->Apply(load);
+            for (auto &page : load) {
+                Cache->Fill(page, EPage::Opaque);
+            }
 
             UNIT_ASSERT(Cache->Stat.Saved == Cache->Stat.Fetch);
 
@@ -157,7 +159,7 @@ namespace {
 
         TCacheWrap& Get(TPageId pageId, bool has, bool grow, bool need, NFwd::TStat stat)
         {
-            auto got = Cache->Handle(this, pageId, AheadLo);
+            auto got = Cache->Get(this, pageId, Part->GetPageType(pageId, { }), AheadLo);
 
             if (has != bool(got.Page) || grow != got.Grow || need != got.Need){
                 Log()
@@ -193,7 +195,9 @@ namespace {
 
             Shuffle(load.begin(), load.end(), Rnd);
 
-            Cache->Apply(load);
+            for (auto &page : load) {
+                Cache->Fill(page, Part->GetPageType(page.PageId, {}));
+            }
 
             UNIT_ASSERT_VALUES_EQUAL_C(Cache->Stat, stat, CurrentStepStr());
 
@@ -232,7 +236,9 @@ namespace {
 
             Shuffle(load.begin(), load.end(), Rnd);
 
-            Cache->Apply(load);
+            for (auto &page : load) {
+                Cache->Fill(page, Part->GetPageType(page.PageId, {}));
+            }
 
             UNIT_ASSERT_VALUES_EQUAL_C(Cache->Stat, stat, CurrentStepStr());
 

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -592,26 +592,34 @@ Y_UNIT_TEST_SUITE(NFwd_TCache) {
 
         TCacheWrap wrap(eggs.Lone(), 201, 350);
         
-        wrap.To(0).Get(0, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(1).Fill({0, 1, 2, 3, 4, 5, 6}, 
-            {7, 7, 1, 0, 0});
-        wrap.To(2).Get(0, true, false, true, 
-            {7, 7, 1, 0, 0});
-        
-        // page 0 goes to trace:
-        wrap.To(3).Get(1, true, false, true, 
-            {7, 7, 2, 0, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
+        wrap.To(2).Get(20, true, false, true, 
+            {453, 453, 453, 0, 0});
 
-        // page 1 goes to trace, pages 2, 3 dropped as unused:
-        wrap.To(4).Get(4, true, false, true, 
-            {7, 7, 3, 2, 0});
+        wrap.To(3).Get(0, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(4).Fill({0, 1, 2, 3, 4, 5, 6}, 
+            {803, 803, 503, 0, 0});
+        wrap.To(5).Get(0, true, false, true, 
+            {803, 803, 503, 0, 0});
+
+        wrap.To(6).Get(1, true, false, true, 
+            {803, 803, 553, 0, 0});
+        wrap.To(7).Get(2, true, false, true, 
+            {803, 803, 603, 0, 0});
+        wrap.To(8).Get(3, true, false, true, 
+            {803, 803, 653, 0, 0});
+        wrap.To(9).Get(4, true, false, true, 
+            {803, 803, 703, 0, 0});
         
-        // have less than 4 pages, grow:
-        wrap.To(5).Get(5, true, true, true, 
-            {7, 7, 4, 2, 0});
-        wrap.To(6).Fill({7, 8, 9}, 
-            {10, 10, 4, 2, 0});
+        wrap.To(10).Get(5, true, true, true, 
+            {803, 803, 753, 0, 0});
+        wrap.To(11).Fill({7, 8, 9},
+            {953, 953, 753, 0, 0});
     }
 
     Y_UNIT_TEST(Twice)

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -516,7 +516,9 @@ Y_UNIT_TEST_SUITE(NFwd_TLoadedPagesCircularBuffer){
             auto page = NFwd::TPage(pageId * 1, pageId * 10 + 1, pageId * 100, pageId * 1000);
             page.Data =  TSharedData::Copy(TString(page.Size, 'x'));
 
-            UNIT_ASSERT_VALUES_EQUAL(buffer.Emplace(page), pageId >= 5 ? (pageId - 5) * 10 + 1 : 0);
+            auto result = buffer.Emplace(page);
+            UNIT_ASSERT_VALUES_EQUAL(result.ReleasedPageId, pageId >= 5 ? (pageId - 5) : Max<TPageId>());
+            UNIT_ASSERT_VALUES_EQUAL(result.ReleasedSize, pageId >= 5 ? (pageId - 5) * 10 + 1 : 0);
 
             // has trace
             for (ui32 i = 0; i < Min(5u, pageId); i++) {

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -198,18 +198,14 @@ namespace {
             return *this;
         }
 
-        TCacheWrap& Forward(const TVector<ui32>& pageIndexes, NFwd::TStat stat)
+        TCacheWrap& Forward(const TVector<TPageId>& pageIds, NFwd::TStat stat)
         {
             if (std::exchange(Grow, false)) {
                 Cache->Forward(this, AheadHi);
             }
 
-            TVector<TPageId> pageIds(::Reserve(pageIndexes.size()));
-            for (auto pageIndex : pageIndexes) {
-                pageIds.push_back(IndexTools::GetPageId(*Part, pageIndex));
-            }
             UNIT_ASSERT_VALUES_EQUAL_C(TVector<TPageId>(Queue.begin(), Queue.end()), pageIds, CurrentStepStr());
-            
+        
             UNIT_ASSERT_VALUES_EQUAL_C(Cache->Stat, stat, CurrentStepStr());
 
             return *this;
@@ -526,13 +522,13 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
             .Col(0, 0,  NScheme::NTypeIds::Uint32)
             .Col(0, 1,  NScheme::NTypeIds::Uint32)
             .Key({0});
-        
+    
         TPartCook cook(lay, conf);
 
         for (ui32 i : xrange<ui32>(0, 40)) {
             cook.Add(*TSchemedCookRow(*lay).Col(i, i * 100));
         }
-        
+    
         TPartEggs eggs = cook.Finish();
 
         Cerr << DumpPart(*eggs.Lone(), 3) << Endl;
@@ -545,32 +541,32 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
-        wrap.To(2).Get(20, true, false, true, 
+        wrap.To(2).Get(20, true, false, true,
             {453, 453, 453, 0, 0});
 
-        wrap.To(3).Get(0, false, true, true, 
+        wrap.To(3).Get(0, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(4).Fill({0, 1, 2, 3, 4, 5, 6}, 
+        wrap.To(4).Fill({0, 1, 2, 3, 4, 5, 6},
             {803, 803, 503, 0, 0});
-        wrap.To(5).Get(0, true, false, true, 
+        wrap.To(5).Get(0, true, false, true,
             {803, 803, 503, 0, 0});
 
-        wrap.To(6).Get(1, true, false, true, 
+        wrap.To(6).Get(1, true, false, true,
             {803, 803, 553, 0, 0});
-        wrap.To(7).Get(2, true, false, true, 
+        wrap.To(7).Get(2, true, false, true,
             {803, 803, 603, 0, 0});
-        wrap.To(8).Get(3, true, false, true, 
+        wrap.To(8).Get(3, true, false, true,
             {803, 803, 653, 0, 0});
-        wrap.To(9).Get(4, true, false, true, 
+        wrap.To(9).Get(4, true, false, true,
             {803, 803, 703, 0, 0});
-        
-        wrap.To(10).Get(5, true, true, true, 
+    
+        wrap.To(10).Get(5, true, true, true,
             {803, 803, 753, 0, 0});
         wrap.To(11).Fill({7, 8, 9},
             {953, 953, 753, 0, 0});
@@ -581,33 +577,33 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Get(20, false, false, true, 
+        wrap.To(1).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(2).Fill({20}, 
+        wrap.To(2).Fill({20},
             {453, 453, 453, 0, 0});
-        wrap.To(3).Get(20, true, false, true, 
+        wrap.To(3).Get(20, true, false, true,
             {453, 453, 453, 0, 0});
-        wrap.To(4).Get(20, true, false, true, 
+        wrap.To(4).Get(20, true, false, true,
             {453, 453, 453, 0, 0});
 
-        wrap.To(5).Get(5, false, true, true, 
+        wrap.To(5).Get(5, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(6).Get(5, false, true, true, 
+        wrap.To(6).Get(5, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(7).Fill({5, 6, 7, 8, 9, 10, 11}, 
+        wrap.To(7).Fill({5, 6, 7, 8, 9, 10, 11},
             {803, 803, 503, 0, 0});
-        wrap.To(8).Get(5, true, false, true, 
+        wrap.To(8).Get(5, true, false, true,
             {803, 803, 503, 0, 0});
-        wrap.To(9).Get(5, true, false, true, 
+        wrap.To(9).Get(5, true, false, true,
             {803, 803, 503, 0, 0});
-        
-        wrap.To(10).Get(6, true, false, true, 
+    
+        wrap.To(10).Get(6, true, false, true,
             {803, 803, 553, 0, 0});
-        wrap.To(11).Get(6, true, false, true, 
+        wrap.To(11).Get(6, true, false, true,
             {803, 803, 553, 0, 0});
     }
 
@@ -616,19 +612,19 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(0, false, true, true, 
+        wrap.To(2).Get(0, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6}, 
+        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6},
             {803, 803, 503, 0, 0});
 
-        wrap.To(4).Get(5, true, true, true, 
+        wrap.To(4).Get(5, true, true, true,
             {803, 803, 553, 200, 0});
         wrap.To(5).Fill({7, 8, 9, 10},
             {1003, 1003, 553, 200, 0});
@@ -639,21 +635,21 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(0, false, true, true, 
+        wrap.To(2).Get(0, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6}, 
+        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6},
             {803, 803, 503, 0, 0});
 
-        wrap.To(4).Get(10, false, true, true, 
+        wrap.To(4).Get(10, false, true, true,
             {853, 803, 553, 300, 0});
-        wrap.To(5).Fill({10, 11, 12, 13, 14, 15}, 
+        wrap.To(5).Fill({10, 11, 12, 13, 14, 15},
             {1103, 1103, 553, 300, 0});
     }
 
@@ -662,17 +658,17 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(0, false, true, true, 
+        wrap.To(2).Get(0, false, true, true,
             {503, 453, 503, 0, 0});
 
-        wrap.To(3).Get(5, false, true, true, 
+        wrap.To(3).Get(5, false, true, true,
             {553, 453, 553, 0, 50});
         wrap.To(4).Fill({0, 5, 6, 7, 8, 9, 10},
             {803, 803, 553, 0, 50});
@@ -683,28 +679,28 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(0, false, true, true, 
+        wrap.To(2).Get(0, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(3).Forward({0, 1, 2, 3, 4, 5, 6}, 
+        wrap.To(3).Forward({0, 1, 2, 3, 4, 5, 6},
             {803, 453, 503, 0, 0});
 
         // page 0 drops keep, pages 1 - 6 drops wait
-        wrap.To(4).Get(10, false, false, true, 
+        wrap.To(4).Get(10, false, false, true,
             {853, 453, 553, 0, 350});
-        wrap.To(5).Fill({0, 1, 2, 3, 4, 5, 6, 10}, 
+        wrap.To(5).Fill({0, 1, 2, 3, 4, 5, 6, 10},
             {853, 853, 553, 0, 350});
-        
+    
         // ready to grow again:
-        wrap.To(6).Get(10, true, true, true, 
+        wrap.To(6).Get(10, true, true, true,
             {853, 853, 553, 0, 350});
-        wrap.To(7).Fill({11, 12, 13, 14, 15, 16}, 
+        wrap.To(7).Fill({11, 12, 13, 14, 15, 16},
             {1153, 1153, 553, 0, 350});
     }
 
@@ -713,44 +709,44 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(0, false, true, true, 
+        wrap.To(2).Get(0, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6}, 
+        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6},
             {803, 803, 503, 0, 0});
-        
+    
         // page 0 goes to trace:
-        wrap.To(4).Get(2, true, false, true, 
+        wrap.To(4).Get(2, true, false, true,
             {803, 803, 553, 50, 0});
 
         // page 2 goes to trace, page 1 drops:
-        wrap.To(5).Get(3, true, false, true, 
+        wrap.To(5).Get(3, true, false, true,
             {803, 803, 603, 50, 0});
-        
+    
         // trace: page 0, page 2:
-        wrap.To(6).Get(0, true, false, true, 
+        wrap.To(6).Get(0, true, false, true,
             {803, 803, 603, 50, 0});
-        wrap.To(7).Get(2, true, false, true, 
+        wrap.To(7).Get(2, true, false, true,
             {803, 803, 603, 50, 0});
-        wrap.To(8).Get(3, true, false, true, 
+        wrap.To(8).Get(3, true, false, true,
             {803, 803, 603, 50, 0});
 
         // page 3 goes to trace:
-        wrap.To(9).Get(4, true, false, true, 
+        wrap.To(9).Get(4, true, false, true,
             {803, 803, 653, 50, 0});
 
         // trace: page 2, page 3:
-        wrap.To(10).Get(2, true, false, true, 
+        wrap.To(10).Get(2, true, false, true,
             {803, 803, 653, 50, 0});
-        wrap.To(11).Get(3, true, false, true, 
+        wrap.To(11).Get(3, true, false, true,
             {803, 803, 653, 50, 0});
-        wrap.To(12).Get(4, true, false, true, 
+        wrap.To(12).Get(4, true, false, true,
             {803, 803, 653, 50, 0});
     }
 
@@ -759,22 +755,22 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(17, false, true, true, 
+        wrap.To(2).Get(17, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(3).Fill({17, 18, 19}, 
+        wrap.To(3).Fill({17, 18, 19},
             {603, 603, 503, 0, 0});
-        wrap.To(4).Get(17, true, false, true, 
+        wrap.To(4).Get(17, true, false, true,
             {603, 603, 503, 0, 0});
-        wrap.To(5).Get(18, true, false, true, 
+        wrap.To(5).Get(18, true, false, true,
             {603, 603, 553, 0, 0});
-        wrap.To(6).Get(19, true, false, true, 
+        wrap.To(6).Get(19, true, false, true,
             {603, 603, 603, 0, 0});
     }
 
@@ -789,20 +785,20 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
         slices->emplace_back(TSlice({ }, { }, 20, 23, true, true));
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, slices), 1000, 1000);
-        
+    
         // provide index page:
-        wrap.To(0).Get(20, false, false, true, 
+        wrap.To(0).Get(20, false, false, true,
             {453, 0, 453, 0, 0});
-        wrap.To(1).Fill({20}, 
+        wrap.To(1).Fill({20},
             {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(5, false, true, true, 
+        wrap.To(2).Get(5, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(3).Fill({5, 6, 7, 8, 9, 10, 11}, 
+        wrap.To(3).Fill({5, 6, 7, 8, 9, 10, 11},
             {803, 803, 503, 0, 0});
-        wrap.To(4).Get(10, true, false, true, 
+        wrap.To(4).Get(10, true, false, true,
             {803, 803, 553, 200, 0});
-        wrap.To(5).Get(11, true, false, true, 
+        wrap.To(5).Get(11, true, false, true,
             {803, 803, 603, 200, 0});
     }
 }
@@ -813,16 +809,16 @@ Y_UNIT_TEST_SUITE(NFwd_TBTreeIndexCache) {
     /**
      20 pages, 50 bytes each
      B-Tree index:
-        {
-            {
-                {0, 1, 2},
-                {3, 4, 5},
-                {6, 7, 8}
+        [28] {
+            [23] {
+                [6] {0, 1, 2},
+                [10] {3, 4, 5},
+                [14] {6, 7, 8}
             },
-            {
-                {9, 10, 11},
-                {12, 13, 14},
-                {15, 16, 17, 18, 19}
+            [27] {
+                [18] {9, 10, 11},
+                [22] {12, 13, 14},
+                [26] {15, 16, 17, 18, 19}
             }
         }
     */
@@ -840,13 +836,13 @@ Y_UNIT_TEST_SUITE(NFwd_TBTreeIndexCache) {
             .Col(0, 0,  NScheme::NTypeIds::Uint32)
             .Col(0, 1,  NScheme::NTypeIds::Uint32)
             .Key({0});
-        
+    
         TPartCook cook(lay, conf);
 
         for (ui32 i : xrange<ui32>(0, 40)) {
             cook.Add(*TSchemedCookRow(*lay).Col(i, i * 100));
         }
-        
+    
         TPartEggs eggs = cook.Finish();
 
         Cerr << DumpPart(*eggs.Lone(), 3) << Endl;
@@ -859,47 +855,435 @@ Y_UNIT_TEST_SUITE(NFwd_TBTreeIndexCache) {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
-        
+    
         // level 0:
-        wrap.To(0).Get(28, false, false, true, 
+        wrap.To(0).Get(28, false, false, true,
             {98, 0, 98, 0, 0});
-        wrap.To(1).Fill({28}, 
+        wrap.To(1).Fill({28},
             {98, 98, 98, 0, 0});
-        wrap.To(2).Get(28, true, false, true, 
+        wrap.To(2).Get(28, true, false, true,
             {98, 98, 98, 0, 0});
 
         // level 1:
-        wrap.To(3).Get(23, false, true, true, 
+        wrap.To(3).Get(23, false, true, true,
             {241, 98, 241, 0, 0});
-        wrap.To(4).Fill({23, 27}, 
+        wrap.To(4).Fill({23, 27},
             {384, 384, 241, 0, 0});
-        wrap.To(5).Get(23, true, false, true, 
+        wrap.To(5).Get(23, true, false, true,
             {384, 384, 241, 0, 0});
-        wrap.To(6).Get(27, true, false, true, 
-            {384, 384, 384, 0, 0});
 
-        return;
+        // level 2:
+        wrap.To(6).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(7).Fill({6, 10, 14, 18},
+            {956, 956, 384, 0, 0});
+        wrap.To(8).Get(6, true, false, true,
+            {956, 956, 384, 0, 0});
 
-        wrap.To(3).Get(0, false, true, true, 
+        // data pages:
+        wrap.To(9).Get(0, false, true, true,
+            {1006, 956, 434, 0, 0});
+        wrap.To(10).Fill({0, 1, 2, 3, 4, 5, 7},
+            {1306, 1306, 434, 0, 0});
+        wrap.To(11).Get(0, true, false, true,
+            {1306, 1306, 434, 0, 0});
+
+        wrap.To(12).Get(1, true, false, true,
+            {1306, 1306, 484, 0, 0});
+        wrap.To(13).Get(2, true, false, true,
+            {1306, 1306, 534, 0, 0});
+
+        wrap.To(14).Get(10, true, false, true,
+            {1306, 1306, 677, 0, 0});
+        wrap.To(15).Get(3, true, false, true,
+            {1306, 1306, 727, 0, 0});
+        wrap.To(16).Get(4, true, false, true,
+            {1306, 1306, 777, 0, 0});
+    
+        wrap.To(17).Get(5, true, true, true,
+            {1306, 1306, 827, 0, 0});
+        wrap.To(18).Fill({22, 8, 9, 11},
+            {1599, 1599, 827, 0, 0});
+    }
+
+    Y_UNIT_TEST(GetTwice)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(2).Fill({28},
+            {98, 98, 98, 0, 0});
+        wrap.To(3).Get(28, true, false, true,
+            {98, 98, 98, 0, 0});
+        wrap.To(4).Get(28, true, false, true,
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(5).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(6).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(7).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+        wrap.To(8).Get(23, true, false, true,
+            {384, 384, 241, 0, 0});
+        wrap.To(9).Get(23, true, false, true,
+            {384, 384, 241, 0, 0});
+    }
+
+    Y_UNIT_TEST(Forward_OnlyUsed)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(2).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(3).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(4).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(5).Fill({6, 10, 14, 18},
+            {956, 956, 384, 0, 0});
+
+        wrap.To(6).Get(10, true, false, true,
+            {956, 956, 527, 0, 0});
+        wrap.To(7).Get(14, true, true, true,
+            {956, 956, 670, 0, 0});
+        wrap.To(8).Fill({22, 26},
+            {1332, 1332, 670, 0, 0});
+
+        // data pages:
+        wrap.To(9).Get(4, false, true, true,
+            {1382, 1332, 720, 0, 0});
+        wrap.To(10).Fill({4, 5, 7, 8, 9, 11, 12},
+            {1682, 1682, 720, 0, 0});
+    }
+
+    Y_UNIT_TEST(Skip_Done)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(2).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(3).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(4).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(5).Fill({6, 10, 14, 18},
+            {956, 956, 384, 0, 0});
+
+        wrap.To(6).Get(14, true, true, true,
+            {956, 956, 527, 143, 0});
+        wrap.To(7).Fill({22, 26},
+            {1332, 1332, 527, 143, 0});
+    }
+
+    Y_UNIT_TEST(Skip_Done_None)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(2).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(3).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(4).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(5).Fill({6, 10, 14, 18},
+            {956, 956, 384, 0, 0});
+
+        wrap.To(6).Get(26, false, false, true,
+            {1189, 956, 617, 429, 0});
+        wrap.To(7).Fill({26},
+            {1189, 1189, 617, 429, 0});
+    }
+
+    Y_UNIT_TEST(Skip_Keep)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(2).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(3).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(4).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+
+        wrap.To(6).Get(22, false, true, true,
+            {670, 384, 527, 0, 143});
+        wrap.To(7).Fill({6, 22},
+            {670, 670, 527, 0, 143});
+
+        wrap.To(8).Get(22, true, true, true,
+            {670, 670, 527, 0, 143});
+        wrap.To(9).Fill({26},
+            {903, 903, 527, 0, 143});
+    }
+
+    Y_UNIT_TEST(Skip_Wait)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(2).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(3).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(4).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(5).Forward({6, 10, 14, 18},
+            {956, 384, 384, 0, 0});
+
+        wrap.To(6).Get(26, false, false, true,
+            {1189, 384, 617, 0, 572});
+        wrap.To(7).Fill({6, 10, 14, 18, 26},
+            {1189, 1189, 617, 0, 572});
+    }
+
+    Y_UNIT_TEST(Trace_BTree)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+        wrap.To(2).Get(28, true, false, true,
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(3).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(4).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+        wrap.To(5).Get(23, true, false, true,
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(6).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(7).Fill({6, 10, 14, 18},
+            {956, 956, 384, 0, 0});
+        wrap.To(8).Get(6, true, false, true,
+            {956, 956, 384, 0, 0});
+        wrap.To(9).Get(14, true, true, true,
+            {956, 956, 527, 143, 0});
+        wrap.To(10).Get(18, true, true, true,
+            {956, 956, 670, 143, 0});
+        wrap.To(11).Get(6, true, false, true,
+            {956, 956, 670, 143, 0});
+        wrap.To(12).Get(14, true, false, true,
+            {956, 956, 670, 143, 0});
+        wrap.To(13).Get(18, true, true, true,
+            {956, 956, 670, 143, 0});
+
+        wrap.To(14).Fill({22, 26},
+            {1332, 1332, 670, 143, 0});
+        wrap.To(15).Get(22, true, false, true,
+            {1332, 1332, 813, 143, 0});
+        wrap.To(16).Get(14, true, false, true,
+            {1332, 1332, 813, 143, 0});
+        wrap.To(17).Get(18, true, false, true,
+            {1332, 1332, 813, 143, 0});
+    }
+
+    Y_UNIT_TEST(Trace_Data)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(2).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(3).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(4).Get(6, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(5).Fill({6, 10, 14, 18},
+            {956, 956, 384, 0, 0});
+
+        // data pages:
+        wrap.To(6).Get(0, false, true, true,
+            {1006, 956, 434, 0, 0});
+        wrap.To(7).Fill({0, 1, 2, 3, 4, 5, 7},
+            {1306, 1306, 434, 0, 0});
+    
+        // page 0 goes to trace:
+        wrap.To(8).Get(2, true, false, true,
+            {1306, 1306, 484, 50, 0});
+
+        // page 2 goes to trace, page 1 drops:
+        wrap.To(9).Get(3, true, false, true,
+            {1306, 1306, 534, 50, 0});
+    
+        // trace: page 0, page 2:
+        wrap.To(10).Get(0, true, false, true,
+            {1306, 1306, 534, 50, 0});
+        wrap.To(11).Get(2, true, false, true,
+            {1306, 1306, 534, 50, 0});
+        wrap.To(12).Get(3, true, false, true,
+            {1306, 1306, 534, 50, 0});
+
+        // page 3 goes to trace:
+        wrap.To(13).Get(4, true, false, true,
+            {1306, 1306, 584, 50, 0});
+
+        // trace: page 2, page 3:
+        wrap.To(14).Get(2, true, false, true,
+            {1306, 1306, 584, 50, 0});
+        wrap.To(15).Get(3, true, false, true,
+            {1306, 1306, 584, 50, 0});
+        wrap.To(16).Get(4, true, false, true,
+            {1306, 1306, 584, 50, 0});
+    }
+
+    Y_UNIT_TEST(End)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+        wrap.To(2).Get(28, true, false, true,
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(3).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(4).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(6).Get(22, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(7).Fill({22, 26},
+            {760, 760, 384, 0, 0});
+        wrap.To(8).Get(26, true, false, true,
+            {760, 760, 617, 0, 0});
+
+        // data pages:
+        wrap.To(9).Get(24, false, true, true,
+            {810, 760, 667, 0, 0});
+        wrap.To(10).Fill({24, 25},
+            {860, 860, 667, 0, 0});
+        wrap.To(11).Get(25, true, false, true,
+            {860, 860, 717, 0, 0});
+    }
+
+    Y_UNIT_TEST(Slices)
+    {
+        const auto eggs = CookPart();
+
+        TIntrusivePtr<TSlices> slices = new TSlices;
+        // pages 5 - 8
+        slices->emplace_back(TSlice({ }, { }, 10, 16, true, false));
+        // pages 12 - 13
+        slices->emplace_back(TSlice({ }, { }, 20, 23, true, true));
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, slices), 1000, 1000);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(1).Fill({28},
+            {98, 98, 98, 0, 0});
+        wrap.To(2).Get(28, true, false, true,
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(3).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(4).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+
+        // level 2:
+        wrap.To(6).Get(10, false, true, true,
+            {527, 384, 384, 0, 0});
+        wrap.To(7).Fill({10, 14, 18},
+            {760, 760, 384, 0, 0});
+
+        wrap.To(8).Get(5, false, true, true,
             {503, 453, 503, 0, 0});
-        wrap.To(4).Fill({0, 1, 2, 3, 4, 5, 6}, 
+        wrap.To(9).Fill({5, 7, 8, 9, 11, 12, 13},
             {803, 803, 503, 0, 0});
-        wrap.To(5).Get(0, true, false, true, 
-            {803, 803, 503, 0, 0});
-
-        wrap.To(6).Get(1, true, false, true, 
-            {803, 803, 553, 0, 0});
-        wrap.To(7).Get(2, true, false, true, 
-            {803, 803, 603, 0, 0});
-        wrap.To(8).Get(3, true, false, true, 
-            {803, 803, 653, 0, 0});
-        wrap.To(9).Get(4, true, false, true, 
-            {803, 803, 703, 0, 0});
-        
-        wrap.To(10).Get(5, true, true, true, 
-            {803, 803, 753, 0, 0});
-        wrap.To(11).Fill({7, 8, 9},
-            {953, 953, 753, 0, 0});
+        wrap.To(10).Get(12, true, false, true,
+            {803, 803, 553, 200, 0});
+        wrap.To(11).Get(13, true, false, true,
+            {803, 803, 603, 200, 0});
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -576,87 +576,136 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
             {953, 953, 753, 0, 0});
     }
 
-    Y_UNIT_TEST(Twice)
+    Y_UNIT_TEST(GetTwice)
     {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
         
-        wrap.To(0).Get(5, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(1).Get(5, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(2).Fill({5, 6, 7, 8, 9, 10, 11}, 
-            {7, 7, 1, 0, 0});
-        
-        wrap.To(3).Get(5, true, false, true, 
-            {7, 7, 1, 0, 0});
-        wrap.To(4).Get(5, true, false, true, 
-            {7, 7, 1, 0, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(2).Fill({20}, 
+            {453, 453, 453, 0, 0});
+        wrap.To(3).Get(20, true, false, true, 
+            {453, 453, 453, 0, 0});
+        wrap.To(4).Get(20, true, false, true, 
+            {453, 453, 453, 0, 0});
 
-        wrap.To(5).Get(6, true, false, true, 
-            {7, 7, 2, 0, 0});
-        wrap.To(6).Get(6, true, false, true, 
-            {7, 7, 2, 0, 0});
+        wrap.To(5).Get(5, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(6).Get(5, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(7).Fill({5, 6, 7, 8, 9, 10, 11}, 
+            {803, 803, 503, 0, 0});
+        wrap.To(8).Get(5, true, false, true, 
+            {803, 803, 503, 0, 0});
+        wrap.To(9).Get(5, true, false, true, 
+            {803, 803, 503, 0, 0});
+        
+        wrap.To(10).Get(6, true, false, true, 
+            {803, 803, 553, 0, 0});
+        wrap.To(11).Get(6, true, false, true, 
+            {803, 803, 553, 0, 0});
     }
 
-    Y_UNIT_TEST(Jump_Done)
+    Y_UNIT_TEST(Skip_Done)
     {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
         
-        wrap.To(0).Get(0, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(1).Fill({0, 1, 2, 3, 4, 5, 6}, 
-            {7, 7, 1, 0, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
 
-        wrap.To(2).Get(10, false, true, true, 
-            {8, 7, 2, 6, 0});
-        wrap.To(3).Fill({10, 11, 12, 13, 14, 15}, 
-            {13, 13, 2, 6, 0});
+        wrap.To(2).Get(0, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6}, 
+            {803, 803, 503, 0, 0});
+
+        wrap.To(4).Get(5, true, true, true, 
+            {803, 803, 553, 200, 0});
+        wrap.To(5).Fill({7, 8, 9, 10},
+            {1003, 1003, 553, 200, 0});
     }
 
-    Y_UNIT_TEST(Jump_Keep)
+    Y_UNIT_TEST(Skip_Done_None)
     {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
         
-        wrap.To(0).Get(0, false, true, true, 
-            {1, 0, 1, 0, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
 
-        // page 0 drops keep
-        wrap.To(1).Get(10, false, true, true, 
-            {2, 0, 2, 0, 1});
+        wrap.To(2).Get(0, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6}, 
+            {803, 803, 503, 0, 0});
 
-        wrap.To(2).Fill({0, 10, 11, 12, 13, 14, 15}, 
-            {7, 7, 2, 0, 1});
+        wrap.To(4).Get(10, false, true, true, 
+            {853, 803, 553, 300, 0});
+        wrap.To(5).Fill({10, 11, 12, 13, 14, 15}, 
+            {1103, 1103, 553, 300, 0});
     }
 
-    Y_UNIT_TEST(Jump_Wait)
+    Y_UNIT_TEST(Skip_Keep)
     {
         const auto eggs = CookPart();
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
         
-        wrap.To(0).Get(0, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(1).Forward({0, 1, 2, 3, 4, 5, 6}, 
-            {7, 0, 1, 0, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
+
+        wrap.To(2).Get(0, false, true, true, 
+            {503, 453, 503, 0, 0});
+
+        wrap.To(3).Get(5, false, true, true, 
+            {553, 453, 553, 0, 50});
+        wrap.To(4).Fill({0, 5, 6, 7, 8, 9, 10},
+            {803, 803, 553, 0, 50});
+    }
+
+    Y_UNIT_TEST(Skip_Wait)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
+        
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
+
+        wrap.To(2).Get(0, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(3).Forward({0, 1, 2, 3, 4, 5, 6}, 
+            {803, 453, 503, 0, 0});
 
         // page 0 drops keep, pages 1 - 6 drops wait
-        wrap.To(2).Get(10, false, false, true, 
-            {8, 0, 2, 0, 7});
-
-        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6, 10}, 
-            {8, 8, 2, 0, 7});
-
+        wrap.To(4).Get(10, false, false, true, 
+            {853, 453, 553, 0, 350});
+        wrap.To(5).Fill({0, 1, 2, 3, 4, 5, 6, 10}, 
+            {853, 853, 553, 0, 350});
+        
         // ready to grow again:
-        wrap.To(4).Get(10, true, true, true, 
-            {8, 8, 2, 0, 7});
-        wrap.To(5).Fill({11, 12, 13, 14, 15, 16}, 
-            {14, 14, 2, 0, 7});
+        wrap.To(6).Get(10, true, true, true, 
+            {853, 853, 553, 0, 350});
+        wrap.To(7).Fill({11, 12, 13, 14, 15, 16}, 
+            {1153, 1153, 553, 0, 350});
     }
 
     Y_UNIT_TEST(Trace)
@@ -665,38 +714,44 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
         
-        wrap.To(0).Get(0, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(1).Fill({0, 1, 2, 3, 4, 5, 6}, 
-            {7, 7, 1, 0, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
+
+        wrap.To(2).Get(0, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(3).Fill({0, 1, 2, 3, 4, 5, 6}, 
+            {803, 803, 503, 0, 0});
         
         // page 0 goes to trace:
-        wrap.To(2).Get(2, true, false, true, 
-            {7, 7, 2, 1, 0});
+        wrap.To(4).Get(2, true, false, true, 
+            {803, 803, 553, 50, 0});
 
         // page 2 goes to trace, page 1 drops:
-        wrap.To(3).Get(3, true, false, true, 
-            {7, 7, 3, 1, 0});
+        wrap.To(5).Get(3, true, false, true, 
+            {803, 803, 603, 50, 0});
         
         // trace: page 0, page 2:
-        wrap.To(4).Get(0, true, false, true, 
-            {7, 7, 3, 1, 0});
-        wrap.To(5).Get(2, true, false, true, 
-            {7, 7, 3, 1, 0});
-        wrap.To(6).Get(3, true, false, true, 
-            {7, 7, 3, 1, 0});
+        wrap.To(6).Get(0, true, false, true, 
+            {803, 803, 603, 50, 0});
+        wrap.To(7).Get(2, true, false, true, 
+            {803, 803, 603, 50, 0});
+        wrap.To(8).Get(3, true, false, true, 
+            {803, 803, 603, 50, 0});
 
         // page 3 goes to trace:
-        wrap.To(7).Get(4, true, false, true, 
-            {7, 7, 4, 1, 0});
+        wrap.To(9).Get(4, true, false, true, 
+            {803, 803, 653, 50, 0});
 
         // trace: page 2, page 3:
-        wrap.To(8).Get(2, true, false, true, 
-            {7, 7, 4, 1, 0});
-        wrap.To(9).Get(3, true, false, true, 
-            {7, 7, 4, 1, 0});
-        wrap.To(10).Get(4, true, false, true, 
-            {7, 7, 4, 1, 0});
+        wrap.To(10).Get(2, true, false, true, 
+            {803, 803, 653, 50, 0});
+        wrap.To(11).Get(3, true, false, true, 
+            {803, 803, 653, 50, 0});
+        wrap.To(12).Get(4, true, false, true, 
+            {803, 803, 653, 50, 0});
     }
 
     Y_UNIT_TEST(End)
@@ -705,16 +760,22 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, nullptr), 200, 350);
         
-        wrap.To(0).Get(17, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(1).Fill({17, 18, 19}, 
-            {3, 3, 1, 0, 0});
-        wrap.To(2).Get(17, true, false, true, 
-            {3, 3, 1, 0, 0});
-        wrap.To(3).Get(18, true, false, true, 
-            {3, 3, 2, 0, 0});
-        wrap.To(4).Get(19, true, false, true, 
-            {3, 3, 3, 0, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
+
+        wrap.To(2).Get(17, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(3).Fill({17, 18, 19}, 
+            {603, 603, 503, 0, 0});
+        wrap.To(4).Get(17, true, false, true, 
+            {603, 603, 503, 0, 0});
+        wrap.To(5).Get(18, true, false, true, 
+            {603, 603, 553, 0, 0});
+        wrap.To(6).Get(19, true, false, true, 
+            {603, 603, 603, 0, 0});
     }
 
     Y_UNIT_TEST(Slices)
@@ -729,14 +790,20 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
 
         TCacheWrap wrap(eggs.Lone(), CreateCache(&*eggs.Lone(), {}, slices), 1000, 1000);
         
-        wrap.To(0).Get(5, false, true, true, 
-            {1, 0, 1, 0, 0});
-        wrap.To(1).Fill({5, 6, 7, 8, 9, 10, 11}, 
-            {7, 7, 1, 0, 0});
-        wrap.To(2).Get(10, true, false, true, 
-            {7, 7, 2, 4, 0});
-        wrap.To(3).Get(11, true, false, true, 
-            {7, 7, 3, 4, 0});
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true, 
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20}, 
+            {453, 453, 453, 0, 0});
+
+        wrap.To(2).Get(5, false, true, true, 
+            {503, 453, 503, 0, 0});
+        wrap.To(3).Fill({5, 6, 7, 8, 9, 10, 11}, 
+            {803, 803, 503, 0, 0});
+        wrap.To(4).Get(10, true, false, true, 
+            {803, 803, 553, 200, 0});
+        wrap.To(5).Get(11, true, false, true, 
+            {803, 803, 603, 200, 0});
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -704,15 +704,19 @@ Y_UNIT_TEST_SUITE(NFwd_TCache) {
             {7, 7, 3, 1, 0});
         wrap.To(5).Get(2, true, false, true, 
             {7, 7, 3, 1, 0});
+        wrap.To(6).Get(3, true, false, true, 
+            {7, 7, 3, 1, 0});
 
         // page 3 goes to trace:
-        wrap.To(6).Get(4, true, false, true, 
+        wrap.To(7).Get(4, true, false, true, 
             {7, 7, 4, 1, 0});
 
         // trace: page 2, page 3:
-        wrap.To(7).Get(2, true, false, true, 
+        wrap.To(8).Get(2, true, false, true, 
             {7, 7, 4, 1, 0});
-        wrap.To(8).Get(3, true, false, true, 
+        wrap.To(9).Get(3, true, false, true, 
+            {7, 7, 4, 1, 0});
+        wrap.To(10).Get(4, true, false, true, 
             {7, 7, 4, 1, 0});
     }
 

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -265,9 +265,9 @@ namespace {
         TAutoPtr<NFwd::IPageLoadingLogic> Cache;
         const ui64 AheadLo;
         const ui64 AheadHi;
+        bool Grow = false;
 
     private:
-        bool Grow = false;
         TDeque<TPageId> Queue;
         TMersenne<ui64> Rnd;
     };
@@ -679,6 +679,27 @@ Y_UNIT_TEST_SUITE(NFwd_TFlatIndexCache) {
             {803, 803, 553, 0, 0});
     }
 
+    Y_UNIT_TEST(ForwardTwice)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), nullptr, 200, 350);
+    
+        // provide index page:
+        wrap.To(0).Get(20, false, false, true,
+            {453, 0, 453, 0, 0});
+        wrap.To(1).Fill({20},
+            {453, 453, 453, 0, 0});
+        
+        wrap.To(2).Get(5, false, true, true,
+            {503, 453, 503, 0, 0});
+        wrap.To(3).Fill({5, 6, 7, 8, 9, 10, 11},
+            {803, 803, 503, 0, 0});
+        wrap.Grow = true;
+        wrap.To(4).Fill({},
+            {803, 803, 503, 0, 0});
+    }
+
     Y_UNIT_TEST(Skip_Done)
     {
         const auto eggs = CookPart();
@@ -1056,6 +1077,31 @@ Y_UNIT_TEST_SUITE(NFwd_TBTreeIndexCache) {
         wrap.To(8).Get(23, true, false, true,
             {384, 384, 241, 0, 0});
         wrap.To(9).Get(23, true, false, true,
+            {384, 384, 241, 0, 0});
+    }
+
+    Y_UNIT_TEST(ForwardTwice)
+    {
+        const auto eggs = CookPart();
+
+        TCacheWrap wrap(eggs.Lone(), nullptr, 200, 350);
+    
+        // level 0:
+        wrap.To(0).Get(28, false, false, true,
+            {98, 0, 98, 0, 0});
+        wrap.To(2).Fill({28},
+            {98, 98, 98, 0, 0});
+        wrap.Grow = true;
+        wrap.To(2).Fill({},
+            {98, 98, 98, 0, 0});
+
+        // level 1:
+        wrap.To(5).Get(23, false, true, true,
+            {241, 98, 241, 0, 0});
+        wrap.To(7).Fill({23, 27},
+            {384, 384, 241, 0, 0});
+        wrap.Grow = true;
+        wrap.To(7).Fill({},
             {384, 384, 241, 0, 0});
     }
 

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -58,14 +58,14 @@ namespace {
     }
 
     struct TTouchEnv : public NTest::TTestEnv {
-        const TSharedData* TryGetPage(const TPart *part, TPageId id, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
         {
             if (PrechargePhase) {
-                Precharged[groupId].insert(id);
-                return NTest::TTestEnv::TryGetPage(part, id, groupId);
+                Precharged[groupId].insert(pageId);
+                return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             } else {
-                Y_VERIFY_S(Precharged[groupId].count(id), "Requested page " << id << " should be precharged");
-                return NTest::TTestEnv::TryGetPage(part, id, groupId);
+                Y_VERIFY_S(Precharged[groupId].count(pageId), "Requested page " << pageId << " should be precharged");
+                return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             }
         }
 

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -11,11 +11,11 @@ namespace {
     using namespace NTest;
 
     struct TTouchEnv : public NTest::TTestEnv {
-        const TSharedData* TryGetPage(const TPart *part, TPageId id, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, TPageId pageId, TGroupId groupId) override
         {
-            UNIT_ASSERT_C(part->GetPageType(id) == EPage::FlatIndex || part->GetPageType(id) == EPage::BTreeIndex, "Shouldn't request non-index pages");
-            if (!Touched[groupId].insert(id).second) {
-                return NTest::TTestEnv::TryGetPage(part, id, groupId);
+            UNIT_ASSERT_C(part->GetPageType(pageId, groupId) == EPage::FlatIndex || part->GetPageType(pageId, groupId) == EPage::BTreeIndex, "Shouldn't request non-index pages");
+            if (!Touched[groupId].insert(pageId).second) {
+                return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             }
             return nullptr;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Test compaction of one 2GB data shard

## Before

### Flat index

~ 12 seconds, 35 page faults, 1688MB

```
2024-04-18T11:48:00.800016Z :TABLET_OPS_HOST INFO: Scan{115 on 1001, Compact{72075186224039004.1.3055, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{11.92s wa 1.220s cnt 35}, trace 0 of 0 ~2p
2024-04-18T11:49:39.472116Z :TABLET_OPS_HOST INFO: Scan{119 on 1001, Compact{72075186224039004.1.3061, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{12.07s wa 1.223s cnt 35}, trace 0 of 0 ~2p
2024-04-18T11:51:20.888970Z :TABLET_OPS_HOST INFO: Scan{123 on 1001, Compact{72075186224039004.1.3067, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{11.95s wa 1.234s cnt 35}, trace 0 of 0 ~2p
2024-04-18T11:51:47.293482Z :TABLET_OPS_HOST INFO: Scan{127 on 1001, Compact{72075186224039004.1.3073, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{11.99s wa 1.238s cnt 35}, trace 0 of 0 ~2p
```

### B-Tree index

~ 17 seconds, 2454 page faults, 1688MB

```
2024-04-18T12:13:48.291778Z :TABLET_OPS_HOST INFO: Scan{7 on 1001, Compact{72075186224039004.3.15, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{17.16s wa 5.740s cnt 2454}, trace 0 of 0 ~2p
2024-04-18T12:14:58.225943Z :TABLET_OPS_HOST INFO: Scan{11 on 1001, Compact{72075186224039004.3.21, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{17.11s wa 5.932s cnt 2454}, trace 0 of 0 ~2p
2024-04-18T12:15:19.227512Z :TABLET_OPS_HOST INFO: Scan{15 on 1001, Compact{72075186224039004.3.27, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{16.86s wa 5.696s cnt 2454}, trace 0 of 0 ~2p
2024-04-18T12:17:04.478667Z :TABLET_OPS_HOST INFO: Scan{19 on 1001, Compact{72075186224039004.3.33, eph -1}} end=0, 27540000r seen, TFwd{fetch=1686739986,saved=1686739986,usage=1686739986,after=0,before=0}, bio Spent{17.36s wa 6.127s cnt 2454}, trace 0 of 0 ~2p
```

## After

### Flat index

~ 12 seconds, 35 page faults, 1701MB

```
2024-04-22T16:25:40.952003Z :TABLET_OPS_HOST INFO: Scan{11 on 1001, Compact{72075186224039004.5.21, eph -1}} end=0, 27540000r seen, TFwd{fetch=1701139363,saved=1701139363,usage=1701139363,after=0,before=0}, bio Spent{12.29s wa 1.330s cnt 35}, trace 0 of 0 ~2p
2024-04-22T16:26:09.268323Z :TABLET_OPS_HOST INFO: Scan{15 on 1001, Compact{72075186224039004.5.27, eph -1}} end=0, 27540000r seen, TFwd{fetch=1701139363,saved=1701139363,usage=1701139363,after=0,before=0}, bio Spent{12.23s wa 1.310s cnt 35}, trace 0 of 0 ~2p
2024-04-22T16:26:25.237104Z :TABLET_OPS_HOST INFO: Scan{19 on 1001, Compact{72075186224039004.5.33, eph -1}} end=0, 27540000r seen, TFwd{fetch=1701139363,saved=1701139363,usage=1701139363,after=0,before=0}, bio Spent{12.17s wa 1.304s cnt 35}, trace 0 of 0 ~2p
2024-04-22T16:26:40.785619Z :TABLET_OPS_HOST INFO: Scan{23 on 1001, Compact{72075186224039004.5.39, eph -1}} end=0, 27540000r seen, TFwd{fetch=1701139363,saved=1701139363,usage=1701139363,after=0,before=0}, bio Spent{12.17s wa 1.300s cnt 35}, trace 0 of 0 ~2p
```

### B-Tree index

~ 12 seconds, 74 page faults, 1704MB

```

2024-04-22T17:33:10.082850Z :TABLET_OPS_HOST INFO: Scan{11 on 1001, Compact{72075186224039004.7.21, eph -1}} end=0, 27540000r seen, TFwd{fetch=1704417646,saved=1704417646,usage=1704417646,after=0,before=0}, bio Spent{12.41s wa 1.372s cnt 74}, trace 0 of 0 ~2p
2024-04-22T17:33:26.388969Z :TABLET_OPS_HOST INFO: Scan{15 on 1001, Compact{72075186224039004.7.27, eph -1}} end=0, 27540000r seen, TFwd{fetch=1704417646,saved=1704417646,usage=1704417646,after=0,before=0}, bio Spent{12.44s wa 1.422s cnt 74}, trace 0 of 0 ~2p
2024-04-22T17:33:54.341521Z :TABLET_OPS_HOST INFO: Scan{19 on 1001, Compact{72075186224039004.7.33, eph -1}} end=0, 27540000r seen, TFwd{fetch=1704417646,saved=1704417646,usage=1704417646,after=0,before=0}, bio Spent{12.31s wa 1.339s cnt 74}, trace 0 of 0 ~2p
2024-04-22T17:34:13.686515Z :TABLET_OPS_HOST INFO: Scan{23 on 1001, Compact{72075186224039004.7.39, eph -1}} end=0, 27540000r seen, TFwd{fetch=1704417646,saved=1704417646,usage=1704417646,after=0,before=0}, bio Spent{12.43s wa 1.424s cnt 74}, trace 0 of 0 ~2p
```
