### PR TITLE
Extract BuildStats for B-Tree index tables

### DIFF
--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -14,6 +14,7 @@ class TChargeBTreeIndex : public ICharge {
     using TGroupId = NPage::TGroupId;
     using TChild = TBtreeIndexNode::TChild;
     using TShortChild = TBtreeIndexNode::TShortChild;
+    using TCells = NPage::TCells;
 
     struct TChildState {
         TPageId PageId;

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -14,7 +14,6 @@ class TChargeBTreeIndex : public ICharge {
     using TGroupId = NPage::TGroupId;
     using TChild = TBtreeIndexNode::TChild;
     using TShortChild = TBtreeIndexNode::TShortChild;
-    using TCells = NPage::TCells;
 
     struct TChildState {
         TPageId PageId;

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -20,7 +20,7 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
     // TODO: call BuildStatsBTreeIndex when histogram is done
     // return mixedIndex
     //     ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)
-    //     : BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);
+    //     : BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, env);
     Y_UNUSED(mixedIndex);
 
     return BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -1,7 +1,8 @@
 #include "flat_part_laid.h"
 #include "flat_stat_table.h"
-#include "flat_stat_part.h"
 #include "flat_table_subset.h"
+#include "flat_stat_table_btree_index.h"
+#include "flat_stat_table_mixed_index.h"
 
 namespace NKikimr {
 namespace NTable {
@@ -9,64 +10,16 @@ namespace NTable {
 bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env, TBuildStatsYieldHandler yieldHandler) {
     stats.Clear();
 
-    TDataStats iteratorStats = { };
-    TStatsIterator statsIterator(subset.Scheme->Keys);
-
-    // TODO: deal with resolution
-
-    // Make index iterators for all parts
-    bool started = true;
+    bool mixedIndex = false;
     for (const auto& part : subset.Flatten) {
-        stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
-        TAutoPtr<TStatsScreenedPartIterator> iter = new TStatsScreenedPartIterator(part, env, subset.Scheme->Keys, part->Small, part->Large, 
-            rowCountResolution, dataSizeResolution);
-        auto ready = iter->Start();
-        if (ready == EReady::Page) {
-            started = false;
-        } else if (ready == EReady::Data) {
-            statsIterator.Add(iter);
-        }
-    }
-    if (!started) {
-        return false;
-    }
-
-    ui64 prevRows = 0;
-    ui64 prevSize = 0;
-    while (true) {
-        yieldHandler();
-        
-        auto ready = statsIterator.Next(iteratorStats);
-        if (ready == EReady::Page) {
-            return false;
-        } else if (ready == EReady::Gone) {
-            break;
-        }
-
-        const bool nextRowsBucket = (iteratorStats.RowCount >= prevRows + rowCountResolution);
-        const bool nextSizeBucket = (iteratorStats.DataSize.Size >= prevSize + dataSizeResolution);
-
-        if (!nextRowsBucket && !nextSizeBucket)
-            continue;
-
-        TDbTupleRef currentKey = statsIterator.GetCurrentKey();
-        TString serializedKey = TSerializedCellVec::Serialize(TConstArrayRef<TCell>(currentKey.Columns, currentKey.ColumnCount));
-
-        if (nextRowsBucket) {
-            prevRows = iteratorStats.RowCount;
-            stats.RowCountHistogram.push_back({serializedKey, prevRows});
-        }
-
-        if (nextSizeBucket) {
-            prevSize = iteratorStats.DataSize.Size;
-            stats.DataSizeHistogram.push_back({serializedKey, prevSize});
+        if (!part->IndexPages.HasBTree() && part->IndexPages.HasFlat()) {
+            mixedIndex = true;
         }
     }
 
-    stats.RowCount = iteratorStats.RowCount;
-    stats.DataSize = std::move(iteratorStats.DataSize);
-
-    return true;
+    return mixedIndex
+        ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)
+        : BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);
 }
 
 void GetPartOwners(const TSubset& subset, THashSet<ui64>& partOwners) {

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -17,9 +17,13 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
         }
     }
 
-    return mixedIndex
-        ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)
-        : BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);
+    // TODO: call BuildStatsBTreeIndex when histogram is done
+    // return mixedIndex
+    //     ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)
+    //     : BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);
+    Y_UNUSED(mixedIndex);
+
+    return BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);
 }
 
 void GetPartOwners(const TSubset& subset, THashSet<ui64>& partOwners) {

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.h
@@ -1,0 +1,112 @@
+#include "flat_stat_table.h"
+#include "flat_table_subset.h"
+
+namespace NKikimr {
+namespace NTable {
+
+namespace {
+    using TGroupId = NPage::TGroupId;
+    using TFrames = NPage::TFrames;
+    using TBtreeIndexNode = NPage::TBtreeIndexNode;
+    using TChild = TBtreeIndexNode::TChild;
+
+    TChild GetPrevChild(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, bool& ready) {
+        auto& meta = part->IndexPages.GetBTree(groupId);
+
+        if (rowId >= meta.RowCount) {
+            return meta;
+        }
+
+        TPageId pageId = meta.PageId;
+        TChild result{0, 0, 0, 0, 0};
+
+        for (ui32 height = 0; height < meta.LevelCount; height++) {
+            auto page = env->TryGetPage(part, pageId, {});
+            if (!page) {
+                ready = false;
+                return result;
+            }
+            auto node = TBtreeIndexNode(*page);
+            auto pos = node.Seek(rowId);
+            pageId = node.GetShortChild(pos).PageId;
+            if (pos) {
+                if (node.IsShortChildFormat()) {
+                    auto& child = node.GetShortChild(pos - 1);
+                    result = {child.PageId, child.RowCount, child.DataSize, 0, 0};
+                } else {
+                    result = node.GetChild(pos - 1);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    void AddBlobsSize(const TPart* part, TChanneledDataSize& stats, const TFrames* frames, ELargeObj lob, TRowId beginRowId, TRowId endRowId) noexcept {
+        ui32 page = frames->Lower(beginRowId, 0, Max<ui32>());
+
+        while (auto &rel = frames->Relation(page)) {
+            if (rel.Row < endRowId) {
+                auto channel = part->GetPageChannel(lob, page);
+                stats.Add(rel.Size, channel);
+                ++page;
+            } else if (!rel.IsHead()) {
+                Y_ABORT("Got unaligned TFrames head record");
+            } else {
+                break;
+            }
+        }
+    }
+
+    bool AddDataSize(const TPartView& part, TStats& stats, IPages* env) {
+        bool ready = true;
+
+        if (!part.Slices || part.Slices->empty()) {
+            return true;
+        }
+
+        for (ui32 groupIndex : xrange(part->GroupsCount)) {
+            auto channel = part->GetGroupChannel(TGroupId(groupIndex));
+            for (const auto& slice : *part.Slices) {
+                auto beginChild = GetPrevChild(part.Part.Get(), {}, slice.BeginRowId(), env, ready);
+                auto endChild = GetPrevChild(part.Part.Get(), {}, slice.EndRowId(), env, ready);
+                if (ready) {
+                    stats.RowCount += endChild.RowCount - beginChild.RowCount;
+                    stats.DataSize.Add(endChild.DataSize - beginChild.DataSize, channel);
+                }
+
+                if (part->Small) {
+                    AddBlobsSize(part.Part.Get(), stats.DataSize, part->Small.Get(), ELargeObj::Outer, slice.BeginRowId(), slice.EndRowId());
+                }
+                if (part->Large) {
+                    AddBlobsSize(part.Part.Get(), stats.DataSize, part->Large.Get(), ELargeObj::Extern, slice.BeginRowId(), slice.EndRowId());
+                }
+            }
+        }
+
+        return ready;
+    }
+
+}
+
+inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env) {
+    stats.Clear();
+
+    Y_UNUSED(rowCountResolution, dataSizeResolution);
+
+    bool ready = true;
+    for (const auto& part : subset.Flatten) {
+        stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
+        ready &= AddDataSize(part, stats, env);
+    }
+
+    if (!ready) {
+        return false;
+    }
+
+    // TODO: build histogram here
+
+    return true;
+}
+
+}}

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.h
@@ -1,10 +1,7 @@
-#include "flat_part_index_iter_bree_index.h"
 #include "flat_stat_table.h"
 #include "flat_table_subset.h"
-#include "library/cpp/int128/int128.h"
 
-namespace NKikimr {
-namespace NTable {
+namespace NKikimr::NTable {
 
 namespace {
 
@@ -14,132 +11,76 @@ using TBtreeIndexNode = NPage::TBtreeIndexNode;
 using TChild = TBtreeIndexNode::TChild;
 using TCells = NPage::TCells;
 
-TChild GetPrevChild(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, bool& ready) {
+ui64 GetPrevDataSize(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, bool& ready) {
     auto& meta = part->IndexPages.GetBTree(groupId);
 
+    if (rowId >= meta.RowCount) {
+        return meta.DataSize;
+    }
+
     TPageId pageId = meta.PageId;
-    TChild result{0, 0, 0, 0, 0};
+    ui64 prevDataSize = 0;
 
     for (ui32 height = 0; height < meta.LevelCount; height++) {
         auto page = env->TryGetPage(part, pageId, {});
         if (!page) {
             ready = false;
-            return result;
+            return prevDataSize;
         }
         auto node = TBtreeIndexNode(*page);
         auto pos = node.Seek(rowId);
+
         pageId = node.GetShortChild(pos).PageId;
         if (pos) {
-            if (node.IsShortChildFormat()) {
-                auto& child = node.GetShortChild(pos - 1);
-                result = {child.PageId, child.RowCount, child.DataSize, 0, 0};
-            } else {
-                result = node.GetChild(pos - 1);
-            }
+            prevDataSize = node.GetShortChild(pos - 1).DataSize;
         }
     }
 
-    return result;
+    return prevDataSize;
 }
 
-TChild GetChild(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, bool& ready) {
+ui64 GetPrevHistoricDataSize(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, TRowId& historicRowId, bool& ready) {
+    Y_ABORT_UNLESS(groupId == TGroupId(0, true));
+
     auto& meta = part->IndexPages.GetBTree(groupId);
 
-    TPageId pageId = meta.PageId;
-    TChild result = meta;
-
-    for (ui32 height = 0; height < meta.LevelCount; height++) {
-        auto page = env->TryGetPage(part, pageId, {});
-        if (!page) {
-            ready = false;
-            return result;
-        }
-        auto node = TBtreeIndexNode(*page);
-        auto pos = node.Seek(rowId);
-        pageId = node.GetShortChild(pos).PageId;
-        if (node.IsShortChildFormat()) {
-            auto& child = node.GetShortChild(pos);
-            result = {child.PageId, child.RowCount, child.DataSize, 0, 0};
-        } else {
-            result = node.GetChild(pos);
-        }
+    if (rowId >= part->IndexPages.GetBTree({}).RowCount) {
+        historicRowId = meta.RowCount;
+        return meta.DataSize;
     }
 
-    return result;
-}
-
-TChild GetPrevHistoryChild(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, bool& ready) {
-    auto& meta = part->IndexPages.GetBTree(groupId);
-
     TPageId pageId = meta.PageId;
-    TChild result{0, 0, 0, 0, 0};
+    ui64 prevDataSize = 0;
+    historicRowId = 0;
 
-    // Minimum key is (rowId, max, max)
+    // Minimum key is (startRowId, max, max)
     ui64 startStep = Max<ui64>();
     ui64 startTxId = Max<ui64>();
-    TCell keyCells[3] = {
+    TCell key1Cells[3] = {
         TCell::Make(rowId),
         TCell::Make(startStep),
         TCell::Make(startTxId),
     };
-    TCells key{ keyCells, 3 };
+    TCells key1{ key1Cells, 3 };
 
     for (ui32 height = 0; height < meta.LevelCount; height++) {
         auto page = env->TryGetPage(part, pageId, {});
         if (!page) {
             ready = false;
-            return result;
+            return prevDataSize;
         }
         auto node = TBtreeIndexNode(*page);
-        auto pos = node.Seek(ESeek::Lower, key, part->Scheme->HistoryGroup.ColsKeyIdx, part->Scheme->HistoryKeys.Get());
+        auto pos = node.Seek(ESeek::Lower, key1, part->Scheme->HistoryGroup.ColsKeyIdx, part->Scheme->HistoryKeys.Get());
+
         pageId = node.GetShortChild(pos).PageId;
         if (pos) {
-            if (node.IsShortChildFormat()) {
-                auto& child = node.GetShortChild(pos - 1);
-                result = {child.PageId, child.RowCount, child.DataSize, 0, 0};
-            } else {
-                result = node.GetChild(pos - 1);
-            }
+            const auto& prevChild = node.GetShortChild(pos - 1);
+            prevDataSize = prevChild.DataSize;
+            historicRowId = prevChild.RowCount;
         }
     }
 
-    return result;
-}
-
-TChild GetHistoryChild(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, bool& ready) {
-    auto& meta = part->IndexPages.GetBTree(groupId);
-
-    TPageId pageId = meta.PageId;
-    TChild result = meta;
-
-    // Maximum key is (rowId, 0, 0)
-    ui64 endStep = 0;
-    ui64 endTxId = 0;
-    TCell keyCells[3] = {
-        TCell::Make(rowId),
-        TCell::Make(endStep),
-        TCell::Make(endTxId),
-    };
-    TCells key{ keyCells, 3 };
-
-    for (ui32 height = 0; height < meta.LevelCount; height++) {
-        auto page = env->TryGetPage(part, pageId, {});
-        if (!page) {
-            ready = false;
-            return result;
-        }
-        auto node = TBtreeIndexNode(*page);
-        auto pos = node.Seek(ESeek::Lower, key, part->Scheme->HistoryGroup.ColsKeyIdx, part->Scheme->HistoryKeys.Get());
-        pageId = node.GetShortChild(pos).PageId;
-        if (node.IsShortChildFormat()) {
-            auto& child = node.GetShortChild(pos);
-            result = {child.PageId, child.RowCount, child.DataSize, 0, 0};
-        } else {
-            result = node.GetChild(pos);
-        }
-    }
-
-    return result;
+    return prevDataSize;
 }
 
 void AddBlobsSize(const TPart* part, TChanneledDataSize& stats, const TFrames* frames, ELargeObj lob, TRowId beginRowId, TRowId endRowId) noexcept {
@@ -158,38 +99,6 @@ void AddBlobsSize(const TPart* part, TChanneledDataSize& stats, const TFrames* f
     }
 }
 
-void AddSliceDataSize(TStats& stats, ui8 channel, const TChild& prevChild, const TChild& lastChild, TRowId beginRowId, TRowId endRowId) {
-    Y_DEBUG_ABORT_UNLESS(lastChild.DataSize > prevChild.DataSize);
-    Y_DEBUG_ABORT_UNLESS(lastChild.RowCount > prevChild.RowCount);
-
-    if (Y_LIKELY(lastChild.DataSize > prevChild.DataSize && lastChild.RowCount > prevChild.RowCount)) {
-        TRowId sliceRows = endRowId - beginRowId;
-        TRowId countedRows = lastChild.RowCount - prevChild.RowCount;
-        Y_DEBUG_ABORT_UNLESS(sliceRows <= countedRows);
-
-        if (sliceRows == countedRows) {
-            stats.DataSize.Add(lastChild.DataSize - prevChild.DataSize, channel);
-        } else {
-            ui128 countedDataSize = lastChild.DataSize - prevChild.DataSize;
-            ui64 sliceDataSize = static_cast<ui64>(countedDataSize * sliceRows / countedRows);
-            stats.DataSize.Add(sliceDataSize, channel);
-        }
-    }
-}
-
-ui64 GetBeginDataSize(TPartGroupBtreeIndexIter iter, TRowId rowId, bool& ready) {
-    auto seek = iter.Seek(rowId);
-    if (seek == EReady::Page) {
-        ready = false;
-        return 0;
-    }
-
-    auto node = iter.GetNode();
-    if (node.BeginRowId == rowId) {
-        return node.B
-    }
-}
-
 bool AddDataSize(const TPartView& part, TStats& stats, IPages* env) {
     bool ready = true;
 
@@ -197,23 +106,18 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env) {
         return true;
     }
 
-    { // main group
+    if (part->GroupsCount) { // main group
         TGroupId groupId{};
         auto channel = part->GetGroupChannel(groupId);
-        TPartGroupBtreeIndexIter iter(part.Part.Get(), env, groupId);
-
+        
         for (const auto& slice : *part.Slices) {
-            iter.Seek(slice.BeginRowId())
-
-            auto prevChild = GetPrevChild(part.Part.Get(), groupId, slice.BeginRowId(), env, ready);
-            auto lastChild = GetChild(part.Part.Get(), groupId, slice.EndRowId() - 1, env, ready);
-            if (!ready) {
-                continue;
-            }
-
             stats.RowCount += slice.EndRowId() - slice.BeginRowId();
             
-            AddSliceDataSize(stats, channel, prevChild, lastChild, slice.BeginRowId(), slice.EndRowId());
+            ui64 beginDataSize = GetPrevDataSize(part.Part.Get(), groupId, slice.BeginRowId(), env, ready);
+            ui64 endDataSize = GetPrevDataSize(part.Part.Get(), groupId, slice.EndRowId(), env, ready);
+            if (ready && endDataSize > beginDataSize) {
+                stats.DataSize.Add(endDataSize - beginDataSize, channel);
+            }
 
             if (part->Small) {
                 AddBlobsSize(part.Part.Get(), stats.DataSize, part->Small.Get(), ELargeObj::Outer, slice.BeginRowId(), slice.EndRowId());
@@ -228,28 +132,41 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env) {
         TGroupId groupId{groupIndex};
         auto channel = part->GetGroupChannel(groupId);
         for (const auto& slice : *part.Slices) {
-            auto prevChild = GetPrevChild(part.Part.Get(), groupId, slice.BeginRowId(), env, ready);
-            auto lastChild = GetChild(part.Part.Get(), groupId, slice.EndRowId() - 1, env, ready);
-            if (!ready) {
-                continue;
+            ui64 beginDataSize = GetPrevDataSize(part.Part.Get(), groupId, slice.BeginRowId(), env, ready);
+            ui64 endDataSize = GetPrevDataSize(part.Part.Get(), groupId, slice.EndRowId(), env, ready);
+            if (ready && endDataSize > beginDataSize) {
+                stats.DataSize.Add(endDataSize - beginDataSize, channel);
             }
-
-            AddSliceDataSize(stats, channel, prevChild, lastChild, slice.BeginRowId(), slice.EndRowId());
         }
     }
 
-    if (part->HistoricGroupsCount) { // main history group
+    TVector<std::pair<TRowId, TRowId>> historicSlices;
+
+    if (part->HistoricGroupsCount) { // main historic group
         TGroupId groupId{0, true};
         auto channel = part->GetGroupChannel(groupId);
         for (const auto& slice : *part.Slices) {
-            auto prevChild = GetPrevHistoryChild(part.Part.Get(), groupId, slice.BeginRowId(), env, ready);
-            auto lastChild = GetHistoryChild(part.Part.Get(), groupId, slice.EndRowId() - 1, env, ready);
-            if (!ready) {
-                continue;
+            TRowId beginRowId, endRowId;
+            ui64 beginDataSize = GetPrevHistoricDataSize(part.Part.Get(), groupId, slice.BeginRowId(), env, beginRowId, ready);
+            ui64 endDataSize = GetPrevHistoricDataSize(part.Part.Get(), groupId, slice.EndRowId(), env, endRowId, ready);
+            if (ready && endDataSize > beginDataSize) {
+                stats.DataSize.Add(endDataSize - beginDataSize, channel);
             }
+            if (ready && endRowId > beginRowId) {
+                historicSlices.emplace_back(beginRowId, endRowId);
+            }
+        }
+    }
 
-            // TODO: don't count twice
-            AddSliceDataSize(stats, channel, prevChild, lastChild, prevChild.RowCount, lastChild.RowCount);
+    for (ui32 groupIndex : xrange<ui32>(1, part->HistoricGroupsCount)) {
+        TGroupId groupId{groupIndex, true};
+        auto channel = part->GetGroupChannel(groupId);
+        for (const auto& slice : historicSlices) {
+            ui64 beginDataSize = GetPrevDataSize(part.Part.Get(), groupId, slice.first, env, ready);
+            ui64 endDataSize = GetPrevDataSize(part.Part.Get(), groupId, slice.second, env, ready);
+            if (ready && endDataSize > beginDataSize) {
+                stats.DataSize.Add(endDataSize - beginDataSize, channel);
+            }
         }
     }
 
@@ -278,4 +195,4 @@ inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui64 rowC
     return true;
 }
 
-}}
+}

--- a/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
@@ -6,7 +6,7 @@
 namespace NKikimr {
 namespace NTable {
 
-inline bool BuildStatsMixedIndex(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env) {
+inline bool BuildStatsMixedIndex(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env, TBuildStatsYieldHandler yieldHandler) {
     stats.Clear();
 
     TDataStats iteratorStats = { };
@@ -32,6 +32,8 @@ inline bool BuildStatsMixedIndex(const TSubset& subset, TStats& stats, ui64 rowC
     ui64 prevRows = 0;
     ui64 prevSize = 0;
     while (true) {
+        yieldHandler();
+
         auto ready = statsIterator.Next(iteratorStats);
         if (ready == EReady::Page) {
             return false;

--- a/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
@@ -1,0 +1,68 @@
+#include "flat_part_laid.h"
+#include "flat_stat_table.h"
+#include "flat_stat_part.h"
+#include "flat_table_subset.h"
+
+namespace NKikimr {
+namespace NTable {
+
+inline bool BuildStatsMixedIndex(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env) {
+    stats.Clear();
+
+    TDataStats iteratorStats = { };
+    TStatsIterator statsIterator(subset.Scheme->Keys);
+
+    // Make index iterators for all parts
+    bool started = true;
+    for (const auto& part : subset.Flatten) {
+        stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
+        TAutoPtr<TStatsScreenedPartIterator> iter = new TStatsScreenedPartIterator(part, env, subset.Scheme->Keys, part->Small, part->Large, 
+            rowCountResolution, dataSizeResolution);
+        auto ready = iter->Start();
+        if (ready == EReady::Page) {
+            started = false;
+        } else if (ready == EReady::Data) {
+            statsIterator.Add(iter);
+        }
+    }
+    if (!started) {
+        return false;
+    }
+
+    ui64 prevRows = 0;
+    ui64 prevSize = 0;
+    while (true) {
+        auto ready = statsIterator.Next(iteratorStats);
+        if (ready == EReady::Page) {
+            return false;
+        } else if (ready == EReady::Gone) {
+            break;
+        }
+
+        const bool nextRowsBucket = (iteratorStats.RowCount >= prevRows + rowCountResolution);
+        const bool nextSizeBucket = (iteratorStats.DataSize.Size >= prevSize + dataSizeResolution);
+
+        if (!nextRowsBucket && !nextSizeBucket)
+            continue;
+
+        TDbTupleRef currentKey = statsIterator.GetCurrentKey();
+        TString serializedKey = TSerializedCellVec::Serialize(TConstArrayRef<TCell>(currentKey.Columns, currentKey.ColumnCount));
+
+        if (nextRowsBucket) {
+            prevRows = iteratorStats.RowCount;
+            stats.RowCountHistogram.push_back({serializedKey, prevRows});
+        }
+
+        if (nextSizeBucket) {
+            prevSize = iteratorStats.DataSize.Size;
+            stats.DataSizeHistogram.push_back({serializedKey, prevSize});
+        }
+    }
+
+    stats.RowCount = iteratorStats.RowCount;
+    stats.DataSize = std::move(iteratorStats.DataSize);
+
+    return true;
+}
+
+}}

--- a/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_mixed_index.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "flat_part_laid.h"
 #include "flat_stat_table.h"
 #include "flat_stat_part.h"

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -40,7 +40,6 @@ namespace {
         }
         conf.SmallEdge = 19;  /* Packed to page collection large cell values */
         conf.LargeEdge = 29;  /* Large values placed to single blobs */
-        conf.SliceSize = conf.Group(0).PageSize * 4;
         conf.CutIndexKeys = false;
         conf.WriteBTreeIndex = writeBTreeIndex;
 
@@ -386,7 +385,7 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckBTreeIndex(*subset, 10440, 1060798, 23760);
+        CheckBTreeIndex(*subset, 10440, 1068937, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
@@ -439,45 +438,6 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
         TMixerSeq mixer(4, Mass1.Saved.Size());
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer, 0.3);
         CheckBTreeIndex(*subset, 24000, 4054290, 34652);
-    }
-
-    Y_UNIT_TEST(Single_LowResolution)
-    {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
-        CheckBTreeIndex(*subset, 24000, 2106439, 66674, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Slices_LowResolution)
-    {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckBTreeIndex(*subset, 12816, 1121048, 66674, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_LowResolution)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
-        CheckBTreeIndex(*subset, 24000, 2460139, 33541, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_Slices_LowResolution)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckBTreeIndex(*subset, 10440, 1060798, 33541, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_History_LowResolution)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
-        CheckBTreeIndex(*subset, 24000, 4054050, 48540, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_History_Slices_LowResolution)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckBTreeIndex(*subset, 13570, 2114857 /* ~2277890 */, 48540, 5310, 531050);
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -1,4 +1,6 @@
 #include "flat_stat_table.h"
+#include "flat_stat_table_mixed_index.h"
+#include "flat_stat_table_btree_index.h"
 #include <ydb/core/tablet_flat/test/libs/table/model/large.h>
 #include <ydb/core/tablet_flat/test/libs/table/test_make.h>
 #include <ydb/core/tablet_flat/test/libs/table/test_mixer.h>
@@ -61,25 +63,37 @@ namespace {
         }
     }
 
-    void Check(const TSubset& subset, THistogram histogram, ui64 resolution) {
+    void CheckMixedIndex(const TSubset& subset, THistogram histogram, ui64 resolution, ui64 total) {
         ui64 additionalErrorRate = 1;
         if (subset.Flatten.size() > 1 && subset.Flatten[0]->GroupsCount > 1) {
             additionalErrorRate = 2;
         }
-        for (ui32 i = 1; i < histogram.size(); i++) {
-            auto delta = histogram[i].Value - histogram[i - 1].Value;
-            UNIT_ASSERT_GE_C(delta, resolution, "Delta = " << delta << " Resolution = " << resolution);
-            UNIT_ASSERT_LE_C(delta, resolution * additionalErrorRate * 3 / 2, "Delta = " << delta << " Resolution = " << resolution);
+
+        ui64 prevValue = 0;
+        for (ui32 i = 0; i <= histogram.size(); i++) {
+            ui64 value = i < histogram.size()
+                ? histogram[i].Value
+                : total;
+            auto delta = value - prevValue;
+            if (i < histogram.size()) {
+                UNIT_ASSERT_GE_C(delta, resolution, "Delta = " << delta << " Resolution = " << resolution);
+            }
+            if (i == 0) {
+                UNIT_ASSERT_LE_C(delta, resolution * 5, "Delta = " << delta << " Resolution = " << resolution);
+            } else {
+                UNIT_ASSERT_LE_C(delta, resolution * additionalErrorRate * 3 / 2, "Delta = " << delta << " Resolution = " << resolution);
+            }
+            prevValue = value;
         }
     }
 
-    void Check(const TSubset& subset, ui64 expectedRows, ui64 expectedData, ui64 expectedIndex, ui64 rowCountResolution = 531, ui64 dataSizeResolution = 53105) {
+    void CheckMixedIndex(const TSubset& subset, ui64 expectedRows, ui64 expectedData, ui64 expectedIndex, ui64 rowCountResolution = 531, ui64 dataSizeResolution = 53105) {
         TStats stats;
         TTouchEnv env;
 
         const ui32 attempts = 10;
         for (ui32 attempt : xrange(attempts)) {
-            if (NTable::BuildStats(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){})) {
+            if (NTable::BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, &env)) {
                 break;
             }
             UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");
@@ -92,210 +106,380 @@ namespace {
 
         Cerr << "RowCountHistogram:" << Endl;
         Dump(subset, stats.RowCountHistogram);
-        Check(subset, stats.RowCountHistogram, rowCountResolution);
+        CheckMixedIndex(subset, stats.RowCountHistogram, rowCountResolution, expectedRows);
         Cerr << "DataSizeHistogram:" << Endl;
         Dump(subset, stats.DataSizeHistogram);
-        Check(subset, stats.DataSizeHistogram, dataSizeResolution);
+        CheckMixedIndex(subset, stats.DataSizeHistogram, dataSizeResolution, expectedData);
+    }
+
+    void CheckBTreeIndex(THistogram histogram, ui64 resolution, ui64 total) {
+        ui64 prevValue = 0;
+        for (ui32 i = 0; i <= histogram.size(); i++) {
+            ui64 value = i < histogram.size()
+                ? histogram[i].Value
+                : total;
+            auto delta = value - prevValue;
+                            
+            // TODO: build histogram
+            // UNIT_ASSERT_GE_C(delta, resolution / 2, "Delta = " << delta << " Resolution = " << resolution);
+            // UNIT_ASSERT_LE_C(delta, resolution * 3 / 2, "Delta = " << delta << " Resolution = " << resolution);
+            Y_UNUSED(delta, resolution);
+
+            prevValue = value;
+        }
+    }
+
+    void CheckBTreeIndex(const TSubset& subset, ui64 expectedRows, ui64 expectedData, ui64 expectedIndex, ui64 rowCountResolution = 531, ui64 dataSizeResolution = 53105) {
+        TStats stats;
+        TTouchEnv env;
+
+        const ui32 attempts = 10;
+        for (ui32 attempt : xrange(attempts)) {
+            if (NTable::BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){})) {
+                break;
+            }
+            UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");
+        }
+
+        Cerr << "Stats: " << stats.RowCount << " " << stats.DataSize.Size << " " << stats.IndexSize.Size << " " << stats.DataSizeHistogram.size() << " " << stats.RowCountHistogram.size() << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(stats.RowCount, expectedRows);
+        UNIT_ASSERT_VALUES_EQUAL(stats.DataSize.Size, expectedData);
+        UNIT_ASSERT_VALUES_EQUAL(stats.IndexSize.Size, expectedIndex);
+
+        Cerr << "RowCountHistogram:" << Endl;
+        Dump(subset, stats.RowCountHistogram);
+        CheckBTreeIndex(stats.RowCountHistogram, rowCountResolution, expectedRows);
+        Cerr << "DataSizeHistogram:" << Endl;
+        Dump(subset, stats.DataSizeHistogram);
+        CheckBTreeIndex(stats.DataSizeHistogram, dataSizeResolution, expectedData);
     }
 }
 
-Y_UNIT_TEST_SUITE(BuildStats) {
+Y_UNIT_TEST_SUITE(BuildStatsFlatIndex) {
     using namespace NTest;
+    const bool WriteBTreeIndex = false;
 
     Y_UNIT_TEST(Single)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2106439, 25272);
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckMixedIndex(*subset, 24000, 2106439, 25272);
     }
 
     Y_UNIT_TEST(Single_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 12816, 1121048, 25272);
+        CheckMixedIndex(*subset, 12816, 1121048, 25272);
     }
 
     Y_UNIT_TEST(Single_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2460139, 13170);
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckMixedIndex(*subset, 24000, 2460139, 13170);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 10440, 1060798, 13170);
+        CheckMixedIndex(*subset, 10440, 1060798, 13170);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0.3);   
-        Check(*subset, 24000, 4054050, 18810);
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        CheckMixedIndex(*subset, 24000, 4054050, 18810);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 13570, 2277890, 18810);
+        CheckMixedIndex(*subset, 13570, 2277890, 18810);
     }
 
     Y_UNIT_TEST(Mixed)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), false)).Mixed(0, 4, TMixerRnd(4));
-        Check(*subset, 24000, 2106459, 25428);
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4));
+        CheckMixedIndex(*subset, 24000, 2106459, 25428);
     }
 
     Y_UNIT_TEST(Mixed_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 4, TMixerRnd(4));
-        Check(*subset, 24000, 2460219, 13482);
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4));
+        CheckMixedIndex(*subset, 24000, 2460219, 13482);
     }
 
     Y_UNIT_TEST(Mixed_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 4, TMixerRnd(4), 0.3);
-        Check(*subset, 24000, 4054270, 19152);
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4), 0.3);
+        CheckMixedIndex(*subset, 24000, 4054270, 19152);
     }
 
     Y_UNIT_TEST(Serial)
     {
         TMixerSeq mixer(4, Mass0.Saved.Size());
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), false)).Mixed(0, 4, mixer);
-        Check(*subset, 24000, 2106459, 25428);
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer);
+        CheckMixedIndex(*subset, 24000, 2106459, 25428);
     }
 
     Y_UNIT_TEST(Serial_Groups)
     {
         TMixerSeq mixer(4, Mass1.Saved.Size());
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 4, mixer);
-        Check(*subset, 24000, 2460259, 13528);
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer);
+        CheckMixedIndex(*subset, 24000, 2460259, 13528);
     }
 
     Y_UNIT_TEST(Serial_Groups_History)
     {
         TMixerSeq mixer(4, Mass1.Saved.Size());
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 4, mixer, 0.3);
-        Check(*subset, 24000, 4054290, 19168);
-    }
-
-    Y_UNIT_TEST(Single_BTreeIndex)
-    {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2106439, 49449);
-    }
-
-    Y_UNIT_TEST(Single_Slices_BTreeIndex)
-    {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 12816, 1121048, 49449);
-    }
-
-    Y_UNIT_TEST(Single_Groups_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2460139, 23760);
-    }
-
-    Y_UNIT_TEST(Single_Groups_Slices_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 10440, 1060798, 23760);
-    }
-
-    Y_UNIT_TEST(Single_Groups_History_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0.3);   
-        Check(*subset, 24000, 4054050, 34837);
-    }
-
-    Y_UNIT_TEST(Single_Groups_History_Slices_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 13570, 2277890, 34837);
-    }
-
-    Y_UNIT_TEST(Mixed_BTreeIndex)
-    {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 4, TMixerRnd(4));
-        Check(*subset, 24000, 2106459, 49449);
-    }
-
-    Y_UNIT_TEST(Mixed_Groups_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 4, TMixerRnd(4));
-        Check(*subset, 24000, 2460219, 23555);
-    }
-
-    Y_UNIT_TEST(Mixed_Groups_History_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true)).Mixed(0, 4, TMixerRnd(4), 0.3);
-        Check(*subset, 24000, 4054270, 34579);
-    }
-
-    Y_UNIT_TEST(Serial_BTreeIndex)
-    {
-        TMixerSeq mixer(4, Mass0.Saved.Size());
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true)).Mixed(0, 4, mixer);
-        Check(*subset, 24000, 2106459, 49502);
-    }
-
-    Y_UNIT_TEST(Serial_Groups_BTreeIndex)
-    {
-        TMixerSeq mixer(4, Mass1.Saved.Size());
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 4, mixer);
-        Check(*subset, 24000, 2460259, 13528);
-    }
-
-    Y_UNIT_TEST(Serial_Groups_History_BTreeIndex)
-    {
-        TMixerSeq mixer(4, Mass1.Saved.Size());
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), false)).Mixed(0, 4, mixer, 0.3);
-        Check(*subset, 24000, 4054290, 19168);
-    }
-
-    Y_UNIT_TEST(Single_LowResolution_BTreeIndex)
-    {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2106439, 66674, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Slices_LowResolution_BTreeIndex)
-    {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 12816, 1121048, 66674, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_LowResolution_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ });   
-        Check(*subset, 24000, 2460139, 33541, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_Slices_LowResolution_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 10440, 1060798, 33541, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_History_LowResolution_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0.3);   
-        Check(*subset, 24000, 4054050, 48540, 5310, 531050);
-    }
-
-    Y_UNIT_TEST(Single_Groups_History_Slices_LowResolution_BTreeIndex)
-    {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, true)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
-        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        Check(*subset, 13570, 2114857 /* ~2277890 */, 48540, 5310, 531050);
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer, 0.3);
+        CheckMixedIndex(*subset, 24000, 4054290, 19168);
     }
 }
 
+Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
+    using namespace NTest;
+    const bool WriteBTreeIndex = true;
+
+    Y_UNIT_TEST(Single)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckMixedIndex(*subset, 24000, 2106439, 49449);
+    }
+
+    Y_UNIT_TEST(Single_Slices)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 12816, 1121048, 49449);
+    }
+
+    Y_UNIT_TEST(Single_Groups)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckMixedIndex(*subset, 24000, 2460139, 23760);
+    }
+
+    Y_UNIT_TEST(Single_Groups_Slices)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 10440, 1060798, 23760);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        CheckMixedIndex(*subset, 24000, 4054050, 34837);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_Slices)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 13570, 2277890, 34837);
+    }
+
+    Y_UNIT_TEST(Mixed)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4));
+        CheckMixedIndex(*subset, 24000, 2106459, 49449);
+    }
+
+    Y_UNIT_TEST(Mixed_Groups)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4));
+        CheckMixedIndex(*subset, 24000, 2460219, 23555);
+    }
+
+    Y_UNIT_TEST(Mixed_Groups_History)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4), 0.3);
+        CheckMixedIndex(*subset, 24000, 4054270, 34579);
+    }
+
+    Y_UNIT_TEST(Serial)
+    {
+        TMixerSeq mixer(4, Mass0.Saved.Size());
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer);
+        CheckMixedIndex(*subset, 24000, 2106459, 49502);
+    }
+
+    Y_UNIT_TEST(Serial_Groups)
+    {
+        TMixerSeq mixer(4, Mass1.Saved.Size());
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer);
+        CheckMixedIndex(*subset, 24000, 2460259, 23628);
+    }
+
+    Y_UNIT_TEST(Serial_Groups_History)
+    {
+        TMixerSeq mixer(4, Mass1.Saved.Size());
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer, 0.3);
+        CheckMixedIndex(*subset, 24000, 4054290, 34652);
+    }
+
+    Y_UNIT_TEST(Single_LowResolution)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckMixedIndex(*subset, 24000, 2106439, 66674, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Slices_LowResolution)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 12816, 1121048, 66674, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckMixedIndex(*subset, 24000, 2460139, 33541, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_Slices_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 10440, 1060798, 33541, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        CheckMixedIndex(*subset, 24000, 4054050, 48540, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_Slices_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 13570, 2114857 /* ~2277890 */, 48540, 5310, 531050);
+    }
+
+Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
+    using namespace NTest;
+    const bool WriteBTreeIndex = true;
+
+    Y_UNIT_TEST(Single)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckBTreeIndex(*subset, 24000, 2106439, 49449);
+    }
+
+    Y_UNIT_TEST(Single_Slices)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckBTreeIndex(*subset, 12816, 1121048, 49449);
+    }
+
+    Y_UNIT_TEST(Single_Groups)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckBTreeIndex(*subset, 24000, 2460139, 23760);
+    }
+
+    Y_UNIT_TEST(Single_Groups_Slices)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckBTreeIndex(*subset, 10440, 1060798, 23760);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        CheckBTreeIndex(*subset, 24000, 4054050, 34837);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_Slices)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckBTreeIndex(*subset, 13570, 2277890, 34837);
+    }
+
+    Y_UNIT_TEST(Mixed)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4));
+        CheckBTreeIndex(*subset, 24000, 2106459, 49449);
+    }
+
+    Y_UNIT_TEST(Mixed_Groups)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4));
+        CheckBTreeIndex(*subset, 24000, 2460219, 23555);
+    }
+
+    Y_UNIT_TEST(Mixed_Groups_History)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, TMixerRnd(4), 0.3);
+        CheckBTreeIndex(*subset, 24000, 4054270, 34579);
+    }
+
+    Y_UNIT_TEST(Serial)
+    {
+        TMixerSeq mixer(4, Mass0.Saved.Size());
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer);
+        CheckBTreeIndex(*subset, 24000, 2106459, 49502);
+    }
+
+    Y_UNIT_TEST(Serial_Groups)
+    {
+        TMixerSeq mixer(4, Mass1.Saved.Size());
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer);
+        CheckBTreeIndex(*subset, 24000, 2460259, 23628);
+    }
+
+    Y_UNIT_TEST(Serial_Groups_History)
+    {
+        TMixerSeq mixer(4, Mass1.Saved.Size());
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 4, mixer, 0.3);
+        CheckBTreeIndex(*subset, 24000, 4054290, 34652);
+    }
+
+    Y_UNIT_TEST(Single_LowResolution)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckBTreeIndex(*subset, 24000, 2106439, 66674, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Slices_LowResolution)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckBTreeIndex(*subset, 12816, 1121048, 66674, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        CheckBTreeIndex(*subset, 24000, 2460139, 33541, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_Slices_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckBTreeIndex(*subset, 10440, 1060798, 33541, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        CheckBTreeIndex(*subset, 24000, 4054050, 48540, 5310, 531050);
+    }
+
+    Y_UNIT_TEST(Single_Groups_History_Slices_LowResolution)
+    {
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckBTreeIndex(*subset, 13570, 2114857 /* ~2277890 */, 48540, 5310, 531050);
+    }
+}
+
+}
 }

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -40,7 +40,7 @@ namespace {
         }
         conf.SmallEdge = 19;  /* Packed to page collection large cell values */
         conf.LargeEdge = 29;  /* Large values placed to single blobs */
