### PR TITLE
YQL-17115: Make ComputationPatternCache::Smoke deterministic

### DIFF
--- a/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_ut.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_ut.cpp
@@ -599,6 +599,16 @@ Y_UNIT_TEST_SUITE(ComputationPatternCache) {
                 auto guard = entry->Env.BindAllocator();
                 entry->Pattern = MakeComputationPattern(explorer, progReturn, {}, opts);
             }
+
+            // XXX: There is no way to accurately define how the entry's
+            // allocator obtains the memory pages: using the free ones from the
+            // global page pool or the ones directly requested by <mmap>. At the
+            // same time, it is the total allocated bytes (not just the number
+            // of the borrowed pages) that is a good estimate of the memory
+            // consumed by the pattern cache entry for real life workload.
+            // Hence, to avoid undesired cache flushes, release the free pages
+            // of the allocator of the particular entry.
+            alloc.ReleaseFreePages();
             cache.EmplacePattern(TString((char)('a' + i)), entry);
         }
 


### PR DESCRIPTION
There is no way to accurately define how the entry's allocator obtained the memory pages: using free ones from global page pool or directly requested by `<mmap>`. At the same time, it is the total allocated bytes (not just the number of the borrowed pages) that is a good estimate of the memory consumed by the pattern cache entry for real life workload.

Hence, to avoid undesired cache flushes, the free pages of the entry's allocator are released as a result of the patch.

### Changelog category

* Bugfix