### PR TITLE
Check VDisk status before reassigning disk in static group

### DIFF
--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -525,6 +525,8 @@ namespace NKikimr::NBsController {
         });
 
         if (!virtualGroupsOnly) {
+            const TMonotonic mono = TActivationContext::Monotonic();
+
             // apply static group
             for (const auto& [pdiskId, pdisk] : StaticPDisks) {
                 if (PDisks.Find(pdiskId)) {
@@ -564,11 +566,11 @@ namespace NKikimr::NBsController {
                     x->MutableVDiskMetrics()->ClearVDiskId();
                 }
                 x->SetStatus(NKikimrBlobStorage::EVDiskStatus_Name(vslot.VDiskStatus));
+                x->SetReady(vslot.ReadySince <= mono);
             }
             if (const auto& s = Self.StorageConfig; s.HasBlobStorageConfig()) {
                 if (const auto& bsConfig = s.GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
                     const auto& ss = bsConfig.GetServiceSet();
-                    const TMonotonic mono = TActivationContext::Monotonic();
                     for (const auto& group : ss.GetGroups()) {
                         auto *x = pb->AddGroup();
                         x->SetGroupId(group.GetGroupID());

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -154,6 +154,8 @@ message TEvNodeConfigInvokeOnRoot {
         NKikimrBlobStorage.TVDiskID VDiskId = 1; // which one to reassign
         optional NKikimrBlobStorage.TPDiskId PDiskId = 2; // where to put it (optional)
         bool ConvertToDonor = 3; // convert the current disk to donor?
+        bool IgnoreGroupFailModelChecks = 4;
+        bool IgnoreDegradedGroupsChecks = 5;
     }
 
     // Regenerate configuration so the slain VDisk is no more reported as DESTROY one in the list.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Check VDisk status before reassigning disk in static group

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

NodeWarden's distconf now checks that ReassignGroupDisk would not break the group (or reduce it to degraded state). It uses direct polling of VDisks along with BSC report to make decision.

#3932