-        conf.SliceSize = conf.Group(0).PageSize * 4;
+
         conf.CutIndexKeys = false;
         conf.WriteBTreeIndex = writeBTreeIndex;
 
@@ -386,6 +386,7 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 13570, 2114857 /* ~2277890 */, 48540, 5310, 531050);
     }
+}
 
 Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
     using namespace NTest;
@@ -414,7 +415,7 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckBTreeIndex(*subset, 9582, 1425198, 61162);
+        CheckBTreeIndex(*subset, 9582, 1425282, 61162);
     }
 
     Y_UNIT_TEST(Single_Groups)
@@ -427,7 +428,7 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckBTreeIndex(*subset, 10440, 1068937, 23760);
+        CheckBTreeIndex(*subset, 10440, 1060767, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
@@ -440,7 +441,7 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
     {
         auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckBTreeIndex(*subset, 13570, 2277890, 34837);
+        CheckBTreeIndex(*subset, 13570, 2273213, 34837);
     }
 
     Y_UNIT_TEST(Mixed)
@@ -483,5 +484,4 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
     }
 }
 
-}
 }

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -99,7 +99,8 @@ namespace {
             UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");
         }
 
-        Cerr << "Stats: " << stats.RowCount << " " << stats.DataSize.Size << " " << stats.IndexSize.Size << " " << stats.DataSizeHistogram.size() << " " << stats.RowCountHistogram.size() << Endl;
+        Cerr << "Got     : " << stats.RowCount << " " << stats.DataSize.Size << " " << stats.IndexSize.Size << " " << stats.DataSizeHistogram.size() << " " << stats.RowCountHistogram.size() << Endl;
+        Cerr << "Expected: " << expectedRows << " " << expectedData << " " << expectedIndex << " " << stats.DataSizeHistogram.size() << " " << stats.RowCountHistogram.size() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(stats.RowCount, expectedRows);
         UNIT_ASSERT_VALUES_EQUAL(stats.DataSize.Size, expectedData);
         UNIT_ASSERT_VALUES_EQUAL(stats.IndexSize.Size, expectedIndex);
