### PR TITLE
Improve distconf compatibility with BSC

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -323,7 +323,7 @@ namespace NKikimr::NStorage {
             THashMap<TVDiskIdShort, NBsController::TPDiskId> replacedDisks,
             const NBsController::TGroupMapper::TForbiddenPDisks& forbid,
             i64 requiredSpace, NKikimrBlobStorage::TBaseConfig *baseConfig,
-            bool convertToDonor);
+            bool convertToDonor, bool ignoreVSlotQuotaCheck, bool isSelfHealReasonDecommit);
 
         void GenerateStateStorageConfig(NKikimrConfig::TDomainsConfig::TStateStorage *ss,
             const NKikimrBlobStorage::TStorageConfig& baseConfig);

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
@@ -370,7 +370,8 @@ namespace NKikimr::NStorage {
                         Self->AllocateStaticGroup(&config, vdiskId.GroupID, vdiskId.GroupGeneration + 1,
                             TBlobStorageGroupType((TBlobStorageGroupType::EErasureSpecies)group.GetErasureSpecies()),
                             settings.GetGeometry(), settings.GetPDiskFilter(), replacedDisks, forbid, maxSlotSize,
-                            &BaseConfig.value(), cmd.GetConvertToDonor());
+                            &BaseConfig.value(), cmd.GetConvertToDonor(), cmd.GetIgnoreVSlotQuotaCheck(),
+                            cmd.GetIsSelfHealReasonDecommit());
                     } catch (const TExConfigError& ex) {
                         STLOG(PRI_NOTICE, BS_NODE, NW49, "ReassignGroupDisk failed to allocate group", (SelfId, SelfId()),
                             (Config, config),

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -441,21 +441,7 @@ namespace NKikimr::NBsController {
     }
 
     void TBlobStorageController::TConfigState::ExecuteStep(const NKikimrBlobStorage::TReadSettings& /*cmd*/, TStatus& status) {
-        auto settings = status.MutableSettings();
-
-        settings->AddDefaultMaxSlots(Self.DefaultMaxSlots);
-        settings->AddEnableSelfHeal(Self.SelfHealEnable);
-        settings->AddEnableDonorMode(Self.DonorMode);
-        settings->AddScrubPeriodicitySeconds(Self.ScrubPeriodicity.Seconds());
-        settings->AddPDiskSpaceMarginPromille(Self.PDiskSpaceMarginPromille);
-        settings->AddGroupReserveMin(Self.GroupReserveMin);
-        settings->AddGroupReservePartPPM(Self.GroupReservePart);
-        settings->AddMaxScrubbedDisksAtOnce(Self.MaxScrubbedDisksAtOnce);
-        settings->AddPDiskSpaceColorBorder(Self.PDiskSpaceColorBorder);
-        settings->AddEnableGroupLayoutSanitizer(Self.GroupLayoutSanitizerEnabled);
-        // TODO:
-        // settings->AddSerialManagementStage(Self.SerialManagementStage);
-        settings->AddAllowMultipleRealmsOccupation(Self.AllowMultipleRealmsOccupation);
+        Self.SerializeSettings(status.MutableSettings());
     }
 
     void TBlobStorageController::TConfigState::ExecuteStep(const NKikimrBlobStorage::TQueryBaseConfig& cmd, TStatus& status) {
@@ -664,6 +650,7 @@ namespace NKikimr::NBsController {
         for (auto& [nodeId, node] : nodes) {
             pb->AddNode()->Swap(&node);
         }
+        Self.SerializeSettings(pb->MutableSettings());
     }
 
     void TBlobStorageController::TConfigState::ExecuteStep(const NKikimrBlobStorage::TDropDonorDisk& cmd, TStatus& /*status*/) {

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -1112,4 +1112,21 @@ namespace NKikimr::NBsController {
             }
         }
 
+        void TBlobStorageController::SerializeSettings(NKikimrBlobStorage::TUpdateSettings *settings) {
+            settings->AddDefaultMaxSlots(DefaultMaxSlots);
+            settings->AddEnableSelfHeal(SelfHealEnable);
+            settings->AddEnableDonorMode(DonorMode);
+            settings->AddScrubPeriodicitySeconds(ScrubPeriodicity.Seconds());
+            settings->AddPDiskSpaceMarginPromille(PDiskSpaceMarginPromille);
+            settings->AddGroupReserveMin(GroupReserveMin);
+            settings->AddGroupReservePartPPM(GroupReservePart);
+            settings->AddMaxScrubbedDisksAtOnce(MaxScrubbedDisksAtOnce);
+            settings->AddPDiskSpaceColorBorder(PDiskSpaceColorBorder);
+            settings->AddEnableGroupLayoutSanitizer(GroupLayoutSanitizerEnabled);
+            // TODO: settings->AddSerialManagementStage(SerialManagementStage);
+            settings->AddAllowMultipleRealmsOccupation(AllowMultipleRealmsOccupation);
+            settings->AddUseSelfHealLocalPolicy(UseSelfHealLocalPolicy);
+            settings->AddTryToRelocateBrokenDisksLocallyFirst(TryToRelocateBrokenDisksLocallyFirst);
+        }
+
 } // NKikimr::NBsController

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -2370,6 +2370,8 @@ public:
     static void SerializeGroupInfo(NKikimrBlobStorage::TGroupInfo *group, const TGroupInfo& groupInfo,
         const TString& storagePoolName, const TMaybe<TKikimrScopeId>& scopeId);
 
+    void SerializeSettings(NKikimrBlobStorage::TUpdateSettings *settings);
+
     static NKikimrBlobStorage::TGroupStatus::E DeriveStatus(const TBlobStorageGroupInfo::TTopology *topology,
         const TBlobStorageGroupInfo::TGroupVDisks& failed);
 };

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -676,6 +676,7 @@ message TBaseConfig {
     repeated TGroup Group = 3;
     repeated TNode Node = 4;
     repeated TDevice Device = 5;
+    TUpdateSettings Settings = 6;
 }
 
 message TMoveCommand {

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -156,6 +156,8 @@ message TEvNodeConfigInvokeOnRoot {
         bool ConvertToDonor = 3; // convert the current disk to donor?
         bool IgnoreGroupFailModelChecks = 4;
         bool IgnoreDegradedGroupsChecks = 5;
+        bool IgnoreVSlotQuotaCheck = 6;
+        bool IsSelfHealReasonDecommit = 7;
     }
 
     // Regenerate configuration so the slain VDisk is no more reported as DESTROY one in the list.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Improve distconf compatibility with BSC

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

NodeWarden's distconf now handles PDisk statuses and space as BSC does -- it cares about PDisk status, decommission, usage after replication and so on.

#4157 