### PR TITLE
24-1: Support arbiters in volatile transactions

### DIFF
--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -27,6 +27,16 @@ message TKqpLocks {
         Rollback = 3; // Rollback buffered changes and erase locks
     }
     optional ELocksOp Op = 4;
+
+    // An optional arbiter for readsets. When specified, all sending shards
+    // send the commit decision to a single arbiter shard, and all receiving
+    // shards wait for the commit decision from a single arbiter shard. The
+    // shard marked as the arbiter is responsible in aggregating all commit
+    // decisions from sending shards and sending the final commit decision to
+    // receiving shards.
+    // This may only be used with generic readsets without any other data and
+    // currently limited to volatile transactions.
+    optional uint64 ArbiterShard = 5;
 }
 
 message TTableId {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1882,6 +1882,10 @@ message TTxVolatileDetails {
 
     // When true all preceding transactions are dependencies
     optional bool CommitOrdered = 8;
+
+    // When true marks an arbiter for other participants
+    // Arbiters hold outgoing readsets until the transaction is decided
+    optional bool IsArbiter = 9;
 }
 
 // Sent by datashard when some overload reason stopped being relevant

--- a/ydb/core/tablet/tablet_pipe_client_cache.cpp
+++ b/ydb/core/tablet/tablet_pipe_client_cache.cpp
@@ -183,12 +183,16 @@ namespace NTabletPipe {
         }
 
     private:
-        void MoveToPool(ui64 tabletId, const TClientCacheEntry& currentClient) {
+        void MoveToPool(ui64 tabletId, TClientCacheEntry& currentClient) {
             TClientCacheEntry* insertedClient;
             if (!PoolContainer->Insert(tabletId, currentClient, insertedClient)) {
                 Y_DEBUG_ABORT_UNLESS(!insertedClient->Client);
                 *insertedClient = currentClient;
             }
+
+            // Note: client was moved to pool, make sure it's not closed by
+            // the eviction callback
+            currentClient.Client = {};
 
             Container->Erase(tabletId);
         }

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -438,6 +438,29 @@ void TDataShard::SendRegistrationRequestTimeCast(const TActorContext &ctx) {
     }
 }
 
+class TDataShard::TSendArbiterReadSets final : public IVolatileTxCallback {
+public:
+    TSendArbiterReadSets(TDataShard* self, TVector<THolder<TEvTxProcessing::TEvReadSet>>&& readSets)
+        : Self(self)
+        , ReadSets(std::move(readSets))
+    {}
+
+    void OnCommit(ui64) override {
+        // The transaction is persistent and committed
+        // Arbiter must now send its outgoing readsets
+        Self->SendReadSets(TActivationContext::ActorContextFor(Self->SelfId()), std::move(ReadSets));
+    }
+
+    void OnAbort(ui64) override {
+        // ReadSets are persistently replaced on abort and sent by volatile tx manager
+        // Previously generated readsets must be ignored
+    }
+
+private:
+    TDataShard* Self;
+    TVector<THolder<TEvTxProcessing::TEvReadSet>> ReadSets;
+};
+
 void TDataShard::PrepareAndSaveOutReadSets(ui64 step,
                                                   ui64 txId,
                                                   const TMap<std::pair<ui64, ui64>, TString>& txOutReadSets,
@@ -450,6 +473,11 @@ void TDataShard::PrepareAndSaveOutReadSets(ui64 step,
     if (txOutReadSets.empty())
         return;
 
+    auto* info = VolatileTxManager.FindByTxId(txId);
+    if (info && !(info->IsArbiter && info->State != EVolatileTxState::Committed)) {
+        info = nullptr;
+    }
+
     ui64 prevSeqno = NextSeqno;
     for (auto& kv : txOutReadSets) {
         ui64 source = kv.first.first;
@@ -459,11 +487,20 @@ void TDataShard::PrepareAndSaveOutReadSets(ui64 step,
             ui64 seqno = NextSeqno++;
             OutReadSets.SaveReadSet(db, seqno, step, rsKey, kv.second);
             preparedRS.push_back(PrepareReadSet(step, txId, source, target, kv.second, seqno));
+            if (info) {
+                // ReadSet seqnos that must be replaced on abort
+                info->ArbiterReadSets.push_back(seqno);
+            }
         }
     }
 
     if (NextSeqno != prevSeqno) {
         PersistSys(db, Schema::Sys_NextSeqno, NextSeqno);
+    }
+
+    if (info) {
+        VolatileTxManager.AttachVolatileTxCallback(txId, new TSendArbiterReadSets(this, std::move(preparedRS)));
+        preparedRS.clear();
     }
 }
 

--- a/ydb/core/tx/datashard/datashard__init.cpp
+++ b/ydb/core/tx/datashard/datashard__init.cpp
@@ -529,6 +529,7 @@ bool TDataShard::TTxInit::ReadEverything(TTransactionContext &txc) {
         if (!Self->VolatileTxManager.Load(db)) {
             return false;
         }
+        Self->OutReadSets.HoldArbiterReadSets();
     }
 
     if (Self->State != TShardState::Offline && txc.DB.GetScheme().GetTableInfo(Schema::CdcStreamScans::TableId)) {

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -286,6 +286,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             /* participants */ { },
             groupProvider.GetCurrentChangeGroup(),
             /* ordered */ false,
+            /* arbiter */ false,
             txc);
         // Note: transaction is already committed, no additional waiting needed
     }

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -212,6 +212,7 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             /* participants */ { },
             groupProvider ? groupProvider->GetCurrentChangeGroup() : std::nullopt,
             /* ordered */ false,
+            /* arbiter */ false,
             *params.Txc);
         // Note: transaction is already committed, no additional waiting needed
     }

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -330,6 +330,7 @@ class TDataShard
 
     class TWaitVolatileDependencies;
     class TSendVolatileResult;
