### PR TITLE
[YQL-18098] Fix type annotation of Aggregate with non-null default value in AggregationTraits

### DIFF
--- a/ydb/library/yql/core/type_ann/type_ann_list.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_list.cpp
@@ -614,16 +614,37 @@ namespace {
                 return IGraphTransformer::TStatus::Error;
             }
 
-            auto finishItemType = RemoveOptionalType(&finishType);
-            if (finishItemType->GetKind() != ETypeAnnotationKind::Null) {
-                auto arg = ctx.Expr.NewArgument(defaultValue->Pos(), "arg");
-                auto status = TrySilentConvertTo(arg, *defaultValue->GetTypeAnn(), finishType, ctx.Expr);
-                if (status == IGraphTransformer::TStatus::Error) {
-                    ctx.Expr.AddError(TIssue(ctx.Expr.GetPosition(defaultValue->Pos()),
-                        TStringBuilder() << "Uncompatible types of default value and " << finishName
-                                         << " : " << *defaultValue->GetTypeAnn() << " != " << finishType));
-                    return status;
-                }
+            // defaultValue should have such type that expression (<value-of-finishType> ?? defaultValue) is the correct one
+            const auto leftType = &finishType;
+            const auto rightType = defaultValue->GetTypeAnn();
+
+            auto leftItemType = leftType;
+            if (leftType->GetKind() == ETypeAnnotationKind::Optional) {
+                leftItemType = leftType->Cast<TOptionalExprType>()->GetItemType();
+            }
+
+            auto rightItemType = rightType;
+            if (leftType->GetKind() != ETypeAnnotationKind::Optional &&
+                rightType->GetKind() == ETypeAnnotationKind::Optional) {
+                rightItemType = rightType->Cast<TOptionalExprType>()->GetItemType();
+            }
+
+            TExprNode::TPtr arg1 = ctx.Expr.NewArgument(input->Pos(), "arg1");
+            TExprNode::TPtr arg2 = defaultValue;
+            auto convertedArg2 = arg2;
+            const TTypeAnnotationNode* commonItemType = nullptr;
+            auto status = SilentInferCommonType(convertedArg2, *rightItemType, arg1, *leftItemType, ctx.Expr, commonItemType,
+                TConvertFlags().Set(NConvertFlags::AllowUnsafeConvert));
+            if (status == IGraphTransformer::TStatus::Error) {
+                ctx.Expr.AddError(TIssue(ctx.Expr.GetPosition(defaultValue->Pos()),
+                    TStringBuilder() << "Uncompatible types of default value and " << finishName
+                                     << " : " << *defaultValue->GetTypeAnn() << " vs " << finishType));
+                return status;
+            }
+
+            if (arg2 != convertedArg2) {
+                output = ctx.Expr.ChangeChild(*input, defaultValueIndex, std::move(convertedArg2));
+                return IGraphTransformer::TStatus::Repeat;
             }
         }
 
