### PR TITLE
Refactor utcnow usage in dstool

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_workload_run.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_workload_run.py
@@ -3,7 +3,7 @@ import time
 import random
 import subprocess
 import ydb.apps.dstool.lib.grouptool as grouptool
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 import sys
 
@@ -215,7 +215,7 @@ def do(args):
 
         ################################################################################################################
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         while recent_restarts and recent_restarts[0] + timedelta(minutes=1) < now:
             recent_restarts.pop(0)
 
@@ -283,7 +283,7 @@ def do(args):
         ################################################################################################################
 
         action_name, action = random.choice(possible_actions)
-        print('%s %s' % (action_name, datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')))
+        print('%s %s' % (action_name, datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')))
 
         try:
             action[0](*action[1:])


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Refactor utcnow usage in dstool

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Switch to the new method of obtaining UTC timestamp.
