### PR TITLE
use multistage build to setcap on binary in dockerfile for  ydbd_slice

### DIFF
--- a/ydb/tools/ydbd_slice/image/Dockerfile
+++ b/ydb/tools/ydbd_slice/image/Dockerfile
@@ -1,9 +1,7 @@
-FROM cr.yandex/mirror/ubuntu:focal
+# syntax=docker/dockerfile:1
+FROM cr.yandex/mirror/ubuntu:focal as base
 
-ARG ARC_COMMIT_ID
-LABEL arc_commit_id=$ARC_COMMIT_ID
-
-RUN \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get -yqq update && \
   apt-get -yqq install libcap2-bin dnsutils telnet netcat-openbsd iputils-ping gdb atop strace curl linux-tools-generic && \
   apt-get -yqq clean all && \
@@ -11,16 +9,20 @@ RUN \
   groupadd -r ydb && \
   useradd --no-log-init -r -m -g ydb -G disk ydb
 
+FROM base as ydbd-setcap
+
+COPY --link ydbd /ydbd
+RUN /sbin/setcap CAP_SYS_RAWIO=ep /ydbd
+
+FROM base
+
+ARG ARC_COMMIT_ID
+LABEL arc_commit_id=$ARC_COMMIT_ID
+
 WORKDIR /opt/ydb/bin
-
-COPY ydb ./ydb
-
-COPY libiconv.so /lib/libiconv.so
-COPY liblibidn-dynamic.so /lib/liblibidn-dynamic.so
-COPY liblibaio-dynamic.so /lib/liblibaio-dynamic.so
-
-COPY ydbd ./ydbd
-
-RUN /sbin/setcap CAP_SYS_RAWIO=ep /opt/ydb/bin/ydbd
-
+COPY --chmod=0755 --chown=ydb:ydb --link ydb /opt/ydb/bin/ydb
+COPY --chmod=0644 --link libiconv.so /lib/libiconv.so
+COPY --chmod=0644 --link liblibidn-dynamic.so /lib/liblibidn-dynamic.so
+COPY --chmod=0644 --link liblibaio-dynamic.so /lib/liblibaio-dynamic.so
+COPY --chmod=0755 --chown=ydb:ydb --link --from=ydbd-setcap /ydbd /opt/ydb/bin/ydbd
 USER ydb


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Update Dockerfile to use multistage build
Using setcap on binary in Dockerfile in separate stage to prevent double size for image
Using `--link` for COPY in Dockerfile to reuse already built layers in subsequent builds
Using `--chmod` and `--chown` for COPY in Dockerfile for explicitly set file modes

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

None
