### PR TITLE
[YQL-18107] Use Uint32 instead of String as parent argument when expanding CalcOverWindow

### DIFF
--- a/ydb/library/yql/core/yql_opt_window.cpp
+++ b/ydb/library/yql/core/yql_opt_window.cpp
@@ -44,13 +44,13 @@ EFrameBoundsType FrameBoundsType(const TWindowFrameSettings& settings) {
     return EFrameBoundsType::GENERIC;
 }
 
-TExprNode::TPtr ReplaceLastLambdaArgWithStringLiteral(const TExprNode& lambda, TStringBuf literal, TExprContext& ctx) {
+TExprNode::TPtr ReplaceLastLambdaArgWithUnsignedLiteral(const TExprNode& lambda, ui32 literal, TExprContext& ctx) {
     YQL_ENSURE(lambda.IsLambda());
     TExprNodeList args = lambda.ChildPtr(0)->ChildrenList();
     YQL_ENSURE(!args.empty());
 
     auto literalNode = ctx.Builder(lambda.Pos())
-        .Callable("String")
+        .Callable("Uint32")
             .Atom(0, literal)
         .Seal()
         .Build();
@@ -220,11 +220,11 @@ TCalcOverWindowTraits ExtractCalcOverWindowTraits(const TExprNode::TPtr& frames,
                 YQL_ENSURE(rawTraits.OutputType);
 
                 if (initLambda->Child(0)->ChildrenSize() == 2) {
-                    initLambda = ReplaceLastLambdaArgWithStringLiteral(*initLambda, name, ctx);
+                    initLambda = ReplaceLastLambdaArgWithUnsignedLiteral(*initLambda, i, ctx);
                 }
 
                 if (updateLambda->Child(0)->ChildrenSize() == 3) {
-                    updateLambda = ReplaceLastLambdaArgWithStringLiteral(*updateLambda, name, ctx);
+                    updateLambda = ReplaceLastLambdaArgWithUnsignedLiteral(*updateLambda, i, ctx);
                 }
 
                 auto lambdaInputType = traits->Child(0)->GetTypeAnn()->Cast<TTypeExprType>()->GetType();
@@ -1752,7 +1752,7 @@ TExprNode::TPtr BuildFold1Lambda(TPositionHandle pos, const TExprNode::TPtr& fra
                 case EFold1LambdaKind::INIT: {
                     auto lambda = traits->ChildPtr(1);
                     if (lambda->Child(0)->ChildrenSize() == 2) {
-                        lambda = ReplaceLastLambdaArgWithStringLiteral(*lambda, column->Content(), ctx);
+                        lambda = ReplaceLastLambdaArgWithUnsignedLiteral(*lambda, i, ctx);
                     }
                     lambda = ReplaceFirstLambdaArgWithCastStruct(*lambda, *rowInputType, ctx);
                     YQL_ENSURE(lambda->Child(0)->ChildrenSize() == 1);
@@ -1781,7 +1781,7 @@ TExprNode::TPtr BuildFold1Lambda(TPositionHandle pos, const TExprNode::TPtr& fra
                 case EFold1LambdaKind::UPDATE: {
                     auto lambda = traits->ChildPtr(2);
                     if (lambda->Child(0)->ChildrenSize() == 3) {
-                        lambda = ReplaceLastLambdaArgWithStringLiteral(*lambda, column->Content(), ctx);
+                        lambda = ReplaceLastLambdaArgWithUnsignedLiteral(*lambda, i, ctx);
                     }
                     lambda = ReplaceFirstLambdaArgWithCastStruct(*lambda, *rowInputType, ctx);
                     YQL_ENSURE(lambda->Child(0)->ChildrenSize() == 2);

--- a/ydb/library/yql/tests/sql/dq_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part0/canondata/result.json
@@ -3277,9 +3277,9 @@
     ],
     "test.test[window-generic/aggregations_mixed--Debug]": [
         {
-            "checksum": "2ada042808b40662c30bf5a81533d767",
-            "size": 7148,
-            "uri": "https://{canondata_backend}/1130705/7dd3fbb351b6ea2ab8b0736da59f105c9241fd78/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
+            "checksum": "169df498bbe6b4e4b64329ef9b901d75",
+            "size": 7085,
+            "uri": "https://{canondata_backend}/1899731/f6b32a6820fc036afae21f367915e7bc82284241/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part1/canondata/result.json
@@ -2955,9 +2955,9 @@
     ],
     "test.test[window-full/aggregations_compact--Debug]": [
         {
-            "checksum": "4925bc8a5c7697739344681d43f8e862",
-            "size": 6987,
-            "uri": "https://{canondata_backend}/1903280/fbbb08f81e8431c873a84474187acbd073ef4018/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql_patched"
+            "checksum": "53d6f835b112408cb7acc8bc0925b49e",
+            "size": 6966,
+            "uri": "https://{canondata_backend}/1600758/7854653343bd5226d6b3f3f5fa085f0193656cc7/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations_compact--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part13/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part13/canondata/result.json
@@ -2865,9 +2865,9 @@
     ],
     "test.test[window-generic/aggregations_include_current--Debug]": [
         {
-            "checksum": "4028a957d9ddc8b7b15b0de620e2e285",
-            "size": 6877,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql_patched"
+            "checksum": "87036b041313965aa36dbce6f83cbb36",
+            "size": 6856,
+            "uri": "https://{canondata_backend}/1784826/8e073b9fd058f3f074a4656c14602ccbd76303e2/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_include_current--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part14/canondata/result.json
@@ -3225,9 +3225,9 @@
     ],
     "test.test[window-current/aggregations--Debug]": [
         {
-            "checksum": "266c7e01f8a5b66415a9d2904893e9f9",
-            "size": 5938,
-            "uri": "https://{canondata_backend}/1936997/ad7538cf8edf8e81865f7eee42c2de851daf1211/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql_patched"
+            "checksum": "f06585b858ac25c524c5d570e6a4f701",
+            "size": 5917,
+            "uri": "https://{canondata_backend}/1871102/0805bf7d763724d22f5600786ba3f36973f091d1/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
@@ -2819,9 +2819,9 @@
     ],
     "test.test[window-lagging/aggregations--Debug]": [
         {
-            "checksum": "4669056e08b2ee4de4de8f0522ddc9d8",
-            "size": 6877,
-            "uri": "https://{canondata_backend}/1809005/6204dd19a10bd9bc701faf558e7ce789c91e22ff/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
+            "checksum": "95e16205ec7497823b1b1d1d2da30526",
+            "size": 6856,
+            "uri": "https://{canondata_backend}/1942100/21c6f8d5c7c9cfa7b2c6a47838f9bacb4f38bb5a/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-lagging/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part19/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part19/canondata/result.json
@@ -2979,9 +2979,9 @@
     ],
     "test.test[window-full/aggregations--Debug]": [
         {
-            "checksum": "4925bc8a5c7697739344681d43f8e862",
-            "size": 6987,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql_patched"
+            "checksum": "53d6f835b112408cb7acc8bc0925b49e",
+            "size": 6966,
+            "uri": "https://{canondata_backend}/1784826/61f7d79c6b081f267865b1f3c0c8b51fcae1ebaa/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part3/canondata/result.json
@@ -2578,9 +2578,9 @@
     ],
     "test.test[window-generic/aggregations_before_current--Debug]": [
         {
-            "checksum": "7cbd7e87b710e5169c98f1ed5cedd003",
-            "size": 7259,
-            "uri": "https://{canondata_backend}/1809005/b5fd98a03b02a29344a248fc7017d3e834d02658/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
+            "checksum": "7c7d30f41f9eebf6bb05c901fd5b8dbf",
+            "size": 7196,
+            "uri": "https://{canondata_backend}/1937429/231d22d843eec78552d52ff0253bfa29e1a7a389/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Plan]": [
@@ -2600,9 +2600,9 @@
     ],
     "test.test[window-win_by_all_aggregate--Debug]": [
         {
-            "checksum": "86ba757e3c824f86e237a974a88e3a7c",
-            "size": 13944,
-            "uri": "https://{canondata_backend}/1937424/4b576a9145599276a930fecbf8d3c34578bbcfd5/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql_patched"
+            "checksum": "9231fe25dddc56f449276305484756c6",
+            "size": 13920,
+            "uri": "https://{canondata_backend}/1937429/231d22d843eec78552d52ff0253bfa29e1a7a389/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_by_all_aggregate--Plan]": [
@@ -2625,9 +2625,9 @@
     ],
     "test.test[window-win_func_aggr_hist--Debug]": [
         {
-            "checksum": "30be7c33f2602edf122fc9cc0dfa4441",
-            "size": 4906,
-            "uri": "https://{canondata_backend}/1871002/aabb588bc49c7d9d5fb52f9cabf8713d4f524b1a/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql_patched"
+            "checksum": "d2757ff2400ff565d0abf142a4ccf31b",
+            "size": 4897,
+            "uri": "https://{canondata_backend}/1937429/231d22d843eec78552d52ff0253bfa29e1a7a389/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_hist--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
@@ -2934,9 +2934,9 @@
     ],
     "test.test[window-generic/aggregations_after_current--Debug]": [
         {
-            "checksum": "2e87e119d176d86d6373aee6b8515655",
-            "size": 7289,
-            "uri": "https://{canondata_backend}/1903280/0db3cff29ce26bdeebe43f7c9bad950e873a4e5d/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
+            "checksum": "0ee7d239db02fedf480a0e8ed9cbea89",
+            "size": 7226,
+            "uri": "https://{canondata_backend}/1937492/fae2471f79672290055b05939c32d42b13b0819b/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
@@ -2693,9 +2693,9 @@
     ],
     "test.test[window-leading/aggregations--Debug]": [
         {
-            "checksum": "b670f43793c5318798cea8ad71b021dc",
-            "size": 6573,
-            "uri": "https://{canondata_backend}/1031349/5f7489d93f6bde373961f8e2806cc32a017775d5/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql_patched"
+            "checksum": "d71c4aeafd83656c3a75ff6529864d28",
+            "size": 6552,
+            "uri": "https://{canondata_backend}/1925821/779282f32823aab27221fa8bf110b57ff2bbac48/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-leading/aggregations--Plan]": [
@@ -2737,9 +2737,9 @@
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Debug]": [
         {
-            "checksum": "ab06224700c9b1f9eb565ee4850da2a0",
-            "size": 4859,
-            "uri": "https://{canondata_backend}/1937367/1710911e4cee83432c347ca77fc35e2630f78589/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql_patched"
+            "checksum": "76f07a6656818d7f63019d9927c015d8",
+            "size": 4835,
+            "uri": "https://{canondata_backend}/1925821/779282f32823aab27221fa8bf110b57ff2bbac48/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Plan]": [
@@ -2759,9 +2759,9 @@
     ],
     "test.test[window-win_func_aggr_stat--Debug]": [
         {
-            "checksum": "2732312c6785e5ac50f5239db3f131b7",
-            "size": 5342,
-            "uri": "https://{canondata_backend}/1937367/1710911e4cee83432c347ca77fc35e2630f78589/resource.tar.gz#test.test_window-win_func_aggr_stat--Debug_/opt.yql_patched"
+            "checksum": "4f0608dd70263cc0975f256293c8e53d",
+            "size": 5339,
+            "uri": "https://{canondata_backend}/1925821/779282f32823aab27221fa8bf110b57ff2bbac48/resource.tar.gz#test.test_window-win_func_aggr_stat--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_stat--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
@@ -2703,9 +2703,9 @@
     ],
     "test.test[window-generic/aggregations_include_current--Debug]": [
         {
-            "checksum": "4b37dd72f64251f713535fb0d6bfbc78",
-            "size": 9827,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql_patched"
+            "checksum": "5a8cc6011960be64103039bd861d120b",
+            "size": 9806,
+            "uri": "https://{canondata_backend}/1784826/4c0fb703e2bf3d3d6d2977ee2244bf93048cb406/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_include_current--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part1/canondata/result.json
@@ -2759,9 +2759,9 @@
     ],
     "test.test[window-win_func_aggr_hist--Debug]": [
         {
-            "checksum": "a81978034a7b992a70e32cdbcabb4bcf",
-            "size": 7054,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql_patched"
+            "checksum": "1a2bb37dbe4b16d14e12091db01fc124",
+            "size": 7045,
+            "uri": "https://{canondata_backend}/1942100/9e10c600658243ef9def34925559150fea4464d5/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_hist--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
@@ -2829,9 +2829,9 @@
     ],
     "test.test[window-full/aggregations_compact--Debug]": [
         {
-            "checksum": "ce8ded7391319f5dc7eb86f093c55f0a",
-            "size": 10272,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql_patched"
+            "checksum": "5473c9a93c87bae38640db12aa1c9e8e",
+            "size": 10251,
+            "uri": "https://{canondata_backend}/1942100/36e8856aeb3dbe102564ba7b01b14e3652fde5e6/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations_compact--Plan]": [
@@ -2857,9 +2857,9 @@
     ],
     "test.test[window-generic/aggregations_before_current--Debug]": [
         {
-            "checksum": "4bfd019fb1d671c86da631ff609aff99",
-            "size": 10193,
-            "uri": "https://{canondata_backend}/1809005/167e3294ea975973acc802f0e59d7cdec616be73/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
+            "checksum": "0955cf75a6fd4616d77f89f4557d9e77",
+            "size": 10130,
+            "uri": "https://{canondata_backend}/1942100/36e8856aeb3dbe102564ba7b01b14e3652fde5e6/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part3/canondata/result.json
@@ -2941,9 +2941,9 @@
     ],
     "test.test[window-current/aggregations--Debug]": [
         {
-            "checksum": "d97b11edecc4b5944bdee6ecbc41c779",
-            "size": 8259,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql_patched"
+            "checksum": "6e189705e1167aa1b365aadbb19a2569",
+            "size": 8238,
+            "uri": "https://{canondata_backend}/1937492/e4d5d6d9d9cf16ad53e6ec723a0d4a250eae8aba/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/aggregations--Plan]": [
@@ -2983,9 +2983,9 @@
     ],
     "test.test[window-full/aggregations--Debug]": [
         {
-            "checksum": "e2cc652d339b072e3bc2a36ca66ad5a7",
-            "size": 14843,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql_patched"
+            "checksum": "16f6034109a60c1941399c887a9098db",
+            "size": 14814,
+            "uri": "https://{canondata_backend}/1937492/e4d5d6d9d9cf16ad53e6ec723a0d4a250eae8aba/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations--Plan]": [
@@ -3025,9 +3025,9 @@
     ],
     "test.test[window-lagging/aggregations--Debug]": [
         {
-            "checksum": "063d5215f0e7ce5d3485a562b7bc6238",
-            "size": 9870,
-            "uri": "https://{canondata_backend}/1809005/22c7ffc44e1102967f4f7c31c632ffbfff73cc8b/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
+            "checksum": "e2b6f8dfcdc4afaee95e52403b04d702",
+            "size": 9849,
+            "uri": "https://{canondata_backend}/1937492/e4d5d6d9d9cf16ad53e6ec723a0d4a250eae8aba/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-lagging/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
@@ -3053,9 +3053,9 @@
     ],
     "test.test[window-win_by_all_aggregate--Debug]": [
         {
-            "checksum": "fa45176f4496bbfa2b347e3cef825bf7",
-            "size": 19222,
-            "uri": "https://{canondata_backend}/1936273/6e54ce804e8cd2c402491df96af4023e63f193e5/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql_patched"
+            "checksum": "2c4c5ff9dad34caf6978fb4ccb350351",
+            "size": 19198,
+            "uri": "https://{canondata_backend}/1809005/161342601473b76623944595105e92912ad1b3f6/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_by_all_aggregate--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part6/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part6/canondata/result.json
@@ -2787,9 +2787,9 @@
     ],
     "test.test[window-generic/aggregations_mixed--Debug]": [
         {
-            "checksum": "f5951f102d1f4381610626850c176211",
-            "size": 10077,
-            "uri": "https://{canondata_backend}/1809005/c9bc99b44b553875f5ce672618fc5c945a3c5f00/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
+            "checksum": "d758a8d1b0c0268fb908997077961da5",
+            "size": 10014,
+            "uri": "https://{canondata_backend}/1937424/1f3cd125c2d8eafb2ebb1dbc7c974f4f15ef1793/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Plan]": [
@@ -2913,9 +2913,9 @@
     ],
     "test.test[window-win_func_aggr_stat--Debug]": [
         {
-            "checksum": "da10f1b6ece5fcd1662c76edd9028a6d",
-            "size": 5368,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_window-win_func_aggr_stat--Debug_/opt.yql_patched"
+            "checksum": "5f158431d4843d8682e21e006ef93726",
+            "size": 5365,
+            "uri": "https://{canondata_backend}/1937424/1f3cd125c2d8eafb2ebb1dbc7c974f4f15ef1793/resource.tar.gz#test.test_window-win_func_aggr_stat--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_stat--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
@@ -2885,9 +2885,9 @@
     ],
     "test.test[window-leading/aggregations--Debug]": [
         {
-            "checksum": "4ea7b444816589f0099d358768591232",
-            "size": 9511,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql_patched"
+            "checksum": "e8bc7b34260eea19ef0006c340d74822",
+            "size": 9490,
+            "uri": "https://{canondata_backend}/1871102/a033a2e45d429b96c8bce2a68eaeafcfa8c8874a/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-leading/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
@@ -2927,9 +2927,9 @@
     ],
     "test.test[window-generic/aggregations_after_current--Debug]": [
         {
-            "checksum": "656f147844ed85b377a34e23e45249ed",
-            "size": 10225,
-            "uri": "https://{canondata_backend}/1917492/092f6b955a43bed7a63b100561946af917330bfe/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
+            "checksum": "f6ab86e0b8ef924335420010ec1370a9",
+            "size": 10162,
+            "uri": "https://{canondata_backend}/1937424/f451f285fc7754f944209343662da0cffa8b8855/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Plan]": [
@@ -2969,9 +2969,9 @@
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Debug]": [
         {
-            "checksum": "aec46d4cf6b1d432d2d65588e143daf5",
-            "size": 6376,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e7556d1abd0367a43c1cec9a3e9e522a",
+            "size": 6352,
+            "uri": "https://{canondata_backend}/1937424/f451f285fc7754f944209343662da0cffa8b8855/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part0/canondata/result.json
@@ -3024,9 +3024,9 @@
     ],
     "test.test[window-generic/aggregations_mixed--Debug]": [
         {
-            "checksum": "60b58b17ed05f21cc4397cc29e9421a6",
-            "size": 7929,
-            "uri": "https://{canondata_backend}/1903280/c2a22324352d4d4e89ea745ef44bf9dafd733cae/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql"
+            "checksum": "573da3249d3a6c1e06c0cafc73bd0043",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1600758/500a0886ac36f1c322115c6419eca13ceabdc8e7/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part1/canondata/result.json
@@ -2862,9 +2862,9 @@
     ],
     "test.test[window-full/aggregations_compact--Debug]": [
         {
-            "checksum": "a42688d13dbcae7d6f20803fdff72d52",
-            "size": 8821,
-            "uri": "https://{canondata_backend}/1937001/6359973ccbec6a57e3a04fc33c488277266b7260/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql"
+            "checksum": "1c0e342712e1c99cfcec58f1fb45a1d9",
+            "size": 8800,
+            "uri": "https://{canondata_backend}/1784826/bc8219a2be29dbaa9a569eb878ef2b778f3ec45e/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql"
         }
     ],
     "test.test[window-full/aggregations_compact--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part13/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part13/canondata/result.json
@@ -2948,9 +2948,9 @@
     ],
     "test.test[window-generic/aggregations_include_current--Debug]": [
         {
-            "checksum": "cdb379743a6ec19b8d0c36a7d3bd18ff",
-            "size": 7671,
-            "uri": "https://{canondata_backend}/212715/e1bc1d6e31fa656365a738e65224a7c3f774bae6/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql"
+            "checksum": "892e26870fdb7e94569a8bd06680ed32",
+            "size": 7650,
+            "uri": "https://{canondata_backend}/1937492/a4223cc548d64bfe5a203c2b71515d747fa1d0ad/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql"
         }
     ],
     "test.test[window-generic/aggregations_include_current--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
@@ -3225,9 +3225,9 @@
     ],
     "test.test[window-current/aggregations--Debug]": [
         {
-            "checksum": "c0b6bcc3dfb8510cd563f862c76d728c",
-            "size": 6699,
-            "uri": "https://{canondata_backend}/1923547/5154c8bd8ef9ead4f609771f831f20c15e795571/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql"
+            "checksum": "b441d664123fec09f1d1b93ab2db3215",
+            "size": 6678,
+            "uri": "https://{canondata_backend}/1600758/124eb8d3af11e618d8bba452b8c261c7bc46a995/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql"
         }
     ],
     "test.test[window-current/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
@@ -2566,9 +2566,9 @@
     ],
     "test.test[window-lagging/aggregations--Debug]": [
         {
-            "checksum": "48837e7d6d5276a26e6ddc3addc5bb81",
-            "size": 7697,
-            "uri": "https://{canondata_backend}/1936842/30423aebff9a8c6c1dfc3d72e65f214bcff8b187/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql"
+            "checksum": "4b6090dd9201a39cb457d6853da485cc",
+            "size": 7676,
+            "uri": "https://{canondata_backend}/1937001/efcc02bbc8c406f4a7dc5bab3dca2ebb55693503/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql"
         }
     ],
     "test.test[window-lagging/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part19/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part19/canondata/result.json
@@ -2749,9 +2749,9 @@
     ],
     "test.test[window-full/aggregations--Debug]": [
         {
-            "checksum": "4c99b9316d2284cab9b0896d0e719c65",
-            "size": 13378,
-            "uri": "https://{canondata_backend}/1937027/16b7289b1b8f5fdff728155d836fa2b238949b2d/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql"
+            "checksum": "fcde0c94836636a5cb185b8611c37e53",
+            "size": 13349,
+            "uri": "https://{canondata_backend}/1942100/2524349255edb5c489ab767b75bb9ce336462cb0/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql"
         }
     ],
     "test.test[window-full/aggregations--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part3/canondata/result.json
@@ -2252,9 +2252,9 @@
     ],
     "test.test[window-generic/aggregations_before_current--Debug]": [
         {
-            "checksum": "8086a1538a933fb82ccdce952a37aa76",
-            "size": 8039,
-            "uri": "https://{canondata_backend}/1130705/ee873772203fa2f395415da04bb9a38d3134ebce/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql"
+            "checksum": "a8d039fe45e2805d5dd81c942eac92dc",
+            "size": 7976,
+            "uri": "https://{canondata_backend}/1925821/672fbaa48e06fb78fce541aba3538972639a2fee/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Plan]": [
@@ -2273,9 +2273,9 @@
     ],
     "test.test[window-win_by_all_aggregate--Debug]": [
         {
-            "checksum": "84d38f2b677f7fa24d83c50331a047f4",
-            "size": 18568,
-            "uri": "https://{canondata_backend}/995452/35abb66f666bf41a823389bdf82567c79ab85a27/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql"
+            "checksum": "932dcf43bba1c9cacba3f86add769b2d",
+            "size": 18544,
+            "uri": "https://{canondata_backend}/1925821/672fbaa48e06fb78fce541aba3538972639a2fee/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql"
         }
     ],
     "test.test[window-win_by_all_aggregate--Plan]": [
@@ -2294,9 +2294,9 @@
     ],
     "test.test[window-win_func_aggr_hist--Debug]": [
         {
-            "checksum": "e854f73d11d9baa824d5c332dc4632b9",
-            "size": 5516,
-            "uri": "https://{canondata_backend}/1871002/862ae8c3c07a5f792e98576ee564d5bcf74129e0/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql"
+            "checksum": "7c0b5cf7c4a0312a9214651d55b73712",
+            "size": 5507,
+            "uri": "https://{canondata_backend}/1925821/672fbaa48e06fb78fce541aba3538972639a2fee/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql"
         }
     ],
     "test.test[window-win_func_aggr_hist--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
@@ -2874,9 +2874,9 @@
     ],
     "test.test[window-generic/aggregations_after_current--Debug]": [
         {
-            "checksum": "81fa0dc8b4905b16ab3b7364f1ef6c02",
-            "size": 8069,
-            "uri": "https://{canondata_backend}/1903280/ee02a69be166901aba8ebd6aa56b953cbf51137e/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql"
+            "checksum": "83132433df3a5871de23b4f9e50f241e",
+            "size": 8006,
+            "uri": "https://{canondata_backend}/1600758/f6065730c1ed13becdfc97fae9b0fa4021a2cffb/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part9/canondata/result.json
@@ -2685,9 +2685,9 @@
     ],
     "test.test[window-leading/aggregations--Debug]": [
         {
-            "checksum": "b927edc1cfaadc124d14fd54aaeb63f5",
-            "size": 7370,
-            "uri": "https://{canondata_backend}/1923547/3632e3870cc25d80ec68458d3729f32c8b6c30f3/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql"
+            "checksum": "db720bf9ce80d44e6c9ab71acd8acc35",
+            "size": 7349,
+            "uri": "https://{canondata_backend}/1600758/1bdefc776c09f01689112d86cd62eb2708c2f27f/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql"
         }
     ],
     "test.test[window-leading/aggregations--Plan]": [
@@ -2727,9 +2727,9 @@
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Debug]": [
         {
-            "checksum": "1da7970269498a0e3200abfff73a8282",
-            "size": 5717,
-            "uri": "https://{canondata_backend}/937458/c1365f21ada77805f3ca6623e256eeadb801d609/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql"
+            "checksum": "7358664e60d9b60d828f34edfc7eaeab",
+            "size": 5693,
+            "uri": "https://{canondata_backend}/1600758/1bdefc776c09f01689112d86cd62eb2708c2f27f/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Plan]": [
@@ -2748,9 +2748,9 @@
     ],
     "test.test[window-win_func_aggr_stat--Debug]": [
         {
-            "checksum": "ef887047ea7823dd779c4074c90c5c0c",
-            "size": 5298,
-            "uri": "https://{canondata_backend}/937458/c1365f21ada77805f3ca6623e256eeadb801d609/resource.tar.gz#test.test_window-win_func_aggr_stat--Debug_/opt.yql"
+            "checksum": "272bc6ff31e2f1dbde7bc39b378a4fea",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1600758/1bdefc776c09f01689112d86cd62eb2708c2f27f/resource.tar.gz#test.test_window-win_func_aggr_stat--Debug_/opt.yql"
         }
     ],
     "test.test[window-win_func_aggr_stat--Plan]": [


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-18107] Use Uint32 instead of String as parent argument when expanding CalcOverWindow

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