@@ -141,7 +142,8 @@ namespace {
             UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");
         }
 
-        Cerr << "Stats: " << stats.RowCount << " " << stats.DataSize.Size << " " << stats.IndexSize.Size << " " << stats.DataSizeHistogram.size() << " " << stats.RowCountHistogram.size() << Endl;
+        Cerr << "Got     : " << stats.RowCount << " " << stats.DataSize.Size << " " << stats.IndexSize.Size << " " << stats.DataSizeHistogram.size() << " " << stats.RowCountHistogram.size() << Endl;
+        Cerr << "Expected: " << expectedRows << " " << expectedData << " " << expectedIndex << " " << stats.DataSizeHistogram.size() << " " << stats.RowCountHistogram.size() << Endl;
         UNIT_ASSERT_VALUES_EQUAL(stats.RowCount, expectedRows);
         UNIT_ASSERT_VALUES_EQUAL(stats.DataSize.Size, expectedData);
         UNIT_ASSERT_VALUES_EQUAL(stats.IndexSize.Size, expectedIndex);
@@ -405,14 +407,14 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
     Y_UNIT_TEST(Single_History)
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
-        CheckMixedIndex(*subset, 24000, 3547100, 61162);
+        CheckBTreeIndex(*subset, 24000, 3547100, 61162);
     }
 
     Y_UNIT_TEST(Single_History_Slices)
     {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
-        CheckMixedIndex(*subset, 9582, 1425198, 61162);
+        CheckBTreeIndex(*subset, 9582, 1425198, 61162);
     }
 
     Y_UNIT_TEST(Single_Groups)

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -40,6 +40,7 @@ namespace {
         }
         conf.SmallEdge = 19;  /* Packed to page collection large cell values */
         conf.LargeEdge = 29;  /* Large values placed to single blobs */
