### PR TITLE
use potential max thread count as resource maximum

### DIFF
--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -284,7 +284,7 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
             TVector<TExecutorThreadStats> sharedStatsCopy;
             ctx.ExecutorThread.ActorSystem->GetPoolStats(AppData()->UserPoolId, poolStats, statsCopy, sharedStatsCopy);
             if (!statsCopy.empty()) {
-                record.MutableResourceMaximum()->SetCPU(poolStats.CurrentThreadCount * 1000000);
+                record.MutableResourceMaximum()->SetCPU(poolStats.MaxThreadCount * 1'000'000);
             }
         }
         if (!record.GetResourceMaximum().HasMemory()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

use max thread count (rather than initial thread count) as resource maximum

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
