### PR TITLE
Remove CHECK_DEPENDENT_DIRS

### DIFF
--- a/ydb/apps/dstool/ya.make
+++ b/ydb/apps/dstool/ya.make
@@ -2,29 +2,6 @@ PY3_PROGRAM(ydb-dstool)
 
 STRIP()
 
-#
-# DON'T ALLOW NEW DEPENDENCIES WITHOUT EXPLICIT APPROVE FROM  kikimr-dev@ or fomichev@
-#
-IF (OPENSOURCE)
-    CHECK_DEPENDENT_DIRS(
-        ALLOW_ONLY
-        PEERDIRS
-        arc/api/public
-        build/external_resources/flake8_py3
-        build/platform
-        certs
-        contrib
-        library
-        tools/archiver
-        tools/enum_parser/enum_parser
-        tools/enum_parser/enum_serialization_runtime
-        tools/rescompressor
-        tools/rorescompiler
-        util
-        ydb
-    )
-ENDIF()
-
 PY_MAIN(ydb.apps.dstool.main)
 
 PY_SRCS(

--- a/ydb/apps/ydb/ya.make
+++ b/ydb/apps/ydb/ya.make
@@ -23,32 +23,6 @@ IF (NOT USE_SSE4 AND NOT OPENSOURCE)
     )
 ENDIF()
 
-#
-# DON'T ALLOW NEW DEPENDENCIES WITHOUT EXPLICIT APPROVE FROM  kikimr-dev@ or fomichev@
-#
-CHECK_DEPENDENT_DIRS(
-    ALLOW_ONLY
-    PEERDIRS
-    build/internal/platform
-    build/platform
-    certs
-    contrib
-    library
-    tools/enum_parser/enum_parser
-    tools/enum_parser/enum_serialization_runtime
-    tools/rescompressor
-    tools/rorescompiler
-    util
-    ydb/apps/ydb
-    ydb/core/fq/libs/protos
-    ydb/core/grpc_services/validation
-    ydb/library
-    ydb/public
-    ydb/library/yql/public/decimal
-    ydb/library/yql/public/issue
-    ydb/library/yql/public/issue/protos
-)
-
 END()
 
 IF (OS_LINUX)

--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -66,26 +66,6 @@ PEERDIR(
     ydb/public/sdk/cpp/client/ydb_persqueue_public/codecs
 )
 
-#
-# DON'T ALLOW NEW DEPENDENCIES WITHOUT EXPLICIT APPROVE FROM  kikimr-dev@ or fomichev@
-#
-CHECK_DEPENDENT_DIRS(
-    ALLOW_ONLY
-    PEERDIRS
-    build
-    certs
-    contrib
-    library
-    tools/archiver
-    tools/enum_parser/enum_parser
-    tools/enum_parser/enum_serialization_runtime
-    tools/rescompressor
-    tools/rorescompiler
-    util
-    ydb
-    yt
-)
-
 YQL_LAST_ABI_VERSION()
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Looks like it was a temporary constraint in Arcadia during migration to GitHub

It was made in 
https://a.yandex-team.ru/review/2197054/details 
KIKIMR-13896: Move open source sources to arcadia/ydb
In Dec 2021  

Also: https://t.me/c/1273017939/823 (?)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
