### PR TITLE
Get rid of unneccessary std::move

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -165,7 +165,7 @@ public:
                 MaskForCookieBruteForcing, std::move(Diffs), DiffCount, Deadline));
         patch->RestartCounter = counter;
         patch->Orbit = std::move(Orbit);
-        return std::move(ev);
+        return ev;
     }
 
     void ApplyDiffs() {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -1086,7 +1086,7 @@ std::unique_ptr<TEvChunkLockResult> TPDisk::ChunkLockFromQuota(TOwner owner, ui3
     }
 
     guard.Release();
-    return std::move(result);
+    return result;
 }
 
 std::unique_ptr<TEvChunkLockResult> TPDisk::ChunkLockFromQuota(TOwner owner, NKikimrBlobStorage::TPDiskSpaceColor::E color) {
@@ -1098,7 +1098,7 @@ std::unique_ptr<TEvChunkLockResult> TPDisk::ChunkLockFromQuota(TOwner owner, NKi
         return std::unique_ptr<TEvChunkLockResult>(new NPDisk::TEvChunkLockResult(NKikimrProto::ERROR,
             {}, Keeper.GetFreeChunkCount(), "Space color flag is already raised"));
     } else {
-        return std::move(ChunkLockFromQuota(owner, number - used));
+        return ChunkLockFromQuota(owner, number - used);
     }
 }
 

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor.cpp
@@ -419,7 +419,7 @@ namespace NKikimr::NPrivate {
                 bool isAligned = (GType.ErasureFamily() != TErasureType::ErasureMirror);
                 diffs.emplace_back(buffer, diff.GetOffset(), isXor, isAligned);
             }
-            return std::move(diffs);
+            return diffs;
         }
 
         bool CheckDiff(const TVector<TDiff> &diffs, const TString &diffName) {

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_vpatch_actor_ut.cpp
@@ -169,14 +169,14 @@ namespace NKikimr {
             for (auto &diffBlock : diffs) {
                 diff->AddDiff(diffBlock.Offset, diffBlock.Buffer);
             }
-            return std::move(diff);
+            return diff;
         }
 
         std::unique_ptr<TEvBlobStorage::TEvVPatchDiff> CreateForceEndVPatchDiff(ui8 partId, TMaybe<ui64> cookie) const {
             std::unique_ptr<TEvBlobStorage::TEvVPatchDiff> diff = std::make_unique<TEvBlobStorage::TEvVPatchDiff>(TLogoBlobID(OriginalBlobId, partId),
                     TLogoBlobID(PatchedBlobId, partId), VDiskIds[partId - 1], false, Deadline, cookie);
             diff->SetForceEnd();
-            return std::move(diff);
+            return diff;
         }
 
         template <typename DecoratorType = void>

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogmsgreader.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogmsgreader.cpp
@@ -17,7 +17,7 @@ namespace NKikimr {
 
             ForEach(Data, writeToList, writeToList, writeToList, writeToList);
 
-            return std::move(records);
+            return records;
         }
 
         bool TNaiveFragmentReader::Check(TString &errorString) {
@@ -53,7 +53,7 @@ namespace NKikimr {
 
             TNaiveFragmentReader::ForEach(Uncompressed, writeToList, writeToList, writeToList, writeToList);
 
-            return std::move(records);
+            return records;
         }
 
         ////////////////////////////////////////////////////////////////////////////
@@ -69,7 +69,7 @@ namespace NKikimr {
             TWriteRecordToList writeToList{records};
 
             ForEachImpl(writeToList, writeToList, writeToList, writeToList);
-            return std::move(records);
+            return records;
         }
 
         ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/debug_tools/ut/main.cpp
+++ b/ydb/core/debug_tools/ut/main.cpp
@@ -13,7 +13,7 @@ Y_UNIT_TEST_SUITE(OperationLog) {
         for (ui32 i = 0; i < size; ++i) {
             data += 'a' + RandomNumber<ui32>() % ('z' - 'a' + 1);
         }
-        return std::move(data);
+        return data;
     }
 
     template<ui32 Size>

--- a/ydb/core/driver_lib/version/version.cpp
+++ b/ydb/core/driver_lib/version/version.cpp
@@ -498,7 +498,7 @@ TString GetTagString() {
         }
     }
 
-    return std::move(tag);
+    return tag;
 }
 
 bool TCompatibilityInfo::CompleteFromTag(NKikimrConfig::TCurrentCompatibilityInfo& current) {

--- a/ydb/core/engine/mkql_engine_flat.cpp
+++ b/ydb/core/engine/mkql_engine_flat.cpp
@@ -147,7 +147,7 @@ private:
             resultItems[1] = pair.second;
         }
 
-        return std::move(results);
+        return results;
     }
 
 private:

--- a/ydb/core/kqp/host/kqp_host_impl.h
+++ b/ydb/core/kqp/host/kqp_host_impl.h
@@ -50,7 +50,7 @@ public:
             result.AddIssues(ExprCtx.IssueManager.GetIssues());
         }
         FillResult(result);
