### PR TITLE
ydb(d) cli: add commands for setting interrupt-inheritance flag in acl

### DIFF
--- a/ydb/core/driver_lib/cli_base/cli_cmds_db.cpp
+++ b/ydb/core/driver_lib/cli_base/cli_cmds_db.cpp
@@ -792,6 +792,90 @@ public:
     }
 };
 
+class TClientCommandSchemaAccessInheritanceBase : public TClientCommand {
+public:
+    TClientCommandSchemaAccessInheritanceBase(
+        const TString& name,
+        const std::initializer_list<TString>& aliases,
+        const TString& description,
+        bool interruptInheritance
+    )
+        : TClientCommand(name, aliases, description)
+        , InterruptInheritance(interruptInheritance)
+    {}
+
+    TAutoPtr<NKikimrClient::TSchemeOperation> Request;
+
+    virtual void Config(TConfig& config) override {
+        TClientCommand::Config(config);
+        config.SetFreeArgsNum(1);
+        SetFreeArgTitle(0, "<PATH>", "Full pathname of an object (e.g. /ru/home/user/mydb/test1/test2).\n"
+            "            Or short pathname if profile path is set (e.g. test1/test2).");
+    }
+
+    TString Base;
+    TString Name;
+    bool InterruptInheritance = false;
+
+    virtual void Parse(TConfig& config) override {
+        TClientCommand::Parse(config);
+        TString pathname = config.ParseResult->GetFreeArgs()[0];
+        size_t pos = pathname.rfind('/');
+        if (config.Path) {
+            // Profile path is set
+            if (!pathname.StartsWith('/')) {
+                Base = config.Path;
+                Name = pathname;
+            } else {
+                WarnProfilePathSet();
+                Base = pathname.substr(0, pos);
+                Name = pathname.substr(pos + 1);
+            }
+        } else {
+            Base = pathname.substr(0, pos);
+            Name = pathname.substr(pos + 1);
+        }
+    }
+
+    virtual int Run(TConfig& config) override {
+        TAutoPtr<NMsgBusProxy::TBusSchemeOperation> request(new NMsgBusProxy::TBusSchemeOperation());
+        NKikimrClient::TSchemeOperation& record(request->Record);
+        auto& modifyScheme = *record.MutableTransaction()->MutableModifyScheme();
+        modifyScheme.SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpModifyACL);
+        modifyScheme.SetWorkingDir(Base);
+        auto& modifyAcl = *modifyScheme.MutableModifyACL();
+        modifyAcl.SetName(Name);
+        NACLibProto::TDiffACL diffAcl;
+        {
+            diffAcl.SetInterruptInheritance(InterruptInheritance);
+        }
+        modifyAcl.SetDiffACL(diffAcl.SerializeAsString());
+        int result = MessageBusCall<NMsgBusProxy::TBusSchemeOperation, NMsgBusProxy::TBusResponse>(config, request,
+            [](const NMsgBusProxy::TBusResponse& response) -> int {
+                if (response.Record.GetStatus() != NMsgBusProxy::MSTATUS_OK) {
+                    Cerr << ToCString(static_cast<NMsgBusProxy::EResponseStatus>(response.Record.GetStatus())) << " " << response.Record.GetErrorReason() << Endl;
+                    return 1;
+                }
+                return 0;
+        });
+        return result;
+    }
+};
+
+class TClientCommandSchemaAccessSetInheritance : public TClientCommandSchemaAccessInheritanceBase {
+public:
+    TClientCommandSchemaAccessSetInheritance()
+        : TClientCommandSchemaAccessInheritanceBase("set-inheritance", {}, "Enable permission inheritance from the parent", false)
+    {}
+};
+
+class TClientCommandSchemaAccessClearInheritance : public TClientCommandSchemaAccessInheritanceBase {
+public:
+    TClientCommandSchemaAccessClearInheritance()
+        : TClientCommandSchemaAccessInheritanceBase("clear-inheritance", {}, "Disable permission inheritance from the parent", true)
+    {}
+};
+
 class TClientCommandSchemaAccess : public TClientCommandTree {
 public:
     TClientCommandSchemaAccess()
@@ -801,6 +885,8 @@ public:
         AddCommand(std::make_unique<TClientCommandSchemaAccessRemove>());
         //AddCommand(std::make_unique<TClientCommandSchemaAccessGrant>());
         //AddCommand(std::make_unique<TClientCommandSchemaAccessRevoke>());
+        AddCommand(std::make_unique<TClientCommandSchemaAccessSetInheritance>());
+        AddCommand(std::make_unique<TClientCommandSchemaAccessClearInheritance>());
     }
 };
 

