### PR TITLE
[YQL-18194] Track allocations in array builder. Limit block length in WideToBlocks by allocated size

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
@@ -260,14 +260,17 @@ private:
         size_t BuilderAllocatedSize_ = 0;
         size_t MaxBuilderAllocatedSize_ = 0;
         std::vector<std::unique_ptr<IArrayBuilder>> Builders_;
+        static const size_t MaxAllocatedFactor_ = 4;
+
         TState(TMemoryUsageInfo* memInfo, TComputationContext& ctx, const TVector<TType*>& types, size_t maxLength, NUdf::TUnboxedValue**const fields)
             : TBlockState(memInfo, types.size() + 1U)
             , Builders_(types.size())
         {
             for (size_t i = 0; i < types.size(); ++i) {
                 fields[i] = &Values[i];
-                Builders_[i] = MakeArrayBuilder(TTypeInfoHelper(), types[i], ctx.ArrowMemoryPool, maxLength, &ctx.Builder->GetPgBuilder());
+                Builders_[i] = MakeArrayBuilder(TTypeInfoHelper(), types[i], ctx.ArrowMemoryPool, maxLength, &ctx.Builder->GetPgBuilder(), &BuilderAllocatedSize_);
             }
+            MaxBuilderAllocatedSize_ = MaxAllocatedFactor_ * BuilderAllocatedSize_;
         }
 
         void Add(const NUdf::TUnboxedValuePod value, size_t idx) {
@@ -277,6 +280,7 @@ private:
         void MakeBlocks(const THolderFactory& holderFactory) {
             Values.back() = holderFactory.CreateArrowBlock(arrow::Datum(std::make_shared<arrow::UInt64Scalar>(Rows_)));
             Rows_ = 0;
+            BuilderAllocatedSize_ = 0;
 
             for (size_t i = 0; i < Builders_.size(); ++i) {
                 if (const auto builder = Builders_[i].get()) {

--- a/ydb/library/yql/minikql/mkql_type_builder.h
+++ b/ydb/library/yql/minikql/mkql_type_builder.h
@@ -21,6 +21,7 @@ public:
 
 constexpr size_t MaxBlockSizeInBytes = 240_KB;
 static_assert(MaxBlockSizeInBytes < (size_t)std::numeric_limits<i32>::max());
+static_assert(MaxBlockSizeInBytes % 64 == 0, "arrow buffers are allocated with buffer size aligned to next 64 byte boundary");
 
 // maximum size of block item in bytes
 size_t CalcMaxBlockItemSize(const TType* type);

--- a/ydb/library/yql/public/udf/arrow/ut/array_builder_ut.cpp
+++ b/ydb/library/yql/public/udf/arrow/ut/array_builder_ut.cpp
@@ -193,4 +193,69 @@ Y_UNIT_TEST_SUITE(TArrayBuilderTest) {
         UNIT_ASSERT_VALUES_EQUAL(item1AfterRead.GetStringRefFromValue(), "test");
         UNIT_ASSERT_VALUES_EQUAL(item2AfterRead.GetStringRefFromValue(), "234");
     }
+
+    Y_UNIT_TEST(TestBuilderAllocatedSize) {
+        TArrayBuilderTestData data;
+        const auto optStringType = data.PgmBuilder.NewDataType(NUdf::EDataSlot::String, true);
+        const auto int64Type = data.PgmBuilder.NewDataType(NUdf::EDataSlot::Int64, false);
+        const auto structType = data.PgmBuilder.NewStructType({{ "a", optStringType }, { "b", int64Type }});
+        const auto optStructType = data.PgmBuilder.NewOptionalType(structType);
+        const auto doubleOptStructType = data.PgmBuilder.NewOptionalType(optStructType);
+
+        size_t itemSize = NMiniKQL::CalcMaxBlockItemSize(doubleOptStructType);
+        size_t blockLen = NMiniKQL::CalcBlockLen(itemSize);
+        Y_ENSURE(blockLen > 8);
+
+        size_t bigStringSize = NMiniKQL::MaxBlockSizeInBytes / 8;
+        size_t hugeStringSize = NMiniKQL::MaxBlockSizeInBytes * 2;
+
+        const TString bString(bigStringSize, 'a');
+        TBlockItem strItem1(bString);
+        TBlockItem intItem1(1);
+        TBlockItem sItems1[] = { strItem1, intItem1 };
+        TBlockItem sItem1(sItems1);
+
+        const TBlockItem bigItem = sItem1.MakeOptional();
+
+        const TString hString(hugeStringSize, 'b');
+        TBlockItem strItem2(hString);
+        TBlockItem intItem2(2);
+        TBlockItem sItems2[] = { strItem2, intItem2 };
+        TBlockItem sItem2(sItems2);
+
+        const TBlockItem hugeItem = sItem2.MakeOptional();
+
+        const size_t stringAllocStep = 
+            arrow::BitUtil::RoundUpToMultipleOf64(blockLen + 1) +        // String NullMask
+            arrow::BitUtil::RoundUpToMultipleOf64((blockLen + 1) * 4) +  // String Offsets
+            NMiniKQL::MaxBlockSizeInBytes;                               // String Data
+        const size_t initialAllocated =
+            stringAllocStep +
+            arrow::BitUtil::RoundUpToMultipleOf64((blockLen + 1) * 8) +  // Int64 Data
+            2 * arrow::BitUtil::RoundUpToMultipleOf64(blockLen + 1);     // Double Optional
+
+
+        size_t totalAllocated = 0;
+        auto builder = MakeArrayBuilder(NMiniKQL::TTypeInfoHelper(), doubleOptStructType, *data.ArrowPool, blockLen, nullptr, &totalAllocated);
+        UNIT_ASSERT_VALUES_EQUAL(totalAllocated, initialAllocated);
+
+        for (ui32 i = 0; i < 8; ++i) {
+            builder->Add(bigItem);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(totalAllocated, initialAllocated);
+        // string data block is fully used here
+
+        size_t beforeBlockBoundary = totalAllocated;
+        builder->Add(bigItem);
+        UNIT_ASSERT_VALUES_EQUAL(totalAllocated, beforeBlockBoundary + stringAllocStep);
+
+        // string data block is partially used
+        size_t beforeHugeString = totalAllocated;
+        builder->Add(hugeItem);
+        UNIT_ASSERT_VALUES_EQUAL(totalAllocated, beforeHugeString + stringAllocStep + hugeStringSize - NMiniKQL::MaxBlockSizeInBytes);
+
+        totalAllocated = 0;
+        builder->Build(false);
+        UNIT_ASSERT_VALUES_EQUAL(totalAllocated, initialAllocated);
+    }
 }

--- a/ydb/library/yql/public/udf/arrow/util.h
+++ b/ydb/library/yql/public/udf/arrow/util.h
@@ -158,6 +158,10 @@ public:
         return Len;
     }
 
+    inline size_t Capacity() const {
+        return Buffer ? size_t(Buffer->capacity()) : 0;
+    }
+
     inline T* MutableData() {
         return reinterpret_cast<T*>(Buffer->mutable_data());
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-18194] Track allocations in array builder. Limit block length in WideToBlocks by allocated size

### Changelog category <!-- remove all except one -->

* Improvement
* Not for changelog (changelog entry is not required)

### Additional information

...