-        return std::move(result);
+        return result;
     }
 
     NThreading::TFuture<bool> Continue() override {
@@ -196,7 +196,7 @@ public:
 
         execResult.AddIssues(Issues);
 
-        return std::move(execResult);
+        return execResult;
     }
 
     NThreading::TFuture<bool> Continue() override {

--- a/ydb/core/kqp/host/kqp_translate.cpp
+++ b/ydb/core/kqp/host/kqp_translate.cpp
@@ -170,7 +170,7 @@ NYql::TAstParseResult ParseQuery(const TString& queryText, bool isSql, TMaybe<ui
         sqlVersion = ast.ActualSyntaxType == NYql::ESyntaxType::YQLv1 ? 1 : 0;
         keepInCache = stmtParseInfo.KeepInCache;
         commandTagName = stmtParseInfo.CommandTagName;
-        return std::move(ast);
+        return ast;
     } else {
         sqlVersion = {};
         deprecatedSQL = true;

--- a/ydb/core/kqp/runtime/kqp_write_table.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_table.cpp
@@ -545,7 +545,7 @@ public:
                 Memory -= batch->GetMemory();
             }
         }
-        return std::move(newBatches);
+        return newBatches;
     }
 
     IBatchPtr FlushBatch(ui64 shardId) override {

--- a/ydb/core/load_test/group_write.cpp
+++ b/ydb/core/load_test/group_write.cpp
@@ -186,7 +186,7 @@ class TLogWriterLoadTestActor : public TActorBootstrapped<TLogWriterLoadTestActo
             const TSharedData buffer = GenerateBuffer<TSharedData>(id);
             auto ev = std::make_unique<TEvBlobStorage::TEvPut>(id, buffer, TInstant::Max(), PutHandleClass);
             InFlightTracker.Request(blobSize);
-            return std::move(ev);
+            return ev;
         }
 
         std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> ManageKeepFlags(ui64 tabletId, ui32 gen, ui32 step,

--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -211,7 +211,7 @@ namespace NKikimr::NBsController {
                     pdisk->NumDomainMatchingDisks = numMatchingDisksInDomain[position.Domain.Index()];
                 }
 
-                return std::move(res);
+                return res;
             }
 
             struct TUndoLog {

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -639,7 +639,7 @@ namespace NKikimr::NBsController {
                 }
             }
 
