### PR TITLE
do not treat initial tablet metrics values as 0

### DIFF
--- a/ydb/core/tablet/tablet_metrics.cpp
+++ b/ydb/core/tablet/tablet_metrics.cpp
@@ -107,9 +107,9 @@ namespace {
             if (value.IsValueReady()) {
                 auto val = !value.IsValueObsolete(now) ? value.GetValue() : 0;
                 ui32 levelVal = val / significantChange;
-                auto& lit = levels[groupId];
-                if (lit != levelVal || force) {
-                    lit = levelVal;
+                auto [lit, inserted] = levels.insert({groupId, 0});
+                if (inserted || lit->second != levelVal || force) {
+                    lit->second = levelVal;
                     haveChanges = true;
                     // N.B. keep going so all levels are properly updated
                 }

--- a/ydb/core/tablet/tablet_metrics.h
+++ b/ydb/core/tablet/tablet_metrics.h
@@ -69,11 +69,11 @@ protected:
     const ui64 TabletId;
     const ui32 FollowerId;
     const TActorId Launcher;
-    ui32 LevelCPU = 0;
-    ui32 LevelMemory = 0;
-    ui32 LevelNetwork = 0;
-    ui32 LevelStorage = 0;
-    ui32 LevelIops = 0;
+    std::optional<ui32> LevelCPU;
+    std::optional<ui32> LevelMemory;
+    std::optional<ui32> LevelNetwork;
+    std::optional<ui32> LevelStorage;
+    std::optional<ui32> LevelIops;
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelReadThroughput;
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelWriteThroughput;
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelReadIops;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

fix a case where tablet metrics were not updated

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

A tablet assumes that initial value for any metric is 0, and if the value does not change much from 0 it does not need to be reported. This is incorrect, because the value in Hive might be different from 0 - because of initialization with average metrics, or because of metrics from the previous generation.