+    class TSendArbiterReadSets;
 
     struct TEvPrivate {
         enum EEv {

--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -764,6 +764,14 @@ bool KqpValidateLocks(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks) 
     return true;
 }
 
+bool KqpLocksHasArbiter(const NKikimrDataEvents::TKqpLocks* kqpLocks) {
+    return kqpLocks && kqpLocks->GetArbiterShard() != 0;
+}
+
+bool KqpLocksIsArbiter(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks) {
+    return KqpLocksHasArbiter(kqpLocks) && kqpLocks->GetArbiterShard() == tabletId;
+}
+
 bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks) {
     auto& kqpLocks = tx->GetDataTx()->GetKqpLocks();
 
@@ -778,6 +786,9 @@ bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLo
     // We expect all stale data to be cleared on restarts
     Y_ABORT_UNLESS(tx->OutReadSets().empty());
     Y_ABORT_UNLESS(tx->AwaitingDecisions().empty());
+
+    const bool hasArbiter = KqpLocksHasArbiter(&kqpLocks);
+    const bool isArbiter = KqpLocksIsArbiter(origin, &kqpLocks);
 
     // Note: usually all shards send locks, since they either have side effects or need to validate locks
     // However it is technically possible to have pure-read shards, that don't contribute to the final decision
@@ -808,6 +819,11 @@ bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLo
                 continue;
             }
 
+            if (hasArbiter && !isArbiter && dstTabletId != kqpLocks.GetArbiterShard()) {
+                // Non-arbiter shards only send locks to the arbiter
+                continue;
+            }
+
             LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Send commit decision from "
                 << origin << " to " << dstTabletId);
 
@@ -821,6 +837,8 @@ bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLo
 
             tx->OutReadSets()[key] = std::move(bodyStr);
         }
+    } else {
+        Y_ABORT_UNLESS(!isArbiter, "Arbiter is not in the sending shards set");
     }
 
     bool receiveLocks = ReceiveLocks(kqpLocks, origin);
@@ -830,6 +848,11 @@ bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLo
         for (ui64 srcTabletId : kqpLocks.GetSendingShards()) {
             if (srcTabletId == origin) {
                 // Don't await decision from ourselves
+                continue;
+            }
+
+            if (hasArbiter && !isArbiter && srcTabletId != kqpLocks.GetArbiterShard()) {
+                // Non-arbiter shards only await decision from the arbiter
                 continue;
             }
 
@@ -891,6 +914,8 @@ bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLo
 
             return false;
         }
