### PR TITLE
Fix VDisk log and chunk status flags logic

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -1319,9 +1319,11 @@ struct TEvCheckSpaceResult : public TEventLocal<TEvCheckSpaceResult, TEvBlobStor
     ui32 NumSlots; // number of VSlots over PDisk
     double Occupancy = 0;
     TString ErrorReason;
+    TStatusFlags LogStatusFlags;
 
     TEvCheckSpaceResult(NKikimrProto::EReplyStatus status, TStatusFlags statusFlags, ui32 freeChunks,
-            ui32 totalChunks, ui32 usedChunks, ui32 numSlots, const TString &errorReason)
+            ui32 totalChunks, ui32 usedChunks, ui32 numSlots, const TString &errorReason,
+            TStatusFlags logStatusFlags = {})
         : Status(status)
         , StatusFlags(statusFlags)
         , FreeChunks(freeChunks)
@@ -1329,6 +1331,7 @@ struct TEvCheckSpaceResult : public TEventLocal<TEvCheckSpaceResult, TEvBlobStor
         , UsedChunks(usedChunks)
         , NumSlots(numSlots)
         , ErrorReason(errorReason)
+        , LogStatusFlags(logStatusFlags)
     {}
 
     TString ToString() const {
@@ -1340,6 +1343,7 @@ struct TEvCheckSpaceResult : public TEventLocal<TEvCheckSpaceResult, TEvBlobStor
         str << " UsedChunks# " << UsedChunks;
         str << " NumSlots# " << NumSlots;
         str << " ErrorReason# \"" << ErrorReason << "\"";
+        str << " LogStatusFlags# " << StatusFlagsToString(LogStatusFlags);
         str << "}";
         return str.Str();
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -2026,7 +2026,8 @@ void TPDisk::CheckSpace(TCheckSpace &evCheckSpace) {
                 GetTotalChunks(evCheckSpace.Owner, evCheckSpace.OwnerGroupType),
                 GetUsedChunks(evCheckSpace.Owner, evCheckSpace.OwnerGroupType),
                 AtomicGet(TotalOwners),
-                TString());
+                TString(),
+                GetStatusFlags(OwnerSystem, evCheckSpace.OwnerGroupType));
     result->Occupancy = occupancy;
     ActorSystem->Send(evCheckSpace.Sender, result.release());
     Mon.CheckSpace.CountResponse();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -946,8 +946,7 @@ void TPDisk::LogWrite(TLogWrite &evLog, TVector<ui32> &logChunksToCommit) {
     }
     Y_ABORT_UNLESS(CommonLogger->NextChunks.empty());
 
-    evLog.Result.Reset(new NPDisk::TEvLogResult(NKikimrProto::OK,
-                GetStatusFlags(evLog.Owner, evLog.OwnerGroupType), nullptr));
+    evLog.Result.Reset(new NPDisk::TEvLogResult(NKikimrProto::OK, GetStatusFlags(OwnerSystem, evLog.OwnerGroupType), nullptr));
     Y_ABORT_UNLESS(evLog.Result.Get());
     evLog.Result->Results.push_back(NPDisk::TEvLogResult::TRecord(evLog.Lsn, evLog.Cookie));
 }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
