### PR TITLE
Aggregate storage pool usage statistics by pool name instead of a pool kind

### DIFF
--- a/ydb/core/cms/console/console__create_tenant.cpp
+++ b/ydb/core/cms/console/console__create_tenant.cpp
@@ -283,7 +283,7 @@ public:
                 if (unitHardQuota && unitSoftQuota && unitHardQuota < unitSoftQuota) {
                     return Error(Ydb::StatusIds::BAD_REQUEST,
                         TStringBuilder() << "Data size soft quota (" << unitSoftQuota << ")"
-                                         << " for a " << storageQuota.unit_kind() << " storage unit "
+                                         << " for a " << storageQuota.storage_unit() << " storage unit "
                                          << " of the database " << path
                                          << " must be smaller than the corresponding hard quota (" << unitHardQuota << ")",
                         ctx

--- a/ydb/core/cms/console/console__create_tenant.cpp
+++ b/ydb/core/cms/console/console__create_tenant.cpp
@@ -273,19 +273,20 @@ public:
                 return Error(Ydb::StatusIds::BAD_REQUEST,
                     TStringBuilder() << "Overall data size soft quota (" << softQuota << ")"
                                      << " of the database " << path
-                                     << " must be smaller than the hard quota (" << hardQuota << ")",
+                                     << " must be less than or equal to the hard quota (" << hardQuota << ")",
                     ctx
                 );
             }
-            for (const auto& storageQuota : quotas.storage_quotas()) {
-                const auto unitHardQuota = storageQuota.data_size_hard_quota();
-                const auto unitSoftQuota = storageQuota.data_size_soft_quota();
+            for (const auto& storageUnitQuota : quotas.storage_quotas()) {
+                const auto unitHardQuota = storageUnitQuota.data_size_hard_quota();
+                const auto unitSoftQuota = storageUnitQuota.data_size_soft_quota();
                 if (unitHardQuota && unitSoftQuota && unitHardQuota < unitSoftQuota) {
                     return Error(Ydb::StatusIds::BAD_REQUEST,
                         TStringBuilder() << "Data size soft quota (" << unitSoftQuota << ")"
-                                         << " for a " << storageQuota.storage_unit() << " storage unit "
+                                         << " for a " << storageUnitQuota.storage_unit() << " storage unit"
                                          << " of the database " << path
-                                         << " must be smaller than the corresponding hard quota (" << unitHardQuota << ")",
+                                         << " must be less than or equal to"
+                                         << " the corresponding hard quota (" << unitHardQuota << ")",
                         ctx
                     );
                 }

--- a/ydb/core/cms/console/console_ut_tenants.cpp
+++ b/ydb/core/cms/console/console_ut_tenants.cpp
@@ -91,17 +91,18 @@ TTenantTestConfig DefaultConsoleTestConfig()
 }
 
 TString DefaultDatabaseQuotas() {
-    return R"(
-        data_size_hard_quota: 3000
-        storage_quotas {
-            unit_kind: "hdd"
-            data_size_hard_quota: 2000
-        }
-        storage_quotas {
-            unit_kind: "hdd-1"
-            data_size_hard_quota: 1000
-        }
-    )";
+    return Sprintf(R"(
+            data_size_hard_quota: 3000
+            storage_quotas {
+                storage_unit: "%s:hdd"
+                data_size_hard_quota: 2000
+            }
+            storage_quotas {
+                storage_unit: "%s:hdd-1"
+                data_size_hard_quota: 1000
+            }
+        )", TENANT1_1_NAME.c_str(), TENANT1_1_NAME.c_str()
+    );
 }
 
 void CheckAlterTenantSlots(TTenantTestRuntime &runtime, const TString &path,
@@ -2083,13 +2084,14 @@ Y_UNIT_TEST_SUITE(TConsoleTests) {
         CheckCreateTenant(runtime, Ydb::StatusIds::BAD_REQUEST,
             TCreateTenantRequest(TENANT1_1_NAME, TCreateTenantRequest::EType::Common)
                 .WithPools({{"hdd", 1}})
-                .WithDatabaseQuotas(R"(
-                        storage_quotas {
-                            unit_kind: "hdd"
-                            data_size_hard_quota: 1
-                            data_size_soft_quota: 1000
-                        }
-                    )"
+                .WithDatabaseQuotas(Sprintf(R"(
+                            storage_quotas {
+                                storage_unit: "%s:hdd"
+                                data_size_hard_quota: 1
+                                data_size_soft_quota: 1000
+                            }
+                        )", TENANT1_1_NAME.c_str()
+                    )
                 )
         );
     }

