### PR TITLE
Make PDisk management declarative in NodeWarden

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -215,7 +215,7 @@ void TNodeWarden::Bootstrap() {
     if (Cfg->BlobStorageConfig.HasServiceSet()) {
         const auto& serviceSet = Cfg->BlobStorageConfig.GetServiceSet();
         if (serviceSet.GroupsSize()) {
-            ApplyServiceSet(Cfg->BlobStorageConfig.GetServiceSet(), true, false, false);
+            ApplyServiceSet(Cfg->BlobStorageConfig.GetServiceSet(), true, false, false, "initial");
         } else {
             Groups.try_emplace(0); // group is gonna be configured soon by DistributedConfigKeeper
         }
@@ -272,7 +272,7 @@ void TNodeWarden::HandleReadCache() {
                     InstanceId.emplace(proto.GetInstanceId());
                 }
 
-                ApplyServiceSet(proto.GetServiceSet(), false, false, false);
+                ApplyServiceSet(proto.GetServiceSet(), false, false, false, "cache");
             } catch (...) {
                 STLOG(PRI_INFO, BS_NODE, NW16, "Bootstrap failed to fetch cache", (Error, CurrentExceptionMessage()));
                 // ignore exception
@@ -360,7 +360,7 @@ void TNodeWarden::Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpdate::TPtr
         const bool comprehensive = record.GetComprehensive();
         IgnoreCache |= comprehensive;
         STLOG(PRI_DEBUG, BS_NODE, NW17, "Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpdate)", (Msg, record));
-        ApplyServiceSet(record.GetServiceSet(), false, comprehensive, true);
+        ApplyServiceSet(record.GetServiceSet(), false, comprehensive, true, "controller");
     }
 
     for (const auto& item : record.GetGroupMetadata()) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
@@ -107,7 +107,21 @@ void TNodeWarden::RenderWholePage(IOutputStream& out) {
         DIV() {
             TString s;
             NProtoBuf::TextFormat::PrintToString(StorageConfig, &s);
-            out << s;
+            out << "<pre>" << s << "</pre>";
+        }
+
+        TAG(TH3) { out << "Static service set"; }
+        DIV() {
+            TString s;
+            NProtoBuf::TextFormat::PrintToString(StaticServices, &s);
+            out << "<pre>" << s << "</pre>";
+        }
+
+        TAG(TH3) { out << "Dynamic service set"; }
+        DIV() {
+            TString s;
+            NProtoBuf::TextFormat::PrintToString(DynamicServices, &s);
+            out << "<pre>" << s << "</pre>";
         }
 
         RenderLocalDrives(out);

--- a/ydb/core/blobstorage/nodewarden/node_warden_pipe.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pipe.cpp
@@ -72,6 +72,7 @@ void TNodeWarden::SendRegisterNode() {
     auto ev = std::make_unique<TEvBlobStorage::TEvControllerRegisterNode>(LocalNodeId, startedDynamicGroups, generations,
         WorkingLocalDrives);
     FillInVDiskStatus(ev->Record.MutableVDiskStatus(), true);
+    ev->Record.SetDeclarativePDiskManagement(true);
 
     SendToController(std::move(ev));
 }

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -33,44 +33,33 @@ void TNodeWarden::IssuePendingMessages(const TActorId& actorId) {
     PendingMessageQ.erase(it);
 }
 
-void TNodeWarden::ApplyServiceSet(const NKikimrBlobStorage::TNodeWardenServiceSet &serviceSet, bool isStatic, bool comprehensive, bool updateCache) {
+void TNodeWarden::ApplyServiceSet(const NKikimrBlobStorage::TNodeWardenServiceSet &serviceSet, bool isStatic,
+        bool comprehensive, bool updateCache, const char *origin) {
     if (Cfg->IsCacheEnabled() && updateCache) {
         Y_ABORT_UNLESS(!isStatic);
         return EnqueueSyncOp(WrapCacheOp(UpdateServiceSet(serviceSet, comprehensive, [=] {
-            return ApplyServiceSet(serviceSet, false, comprehensive, false);
+            ApplyServiceSet(serviceSet, false, comprehensive, false, origin);
         })));
     }
 
-    STLOG(PRI_DEBUG, BS_NODE, NW18, "ApplyServiceSet", (IsStatic, isStatic), (Comprehensive, comprehensive));
+    STLOG(PRI_DEBUG, BS_NODE, NW18, "ApplyServiceSet", (IsStatic, isStatic), (Comprehensive, comprehensive),
+        (Origin, origin), (ServiceSet, serviceSet));
 
     // apply proxy information before we try to start VDisks/PDisks
     ApplyGroupInfoFromServiceSet(serviceSet);
 
+    // merge new configuration into current one
+    NKikimrBlobStorage::TNodeWardenServiceSet *target = isStatic ? &StaticServices : &DynamicServices;
+    NProtoBuf::RepeatedPtrField<TServiceSetPDisk> *to = target->MutablePDisks();
+    if (comprehensive) {
+        to->Clear();
+    }
+    MergeServiceSetPDisks(to, serviceSet.GetPDisks());
+
     if (!EnableProxyMock) {
         // in mock mode we don't need PDisk/VDisk instances
-        ApplyServiceSetPDisks(serviceSet);
+        ApplyServiceSetPDisks();
         ApplyServiceSetVDisks(serviceSet);
-    }
-
-    // for comprehensive configuration -- stop created, but missing entities
-    if (comprehensive) {
-        std::set<TPDiskKey> pdiskQ;
-        for (const auto& [pdiskId, _] : LocalPDisks) { // insert all running PDisk ids in the set
-            pdiskQ.insert(pdiskId);
-        }
-        for (const auto& item : serviceSet.GetPDisks()) { // remove enumerated ids
-            if (item.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::INITIAL ||
-                    item.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::CREATE) {
-                pdiskQ.erase({item.GetNodeID(), item.GetPDiskID()});
-            }
-        }
-        for (const auto& [vslotId, _] : LocalVDisks) { // remove ids for PDisks with active VSlots
-            pdiskQ.erase({vslotId.NodeId, vslotId.PDiskId});
-        }
-        for (const TPDiskKey& pdiskId : pdiskQ) { // terminate excessive PDisks
-            Y_ABORT_UNLESS(pdiskId.NodeId == LocalNodeId);
-            DestroyLocalPDisk(pdiskId.PDiskId);
-        }
     }
 
     for (auto& [vslotId, vdisk] : LocalVDisks) {
@@ -286,7 +275,7 @@ void TNodeWarden::HandleGone(STATEFN_SIG) {
 }
 
 void TNodeWarden::ApplyStaticServiceSet(const NKikimrBlobStorage::TNodeWardenServiceSet& ss) {
-    ApplyServiceSet(ss, true, false, false);
+    ApplyServiceSet(ss, true /*isStatic*/, true /*comprehensive*/, false /*updateCache*/, "distconf");
 }
 
 void TNodeWarden::HandleIncrHugeInit(NIncrHuge::TEvIncrHugeInit::TPtr ev) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -277,6 +277,7 @@ namespace NKikimr::NStorage {
             }
             DestroyLocalVDisk(record);
             LocalVDisks.erase(it);
+            ApplyServiceSetPDisks(); // delete unneeded PDisks
         } else if (vdisk.GetDoWipe()) {
             Slay(record);
         } else if (!record.RuntimeData) {

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -66,16 +66,14 @@ namespace NKikimr::NBsController {
             }
 
             void ApplyPDiskCreated(const TPDiskId &pdiskId, const TPDiskInfo &pdiskInfo) {
-                if (!State.StaticPDisks.count(pdiskId)) {
-                    // don't create static PDisks as they are already created
-                    NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk *pdisk = CreatePDiskEntry(pdiskId, pdiskInfo);
-                    pdisk->SetEntityStatus(NKikimrBlobStorage::CREATE);
-                }
+                NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk *pdisk = CreatePDiskEntry(pdiskId, pdiskInfo);
+                pdisk->SetEntityStatus(NKikimrBlobStorage::CREATE);
             }
 
             void ApplyPDiskDeleted(const TPDiskId &pdiskId, const TPDiskInfo &pdiskInfo) {
                 DeletedPDiskIds.insert(pdiskId);
-                if (!State.StaticPDisks.count(pdiskId)) {
+                TNodeInfo *nodeInfo = Self->FindNode(pdiskId.NodeId);
+                if (!State.StaticPDisks.count(pdiskId) || (nodeInfo && nodeInfo->DeclarativePDiskManagement)) {
                     NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk *pdisk = CreatePDiskEntry(pdiskId, pdiskInfo);
                     pdisk->SetEntityStatus(NKikimrBlobStorage::DESTROY);
                 }

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -870,6 +870,7 @@ public:
         std::map<TString, NPDisk::TDriveData> KnownDrives;
         THashSet<TGroupId> WaitingForGroups;
         THashSet<TGroupId> GroupsRequested;
+        bool DeclarativePDiskManagement = false;
 
         template<typename T>
         static void Apply(TBlobStorageController* /*controller*/, T&& callback) {

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -81,9 +81,10 @@ class TBlobStorageController::TTxUpdateNodeDrives
 
             // update pdisk's LastSeenSerial if necessary
             if (pdiskInfo.LastSeenSerial != serial) {
-                getMutableItem()->LastSeenSerial = serial;
+                auto *item = getMutableItem();
+                item->LastSeenSerial = serial;
                 if (serial) {
-                    Self->ReadPDisk(pdiskId, pdiskInfo, result, NKikimrBlobStorage::RESTART);
+                    Self->ReadPDisk(pdiskId, *item, result, NKikimrBlobStorage::RESTART);
                 }
             }
 
@@ -320,6 +321,7 @@ public:
 
         NIceDb::TNiceDb db(txc.DB);
         auto& node = Self->GetNode(nodeId);
+        node.DeclarativePDiskManagement = record.GetDeclarativePDiskManagement();
         db.Table<Schema::Node>().Key(nodeId).Update<Schema::Node::LastConnectTimestamp>(node.LastConnectTimestamp);
 
         for (ui32 groupId : record.GetGroups()) {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1084,6 +1084,7 @@ message TEvControllerRegisterNode {
     repeated uint32 GroupGenerations = 5; // must be zero entries (for old nodes) and the same number as in Groups for new ones
     repeated TVDiskStatus VDiskStatus = 6; // actual status for currently operating VDisks
     repeated TDriveData DrivesData = 7;
+    optional bool DeclarativePDiskManagement = 8;
 }
 
 message TEvControllerUpdateNodeDrives {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make PDisk management declarative in NodeWarden

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Modified PDisk handling in NodeWarden so it can handle static configuration changes correctly.
