### PR TITLE
Native yt large tests for big dates (github part)

### DIFF
--- a/ydb/library/yql/tests/common/test_framework/yql_utils.py
+++ b/ydb/library/yql/tests/common/test_framework/yql_utils.py
@@ -488,6 +488,19 @@ def is_canonize_lineage(cfg):
     return False
 
 
+def is_canonize_yt(cfg):
+    for item in cfg:
+        if item[0] == 'canonize_yt':
+            return True
+    return False
+
+
+def skip_test_if_required(cfg):
+    for item in cfg:
+        if item[0] == 'skip_test':
+            pytest.skip(item[1])
+
+
 def get_pragmas(cfg):
     pragmas = []
     for item in cfg:

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -2932,6 +2932,13 @@
             "uri": "https://{canondata_backend}/1942671/84bd3f7d80a7ec30a2f4851da64d8ae4cd651719/resource.tar.gz#test_sql2yql.test_bigdate-table_io_/sql.yql"
         }
     ],
+    "test_sql2yql.test[bigdate-table_yt_native]": [
+        {
+            "checksum": "b598f98ab939e713ca8b0bce6347b09b",
+            "size": 2417,
+            "uri": "https://{canondata_backend}/212715/99c394fc142b628d22e13d9433512bcac243f701/resource.tar.gz#test_sql2yql.test_bigdate-table_yt_native_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[binding-anon_table_binding]": [
         {
             "checksum": "cf1e9ee529d4fcca3781cc85b3e555d8",
@@ -21375,6 +21382,13 @@
             "checksum": "395d15e0b34ca7610c172ec6c7f232f3",
             "size": 384,
             "uri": "https://{canondata_backend}/1942671/84bd3f7d80a7ec30a2f4851da64d8ae4cd651719/resource.tar.gz#test_sql_format.test_bigdate-table_io_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[bigdate-table_yt_native]": [
+        {
+            "checksum": "5d3db5e1fe04a2235a432f6b61868082",
+            "size": 332,
+            "uri": "https://{canondata_backend}/212715/99c394fc142b628d22e13d9433512bcac243f701/resource.tar.gz#test_sql_format.test_bigdate-table_yt_native_/formatted.sql"
         }
     ],
     "test_sql_format.test[binding-anon_table_binding]": [

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-default.cfg
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-default.cfg
@@ -1,0 +1,3 @@
+out Output output.txt
+providers yt
+canonize_yt

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-on.cfg
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-on.cfg
@@ -1,0 +1,5 @@
+out Output output.txt
+providers yt
+canonize_yt
+pragma yt.UseNativeYtTypes;
+pragma yt.NativeYtTypeCompatibility = "bigdate";

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-on.cfg
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-on.cfg
@@ -1,4 +1,3 @@
-skip_test YQL-18333
 out Output output.txt
 providers yt
 canonize_yt

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-on.cfg
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-on.cfg
@@ -1,3 +1,4 @@
+skip_test YQL-18333
 out Output output.txt
 providers yt
 canonize_yt

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-wo_compat.cfg
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-wo_compat.cfg
@@ -1,0 +1,5 @@
+out Output output.txt
+providers yt
+canonize_yt
+pragma yt.UseNativeYtTypes;
+pragma yt.NativeYtTypeCompatibility = "date";

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-wo_compat.cfg
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-wo_compat.cfg
@@ -1,4 +1,3 @@
-skip_test YQL-18333
 out Output output.txt
 providers yt
 canonize_yt

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-wo_compat.cfg
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native-wo_compat.cfg
@@ -1,3 +1,4 @@
+skip_test YQL-18333
 out Output output.txt
 providers yt
 canonize_yt

--- a/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native.sql
+++ b/ydb/library/yql/tests/sql/suites/bigdate/table_yt_native.sql
@@ -1,0 +1,11 @@
+/* postgres can not */
+/* multirun can not */
+use plato;
+
+insert into @tmpTable
+select date32('1969-12-31') as d32, datetime64('1969-12-31T0:0:0Z') as dt64, timestamp64('1969-12-31T0:0:0Z') as ts64, interval64('P65536D') as i64;
+
+commit;
+
+insert into Output
+select * from @tmpTable where d32 < date32('1970-1-1');

--- a/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
@@ -398,6 +398,32 @@
             "uri": "https://{canondata_backend}/1809005/40931b4ca83c5d01d9f04e8de1077ebd3a376c59/resource.tar.gz#test.test_bigdate-table_arithmetic_sub-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[bigdate-table_yt_native-on-Debug]": [
+        {
+            "checksum": "4867b965f942ec47bea0a26b505a1d19",
+            "size": 2236,
+            "uri": "https://{canondata_backend}/1600758/62b191f5c0d7903b52494f948a25c3944a128449/resource.tar.gz#test.test_bigdate-table_yt_native-on-Debug_/opt.yql"
+        }
+    ],
+    "test.test[bigdate-table_yt_native-on-Plan]": [
+        {
+            "checksum": "e0f35ef373cd9d021ca9fb323a644a86",
+            "size": 9997,
+            "uri": "https://{canondata_backend}/1600758/62b191f5c0d7903b52494f948a25c3944a128449/resource.tar.gz#test.test_bigdate-table_yt_native-on-Plan_/plan.txt"
+        }
+    ],
+    "test.test[bigdate-table_yt_native-on-Results]": [
+        {
+            "checksum": "acf426a10cca74e7a405e0eb7da4a20c",
+            "size": 98,
+            "uri": "https://{canondata_backend}/1600758/62b191f5c0d7903b52494f948a25c3944a128449/resource.tar.gz#test.test_bigdate-table_yt_native-on-Results_/Output.txt"
+        },
+        {
+            "checksum": "c353f166547865ff2066e901189db034",
+            "size": 759,
+            "uri": "https://{canondata_backend}/1600758/62b191f5c0d7903b52494f948a25c3944a128449/resource.tar.gz#test.test_bigdate-table_yt_native-on-Results_/Output.yqlrun.txt.attr"
+        }
+    ],
     "test.test[binding-anon_table_binding-default.txt-Debug]": [
         {
             "checksum": "19ecdd750e27f230de4a0616bb69c01c",

--- a/ydb/library/yql/tests/sql/yt_native_file/part15/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part15/canondata/result.json
@@ -587,6 +587,32 @@
             "uri": "https://{canondata_backend}/1031349/e5d1799a61a873650fc835d1adb819a8a8b7486d/resource.tar.gz#test.test_bigdate-round-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[bigdate-table_yt_native-wo_compat-Debug]": [
+        {
+            "checksum": "02e287f97f9c3f26559b08dcfd63f2ae",
+            "size": 2233,
+            "uri": "https://{canondata_backend}/1600758/92222eda66311de21f198cbe659c30169e1e43cd/resource.tar.gz#test.test_bigdate-table_yt_native-wo_compat-Debug_/opt.yql"
+        }
+    ],
+    "test.test[bigdate-table_yt_native-wo_compat-Plan]": [
+        {
+            "checksum": "e0f35ef373cd9d021ca9fb323a644a86",
+            "size": 9997,
+            "uri": "https://{canondata_backend}/1600758/92222eda66311de21f198cbe659c30169e1e43cd/resource.tar.gz#test.test_bigdate-table_yt_native-wo_compat-Plan_/plan.txt"
+        }
+    ],
+    "test.test[bigdate-table_yt_native-wo_compat-Results]": [
+        {
+            "checksum": "acf426a10cca74e7a405e0eb7da4a20c",
+            "size": 98,
+            "uri": "https://{canondata_backend}/1600758/92222eda66311de21f198cbe659c30169e1e43cd/resource.tar.gz#test.test_bigdate-table_yt_native-wo_compat-Results_/Output.txt"
+        },
+        {
+            "checksum": "4ed7b7fbbcc093abc1d69b1946523398",
+            "size": 1477,
+            "uri": "https://{canondata_backend}/1600758/92222eda66311de21f198cbe659c30169e1e43cd/resource.tar.gz#test.test_bigdate-table_yt_native-wo_compat-Results_/Output.yqlrun.txt.attr"
+        }
+    ],
     "test.test[binding-table_filter_strict_binding-default.txt-Debug]": [
         {
             "checksum": "66cb44ef8b425e9cbcaf42c07007c800",

--- a/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
@@ -425,6 +425,32 @@
             "uri": "https://{canondata_backend}/1817427/0b979af6b2bfa42e752a296b0288b726527203dd/resource.tar.gz#test.test_bigdate-const_timestamp64-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[bigdate-table_yt_native-default-Debug]": [
+        {
+            "checksum": "4623ff6b98241ec577bac8454959e4b7",
+            "size": 2022,
+            "uri": "https://{canondata_backend}/1937367/508213fdba2e7507330cb1bc19ea47bd778cbf34/resource.tar.gz#test.test_bigdate-table_yt_native-default-Debug_/opt.yql"
+        }
+    ],
+    "test.test[bigdate-table_yt_native-default-Plan]": [
+        {
+            "checksum": "4eace05b520afd5be2873e512f8d9b2b",
+            "size": 9991,
+            "uri": "https://{canondata_backend}/1937367/508213fdba2e7507330cb1bc19ea47bd778cbf34/resource.tar.gz#test.test_bigdate-table_yt_native-default-Plan_/plan.txt"
+        }
+    ],
+    "test.test[bigdate-table_yt_native-default-Results]": [
+        {
+            "checksum": "acf426a10cca74e7a405e0eb7da4a20c",
+            "size": 98,
+            "uri": "https://{canondata_backend}/1937367/508213fdba2e7507330cb1bc19ea47bd778cbf34/resource.tar.gz#test.test_bigdate-table_yt_native-default-Results_/Output.txt"
+        },
+        {
+            "checksum": "bf5072358c62a0d93e63040543c04bca",
+            "size": 1439,
+            "uri": "https://{canondata_backend}/1937367/508213fdba2e7507330cb1bc19ea47bd778cbf34/resource.tar.gz#test.test_bigdate-table_yt_native-default-Results_/Output.yqlrun.txt.attr"
+        }
+    ],
     "test.test[bitcast_implicit-mod_bitcast-default.txt-Debug]": [
         {
             "checksum": "f50d1e0b0ba350113b7500aab926dcd0",


### PR DESCRIPTION
`canonize_yt` cfg directive instructs test_framework to canonize local YT table output files if any
`skip_test` cfg directive instructs test_framework to skip test
Test `bigdate/table_yt_native-on.cfg` should be skipped until fresh local YT with bigdates support is deployed