@@ -4983,35 +5004,26 @@ namespace {
                                 !item->IsOptionalOrNull() ? ctx.Expr.MakeType<TOptionalExprType>(item) : item));
                     }
                 } else {
-                    const TTypeAnnotationNode* defValType;
-                    bool isDefNull;
-                    if (isTraits) {
-                        auto defVal = child->Child(1)->Child(7);
-                        isDefNull = defVal->IsCallable("Null");
-                        defValType = defVal->GetTypeAnn();
-                    } else {
-                        auto name = child->Child(1)->Child(0)->Content();
-                        if (name == "count" || name == "count_all") {
-                            isDefNull = false;
-                            defValType = ctx.Expr.MakeType<TDataExprType>(EDataSlot::Uint64);
+                    if (input->Child(1)->ChildrenSize() == 0 && !isHopping) {
+                        if (isTraits) {
+                            // need to apply default value
+                            auto defVal = child->Child(1)->ChildPtr(7);
+                            if (!defVal->IsCallable("Null")) {
+                                finishType = defVal->GetTypeAnn();
+                            } else if (!finishType->IsOptionalOrNull()) {
+                                finishType = ctx.Expr.MakeType<TOptionalExprType>(finishType);
+                            }
                         } else {
-                            isDefNull = true;
-                            defValType = ctx.Expr.MakeType<TNullExprType>();
+                            auto name = child->Child(1)->Child(0)->Content();
+                            if ((name == "count" || name == "count_all")) {
+                                if (isOptional) {
+                                    finishType = finishType->Cast<TOptionalExprType>()->GetItemType();
+                                }
+                            } else if (!finishType->IsOptionalOrNull()) {
+                                finishType = ctx.Expr.MakeType<TOptionalExprType>(finishType);
+                            }
                         }
                     }
-
-                    if (isDefNull && !isOptional && !isHopping && input->Child(1)->ChildrenSize() == 0) {
-                        if (finishType->GetKind() != ETypeAnnotationKind::Null &&
-                            finishType->GetKind() != ETypeAnnotationKind::Pg) {
-                            finishType = ctx.Expr.MakeType<TOptionalExprType>(finishType);
-                        }
-                    } else if (!isDefNull && defValType->GetKind() != ETypeAnnotationKind::Optional
-                        && finishType->GetKind() == ETypeAnnotationKind::Optional) {
-                        finishType = finishType->Cast<TOptionalExprType>()->GetItemType();
-                    } else if (!isDefNull && finishType->GetKind() == ETypeAnnotationKind::Null && input->Child(1)->ChildrenSize() == 0) {
-                        finishType = defValType;
-                    }
-
                     rowColumns.push_back(ctx.Expr.MakeType<TItemExprType>(child->Head().Content(), finishType));
                 }
             } else if (suffix == "Combine" || suffix == "CombineState" || suffix == "MergeState") {

--- a/ydb/library/yql/tests/s-expressions/yt_native_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/s-expressions/yt_native_file/part3/canondata/result.json
@@ -6255,9 +6255,9 @@
     ],
     "test.test[Udf-TopFreq-Debug]": [
         {
-            "checksum": "0165fc4b55d06481e09e222eeb2ae12f",
-            "size": 5573,
-            "uri": "https://{canondata_backend}/1937429/ee1dc97fdb7ce980999482311c9b3c21628733a4/resource.tar.gz#test.test_Udf-TopFreq-Debug_/opt.yql"
+            "checksum": "02807cf360c2310bd107a9df22d1cf6c",
+            "size": 5603,
+            "uri": "https://{canondata_backend}/1889210/5c38be307a1bcc56586511ac7eac4e75066ff5f6/resource.tar.gz#test.test_Udf-TopFreq-Debug_/opt.yql"
         }
     ],
     "test.test[Udf-TopFreq-Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part0/canondata/result.json
@@ -3277,9 +3277,9 @@
     ],
     "test.test[window-generic/aggregations_mixed--Debug]": [
         {
-            "checksum": "e3e237f950d5e6e5b8970dfa289bb409",
-            "size": 7046,
-            "uri": "https://{canondata_backend}/1942100/a4c7af0cfa6de91d520eb74fb8af1e64b13ecf0a/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
+            "checksum": "2ada042808b40662c30bf5a81533d767",
+            "size": 7148,
+            "uri": "https://{canondata_backend}/1130705/7dd3fbb351b6ea2ab8b0736da59f105c9241fd78/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part10/canondata/result.json
@@ -190,9 +190,9 @@
     ],
     "test.test[aggr_factory-bottom-default.txt-Debug]": [
         {
-            "checksum": "feb82529e74c587eafff41b1bc7f0a5d",
-            "size": 7377,
-            "uri": "https://{canondata_backend}/1031349/6c70521322fc43f752ef6b89f8667fefd006af8b/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b1258866995ee0c237856f6fcd19cd80",
+            "size": 7385,
+            "uri": "https://{canondata_backend}/1809005/a1fd498781ad8b3801c9a55d0bd7d614dc85bb93/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-bottom-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part12/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part12/canondata/result.json
@@ -177,9 +177,9 @@
     ],
     "test.test[aggr_factory-mode-default.txt-Debug]": [
         {
-            "checksum": "251729805f597fafb1a3d50b19792bb0",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1942173/50b4ae48e906d86b27ee0b68ed5a08b5ad6bf50e/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b4a62a7a804be70149ab082c37b922ca",
+            "size": 8464,
+            "uri": "https://{canondata_backend}/1130705/ef53df0087abe70482ce7b2a8f02692fa114faa8/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-mode-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part15/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part15/canondata/result.json
@@ -281,9 +281,9 @@
     ],
     "test.test[aggr_factory-top-default.txt-Debug]": [
         {
-            "checksum": "a3ee40a7333056081eadeb60d9839797",
-            "size": 7376,
-            "uri": "https://{canondata_backend}/1925842/a4b71373097359ba466e2713f3de746df8a53ab1/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql_patched"
+            "checksum": "31b55bd53878eb318566a97877e62fc0",
+            "size": 7384,
+            "uri": "https://{canondata_backend}/1903280/46af5dd813e524044963c92a5f2ce6250ce88cd1/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-top-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
@@ -2819,9 +2819,9 @@
     ],
     "test.test[window-lagging/aggregations--Debug]": [
         {
-            "checksum": "5219b7bb2217832aaea18c7e2c690a65",
-            "size": 6819,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
+            "checksum": "4669056e08b2ee4de4de8f0522ddc9d8",
+            "size": 6877,
+            "uri": "https://{canondata_backend}/1809005/6204dd19a10bd9bc701faf558e7ce789c91e22ff/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-lagging/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part3/canondata/result.json
@@ -2578,9 +2578,9 @@
     ],
     "test.test[window-generic/aggregations_before_current--Debug]": [
         {
-            "checksum": "9c85297b4224c3080023af43abfe8a40",
-            "size": 7203,
-            "uri": "https://{canondata_backend}/1031349/d86a7eaf6f5bc2cdaedba52c0890601b8cc1d981/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
+            "checksum": "7cbd7e87b710e5169c98f1ed5cedd003",
+            "size": 7259,
+            "uri": "https://{canondata_backend}/1809005/b5fd98a03b02a29344a248fc7017d3e834d02658/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
@@ -2934,9 +2934,9 @@
     ],
     "test.test[window-generic/aggregations_after_current--Debug]": [
         {
-            "checksum": "5f9f9e4572a3a2d1918a6bd7495d1058",
-            "size": 7233,
-            "uri": "https://{canondata_backend}/1937001/3df1bf80f5738c3f0205526961db8957f75fdaea/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
+            "checksum": "2e87e119d176d86d6373aee6b8515655",
+            "size": 7289,
+            "uri": "https://{canondata_backend}/1903280/0db3cff29ce26bdeebe43f7c9bad950e873a4e5d/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part7/canondata/result.json
@@ -175,6 +175,28 @@
         }
     ],
     "test.test[agg_apply-min-default.txt-Results]": [],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Analyze]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1889210/25bb12516fb50fd6341f375d4bd251cc1316e0aa/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Analyze_/plan.txt"
+        }
+    ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Debug]": [
+        {
+            "checksum": "2ab470351943b187ad5610f599b37e0d",
+            "size": 1480,
+            "uri": "https://{canondata_backend}/1889210/25bb12516fb50fd6341f375d4bd251cc1316e0aa/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Plan]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1889210/25bb12516fb50fd6341f375d4bd251cc1316e0aa/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Plan_/plan.txt"
+        }
+    ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Results]": [],
     "test.test[aggregate-aggregate_key_column-default.txt-Analyze]": [
         {
             "checksum": "e447076882c3384f28df0db8089de406",

--- a/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
@@ -87,6 +87,28 @@
         }
     ],
     "test.test[agg_phases-sum_opt-default.txt-Results]": [],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Analyze]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1889210/1f0152f3c0f7d63c8452e9855872f2e930cd4c7e/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Analyze_/plan.txt"
+        }
+    ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Debug]": [
+        {
+            "checksum": "79a546e982f857db89b544335ea7a6b7",
+            "size": 1323,
+            "uri": "https://{canondata_backend}/1889210/1f0152f3c0f7d63c8452e9855872f2e930cd4c7e/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Plan]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1889210/1f0152f3c0f7d63c8452e9855872f2e930cd4c7e/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Plan_/plan.txt"
+        }
+    ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Results]": [],
     "test.test[aggr_factory-max_by-default.txt-Analyze]": [
         {
             "checksum": "ca7f94de5d04fd68ac4b3dc3c6616091",

--- a/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
@@ -2857,9 +2857,9 @@
     ],
     "test.test[window-generic/aggregations_before_current--Debug]": [
         {
-            "checksum": "701c249597bc1d95c048911630a465f9",
-            "size": 10133,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
+            "checksum": "4bfd019fb1d671c86da631ff609aff99",
+            "size": 10193,
+            "uri": "https://{canondata_backend}/1809005/167e3294ea975973acc802f0e59d7cdec616be73/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part2/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part2/canondata/result.json
@@ -169,9 +169,9 @@
     ],
     "test.test[aggr_factory-top-default.txt-Debug]": [
         {
-            "checksum": "9e3cdee1f6386c21634f53b855c0e98c",
-            "size": 8925,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9954f8a5d2a71d2ab1706bd0ea7131ad",
+            "size": 8917,
+            "uri": "https://{canondata_backend}/1809005/623e3b35000a48f04e7b1f70e57a24491fabbde8/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-top-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part3/canondata/result.json
@@ -363,6 +363,20 @@
             "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggr_factory-bitxor-default.txt-Plan_/plan.txt"
         }
     ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Debug]": [
+        {
+            "checksum": "1ea518f983f7d114889cb4ffe5cf68b0",
+            "size": 1322,
+            "uri": "https://{canondata_backend}/1936997/f69902e9df436dbd7c079c9b996bb43c65b9828c/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Plan]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1936997/f69902e9df436dbd7c079c9b996bb43c65b9828c/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Plan_/plan.txt"
+        }
+    ],
     "test.test[aggr_factory-min_by-default.txt-Debug]": [
         {
             "checksum": "3af40a82a2d282041a5c43943745fa5a",
@@ -3011,9 +3025,9 @@
     ],
     "test.test[window-lagging/aggregations--Debug]": [
         {
-            "checksum": "53eadaee1e5feb1f260b3aa048d08da6",
-            "size": 9809,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
+            "checksum": "063d5215f0e7ce5d3485a562b7bc6238",
+            "size": 9870,
+            "uri": "https://{canondata_backend}/1809005/22c7ffc44e1102967f4f7c31c632ffbfff73cc8b/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-lagging/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
@@ -253,9 +253,9 @@
     ],
     "test.test[aggr_factory-mode-default.txt-Debug]": [
         {
-            "checksum": "819ff2caa18dfa45195e7c53d09ebdec",
-            "size": 10022,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4319aa96cd86c3cbf9ac952898211ed4",
+            "size": 10007,
+            "uri": "https://{canondata_backend}/1809005/598dad0f68894de6de54be0cbb32ec9d0122f411/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-mode-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part5/canondata/result.json
@@ -209,6 +209,20 @@
             "uri": "https://{canondata_backend}/1936947/a5f83e5d38179c14126d53519dc062cef98113ec/resource.tar.gz#test.test_aggr_factory-container_empty-default.txt-Plan_/plan.txt"
         }
     ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Debug]": [
+        {
+            "checksum": "ff2c8f0993c0eedf24568d1bae5e3bf3",
+            "size": 1479,
+            "uri": "https://{canondata_backend}/1946324/a73667b195068cad6a1c7af344e8899b2a9f8586/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Plan]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1946324/a73667b195068cad6a1c7af344e8899b2a9f8586/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Plan_/plan.txt"
+        }
+    ],
     "test.test[aggr_factory-multi_list_distinct_expr-default.txt-Debug]": [
         {
             "checksum": "aa15a87515158b46adf8d69b003ca4cd",

--- a/ydb/library/yql/tests/sql/hybrid_file/part6/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part6/canondata/result.json
@@ -2787,9 +2787,9 @@
     ],
     "test.test[window-generic/aggregations_mixed--Debug]": [
         {
-            "checksum": "02a3c2cf5edcb1b22364711c5e90f5ad",
-            "size": 9967,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
+            "checksum": "f5951f102d1f4381610626850c176211",
+            "size": 10077,
+            "uri": "https://{canondata_backend}/1809005/c9bc99b44b553875f5ce672618fc5c945a3c5f00/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
@@ -225,9 +225,9 @@
     ],
     "test.test[aggr_factory-bottom-default.txt-Debug]": [
         {
-            "checksum": "3a6b28f8efc619d8217a4df0ba2c0c8d",
-            "size": 8926,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql_patched"
+            "checksum": "36e2d5feac591c9e81f418a680de1fe8",
+            "size": 8918,
+            "uri": "https://{canondata_backend}/1130705/4be687a065d9aed2f683f3825532a5d8679df5ff/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-bottom-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
@@ -2927,9 +2927,9 @@
     ],
     "test.test[window-generic/aggregations_after_current--Debug]": [
         {
-            "checksum": "4e80aef351a4f961e6ed84b86a28c67a",
-            "size": 10165,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
+            "checksum": "656f147844ed85b377a34e23e45249ed",
+            "size": 10225,
+            "uri": "https://{canondata_backend}/1917492/092f6b955a43bed7a63b100561946af917330bfe/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Plan]": [

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -1301,6 +1301,20 @@
             "uri": "https://{canondata_backend}/1784117/d56ae82ad9d30397a41490647be1bd2124718f98/resource.tar.gz#test_sql2yql.test_aggr_factory-count_if_/sql.yql"
         }
     ],
+    "test_sql2yql.test[aggr_factory-def_value_full_table]": [
+        {
+            "checksum": "f88c95f4903c32187fc381bda1336b46",
+            "size": 7322,
+            "uri": "https://{canondata_backend}/1942173/5547b75707e10619dbd7727d7d0f2404ab9b13ca/resource.tar.gz#test_sql2yql.test_aggr_factory-def_value_full_table_/sql.yql"
+        }
+    ],
+    "test_sql2yql.test[aggr_factory-def_value_with_keys]": [
+        {
+            "checksum": "ade829860b226398a4d468e42ad95d17",
+            "size": 7477,
+            "uri": "https://{canondata_backend}/1942173/5547b75707e10619dbd7727d7d0f2404ab9b13ca/resource.tar.gz#test_sql2yql.test_aggr_factory-def_value_with_keys_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[aggr_factory-every]": [
         {
             "checksum": "97b4c5b6747623995d6fd8bbbb47b325",
@@ -19723,6 +19737,20 @@
             "checksum": "bcbc90573d75b6467cd13d799948fe00",
             "size": 575,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_aggr_factory-count_if_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[aggr_factory-def_value_full_table]": [
+        {
+            "checksum": "7af8129a4f271ccba996be1e810dbed4",
+            "size": 1313,
+            "uri": "https://{canondata_backend}/1942173/5547b75707e10619dbd7727d7d0f2404ab9b13ca/resource.tar.gz#test_sql_format.test_aggr_factory-def_value_full_table_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[aggr_factory-def_value_with_keys]": [
+        {
+            "checksum": "a298cf11b7a5a217671ae761ec9eb406",
+            "size": 1338,
+            "uri": "https://{canondata_backend}/1942173/5547b75707e10619dbd7727d7d0f2404ab9b13ca/resource.tar.gz#test_sql_format.test_aggr_factory-def_value_with_keys_/formatted.sql"
         }
     ],
     "test_sql_format.test[aggr_factory-every]": [

--- a/ydb/library/yql/tests/sql/suites/aggr_factory/def_value_full_table.sql
+++ b/ydb/library/yql/tests/sql/suites/aggr_factory/def_value_full_table.sql
@@ -1,0 +1,63 @@
+$my_table =
+SELECT
+    1 AS id
+    , 1 AS ts
+    , 4 AS value1
+    , 5 AS value2
+UNION ALL
+SELECT
+    3 AS id
+    , 10 AS ts
+    , 40 AS value1
+    , NULL AS value2
+UNION ALL
+SELECT
+    2 AS id
+    , 1 AS ts
+    , NULL AS value1
+    , NULL AS value2
+UNION ALL
+SELECT
+    1 AS id
+    , 2 AS ts
+    , 4 AS value1
+    , 5 AS value2
+UNION ALL
+SELECT
+    3 AS id
+    , 2 AS ts
+    , 40 AS value1
+    , NULL AS value2
+UNION ALL
+SELECT
+    3 AS id
+    , 5 AS ts
+    , 2 AS value1
+    , 7 AS value2
+;
+
+-- Эмуляция агрегационной функции COUNT
+$cnt_create = ($_item, $_parent) -> { return 1ul };
+$cnt_add = ($state, $_item, $_parent) -> { return 1ul + $state };
+$cnt_merge = ($state1, $state2) -> { return $state1 + $state2 };
+$cnt_get_result = ($state) -> { return $state };
+$cnt_serialize = ($state) -> { return $state };
+$cnt_deserialize = ($state) -> { return $state };
+$cnt_default = 0l;
+
+$cnt_udaf_factory = AggregationFactory(
+	    "UDAF",
+	    $cnt_create,
+	    $cnt_add,
+	    $cnt_merge,
+	    $cnt_get_result,
+	    $cnt_serialize,
+	    $cnt_deserialize,
+	    $cnt_default
+);
+
+
+SELECT
+    AGGREGATE_BY(value1, $cnt_udaf_factory) AS cnt1
+FROM $my_table
+;

--- a/ydb/library/yql/tests/sql/suites/aggr_factory/def_value_with_keys.sql
+++ b/ydb/library/yql/tests/sql/suites/aggr_factory/def_value_with_keys.sql
@@ -1,0 +1,66 @@
+$my_table =
+SELECT
+    1 AS id
+    , 1 AS ts
+    , 4 AS value1
+    , 5 AS value2
+UNION ALL
+SELECT
+    3 AS id
+    , 10 AS ts
+    , 40 AS value1
+    , NULL AS value2
+UNION ALL
+SELECT
+    2 AS id
+    , 1 AS ts
+    , NULL AS value1
+    , NULL AS value2
+UNION ALL
+SELECT
+    1 AS id
+    , 2 AS ts
+    , 4 AS value1
+    , 5 AS value2
+UNION ALL
+SELECT
+    3 AS id
+    , 2 AS ts
+    , 40 AS value1
+    , NULL AS value2
+UNION ALL
+SELECT
+    3 AS id
+    , 5 AS ts
+    , 2 AS value1
+    , 7 AS value2
+;
+
+-- Эмуляция агрегационной функции COUNT
+$cnt_create = ($_item, $_parent) -> { return 1ul };
+$cnt_add = ($state, $_item, $_parent) -> { return 1ul + $state };
+$cnt_merge = ($state1, $state2) -> { return $state1 + $state2 };
+$cnt_get_result = ($state) -> { return $state };
+$cnt_serialize = ($state) -> { return $state };
+$cnt_deserialize = ($state) -> { return $state };
+$cnt_default = 0ul;
+
+$cnt_udaf_factory = AggregationFactory(
+	    "UDAF",
+	    $cnt_create,
+	    $cnt_add,
+	    $cnt_merge,
+	    $cnt_get_result,
+	    $cnt_serialize,
+	    $cnt_deserialize,
+	    $cnt_default
+);
+
+
+SELECT
+    id,
+    AGGREGATE_BY(value1, $cnt_udaf_factory) AS cnt1
+FROM $my_table
+GROUP BY
+    id
+;

--- a/ydb/library/yql/tests/sql/yt_native_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part0/canondata/result.json
@@ -3024,9 +3024,9 @@
     ],
     "test.test[window-generic/aggregations_mixed--Debug]": [
         {
-            "checksum": "1181e9b51e6bd810254d7c6b1b35b39b",
-            "size": 7826,
-            "uri": "https://{canondata_backend}/1925842/7116e4a5b3b3e69698c13d345f181d8371ba2ec4/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql"
+            "checksum": "60b58b17ed05f21cc4397cc29e9421a6",
+            "size": 7929,
+            "uri": "https://{canondata_backend}/1903280/c2a22324352d4d4e89ea745ef44bf9dafd733cae/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part10/canondata/result.json
@@ -163,9 +163,9 @@
     ],
     "test.test[aggr_factory-bottom-default.txt-Debug]": [
         {
-            "checksum": "124de8b879fe0de5350715b6f605ea99",
-            "size": 7886,
-            "uri": "https://{canondata_backend}/1777230/e531db07d3e2131a85fc53f8f26e2eb72c689723/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql"
+            "checksum": "82c9830db3f969bc627646f2d5b9d1f5",
+            "size": 7878,
+            "uri": "https://{canondata_backend}/1936842/bed5ad28e8973846092670afbba334d994430910/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[aggr_factory-bottom-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part12/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part12/canondata/result.json
@@ -152,9 +152,9 @@
     ],
     "test.test[aggr_factory-mode-default.txt-Debug]": [
         {
-            "checksum": "979b1ed4cd1b70fc08cb279d663f9977",
-            "size": 8988,
-            "uri": "https://{canondata_backend}/1942671/ac36e32b416efc8f93cb5202f37a646b82ff44f5/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql"
+            "checksum": "c41466850e47fd3c4ce63a647763a811",
+            "size": 8972,
+            "uri": "https://{canondata_backend}/1942100/4a29aceeeb2af31abc359568cca09d711e28349f/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[aggr_factory-mode-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part15/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part15/canondata/result.json
@@ -253,9 +253,9 @@
     ],
     "test.test[aggr_factory-top-default.txt-Debug]": [
         {
-            "checksum": "604eb0532536c965ae9169dd0d2c5d2e",
-            "size": 7885,
-            "uri": "https://{canondata_backend}/1942173/74408257f99fa053878b4c348dd56d42ab4853e2/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql"
+            "checksum": "bcd6e213dcf93c02e60aae6da53a62aa",
+            "size": 7877,
+            "uri": "https://{canondata_backend}/1903280/7468524e3d561bebec3932d27b90fab4825f5047/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[aggr_factory-top-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
@@ -2566,9 +2566,9 @@
     ],
     "test.test[window-lagging/aggregations--Debug]": [
         {
-            "checksum": "e032d09d3862b6ae13514a5598de9621",
-            "size": 7641,
-            "uri": "https://{canondata_backend}/1924537/d66bfe69aa802f6a81aadbac897621b721f31b4b/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql"
+            "checksum": "48837e7d6d5276a26e6ddc3addc5bb81",
+            "size": 7697,
+            "uri": "https://{canondata_backend}/1936842/30423aebff9a8c6c1dfc3d72e65f214bcff8b187/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql"
         }
     ],
     "test.test[window-lagging/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part3/canondata/result.json
@@ -2252,9 +2252,9 @@
     ],
     "test.test[window-generic/aggregations_before_current--Debug]": [
         {
-            "checksum": "0e7a351e7a51b9ab0af1df15303a6e30",
-            "size": 7983,
-            "uri": "https://{canondata_backend}/1937001/501db203b8231f91537ae2b97c666fbbeac7d8f3/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql"
+            "checksum": "8086a1538a933fb82ccdce952a37aa76",
+            "size": 8039,
+            "uri": "https://{canondata_backend}/1130705/ee873772203fa2f395415da04bb9a38d3134ebce/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
@@ -2874,9 +2874,9 @@
     ],
     "test.test[window-generic/aggregations_after_current--Debug]": [
         {
-            "checksum": "8022d9ffd69e8c7ed2db20b96aee3c36",
-            "size": 8013,
-            "uri": "https://{canondata_backend}/1775059/3eec83f05edefb1e01aecad353735b7ca430d358/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql"
+            "checksum": "81fa0dc8b4905b16ab3b7364f1ef6c02",
+            "size": 8069,
+            "uri": "https://{canondata_backend}/1903280/ee02a69be166901aba8ebd6aa56b953cbf51137e/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part7/canondata/result.json
@@ -172,6 +172,27 @@
             "uri": "https://{canondata_backend}/1937001/37554cdd914aa454d296c9271a21521d48531395/resource.tar.gz#test.test_agg_apply-min-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Debug]": [
+        {
+            "checksum": "3894d79b2845a332dd21c112eb196809",
+            "size": 1410,
+            "uri": "https://{canondata_backend}/1942100/c5d309620215f295cf9e202b61bd3148a46e9f4f/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Debug_/opt.yql"
+        }
+    ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Plan]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1942100/c5d309620215f295cf9e202b61bd3148a46e9f4f/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Plan_/plan.txt"
+        }
+    ],
+    "test.test[aggr_factory-def_value_with_keys-default.txt-Results]": [
+        {
+            "checksum": "5e8b0a0be93154db5b5f75f4565ab7eb",
+            "size": 1431,
+            "uri": "https://{canondata_backend}/1942100/c5d309620215f295cf9e202b61bd3148a46e9f4f/resource.tar.gz#test.test_aggr_factory-def_value_with_keys-default.txt-Results_/results.txt"
+        }
+    ],
     "test.test[aggregate-aggregate_key_column-default.txt-Debug]": [
         {
             "checksum": "c60da4cbe0b4cca121463521298fb784",

--- a/ydb/library/yql/tests/sql/yt_native_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part9/canondata/result.json
@@ -83,6 +83,27 @@
             "uri": "https://{canondata_backend}/1775059/59a8dbe71df1bdc11b3f063ab535eee737c36649/resource.tar.gz#test.test_agg_phases-sum_opt-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Debug]": [
+        {
+            "checksum": "9abf3c83a73d29257334b992690b94c8",
+            "size": 1252,
+            "uri": "https://{canondata_backend}/1937492/08c7557d3eb0caa0b394c9c83118b551fd21a6a3/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Debug_/opt.yql"
+        }
+    ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Plan]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1937492/08c7557d3eb0caa0b394c9c83118b551fd21a6a3/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Plan_/plan.txt"
+        }
+    ],
+    "test.test[aggr_factory-def_value_full_table-default.txt-Results]": [
+        {
+            "checksum": "633f5f966aadd6a0ded95686032be449",
+            "size": 693,
+            "uri": "https://{canondata_backend}/1937492/08c7557d3eb0caa0b394c9c83118b551fd21a6a3/resource.tar.gz#test.test_aggr_factory-def_value_full_table-default.txt-Results_/results.txt"
+        }
+    ],
     "test.test[aggr_factory-max_by-default.txt-Debug]": [
         {
             "checksum": "d3f4ef57cfbf135409ee63438a587ff6",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-18098] Fix type annotation of Aggregate with non-null default value in AggregationTraits

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
