### PR TITLE
Decrease soft limit to 75%

### DIFF
--- a/ydb/core/mon_alloc/monitor.cpp
+++ b/ydb/core/mon_alloc/monitor.cpp
@@ -288,8 +288,8 @@ namespace NKikimr {
             struct TDumpLogConfig {
                 static constexpr double RssUsageHard = 0.9;
                 static constexpr double RssUsageSoft = 0.85;
-                static constexpr double RssUsageSoftLimit = 0.8;
-                static constexpr double RssUsageNotifySlowLimit = 0.7;
+                static constexpr double RssUsageSoftLimit = 0.75;
+                static constexpr double RssUsageNotifySlowLimit = 0.5;
                 static constexpr TDuration RepeatInterval = TDuration::Seconds(10);
                 static constexpr TDuration DumpInterval = TDuration::Minutes(10);
                 static constexpr TDuration NotifySlowInterval = TDuration::Seconds(10);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Here we see a case when 80% is enough for Out of memory: Killed process

https://nda.ya.ru/t/xCXTKD5K75c8JJ

Obviously without cache limiting the situation would have been even worse (we managed to work for some time on 80%)

https://nda.ya.ru/t/3kbTBHb375c8L4

Also we have an alert on 80% plus we don't count tcmalloc free caches
