### PR TITLE
24-1-14-hotfix: Mark reenqueued records & forcibly request them

### DIFF
--- a/ydb/core/change_exchange/change_sender_common_ops.h
+++ b/ydb/core/change_exchange/change_sender_common_ops.h
@@ -76,19 +76,35 @@ public:
 };
 
 class TBaseChangeSender: public IChangeSender {
-    using TEnqueuedRecord = TEvChangeExchange::TEvRequestRecords::TRecordInfo;
-    using TRequestedRecord = TEvChangeExchange::TEvRequestRecords::TRecordInfo;
+    using TIncompleteRecord = TEvChangeExchange::TEvRequestRecords::TRecordInfo;
+
+    struct TEnqueuedRecord: TIncompleteRecord {
+        bool ReEnqueued = false;
+
+        using TIncompleteRecord::TIncompleteRecord;
+        explicit TEnqueuedRecord(const TIncompleteRecord& record)
+            : TIncompleteRecord(record)
+        {
+        }
+    };
+
+    template <typename... Args>
+    static TEnqueuedRecord ReEnqueue(Args&&... args) {
+        TEnqueuedRecord record(std::forward<Args>(args)...);
+        record.ReEnqueued = true;
+        return record;
+    }
 
     struct TSender {
         TActorId ActorId;
         bool Ready = false;
-        TVector<TEnqueuedRecord> Pending;
+        TVector<TIncompleteRecord> Pending;
         TVector<IChangeRecord::TPtr> Prepared;
         TVector<ui64> Broadcasting;
     };
 
     struct TBroadcast {
-        const TEnqueuedRecord Record;
+        const TIncompleteRecord Record;
         THashSet<ui64> Partitions;
         THashSet<ui64> PendingPartitions;
         THashSet<ui64> CompletedPartitions;
@@ -99,7 +115,7 @@ class TBaseChangeSender: public IChangeSender {
     void CreateMissingSenders(const TVector<ui64>& partitionIds);
     void RecreateSenders(const TVector<ui64>& partitionIds);
 
-    bool RequestRecords(bool forceAtLeastOne = false);
+    bool RequestRecords();
     void SendRecords();
 
     void SendPreparedRecords(ui64 partitionId);
@@ -156,7 +172,7 @@ private:
 
     THashMap<ui64, TSender> Senders; // ui64 is partition id
     TSet<TEnqueuedRecord> Enqueued;
-    TSet<TRequestedRecord> PendingBody;
+    TSet<TIncompleteRecord> PendingBody;
     TMap<ui64, IChangeRecord::TPtr> PendingSent; // ui64 is order
     THashMap<ui64, TBroadcast> Broadcasting; // ui64 is order
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed a potential deadlock between requesting records and sending them.

### Changelog category <!-- remove all except one -->

* Bugfix

### Additional information

...
