### PR TITLE
L2 cache uses TPartitionId

### DIFF
--- a/ydb/core/persqueue/pq_l2_cache.h
+++ b/ydb/core/persqueue/pq_l2_cache.h
@@ -42,7 +42,7 @@ class TPersQueueCacheL2 : public TActorBootstrapped<TPersQueueCacheL2> {
 public:
     struct TKey {
         ui64 TabletId;
-        ui32 Partition;
+        TPartitionId Partition;
         ui64 Offset;
         ui16 PartNo;
 
@@ -52,13 +52,13 @@ public:
             , Offset(blob.Offset)
             , PartNo(blob.PartNo)
         {
-            KeyHash = Hash128to32(TabletId, (static_cast<ui64>(Partition) << 16) + PartNo);
+            KeyHash = Hash128to32(TabletId, (static_cast<ui64>(Partition.InternalPartitionId) << 17) + PartNo + Partition.IsSupportivePartition() ? 0 : (1 << 16));
             KeyHash = Hash128to32(KeyHash, Offset);
         }
 
         bool operator == (const TKey& key) const {
             return TabletId == key.TabletId &&
-                Partition == key.Partition &&
+                Partition.IsEqual(key.Partition) &&
                 Offset == key.Offset &&
                 PartNo == key.PartNo;
         }

--- a/ydb/core/persqueue/pq_l2_service.h
+++ b/ydb/core/persqueue/pq_l2_service.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "partition_id.h"
+
 #include <ydb/library/actors/core/defs.h>
 #include <ydb/library/actors/core/actor.h>
 
@@ -67,7 +69,7 @@ private:
 };
 
 struct TCacheBlobL2 {
-    ui32 Partition;
+    TPartitionId Partition;
     ui64 Offset;
     ui16 PartNo;
     TCacheValue::TPtr Value;

--- a/ydb/core/persqueue/read.h
+++ b/ydb/core/persqueue/read.h
@@ -48,7 +48,7 @@ namespace NPQ {
         void SaveInProgress(const TKvRequest& kvRequest)
         {
             for (const TRequestedBlob& reqBlob : kvRequest.Blobs) {
-                TBlobId blob(kvRequest.Partition.InternalPartitionId, reqBlob.Offset, reqBlob.PartNo, reqBlob.Count, reqBlob.InternalPartsCount);
+                TBlobId blob(kvRequest.Partition, reqBlob.Offset, reqBlob.PartNo, reqBlob.Count, reqBlob.InternalPartsCount);
                 ReadsInProgress.insert(blob);
             }
         }
@@ -56,7 +56,7 @@ namespace NPQ {
         bool CheckInProgress(const TActorContext& ctx, TKvRequest& kvRequest)
         {
             for (const TRequestedBlob& reqBlob : kvRequest.Blobs) {
-                TBlobId blob(kvRequest.Partition.InternalPartitionId, reqBlob.Offset, reqBlob.PartNo, reqBlob.Count, reqBlob.InternalPartsCount);
+                TBlobId blob(kvRequest.Partition, reqBlob.Offset, reqBlob.PartNo, reqBlob.Count, reqBlob.InternalPartsCount);
                 auto it = ReadsInProgress.find(blob);
                 if (it != ReadsInProgress.end()) {
                     LOG_DEBUG_S(ctx, NKikimrServices::PERSQUEUE, "Read request is blocked. Partition "
@@ -73,7 +73,7 @@ namespace NPQ {
         {
             TVector<TKvRequest> unblocked;
             for (const TRequestedBlob& reqBlob : blocker.Blobs) {
-                TBlobId blob(blocker.Partition.InternalPartitionId, reqBlob.Offset, reqBlob.PartNo, reqBlob.Count, reqBlob.InternalPartsCount);
+                TBlobId blob(blocker.Partition, reqBlob.Offset, reqBlob.PartNo, reqBlob.Count, reqBlob.InternalPartsCount);
                 ReadsInProgress.erase(blob);
 
                 auto it = BlockedReads.find(blob);
@@ -105,7 +105,7 @@ namespace NPQ {
         void Handle(TEvPQ::TEvBlobRequest::TPtr& ev, const TActorContext& ctx)
         {
             const TPartitionId& partition = ev->Get()->Partition;
-            Cache.SetUserOffset(ctx, ev->Get()->User, partition.InternalPartitionId, ev->Get()->ReadOffset);
+            Cache.SetUserOffset(ctx, ev->Get()->User, partition, ev->Get()->ReadOffset);
 
             TKvRequest kvReq(TKvRequest::TypeRead, ev->Sender, ev->Get()->Cookie, partition);
             kvReq.Blobs = std::move(ev->Get()->Blobs);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

L2 cache uses TPartitionId

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)
