### PR TITLE
Add missing includes

### DIFF
--- a/ydb/library/http_proxy/authorization/signature.cpp
+++ b/ydb/library/http_proxy/authorization/signature.cpp
@@ -9,6 +9,8 @@
 #include <openssl/sha.h>
 
 #include <util/generic/algorithm.h>
+#include <util/generic/map.h>
+#include <util/generic/vector.h>
 #include <util/stream/str.h>
 #include <util/string/builder.h>
 #include <library/cpp/cgiparam/cgiparam.h>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add missing includes

### Changelog category <!-- remove all except one -->

- Not for changelog (changelog entry is not required)

### Additional information

`vector.h`is included transitively via [`library/cpp/http/io/headers.h`](https://github.com/ydb-platform/ydb/blob/ea11c4b61ef4e491c701847533ff93d3de81f127/library/cpp/http/io/headers.h#L7), but `headers.h` doesn't use it.
Currently it's impossible to remove this unused include, because it breaks compilation of `ydb/library/http_proxy/authorization/signature.cpp`