+    } else {
+        Y_ABORT_UNLESS(!isArbiter, "Arbiter is not in the receiving shards set");
     }
 
     return true;

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -38,6 +38,9 @@ void KqpPrepareInReadsets(TInputOpData::TInReadSets& inReadSets,
 bool KqpValidateLocks(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks);
 bool KqpValidateVolatileTx(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks);
 
+bool KqpLocksHasArbiter(const NKikimrDataEvents::TKqpLocks* kqpLocks);
+bool KqpLocksIsArbiter(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks);
+
 void KqpEraseLocks(ui64 origin, TActiveTransaction* tx, TSysLocks& sysLocks);
 void KqpCommitLocks(ui64 origin, TActiveTransaction* tx, const TRowVersion& writeVersion, TDataShard& dataShard);
 

--- a/ydb/core/tx/datashard/datashard_outreadset.cpp
+++ b/ydb/core/tx/datashard/datashard_outreadset.cpp
@@ -178,7 +178,7 @@ void TOutReadSets::ResendAll(const TActorContext& ctx) {
         }
         ui64 seqNo = rs.first;
         ui64 target = rs.second.To;
-        Self->ResendReadSetQueue.Progress(rs.first, ctx);
+        Self->ResendReadSetQueue.Progress(seqNo, ctx);
         pendingPipeTrackerCommands.AttachTablet(seqNo, target);
     }
     pendingPipeTrackerCommands.Apply(Self->ResendReadSetPipeTracker, ctx);

