### PR TITLE
Disable spilling in LastWideCombiner if input or state is not serializable (currently has Resource type).

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -344,7 +344,7 @@ public:
         TMemoryUsageInfo* memInfo,
         const TCombinerNodes& nodes, IComputationWideFlowNode *const flow, size_t wideFieldsIndex,
         const TMultiType* usedInputItemType, const TMultiType* keyAndStateType, ui32 keyWidth,
-        const THashFunc& hash, const TEqualsFunc& equal
+        const THashFunc& hash, const TEqualsFunc& equal, bool allowSpilling
     )
         : TBase(memInfo)
         , InMemoryProcessingState(memInfo, keyWidth, keyAndStateType->GetElementsCount() - keyWidth, hash, equal)
@@ -358,6 +358,7 @@ public:
         , Mode(EOperatingMode::InMemory)
         , MemInfo(memInfo)
         , Equal(equal)
+        , AllowSpilling(allowSpilling)
     {
         BufferForUsedInputItems.reserve(usedInputItemType->GetElementsCount());
         BufferForKeyAnsState.reserve(keyAndStateType->GetElementsCount());
@@ -430,7 +431,7 @@ private:
                         isNew ? nullptr : static_cast<NUdf::TUnboxedValue *>(InMemoryProcessingState.Tongue),
                         static_cast<NUdf::TUnboxedValue *>(InMemoryProcessingState.Throat)
                     );
-                    if (ctx.SpillerFactory && IsSwitchToSpillingModeCondition()) {
+                    if (AllowSpilling && ctx.SpillerFactory && IsSwitchToSpillingModeCondition()) {
                         SwitchMode(EOperatingMode::Spilling, ctx);
                         return EFetchResult::Yield;
                     }
@@ -488,7 +489,7 @@ private:
                 } else {
                     bucket.SpilledData->AsyncWriteCompleted(bucket.AsyncWriteOperation->ExtractValue());
                     bucket.AsyncWriteOperation = std::nullopt;
-                }     
+                }
             }
         }
     }
@@ -536,7 +537,7 @@ private:
                     Nodes.ExtractKey(ctx, fields, static_cast<NUdf::TUnboxedValue *>(BufferForKeyAnsState.data()));
 
                     auto hash = Hasher(BufferForKeyAnsState.data());
-                    
+
                     auto bucketId = hash % SpilledBucketCount;
 
                     auto& bucket = SpilledBuckets[bucketId];
@@ -608,7 +609,7 @@ private:
             AsyncReadOperation = std::nullopt;
         }
         while(!SpilledBuckets.empty()){
-            
+
             auto& bucket = SpilledBuckets.front();
             //recover spilled state
             while(!bucket.SpilledState->Empty()) {
@@ -656,7 +657,7 @@ private:
                 );
                 BufferForUsedInputItems.resize(0);
             }
-            
+
             if (const auto values = static_cast<NUdf::TUnboxedValue*>(bucket.InMemoryProcessingState->Extract())) {
                 Nodes.FinishItem(ctx, values, output);
 
@@ -732,6 +733,7 @@ private:
 
     TMemoryUsageInfo* MemInfo = nullptr;
     TEqualsFunc const Equal;
+    const bool AllowSpilling;
 };
 
 #ifndef MKQL_DISABLE_CODEGEN
@@ -1205,12 +1207,13 @@ class TWideLastCombinerWrapper: public TStatefulWideFlowCodegeneratorNode<TWideL
 using TBaseComputation = TStatefulWideFlowCodegeneratorNode<TWideLastCombinerWrapper>;
 public:
     TWideLastCombinerWrapper(
-        TComputationMutables& mutables, 
-        IComputationWideFlowNode* flow, 
-        TCombinerNodes&& nodes, 
+        TComputationMutables& mutables,
+        IComputationWideFlowNode* flow,
+        TCombinerNodes&& nodes,
         const TMultiType* usedInputItemType,
         TKeyTypes&& keyTypes,
-        const TMultiType* keyAndStateType)
+        const TMultiType* keyAndStateType,
+        bool allowSpilling)
         : TBaseComputation(mutables, flow, EValueRepresentation::Boxed)
         , Flow(flow)
         , Nodes(std::move(nodes))
@@ -1218,11 +1221,12 @@ public:
         , UsedInputItemType(usedInputItemType)
         , KeyAndStateType(keyAndStateType)
         , WideFieldsIndex(mutables.IncrementWideFieldsIndex(Nodes.ItemNodes.size()))
+        , AllowSpilling(allowSpilling)
     {}
 
 	EFetchResult DoCalculate(NUdf::TUnboxedValue& stateValue, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
         if (!stateValue.HasValue()) {
-            MakeSpillingSupportState(ctx, stateValue);
+            MakeSpillingSupportState(ctx, stateValue, AllowSpilling);
         }
         auto *const state = static_cast<TSpillingSupportState *>(stateValue.AsBoxed().Get());
         return state->DoCalculate(ctx, output);
@@ -1466,12 +1470,13 @@ private:
 #endif
     }
 
-    void MakeSpillingSupportState(TComputationContext& ctx, NUdf::TUnboxedValue& state) const {
+    void MakeSpillingSupportState(TComputationContext& ctx, NUdf::TUnboxedValue& state, bool allowSpilling) const {
         state = ctx.HolderFactory.Create<TSpillingSupportState>(Nodes, Flow, WideFieldsIndex,
             UsedInputItemType, KeyAndStateType,
             Nodes.KeyNodes.size(),
             TMyValueHasher(KeyTypes),
-            TMyValueEqual(KeyTypes)
+            TMyValueEqual(KeyTypes),
+            allowSpilling
         );
     }
 
@@ -1492,6 +1497,8 @@ private:
     const TMultiType* const KeyAndStateType;
 
     const ui32 WideFieldsIndex;
+
+    const bool AllowSpilling;
 
 #ifndef MKQL_DISABLE_CODEGEN
     TEqualsPtr Equals = nullptr;
@@ -1523,6 +1530,10 @@ private:
 #endif
 };
 
