### PR TITLE
Split resource.storage.used_bytes metric by storage kind

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -197,6 +197,13 @@ enum ESimpleCounters {
     COUNTER_GRAPHSHARD_COUNT = 158 [(CounterOpts) = {Name: "GraphShards"}];
 
     COUNTER_IN_FLIGHT_OPS_TxCopySequence = 159            [(CounterOpts) = {Name: "InFlightOps/CopySequence"}];
+    
+    COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_SSD = 160     [(CounterOpts) = {Name: "DiskSpaceTablesDataBytesOnSsd"}];
+    COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_SSD = 161    [(CounterOpts) = {Name: "DiskSpaceTablesIndexBytesOnSsd"}];
+    COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_SSD = 162    [(CounterOpts) = {Name: "DiskSpaceTablesTotalBytesOnSsd"}];
+    COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_HDD = 163     [(CounterOpts) = {Name: "DiskSpaceTablesDataBytesOnHdd"}];
+    COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_HDD = 164    [(CounterOpts) = {Name: "DiskSpaceTablesIndexBytesOnHdd"}];
+    COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_HDD = 165    [(CounterOpts) = {Name: "DiskSpaceTablesTotalBytesOnHdd"}];
 }
 
 enum ECumulativeCounters {

--- a/ydb/core/sys_view/service/ext_counters.cpp
+++ b/ydb/core/sys_view/service/ext_counters.cpp
@@ -23,6 +23,8 @@ class TExtCountersUpdaterActor
     TCounterPtr MemoryUsedBytes;
     TCounterPtr MemoryLimitBytes;
     TCounterPtr StorageUsedBytes;
+    TCounterPtr StorageUsedBytesOnSsd;
+    TCounterPtr StorageUsedBytesOnHdd;
     TVector<TCounterPtr> CpuUsedCorePercents;
     TVector<TCounterPtr> CpuLimitCorePercents;
     THistogramPtr ExecuteLatencyMs;
@@ -54,6 +56,10 @@ public:
             "resources.memory.limit_bytes", false);
         StorageUsedBytes = ydbGroup->GetNamedCounter("name",
             "resources.storage.used_bytes", false);
+        StorageUsedBytesOnSsd = ydbGroup->GetNamedCounter("name",
+            "resources.storage.used_bytes.ssd", false);
+        StorageUsedBytesOnHdd = ydbGroup->GetNamedCounter("name",
+            "resources.storage.used_bytes.hdd", false);
 
         auto poolCount = Config.Pools.size();
         CpuUsedCorePercents.resize(poolCount);
@@ -109,6 +115,12 @@ private:
         }
         if (StorageUsedBytes->Val() != 0) {
             metrics->AddMetric("resources.storage.used_bytes", StorageUsedBytes->Val());
+        }
+        if (StorageUsedBytesOnSsd->Val() != 0) {
+            metrics->AddMetric("resources.storage.used_bytes.ssd", StorageUsedBytesOnSsd->Val());
+        }
+        if (StorageUsedBytesOnHdd->Val() != 0) {
+            metrics->AddMetric("resources.storage.used_bytes.hdd", StorageUsedBytesOnHdd->Val());
         }
         if (!Config.Pools.empty()) {
             double cpuUsage = 0;

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -865,6 +865,10 @@ private:
                 "resources.storage.limit_bytes", false);
             ResourcesStorageTableUsedBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.table.used_bytes", false);
+            ResourcesStorageTableUsedBytesOnSsd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.table.used_bytes.ssd", false);
+            ResourcesStorageTableUsedBytesOnHdd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.table.used_bytes.hdd", false);
             ResourcesStorageTopicUsedBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.topic.used_bytes", false);
 

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -768,8 +768,12 @@ private:
         TCounterPtr ColumnShardBulkUpsertRows_;
         TCounterPtr ColumnShardBulkUpsertBytes_;
         TCounterPtr ResourcesStorageUsedBytes;
+        TCounterPtr ResourcesStorageUsedBytesOnSsd;
+        TCounterPtr ResourcesStorageUsedBytesOnHdd;
         TCounterPtr ResourcesStorageLimitBytes;
         TCounterPtr ResourcesStorageTableUsedBytes;