--- a/ydb/docs/en/core/reference/ydb-cli/_includes/commands.md
+++ b/ydb/docs/en/core/reference/ydb-cli/_includes/commands.md
@@ -50,6 +50,8 @@ Any command can be run from the command line with the `--help` option to get hel
 | scheme permissions remove | Removing a permission |
 | scheme permissions revoke | Revoking a permission |
 | scheme permissions set | Setting permissions |
+| scheme permissions clear-inheritance | Disabling permissions inheritance |
+| scheme permissions set-inheritance | Enabling permissions inheritance |
 | [scheme rmdir](../commands/dir.md#rmdir) | Deleting a directory |
 | [scripting yql](../scripting-yql.md) | Executing a YQL script |
 | table attribute add | Adding a table attribute |

--- a/ydb/docs/ru/core/reference/ydb-cli/_includes/commands.md
+++ b/ydb/docs/ru/core/reference/ydb-cli/_includes/commands.md
@@ -50,6 +50,8 @@ scheme permissions grant | Предоставление разрешения
 scheme permissions remove | Удаление разрешения
 scheme permissions revoke | Удаление разрешения
 scheme permissions set | Установка разрешений
+scheme permissions clear-inheritance | Запрет наследования разрешений
+scheme permissions set-inheritance | Установка наследования разрешений
 [scheme rmdir](../commands/dir.md#rmdir) | Удаление директории
 [scripting yql](../scripting-yql.md) | Выполнение YQL-скрипта
 table attribute add | Добавление атрибута таблицы

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
@@ -915,6 +915,8 @@ TCommandPermissions::TCommandPermissions()
     AddCommand(std::make_unique<TCommandPermissionSet>());
     AddCommand(std::make_unique<TCommandChangeOwner>());
     AddCommand(std::make_unique<TCommandPermissionClear>());
+    AddCommand(std::make_unique<TCommandPermissionSetInheritance>());
+    AddCommand(std::make_unique<TCommandPermissionClearInheritance>());
     AddCommand(std::make_unique<TCommandPermissionList>());
 }
 
@@ -1100,6 +1102,66 @@ int TCommandPermissionClear::Run(TConfig& config) {
             FillSettings(
                 NScheme::TModifyPermissionsSettings()
                 .AddClearAcl()
+            )
+        ).GetValueSync()
+    );
+    return EXIT_SUCCESS;
+}
+
+TCommandPermissionSetInheritance::TCommandPermissionSetInheritance()
+    : TYdbOperationCommand("set-inheritance", std::initializer_list<TString>(), "Set to inherit permissions from the parent")
+{}
+
+void TCommandPermissionSetInheritance::Config(TConfig& config) {
+    TYdbOperationCommand::Config(config);
+
+    config.SetFreeArgsNum(1);
+    SetFreeArgTitle(0, "<path>", "Path to set interrupt-inheritance flag for");
+}
+
+void TCommandPermissionSetInheritance::Parse(TConfig& config) {
+    TClientCommand::Parse(config);
+    ParsePath(config, 0);
+}
+
+int TCommandPermissionSetInheritance::Run(TConfig& config) {
+    NScheme::TSchemeClient client(CreateDriver(config));
+    ThrowOnError(
+        client.ModifyPermissions(
+            Path,
+            FillSettings(
+                NScheme::TModifyPermissionsSettings()
+                .AddInterruptInheritance(false)
+            )
+        ).GetValueSync()
+    );
+    return EXIT_SUCCESS;
+}
+
+TCommandPermissionClearInheritance::TCommandPermissionClearInheritance()
+    : TYdbOperationCommand("clear-inheritance", std::initializer_list<TString>(), "Set to do not inherit permissions from the parent")
+{}
+
+void TCommandPermissionClearInheritance::Config(TConfig& config) {
+    TYdbOperationCommand::Config(config);
+
+    config.SetFreeArgsNum(1);
+    SetFreeArgTitle(0, "<path>", "Path to set interrupt-inheritance flag for");
+}
+
+void TCommandPermissionClearInheritance::Parse(TConfig& config) {
+    TClientCommand::Parse(config);
+    ParsePath(config, 0);
+}
+
+int TCommandPermissionClearInheritance::Run(TConfig& config) {
+    NScheme::TSchemeClient client(CreateDriver(config));
+    ThrowOnError(
+        client.ModifyPermissions(
+            Path,
+            FillSettings(
+                NScheme::TModifyPermissionsSettings()
+                .AddInterruptInheritance(true)
             )
         ).GetValueSync()
     );

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.h
@@ -165,6 +165,22 @@ public:
     virtual int Run(TConfig& config) override;
 };
 
