### PR TITLE
Support arbiters in volatile transactions

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2309,6 +2309,7 @@ private:
 
             absl::flat_hash_set<ui64> sendingShardsSet;
             absl::flat_hash_set<ui64> receivingShardsSet;
+            ui64 arbiter = 0;
 
             // Gather shards that need to send/receive readsets (shards with effects)
             if (needCommit) {
@@ -2350,6 +2351,48 @@ private:
                 if (auto tabletIds = Request.TopicOperations.GetReceivingTabletIds()) {
                     receivingShardsSet.insert(tabletIds.begin(), tabletIds.end());
                 }
+
+                // The current value of 5 is arbitrary. Writing to 5 shards in
+                // a single transaction is unusual enough, and having latency
+                // regressions is unlikely. Full mesh readset count grows like
+                // 2n(n-1), and arbiter reduces it to 4(n-1). Here's a readset
+                // count table for various small `n`:
+                //
+                // n = 2: 4 -> 4
+                // n = 3: 12 -> 8
+                // n = 4: 24 -> 12
+                // n = 5: 40 -> 16
+                // n = 6: 60 -> 20
+                // n = 7: 84 -> 24
+                //
+                // The ideal crossover is at n = 4, since the readset count
+                // doesn't change when going from 3 to 4 shards, but the
+                // increase in latency may not really be worth it. With n = 5
+                // the readset count lowers from 24 to 16 readsets when going
+                // from 4 to 5 shards. This makes 5 shards potentially cheaper
+                // than 4 shards when readsets dominate the workload, but at
+                // the price of possible increase in latency. Too many readsets
+                // cause interconnect overload and reduce throughput however,
+                // so we don't want to use a crossover value that is too high.
+                const size_t minArbiterMeshSize = 5; // TODO: make configurable?
+                if (VolatileTx &&
+                    receivingShardsSet.size() >= minArbiterMeshSize &&
+                    AppData()->FeatureFlags.GetEnableVolatileTransactionArbiters())
+                {
+                    std::vector<ui64> candidates;
+                    candidates.reserve(receivingShardsSet.size());
+                    for (ui64 candidate : receivingShardsSet) {
+                        // Note: all receivers are also senders in volatile transactions
+                        if (Y_LIKELY(sendingShardsSet.contains(candidate))) {
+                            candidates.push_back(candidate);
+                        }
+                    }
+                    if (candidates.size() >= minArbiterMeshSize) {
+                        // Select a random arbiter
+                        ui32 index = RandomNumber<ui32>(candidates.size());
+                        arbiter = candidates.at(index);
+                    }
+                }
             }
 
             // Encode sending/receiving shards in tx bodies
@@ -2364,18 +2407,25 @@ private:
                     shardTx->MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
                     *shardTx->MutableLocks()->MutableSendingShards() = sendingShards;
                     *shardTx->MutableLocks()->MutableReceivingShards() = receivingShards;
+                    if (arbiter) {
+                        shardTx->MutableLocks()->SetArbiterShard(arbiter);
+                    }
                 }
 
                 for (auto& [_, tx] : evWriteTxs) {
                     tx->MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
                     *tx->MutableLocks()->MutableSendingShards() = sendingShards;
                     *tx->MutableLocks()->MutableReceivingShards() = receivingShards;
+                    if (arbiter) {
+                        tx->MutableLocks()->SetArbiterShard(arbiter);
+                    }
                 }
 
                 for (auto& [_, tx] : topicTxs) {
                     tx.SetOp(NKikimrPQ::TDataTransaction::Commit);
                     *tx.MutableSendingShards() = sendingShards;
                     *tx.MutableReceivingShards() = receivingShards;
+                    YQL_ENSURE(!arbiter);
                 }
             }
         }

--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -27,6 +27,16 @@ message TKqpLocks {
         Rollback = 3; // Rollback buffered changes and erase locks
     }
     optional ELocksOp Op = 4;
