### PR TITLE
packed_tuple: Fix runtime detection vs inlines

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/packed_tuple/hashes_calc.h
+++ b/ydb/library/yql/minikql/comp_nodes/packed_tuple/hashes_calc.h
@@ -148,6 +148,12 @@ inline ui32 CalculateCRC32(const ui8 * data, ui32 size, ui32 hash = 0 ) {
     return hash;
 
 }
+template
+__attribute__((target("avx2")))
+ui32 CalculateCRC32<NSimd::TSimdAVX2Traits>(const ui8 * data, ui32 size, ui32 hash = 0 );
+template
+__attribute__((target("sse4.2")))
+ui32 CalculateCRC32<NSimd::TSimdSSE42Traits>(const ui8 * data, ui32 size, ui32 hash = 0 );
 }
 
 }

--- a/ydb/library/yql/minikql/comp_nodes/packed_tuple/hashes_calc.h
+++ b/ydb/library/yql/minikql/comp_nodes/packed_tuple/hashes_calc.h
@@ -12,7 +12,7 @@ namespace NPackedTuple {
 template<typename TTraits, ui32 Size> ui32 CalculateCRC32(const ui8 * data, ui32 initHash = 0) {
     static_assert(Size <= 16, "Size for template CRC32 calculation should be <= 16 !");
 
-    using TSimdI8 = TTraits::TSimdI8;
+    using TSimdI8 = typename TTraits::TSimdI8;
 
     ui32 hash = initHash;
 
@@ -107,7 +107,7 @@ template<typename TTraits, ui32 Size> ui32 CalculateCRC32(const ui8 * data, ui32
 template <typename TTraits>
 inline ui32 CalculateCRC32(const ui8 * data, ui32 size, ui32 hash = 0 ) {
 
-    using TSimdI8 = TTraits::TSimdI8;
+    using TSimdI8 = typename TTraits::TSimdI8;
 
     while (size >= 8) {
         hash = TSimdI8::CRC32u64(hash, ReadUnaligned<ui64>(data));

--- a/ydb/library/yql/minikql/comp_nodes/packed_tuple/tuple.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/packed_tuple/tuple.cpp
@@ -233,6 +233,12 @@ namespace NPackedTuple {
             WriteUnaligned<ui32>(res, hash);
         }
     }
+    template
+    __attribute__((target("avx2")))
+    void TTupleLayoutFallback<NSimd::TSimdAVX2Traits>::Pack( const ui8** columns, const ui8** isValidBitmask, ui8 * res, std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start, ui32 count) const;
+    template
+    __attribute__((target("sse4.2")))
+    void TTupleLayoutFallback<NSimd::TSimdSSE42Traits>::Pack( const ui8** columns, const ui8** isValidBitmask, ui8 * res, std::vector<ui8, TMKQLAllocator<ui8>> &overflow, ui32 start, ui32 count) const;
 }
 }
 }

--- a/ydb/library/yql/minikql/comp_nodes/packed_tuple/tuple.h
+++ b/ydb/library/yql/minikql/comp_nodes/packed_tuple/tuple.h
@@ -73,7 +73,7 @@ private:
     std::array<std::vector<TColumnDesc>, 5> FixedPOTColumns_; // Fixed-size columns for power-of-two sizes from 1 to 16 bytes
     std::vector<TColumnDesc> FixedNPOTColumns_; // Remaining fixed-size columns
     std::vector<TColumnDesc> VariableColumns_; // Variable-size columns only
-    using TSimdI8 = TTrait::TSimdI8;
+    using TSimdI8 = typename TTrait::TSimdI8;
 };
 
 }

--- a/ydb/library/yql/minikql/comp_nodes/ya.make
+++ b/ydb/library/yql/minikql/comp_nodes/ya.make
@@ -18,6 +18,7 @@ END()
 RECURSE(
     llvm14
     no_llvm
+    packed_tuple
 )
 
 RECURSE_FOR_TESTS(


### PR DESCRIPTION
Functions for TTraits != *Fallback must be explicitly instantiated with `__attribute__((target))`, otherwise intrinsics are not properly inlined.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
