### PR TITLE
Reimplement IFunctionTypeInfoBuilder15 via NVI

### DIFF
--- a/ydb/library/yql/minikql/mkql_type_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_type_builder.cpp
@@ -1648,12 +1648,12 @@ void TFunctionTypeInfoBuilder::Unused2() {
 void TFunctionTypeInfoBuilder::Unused3() {
 }
 
-NUdf::IFunctionTypeInfoBuilder15& TFunctionTypeInfoBuilder::SupportsBlocks() {
+NUdf::IFunctionTypeInfoBuilder15& TFunctionTypeInfoBuilder::SupportsBlocksImpl() {
     SupportsBlocks_ = true;
     return *this;
 }
 
-NUdf::IFunctionTypeInfoBuilder15& TFunctionTypeInfoBuilder::IsStrict() {
+NUdf::IFunctionTypeInfoBuilder15& TFunctionTypeInfoBuilder::IsStrictImpl() {
     IsStrict_ = true;
     return *this;
 }

--- a/ydb/library/yql/minikql/mkql_type_builder.h
+++ b/ydb/library/yql/minikql/mkql_type_builder.h
@@ -163,8 +163,8 @@ public:
     void Unused2() override;
     void Unused3() override;
 
-    NUdf::IFunctionTypeInfoBuilder15& SupportsBlocks() override;
-    NUdf::IFunctionTypeInfoBuilder15& IsStrict() override;
+    NUdf::IFunctionTypeInfoBuilder15& SupportsBlocksImpl() override;
+    NUdf::IFunctionTypeInfoBuilder15& IsStrictImpl() override;
     const NUdf::IBlockTypeHelper& IBlockTypeHelper() const override;
 
     bool GetSecureParam(NUdf::TStringRef key, NUdf::TStringRef& value) const override;

--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -623,11 +623,11 @@ public:
 
 #define BEGIN_SIMPLE_ARROW_UDF_WITH_OPTIONAL_ARGS(udfName, signatureFunc, optArgc) \
     BEGIN_ARROW_UDF_IMPL(udfName##_BlocksImpl, signatureFunc, optArgc, false) \
-    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().OptionalArgs(optArgc).SupportsBlocks();, ;, ;, "", "", udfName##_BlocksImpl)
+    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().SupportsBlocks().OptionalArgs(optArgc);, ;, ;, "", "", udfName##_BlocksImpl)
 
 #define BEGIN_SIMPLE_STRICT_ARROW_UDF_WITH_OPTIONAL_ARGS(udfName, signatureFunc, optArgc) \
     BEGIN_ARROW_UDF_IMPL(udfName##_BlocksImpl, signatureFunc, optArgc, true) \
-    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().OptionalArgs(optArgc).SupportsBlocks().IsStrict();, ;, ;, "", "", udfName##_BlocksImpl)
+    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().SupportsBlocks().IsStrict().OptionalArgs(optArgc);, ;, ;, "", "", udfName##_BlocksImpl)
 
 #define END_ARROW_UDF(udfNameBlocks, exec) \
     inline bool udfNameBlocks::DeclareSignature(\

--- a/ydb/library/yql/public/udf/udf_type_builder.h
+++ b/ydb/library/yql/public/udf/udf_type_builder.h
@@ -646,8 +646,8 @@ public:
 #if UDF_ABI_COMPATIBILITY_VERSION_CURRENT >= UDF_ABI_COMPATIBILITY_VERSION(2, 28)
 class IFunctionTypeInfoBuilder15: public IFunctionTypeInfoBuilder14 {
 public:
-    virtual IFunctionTypeInfoBuilder15& SupportsBlocks() = 0;
-    virtual IFunctionTypeInfoBuilder15& IsStrict() = 0;
+    virtual IFunctionTypeInfoBuilder15& SupportsBlocksImpl() = 0;
+    virtual IFunctionTypeInfoBuilder15& IsStrictImpl() = 0;
 };
 #endif
 
@@ -708,6 +708,18 @@ public:
         OptionalArgsImpl(optionalArgs);
         return *this;
     }
+
+#if UDF_ABI_COMPATIBILITY_VERSION_CURRENT >= UDF_ABI_COMPATIBILITY_VERSION(2, 28)
+    IFunctionTypeInfoBuilder& SupportsBlocks() {
+        SupportsBlocksImpl();
+        return *this;
+    }
+
+    IFunctionTypeInfoBuilder& IsStrict() {
+        IsStrictImpl();
+        return *this;
+    }
+#endif
 
     IFunctionTypeInfoBuilder& Returns(TDataTypeId type) {
         ReturnsImpl(type);


### PR DESCRIPTION
All the interfaces provided by `IFunctionTypeInfoBuilder15` has no non-virtual wrappers in the public interface `IFunctionTypeInfoBuilder`, and yield the instance of the particular version of the interface. This might break the chain of hints for function type builder.

This patch reimplements `IFunctionTypeInfoBuilder15` via NVI pattern following the way all previous versions of this interface are written.

To ensure everything works fine as a result of the previous patch, the hints used to create simple Arrow UDFs with optional arguments are reordered in the right way.

### Changelog category

* Not for changelog (changelog entry is not required)