### PR TITLE
Do not modify SHELLOPTS env var

### DIFF
--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -37,7 +37,6 @@ runs:
       env:
         build_preset: ${{ inputs.build_preset }}
       run: |
-        echo "SHELLOPTS=xtrace" >> $GITHUB_ENV
         export TMP_DIR=$(pwd)/tmp_build
         echo "TMP_DIR=$TMP_DIR" >> $GITHUB_ENV
         
@@ -54,6 +53,7 @@ runs:
       id: build
       shell: bash
       run: |
+        set -x
         extra_params=()
 
         if [ ! -z "${{ inputs.build_target }}" ]; then
@@ -128,6 +128,7 @@ runs:
       if: always()
       shell: bash
       run: |
+        set -x
         echo "::group::s3-sync"
         s3cmd sync --acl-private --exclude="ya_make.log" --no-progress --stats --no-check-md5 "$TMP_DIR/" "$S3_BUCKET_PATH/build_logs/"
         s3cmd sync --acl-public --no-progress --stats --no-check-md5 "$TMP_DIR/ya_make.log" "$S3_BUCKET_PATH/build_logs/"
@@ -137,6 +138,7 @@ runs:
       if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
       shell: bash
       run: |
+        set -x
         if [ "${{ steps.build.outputs.status }}" == "failed" ]; then
           echo "Build failed. see the [build logs]($LOG_URL)." | .github/scripts/tests/comment-pr.py --fail
         else

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -35,7 +35,6 @@ runs:
       id: init
       shell: bash
       run: |
-        echo "SHELLOPTS=xtrace" >> $GITHUB_ENV
         export TMP_DIR=$(pwd)/tmp
         echo "TMP_DIR=$TMP_DIR" >> $GITHUB_ENV
         echo "LOG_DIR=$TMP_DIR/logs" >> $GITHUB_ENV
@@ -54,6 +53,7 @@ runs:
     - name: prepare
       shell: bash
       run: |
+        set -x
         rm -rf $TMP_DIR $JUNIT_REPORT_XML $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR
         mkdir -p $TMP_DIR $OUT_DIR $ARTIFACTS_DIR $TEST_ARTIFACTS_DIR $LOG_DIR $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR
     
@@ -73,6 +73,7 @@ runs:
       env:
         PR_NUMBER: ${{ github.event.number }}
       run: |
+        set -x
         RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         BRANCH_TAG="$GITHUB_REF_NAME"
         ARCH="${{ runner.arch == 'X64' && 'x86-64' || runner.arch == 'ARM64' && 'arm64' || 'unknown' }}"
@@ -141,6 +142,7 @@ runs:
     - name: ya test
       shell: bash
       run: |
+        set -x
         readarray -d ',' -t test_size < <(printf "%s" "${{ inputs.test_size }}")
 
         params=(
@@ -214,6 +216,7 @@ runs:
     - name: postprocess junit report
       shell: bash
       run: |
+        set -x
         .github/scripts/tests/transform-ya-junit.py -i \
           -m .github/config/muted_ya.txt \
           --ya-out "$OUT_DIR" \
@@ -234,6 +237,7 @@ runs:
       if: inputs.testman_token
       shell: bash
       run: |
+        set -x
         PROXY_ADDR=127.0.0.1:8888
 
         openssl req -x509 -newkey rsa:2048 \
@@ -265,6 +269,7 @@ runs:
       shell: bash
       if: always()
       run: |
+        set -x
         mkdir $ARTIFACTS_DIR/summary/
         
         cat $SUMMARY_LINKS | python3 -c 'import sys; print(" | ".join([v for _, v in sorted([l.strip().split(" ", 1) for l in sys.stdin], key=lambda a: (int(a[0]), a))]))' >> $GITHUB_STEP_SUMMARY
@@ -280,6 +285,7 @@ runs:
       if: always()
       shell: bash
       run: |
+        set -x
         echo "::group::s3-sync"
         s3cmd sync -r --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$ARTIFACTS_DIR/" "$S3_BUCKET_PATH/"
         s3cmd sync -r --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$TEST_ARTIFACTS_DIR/" "$S3_TEST_ARTIFACTS_BUCKET_PATH/"
@@ -289,6 +295,7 @@ runs:
       if: always()
       shell: bash
       run: |
+        set -x
         echo "::group::s3-sync"
         s3cmd sync --follow-symlinks --acl-private --no-progress --stats --no-check-md5 "$LOG_DIR/" "$S3_BUCKET_PATH/test_logs/"
         echo "::endgroup::"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Setting SHELLOPTS environment variable lead to unconditional inheritance of shell options. 

Github action set this variable, do `set -e` and that situation lead that **all** shell invocations from tests inherit `set -e` by default, but tests expect the default behaviour without `set -e`. 

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information
Minimal example:

Consider the following scripts
```
maxim-yurchuk@maxim-yurchuk-vm:/tmp/shellopts$ cat first.sh 
#!/usr/bin/env bash
set -e

echo "Before second.sh invocation" 
./second.sh
echo "After second.sh invocation" 

maxim-yurchuk@maxim-yurchuk-vm:/tmp/shellopts$ cat second.sh 
#!/usr/bin/env bash

echo "Before fail invocation" 
./non_existing
echo "After fail invocation"
```

In the default environment output of `first.sh` is following:

```
maxim-yurchuk@maxim-yurchuk-vm:/tmp/shellopts$ ./first.sh 
Before second.sh invocation
Before fail invocation
./second.sh: line 4: ./non_existing: No such file or directory
After fail invocation
After second.sh invocation
```

i.e. `set -e` was not inherited by `second.sh`

**But** if someone creates environment variable `SHELLOPTS` behaviour is changed: 
```
maxim-yurchuk@maxim-yurchuk-vm:/tmp/shellopts$ export SHELLOPTS
maxim-yurchuk@maxim-yurchuk-vm:/tmp/shellopts$ ./first.sh 
Before second.sh invocation
Before fail invocation
./second.sh: line 4: ./non_existing: No such file or directory
```
I.e. `second.sh` got `set -e` implicitly. This behaviour is strongly unexpected. 

So I've just remove setting of SHELLOPTS.


