### PR TITLE
[YQL-18313] Mark Datetime::Split as strict

### DIFF
--- a/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
@@ -2625,23 +2625,23 @@
     ],
     "test.test[tpch-q4-default.txt-Analyze]": [
         {
-            "checksum": "b962d5d2abe669d56e6cccf9fb62a577",
-            "size": 8267,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_tpch-q4-default.txt-Analyze_/plan.txt"
+            "checksum": "01fb8e3fe69ac9f79beaf7ba06fcd1bc",
+            "size": 8160,
+            "uri": "https://{canondata_backend}/1871182/a09ccd00a4b0358de052d958e9948bdc99497247/resource.tar.gz#test.test_tpch-q4-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[tpch-q4-default.txt-Debug]": [
         {
-            "checksum": "81e4a64ede6832944ff249ac3d6b261c",
-            "size": 6559,
-            "uri": "https://{canondata_backend}/1937429/7495c8355df97f85fa824cc601aaf3eb891c07d7/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2655791444f7c9a6a874b3770b0acbef",
+            "size": 6541,
+            "uri": "https://{canondata_backend}/1784117/27b0e0d4174a9b20aa647497437aba160563b297/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q4-default.txt-Plan]": [
         {
-            "checksum": "b962d5d2abe669d56e6cccf9fb62a577",
-            "size": 8267,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
+            "checksum": "01fb8e3fe69ac9f79beaf7ba06fcd1bc",
+            "size": 8160,
+            "uri": "https://{canondata_backend}/1871182/a09ccd00a4b0358de052d958e9948bdc99497247/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q4-default.txt-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part14/canondata/result.json
@@ -3086,9 +3086,9 @@
     ],
     "test.test[tpch-q9-default.txt-Debug]": [
         {
-            "checksum": "71ec838e72e8a8f7bfc54b04831a6d0a",
-            "size": 15066,
-            "uri": "https://{canondata_backend}/1880306/b8a146dff266e2b5388e4e9ae22aa20c1b4fbc64/resource.tar.gz#test.test_tpch-q9-default.txt-Debug_/opt.yql_patched"
+            "checksum": "dcef1f89ee98c3949b45ce9b37702f84",
+            "size": 15089,
+            "uri": "https://{canondata_backend}/1777230/62026d5ecd221a8c0ee8ca8a9643da3b542aaa43/resource.tar.gz#test.test_tpch-q9-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q9-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
@@ -2599,9 +2599,9 @@
     ],
     "test.test[tpch-q7-default.txt-Debug]": [
         {
-            "checksum": "2522ab12a4fdfad723cdcb8fc750dcdb",
-            "size": 13798,
-            "uri": "https://{canondata_backend}/1031349/d6f6fbd690e2387ef546b9d231ad34955cbea3f2/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9c36bb62ddc989500e6162b12b2b83ee",
+            "size": 13820,
+            "uri": "https://{canondata_backend}/1880306/881d1135ff5eb1be4e84ddd070874584645717ea/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q7-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part7/canondata/result.json
@@ -728,9 +728,9 @@
     ],
     "test.test[expr-common_type_for_resource_and_data--Debug]": [
         {
-            "checksum": "621cfd72f53a2bb03550905efb031c3a",
-            "size": 3493,
-            "uri": "https://{canondata_backend}/1923547/4a11bf336fd7fb8da5f5162c16271b830cef13e4/resource.tar.gz#test.test_expr-common_type_for_resource_and_data--Debug_/opt.yql_patched"
+            "checksum": "ae28d0bdc3d0a59f3e99d005f955d630",
+            "size": 3492,
+            "uri": "https://{canondata_backend}/1689644/6139df48f06d115a1d5f163e031f1e5df6703b0a/resource.tar.gz#test.test_expr-common_type_for_resource_and_data--Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-common_type_for_resource_and_data--Plan]": [
@@ -2737,9 +2737,9 @@
     ],
     "test.test[tpch-q8-default.txt-Debug]": [
         {
-            "checksum": "49ea4cdff7dfb5e4c591a323519d1c0a",
-            "size": 19209,
-            "uri": "https://{canondata_backend}/212715/a575a87b0ddb5b480fdcb6e3622436bf4a82b2a1/resource.tar.gz#test.test_tpch-q8-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cb22c1327ff91d9fa3cbd94b5842487c",
+            "size": 19230,
+            "uri": "https://{canondata_backend}/1689644/6139df48f06d115a1d5f163e031f1e5df6703b0a/resource.tar.gz#test.test_tpch-q8-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q8-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/dq_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part8/canondata/result.json
@@ -986,9 +986,9 @@
     ],
     "test.test[expr-current_tz-default.txt-Debug]": [
         {
-            "checksum": "ab423d4b7b8608e6e7c15a5f2b7a4446",
-            "size": 1565,
-            "uri": "https://{canondata_backend}/1777230/65685e9d54d416f54450defb84f83fe3b04456b0/resource.tar.gz#test.test_expr-current_tz-default.txt-Debug_/opt.yql_patched"
+            "checksum": "853bd1a6551bf7536d82724783e1a544",
+            "size": 1564,
+            "uri": "https://{canondata_backend}/1814674/3d7a051907f912bc7d3b372a45188178d665b7e0/resource.tar.gz#test.test_expr-current_tz-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-current_tz-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
@@ -2661,23 +2661,23 @@
     ],
     "test.test[tpch-q4-default.txt-Debug]": [
         {
-            "checksum": "90a7018bdd6d770a9781ec161be046bb",
-            "size": 10300,
-            "uri": "https://{canondata_backend}/1871102/bc396b8b31a3dc31af3e0918ca66137d03d31eff/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql_patched"
+            "checksum": "33c1896a2d354cc13ecaa0b73421a590",
+            "size": 8923,
+            "uri": "https://{canondata_backend}/1814674/3093cfcf161964e2f455dca1526460f8a4e7c86f/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q4-default.txt-Plan]": [
         {
-            "checksum": "1f1b0638c20d6377a790a877b95bf14b",
-            "size": 13752,
-            "uri": "https://{canondata_backend}/937458/aa1a4b224077b60e774dc643908515e34d2c28f0/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
+            "checksum": "175db821e1c9a7d0ee266641845a4fed",
+            "size": 14458,
+            "uri": "https://{canondata_backend}/1924537/c7ea2c3fd8e76be397eb059191897d8d01921d1b/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q7-default.txt-Debug]": [
         {
-            "checksum": "263ad70ab99b756def47e7e7778ee37b",
-            "size": 11201,
-            "uri": "https://{canondata_backend}/1900335/a4b30703d82869b503efc599b7c6522b6354bba8/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql_patched"
+            "checksum": "184514dc0f1a53d2d2376ea0c748452d",
+            "size": 11224,
+            "uri": "https://{canondata_backend}/1814674/3093cfcf161964e2f455dca1526460f8a4e7c86f/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q7-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
@@ -799,9 +799,9 @@
     ],
     "test.test[expr-common_type_for_resource_and_data--Debug]": [
         {
-            "checksum": "745e96dd764a7a228243c315c0ba7e43",
-            "size": 3492,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_expr-common_type_for_resource_and_data--Debug_/opt.yql_patched"
+            "checksum": "0d33cc2cb1690eb76e4208ae8e76c67e",
+            "size": 3491,
+            "uri": "https://{canondata_backend}/1880306/db875f28b03398c9661cb0ec816d8867491e05bb/resource.tar.gz#test.test_expr-common_type_for_resource_and_data--Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-common_type_for_resource_and_data--Plan]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
@@ -827,9 +827,9 @@
     ],
     "test.test[expr-current_tz-default.txt-Debug]": [
         {
-            "checksum": "7cd84f946d106461f341b3a2b2de651b",
-            "size": 1564,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_expr-current_tz-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f8c167a977f4d87b2d1bf706734360f8",
+            "size": 1563,
+            "uri": "https://{canondata_backend}/1775059/9aa23ed5d89caacd583c9faefbbfe392cd1d2400/resource.tar.gz#test.test_expr-current_tz-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-current_tz-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part11/canondata/result.json
@@ -2427,16 +2427,16 @@
     ],
     "test.test[tpch-q4-default.txt-Debug]": [
         {
-            "checksum": "319ab15435d9dcbe44a63956c5e35ea4",
-            "size": 9051,
-            "uri": "https://{canondata_backend}/1942671/7de43a7dcd1136eca8bf18eadbdb9e231f419930/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql"
+            "checksum": "3295e6c879460d6ad76cf82cb29d9482",
+            "size": 7184,
+            "uri": "https://{canondata_backend}/1946324/2cca85e5512989175de09b194ca5677703bb5f58/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[tpch-q4-default.txt-Plan]": [
         {
-            "checksum": "1a4130794d41ab428098473197afe179",
-            "size": 11743,
-            "uri": "https://{canondata_backend}/1781765/ca9cefdd5b52568a3d5b738bc7c1db7fb1f980f7/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
+            "checksum": "8103b975b300856c1f82ad4d7d6922b2",
+            "size": 10766,
+            "uri": "https://{canondata_backend}/1937492/b744d6f3912eb74174def20236041c041b427578/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q4-default.txt-Results]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
@@ -3096,9 +3096,9 @@
     ],
     "test.test[tpch-q9-default.txt-Debug]": [
         {
-            "checksum": "8b46ce7da9ce6e6ee5b086f5d3c4bf46",
-            "size": 7516,
-            "uri": "https://{canondata_backend}/1916746/fe05732d8ed5a83c1e03dfdae75a14800532b3c8/resource.tar.gz#test.test_tpch-q9-default.txt-Debug_/opt.yql"
+            "checksum": "4f83a605b756aaf89456d50d40027371",
+            "size": 7534,
+            "uri": "https://{canondata_backend}/1937027/6c834c972d54c58984c0a4a09aed91affd1690cb/resource.tar.gz#test.test_tpch-q9-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[tpch-q9-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
@@ -2356,9 +2356,9 @@
     ],
     "test.test[tpch-q7-default.txt-Debug]": [
         {
-            "checksum": "ec0244d721d8c83281f4630324c0aeef",
-            "size": 9640,
-            "uri": "https://{canondata_backend}/1871182/554faa3c0333e8f2068b2828db20a52ef05f3683/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql"
+            "checksum": "b0ff32853874a217585405741267f858",
+            "size": 9663,
+            "uri": "https://{canondata_backend}/1925842/a2196a83e3ed2481dab6fe0d24436490c5acc982/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[tpch-q7-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part7/canondata/result.json
@@ -710,9 +710,9 @@
     ],
     "test.test[expr-common_type_for_resource_and_data--Debug]": [
         {
-            "checksum": "7b153cf52720a891dd615d1388383d42",
-            "size": 3423,
-            "uri": "https://{canondata_backend}/1777230/1eefebeaa3ca9cd9cdd1b5dfe63e67427f585bf2/resource.tar.gz#test.test_expr-common_type_for_resource_and_data--Debug_/opt.yql"
+            "checksum": "653b39d39ce603a7545ca03d507ad1d2",
+            "size": 3422,
+            "uri": "https://{canondata_backend}/1809005/08de6862972d7f4bb4f59f5b43b4d61ce56b96e9/resource.tar.gz#test.test_expr-common_type_for_resource_and_data--Debug_/opt.yql"
         }
     ],
     "test.test[expr-common_type_for_resource_and_data--Plan]": [
@@ -2579,9 +2579,9 @@
     ],
     "test.test[tpch-q8-default.txt-Debug]": [
         {
-            "checksum": "32803c048735b8848ef44afe62ddaa66",
-            "size": 11027,
-            "uri": "https://{canondata_backend}/1936947/4394c236e3847e8adaa61b7fed1ffbe54ba65572/resource.tar.gz#test.test_tpch-q8-default.txt-Debug_/opt.yql"
+            "checksum": "f4840be9999aca6919becac2499c4bb3",
+            "size": 11048,
+            "uri": "https://{canondata_backend}/1809005/08de6862972d7f4bb4f59f5b43b4d61ce56b96e9/resource.tar.gz#test.test_tpch-q8-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[tpch-q8-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part8/canondata/result.json
@@ -1012,9 +1012,9 @@
     ],
     "test.test[expr-current_tz-default.txt-Debug]": [
         {
-            "checksum": "4b16c8c35292499daaf70454b8f451af",
-            "size": 1495,
-            "uri": "https://{canondata_backend}/1942671/767575ccaef141f6020a2d1d51e19c44fe51febe/resource.tar.gz#test.test_expr-current_tz-default.txt-Debug_/opt.yql"
+            "checksum": "2e87d59c99f0504f60e27493f8207643",
+            "size": 1494,
+            "uri": "https://{canondata_backend}/1814674/2a2a4582460758828b95b73d13812d5c87810795/resource.tar.gz#test.test_expr-current_tz-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[expr-current_tz-default.txt-Plan]": [

--- a/ydb/library/yql/udfs/common/datetime2/datetime_udf.cpp
+++ b/ydb/library/yql/udfs/common/datetime2/datetime_udf.cpp
@@ -519,6 +519,7 @@ NUdf::TUnboxedValuePod DoAddYears(const NUdf::TUnboxedValuePod& date, i64 years,
             builder.UserType(userType);
             builder.Args()->Add<TUserDataType>().Flags(ICallablePayload::TArgumentFlags::AutoMap);
             builder.Returns(builder.Resource(TMResourceName));
+            builder.IsStrict();
 
             if (!typesOnly) {
                 builder.Implementation(new TSplit<TUserDataType>(builder.GetSourcePosition()));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-18313] Mark Datetime::Split as strict

### Changelog category <!-- remove all except one -->

* Performance improvement
* Not for changelog (changelog entry is not required)

### Additional information

...
