### PR TITLE
the actor of the partition deleted the configuration of the PQ tablet

### DIFF
--- a/ydb/core/persqueue/key.cpp
+++ b/ydb/core/persqueue/key.cpp
@@ -1,0 +1,13 @@
+#include "key.h"
+
+namespace NKikimr::NPQ {
+
+std::pair<TKeyPrefix, TKeyPrefix> MakeKeyPrefixRange(TKeyPrefix::EType type, const TPartitionId& partition)
+{
+    TKeyPrefix from(type, partition);
+    TKeyPrefix to(type, TPartitionId(partition.OriginalPartitionId, partition.WriteId, partition.InternalPartitionId + 1));
+
+    return {std::move(from), std::move(to)};
+}
+
+}

--- a/ydb/core/persqueue/key.h
+++ b/ydb/core/persqueue/key.h
@@ -152,6 +152,8 @@ private:
 
 };
 
+std::pair<TKeyPrefix, TKeyPrefix> MakeKeyPrefixRange(TKeyPrefix::EType type, const TPartitionId& partition);
+
 // {char type; ui32 partiton; ui64 offset; ui16 partNo; ui32 count, ui16 internalPartsCount}
 // offset, partNo - index of first rec
 // count - diff of last record offset and first record offset in blob

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -14,6 +14,7 @@ SRCS(
     fetch_request_actor.cpp
     header.cpp
     heartbeat.cpp
+    key.cpp
     metering_sink.cpp
     mirrorer.cpp
     mirrorer.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The prefix range for the delete command is set incorrectly. The `from` prefix starts with a capital letter, and the `to` prefix starts with a small letter. As a result, the `_config` key falls into the range.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
