### PR TITLE
Added test ShouldNotFailOnMetricWithoutSensorLabel for prometheus encoder

### DIFF
--- a/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
+++ b/library/cpp/monlib/encode/prometheus/prometheus_encoder_ut.cpp
@@ -494,4 +494,22 @@ _99_9 99.9
 
 )");
     }
+
+    Y_UNIT_TEST(ShouldNotFailOnMetricWithoutSensorLabel) {
+        auto result = EncodeToString([](IMetricEncoder* e) {
+            e->OnStreamBegin();
+            e->OnStreamEnd();
+            {
+                e->OnMetricBegin(EMetricType::GAUGE);
+                {
+                    e->OnLabelsBegin();
+                    e->OnLabel("name", "cpuUsage");
+                    e->OnLabelsEnd();
+                }
+                e->OnInt64(TInstant::Zero(), 0);
+                e->OnMetricEnd();
+            }
+        });
+        UNIT_ASSERT_STRINGS_EQUAL(result, "\n");
+    }
 }


### PR DESCRIPTION
There was a bug with metrics without "sensor" label in prometheus format. This bug was fixed [here](https://github.com/ydb-platform/ydb/commit/d7c2d188d2464ce858465870a39220c4dfbb5509), but no tests were provided. This PR adds test for this case