### PR TITLE
[YQL-18194] Prepare to limit builders memory consumption in WideToBlocks

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
@@ -93,7 +93,7 @@ public:
                         break;
                 }
                 break;
-            } while (++s.Rows_ < MaxLength_);
+            } while (++s.Rows_ < MaxLength_ && s.BuilderAllocatedSize_ <= s.MaxBuilderAllocatedSize_);
 
             if (s.Rows_)
                 s.MakeBlocks(ctx.HolderFactory);
@@ -257,6 +257,8 @@ private:
     struct TState : public TBlockState {
         size_t Rows_ = 0;
         bool IsFinished_ = false;
+        size_t BuilderAllocatedSize_ = 0;
+        size_t MaxBuilderAllocatedSize_ = 0;
         std::vector<std::unique_ptr<IArrayBuilder>> Builders_;
         TState(TMemoryUsageInfo* memInfo, TComputationContext& ctx, const TVector<TType*>& types, size_t maxLength, NUdf::TUnboxedValue**const fields)
             : TBlockState(memInfo, types.size() + 1U)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-18194] Prepare to limit builders memory consumption in WideToBlocks

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