+
+    // An optional arbiter for readsets. When specified, all sending shards
+    // send the commit decision to a single arbiter shard, and all receiving
+    // shards wait for the commit decision from a single arbiter shard. The
+    // shard marked as the arbiter is responsible in aggregating all commit
+    // decisions from sending shards and sending the final commit decision to
+    // receiving shards.
+    // This may only be used with generic readsets without any other data and
+    // currently limited to volatile transactions.
+    optional uint64 ArbiterShard = 5;
 }
 
 message TTableId {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -136,4 +136,5 @@ message TFeatureFlags {
     optional bool ExtendedPDiskSensors = 121 [default = true];
     optional bool EnableDynamicNodeNameGeneration = 122 [default = false];
     optional bool EnableBackupService = 123 [default = false];
+    optional bool EnableVolatileTransactionArbiters = 124 [default = false];
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1904,6 +1904,10 @@ message TTxVolatileDetails {
 
     // When true all preceding transactions are dependencies
     optional bool CommitOrdered = 8;
+
+    // When true marks an arbiter for other participants
+    // Arbiters hold outgoing readsets until the transaction is decided
+    optional bool IsArbiter = 9;
 }
 
 // Sent by datashard when some overload reason stopped being relevant

--- a/ydb/core/tx/datashard/datashard__init.cpp
+++ b/ydb/core/tx/datashard/datashard__init.cpp
@@ -529,6 +529,7 @@ bool TDataShard::TTxInit::ReadEverything(TTransactionContext &txc) {
         if (!Self->VolatileTxManager.Load(db)) {
             return false;
         }
+        Self->OutReadSets.HoldArbiterReadSets();
     }
 
     if (Self->State != TShardState::Offline && txc.DB.GetScheme().GetTableInfo(Schema::CdcStreamScans::TableId)) {

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -286,6 +286,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             /* participants */ { },
             groupProvider.GetCurrentChangeGroup(),
             /* ordered */ false,
+            /* arbiter */ false,
             txc);
         // Note: transaction is already committed, no additional waiting needed
     }

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -212,6 +212,7 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             /* participants */ { },
             groupProvider ? groupProvider->GetCurrentChangeGroup() : std::nullopt,
             /* ordered */ false,
+            /* arbiter */ false,
             *params.Txc);
         // Note: transaction is already committed, no additional waiting needed
     }

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -334,6 +334,7 @@ class TDataShard
     class TWaitVolatileDependencies;
     class TSendVolatileResult;
     class TSendVolatileWriteResult;
+    class TSendArbiterReadSets;
 
     struct TEvPrivate {
         enum EEv {

--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -680,6 +680,14 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateLocks(ui64 origin
     return {true, {}};
 }
 
+bool KqpLocksHasArbiter(const NKikimrDataEvents::TKqpLocks* kqpLocks) {
+    return kqpLocks && kqpLocks->GetArbiterShard() != 0;
+}
+
+bool KqpLocksIsArbiter(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks) {
+    return KqpLocksHasArbiter(kqpLocks) && kqpLocks->GetArbiterShard() == tabletId;
+}
+
 std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 origin, TSysLocks& sysLocks, const NKikimrDataEvents::TKqpLocks* kqpLocks, bool useGenericReadSets, ui64 txId, const TVector<NKikimrTx::TEvReadSet>& delayedInReadSets, TInputOpData::TAwaitingDecisions& awaitingDecisions, TOutputOpData::TOutReadSets& outReadSets) {
     if (kqpLocks == nullptr || !NeedValidateLocks(kqpLocks->GetOp())) {
         return {true, {}};
@@ -692,6 +700,9 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 o
     // We expect all stale data to be cleared on restarts
     Y_ABORT_UNLESS(outReadSets.empty());
     Y_ABORT_UNLESS(awaitingDecisions.empty());
+
+    const bool hasArbiter = KqpLocksHasArbiter(kqpLocks);
+    const bool isArbiter = KqpLocksIsArbiter(origin, kqpLocks);
 
     // Note: usually all shards send locks, since they either have side effects or need to validate locks
     // However it is technically possible to have pure-read shards, that don't contribute to the final decision
@@ -711,6 +722,11 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 o
                 continue;
             }
 
+            if (hasArbiter && !isArbiter && dstTabletId != kqpLocks->GetArbiterShard()) {
+                // Non-arbiter shards only send locks to the arbiter
+                continue;
+            }
+
             LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Send commit decision from " << origin << " to " << dstTabletId);
 
             auto key = std::make_pair(origin, dstTabletId);
@@ -723,6 +739,8 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 o
 
             outReadSets[key] = std::move(bodyStr);
         }
+    } else {
+        Y_ABORT_UNLESS(!isArbiter, "Arbiter is not in the sending shards set");
     }
 
     bool receiveLocks = ReceiveLocks(*kqpLocks, origin);
