### PR TITLE
Make interconnect proxy retry timeout parameters configurable

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -538,6 +538,16 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
     }
     result.SocketBacklogSize = config.GetSocketBacklogSize();
 
+    if (config.HasFirstErrorSleep()) {
+        result.FirstErrorSleep = DurationFromProto(config.GetFirstErrorSleep());
+    }
+    if (config.HasMaxErrorSleep()) {
+        result.MaxErrorSleep = DurationFromProto(config.GetMaxErrorSleep());
+    }
+    if (config.HasErrorSleepRetryMultiplier()) {
+        result.ErrorSleepRetryMultiplier = config.GetErrorSleepRetryMultiplier();
+    }
+
     return result;
 }
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -423,6 +423,10 @@ message TInterconnectConfig {
     optional NKikimrConfigUnits.TDuration LostConnectionDuration = 28;
     optional NKikimrConfigUnits.TDuration BatchPeriodDuration = 29;
 
+    optional NKikimrConfigUnits.TDuration FirstErrorSleep = 46;
+    optional NKikimrConfigUnits.TDuration MaxErrorSleep = 47;
+    optional double ErrorSleepRetryMultiplier = 48;
+
     optional uint32 OutgoingHandshakeInflightLimit = 43;
 }
 

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -51,6 +51,9 @@ namespace NActors {
         bool EnableExternalDataChannel = false;
         bool ValidateIncomingPeerViaDirectLookup = false;
         ui32 SocketBacklogSize = 0; // SOMAXCONN if zero
+        TDuration FirstErrorSleep = TDuration::MilliSeconds(10);
+        TDuration MaxErrorSleep = TDuration::Seconds(1);
+        double ErrorSleepRetryMultiplier = 4.0;
 
         ui32 GetSendBufferSize() const {
             ui32 res = 512 * 1024; // 512 kb is the default value for send buffer

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -9,10 +9,6 @@
 namespace NActors {
     static constexpr TDuration GetNodeRequestTimeout = TDuration::Seconds(5);
 
-    static constexpr TDuration FirstErrorSleep = TDuration::MilliSeconds(10);
-    static constexpr TDuration MaxErrorSleep = TDuration::Seconds(10);
-    static constexpr ui32 SleepRetryMultiplier = 4;
-
     static TString PeerNameForHuman(ui32 nodeNum, const TString& longName, ui16 port) {
         TStringBuf token;
         TStringBuf(longName).NextTok('.', token);
@@ -763,9 +759,10 @@ namespace NActors {
 
         // recalculate wakeup timeout -- if this is the first failure, then we sleep for default timeout; otherwise we
         // sleep N times longer than the previous try, but not longer than desired number of seconds
+        auto& s = Common->Settings;
         HoldByErrorWakeupDuration = HoldByErrorWakeupDuration != TDuration::Zero()
-                                        ? Min(HoldByErrorWakeupDuration * SleepRetryMultiplier, MaxErrorSleep)
-                                        : FirstErrorSleep;
+            ? Min(HoldByErrorWakeupDuration * s.ErrorSleepRetryMultiplier, s.MaxErrorSleep)
+            : Common->Settings.FirstErrorSleep;
 
         // transit to required state and arm wakeup timer
         if (Terminated) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make interconnect proxy retry timeout parameters configurable

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Added configuration parameters to customize error sleep timeout. Also default maximum timeout has been reduced to 1 second instead of 10.
