### PR TITLE
YQL-18327 Disable yellow zone of allocator on 50%. Update yellow zone on free

### DIFF
--- a/ydb/library/yql/minikql/aligned_page_pool.cpp
+++ b/ydb/library/yql/minikql/aligned_page_pool.cpp
@@ -379,6 +379,7 @@ void TAlignedPagePoolImpl<T>::ReturnBlock(void* ptr, size_t size) noexcept {
         Y_DEBUG_ABORT_UNLESS(ActiveBlocks.erase(ptr));
     }
 #endif
+    UpdateMemoryYellowZone();
 }
 
 template<typename T>
@@ -497,6 +498,19 @@ void TAlignedPagePoolImpl<T>::Free(void* ptr, size_t size) noexcept {
     TotalAllocated -= size;
     if (Counters.TotalBytesAllocatedCntr) {
         (*Counters.TotalBytesAllocatedCntr) -= size;
+    }
+}
+
+template<typename T>
+void TAlignedPagePoolImpl<T>::UpdateMemoryYellowZone() {
+    if (IncreaseMemoryLimitCallback) return;
+    if (Limit == 0) return;
+
+    ui8 usedMemoryPercent = 100 * GetUsed() / Limit;
+    if (usedMemoryPercent >= EnableMemoryYellowZoneThreshold) {
+        IsMemoryYellowZoneReached = true;
+    } else if (usedMemoryPercent <= DisableMemoryYellowZoneThreshold) {
+        IsMemoryYellowZoneReached = false;
     }
 }
 

--- a/ydb/library/yql/minikql/aligned_page_pool.h
+++ b/ydb/library/yql/minikql/aligned_page_pool.h
@@ -237,13 +237,7 @@ protected:
         UpdateMemoryYellowZone();
     }
 
-    void UpdateMemoryYellowZone() {
-        if (IncreaseMemoryLimitCallback) return;
-
-        if (Limit != 0) {
-            IsMemoryYellowZoneReached = (100 * GetUsed() / Limit) > MemoryYellowZoneThreshold;
-        }
-    }
+    void UpdateMemoryYellowZone();
 
     bool TryIncreaseLimit(ui64 required);
 
@@ -279,8 +273,10 @@ protected:
     // Indicates when memory limit is almost reached.
     bool IsMemoryYellowZoneReached = false;
     // This theshold is used to determine is memory limit is almost reached.
-    // If TIncreaseMemoryLimitCallback is set this threshold should be ignored.
-    const ui8 MemoryYellowZoneThreshold = 80;
+    // If TIncreaseMemoryLimitCallback is set this thresholds should be ignored.
+    // The yellow zone turns on when memory consumption reaches 80% and turns off when consumption drops below 50%.
+    const ui8 EnableMemoryYellowZoneThreshold = 80;
+    const ui8 DisableMemoryYellowZoneThreshold = 50;
 };
 
 using TAlignedPagePool = TAlignedPagePoolImpl<>;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
- Yellow zone of MKQL allocator turns on when memory consumption reaches 80% and turns off when consumption drops below 50%.
- Update yellow zone flag on memory deallocation
...

### Changelog category <!-- remove all except one -->
* Improvement

### Additional information

...