-            return std::move(groupDefinition);
+            return groupDefinition;
         }
 
         void HandleWakeup() {

--- a/ydb/core/mon_alloc/profiler.cpp
+++ b/ydb/core/mon_alloc/profiler.cpp
@@ -114,7 +114,7 @@ namespace NActors {
             }
 
             if (profiler) {
-                return std::move(profiler);
+                return profiler;
             }
 
 #if defined(EXEC_PROFILER_ENABLED)

--- a/ydb/core/security/certificate_check/cert_auth_utils.cpp
+++ b/ydb/core/security/certificate_check/cert_auth_utils.cpp
@@ -132,7 +132,7 @@ PKeyPtr GenerateKeys() {
 
   rsa.release(); // mem is grabbed by pkkey
 
-  return std::move(pkey);
+  return pkey;
 }
 
 int FillNameFromProps(X509_NAME* name, const TProps& props) {
@@ -249,7 +249,7 @@ X509Ptr GenerateSelfSignedCertificate(PKeyPtr& pkey, const TProps& props) {
     errNo = X509_sign(x509.get(), pkey.get(), EVP_sha1());
     CHECK(errNo, "Error signing certificate.");
 
-    return std::move(x509);
+    return x509;
 }
 
 std::string WriteAsPEM(PKeyPtr& pkey) {
@@ -285,7 +285,7 @@ X509Ptr ReadCertAsPEM(const std::string& cert) {
     auto x509 = X509Ptr(PEM_read_bio_X509(bio.get(), NULL, NULL, NULL));
     CHECK(x509, "failed to load certificate");
 
-    return std::move(x509);
+    return x509;
 }
 
 PKeyPtr ReadPrivateKeyAsPEM(const std::string& key) {
@@ -295,7 +295,7 @@ PKeyPtr ReadPrivateKeyAsPEM(const std::string& key) {
     auto pkey = PKeyPtr(PEM_read_bio_PrivateKey(bio.get(), NULL, NULL, NULL));
     CHECK(pkey, "failed to private key certificate");
 
-    return std::move(pkey);
+    return pkey;
 }
 
 void add_ext(X509V3_CTX* ctx, STACK_OF(X509_EXTENSION)* exts, int nid, const char *value) {
@@ -384,7 +384,7 @@ X509REQPtr GenerateRequest(PKeyPtr& pkey, const TProps& props) {
     errNo = X509_REQ_sign(request.get(), pkey.get(), EVP_md5());
     CHECK(errNo, "Error MD5 signing X509_REQ structure.");
 
-    return std::move(request);
+    return request;
 }
 
 X509Ptr SignRequest(X509REQPtr& request, X509Ptr& rootCert, PKeyPtr& rootKey, const TProps& props) {
@@ -443,7 +443,7 @@ X509Ptr SignRequest(X509REQPtr& request, X509Ptr& rootCert, PKeyPtr& rootKey, co
 
     pktmp = nullptr;
 
-    return std::move(x509);
+    return x509;
 }
 
 }

--- a/ydb/core/statistics/service/ut/ut_service.cpp
+++ b/ydb/core/statistics/service/ut/ut_service.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<TEvStatistics::TEvAggregateStatistics> CreateStatisticsRequest(c
         }
     }
 
-    return std::move(ev);
+    return ev;
 }
 
 std::unique_ptr<TEvStatistics::TEvAggregateStatisticsResponse> CreateAggregateStatisticsResponse(const TAggregateStatisticsResponse& data) {
@@ -102,7 +102,7 @@ std::unique_ptr<TEvStatistics::TEvAggregateStatisticsResponse> CreateAggregateSt
         statistics->SetData(buf.data(), buf.size());
     }
 
-    return std::move(ev);
+    return ev;
 }
 
 std::unique_ptr<TEvStatistics::TEvStatisticsResponse> CreateStatisticsResponse(const TStatisticsResponse& data) {
@@ -127,7 +127,7 @@ std::unique_ptr<TEvStatistics::TEvStatisticsResponse> CreateStatisticsResponse(c
         statistics->SetData(buf.data(), buf.size());
     }
 
-    return std::move(ev);
+    return ev;
 }
 
 TStatServiceSettings GetDefaultSettings() {

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -310,7 +310,7 @@ namespace NKikimr::NTable::NPage {
                 TString key = std::move(Keys.front());
                 KeysSize -= key.size();
                 Keys.pop_front();
-                return std::move(key);
+                return key;
             }
 
             void PushChild(TChild child) {

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<TEvBlobStorage::TEvCollectGarbage> TGCTask::BuildRequest(const T
         new TVector<TLogoBlobID>(it->second.DontKeepList.begin(), it->second.DontKeepList.end()),
         TInstant::Max(), true);
     result->PerGenerationCounter = PerGenerationCounter.Add(result->PerGenerationCounterStepSize());
-    return std::move(result);
+    return result;
 }
 
 }

--- a/ydb/core/tx/columnshard/blobs_reader/task.cpp
+++ b/ydb/core/tx/columnshard/blobs_reader/task.cpp
@@ -130,7 +130,7 @@ TCompositeReadBlobs ITask::ExtractBlobsData() {
     for (auto&& i : Agents) {
         result.Add(i.second->GetStorageId(), i.second->ExtractBlobsData());
     }
-    return std::move(result);
+    return result;
 }
 
 }

--- a/ydb/core/tx/columnshard/engines/changes/ttl.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/ttl.cpp
@@ -59,7 +59,7 @@ std::optional<TWritePortionInfoWithBlobsResult> TTTLColumnEngineChanges::UpdateE
     std::optional<TWritePortionInfoWithBlobsResult> result =
         TReadPortionInfoWithBlobs::SyncPortion(std::move(portionWithBlobs), blobSchema, evictFeatures.GetTargetScheme(),
             evictFeatures.GetTargetTierName(), SaverContext.GetStoragesManager(), context.Counters.SplitterCounters);
-    return std::move(result);
+    return result;
 }
 
 NKikimr::TConclusionStatus TTTLColumnEngineChanges::DoConstructBlobs(TConstructionContext& context) noexcept {

--- a/ydb/core/tx/datashard/datashard__engine_host.cpp
+++ b/ydb/core/tx/datashard/datashard__engine_host.cpp
@@ -37,7 +37,7 @@ NUdf::TUnboxedValue CreateRow(const TVector<TCell>& inRow,
         rowItems[i] = GetCellValue(inRow[i], inType[i]);
     }
 
-    return std::move(row);
+    return row;
 }
 
 } // namespace

--- a/ydb/core/tx/datashard/datashard_kqp_lookup_table.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_lookup_table.cpp
@@ -119,7 +119,7 @@ public:
                     TaskTableStats += stats;
 
                     if (fetched) {
-                        return std::move(result);
+                        return result;
                     }
 
                     if (ComputeCtx.IsTabletNotReady() || ComputeCtx.HadInconsistentReads()) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -100,7 +100,7 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
             " Actually that shouldn't have happened."
             " Note that tx body equality isn't granted."
             " StatusAccepted is just returned on retries.");
-        return std::move(response);
+        return response;
     }
 
     TOperation::TPtr operation = new TOperation(txId);
@@ -110,7 +110,7 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
         if (quotaResult.Status != NKikimrScheme::StatusSuccess) {
             response.Reset(new TProposeResponse(quotaResult.Status, ui64(txId), ui64(selfId)));
             response->SetError(quotaResult.Status, quotaResult.Reason);
-            return std::move(response);
+            return response;
         }
     }
 
