### PR TITLE
periodically update *all* metrics

### DIFF
--- a/ydb/core/tablet/tablet_metrics.h
+++ b/ydb/core/tablet/tablet_metrics.h
@@ -66,6 +66,41 @@ protected:
     static constexpr ui64 SignificantChangeStorage = 100 << 20/* 100Mb */;
     static constexpr ui64 SignificantChangeIops = 10 /* 10 iops? */;
 
+    struct TLastUpdates {
+        TInstant LastCPUUpdate;
+        TInstant LastMemoryUpdate;
+        TInstant LastNetworkUpdate;
+        TInstant LastStorageUpdate;
+        TInstant LastReadThroughputUpdate;
+        TInstant LastWriteThroughputUpdate;
+        TInstant LastReadIopsUpdate;
+        TInstant LastWriteIopsUpdate;
+
+        // Last time we updated any metric
+        TInstant LastAnyUpdate() const {
+            return std::max({LastCPUUpdate, LastMemoryUpdate, LastNetworkUpdate, LastStorageUpdate,
+                             LastReadThroughputUpdate, LastWriteThroughputUpdate, LastReadIopsUpdate,
+                             LastWriteIopsUpdate});
+        }
+
+        // Last time s. t. we updated all metrics since that time
+        TInstant LastAllUpdate() const {
+            // Ignoring ones that we never updated
+            auto cmp = [](const TInstant& lhs, const TInstant& rhs) {
+                if (lhs == TInstant{}) {
+                    return false;
+                }
+                if (rhs == TInstant{}) {
+                    return true;
+                }
+                return lhs < rhs;
+            };
+            return std::min({LastCPUUpdate, LastMemoryUpdate, LastNetworkUpdate, LastStorageUpdate,
+                             LastReadThroughputUpdate, LastWriteThroughputUpdate, LastReadIopsUpdate,
+                             LastWriteIopsUpdate}, cmp);
+        }
+    };
+
     const ui64 TabletId;
     const ui32 FollowerId;
     const TActorId Launcher;
@@ -78,7 +113,7 @@ protected:
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelWriteThroughput;
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelReadIops;
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelWriteIops;
-    TInstant LastUpdate;
+    TLastUpdates LastUpdates;
 };
 
 class TResourceMetrics : public TResourceMetricsValues, public TResourceMetricsSendState {

--- a/ydb/core/tablet/tablet_metrics.h
+++ b/ydb/core/tablet/tablet_metrics.h
@@ -66,41 +66,6 @@ protected:
     static constexpr ui64 SignificantChangeStorage = 100 << 20/* 100Mb */;
     static constexpr ui64 SignificantChangeIops = 10 /* 10 iops? */;
 
-    struct TLastUpdates {
-        TInstant LastCPUUpdate;
-        TInstant LastMemoryUpdate;
-        TInstant LastNetworkUpdate;
-        TInstant LastStorageUpdate;
-        TInstant LastReadThroughputUpdate;
-        TInstant LastWriteThroughputUpdate;
-        TInstant LastReadIopsUpdate;
-        TInstant LastWriteIopsUpdate;
-
-        // Last time we updated any metric
-        TInstant LastAnyUpdate() const {
-            return std::max({LastCPUUpdate, LastMemoryUpdate, LastNetworkUpdate, LastStorageUpdate,
-                             LastReadThroughputUpdate, LastWriteThroughputUpdate, LastReadIopsUpdate,
-                             LastWriteIopsUpdate});
-        }
-
-        // Last time s. t. we updated all metrics since that time
-        TInstant LastAllUpdate() const {
-            // Ignoring ones that we never updated
-            auto cmp = [](const TInstant& lhs, const TInstant& rhs) {
-                if (lhs == TInstant{}) {
-                    return false;
-                }
-                if (rhs == TInstant{}) {
-                    return true;
-                }
-                return lhs < rhs;
-            };
-            return std::min({LastCPUUpdate, LastMemoryUpdate, LastNetworkUpdate, LastStorageUpdate,
-                             LastReadThroughputUpdate, LastWriteThroughputUpdate, LastReadIopsUpdate,
-                             LastWriteIopsUpdate}, cmp);
-        }
-    };
-
     const ui64 TabletId;
     const ui32 FollowerId;
     const TActorId Launcher;
@@ -113,7 +78,8 @@ protected:
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelWriteThroughput;
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelReadIops;
     THashMap<std::pair<TChannel, TGroupId>, ui32> LevelWriteIops;
-    TLastUpdates LastUpdates;
+    TInstant LastAllUpdate;
+    TInstant LastAnyUpdate;
 };
 
 class TResourceMetrics : public TResourceMetricsValues, public TResourceMetricsSendState {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

ensure that all tablet metrics are periodically updated

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

This ensures we update each metric regularly - in the old version it was possible to never update one metric as long as some other metric is constantly being updated
