### PR TITLE
EnforceUserTokenCheckRequirement option: require token check if token was specified

### DIFF
--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -233,6 +233,7 @@ struct TAppData {
     NKikimrConfig::TBackgroundCleaningConfig& BackgroundCleaningConfig;
     NKikimrConfig::TGraphConfig& GraphConfig;
     bool EnforceUserTokenRequirement = false;
+    bool EnforceUserTokenCheckRequirement = true; // check token if it was specified
     bool AllowHugeKeyValueDeletes = true; // delete when all clients limit deletes per request
     bool EnableKqpSpilling = false;
     bool AllowShadowDataInSchemeShardForTests = false;

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -212,6 +212,7 @@ public:
 
         const auto& securityConfig(Config.GetDomainsConfig().GetSecurityConfig());
         appData->EnforceUserTokenRequirement = securityConfig.GetEnforceUserTokenRequirement();
+        appData->EnforceUserTokenCheckRequirement = securityConfig.GetEnforceUserTokenCheckRequirement();
         if (securityConfig.AdministrationAllowedSIDsSize() > 0) {
             TVector<TString> administrationAllowedSIDs(securityConfig.GetAdministrationAllowedSIDs().begin(), securityConfig.GetAdministrationAllowedSIDs().end());
             appData->AdministrationAllowedSIDs = std::move(administrationAllowedSIDs);

--- a/ydb/core/grpc_services/grpc_request_proxy.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy.cpp
@@ -187,7 +187,7 @@ private:
                 databaseName = CanonizePath(maybeDatabaseName.GetRef());
             } else {
                 if (!AllowYdbRequestsWithoutDatabase && DynamicNode) {
-                    requestBaseCtx->ReplyUnauthenticated("Requests without specified database is not allowed");
+                    requestBaseCtx->ReplyUnauthenticated("Requests without specified database are not allowed");
                     requestBaseCtx->FinishSpan();
                     return;
                 } else {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -232,6 +232,7 @@ message TDomainsConfig {
 
     message TSecurityConfig {
         optional bool EnforceUserTokenRequirement = 1 [default = false];
+        optional bool EnforceUserTokenCheckRequirement = 7 [default = false]; // Check if a token was specified // If not, or if the token was incorrect or access was denied, the request will be handled as if no token was provided
         repeated string MonitoringAllowedSIDs = 2;
         repeated string AdministrationAllowedSIDs = 3;
         repeated string DefaultUserSIDs = 4;

--- a/ydb/core/security/secure_request.h
+++ b/ydb/core/security/secure_request.h
@@ -20,6 +20,10 @@ private:
         return AppData()->EnforceUserTokenRequirement;
     }
 
+    static bool GetEnforceUserTokenCheckRequirement() {
+        return AppData()->EnforceUserTokenCheckRequirement;
+    }
+
     static const TVector<TString>& GetAdministrationAllowedSIDs() {
         return AppData()->AdministrationAllowedSIDs;
     }
@@ -137,7 +141,23 @@ public:
 
 public:
     bool IsTokenRequired() const {
-        return GetEnforceUserTokenRequirement() || (RequireAdminAccess && !GetAdministrationAllowedSIDs().empty());
+        if (GetEnforceUserTokenRequirement()) {
+            return true;
+        }
+
+        // Admin access
+        if (RequireAdminAccess && !GetAdministrationAllowedSIDs().empty()) {
+            return true;
+        }
+
+         // Acts in case of !EnforceUserTokenRequirement: If user specify token,
+         // it is checked and required to be valid for futher usage of YDB.
+         // If user doesn't specify token, no checks are made.
+        if (GetEnforceUserTokenCheckRequirement() && IsTokenExists()) {
+            return true;
+        }
+
+        return false;
     }
 
     void Bootstrap(const TActorContext& ctx) {
@@ -185,4 +205,3 @@ public:
 };
 
 }
-

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -235,6 +235,7 @@ namespace Tests {
             appData.NetClassifierConfig.MergeFrom(Settings->NetClassifierConfig);
             appData.StreamingConfig.MergeFrom(Settings->AppConfig->GetGRpcConfig().GetStreamingConfig());
             appData.EnforceUserTokenRequirement = Settings->AppConfig->GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenRequirement();
+            appData.EnforceUserTokenCheckRequirement = Settings->AppConfig->GetDomainsConfig().GetSecurityConfig().GetEnforceUserTokenCheckRequirement();
             appData.DomainsConfig.MergeFrom(Settings->AppConfig->GetDomainsConfig());
             appData.ColumnShardConfig.MergeFrom(Settings->AppConfig->GetColumnShardConfig());
             appData.PersQueueGetReadSessionsInfoWorkerFactory = Settings->PersQueueGetReadSessionsInfoWorkerFactory.get();


### PR DESCRIPTION
EnforceUserTokenCheckRequirement option: require token check if token was specified. Valid only when EnforceUserTokenRequirement option is false.

This behavour is expected by users: when they specify token, they expect that they use authorized access to database. But for historical reasons unauthorized tokens now are accepted as if user not specified token at all. In this mode it is hard to check correctness of authorization: both in server and in client.


### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
