### PR TITLE
Add RemoteData to YQL operation progress. Add cluster_name for YT YQL operations

### DIFF
--- a/ydb/library/yql/core/progress_merger/progress_merger.cpp
+++ b/ydb/library/yql/core/progress_merger/progress_merger.cpp
@@ -64,6 +64,12 @@ bool TNodeProgressBase::MergeWith(const TOperationProgress& p) {
         Stages_.push_back(p.Stage);
         dirty = true;
     }
+
+    // (6) remote data
+    if (!p.RemoteData.empty() && p.RemoteData != Progress_.RemoteData) {
+        Progress_.RemoteData = p.RemoteData;
+        dirty = true;
+    }
     return Dirty_ = dirty;
 }
 

--- a/ydb/library/yql/core/yql_execution.h
+++ b/ydb/library/yql/core/yql_execution.h
@@ -36,6 +36,7 @@ namespace NYql {
         TStage Stage;
 
         TString RemoteId;
+        THashMap<TString, TString> RemoteData;
 
         struct TCounters {
             ui64 Completed = 0ULL;

--- a/ydb/library/yql/providers/yt/gateway/native/yql_yt_op_tracker.cpp
+++ b/ydb/library/yql/providers/yt/gateway/native/yql_yt_op_tracker.cpp
@@ -98,7 +98,7 @@ TFuture<void> TOperationTracker::MakeOperationWaiter(const NYT::IOperationPtr& o
     auto filter = NYT::TOperationAttributeFilter();
     filter.Add(NYT::EOperationAttribute::State);
 
-    auto checker = [future, operation, ytServer, progress, progressWriter, filter] () mutable {
+    auto checker = [future, operation, ytServer, progress, progressWriter, filter, ytClusterName] () mutable {
         bool done = future.Wait(TDuration::Zero());
 
         if (!done) {
@@ -108,6 +108,7 @@ TFuture<void> TOperationTracker::MakeOperationWaiter(const NYT::IOperationPtr& o
                 if (!progress.RemoteId) {
                     progress.RemoteId = ytServer + "/" + GetGuidAsString(operation->GetId());
                 }
+                progress.RemoteData["cluster_name"] = ytClusterName;
                 if (auto briefProgress = operation->GetBriefProgress()) {
                     progress.Counters.ConstructInPlace();
                     progress.Counters->Completed = briefProgress->Completed;

--- a/ydb/library/yql/yt/native/progress_merger.cpp
+++ b/ydb/library/yql/yt/native/progress_merger.cpp
@@ -21,6 +21,14 @@ void TNodeProgress::Serialize(::NYson::TYsonWriter& writer) const
         writer.OnKeyedItem("remoteId");
         writer.OnStringScalar(Progress_.RemoteId);
 
+        writer.OnKeyedItem("remoteData");
+        writer.OnBeginMap();
+        for (const auto& it : Progress_.RemoteData) {
+            writer.OnKeyedItem(it.first);
+            writer.OnStringScalar(it.second);
+        }
+        writer.OnEndMap();
+
         writer.OnKeyedItem("stages");
         writer.OnBeginMap();
         for (size_t index = 0; index < Stages_.size(); index++) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Ytsaurus issue: https://github.com/ytsaurus/ytsaurus/issues/551

Previously [we added](https://github.com/ytsaurus/ytsaurus/issues/425) yt cluster name to yql_statistics. Now we discovered that yql_statistics is populated once at the end of an operation and this is not convenient for debugging why an operation is taking too long.

Adding the same field to yql_progress which is populated during operation execution

I deployed it to our yt cluster and I see it in yql_progress now:
```
"remoteData": {
    "cluster_name": "dirac"
},
"remoteId": "http-proxies.dirac.svc.cluster.local/operation-id-here",
```
I can confirm that it becomes available during an operation execution