### PR TITLE
Support donor mode in distconf static group disk reassignment

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -322,8 +322,8 @@ namespace NKikimr::NStorage {
             const NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TPDiskFilter>& pdiskFilters,
             THashMap<TVDiskIdShort, NBsController::TPDiskId> replacedDisks,
             const NBsController::TGroupMapper::TForbiddenPDisks& forbid,
-            i64 requiredSpace,
-            NKikimrBlobStorage::TBaseConfig *baseConfig);
+            i64 requiredSpace, NKikimrBlobStorage::TBaseConfig *baseConfig,
+            bool convertToDonor);
 
         void GenerateStateStorageConfig(NKikimrConfig::TDomainsConfig::TStateStorage *ss,
             const NKikimrBlobStorage::TStorageConfig& baseConfig);
@@ -572,6 +572,9 @@ namespace NKikimr::NStorage {
                 return makeError("incorrect TVDisk record");
             }
             if (vdisk.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::DESTROY) {
+                continue;
+            }
+            if (vdisk.HasDonorMode()) {
                 continue;
             }
             const auto vdiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
@@ -137,6 +137,9 @@ namespace NKikimr::NStorage {
                 case TQuery::kStaticVDiskSlain:
                     return StaticVDiskSlain(record.GetStaticVDiskSlain());
 
+                case TQuery::kDropDonor:
+                    return DropDonor(record.GetDropDonor());
+
                 case TQuery::REQUEST_NOT_SET:
                     return FinishWithError(TResult::ERROR, "Request field not set");
             }
