### PR TITLE
Support static group reconfiguration through distconf

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -839,6 +839,8 @@ struct TEvBlobStorage {
         EvNodeConfigInvokeOnRoot,
         EvNodeConfigInvokeOnRootResult,
         EvNodeWardenStorageConfigConfirm,
+        EvNodeWardenQueryBaseConfig,
+        EvNodeWardenBaseConfig,
 
         // Other
         EvRunActor = EvPut + 15 * 512,

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -917,7 +917,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         auto res = responseEvent->Record.MutableResponse();
         res->SetSuccess(false);
         res->SetErrorDescription("Fake error");
-        runtime.Send(new IEventHandle(nodeWarden, fakeBSC, responseEvent, 0, cookie), nodeId);
+        runtime.Send(new IEventHandle(nodeWarden, fakeBSC, responseEvent, 0, 1), nodeId);
 
         auto evPtr = runtime.WaitForEdgeActorEvent<TEvBlobStorage::TEvAskWardenRestartPDiskResult>(pdiskActorId);
         auto restartPDiskEv = evPtr->Get();

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -316,7 +316,15 @@ namespace NKikimr::NStorage {
         struct TExConfigError : yexception {};
 
         bool GenerateFirstConfig(NKikimrBlobStorage::TStorageConfig *config);
-        void AllocateStaticGroup(NKikimrBlobStorage::TStorageConfig *config);
+
+        void AllocateStaticGroup(NKikimrBlobStorage::TStorageConfig *config, ui32 groupId, ui32 groupGeneration,
+            TBlobStorageGroupType gtype, const NKikimrBlobStorage::TGroupGeometry& geometry,
+            const NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TPDiskFilter>& pdiskFilters,
+            THashMap<TVDiskIdShort, NBsController::TPDiskId> replacedDisks,
+            const NBsController::TGroupMapper::TForbiddenPDisks& forbid,
+            i64 requiredSpace,
+            NKikimrBlobStorage::TBaseConfig *baseConfig);
+
         void GenerateStateStorageConfig(NKikimrConfig::TDomainsConfig::TStateStorage *ss,
             const NKikimrBlobStorage::TStorageConfig& baseConfig);
         bool UpdateConfig(NKikimrBlobStorage::TStorageConfig *config);
@@ -562,6 +570,9 @@ namespace NKikimr::NStorage {
         for (const auto& vdisk : ss.GetVDisks()) {
             if (!vdisk.HasVDiskID() || !vdisk.HasVDiskLocation()) {
                 return makeError("incorrect TVDisk record");
+            }
+            if (vdisk.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::DESTROY) {
+                continue;
             }
             const auto vdiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
             const auto it = groups.find(vdiskId.GroupID);

--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -10,7 +10,16 @@ namespace NKikimr::NStorage {
             const bool noStaticGroup = !bsConfig.HasServiceSet() || !bsConfig.GetServiceSet().GroupsSize();
             if (noStaticGroup && bsConfig.HasAutoconfigSettings() && bsConfig.GetAutoconfigSettings().HasErasureSpecies()) {
                 try {
-                    AllocateStaticGroup(config);
+                    const auto& settings = bsConfig.GetAutoconfigSettings();
+
+                    const auto species = TBlobStorageGroupType::ErasureSpeciesByName(settings.GetErasureSpecies());
+                    if (species == TBlobStorageGroupType::ErasureSpeciesCount) {
+                        throw TExConfigError() << "invalid erasure specified for static group"
+                            << " Erasure# " << settings.GetErasureSpecies();
+                    }
+
+                    AllocateStaticGroup(config, 0 /*groupId*/, 1 /*groupGeneration*/, TBlobStorageGroupType(species),
+                        settings.GetGeometry(), settings.GetPDiskFilter(), {}, {}, 0, nullptr);
                     changes = true;
                     STLOG(PRI_DEBUG, BS_NODE, NWDC33, "Allocated static group", (Group, bsConfig.GetServiceSet().GetGroups(0)));
                 } catch (const TExConfigError& ex) {
@@ -39,7 +48,14 @@ namespace NKikimr::NStorage {
         return changes;
     }
 
-    void TDistributedConfigKeeper::AllocateStaticGroup(NKikimrBlobStorage::TStorageConfig *config) {
+    void TDistributedConfigKeeper::AllocateStaticGroup(NKikimrBlobStorage::TStorageConfig *config, ui32 groupId,
+            ui32 groupGeneration, TBlobStorageGroupType gtype, const NKikimrBlobStorage::TGroupGeometry& geometry,
+            const NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TPDiskFilter>& pdiskFilters,
+            THashMap<TVDiskIdShort, NBsController::TPDiskId> replacedDisks,
+            const NBsController::TGroupMapper::TForbiddenPDisks& forbid, i64 requiredSpace,
+            NKikimrBlobStorage::TBaseConfig *baseConfig) {
+        using TPDiskId = NBsController::TPDiskId;
+
         NKikimrConfig::TBlobStorageConfig *bsConfig = config->MutableBlobStorageConfig();
         const auto& settings = bsConfig->GetAutoconfigSettings();
 
@@ -49,14 +65,178 @@ namespace NKikimr::NStorage {
             nodeLocations.try_emplace(node.GetNodeId(), node.GetLocation());
         }
 
-        // group mapper
-        const auto species = TBlobStorageGroupType::ErasureSpeciesByName(settings.GetErasureSpecies());
-        if (species == TBlobStorageGroupType::ErasureSpeciesCount) {
-            throw TExConfigError() << "invalid erasure specified for static group"
-                << " Erasure# " << settings.GetErasureSpecies();
+        struct TPDiskInfo {
+            NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk Record;
+            ui32 UsedSlots = 0;
+            bool Usable = true;
+        };
+
+        THashMap<TPDiskId, TPDiskInfo> pdisks;
+
+        auto checkMatch = [&](NKikimrBlobStorage::EPDiskType type, bool sharedWithOs, bool readCentric, ui64 kind) {
+            for (const auto& pdiskFilter : pdiskFilters) {
+                bool m = true;
+                for (const auto& p : pdiskFilter.GetProperty()) {
+                    bool pMatch = false;
+                    switch (p.GetPropertyCase()) {
+                        case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kType:
+                            pMatch = p.GetType() == type;
+                            break;
+                        case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kSharedWithOs:
+                            pMatch = p.GetSharedWithOs() == sharedWithOs;
+                            break;
+                        case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kReadCentric:
+                            pMatch = p.GetReadCentric() == readCentric;
+                            break;
+                        case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kKind:
+                            pMatch = p.GetKind() == kind;
+                            break;
+                        case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::PROPERTY_NOT_SET:
+                            throw TExConfigError() << "invalid TPDiskFilter record";
+                    }
+                    if (!pMatch) {
+                        m = false;
+                        break;
+                    }
+                }
+                if (m) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        if (baseConfig) {
+            for (const auto& pdisk : baseConfig->GetPDisk()) {
+                if (!checkMatch(pdisk.GetType(), pdisk.GetSharedWithOs(), pdisk.GetReadCentric(), pdisk.GetKind())) {
+                    continue;
+                }
+
+                const TPDiskId pdiskId(pdisk.GetNodeId(), pdisk.GetPDiskId());
+                if (const auto [it, inserted] = pdisks.try_emplace(pdiskId); inserted) {
+                    auto& r = it->second.Record;
+                    r.SetNodeID(pdiskId.NodeId);
+                    r.SetPDiskID(pdiskId.PDiskId);
+                    r.SetPath(pdisk.GetPath());
+                    r.SetPDiskGuid(pdisk.GetGuid());
+                    r.SetPDiskCategory(TPDiskCategory(static_cast<NPDisk::EDeviceType>(pdisk.GetType()),
+                        pdisk.GetKind()).GetRaw());
+                    if (pdisk.HasPDiskConfig()) {
+                        r.MutablePDiskConfig()->CopyFrom(pdisk.GetPDiskConfig());
+                    }
+                } else {
+                    Y_ABORT("duplicate PDisk record in TBaseConfig");
+                }
+            }
+
+            for (const auto& vslot : baseConfig->GetVSlot()) {
+                const auto& vslotId = vslot.GetVSlotId();
+                const TPDiskId pdiskId(vslotId.GetNodeId(), vslotId.GetPDiskId());
+                if (const auto it = pdisks.find(pdiskId); it != pdisks.end()) {
+                    ++it->second.UsedSlots;
+                }
+            }
         }
-        NBsController::TGroupGeometryInfo geom(species, settings.GetGeometry());
-        NBsController::TGroupMapper mapper(geom);
+
+        // then all existing drives from the current storage config; also extract group definition, if it exists
+        NBsController::TGroupMapper::TGroupDefinition groupDefinition;
+        THashMap<ui32, ui32> maxPDiskId;
+        THashMap<TPDiskId, ui32> maxVSlotId;
+        THashSet<TPDiskId> addedPDisks;
+        THashMap<TVDiskIdShort, NKikimrBlobStorage::TVDiskLocation> vdiskLocations;
+
+        if (bsConfig->HasServiceSet()) {
+            const auto& ss = bsConfig->GetServiceSet();
+
+            for (const auto& vdisk : ss.GetVDisks()) {
+                const TVDiskID vdiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
+                if (vdiskId.GroupID == groupId) {
+                    vdiskLocations.emplace(vdiskId, vdisk.GetVDiskLocation());
+                }
+            }
+
+            std::vector<std::tuple<TPDiskId, i32>> usageIncr;
+
+            THashSet<TPDiskId> requiredPDiskIds;
+            for (const auto& group : ss.GetGroups()) {
+                if (group.GetGroupID() == groupId) {
+                    ui32 failRealmIdx = 0;
+                    Y_DEBUG_ABORT_UNLESS(groupDefinition.empty());
+                    groupDefinition.clear();
+
+                    for (const auto& r : group.GetRings()) {
+                        ui32 failDomainIdx = 0;
+                        auto& grDefRealm = groupDefinition.emplace_back();
+
+                        for (const auto& fd : r.GetFailDomains()) {
+                            ui32 vdiskIdx = 0;
+                            auto& grDefDomain = grDefRealm.emplace_back();
+
+                            for (const auto& v : fd.GetVDiskLocations()) {
+                                const TVDiskIdShort vdiskId(failRealmIdx, failDomainIdx, vdiskIdx);
+
+                                TPDiskId pdiskId(v.GetNodeID(), v.GetPDiskID());
+                                requiredPDiskIds.insert(pdiskId);
+
+                                if (const auto it = replacedDisks.find(vdiskId); it != replacedDisks.end()) {
+                                    usageIncr.emplace_back(pdiskId, -1); // drop usage count of current PDisk
+                                    std::swap(pdiskId, it->second);
+                                    if (pdiskId != TPDiskId()) {
+                                        usageIncr.emplace_back(pdiskId, +1); // and increase for the new PDisk
+                                    }
+                                    vdiskLocations.erase(vdiskId);
+                                }
+                                grDefDomain.emplace_back(pdiskId);
+
+                                ++vdiskIdx;
+                            }
+                            ++failDomainIdx;
+                        }
+                        ++failRealmIdx;
+                    }
+                }
+            }
+
+            for (const auto& pdisk : ss.GetPDisks()) {
+                const TPDiskId pdiskId(pdisk.GetNodeID(), pdisk.GetPDiskID());
+                if (requiredPDiskIds.contains(pdiskId)) {
+                    if (const auto [it, inserted] = pdisks.try_emplace(pdiskId); inserted) {
+                        auto& r = it->second.Record;
+                        r.CopyFrom(pdisk);
+                    }
+                }
+
+                auto& m = maxPDiskId[pdiskId.NodeId];
+                m = Max(m, pdiskId.PDiskId);
+
+                addedPDisks.insert(pdiskId);
+            }
+
+            for (const auto& [pdiskId, incr] : usageIncr) {
+                if (const auto it = pdisks.find(pdiskId); it != pdisks.end()) {
+                    it->second.UsedSlots += incr;
+                } else {
+                    Y_ABORT("missing PDiskId from group");
+                }
+            }
+
+            for (const auto& vdisk : ss.GetVDisks()) {
+                const auto& loc = vdisk.GetVDiskLocation();
+                const TPDiskId pdiskId(loc.GetNodeID(), loc.GetPDiskID());
+                if (const auto it = pdisks.find(pdiskId); it != pdisks.end()) {
+                    ++it->second.UsedSlots;
+                }
+
+                auto& m = maxVSlotId[pdiskId];
+                m = Max(m, loc.GetVDiskSlotID());
+            }
+        }
+
+        // build PDisk locator map (nodeId:path -> pdiskId)
+        THashSet<std::tuple<ui32, TString>> pdiskLocations;
+        for (const auto& [pdiskId, item] : pdisks) {
+            pdiskLocations.emplace(std::make_tuple(pdiskId.NodeId, item.Record.GetPath()));
+        }
 
         // build host config map
         THashMap<ui64, const NKikimrBlobStorage::TDefineHostConfig*> hostConfigs;
@@ -66,7 +246,6 @@ namespace NKikimr::NStorage {
         }
 
         // find all drives
-        THashMap<NBsController::TPDiskId, NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk> pdiskMap;
         const auto& defineBox = settings.GetDefineBox();
         for (const auto& host : defineBox.GetHost()) {
             const ui32 nodeId = host.GetEnforcedNodeId();
@@ -81,129 +260,157 @@ namespace NKikimr::NStorage {
             }
             const auto& defineHostConfig = *it->second;
 
-            ui32 pdiskId = 1;
             for (const auto& drive : defineHostConfig.GetDrive()) {
-                bool matching = false;
-                for (const auto& pdiskFilter : settings.GetPDiskFilter()) {
-                    bool m = true;
-                    for (const auto& p : pdiskFilter.GetProperty()) {
-                        bool pMatch = false;
-                        switch (p.GetPropertyCase()) {
-                            case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kType:
-                                pMatch = p.GetType() == drive.GetType();
-                                break;
-                            case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kSharedWithOs:
-                                pMatch = p.GetSharedWithOs() == drive.GetSharedWithOs();
-                                break;
-                            case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kReadCentric:
-                                pMatch = p.GetReadCentric() == drive.GetReadCentric();
-                                break;
-                            case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::kKind:
-                                pMatch = p.GetKind() == drive.GetKind();
-                                break;
-                            case NKikimrBlobStorage::TPDiskFilter::TRequiredProperty::PROPERTY_NOT_SET:
-                                throw TExConfigError() << "invalid TPDiskFilter record";
+                if (pdiskLocations.contains(std::make_tuple(nodeId, drive.GetPath()))) {
+                    continue;
+                }
+                if (checkMatch(drive.GetType(), drive.GetSharedWithOs(), drive.GetReadCentric(), drive.GetKind())) {
+                    const TPDiskId pdiskId(nodeId, ++maxPDiskId[nodeId]);
+                    if (const auto [it, inserted] = pdisks.try_emplace(pdiskId); inserted) {
+                        auto& r = it->second.Record;
+                        r.SetNodeID(pdiskId.NodeId);
+                        r.SetPDiskID(pdiskId.PDiskId);
+                        r.SetPath(drive.GetPath());
+                        r.SetPDiskGuid(RandomNumber<ui64>());
+                        r.SetPDiskCategory(TPDiskCategory(static_cast<NPDisk::EDeviceType>(drive.GetType()),
+                            drive.GetKind()).GetRaw());
+                        if (drive.HasPDiskConfig()) {
+                            r.MutablePDiskConfig()->CopyFrom(drive.GetPDiskConfig());
                         }
-                        if (!pMatch) {
-                            m = false;
-                            break;
-                        }
-                    }
-                    if (m) {
-                        matching = true;
-                        break;
+                    } else {
+                        Y_ABORT("duplicate PDiskId");
                     }
                 }
-                if (matching) {
-                    const auto it = nodeLocations.find(nodeId);
-                    if (it == nodeLocations.end()) {
-                        throw TExConfigError() << "no location for node";
-                    }
-
-                    NBsController::TPDiskId fullPDiskId{nodeId, pdiskId};
-                    mapper.RegisterPDisk({
-                        .PDiskId = fullPDiskId,
-                        .Location = it->second,
-                        .Usable = true,
-                        .NumSlots = 0,
-                        .MaxSlots = 1,
-                        .Groups{},
-                        .SpaceAvailable = 0,
-                        .Operational = true,
-                        .Decommitted = false,
-                        .WhyUnusable{},
-                    });
-
-                    const auto [pdiskIt, inserted] = pdiskMap.try_emplace(fullPDiskId);
-                    Y_ABORT_UNLESS(inserted);
-                    auto& pdisk = pdiskIt->second;
-                    pdisk.SetNodeID(nodeId);
-                    pdisk.SetPDiskID(pdiskId);
-                    pdisk.SetPath(drive.GetPath());
-                    pdisk.SetPDiskGuid(RandomNumber<ui64>());
-                    pdisk.SetPDiskCategory(TPDiskCategory(static_cast<NPDisk::EDeviceType>(drive.GetType()),
-                        drive.GetKind()).GetRaw());
-                    if (drive.HasPDiskConfig()) {
-                        pdisk.MutablePDiskConfig()->CopyFrom(drive.GetPDiskConfig());
-                    }
-                }
-                ++pdiskId;
             }
         }
 
-        NBsController::TGroupMapper::TGroupDefinition group;
-        const ui32 groupId = 0;
-        const ui32 groupGeneration = 1;
+        // group mapper
+        NBsController::TGroupGeometryInfo geom(gtype.GetErasure(), geometry);
+        NBsController::TGroupMapper mapper(geom);
+
+        for (const auto& [pdiskId, item] : pdisks) {
+            const auto it = nodeLocations.find(pdiskId.NodeId);
+            if (it == nodeLocations.end()) {
+                throw TExConfigError() << "no location for node";
+            }
+
+            ui32 maxSlots = 16;
+            if (item.Record.HasPDiskConfig()) {
+                const auto& pdiskConfig = item.Record.GetPDiskConfig();
+                if (pdiskConfig.HasExpectedSlotCount()) {
+                    maxSlots = pdiskConfig.GetExpectedSlotCount();
+                }
+            }
+
+            mapper.RegisterPDisk({
+                .PDiskId = pdiskId,
+                .Location = it->second,
+                .Usable = item.Usable,
+                .NumSlots = item.UsedSlots,
+                .MaxSlots = maxSlots,
+                .Groups{},
+                .SpaceAvailable = 0,
+                .Operational = true,
+                .Decommitted = false,
+                .WhyUnusable{},
+            });
+        }
+
+        auto dumpGroupDefinition = [&] {
+            TStringStream s;
+            for (const auto& r : groupDefinition) {
+                s << '{';
+                for (const auto& d : r) {
+                    s << '[';
+                    bool first = true;
+                    for (const auto& p : d) {
+                        s << (std::exchange(first, false) ? "" : " ") << p;
+                    }
+                    s << ']';
+                }
+                s << '}';
+            }
+            return s.Str();
+        };
+
         TString error;
-        if (!mapper.AllocateGroup(groupId, group, {}, {}, 0, false, error)) {
-            throw TExConfigError() << "group allocation failed"
-                << " Error# " << error;
+        if (!mapper.AllocateGroup(groupId, groupDefinition, replacedDisks, forbid, requiredSpace, false, error)) {
+            throw TExConfigError() << "group allocation failed Error# " << error
+                << " groupDefinition# " << dumpGroupDefinition();
         }
 
         auto *sSet = bsConfig->MutableServiceSet();
-        auto *sGroup = sSet->AddGroups();
-        sGroup->SetGroupID(groupId);
-        sGroup->SetGroupGeneration(groupGeneration);
-        sGroup->SetErasureSpecies(species);
 
-        THashSet<NBsController::TPDiskId> addedPDisks;
-
-        for (size_t realmIdx = 0; realmIdx < group.size(); ++realmIdx) {
-            const auto& realm = group[realmIdx];
-            auto *sRealm = sGroup->AddRings();
-
-            for (size_t domainIdx = 0; domainIdx < realm.size(); ++domainIdx) {
-                const auto& domain = realm[domainIdx];
-                auto *sDomain = sRealm->AddFailDomains();
-
-                for (size_t vdiskIdx = 0; vdiskIdx < domain.size(); ++vdiskIdx) {
-                    const NBsController::TPDiskId pdiskId = domain[vdiskIdx];
-
-                    const auto pdiskIt = pdiskMap.find(pdiskId);
-                    Y_ABORT_UNLESS(pdiskIt != pdiskMap.end());
-                    const auto& pdisk = pdiskIt->second;
-
-                    if (addedPDisks.insert(pdiskId).second) {
-                        sSet->AddPDisks()->CopyFrom(pdisk);
-                    }
-
-                    auto *sDisk = sSet->AddVDisks();
-
-                    VDiskIDFromVDiskID(TVDiskID(groupId, groupGeneration, realmIdx, domainIdx, vdiskIdx),
-                        sDisk->MutableVDiskID());
-
-                    auto *sLoc = sDisk->MutableVDiskLocation();
-                    sLoc->SetNodeID(pdiskId.NodeId);
-                    sLoc->SetPDiskID(pdiskId.PDiskId);
-                    sLoc->SetVDiskSlotID(0);
-                    sLoc->SetPDiskGuid(pdisk.GetPDiskGuid());
-
-                    sDisk->SetVDiskKind(NKikimrBlobStorage::TVDiskKind::Default);
-
-                    sDomain->AddVDiskLocations()->CopyFrom(*sLoc);
-                }
+        NKikimrBlobStorage::TGroupInfo *sGroup = nullptr;
+        for (size_t i = 0; i < sSet->GroupsSize(); ++i) {
+            if (const auto& group = sSet->GetGroups(i); group.GetGroupID() == groupId) {
+                sGroup = sSet->MutableGroups(i);
+                break;
             }
         }
+        if (!sGroup) {
+            sGroup = sSet->AddGroups();
+            sGroup->SetGroupID(groupId);
+            sGroup->SetErasureSpecies(gtype.GetErasure());
+        } else {
+            sGroup->ClearRings();
+        }
+        sGroup->SetGroupGeneration(groupGeneration);
+
+        TVDiskIdShort prev;
+        NKikimrBlobStorage::TGroupInfo::TFailRealm *sRealm = nullptr;
+        NKikimrBlobStorage::TGroupInfo::TFailRealm::TFailDomain *sDomain = nullptr;
+
+        for (size_t i = 0; i < sSet->VDisksSize(); ++i) {
+            const auto& vdisk = sSet->GetVDisks(i);
+            const TVDiskID vdiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
+            if (vdiskId.GroupID != groupId) {
+                continue;
+            }
+            if (vdisk.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::DESTROY) {
+                continue;
+            }
+            auto *m = sSet->MutableVDisks(i);
+            if (replacedDisks.contains(vdiskId)) {
+                m->SetEntityStatus(NKikimrBlobStorage::EEntityStatus::DESTROY);
+            } else {
+                m->MutableVDiskID()->SetGroupGeneration(groupGeneration);
+            }
+        }
+
+        NBsController::TGroupMapper::Traverse(groupDefinition, [&](TVDiskIdShort vdiskId, TPDiskId pdiskId) {
+            if (!sRealm || vdiskId.FailRealm != prev.FailRealm) {
+                sRealm = sGroup->AddRings();
+                sDomain = nullptr;
+            }
+            if (!sDomain || vdiskId.FailDomain != prev.FailDomain) {
+                sDomain = sRealm->AddFailDomains();
+            }
+            prev = vdiskId;
+
+            const auto pdiskIt = pdisks.find(pdiskId);
+            Y_ABORT_UNLESS(pdiskIt != pdisks.end());
+            const auto& pdisk = pdiskIt->second.Record;
+
+            if (addedPDisks.insert(pdiskId).second) {
+                sSet->AddPDisks()->CopyFrom(pdisk);
+            }
+
+            auto *sLoc = sDomain->AddVDiskLocations();
+            if (const auto it = vdiskLocations.find(vdiskId); it != vdiskLocations.end()) {
+                sLoc->CopyFrom(it->second);
+            } else {
+                sLoc->SetNodeID(pdiskId.NodeId);
+                sLoc->SetPDiskID(pdiskId.PDiskId);
+                sLoc->SetVDiskSlotID(++maxVSlotId[pdiskId]); // keep VDiskSlotID for unchanged items
+                sLoc->SetPDiskGuid(pdisk.GetPDiskGuid());
+
+                auto *sDisk = sSet->AddVDisks();
+                VDiskIDFromVDiskID(TVDiskID(groupId, groupGeneration, vdiskId), sDisk->MutableVDiskID());
+                sDisk->SetVDiskKind(NKikimrBlobStorage::TVDiskKind::Default);
+                sDisk->MutableVDiskLocation()->CopyFrom(*sLoc);
+            }
+        });
     }
 
     void TDistributedConfigKeeper::GenerateStateStorageConfig(NKikimrConfig::TDomainsConfig::TStateStorage *ss,

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -151,6 +151,27 @@ namespace NKikimr::NStorage {
                     }
                 }
 
+                auto outputConfig = [&](const char *name, auto *config) {
+                    DIV_CLASS("panel panel-info") {
+                        DIV_CLASS("panel-heading") {
+                            out << name;
+                        }
+                        DIV_CLASS("panel-body") {
+                            if (config) {
+                                TString s;
+                                NProtoBuf::TextFormat::PrintToString(*config, &s);
+                                out << "<pre>" << s << "</pre>";
+                            } else {
+                                out << "not defined";
+                            }
+                        }
+                    }
+                };
+                outputConfig("StorageConfig", StorageConfig ? &StorageConfig.value() : nullptr);
+                outputConfig("BaseConfig", &BaseConfig);
+                outputConfig("InitialConfig", &InitialConfig);
+                outputConfig("ProposedStorageConfig", ProposedStorageConfig ? &ProposedStorageConfig.value() : nullptr);
+
                 DIV_CLASS("panel panel-info") {
                     DIV_CLASS("panel-heading") {
                         out << "Outgoing binding";

--- a/ydb/core/blobstorage/nodewarden/node_warden_events.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_events.h
@@ -57,4 +57,14 @@ namespace NKikimr::NStorage {
         : TEventPB<TEvNodeConfigInvokeOnRootResult, NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult, TEvBlobStorage::EvNodeConfigInvokeOnRootResult>
     {};
 
+    struct TEvNodeWardenQueryBaseConfig
+        : TEventLocal<TEvNodeWardenQueryBaseConfig, TEvBlobStorage::EvNodeWardenQueryBaseConfig>
+    {};
+
+    struct TEvNodeWardenBaseConfig
+        : TEventLocal<TEvNodeWardenBaseConfig, TEvBlobStorage::EvNodeWardenBaseConfig>
+    {
+        NKikimrBlobStorage::TBaseConfig BaseConfig;
+    };
+
 } // NKikimr::NStorage

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -106,6 +106,9 @@ namespace NKikimr::NStorage {
         std::optional<TString> InstanceId; // instance ID of BS_CONTROLLER running this node
         TActorId PipeClientId;
 
+        ui64 NextConfigCookie = 1;
+        std::unordered_map<ui64, std::function<void(TEvBlobStorage::TEvControllerConfigResponse*)>> ConfigInFlight;
+
         TVector<NPDisk::TDriveData> WorkingLocalDrives;
 
         NPDisk::TOwnerRound LocalPDiskInitOwnerRound = 1;
@@ -470,7 +473,7 @@ namespace NKikimr::NStorage {
         void SendDropDonorQuery(ui32 nodeId, ui32 pdiskId, ui32 vslotId, const TVDiskID& vdiskId);
 
         void SendVDiskReport(TVSlotId vslotId, const TVDiskID& vdiskId,
-            NKikimrBlobStorage::TEvControllerNodeReport::EVDiskPhase phase);
+            NKikimrBlobStorage::TEvControllerNodeReport::EVDiskPhase phase, TDuration backoff = {});
 
         void SendPDiskReport(ui32 pdiskId, NKikimrBlobStorage::TEvControllerNodeReport::EPDiskPhase phase);
 
@@ -530,6 +533,15 @@ namespace NKikimr::NStorage {
         void ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConfig *proposed);
         void HandleGone(STATEFN_SIG);
         void ApplyStaticServiceSet(const NKikimrBlobStorage::TNodeWardenServiceSet& ss);
+
+        void Handle(TEvNodeWardenQueryBaseConfig::TPtr ev);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        ui64 NextInvokeCookie = 1;
+        std::unordered_map<ui64, std::function<void(TEvNodeConfigInvokeOnRootResult&)>> InvokeCallbacks;
+
+        void Handle(TEvNodeConfigInvokeOnRootResult::TPtr ev);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -613,6 +625,9 @@ namespace NKikimr::NStorage {
                 fFunc(TEvBlobStorage::EvNodeConfigScatter, ForwardToDistributedConfigKeeper);
                 fFunc(TEvBlobStorage::EvNodeConfigGather, ForwardToDistributedConfigKeeper);
                 fFunc(TEvBlobStorage::EvNodeConfigInvokeOnRoot, ForwardToDistributedConfigKeeper);
+
+                hFunc(TEvNodeWardenQueryBaseConfig, Handle);
+                hFunc(TEvNodeConfigInvokeOnRootResult, Handle);
 
                 fFunc(TEvents::TSystem::Gone, HandleGone);
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_pipe.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pipe.cpp
@@ -52,7 +52,10 @@ void TNodeWarden::OnPipeError() {
             VDisksWithUnreportedMetrics.PushBack(&vdisk);
         }
     }
-    PDiskRestartRequests.clear();
+    for (const auto& [cookie, callback] : ConfigInFlight) {
+        callback(nullptr);
+    }
+    ConfigInFlight.clear();
     EstablishPipe();
 }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -275,7 +275,7 @@ namespace NKikimr::NStorage {
             }
             DestroyLocalVDisk(record);
             LocalVDisks.erase(it);
-            ApplyServiceSetPDisks(); // delete unneeded PDisks
+            ApplyServiceSetPDisks(); // destroy unneeded PDisk actors
         } else if (vdisk.GetDoWipe()) {
             Slay(record);
         } else if (!record.RuntimeData) {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -246,18 +246,13 @@ message TQueryBaseConfig {
 message TReadSettings {
 }
 
-message TPDiskId {
-    uint32 NodeId = 1;
-    uint32 PDiskId = 2;
-}
-
 message TReassignGroupDisk {
     uint32 GroupId = 1;
     uint32 GroupGeneration = 2;
     uint32 FailRealmIdx = 3;
     uint32 FailDomainIdx = 4;
     uint32 VDiskIdx = 5;
-    TPDiskId TargetPDiskId = 6; // optional; when not specified, selected automatically
+    NKikimrBlobStorage.TPDiskId TargetPDiskId = 6; // optional; when not specified, selected automatically
     bool SuppressDonorMode = 7; // when set, donor mode is not used even if it is enabled through BSC
     reserved 8;
 }
@@ -401,7 +396,7 @@ message TWipeVDisk {
 }
 
 message TRestartPDisk {
-    TPDiskId TargetPDiskId = 1;
+    NKikimrBlobStorage.TPDiskId TargetPDiskId = 1;
 }
 
 message TSetScrubPeriodicity {

--- a/ydb/core/protos/blobstorage_disk.proto
+++ b/ydb/core/protos/blobstorage_disk.proto
@@ -39,6 +39,11 @@ message TVDiskID {
     optional uint32 VDisk = 5;
 }
 
+message TPDiskId {
+    optional uint32 NodeId = 1;
+    optional uint32 PDiskId = 2;
+}
+
 message TVSlotId {
     optional uint32 NodeId = 1;
     optional uint32 PDiskId = 2;

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "ydb/core/protos/config.proto";
+import "ydb/core/protos/blobstorage_disk.proto";
 import "ydb/library/actors/protos/interconnect.proto";
 
 package NKikimrBlobStorage;
@@ -149,9 +150,22 @@ message TEvNodeConfigInvokeOnRoot {
     message TQueryConfig
     {}
 
+    message TReassignGroupDisk {
+        NKikimrBlobStorage.TVDiskID VDiskId = 1; // which one to reassign
+        optional NKikimrBlobStorage.TPDiskId PDiskId = 2; // where to put it (optional)
+    }
+
+    // Regenerate configuration so the slain VDisk is no more reported as DESTROY one in the list.
+    message TStaticVDiskSlain {
+        NKikimrBlobStorage.TVDiskID VDiskId = 1;
+        NKikimrBlobStorage.TVSlotId VSlotId = 2;
+    }
+
     oneof Request {
         TUpdateConfig UpdateConfig = 1;
         TQueryConfig QueryConfig = 2;
+        TReassignGroupDisk ReassignGroupDisk = 3;
+        TStaticVDiskSlain StaticVDiskSlain = 4;
     }
 }
 
@@ -177,6 +191,12 @@ message TEvNodeConfigInvokeOnRootResult {
         TStorageConfig CurrentProposedStorageConfig = 2;
     }
 
+    message TReassignGroupDisk {
+    }
+
+    message TStaticVDiskSlain {
+    }
+
     EStatus Status = 1;
     optional string ErrorReason = 2;
     TScepter Scepter = 3;
@@ -184,5 +204,7 @@ message TEvNodeConfigInvokeOnRootResult {
     oneof Response {
         TUpdateConfig UpdateConfig = 4;
         TQueryConfig QueryConfig = 5;
+        TReassignGroupDisk ReassignGroupDisk = 6;
+        TStaticVDiskSlain StaticVDiskSlain = 7;
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support static group reconfiguration through distconf

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

A support for on-line static group reconfiguration has been added to the NodeWarden.

#3887 
