### PR TITLE
Clear unneeded IC flags when forwarding messages to other nodes

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -21,7 +21,7 @@ namespace NActors {
         event.Span.EndOk();
 
         Y_ABORT_UNLESS(SerializationInfo);
-        const ui32 flags = (event.Descr.Flags & ~IEventHandle::FlagForwardOnNondelivery) |
+        const ui32 flags = (event.Descr.Flags & ~(IEventHandle::FlagForwardOnNondelivery | IEventHandle::FlagSubscribeOnSession)) |
             (SerializationInfo->IsExtendedFormat ? IEventHandle::FlagExtendedFormat : 0);
 
         // prepare descriptor record

--- a/ydb/library/actors/interconnect/packet.cpp
+++ b/ydb/library/actors/interconnect/packet.cpp
@@ -23,7 +23,7 @@ ui32 TEventHolder::Fill(IEventHandle& ev) {
     } else if (ev.HasEvent()) {
         Event.Reset(ev.ReleaseBase());
         EventSerializedSize = Event->CalculateSerializedSize();
-        Y_DEBUG_ABORT_UNLESS(Event->IsSerializable());
+        Y_ABORT_UNLESS(Event->IsSerializable());
     } else {
         EventSerializedSize = 0;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Clear unneeded IC flags when forwarding messages to other nodes

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Previously, when message was forwarded via IC session actor to other node, FlagSubscribeOnSession was transmitted along other ones. Now it is cleared so when the message is forwarded at the receiving node, no unexpected subscriptions were made.
