### PR TITLE
Fix huge blob keeper FirstLsnToKeep logic

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_context.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_context.h
@@ -125,6 +125,7 @@ namespace NKikimr {
                         OutOfSpaceState.UpdateLocalLog(ev.StatusFlags);
                     }
                     return true;
+                case NKikimrProto::ERROR:
                 case NKikimrProto::INVALID_OWNER:
                 case NKikimrProto::INVALID_ROUND:
                     // BlobStorage group reconfiguration, just return false and wait until

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugedefs.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugedefs.h
@@ -129,11 +129,7 @@ namespace NKikimr {
             }
 
             ui64 Hash() const {
-                ui64 x = 0;
-                x |= (ui64)ChunkId;
-                x <<= 32u;
-                x |= (ui64)Offset;
-                return x;
+                return MultiHash(ChunkId, Offset);
             }
 
             void Serialize(IOutputStream &str) const {

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.cpp
@@ -102,6 +102,7 @@ namespace NKikimr {
                                     maxBlobInBytes, overhead, freeChunksReservation))
             , AllocatedSlots()
             , Guid(TAppData::RandomProvider->GenRand64())
+            , PersistentLsn(entryPointLsn)
         {
             ParseFromString(entryPointData);
             Y_ABORT_UNLESS(entryPointLsn == LogPos.EntryPointLsn);
@@ -129,6 +130,7 @@ namespace NKikimr {
                                     maxBlobInBytes, overhead, freeChunksReservation))
             , AllocatedSlots()
             , Guid(TAppData::RandomProvider->GenRand64())
+            , PersistentLsn(entryPointLsn)
         {
             ParseFromArray(entryPointData.GetData(), entryPointData.GetSize());
             Y_ABORT_UNLESS(entryPointLsn == LogPos.EntryPointLsn);
@@ -304,7 +306,7 @@ namespace NKikimr {
         }
 
         ui64 THullHugeKeeperPersState::FirstLsnToKeep(ui64 minInFlightLsn) const {
-            const ui64 res = Min(minInFlightLsn, LogPos.EntryPointLsn);
+            const ui64 res = Min(minInFlightLsn, PersistentLsn);
 
             Y_VERIFY_S(FirstLsnToKeepReported <= res, "FirstLsnToKeepReported# " << FirstLsnToKeepReported
                 << " res# " << res << " state# " << FirstLsnToKeepDecomposed() << " minInFlightLsn# " << minInFlightLsn);
@@ -321,13 +323,14 @@ namespace NKikimr {
 
         bool THullHugeKeeperPersState::WouldNewEntryPointAdvanceLog(ui64 freeUpToLsn, ui64 minInFlightLsn,
                 ui32 itemsAfterCommit) const {
-            return freeUpToLsn < minInFlightLsn && (LogPos.EntryPointLsn <= freeUpToLsn || itemsAfterCommit > 10000);
+            return freeUpToLsn < minInFlightLsn && (PersistentLsn <= freeUpToLsn || itemsAfterCommit > 10000);
         }
 
         // initiate commit
-        void THullHugeKeeperPersState::InitiateNewEntryPointCommit(ui64 lsn) {
+        void THullHugeKeeperPersState::InitiateNewEntryPointCommit(ui64 lsn, ui64 minInFlightLsn) {
             Y_ABORT_UNLESS(lsn > LogPos.EntryPointLsn);
             LogPos.EntryPointLsn = lsn;
+            PersistentLsn = Min(lsn, minInFlightLsn);
 
             // these metabases never have huge blobs and we never care about them actually
             LogPos.BlocksDbSlotDelLsn = lsn;
@@ -353,6 +356,7 @@ namespace NKikimr {
                                 Guid, lsn, LogPos.EntryPointLsn, rec.ToString().data()));
                 Heap->RecoveryModeAddChunk(rec.ChunkId);
                 LogPos.ChunkAllocationLsn = lsn;
+                PersistentLsn = Min(PersistentLsn, lsn);
                 return TRlas(true, false);
             } else {
                 // skip
@@ -380,6 +384,7 @@ namespace NKikimr {
                                 Guid, lsn, LogPos.EntryPointLsn, rec.ToString().data()));
                 Heap->RecoveryModeRemoveChunks(rec.ChunkIds);
                 LogPos.ChunkFreeingLsn = lsn;
+                PersistentLsn = Min(PersistentLsn, lsn);
                 return TRlas(true, false);
             } else {
                 // skip
@@ -424,6 +429,7 @@ namespace NKikimr {
                     Heap->RecoveryModeFree(x);
 
                 *logPosDelLsn = lsn;
+                PersistentLsn = Min(PersistentLsn, lsn);
                 return TRlas(true, false);
             } else {
                 // skip
@@ -472,6 +478,7 @@ namespace NKikimr {
                     Heap->RecoveryModeAllocate(rec.DiskAddr);
                 }
                 LogPos.HugeBlobLoggedLsn = lsn;
+                PersistentLsn = Min(PersistentLsn, lsn);
                 return TRlas(true, false);
             } else {
                 // skip

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.h
@@ -86,6 +86,7 @@ namespace NKikimr {
             const ui64 Guid;
             // last reported FirstLsnToKeep; can't decrease
             mutable ui64 FirstLsnToKeepReported = 0;
+            ui64 PersistentLsn = 0;
 
             THullHugeKeeperPersState(TIntrusivePtr<TVDiskContext> vctx,
                                      const ui32 chunkSize,
@@ -138,7 +139,7 @@ namespace NKikimr {
             bool WouldNewEntryPointAdvanceLog(ui64 freeUpToLsn, ui64 minInFlightLsn, ui32 itemsAfterCommit) const;
 
             // initiate commit
-            void InitiateNewEntryPointCommit(ui64 lsn);
+            void InitiateNewEntryPointCommit(ui64 lsn, ui64 minInFlightLsn);
             // finish commit
             void EntryPointCommitted(ui64 lsn);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix huge blob keeper FirstLsnToKeep logic

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

PendingWrites are now accounted too when calculating FirstLsnToKeep.