@@ -129,7 +129,7 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
         if (splitResult.Status != NKikimrScheme::StatusSuccess) {
             response.Reset(new TProposeResponse(splitResult.Status, ui64(txId), ui64(selfId)));
             response->SetError(splitResult.Status, splitResult.Reason);
-            return std::move(response);
+            return response;
         }
 
         std::move(splitResult.Transactions.begin(), splitResult.Transactions.end(), std::back_inserter(transactions));
@@ -201,7 +201,7 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
 
                 AbortOperationPropose(txId, context);
 
-                return std::move(response);
+                return response;
             }
 
             // Check suboperations for undo safety. Log first unsafe suboperation in the schema transaction.
@@ -218,7 +218,7 @@ THolder<TProposeResponse> TSchemeShard::IgniteOperation(TProposeRequest& request
         }
     }
 
-    return std::move(response);
+    return response;
 }
 
 void TSchemeShard::AbortOperationPropose(const TTxId txId, TOperationContext& context) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.h
@@ -28,7 +28,7 @@ inline TPath::TChecker IsParentPathValid(const TPath& parentPath, const TTxTrans
     }
     Y_UNUSED(tx);
 
-    return std::move(checks);
+    return checks;
 }
 
 inline bool IsParentPathValid(const THolder<TProposeResponse>& result,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
@@ -32,7 +32,7 @@ TPath::TChecker IsParentPathValid(const TPath& parentPath) {
         .IsCommonSensePath()
         .IsLikeDirectory();
 
-    return std::move(checks);
+    return checks;
 }
 
 bool IsParentPathValid(const THolder<TProposeResponse>& result, const TPath& parentPath) {

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -152,7 +152,7 @@ THolder<TProposeRequest> MergeRequest(
         merge.AddSourceTabletId(ui64(tabletId));
     }
 
-    return std::move(request);
+    return request;
 }
 
 template <typename T>

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -425,7 +425,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             request->ResultSet.emplace_back(entry);
         }
 
-        return std::move(request);
+        return request;
     }
 
     void ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus status,
@@ -853,7 +853,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             request->ResultSet.emplace_back(std::move(entry));
         }
 
-        return std::move(request);
+        return request;
     }
 
     ui64 GetShardToRequest(NSchemeCache::TSchemeCacheNavigate::TEntry& resolveResult, const TPathToResolve& resolveTask) {

--- a/ydb/core/ymq/actor/action.h
+++ b/ydb/core/ymq/actor/action.h
@@ -191,7 +191,7 @@ protected:
             ret << " QueueAttributes: " << *QueueAttributes_;
         }
         ret << "Response: " << Response_;
-        return std::move(ret);
+        return ret;
     }
 
     virtual bool HandleWakeup(TEvWakeup::TPtr& ev) {

--- a/ydb/core/ymq/actor/executor.cpp
+++ b/ydb/core/ymq/actor/executor.cpp
@@ -424,7 +424,7 @@ TString TMiniKqlExecutionActor::GetRequestType() const {
     } else {
         ret << "Query";
     }
-    return std::move(ret);
+    return ret;
 }
 
 void TMiniKqlExecutionActor::PassAway() {

--- a/ydb/core/ymq/actor/receive_message.cpp
+++ b/ydb/core/ymq/actor/receive_message.cpp
@@ -243,7 +243,7 @@ private:
             << " MaxMessagesCount: " << MaxMessagesCount_
             << " TotalWaitDuration: " << TotalWaitDuration_
             << " ReceiveAttemptId: " << ReceiveAttemptId_;
-        return std::move(ret);
+        return ret;
     }
 
     const TReceiveMessageRequest& Request() const {

--- a/ydb/core/ymq/http/http.cpp
+++ b/ydb/core/ymq/http/http.cpp
@@ -856,7 +856,7 @@ static TString FormatNames(const TMap<int, TMessageAttribute>& messageAttributes
         }
         names << "\"" << item.second.GetName() << "\"";
     }
-    return std::move(names);
+    return names;
 }
 
 void THttpRequest::SetupSendMessage(TSendMessageRequest* const req) {

--- a/ydb/library/actors/queues/bench/bench_cases.h
+++ b/ydb/library/actors/queues/bench/bench_cases.h
@@ -59,7 +59,7 @@ namespace NActors::NQueueBench {
                     }
                 );
                 RunThreads(std::make_unique<TTestThread<decltype(worker), TStatsCollector>>(worker, &collector));