+        TCounterPtr ResourcesStorageTableUsedBytesOnSsd;
+        TCounterPtr ResourcesStorageTableUsedBytesOnHdd;
         TCounterPtr ResourcesStorageTopicUsedBytes;
         TCounterPtr ResourcesStreamUsedShards;
         TCounterPtr ResourcesStreamLimitShards;
@@ -802,6 +806,8 @@ private:
         TCounterPtr ColumnShardUpsertBytesWritten_;
 
         TCounterPtr DiskSpaceTablesTotalBytes;
+        TCounterPtr DiskSpaceTablesTotalBytesOnSsd;
+        TCounterPtr DiskSpaceTablesTotalBytesOnHdd;
         TCounterPtr DiskSpaceTopicsTotalBytes;
         TCounterPtr DiskSpaceSoftQuotaBytes;
 
@@ -851,6 +857,10 @@ private:
 
             ResourcesStorageUsedBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.used_bytes", false);
+            ResourcesStorageUsedBytesOnSsd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.used_bytes.ssd", false);
+            ResourcesStorageUsedBytesOnHdd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.used_bytes.hdd", false);
             ResourcesStorageLimitBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.limit_bytes", false);
             ResourcesStorageTableUsedBytes = ydbGroup->GetNamedCounter("name",
@@ -919,6 +929,8 @@ private:
                 auto appGroup = schemeshardGroup->GetSubgroup("category", "app");
 
                 DiskSpaceTablesTotalBytes = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTablesTotalBytes)");
+                DiskSpaceTablesTotalBytesOnSsd = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTablesTotalBytesOnSsd)");
+                DiskSpaceTablesTotalBytesOnHdd = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTablesTotalBytesOnHdd)");
                 DiskSpaceTopicsTotalBytes = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTopicsTotalBytes)");
                 DiskSpaceSoftQuotaBytes = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceSoftQuotaBytes)");
 
@@ -960,12 +972,18 @@ private:
             if (DiskSpaceTablesTotalBytes) {
                 ResourcesStorageLimitBytes->Set(DiskSpaceSoftQuotaBytes->Val());
                 ResourcesStorageTableUsedBytes->Set(DiskSpaceTablesTotalBytes->Val());
+                ResourcesStorageTableUsedBytesOnSsd->Set(DiskSpaceTablesTotalBytesOnSsd->Val());
+                ResourcesStorageTableUsedBytesOnHdd->Set(DiskSpaceTablesTotalBytesOnHdd->Val());
                 ResourcesStorageTopicUsedBytes->Set(DiskSpaceTopicsTotalBytes->Val());
 
                 if (AppData()->FeatureFlags.GetEnableTopicDiskSubDomainQuota()) {
                     ResourcesStorageUsedBytes->Set(ResourcesStorageTableUsedBytes->Val() + ResourcesStorageTopicUsedBytes->Val());
+                    ResourcesStorageUsedBytesOnSsd->Set(ResourcesStorageTableUsedBytesOnSsd->Val());
+                    ResourcesStorageUsedBytesOnHdd->Set(ResourcesStorageTableUsedBytesOnHdd->Val());
                 } else {
                     ResourcesStorageUsedBytes->Set(ResourcesStorageTableUsedBytes->Val());
+                    ResourcesStorageUsedBytesOnSsd->Set(ResourcesStorageTableUsedBytesOnSsd->Val());
+                    ResourcesStorageUsedBytesOnHdd->Set(ResourcesStorageTableUsedBytesOnHdd->Val());
                 }
 
                 auto quota = StreamShardsQuota->Val();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -7107,6 +7107,30 @@ void TSchemeShard::ChangeDiskSpaceTablesTotalBytes(i64 delta) {
     TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES].Add(delta);
 }
 
