### PR TITLE
[YQL-15502] Avoid rewriting lazy functions (like If) to blocks if arguments can fail in runtime

### DIFF
--- a/ydb/library/yql/core/yql_opt_utils.cpp
+++ b/ydb/library/yql/core/yql_opt_utils.cpp
@@ -1853,7 +1853,7 @@ bool IsStrict(const TExprNode::TPtr& root) {
         }
 
         auto maybeStrict = IsStrictNoRecurse(*node);
-        if (maybeStrict.Defined() && !maybeStrict) {
+        if (maybeStrict.Defined() && !*maybeStrict) {
             isStrict = false;
         }
 

--- a/ydb/library/yql/core/yql_opt_utils.cpp
+++ b/ydb/library/yql/core/yql_opt_utils.cpp
@@ -1829,28 +1829,35 @@ bool IsYieldTransparent(const TExprNode::TPtr& root, const TTypeAnnotationContex
     return !FindNonYieldTransparentNode(root, typeCtx);
 }
 
+TMaybe<bool> IsStrictNoRecurse(const TExprNode& node) {
+    if (node.IsCallable({"Unwrap", "Ensure", "ScripUdf"})) {
+        return false;
+    }
+    if (node.IsCallable("Udf")) {
+        return HasSetting(*node.Child(TCoUdf::idx_Settings), "strict");
+    }
+    return {};
+}
+
 bool IsStrict(const TExprNode::TPtr& root) {
     // TODO: add TExprNode::IsStrict() method (with corresponding flag). Fill it as part of type annotation pass
     bool isStrict = true;
-    size_t insideAssumeStrict = 0;
-
     VisitExpr(root, [&](const TExprNode::TPtr& node) {
+        if (node->IsCallable("AssumeStrict")) {
+            return false;
+        }
+
         if (node->IsCallable("AssumeNonStrict")) {
             isStrict = false;
-        } else if (node->IsCallable("AssumeStrict")) {
-            ++insideAssumeStrict;
-        } else if (isStrict && !insideAssumeStrict && node->IsCallable({"Udf", "ScriptUdf", "Unwrap", "Ensure"})) {
-            if (!node->IsCallable("Udf") || !HasSetting(*node->Child(TCoUdf::idx_Settings), "strict")) {
-                isStrict = false;
-            }
+            return false;
         }
+
+        auto maybeStrict = IsStrictNoRecurse(*node);
+        if (maybeStrict.Defined() && !maybeStrict) {
+            isStrict = false;
+        }
+
         return isStrict;
-    }, [&](const TExprNode::TPtr& node) {
-        if (node->IsCallable("AssumeStrict")) {
-            YQL_ENSURE(insideAssumeStrict > 0);
-            --insideAssumeStrict;
-        }
-        return true;
     });
 
     return isStrict;

--- a/ydb/library/yql/core/yql_opt_utils.h
+++ b/ydb/library/yql/core/yql_opt_utils.h
@@ -142,6 +142,8 @@ TExprNode::TPtr FindNonYieldTransparentNode(const TExprNode::TPtr& root, const T
 bool IsYieldTransparent(const TExprNode::TPtr& root, const TTypeAnnotationContext& typeCtx);
 
 bool IsStrict(const TExprNode::TPtr& node);
+TMaybe<bool> IsStrictNoRecurse(const TExprNode& node);
+
 bool HasDependsOn(const TExprNode::TPtr& node, const TExprNode::TPtr& arg);
 
 TExprNode::TPtr KeepSortedConstraint(TExprNode::TPtr node, const TSortedConstraintNode* sorted, const TTypeAnnotationNode* rowType, TExprContext& ctx);

--- a/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
@@ -533,6 +533,28 @@
         }
     ],
     "test.test[blocks-filter_direct_col--Results]": [],
+    "test.test[blocks-lazy_nonstrict_nested--Analyze]": [
+        {
+            "checksum": "e7f1fda0c2552005796092179e53d72e",
+            "size": 3708,
+            "uri": "https://{canondata_backend}/1871182/a45e63e762a7c398115e16e6525a417775b3a286/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Analyze_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_nested--Debug]": [
+        {
+            "checksum": "16393cbbd7a1b4f34813068cdaa837bb",
+            "size": 1946,
+            "uri": "https://{canondata_backend}/1871182/a45e63e762a7c398115e16e6525a417775b3a286/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_nested--Plan]": [
+        {
+            "checksum": "e7f1fda0c2552005796092179e53d72e",
+            "size": 3708,
+            "uri": "https://{canondata_backend}/1871182/a45e63e762a7c398115e16e6525a417775b3a286/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_nested--Results]": [],
     "test.test[blocks-member--Analyze]": [
         {
             "checksum": "b08274fd137c1878d90520c832f06fd3",

--- a/ydb/library/yql/tests/sql/dq_file/part12/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part12/canondata/result.json
@@ -483,6 +483,28 @@
         }
     ],
     "test.test[blocks-combine_hashed_sum--Results]": [],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Analyze]": [
+        {
+            "checksum": "1ac2168b6dc19a2b64a8ef3cd8f1dc9b",
+            "size": 8094,
+            "uri": "https://{canondata_backend}/1936842/ac577f16f8e6bca674998429b5b9423070b2dc8a/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Analyze_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Debug]": [
+        {
+            "checksum": "e050972347325a1fc1ea7f88d797b2fb",
+            "size": 3439,
+            "uri": "https://{canondata_backend}/1936842/ac577f16f8e6bca674998429b5b9423070b2dc8a/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Plan]": [
+        {
+            "checksum": "1ac2168b6dc19a2b64a8ef3cd8f1dc9b",
+            "size": 8094,
+            "uri": "https://{canondata_backend}/1936842/ac577f16f8e6bca674998429b5b9423070b2dc8a/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Results]": [],
     "test.test[blocks-minmax_strings_filter--Analyze]": [
         {
             "checksum": "96b8e427563eb2aff7b5d762278b8f3c",

--- a/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
@@ -489,6 +489,28 @@
         }
     ],
     "test.test[blocks-group_by_complex_key--Results]": [],
+    "test.test[blocks-lazy_nonstrict_basic--Analyze]": [
+        {
+            "checksum": "0d031fc0e9a4b3bd54c37fccf921aff3",
+            "size": 5806,
+            "uri": "https://{canondata_backend}/1784117/c661e0665727833e46e467de09782cba16c8d2ec/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Analyze_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_basic--Debug]": [
+        {
+            "checksum": "3fe92f3a4a2a1ae682409987cfcc314b",
+            "size": 2922,
+            "uri": "https://{canondata_backend}/1784117/c661e0665727833e46e467de09782cba16c8d2ec/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_basic--Plan]": [
+        {
+            "checksum": "0d031fc0e9a4b3bd54c37fccf921aff3",
+            "size": 5806,
+            "uri": "https://{canondata_backend}/1784117/c661e0665727833e46e467de09782cba16c8d2ec/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_basic--Results]": [],
     "test.test[case-case_multi_val-default.txt-Analyze]": [
         {
             "checksum": "b913ead12af51bc046e1f3344ff5134c",

--- a/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
@@ -517,6 +517,20 @@
             "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_blocks-filter_direct_col--Plan_/plan.txt"
         }
     ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Debug]": [
+        {
+            "checksum": "3603b41c289d1fa4931c3b215e445106",
+            "size": 4409,
+            "uri": "https://{canondata_backend}/1871182/ff2fb07469c37755c1fa0f067a3d7f3a7c2115ce/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Plan]": [
+        {
+            "checksum": "c0b652d1d0f534a65d352fa14f8a548b",
+            "size": 12315,
+            "uri": "https://{canondata_backend}/1871182/ff2fb07469c37755c1fa0f067a3d7f3a7c2115ce/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Plan_/plan.txt"
+        }
+    ],
     "test.test[blocks-mul_uint64_opt2--Debug]": [
         {
             "checksum": "bb4d089250e3c886106611accfea4008",

--- a/ydb/library/yql/tests/sql/hybrid_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part1/canondata/result.json
@@ -601,6 +601,20 @@
             "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_blocks-distinct_opt_state_all--Plan_/plan.txt"
         }
     ],
+    "test.test[blocks-lazy_nonstrict_nested--Debug]": [
+        {
+            "checksum": "169081699f9abdf588242a82bdd3cd74",
+            "size": 2601,
+            "uri": "https://{canondata_backend}/1937027/a8cb491c8a572af7f72d8d3eb20ec26e6e9f69d2/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_nested--Plan]": [
+        {
+            "checksum": "479fec114def8f2e4489e2b86168b8b5",
+            "size": 4077,
+            "uri": "https://{canondata_backend}/1937027/a8cb491c8a572af7f72d8d3eb20ec26e6e9f69d2/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Plan_/plan.txt"
+        }
+    ],
     "test.test[blocks-partial_blocks1--Debug]": [
         {
             "checksum": "abf843957bbff9a543801442406f43a7",

--- a/ydb/library/yql/tests/sql/hybrid_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part8/canondata/result.json
@@ -615,6 +615,20 @@
             "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_blocks-filter_expr--Plan_/plan.txt"
         }
     ],
+    "test.test[blocks-lazy_nonstrict_basic--Debug]": [
+        {
+            "checksum": "af3dced38ddb9a0b74aef47d4f69bb2b",
+            "size": 3999,
+            "uri": "https://{canondata_backend}/1936842/31a86a143fdd8df759ccdc8a17183ecf9da2c551/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_basic--Plan]": [
+        {
+            "checksum": "2dcc6cb9914f62065d2ef89577ee90bd",
+            "size": 8759,
+            "uri": "https://{canondata_backend}/1936842/31a86a143fdd8df759ccdc8a17183ecf9da2c551/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Plan_/plan.txt"
+        }
+    ],
     "test.test[blocks-pg_call--Debug]": [
         {
             "checksum": "b427097ed1bad2d2b952961edac4a038",

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -3576,6 +3576,13 @@
             "uri": "https://{canondata_backend}/1917492/bf361ba6aca9974e26535026fb228b74d0ff24ef/resource.tar.gz#test_sql2yql.test_blocks-if_/sql.yql"
         }
     ],
+    "test_sql2yql.test[blocks-lazy_nonstrict_nested]": [
+        {
+            "checksum": "2eafb1a166d573561db215f1b89564d1",
+            "size": 1708,
+            "uri": "https://{canondata_backend}/1889210/98f6fd4d010cb71a3a74f921494b3f4682dc5c71/resource.tar.gz#test_sql2yql.test_blocks-lazy_nonstrict_nested_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[blocks-lazy_nonstrict_with_scalar_ctx]": [
         {
             "checksum": "cf75bc6ce806c3a1e35ad6330fb52fc3",
@@ -21956,6 +21963,13 @@
             "checksum": "b649410c2a4dbec4627225e51894b5fe",
             "size": 532,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_blocks-if_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-lazy_nonstrict_nested]": [
+        {
+            "checksum": "9bff11601ddad74ad28455febf201137",
+            "size": 221,
+            "uri": "https://{canondata_backend}/1889210/98f6fd4d010cb71a3a74f921494b3f4682dc5c71/resource.tar.gz#test_sql_format.test_blocks-lazy_nonstrict_nested_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-lazy_nonstrict_with_scalar_ctx]": [

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -3576,6 +3576,13 @@
             "uri": "https://{canondata_backend}/1917492/bf361ba6aca9974e26535026fb228b74d0ff24ef/resource.tar.gz#test_sql2yql.test_blocks-if_/sql.yql"
         }
     ],
+    "test_sql2yql.test[blocks-lazy_nonstrict_with_scalar_ctx]": [
+        {
+            "checksum": "cf75bc6ce806c3a1e35ad6330fb52fc3",
+            "size": 4333,
+            "uri": "https://{canondata_backend}/1946324/c8f87009bde7cdc3b5b9a77da3e917fd59702752/resource.tar.gz#test_sql2yql.test_blocks-lazy_nonstrict_with_scalar_ctx_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[blocks-member]": [
         {
             "checksum": "88c9131d7ea3c80ecc268cb7f458fc86",
@@ -21949,6 +21956,13 @@
             "checksum": "b649410c2a4dbec4627225e51894b5fe",
             "size": 532,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_blocks-if_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-lazy_nonstrict_with_scalar_ctx]": [
+        {
+            "checksum": "1a0fee4a6f1ae3427085fb1c41008fa4",
+            "size": 449,
+            "uri": "https://{canondata_backend}/1946324/c8f87009bde7cdc3b5b9a77da3e917fd59702752/resource.tar.gz#test_sql_format.test_blocks-lazy_nonstrict_with_scalar_ctx_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-member]": [

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -3576,6 +3576,13 @@
             "uri": "https://{canondata_backend}/1917492/bf361ba6aca9974e26535026fb228b74d0ff24ef/resource.tar.gz#test_sql2yql.test_blocks-if_/sql.yql"
         }
     ],
+    "test_sql2yql.test[blocks-lazy_nonstrict_basic]": [
+        {
+            "checksum": "bb3c3b4a2e9d968a4e3d7d5c70d98e4d",
+            "size": 4234,
+            "uri": "https://{canondata_backend}/1936842/8d77b55c95ef4699963bd71d8cf4248f656f1473/resource.tar.gz#test_sql2yql.test_blocks-lazy_nonstrict_basic_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[blocks-lazy_nonstrict_nested]": [
         {
             "checksum": "2eafb1a166d573561db215f1b89564d1",
@@ -21963,6 +21970,13 @@
             "checksum": "b649410c2a4dbec4627225e51894b5fe",
             "size": 532,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_blocks-if_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-lazy_nonstrict_basic]": [
+        {
+            "checksum": "285bfbbe81a6ea4974ba99c38efbb87f",
+            "size": 633,
+            "uri": "https://{canondata_backend}/1936842/8d77b55c95ef4699963bd71d8cf4248f656f1473/resource.tar.gz#test_sql_format.test_blocks-lazy_nonstrict_basic_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-lazy_nonstrict_nested]": [

--- a/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_basic.cfg
+++ b/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_basic.cfg
@@ -1,0 +1,2 @@
+in Input input_strings.txt
+udf string_udf

--- a/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_basic.sql
+++ b/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_basic.sql
@@ -1,0 +1,18 @@
+USE plato;
+
+pragma UseBlocks;
+pragma yt.DisableOptimizers="OutHorizontalJoin,HorizontalJoin,MultiHorizontalJoin";
+
+
+$ns_tolower = ($x) -> (AssumeNonStrict(String::AsciiToLower($x)));
+$ns_toupper = ($x) -> (AssumeNonStrict(String::AsciiToUpper($x)));
+
+-- full block
+select * from Input where $ns_tolower(value) > "aaa" and subkey == "1";
+
+-- partial block due to lazy non-strict node
+select * from Input where subkey == "2" and $ns_toupper(value) <= "ZZZ";
+
+-- full block - same non strict is used in first arg of AND
+select * from Input where $ns_toupper(value) >= "AAA" and $ns_toupper(value) <= "ZZZ" and subkey == "3";
+

--- a/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_nested.cfg
+++ b/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_nested.cfg
@@ -1,0 +1,2 @@
+in Input input_strings.txt
+udf string_udf

--- a/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_nested.sql
+++ b/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_nested.sql
@@ -1,0 +1,6 @@
+USE plato;
+
+pragma UseBlocks;
+
+-- partial blocks due to non strict in second arg of AND
+select if(value > "aaa" and String::AsciiToLower(AssumeNonStrict(subkey)) > "3", "foo", "bar"), value, subkey from Input;

--- a/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_with_scalar_ctx.cfg
+++ b/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_with_scalar_ctx.cfg
@@ -1,0 +1,1 @@
+in Input input_strings.txt

--- a/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_with_scalar_ctx.sql
+++ b/ydb/library/yql/tests/sql/suites/blocks/lazy_nonstrict_with_scalar_ctx.sql
@@ -1,0 +1,12 @@
+USE plato;
+
+pragma UseBlocks;
+
+$one = select min(AssumeNonStrict(value)) from Input;
+$two = select AssumeNonStrict(min(value)) from Input;
+
+-- fully converted to blocks - scalar context is assumed strict
+select * from Input where subkey != "1" and value > $one;
+
+-- partially converted to blocks - AssumeStrict is calculated outside of scalar context
+select * from Input where subkey != "2" and value > $two;

--- a/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
@@ -548,6 +548,34 @@
             "uri": "https://{canondata_backend}/1689644/8bfa47b4b6b4d6f6543bfef6c07a8937dfb0470d/resource.tar.gz#test.test_blocks-filter_direct_col--Results_/results.txt"
         }
     ],
+    "test.test[blocks-lazy_nonstrict_nested--Debug]": [
+        {
+            "checksum": "d1041c76aad74c12698c8f5592dee2c6",
+            "size": 1970,
+            "uri": "https://{canondata_backend}/1889210/fa8fb97ca9e42f1aa5ae5ba7faaa0f1244b6512b/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_nested--Peephole]": [
+        {
+            "checksum": "8ca14d52c8d3c8c34113196fa7cb6765",
+            "size": 1949,
+            "uri": "https://{canondata_backend}/1889210/fa8fb97ca9e42f1aa5ae5ba7faaa0f1244b6512b/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_nested--Plan]": [
+        {
+            "checksum": "7adb2ff33045651c0a692434b55130c2",
+            "size": 3533,
+            "uri": "https://{canondata_backend}/1889210/fa8fb97ca9e42f1aa5ae5ba7faaa0f1244b6512b/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_nested--Results]": [
+        {
+            "checksum": "12dd1f9a5678b9f5837f9f38ba8f89d0",
+            "size": 2500,
+            "uri": "https://{canondata_backend}/1889210/fa8fb97ca9e42f1aa5ae5ba7faaa0f1244b6512b/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Results_/results.txt"
+        }
+    ],
     "test.test[blocks-member--Debug]": [
         {
             "checksum": "bc4498c90892a7f1e023ac57dbcbc16d",

--- a/ydb/library/yql/tests/sql/yt_native_file/part12/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part12/canondata/result.json
@@ -475,6 +475,34 @@
             "uri": "https://{canondata_backend}/1936997/a95cccf3209d441f2d222d56081bdfc240fc8b83/resource.tar.gz#test.test_blocks-combine_hashed_sum--Results_/results.txt"
         }
     ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Debug]": [
+        {
+            "checksum": "6f91a2c9be4e63aa2603467a3775d663",
+            "size": 4345,
+            "uri": "https://{canondata_backend}/1946324/3d31b9d61b72ca9cdd0bdf31714fd56ff70a0fb3/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Peephole]": [
+        {
+            "checksum": "6652cd5761c3af50b3c30de660f1664e",
+            "size": 4380,
+            "uri": "https://{canondata_backend}/1946324/3d31b9d61b72ca9cdd0bdf31714fd56ff70a0fb3/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Plan]": [
+        {
+            "checksum": "c6a47fbc834c08bb31b08982d4c23724",
+            "size": 12315,
+            "uri": "https://{canondata_backend}/1946324/3d31b9d61b72ca9cdd0bdf31714fd56ff70a0fb3/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_with_scalar_ctx--Results]": [
+        {
+            "checksum": "b3b54b7ed3f988a1b9d2180448dcd0c7",
+            "size": 4180,
+            "uri": "https://{canondata_backend}/1946324/3d31b9d61b72ca9cdd0bdf31714fd56ff70a0fb3/resource.tar.gz#test.test_blocks-lazy_nonstrict_with_scalar_ctx--Results_/results.txt"
+        }
+    ],
     "test.test[blocks-minmax_strings_filter--Debug]": [
         {
             "checksum": "f14b3b085a8965edad99f27a3eb60715",

--- a/ydb/library/yql/tests/sql/yt_native_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part9/canondata/result.json
@@ -490,6 +490,34 @@
             "uri": "https://{canondata_backend}/1775059/d0c85f9ec0b8e84cf0b352e7062a1381f04420c8/resource.tar.gz#test.test_blocks-group_by_complex_key--Results_/results.txt"
         }
     ],
+    "test.test[blocks-lazy_nonstrict_basic--Debug]": [
+        {
+            "checksum": "d63626da1e7396a93fde4f5a82ca4a82",
+            "size": 2860,
+            "uri": "https://{canondata_backend}/1784117/b0e606c86d016fe31b5535c6dc49f4ffe2b01813/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_basic--Peephole]": [
+        {
+            "checksum": "e6bd706fd59f342eccf6505149bbf7fd",
+            "size": 3171,
+            "uri": "https://{canondata_backend}/1784117/b0e606c86d016fe31b5535c6dc49f4ffe2b01813/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_basic--Plan]": [
+        {
+            "checksum": "109bb0bb187f73bc1bcd4d766a7e4d9c",
+            "size": 7333,
+            "uri": "https://{canondata_backend}/1784117/b0e606c86d016fe31b5535c6dc49f4ffe2b01813/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Plan_/plan.txt"
+        }
+    ],
+    "test.test[blocks-lazy_nonstrict_basic--Results]": [
+        {
+            "checksum": "1195710448fb2ef6fde293983a4a52a8",
+            "size": 3974,
+            "uri": "https://{canondata_backend}/1784117/b0e606c86d016fe31b5535c6dc49f4ffe2b01813/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Results_/results.txt"
+        }
+    ],
     "test.test[case-case_multi_val-default.txt-Debug]": [
         {
             "checksum": "4bb4e7f93470623e692086882c8dfcff",


### PR DESCRIPTION
- initial
- fix IsStrict()
- test about scalar ctx
- fix handling nested if/and
- add test for nested if/and
- another test

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-15502] Avoid rewriting lazy functions (like If) to blocks if arguments can fail in runtime

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
