### PR TITLE
Add assert on sender side to fail on send of local event to different node.

### DIFF
--- a/ydb/library/yql/dq/actors/compute/retry_queue.cpp
+++ b/ydb/library/yql/dq/actors/compute/retry_queue.cpp
@@ -66,6 +66,7 @@ void TRetryEventsQueue::Retry() {
 
 void TRetryEventsQueue::Connect() {
     auto connectEvent = MakeHolder<NActors::TEvInterconnect::TEvConnectNode>();
+    Y_ASSERT(NActors::TActivationContext::ActorSystem()->NodeId == SenderId.NodeId());
     NActors::TActivationContext::Send(
         new NActors::IEventHandle(NActors::TActivationContext::InterconnectProxy(RecipientId.NodeId()), SenderId, connectEvent.Release(), 0, 0));
 }


### PR DESCRIPTION
Add assert on sender side to fail on send of local event to different node to get stack trace of sender.

* Not for changelog (changelog entry is not required)