+void TSchemeShard::ChangeDiskSpaceTablesDataBytesOnSsd(i64 delta) {
+    TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_SSD].Add(delta);
+}
+
+void TSchemeShard::ChangeDiskSpaceTablesIndexBytesOnSsd(i64 delta) {
+    TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_SSD].Add(delta);
+}
+
+void TSchemeShard::ChangeDiskSpaceTablesTotalBytesOnSsd(i64 delta) {
+    TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_SSD].Add(delta);
+}
+
+void TSchemeShard::ChangeDiskSpaceTablesDataBytesOnHdd(i64 delta) {
+    TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_HDD].Add(delta);
+}
+
+void TSchemeShard::ChangeDiskSpaceTablesIndexBytesOnHdd(i64 delta) {
+    TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_HDD].Add(delta);
+}
+
+void TSchemeShard::ChangeDiskSpaceTablesTotalBytesOnHdd(i64 delta) {
+    TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_HDD].Add(delta);
+}
+
 void TSchemeShard::ChangeDiskSpaceTopicsTotalBytes(ui64 value) {
     TabletCounters->Simple()[COUNTER_DISK_SPACE_TOPICS_TOTAL_BYTES].Set(value);
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1356,6 +1356,12 @@ public:
     void ChangeDiskSpaceTablesDataBytes(i64 delta) override;
     void ChangeDiskSpaceTablesIndexBytes(i64 delta) override;
     void ChangeDiskSpaceTablesTotalBytes(i64 delta) override;
+    void ChangeDiskSpaceTablesDataBytesOnSsd(i64 delta) override;
+    void ChangeDiskSpaceTablesIndexBytesOnSsd(i64 delta) override;
+    void ChangeDiskSpaceTablesTotalBytesOnSsd(i64 delta) override;
+    void ChangeDiskSpaceTablesDataBytesOnHdd(i64 delta) override;
+    void ChangeDiskSpaceTablesIndexBytesOnHdd(i64 delta) override;
+    void ChangeDiskSpaceTablesTotalBytesOnHdd(i64 delta) override;
     void ChangeDiskSpaceTopicsTotalBytes(ui64 value) override;
     void ChangeDiskSpaceQuotaExceeded(i64 delta) override;
     void ChangeDiskSpaceHardQuotaBytes(i64 delta) override;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -1437,6 +1437,12 @@ struct IQuotaCounters {
     virtual void ChangeDiskSpaceTablesDataBytes(i64 delta) = 0;
     virtual void ChangeDiskSpaceTablesIndexBytes(i64 delta) = 0;
     virtual void ChangeDiskSpaceTablesTotalBytes(i64 delta) = 0;
+    virtual void ChangeDiskSpaceTablesDataBytesOnSsd(i64 delta) = 0;
+    virtual void ChangeDiskSpaceTablesIndexBytesOnSsd(i64 delta) = 0;
+    virtual void ChangeDiskSpaceTablesTotalBytesOnSsd(i64 delta) = 0;
+    virtual void ChangeDiskSpaceTablesDataBytesOnHdd(i64 delta) = 0;
+    virtual void ChangeDiskSpaceTablesIndexBytesOnHdd(i64 delta) = 0;
+    virtual void ChangeDiskSpaceTablesTotalBytesOnHdd(i64 delta) = 0;
     virtual void ChangeDiskSpaceTopicsTotalBytes(ui64 value) = 0;
     virtual void ChangeDiskSpaceQuotaExceeded(i64 delta) = 0;
     virtual void ChangeDiskSpaceHardQuotaBytes(i64 delta) = 0;


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/3275

RFC with a discussion on the solution can be read [here](https://github.com/ydb-platform/ydb-rfc/blob/main/per_storage_kind_quotas.md#metrics).

Add
- `resources.storage.used_bytes.ssd`
- `resources.storage.used_bytes.hdd`
counters and all of the necessary subcounters. These counters are needed to monitor ssd and hdd storage usage separately. 

The data is sourced from the SchemeShard's counters:
- `SchemeShard/DiskSpaceTablesTotalBytesOnSsd`
- `SchemeShard/DiskSpaceTablesTotalBytesOnHdd`
which are updated each time the SchemeShard receives TEvPeriodicTableStats from DataShards.

In the upcoming PRs `resources.storage.limit_bytes` is going to be split too.