@@ -2758,14 +2758,7 @@ void TTestRedZoneSurvivability::TestFSM(const TActorContext &ctx) {
     case 30:
     {
         //TEST_RESPONSE(EvLogResult, ERROR);
-        TEST_PDISK_STATUS(ui32(NKikimrBlobStorage::StatusIsValid)
-            | ui32(NKikimrBlobStorage::StatusDiskSpaceCyan)
-            | ui32(NKikimrBlobStorage::StatusDiskSpaceRed)
-            | ui32(NKikimrBlobStorage::StatusDiskSpaceOrange)
-            | ui32(NKikimrBlobStorage::StatusDiskSpacePreOrange)
-            | ui32(NKikimrBlobStorage::StatusDiskSpaceLightOrange)
-            | ui32(NKikimrBlobStorage::StatusDiskSpaceYellowStop)
-            | ui32(NKikimrBlobStorage::StatusDiskSpaceLightYellowMove));
+        TEST_PDISK_STATUS(ui32(NKikimrBlobStorage::StatusIsValid));
         VERBOSE_COUT(" Sending TEvLog to delete a chunk");
         NPDisk::TCommitRecord commitRecord;
         TRcBuf commitData = TRcBuf(TString("hello"));
@@ -2790,7 +2783,10 @@ void TTestRedZoneSurvivability::TestFSM(const TActorContext &ctx) {
     case 50:
     {
         TEST_RESPONSE(EvLogResult, OK);
-        TEST_PDISK_STATUS(ui32(NKikimrBlobStorage::StatusIsValid));
+        TEST_PDISK_STATUS(ui32(NKikimrBlobStorage::StatusIsValid)
+            | ui32(NKikimrBlobStorage::StatusDiskSpaceCyan)
+            | ui32(NKikimrBlobStorage::StatusDiskSpaceLightYellowMove)
+            | ui32(NKikimrBlobStorage::StatusDiskSpaceYellowStop));
 
         VERBOSE_COUT(" Sending TEvLog to log 3 * ChunkSize bytes");
         TRcBuf largeData = TRcBuf(PrepareData(ChunkSize * 3));
@@ -2800,7 +2796,10 @@ void TTestRedZoneSurvivability::TestFSM(const TActorContext &ctx) {
     case 60:
     {
         TEST_RESPONSE(EvLogResult, OK);
-        TEST_PDISK_STATUS(ui32(NKikimrBlobStorage::StatusIsValid));
+        TEST_PDISK_STATUS(ui32(NKikimrBlobStorage::StatusIsValid)
+            | ui32(NKikimrBlobStorage::StatusDiskSpaceCyan)
+            | ui32(NKikimrBlobStorage::StatusDiskSpaceLightYellowMove)
+            | ui32(NKikimrBlobStorage::StatusDiskSpaceYellowStop));
 
         VERBOSE_COUT(" Sending TEvLog to cut log");
         NPDisk::TCommitRecord commitRecord;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_context.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_context.h
@@ -119,7 +119,7 @@ namespace NKikimr {
                 case NKikimrProto::OK:
                     if constexpr (T::EventType != TEvBlobStorage::EvLogResult) {
                         // we have different semantics for TEvLogResult StatusFlags
-                        OutOfSpaceState.UpdateLocal(ev.StatusFlags);
+                        OutOfSpaceState.UpdateLocalChunk(ev.StatusFlags);
                     } else {
                         // update log space flags
                         OutOfSpaceState.UpdateLocalLog(ev.StatusFlags);

--- a/ydb/core/blobstorage/vdisk/common/vdisk_outofspace_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_outofspace_ut.cpp
@@ -18,7 +18,7 @@ namespace NKikimr {
             UNIT_ASSERT_EQUAL(state.GetGlobalColor(), TSpaceColor::GREEN);
 
             NPDisk::TStatusFlags flags = NKikimrBlobStorage::StatusIsValid;
-            state.UpdateLocal(flags);
+            state.UpdateLocalChunk(flags);
             UNIT_ASSERT_EQUAL(state.GetGlobalColor(), TSpaceColor::GREEN);
             UNIT_ASSERT_EQUAL(state.GetLocalStatusFlags(), flags);
             UNIT_ASSERT_EQUAL(state.GetGlobalStatusFlags().Flags, flags);

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_logic.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_logic.cpp
@@ -268,8 +268,7 @@ namespace NKikimr {
     ESpaceColor TOutOfSpaceLogic::GetSpaceColor() const {
         auto& oos = VCtx->GetOutOfSpaceState();
         const ESpaceColor global = oos.GetGlobalColor();
-        const ESpaceColor log = oos.GetLocalLogColor();
-        return Max(log, global >= TSpaceColor::ORANGE ? global : oos.GetLocalColor());
+        return global >= TSpaceColor::ORANGE ? global : oos.GetLocalColor();
     }
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_tracker.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_oos_tracker.cpp
@@ -86,7 +86,8 @@ namespace NKikimr {
 
             TotalChunks = msg->TotalChunks;
             FreeChunks = msg->FreeChunks;
-            VCtx->OutOfSpaceState.UpdateLocal(msg->StatusFlags);
+            VCtx->OutOfSpaceState.UpdateLocalChunk(msg->StatusFlags);
+            VCtx->OutOfSpaceState.UpdateLocalLog(msg->LogStatusFlags);
             VCtx->OutOfSpaceState.UpdateLocalFreeSpaceShare(ui64(1 << 24) * (1.0 - msg->Occupancy));
             VCtx->OutOfSpaceState.UpdateLocalUsedChunks(msg->UsedChunks);
             MonGroup.DskTotalBytes() = msg->TotalChunks * PDiskCtx->Dsk->ChunkSize;
@@ -124,6 +125,16 @@ namespace NKikimr {
                                 TABLER() {
                                     auto flags = VCtx->OutOfSpaceState.GetLocalStatusFlags();
                                     TABLED() {str << "Local Disk State";}
+                                    TABLED() {str << StatusFlagToSpaceColor(flags);}
+                                }
+                                TABLER() {
+                                    auto flags = VCtx->OutOfSpaceState.GetLocalChunkStatusFlags();
+                                    TABLED() {str << "Local Disk State (chunks)";}
+                                    TABLED() {str << StatusFlagToSpaceColor(flags);}
+                                }
+                                TABLER() {
+                                    auto flags = VCtx->OutOfSpaceState.GetLocalLogStatusFlags();
+                                    TABLED() {str << "Local Disk State (log)";}
                                     TABLED() {str << StatusFlagToSpaceColor(flags);}
                                 }
                                 TABLER() {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix VDisk log and chunk status flags logic

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Chunk and log color flags are now handled independently, but choosing the worst one for the final color of the VDisk.