@@ -732,6 +750,11 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 o
         for (ui64 srcTabletId : kqpLocks->GetSendingShards()) {
             if (srcTabletId == origin) {
                 // Don't await decision from ourselves
+                continue;
+            }
+
+            if (hasArbiter && !isArbiter && srcTabletId != kqpLocks->GetArbiterShard()) {
+                // Non-arbiter shards only await decision from the arbiter
                 continue;
             }
 
@@ -780,6 +803,8 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 o
         if (aborted) {
             return {false, {}};
         }
+    } else {
+        Y_ABORT_UNLESS(!isArbiter, "Arbiter is not in the receiving shards set");
     }
 
     return {true, {}};

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -43,6 +43,9 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 t
     const NKikimrDataEvents::TKqpLocks* kqpLocks, bool useGenericReadSets, ui64 txId, const TVector<NKikimrTx::TEvReadSet>& delayedInReadSets, 
     TInputOpData::TAwaitingDecisions& awaitingDecisions, TOutputOpData::TOutReadSets& outReadSets);
 
+bool KqpLocksHasArbiter(const NKikimrDataEvents::TKqpLocks* kqpLocks);
+bool KqpLocksIsArbiter(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks);
+
 void KqpEraseLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks);
 void KqpCommitLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, const TRowVersion& writeVersion, IDataShardUserDb& userDb);
 

