### PR TITLE
[YQL-18107] Do not reset expected types/column order in ParseType

### DIFF
--- a/ydb/library/yql/core/type_ann/type_ann_types.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_types.cpp
@@ -942,8 +942,9 @@ namespace NTypeAnnImpl {
         }
 
         // TODO: Collect type annotation directly from AST.
-        auto callableTransformer = CreateExtCallableTypeAnnotationTransformer(ctx.Types);
-        auto typeTransformer = CreateTypeAnnotationTransformer(callableTransformer, ctx.Types);
+        NYql::TTypeAnnotationContext cleanTypes;
+        auto callableTransformer = CreateExtCallableTypeAnnotationTransformer(cleanTypes);
+        auto typeTransformer = CreateTypeAnnotationTransformer(callableTransformer, cleanTypes);
         if (InstantTransform(*typeTransformer, exprRoot, ctx.Expr) != IGraphTransformer::TStatus::Ok) {
             return IGraphTransformer::TStatus::Error;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-18107] Do not reset expected types/column order in ParseType

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
