### PR TITLE
YQL-18097: add support for non-struct SCHEMA for YT

### DIFF
--- a/ydb/library/yql/sql/v1/sql_into_tables.cpp
+++ b/ydb/library/yql/sql/v1/sql_into_tables.cpp
@@ -141,7 +141,7 @@ TNodePtr TSqlIntoTable::Build(const TRule_into_table_stmt& node) {
     bool withTruncate = false;
     TTableHints tableHints;
     if (tableRef.HasBlock2()) {
-        auto hints = TableHintsImpl(tableRef.GetBlock2().GetRule_table_hints1());
+        auto hints = TableHintsImpl(tableRef.GetBlock2().GetRule_table_hints1(), service);
         if (!hints) {
             Ctx.Error() << "Failed to parse table hints";
             return nullptr;

--- a/ydb/library/yql/sql/v1/sql_translation.cpp
+++ b/ydb/library/yql/sql/v1/sql_translation.cpp
@@ -3101,11 +3101,6 @@ bool TSqlTranslation::TableHintImpl(const TRule_table_hint& rule, TTableHints& h
         TVector<TNodePtr> labels;
         TVector<TNodePtr> structTypeItems;
         if (alt.HasBlock4()) {
-            // if (!isNonSturctSchemaHintAllowed(provider, keyFunc)) {
-            //     Error() << "Expected Struct type after SCHEMA hint";
-            //     return false;
-            // }
-
             bool warn = false;
             auto processItem = [&](const TRule_struct_arg_positional& arg) {
                 // struct_arg_positional:

--- a/ydb/library/yql/sql/v1/sql_translation.h
+++ b/ydb/library/yql/sql/v1/sql_translation.h
@@ -210,8 +210,8 @@ protected:
     TNodePtr ListLiteral(const TRule_list_literal& node);
     TNodePtr DictLiteral(const TRule_dict_literal& node);
     TNodePtr StructLiteral(const TRule_struct_literal& node);
-    TMaybe<TTableHints> TableHintsImpl(const TRule_table_hints& node, const TString& keyFunc = "");
-    bool TableHintImpl(const TRule_table_hint& rule, TTableHints& hints, const TString& keyFunc = "");
+    TMaybe<TTableHints> TableHintsImpl(const TRule_table_hints& node, const TString& provider, const TString& keyFunc = "");
+    bool TableHintImpl(const TRule_table_hint& rule, TTableHints& hints, const TString& provider, const TString& keyFunc = "");
     bool SimpleTableRefImpl(const TRule_simple_table_ref& node, TTableRef& result);
     bool TopicRefImpl(const TRule_topic_ref& node, TTopicRef& result);
     TWindowSpecificationPtr WindowSpecification(const TRule_window_specification_details& rule);

--- a/ydb/library/yql/sql/v1/sql_translation.h
+++ b/ydb/library/yql/sql/v1/sql_translation.h
@@ -210,8 +210,8 @@ protected:
     TNodePtr ListLiteral(const TRule_list_literal& node);
     TNodePtr DictLiteral(const TRule_dict_literal& node);
     TNodePtr StructLiteral(const TRule_struct_literal& node);
-    TMaybe<TTableHints> TableHintsImpl(const TRule_table_hints& node);
-    bool TableHintImpl(const TRule_table_hint& rule, TTableHints& hints);
+    TMaybe<TTableHints> TableHintsImpl(const TRule_table_hints& node, const TString& keyFunc = "");
+    bool TableHintImpl(const TRule_table_hint& rule, TTableHints& hints, const TString& keyFunc = "");
     bool SimpleTableRefImpl(const TRule_simple_table_ref& node, TTableRef& result);
     bool TopicRefImpl(const TRule_topic_ref& node, TTopicRef& result);
     TWindowSpecificationPtr WindowSpecification(const TRule_window_specification_details& rule);

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6693,14 +6693,14 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
     
     Y_UNIT_TEST(YtAlternativeSchemaSyntax) {
         NYql::TAstParseResult res = SqlToYql(R"(
-            SELECT * FROM plato.Input WITH schema(y Int32, x String);
+            SELECT * FROM plato.Input WITH schema(y Int32, x String not null);
         )");
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
 
         TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
             if (word == "userschema") {
                 UNIT_ASSERT_VALUES_UNEQUAL(TString::npos,
-                    line.find(R"__('('('"userschema" (StructType '('"y" (AsOptionalType (DataType 'Int32))) '('"x" (AsOptionalType (DataType 'String)))))))__"));
+                    line.find(R"__('('('"userschema" (StructType '('"y" (AsOptionalType (DataType 'Int32))) '('"x" (DataType 'String))))))__"));
             }
         };
 

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -2522,7 +2522,12 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
     Y_UNIT_TEST(WithSchemaEquals) {
         UNIT_ASSERT(SqlToYql("select * from plato.T with schema Struct<a:Int32, b:String>;").IsOk());
         UNIT_ASSERT(SqlToYql("select * from plato.T with columns = Struct<a:Int32, b:String>;").IsOk());
-        UNIT_ASSERT(SqlToYql("select * from plato.T with (format=csv_with_names, schema=(year Int32, month String, day String, a Utf8, b Uint16));").IsOk());
+    }
+
+    Y_UNIT_TEST(WithNonStructSchemaS3) {
+        NSQLTranslation::TTranslationSettings settings;
+        settings.ClusterMapping["s3bucket"] = NYql::S3ProviderName;
+        UNIT_ASSERT(SqlToYql("select * from s3bucket.`foo` with schema (col1 Int32, String as col2, Int64 as col3);", settings).IsOk());
     }
 
     Y_UNIT_TEST(AllowNestedTuplesInGroupBy) {
@@ -4524,9 +4529,11 @@ select FormatType($f());
     }
 
     Y_UNIT_TEST(WarnForDeprecatedSchema) {
-        NYql::TAstParseResult res = SqlToYql("select * from plato.T with schema (col1 Int32, String as col2, Int64 as col3);");
+        NSQLTranslation::TTranslationSettings settings;
+        settings.ClusterMapping["s3bucket"] = NYql::S3ProviderName;
+        NYql::TAstParseResult res = SqlToYql("select * from s3bucket.`foo` with schema (col1 Int32, String as col2, Int64 as col3);", settings);
         UNIT_ASSERT(res.Root);
-        UNIT_ASSERT_NO_DIFF(Err2Str(res), "<main>:1:48: Warning: Deprecated syntax for positional schema: please use 'column type' instead of 'type AS column', code: 4535\n");
+        UNIT_ASSERT_STRING_CONTAINS(res.Issues.ToString(), "Warning: Deprecated syntax for positional schema: please use 'column type' instead of 'type AS column', code: 4535\n");
     }
 
     Y_UNIT_TEST(ErrorOnColumnNameInMaxByLimit) {

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6708,7 +6708,5 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         VerifyProgram(res, elementStat, verifyLine);
 
         UNIT_ASSERT_VALUES_EQUAL(1, elementStat["userschema"]);
-
-        // UNIT_ASSERT_STRING_CONTAINS(res.Issues.ToString(), "Expected Struct type after SCHEMA hint");
     }
 }

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6683,4 +6683,11 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
+    
+    Y_UNIT_TEST(DisallowNonStructSchema) {
+        NYql::TAstParseResult res = SqlToYql(R"(
+            SELECT * FROM plato.Input WITH schema(a String);
+        )");
+        UNIT_ASSERT_STRING_CONTAINS(res.Issues.ToString(), "Expected Struct type after SCHEMA hint");
+    }
 }

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6693,14 +6693,14 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
     
     Y_UNIT_TEST(YtAlternativeSchemaSyntax) {
         NYql::TAstParseResult res = SqlToYql(R"(
-            SELECT * FROM plato.Input WITH schema(Int32 as y, String as x);
+            SELECT * FROM plato.Input WITH schema(y Int32, x String);
         )");
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
 
         TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
             if (word == "userschema") {
                 UNIT_ASSERT_VALUES_UNEQUAL(TString::npos,
-                    line.find(R"__('('('"userschema" (StructType '('"y" (DataType 'Int32)) '('"x" (DataType 'String))))))__"));
+                    line.find(R"__('('('"userschema" (StructType '('"y" (AsOptionalType (DataType 'Int32))) '('"x" (AsOptionalType (DataType 'String)))))))__"));
             }
         };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

This pr adds support for syntax `SCHEMA(foo Int32)` or `SCHEMA(bar as Int32)` (currently used for MrObject/S3).

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