--- a/ydb/core/tx/datashard/datashard_outreadset.cpp
+++ b/ydb/core/tx/datashard/datashard_outreadset.cpp
@@ -19,6 +19,7 @@ bool TOutReadSets::LoadReadSets(NIceDb::TNiceDb& db) {
     // TODO[serxa]: this should be Range but it is not working right now
     auto rowset = db.Table<Schema::OutReadSets>().GreaterOrEqual(0).Select<
                                     Schema::OutReadSets::Seqno,
+                                    Schema::OutReadSets::Step,
                                     Schema::OutReadSets::TxId,
                                     Schema::OutReadSets::Origin,
                                     Schema::OutReadSets::From,
@@ -27,12 +28,18 @@ bool TOutReadSets::LoadReadSets(NIceDb::TNiceDb& db) {
         return false;
     while (!rowset.EndOfSet()) {
         ui64 seqNo = rowset.GetValue<Schema::OutReadSets::Seqno>();
+        ui64 step = rowset.GetValue<Schema::OutReadSets::Step>();
         ui64 txId = rowset.GetValue<Schema::OutReadSets::TxId>();
         ui64 origin = rowset.GetValue<Schema::OutReadSets::Origin>();
         ui64 source = rowset.GetValue<Schema::OutReadSets::From>();
         ui64 target = rowset.GetValue<Schema::OutReadSets::To>();
 
-        TReadSetKey rsInfo(txId, origin, source, target);
+        TReadSetInfo rsInfo;
+        rsInfo.TxId = txId;
+        rsInfo.Step = step;
+        rsInfo.Origin = origin;
+        rsInfo.From = source;
+        rsInfo.To = target;
 
         Y_ABORT_UNLESS(!CurrentReadSets.contains(seqNo));
         Y_ABORT_UNLESS(!CurrentReadSetInfos.contains(rsInfo));
@@ -48,24 +55,52 @@ bool TOutReadSets::LoadReadSets(NIceDb::TNiceDb& db) {
     return true;
 }
 
-void TOutReadSets::SaveReadSet(NIceDb::TNiceDb& db, ui64 seqNo, ui64 step, const TReadSetKey& rsInfo, TString body) {
+void TOutReadSets::SaveReadSet(NIceDb::TNiceDb& db, ui64 seqNo, ui64 step, const TReadSetKey& rsKey, const TString& body) {
     using Schema = TDataShard::Schema;
 
     Y_ABORT_UNLESS(!CurrentReadSets.contains(seqNo));
-    Y_ABORT_UNLESS(!CurrentReadSetInfos.contains(rsInfo));
+    Y_ABORT_UNLESS(!CurrentReadSetInfos.contains(rsKey));
 
-    CurrentReadSetInfos[rsInfo] = seqNo;
+    TReadSetInfo rsInfo(rsKey);
+    rsInfo.Step = step;
+
+    CurrentReadSetInfos[rsKey] = seqNo;
     CurrentReadSets[seqNo] = rsInfo;
 
     UpdateMonCounter();
 
     db.Table<Schema::OutReadSets>().Key(seqNo).Update(
-        NIceDb::TUpdate<Schema::OutReadSets::Step>(step),
+        NIceDb::TUpdate<Schema::OutReadSets::Step>(rsInfo.Step),
         NIceDb::TUpdate<Schema::OutReadSets::TxId>(rsInfo.TxId),
         NIceDb::TUpdate<Schema::OutReadSets::Origin>(rsInfo.Origin),
         NIceDb::TUpdate<Schema::OutReadSets::From>(rsInfo.From),
         NIceDb::TUpdate<Schema::OutReadSets::To>(rsInfo.To),
         NIceDb::TUpdate<Schema::OutReadSets::Body>(body));
+}
+
+void TOutReadSets::RemoveReadSet(NIceDb::TNiceDb& db, ui64 seqNo) {
+    using Schema = TDataShard::Schema;
+
+    db.Table<Schema::OutReadSets>().Key(seqNo).Delete();
+
+    auto it = CurrentReadSets.find(seqNo);
+    if (it != CurrentReadSets.end()) {
+        CurrentReadSetInfos.erase(it->second);
+        CurrentReadSets.erase(it);
+    }
+}
+
+TReadSetInfo TOutReadSets::ReplaceReadSet(NIceDb::TNiceDb& db, ui64 seqNo, const TString& body) {
+    using Schema = TDataShard::Schema;
+
+    auto it = CurrentReadSets.find(seqNo);
+    if (it != CurrentReadSets.end()) {
+        db.Table<Schema::OutReadSets>().Key(seqNo).Update(
+            NIceDb::TUpdate<Schema::OutReadSets::Body>(body));
+        return it->second;
+    } else {
+        return TReadSetInfo();
+    }
 }
 
 void TOutReadSets::AckForDeletedDestination(ui64 tabletId, ui64 seqNo, const TActorContext &ctx) {
@@ -113,8 +148,6 @@ void TOutReadSets::SaveAck(const TActorContext &ctx, TAutoPtr<TEvTxProcessing::T
 }
 
 void TOutReadSets::Cleanup(NIceDb::TNiceDb& db, const TActorContext& ctx) {
-    using Schema = TDataShard::Schema;
-
     // Note that this code should be called only after no-more-reads to ensure we wont lost updates
     for (TIntrusivePtr<TEvTxProcessing::TEvReadSetAck>& event : ReadSetAcks) {
         TEvTxProcessing::TEvReadSetAck& ev = *event;
@@ -128,7 +161,7 @@ void TOutReadSets::Cleanup(NIceDb::TNiceDb& db, const TActorContext& ctx) {
             "Deleted RS at %" PRIu64 " source %" PRIu64 " dest %" PRIu64 " consumer %" PRIu64 " seqno %" PRIu64" txId %" PRIu64,
             Self->TabletID(), sender, dest, consumer, seqno, txId);
 
-        db.Table<Schema::OutReadSets>().Key(seqno).Delete();
+        RemoveReadSet(db, seqno);
         Self->ResendReadSetPipeTracker.DetachTablet(seqno, ev.Record.GetTabletDest(), 0, ctx);
     }
     ReadSetAcks.clear();
@@ -140,10 +173,40 @@ void TOutReadSets::Cleanup(NIceDb::TNiceDb& db, const TActorContext& ctx) {
 void TOutReadSets::ResendAll(const TActorContext& ctx) {
     TPendingPipeTrackerCommands pendingPipeTrackerCommands;
     for (const auto& rs : CurrentReadSets) {
+        if (rs.second.OnHold) {
+            continue;
+        }
         ui64 seqNo = rs.first;
         ui64 target = rs.second.To;
         Self->ResendReadSetQueue.Progress(rs.first, ctx);
         pendingPipeTrackerCommands.AttachTablet(seqNo, target);
+    }
+    pendingPipeTrackerCommands.Apply(Self->ResendReadSetPipeTracker, ctx);
+}
+
+void TOutReadSets::HoldArbiterReadSets() {
+    for (auto& rs : CurrentReadSets) {
+        const ui64& seqNo = rs.first;
+        const ui64& txId = rs.second.TxId;
+        auto* info = Self->VolatileTxManager.FindByTxId(txId);
+        if (info && info->IsArbiter && info->State != EVolatileTxState::Committed) {
+            info->ArbiterReadSets.push_back(seqNo);
+            info->IsArbiterOnHold = true;
+            rs.second.OnHold = true;
+        }
+    }
+}
+
+void TOutReadSets::ReleaseOnHoldReadSets(const std::vector<ui64>& seqNos, const TActorContext& ctx) {
+    TPendingPipeTrackerCommands pendingPipeTrackerCommands;
+    for (ui64 seqNo : seqNos) {
+        auto it = CurrentReadSets.find(seqNo);
+        if (it != CurrentReadSets.end() && it->second.OnHold) {
+            it->second.OnHold = false;
+            ui64 target = it->second.To;
+            Self->ResendReadSetQueue.Progress(seqNo, ctx);
+            pendingPipeTrackerCommands.AttachTablet(seqNo, target);
+        }
     }
     pendingPipeTrackerCommands.Apply(Self->ResendReadSetPipeTracker, ctx);
 }

--- a/ydb/core/tx/datashard/datashard_ut_volatile.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_volatile.cpp
@@ -2397,6 +2397,494 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         }
     }
 
+    class TForceVolatileProposeArbiter {
+    public:
+        TForceVolatileProposeArbiter(TTestActorRuntime& runtime, ui64 arbiterShard)
+            : ArbiterShard(arbiterShard)
+            , Observer(runtime.AddObserver<TEvDataShard::TEvProposeTransaction>(
+                [this](auto& ev) {
+                    this->OnEvent(ev);
+                }))
+        {}
+
+        void Remove() {
+            Observer.Remove();
+        }
+
+    private:
+        void OnEvent(TEvDataShard::TEvProposeTransaction::TPtr& ev) {
+            auto* msg = ev->Get();
+            int kind = msg->Record.GetTxKind();
+            if (kind != NKikimrTxDataShard::TX_KIND_DATA) {
+                Cerr << "... skipping TEvProposeTransaction with kind " << kind
+                    << " (expected " << int(NKikimrTxDataShard::TX_KIND_DATA) << ")"
+                    << Endl;
+                return;
+            }
+
+            ui32 flags = msg->Record.GetFlags();
+            if (!(flags & TTxFlags::VolatilePrepare)) {
+                Cerr << "... skipping TEvProposeTransaction with flags " << flags
+                    << " (missing VolatilePrepare flag)"
+                    << Endl;
+                return;
+            }
+
+            NKikimrTxDataShard::TDataTransaction tx;
+            bool ok = tx.ParseFromString(msg->Record.GetTxBody());
+            Y_ABORT_UNLESS(ok, "Failed to parse data transaction");
+            if (!tx.HasKqpTransaction()) {
+                Cerr << "... skipping TEvProposeTransaction without kqp transaction" << Endl;
+                return;
+            }
+
+            auto* kqpTx = tx.MutableKqpTransaction();
+
+            int kqpType = kqpTx->GetType();
+            if (kqpType != NKikimrTxDataShard::KQP_TX_TYPE_DATA) {
+                Cerr << "... skipping TEvProposeTransaction with kqp type " << kqpType
+                    << " (expected " << int(NKikimrTxDataShard::KQP_TX_TYPE_DATA) << ")"
+                    << Endl;
+                return;
+            }
+
+            if (!kqpTx->HasLocks()) {
+                Cerr << "... skipping TEvProposeTransaction without locks" << Endl;
+                return;
+            }
+
+            auto* kqpLocks = kqpTx->MutableLocks();
+            const auto& sendingShards = kqpLocks->GetSendingShards();
+            const auto& receivingShards = kqpLocks->GetReceivingShards();
+
+            if (std::find(sendingShards.begin(), sendingShards.end(), ArbiterShard) == sendingShards.end()) {
+                Cerr << "... skipping TEvProposeTransaction without " << ArbiterShard << " in sending shards" << Endl;
+                return;
+            }
+
+            if (std::find(receivingShards.begin(), receivingShards.end(), ArbiterShard) == receivingShards.end()) {
+                Cerr << "... skipping TEvProposeTransaction without " << ArbiterShard << " in receiving shards" << Endl;
+                return;
+            }
+
+            kqpLocks->SetArbiterShard(ArbiterShard);
+            ok = tx.SerializeToString(msg->Record.MutableTxBody());
+            Y_ABORT_UNLESS(ok, "Failed to serialize data transaction");
+            ++Modified;
+        }
+
+    public:
+        size_t Modified = 0;
+
+    private:
+        const ui64 ArbiterShard;
+        TTestActorRuntime::TEventObserverHolder Observer;
+    };
+
+    class TForceBrokenLock {
+    public:
+        TForceBrokenLock(TTestActorRuntime& runtime, const TTableId& tableId, ui64 shard)
+            : TableId(tableId)
+            , Shard(shard)
+            , ShardActor(ResolveTablet(runtime, shard))
+            , Observer(runtime.AddObserver<TEvDataShard::TEvProposeTransaction>(
+                [this](auto& ev) {
+                    this->OnEvent(ev);
+                }))
+        {}
+
+    private:
+        void OnEvent(TEvDataShard::TEvProposeTransaction::TPtr& ev) {
+            if (ev->GetRecipientRewrite() != ShardActor) {
+                return;
+            }
+
+            auto* msg = ev->Get();
+            int kind = msg->Record.GetTxKind();
+            if (kind != NKikimrTxDataShard::TX_KIND_DATA) {
+                Cerr << "... skipping TEvProposeTransaction with kind " << kind
+                    << " (expected " << int(NKikimrTxDataShard::TX_KIND_DATA) << ")"
+                    << Endl;
+                return;
+            }
+
+            ui32 flags = msg->Record.GetFlags();
+            if (!(flags & TTxFlags::VolatilePrepare)) {
+                Cerr << "... skipping TEvProposeTransaction with flags " << flags
+                    << " (missing VolatilePrepare flag)"
+                    << Endl;
+                return;
+            }
+
+            NKikimrTxDataShard::TDataTransaction tx;
+            bool ok = tx.ParseFromString(msg->Record.GetTxBody());
+            Y_ABORT_UNLESS(ok, "Failed to parse data transaction");
+            if (!tx.HasKqpTransaction()) {
+                Cerr << "... skipping TEvProposeTransaction without kqp transaction" << Endl;
+                return;
+            }
+
+            auto* kqpTx = tx.MutableKqpTransaction();
+
+            int kqpType = kqpTx->GetType();
+            if (kqpType != NKikimrTxDataShard::KQP_TX_TYPE_DATA) {
+                Cerr << "... skipping TEvProposeTransaction with kqp type " << kqpType
+                    << " (expected " << int(NKikimrTxDataShard::KQP_TX_TYPE_DATA) << ")"
+                    << Endl;
+                return;
+            }
+
+            if (!kqpTx->HasLocks()) {
+                Cerr << "... skipping TEvProposeTransaction without locks" << Endl;
+                return;
+            }
+
+            auto* kqpLocks = kqpTx->MutableLocks();
+
+            // We use a lock that should have never existed to simulate a broken lock
+            auto* kqpLock = kqpLocks->AddLocks();
+            kqpLock->SetLockId(msg->Record.GetTxId());
+            kqpLock->SetDataShard(Shard);
+            kqpLock->SetGeneration(1);
+            kqpLock->SetCounter(1);
+            kqpLock->SetSchemeShard(TableId.PathId.OwnerId);
+            kqpLock->SetPathId(TableId.PathId.LocalPathId);
+
+            ok = tx.SerializeToString(msg->Record.MutableTxBody());
+            Y_ABORT_UNLESS(ok, "Failed to serialize data transaction");
+            ++Modified;
+        }
+
+    public:
+        size_t Modified = 0;
+
+    private:
+        const TTableId TableId;
+        const ui64 Shard;
+        const TActorId ShardActor;
+        TTestActorRuntime::TEventObserverHolder Observer;
+    };
+
+    class TBlockReadSets : public std::vector<TEvTxProcessing::TEvReadSet::TPtr> {
+    public:
+        TBlockReadSets(TTestActorRuntime& runtime)
+            : Runtime(runtime)
+            , Observer(runtime.AddObserver<TEvTxProcessing::TEvReadSet>(
+                [this](auto& ev) {
+                    this->OnEvent(ev);
+                }))
+        {}
+
+        void Remove() {
+            Observer.Remove();
+            clear();
+        }
+
+        void Unblock() {
+            Observer.Remove();
+            for (auto& ev : *this) {
+                Runtime.Send(ev.Release(), 0, true);
+            }
+            clear();
+        }
+
+    private:
+        void OnEvent(TEvTxProcessing::TEvReadSet::TPtr& ev) {
+            push_back(std::move(ev));
+        }
+
+    private:
+        TTestActorRuntime& Runtime;
+        TTestActorRuntime::TEventObserverHolder Observer;
+    };
+
+    class TCountReadSets {
+    public:
+        TCountReadSets(TTestActorRuntime& runtime)
+            : Observer(runtime.AddObserver<TEvTxProcessing::TEvReadSet>(
+                [this](auto& ev) {
+                    this->OnEvent(ev);
+                }))
+        {}
+
+    private:
+        void OnEvent(TEvTxProcessing::TEvReadSet::TPtr&) {
+            ++Count;
+        }
+
+    public:
+        size_t Count = 0;
+
+    private:
+        TTestActorRuntime::TEventObserverHolder Observer;
+    };
+
+    Y_UNIT_TEST(UpsertNoLocksArbiter) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardVolatileTransactions(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        TForceVolatileProposeArbiter forceArbiter(runtime, shards.at(0));
+        TCountReadSets countReadSets(runtime);
+
+        Cerr << "========= Starting upsert =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value)
+                VALUES (1, 11), (11, 111), (21, 211), (31, 311);
+            )"),
+            "<empty>");
+
+        // arbiter will send 6 readsets (3 decisions + 3 expectations)
+        // shards will send 2 readsets each (decision + expectation)
+        UNIT_ASSERT_VALUES_EQUAL(countReadSets.Count, 6 + 3 * 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(forceArbiter.Modified, 4u);
+        forceArbiter.Remove();
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 11 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 111 } }, "
+            "{ items { int32_value: 21 } items { int32_value: 211 } }, "
+            "{ items { int32_value: 31 } items { int32_value: 311 } }");
+    }
+
+    Y_UNIT_TEST(UpsertBrokenLockArbiter) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardVolatileTransactions(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        for (size_t i = 0; i < shards.size(); ++i) {
+            TForceVolatileProposeArbiter forceArbiter(runtime, shards.at(0));
+            TForceBrokenLock forceBrokenLock(runtime, tableId, shards.at(i));
+            TCountReadSets countReadSets(runtime);
+
+            int key = 1 + i;
+            int value = key * 10 + key;
+            TString query = Sprintf(
+                R"(UPSERT INTO `/Root/table` (key, value) VALUES (%d, %d), (%d, %d), (%d, %d), (%d, %d);)",
+                key, value,
+                key + 10, value + 100,
+                key + 20, value + 200,
+                key + 30, value + 300);
+
+            Cerr << "========= Starting query " << query << " =========" << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(
+                KqpSimpleExec(runtime, query),
+                "ERROR: ABORTED");
+
+            // Note: kqp stops gathering responses early on abort, allow everyone to settle
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+            // arbiter will send 3 or 6 readsets (3 aborts or 3 decisions + 3 expectations)
+            // shards will send 1 or 2 readsets each (abort or decision + expectation)
+            size_t expectedReadSets = (i == 0 ? 3 + 3 * 2 : 6 + 2 * 2 + 1);
+            UNIT_ASSERT_VALUES_EQUAL(countReadSets.Count, expectedReadSets);
+
+            UNIT_ASSERT_VALUES_EQUAL(forceBrokenLock.Modified, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(forceArbiter.Modified, 4u);
+        }
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "");
+    }
+
+    Y_UNIT_TEST(UpsertNoLocksArbiterRestart) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardVolatileTransactions(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::PIPE_CLIENT, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        TForceVolatileProposeArbiter forceArbiter(runtime, shards.at(0));
+        TBlockReadSets blockedReadSets(runtime);
+
+        Cerr << "========= Starting upsert =========" << Endl;
+        auto upsertFuture = KqpSimpleSend(runtime, R"(
+            UPSERT INTO `/Root/table` (key, value)
+            VALUES (1, 11), (11, 111), (21, 211), (31, 311);
+            )");
+
+        // arbiter will send 3 expectations
+        // shards will send 1 commit decision + 1 expectation
+        size_t expectedReadSets = 3 + 3 * 2;
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        // Reboot arbiter
+        Cerr << "========= Rebooting arbiter =========" << Endl;
+        blockedReadSets.clear();
+        RebootTablet(runtime, shards.at(0), sender);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        Cerr << "========= Unblocking readsets =========" << Endl;
+        blockedReadSets.Unblock();
+        TCountReadSets countReadSets(runtime);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // arbiter will send 3 additional commit decisions
+        UNIT_ASSERT_VALUES_EQUAL(countReadSets.Count, expectedReadSets + 3);
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 11 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 111 } }, "
+            "{ items { int32_value: 21 } items { int32_value: 211 } }, "
+            "{ items { int32_value: 31 } items { int32_value: 311 } }");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            FormatResult(AwaitResponse(runtime, std::move(upsertFuture))),
+            "ERROR: UNDETERMINED");
+    }
+
+    Y_UNIT_TEST(UpsertBrokenLockArbiterRestart) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardVolatileTransactions(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::PIPE_CLIENT, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10, 20, 30));
+            )"),
+            "SUCCESS");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 4u);
+
+        TForceVolatileProposeArbiter forceArbiter(runtime, shards.at(0));
+        TForceBrokenLock forceBrokenLock(runtime, tableId, shards.at(3));
+
+        TBlockReadSets blockedReadSets(runtime);
+
+        Cerr << "========= Starting upsert =========" << Endl;
+        auto upsertFuture = KqpSimpleSend(runtime, R"(
+            UPSERT INTO `/Root/table` (key, value)
+            VALUES (1, 11), (11, 111), (21, 211), (31, 311);
+            )");
+
+        // arbiter will send 3 expectations
+        // two shards will send 1 commit decision + 1 expectation
+        size_t expectedReadSets = 3 + 2 * 2;
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        // Reboot arbiter
+        Cerr << "========= Rebooting arbiter =========" << Endl;
+        blockedReadSets.clear();
+        RebootTablet(runtime, shards.at(0), sender);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
+
+        Cerr << "========= Unblocking readsets =========" << Endl;
+        blockedReadSets.Unblock();
+        TCountReadSets countReadSets(runtime);
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // arbiter will send 3 additional commit decisions
+        // the last shard sends a nodata readset to answer expectation
+        UNIT_ASSERT_VALUES_EQUAL(countReadSets.Count, expectedReadSets + 4);
+
+        Cerr << "========= Checking table =========" << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            FormatResult(AwaitResponse(runtime, std::move(upsertFuture))),
+            "ERROR: ABORTED");
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardVolatile)
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/execute_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_data_tx_unit.cpp
@@ -332,6 +332,7 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
             participants,
             tx->GetDataTx()->GetVolatileChangeGroup(),
             tx->GetDataTx()->GetVolatileCommitOrdered(),
+            /* arbiter */ false,
             txc);
     }
 

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -215,6 +215,7 @@ public:
                 /* participants */ { },
                 groupProvider ? groupProvider->GetCurrentChangeGroup() : std::nullopt,
                 volatileOrdered,
+                /* arbiter */ false,
                 txc);
             // Note: transaction is already committed, no additional waiting needed
         }

--- a/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
@@ -225,6 +225,8 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
 
         LWTRACK(ProposeTransactionKqpDataExecute, op->Orbit);
 
+        const bool isArbiter = op->HasVolatilePrepareFlag() && KqpLocksIsArbiter(tabletId, &kqpLocks);
+
         KqpCommitLocks(tabletId, tx, writeVersion, DataShard);
 
         auto& computeCtx = tx->GetDataTx()->GetKqpComputeCtx();
@@ -335,6 +337,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
                 participants,
                 dataTx->GetVolatileChangeGroup(),
                 dataTx->GetVolatileCommitOrdered(),
+                isArbiter,
                 txc);
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Partial merge of #4331 and #4544 to support arbiters in 24-1. This doesn't include support for the feature flag, so it cannot be enabled. But it includes all code to correctly handle distributed transactions that have an arbiter specified, so it will be possible to enable in 24-2 and beyond.