### PR TITLE
fix(http_proxy): remove cached resolve

### DIFF
--- a/ydb/library/actors/http/http_proxy.cpp
+++ b/ydb/library/actors/http/http_proxy.cpp
@@ -146,37 +146,32 @@ protected:
             } else {
                 // TODO(xenoxeno): move to another, possible blocking actor
                 try {
-                    const NDns::TResolvedHost* result = NDns::CachedResolve(NDns::TResolveInfo(addressPart, portPart));
-                    if (result != nullptr) {
-                        auto pAddr = result->Addr.Begin();
-                        while (pAddr != result->Addr.End() && pAddr->ai_family != AF_INET && pAddr->ai_family != AF_INET6) {
-                            ++pAddr;
-                        }
-                        if (pAddr == result->Addr.End()) {
-                            ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse("Invalid address family resolved"));
-                            return;
-                        }
-                        THttpConfig::SocketAddressType address;
-                        switch (pAddr->ai_family) {
-                            case AF_INET:
-                                address = std::make_shared<TSockAddrInet>();
-                                break;
-                            case AF_INET6:
-                                address = std::make_shared<TSockAddrInet6>();
-                                break;
-                        }
-                        if (address) {
-                            memcpy(address->SockAddr(), pAddr->ai_addr, pAddr->ai_addrlen);
-                            LOG_DEBUG_S(ctx, HttpLog, "Host " << host << " resolved to " << address->ToString());
-                            if (it == Hosts.end()) {
-                                it = Hosts.emplace(host, THostEntry()).first;
-                            }
-                            it->second.Address = address;
-                            it->second.DeadlineTime = ctx.Now() + HostsTimeToLive;
-                        }
-                    } else {
-                        ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse("Error resolving host"));
+                    TNetworkAddress addr(addressPart, portPart);
+                    auto pAddr = addr.Begin();
+                    while (pAddr != addr.End() && pAddr->ai_family != AF_INET && pAddr->ai_family != AF_INET6) {
+                        ++pAddr;
+                    }
+                    if (pAddr == addr.End()) {
+                        ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse("Invalid address family resolved"));
                         return;
+                    }
+                    THttpConfig::SocketAddressType address;
+                    switch (pAddr->ai_family) {
+                        case AF_INET:
+                            address = std::make_shared<TSockAddrInet>();
+                            break;
+                        case AF_INET6:
+                            address = std::make_shared<TSockAddrInet6>();
+                            break;
+                    }
+                    if (address) {
+                        memcpy(address->SockAddr(), pAddr->ai_addr, pAddr->ai_addrlen);
+                        LOG_DEBUG_S(ctx, HttpLog, "Host " << host << " resolved to " << address->ToString());
+                        if (it == Hosts.end()) {
+                            it = Hosts.emplace(host, THostEntry()).first;
+                        }
+                        it->second.Address = address;
+                        it->second.DeadlineTime = ctx.Now() + HostsTimeToLive;
                     }
                 }
                 catch (const yexception& e) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

This PR removes caching from DNS resolution queries done by http_proxy actor. This should be safe to remove in `ydb/library` (checked with @adameat), even though the change is necessary in the oidc proxy service (in an entirely different repo). 