### PR TITLE
consider overcommitment when checking for node overloads

### DIFF
--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -3937,7 +3937,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         //
         static const int NUM_NODES = 4;
         static const int NUM_TABLETS = 3;
-        static const ui64 SINGLE_TABLET_NETWORK_USAGE = 5000000;
+        static const ui64 SINGLE_TABLET_NETWORK_USAGE = 15'000'000;
 
         TTestBasicRuntime runtime(NUM_NODES, false);
 

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -327,7 +327,9 @@ ui64 TNodeInfo::GetMaxCountForTabletType(TTabletTypes::EType tabletType) const {
 }
 
 bool TNodeInfo::IsOverloaded() const {
-    return GetNodeUsage() >= Hive.GetMaxNodeUsageToKick();
+    auto maxValues = GetResourceMaximumValues() * Hive.GetResourceOvercommitment();
+    auto normValues = NormalizeRawValues(GetResourceCurrentValues(), maxValues);
+    return GetNodeUsage(normValues) >= Hive.GetMaxNodeUsageToKick();
 }
 
 bool TNodeInfo::BecomeConnected() {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

consider overcommitment when checking for node overloads

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
