### PR TITLE
the `heap-use-after-free` error

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2262,15 +2262,15 @@ void TPartition::ProcessImmediateTx(const NKikimrPQ::TEvProposeTransaction& tx,
         userInfo.Offset = operation.GetEnd();
     }
 
+    ScheduleReplyPropose(tx,
+                         NKikimrPQ::TEvProposeTransactionResult::COMPLETE);
+
     if (WriteInfoResponse) {
         UserActionAndTransactionEvents.pop_front();
         --ImmediateTxCount;
     }
 
     CommitWriteOperations(ctx);
-
-    ScheduleReplyPropose(tx,
-                         NKikimrPQ::TEvProposeTransactionResult::COMPLETE);
 }
 
 TPartition::EProcessResult TPartition::ProcessUserActionOrTransaction(TEvPQ::TEvSetClientInfo& act,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The transaction reference was used after the transaction itself was removed from the queue.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
