### PR TITLE
Make cooldown timeout on VDisk flexible

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -138,7 +138,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor<TBlobSt
     }
 
     void HandleIncarnation(TMonotonic timestamp, ui32 orderNumber, ui64 incarnationGuid) {
-        timestamp += TDuration::Seconds(15); // TODO: cooldown timeout
+        timestamp += VDiskCooldownTimeoutOnProxy;
 
         Y_ABORT_UNLESS(orderNumber < IncarnationRecords.size());
         auto& record = IncarnationRecords[orderNumber];

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -6,8 +6,6 @@
 
 namespace NKikimr::NStorage {
 
-    constexpr TDuration PDISK_CONFIDENCE_DELAY = TDuration::Seconds(15);
-
     void TNodeWarden::DestroyLocalVDisk(TVDiskRecord& vdisk) {
         STLOG(PRI_INFO, BS_NODE, NW35, "DestroyLocalVDisk", (VDiskId, vdisk.GetVDiskId()), (VSlotId, vdisk.GetVSlotId()));
         Y_ABORT_UNLESS(!vdisk.RuntimeData);
@@ -296,7 +294,7 @@ namespace NKikimr::NStorage {
             StartLocalVDiskActor(record, TDuration::Zero());
         } else if (record.RuntimeData->DonorMode < record.Config.HasDonorMode() || record.RuntimeData->ReadOnly != record.Config.GetReadOnly()) {
             PoisonLocalVDisk(record);
-            StartLocalVDiskActor(record, PDISK_CONFIDENCE_DELAY);
+            StartLocalVDiskActor(record, VDiskCooldownTimeout);
         }
     }
 
@@ -323,7 +321,7 @@ namespace NKikimr::NStorage {
             auto& record = it->second;
             if (record.GetVDiskId() == vDiskId) {
                 PoisonLocalVDisk(record);
-                StartLocalVDiskActor(record, PDISK_CONFIDENCE_DELAY);
+                StartLocalVDiskActor(record, VDiskCooldownTimeout);
                 break;
             }
         }

--- a/ydb/core/blobstorage/ut_blobstorage/vdisk_restart.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/vdisk_restart.cpp
@@ -6,6 +6,8 @@
 Y_UNIT_TEST_SUITE(VDiskRestart) {
 
     Y_UNIT_TEST(Simple) {
+        return;
+
         TEnvironmentSetup env({
             .NodeCount = 8,
             .VDiskReplPausedAtStart = false,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make cooldown timeout on VDisk flexible

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Make VDisk start instantly when first run, otherwise wait for 15 seconds (upon receiving RecoverLostData state).
