### PR TITLE
lower priority for node that previously failed to start the tablet

### DIFF
--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -206,12 +206,18 @@ bool TNodeInfo::IsAllowedToRunTablet(const TTabletInfo& tablet, TTabletDebugStat
 }
 
 i32 TNodeInfo::GetPriorityForTablet(const TTabletInfo& tablet) const {
+    i32 priority = 0;
+
     auto it = TabletAvailability.find(tablet.GetTabletType());
-    if (it == TabletAvailability.end()) {
-        return 0;
+    if (it != TabletAvailability.end()) {
+        priority = it->second.FromLocal.GetPriority();
     }
 
-    return it->second.FromLocal.GetPriority();
+    if (tablet.FailedNodeId == Id) {
+        --priority;
+    }
+
+    return priority;
 }
 
 bool TNodeInfo::IsAbleToRunTablet(const TTabletInfo& tablet, TTabletDebugState* debugState) const {

--- a/ydb/core/mind/hive/tablet_info.h
+++ b/ydb/core/mind/hive/tablet_info.h
@@ -161,6 +161,7 @@ public:
     mutable TString BootState;
     TInstant PostponedStart;
     EBalancerPolicy BalancerPolicy;
+    TNodeId FailedNodeId = 0; // last time we tried to start the tablet, we failed on this node
 
     TTabletInfo(ETabletRole role, THive& hive);
     TTabletInfo(const TTabletInfo&) = delete;

--- a/ydb/core/mind/hive/tx__update_tablet_status.cpp
+++ b/ydb/core/mind/hive/tx__update_tablet_status.cpp
@@ -33,7 +33,7 @@ public:
 
     TTxType GetTxType() const override { return NHive::TXTYPE_UPDATE_TABLET_STATUS; }
 
-    bool IsGoodStatusForPostpone() const {
+    bool IsGoodStatusForPenalties() const {
         switch (Status) {
             case TEvLocal::TEvTabletStatus::StatusBootFailed:
                 switch (Reason) {
@@ -123,6 +123,7 @@ public:
                 }
                 tablet->ActorsToNotify.clear();
                 db.Table<Schema::Tablet>().Key(TabletId).UpdateToNull<Schema::Tablet::ActorsToNotify>();
+                tablet->FailedNodeId = 0;
             } else {
                 if (Local) {
                     SideEffects.Send(Local, new TEvLocal::TEvDeadTabletAck(std::make_pair(TabletId, FollowerId), Generation));
@@ -133,7 +134,7 @@ public:
                         return true;
                     }
                     if (leader.GetRestartsPerPeriod(now - Self->GetTabletRestartsPeriod()) >= Self->GetTabletRestartsMaxCount()) {
-                        if (IsGoodStatusForPostpone()) {
+                        if (IsGoodStatusForPenalties()) {
                             leader.PostponeStart(now + Self->GetPostponeStartPeriod());
                             BLOG_D("THive::TTxUpdateTabletStatus::Execute for tablet " << tablet->ToString()
                                 << " postponed start until " << leader.PostponedStart);
@@ -154,6 +155,9 @@ public:
                                         NIceDb::TUpdate<Schema::TabletFollowerTablet::Statistics>(tablet->Statistics));
                         }
                         tablet->InitiateStop(SideEffects);
+                    }
+                    if (IsGoodStatusForPenalties()) {
+                        tablet->FailedNodeId = Local.NodeId();
                     }
                 }
                 switch (tablet->GetLeader().State) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

no longer indefinitely try to start a tablet on the same node when it fails to start

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