+        conf.SliceSize = conf.Group(0).PageSize * 4;
         conf.CutIndexKeys = false;
         conf.WriteBTreeIndex = writeBTreeIndex;
 
@@ -92,7 +93,7 @@ namespace {
 
         const ui32 attempts = 10;
         for (ui32 attempt : xrange(attempts)) {
-            if (NTable::BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, &env)) {
+            if (NTable::BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){})) {
                 break;
             }
             UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");
@@ -169,6 +170,19 @@ Y_UNIT_TEST_SUITE(BuildStatsFlatIndex) {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 25272);
+    }
+
+    Y_UNIT_TEST(Single_History)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        CheckMixedIndex(*subset, 24000, 3547100, 31242);
+    }
+
+    Y_UNIT_TEST(Single_History_Slices)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 9582, 1425198, 31242);
     }
 
     Y_UNIT_TEST(Single_Groups)
@@ -252,6 +266,19 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 49449);
+    }
+
+    Y_UNIT_TEST(Single_History)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
+        CheckMixedIndex(*subset, 24000, 3547100, 61162);
+    }
+
+    Y_UNIT_TEST(Single_History_Slices)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 9582, 1425198, 61162);
     }
 
     Y_UNIT_TEST(Single_Groups)
@@ -373,6 +400,19 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
         auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 12816, 1121048, 49449);
+    }
+
+    Y_UNIT_TEST(Single_History)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
+        CheckMixedIndex(*subset, 24000, 3547100, 61162);
+    }
+
+    Y_UNIT_TEST(Single_History_Slices)
+    {
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
+        CheckMixedIndex(*subset, 9582, 1425198, 61162);
     }
 
     Y_UNIT_TEST(Single_Groups)

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -136,7 +136,7 @@ namespace {
 
         const ui32 attempts = 10;
         for (ui32 attempt : xrange(attempts)) {
-            if (NTable::BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){})) {
+            if (NTable::BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, &env)) {
                 break;
             }
             UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Extract `BuildStatsBTreeIndex` for further effective implementation of stats collecting in case when all parts have B-Tree index

Implement first part that calculates index and data sizes with by channel statistic
