### PR TITLE
Add missing <functional> include

### DIFF
--- a/ydb/library/yql/minikql/dom/convert.h
+++ b/ydb/library/yql/minikql/dom/convert.h
@@ -8,6 +8,8 @@
 #include <util/string/cast.h>
 #include <util/string/builder.h>
 
+#include <functional>
+
 namespace NYql::NDom {
 
 template<bool Strict, bool AutoConvert>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Avoid this type of errors on upcoming protobuf update since some transitive includes have been removed.
```
$(SOURCE_ROOT)/contrib/ydb/library/yql/minikql/dom/convert.h:327:26: error: implicit instantiation of undefined template 'std::function<NYql::NUdf::TUnboxedValuePod (NYql::NUdf::TUnboxedValuePod)>'
        const TConverter Converter;
                         ^
$(SOURCE_ROOT)/contrib/libs/cxxsupp/libcxx/include/stlfwd:46:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS function;
```
...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Additional information

...