--- a/ydb/core/tx/datashard/datashard_outreadset.cpp
+++ b/ydb/core/tx/datashard/datashard_outreadset.cpp
@@ -19,6 +19,7 @@ bool TOutReadSets::LoadReadSets(NIceDb::TNiceDb& db) {
     // TODO[serxa]: this should be Range but it is not working right now
     auto rowset = db.Table<Schema::OutReadSets>().GreaterOrEqual(0).Select<
                                     Schema::OutReadSets::Seqno,
+                                    Schema::OutReadSets::Step,
                                     Schema::OutReadSets::TxId,
                                     Schema::OutReadSets::Origin,
                                     Schema::OutReadSets::From,
@@ -27,12 +28,18 @@ bool TOutReadSets::LoadReadSets(NIceDb::TNiceDb& db) {
         return false;
     while (!rowset.EndOfSet()) {
         ui64 seqNo = rowset.GetValue<Schema::OutReadSets::Seqno>();
+        ui64 step = rowset.GetValue<Schema::OutReadSets::Step>();
         ui64 txId = rowset.GetValue<Schema::OutReadSets::TxId>();
         ui64 origin = rowset.GetValue<Schema::OutReadSets::Origin>();
         ui64 source = rowset.GetValue<Schema::OutReadSets::From>();
         ui64 target = rowset.GetValue<Schema::OutReadSets::To>();
 
-        TReadSetKey rsInfo(txId, origin, source, target);
+        TReadSetInfo rsInfo;
+        rsInfo.TxId = txId;
+        rsInfo.Step = step;
+        rsInfo.Origin = origin;
+        rsInfo.From = source;
+        rsInfo.To = target;
 
         Y_ABORT_UNLESS(!CurrentReadSets.contains(seqNo));
         Y_ABORT_UNLESS(!CurrentReadSetInfos.contains(rsInfo));
@@ -48,24 +55,52 @@ bool TOutReadSets::LoadReadSets(NIceDb::TNiceDb& db) {
     return true;
 }
 
-void TOutReadSets::SaveReadSet(NIceDb::TNiceDb& db, ui64 seqNo, ui64 step, const TReadSetKey& rsInfo, TString body) {
+void TOutReadSets::SaveReadSet(NIceDb::TNiceDb& db, ui64 seqNo, ui64 step, const TReadSetKey& rsKey, const TString& body) {
     using Schema = TDataShard::Schema;
 
     Y_ABORT_UNLESS(!CurrentReadSets.contains(seqNo));
-    Y_ABORT_UNLESS(!CurrentReadSetInfos.contains(rsInfo));
+    Y_ABORT_UNLESS(!CurrentReadSetInfos.contains(rsKey));
 
-    CurrentReadSetInfos[rsInfo] = seqNo;
+    TReadSetInfo rsInfo(rsKey);
+    rsInfo.Step = step;
+
+    CurrentReadSetInfos[rsKey] = seqNo;
     CurrentReadSets[seqNo] = rsInfo;
 
     UpdateMonCounter();
 
     db.Table<Schema::OutReadSets>().Key(seqNo).Update(
-        NIceDb::TUpdate<Schema::OutReadSets::Step>(step),
+        NIceDb::TUpdate<Schema::OutReadSets::Step>(rsInfo.Step),
         NIceDb::TUpdate<Schema::OutReadSets::TxId>(rsInfo.TxId),
         NIceDb::TUpdate<Schema::OutReadSets::Origin>(rsInfo.Origin),
         NIceDb::TUpdate<Schema::OutReadSets::From>(rsInfo.From),
         NIceDb::TUpdate<Schema::OutReadSets::To>(rsInfo.To),
         NIceDb::TUpdate<Schema::OutReadSets::Body>(body));
+}
+
+void TOutReadSets::RemoveReadSet(NIceDb::TNiceDb& db, ui64 seqNo) {
+    using Schema = TDataShard::Schema;
+
+    db.Table<Schema::OutReadSets>().Key(seqNo).Delete();
+
+    auto it = CurrentReadSets.find(seqNo);
+    if (it != CurrentReadSets.end()) {
+        CurrentReadSetInfos.erase(it->second);
+        CurrentReadSets.erase(it);
+    }
+}
+
+TReadSetInfo TOutReadSets::ReplaceReadSet(NIceDb::TNiceDb& db, ui64 seqNo, const TString& body) {
+    using Schema = TDataShard::Schema;
+
+    auto it = CurrentReadSets.find(seqNo);
+    if (it != CurrentReadSets.end()) {
+        db.Table<Schema::OutReadSets>().Key(seqNo).Update(
+            NIceDb::TUpdate<Schema::OutReadSets::Body>(body));
+        return it->second;
+    } else {
+        return TReadSetInfo();
+    }
 }
 
 void TOutReadSets::AckForDeletedDestination(ui64 tabletId, ui64 seqNo, const TActorContext &ctx) {
@@ -113,8 +148,6 @@ void TOutReadSets::SaveAck(const TActorContext &ctx, TAutoPtr<TEvTxProcessing::T
 }
 
 void TOutReadSets::Cleanup(NIceDb::TNiceDb& db, const TActorContext& ctx) {
-    using Schema = TDataShard::Schema;
-
     // Note that this code should be called only after no-more-reads to ensure we wont lost updates
     for (TIntrusivePtr<TEvTxProcessing::TEvReadSetAck>& event : ReadSetAcks) {
         TEvTxProcessing::TEvReadSetAck& ev = *event;
@@ -128,7 +161,7 @@ void TOutReadSets::Cleanup(NIceDb::TNiceDb& db, const TActorContext& ctx) {
             "Deleted RS at %" PRIu64 " source %" PRIu64 " dest %" PRIu64 " consumer %" PRIu64 " seqno %" PRIu64" txId %" PRIu64,
             Self->TabletID(), sender, dest, consumer, seqno, txId);
 
-        db.Table<Schema::OutReadSets>().Key(seqno).Delete();
+        RemoveReadSet(db, seqno);
         Self->ResendReadSetPipeTracker.DetachTablet(seqno, ev.Record.GetTabletDest(), 0, ctx);
     }
     ReadSetAcks.clear();
@@ -140,10 +173,40 @@ void TOutReadSets::Cleanup(NIceDb::TNiceDb& db, const TActorContext& ctx) {
 void TOutReadSets::ResendAll(const TActorContext& ctx) {
     TPendingPipeTrackerCommands pendingPipeTrackerCommands;
     for (const auto& rs : CurrentReadSets) {
+        if (rs.second.OnHold) {
+            continue;
+        }
         ui64 seqNo = rs.first;
         ui64 target = rs.second.To;
         Self->ResendReadSetQueue.Progress(rs.first, ctx);
         pendingPipeTrackerCommands.AttachTablet(seqNo, target);
+    }
+    pendingPipeTrackerCommands.Apply(Self->ResendReadSetPipeTracker, ctx);
+}
+
+void TOutReadSets::HoldArbiterReadSets() {
+    for (auto& rs : CurrentReadSets) {
+        const ui64& seqNo = rs.first;
+        const ui64& txId = rs.second.TxId;
+        auto* info = Self->VolatileTxManager.FindByTxId(txId);
+        if (info && info->IsArbiter && info->State != EVolatileTxState::Committed) {
+            info->ArbiterReadSets.push_back(seqNo);
+            info->IsArbiterOnHold = true;
+            rs.second.OnHold = true;
+        }
+    }
+}
+
+void TOutReadSets::ReleaseOnHoldReadSets(const std::vector<ui64>& seqNos, const TActorContext& ctx) {
+    TPendingPipeTrackerCommands pendingPipeTrackerCommands;
+    for (ui64 seqNo : seqNos) {
+        auto it = CurrentReadSets.find(seqNo);
+        if (it != CurrentReadSets.end() && it->second.OnHold) {
+            it->second.OnHold = false;
+            ui64 target = it->second.To;
+            Self->ResendReadSetQueue.Progress(seqNo, ctx);
+            pendingPipeTrackerCommands.AttachTablet(seqNo, target);
+        }
     }
     pendingPipeTrackerCommands.Apply(Self->ResendReadSetPipeTracker, ctx);
 }

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -2,10 +2,13 @@
 #include "datashard_ut_read_table.h"
 #include <ydb/core/tx/data_events/payload_helper.h>
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include <ydb/core/base/tablet_pipecache.h>
+#include "datashard_ut_common_kqp.h"
 
 namespace NKikimr {
 
 using namespace NKikimr::NDataShard;
+using namespace NKikimr::NDataShard::NKqpHelpers;
 using namespace NSchemeShard;
 using namespace Tests;
 using namespace NDataShardReadTableTest;
@@ -715,6 +718,453 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         }
 
     }  // Y_UNIT_TEST
+
+    using TWriteRequestPtr = std::unique_ptr<NEvents::TDataEvents::TEvWrite>;
+    using TModifyWriteRequestCallback = std::function<void(const TWriteRequestPtr&)>;
+
+    void PrepareMultiShardWrite(
+            TTestActorRuntime& runtime,
+            const TActorId& sender,
+            const TTableId& tableId,
+            ui64 txId, ui64& coordinator, ui64& minStep, ui64& maxStep,
+            ui64 shardId,
+            i32 key,
+            i32 value,
+            ui64 arbiterShard,
+            const std::vector<ui64>& sendingShards,
+            const std::vector<ui64>& receivingShards,
+            const TModifyWriteRequestCallback& modifyWriteRequest = [](auto&){})
+    {
+        Cerr << "========= Sending prepare to " << shardId << " =========" << Endl;
+
+        auto req = std::make_unique<NEvents::TDataEvents::TEvWrite>(txId, NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE);
+
+        const std::vector<ui32> columnIds({ 1, 2 });
+
+        TVector<TCell> cells;
+        cells.push_back(TCell::Make(key));
+        cells.push_back(TCell::Make(value));
+        TSerializedCellMatrix matrix(cells, 1, columnIds.size());
+        TString data = matrix.ReleaseBuffer();
+        const ui64 payloadIndex = req->AddPayload(TRope(std::move(data)));
+        req->AddOperation(NKikimrDataEvents::TEvWrite_TOperation::OPERATION_UPSERT, tableId, columnIds, payloadIndex, NKikimrDataEvents::FORMAT_CELLVEC);
+
+        auto* kqpLocks = req->Record.MutableLocks();
+        kqpLocks->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+        if (arbiterShard) {
+            kqpLocks->SetArbiterShard(arbiterShard);
+        }
+        for (ui64 sendingShard : sendingShards) {
+            kqpLocks->AddSendingShards(sendingShard);
+        }
+        for (ui64 receivingShard : receivingShards) {
+            kqpLocks->AddReceivingShards(receivingShard);
+        }
+
+        modifyWriteRequest(req);
+
+        SendViaPipeCache(runtime, shardId, sender, std::move(req));
+
+        auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(sender);
+        auto* msg = ev->Get();
+        UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetStatus(), NKikimrDataEvents::TEvWriteResult::STATUS_PREPARED);
+        minStep = Max(minStep, msg->Record.GetMinStep());
+        maxStep = Min(maxStep, msg->Record.GetMaxStep());
+        UNIT_ASSERT_VALUES_EQUAL(msg->Record.DomainCoordinatorsSize(), 1);
+        if (coordinator == 0) {
+            coordinator = msg->Record.GetDomainCoordinators(0);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(coordinator, msg->Record.GetDomainCoordinators(0));
+        }
+    }
+
+    void SendProposeToCoordinator(
+            TTestActorRuntime& runtime,
+            const TActorId& sender,
+            ui64 txId,
+            ui64 coordinator,
+            ui64 minStep,
+            ui64 maxStep,
+            const std::vector<ui64>& shards)
+    {
+        Cerr << "========= Sending propose to coordinator " << coordinator << " =========" << Endl;
+
+        auto req = std::make_unique<TEvTxProxy::TEvProposeTransaction>(coordinator, txId, 0, minStep, maxStep);
+
+        auto* affectedSet = req->Record.MutableTransaction()->MutableAffectedSet();
+        affectedSet->Reserve(shards.size());
+        for (ui64 shardId : shards) {
+            auto* x = affectedSet->Add();
+            x->SetTabletId(shardId);
+            x->SetFlags(TEvTxProxy::TEvProposeTransaction::AffectedWrite);
+        }
+
+        SendViaPipeCache(runtime, coordinator, sender, std::move(req));
+    }
+
+    void RunUpsertWithArbiter(
+            TTestActorRuntime& runtime,
+            const TTableId& tableId,
+            const std::vector<ui64>& shards,
+            const ui64 txId,
+            const size_t expectedReadSets,
+            int keyBase = 1,
+            int keyFactor = 10,
+            const std::unordered_set<size_t>& shardsWithoutPrepare = {},
+            const std::unordered_set<size_t>& shardsWithBrokenLocks = {},
+            NKikimrDataEvents::TEvWriteResult::EStatus expectedStatus = NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED,
+            const std::unordered_map<ui64, NKikimrDataEvents::TEvWriteResult::EStatus>& expectedShardStatus = {})
+    {
+        auto sender = runtime.AllocateEdgeActor();
+
+        ui64 coordinator = 0;
+        ui64 minStep = 0;
+        ui64 maxStep = Max<ui64>();
+
+        size_t expectedResults = 0;
+        for (size_t i = 0; i < shards.size(); ++i) {
+            if (shardsWithoutPrepare.contains(i)) {
+                continue;
+            }
+
+            const ui64 shardId = shards.at(i);
+            const i32 key = i * keyFactor + keyBase;
+            const i32 value = key * keyFactor + keyBase;
+
+            PrepareMultiShardWrite(
+                runtime,
+                sender,
+                tableId,
+                txId, coordinator, minStep, maxStep,
+                shardId,
+                key,
+                value,
+                /* arbiter */ shards.at(0),
+                /* sending */ shards,
+                /* receiving */ shards,
+                [&](const TWriteRequestPtr& req) {
+                    // We use a lock that should have never existed to simulate a broken lock
+                    if (shardsWithBrokenLocks.contains(i)) {
+                        auto* kqpLock = req->Record.MutableLocks()->AddLocks();
+                        kqpLock->SetLockId(txId);
+                        kqpLock->SetDataShard(shardId);
+                        kqpLock->SetGeneration(1);
+                        kqpLock->SetCounter(1);
+                        kqpLock->SetSchemeShard(tableId.PathId.OwnerId);
+                        kqpLock->SetPathId(tableId.PathId.LocalPathId);
+                    }
+                });
+
+            ++expectedResults;
+        }
+
+        size_t observedReadSets = 0;
+        auto observeReadSets = runtime.AddObserver<TEvTxProcessing::TEvReadSet>(
+            [&](TEvTxProcessing::TEvReadSet::TPtr&) {
+                ++observedReadSets;
+            });
+
+        SendProposeToCoordinator(runtime, sender, txId, coordinator, minStep, maxStep, shards);
+
+        Cerr << "========= Waiting for write results =========" << Endl;
+        for (size_t i = 0; i < expectedResults; ++i) {
+            auto ev = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(sender);
+            auto* msg = ev->Get();
+            auto it = expectedShardStatus.find(msg->Record.GetOrigin());
+            if (it != expectedShardStatus.end()) {
+                UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetStatus(), it->second);
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetStatus(), expectedStatus);
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(observedReadSets, expectedReadSets);
+    }
+
+    Y_UNIT_TEST(UpsertNoLocksArbiter) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        RunUpsertWithArbiter(
+            runtime, tableId, shards,
+            /* txId */ 1000001,
+            // arbiter will send 6 readsets (3 decisions + 3 expectations)
+            // shards will send 2 readsets each (decision + expectation)
+            /* expectedReadSets */ 6 + 3 * 2);
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 11 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 111 } }, "
+            "{ items { int32_value: 21 } items { int32_value: 211 } }, "
+            "{ items { int32_value: 31 } items { int32_value: 311 } }");
+    }
+
+    Y_UNIT_TEST(UpsertLostPrepareArbiter) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        for (size_t i = 0; i < shards.size(); ++i) {
+            RunUpsertWithArbiter(
+                runtime, tableId, shards,
+                /* txId */ 1000001 + i,
+                // arbiter will send 3 or 6 readsets (3 nodata or 3 decisions + 3 expectations)
+                // shards will send 1 or 2 readsets each (nodata or decistion + expectation)
+                /* expectedReadSets */ (i == 0 ? 3 + 3 * 2 : 6 + 2 * 2 + 1),
+                /* keyBase */ 1 + i,
+                /* keyFactor */ 10,
+                /* shardsWithoutPrepare */ { i },
+                /* shardsWithBrokenLocks */ {},
+                /* expectedStatus */ NKikimrDataEvents::TEvWriteResult::STATUS_ABORTED);
+        }
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "");
+    }
+
+    Y_UNIT_TEST(UpsertBrokenLockArbiter) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        for (size_t i = 0; i < shards.size(); ++i) {
+            RunUpsertWithArbiter(
+                runtime, tableId, shards,
+                /* txId */ 1000001 + i,
+                // arbiter will send 3 or 6 readsets (3 aborts or 3 decisions + 3 expectations)
+                // shards will send 1 or 2 readsets each (abort or decision + expectation)
+                /* expectedReadSets */ (i == 0 ? 3 + 3 * 2 : 6 + 2 * 2 + 1),
+                /* keyBase */ 1 + i,
+                /* keyFactor */ 10,
+                /* shardsWithoutPrepare */ {},
+                /* shardsWithBrokenLocks */ { i },
+                /* expectedStatus */ NKikimrDataEvents::TEvWriteResult::STATUS_ABORTED,
+                /* expectedShardStatus */ { { shards[i], NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN } });
+        }
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "");
+    }
+
+    Y_UNIT_TEST(UpsertNoLocksArbiterRestart) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        ui64 txId = 1000001;
+        ui64 coordinator = 0;
+        ui64 minStep = 0;
+        ui64 maxStep = Max<ui64>();
+
+        for (size_t i = 0; i < shards.size(); ++i) {
+            ui64 shardId = shards.at(i);
+            i32 key = 10 * i + 1;
+            i32 value = 100 * i + 11;
+            PrepareMultiShardWrite(
+                runtime,
+                sender,
+                tableId,
+                txId, coordinator, minStep, maxStep,
+                shardId,
+                key,
+                value,
+                /* arbiter */ shards.at(0),
+                /* sending */ shards,
+                /* receiving */ shards);
+        }
+
+        std::vector<TEvTxProcessing::TEvReadSet::TPtr> blockedReadSets;
+        auto blockReadSets = runtime.AddObserver<TEvTxProcessing::TEvReadSet>(
+            [&](TEvTxProcessing::TEvReadSet::TPtr& ev) {
+                Cerr << "... blocking readset" << Endl;
+                blockedReadSets.push_back(std::move(ev));
+            });
+
+        SendProposeToCoordinator(runtime, sender, txId, coordinator, minStep, maxStep, shards);
+
+        // arbiter will send 3 expectations
+        // shards will send 1 commit decision + 1 expectation
+        size_t expectedReadSets = 3 + 3 * 2;
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        // Reboot arbiter
+        blockedReadSets.clear();
+        Cerr << "========= Rebooting arbiter =========" << Endl;
+        RebootTablet(runtime, shards.at(0), sender);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        blockReadSets.Remove();
+        Cerr << "========= Unblocking readsets =========" << Endl;
+        for (auto& ev : blockedReadSets) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 11 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 111 } }, "
+            "{ items { int32_value: 21 } items { int32_value: 211 } }, "
+            "{ items { int32_value: 31 } items { int32_value: 311 } }");
+    }
+
+    Y_UNIT_TEST(UpsertLostPrepareArbiterRestart) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        ui64 txId = 1000001;
+        ui64 coordinator = 0;
+        ui64 minStep = 0;
+        ui64 maxStep = Max<ui64>();
+
+        // Note: we skip prepare at the last shard, so tx must abort
+        for (size_t i = 0; i < shards.size()-1; ++i) {
+            ui64 shardId = shards.at(i);
+            i32 key = 10 * i + 1;
+            i32 value = 100 * i + 11;
+            PrepareMultiShardWrite(
+                runtime,
+                sender,
+                tableId,
+                txId, coordinator, minStep, maxStep,
+                shardId,
+                key,
+                value,
+                /* arbiter */ shards.at(0),
+                /* sending */ shards,
+                /* receiving */ shards);
+        }
+
+        std::vector<TEvTxProcessing::TEvReadSet::TPtr> blockedReadSets;
+        auto blockReadSets = runtime.AddObserver<TEvTxProcessing::TEvReadSet>(
+            [&](TEvTxProcessing::TEvReadSet::TPtr& ev) {
+                Cerr << "... blocking readset" << Endl;
+                blockedReadSets.push_back(std::move(ev));
+            });
+
+        SendProposeToCoordinator(runtime, sender, txId, coordinator, minStep, maxStep, shards);
+
+        // arbiter will send 3 expectations
+        // shards will send 1 commit decision + 1 expectation
+        size_t expectedReadSets = 3 + 2 * 2;
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        // Reboot arbiter
+        blockedReadSets.clear();
+        Cerr << "========= Rebooting arbiter =========" << Endl;
+        RebootTablet(runtime, shards.at(0), sender);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        blockReadSets.Remove();
+        Cerr << "========= Unblocking readsets =========" << Endl;
+        for (auto& ev : blockedReadSets) {
+            runtime.Send(ev.Release(), 0, true);
+        }
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "");
+    }
 
 } // Y_UNIT_TEST_SUITE
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/execute_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_data_tx_unit.cpp
@@ -332,6 +332,7 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
             participants,
             tx->GetDataTx()->GetVolatileChangeGroup(),
             tx->GetDataTx()->GetVolatileCommitOrdered(),
