### PR TITLE
YQL-18327 Disable yellow zone of allocator on 50%

### DIFF
--- a/ydb/library/yql/minikql/aligned_page_pool.h
+++ b/ydb/library/yql/minikql/aligned_page_pool.h
@@ -239,9 +239,13 @@ protected:
 
     void UpdateMemoryYellowZone() {
         if (IncreaseMemoryLimitCallback) return;
+        if (Limit == 0) return;
 
-        if (Limit != 0) {
-            IsMemoryYellowZoneReached = (100 * GetUsed() / Limit) > MemoryYellowZoneThreshold;
+        ui64 usedMemoryPercent = 100 * GetUsed() / Limit;
+        if (usedMemoryPercent >= EnableMemoryYellowZoneThreshold) {
+            IsMemoryYellowZoneReached = true;
+        } else if (usedMemoryPercent <= DisableMemoryYellowZoneThreshold) {
+            IsMemoryYellowZoneReached = false;
         }
     }
 
@@ -279,8 +283,10 @@ protected:
     // Indicates when memory limit is almost reached.
     bool IsMemoryYellowZoneReached = false;
     // This theshold is used to determine is memory limit is almost reached.
-    // If TIncreaseMemoryLimitCallback is set this threshold should be ignored.
-    const ui8 MemoryYellowZoneThreshold = 80;
+    // If TIncreaseMemoryLimitCallback is set this thresholds should be ignored.
+    // The yellow zone turns on when memory consumption reaches 80% and turns off when consumption drops below 50%.
+    const ui8 EnableMemoryYellowZoneThreshold = 80;
+    const ui8 DisableMemoryYellowZoneThreshold = 50;
 };
 
 using TAlignedPagePool = TAlignedPagePoolImpl<>;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Yellow zone of MKQL allocator turns on when memory consumption reaches 80% and turns off when consumption drops below 50%.
...

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
