### PR TITLE
Fixed help for --null-value in import file command and refactored csv parser error handling

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
@@ -286,9 +286,7 @@ int TCommandImportFromCsv::Run(TConfig& config) {
     settings.Header(Header);
     settings.NewlineDelimited(NewlineDelimited);
     settings.HeaderRow(HeaderRow);
-    if (config.ParseResult->Has("null-value")) {
-        settings.NullValue(NullValue);
-    }
+    settings.NullValue(NullValue);
 
     if (Delimiter.size() != 1) {
         throw TMisuseException()

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
@@ -269,8 +269,8 @@ void TCommandImportFromCsv::Config(TConfig& config) {
         config.Opts->AddLongOption("delimiter", "Field delimiter in rows")
             .RequiredArgument("STRING").StoreResult(&Delimiter).DefaultValue(Delimiter);
     }
-    config.Opts->AddLongOption("null-value", "Value that would be interpreted as NULL")
-            .RequiredArgument("STRING").StoreResult(&NullValue).DefaultValue(NullValue);
+    config.Opts->AddLongOption("null-value", "Value that would be interpreted as NULL, no NULL value by default")
+            .RequiredArgument("STRING").StoreResult(&NullValue);
     // TODO: quoting/quote_char
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.h
@@ -78,7 +78,7 @@ public:
 protected:
     TString HeaderRow;
     TString Delimiter;
-    TString NullValue;
+    std::optional<TString> NullValue;
     ui32 SkipRows = 0;
     bool Header = false;
     bool NewlineDelimited = true;

--- a/ydb/public/lib/ydb_cli/common/csv_parser.cpp
+++ b/ydb/public/lib/ydb_cli/common/csv_parser.cpp
@@ -320,7 +320,7 @@ private:
     TValueBuilder Builder;
 };
 
-TStringBuf Consume( const TExceptionData& state, NCsvFormat::CsvSplitter& splitter) {
+TStringBuf Consume(const TExceptionData& state, NCsvFormat::CsvSplitter& splitter) {
     try {
         return splitter.Consume();
     } catch (std::exception& e) {

--- a/ydb/public/lib/ydb_cli/common/csv_parser.h
+++ b/ydb/public/lib/ydb_cli/common/csv_parser.h
@@ -27,6 +27,7 @@ public:
     void GetParams(TString&& data, TParamsBuilder& builder) const;
     void GetValue(TString&& data, TValueBuilder& builder, const TType& type) const;
     TType GetColumnsType() const;
+    TStringBuf Consume(NCsvFormat::CsvSplitter& splitter) const;
 
 private:
     TValue FieldToValue(TTypeParser& parser, TStringBuf token) const;

--- a/ydb/public/lib/ydb_cli/common/csv_parser.h
+++ b/ydb/public/lib/ydb_cli/common/csv_parser.h
@@ -7,8 +7,15 @@
 namespace NYdb {
 namespace NConsoleClient {
 
+class TCsvParseException : public yexception {};
+
 class TCsvParser {
 public:
+    struct TParseMetadata {
+        std::optional<uint64_t> Line;
+        std::optional<TString> Filename;
+    };
+
     TCsvParser() = default;
 
     TCsvParser(const TCsvParser&) = delete;
@@ -24,8 +31,8 @@ public:
                const std::map<TString, TType>* paramTypes = nullptr,
                const std::map<TString, TString>* paramSources = nullptr);
 
-    void GetParams(ui64 line, TString&& data, TParamsBuilder& builder) const;
-    void GetValue(ui64 line, TString&& data, TValueBuilder& builder, const TType& type) const;
+    void GetParams(TString&& data, TParamsBuilder& builder, const TParseMetadata& meta) const;
+    void GetValue(TString&& data, TValueBuilder& builder, const TType& type, const TParseMetadata& meta) const;
     TType GetColumnsType() const;
 
 private:

--- a/ydb/public/lib/ydb_cli/common/csv_parser.h
+++ b/ydb/public/lib/ydb_cli/common/csv_parser.h
@@ -24,14 +24,11 @@ public:
                const std::map<TString, TType>* paramTypes = nullptr,
                const std::map<TString, TString>* paramSources = nullptr);
 
-    void GetParams(TString&& data, TParamsBuilder& builder) const;
-    void GetValue(TString&& data, TValueBuilder& builder, const TType& type) const;
+    void GetParams(ui64 line, TString&& data, TParamsBuilder& builder) const;
+    void GetValue(ui64 line, TString&& data, TValueBuilder& builder, const TType& type) const;
     TType GetColumnsType() const;
-    TStringBuf Consume(NCsvFormat::CsvSplitter& splitter) const;
 
 private:
-    TValue FieldToValue(TTypeParser& parser, TStringBuf token) const;
-
     TVector<TString> Header;
     TString HeaderRow;
     char Delimeter;

--- a/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
@@ -23,7 +23,7 @@ Y_UNIT_TEST_SUITE(YdbCliCsvParserTests) {
         std::map<TString, TString> paramSources;
         TCsvParser parser(std::move(header), ',', "", &paramTypes, &paramSources);
         TParamsBuilder paramBuilder;
-        parser.GetParams(std::move(data), paramBuilder);
+        parser.GetParams(0, std::move(data), paramBuilder);
         auto values = paramBuilder.Build().GetValues();
         UNIT_ASSERT_EQUAL(values.size(), result.size());
         for (const auto& [name, value] : result) {
@@ -41,7 +41,7 @@ Y_UNIT_TEST_SUITE(YdbCliCsvParserTests) {
 
         TCsvParser parser(std::move(header), ',', "", &paramTypes, nullptr);
         TValueBuilder valueBuilder;
-        parser.GetValue(std::move(data), valueBuilder, result.GetType());
+        parser.GetValue(0, std::move(data), valueBuilder, result.GetType());
         UNIT_ASSERT(CompareValues(valueBuilder.Build(), result));
     }
 

--- a/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
@@ -23,7 +23,7 @@ Y_UNIT_TEST_SUITE(YdbCliCsvParserTests) {
         std::map<TString, TString> paramSources;
         TCsvParser parser(std::move(header), ',', "", &paramTypes, &paramSources);
         TParamsBuilder paramBuilder;
-        parser.GetParams(0, std::move(data), paramBuilder);
+        parser.GetParams(std::move(data), paramBuilder, TCsvParser::TParseMetadata{});
         auto values = paramBuilder.Build().GetValues();
         UNIT_ASSERT_EQUAL(values.size(), result.size());
         for (const auto& [name, value] : result) {
@@ -41,7 +41,7 @@ Y_UNIT_TEST_SUITE(YdbCliCsvParserTests) {
 
         TCsvParser parser(std::move(header), ',', "", &paramTypes, nullptr);
         TValueBuilder valueBuilder;
-        parser.GetValue(0, std::move(data), valueBuilder, result.GetType());
+        parser.GetValue(std::move(data), valueBuilder, result.GetType(), TCsvParser::TParseMetadata{});
         UNIT_ASSERT(CompareValues(valueBuilder.Build(), result));
     }
 

--- a/ydb/public/lib/ydb_cli/common/parameters.cpp
+++ b/ydb/public/lib/ydb_cli/common/parameters.cpp
@@ -206,7 +206,6 @@ void TCommandWithParameters::AddParams(TParamsBuilder& paramBuilder) {
 bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder) {
     paramBuilder = MakeHolder<TParamsBuilder>();
     if (IsFirstEncounter) {
-        Row = SkipRows;
         IsFirstEncounter = false;
         ParamTypes = ValidateResult->GetParameterTypes();
         if (IsStdinInteractive()) {
@@ -238,7 +237,6 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
     if (IsStdinInteractive()) {
         return false;
     }
-    ++Row;
 
     AddParams(*paramBuilder);
     if (BatchMode == EBatchMode::Iterative) {
@@ -261,7 +259,7 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
                 }
                 case EOutputFormat::Csv:
                 case EOutputFormat::Tsv: {
-                    CsvParser.GetParams(Row, std::move(*data), *paramBuilder);
+                    CsvParser.GetParams(std::move(*data), *paramBuilder, TCsvParser::TParseMetadata{});
                     break;
                 }
                 default:
@@ -304,7 +302,7 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
                     case EOutputFormat::Csv:
                     case EOutputFormat::Tsv: {
                         TValueBuilder valueBuilder;
-                        CsvParser.GetValue(Row, std::move(*data), valueBuilder, type);
+                        CsvParser.GetValue(std::move(*data), valueBuilder, type, TCsvParser::TParseMetadata{});
                         paramBuilder->AddParam(fullname, valueBuilder.Build());
                         break;
                     }
@@ -383,7 +381,7 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
                 case EOutputFormat::Csv:
                 case EOutputFormat::Tsv: {
                     valueBuilder.AddListItem();
-                    CsvParser.GetValue(Row, std::move(*data), valueBuilder, type.GetProto().list_type().item());
+                    CsvParser.GetValue(std::move(*data), valueBuilder, type.GetProto().list_type().item(), TCsvParser::TParseMetadata{});
                     break;
                 }
                 default:

--- a/ydb/public/lib/ydb_cli/common/parameters.cpp
+++ b/ydb/public/lib/ydb_cli/common/parameters.cpp
@@ -206,6 +206,7 @@ void TCommandWithParameters::AddParams(TParamsBuilder& paramBuilder) {
 bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder) {
     paramBuilder = MakeHolder<TParamsBuilder>();
     if (IsFirstEncounter) {
+        Row = SkipRows;
         IsFirstEncounter = false;
         ParamTypes = ValidateResult->GetParameterTypes();
         if (IsStdinInteractive()) {
@@ -237,6 +238,7 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
     if (IsStdinInteractive()) {
         return false;
     }
+    ++Row;
 
     AddParams(*paramBuilder);
     if (BatchMode == EBatchMode::Iterative) {
@@ -259,7 +261,7 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
                 }
                 case EOutputFormat::Csv:
                 case EOutputFormat::Tsv: {
-                    CsvParser.GetParams(std::move(*data), *paramBuilder);
+                    CsvParser.GetParams(Row, std::move(*data), *paramBuilder);
                     break;
                 }
                 default:
@@ -302,7 +304,7 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
                     case EOutputFormat::Csv:
                     case EOutputFormat::Tsv: {
                         TValueBuilder valueBuilder;
-                        CsvParser.GetValue(std::move(*data), valueBuilder, type);
+                        CsvParser.GetValue(Row, std::move(*data), valueBuilder, type);
                         paramBuilder->AddParam(fullname, valueBuilder.Build());
                         break;
                     }
@@ -381,7 +383,7 @@ bool TCommandWithParameters::GetNextParams(THolder<TParamsBuilder>& paramBuilder
                 case EOutputFormat::Csv:
                 case EOutputFormat::Tsv: {
                     valueBuilder.AddListItem();
-                    CsvParser.GetValue(std::move(*data), valueBuilder, type.GetProto().list_type().item());
+                    CsvParser.GetValue(Row, std::move(*data), valueBuilder, type.GetProto().list_type().item());
                     break;
                 }
                 default:

--- a/ydb/public/lib/ydb_cli/common/parameters.h
+++ b/ydb/public/lib/ydb_cli/common/parameters.h
@@ -41,6 +41,7 @@ private:
     THolder<IParamStream> Input;
     bool IsFirstEncounter = true;
     size_t SkipRows = 0;
+    ui64 Row = 0;
     char Delimiter;
     TCsvParser CsvParser;
 

--- a/ydb/public/lib/ydb_cli/common/parameters.h
+++ b/ydb/public/lib/ydb_cli/common/parameters.h
@@ -41,7 +41,6 @@ private:
     THolder<IParamStream> Input;
     bool IsFirstEncounter = true;
     size_t SkipRows = 0;
-    ui64 Row = 0;
     char Delimiter;
     TCsvParser CsvParser;
 

--- a/ydb/public/lib/ydb_cli/import/import.cpp
+++ b/ydb/public/lib/ydb_cli/import/import.cpp
@@ -487,7 +487,7 @@ TStatus TImportFileClient::UpsertCsv(IInputStream& input,
 
         if (readBytes >= nextBorder && RetrySettings.Verbose_) {
             nextBorder += VerboseModeReadSize;
-            Cerr << "Processed " << 1.0 * readBytes / (1 << 20) << "Mb and " << row << " records" << Endl;
+            Cerr << "Processed " << 1.0 * readBytes / (1 << 20) << "Mb and " << row + batchRows << " records" << Endl;
         }
 
         if (batchBytes < settings.BytesPerRequest_) {

--- a/ydb/public/lib/ydb_cli/import/import.cpp
+++ b/ydb/public/lib/ydb_cli/import/import.cpp
@@ -81,14 +81,14 @@ TStatus WaitForQueue(const size_t maxQueueSize, std::vector<TAsyncStatus>& inFli
 
 void InitCsvParser(TCsvParser& parser,
                    bool& removeLastDelimiter,
-                   TString&& defaultHeader,
+                   NCsvFormat::TLinesSplitter& csvSource,
                    const TImportFileSettings& settings,
                    const std::map<TString, TType>* columnTypes,
                    const NTable::TTableDescription* dbTableInfo) {
     if (settings.Header_ || settings.HeaderRow_) {
         TString headerRow;
         if (settings.Header_) {
-            headerRow = std::move(defaultHeader);
+            headerRow = csvSource.ConsumeLine();
         }
         if (settings.HeaderRow_) {
             headerRow = settings.HeaderRow_;
@@ -370,7 +370,7 @@ TStatus TImportFileClient::Import(const TVector<TString>& filePaths, const TStri
                     if (settings.NewlineDelimited_) {
                         return UpsertCsvByBlocks(filePath, dbPath, settings);
                     } else {
-                        return UpsertCsv(input, dbPath, settings, fileSizeHint, progressCallback);
+                        return UpsertCsv(input, dbPath, settings, filePath, fileSizeHint, progressCallback);
                     }
                 case EOutputFormat::Json:
                 case EOutputFormat::JsonUnicode:
@@ -418,8 +418,13 @@ TAsyncStatus TImportFileClient::UpsertTValueBuffer(const TString& dbPath, TValue
     return TableClient->RetryOperation(upsert, RetrySettings);
 }
 
-TStatus TImportFileClient::UpsertCsv(IInputStream& input, const TString& dbPath, const TImportFileSettings& settings,
-                                     std::optional<ui64> inputSizeHint, ProgressCallbackFunc & progressCallback) {
+TStatus TImportFileClient::UpsertCsv(IInputStream& input,
+                                     const TString& dbPath,
+                                     const TImportFileSettings& settings,
+                                     const TString& filePath,
+                                     std::optional<ui64> inputSizeHint,
+                                     ProgressCallbackFunc & progressCallback) {
+
     TMaxInflightGetter inFlightGetter(settings.MaxInFlightRequests_, FilesCount);
 
     TCountingInput countInput(&input);
@@ -430,7 +435,7 @@ TStatus TImportFileClient::UpsertCsv(IInputStream& input, const TString& dbPath,
 
     TCsvParser parser;
     bool removeLastDelimiter = false;
-    InitCsvParser(parser, removeLastDelimiter, splitter.ConsumeLine(), settings, &columnTypes, DbTableInfo.get());
+    InitCsvParser(parser, removeLastDelimiter, splitter, settings, &columnTypes, DbTableInfo.get());
 
     for (ui32 i = 0; i < settings.SkipRows_; ++i) {
         splitter.ConsumeLine();
@@ -440,7 +445,8 @@ TStatus TImportFileClient::UpsertCsv(IInputStream& input, const TString& dbPath,
 
     THolder<IThreadPool> pool = CreateThreadPool(settings.Threads_);
 
-    ui32 row = settings.SkipRows_;
+    ui64 row = settings.SkipRows_ + settings.Header_ + 1;
+    ui64 batchRows = 0;
     ui64 nextBorder = VerboseModeReadSize;
     ui64 batchBytes = 0;
     ui64 readBytes = 0;
@@ -454,14 +460,15 @@ TStatus TImportFileClient::UpsertCsv(IInputStream& input, const TString& dbPath,
         builder.BeginList();
         for (auto&& line : buffer) {
             builder.AddListItem();
-            parser.GetValue(row, std::move(line), builder, lineType);
+            parser.GetValue(std::move(line), builder, lineType, TCsvParser::TParseMetadata{row, filePath});
+            ++row;
         }
         builder.EndList();
         return UpsertTValueBuffer(dbPath, builder).ExtractValueSync();
     };
 
     while (TString line = splitter.ConsumeLine()) {
-        ++row;
+        ++batchRows;
         if (line.empty()) {
             continue;
         }
@@ -494,7 +501,8 @@ TStatus TImportFileClient::UpsertCsv(IInputStream& input, const TString& dbPath,
         auto asyncUpsertCSV = [&upsertCsv, row, buffer = std::move(buffer)]() mutable {
             return upsertCsv(row, std::move(buffer));
         };
-
+        row += batchRows;
+        batchRows = 0;
         batchBytes = 0;
         buffer.clear();
 
@@ -513,7 +521,10 @@ TStatus TImportFileClient::UpsertCsv(IInputStream& input, const TString& dbPath,
     return WaitForQueue(0, inFlightRequests);
 }
 
-TStatus TImportFileClient::UpsertCsvByBlocks(const TString& filePath, const TString& dbPath, const TImportFileSettings& settings) {
+TStatus TImportFileClient::UpsertCsvByBlocks(const TString& filePath,
+                                             const TString& dbPath,
+                                             const TImportFileSettings& settings) {
+
     TMaxInflightGetter inFlightGetter(settings.MaxInFlightRequests_, FilesCount);
     TString headerRow;
     TCsvFileReader splitter(filePath, settings, headerRow, inFlightGetter);
@@ -523,7 +534,9 @@ TStatus TImportFileClient::UpsertCsvByBlocks(const TString& filePath, const TStr
 
     TCsvParser parser;
     bool removeLastDelimiter = false;
-    InitCsvParser(parser, removeLastDelimiter, std::move(headerRow), settings, &columnTypes, DbTableInfo.get());
+    TStringInput headerInput(headerRow);
+    NCsvFormat::TLinesSplitter headerSplitter(headerInput, settings.Delimiter_[0]);
+    InitCsvParser(parser, removeLastDelimiter, headerSplitter, settings, &columnTypes, DbTableInfo.get());
 
     TType lineType = parser.GetColumnsType();
 
@@ -536,7 +549,7 @@ TStatus TImportFileClient::UpsertCsvByBlocks(const TString& filePath, const TStr
                 builder.BeginList();
                 for (auto&& line : buffer) {
                     builder.AddListItem();
-                    parser.GetValue(0, std::move(line), builder, lineType);
+                    parser.GetValue(std::move(line), builder, lineType, TCsvParser::TParseMetadata{std::nullopt, filePath});
                 }
                 builder.EndList();
                 return UpsertTValueBuffer(dbPath, builder);

--- a/ydb/public/lib/ydb_cli/import/import.h
+++ b/ydb/public/lib/ydb_cli/import/import.h
@@ -80,9 +80,17 @@ private:
 
     using ProgressCallbackFunc = std::function<void (ui64, ui64)>;
 
-    TStatus UpsertCsv(IInputStream& input, const TString& dbPath, const TImportFileSettings& settings,
-                    std::optional<ui64> inputSizeHint, ProgressCallbackFunc & progressCallback);
-    TStatus UpsertCsvByBlocks(const TString& filePath, const TString& dbPath, const TImportFileSettings& settings);
+    TStatus UpsertCsv(IInputStream& input,
+                      const TString& dbPath,
+                      const TImportFileSettings& settings,
+                      const TString& filePath,
+                      std::optional<ui64> inputSizeHint,
+                      ProgressCallbackFunc & progressCallback);
+
+    TStatus UpsertCsvByBlocks(const TString& filePath,
+                              const TString& dbPath,
+                              const TImportFileSettings& settings);
+
     TAsyncStatus UpsertTValueBuffer(const TString& dbPath, TValueBuilder& builder);
 
     TStatus UpsertJson(IInputStream &input, const TString &dbPath, const TImportFileSettings &settings,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed default for --null-value in ydb import file csv/tsv commands and improved error text

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
