### PR TITLE
IGNIETFERRO-2059: Fix use-after-free error in the TDqExecuter

### DIFF
--- a/ydb/library/yql/providers/dq/actors/executer_actor.cpp
+++ b/ydb/library/yql/providers/dq/actors/executer_actor.cpp
@@ -99,7 +99,8 @@ private:
         Yql::DqsProto::TWorkerFilter pragmaFilter;
         if (Settings->WorkerFilter.Get()) {
             try {
-                TStringInput inputStream1(Settings->WorkerFilter.Get().GetOrElse(""));
+                TString inputString = Settings->WorkerFilter.Get().GetOrElse("");
+                TStringInput inputStream1(inputString);
                 ParseFromTextFormat(inputStream1, pragmaFilter);
             } catch (...) {
                 YQL_CLOG(INFO, ProviderDq) << "Cannot parse filter pragma " << CurrentExceptionMessage();

--- a/ydb/library/yql/providers/dq/actors/executer_actor.cpp
+++ b/ydb/library/yql/providers/dq/actors/executer_actor.cpp
@@ -97,10 +97,9 @@ private:
 
     Yql::DqsProto::TWorkerFilter GetPragmaFilter() {
         Yql::DqsProto::TWorkerFilter pragmaFilter;
-        if (Settings->WorkerFilter.Get()) {
+        if (const auto& filter = Settings->WorkerFilter.Get(); filter.Defined()) {
             try {
-                TString inputString = Settings->WorkerFilter.Get().GetOrElse("");
-                TStringInput inputStream1(inputString);
+                TStringInput inputStream1(*filter);
                 ParseFromTextFormat(inputStream1, pragmaFilter);
             } catch (...) {
                 YQL_CLOG(INFO, ProviderDq) << "Cannot parse filter pragma " << CurrentExceptionMessage();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix use-after-free error caused by constructing an input stream over a temporary string object

### Changelog category <!-- remove all except one -->

* Bugfix 