+class TCommandPermissionSetInheritance : public TYdbOperationCommand, public TCommandWithPath {
+public:
+    TCommandPermissionSetInheritance();
+    virtual void Config(TConfig& config) override;
+    virtual void Parse(TConfig& config) override;
+    virtual int Run(TConfig& config) override;
+};
+
+class TCommandPermissionClearInheritance : public TYdbOperationCommand, public TCommandWithPath {
+public:
+    TCommandPermissionClearInheritance();
+    virtual void Config(TConfig& config) override;
+    virtual void Parse(TConfig& config) override;
+    virtual int Run(TConfig& config) override;
+};
+
 class TCommandPermissionList : public TYdbOperationCommand, public TCommandWithPath {
 public:
     TCommandPermissionList();

--- a/ydb/public/sdk/cpp/client/ydb_scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_scheme/scheme.cpp
@@ -218,6 +218,9 @@ public:
         if (settings.ClearAcl_) {
             request.set_clear_permissions(true);
         }
+        if (settings.SetInterruptInheritance_) {
+            request.set_interrupt_inheritance(settings.InterruptInheritanceValue_);
+        }
 
         for (const auto& action : settings.Actions_) {
             auto protoAction = request.add_actions();

--- a/ydb/public/sdk/cpp/client/ydb_scheme/scheme.h
+++ b/ydb/public/sdk/cpp/client/ydb_scheme/scheme.h
@@ -126,8 +126,16 @@ struct TModifyPermissionsSettings : public TOperationRequestSettings<TModifyPerm
         return *this;
     }
 
+    TModifyPermissionsSettings& AddInterruptInheritance(bool value) {
+        SetInterruptInheritance_ = true;
+        InterruptInheritanceValue_ = value;
+        return *this;
+    }
+
     TVector<std::pair<EModifyPermissionsAction, TPermissions>> Actions_;
     bool ClearAcl_ = false;
+    bool SetInterruptInheritance_ = false;
+    bool InterruptInheritanceValue_ = false;
     void AddAction(EModifyPermissionsAction action, const TPermissions& permissions) {
         Actions_.emplace_back(std::pair<EModifyPermissionsAction, TPermissions>{action, permissions});
     }


### PR DESCRIPTION
### Changelog entry

Add `ydb scheme permissions {clear,set}-inheritance` commands.
Add `ydbd db schema access {clear,set}-inheritance` commands.

### Changelog category

* Improvement

### Additional information

`InterruptInheritance` is a special flag that blocks permission inheritance for a target path. There are a variance of inheritance type modifiers which effect how inheritance works for an individual access control entry, but InterruptInheritance flag have a global effect for a path.
InterruptInheritance was a part of the public api for a while now (and it was used internally), but there was no cli commands to actually manipulate it.