+            /* arbiter */ false,
             txc);
     }
 

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -215,6 +215,7 @@ public:
                 /* participants */ { },
                 groupProvider ? groupProvider->GetCurrentChangeGroup() : std::nullopt,
                 volatileOrdered,
+                /* arbiter */ false,
                 txc);
             // Note: transaction is already committed, no additional waiting needed
         }

--- a/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
@@ -243,6 +243,8 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
 
         LWTRACK(ProposeTransactionKqpDataExecute, op->Orbit);
 
+        const bool isArbiter = op->HasVolatilePrepareFlag() && KqpLocksIsArbiter(tabletId, kqpLocks);
+
         KqpCommitLocks(tabletId, kqpLocks, sysLocks, writeVersion, tx->GetDataTx()->GetUserDb());
 
         auto& computeCtx = tx->GetDataTx()->GetKqpComputeCtx();
@@ -353,6 +355,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
                 participants,
                 dataTx->GetVolatileChangeGroup(),
                 dataTx->GetVolatileCommitOrdered(),
+                isArbiter,
                 txc);
         }
 

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -341,6 +341,8 @@ public:
                 return EExecutionStatus::Executed;
             }
 
+            const bool isArbiter = op->HasVolatilePrepareFlag() && KqpLocksIsArbiter(tabletId, kqpLocks);
+
             KqpCommitLocks(tabletId, kqpLocks, sysLocks, writeVersion, userDb);
 
             TValidatedWriteTx::TPtr& writeTx = writeOp->GetWriteTx();
@@ -385,6 +387,7 @@ public:
                     participants,
                     userDb.GetChangeGroup(),
                     userDb.GetVolatileCommitOrdered(),
+                    isArbiter,
                     txc
                 );
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support arbiters in volatile transactions, reducing the number of messages exchanged for distributed transactions with a large number of participants.

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Volatile distributed transactions often cause every shard to exchange readsets with every other shard, which leads to the total number of messages growing quadratically. Selecting a single arbiter shard changes a full mesh graph to a star, which reduces the number of messages at the expense of possibly increased latency. This patch implements arbiters for volatile transactions which may be enabled using the `EnableVolatileTransactionArbiters` feature flag.

Fixes #3918.