### PR TITLE
Fix format and non-block devices in ydbd_slice

### DIFF
--- a/ydb/tools/ydbd_slice/handlers.py
+++ b/ydb/tools/ydbd_slice/handlers.py
@@ -60,14 +60,7 @@ class Slice:
     def _format_drives(self):
         tasks = []
         for (host_name, drive_path) in self._get_all_drives():
-            cmd = "dd if=/dev/zero of={} bs=1M count=1 status=none conv=notrunc".format(drive_path)
-            tasks.extend(self.nodes.execute_async_ret(cmd, nodes=[host_name]))
-        self.nodes._check_async_execution(tasks)
-
-    def _check_drives_exist(self):
-        tasks = []
-        for (host_name, drive_path) in self._get_all_drives():
-            cmd = "echo 'Check existance of drive' && test -f {}".format(drive_path)
+            cmd = "sudo dd if=/dev/zero of={} bs=1M count=1 status=none conv=notrunc".format(drive_path)
             tasks.extend(self.nodes.execute_async_ret(cmd, nodes=[host_name]))
         self.nodes._check_async_execution(tasks)
 
@@ -132,7 +125,6 @@ class Slice:
             self._clear_logs()
 
         if 'kikimr' in self.components:
-            self._check_drives_exist()
             self._format_drives()
 
             if 'bin' in self.components.get('kikimr', []):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

In case of real drives there were problems: 
- missing sudo 
- `file -f` is false for block devices/symlinks

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information
