### PR TITLE
YA-1759: add `cpu:all` requirement to `IF (OPENSOURCE)` clause

### DIFF
--- a/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
@@ -6,11 +6,6 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/datasource/clickh
 DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=clickhouse)
 
-# This requirement forces tests to be launched consequently,
-# otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
-# See DEVTOOLSSUPPORT-44103 for details
-REQUIREMENTS(cpu:all)
-
 IF (AUTOCHECK) 
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
@@ -25,6 +20,7 @@ IF (AUTOCHECK)
     )
 
     REQUIREMENTS(
+        cpu:all
         container:4467981730
         dns:dns64
     )
@@ -39,6 +35,11 @@ IF (OPENSOURCE)
     SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
+
+    # This requirement forces tests to be launched consequently,
+    # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
+    # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
@@ -7,9 +7,12 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=clickhouse)
 
 IF (AUTOCHECK) 
+    # Temporarily disable these tests due to infrastructure incompatibility
+    SKIP_TEST("DEVTOOLSUPPORT-44637")
+
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
-    # Look through https://st.yandex-team.ru/DEVTOOLSSUPPORT-39642 for more information.
+    # Look through DEVTOOLSSUPPORT-39642 for more information.
     FORK_SUBTESTS()
 
     # TAG and REQUIREMENTS are copied from: https://docs.yandex-team.ru/devtools/test/environment#docker-compose
@@ -39,6 +42,7 @@ IF (OPENSOURCE)
     # This requirement forces tests to be launched consequently,
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    TAG(ya:not_autocheck)
     REQUIREMENTS(cpu:all)
 ENDIF()
 

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
@@ -6,11 +6,6 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/datasource/postgr
 DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=postgresql)
 
-# This requirement forces tests to be launched consequently,
-# otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
-# See DEVTOOLSSUPPORT-44103 for details
-REQUIREMENTS(cpu:all)
-
 IF (AUTOCHECK) 
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
@@ -25,6 +20,7 @@ IF (AUTOCHECK)
     )
 
     REQUIREMENTS(
+        cpu:all
         container:4467981730
         dns:dns64
     )
@@ -39,6 +35,11 @@ IF (OPENSOURCE)
     SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
+
+    # This requirement forces tests to be launched consequently,
+    # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
+    # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
@@ -7,9 +7,12 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=postgresql)
 
 IF (AUTOCHECK) 
+    # Temporarily disable these tests due to infrastructure incompatibility
+    SKIP_TEST("DEVTOOLSUPPORT-44637")
+
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
-    # Look through https://st.yandex-team.ru/DEVTOOLSSUPPORT-39642 for more information.
+    # Look through DEVTOOLSSUPPORT-39642 for more information.
     FORK_SUBTESTS()
 
     # TAG and REQUIREMENTS are copied from: https://docs.yandex-team.ru/devtools/test/environment#docker-compose
@@ -39,6 +42,7 @@ IF (OPENSOURCE)
     # This requirement forces tests to be launched consequently,
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    TAG(ya:not_autocheck)
     REQUIREMENTS(cpu:all)
 ENDIF()
 

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/docker-compose.yml
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.4'
 services:
   ydb:
-     image: cr.yandex/yc/yandex-docker-local-ydb:23.3.17@sha256:bf9001c849cc6c4c9b56f32f5440a6e8390c4e841937c9f9caf929fd70a689c8
-     container_name: fq-tests-ydb-ydb
-     hostname: fq-tests-ydb-ydb
-     environment:
-       YDB_DEFAULT_LOG_LEVEL: INFO
-       POSTGRES_USER: user
-       POSTGRES_PASSWORD: password
-     volumes:
+    image: ghcr.io/ydb-platform/local-ydb:latest@sha256:9045e00afec1923dc3277564c7b2f829087c2115f45f18e1d38b80bb89f98be6
+    container_name: fq-tests-ydb-ydb
+    hostname: fq-tests-ydb-ydb
+    environment:
+      YDB_DEFAULT_LOG_LEVEL: DEBUG
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    volumes:
        - ./init/init_ydb:/init_ydb
        - ./init/01_basic.sh:/01_basic.sh
 

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
@@ -8,9 +8,12 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=ydb)
 
 IF (AUTOCHECK) 
+    # Temporarily disable these tests due to infrastructure incompatibility
+    SKIP_TEST("DEVTOOLSUPPORT-44637")
+
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
-    # Look through https://st.yandex-team.ru/DEVTOOLSSUPPORT-39642 for more information.
+    # Look through DEVTOOLSSUPPORT-39642 for more information.
     FORK_SUBTESTS()
 
     # TAG and REQUIREMENTS are copied from: https://docs.yandex-team.ru/devtools/test/environment#docker-compose
@@ -40,6 +43,7 @@ IF (OPENSOURCE)
     # This requirement forces tests to be launched consequently,
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    TAG(ya:not_autocheck)
     REQUIREMENTS(cpu:all)
 ENDIF()
 

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
@@ -7,11 +7,6 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/do
 DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=ydb)
 
-# This requirement forces tests to be launched consequently,
-# otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
-# See DEVTOOLSSUPPORT-44103 for details
-REQUIREMENTS(cpu:all)
-
 IF (AUTOCHECK) 
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
@@ -26,6 +21,7 @@ IF (AUTOCHECK)
     )
 
     REQUIREMENTS(
+        cpu:all
         container:4467981730
         dns:dns64
     )
@@ -40,6 +36,11 @@ IF (OPENSOURCE)
     SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
+
+    # This requirement forces tests to be launched consequently,
+    # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
+    # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/join/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/join/ya.make
@@ -6,11 +6,6 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/join/docker-compo
 DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=join)
 
-# This requirement forces tests to be launched consequently,
-# otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
-# See DEVTOOLSSUPPORT-44103 for details
-REQUIREMENTS(cpu:all)
-
 IF (AUTOCHECK) 
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
@@ -25,6 +20,7 @@ IF (AUTOCHECK)
     )
 
     REQUIREMENTS(
+        cpu:all
         container:4467981730
         dns:dns64
     )
@@ -39,6 +35,11 @@ IF (OPENSOURCE)
     SIZE(MEDIUM)
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
+
+    # This requirement forces tests to be launched consequently,
+    # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
+    # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/join/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/join/ya.make
@@ -7,9 +7,12 @@ DATA(arcadia/ydb/library/yql/providers/generic/connector/tests/fq-connector-go)
 ENV(COMPOSE_PROJECT_NAME=join)
 
 IF (AUTOCHECK) 
+    # Temporarily disable these tests due to infrastructure incompatibility
+    SKIP_TEST("DEVTOOLSUPPORT-44637")
+
     # Split tests to chunks only when they're running on different machines with distbuild,
     # otherwise this directive will slow down local test execution.
-    # Look through https://st.yandex-team.ru/DEVTOOLSSUPPORT-39642 for more information.
+    # Look through DEVTOOLSSUPPORT-39642 for more information.
     FORK_SUBTESTS()
 
     # TAG and REQUIREMENTS are copied from: https://docs.yandex-team.ru/devtools/test/environment#docker-compose
@@ -39,6 +42,7 @@ IF (OPENSOURCE)
     # This requirement forces tests to be launched consequently,
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
+    TAG(ya:not_autocheck)
     REQUIREMENTS(cpu:all)
 ENDIF()
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* YA-1759: add cpu:all requirement to `IF (OPENSOURCE)` clause
* Disable tests in Arcadia

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

