### PR TITLE
YQL-18192: fix crash in WalkFolders with failed RANGE

### DIFF
--- a/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
@@ -537,7 +537,7 @@ public:
         CanonizeFuture_ = {};
         CanonizationRangesFoldersFuture_ = {};
 
-        if (!PendingWalkFolders_.empty()) {
+        if (status == TStatus::Ok && !PendingWalkFolders_.empty()) {
             const auto walkFoldersStatus = RewriteWalkFoldersOnAsyncOrEvalChanges(output, ctx);
             if (walkFoldersStatus != TStatus::Ok) {
                 return walkFoldersStatus;

--- a/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_io_discovery.cpp
@@ -539,9 +539,7 @@ public:
 
         if (status == TStatus::Ok && !PendingWalkFolders_.empty()) {
             const auto walkFoldersStatus = RewriteWalkFoldersOnAsyncOrEvalChanges(output, ctx);
-            if (walkFoldersStatus != TStatus::Ok) {
-                return walkFoldersStatus;
-            }
+            return walkFoldersStatus;
         }
 
         YQL_CLOG(INFO, ProviderYt) << "YtIODiscovery DoApplyAsyncChanges - finish";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Example of a crashing query:
```
USE hahn;

$postHandler = ($nodes, $state, $level) -> {
    $subfolders = ListFilter($nodes, ($x)->($x.Type = "map_node"));
    return ListExtend($state, ListExtract($subfolders, "Path"));
};

$tables = SELECT State FROM WalkFolders(`//home`, $postHandler AS PostHandler);
SELECT $tables;

select * from RANGE("//non_existent_path");
```

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Test is included in yql/tests/walk_folders
