### PR TITLE
Report detailed PDisk metrics to whiteboard

### DIFF
--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -125,6 +125,11 @@ message TPDiskStateInfo {
     // overall state - to be filled
     optional EFlag Overall = 17;
     optional string SerialNumber = 18;
+    optional uint64 SystemSize = 19;
+    optional uint64 LogUsedSize = 20;
+    optional uint64 LogTotalSize = 21;
+    optional uint32 ExpectedSlotCount = 22;
+    optional uint64 EnforcedDynamicSlotSize = 23;
 }
 
 message TEvPDiskStateRequest {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Report detailed PDisk metrics to whiteboard

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

The following metrics were added to PDisk's whiteboard info:
* used and total space for system usage (chunk0, syslog, reserve);
* used and total space for common and static group log.
