### PR TITLE
Object storage listing

### DIFF
--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -1,0 +1,837 @@
+#include "flat_ut_client.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <ydb/public/api/protos/draft/ydb_object_storage.pb.h>
+#include <ydb/public/api/grpc/draft/ydb_object_storage_v1.grpc.pb.h>
+#include <grpc++/client_context.h>
+#include <grpc++/create_channel.h>
+
+namespace NKikimr {
+namespace NFlatTests {
+
+using namespace Tests;
+using NClient::TValue;
+
+Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
+
+    static int GRPC_PORT = 0;
+
+    void S3WriteRow(TFlatMsgBusClient& annoyingClient, ui64 hash, TString name, TString path, ui64 version, ui64 ts, TString data, TString table) {
+        TString insertRowQuery =  R"(
+                    (
+                    (let key '(
+                        '('Hash (Uint64 '%llu))
+                        '('Name (Utf8 '"%s"))
+                        '('Path (Utf8 '"%s"))
+                        '('Version (Uint64 '%llu))
+                    ))
+                    (let value '(
+                        '('Timestamp (Uint64 '%llu))
+                        '('Data (String '"%s"))
+                        '('Int32Data (Null))
+                    ))
+                    (let ret_ (AsList
+                        (UpdateRow '/dc-1/Dir/%s key value)
+                    ))
+                    (return ret_)
+                    )
+                )";
+
+        annoyingClient.FlatQuery(Sprintf(insertRowQuery.data(), hash, name.data(), path.data(), version, ts, data.data(), table.data()));
+    }
+
+    void S3DeleteRow(TFlatMsgBusClient& annoyingClient, ui64 hash, TString name, TString path, ui64 version, TString table) {
+        TString eraseRowQuery =  R"(
+                    (
+                    (let key '(
+                        '('Hash (Uint64 '%llu))
+                        '('Name (Utf8 '"%s"))
+                        '('Path (Utf8 '"%s"))
+                        '('Version (Uint64 '%llu))
+                    ))
+                    (let ret_ (AsList
+                        (EraseRow '/dc-1/Dir/%s key)
+                    ))
+                    (return ret_)
+                    )
+                )";
+
+        annoyingClient.FlatQuery(Sprintf(eraseRowQuery.data(), hash, name.data(), path.data(), version, table.data()));
+    }
+
+    void PrepareS3Data(TFlatMsgBusClient& annoyingClient) {
+        annoyingClient.InitRoot();
+        annoyingClient.MkDir("/dc-1", "Dir");
+        annoyingClient.CreateTable("/dc-1/Dir",
+            R"(Name: "Table"
+                Columns { Name: "Hash"      Type: "Uint64"}
+                Columns { Name: "Name"      Type: "Utf8"}
+                Columns { Name: "Path"      Type: "Utf8"}
+                Columns { Name: "Version"   Type: "Uint64"}
+                Columns { Name: "Timestamp" Type: "Uint64"}
+                Columns { Name: "Data"      Type: "String"}
+                Columns { Name: "ExtraData" Type: "String"}
+                Columns { Name: "Int32Data" Type: "Int32"}
+                Columns { Name: "Unused1"   Type: "Uint32"}
+                KeyColumnNames: [
+                    "Hash",
+                    "Name",
+                    "Path",
+                    "Version"
+                    ]
+                SplitBoundary { KeyPrefix {
+                    Tuple { Optional { Uint64 : 60 }}
+                }}
+                SplitBoundary { KeyPrefix {
+                    Tuple { Optional { Uint64 : 100 }}
+                    Tuple { Optional { Text : 'Bucket100' }}
+                    Tuple { Optional { Text : '/Videos/Game of Thrones/Season 1/Episode 2' }}
+                }}
+                SplitBoundary { KeyPrefix {
+                    Tuple { Optional { Uint64 : 100 }}
+                    Tuple { Optional { Text : 'Bucket100' }}
+                    Tuple { Optional { Text : '/Videos/Game of Thrones/Season 1/Episode 8' }}
+                }}
+                SplitBoundary { KeyPrefix {
+                    Tuple { Optional { Uint64 : 100 }}
+                    Tuple { Optional { Text : 'Bucket100' }}
+                    Tuple { Optional { Text : '/Videos/Godfather 2.avi' }}
+                }}
+                PartitionConfig {
+                    ExecutorCacheSize: 100
+
+                                        CompactionPolicy {
+                                                InMemSizeToSnapshot: 2000
+                                                InMemStepsToSnapshot: 1
+                                                InMemForceStepsToSnapshot: 50
+                                                InMemForceSizeToSnapshot: 16777216
+                                                InMemCompactionBrokerQueue: 0
+                                                ReadAheadHiThreshold: 1048576
+                                                ReadAheadLoThreshold: 16384
+                                                MinDataPageSize: 300
+                                                SnapBrokerQueue: 0
+
+                                                LogOverheadSizeToSnapshot: 16777216
+                                                LogOverheadCountToSnapshot: 500
+                                                DroppedRowsPercentToCompact: 146
+
+                                                Generation {
+                                                  GenerationId: 0
+                                                  SizeToCompact: 0
+                                                  CountToCompact: 2000
+                                                  ForceCountToCompact: 4000
+                                                  ForceSizeToCompact: 100000000
+                                                  #CompactionBrokerQueue: 4294967295
+                                                  KeepInCache: false
+                                                  ResourceBrokerTask: "compaction_gen1"
+                                                  ExtraCompactionPercent: 100
+                                                  ExtraCompactionMinSize: 16384
+                                                  ExtraCompactionExpPercent: 110
+                                                  ExtraCompactionExpMaxSize: 0
+                                                  UpliftPartSize: 0
+                                                }
+                                        }
+
+                }
+            )");
+
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Shoot to Thrill.mp3", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Thunderstruck.mp3", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/rock.m3u", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/Nirvana", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/Nirvana/Smeels Like Teen Spirit.mp3", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/Nirvana/In Bloom.mp3", 1, 20, "", "Table");
+
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/face.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/facepalm.jpg", 1, 20, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/palm.jpg", 1, 30, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 1.avi", 1, 100, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 10.avi", 1, 300, "", "Table");
+
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 2.avi", 1, 200, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 3.avi", 1, 300, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 4.avi", 1, 300, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 5.avi", 1, 300, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 6.avi", 1, 300, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 7.avi", 1, 300, "", "Table");
+
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 8.avi", 1, 300, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 9.avi", 1, 300, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 2/Episode 1.avi", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Godfather 2.avi", 1, 500, "", "Table");
+
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Godfather.avi", 1, 500, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Godmother.avi", 1, 500, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/House of Cards/Season 1/Chapter 1.avi", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/House of Cards/Season 1/Chapter 2.avi", 1, 1200, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Videos/Terminator 2.avi", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/XXX/1.avi", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/XXX/2.avi", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/XXX/3.avi", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/XXX/3d.avi", 1, 1100, "", "Table");
+
+        S3WriteRow(annoyingClient, 333, "Bucket333", "asdf", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 333, "Bucket333", "boo/bar", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 333, "Bucket333", "boo/baz/xyzzy", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 333, "Bucket333", "cquux/thud", 1, 1100, "", "Table");
+        S3WriteRow(annoyingClient, 333, "Bucket333", "cquux/bla", 1, 1100, "", "Table");
+
+        S3DeleteRow(annoyingClient, 50, "Bucket50", "Music/Nirvana/Smells Like Teen Spirit.mp3", 1, "Table");
+        S3DeleteRow(annoyingClient, 100, "Bucket100", "/Photos/palm.jpg", 1, "Table");
+        S3DeleteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 2.avi", 1, "Table");
+        S3DeleteRow(annoyingClient, 100, "Bucket100", "/Videos/Game of Thrones/Season 1/Episode 5.avi", 1, "Table");
+        S3DeleteRow(annoyingClient, 100, "Bucket100", "/Videos/House of Cards/Season 1/Chapter 2.avi", 1, "Table");
+    }
+
+    void DoListingBySelectRange(TFlatMsgBusClient& annoyingClient,
+                                ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter, const TString& startAfter, ui32 maxKeys,
+                                TSet<TString>& commonPrefixes, TSet<TString>& contents)
+    {
+        // Read all rows from the bucket
+        TString table = "Table";
+        ui64 hash = bucket;
+        TString name = "Bucket" + ToString(bucket);
+        TString selectBucketQuery =  R"(
+                (
+                    (let range '(
+                        '('Hash (Uint64 '%llu) (Uint64 '%llu))
+                        '('Name (Utf8 '"%s") (Utf8 '"%s"))
+                        '('Path (Nothing (OptionalType (DataType 'Utf8))) (Void))
+                        '('Version (Nothing (OptionalType (DataType 'Uint64))) (Void))
+                    ))
+                    (let columns '(
+                        'Path
+                    ))
+                    (let res
+                        (SelectRange '/dc-1/Dir/%s range columns '() )
+                    )
+                    (return (AsList (SetResult 'Objects res)))
+                )
+                )";
+
+        TClient::TFlatQueryOptions opts;
+        NKikimrMiniKQL::TResult res;
+        annoyingClient.FlatQuery(Sprintf(selectBucketQuery.data(), hash, hash, name.data(), name.data(), table.data()), opts, res);
+
+        TValue value = TValue::Create(res.GetValue(), res.GetType());
+        TValue objects = value["Objects"];
+        TValue l = objects["List"];
+        TVector<TString> paths;
+        for (ui32 i = 0; i < l.Size(); ++i) {
+            TValue ps = l[i];
+            paths.emplace_back(ps["Path"]);
+        }
+
+        // Make a list of common prefixes and a list of full paths that match the parameter
+        commonPrefixes.clear();
+        contents.clear();
+        for (const auto& p : paths) {
+            if (commonPrefixes.size() + contents.size() == maxKeys)
+                break;
+
+            if (!p.StartsWith(pathPrefix))
+                continue;
+
+            if (p <= startAfter)
+                continue;
+
+            size_t delimPos = p.find_first_of(pathDelimiter, pathPrefix.length());
+            if (delimPos == TString::npos) {
+                contents.insert(p);
+            } else {
+                TString prefix = p.substr(0, delimPos + pathDelimiter.length());
+                if (prefix > startAfter) {
+                    commonPrefixes.insert(prefix);
+                }
+            }
+        }
+    }
+
+    TString MakeTuplePb(const TVector<TString>& values) {
+        TStringStream pbPrefixCols;
+
+        pbPrefixCols <<
+            "type {"
+            "   tuple_type {";
+        for (size_t i = 0; i < values.size(); ++i) {
+            pbPrefixCols <<
+                "       elements { type_id : UTF8 }";
+        }
+        pbPrefixCols <<
+            "   }"
+            "}"
+            "value { ";
+        for (const auto& pc : values) {
+            pbPrefixCols <<
+                "   items { text_value : '" << pc <<  "' } ";
+        }
+        pbPrefixCols << "}";
+
+        return pbPrefixCols.Str();
+    }
+
+    void S3Listing(const int grpcPort, const TString& table, const TString& pbPrefixCols,
+                    const TString& pathPrefix, const TString& pathDelimiter,
+                    const TString& pbStartAfterSuffixCols,
+                    const TVector<TString>& columnsToReturn, ui32 maxKeys,
+                    Ydb::ObjectStorage::ListingResponse& res) {
+        TStringBuilder endpoint;
+        endpoint << "localhost:" << grpcPort;
+        std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(endpoint, grpc::InsecureChannelCredentials());
+        auto stub = Ydb::ObjectStorage::V1::ObjectStorageService::NewStub(channel);
+        
+        TAutoPtr<Ydb::ObjectStorage::ListingRequest> request = new Ydb::ObjectStorage::ListingRequest();
+        request->Setpath_column_prefix(pathPrefix);
+        request->Settable_name(table);
+        request->Setpath_column_delimiter(pathDelimiter);
+        for (const TString& c : columnsToReturn) {
+            request->Addcolumns_to_return(c);
+        }
+        request->set_max_keys(maxKeys);
+
+        bool parseOk = ::google::protobuf::TextFormat::ParseFromString(pbPrefixCols, request->mutable_key_prefix());
+        UNIT_ASSERT(parseOk);
+        parseOk = ::google::protobuf::TextFormat::ParseFromString(pbStartAfterSuffixCols, request->mutable_start_after_key_suffix());
+        UNIT_ASSERT(parseOk);
+        grpc::ClientContext rcontext;
+        grpc::Status status = stub->List(&rcontext, *request, &res);
+    }
+
+    TString DoS3Listing(ui16 grpcPort, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter, const TString& startAfter,
+                    TString continuationToken,
+                    const TVector<TString>& columnsToReturn, ui32 maxKeys,
+                    TVector<TString>& commonPrefixes, TVector<TString>& contents)
+    {
+        std::shared_ptr<grpc::Channel> channel;
+        TStringBuilder endpoint;
+        endpoint << "localhost:" <<  grpcPort;
+        channel = grpc::CreateChannel(endpoint, grpc::InsecureChannelCredentials());
+        std::unique_ptr<Ydb::ObjectStorage::V1::ObjectStorageService::Stub> stub;
+        stub = Ydb::ObjectStorage::V1::ObjectStorageService::NewStub(channel);
+
+        TString keyPrefix = R"(
+            type {
+                tuple_type {
+                    elements {
+                        type_id: UINT64
+                    }
+                    elements {
+                        type_id: UTF8
+                    }
+                }
+            }
+            value {
+                items {
+                    uint64_value: )" + ToString(bucket) + R"(
+                }
+                items {
+                    text_value: "Bucket)" + ToString(bucket) + R"("
+                }
+            }
+        )";
+
+
+        TString pbStartAfterSuffix;
+        if (startAfter) {
+            pbStartAfterSuffix = R"(
+                type {
+                    tuple_type {
+                        elements {
+                            type_id: UTF8
+                        }
+                    }
+                }
+                value {
+                    items {
+                        text_value: ")" + startAfter + R"("
+                    }
+                }
+            )";
+        }
+
+        TAutoPtr<Ydb::ObjectStorage::ListingRequest> request = new Ydb::ObjectStorage::ListingRequest();
+        request->Setpath_column_prefix(pathPrefix);
+        request->Settable_name("/dc-1/Dir/Table");
+        request->Setpath_column_delimiter(pathDelimiter);
+        request->set_continuation_token(continuationToken);
+        for (const TString& c : columnsToReturn) {
+            request->Addcolumns_to_return(c);
+        }
+        request->set_max_keys(maxKeys);
+        bool parseOk = ::google::protobuf::TextFormat::ParseFromString(keyPrefix, request->mutable_key_prefix());
+        UNIT_ASSERT(parseOk);
+        parseOk = ::google::protobuf::TextFormat::ParseFromString(pbStartAfterSuffix, request->mutable_start_after_key_suffix());
+        UNIT_ASSERT(parseOk);
+        grpc::ClientContext rcontext;
+        Ydb::ObjectStorage::ListingResponse response;
+        grpc::Status status = stub->List(&rcontext, *request, &response);
+
+        UNIT_ASSERT_VALUES_EQUAL(response.status(), Ydb::StatusIds::SUCCESS);
+        
+        commonPrefixes.clear();
+        contents.clear();
+
+        if (response.common_prefixes_size() > 0) {
+            auto &folders = response.common_prefixes();
+            for (auto row : folders) {
+                commonPrefixes.emplace_back(row);
+            }
+        }
+        
+        if (response.has_contents()) {
+            auto &files = response.contents();
+            for (auto row : files.rows()) {
+                for (auto item : row.items()) {
+                    if (item.has_text_value()) {
+                        contents.emplace_back(item.text_value());
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (response.next_continuation_token().size()) {
+            TString token = response.next_continuation_token();
+
+            return token;
+        }
+
+        return "";
+    }
+
+    void CompareS3Listing(TFlatMsgBusClient& annoyingClient, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter,
+                       const TString& startAfter, ui32 maxKeys, const TVector<TString>& columnsToReturn)
+    {
+        TSet<TString> expectedCommonPrefixes;
+        TSet<TString> expectedContents;
+        DoListingBySelectRange(annoyingClient, bucket, pathPrefix, pathDelimiter, startAfter, maxKeys, expectedCommonPrefixes, expectedContents);
+
+        TVector<TString> commonPrefixes;
+        TVector<TString> contents;
+        DoS3Listing(GRPC_PORT, bucket, pathPrefix, pathDelimiter, startAfter, nullptr, columnsToReturn, maxKeys, commonPrefixes, contents);
+
+        UNIT_ASSERT_VALUES_EQUAL(expectedCommonPrefixes.size(), commonPrefixes.size());
+        ui32 i = 0;
+        for (const auto& p : expectedCommonPrefixes) {
+            UNIT_ASSERT_VALUES_EQUAL(p, commonPrefixes[i]);
+            ++i;
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(expectedContents.size(), contents.size());
+        i = 0;
+        for (const auto& p : expectedContents) {
+            UNIT_ASSERT_VALUES_EQUAL(p, contents[i]);
+            ++i;
+        }
+    }
+
+    void TestS3Listing(TFlatMsgBusClient& annoyingClient, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter,
+                       ui32 maxKeys, const TVector<TString>& columnsToReturn)
+    {
+        Cout << Endl << "---------------------------------------" << Endl
+             << "Bucket" << bucket << " : " << pathPrefix << Endl;
+
+        CompareS3Listing(annoyingClient, bucket, pathPrefix, pathDelimiter, "", maxKeys, columnsToReturn);
+        CompareS3Listing(annoyingClient, bucket, pathPrefix, pathDelimiter, pathPrefix, maxKeys, columnsToReturn);
+
+        TSet<TString> expectedCommonPrefixes;
+        TSet<TString> expectedContents;
+        DoListingBySelectRange(annoyingClient, bucket, pathPrefix, pathDelimiter, "",  100500, expectedCommonPrefixes, expectedContents);
+
+        for (const TString& after : expectedCommonPrefixes) {
+            CompareS3Listing(annoyingClient, bucket, pathPrefix, pathDelimiter, after, maxKeys, columnsToReturn);
+        }
+
+        for (const TString& after : expectedContents) {
+            CompareS3Listing(annoyingClient, bucket, pathPrefix, pathDelimiter, after, maxKeys, columnsToReturn);
+        }
+    }
+
+    Y_UNIT_TEST(Listing) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServer cleverServer = TServer(TServerSettings(port));
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        PrepareS3Data(annoyingClient);
+
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::MSGBUS_REQUEST, NActors::NLog::PRI_DEBUG);
+//        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TestS3Listing(annoyingClient, 50, "", "", 10, {});
+        TestS3Listing(annoyingClient, 50, "", "/", 7, {});
+        TestS3Listing(annoyingClient, 50, "Music/", "/", 9, {});
+        TestS3Listing(annoyingClient, 50, "Music/Nirvana", "/", 11, {});
+        TestS3Listing(annoyingClient, 50, "Music/Nirvana/", "/", 2, {});
+        TestS3Listing(annoyingClient, 50, "Photos/", "/", 3, {});
+
+        TestS3Listing(annoyingClient, 100, "", "", 4, {});
+        TestS3Listing(annoyingClient, 100, "", "/", 7, {});
+        TestS3Listing(annoyingClient, 100, "/", "", 3, {});
+        TestS3Listing(annoyingClient, 100, "/", "/", 1, {});
+        TestS3Listing(annoyingClient, 100, "/Photos/", "/", 11, {});
+        TestS3Listing(annoyingClient, 100, "/Videos/", "/", 18, {});
+        TestS3Listing(annoyingClient, 100, "/Videos", "/", 3, {"Path", "Timestamp"});
+        TestS3Listing(annoyingClient, 100, "/Videos/Game ", "/", 5, {"Path", "Timestamp"});
+        TestS3Listing(annoyingClient, 100, "/Videos/Game of Thrones/Season 1/", "/", 6, {"Path", "Timestamp"});
+        TestS3Listing(annoyingClient, 100, "/Videos/Game of Thr", " ", 4, {"Path", "Timestamp"});
+
+        TestS3Listing(annoyingClient, 20, "", "/", 8, {"Path", "Timestamp"});
+        TestS3Listing(annoyingClient, 200, "/", "/", 3, {"Path", "Timestamp"});
+
+        // Request NULL columns
+        TestS3Listing(annoyingClient, 50, "Photos/", "/", 7, {"ExtraData"});
+        TestS3Listing(annoyingClient, 50, "Photos/", "", 2, {"Unused1"});
+        TestS3Listing(annoyingClient, 50, "Music/", "/", 11, {"ExtraData"});
+        TestS3Listing(annoyingClient, 50, "/", "", 8, {"Unused1"});
+        TestS3Listing(annoyingClient, 50, "Music/Nirvana", "/", 11, {"Int32Data"});
+
+        TestS3Listing(annoyingClient, 333, "", "", 2, {});
+        TestS3Listing(annoyingClient, 333, "", "/", 2, {});
+        TestS3Listing(annoyingClient, 333, "", "", 3, {});
+        TestS3Listing(annoyingClient, 333, "", "/", 3, {});
+    }
+
+    Y_UNIT_TEST(MaxKeysAndSharding) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServer cleverServer = TServer(TServerSettings(port));
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        PrepareS3Data(annoyingClient);
+
+        for (auto commonPrefix: {"/", "/Videos", "/Videos/", "/W", "/X",
+                "/Videos/Game of", "/Videos/Game of Thrones/",
+                "/Videos/Game of Thrones/Season 1",
+                "/Videos/Game of Thrones/Season 1/"})
+        {
+            for (ui32 maxKeys = 1; maxKeys < 20; ++maxKeys) {
+                TestS3Listing(annoyingClient, 100, commonPrefix, "/", maxKeys, {});
+            }
+        }
+    }
+
+    void TestS3GenericListingRequest(const TVector<TString>& prefixColumns, const TString& pathPrefix, const TString& pathDelimiter,
+                    const TVector<TString>& startAfterSuffixColumns,
+                    const TVector<TString>& columnsToReturn, ui32 maxKeys,
+                    Ydb::StatusIds_StatusCode expectedStatus = Ydb::StatusIds::SUCCESS,
+                    const TString& expectedErrMessage = "")
+    {
+        TString pbPrefixCols = MakeTuplePb(prefixColumns);
+
+        TString pbStartAfterSuffixCols = MakeTuplePb(startAfterSuffixColumns);
+
+        Ydb::ObjectStorage::ListingResponse response;
+        S3Listing(GRPC_PORT, "/dc-1/Dir/Table", pbPrefixCols, pathPrefix, pathDelimiter,
+                    pbStartAfterSuffixCols, columnsToReturn, maxKeys, response);
+
+        UNIT_ASSERT_VALUES_EQUAL(response.status(), expectedStatus);
+        if (expectedErrMessage) {
+            UNIT_ASSERT_VALUES_EQUAL(response.issues().size(), 1);
+            auto &issueMessage = response.issues()[0];
+            UNIT_ASSERT_VALUES_EQUAL(issueMessage.message(), expectedErrMessage);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(response.issues().size(), 0);
+        }
+    }
+
+    void TestS3ListingRequest(const TVector<TString>& prefixColumns, 
+                    const TString& pathPrefix, const TString& pathDelimiter,
+                    const TString& startAfter, const TVector<TString>& columnsToReturn, ui32 maxKeys,
+                    Ydb::StatusIds_StatusCode expectedStatus = Ydb::StatusIds::SUCCESS,
+                    const TString& expectedErrMessage = "")
+    {
+        TVector<TString> startAfterSuffix;
+        if (!startAfter.empty()) {
+            startAfterSuffix.push_back(startAfter);
+        }
+        TestS3GenericListingRequest(prefixColumns, pathPrefix, pathDelimiter,
+                                           startAfterSuffix,
+                                           columnsToReturn, maxKeys,
+                                           expectedStatus, expectedErrMessage);
+    }
+
+    Y_UNIT_TEST(SchemaChecks) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServer cleverServer = TServer(TServerSettings(port));
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        PrepareS3Data(annoyingClient);
+
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::MSGBUS_REQUEST, NActors::NLog::PRI_DEBUG);
+
+        TestS3ListingRequest({}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Value for path column 'Hash' has type Uint64, expected Utf8");
+
+        TestS3ListingRequest({""}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Cannot parse value of type Uint64 from text '' in tuple at position 0");
+
+        TestS3ListingRequest({"AAA"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Cannot parse value of type Uint64 from text 'AAA' in tuple at position 0");
+
+        TestS3ListingRequest({"-1"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Cannot parse value of type Uint64 from text '-1' in tuple at position 0");
+
+        TestS3ListingRequest({"1"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::SUCCESS,
+            "");
+
+        TestS3ListingRequest({"1", "Bucket1", "/"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Value for path column 'Version' has type Uint64, expected Utf8");
+
+        TestS3ListingRequest({"1", "Bucket1", "/Photos", "1"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Tuple size 4 is greater that expected size 3");
+
+        TestS3ListingRequest({"1", "Bucket1", "/Photos", "/"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Tuple size 4 is greater that expected size 3");
+
+        TestS3ListingRequest({"1", "2", "3"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Value for path column 'Version' has type Uint64, expected Utf8");
+
+        TestS3ListingRequest({"1", "2", "3", "4"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Tuple size 4 is greater that expected size 3");
+
+        TestS3ListingRequest({"1", "2", "3", "4", "5"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Tuple size 5 is greater that expected size 3");
+
+        TestS3ListingRequest({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid KeyPrefix: Tuple size 10 is greater that expected size 3");
+
+        TestS3ListingRequest({"1"}, "/", "/", "", {"NonExistingColumn"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Unknown column 'NonExistingColumn'");
+
+        TestS3ListingRequest({"1", "Bucket1"}, "/", "/", "abc", {"Path"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid StartAfterKeySuffix: StartAfter parameter doesn't match PathPrefix");
+    }
+
+    Y_UNIT_TEST(Split) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServer cleverServer = TServer(TServerSettings(port));
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+        SetSplitMergePartCountLimit(cleverServer.GetRuntime(), -1);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        PrepareS3Data(annoyingClient);
+
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::MSGBUS_REQUEST, NActors::NLog::PRI_DEBUG);
+//        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_DEBUG);
+
+        TestS3ListingRequest({"100", "Bucket100"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::SUCCESS,
+            "");
+
+        // Split shard #1 (where Bucket100 is stored)
+        TVector<ui64> shards = annoyingClient.GetTablePartitions("/dc-1/Dir/Table");
+        annoyingClient.SplitTablePartition("/dc-1/Dir/Table",
+                "SourceTabletId: " + ToString(shards[1]) + " "
+                "SplitBoundary { KeyPrefix { "
+                "   Tuple { Optional { Uint64: 100 } } "
+                "   Tuple { Optional { Text: 'Bucket100' } } "
+                "   Tuple { Optional { Text: '/Vid' } } "
+                "} }");
+
+        TVector<ui64> shardsAfter = annoyingClient.GetTablePartitions("/dc-1/Dir/Table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size() + 1, shardsAfter.size());
+
+        TestS3ListingRequest({"100", "Bucket100"}, "/", "/", "", {"Path"}, 10,
+            Ydb::StatusIds::SUCCESS,
+            "");
+
+        CompareS3Listing(annoyingClient, 100, "/", "/", "", 100500, {"Path"});
+    }
+
+    Y_UNIT_TEST(SuffixColumns) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServer cleverServer = TServer(TServerSettings(port));
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        PrepareS3Data(annoyingClient);
+
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Shoot to Thrill.mp3", 55, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Shoot to Thrill.mp3", 66, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Shoot to Thrill.mp3", 77, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Shoot to Thrill.mp3", 88, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Shoot to Thrill.mp3", 666, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/AC DC/Thunderstruck.mp3", 66, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/rock.m3u", 111, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/rock.m3u", 222, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/rock.m3u", 333, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/Nirvana", 112, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/Nirvana/Smeels Like Teen Spirit.mp3", 100, 10, "", "Table");
+        S3WriteRow(annoyingClient, 50, "Bucket50", "Music/Nirvana/In Bloom.mp3", 120, 20, "", "Table");
+
+        //
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TestS3GenericListingRequest({"50", "Bucket50"}, "Music/AC DC/", "/", {"Music/AC DC/Shoot to Thrill.mp3", "66"}, {"Path", "Version", "Data"}, 10,
+            Ydb::StatusIds::SUCCESS,
+            "");
+
+        TestS3GenericListingRequest({"50", "Bucket50"}, "Music/AC DC/", "/", {"Music/AC DC/Shoot to Thrill.mp3"}, {"Path", "Version", "Timestamp"}, 10,
+            Ydb::StatusIds::SUCCESS,
+            "");
+
+        TestS3GenericListingRequest({"50", "Bucket50"}, "Music/AC DC/", "/", {"Music/AC DC/Shoot to Thrill.mp3", "66", "abcd"}, {"Path", "Version"}, 10,
+            Ydb::StatusIds::BAD_REQUEST,
+            "Invalid StartAfterKeySuffix: Tuple size 3 is greater that expected size 2");
+    }
+
+    Y_UNIT_TEST(ManyDeletes) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServerSettings settings(port);
+        settings.NodeCount = 1;
+        TServer cleverServer = TServer(TServerSettings(port));
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        // Disable shared cache to trigger restarts
+        TAtomic unused = 42;
+        cleverServer.GetRuntime()->GetAppData().Icb->SetValue("SharedPageCache_Size", 10, unused);
+        cleverServer.GetRuntime()->GetAppData().Icb->SetValue("SharedPageCache_Size", 10, unused);
+        UNIT_ASSERT_VALUES_EQUAL(unused, 10);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        PrepareS3Data(annoyingClient);
+
+#ifdef NDEBUG
+        const int N_ROWS = 10000;
+#else
+        const int N_ROWS = 5000;
+#endif
+
+        TString bigData(300, 'a');
+
+        for (int i = 0; i < N_ROWS; ++i) {
+            S3WriteRow(annoyingClient, 100, "Bucket100", "/A/Santa Barbara " + ToString(i), 1, 1100, bigData, "Table");
+            S3WriteRow(annoyingClient, 100, "Bucket100", "/B/Santa Barbara " + ToString(i%4000), 1, 1100, bigData, "Table");
+            S3WriteRow(annoyingClient, 100, "Bucket100", "/C/Santa Barbara " + ToString(i), 1, 1100, bigData, "Table");
+            S3WriteRow(annoyingClient, 100, "Bucket100", "/D/Santa Barbara " + ToString(i), 1, 1100, bigData, "Table");
+            if (i % 100 == 0)
+                Cerr << ".";
+        }
+        Cerr << "\n";
+
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_DEBUG);
+
+        CompareS3Listing(annoyingClient, 100, "/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/A/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/B/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/P/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/Photos/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/Videos/", "/", "", 1000, {});
+
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_ERROR);
+
+        for (int i = 0; i < N_ROWS/2; ++i) {
+            S3DeleteRow(annoyingClient, 100, "Bucket100", "/A/Santa Barbara " + ToString(i), 1, "Table");
+            S3DeleteRow(annoyingClient, 100, "Bucket100", "/B/Santa Barbara " + ToString(i), 1, "Table");
+            S3DeleteRow(annoyingClient, 100, "Bucket100", "/C/Santa Barbara " + ToString(i), 1, "Table");
+            S3DeleteRow(annoyingClient, 100, "Bucket100", "/D/Santa Barbara " + ToString(i), 1, "Table");
+            if (i % 100 == 0)
+                Cerr << ".";
+        }
+        Cerr << "\n";
+
+        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_DEBUG);
+
+        CompareS3Listing(annoyingClient, 100, "/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/A/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/B/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/P/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/Photos/", "/", "", 1000, {});
+        CompareS3Listing(annoyingClient, 100, "/Videos/", "/", "", 1000, {});
+    }
+
+    Y_UNIT_TEST(CornerCases) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServer cleverServer = TServer(TServerSettings(port));
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        PrepareS3Data(annoyingClient);
+
+        S3WriteRow(annoyingClient, 750, "Bucket750", "foo/1.mp4", 55, 10, "", "Table");
+        S3WriteRow(annoyingClient, 750, "Bucket750", "foo/bar/1.mp3", 55, 10, "", "Table");
+        S3WriteRow(annoyingClient, 750, "Bucket750", "foo/bar0", 55, 10, "", "Table");
+        S3WriteRow(annoyingClient, 750, "Bucket750", "foo/cat.jpg", 55, 10, "", "Table");
+
+        CompareS3Listing(annoyingClient, 750, "foo/", "/", "", 10, {});
+        CompareS3Listing(annoyingClient, 750, "foo/", "/", "foo/1.mp4", 1, {});
+        CompareS3Listing(annoyingClient, 750, "foo/", "/", "foo/bar/", 1, {});
+        CompareS3Listing(annoyingClient, 750, "foo/", "/", "foo/bar0", 1, {});
+
+        TVector<TString> commonPrefixes;
+        TVector<TString> contents;
+
+        auto continuationToken = DoS3Listing(GRPC_PORT, 750, "foo/", "/", "", "", {}, 1, commonPrefixes, contents);
+        
+        UNIT_ASSERT(continuationToken);
+        UNIT_ASSERT_EQUAL(1, contents.size());
+        UNIT_ASSERT_EQUAL(0, commonPrefixes.size());
+        UNIT_ASSERT_STRINGS_EQUAL("foo/1.mp4", contents[0]);
+
+        continuationToken = DoS3Listing(GRPC_PORT, 750, "foo/", "/", "", continuationToken, {}, 1, commonPrefixes, contents);
+
+        UNIT_ASSERT(continuationToken);
+        UNIT_ASSERT_EQUAL(0, contents.size());
+        UNIT_ASSERT_EQUAL(1, commonPrefixes.size());
+        UNIT_ASSERT_STRINGS_EQUAL("foo/bar/", commonPrefixes[0]);
+
+        continuationToken = DoS3Listing(GRPC_PORT, 750, "foo/", "/", "", continuationToken, {}, 1, commonPrefixes, contents);
+
+        UNIT_ASSERT(continuationToken);
+        UNIT_ASSERT_EQUAL(1, contents.size());
+        UNIT_ASSERT_EQUAL(0, commonPrefixes.size());
+        UNIT_ASSERT_STRINGS_EQUAL("foo/bar0", contents[0]);
+
+        continuationToken = DoS3Listing(GRPC_PORT, 750, "foo/", "/", "", continuationToken, {}, 1, commonPrefixes, contents);
+
+        UNIT_ASSERT(continuationToken);
+        UNIT_ASSERT_EQUAL(1, contents.size());
+        UNIT_ASSERT_EQUAL(0, commonPrefixes.size());
+        UNIT_ASSERT_STRINGS_EQUAL("foo/cat.jpg", contents[0]);
+
+        continuationToken = DoS3Listing(GRPC_PORT, 750, "foo/", "/", "", continuationToken, {}, 1, commonPrefixes, contents);
+
+        UNIT_ASSERT(!continuationToken);
+        UNIT_ASSERT_EQUAL(0, contents.size());
+        UNIT_ASSERT_EQUAL(0, commonPrefixes.size());
+    }
+}
+
+}}

--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -306,7 +306,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     TString DoS3Listing(ui16 grpcPort, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter, const TString& startAfter,
                     TString continuationToken,
                     const TVector<TString>& columnsToReturn, ui32 maxKeys,
-                    TVector<TString>& commonPrefixes, TVector<TString>& contents, bool filter = false)
+                    TVector<TString>& commonPrefixes, TVector<TString>& contents, std::optional<Ydb::ObjectStorage::ListingRequest_EMatchType> filter = {}, bool useOldFilter = false)
     {
         std::shared_ptr<grpc::Channel> channel;
         TStringBuilder endpoint;
@@ -366,27 +366,81 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         request->set_max_keys(maxKeys);
 
         if (filter) {
-            auto* filterMsg = request->mutable_filter();
+            if (useOldFilter) {
+                auto* filterMsg = request->mutable_filter();
 
-            TString filter = R"(
-                type {
-                    tuple_type {
-                        elements {
-                            type_id: BOOL
+                TString filter = R"(
+                    type {
+                        tuple_type {
+                            elements {
+                                type_id: BOOL
+                            }
                         }
                     }
-                }
-                value {
-                    items {
-                        bool_value: )" + ToString(true) + R"(
+                    value {
+                        items {
+                            bool_value: )" + ToString(true) + R"(
+                        }
                     }
-                }
-            )";
+                )";
 
-            bool parseOk = ::google::protobuf::TextFormat::ParseFromString(filter, filterMsg->mutable_values());
-            UNIT_ASSERT(parseOk);
-            
-            filterMsg->add_columns("SomeBool");
+                bool parseOk = ::google::protobuf::TextFormat::ParseFromString(filter, filterMsg->mutable_values());
+                UNIT_ASSERT(parseOk);
+
+                filterMsg->add_columns("SomeBool");
+            } else {
+                auto* filterMsg = request->mutable_matching_filter();
+
+                ui32 eq = (ui32) filter.value();
+
+                TString filter = R"(
+                    type {
+                        tuple_type {
+                            elements {
+                                list_type {
+                                    item {
+                                        type_id: STRING
+                                    }
+                                }
+                            }
+                            elements {
+                                list_type {
+                                    item {
+                                        type_id: UINT32
+                                    }
+                                }
+                            }
+                            elements {
+                                tuple_type {
+                                    elements {
+                                        type_id: BOOL
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    value {
+                        items {
+                            items {
+                                text_value: "SomeBool"
+                            }
+                        }
+                        items {
+                            items {
+                                uint32_value: )" + ToString(eq) + R"(
+                            }
+                        }
+                        items {
+                            items {
+                                bool_value: )" + ToString(true) + R"(
+                            }
+                        }
+                    }
+                )";
+
+                bool parseOk = ::google::protobuf::TextFormat::ParseFromString(filter, filterMsg);
+                UNIT_ASSERT(parseOk);
+            }
         }
 
         bool parseOk = ::google::protobuf::TextFormat::ParseFromString(keyPrefix, request->mutable_key_prefix());
@@ -919,16 +973,42 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/inner2/c.jpg", 1, 10, "", "Table", false);
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/xyz.io", 1, 10, "", "Table", false);
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/yyyyy.txt", 1, 10, "", "Table", false);
+        
+        {
+            TVector<TString> folders;
+            TVector<TString> files;
+            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", nullptr, nullptr, {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_EQUAL, true);
 
-        TVector<TString> folders;
-        TVector<TString> files;
-        DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", nullptr, nullptr, {}, 1000, folders, files, true);
+            TVector<TString> expectedFolders = {"/Photos/games/", "/Photos/inner/", "/Photos/test/", "/Photos/test3/", "/Photos/test5/", "/Photos/test6/"};
+            TVector<TString> expectedFiles = {"/Photos/a.jpg", "/Photos/c.jpg"};
 
-        TVector<TString> expectedFolders = {"/Photos/games/", "/Photos/inner/", "/Photos/test/", "/Photos/test3/", "/Photos/test5/", "/Photos/test6/"};
-        TVector<TString> expectedFiles = {"/Photos/a.jpg", "/Photos/c.jpg"};
+            UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
+            UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
+        }
 
-        UNIT_ASSERT_EQUAL(expectedFolders, folders);
-        UNIT_ASSERT_EQUAL(expectedFiles, files);
+        {
+            TVector<TString> folders;
+            TVector<TString> files;
+            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", nullptr, nullptr, {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_EQUAL);
+
+            TVector<TString> expectedFolders = {"/Photos/games/", "/Photos/inner/", "/Photos/test/", "/Photos/test3/", "/Photos/test5/", "/Photos/test6/"};
+            TVector<TString> expectedFiles = {"/Photos/a.jpg", "/Photos/c.jpg"};
+
+            UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
+            UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
+        }
+
+        {
+            TVector<TString> folders;
+            TVector<TString> files;
+            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", nullptr, nullptr, {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_NOT_EQUAL);
+
+            TVector<TString> expectedFolders = {"/Photos/folder/", "/Photos/inner/", "/Photos/test/", "/Photos/test2/", "/Photos/test3/", "/Photos/test4/", "/Photos/test5/", "/Photos/test6/"};
+            TVector<TString> expectedFiles = {"/Photos/b.jpg"};
+            
+            UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
+            UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
+        }
     }
 }
 

--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -486,8 +486,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     }
 
     void TestS3Listing(TFlatMsgBusClient& annoyingClient, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter,
-                       ui32 maxKeys, const TVector<TString>& columnsToReturn)
-    {
+                       ui32 maxKeys, const TVector<TString>& columnsToReturn) {
         Cout << Endl << "---------------------------------------" << Endl
              << "Bucket" << bucket << " : " << pathPrefix << Endl;
 

--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -306,8 +306,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     TString DoS3Listing(ui16 grpcPort, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter, const TString& startAfter,
                     TString continuationToken,
                     const TVector<TString>& columnsToReturn, ui32 maxKeys,
-                    TVector<TString>& commonPrefixes, TVector<TString>& contents, std::optional<Ydb::ObjectStorage::ListingRequest_EMatchType> filter = {}, bool useOldFilter = false)
-    {
+                    TVector<TString>& commonPrefixes, TVector<TString>& contents, std::optional<Ydb::ObjectStorage::ListingRequest_EMatchType> filter = {}) {
         std::shared_ptr<grpc::Channel> channel;
         TStringBuilder endpoint;
         endpoint << "localhost:" <<  grpcPort;
@@ -366,81 +365,57 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         request->set_max_keys(maxKeys);
 
         if (filter) {
-            if (useOldFilter) {
-                auto* filterMsg = request->mutable_filter();
+            auto* filterMsg = request->mutable_matching_filter();
 
-                TString filter = R"(
-                    type {
-                        tuple_type {
-                            elements {
-                                type_id: BOOL
+            ui32 eq = (ui32) filter.value();
+
+            TString filter = R"(
+                type {
+                    tuple_type {
+                        elements {
+                            list_type {
+                                item {
+                                    type_id: STRING
+                                }
+                            }
+                        }
+                        elements {
+                            list_type {
+                                item {
+                                    type_id: UINT32
+                                }
+                            }
+                        }
+                        elements {
+                            tuple_type {
+                                elements {
+                                    type_id: BOOL
+                                }
                             }
                         }
                     }
-                    value {
+                }
+                value {
+                    items {
+                        items {
+                            text_value: "SomeBool"
+                        }
+                    }
+                    items {
+                        items {
+                            uint32_value: )" + ToString(eq) + R"(
+                        }
+                    }
+                    items {
                         items {
                             bool_value: )" + ToString(true) + R"(
                         }
                     }
-                )";
+                }
+            )";
 
-                bool parseOk = ::google::protobuf::TextFormat::ParseFromString(filter, filterMsg->mutable_values());
-                UNIT_ASSERT(parseOk);
-
-                filterMsg->add_columns("SomeBool");
-            } else {
-                auto* filterMsg = request->mutable_matching_filter();
-
-                ui32 eq = (ui32) filter.value();
-
-                TString filter = R"(
-                    type {
-                        tuple_type {
-                            elements {
-                                list_type {
-                                    item {
-                                        type_id: STRING
-                                    }
-                                }
-                            }
-                            elements {
-                                list_type {
-                                    item {
-                                        type_id: UINT32
-                                    }
-                                }
-                            }
-                            elements {
-                                tuple_type {
-                                    elements {
-                                        type_id: BOOL
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    value {
-                        items {
-                            items {
-                                text_value: "SomeBool"
-                            }
-                        }
-                        items {
-                            items {
-                                uint32_value: )" + ToString(eq) + R"(
-                            }
-                        }
-                        items {
-                            items {
-                                bool_value: )" + ToString(true) + R"(
-                            }
-                        }
-                    }
-                )";
-
-                bool parseOk = ::google::protobuf::TextFormat::ParseFromString(filter, filterMsg);
-                UNIT_ASSERT(parseOk);
-            }
+            bool parseOk = ::google::protobuf::TextFormat::ParseFromString(filter, filterMsg);
+            UNIT_ASSERT(parseOk);
         }
 
         bool parseOk = ::google::protobuf::TextFormat::ParseFromString(keyPrefix, request->mutable_key_prefix());
@@ -973,18 +948,6 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/inner2/c.jpg", 1, 10, "", "Table", false);
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/xyz.io", 1, 10, "", "Table", false);
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/yyyyy.txt", 1, 10, "", "Table", false);
-        
-        {
-            TVector<TString> folders;
-            TVector<TString> files;
-            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", nullptr, nullptr, {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_EQUAL, true);
-
-            TVector<TString> expectedFolders = {"/Photos/games/", "/Photos/inner/", "/Photos/test/", "/Photos/test3/", "/Photos/test5/", "/Photos/test6/"};
-            TVector<TString> expectedFiles = {"/Photos/a.jpg", "/Photos/c.jpg"};
-
-            UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
-            UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
-        }
 
         {
             TVector<TString> folders;

--- a/ydb/core/client/ut/ya.make
+++ b/ydb/core/client/ut/ya.make
@@ -40,6 +40,7 @@ SRCS(
     flat_ut.cpp
     locks_ut.cpp
     query_stats_ut.cpp
+    object_storage_listing_ut.cpp
 )
 
 END()

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -563,7 +563,7 @@ void TKikimrRunner::InitializeGRpc(const TKikimrRunConfig& runConfig) {
         names["topic"] = &hasTopic;
         TServiceCfg hasPQCD = services.empty();
         names["pqcd"] = &hasPQCD;
-        TServiceCfg hasObjectStorage = true;
+        TServiceCfg hasObjectStorage = services.empty();
         names["object_storage"] = &hasObjectStorage;
         TServiceCfg hasClickhouseInternal = services.empty();
         names["clickhouse_internal"] = &hasClickhouseInternal;

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -121,6 +121,7 @@
 #include <ydb/services/ydb/ydb_scheme.h>
 #include <ydb/services/ydb/ydb_scripting.h>
 #include <ydb/services/ydb/ydb_table.h>
+#include <ydb/services/ydb/ydb_object_storage.h>
 
 #include <ydb/core/fq/libs/init/init.h>
 
@@ -562,6 +563,8 @@ void TKikimrRunner::InitializeGRpc(const TKikimrRunConfig& runConfig) {
         names["topic"] = &hasTopic;
         TServiceCfg hasPQCD = services.empty();
         names["pqcd"] = &hasPQCD;
+        TServiceCfg hasObjectStorage = true;
+        names["object_storage"] = &hasObjectStorage;
         TServiceCfg hasClickhouseInternal = services.empty();
         names["clickhouse_internal"] = &hasClickhouseInternal;
         TServiceCfg hasRateLimiter = false;
@@ -722,6 +725,11 @@ void TKikimrRunner::InitializeGRpc(const TKikimrRunConfig& runConfig) {
         if (hasClickhouseInternal) {
             server.AddService(new NGRpcService::TGRpcYdbClickhouseInternalService(ActorSystem.Get(), Counters,
                 AppData->InFlightLimiterRegistry, grpcRequestProxies[0], hasClickhouseInternal.IsRlAllowed()));
+        }
+
+        if (hasObjectStorage) {
+            server.AddService(new NGRpcService::TGRpcYdbObjectStorageService(ActorSystem.Get(), Counters,
+                grpcRequestProxies[0], hasObjectStorage.IsRlAllowed()));
         }
 
         if (hasScripting) {

--- a/ydb/core/grpc_services/rpc_calls.h
+++ b/ydb/core/grpc_services/rpc_calls.h
@@ -12,6 +12,8 @@
 #include <ydb/public/api/protos/ydb_discovery.pb.h>
 #include <ydb/public/api/protos/ydb_monitoring.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
+#include <ydb/public/api/protos/ydb_table.pb.h>
+#include <ydb/public/api/protos/draft/ydb_object_storage.pb.h>
 #include <ydb/public/api/protos/ydb_persqueue_cluster_discovery.pb.h>
 #include <ydb/public/api/protos/ydb_persqueue_v1.pb.h>
 #include <ydb/public/api/protos/ydb_federation_discovery.pb.h>

--- a/ydb/core/grpc_services/rpc_object_storage.cpp
+++ b/ydb/core/grpc_services/rpc_object_storage.cpp
@@ -1,0 +1,819 @@
+#include "grpc_request_proxy.h"
+#include "rpc_calls.h"
+
+#include "util/string/vector.h"
+#include "ydb/library/yql/minikql/mkql_type_ops.h"
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/core/tx/datashard/datashard.h>
+#include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/base/path.h>
+#include <ydb/core/engine/mkql_proto.h>
+#include <ydb/core/actorlib_impl/long_timer.h>
+#include <ydb/core/grpc_services/rpc_calls.h>
+#include <ydb/core/ydb_convert/ydb_convert.h>
+#include <ydb/core/kqp/common/kqp_types.h>
+#include <ydb/core/scheme/scheme_type_info.h>
+#include <util/system/unaligned_mem.h>
+
+#include <ydb/public/sdk/cpp/client/ydb_proto/accessor.h>
+
+namespace NKikimr {
+namespace NGRpcService {
+
+using TEvObjectStorageListingRequest = TGrpcRequestOperationCall<Ydb::ObjectStorage::ListingRequest, Ydb::ObjectStorage::ListingResponse>;
+
+// NOTE: TCell's can reference memomry from tupleValue
+bool CellsFromTuple(const Ydb::Type* tupleType,
+                    const Ydb::Value& tupleValue,
+                    const TConstArrayRef<NScheme::TTypeInfo>& types,
+                    bool allowCastFromString,
+                    TVector<TCell>& key,
+                    TString& errStr,
+                    TVector<TString>& memoryOwner)
+{
+
+#define CHECK_OR_RETURN_ERROR(cond, descr) \
+    if (!(cond)) { \
+        errStr = descr; \
+        return false; \
+    }
+
+    if (tupleType) {
+        Ydb::Type::TypeCase typeCase = tupleType->type_case();
+        CHECK_OR_RETURN_ERROR(typeCase == Ydb::Type::kTupleType ||
+                              (typeCase == Ydb::Type::TYPE_NOT_SET && tupleType->tuple_type().elementsSize() == 0), "Must be a tuple");
+        CHECK_OR_RETURN_ERROR(tupleType->tuple_type().elementsSize() <= types.size(),
+            "Tuple size " + ToString(tupleType->tuple_type().elementsSize()) + " is greater that expected size " + ToString(types.size()));
+
+        for (size_t i = 0; i < tupleType->tuple_type().elementsSize(); ++i) {
+            const auto& ti = tupleType->tuple_type().Getelements(i);
+            CHECK_OR_RETURN_ERROR(ti.type_case() == Ydb::Type::kTypeId, "Element at index " + ToString(i) + " in not a TypeId");
+            const auto& typeId = ti.Gettype_id();
+            CHECK_OR_RETURN_ERROR(typeId == types[i].GetTypeId() ||
+                allowCastFromString && (typeId == NScheme::NTypeIds::Utf8),
+                "Element at index " + ToString(i) + " has type " + Type_PrimitiveTypeId_Name(typeId) + " but expected type is " + ToString(types[i].GetTypeId()));
+        }
+
+        CHECK_OR_RETURN_ERROR(tupleType->Gettuple_type().elementsSize() == tupleValue.itemsSize(),
+            Sprintf("Tuple value length %" PRISZT " doesn't match the length in type %" PRISZT, tupleValue.itemsSize(), tupleType->Gettuple_type().elementsSize()));
+    } else {
+        CHECK_OR_RETURN_ERROR(types.size() >= tupleValue.itemsSize(),
+            Sprintf("Tuple length %" PRISZT " is greater than key column count %" PRISZT, tupleValue.itemsSize(), types.size()));
+    }
+
+    for (ui32 i = 0; i < tupleValue.itemsSize(); ++i) {
+        auto& v = tupleValue.Getitems(i);
+
+        auto value_case = v.value_case();
+
+        CHECK_OR_RETURN_ERROR(value_case != Ydb::Value::VALUE_NOT_SET,
+                              Sprintf("Data must be present at position %" PRIu32, i));
+
+        CHECK_OR_RETURN_ERROR(v.itemsSize() == 0 &&
+                              v.pairsSize() == 0,
+                              Sprintf("Simple type is expected in tuple at position %" PRIu32, i));
+
+        TCell c;
+        auto typeId = types[i].GetTypeId();
+        switch (typeId) {
+
+#define CASE_SIMPLE_TYPE(name, type, protoField) \
+        case NScheme::NTypeIds::name: \
+        { \
+            bool valuePresent = v.Has##protoField##_value(); \
+            if (valuePresent) { \
+                type val = v.Get##protoField##_value(); \
+                c = TCell((const char*)&val, sizeof(val)); \
+            } else if (allowCastFromString && v.Hastext_value()) { \
+                const auto slot = NUdf::GetDataSlot(typeId); \
+                const auto out = NMiniKQL::ValueFromString(slot, v.Gettext_value()); \
+                CHECK_OR_RETURN_ERROR(out, Sprintf("Cannot parse value of type " #name " from text '%s' in tuple at position %" PRIu32, v.Gettext_value().data(), i)); \
+                const auto val = out.Get<type>(); \
+                c = TCell((const char*)&val, sizeof(val)); \
+            } else { \
+                CHECK_OR_RETURN_ERROR(false, Sprintf("Value of type " #name " expected in tuple at position %" PRIu32, i)); \
+            } \
+            Y_ABORT_UNLESS(c.IsInline()); \
+            break; \
+        }
+
+        CASE_SIMPLE_TYPE(Bool,   bool,  bool);
+        CASE_SIMPLE_TYPE(Int8,   i8,    int32);
+        CASE_SIMPLE_TYPE(Uint8,  ui8,   uint32);
+        CASE_SIMPLE_TYPE(Int16,  i16,   int32);
+        CASE_SIMPLE_TYPE(Uint16, ui16,  uint32);
+        CASE_SIMPLE_TYPE(Int32,  i32,   int32);
+        CASE_SIMPLE_TYPE(Uint32, ui32,  uint32);
+        CASE_SIMPLE_TYPE(Int64,  i64,   int64);
+        CASE_SIMPLE_TYPE(Uint64, ui64,  uint64);
+        CASE_SIMPLE_TYPE(Float,  float, float);
+        CASE_SIMPLE_TYPE(Double, double, double);
+        CASE_SIMPLE_TYPE(Date,   ui16,  uint32);
+        CASE_SIMPLE_TYPE(Datetime, ui32, uint32);
+        CASE_SIMPLE_TYPE(Timestamp, ui64, uint64);
+        CASE_SIMPLE_TYPE(Interval, i64, int64);
+
+
+#undef CASE_SIMPLE_TYPE
+
+        case NScheme::NTypeIds::Yson:
+        case NScheme::NTypeIds::Json:
+        case NScheme::NTypeIds::Utf8:
+        {
+            c = TCell(v.Gettext_value().data(), v.Gettext_value().size());
+            break;
+        }
+        case NScheme::NTypeIds::JsonDocument:
+        case NScheme::NTypeIds::DyNumber:
+        {
+            c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
+            break;
+        }
+        case NScheme::NTypeIds::String:
+        {
+            if (v.Hasbytes_value()) {
+                c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
+            } else if (allowCastFromString && v.Hastext_value()) {
+                c = TCell(v.Gettext_value().data(), v.Gettext_value().size());
+            } else {
+                CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type String in tuple at position %" PRIu32, i));
+            }
+            break;
+        }
+        case NScheme::NTypeIds::Pg:
+        {
+            if (v.Hasbytes_value()) {
+                c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
+            } else if (v.Hastext_value()) {
+                auto typeDesc = types[i].GetTypeDesc();
+                auto convert = NPg::PgNativeBinaryFromNativeText(v.Gettext_value(), NPg::PgTypeIdFromTypeDesc(typeDesc));
+                if (convert.Error) {
+                    CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Pg: %s in tuple at position %" PRIu32, convert.Error->data(), i));
+                } else {
+                    auto &data = memoryOwner.emplace_back(convert.Str);
+                    c = TCell(data);
+                }
+            } else {
+                CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Pg in tuple at position %" PRIu32, i));
+            }
+            break;
+        }
+        case NScheme::NTypeIds::Uuid:
+        {
+            if (v.Haslow_128()) {
+                auto &data = memoryOwner.emplace_back();
+                data.resize(NUuid::UUID_LEN);
+                NUuid::UuidHalfsToBytes(data.Detach(), data.size(), v.Gethigh_128(), v.Getlow_128());
+                c = TCell(data);
+            } else if (v.Hasbytes_value()) {
+                Y_ABORT_UNLESS(v.Getbytes_value().size() == NUuid::UUID_LEN);
+                c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
+            } else {
+                CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Uuid in tuple at position %" PRIu32, i));
+            }
+            break;
+        }
+        default:
+            CHECK_OR_RETURN_ERROR(false, Sprintf("Unsupported typeId %" PRIu16 " at index %" PRIu32, typeId, i));
+            break;
+        }
+
+        CHECK_OR_RETURN_ERROR(!c.IsNull(), Sprintf("Invalid non-NULL value at index %" PRIu32, i));
+        key.push_back(c);
+    }
+
+#undef CHECK_OR_RETURN_ERROR
+
+    return true;
+}
+
+class TObjectStorageListingRequestGrpc : public TActorBootstrapped<TObjectStorageListingRequestGrpc> {
+private:
+    typedef TActorBootstrapped<TThis> TBase;
+
+    static constexpr i32 DEFAULT_MAX_KEYS = 1001;
+    static constexpr ui32 DEFAULT_TIMEOUT_SEC = 5*60;
+
+    std::unique_ptr<IRequestNoOpCtx> GrpcRequest;
+    const Ydb::ObjectStorage::ListingRequest* Request;
+    std::optional<Ydb::ObjectStorage::ContinuationToken> ContinuationToken;
+    THolder<const NACLib::TUserToken> UserToken;
+    ui32 MaxKeys;
+    TActorId SchemeCache;
+    TActorId LeaderPipeCache;
+    TDuration Timeout;
+    TActorId TimeoutTimerActorId;
+    TAutoPtr<TKeyDesc> KeyRange;
+    bool WaitingResolveReply;
+    bool Finished;
+    TAutoPtr<NSchemeCache::TSchemeCacheNavigate> ResolveNamesResult;
+    TVector<NScheme::TTypeInfo> KeyColumnTypes;
+    TSysTables::TTableColumnInfo PathColumnInfo;
+    TVector<TSysTables::TTableColumnInfo> CommonPrefixesColumns;
+    TVector<TSysTables::TTableColumnInfo> ContentsColumns;
+    TSerializedCellVec PrefixColumns;
+    TSerializedCellVec StartAfterSuffixColumns;
+    TSerializedCellVec KeyRangeFrom;
+    TSerializedCellVec KeyRangeTo;
+    ui32 CurrentShardIdx;
+    TVector<TString> CommonPrefixesRows;
+    TVector<TSerializedCellVec> ContentsRows;
+
+public:
+    static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
+        return NKikimrServices::TActivity::GRPC_REQ;
+    }
+
+    TObjectStorageListingRequestGrpc(std::unique_ptr<IRequestNoOpCtx> request, TActorId schemeCache, THolder<const NACLib::TUserToken>&& userToken)
+        : GrpcRequest(std::move(request))
+        , Request(TEvObjectStorageListingRequest::GetProtoRequest(GrpcRequest.get()))
+        , UserToken(std::move(userToken))
+        , MaxKeys(DEFAULT_MAX_KEYS)
+        , SchemeCache(schemeCache)
+        , LeaderPipeCache(MakePipePeNodeCacheID(false))
+        , Timeout(TDuration::Seconds(DEFAULT_TIMEOUT_SEC))
+        , WaitingResolveReply(false)
+        , Finished(false)
+        , CurrentShardIdx(0)
+    {
+    }
+
+    void Bootstrap(const NActors::TActorContext& ctx) {
+        TString errDescr;
+        if (!Request) {
+            return ReplyWithError(Ydb::StatusIds::BAD_REQUEST, errDescr, ctx);
+        }
+
+        if (Request->Getmax_keys() > 0 && Request->Getmax_keys() <= DEFAULT_MAX_KEYS) {
+            MaxKeys = Request->Getmax_keys();
+        }
+
+        if (Request->continuation_token()) {
+            Ydb::ObjectStorage::ContinuationToken token;
+            if (!token.ParseFromString(Request->continuation_token())) {
+                return ReplyWithError(Ydb::StatusIds::BAD_REQUEST, "Invalid ContinuationToken", ctx);
+            }
+            ContinuationToken = std::move(token);
+        }
+
+        // TODO: respect timeout parameter
+        // ui32 userTimeoutMillisec = Request->GetTimeout();
+        // if (userTimeoutMillisec > 0 && TDuration::MilliSeconds(userTimeoutMillisec) < Timeout) {
+        //     Timeout = TDuration::MilliSeconds(userTimeoutMillisec);
+        // }
+
+        ResolveTable(Request->Gettable_name(), ctx);
+    }
+
+    void Die(const NActors::TActorContext& ctx) override {
+        Y_VERIFY(Finished);
+        Y_VERIFY(!WaitingResolveReply);
+        ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvUnlink(0));
+        if (TimeoutTimerActorId) {
+            ctx.Send(TimeoutTimerActorId, new TEvents::TEvPoisonPill());
+        }
+        TBase::Die(ctx);
+    }
+
+private:
+    STFUNC(StateWaitResolveTable) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+            CFunc(TEvents::TSystem::Wakeup, HandleTimeout);
+
+            default:
+                break;
+        }
+    }
+
+    void ResolveTable(const TString& table, const NActors::TActorContext& ctx) {
+        // TODO: check all params;
+
+        TAutoPtr<NSchemeCache::TSchemeCacheNavigate> request(new NSchemeCache::TSchemeCacheNavigate());
+        NSchemeCache::TSchemeCacheNavigate::TEntry entry;
+        entry.Path = NKikimr::SplitPath(table);
+        if (entry.Path.empty()) {
+            return ReplyWithError(Ydb::StatusIds::SCHEME_ERROR, "Invalid table path specified", ctx);
+        }
+        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpTable;
+        request->ResultSet.emplace_back(entry);
+        ctx.Send(SchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(request));
+
+        TimeoutTimerActorId = CreateLongTimer(ctx, Timeout,
+            new IEventHandle(ctx.SelfID, ctx.SelfID, new TEvents::TEvWakeup()));
+
+        TBase::Become(&TThis::StateWaitResolveTable);
+        WaitingResolveReply = true;
+    }
+
+    Ydb::ObjectStorage::ListingResponse* CreateResponse() {
+        return google::protobuf::Arena::CreateMessage<Ydb::ObjectStorage::ListingResponse>(Request->GetArena());
+    }
+
+    void ReplyWithError(Ydb::StatusIds::StatusCode grpcStatus, const TString& message, const TActorContext& ctx) {
+        auto* resp = CreateResponse();
+        resp->set_status(grpcStatus);
+
+        if (!message.empty()) {
+            const NYql::TIssue& issue = NYql::TIssue(message);
+            auto* protoIssue = resp->add_issues();
+            NYql::IssueToMessage(issue, protoIssue);
+        }
+
+        GrpcRequest->Reply(resp, grpcStatus);
+
+        Finished = true;
+
+        // We cannot Die() while scheme cache request is in flight because that request has pointer to
+        // KeyRange member so we must not destroy it before we get the response
+        if (!WaitingResolveReply) {
+            Die(ctx);
+        }
+    }
+
+    void HandleTimeout(const TActorContext& ctx) {
+        return ReplyWithError(Ydb::StatusIds::TIMEOUT, "Request timed out", ctx);
+    }
+
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx) {
+        WaitingResolveReply = false;
+        if (Finished) {
+            return Die(ctx);
+        }
+
+        const NSchemeCache::TSchemeCacheNavigate& request = *ev->Get()->Request;
+        Y_VERIFY(request.ResultSet.size() == 1);
+        if (request.ResultSet.front().Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+            return ReplyWithError(Ydb::StatusIds::SCHEME_ERROR,
+                                  ToString(request.ResultSet.front().Status), ctx);
+        }
+        ResolveNamesResult = ev->Get()->Request;
+
+        if (!BuildSchema(ctx)) {
+            return;
+        }
+
+        if (!BuildKeyRange(ctx)) {
+            return;
+        }
+
+        ResolveShards(ctx);
+    }
+
+    bool BuildSchema(const NActors::TActorContext& ctx) {
+        Y_UNUSED(ctx);
+
+        auto& entry = ResolveNamesResult->ResultSet.front();
+
+        TVector<ui32> keyColumnIds;
+        THashMap<TString, ui32> columnByName;
+        for (const auto& ci : entry.Columns) {
+            columnByName[ci.second.Name] = ci.second.Id;
+            i32 keyOrder = ci.second.KeyOrder;
+            if (keyOrder != -1) {
+                Y_VERIFY(keyOrder >= 0);
+                KeyColumnTypes.resize(Max<size_t>(KeyColumnTypes.size(), keyOrder + 1));
+                KeyColumnTypes[keyOrder] = ci.second.PType;
+                keyColumnIds.resize(Max<size_t>(keyColumnIds.size(), keyOrder + 1));
+                keyColumnIds[keyOrder] = ci.second.Id;
+            }
+        }
+
+        TString errStr;
+        TVector<TCell> prefixCells;
+        TVector<TString> prefixMemoryOwner;
+        TConstArrayRef<NScheme::TTypeInfo> prefixTypes(KeyColumnTypes.data(), KeyColumnTypes.size() - 1); // -1 for path column
+        CellsFromTuple(&Request->Getkey_prefix().Gettype(), Request->Getkey_prefix().Getvalue(),
+                prefixTypes, true, prefixCells, errStr, prefixMemoryOwner);
+
+        if (!errStr.empty()) {
+            ReplyWithError(Ydb::StatusIds::BAD_REQUEST, "Invalid KeyPrefix: " + errStr, ctx);
+            return false;
+        }
+
+        PrefixColumns.Parse(TSerializedCellVec::Serialize(prefixCells));
+
+        // Check path column
+        ui32 pathColPos = prefixCells.size();
+        Y_VERIFY(pathColPos < KeyColumnTypes.size());
+        PathColumnInfo = entry.Columns[keyColumnIds[pathColPos]];
+        if (PathColumnInfo.PType.GetTypeId() != NScheme::NTypeIds::Utf8) {
+            ReplyWithError(Ydb::StatusIds::BAD_REQUEST,
+                           Sprintf("Value for path column '%s' has type %s, expected Utf8",
+                                   PathColumnInfo.Name.data(), NScheme::TypeName(PathColumnInfo.PType).c_str()), ctx);
+            return false;
+        }
+
+        CommonPrefixesColumns.push_back(PathColumnInfo);
+
+        TVector<TCell> suffixCells;
+        TVector<TString> suffixMemoryOwner;
+        TConstArrayRef<NScheme::TTypeInfo> suffixTypes(KeyColumnTypes.data() + pathColPos, KeyColumnTypes.size() - pathColPos); // starts at path column
+        CellsFromTuple(&Request->Getstart_after_key_suffix().Gettype(), Request->Getstart_after_key_suffix().Getvalue(),
+                                 suffixTypes, true, suffixCells, errStr, suffixMemoryOwner);
+        if (!errStr.empty()) {
+            ReplyWithError(Ydb::StatusIds::BAD_REQUEST,
+                           "Invalid StartAfterKeySuffix: " + errStr, ctx);
+            return false;
+        }
+
+        StartAfterSuffixColumns.Parse(TSerializedCellVec::Serialize(suffixCells));
+
+        if (!StartAfterSuffixColumns.GetCells().empty()) {
+            TString startAfterPath = TString(StartAfterSuffixColumns.GetCells()[0].Data(), StartAfterSuffixColumns.GetCells()[0].Size());
+            if (!startAfterPath.StartsWith(Request->Getpath_column_prefix())) {
+                ReplyWithError(Ydb::StatusIds::BAD_REQUEST,
+                               "Invalid StartAfterKeySuffix: StartAfter parameter doesn't match PathPrefix", ctx);
+                return false;
+            }
+        }
+
+        // Check ColumsToReturn
+        TSet<TString> requestedColumns(Request->Getcolumns_to_return().begin(), Request->Getcolumns_to_return().end());
+
+        // Always request all suffix columns starting from path column
+        for (size_t i = pathColPos; i < keyColumnIds.size(); ++i) {
+            ui32 colId = keyColumnIds[i];
+            requestedColumns.erase(entry.Columns[colId].Name);
+            ContentsColumns.push_back(entry.Columns[colId]);
+        }
+
+        for (const auto& name : requestedColumns) {
+            if (!columnByName.contains(name)) {
+                ReplyWithError(Ydb::StatusIds::BAD_REQUEST,
+                               Sprintf("Unknown column '%s'", name.data()), ctx);
+                return false;
+            }
+            ContentsColumns.push_back(entry.Columns[columnByName[name]]);
+        }
+
+        return true;
+    }
+
+    bool BuildKeyRange(const NActors::TActorContext& ctx) {
+        Y_UNUSED(ctx);
+
+        TVector<TCell> fromValues(PrefixColumns.GetCells().begin(), PrefixColumns.GetCells().end());
+        TVector<TCell> toValues(PrefixColumns.GetCells().begin(), PrefixColumns.GetCells().end());
+
+        TString pathPrefix = Request->Getpath_column_prefix();
+        TString endPathPrefix;
+
+        if (pathPrefix.empty()) {
+            fromValues.resize(KeyColumnTypes.size());
+        } else {
+            // TODO: check for valid UTF-8
+
+            fromValues.push_back(TCell(pathPrefix.data(), pathPrefix.size()));
+            fromValues.resize(KeyColumnTypes.size());
+
+            endPathPrefix = pathPrefix;
+            // pathPrefix must be a valid Utf8 string, so it cannot contain 0xff byte and its safe to add 1
+            // to make end of range key
+            endPathPrefix.back() = endPathPrefix.back() + 1;
+            toValues.push_back(TCell(endPathPrefix.data(), endPathPrefix.size()));
+            toValues.resize(KeyColumnTypes.size());
+        }
+
+        if (!StartAfterSuffixColumns.GetCells().empty()) {
+            // TODO: check for valid UTF-8
+            for (size_t i = 0; i < StartAfterSuffixColumns.GetCells().size(); ++i) {
+                fromValues[PathColumnInfo.KeyOrder + i] = StartAfterSuffixColumns.GetCells()[i];
+            }
+        }
+
+        if (ContinuationToken) {
+            TString lastPath = ContinuationToken->Getlast_path();
+            fromValues[PathColumnInfo.KeyOrder] = TCell(lastPath.data(), lastPath.size());
+        }
+
+        KeyRangeFrom.Parse(TSerializedCellVec::Serialize(fromValues));
+        KeyRangeTo.Parse(TSerializedCellVec::Serialize(toValues));
+
+        TTableRange range(KeyRangeFrom.GetCells(), true,
+                          KeyRangeTo.GetCells(), false,
+                          false);
+
+        TVector<TKeyDesc::TColumnOp> columns;
+        for (const auto& ci : ContentsColumns) {
+            TKeyDesc::TColumnOp op = { ci.Id, TKeyDesc::EColumnOperation::Read, ci.PType, 0, 0 };
+            columns.push_back(op);
+        }
+
+        auto& entry = ResolveNamesResult->ResultSet.front();
+
+        KeyRange.Reset(new TKeyDesc(entry.TableId, range, TKeyDesc::ERowOperation::Read, KeyColumnTypes, columns));
+        return true;
+    }
+
+    void ResolveShards(const NActors::TActorContext& ctx) {
+        TAutoPtr<NSchemeCache::TSchemeCacheRequest> request(new NSchemeCache::TSchemeCacheRequest());
+
+        request->ResultSet.emplace_back(std::move(KeyRange));
+
+        TAutoPtr<TEvTxProxySchemeCache::TEvResolveKeySet> resolveReq(new TEvTxProxySchemeCache::TEvResolveKeySet(request));
+        ctx.Send(SchemeCache, resolveReq.Release());
+
+        TBase::Become(&TThis::StateWaitResolveShards);
+        WaitingResolveReply = true;
+    }
+
+    STFUNC(StateWaitResolveShards) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvTxProxySchemeCache::TEvResolveKeySetResult, Handle);
+            CFunc(TEvents::TSystem::Wakeup, HandleTimeout);
+
+            default:
+                break;
+        }
+    }
+
+    bool CheckAccess(TString& errorMessage) {
+        const ui32 access = NACLib::EAccessRights::SelectRow;
+        if (access != 0
+                && UserToken != nullptr
+                && KeyRange->Status == TKeyDesc::EStatus::Ok
+                && KeyRange->SecurityObject != nullptr
+                && !KeyRange->SecurityObject->CheckAccess(access, *UserToken))
+        {
+            TStringStream explanation;
+            explanation << "Access denied for " << UserToken->GetUserSID()
+                        << " with access " << NACLib::AccessRightsToString(access)
+                        << " to table [" << Request->Gettable_name() << "]";
+
+            errorMessage = explanation.Str();
+            return false;
+        }
+        return true;
+    }
+
+    void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr &ev, const TActorContext &ctx) {
+        WaitingResolveReply = false;
+        if (Finished) {
+            return Die(ctx);
+        }
+
+        TEvTxProxySchemeCache::TEvResolveKeySetResult *msg = ev->Get();
+        Y_VERIFY(msg->Request->ResultSet.size() == 1);
+        KeyRange = std::move(msg->Request->ResultSet[0].KeyDescription);
+
+        if (msg->Request->ErrorCount > 0) {
+            return ReplyWithError(Ydb::StatusIds::SCHEME_ERROR,
+                                  Sprintf("Unknown table '%s'", Request->Gettable_name().data()), ctx);
+        }
+
+        TString accessCheckError;
+        if (!CheckAccess(accessCheckError)) {
+            return ReplyWithError(Ydb::StatusIds::UNAUTHORIZED, accessCheckError, ctx);
+        }
+
+        auto getShardsString = [] (const TVector<TKeyDesc::TPartitionInfo>& partitions) {
+            TVector<ui64> shards;
+            shards.reserve(partitions.size());
+            for (auto& partition : partitions) {
+                shards.push_back(partition.ShardId);
+            }
+
+            return JoinVectorIntoString(shards, ", ");
+        };
+
+        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Range shards: "
+            << getShardsString(KeyRange->GetPartitions()));
+
+        if (KeyRange->GetPartitions().size() > 0) {
+            CurrentShardIdx = 0;
+            MakeShardRequest(CurrentShardIdx, ctx);
+        } else {
+            ReplySuccess(ctx, false);
+        }
+    }
+
+    void MakeShardRequest(ui32 idx, const NActors::TActorContext& ctx) {
+        ui64 shardId = KeyRange->GetPartitions()[idx].ShardId;
+
+        THolder<TEvDataShard::TEvS3ListingRequest> ev(new TEvDataShard::TEvS3ListingRequest());
+        ev->Record.SetTableId(KeyRange->TableId.PathId.LocalPathId);
+        ev->Record.SetSerializedKeyPrefix(PrefixColumns.GetBuffer());
+        ev->Record.SetPathColumnPrefix(Request->Getpath_column_prefix());
+        ev->Record.SetPathColumnDelimiter(Request->Getpath_column_delimiter());
+        ev->Record.SetSerializedStartAfterKeySuffix(StartAfterSuffixColumns.GetBuffer());
+        ev->Record.SetMaxKeys(MaxKeys - ContentsRows.size() - CommonPrefixesRows.size());
+        
+        if (!CommonPrefixesRows.empty()) {
+            // Next shard might have the same common prefix, need to skip it
+            ev->Record.SetLastCommonPrefix(CommonPrefixesRows.back());
+        }
+
+        if (ContinuationToken) {
+            ev->Record.SetLastPath(ContinuationToken->Getlast_path());
+            if (CommonPrefixesRows.empty() && ContinuationToken->is_folder()) {
+                ev->Record.SetLastCommonPrefix(ContinuationToken->Getlast_path());
+            }
+        }
+
+        for (const auto& ci : ContentsColumns) {
+            ev->Record.AddColumnsToReturn(ci.Id);
+        }
+
+        LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Sending request to shards " << shardId);
+
+        ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvForward(ev.Release(), shardId, true), IEventHandle::FlagTrackDelivery);
+
+        TBase::Become(&TThis::StateWaitResults);
+    }
+
+    void Handle(TEvents::TEvUndelivered::TPtr &ev, const TActorContext &ctx) {
+        Y_UNUSED(ev);
+        ReplyWithError(Ydb::StatusIds::INTERNAL_ERROR,
+                       "Internal error: pipe cache is not available, the cluster might not be configured properly", ctx);
+    }
+
+    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr &ev, const TActorContext &ctx) {
+        Y_UNUSED(ev);
+        // Invalidate scheme cache in case of partitioning change
+        ctx.Send(SchemeCache, new TEvTxProxySchemeCache::TEvInvalidateTable(KeyRange->TableId, TActorId()));
+        ReplyWithError(Ydb::StatusIds::UNAVAILABLE, "Failed to connect to shard", ctx);
+    }
+
+    STFUNC(StateWaitResults) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvDataShard::TEvS3ListingResponse, Handle);
+            HFunc(TEvents::TEvUndelivered, Handle);
+            HFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
+            CFunc(TEvents::TSystem::Wakeup, HandleTimeout);
+
+            default:
+                break;
+        }
+    }
+
+    void Handle(TEvDataShard::TEvS3ListingResponse::TPtr& ev, const NActors::TActorContext& ctx) {
+        const auto& shardResponse = ev->Get()->Record;
+
+        // Notify the cache that we are done with the pipe
+        ctx.Send(LeaderPipeCache, new TEvPipeCache::TEvUnlink(shardResponse.GetTabletID()));
+
+        if (shardResponse.GetStatus() == NKikimrTxDataShard::TError::WRONG_SHARD_STATE) {
+            // Invalidate scheme cache in case of partitioning change
+            ctx.Send(SchemeCache, new TEvTxProxySchemeCache::TEvInvalidateTable(KeyRange->TableId, TActorId()));
+            ReplyWithError(Ydb::StatusIds::UNAVAILABLE, shardResponse.GetErrorDescription(), ctx);
+            return;
+        }
+
+        if (shardResponse.GetStatus() != NKikimrTxDataShard::TError::OK) {
+            ReplyWithError(Ydb::StatusIds::GENERIC_ERROR, shardResponse.GetErrorDescription(), ctx);
+            return;
+        }
+
+        for (size_t i = 0; i < shardResponse.CommonPrefixesRowsSize(); ++i) {
+            if (!CommonPrefixesRows.empty() && CommonPrefixesRows.back() == shardResponse.GetCommonPrefixesRows(i)) {
+                LOG_ERROR_S(ctx, NKikimrServices::RPC_REQUEST, "S3 listing got duplicate common prefix from shard " << shardResponse.GetTabletID());
+            }
+            CommonPrefixesRows.emplace_back(shardResponse.GetCommonPrefixesRows(i));
+        }
+
+        for (size_t i = 0; i < shardResponse.ContentsRowsSize(); ++i) {
+            ContentsRows.emplace_back(shardResponse.GetContentsRows(i));
+        }
+
+        bool hasMoreShards = CurrentShardIdx + 1 < KeyRange->GetPartitions().size();
+        bool maxKeysExhausted = MaxKeys <= ContentsRows.size() + CommonPrefixesRows.size();
+
+        if (hasMoreShards &&
+            !maxKeysExhausted &&
+            shardResponse.GetMoreRows())
+        {
+            ++CurrentShardIdx;
+            MakeShardRequest(CurrentShardIdx, ctx);
+        } else {
+            ReplySuccess(ctx, (hasMoreShards && shardResponse.GetMoreRows()) || maxKeysExhausted);
+        }
+    }
+
+    void FillResultRows(Ydb::ResultSet &resultSet, TVector<TSysTables::TTableColumnInfo> &columns, TVector<TSerializedCellVec> resultRows) {
+        const auto getPgTypeFromColMeta = [](const auto &colMeta) {
+            return NYdb::TPgType(NPg::PgTypeNameFromTypeDesc(colMeta.PType.GetTypeDesc()),
+                                 colMeta.PTypeMod);
+        };
+
+        const auto getTypeFromColMeta = [&](const auto &colMeta) {
+            if (colMeta.PType.GetTypeId() == NScheme::NTypeIds::Pg) {
+                return NYdb::TTypeBuilder().Pg(getPgTypeFromColMeta(colMeta)).Build();
+            } else {
+                return NYdb::TTypeBuilder()
+                    .Primitive((NYdb::EPrimitiveType)colMeta.PType.GetTypeId())
+                    .Build();
+            }
+        };
+
+        for (const auto& colMeta : columns) {
+            const auto type = getTypeFromColMeta(colMeta);
+            auto* col = resultSet.Addcolumns();
+            
+            *col->mutable_type()->mutable_optional_type()->mutable_item() = NYdb::TProtoAccessor::GetProto(type);
+            *col->mutable_name() = colMeta.Name;
+        }
+
+        for (auto& row : resultRows) {
+            NYdb::TValueBuilder vb;
+            vb.BeginStruct();
+            for (size_t i = 0; i < columns.size(); ++i) {
+                const auto& colMeta = columns[i];
+
+                const auto& cell = row.GetCells()[i];
+                vb.AddMember(colMeta.Name);
+                if (colMeta.PType.GetTypeId() == NScheme::NTypeIds::Pg)
+                {
+                    const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(cell.AsBuf(), colMeta.PType.GetTypeDesc());
+                    if (pgResult.Error) {
+                        LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "PgNativeTextFromNativeBinary error " << *pgResult.Error);
+                    }
+                    const NYdb::TPgValue pgValue{cell.IsNull() ? NYdb::TPgValue::VK_NULL : NYdb::TPgValue::VK_TEXT, pgResult.Str, getPgTypeFromColMeta(colMeta)};
+                    vb.Pg(pgValue);
+                }
+                else
+                {
+                    const NScheme::TTypeInfo& typeInfo = colMeta.PType;
+
+                    if (cell.IsNull()) {
+                        vb.EmptyOptional((NYdb::EPrimitiveType)typeInfo.GetTypeId());
+                    } else {
+                        vb.BeginOptional();
+                        ProtoValueFromCell(vb, typeInfo, cell);
+                        vb.EndOptional();
+                    }
+                }
+            }
+            vb.EndStruct();
+            auto proto = NYdb::TProtoAccessor::GetProto(vb.Build());
+            *resultSet.add_rows() = std::move(proto);
+        }
+    }
+
+    void ReplySuccess(const NActors::TActorContext& ctx, bool isTruncated) {
+        auto* resp = CreateResponse();
+        resp->set_status(Ydb::StatusIds::SUCCESS);
+
+        resp->set_is_truncated(isTruncated);
+
+        for (auto commonPrefix : CommonPrefixesRows) {
+            resp->add_common_prefixes(commonPrefix);
+        }
+
+        auto &contents = *resp->mutable_contents();
+        contents.set_truncated(false);
+        FillResultRows(contents, ContentsColumns, ContentsRows);
+
+        TString lastFile;
+        TString lastDirectory;
+        if (ContentsRows.size() > 0) {
+            // Path column is always first.
+            TSerializedCellVec &row = ContentsRows[ContentsRows.size() - 1];
+            const auto& cell = row.GetCells()[0];
+            lastFile = TString(cell.AsBuf().data(), cell.AsBuf().size());
+        }
+
+        if (CommonPrefixesRows.size() > 0) {
+            lastDirectory = CommonPrefixesRows[CommonPrefixesRows.size() - 1];
+        }
+        
+        if (isTruncated && (lastDirectory || lastFile)) {
+            Ydb::ObjectStorage::ContinuationToken token;
+            
+            if (lastDirectory > lastFile) {
+                token.set_last_path(lastDirectory);
+                token.set_is_folder(true);
+            } else {
+                token.set_last_path(lastFile);
+                token.set_is_folder(false);
+            }
+
+            TString serializedToken = token.SerializeAsString();
+            
+            resp->set_next_continuation_token(serializedToken);
+        }
+
+        try {
+            GrpcRequest->Reply(resp, Ydb::StatusIds::SUCCESS);
+        } catch(std::exception ex) {
+            GrpcRequest->RaiseIssue(NYql::ExceptionToIssue(ex));
+            GrpcRequest->ReplyWithYdbStatus(Ydb::StatusIds::INTERNAL_ERROR);
+        }
+        
+        Finished = true;
+        Die(ctx);
+    }
+};
+
+IActor* CreateGrpcObjectStorageListingHandler(std::unique_ptr<IRequestNoOpCtx> request) {
+    TActorId schemeCache = MakeSchemeCacheID();
+    auto token = THolder<const NACLib::TUserToken>(request->GetInternalToken() ? new NACLib::TUserToken(request->GetSerializedToken()) : nullptr);
+    return new TObjectStorageListingRequestGrpc(std::move(request), schemeCache, std::move(token));
+}
+
+void DoObjectStorageListingRequest(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider& f) {
+    f.RegisterActor(CreateGrpcObjectStorageListingHandler(std::move(p)));
+}
+
+} // namespace NKikimr
+} // namespace NGRpcService

--- a/ydb/core/grpc_services/rpc_object_storage.cpp
+++ b/ydb/core/grpc_services/rpc_object_storage.cpp
@@ -845,8 +845,7 @@ private:
 
                 const auto& cell = row.GetCells()[i];
                 vb.AddMember(colMeta.Name);
-                if (colMeta.PType.GetTypeId() == NScheme::NTypeIds::Pg)
-                {
+                if (colMeta.PType.GetTypeId() == NScheme::NTypeIds::Pg) {
                     const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(cell.AsBuf(), colMeta.PType.GetTypeDesc());
                     if (pgResult.Error) {
                         LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::RPC_REQUEST, "PgNativeTextFromNativeBinary error " << *pgResult.Error);
@@ -854,8 +853,7 @@ private:
                     const NYdb::TPgValue pgValue{cell.IsNull() ? NYdb::TPgValue::VK_NULL : NYdb::TPgValue::VK_TEXT, pgResult.Str, getPgTypeFromColMeta(colMeta)};
                     vb.Pg(pgValue);
                 }
-                else
-                {
+                else {
                     const NScheme::TTypeInfo& typeInfo = colMeta.PType;
 
                     if (cell.IsNull()) {

--- a/ydb/core/grpc_services/rpc_object_storage.cpp
+++ b/ydb/core/grpc_services/rpc_object_storage.cpp
@@ -215,7 +215,7 @@ private:
 
     std::unique_ptr<IRequestNoOpCtx> GrpcRequest;
     const Ydb::ObjectStorage::ListingRequest* Request;
-    std::optional<Ydb::ObjectStorage::ContinuationToken> ContinuationToken;
+    std::optional<NKikimrTxDataShard::TObjectStorageListingContinuationToken> ContinuationToken;
     THolder<const NACLib::TUserToken> UserToken;
     ui32 MaxKeys;
     TActorId SchemeCache;
@@ -269,7 +269,7 @@ public:
         }
 
         if (Request->continuation_token()) {
-            Ydb::ObjectStorage::ContinuationToken token;
+            NKikimrTxDataShard::TObjectStorageListingContinuationToken token;
             if (!token.ParseFromString(Request->continuation_token())) {
                 return ReplyWithError(Ydb::StatusIds::BAD_REQUEST, "Invalid ContinuationToken", ctx);
             }
@@ -901,7 +901,7 @@ private:
         }
         
         if (isTruncated && (lastDirectory || lastFile)) {
-            Ydb::ObjectStorage::ContinuationToken token;
+            NKikimrTxDataShard::TObjectStorageListingContinuationToken token;
             
             if (lastDirectory > lastFile) {
                 token.set_last_path(lastDirectory);

--- a/ydb/core/grpc_services/rpc_object_storage.cpp
+++ b/ydb/core/grpc_services/rpc_object_storage.cpp
@@ -22,6 +22,139 @@ namespace NGRpcService {
 
 using TEvObjectStorageListingRequest = TGrpcRequestOperationCall<Ydb::ObjectStorage::ListingRequest, Ydb::ObjectStorage::ListingResponse>;
 
+#define CHECK_OR_RETURN_ERROR(cond, descr) \
+    if (!(cond)) { \
+        errStr = descr; \
+        return false; \
+    }
+
+bool CellFromTuple(NScheme::TTypeInfo type,
+                   const Ydb::Value& tupleValue,
+                   ui32 position,
+                   bool allowCastFromString,
+                   TVector<TCell>& cells,
+                   TString& errStr,
+                   TVector<TString>& memoryOwner) {
+    auto value_case = tupleValue.value_case();
+
+    CHECK_OR_RETURN_ERROR(value_case != Ydb::Value::VALUE_NOT_SET,
+                            Sprintf("Data must be present at position %" PRIu32, position));
+
+    CHECK_OR_RETURN_ERROR(tupleValue.itemsSize() == 0 &&
+                            tupleValue.pairsSize() == 0,
+                            Sprintf("Simple type is expected in tuple at position %" PRIu32, position));
+
+    TCell c;
+    auto typeId = type.GetTypeId();
+    switch (typeId) {
+
+#define CASE_SIMPLE_TYPE(name, type, protoField) \
+    case NScheme::NTypeIds::name: \
+    { \
+        bool valuePresent = tupleValue.Has##protoField##_value(); \
+        if (valuePresent) { \
+            type val = tupleValue.Get##protoField##_value(); \
+            c = TCell((const char*)&val, sizeof(val)); \
+        } else if (allowCastFromString && tupleValue.Hastext_value()) { \
+            const auto slot = NUdf::GetDataSlot(typeId); \
+            const auto out = NMiniKQL::ValueFromString(slot, tupleValue.Gettext_value()); \
+            CHECK_OR_RETURN_ERROR(out, Sprintf("Cannot parse value of type " #name " from text '%s' in tuple at position %" PRIu32, tupleValue.Gettext_value().data(), position)); \
+            const auto val = out.Get<type>(); \
+            c = TCell((const char*)&val, sizeof(val)); \
+        } else { \
+            CHECK_OR_RETURN_ERROR(false, Sprintf("Value of type " #name " expected in tuple at position %" PRIu32, position)); \
+        } \
+        Y_ABORT_UNLESS(c.IsInline()); \
+        break; \
+    }
+
+    CASE_SIMPLE_TYPE(Bool,   bool,  bool);
+    CASE_SIMPLE_TYPE(Int8,   i8,    int32);
+    CASE_SIMPLE_TYPE(Uint8,  ui8,   uint32);
+    CASE_SIMPLE_TYPE(Int16,  i16,   int32);
+    CASE_SIMPLE_TYPE(Uint16, ui16,  uint32);
+    CASE_SIMPLE_TYPE(Int32,  i32,   int32);
+    CASE_SIMPLE_TYPE(Uint32, ui32,  uint32);
+    CASE_SIMPLE_TYPE(Int64,  i64,   int64);
+    CASE_SIMPLE_TYPE(Uint64, ui64,  uint64);
+    CASE_SIMPLE_TYPE(Float,  float, float);
+    CASE_SIMPLE_TYPE(Double, double, double);
+    CASE_SIMPLE_TYPE(Date,   ui16,  uint32);
+    CASE_SIMPLE_TYPE(Datetime, ui32, uint32);
+    CASE_SIMPLE_TYPE(Timestamp, ui64, uint64);
+    CASE_SIMPLE_TYPE(Interval, i64, int64);
+
+
+#undef CASE_SIMPLE_TYPE
+
+    case NScheme::NTypeIds::Yson:
+    case NScheme::NTypeIds::Json:
+    case NScheme::NTypeIds::Utf8:
+    {
+        c = TCell(tupleValue.Gettext_value().data(), tupleValue.Gettext_value().size());
+        break;
+    }
+    case NScheme::NTypeIds::JsonDocument:
+    case NScheme::NTypeIds::DyNumber:
+    {
+        c = TCell(tupleValue.Getbytes_value().data(), tupleValue.Getbytes_value().size());
+        break;
+    }
+    case NScheme::NTypeIds::String:
+    {
+        if (tupleValue.Hasbytes_value()) {
+            c = TCell(tupleValue.Getbytes_value().data(), tupleValue.Getbytes_value().size());
+        } else if (allowCastFromString && tupleValue.Hastext_value()) {
+            c = TCell(tupleValue.Gettext_value().data(), tupleValue.Gettext_value().size());
+        } else {
+            CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type String in tuple at position %" PRIu32, position));
+        }
+        break;
+    }
+    case NScheme::NTypeIds::Pg:
+    {
+        if (tupleValue.Hasbytes_value()) {
+            c = TCell(tupleValue.Getbytes_value().data(), tupleValue.Getbytes_value().size());
+        } else if (tupleValue.Hastext_value()) {
+            auto typeDesc = type.GetTypeDesc();
+            auto convert = NPg::PgNativeBinaryFromNativeText(tupleValue.Gettext_value(), NPg::PgTypeIdFromTypeDesc(typeDesc));
+            if (convert.Error) {
+                CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Pg: %s in tuple at position %" PRIu32, convert.Error->data(), position));
+            } else {
+                auto &data = memoryOwner.emplace_back(convert.Str);
+                c = TCell(data);
+            }
+        } else {
+            CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Pg in tuple at position %" PRIu32, position));
+        }
+        break;
+    }
+    case NScheme::NTypeIds::Uuid:
+    {
+        if (tupleValue.Haslow_128()) {
+            auto &data = memoryOwner.emplace_back();
+            data.resize(NUuid::UUID_LEN);
+            NUuid::UuidHalfsToBytes(data.Detach(), data.size(), tupleValue.Gethigh_128(), tupleValue.Getlow_128());
+            c = TCell(data);
+        } else if (tupleValue.Hasbytes_value()) {
+            Y_ABORT_UNLESS(tupleValue.Getbytes_value().size() == NUuid::UUID_LEN);
+            c = TCell(tupleValue.Getbytes_value().data(), tupleValue.Getbytes_value().size());
+        } else {
+            CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Uuid in tuple at position %" PRIu32, position));
+        }
+        break;
+    }
+    default:
+        CHECK_OR_RETURN_ERROR(false, Sprintf("Unsupported typeId %" PRIu16 " at index %" PRIu32, typeId, position));
+        break;
+    }
+
+    CHECK_OR_RETURN_ERROR(!c.IsNull(), Sprintf("Invalid non-NULL value at index %" PRIu32, position));
+    cells.push_back(c);
+
+    return true;
+}
+
 // NOTE: TCell's can reference memory from tupleValue
 bool CellsFromTuple(const Ydb::Type* tupleType,
                     const Ydb::Value& tupleValue,
@@ -29,15 +162,7 @@ bool CellsFromTuple(const Ydb::Type* tupleType,
                     bool allowCastFromString,
                     TVector<TCell>& key,
                     TString& errStr,
-                    TVector<TString>& memoryOwner)
-{
-
-#define CHECK_OR_RETURN_ERROR(cond, descr) \
-    if (!(cond)) { \
-        errStr = descr; \
-        return false; \
-    }
-
+                    TVector<TString>& memoryOwner) {
     if (tupleType) {
         Ydb::Type::TypeCase typeCase = tupleType->type_case();
         CHECK_OR_RETURN_ERROR(typeCase == Ydb::Type::kTupleType ||
@@ -64,132 +189,21 @@ bool CellsFromTuple(const Ydb::Type* tupleType,
     for (ui32 i = 0; i < tupleValue.itemsSize(); ++i) {
         auto& v = tupleValue.Getitems(i);
 
-        auto value_case = v.value_case();
+        bool parsed = CellFromTuple(types[i], v, i, allowCastFromString, key, errStr, memoryOwner);
 
-        CHECK_OR_RETURN_ERROR(value_case != Ydb::Value::VALUE_NOT_SET,
-                              Sprintf("Data must be present at position %" PRIu32, i));
-
-        CHECK_OR_RETURN_ERROR(v.itemsSize() == 0 &&
-                              v.pairsSize() == 0,
-                              Sprintf("Simple type is expected in tuple at position %" PRIu32, i));
-
-        TCell c;
-        auto typeId = types[i].GetTypeId();
-        switch (typeId) {
-
-#define CASE_SIMPLE_TYPE(name, type, protoField) \
-        case NScheme::NTypeIds::name: \
-        { \
-            bool valuePresent = v.Has##protoField##_value(); \
-            if (valuePresent) { \
-                type val = v.Get##protoField##_value(); \
-                c = TCell((const char*)&val, sizeof(val)); \
-            } else if (allowCastFromString && v.Hastext_value()) { \
-                const auto slot = NUdf::GetDataSlot(typeId); \
-                const auto out = NMiniKQL::ValueFromString(slot, v.Gettext_value()); \
-                CHECK_OR_RETURN_ERROR(out, Sprintf("Cannot parse value of type " #name " from text '%s' in tuple at position %" PRIu32, v.Gettext_value().data(), i)); \
-                const auto val = out.Get<type>(); \
-                c = TCell((const char*)&val, sizeof(val)); \
-            } else { \
-                CHECK_OR_RETURN_ERROR(false, Sprintf("Value of type " #name " expected in tuple at position %" PRIu32, i)); \
-            } \
-            Y_ABORT_UNLESS(c.IsInline()); \
-            break; \
+        if (!parsed) {
+            return false;
         }
-
-        CASE_SIMPLE_TYPE(Bool,   bool,  bool);
-        CASE_SIMPLE_TYPE(Int8,   i8,    int32);
-        CASE_SIMPLE_TYPE(Uint8,  ui8,   uint32);
-        CASE_SIMPLE_TYPE(Int16,  i16,   int32);
-        CASE_SIMPLE_TYPE(Uint16, ui16,  uint32);
-        CASE_SIMPLE_TYPE(Int32,  i32,   int32);
-        CASE_SIMPLE_TYPE(Uint32, ui32,  uint32);
-        CASE_SIMPLE_TYPE(Int64,  i64,   int64);
-        CASE_SIMPLE_TYPE(Uint64, ui64,  uint64);
-        CASE_SIMPLE_TYPE(Float,  float, float);
-        CASE_SIMPLE_TYPE(Double, double, double);
-        CASE_SIMPLE_TYPE(Date,   ui16,  uint32);
-        CASE_SIMPLE_TYPE(Datetime, ui32, uint32);
-        CASE_SIMPLE_TYPE(Timestamp, ui64, uint64);
-        CASE_SIMPLE_TYPE(Interval, i64, int64);
-
-
-#undef CASE_SIMPLE_TYPE
-
-        case NScheme::NTypeIds::Yson:
-        case NScheme::NTypeIds::Json:
-        case NScheme::NTypeIds::Utf8:
-        {
-            c = TCell(v.Gettext_value().data(), v.Gettext_value().size());
-            break;
-        }
-        case NScheme::NTypeIds::JsonDocument:
-        case NScheme::NTypeIds::DyNumber:
-        {
-            c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
-            break;
-        }
-        case NScheme::NTypeIds::String:
-        {
-            if (v.Hasbytes_value()) {
-                c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
-            } else if (allowCastFromString && v.Hastext_value()) {
-                c = TCell(v.Gettext_value().data(), v.Gettext_value().size());
-            } else {
-                CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type String in tuple at position %" PRIu32, i));
-            }
-            break;
-        }
-        case NScheme::NTypeIds::Pg:
-        {
-            if (v.Hasbytes_value()) {
-                c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
-            } else if (v.Hastext_value()) {
-                auto typeDesc = types[i].GetTypeDesc();
-                auto convert = NPg::PgNativeBinaryFromNativeText(v.Gettext_value(), NPg::PgTypeIdFromTypeDesc(typeDesc));
-                if (convert.Error) {
-                    CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Pg: %s in tuple at position %" PRIu32, convert.Error->data(), i));
-                } else {
-                    auto &data = memoryOwner.emplace_back(convert.Str);
-                    c = TCell(data);
-                }
-            } else {
-                CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Pg in tuple at position %" PRIu32, i));
-            }
-            break;
-        }
-        case NScheme::NTypeIds::Uuid:
-        {
-            if (v.Haslow_128()) {
-                auto &data = memoryOwner.emplace_back();
-                data.resize(NUuid::UUID_LEN);
-                NUuid::UuidHalfsToBytes(data.Detach(), data.size(), v.Gethigh_128(), v.Getlow_128());
-                c = TCell(data);
-            } else if (v.Hasbytes_value()) {
-                Y_ABORT_UNLESS(v.Getbytes_value().size() == NUuid::UUID_LEN);
-                c = TCell(v.Getbytes_value().data(), v.Getbytes_value().size());
-            } else {
-                CHECK_OR_RETURN_ERROR(false, Sprintf("Cannot parse value of type Uuid in tuple at position %" PRIu32, i));
-            }
-            break;
-        }
-        default:
-            CHECK_OR_RETURN_ERROR(false, Sprintf("Unsupported typeId %" PRIu16 " at index %" PRIu32, typeId, i));
-            break;
-        }
-
-        CHECK_OR_RETURN_ERROR(!c.IsNull(), Sprintf("Invalid non-NULL value at index %" PRIu32, i));
-        key.push_back(c);
     }
-
-#undef CHECK_OR_RETURN_ERROR
 
     return true;
 }
+#undef CHECK_OR_RETURN_ERROR
 
 struct TFilter {
     TVector<ui32> ColumnIds;
     TSerializedCellVec FilterValues;
+    TVector<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType> MatchTypes;
 };
 
 class TObjectStorageListingRequestGrpc : public TActorBootstrapped<TObjectStorageListingRequestGrpc> {
@@ -389,10 +403,10 @@ private:
         TVector<TCell> prefixCells;
         TVector<TString> prefixMemoryOwner;
         TConstArrayRef<NScheme::TTypeInfo> prefixTypes(KeyColumnTypes.data(), KeyColumnTypes.size() - 1); // -1 for path column
-        CellsFromTuple(&Request->Getkey_prefix().Gettype(), Request->Getkey_prefix().Getvalue(),
+        bool prefixParsedOk = CellsFromTuple(&Request->Getkey_prefix().Gettype(), Request->Getkey_prefix().Getvalue(),
                 prefixTypes, true, prefixCells, errStr, prefixMemoryOwner);
 
-        if (!errStr.empty()) {
+        if (!prefixParsedOk) {
             ReplyWithError(Ydb::StatusIds::BAD_REQUEST, "Invalid KeyPrefix: " + errStr, ctx);
             return false;
         }
@@ -415,9 +429,9 @@ private:
         TVector<TCell> suffixCells;
         TVector<TString> suffixMemoryOwner;
         TConstArrayRef<NScheme::TTypeInfo> suffixTypes(KeyColumnTypes.data() + pathColPos, KeyColumnTypes.size() - pathColPos); // starts at path column
-        CellsFromTuple(&Request->Getstart_after_key_suffix().Gettype(), Request->Getstart_after_key_suffix().Getvalue(),
+        bool suffixParsedOk = CellsFromTuple(&Request->Getstart_after_key_suffix().Gettype(), Request->Getstart_after_key_suffix().Getvalue(),
                                  suffixTypes, true, suffixCells, errStr, suffixMemoryOwner);
-        if (!errStr.empty()) {
+        if (!suffixParsedOk) {
             ReplyWithError(Ydb::StatusIds::BAD_REQUEST,
                            "Invalid StartAfterKeySuffix: " + errStr, ctx);
             return false;
@@ -453,6 +467,12 @@ private:
             ContentsColumns.push_back(entry.Columns[columnByName[name]]);
         }
 
+        if (Request->has_filter() && Request->has_matching_filter()) {
+            ReplyWithError(Ydb::StatusIds::BAD_REQUEST,
+                            "Either filter or matching_filter should be present", ctx);
+            return false;
+        }
+
         if (Request->has_filter()) {
             THashMap<TString, ui32> columnToRequestIndex;
 
@@ -465,7 +485,15 @@ private:
             TVector<NScheme::TTypeInfo> types;
 
             for (const auto& colName : filter.columns()) {
-                const auto& columnInfo = entry.Columns[columnByName[colName]];
+                const auto colIdIt = columnByName.find(colName);
+
+                if (colIdIt == columnByName.end()) {
+                    ReplyWithError(Ydb::StatusIds::BAD_REQUEST,
+                            Sprintf("Unknown filter column '%s'", colName.data()), ctx);
+                    return false;
+                }
+
+                const auto& columnInfo = entry.Columns[colIdIt->second];
                 const auto& type = columnInfo.PType;
 
                 types.push_back(type);
@@ -488,9 +516,85 @@ private:
 
             const auto& values = filter.values();
 
-            CellsFromTuple(&values.Gettype(), values.Getvalue(), typesRef, true, cells, err, owner);
+            bool filterParsedOk = CellsFromTuple(&values.Gettype(), values.Getvalue(), typesRef, true, cells, err, owner);
             
-            if (!err.empty()) {
+            if (!filterParsedOk) {
+                ReplyWithError(Ydb::StatusIds::BAD_REQUEST, Sprintf("Invalid filter: '%s'", err.data()), ctx);
+                return false;
+            }
+
+            Filter.FilterValues.Parse(TSerializedCellVec::Serialize(cells));
+        }
+
+        if (Request->has_matching_filter()) {
+            THashMap<TString, ui32> columnToRequestIndex;
+
+            for (size_t i = 0; i < ContentsColumns.size(); i++) {
+                columnToRequestIndex[ContentsColumns[i].Name] = i;
+            }
+
+            const auto filter = Request->matching_filter();
+
+            const auto& filterValue = filter.value();
+            const auto& filterType = filter.type().tuple_type().get_idx_elements(2);
+
+            if (filterValue.items_size() != 3) {
+                ReplyWithError(Ydb::StatusIds::BAD_REQUEST, "Wrong matching_filter format", ctx);
+                return false;
+            }
+
+            const auto& columnNames = filterValue.get_idx_items(0);
+            const auto& matcherTypes = filterValue.get_idx_items(1);
+            const auto& columnValues = filterValue.get_idx_items(2);
+
+            TVector<NScheme::TTypeInfo> types;
+
+            for (int i = 0; i < columnNames.get_arr_items().size(); i++) {
+                const auto& colNameValue = columnNames.get_idx_items(i);
+                const auto& colName = colNameValue.text_value();
+
+                const auto& columnInfo = entry.Columns[columnByName[colName]];
+                const auto& type = columnInfo.PType;
+
+                types.push_back(type);
+
+                const auto [it, inserted] = columnToRequestIndex.try_emplace(colName, columnToRequestIndex.size());
+
+                if (inserted) {
+                    ContentsColumns.push_back(columnInfo);
+                }
+
+                Filter.ColumnIds.push_back(it->second);
+
+                ui32 matchType = matcherTypes.get_idx_items(i).uint32_value();
+
+                NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType dsMatchType;
+
+                switch (matchType) {
+                    case Ydb::ObjectStorage::ListingRequest_EMatchType::ListingRequest_EMatchType_EQUAL:
+                        dsMatchType = NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType::TObjectStorageListingFilter_EMatchType_EQUAL;
+                        break;
+                    case Ydb::ObjectStorage::ListingRequest_EMatchType::ListingRequest_EMatchType_NOT_EQUAL:
+                        dsMatchType = NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType::TObjectStorageListingFilter_EMatchType_NOT_EQUAL;
+                        break;
+                    default:
+                        ReplyWithError(Ydb::StatusIds::BAD_REQUEST, Sprintf("Wrong matching_filter match type %" PRIu32, matchType), ctx);
+                        return false;
+                }
+
+                Filter.MatchTypes.push_back(dsMatchType);
+            }
+
+            TConstArrayRef<NScheme::TTypeInfo> typesRef(types.data(), types.size());
+
+            TVector<TCell> cells;
+            TVector<TString> owner;
+
+            TString err;
+
+            bool filterParsedOk = CellsFromTuple(&filterType, columnValues, typesRef, true, cells, err, owner);
+            
+            if (!filterParsedOk) {
                 ReplyWithError(Ydb::StatusIds::BAD_REQUEST, Sprintf("Invalid filter: '%s'", err.data()), ctx);
                 return false;
             }
@@ -674,6 +778,10 @@ private:
             }
 
             filter->set_values(Filter.FilterValues.GetBuffer());
+
+            for (const auto& matchType : Filter.MatchTypes) {
+                filter->add_matchtypes(matchType);
+            }
         }
 
         LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, "Sending request to shards " << shardId);

--- a/ydb/core/grpc_services/service_object_storage.h
+++ b/ydb/core/grpc_services/service_object_storage.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <memory>
+
+namespace NKikimr {
+namespace NGRpcService {
+
+class IRequestNoOpCtx;
+class IFacilityProvider;
+
+void DoObjectStorageListingRequest(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider& f);
+
+} // namespace NGRpcService
+} // namespace NKikimr

--- a/ydb/core/grpc_services/ya.make
+++ b/ydb/core/grpc_services/ya.make
@@ -72,6 +72,7 @@ SRCS(
     rpc_stream_execute_scan_query.cpp
     rpc_stream_execute_yql_script.cpp
     rpc_whoami.cpp
+    rpc_object_storage.cpp
     table_settings.cpp
 
     rpc_common/rpc_common_kqp_session.cpp

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -806,7 +806,12 @@ message TEvPeriodicTableStats {
     repeated TEvPeriodicTableStats Tables = 14;
 }
 
-message TEvS3ListingRequest {
+message TObjectStorageListingFilter {
+    optional bytes Values = 1;
+    repeated uint32 Columns = 2;
+}
+
+message TEvObjectStorageListingRequest {
     optional uint64 TableId = 1;
     optional bytes SerializedKeyPrefix = 2;
 
@@ -820,9 +825,11 @@ message TEvS3ListingRequest {
 
     optional string LastCommonPrefix = 8;
     optional string LastPath = 9;
+
+    optional TObjectStorageListingFilter Filter = 10;
 }
 
-message TEvS3ListingResponse {
+message TEvObjectStorageListingResponse {
     optional uint64 TabletID = 1;
     optional uint32 Status = 2;
     optional string ErrorDescription = 3;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -806,6 +806,31 @@ message TEvPeriodicTableStats {
     repeated TEvPeriodicTableStats Tables = 14;
 }
 
+message TEvS3ListingRequest {
+    optional uint64 TableId = 1;
+    optional bytes SerializedKeyPrefix = 2;
+
+    optional string PathColumnPrefix = 3;
+    optional string PathColumnDelimiter = 4;
+
+    optional bytes SerializedStartAfterKeySuffix = 5;
+
+    repeated uint32 ColumnsToReturn = 6;
+    optional uint32 MaxKeys = 7;
+
+    optional string LastCommonPrefix = 8;
+    optional string LastPath = 9;
+}
+
+message TEvS3ListingResponse {
+    optional uint64 TabletID = 1;
+    optional uint32 Status = 2;
+    optional string ErrorDescription = 3;
+    repeated string CommonPrefixesRows = 4;
+    repeated bytes ContentsRows = 5;        // TSerializedCellVec
+    optional bool MoreRows = 6;
+}
+
 message TSerializedRowColumnsScheme {
     repeated uint32 KeyColumnIds = 1;
     repeated uint32 ValueColumnIds = 2;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -807,8 +807,13 @@ message TEvPeriodicTableStats {
 }
 
 message TObjectStorageListingFilter {
+    enum EMatchType {
+        EQUAL = 0;
+        NOT_EQUAL = 1;
+    }
     optional bytes Values = 1;
     repeated uint32 Columns = 2;
+    repeated EMatchType MatchTypes = 3; 
 }
 
 message TEvObjectStorageListingRequest {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -843,6 +843,11 @@ message TEvObjectStorageListingResponse {
     optional bool MoreRows = 6;
 }
 
+message TObjectStorageListingContinuationToken {
+    optional string last_path = 1;
+    optional bool is_folder = 2;
+}
+
 message TSerializedRowColumnsScheme {
     repeated uint32 KeyColumnIds = 1;
     repeated uint32 ValueColumnIds = 2;

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -20,6 +20,7 @@
 #include <ydb/services/ydb/ydb_export.h>
 #include <ydb/services/ydb/ydb_import.h>
 #include <ydb/services/ydb/ydb_operation.h>
+#include <ydb/services/ydb/ydb_object_storage.h>
 #include <ydb/services/ydb/ydb_query.h>
 #include <ydb/services/ydb/ydb_scheme.h>
 #include <ydb/services/ydb/ydb_scripting.h>
@@ -383,6 +384,7 @@ namespace Tests {
         }
         GRpcServer->AddService(discoveryService);
         GRpcServer->AddService(new NGRpcService::TGRpcYdbClickhouseInternalService(system, counters, appData.InFlightLimiterRegistry, grpcRequestProxies[0], true));
+        GRpcServer->AddService(new NGRpcService::TGRpcYdbObjectStorageService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NQuoter::TRateLimiterGRpcService(system, counters, grpcRequestProxies[0]));
         GRpcServer->AddService(new NGRpcService::TGRpcDataStreamsService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NGRpcService::TGRpcMonitoringService(system, counters, grpcRequestProxies[0], true));

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -241,8 +241,8 @@ struct TEvDataShard {
         EvGetTableStatsResult,
         EvPeriodicTableStats,
 
-        EvS3ListingRequest,
-        EvS3ListingResponse,
+        EvObjectStorageListingRequest,
+        EvObjectStorageListingResponse,
 
         EvUploadRowsRequest,
         EvUploadRowsResponse,
@@ -1383,20 +1383,20 @@ struct TEvDataShard {
         }
     };
 
-    struct TEvS3ListingRequest
-        : public TEventPB<TEvS3ListingRequest,
-                            NKikimrTxDataShard::TEvS3ListingRequest,
-                            TEvDataShard::EvS3ListingRequest> {
-        TEvS3ListingRequest() = default;
+    struct TEvObjectStorageListingRequest
+        : public TEventPB<TEvObjectStorageListingRequest,
+                            NKikimrTxDataShard::TEvObjectStorageListingRequest,
+                            TEvDataShard::EvObjectStorageListingRequest> {
+        TEvObjectStorageListingRequest() = default;
     };
 
-    struct TEvS3ListingResponse
-         : public TEventPB<TEvS3ListingResponse,
-                            NKikimrTxDataShard::TEvS3ListingResponse,
-                            TEvDataShard::EvS3ListingResponse> {
-        TEvS3ListingResponse() = default;
+    struct TEvObjectStorageListingResponse
+         : public TEventPB<TEvObjectStorageListingResponse,
+                            NKikimrTxDataShard::TEvObjectStorageListingResponse,
+                            TEvDataShard::EvObjectStorageListingResponse> {
+        TEvObjectStorageListingResponse() = default;
 
-        explicit TEvS3ListingResponse(ui64 tabletId, ui32 status = NKikimrTxDataShard::TError::OK) {
+        explicit TEvObjectStorageListingResponse(ui64 tabletId, ui32 status = NKikimrTxDataShard::TError::OK) {
             Record.SetTabletID(tabletId);
             Record.SetStatus(status);
         }

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -1383,6 +1383,25 @@ struct TEvDataShard {
         }
     };
 
+    struct TEvS3ListingRequest
+        : public TEventPB<TEvS3ListingRequest,
+                            NKikimrTxDataShard::TEvS3ListingRequest,
+                            TEvDataShard::EvS3ListingRequest> {
+        TEvS3ListingRequest() = default;
+    };
+
+    struct TEvS3ListingResponse
+         : public TEventPB<TEvS3ListingResponse,
+                            NKikimrTxDataShard::TEvS3ListingResponse,
+                            TEvDataShard::EvS3ListingResponse> {
+        TEvS3ListingResponse() = default;
+
+        explicit TEvS3ListingResponse(ui64 tabletId, ui32 status = NKikimrTxDataShard::TError::OK) {
+            Record.SetTabletID(tabletId);
+            Record.SetStatus(status);
+        }
+    };
+
     struct TEvEraseRowsRequest
         : public TEventPB<TEvEraseRowsRequest,
                           NKikimrTxDataShard::TEvEraseRowsRequest,

--- a/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
@@ -194,7 +194,7 @@ public:
             }
         }
 
-        TAutoPtr<NTable::TTableIt> iter = txc.DB.IterateRange(localTableId, keyRange, columnsToReturn);
+        TAutoPtr<NTable::TTableIter> iter = txc.DB.IterateRange(localTableId, keyRange, columnsToReturn);
 
         ui64 foundKeys = Result->Record.ContentsRowsSize() + Result->Record.CommonPrefixesRowsSize();
         while (iter->Next(NTable::ENext::All) == NTable::EReady::Data) {

--- a/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
@@ -257,13 +257,7 @@ public:
 
                             Y_VERIFY(columnId < value.Cells().size());
 
-                            NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType matchType;
-
-                            if (matchTypes.size() == filterColumnIds.size()) {
-                                matchType = matchTypes[i];
-                            } else {
-                                matchType = NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_EQUAL;
-                            }
+                            NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType matchType = matchTypes[i];
 
                             switch (matchType) {
                                 case NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_EQUAL:

--- a/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
@@ -6,7 +6,7 @@ namespace NDataShard {
 
 using namespace NTabletFlatExecutor;
 
-class TDataShard::TTxS3Listing : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+class TDataShard::TTxObjectStorageListing : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
 private:
     TEvDataShard::TEvObjectStorageListingRequest::TPtr Ev;
     TAutoPtr<TEvDataShard::TEvObjectStorageListingResponse> Result;
@@ -19,7 +19,7 @@ private:
     ui32 RestartCount;
 
 public:
-    TTxS3Listing(TDataShard* ds, TEvDataShard::TEvObjectStorageListingRequest::TPtr ev)
+    TTxObjectStorageListing(TDataShard* ds, TEvDataShard::TEvObjectStorageListingRequest::TPtr ev)
         : TBase(ds)
         , Ev(ev)
         , RestartCount(0)
@@ -175,6 +175,7 @@ public:
         bool hasFilter = Ev->Get()->Record.has_filter();
         TSerializedCellVec filterColumnValues;
         TVector<ui32> filterColumnIds;
+        TVector<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType> matchTypes;
 
         if (hasFilter) {
             const auto& filter = Ev->Get()->Record.filter();
@@ -182,6 +183,14 @@ public:
             filterColumnValues.Parse(filter.values());
             for (const auto& colId : filter.columns()) {
                 filterColumnIds.push_back(colId);
+            }
+            
+            for (const auto& matchType : filter.matchtypes()) {
+                if (!NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_IsValid(matchType)) {
+                    SetError(NKikimrTxDataShard::TError::BAD_ARGUMENT, Sprintf("Unknown match type %" PRIu32, matchType));
+                    return true;
+                }
+                matchTypes.push_back(static_cast<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType>(matchType));
             }
         }
 
@@ -239,15 +248,41 @@ public:
 
                 if (Result->Record.GetContentsRows().empty() ||
                     *Result->Record.GetContentsRows().rbegin() != newContentsRow) {
+
                     if (hasFilter) {
                         bool matches = true;
 
                         for (size_t i = 0; i < filterColumnIds.size(); i++) {
                             auto &columnId = filterColumnIds[i];
-                            int cmp = CompareTypedCells(value.Cells()[columnId], filterColumnValues.GetCells()[i], value.Types[columnId]);
 
-                            if (cmp != 0) {
-                                matches = false;
+                            Y_VERIFY(columnId < value.Cells().size());
+
+                            NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType matchType;
+
+                            if (matchTypes.size() == filterColumnIds.size()) {
+                                matchType = matchTypes[i];
+                            } else {
+                                matchType = NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_EQUAL;
+                            }
+
+                            switch (matchType) {
+                                case NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_EQUAL:
+                                    if (CompareTypedCells(value.Cells()[columnId], filterColumnValues.GetCells()[i], value.Types[columnId]) != 0) {
+                                        matches = false;
+                                    }
+                                    break;
+                                case NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_NOT_EQUAL: {
+                                    int cmp = CompareTypedCells(value.Cells()[columnId], filterColumnValues.GetCells()[i], value.Types[columnId]);
+
+                                    if (cmp == 0) {
+                                        matches = false;
+                                    }
+
+                                    break;
+                                }
+                            }
+
+                            if (!matches) {
                                 break;
                             }
                         }
@@ -269,8 +304,35 @@ public:
 
                     for (size_t i = 0; i < filterColumnIds.size(); i++) {
                         auto &columnId = filterColumnIds[i];
-                        if (value.Cells()[columnId].AsBuf() != filterColumnValues.GetCells()[i].AsBuf()) {
-                            matches = false;
+
+                        Y_VERIFY(columnId < value.Cells().size());
+
+                        NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType matchType;
+                        
+                        if (matchTypes.size() == filterColumnIds.size()) {
+                            matchType = matchTypes[i];
+                        } else {
+                            matchType = NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_EQUAL;
+                        }
+
+                        switch (matchType) {
+                            case NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_EQUAL:
+                                if (CompareTypedCells(value.Cells()[columnId], filterColumnValues.GetCells()[i], value.Types[columnId]) != 0) {
+                                    matches = false;
+                                }
+                                break;
+                            case NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_NOT_EQUAL: {
+                                int cmp = CompareTypedCells(value.Cells()[columnId], filterColumnValues.GetCells()[i], value.Types[columnId]);
+
+                                if (cmp == 0) {
+                                    matches = false;
+                                }
+
+                                break;
+                            }
+                        }
+
+                        if (!matches) {
                             break;
                         }
                     }
@@ -364,7 +426,7 @@ private:
 };
 
 void TDataShard::Handle(TEvDataShard::TEvObjectStorageListingRequest::TPtr& ev, const TActorContext& ctx) {
-    Executor()->Execute(new TTxS3Listing(this, ev), ctx);
+    Executor()->Execute(new TTxObjectStorageListing(this, ev), ctx);
 }
 
 } // namespace NDataShard

--- a/ydb/core/tx/datashard/datashard__s3_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__s3_listing.cpp
@@ -1,0 +1,325 @@
+#include "datashard_impl.h"
+#include <util/string/vector.h>
+
+namespace NKikimr {
+namespace NDataShard {
+
+using namespace NTabletFlatExecutor;
+
+class TDataShard::TTxS3Listing : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+private:
+    TEvDataShard::TEvS3ListingRequest::TPtr Ev;
+    TAutoPtr<TEvDataShard::TEvS3ListingResponse> Result;
+
+    // Used to continue iteration from last known position instead of restarting from the beginning
+    // This greatly improves performance for the cases with many deletion markers but sacrifices
+    // consitency within the shard. This in not a big deal because listings are not consistent across shards.
+    TString LastPath;
+    TString LastCommonPath;
+    ui32 RestartCount;
+
+public:
+    TTxS3Listing(TDataShard* ds, TEvDataShard::TEvS3ListingRequest::TPtr ev)
+        : TBase(ds)
+        , Ev(ev)
+        , RestartCount(0)
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_S3_LISTING; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        ++RestartCount;
+
+        if (!Result) {
+            Result = new TEvDataShard::TEvS3ListingResponse(Self->TabletID());
+        }
+
+        if (Self->State != TShardState::Ready &&
+            Self->State != TShardState::Readonly &&
+            Self->State != TShardState::SplitSrcWaitForNoTxInFlight &&
+            Self->State != TShardState::Frozen)
+        {
+            SetError(NKikimrTxDataShard::TError::WRONG_SHARD_STATE,
+                        Sprintf("Wrong shard state: %" PRIu32 " tablet id: %" PRIu64, Self->State, Self->TabletID()));
+            return true;
+        }
+
+        const ui64 tableId = Ev->Get()->Record.GetTableId();
+        const ui64 maxKeys = Ev->Get()->Record.GetMaxKeys();
+
+        if (!Self->TableInfos.contains(tableId)) {
+            SetError(NKikimrTxDataShard::TError::SCHEME_ERROR, Sprintf("Unknown table id %" PRIu64, tableId));
+            return true;
+        }
+
+        const TUserTable& tableInfo = *Self->TableInfos[tableId];
+        if (tableInfo.IsBackup) {
+            SetError(NKikimrTxDataShard::TError::SCHEME_ERROR, "Cannot read from a backup table");
+            return true;
+        }
+
+        const ui32 localTableId = tableInfo.LocalTid;
+
+        TVector<TRawTypeValue> key;
+        TVector<TRawTypeValue> endKey;
+        bool endKeyInclusive = true;
+
+        // TODO: check prefix column count against key column count
+        const TSerializedCellVec prefixColumns(Ev->Get()->Record.GetSerializedKeyPrefix());
+        for (ui32 ki = 0; ki < prefixColumns.GetCells().size(); ++ki) {
+            // TODO: check prefix column type
+            auto &cell = prefixColumns.GetCells()[ki];
+            auto &type = tableInfo.KeyColumnTypes[ki];
+            key.emplace_back(cell.Data(), cell.Size(), type);
+            endKey.emplace_back(cell.Data(), cell.Size(), type);
+        }
+        const ui32 pathColPos = prefixColumns.GetCells().size();
+
+        size_t columnCount = txc.DB.GetScheme().GetTableInfo(localTableId)->KeyColumns.size();
+
+        // TODO: check path column is present in schema and has Utf8 type
+        const TString pathPrefix = Ev->Get()->Record.GetPathColumnPrefix();
+        const TString pathSeparator = Ev->Get()->Record.GetPathColumnDelimiter();
+
+        TString startAfterPath;
+        bool minKeyInclusive = false;
+        TSerializedCellVec suffixColumns;
+        if (Ev->Get()->Record.GetSerializedStartAfterKeySuffix().empty()) {
+            if (Ev->Get()->Record.HasLastPath()) {
+                TString reqLastPath = Ev->Get()->Record.GetLastPath();
+
+                key.emplace_back(reqLastPath, NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+
+                startAfterPath = reqLastPath;
+            } else {
+                minKeyInclusive = true;
+                key.emplace_back(pathPrefix.data(), pathPrefix.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+                key.resize(columnCount);
+            }
+        } else {
+            suffixColumns.Parse(Ev->Get()->Record.GetSerializedStartAfterKeySuffix());
+            size_t prefixSize = prefixColumns.GetCells().size();
+
+            if (Ev->Get()->Record.HasLastPath()) {
+                TString reqLastPath = Ev->Get()->Record.GetLastPath();
+                
+                key.emplace_back(reqLastPath, tableInfo.KeyColumnTypes[prefixSize]);
+
+                for (size_t i = 1; i < suffixColumns.GetCells().size(); ++i) {
+                    size_t ki = prefixSize + i;
+                    key.emplace_back(suffixColumns.GetCells()[i].Data(), suffixColumns.GetCells()[i].Size(), tableInfo.KeyColumnTypes[ki]);
+                }
+                
+                startAfterPath = reqLastPath;
+            } else {
+                for (size_t i = 0; i < suffixColumns.GetCells().size(); ++i) {
+                    size_t ki = prefixSize + i;
+                    key.emplace_back(suffixColumns.GetCells()[i].Data(), suffixColumns.GetCells()[i].Size(), tableInfo.KeyColumnTypes[ki]);
+                }
+                startAfterPath = TString(suffixColumns.GetCells()[0].Data(), suffixColumns.GetCells()[0].Size());
+            }
+        }
+
+        TString lastCommonPath; // we will skip a common prefix iff it has been already returned from the prevoius shard
+        if (Ev->Get()->Record.HasLastCommonPrefix()) {
+            lastCommonPath = Ev->Get()->Record.GetLastCommonPrefix();
+        }
+
+        // If this trasaction has restarted we want to continue from the last seen key
+        if (LastPath) {
+            const size_t pathColIdx =  prefixColumns.GetCells().size();
+            key.resize(pathColIdx);
+            key.emplace_back(LastPath.data(), LastPath.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+            key.resize(columnCount);
+
+            lastCommonPath = LastCommonPath;
+        } else {
+            LastCommonPath = lastCommonPath;
+        }
+
+        const TString pathEndPrefix = NextPrefix(pathPrefix);
+        if (pathEndPrefix) {
+            endKey.emplace_back(pathEndPrefix.data(), pathEndPrefix.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+            while (endKey.size() < tableInfo.KeyColumnTypes.size()) {
+                endKey.emplace_back();
+            }
+            endKeyInclusive = false;
+        }
+
+        LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID() << " S3 Listing: start at key ("
+            << JoinVectorIntoString(key, " ") << "), end at key (" << JoinVectorIntoString(endKey, " ") << ")"
+            << " restarted: " << RestartCount-1 << " last path: \"" << LastPath << "\""
+            << " contents: " << Result->Record.ContentsRowsSize()
+            << " common prefixes: " << Result->Record.CommonPrefixesRowsSize());
+
+        Result->Record.SetMoreRows(!IsKeyInRange(endKey, tableInfo));
+
+        if (!maxKeys) {
+            // Nothing to return, don't bother searching
+            return true;
+        }
+
+        // Select path column and all user-requested columns
+        const TVector<ui32> columnsToReturn(Ev->Get()->Record.GetColumnsToReturn().begin(), Ev->Get()->Record.GetColumnsToReturn().end());
+
+        NTable::TKeyRange keyRange;
+        keyRange.MinKey = key;
+        keyRange.MinInclusive = minKeyInclusive;
+        keyRange.MaxKey = endKey;
+        keyRange.MaxInclusive = endKeyInclusive;
+
+        if (LastPath) {
+            // Don't include the last key in case of restart
+            keyRange.MinInclusive = false;
+        }
+
+        TAutoPtr<NTable::TTableIt> iter = txc.DB.IterateRange(localTableId, keyRange, columnsToReturn);
+
+        ui64 foundKeys = Result->Record.ContentsRowsSize() + Result->Record.CommonPrefixesRowsSize();
+        while (iter->Next(NTable::ENext::All) == NTable::EReady::Data) {
+            TDbTupleRef currentKey = iter->GetKey();
+
+            // Check all columns that prefix columns are in the current key are equal to the specified values
+            Y_VERIFY(currentKey.Cells().size() > prefixColumns.GetCells().size());
+            Y_VERIFY_DEBUG(
+                0 == CompareTypedCellVectors(
+                        prefixColumns.GetCells().data(),
+                        currentKey.Cells().data(),
+                        currentKey.Types,
+                        prefixColumns.GetCells().size()),
+                "Unexpected out of range key returned from iterator");
+
+            Y_VERIFY(currentKey.Types[pathColPos].GetTypeId() == NScheme::NTypeIds::Utf8);
+            const TCell& pathCell = currentKey.Cells()[pathColPos];
+            TString path = TString((const char*)pathCell.Data(), pathCell.Size());
+
+            LastPath = path;
+
+            // Explicitly skip erased rows after saving LastPath. This allows to continue exactly from
+            // this key in case of restart
+            if (iter->Row().GetRowState() == NTable::ERowOp::Erase) {
+                continue;
+            }
+
+            // Check that path begins with the specified prefix
+            Y_VERIFY_DEBUG(path.StartsWith(pathPrefix),
+                "Unexpected out of range key returned from iterator");
+
+            bool isLeafPath = true;
+            if (!pathSeparator.empty()) {
+                size_t separatorPos = path.find_first_of(pathSeparator, pathPrefix.length());
+                if (separatorPos != TString::npos) {
+                    path.resize(separatorPos + pathSeparator.length());
+                    isLeafPath = false;
+                }
+            }
+
+            TDbTupleRef value = iter->GetValues();
+            LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID() << " S3 Listing: "
+                "\"" << path << "\"" << (isLeafPath ? " -> " + DbgPrintTuple(value, *AppData(ctx)->TypeRegistry) : TString()));
+
+            if (isLeafPath) {
+                Y_VERIFY(value.Cells()[0].Size() >= 1);
+                Y_VERIFY(path == TStringBuf((const char*)value.Cells()[0].Data(), value.Cells()[0].Size()),
+                    "Path column must be requested at pos 0");
+
+                TString newContentsRow = TSerializedCellVec::Serialize(value.Cells());
+
+                if (Result->Record.GetContentsRows().empty() ||
+                    *Result->Record.GetContentsRows().rbegin() != newContentsRow)
+                {
+                    // Add a row with path column and all columns requested by user
+                    Result->Record.AddContentsRows(newContentsRow);
+                    if (++foundKeys >= maxKeys)
+                        break;
+                }
+            } else {
+                // For prefix save only path
+                if (path > startAfterPath && path != lastCommonPath) {
+                    LastCommonPath = path;
+                    Result->Record.AddCommonPrefixesRows(path);
+                    if (++foundKeys >= maxKeys)
+                        break;
+                }
+
+                TString lookup = NextPrefix(path);
+                if (!lookup) {
+                    // May only happen if path is equal to separator, which consists of only '\xff'
+                    // This would imply separator is not a valid UTF-8 string, but in any case no
+                    // other path exists after the current prefix.
+                    break;
+                }
+
+                // Skip to the next key after path+separator
+                key.resize(prefixColumns.GetCells().size());
+                key.emplace_back(lookup.data(), lookup.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+                key.resize(columnCount);
+
+                if (!iter->SkipTo(key, /* inclusive = */ true)) {
+                    return false;
+                }
+            }
+        }
+
+        return iter->Last() != NTable::EReady::Page;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID() << " S3 Listing: finished "
+                    << " status: " << Result->Record.GetStatus()
+                    << " description: \"" << Result->Record.GetErrorDescription() << "\""
+                    << " contents: " << Result->Record.ContentsRowsSize()
+                    << " common prefixes: " << Result->Record.CommonPrefixesRowsSize());
+        ctx.Send(Ev->Sender, Result.Release());
+    }
+
+private:
+    void SetError(ui32 status, TString descr) {
+        Result = new TEvDataShard::TEvS3ListingResponse(Self->TabletID());
+
+        Result->Record.SetStatus(status);
+        Result->Record.SetErrorDescription(descr);
+    }
+
+    static bool IsKeyInRange(TArrayRef<const TRawTypeValue> key, const TUserTable& tableInfo) {
+        if (!key) {
+            return false;
+        }
+        auto range = tableInfo.GetTableRange();
+        size_t prefixSize = Min(key.size(), range.To.size());
+        for (size_t pos = 0; pos < prefixSize; ++pos) {
+            if (int cmp = CompareTypedCells(TCell(&key[pos]), range.To[pos], tableInfo.KeyColumnTypes[pos])) {
+                return cmp < 0;
+            }
+        }
+        if (key.size() != range.To.size()) {
+            return key.size() > range.To.size();
+        }
+        return range.InclusiveTo;
+    }
+
+    /**
+     * Given a prefix p will return the first prefix p' that is
+     * lexicographically after all strings that have prefix p.
+     * Will return an empty string if prefix p' does not exist.
+     */
+    static TString NextPrefix(TString p) {
+        while (p) {
+            if (char next = (char)(((unsigned char)p.back()) + 1)) {
+                p.back() = next;
+                break;
+            } else {
+                p.pop_back(); // overflow, move to the next character
+            }
+        }
+
+        return p;
+    }
+};
+
+void TDataShard::Handle(TEvDataShard::TEvS3ListingRequest::TPtr& ev, const TActorContext& ctx) {
+    Executor()->Execute(new TTxS3Listing(this, ev), ctx);
+}
+
+} // namespace NDataShard
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/datashard__s3_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__s3_listing.cpp
@@ -8,8 +8,8 @@ using namespace NTabletFlatExecutor;
 
 class TDataShard::TTxS3Listing : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
 private:
-    TEvDataShard::TEvS3ListingRequest::TPtr Ev;
-    TAutoPtr<TEvDataShard::TEvS3ListingResponse> Result;
+    TEvDataShard::TEvObjectStorageListingRequest::TPtr Ev;
+    TAutoPtr<TEvDataShard::TEvObjectStorageListingResponse> Result;
 
     // Used to continue iteration from last known position instead of restarting from the beginning
     // This greatly improves performance for the cases with many deletion markers but sacrifices
@@ -19,7 +19,7 @@ private:
     ui32 RestartCount;
 
 public:
-    TTxS3Listing(TDataShard* ds, TEvDataShard::TEvS3ListingRequest::TPtr ev)
+    TTxS3Listing(TDataShard* ds, TEvDataShard::TEvObjectStorageListingRequest::TPtr ev)
         : TBase(ds)
         , Ev(ev)
         , RestartCount(0)
@@ -31,14 +31,13 @@ public:
         ++RestartCount;
 
         if (!Result) {
-            Result = new TEvDataShard::TEvS3ListingResponse(Self->TabletID());
+            Result = new TEvDataShard::TEvObjectStorageListingResponse(Self->TabletID());
         }
 
         if (Self->State != TShardState::Ready &&
             Self->State != TShardState::Readonly &&
             Self->State != TShardState::SplitSrcWaitForNoTxInFlight &&
-            Self->State != TShardState::Frozen)
-        {
+            Self->State != TShardState::Frozen) {
             SetError(NKikimrTxDataShard::TError::WRONG_SHARD_STATE,
                         Sprintf("Wrong shard state: %" PRIu32 " tablet id: %" PRIu64, Self->State, Self->TabletID()));
             return true;
@@ -173,6 +172,19 @@ public:
             keyRange.MinInclusive = false;
         }
 
+        bool hasFilter = Ev->Get()->Record.has_filter();
+        TSerializedCellVec filterColumnValues;
+        TVector<ui32> filterColumnIds;
+
+        if (hasFilter) {
+            const auto& filter = Ev->Get()->Record.filter();
+
+            filterColumnValues.Parse(filter.values());
+            for (const auto& colId : filter.columns()) {
+                filterColumnIds.push_back(colId);
+            }
+        }
+
         TAutoPtr<NTable::TTableIt> iter = txc.DB.IterateRange(localTableId, keyRange, columnsToReturn);
 
         ui64 foundKeys = Result->Record.ContentsRowsSize() + Result->Record.CommonPrefixesRowsSize();
@@ -226,14 +238,48 @@ public:
                 TString newContentsRow = TSerializedCellVec::Serialize(value.Cells());
 
                 if (Result->Record.GetContentsRows().empty() ||
-                    *Result->Record.GetContentsRows().rbegin() != newContentsRow)
-                {
+                    *Result->Record.GetContentsRows().rbegin() != newContentsRow) {
+                    if (hasFilter) {
+                        bool matches = true;
+
+                        for (size_t i = 0; i < filterColumnIds.size(); i++) {
+                            auto &columnId = filterColumnIds[i];
+                            int cmp = CompareTypedCells(value.Cells()[columnId], filterColumnValues.GetCells()[i], value.Types[columnId]);
+
+                            if (cmp != 0) {
+                                matches = false;
+                                break;
+                            }
+                        }
+
+                        if (!matches) {
+                            continue;
+                        }
+                    }
+                    
                     // Add a row with path column and all columns requested by user
                     Result->Record.AddContentsRows(newContentsRow);
-                    if (++foundKeys >= maxKeys)
+                    if (++foundKeys >= maxKeys) {
                         break;
+                    }
                 }
             } else {
+                if (hasFilter) {
+                    bool matches = true;
+
+                    for (size_t i = 0; i < filterColumnIds.size(); i++) {
+                        auto &columnId = filterColumnIds[i];
+                        if (value.Cells()[columnId].AsBuf() != filterColumnValues.GetCells()[i].AsBuf()) {
+                            matches = false;
+                            break;
+                        }
+                    }
+
+                    if (!matches) {
+                        continue;
+                    }
+                }
+                
                 // For prefix save only path
                 if (path > startAfterPath && path != lastCommonPath) {
                     LastCommonPath = path;
@@ -275,7 +321,7 @@ public:
 
 private:
     void SetError(ui32 status, TString descr) {
-        Result = new TEvDataShard::TEvS3ListingResponse(Self->TabletID());
+        Result = new TEvDataShard::TEvObjectStorageListingResponse(Self->TabletID());
 
         Result->Record.SetStatus(status);
         Result->Record.SetErrorDescription(descr);
@@ -317,7 +363,7 @@ private:
     }
 };
 
-void TDataShard::Handle(TEvDataShard::TEvS3ListingRequest::TPtr& ev, const TActorContext& ctx) {
+void TDataShard::Handle(TEvDataShard::TEvObjectStorageListingRequest::TPtr& ev, const TActorContext& ctx) {
     Executor()->Execute(new TTxS3Listing(this, ev), ctx);
 }
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1312,7 +1312,7 @@ class TDataShard
     void Handle(TEvDataShard::TEvGetS3DownloadInfo::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvStoreS3DownloadInfo::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvS3UploadRowsRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvS3ListingRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvObjectStorageListingRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, const TActorContext& ctx);
     void HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvCdcStreamScanRequest::TPtr& ev, const TActorContext& ctx);
@@ -2981,7 +2981,7 @@ protected:
             HFuncTraced(TEvDataShard::TEvGetS3DownloadInfo, Handle);
             HFuncTraced(TEvDataShard::TEvStoreS3DownloadInfo, Handle);
             HFuncTraced(TEvDataShard::TEvS3UploadRowsRequest, Handle);
-            HFuncTraced(TEvDataShard::TEvS3ListingRequest, Handle);
+            HFuncTraced(TEvDataShard::TEvObjectStorageListingRequest, Handle);
             HFuncTraced(TEvDataShard::TEvMigrateSchemeShardRequest, Handle);
             HFuncTraced(TEvTxProcessing::TEvPlanStep, Handle);
             HFuncTraced(TEvTxProcessing::TEvReadSet, Handle);

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -224,7 +224,7 @@ class TDataShard
     class TTxGetS3DownloadInfo;
     class TTxStoreS3DownloadInfo;
     class TTxS3UploadRows;
-    class TTxS3Listing;
+    class TTxObjectStorageListing;
     class TTxExecuteMvccStateChange;
     class TTxGetRemovedRowVersions;
     class TTxCompactBorrowed;

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -224,6 +224,7 @@ class TDataShard
     class TTxGetS3DownloadInfo;
     class TTxStoreS3DownloadInfo;
     class TTxS3UploadRows;
+    class TTxS3Listing;
     class TTxExecuteMvccStateChange;
     class TTxGetRemovedRowVersions;
     class TTxCompactBorrowed;
@@ -1311,6 +1312,7 @@ class TDataShard
     void Handle(TEvDataShard::TEvGetS3DownloadInfo::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvStoreS3DownloadInfo::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvS3UploadRowsRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvS3ListingRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, const TActorContext& ctx);
     void HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvCdcStreamScanRequest::TPtr& ev, const TActorContext& ctx);
@@ -2979,6 +2981,7 @@ protected:
             HFuncTraced(TEvDataShard::TEvGetS3DownloadInfo, Handle);
             HFuncTraced(TEvDataShard::TEvStoreS3DownloadInfo, Handle);
             HFuncTraced(TEvDataShard::TEvS3UploadRowsRequest, Handle);
+            HFuncTraced(TEvDataShard::TEvS3ListingRequest, Handle);
             HFuncTraced(TEvDataShard::TEvMigrateSchemeShardRequest, Handle);
             HFuncTraced(TEvTxProcessing::TEvPlanStep, Handle);
             HFuncTraced(TEvTxProcessing::TEvReadSet, Handle);

--- a/ydb/core/tx/datashard/datashard_ut_object_storage_listing.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_object_storage_listing.cpp
@@ -1,0 +1,277 @@
+#include "defs.h"
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include "datashard_ut_common_kqp.h"
+
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/core/tx/tx.h>
+
+#include <util/generic/bitmap.h>
+#include <util/string/printf.h>
+#include <util/string/strip.h>
+
+namespace NKikimr {
+
+using namespace NDataShard::NKqpHelpers;
+using namespace Tests;
+
+struct TProto {
+    using TEvListingRequest = NKikimrTxDataShard::TEvObjectStorageListingRequest;
+    using TEvListingResponse = NKikimrTxDataShard::TEvObjectStorageListingResponse;
+};
+
+namespace {
+
+void CreateTable(TServer::TPtr server, const TActorId& sender, const TString& root, const TString& name) {
+    auto opts = TShardedTableOptions()
+        .Columns({
+            {"bucket", "Uint32", true, false},
+            {"path", "Utf8", true, false},
+            {"value", "Utf8", false, false},
+            {"deleted", "Bool", false, false}
+        });
+    CreateShardedTable(server, sender, root, name, opts);
+}
+
+TProto::TEvListingRequest MakeListingRequest(const TTableId& tableId, const std::optional<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType> filterType) {
+    TProto::TEvListingRequest request;
+
+    TVector<TCell> bucketPrefixCell = {TCell::Make(100)};
+    TString prefix = TSerializedCellVec::Serialize(bucketPrefixCell);
+
+    request.SetTableId(tableId.PathId.LocalPathId);
+    request.SetSerializedKeyPrefix(prefix);
+    request.SetPathColumnPrefix("/test/");
+    request.SetPathColumnDelimiter("/");
+    request.SetMaxKeys(10);
+
+    request.add_columnstoreturn(2);
+    request.add_columnstoreturn(3);
+    request.add_columnstoreturn(4);
+
+    if (filterType) {
+        TVector<TCell> filterCell = {TCell::Make(false)};
+        auto* filter = request.mutable_filter();
+
+        filter->add_columns(2);
+        filter->set_values(TSerializedCellVec::Serialize(filterCell));
+        filter->add_matchtypes(filterType.value());
+    }
+
+    return request;
+}
+
+template <typename TEvResponse, typename TDerived>
+class TRequestRunner: public TActorBootstrapped<TDerived> {
+    void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
+        if (ev->Get()->Status == NKikimrProto::OK) {
+            return;
+        }
+
+        Bootstrap();
+    }
+
+protected:
+    void Reply(typename TEvResponse::TPtr& ev) {
+        TlsActivationContext->AsActorContext().Send(ev->Forward(ReplyTo));
+    }
+
+    virtual void Handle(typename TEvResponse::TPtr& ev) {
+        Reply(ev);
+        PassAway();
+    }
+
+    void PassAway() override {
+        if (Pipe) {
+            NTabletPipe::CloseAndForgetClient(this->SelfId(), Pipe);
+        }
+
+        IActor::PassAway();
+    }
+
+    virtual IEventBase* MakeRequest() const = 0;
+
+public:
+    explicit TRequestRunner(const TActorId& replyTo, ui64 tabletID)
+        : ReplyTo(replyTo)
+        , TabletID(tabletID)
+    {
+    }
+
+    void Bootstrap() {
+        if (Pipe) {
+            NTabletPipe::CloseAndForgetClient(this->SelfId(), Pipe);
+        }
+
+        Pipe = this->Register(NTabletPipe::CreateClient(this->SelfId(), TabletID));
+        NTabletPipe::SendData(this->SelfId(), Pipe, this->MakeRequest());
+
+        this->Become(&TDerived::StateWork);
+    }
+
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTabletPipe::TEvClientConnected, Handle);
+            cFunc(TEvTabletPipe::TEvClientDestroyed::EventType, Bootstrap);
+            hFunc(TEvResponse, Handle);
+        }
+    }
+
+    using TBase = TRequestRunner<TEvResponse, TDerived>;
+
+private:
+    const TActorId ReplyTo;
+    const ui64 TabletID;
+
+    TActorId Pipe;
+};
+
+std::pair<std::vector<std::string>, std::vector<std::string>> List(
+        TServer::TPtr server, const TActorId& sender, const TString& path,
+        const std::optional<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType> doFilter,
+        ui32 status = NKikimrTxDataShard::TError::OK)
+{
+    using TEvRequest = TEvDataShard::TEvObjectStorageListingRequest;
+    using TEvResponse = TEvDataShard::TEvObjectStorageListingResponse;
+
+    class TLister: public TRequestRunner<TEvResponse, TLister> {
+    public:
+        explicit TLister(
+                const TActorId& replyTo, ui64 tabletID,
+                const TTableId& tableId, const std::optional<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType> doFilter)
+            : TBase(replyTo, tabletID)
+            , TableId(tableId)
+            , DoFilter(doFilter)
+        {
+        }
+
+        IEventBase* MakeRequest() const override {
+            auto request = MakeHolder<TEvRequest>();
+            request->Record = MakeListingRequest(TableId, DoFilter);
+            return request.Release();
+        }
+
+    private:
+        const TTableId TableId;
+        const std::optional<NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType> DoFilter;
+    };
+
+    auto tableId = ResolveTableId(server, sender, path);
+
+    auto tabletIDs = GetTableShards(server, sender, path);
+    UNIT_ASSERT_VALUES_EQUAL(tabletIDs.size(), 1);
+    server->GetRuntime()->Register(new TLister(sender, tabletIDs[0], tableId, doFilter));
+
+    auto ev = server->GetRuntime()->GrabEdgeEventRethrow<TEvResponse>(sender);
+
+    auto& rec = ev->Get()->Record;
+
+    UNIT_ASSERT_VALUES_EQUAL(static_cast<ui32>(rec.GetStatus()), status);
+
+    std::vector<std::string> contents;
+    std::vector<std::string> commonPrefixes;
+
+    if (rec.CommonPrefixesRowsSize() > 0) {
+        auto& folders = rec.commonprefixesrows();
+        for (auto row : folders) {
+            commonPrefixes.emplace_back(row);
+        }
+    }
+        
+    if (rec.ContentsRowsSize() > 0) {
+        auto& files = rec.contentsrows();
+        for (auto row : files) {
+            auto vec = TSerializedCellVec(row);
+            const auto& cell = vec.GetCells()[0];
+            contents.emplace_back(cell.AsBuf().data(), cell.AsBuf().size());
+        }
+    }
+
+    return std::make_pair(commonPrefixes, contents);
+}
+
+} // anonymous
+
+Y_UNIT_TEST_SUITE(ObjectStorageListingTest) {
+
+    Y_UNIT_TEST(ListingNoFilter) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings
+            .SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        const TActorId sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        InitRoot(server, sender);
+
+        CreateTable(server, sender, "/Root", "table-1");
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table-1` (bucket, path, value, deleted) VALUES
+            (100, "/test/foo.txt", "foo", false),
+            (100, "/test/visible/bar.txt", "bar", false),
+            (100, "/test/deleted/baz.txt", "baz", true),
+            (100, "/test/foobar.txt", "foobar", false),
+            (100, "/test/deleted.txt", "foobar", true)
+        )");
+
+        auto res = List(server, sender, "/Root/table-1", {});
+
+        std::vector<std::string> expectedFolders = {"/test/deleted/", "/test/visible/"};
+        std::vector<std::string> expectedFiles = {"/test/deleted.txt", "/test/foo.txt", "/test/foobar.txt"};
+
+        UNIT_ASSERT_VALUES_EQUAL(expectedFolders, res.first);
+        UNIT_ASSERT_VALUES_EQUAL(expectedFiles, res.second);
+    }
+
+    Y_UNIT_TEST(FilterListing) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings
+            .SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        const TActorId sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        InitRoot(server, sender);
+
+        CreateTable(server, sender, "/Root", "table-1");
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table-1` (bucket, path, value, deleted) VALUES
+            (100, "/test/foo.txt", "foo", false),
+            (100, "/test/visible/bar.txt", "bar", false),
+            (100, "/test/deleted/baz.txt", "baz", true),
+            (100, "/test/foobar.txt", "foobar", false),
+            (100, "/test/deleted.txt", "foobar", true)
+        )");
+
+        {
+            auto res = List(server, sender, "/Root/table-1", NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_EQUAL);
+
+            std::vector<std::string> expectedFolders = {"/test/visible/"};
+            std::vector<std::string> expectedFiles = {"/test/foo.txt", "/test/foobar.txt"};
+
+            UNIT_ASSERT_VALUES_EQUAL(expectedFolders, res.first);
+            UNIT_ASSERT_VALUES_EQUAL(expectedFiles, res.second);
+        }
+
+        {
+            auto res = List(server, sender, "/Root/table-1", NKikimrTxDataShard::TObjectStorageListingFilter_EMatchType_NOT_EQUAL);
+
+            std::vector<std::string> expectedFolders = {"/test/deleted/"};
+            std::vector<std::string> expectedFiles = {"/test/deleted.txt"};
+
+            UNIT_ASSERT_VALUES_EQUAL(expectedFolders, res.first);
+            UNIT_ASSERT_VALUES_EQUAL(expectedFiles, res.second);
+        }
+    }
+}
+
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/ut_object_storage_listing/ya.make
+++ b/ydb/core/tx/datashard/ut_object_storage_listing/ya.make
@@ -1,0 +1,38 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+FORK_SUBTESTS()
+
+SPLIT_FACTOR(15)
+
+IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+    TIMEOUT(3600)
+    SIZE(LARGE)
+    TAG(ya:fat)
+    REQUIREMENTS(ram:16)
+ELSE()
+    TIMEOUT(600)
+    SIZE(MEDIUM)
+ENDIF()
+
+PEERDIR(
+    ydb/core/tx/datashard/ut_common
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/default
+    ydb/core/tx
+    ydb/library/yql/public/udf/service/exception_policy
+    ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/client/ydb_result
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    datashard_ut_object_storage_listing.cpp
+)
+
+REQUIREMENTS(ram:32)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -68,6 +68,7 @@ SRCS(
     datashard__read_columns.cpp
     datashard__s3_download_txs.cpp
     datashard__s3_upload_txs.cpp
+    datashard__s3_listing.cpp
     datashard__kqp_scan.cpp
     datashard__snapshot_txs.cpp
     datashard__stats.cpp

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -301,6 +301,7 @@ RECURSE_FOR_TESTS(
     ut_locks
     ut_minikql
     ut_minstep
+    ut_object_storage_listing
     ut_order
     ut_range_ops
     ut_read_iterator
@@ -311,8 +312,8 @@ RECURSE_FOR_TESTS(
     ut_sequence
     ut_snapshot
     ut_stats
+    ut_trace
     ut_upload_rows
     ut_volatile
     ut_write
-    ut_trace
 )

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -68,7 +68,7 @@ SRCS(
     datashard__read_columns.cpp
     datashard__s3_download_txs.cpp
     datashard__s3_upload_txs.cpp
-    datashard__s3_listing.cpp
+    datashard__object_storage_listing.cpp
     datashard__kqp_scan.cpp
     datashard__snapshot_txs.cpp
     datashard__stats.cpp

--- a/ydb/core/ydb_convert/ydb_convert.cpp
+++ b/ydb/core/ydb_convert/ydb_convert.cpp
@@ -1329,11 +1329,15 @@ void ProtoValueFromCell(NYdb::TValueBuilder& vb, const NScheme::TTypeInfo& typeI
     case EPrimitiveType::Json:
         vb.Json(getString());
         break;
-    case EPrimitiveType::Uuid:
-        vb.Uuid(getString());
+    case EPrimitiveType::Uuid: {
+        ui64 hi;
+        ui64 lo;
+        NUuid::UuidBytesToHalfs(cell.AsBuf().Data(), 16, hi, lo);
+        vb.Uuid(TUuidValue(lo, hi));
         break;
+    }
     case EPrimitiveType::JsonDocument:
-        vb.JsonDocument(getString());
+        vb.JsonDocument(NBinaryJson::SerializeToJson(getString()));
         break;
     case EPrimitiveType::DyNumber:
         vb.DyNumber(getString());

--- a/ydb/public/api/grpc/draft/ya.make
+++ b/ydb/public/api/grpc/draft/ya.make
@@ -14,6 +14,7 @@ SRCS(
     ydb_logstore_v1.proto
     ydb_maintenance_v1.proto
     ydb_persqueue_v1.proto
+    ydb_object_storage_v1.proto
 )
 
 PEERDIR(

--- a/ydb/public/api/grpc/draft/ydb_object_storage_v1.proto
+++ b/ydb/public/api/grpc/draft/ydb_object_storage_v1.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package Ydb.ObjectStorage.V1;
+option java_package = "com.yandex.ydb.object_storage.v1";
+
+import "ydb/public/api/protos/draft/ydb_object_storage.proto";
+
+service ObjectStorageService {
+    rpc List(ObjectStorage.ListingRequest) returns (ObjectStorage.ListingResponse);
+}

--- a/ydb/public/api/protos/draft/ydb_object_storage.proto
+++ b/ydb/public/api/protos/draft/ydb_object_storage.proto
@@ -9,6 +9,11 @@ import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/ydb_value.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
 
+message ListingFilter {
+    repeated string columns = 1;
+    TypedValue values = 2;
+}
+
 message ListingRequest {
     string table_name = 1;
     TypedValue key_prefix = 2; // A tuple representing all key columns that preceed path column
@@ -18,6 +23,7 @@ message ListingRequest {
     TypedValue start_after_key_suffix = 6; // A tuple representing key columns that succeed path column
     int32 max_keys = 7;
     repeated string columns_to_return = 8;
+    ListingFilter filter = 9;
 }
 
 message ListingResponse {

--- a/ydb/public/api/protos/draft/ydb_object_storage.proto
+++ b/ydb/public/api/protos/draft/ydb_object_storage.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+option cc_enable_arenas = true;
+
+package Ydb.ObjectStorage;
+option java_package = "com.yandex.ydb.object_storage";
+option java_outer_classname = "ObjectStorageProtos";
+
+import "ydb/public/api/protos/ydb_issue_message.proto";
+import "ydb/public/api/protos/ydb_value.proto";
+import "ydb/public/api/protos/ydb_status_codes.proto";
+
+message ListingRequest {
+    string table_name = 1;
+    TypedValue key_prefix = 2; // A tuple representing all key columns that preceed path column
+    string path_column_prefix = 3;
+    string path_column_delimiter = 4;
+    bytes continuation_token = 5;
+    TypedValue start_after_key_suffix = 6; // A tuple representing key columns that succeed path column
+    int32 max_keys = 7;
+    repeated string columns_to_return = 8;
+}
+
+message ListingResponse {
+    StatusIds.StatusCode status = 1;
+    repeated Ydb.Issue.IssueMessage issues = 2;
+    repeated string common_prefixes = 3;    // Folders.
+    Ydb.ResultSet contents = 4;           // Every Contents row starts with key suffix with KeySuffixSize columns
+    bool is_truncated = 5;
+    bytes next_continuation_token = 6;
+}
+
+message ContinuationToken {
+    string last_path = 1;
+    bool is_folder = 2;
+}

--- a/ydb/public/api/protos/draft/ydb_object_storage.proto
+++ b/ydb/public/api/protos/draft/ydb_object_storage.proto
@@ -9,11 +9,6 @@ import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/ydb_value.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
 
-message ListingFilter {
-    repeated string columns = 1;
-    TypedValue values = 2;
-}
-
 message ListingRequest {
     enum EMatchType {
         EQUAL = 0;
@@ -27,7 +22,7 @@ message ListingRequest {
     TypedValue start_after_key_suffix = 6; // A tuple representing key columns that succeed path column
     int32 max_keys = 7;
     repeated string columns_to_return = 8;
-    ListingFilter filter = 9;
+    reserved 9; // Deprecated filter
     TypedValue matching_filter = 10;
 }
 

--- a/ydb/public/api/protos/draft/ydb_object_storage.proto
+++ b/ydb/public/api/protos/draft/ydb_object_storage.proto
@@ -15,6 +15,10 @@ message ListingFilter {
 }
 
 message ListingRequest {
+    enum EMatchType {
+        EQUAL = 0;
+        NOT_EQUAL = 1;
+    }
     string table_name = 1;
     TypedValue key_prefix = 2; // A tuple representing all key columns that preceed path column
     string path_column_prefix = 3;
@@ -24,6 +28,7 @@ message ListingRequest {
     int32 max_keys = 7;
     repeated string columns_to_return = 8;
     ListingFilter filter = 9;
+    TypedValue matching_filter = 10;
 }
 
 message ListingResponse {

--- a/ydb/public/api/protos/draft/ydb_object_storage.proto
+++ b/ydb/public/api/protos/draft/ydb_object_storage.proto
@@ -34,8 +34,3 @@ message ListingResponse {
     bool is_truncated = 5;
     bytes next_continuation_token = 6;
 }
-
-message ContinuationToken {
-    string last_path = 1;
-    bool is_folder = 2;
-}

--- a/ydb/public/api/protos/ya.make
+++ b/ydb/public/api/protos/ya.make
@@ -15,6 +15,7 @@ SRCS(
     draft/ydb_dynamic_config.proto
     draft/ydb_logstore.proto
     draft/ydb_maintenance.proto
+    draft/ydb_object_storage.proto
     ydb_federation_discovery.proto
     persqueue_error_codes_v1.proto
     ydb_auth.proto

--- a/ydb/public/lib/experimental/ya.make
+++ b/ydb/public/lib/experimental/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     ydb_clickhouse_internal.cpp
     ydb_logstore.cpp
+    ydb_object_storage.cpp
 )
 
 PEERDIR(

--- a/ydb/public/lib/experimental/ydb_object_storage.cpp
+++ b/ydb/public/lib/experimental/ydb_object_storage.cpp
@@ -1,0 +1,136 @@
+#include "ydb_object_storage.h"
+
+#define INCLUDE_YDB_INTERNAL_H
+#include <ydb/public/sdk/cpp/client/impl/ydb_internal/make_request/make.h>
+#undef INCLUDE_YDB_INTERNAL_H
+
+#include <ydb/public/api/grpc/draft/ydb_object_storage_v1.grpc.pb.h>
+
+#include <ydb/library/yql/public/issue/yql_issue.h>
+#include <ydb/library/yql/public/issue/yql_issue_message.h>
+
+#include <ydb/public/sdk/cpp/client/ydb_proto/accessor.h>
+#include <ydb/public/sdk/cpp/client/ydb_common_client/impl/client.h>
+
+namespace NYdb {
+namespace NObjectStorage {
+
+TObjectStorageListingResult::TObjectStorageListingResult(std::vector<std::string>&& commonPrefixes, TResultSet&& contents, TString nextContinuationToken, bool isTruncated, TStatus&& status)
+    : TStatus(std::move(status))
+    , CommonPrefixes(std::move(commonPrefixes))
+    , Contents(std::move(contents))
+    , NextContinuationToken(nextContinuationToken)
+    , IsTruncated(isTruncated)
+{}
+
+const std::vector<std::string>& TObjectStorageListingResult::GetCommonPrefixes() const {
+    return CommonPrefixes;
+}
+
+const TResultSet& TObjectStorageListingResult::GetContents() const {
+    return Contents;
+}
+
+const TString& TObjectStorageListingResult::GetContinuationToken() const {
+    return NextContinuationToken;
+}
+
+bool TObjectStorageListingResult::GetIsTruncated() const {
+    return IsTruncated;
+}
+
+void SetProtoValue(Ydb::TypedValue& out, TValue&& in) {
+    *out.mutable_type() = TProtoAccessor::GetProto(in.GetType());
+    *out.mutable_value() = TProtoAccessor::GetProto(in);
+}
+
+
+class TObjectStorageClient::TImpl : public TClientImplCommon<TObjectStorageClient::TImpl> {
+public:
+    TImpl(std::shared_ptr<TGRpcConnectionsImpl>&& connections, const TCommonClientSettings& settings)
+        : TClientImplCommon(std::move(connections), settings) {}
+
+    TAsyncObjectStorageListingResult List(const TString& tableName,
+                           TValue&& keyPrefix,
+                           const TString& pathColumnPrefix,
+                           const TString& pathColumnDelimiter,
+                           TString& continuationToken,
+                           TValue&& startAfterKeySuffix,
+                           ui32 maxKeys,
+                           const TVector<TString> columnsToReturn,
+                           const TObjectStorageListingSettings& settings)
+    {
+        auto request = MakeRequest<Ydb::ObjectStorage::ListingRequest>();
+        request.set_table_name(tableName);
+        SetProtoValue(*request.mutable_key_prefix(), std::move(keyPrefix));
+        request.set_path_column_prefix(pathColumnPrefix);
+        request.set_path_column_delimiter(pathColumnDelimiter);
+        if (continuationToken) {
+            request.Setcontinuation_token(continuationToken);
+        }
+        SetProtoValue(*request.mutable_start_after_key_suffix(), std::move(startAfterKeySuffix));
+        request.set_max_keys(maxKeys);
+        for (auto& c : columnsToReturn) {
+            request.add_columns_to_return(c);
+        }
+
+        auto promise = NThreading::NewPromise<TObjectStorageListingResult>();
+
+        auto extractor = [promise]
+            (Ydb::ObjectStorage::ListingResponse* response, TPlainStatus status) mutable {
+                std::vector<std::string> commonPrefixes;
+                Ydb::ResultSet contents;
+                if (response) {
+                    Ydb::StatusIds::StatusCode msgStatus = response->status();
+                    NYql::TIssues issues;
+                    NYql::IssuesFromMessage(response->issues(), issues);
+                    status = TPlainStatus(static_cast<EStatus>(msgStatus), std::move(issues));    
+                    
+                    for (auto commonPrefix : response->Getcommon_prefixes()) {
+                        commonPrefixes.push_back(commonPrefix);
+                    }
+                    contents = std::move(response->Getcontents());
+                }
+
+                TObjectStorageListingResult val(std::move(commonPrefixes), std::move(contents), response->next_continuation_token(), response->is_truncated(), TStatus(std::move(status)));
+                promise.SetValue(std::move(val));
+            };
+
+        Connections_->Run<Ydb::ObjectStorage::V1::ObjectStorageService, Ydb::ObjectStorage::ListingRequest, Ydb::ObjectStorage::ListingResponse>(
+            std::move(request),
+            extractor,
+            &Ydb::ObjectStorage::V1::ObjectStorageService::Stub::AsyncList,
+            DbDriverState_,
+            TRpcRequestSettings::Make(settings));
+
+        return promise.GetFuture();
+    }
+};
+
+
+TObjectStorageClient::TObjectStorageClient(const TDriver& driver, const TCommonClientSettings& settings)
+    : Impl_(new TImpl(CreateInternalInterface(driver), settings))
+{}
+
+TAsyncObjectStorageListingResult TObjectStorageClient::List(const TString& tableName,
+                                          TValue&& keyPrefix,
+                                          const TString& pathColumnPrefix,
+                                          const TString& pathColumnDelimiter,
+                                          TString continuationToken,
+                                          TValue&& startAfterKeySuffix,
+                                          ui32 maxKeys,
+                                          const TVector<TString>& columnsToReturn,
+                                          const TObjectStorageListingSettings& settings)
+{
+    return Impl_->List(tableName,
+                            std::move(keyPrefix),
+                            pathColumnPrefix,
+                            pathColumnDelimiter,
+                            continuationToken,
+                            std::move(startAfterKeySuffix),
+                            maxKeys,
+                            columnsToReturn,
+                            settings);
+}
+
+}}

--- a/ydb/public/lib/experimental/ydb_object_storage.h
+++ b/ydb/public/lib/experimental/ydb_object_storage.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/client/ydb_result/result.h>
+#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
+
+namespace NYdb {
+namespace NObjectStorage {
+
+struct TObjectStorageListingSettings : public TOperationRequestSettings<TObjectStorageListingSettings> {};
+
+
+class TObjectStorageListingResult : public TStatus {
+    friend class TObjectStorageClient;
+private:
+    TObjectStorageListingResult(std::vector<std::string>&& commonPrefixes, TResultSet&& contents, TString nextContinuationToken, bool isTruncated, TStatus&& status);
+
+public:
+    const std::vector<std::string>& GetCommonPrefixes() const;
+    const TResultSet& GetContents() const;
+    const TString& GetContinuationToken() const;
+    bool GetIsTruncated() const;
+
+private:
+    std::vector<std::string> CommonPrefixes;
+    TResultSet Contents;
+    TString NextContinuationToken;
+    bool IsTruncated;
+};
+
+using TAsyncObjectStorageListingResult = NThreading::TFuture<TObjectStorageListingResult>;
+
+
+class TObjectStorageClient {
+    class TImpl;
+
+public:
+    TObjectStorageClient(const TDriver& driver, const TCommonClientSettings& settings = TCommonClientSettings());
+
+    TAsyncObjectStorageListingResult List(const TString& tableName,
+                           TValue&& keyPrefix,
+                           const TString& pathColumnPrefix,
+                           const TString& pathColumnDelimiter,
+                           TString continuationToken,
+                           TValue&& startAfterKeySuffix,
+                           ui32 maxKeys,
+                           const TVector<TString> &columnsToReturn,
+                           const TObjectStorageListingSettings& settings = TObjectStorageListingSettings());
+
+private:
+    std::shared_ptr<TImpl> Impl_;
+};
+
+}}

--- a/ydb/services/ydb/ut/ya.make
+++ b/ydb/services/ydb/ut/ya.make
@@ -28,6 +28,7 @@ SRCS(
     cert_gen.cpp
     ydb_query_ut.cpp
     ydb_ldap_login_ut.cpp
+    ydb_object_storage_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/services/ydb/ya.make
+++ b/ydb/services/ydb/ya.make
@@ -11,6 +11,7 @@ SRCS(
     ydb_scheme.cpp
     ydb_scripting.cpp
     ydb_table.cpp
+    ydb_object_storage.cpp
 )
 
 PEERDIR(

--- a/ydb/services/ydb/ydb_object_storage.cpp
+++ b/ydb/services/ydb/ydb_object_storage.cpp
@@ -1,0 +1,31 @@
+#include "ydb_object_storage.h"
+
+#include <ydb/core/grpc_services/service_object_storage.h>
+#include <ydb/core/grpc_services/grpc_helper.h>
+#include <ydb/core/grpc_services/base/base.h>
+
+namespace NKikimr {
+namespace NGRpcService {
+
+void TGRpcYdbObjectStorageService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
+    auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
+
+#ifdef ADD_REQUEST
+#error ADD_REQUEST macro already defined
+#endif
+#define ADD_REQUEST(NAME, IN, OUT, CB) \
+    MakeIntrusive<TGRpcRequest<Ydb::ObjectStorage::IN, Ydb::ObjectStorage::OUT, TGRpcYdbObjectStorageService>>(this, &Service_, CQ_, \
+        [this](NYdbGrpc::IRequestContextBase *ctx) { \
+            NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer()); \
+            ActorSystem_->Send(GRpcRequestProxyId_, \
+                new NGRpcService::TGrpcRequestNoOperationCall<Ydb::ObjectStorage::IN, Ydb::ObjectStorage::OUT> \
+                    (ctx, &CB, NGRpcService::TRequestAuxSettings{NGRpcService::TRateLimiterMode::Off, nullptr})); \
+        }, &Ydb::ObjectStorage::V1::ObjectStorageService::AsyncService::Request ## NAME, \
+        #NAME, logger, getCounterBlock("object-storage-list", #NAME))->Run();
+
+    ADD_REQUEST(List, ListingRequest, ListingResponse, DoObjectStorageListingRequest);
+#undef ADD_REQUEST
+}
+
+} // namespace NGRpcService
+} // namespace NKikimr

--- a/ydb/services/ydb/ydb_object_storage.h
+++ b/ydb/services/ydb/ydb_object_storage.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/grpc/server/grpc_server.h>
+#include <ydb/public/api/grpc/draft/ydb_object_storage_v1.grpc.pb.h>
+#include <ydb/core/grpc_services/base/base_service.h>
+
+namespace NKikimr {
+namespace NGRpcService {
+
+class TGRpcYdbObjectStorageService
+    : public TGrpcServiceBase<Ydb::ObjectStorage::V1::ObjectStorageService>
+{
+public:
+    using TGrpcServiceBase<Ydb::ObjectStorage::V1::ObjectStorageService>::TGrpcServiceBase;
+
+private:
+    void SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger);
+};
+
+} // namespace NGRpcService
+} // namespace NKikimr

--- a/ydb/services/ydb/ydb_object_storage_ut.cpp
+++ b/ydb/services/ydb/ydb_object_storage_ut.cpp
@@ -1,0 +1,286 @@
+#include "ydb_common_ut.h"
+
+#include <ydb/public/lib/experimental/ydb_object_storage.h>
+#include <ydb/public/sdk/cpp/client/ydb_result/result.h>
+#include <ydb/public/sdk/cpp/client/ydb_scheme/scheme.h>
+#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
+
+using namespace NYdb;
+
+Y_UNIT_TEST_SUITE(YdbS3Internal) {
+
+    void PrepareData(TString location) {
+        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location));
+
+        NYdb::NTable::TTableClient client(connection);
+        auto session = client.GetSession().ExtractValueSync().GetSession();
+
+        {
+            auto tableBuilder = client.GetTableBuilder();
+            tableBuilder
+                .AddNullableColumn("Hash", EPrimitiveType::Uint64)
+                .AddNullableColumn("Name", EPrimitiveType::Utf8)
+                .AddNullableColumn("Path", EPrimitiveType::Utf8)
+                .AddNullableColumn("Version", EPrimitiveType::Uint64)
+                .AddNullableColumn("Timestamp", EPrimitiveType::Uint64)
+                .AddNullableColumn("Data", EPrimitiveType::String)
+                .AddNullableColumn("ExtraData", EPrimitiveType::String)
+                .AddNullableColumn("Unused1", EPrimitiveType::Uint32);
+            tableBuilder.SetPrimaryKeyColumns({"Hash", "Name", "Path", "Version"});
+            NYdb::NTable::TCreateTableSettings tableSettings;
+            tableSettings.PartitioningPolicy(NYdb::NTable::TPartitioningPolicy().UniformPartitions(32));
+            auto result = session.CreateTable("/Root/ListingObjects", tableBuilder.Build(), tableSettings).ExtractValueSync();
+
+            UNIT_ASSERT_EQUAL(result.IsTransportError(), false);
+            UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+        }
+
+        // Write some rows
+        {
+            auto res = session.ExecuteDataQuery(
+                        "REPLACE INTO `/Root/ListingObjects` (Hash, Name, Path, Version, Timestamp, Data) VALUES\n"
+                        "(50, 'bucket50', '/home/Music/Bohemian Rapshody.mp3', 1, 10, 'MP3'),\n"
+                        "(50, 'bucket50', '/home/.bashrc', 1, 10, '#bashrc')\n"
+                        ";",
+                            NYdb::NTable::TTxControl::BeginTx().CommitTx()
+                        ).ExtractValueSync();
+
+            UNIT_ASSERT_EQUAL(res.GetStatus(), EStatus::SUCCESS);
+        }
+    }
+
+    Y_UNIT_TEST(TestS3Listing) {
+        TKikimrWithGrpcAndRootSchema server;
+        ui16 grpc = server.GetPort();
+        TString location = TStringBuilder() << "localhost:" << grpc;
+
+        PrepareData(location);
+
+        // List
+        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location));
+        NObjectStorage::TObjectStorageClient s3conn(connection);
+
+        TValueBuilder keyPrefix;
+        keyPrefix.BeginTuple()
+                .AddElement().Uint64(50)
+                .AddElement().Utf8("bucket50")
+                .EndTuple();
+        TValueBuilder suffix;
+        suffix.BeginTuple().EndTuple();
+        auto res = s3conn.List("/Root/ListingObjects",
+                                    keyPrefix.Build(),
+                                    "/home/",
+                                    "/",
+                                    "",
+                                    suffix.Build(),
+                                    100,
+                                    {"Name", "Data", "Timestamp"}
+            ).GetValueSync();
+
+        Cerr << res.GetStatus() << Endl;
+        UNIT_ASSERT_EQUAL(res.GetStatus(), EStatus::SUCCESS);
+
+        UNIT_ASSERT(!res.GetIsTruncated());
+        UNIT_ASSERT(!res.GetContinuationToken());
+
+        {
+            UNIT_ASSERT_VALUES_EQUAL(res.GetCommonPrefixes().size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(res.GetCommonPrefixes()[0], "/home/Music/");
+        }
+
+        {
+            UNIT_ASSERT_VALUES_EQUAL(res.GetContents().RowsCount(), 1);
+            TResultSetParser parser(res.GetContents());
+            UNIT_ASSERT(parser.TryNextRow());
+            UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("Name").GetOptionalUtf8().GetRef(), "bucket50");
+            UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("Path").GetOptionalUtf8().GetRef(), "/home/.bashrc");
+            UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("Timestamp").GetOptionalUint64().GetRef(), 10);
+        }
+    }
+
+    void SetPermissions(TString location) {
+        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location));
+        auto scheme = NYdb::NScheme::TSchemeClient(connection);
+        auto status = scheme.ModifyPermissions("/Root/ListingObjects",
+                                               NYdb::NScheme::TModifyPermissionsSettings()
+                                               .AddSetPermissions(
+                                                   NYdb::NScheme::TPermissions("reader@builtin", {"ydb.tables.read"})
+                                                   )
+                                               .AddSetPermissions(
+                                                   NYdb::NScheme::TPermissions("generic_reader@builtin", {"ydb.generic.read"})
+                                                   )
+                                               .AddSetPermissions(
+                                                   NYdb::NScheme::TPermissions("writer@builtin", {"ydb.tables.modify"})
+                                                   )
+                                               .AddSetPermissions(
+                                                   NYdb::NScheme::TPermissions("generic_writer@builtin", {"ydb.generic.write"})
+                                                   )
+                                               ).ExtractValueSync();
+        UNIT_ASSERT_EQUAL(status.IsTransportError(), false);
+        UNIT_ASSERT_EQUAL(status.GetStatus(), EStatus::SUCCESS);
+    }
+
+    NYdb::EStatus MakeListingRequest(TString location, TString userToken) {
+        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location).SetAuthToken(userToken));
+        NObjectStorage::TObjectStorageClient s3conn(connection);
+
+        TValueBuilder keyPrefix;
+        keyPrefix.BeginTuple()
+                .AddElement().Uint64(50)
+                .AddElement().Utf8("bucket50")
+                .EndTuple();
+        TValueBuilder suffix;
+        suffix.BeginTuple().EndTuple();
+        auto res = s3conn.List("/Root/ListingObjects",
+                                    keyPrefix.Build(),
+                                    "/home/",
+                                    "/",
+                                    "",
+                                    suffix.Build(),
+                                    100,
+                                    {"Name", "Data", "Timestamp"}
+            ).GetValueSync();
+
+        return res.GetStatus();
+    }
+
+    Y_UNIT_TEST(TestAccessCheck) {
+        TKikimrWithGrpcAndRootSchema server;
+        ui16 grpc = server.GetPort();
+        TString location = TStringBuilder() << "localhost:" << grpc;
+
+        PrepareData(location);
+        SetPermissions(location);
+        server.ResetSchemeCache("/Root/ListingObjects");
+
+        UNIT_ASSERT_EQUAL(MakeListingRequest(location, ""), EStatus::SUCCESS);
+        UNIT_ASSERT_EQUAL(MakeListingRequest(location, "reader@builtin"), EStatus::SUCCESS);
+        UNIT_ASSERT_EQUAL(MakeListingRequest(location, "generic_reader@builtin"), EStatus::SUCCESS);
+        UNIT_ASSERT_EQUAL(MakeListingRequest(location, "root@builtin"), EStatus::SUCCESS);
+
+        UNIT_ASSERT_EQUAL(MakeListingRequest(location, "writer@builtin"), EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_EQUAL(MakeListingRequest(location, "generic_writer@builtin"), EStatus::UNAUTHORIZED);
+        UNIT_ASSERT_EQUAL(MakeListingRequest(location, "badguy@builtin"), EStatus::UNAUTHORIZED);
+    }
+
+    NYdb::EStatus TestRequest(NObjectStorage::TObjectStorageClient s3conn, TValue&& keyPrefix, TValue&& suffix) {
+        auto res = s3conn.List("/Root/ListingObjects",
+                                    std::move(keyPrefix),
+                                    "/home/",
+                                    "/",
+                                    "",
+                                    std::move(suffix),
+                                    100,
+                                    {"Name", "Data", "Timestamp"}
+            ).GetValueSync();
+
+        return res.GetStatus();
+    }
+
+    // Test request with good suffix
+    NYdb::EStatus TestKeyPrefixRequest(NObjectStorage::TObjectStorageClient s3conn, TValue&& keyPrefix) {
+        return TestRequest(s3conn,
+                           std::move(keyPrefix),
+                           TValueBuilder().BeginTuple().EndTuple().Build());
+    }
+
+    // Test request with good keyPrefix
+    NYdb::EStatus TestKeySuffixRequest(NObjectStorage::TObjectStorageClient s3conn, TValue&& keySuffix) {
+        return TestRequest(s3conn,
+                           TValueBuilder()
+                              .BeginTuple()
+                                  .AddElement().Uint64(1)
+                                  .AddElement().Utf8("Bucket50")
+                              .EndTuple().Build(),
+                           std::move(keySuffix));
+    }
+
+    Y_UNIT_TEST(BadRequests) {
+        TKikimrWithGrpcAndRootSchema server;
+        ui16 grpc = server.GetPort();
+        TString location = TStringBuilder() << "localhost:" << grpc;
+
+        PrepareData(location);
+
+        auto connection = NYdb::TDriver(TDriverConfig().SetEndpoint(location));
+        NObjectStorage::TObjectStorageClient s3conn(connection);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                                      TValueBuilder()
+                                                        .BeginTuple()
+                                                            .AddElement().Uint64(1)
+                                                            .AddElement().Utf8("Bucket50")
+                                                        .EndTuple().Build()),
+                                 EStatus::SUCCESS);
+
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                                      TValueBuilder().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                                      TValueBuilder()
+                                                        .BeginTuple()
+                                                            .AddElement().BeginList().EndList()
+                                                            .AddElement().Utf8("Bucket50")
+                                                        .EndTuple().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                             TValueBuilder().BeginStruct().EndStruct().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                             TValueBuilder().BeginList().EndList().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                             TValueBuilder()
+                                                .BeginList()
+                                                    .AddListItem().Uint64(1)
+                                                    .AddListItem().Uint64(22)
+                                                .EndList().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                             TValueBuilder().Uint64(50).Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeyPrefixRequest(s3conn,
+                                             TValueBuilder().Uint64(50).Build()),
+                                 EStatus::BAD_REQUEST);
+
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeySuffixRequest(s3conn,
+                                             TValueBuilder().BeginTuple().EndTuple().Build()),
+                                 EStatus::SUCCESS);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeySuffixRequest(s3conn,
+                                             TValueBuilder().Build()),
+                                 EStatus::SUCCESS);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeySuffixRequest(s3conn,
+                                             TValueBuilder().BeginStruct().EndStruct().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeySuffixRequest(s3conn,
+                                             TValueBuilder().BeginList().EndList().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeySuffixRequest(s3conn,
+                                             TValueBuilder()
+                                                      .BeginList()
+                                                          .AddListItem().Uint64(1)
+                                                          .AddListItem().Uint64(22)
+                                                      .EndList().Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeySuffixRequest(s3conn,
+                                             TValueBuilder().Uint64(50).Build()),
+                                 EStatus::BAD_REQUEST);
+
+        UNIT_ASSERT_VALUES_EQUAL(TestKeySuffixRequest(s3conn,
+                                             TValueBuilder().Uint64(50).Build()),
+                                 EStatus::BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* New feature

# Proposed docs


## Object Storage Listing API

Objects in (S3-like) object storage have a name column. Although object storage is unstructured, users often give their objects name similar to file path, e.g. /foo/baz.txt, /foo/bar/test.txt. One of the common operations is listing. For example, listing folder /foo/ should yield:

/bar/
/foo/baz.txt

### Request

#### Table name
Name of the table to list objects from

#### Key prefix
Limits the response to keys that begin with the specified key prefix. keyColumn0 ... path column (exclusive) values.

Example in Go:
```
Ydb.TypedValue{
    Type: &Ydb.Type{
        Type: &Ydb.Type_TupleType{
            TupleType: &Ydb.TupleType{
                Elements: []*Ydb.Type{
                    {
                        Type: &Ydb.Type_TypeId{
                            TypeId: Ydb.Type_UINT64,
                        },
                    },
                },
            },
        },
    },
    Value: &Ydb.Value{
        Items: []*Ydb.Value{
            {
                Value: &Ydb.Value_Uint64Value{
                    Uint64Value: 100,
                },
            },
        },
    },
}
```

This is a Ydb.TypedValue that contains key column values in PK order. Must have all columns from first until the "path" column (excluding it). 

#### Path column prefix
Limits the response to keys that begin with the specified path prefix (e.g. /foo)

#### Path column delimiter
A delimiter is a character that you use to group keys. For example, if path is /foo/bar/baz.txt, then delimiter should be "/"

#### Start after key suffix
Key's suffix column values: path column (inclusive) ... columnN values.
StartAfterKeySuffix is where you want to start listing from. This API starts listing after this specified key. StartAfterKeySuffix can be any existing or non-existing key

Example in Go:
```
Ydb.TypedValue{
    Type: &Ydb.Type{
        Type: &Ydb.Type_TupleType{
            TupleType: &Ydb.TupleType{
                Elements: []*Ydb.Type{
                    {
                        Type: &Ydb.Type_TypeId{
                            TypeId: Ydb.Type_UTF8,
                        },
                    },
                },
            },
        },
    },
    Value: &Ydb.Value{
        Items: []*Ydb.Value{
            {
                Value: &Ydb.Value_TextValue{
                    TextValue: "/Foo/bar/",
                },
            },
        },
    },
}
```

This is a Ydb.TypedValue that contains key column values in PK order.

#### Matching filter
Column values to filter out rows

Here is a filter that filters out all rows with "deleted" column's value equal to true.
Example in Go:
```
Ydb.TypedValue{
    Type: &Ydb.Type{
        Type: &Ydb.Type_TupleType{
            TupleType: &Ydb.TupleType{
                Elements: []*Ydb.Type{
                    {
                        Type: &Ydb.Type_ListType{
                            ListType: &Ydb.ListType{
                                Item: &Ydb.Type{
                                    Type: &Ydb.Type_TypeId{
                                        TypeId: Ydb.Type_STRING,
                                    },
                                },
                            },
                        },
                    },
                    {
                        Type: &Ydb.Type_ListType{
                            ListType: &Ydb.ListType{
                                Item: &Ydb.Type{
                                    Type: &Ydb.Type_TypeId{
                                        TypeId: Ydb.Type_UINT32,
                                    },
                                },
                            },
                        },
                    },
                    {
                        Type: &Ydb.Type_TupleType{
                            TupleType: &Ydb.TupleType{
                                Elements: []*Ydb.Type{
                                    {
                                        Type: &Ydb.Type_TypeId{
                                            TypeId: Ydb.Type_BOOL,
                                        },
                                    },
                                },
                            },
                        },
                    },
                },
            },
        },
    },
    Value: &Ydb.Value{
        Items: []*Ydb.Value{
            {
                Items: []*Ydb.Value{
                    {
                        Value: &Ydb.Value_TextValue{
                            TextValue: "deleted",
                        },
                    },
                },
            },
            {
                Items: []*Ydb.Value{
                    {
                        Value: &Ydb.Value_Uint32Value{
                            Uint32Value: uint32(Ydb_ObjectStorage.ListingRequest_EQUAL),
                        },
                    },
                },
            },
            {
                Items: []*Ydb.Value{
                    {
                        Value: &Ydb.Value_BoolValue{
                            BoolValue: true,
                        },
                    },
                },
            },
        },
    },
}
```

This is a Ydb.TypedValue that contains list of column names, list of matching types (either EQUAL or NOT_EQUAL) and list of values for the columns.

#### Continuation token
ContinuationToken indicates that the list is being continued on with a token. ContinuationToken is obfuscated and is not a real key. You can use this ContinuationToken for pagination of the list results

#### Columns to return
Which columns of the row to return. Path column and filter columns are added automatically 

#### Max keys
Sets the maximum number of keys returned in the response. By default, the action returns up to 1,000 key names. The response might contain fewer keys but will never contain more

### Response

#### Status
YDB operation status code

#### Issues
YDB operation issue messages

#### Common prefixes
All the keys (up to 1_000) that share the same prefix are grouped together. When counting the total numbers of returns by this API operation, this group of keys is considered as one item.  
A response can contain CommonPrefixes only if you specify a delimiter.  
CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by a delimiter.  

#### Contents
Returned rows with specified columns (path and filter columns are added automatically)

#### Next continuation token
NextContinuationToken is sent when isTruncated is true, which means there are more keys that can be listed. The next list requests can be continued with this NextContinuationToken. NextContinuationToken is obfuscated and is not a real key

### Is truncated
Set to false if all of the results were returned. Set to true if more keys are available to return
