### PR TITLE
auditlog: fix logged table path for SplitMergeTablePartitions

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -272,7 +272,8 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetDrop().GetName()}));
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpSplitMergeTablePartitions:
-        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSplitMergeTablePartitions().GetTablePath()}));
+        // Different to other operations, SplitMergeTable holds absolute table path instead of a leaf name.
+        result.emplace_back(tx.GetSplitMergeTablePartitions().GetTablePath());
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpBackup:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetBackup().GetTableName()}));


### PR DESCRIPTION
Common path reconstruction from WorkingDir+Name should not be applied to SplitMergeTablePartitions operation as its TableName already holds an absolute path.

SplitMergeTablePartitions usually does not get into the auditlog, being internal operation in nature. But still it cound be issued externally by some ydb cli command and in that case it must and will be logged.

### Changelog category

* Not for changelog