-                return std::move(collector);
+                return collector;
             }
 
             TThreadCounts GetThreads(ui64) override {
@@ -89,7 +89,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             TThreadCounts GetThreads(ui64) override {
@@ -112,7 +112,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             TThreadCounts GetThreads(ui64) override {
@@ -135,7 +135,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             TThreadCounts GetThreads(ui64) override {
@@ -165,7 +165,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             TThreadCounts GetThreads(ui64) override {
@@ -209,7 +209,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             std::variant<TThreadCounts, ui64> GetThreads(ui64 globalThreads) override {
@@ -259,7 +259,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             TString Validate(ui64 globalThreads) override {
@@ -318,7 +318,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             TString Validate(ui64 globalThreads) override {
@@ -375,7 +375,7 @@ namespace NActors::NQueueBench {
                     threads.emplace_back(new TTestThread<decltype(worker), TStatsCollector>(worker, &collector));
                 }
                 RunThreads(threads);
-                return std::move(collector);
+                return collector;
             }
 
             TString Validate(ui64 globalThreads) override {

--- a/ydb/library/mkql_proto/mkql_proto.cpp
+++ b/ydb/library/mkql_proto/mkql_proto.cpp
@@ -1839,7 +1839,7 @@ NUdf::TUnboxedValue TProtoImporter::ImportValueFromProto(const TType* type, cons
                 *items++ = ImportValueFromProto(itemType, x, factory);
             }
 
-            return std::move(array);
+            return array;
         }
 
         case TType::EKind::Struct: {
@@ -1853,7 +1853,7 @@ NUdf::TUnboxedValue TProtoImporter::ImportValueFromProto(const TType* type, cons
                 itemsPtr[index] = ImportValueFromProto(memberType, value.GetStruct(remapped), factory);
             }
 
-            return std::move(res);
+            return res;
         }
 
         case TType::EKind::Tuple: {
@@ -1865,7 +1865,7 @@ NUdf::TUnboxedValue TProtoImporter::ImportValueFromProto(const TType* type, cons
                 itemsPtr[index] = ImportValueFromProto(elementType, value.GetTuple(index), factory);
             }
 
-            return std::move(res);
+            return res;
         }
 
         case TType::EKind::Dict: {

--- a/ydb/library/yql/core/spilling/storage/storage.cpp
+++ b/ydb/library/yql/core/spilling/storage/storage.cpp
@@ -100,7 +100,7 @@ TString TSpillMetaRecord::AsString() {
     res = "RecordHash: " + std::to_string(RecordHash_) + " |Offset: " + std::to_string(Offset_) + " |RecordNumber: " + std::to_string(RecordNumber_) + " |Meta1: " + std::format("{:#08x}", Meta1_) + 
             " |DataSize: " + std::to_string(DataSize_) + " |DataHash: " + std::to_string(DataHash_) + " |Name: " + Name_;
 
-    return std::move(res);
+    return res;
 
 }
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -636,7 +636,7 @@ protected:
             issues.PrintTo(log.Out, true /* oneLine */);
         }
         log << '.';
-        return std::move(log);
+        return log;
     }
 
     void ContinueExecute(EResumeSource source = EResumeSource::Default) {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
@@ -660,7 +660,7 @@ public:
                     }
                 }
 
-                return std::move(structObj);
+                return structObj;
             }
         }
 

--- a/ydb/library/yql/minikql/computation/mkql_block_transport.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_block_transport.cpp
@@ -692,7 +692,7 @@ std::unique_ptr<IBlockSerializer> MakeBlockSerializer(const NYql::NUdf::ITypeInf
 std::unique_ptr<IBlockDeserializer> MakeBlockDeserializer(const NYql::NUdf::ITypeInfoHelper& typeInfoHelper, const NYql::NUdf::TType* type) {
     std::unique_ptr<TBlockDeserializerBase> result =  NYql::NUdf::MakeBlockReaderImpl<TDeserializerTraits>(typeInfoHelper, type, nullptr);
     result->SetArrowType(NYql::NUdf::GetArrowType(typeInfoHelper, type));
-    return std::move(result);
+    return result;
 }
 
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_pack.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_pack.cpp
@@ -439,7 +439,7 @@ NUdf::TUnboxedValue UnpackFromChunkedBuffer(const TType* type, TChunkedInputBuff
             items[i] = std::move(tmp[i]);
         }
 
-        return std::move(list);
+        return list;
     }
 
     case TType::EKind::Struct: {
@@ -450,7 +450,7 @@ NUdf::TUnboxedValue UnpackFromChunkedBuffer(const TType* type, TChunkedInputBuff
             auto memberType = structType->GetMemberType(index);
             itemsPtr[index] = UnpackFromChunkedBuffer<Fast>(memberType, buf, topLength, holderFactory, s);
         }
-        return std::move(res);
+        return res;
     }
 
     case TType::EKind::Tuple: {
@@ -461,7 +461,7 @@ NUdf::TUnboxedValue UnpackFromChunkedBuffer(const TType* type, TChunkedInputBuff
             auto elementType = tupleType->GetElementType(index);
             itemsPtr[index] = UnpackFromChunkedBuffer<Fast>(elementType, buf, topLength, holderFactory, s);
         }
-        return std::move(res);
+        return res;
     }
 
     case TType::EKind::Dict: {

--- a/ydb/library/yql/minikql/jsonpath/binary.h
+++ b/ydb/library/yql/minikql/jsonpath/binary.h
@@ -263,7 +263,7 @@ private:
         static_assert(std::is_pod_v<T>, "Type must be POD");
         T value = ReadUnaligned<T>(Path->Begin() + pos);
         pos += sizeof(T);
-        return std::move(value);
+        return value;
     }
 
     const TJsonPathPtr Path;

--- a/ydb/library/yql/minikql/jsonpath/executor.cpp
+++ b/ydb/library/yql/minikql/jsonpath/executor.cpp
@@ -231,7 +231,7 @@ TResult TExecutor::MemberAccess(const TJsonPathItem& item) {
         }
     }
 
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::WildcardMemberAccess(const TJsonPathItem& item) {
@@ -257,7 +257,7 @@ TResult TExecutor::WildcardMemberAccess(const TJsonPathItem& item) {
         }
     }
 
-    return std::move(result);
+    return result;
 }
 
 TMaybe<TIssue> TExecutor::EnsureSingleSubscript(TPosition pos, const TJsonNodes& index, i64& result) {
@@ -371,7 +371,7 @@ TResult TExecutor::ArrayAccess(const TJsonPathItem& item) {
             }
         }
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::WildcardArrayAccess(const TJsonPathItem& item) {
@@ -391,7 +391,7 @@ TResult TExecutor::WildcardArrayAccess(const TJsonPathItem& item) {
             result.push_back(value);
         }
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::UnaryArithmeticOp(const TJsonPathItem& item) {
@@ -421,7 +421,7 @@ TResult TExecutor::UnaryArithmeticOp(const TJsonPathItem& item) {
         result.push_back(TValue(MakeDouble(-value)));
     }
 
-    return std::move(result);
+    return result;
 }
 
 TMaybe<TIssue> TExecutor::EnsureBinaryArithmeticOpArgument(TPosition pos, const TJsonNodes& nodes, double& result) {
@@ -784,7 +784,7 @@ TResult TExecutor::FilterPredicate(const TJsonPathItem& item) {
             continue;
         }
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::NumericMethod(const TJsonPathItem& item) {
@@ -814,7 +814,7 @@ TResult TExecutor::NumericMethod(const TJsonPathItem& item) {
         }
         result.push_back(TValue(MakeDouble(applied)));
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::DoubleMethod(const TJsonPathItem& item) {
@@ -839,7 +839,7 @@ TResult TExecutor::DoubleMethod(const TJsonPathItem& item) {
 
         result.push_back(TValue(MakeDouble(parsed)));
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::TypeMethod(const TJsonPathItem& item) {
@@ -872,7 +872,7 @@ TResult TExecutor::TypeMethod(const TJsonPathItem& item) {
         }
         result.push_back(TValue(MakeString(type, ValueBuilder)));
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::SizeMethod(const TJsonPathItem& item) {
@@ -888,7 +888,7 @@ TResult TExecutor::SizeMethod(const TJsonPathItem& item) {
         }
         result.push_back(TValue(MakeDouble(static_cast<double>(size))));
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::KeyValueMethod(const TJsonPathItem& item) {
@@ -918,7 +918,7 @@ TResult TExecutor::KeyValueMethod(const TJsonPathItem& item) {
             result.push_back(TValue(MakeDict(row, 2)));
         }
     }
-    return std::move(result);
+    return result;
 }
 
 TResult TExecutor::StartsWithPredicate(const TJsonPathItem& item) {

--- a/ydb/library/yql/providers/common/http_gateway/mock/yql_http_mock_gateway.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/mock/yql_http_mock_gateway.cpp
@@ -51,7 +51,7 @@ public:
             ret << " \"" << field << "\"";
         }
         ret << " ] Data: \"" << std::get<2>(key) << "\" }";
-        return std::move(ret);
+        return ret;
     }
 
     void Upload(TString, THeaders, TString, TOnResult, bool, TRetryPolicy::TPtr) final {}

--- a/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
+++ b/ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/connector_client_mock.h
@@ -823,7 +823,7 @@ namespace NYql::NConnector::NTest {
             if (status.InternalError) {
                 s << " (internal error)";
             }
-            return std::move(s);
+            return s;
         }
     };
 } // namespace NYql::NConnector::NTest

--- a/ydb/library/yql/providers/yt/comp_nodes/dq/stream_decoder.cpp
+++ b/ydb/library/yql/providers/yt/comp_nodes/dq/stream_decoder.cpp
@@ -582,7 +582,7 @@ Result<std::shared_ptr<Buffer>> DecompressBuffer(const std::shared_ptr<Buffer>& 
                            actual_decompressed);
   }
 
-  return std::move(uncompressed);
+  return uncompressed;
 }
 
 Status DecompressBuffers(Compression::type compression, const IpcReadOptions& options,

--- a/ydb/library/yql/public/udf/udf_value_inl.h
+++ b/ydb/library/yql/public/udf/udf_value_inl.h
@@ -551,7 +551,7 @@ inline TUnboxedValue TUnboxedValuePod::GetVariantItem() const {
     if (Raw.GetIndex()) {
         TUnboxedValuePod item(*this);
         item.Raw.Simple.Meta &= 0x3;
-        return std::move(item);
+        return item;
     }
     UDF_VERIFY(IsBoxed(), "Value is not a variant");
     return TBoxedValueAccessor::GetVariantItem(*Raw.Boxed.Value);

--- a/ydb/library/yql/sql/v0/node.cpp
+++ b/ydb/library/yql/sql/v0/node.cpp
@@ -486,7 +486,7 @@ TString TCallNode::GetCallExplain() const {
     if (derivedName != OpName) {
         sb << ", converted to " << OpName << "()";
     }
-    return std::move(sb);
+    return sb;
 }
 
 bool TCallNode::ValidateArguments(TContext& ctx) const {
@@ -1159,7 +1159,7 @@ TString ISource::MakeLocalName(const TString& name) {
     TStringBuilder str;
     str << name << iter->second;
     ++iter->second;
-    return std::move(str);
+    return str;
 }
 
 bool ISource::AddAggregation(TContext& ctx, TAggregationPtr aggr) {

--- a/ydb/library/yql/sql/v1/node.cpp
+++ b/ydb/library/yql/sql/v1/node.cpp
@@ -865,7 +865,7 @@ TString TCallNode::GetCallExplain() const {
     if (derivedName != OpName) {
         sb << ", converted to " << OpName << "()";
     }
-    return std::move(sb);
+    return sb;
 }
 
 void TCallNode::CollectPreaggregateExprs(TContext& ctx, ISource& src, TVector<INode::TPtr>& exprs) {

--- a/ydb/library/yql/sql/v1/source.cpp
+++ b/ydb/library/yql/sql/v1/source.cpp
@@ -204,7 +204,7 @@ TString ISource::MakeLocalName(const TString& name) {
     TStringBuilder str;
     str << name << iter->second;
     ++iter->second;
-    return std::move(str);
+    return str;
 }
 
 bool ISource::AddAggregation(TContext& ctx, TAggregationPtr aggr) {

--- a/ydb/library/yql/utils/url_builder.cpp
+++ b/ydb/library/yql/utils/url_builder.cpp
@@ -44,7 +44,7 @@ TString TUrlBuilder::Build() const {
         }
         separator = "&"sv;
     }
-    return std::move(res);
+    return res;
 }
 
 } // NYql

--- a/ydb/public/lib/value/value.h
+++ b/ydb/public/lib/value/value.h
@@ -113,7 +113,7 @@ public:
         dump << "Type:" << Endl << res << Endl;
         ::google::protobuf::TextFormat::PrintToString(Value, &res);
         dump << "Value:" << Endl << res << Endl;
-        return std::move(dump);
+        return dump;
     }
 
     void DumpValue() const {

--- a/ydb/public/sdk/cpp/client/impl/ydb_internal/logger/log.cpp
+++ b/ydb/public/sdk/cpp/client/impl/ydb_internal/logger/log.cpp
@@ -36,7 +36,7 @@ TLogFormatter GetPrefixLogFormatter(const TString& prefix) {
 
         result << TInstant::Now() << priorityString << prefix << message << Endl;
         Y_ASSERT(result.size() == toReserve);
-        return std::move(result);
+        return result;
     };
 }
 

--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_topic_impl.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_topic_impl.cpp
@@ -10,7 +10,7 @@ TFederatedTopicClient::TImpl::CreateReadSession(const TFederatedReadSessionSetti
     InitObserver();
     auto session = std::make_shared<TFederatedReadSession>(settings, Connections, ClientSettings, GetObserver(), ProvidedCodecs);
     session->Start();
-    return std::move(session);
+    return session;
 }
 
 // std::shared_ptr<NTopic::ISimpleBlockingWriteSession>
@@ -18,7 +18,7 @@ TFederatedTopicClient::TImpl::CreateReadSession(const TFederatedReadSessionSetti
 //     InitObserver();
 //     auto session = std::make_shared<TSimpleBlockingFederatedWriteSession>(settings, Connections, ClientSettings, GetObserver());
 //     session->Start();
-//     return std::move(session);
+//     return session;
 
 // }
 
@@ -38,7 +38,7 @@ TFederatedTopicClient::TImpl::CreateWriteSession(const TFederatedWriteSessionSet
     auto session = std::make_shared<TFederatedWriteSession>(
         splitSettings, Connections, ClientSettings, GetObserver(), ProvidedCodecs, GetSubsessionHandlersExecutor());
     session->Start();
-    return std::move(session);
+    return session;
 }
 
 void TFederatedTopicClient::TImpl::InitObserver() {

--- a/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/persqueue_impl.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/persqueue_impl.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<IReadSession> TPersQueueClient::TImpl::CreateReadSession(const T
     }
     auto session = std::make_shared<TReadSession>(maybeSettings.GetOrElse(settings), shared_from_this(), Connections_, DbDriverState_);
     session->Start();
-    return std::move(session);
+    return session;
 }
 
 std::shared_ptr<IWriteSession> TPersQueueClient::TImpl::CreateWriteSession(
@@ -42,7 +42,7 @@ std::shared_ptr<IWriteSession> TPersQueueClient::TImpl::CreateWriteSession(
             maybeSettings.GetOrElse(settings), shared_from_this(), Connections_, DbDriverState_
     );
     session->Start(TDuration::Zero());
-    return std::move(session);
+    return session;
 }
 
 std::shared_ptr<ISimpleBlockingWriteSession> TPersQueueClient::TImpl::CreateSimpleWriteSession(
@@ -59,7 +59,7 @@ std::shared_ptr<ISimpleBlockingWriteSession> TPersQueueClient::TImpl::CreateSimp
     auto session = std::make_shared<TSimpleBlockingWriteSession>(
             alteredSettings, shared_from_this(), Connections_, DbDriverState_
     );
-    return std::move(session);
+    return session;
 }
 
 std::shared_ptr<TPersQueueClient::TImpl> TPersQueueClient::TImpl::GetClientForEndpoint(const TString& clusterEndoint) {

--- a/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/read_session.cpp
@@ -627,7 +627,7 @@ TString TReadSessionEvent::TDataReceivedEvent::DebugString(bool printData) const
         message.DebugString(ret, printData);
     }
     ret << " }";
-    return std::move(ret);
+    return ret;
 }
 
 TString TReadSessionEvent::TCommitAcknowledgementEvent::DebugString() const {

--- a/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/read_session_messages.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/read_session_messages.cpp
@@ -94,7 +94,7 @@ const TString TReadSessionEvent::TDataReceivedEvent::IMessage::GetExplicitHash()
 TString TReadSessionEvent::TDataReceivedEvent::IMessage::DebugString(bool printData) const {
     TStringBuilder ret;
     DebugString(ret, printData);
-    return std::move(ret);
+    return ret;
 }
 
 TReadSessionEvent::TDataReceivedEvent::IMessage::IMessage(const TString& data,

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/common.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/common.h
@@ -377,7 +377,7 @@ protected:
     TWaiter PopWaiterImpl() { // Assumes that we're under lock.
         TWaiter waiter(Waiter.ExtractPromise(), this);
         WaiterWillBeSignaled = true;
-        return std::move(waiter);
+        return waiter;
     }
 
     void WaitEventsImpl() { // Assumes that we're under lock. Posteffect: HasEventsImpl() is true.

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/topic_impl.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/topic_impl.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<IReadSession> TTopicClient::TImpl::CreateReadSession(const TRead
     }
     auto session = std::make_shared<TReadSession>(maybeSettings.GetOrElse(settings), shared_from_this(), Connections_, DbDriverState_);
     session->Start();
-    return std::move(session);
+    return session;
 }
 
 std::shared_ptr<IWriteSession> TTopicClient::TImpl::CreateWriteSession(
@@ -42,7 +42,7 @@ std::shared_ptr<IWriteSession> TTopicClient::TImpl::CreateWriteSession(
             maybeSettings.GetOrElse(settings), shared_from_this(), Connections_, DbDriverState_
     );
     session->Start(TDuration::Zero());
-    return std::move(session);
+    return session;
 }
 
 std::shared_ptr<ISimpleBlockingWriteSession> TTopicClient::TImpl::CreateSimpleWriteSession(
@@ -59,7 +59,7 @@ std::shared_ptr<ISimpleBlockingWriteSession> TTopicClient::TImpl::CreateSimpleWr
     auto session = std::make_shared<TSimpleBlockingWriteSession>(
             alteredSettings, shared_from_this(), Connections_, DbDriverState_
     );
-    return std::move(session);
+    return session;
 }
 
 std::shared_ptr<TTopicClient::TImpl::IReadSessionConnectionProcessorFactory> TTopicClient::TImpl::CreateReadSessionConnectionProcessorFactory() {

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -6791,7 +6791,7 @@ TPersQueueV1TestServer server{{.CheckACL=true, .NodeCount=1}};
         alterSettings.BeginAddConsumer("debug");
         auto alterRes = topicClient.AlterTopic(TString("/Root/PQ/") + topicName, alterSettings).GetValueSync();
         UNIT_ASSERT(alterRes.IsSuccess());
-        return std::move(driver);
+        return driver;
     }
 
     Y_UNIT_TEST(MessageMetadata) {
@@ -7341,7 +7341,7 @@ TPersQueueV1TestServer server{{.CheckACL=true, .NodeCount=1}};
             TPQDataWriter writer("source", server);
             TString s{writeKbCount/4, 'c'}; // writes 4 times
             writer.Write(SHORT_TOPIC_NAME, {s});
-            return std::move(server);
+            return server;
         };
 
         auto serverWithNoInflightLimit = createServerAndWrite80kb(100);


### PR DESCRIPTION
Fixes #1246


Compile-tested (ydb & ydbd)

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Rev 2: also changed

```
Bar foo(..., Bar && res,...) {
....
    return std::move(res);
}
```
Rev 3: reverted incorrect changes for `Bar && foo(..., Bar &&,...)`

Rev 4: completely reverted changes from rev.2/rev.3 (with `Bar && res`, expression `res` has type *r-value reference*, but *value category* of *l-value*; hence, `std::move()` must be used, and, part 2 was completely incorrect)
Partially revert changes from first patch where local variable type mismatched returned type (`std::move()` must be used)