### PR TITLE
test TPersQueueTest::DirectReadStop

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -62,7 +62,6 @@ ydb/services/persqueue_v1/ut TPersQueueTest.SetupLockSession
 ydb/services/persqueue_v1/ut TPQCompatTest.BadTopics
 ydb/services/persqueue_v1/ut TPersQueueTest.DirectRead*Cache*
 ydb/services/persqueue_v1/ut [3/10]*
-ydb/services/persqueue_v1/ut TPersQueueTest.DirectReadStop
 ydb/services/ydb/sdk_sessions_pool_ut YdbSdkSessionsPool.StressTestSync*
 ydb/services/ydb/sdk_sessions_ut YdbSdkSessions.TestActiveSessionCountAfterBadSession
 ydb/services/ydb/sdk_sessions_ut [6/10]*

--- a/ydb/services/persqueue_v1/persqueue_new_schemecache_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_new_schemecache_ut.cpp
@@ -506,7 +506,7 @@ namespace NKikimr::NPersQueueTests {
 
     Y_UNIT_TEST_SUITE(TPersqueueDataPlaneTestSuite) {
         Y_UNIT_TEST(WriteSession) {
-            TPersQueueV1TestServer server(true, true);
+            TPersQueueV1TestServer server({.CheckACL=true, .TenantModeEnabled=true});
 
             TString topic = "/Root/account1/write_topic";
             TString consumer = "consumer_aba";
@@ -570,7 +570,7 @@ namespace NKikimr::NPersQueueTests {
 
     Y_UNIT_TEST_SUITE(TPersqueueControlPlaneTestSuite) {
         Y_UNIT_TEST(SetupReadLockSessionWithDatabase) {
-            TPersQueueV1TestServer server(false, true);
+            TPersQueueV1TestServer server({.TenantModeEnabled=true});
 
             {
                 auto res = server.PersQueueClient->AddReadRule("/Root/acc/topic1", TAddReadRuleSettings().ReadRule(TReadRuleSettings().ConsumerName("user1")));
@@ -606,7 +606,7 @@ namespace NKikimr::NPersQueueTests {
         }
 
         Y_UNIT_TEST(SetupWriteLockSessionWithDatabase) {
-            TPersQueueV1TestServer server(false, true);
+            TPersQueueV1TestServer server({.TenantModeEnabled=true});
 
             auto stub = Ydb::PersQueue::V1::PersQueueService::NewStub(server.InsecureChannel);
             grpc::ClientContext grpcContext;
@@ -631,7 +631,7 @@ namespace NKikimr::NPersQueueTests {
         }
 
         Y_UNIT_TEST(TestAddRemoveReadRule) {
-            TPersQueueV1TestServer server(false, true);
+            TPersQueueV1TestServer server({.TenantModeEnabled=true});
             SET_LOCALS;
 
             pqClient->CreateConsumer("goodUser");

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -953,7 +953,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadPreCached) {
-        TPersQueueV1TestServer server{{.CheckAcl=true}};
+        TPersQueueV1TestServer server{{.CheckACL=true}};
         SET_LOCALS;
         TDirectReadTestSetup setup{server};
         setup.DoWrite(pqClient->GetDriver(), "acc/topic1", 1_MB, 30);
@@ -981,7 +981,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadNotCached) {
-        TPersQueueV1TestServer server{{.CheckAcl=true}};
+        TPersQueueV1TestServer server{{.CheckACL=true}};
         SET_LOCALS;
         TDirectReadTestSetup setup{server};
 
@@ -1013,7 +1013,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadBadCases) {
-        TPersQueueV1TestServer server{{.CheckAcl=true}};
+        TPersQueueV1TestServer server{{.CheckACL=true}};
         SET_LOCALS;
         TDirectReadTestSetup setup{server};
         setup.InitControlSession("acc/topic1");
@@ -1042,7 +1042,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadStop) {
-        TPersQueueV1TestServer server{{.CheckAcl=true}};
+        TPersQueueV1TestServer server{{.CheckACL=true}};
         SET_LOCALS;
 
         server.Server->AnnoyingClient->AlterTopicNoLegacy("Root/PQ/rt3.dc1--acc--topic1", 2);

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -953,7 +953,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadPreCached) {
-        TPersQueueV1TestServer server{true};
+        TPersQueueV1TestServer server{{.CheckAcl=true}};
         SET_LOCALS;
         TDirectReadTestSetup setup{server};
         setup.DoWrite(pqClient->GetDriver(), "acc/topic1", 1_MB, 30);
@@ -981,7 +981,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadNotCached) {
-        TPersQueueV1TestServer server{true};
+        TPersQueueV1TestServer server{{.CheckAcl=true}};
         SET_LOCALS;
         TDirectReadTestSetup setup{server};
 
@@ -1013,7 +1013,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadBadCases) {
-        TPersQueueV1TestServer server{true};
+        TPersQueueV1TestServer server{{.CheckAcl=true}};
         SET_LOCALS;
         TDirectReadTestSetup setup{server};
         setup.InitControlSession("acc/topic1");
@@ -1042,7 +1042,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadStop) {
-        TPersQueueV1TestServer server{true};
+        TPersQueueV1TestServer server{{.CheckAcl=true}};
         SET_LOCALS;
 
         server.Server->AnnoyingClient->AlterTopicNoLegacy("Root/PQ/rt3.dc1--acc--topic1", 2);

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -1042,7 +1042,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     }
 
     Y_UNIT_TEST(DirectReadStop) {
-        TPersQueueV1TestServer server{{.CheckACL=true}};
+        TPersQueueV1TestServer server{{.CheckACL=true, .NodeCount=1}};
         SET_LOCALS;
 
         server.Server->AnnoyingClient->AlterTopicNoLegacy("Root/PQ/rt3.dc1--acc--topic1", 2);

--- a/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
@@ -51,7 +51,7 @@ public:
     {}
 
     TPersQueueV1TestServer CreateServer() {
-        return TPersQueueV1TestServer(false, TenantModeEnabled);
+        return TPersQueueV1TestServer({.CheckAcl=false, .TenantModeEnabled=TenantModeEnabled});
     }
 
     TPersQueueV1TestServerWithRateLimiter CreateServerWithRateLimiter() {

--- a/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
@@ -51,7 +51,7 @@ public:
     {}
 
     TPersQueueV1TestServer CreateServer() {
-        return TPersQueueV1TestServer({.CheckAcl=false, .TenantModeEnabled=TenantModeEnabled});
+        return TPersQueueV1TestServer({.CheckACL=false, .TenantModeEnabled=TenantModeEnabled});
     }
 
     TPersQueueV1TestServerWithRateLimiter CreateServerWithRateLimiter() {

--- a/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
@@ -51,7 +51,7 @@ public:
     {}
 
     TPersQueueV1TestServer CreateServer() {
-        return TPersQueueV1TestServer({.CheckACL=false, .TenantModeEnabled=TenantModeEnabled});
+        return TPersQueueV1TestServer({.TenantModeEnabled=TenantModeEnabled});
     }
 
     TPersQueueV1TestServerWithRateLimiter CreateServerWithRateLimiter() {

--- a/ydb/services/persqueue_v1/ut/persqueue_test_fixture.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_test_fixture.h
@@ -214,11 +214,17 @@ static void ModifyTopicACL(NYdb::TDriver* driver, const TString& topic, const TV
         THolder<NYdb::NPersQueue::TPersQueueClient> PersQueueClient;
     };
 
+    struct TPersQueueV1TestServerSettings {
+        bool CheckAcl = false;
+        bool TenantModeEnabled = false;
+        ui32 NodeCount = PQ_DEFAULT_NODE_COUNT;
+    };
+
     class TPersQueueV1TestServer : public TPersQueueV1TestServerBase {
     public:
-        TPersQueueV1TestServer(bool checkAcl = false, bool tenantModeEnabled = false)
-            : TPersQueueV1TestServerBase(tenantModeEnabled)
-            , CheckACL(checkAcl)
+        explicit TPersQueueV1TestServer(const TPersQueueV1TestServerSettings& settings = {})
+            : TPersQueueV1TestServerBase(settings.TenantModeEnabled)
+            , CheckACL(settings.CheckAcl)
         {
             InitAll();
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Two nodes were created in the test environment. The `PQ` tablet uses `PQCacheProxy` on its node. Requests came to different nodes and `PQCacheProxy` returned the response "unknown session"

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
