### PR TITLE
Move stats collection after tests 

### DIFF
--- a/.github/actions/build_and_test_ya/action.yml
+++ b/.github/actions/build_and_test_ya/action.yml
@@ -134,6 +134,7 @@ runs:
     - name: build_stats
       shell: bash
       continue-on-error: true
+      if: always()
       run: |
         set -x
         export build_preset="${{ inputs.build_preset }}" 

--- a/.github/actions/build_and_test_ya/action.yml
+++ b/.github/actions/build_and_test_ya/action.yml
@@ -130,7 +130,16 @@ runs:
         fi
         
         exit 1
-    
+        
+    - name: build_stats
+      shell: bash
+      continue-on-error: true
+      run: |
+        set -x
+        export build_preset="${{ inputs.build_preset }}" 
+        python3 -m pip install ydb ydb[yc]
+        python3 .github/scripts/send_build_stats.py
+
     - name: comment-if-cancel
       shell: bash
       if: cancelled() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -145,15 +145,6 @@ runs:
           echo "Build successful." | .github/scripts/tests/comment-pr.py --ok
         fi
 
-    - name: build_stats
-      shell: bash
-      continue-on-error: true
-      run: |
-        set -x
-        export build_preset="${{ inputs.build_preset }}" 
-        python3 -m pip install ydb ydb[yc]
-        python3 .github/scripts/send_build_stats.py
-
     - name: show free space
       if: always()
       shell: bash

--- a/.github/scripts/send_build_stats.py
+++ b/.github/scripts/send_build_stats.py
@@ -52,6 +52,10 @@ def main():
         print("Env variable YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping")
         return 1
 
+    if not os.path.exists(YDBD_PATH):
+        # can be possible due to incremental builds and ydbd itself is not affected by changes
+        print("{} not exists, exiting".format(YDBD_PATH))
+
     with ydb.Driver(
         endpoint="grpcs://ydb.serverless.yandexcloud.net:2135",
         database="/ru-central1/b1ggceeul2pkher8vhb6/etn6d1qbals0c29ho4lf",

--- a/.github/scripts/send_build_stats.py
+++ b/.github/scripts/send_build_stats.py
@@ -54,7 +54,8 @@ def main():
 
     if not os.path.exists(YDBD_PATH):
         # can be possible due to incremental builds and ydbd itself is not affected by changes
-        print("{} not exists, exiting".format(YDBD_PATH))
+        print("{} not exists, skipping".format(YDBD_PATH))
+        return 1
 
     with ydb.Driver(
         endpoint="grpcs://ydb.serverless.yandexcloud.net:2135",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

There is no linkage in build_ya, so try to collect stats after tests

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
