### PR TITLE
Make Arrow Datum check message more verbose

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
@@ -722,7 +722,7 @@ private:
         NUdf::TUnboxedValuePod Get(const THolderFactory& holderFactory, size_t idx) const {
             TBlockItem item;
             const auto& datum = TArrowBlock::From(Values_[idx]).GetDatum();
-            Y_DEBUG_ABORT_UNLESS(ValuesDescr_[idx] == datum.descr());
+            ARROW_DEBUG_CHECK_DATUM_TYPES(ValuesDescr_[idx], datum.descr());
             if (datum.is_scalar()) {
                 item = Readers_[idx]->GetScalarItem(*datum.scalar());
             } else {

--- a/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
@@ -207,7 +207,7 @@ NUdf::TUnboxedValuePod TBlockFuncNode::DoCalculate(TComputationContext& ctx) con
     std::vector<arrow::Datum> argDatums;
     for (ui32 i = 0; i < ArgsNodes.size(); ++i) {
         argDatums.emplace_back(TArrowBlock::From(ArgsNodes[i]->GetValue(ctx)).GetDatum());
-        Y_DEBUG_ABORT_UNLESS(ArgsValuesDescr[i] == argDatums.back().descr());
+        ARROW_DEBUG_CHECK_DATUM_TYPES(ArgsValuesDescr[i], argDatums.back().descr());
     }
 
     if (ScalarOutput) {

--- a/ydb/library/yql/public/udf/arrow/defs.h
+++ b/ydb/library/yql/public/udf/arrow/defs.h
@@ -25,3 +25,8 @@ do {                                                                            
     }()
 
 #define ARROW_RESULT(op)       ARROW_RESULT_S(op, "Bad status")
+
+#define ARROW_DEBUG_CHECK_DATUM_TYPES(expected, got) do {                              \
+    Y_DEBUG_ABORT_UNLESS((expected) == (got), "Bad datum type: %s expected, %s got",   \
+                         (expected).ToString().c_str(), (got).ToString().c_str());     \
+} while(false)


### PR DESCRIPTION
It's worth to provide both expected and got Arrow Datum types in the assertion message for convenient analysis.

Follows up #4096

### Changelog category

* Not for changelog (changelog entry is not required)