### PR TITLE
S3 mock fix

### DIFF
--- a/ydb/core/wrappers/s3_storage.h
+++ b/ydb/core/wrappers/s3_storage.h
@@ -67,9 +67,7 @@ private:
                 Y_DEFER {
                     std::unique_lock guard(RunningQueriesMutex);
                     --RunningQueriesCount;
-                    bool needNotify = (RunningQueriesCount == 0);
-                    guard.unlock();
-                    if (needNotify) {
+                    if (RunningQueriesCount == 0) {
                         RunningQueriesNotifier.notify_all();
                     }
                 };

--- a/ydb/core/wrappers/ut_helpers/s3_mock.cpp
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.cpp
@@ -20,13 +20,13 @@ TS3Mock::TSettings::TSettings()
 }
 
 TS3Mock::TSettings::TSettings(ui16 port)
-    : HttpOptions(TOptions(port).SetThreads(1))
+    : HttpOptions(THttpServer::TOptions(port).SetThreads(1))
     , CorruptETags(false)
     , RejectUploadParts(false)
 {
 }
 
-TS3Mock::TSettings& TS3Mock::TSettings::WithHttpOptions(const TOptions& opts) {
+TS3Mock::TSettings& TS3Mock::TSettings::WithHttpOptions(const THttpServer::TOptions& opts) {
     HttpOptions = opts;
     return *this;
 }
@@ -388,23 +388,27 @@ bool TS3Mock::TRequest::DoReply(const TReplyParams& params) {
     }
 }
 
+bool TS3Mock::Start() {
+    return HttpServer.Start();
+}
+
 TS3Mock::TS3Mock(const TSettings& settings)
-    : THttpServer(this, settings.HttpOptions)
-    , Settings(settings)
+    : Settings(settings)
+    , HttpServer(this, settings.HttpOptions)
 {
 }
 
 TS3Mock::TS3Mock(THashMap<TString, TString>&& data, const TSettings& settings)
-    : THttpServer(this, settings.HttpOptions)
-    , Settings(settings)
+    : Settings(settings)
     , Data(std::move(data))
+    , HttpServer(this, settings.HttpOptions)
 {
 }
 
 TS3Mock::TS3Mock(const THashMap<TString, TString>& data, const TSettings& settings)
-    : THttpServer(this, settings.HttpOptions)
-    , Settings(settings)
+    : Settings(settings)
     , Data(data)
+    , HttpServer(this, settings.HttpOptions)
 {
 }
 

--- a/ydb/core/wrappers/ut_helpers/s3_mock.h
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.h
@@ -11,17 +11,17 @@ namespace NKikimr {
 namespace NWrappers {
 namespace NTestHelpers {
 
-class TS3Mock: public THttpServer, public THttpServer::ICallBack {
+class TS3Mock: public THttpServer::ICallBack {
 public:
     struct TSettings {
-        TOptions HttpOptions;
+        THttpServer::TOptions HttpOptions;
         bool CorruptETags;
         bool RejectUploadParts;
 
         TSettings();
         explicit TSettings(ui16 port);
 
-        TSettings& WithHttpOptions(const TOptions& opts);
+        TSettings& WithHttpOptions(const THttpServer::TOptions& opts);
         TSettings& WithCorruptETags(bool value);
         TSettings& WithRejectUploadParts(bool value);
 
@@ -65,7 +65,8 @@ public:
     explicit TS3Mock(THashMap<TString, TString>&& data, const TSettings& settings = {});
     explicit TS3Mock(const THashMap<TString, TString>& data, const TSettings& settings = {});
 
-    TClientRequest* CreateClient() override;
+    TClientRequest* CreateClient();
+    bool Start();
 
     const THashMap<TString, TString>& GetData() const { return Data; }
 
@@ -75,6 +76,7 @@ private:
 
     int NextUploadId = 1;
     THashMap<std::pair<TString, TString>, TVector<TString>> MultipartUploads;
+    THttpServer HttpServer;
 
 }; // TS3Mock
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed flaky TExportToS3Tests.CorruptedDyNumber unit test. After the destruction of S3Mock object, there could be access to the S3Mock class data in HttpServer handlers. To exclude this, replaced inheritance to aggregation.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

https://github.com/ydb-platform/ydb/pull/3113

...
