### PR TITLE
Remove recurses to proto libraries to avoid compilation for every possible language

### DIFF
--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -115,7 +115,7 @@ runs:
         # to be sure
         set -o pipefail
         
-        ./ya make -k --build "${build_type}" --force-build-depends -D'BUILD_LANGUAGES=CPP PY3 PY2 GO' -T --stat -DCONSISTENT_DEBUG \
+        ./ya make -k --build "${build_type}" --force-build-depends -T --stat -DCONSISTENT_DEBUG \
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \
           "${extra_params[@]}" |& tee $TMP_DIR/ya_make.log && echo "status=true" >> $GITHUB_OUTPUT || (

--- a/ydb/core/blobstorage/vdisk/ya.make
+++ b/ydb/core/blobstorage/vdisk/ya.make
@@ -37,7 +37,6 @@ RECURSE(
     hullop
     ingress
     localrecovery
-    protos
     query
     repl
     scrub

--- a/ydb/core/config/ya.make
+++ b/ydb/core/config/ya.make
@@ -1,6 +1,5 @@
 RECURSE(
     init
-    protos
     tools
     utils
     validation

--- a/ydb/core/fq/libs/checkpoint_storage/ya.make
+++ b/ydb/core/fq/libs/checkpoint_storage/ya.make
@@ -32,7 +32,6 @@ END()
 
 RECURSE(
     events
-    proto
 )
 
 RECURSE_FOR_TESTS(

--- a/ydb/core/fq/libs/config/ya.make
+++ b/ydb/core/fq/libs/config/ya.make
@@ -11,6 +11,3 @@ PEERDIR(
 
 END()
 
-RECURSE(
-    protos
-)

--- a/ydb/core/fq/libs/control_plane_storage/ya.make
+++ b/ydb/core/fq/libs/control_plane_storage/ya.make
@@ -49,5 +49,4 @@ END()
 RECURSE(
     events
     internal
-    proto
 )

--- a/ydb/core/fq/libs/graph_params/ya.make
+++ b/ydb/core/fq/libs/graph_params/ya.make
@@ -1,3 +1,0 @@
-RECURSE(
-    proto
-)

--- a/ydb/core/fq/libs/quota_manager/ya.make
+++ b/ydb/core/fq/libs/quota_manager/ya.make
@@ -22,6 +22,5 @@ END()
 
 RECURSE(
     events
-    proto
     ut_helpers
 )

--- a/ydb/core/fq/libs/ya.make
+++ b/ydb/core/fq/libs/ya.make
@@ -25,7 +25,6 @@ RECURSE(
     mock
     pretty_printers
     private_client
-    protos
     quota_manager
     rate_limiter
     read_rule

--- a/ydb/core/graph/ya.make
+++ b/ydb/core/graph/ya.make
@@ -5,7 +5,6 @@ OWNER(
 
 RECURSE(
     api
-    protos
     service
     shard
 )

--- a/ydb/core/keyvalue/ya.make
+++ b/ydb/core/keyvalue/ya.make
@@ -56,10 +56,6 @@ PEERDIR(
 
 END()
 
-RECURSE(
-    protos
-)
-
 RECURSE_FOR_TESTS(
     ut
     ut_trace

--- a/ydb/core/kqp/proxy_service/ya.make
+++ b/ydb/core/kqp/proxy_service/ya.make
@@ -41,10 +41,6 @@ YQL_LAST_ABI_VERSION()
 
 END()
 
-RECURSE(
-    proto
-)
-
 RECURSE_FOR_TESTS(
     ut
 )

--- a/ydb/core/ya.make
+++ b/ydb/core/ya.make
@@ -42,7 +42,6 @@ RECURSE(
     node_whiteboard
     persqueue
     pgproxy
-    protos
     public_http
     quoter
     raw_socket

--- a/ydb/core/ymq/ya.make
+++ b/ydb/core/ymq/ya.make
@@ -3,7 +3,6 @@ RECURSE(
     base
     client
     http
-    proto
     queues
 )
 

--- a/ydb/library/actors/ya.make
+++ b/ydb/library/actors/ya.make
@@ -9,7 +9,6 @@ RECURSE(
     log_backend
     memory_log
     prof
-    protos
     testlib
     util
     wilson

--- a/ydb/library/folder_service/ya.make
+++ b/ydb/library/folder_service/ya.make
@@ -16,5 +16,4 @@ END()
 
 RECURSE(
     mock
-    proto
 )

--- a/ydb/library/schlab/ya.make
+++ b/ydb/library/schlab/ya.make
@@ -15,7 +15,6 @@ END()
 RECURSE(
     mon
     probes
-    protos
     schemu
     schine
     schoot

--- a/ydb/library/yql/dq/actors/ya.make
+++ b/ydb/library/yql/dq/actors/ya.make
@@ -15,7 +15,6 @@ END()
 
 RECURSE(
     compute
-    protos
     spilling
     task_runner
 )

--- a/ydb/library/yql/dq/ya.make
+++ b/ydb/library/yql/dq/ya.make
@@ -5,7 +5,6 @@ RECURSE(
     expr_nodes
     integration
     opt
-    proto
     runtime
     state
     tasks

--- a/ydb/library/yql/providers/clickhouse/ya.make
+++ b/ydb/library/yql/providers/clickhouse/ya.make
@@ -1,6 +1,5 @@
 RECURSE(
     actors
     expr_nodes
-    proto
     provider
 )

--- a/ydb/library/yql/providers/common/metrics/ya.make
+++ b/ydb/library/yql/providers/common/metrics/ya.make
@@ -13,7 +13,3 @@ PEERDIR(
 )
 
 END()
-
-RECURSE(
-    protos
-)

--- a/ydb/library/yql/providers/common/token_accessor/ya.make
+++ b/ydb/library/yql/providers/common/token_accessor/ya.make
@@ -1,4 +1,3 @@
 RECURSE(
     client
-    grpc
 )

--- a/ydb/library/yql/providers/common/ya.make
+++ b/ydb/library/yql/providers/common/ya.make
@@ -11,7 +11,6 @@ RECURSE(
     http_gateway
     metrics
     mkql
-    proto
     proto/python
     provider
     pushdown

--- a/ydb/library/yql/providers/dq/ya.make
+++ b/ydb/library/yql/providers/dq/ya.make
@@ -1,8 +1,6 @@
 RECURSE(
     actors
-    api
     common
-    config
     counters
     expr_nodes
     global_worker_manager

--- a/ydb/library/yql/providers/function/ya.make
+++ b/ydb/library/yql/providers/function/ya.make
@@ -2,6 +2,5 @@ RECURSE(
     common
     expr_nodes
     gateway
-    proto
     provider
 )

--- a/ydb/library/yql/providers/generic/connector/ya.make
+++ b/ydb/library/yql/providers/generic/connector/ya.make
@@ -1,5 +1,4 @@
 RECURSE(
-    api
     libcpp
 )
 

--- a/ydb/library/yql/providers/pq/ya.make
+++ b/ydb/library/yql/providers/pq/ya.make
@@ -4,7 +4,6 @@ RECURSE(
     common
     expr_nodes
     gateway
-    proto
     provider
     task_meta
 )

--- a/ydb/library/yql/providers/s3/ya.make
+++ b/ydb/library/yql/providers/s3/ya.make
@@ -6,7 +6,6 @@ RECURSE(
     expr_nodes
     object_listers
     path_generator
-    proto
     provider
     range_helpers
     serializations

--- a/ydb/library/yql/providers/solomon/ya.make
+++ b/ydb/library/yql/providers/solomon/ya.make
@@ -2,6 +2,5 @@ RECURSE(
     async_io
     expr_nodes
     gateway
-    proto
     provider
 )

--- a/ydb/library/yql/providers/ydb/ya.make
+++ b/ydb/library/yql/providers/ydb/ya.make
@@ -2,6 +2,5 @@ RECURSE(
     actors
     comp_nodes
     expr_nodes
-    proto
     provider
 )

--- a/ydb/library/yql/public/issue/ya.make
+++ b/ydb/library/yql/public/issue/ya.make
@@ -21,10 +21,6 @@ GENERATE_ENUM_SERIALIZATION(yql_warning.h)
 
 END()
 
-RECURSE(
-    protos
-)
-
 RECURSE_FOR_TESTS(
     ut
 )

--- a/ydb/library/yql/public/ya.make
+++ b/ydb/library/yql/public/ya.make
@@ -4,6 +4,5 @@ RECURSE(
     fastcheck
     issue
     purecalc
-    types
     udf
 )

--- a/ydb/library/yql/utils/log/ya.make
+++ b/ydb/library/yql/utils/log/ya.make
@@ -17,10 +17,6 @@ PEERDIR(
 
 END()
 
-RECURSE(
-    proto
-)
-
 RECURSE_FOR_TESTS(
     ut
 )

--- a/ydb/library/yql/ya.make
+++ b/ydb/library/yql/ya.make
@@ -4,7 +4,6 @@ RECURSE(
     dq
     minikql
     parser
-    protos
     providers
     public
     sql

--- a/ydb/public/lib/validation/ya.make
+++ b/ydb/public/lib/validation/ya.make
@@ -14,5 +14,4 @@ END()
 
 RECURSE_FOR_TESTS(
     ut
-    ut/protos
 )

--- a/ydb/public/ya.make
+++ b/ydb/public/ya.make
@@ -1,5 +1,4 @@
 RECURSE(
-    api
     lib
     sdk
     tools

--- a/ydb/services/ya.make
+++ b/ydb/services/ya.make
@@ -4,7 +4,6 @@ RECURSE(
     cms
     datastreams
     deprecated/persqueue_v0
-    deprecated/persqueue_v0/api
     discovery
     dynamic_config
     ext_index

--- a/ydb/ya.make
+++ b/ydb/ya.make
@@ -1,9 +1,6 @@
 RECURSE(
     apps
     core
-    docs
-    docs/en/core
-    docs/ru/core
     library
     mvp
     public


### PR DESCRIPTION
- **Remove recurse to proto libraries to avoid compilation for all languages**
- **Update build action removing languages filter**
- **Remove recurses to proto libraries to avoid compilation for all available languages**
- **Remove recurse to protolibraries from tests**
- **Temporary remove docs from recurse to avoid building as part of /ydb**