+bool IsTypeSerializable(const TType* type) {
+    return !type->IsResource();
+}
+
 }
 
 template<bool Last>
@@ -1542,13 +1553,17 @@ IComputationNode* WrapWideCombinerT(TCallable& callable, const TComputationNodeF
 
     ++index += inputWidth;
 
+    bool allowSpilling = true;
+
     std::vector<TType*> keyAndStateItemTypes;
     keyAndStateItemTypes.reserve(keysSize + stateSize);
 
     TKeyTypes keyTypes;
     keyTypes.reserve(keysSize);
     for (ui32 i = index; i < index + keysSize; ++i) {
-		keyAndStateItemTypes.push_back(callable.GetInput(i).GetStaticType());
+        TType *type = callable.GetInput(i).GetStaticType();
+        allowSpilling = IsTypeSerializable(type);
+		keyAndStateItemTypes.push_back(type);
         bool optional;
         keyTypes.emplace_back(*UnpackOptionalData(callable.GetInput(i).GetStaticType(), optional)->GetDataSlot(), optional);
     }
@@ -1560,7 +1575,9 @@ IComputationNode* WrapWideCombinerT(TCallable& callable, const TComputationNodeF
     index += keysSize;
     nodes.InitResultNodes.reserve(stateSize);
     for (size_t i = 0; i != stateSize; ++i) {
-        keyAndStateItemTypes.push_back(callable.GetInput(index).GetStaticType());
+        TType *type = callable.GetInput(index).GetStaticType();
+        allowSpilling = IsTypeSerializable(type);
+        keyAndStateItemTypes.push_back(type);
         nodes.InitResultNodes.push_back(LocateNode(ctx.NodeLocator, callable, index++));
     }
 
@@ -1597,13 +1614,15 @@ IComputationNode* WrapWideCombinerT(TCallable& callable, const TComputationNodeF
             usedInputItemTypes.reserve(inputItemTypes.size());
             for (size_t i = 0; i != inputItemTypes.size(); ++i) {
                 if (nodes.IsInputItemNodeUsed(i)) {
+                    allowSpilling = IsTypeSerializable(inputItemTypes[i]);
                     usedInputItemTypes.push_back(inputItemTypes[i]);
                 }
             }
             return new TWideLastCombinerWrapper(ctx.Mutables, wide, std::move(nodes),
                 TMultiType::Create(usedInputItemTypes.size(), usedInputItemTypes.data(), ctx.Env),
                 std::move(keyTypes),
-                TMultiType::Create(keyAndStateItemTypes.size(),keyAndStateItemTypes.data(), ctx.Env)
+                TMultiType::Create(keyAndStateItemTypes.size(),keyAndStateItemTypes.data(), ctx.Env),
+                allowSpilling
             );
         } else {
             if constexpr (RuntimeVersion < 46U) {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -1531,7 +1531,8 @@ private:
 };
 
 bool IsTypeSerializable(const TType* type) {
-    return !type->IsResource();
+    return ! (type->IsResource() || type->IsType() || type->IsStream() || type->IsCallable()
+        || type->IsAny() || type->IsFlow() || type->IsReservedKind());
 }
 
 }
@@ -1562,7 +1563,7 @@ IComputationNode* WrapWideCombinerT(TCallable& callable, const TComputationNodeF
     keyTypes.reserve(keysSize);
     for (ui32 i = index; i < index + keysSize; ++i) {
         TType *type = callable.GetInput(i).GetStaticType();
-        allowSpilling = IsTypeSerializable(type);
+        allowSpilling = allowSpilling && IsTypeSerializable(type);
 		keyAndStateItemTypes.push_back(type);
         bool optional;
         keyTypes.emplace_back(*UnpackOptionalData(callable.GetInput(i).GetStaticType(), optional)->GetDataSlot(), optional);
@@ -1576,7 +1577,7 @@ IComputationNode* WrapWideCombinerT(TCallable& callable, const TComputationNodeF
     nodes.InitResultNodes.reserve(stateSize);
     for (size_t i = 0; i != stateSize; ++i) {
         TType *type = callable.GetInput(index).GetStaticType();
-        allowSpilling = IsTypeSerializable(type);
+        allowSpilling = allowSpilling && IsTypeSerializable(type);
         keyAndStateItemTypes.push_back(type);
         nodes.InitResultNodes.push_back(LocateNode(ctx.NodeLocator, callable, index++));
     }
@@ -1614,7 +1615,7 @@ IComputationNode* WrapWideCombinerT(TCallable& callable, const TComputationNodeF
             usedInputItemTypes.reserve(inputItemTypes.size());
             for (size_t i = 0; i != inputItemTypes.size(); ++i) {
                 if (nodes.IsInputItemNodeUsed(i)) {
-                    allowSpilling = IsTypeSerializable(inputItemTypes[i]);
+                    allowSpilling = allowSpilling && IsTypeSerializable(inputItemTypes[i]);
                     usedInputItemTypes.push_back(inputItemTypes[i]);
                 }
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Disable spilling in LastWideCombiner if input or state is not serializable (currently has Resource type).

### Changelog category <!-- remove all except one -->

* Bugfix
* 
### Additional information

...