--- a/ydb/core/protos/subdomains.proto
+++ b/ydb/core/protos/subdomains.proto
@@ -62,8 +62,8 @@ message TDiskSpaceUsage {
     }
 
     message TStoragePoolUsage {
+        optional string PoolName = 1;
         // in bytes
-        optional string PoolKind = 1;
         optional uint64 TotalSize = 2;
         optional uint64 DataSize = 3;
         optional uint64 IndexSize = 4;

--- a/ydb/core/protos/table_stats.proto
+++ b/ydb/core/protos/table_stats.proto
@@ -18,7 +18,7 @@ message TChannelStats {
 
 message TStoragePoolsStats {
     message TPoolUsage {
-        optional string PoolKind = 1;
+        optional string PoolName = 1;
         optional uint64 DataSize = 2;
         optional uint64 IndexSize = 3;
     }

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2272,7 +2272,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     );
                     for (const auto& poolUsage : protobufRepresentation.GetPoolsUsage()) {
                         stats.StoragePoolsStats.emplace(
-                            poolUsage.GetPoolKind(),
+                            poolUsage.GetPoolName(),
                             TPartitionStats::TStoragePoolStats{poolUsage.GetDataSize(),
                                                                poolUsage.GetIndexSize()
                             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
@@ -263,7 +263,7 @@ VerifyParams(TParamsDelta* delta, const TPathId pathId, const TSubDomainInfo::TP
         if (const auto& effectivePools = requestedPools.empty()
                 ? actualPools
                 : requestedPools;
-            !CheckStorageQuotasKinds(input.GetDatabaseQuotas(), effectivePools, pathId.ToString(), error)
+            !CheckStoragePoolsInQuotas(input.GetDatabaseQuotas(), effectivePools, pathId.ToString(), error)
         ) {
             return paramError(error);
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
@@ -290,7 +290,7 @@ public:
             if (const auto& effectivePools = requestedPools.empty()
                     ? actualPools
                     : requestedPools;
-                !CheckStorageQuotasKinds(settings.GetDatabaseQuotas(), effectivePools, path.PathString(), errStr)
+                !CheckStoragePoolsInQuotas(settings.GetDatabaseQuotas(), effectivePools, path.PathString(), errStr)
             ) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                 return result;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
@@ -296,7 +296,7 @@ public:
 
         if (settings.HasDatabaseQuotas()) {
             if (!requestedStoragePools.empty()
-                    && !CheckStorageQuotasKinds(settings.GetDatabaseQuotas(), requestedStoragePools, dstPath.PathString(), errStr)
+                    && !CheckStoragePoolsInQuotas(settings.GetDatabaseQuotas(), requestedStoragePools, dstPath.PathString(), errStr)
             ) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                 return result;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -2452,9 +2452,9 @@ void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId
 
     if (!stats.StoragePoolsStats.empty()) {
         NKikimrTableStats::TStoragePoolsStats protobufRepresentation;
-        for (const auto& [poolKind, storagePoolStats] : stats.StoragePoolsStats) {
+        for (const auto& [poolName, storagePoolStats] : stats.StoragePoolsStats) {
             auto* poolUsage = protobufRepresentation.MutablePoolsUsage()->Add();
-            poolUsage->SetPoolKind(poolKind);
+            poolUsage->SetPoolName(poolName);
             poolUsage->SetDataSize(storagePoolStats.DataSize);
             poolUsage->SetIndexSize(storagePoolStats.IndexSize);
         }

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1462,8 +1462,7 @@ void TTableInfo::SetPartitioning(TVector<TTableShardInfo>&& newPartitioning) {
         newAggregatedStats.DataSize += newStats.DataSize;
         newAggregatedStats.IndexSize += newStats.IndexSize;
         for (const auto& [poolName, newStoragePoolStats] : newStats.StoragePoolsStats) {
-            auto& aggregatedStoragePoolStats = newAggregatedStats.StoragePoolsStats[poolName];
-            aggregatedStoragePoolStats += newStoragePoolStats;
+            newAggregatedStats.StoragePoolsStats[poolName] += newStoragePoolStats;
         }
         newAggregatedStats.InFlightTxCount += newStats.InFlightTxCount;
         cpuTotal += newStats.GetCurrentRawCpuUsage();

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -229,6 +229,23 @@ struct TPartitionStats {
     struct TStoragePoolStats {
         ui64 DataSize = 0;
         ui64 IndexSize = 0;
+
+        TStoragePoolStats& operator+=(const TStoragePoolStats& other) {
+            DataSize += other.DataSize;
+            IndexSize += other.IndexSize;
+            return *this;
+        }
+
+        TStoragePoolStats& operator-=(const TStoragePoolStats& other) {
+            DataSize -= other.DataSize;
+            IndexSize -= other.IndexSize;
+            return *this;
+        }
+
+        friend TStoragePoolStats operator-(TStoragePoolStats lhs, const TStoragePoolStats& rhs) {
+            lhs -= rhs;
+            return lhs;
+        }
     };
     THashMap<TString, TStoragePoolStats> StoragePoolsStats;
 
@@ -1314,6 +1331,12 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         struct TStoragePoolUsage {
             ui64 DataSize = 0;
             ui64 IndexSize = 0;
+        
+            TStoragePoolUsage& operator+=(const TStoragePoolUsage& other) {
+                DataSize += other.DataSize;
+                IndexSize += other.IndexSize;
+                return *this;
+            }
         };
         THashMap<TString, TStoragePoolUsage> StoragePoolsUsage;
     };

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -33,9 +33,9 @@ static void FillTableStats(NKikimrTableStats::TTableStats* stats, const TPartiti
     stats->SetPartCount(tableStats.PartCount);
 
     auto* storagePoolsStats = stats->MutableStoragePools()->MutablePoolsUsage();
-    for (const auto& [poolKind, stats] : tableStats.StoragePoolsStats) {
+    for (const auto& [poolName, stats] : tableStats.StoragePoolsStats) {
         auto* storagePoolStats = storagePoolsStats->Add();
-        storagePoolStats->SetPoolKind(poolKind);
+        storagePoolStats->SetPoolName(poolName);
         storagePoolStats->SetDataSize(stats.DataSize);
         storagePoolStats->SetIndexSize(stats.IndexSize);
     }
@@ -716,9 +716,9 @@ void TPathDescriber::DescribeDomainRoot(TPathElement::TPtr pathEl) {
     diskSpaceUsage->MutableTopics()->SetDataSize(subDomainInfo->GetDiskSpaceUsage().Topics.DataSize);
     diskSpaceUsage->MutableTopics()->SetUsedReserveSize(subDomainInfo->GetDiskSpaceUsage().Topics.UsedReserveSize);
     auto* storagePoolsUsage = diskSpaceUsage->MutableStoragePoolsUsage();
-    for (const auto& [poolKind, usage] : subDomainInfo->GetDiskSpaceUsage().StoragePoolsUsage) {
+    for (const auto& [poolName, usage] : subDomainInfo->GetDiskSpaceUsage().StoragePoolsUsage) {
         auto* storagePoolUsage = storagePoolsUsage->Add();
-        storagePoolUsage->SetPoolKind(poolKind);
+        storagePoolUsage->SetPoolName(poolName);
         storagePoolUsage->SetDataSize(usage.DataSize);
         storagePoolUsage->SetIndexSize(usage.IndexSize);
         storagePoolUsage->SetTotalSize(usage.DataSize + usage.IndexSize);

--- a/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
@@ -3364,7 +3364,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
 
     Y_UNIT_TEST_FLAG(DisableWritesToDatabase, IsExternalSubdomain) {
         TTestBasicRuntime runtime;
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
 
         TTestEnvOptions opts;
         opts.DisableStatsBatching(true);
@@ -3486,7 +3486,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
 
     Y_UNIT_TEST_FLAG(QuoteNonexistentPool, IsExternalSubdomain) {
         TTestBasicRuntime runtime;
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
 
         TTestEnvOptions opts;
         TTestEnv env(runtime, opts);
@@ -3535,7 +3535,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
     // To fix the test you need to update canonical quotas and / or batch sizes.
     Y_UNIT_TEST_FLAG(DifferentQuotasInteraction, IsExternalSubdomain) {
         TTestBasicRuntime runtime;
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
 
         TTestEnvOptions opts;
         opts.DisableStatsBatching(true);

--- a/ydb/public/api/protos/ydb_cms.proto
+++ b/ydb/public/api/protos/ydb_cms.proto
@@ -96,8 +96,7 @@ message DatabaseQuotas {
     uint32 ttl_min_run_internal_seconds = 4;
     
     message StorageQuotas {
-        // in theory an arbitrary string, but in practice "hdd" or "ssd"
-        string unit_kind = 1;
+        string storage_unit = 1;
         uint64 data_size_hard_quota = 2;
         uint64 data_size_soft_quota = 3;
     }

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -5574,7 +5574,7 @@ Y_UNIT_TEST(DisableWritesToDatabase) {
     auto sender = runtime.AllocateEdgeActor();
     InitRoot(server, sender);
 
-    runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+    runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
     NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
     NDataShard::gDbStatsDataSizeResolution = 1;
     NDataShard::gDbStatsRowCountResolution = 1;

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -5586,12 +5586,13 @@ Y_UNIT_TEST(DisableWritesToDatabase) {
 
     auto subdomainSettings = GetSubDomainDefaultSetting(tenant, storagePools);
     auto* parsedQuotas = subdomainSettings.MutableDatabaseQuotas();
-    constexpr const char* quotas = R"(
-        storage_quotas {
-            unit_kind: "hdd"
-            data_size_hard_quota: 1
-        }
-    )";
+    TString quotas = Sprintf(R"(
+            storage_quotas {
+                storage_unit: "%s"
+                data_size_hard_quota: 1
+            }
+        )", storagePools[1].GetName().c_str()
+    );
     UNIT_ASSERT_C(NProtoBuf::TextFormat::ParseFromString(quotas, parsedQuotas), quotas);
     AlterSubdomain(server, sender, "/Root", subdomainSettings);
 


### PR DESCRIPTION
Changes: https://github.com/ydb-platform/ydb/pull/2678
[Draft ticket](https://github.com/orgs/ydb-platform/projects/31/views/6?pane=issue&itemId=53688221)
Legacy ticket: KIKIMR-18302

We decided to change the way separate storage pool quotas for databases work.

Initially we quoted a particular storage pool kind, because when the database is created (for example, using `ydbd admin database create` command), the user specifies only the `kind` of a storage pool they would like to create for this database to use, not the storage pool `name`. The `name` of the storage pool is autogenerated based on the specified `kind` and the path to the subdomain (a.k.a. database) like this:
`/Root/dedicated:hdd`, where `/Root/dedicated` is the path to the database, `hdd` is the storage pool `kind`, `:` is a separator.

However, quoting by storage pool `kind` is meaningless. If the physical storage of a particular storage pool was depleted, then it would <ins>not</ins> start writing its data to another storage pool with the same kind. The writes will just stop. Abruptly. To prevent this you need to set quotas not on the storage pool `kind`, but on the particular storage pool `name`.

Code changes in this PR are mainly of the following form:
- `unit_kind` (a.k.a. storage pool `kind`) -> `storage_unit` (a.k.a. storage pool `name`)
- `PoolKind` -> `PoolName`