### PR TITLE
Reduce CPU reporting threshold delta from 10% to 2%

### DIFF
--- a/ydb/core/tablet/tablet_metrics.h
+++ b/ydb/core/tablet/tablet_metrics.h
@@ -59,7 +59,7 @@ public:
     bool TryUpdate(TResourceMetricsValues& src, const TActorContext& ctx);
 
 protected:
-    static constexpr ui64 SignificantChangeCPU = 100000/* 100msec */;
+    static constexpr ui64 SignificantChangeCPU = 20000/* 20msec */;
     static constexpr ui64 SignificantChangeMemory = 1 << 20/* 1Mb */;
     static constexpr ui64 SignificantChangeNetwork = 1 << 20/* 1Mb */;
     static constexpr ui64 SignificantChangeThroughput = 1 << 20/* 1Mb */;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Reporting CPU usage with 10% threshold is too confusing, simple key-value reading may consume around 5%

Also if we have a huge cluster with hundred thousand tablets, treating 7% CPU usage as zero seems wrong

Before that fix UI shows:

![telegram-cloud-photo-size-2-5326022372509211720-y](https://github.com/ydb-platform/ydb/assets/6822967/0c8ef93e-247c-4678-b746-521edfd2df47)

Hive shows:

![telegram-cloud-photo-size-2-5326022372509211727-y](https://github.com/ydb-platform/ydb/assets/6822967/dfa00237-42f7-4c24-bde0-d6b2b5e4865a)

And restarts didn't help to fix tablet 72075186224037908 usage in Hive