@@ -214,7 +217,8 @@ namespace NKikimr::NStorage {
                     try {
                         Self->AllocateStaticGroup(&config, vdiskId.GroupID, vdiskId.GroupGeneration + 1,
                             TBlobStorageGroupType((TBlobStorageGroupType::EErasureSpecies)group.GetErasureSpecies()),
-                            settings.GetGeometry(), settings.GetPDiskFilter(), replacedDisks, {}, 0, &ev->Get()->BaseConfig);
+                            settings.GetGeometry(), settings.GetPDiskFilter(), replacedDisks, {}, 0, &ev->Get()->BaseConfig,
+                            cmd.GetConvertToDonor());
                     } catch (const TExConfigError& ex) {
                         STLOG(PRI_NOTICE, BS_NODE, NW49, "ReassignGroupDisk failed to allocate group", (Config, config),
                             (BaseConfig, ev->Get()->BaseConfig),
@@ -231,14 +235,18 @@ namespace NKikimr::NStorage {
         }
 
         void StaticVDiskSlain(const NKikimrBlobStorage::TEvNodeConfigInvokeOnRoot::TStaticVDiskSlain& cmd) {
+            HandleDropDonorAndSlain(VDiskIDFromVDiskID(cmd.GetVDiskId()), cmd.GetVSlotId(), false);
+        }
+
+        void DropDonor(const NKikimrBlobStorage::TEvNodeConfigInvokeOnRoot::TDropDonor& cmd) {
+            HandleDropDonorAndSlain(VDiskIDFromVDiskID(cmd.GetVDiskId()), cmd.GetVSlotId(), true);
+        }
+
+        void HandleDropDonorAndSlain(TVDiskID vdiskId, const NKikimrBlobStorage::TVSlotId& vslotId, bool isDropDonor) {
             if (!RunCommonChecks()) {
                 return;
             }
 
-            const TVDiskID slainVDiskId = VDiskIDFromVDiskID(cmd.GetVDiskId());
-            const auto& slainVSlotId = cmd.GetVSlotId();
-            const ui32 nodeId = slainVSlotId.GetNodeId();
-            const ui32 pdiskId = slainVSlotId.GetPDiskId();
             NKikimrBlobStorage::TStorageConfig config = *Self->StorageConfig;
 
             if (!config.HasBlobStorageConfig()) {
@@ -251,31 +259,78 @@ namespace NKikimr::NStorage {
             }
             auto *ss = bsConfig->MutableServiceSet();
 
-            bool pdiskIsUsed = false;
             bool changes = false;
+            ui32 pdiskUsageCount = 0;
+
+            ui32 actualGroupGeneration = 0;
+            for (const auto& group : ss->GetGroups()) {
+                if (group.GetGroupID() == vdiskId.GroupID) {
+                    actualGroupGeneration = group.GetGroupGeneration();
+                    break;
+                }
+            }
+            Y_ABORT_UNLESS(0 < actualGroupGeneration && vdiskId.GroupGeneration < actualGroupGeneration);
 
             for (size_t i = 0; i < ss->VDisksSize(); ++i) {
                 if (const auto& vdisk = ss->GetVDisks(i); vdisk.HasVDiskID() && vdisk.HasVDiskLocation()) {
-                    const auto& loc = vdisk.GetVDiskLocation();
-                    if (loc.GetNodeID() != nodeId || loc.GetPDiskID() != pdiskId) {
+                    const TVDiskID currentVDiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
+                    if (!currentVDiskId.SameExceptGeneration(vdiskId) ||
+                            vdisk.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::DESTROY) {
                         continue;
                     }
 
-                    const TVDiskID vdiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
-                    if (vdiskId == slainVDiskId && loc.GetVDiskSlotID() == slainVSlotId.GetVSlotId() &&
-                            vdisk.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::DESTROY) {
+                    if (isDropDonor && !vdisk.HasDonorMode()) {
+                        Y_ABORT_UNLESS(currentVDiskId.GroupGeneration == actualGroupGeneration);
+                        auto *m = ss->MutableVDisks(i);
+                        if (vdiskId.GroupGeneration) { // drop specific donor
+                            for (size_t k = 0; k < m->DonorsSize(); ++k) {
+                                const auto& donor = m->GetDonors(k);
+                                const auto& loc = donor.GetVDiskLocation();
+                                if (VDiskIDFromVDiskID(donor.GetVDiskId()) == vdiskId && loc.GetNodeID() == vslotId.GetNodeId() &&
+                                        loc.GetPDiskID() == vslotId.GetPDiskId() && loc.GetVDiskSlotID() == vslotId.GetVSlotId()) {
+                                    m->MutableDonors()->DeleteSubrange(k, 1);
+                                    changes = true;
+                                    break;
+                                }
+                            }
+                        } else { // drop all of them
+                            m->ClearDonors();
+                            changes = true;
+                        }
+                        continue;
+                    }
+
+                    const auto& loc = vdisk.GetVDiskLocation();
+                    if (loc.GetNodeID() != vslotId.GetNodeId() || loc.GetPDiskID() != vslotId.GetPDiskId()) {
+                        continue;
+                    }
+                    ++pdiskUsageCount;
+
+                    if (loc.GetVDiskSlotID() != vslotId.GetVSlotId()) {
+                        continue;
+                    }
+
+                    Y_ABORT_UNLESS(currentVDiskId.GroupGeneration < actualGroupGeneration);
+
+                    if (!isDropDonor) {
+                        --pdiskUsageCount;
                         ss->MutableVDisks()->DeleteSubrange(i--, 1);
                         changes = true;
-                    } else {
-                        pdiskIsUsed = true;
+                    } else if (vdisk.HasDonorMode()) {
+                        if (currentVDiskId == vdiskId || vdiskId.GroupGeneration == 0) {
+                            auto *m = ss->MutableVDisks(i);
+                            m->ClearDonorMode();
+                            m->SetEntityStatus(NKikimrBlobStorage::EEntityStatus::DESTROY);
+                            changes = true;
+                        }
                     }
                 }
             }
 
-            if (!pdiskIsUsed) {
+            if (!isDropDonor && !pdiskUsageCount) {
                 for (size_t i = 0; i < ss->PDisksSize(); ++i) {
                     if (const auto& pdisk = ss->GetPDisks(i); pdisk.HasNodeID() && pdisk.HasPDiskID() &&
-                            pdisk.GetNodeID() == nodeId && pdisk.GetPDiskID() == pdiskId) {
+                            pdisk.GetNodeID() == vslotId.GetNodeId() && pdisk.GetPDiskID() == vslotId.GetPDiskId()) {
                         ss->MutablePDisks()->DeleteSubrange(i--, 1);
                         changes = true;
                         break;
@@ -283,7 +338,7 @@ namespace NKikimr::NStorage {
                 }
             }
 
-            if (!changes) { // no configuration updates required
+            if (!changes) {
                 return Finish(Sender, SelfId(), PrepareResult(TResult::OK, std::nullopt).release(), 0, Cookie);
             }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -372,19 +372,51 @@ void TNodeWarden::Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpdate::TPtr
     }
 }
 
-void TNodeWarden::SendDropDonorQuery(ui32 nodeId, ui32 pdiskId, ui32 vslotId, const TVDiskID& vdiskId) {
+void TNodeWarden::SendDropDonorQuery(ui32 nodeId, ui32 pdiskId, ui32 vslotId, const TVDiskID& vdiskId, TDuration backoff) {
     STLOG(PRI_NOTICE, BS_NODE, NW87, "SendDropDonorQuery", (NodeId, nodeId), (PDiskId, pdiskId), (VSlotId, vslotId),
         (VDiskId, vdiskId));
-    auto ev = std::make_unique<TEvBlobStorage::TEvControllerConfigRequest>();
-    auto& record = ev->Record;
-    auto *request = record.MutableRequest();
-    auto *cmd = request->AddCommand()->MutableDropDonorDisk();
-    auto *p = cmd->MutableVSlotId();
-    p->SetNodeId(nodeId);
-    p->SetPDiskId(pdiskId);
-    p->SetVSlotId(vslotId);
-    VDiskIDFromVDiskID(vdiskId, cmd->MutableVDiskId());
-    SendToController(std::move(ev));
+    if (TGroupID groupId(vdiskId.GroupID); groupId.ConfigurationType() == EGroupConfigurationType::Static) {
+        auto ev = std::make_unique<TEvNodeConfigInvokeOnRoot>();
+        auto *record = &ev->Record;
+        auto *cmd = record->MutableDropDonor();
+        VDiskIDFromVDiskID(vdiskId, cmd->MutableVDiskId());
+        auto *slot = cmd->MutableVSlotId();
+        slot->SetNodeId(nodeId);
+        slot->SetPDiskId(pdiskId);
+        slot->SetVSlotId(vslotId);
+        const ui64 cookie = NextInvokeCookie++;
+        if (backoff != TDuration::Zero()) {
+            TActivationContext::Schedule(backoff, new IEventHandle(DistributedConfigKeeperId, SelfId(), ev.release(), 0, cookie));
+        } else {
+            Send(DistributedConfigKeeperId, ev.release(), 0, cookie);
+        }
+        InvokeCallbacks.emplace(cookie, [=](TEvNodeConfigInvokeOnRootResult& msg) {
+            if (msg.Record.GetStatus() != NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult::OK) {
+                for (const auto& vdisk : StorageConfig.GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
+                    const TVDiskID currentVDiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
+                    const auto& loc = vdisk.GetVDiskLocation();
+                    if (currentVDiskId.SameExceptGeneration(vdiskId) &&
+                            (currentVDiskId.GroupGeneration == vdiskId.GroupGeneration || !vdiskId.GroupGeneration) &&
+                            loc.GetNodeID() == nodeId && loc.GetPDiskID() == pdiskId &&
+                            loc.GetVDiskSlotID() == vslotId) {
+                        SendDropDonorQuery(nodeId, pdiskId, vslotId, vdiskId, TDuration::Seconds(3));
+                        break;
+                    }
+                }
+            }
+        });
+    } else {
+        auto ev = std::make_unique<TEvBlobStorage::TEvControllerConfigRequest>();
+        auto& record = ev->Record;
+        auto *request = record.MutableRequest();
+        auto *cmd = request->AddCommand()->MutableDropDonorDisk();
+        auto *p = cmd->MutableVSlotId();
+        p->SetNodeId(nodeId);
+        p->SetPDiskId(pdiskId);
+        p->SetVSlotId(vslotId);
+        VDiskIDFromVDiskID(vdiskId, cmd->MutableVDiskId());
+        SendToController(std::move(ev));
+    }
 }
 
 void TNodeWarden::SendVDiskReport(TVSlotId vslotId, const TVDiskID &vDiskId,
@@ -409,7 +441,17 @@ void TNodeWarden::SendVDiskReport(TVSlotId vslotId, const TVDiskID &vDiskId,
         }
         InvokeCallbacks.emplace(cookie, [=](TEvNodeConfigInvokeOnRootResult& msg) {
             if (msg.Record.GetStatus() != NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult::OK) {
-                SendVDiskReport(vslotId, vDiskId, phase, TDuration::Seconds(3));
+                for (const auto& vdisk : StorageConfig.GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
+                    const TVDiskID currentVDiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
+                    const auto& loc = vdisk.GetVDiskLocation();
+                    if (currentVDiskId == vDiskId && loc.GetNodeID() == vslotId.NodeId &&
+                            loc.GetPDiskID() == vslotId.PDiskId &&
+                            loc.GetVDiskSlotID() == vslotId.VDiskSlotId &&
+                            vdisk.GetEntityStatus() == NKikimrBlobStorage::EEntityStatus::DESTROY) {
+                        SendVDiskReport(vslotId, vDiskId, phase, TDuration::Seconds(3));
+                        break;
+                    }
+                }
             }
         });
     } else {
@@ -577,6 +619,23 @@ void TNodeWarden::Handle(TEvStatusUpdate::TPtr ev) {
         if (msg->Status == NKikimrBlobStorage::EVDiskStatus::READY && vdisk.WhiteboardVDiskId) {
             Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvVDiskDropDonors(*vdisk.WhiteboardVDiskId,
                 vdisk.WhiteboardInstanceGuid, NNodeWhiteboard::TEvWhiteboard::TEvVDiskDropDonors::TDropAllDonors()));
+        }
+
+        if (vdisk.Status == NKikimrBlobStorage::EVDiskStatus::READY && vdisk.RuntimeData) {
+            const auto& r = vdisk.RuntimeData;
+            const auto& info = r->GroupInfo;
+
+            if (const ui32 groupId = info->GroupID; TGroupID(groupId).ConfigurationType() == EGroupConfigurationType::Static) {
+                for (const auto& item : StorageConfig.GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
+                    const TVDiskID vdiskId = VDiskIDFromVDiskID(item.GetVDiskID());
+                    if (vdiskId.GroupID == groupId && info->GetTopology().GetOrderNumber(vdiskId) == r->OrderNumber &&
+                            item.HasDonorMode() && item.GetEntityStatus() != NKikimrBlobStorage::EEntityStatus::DESTROY) {
+                        SendDropDonorQuery(vslotId.NodeId, vslotId.PDiskId, vslotId.VDiskSlotId, TVDiskID(groupId, 0,
+                            info->GetVDiskId(r->OrderNumber)));
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -470,7 +470,7 @@ namespace NKikimr::NStorage {
         void Handle(TEvRegisterPDiskLoadActor::TPtr ev);
         void Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpdate::TPtr ev);
 
-        void SendDropDonorQuery(ui32 nodeId, ui32 pdiskId, ui32 vslotId, const TVDiskID& vdiskId);
+        void SendDropDonorQuery(ui32 nodeId, ui32 pdiskId, ui32 vslotId, const TVDiskID& vdiskId, TDuration backoff = {});
 
         void SendVDiskReport(TVSlotId vslotId, const TVDiskID& vdiskId,
             NKikimrBlobStorage::TEvControllerNodeReport::EVDiskPhase phase, TDuration backoff = {});

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -153,10 +153,16 @@ message TEvNodeConfigInvokeOnRoot {
     message TReassignGroupDisk {
         NKikimrBlobStorage.TVDiskID VDiskId = 1; // which one to reassign
         optional NKikimrBlobStorage.TPDiskId PDiskId = 2; // where to put it (optional)
+        bool ConvertToDonor = 3; // convert the current disk to donor?
     }
 
     // Regenerate configuration so the slain VDisk is no more reported as DESTROY one in the list.
     message TStaticVDiskSlain {
+        NKikimrBlobStorage.TVDiskID VDiskId = 1;
+        NKikimrBlobStorage.TVSlotId VSlotId = 2;
+    }
+
+    message TDropDonor {
         NKikimrBlobStorage.TVDiskID VDiskId = 1;
         NKikimrBlobStorage.TVSlotId VSlotId = 2;
     }
@@ -166,6 +172,7 @@ message TEvNodeConfigInvokeOnRoot {
         TQueryConfig QueryConfig = 2;
         TReassignGroupDisk ReassignGroupDisk = 3;
         TStaticVDiskSlain StaticVDiskSlain = 4;
+        TDropDonor DropDonor = 5;
     }
 }
 
@@ -197,6 +204,9 @@ message TEvNodeConfigInvokeOnRootResult {
     message TStaticVDiskSlain {
     }
 
+    message TDropDonor {
+    }
+
     EStatus Status = 1;
     optional string ErrorReason = 2;
     TScepter Scepter = 3;
@@ -206,5 +216,6 @@ message TEvNodeConfigInvokeOnRootResult {
         TQueryConfig QueryConfig = 5;
         TReassignGroupDisk ReassignGroupDisk = 6;
         TStaticVDiskSlain StaticVDiskSlain = 7;
+        TDropDonor DropDonor = 8;
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support donor mode in distconf static group disk reassignment

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Supported donor mode option while reassigning static group disk. Donors are created and managed automatically by NodeWarden.

#3924
