### PR TITLE
Change log space color limits, #4550

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_color_limits.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_color_limits.h
@@ -66,27 +66,27 @@ struct TColorLimits {
 
     static TColorLimits MakeLogLimits() {
         return {
-            {250, 1000}, // Black: Stop early to leave some space for disaster recovery
-            {350, 1000}, // Red
-            {500, 1000}, // Orange
-            {600, 1000}, // PreOrange
-            {700, 1000}, // LightOrange
-            {900, 1000}, // Yellow
-            {930, 1000}, // LightYellow
-            {982, 1000}, // Cyan: Ask to cut log
+            {100, 1000}, // Black: Stop early to leave some space for disaster recovery
+            {150, 1000}, // Red
+            {200, 1000}, // Orange
+            {210, 1000}, // PreOrange
+            {250, 1000}, // LightOrange
+            {350, 1000}, // Yellow
+            {400, 1000}, // LightYellow
+            {450, 1000}, // Cyan
         };
     }
 
     static TColorLimits MakeExtendedLogLimits() {
         return {
-            {150, 1000}, // Black: Stop early to leave some space for disaster recovery
-            {200, 1000}, // Red
-            {500, 1000}, // Orange
-            {600, 1000}, // PreOrange
-            {700, 1000}, // LightOrange
-            {900, 1000}, // Yellow
-            {930, 1000}, // LightYellow
-            {982, 1000}, // Cyan: Ask to cut log
+            {50, 1000}, // Black: Stop early to leave some space for disaster recovery
+            {100, 1000}, // Red
+            {200, 1000}, // Orange
+            {210, 1000}, // PreOrange
+            {250, 1000}, // LightOrange
+            {350, 1000}, // Yellow
+            {400, 1000}, // LightYellow
+            {450, 1000}, // Cyan
         };
     }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -654,48 +654,6 @@ void TPDisk::AskVDisksToCutLogs(TOwner ownerFilter, bool doForce) {
         *Mon.TooMuchLogChunks = 0;
     }
     if (logChunkCount > cutThreshold || doForce) {
-        if (logChunkCount > cutThreshold * Cfg->InsaneLogChunksMultiplier) {
-            if (InsaneLogChunks == 0) {
-                InsaneLogChunks = logChunkCount + activeOwners;
-            } else {
-                if (logChunkCount > InsaneLogChunks) {
-                    // There were too many log chunks and now there are even more.
-                    // We asked VDisks to cut logs, but either they ignored us, or there is some error in PDisk.
-                    // VERIFY with as much info as possible, so that PDisk starts up rather fast.
-                    TStringStream str;
-                    str << "VDisk did not cut the log!";
-                    str << " logChunkCount# " << logChunkCount << " > " << " InsaneLogChunks# " << InsaneLogChunks;
-                    str << " at PDiskId# " << (ui32)PDiskId;
-                    str << " cutThreshold# " << cutThreshold;
-                    for (ui32 owner = 0; owner < OwnerData.size(); ++owner) {
-                        const TOwnerData &data = OwnerData[owner];
-                        if (data.VDiskId != TVDiskID::InvalidId) {
-                            str << " OwnerId# " << (ui32)owner;
-                            str << " { VDiskId# " << data.VDiskId.ToStringWOGeneration();
-                            str << " CutLogId# " << data.CutLogId.ToString();
-                            str << " WhiteboardProxyId# " << data.WhiteboardProxyId;
-                            str << " CurLsnToKeep# " << data.CurrentFirstLsnToKeep;
-                            str << " FirstNonceToKeep# " << SysLogFirstNoncesToKeep.FirstNonceToKeep[owner];
-                            str << " AskedToCutLogAt# " << data.AskedToCutLogAt;
-                            str << " CutLogAt# " << data.CutLogAt;
-                            str << " } ";
-                        }
-                    }
-                    str << " LogChunks.begin# { ";
-                    auto chunkIt = LogChunks.begin();
-                    str << chunkIt->ToString();
-                    str << "}";
-                    str << " CommitState# ";
-                    str << ChunkState[LogChunks.begin()->ChunkIdx].CommitState;
-                    str << " details# ";
-                    OutputHtmlLogChunksDetails(str);
-                    Y_FAIL_S(str.Str());
-                }
-            }
-        } else {
-            InsaneLogChunks = 0;
-        }
-
         struct TChunkCutInfoPerOwner {
             size_t ChunksToCut = 0;
             size_t FirstLogChunkNumber = 0;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
@@ -2776,7 +2776,7 @@ void TTestRedZoneSurvivability::TestFSM(const TActorContext &ctx) {
         TEST_RESPONSE(EvLogResult, OK);
 
         VERBOSE_COUT(" Sending TEvLog to log ChunkSize bytes");
-        TRcBuf largeData = TRcBuf(PrepareData(ChunkSize * 20));
+        TRcBuf largeData = TRcBuf(PrepareData(ChunkSize * 130));
         ctx.Send(Yard, new NPDisk::TEvLog(Owner, OwnerRound, 0, largeData, TLsnSeg(3, 3), (void*)43));
         break;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

PDisk should raise yellow move flag at 120 busy log chunks and yellow stop flag at 130 busy log chunks.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

PDisk log space flags were ignored by VDisk and were raised at incorrect thresholds. Now that VDisks use theese flags, thresholds should be fixed. This commit fixes the thresholds so that pdisk does not raise the yellow_stop flag at 20 busy chunks.