### PR TITLE
YQL-18435: Clear the error in Python numeric casts 

### DIFF
--- a/ydb/library/yql/udfs/common/python/bindings/py_cast.cpp
+++ b/ydb/library/yql/udfs/common/python/bindings/py_cast.cpp
@@ -74,6 +74,7 @@
     Type PyCast<Type>(PyObject* value) { \
         double result = PyFloat_AsDouble(value); \
         if (result == -1.0 && PyErr_Occurred()) { \
+            PyErr_Clear(); \
             ThrowCastException(value, "Float"); \
         } \
         return static_cast<Type>(result); \
@@ -85,6 +86,7 @@
         if (PyLong_Check(value)) { \
             auto result = YQL_PyLong_As##BigType(value); \
             if (result == static_cast<Type>(-1L) && PyErr_Occurred()) { \
+                PyErr_Clear(); \
                 ThrowCastException(value, "Long"); \
             } \
             if (result < Min<Type>() || result > Max<Type>()) { \
@@ -102,6 +104,7 @@
         if (PyInt_Check(value)) { \
             long result = PyInt_AsLong(value); \
             if (result == -1L && PyErr_Occurred()) { \
+                PyErr_Clear(); \
                 ThrowCastException(value, "Long"); \
             } \
             if ( \
@@ -115,6 +118,7 @@
         } else if (PyLong_Check(value)) { \
             auto result = YQL_PyLong_As##BigType(value); \
             if (result == static_cast<Type>(-1L) && PyErr_Occurred()) { \
+                PyErr_Clear(); \
                 ThrowCastException(value, "Long"); \
             } \
             if (result < Min<Type>() || result > Max<Type>()) { \

--- a/ydb/library/yql/udfs/common/python/bindings/py_cast_ut.cpp
+++ b/ydb/library/yql/udfs/common/python/bindings/py_cast_ut.cpp
@@ -54,4 +54,31 @@ Y_UNIT_TEST_SUITE(TPyCastTest) {
                 }),
             yexception, "None");
     }
+
+    Y_UNIT_TEST(BadFromPythonFloat) {
+        TPythonTestEngine engine;
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            engine.ToMiniKQL<float>(
+                "def Test():\n"
+                "    return '3 <dot> 1415926'",
+                [](const NUdf::TUnboxedValuePod& value) {
+                    Y_UNUSED(value);
+                    Y_UNREACHABLE();
+                }),
+            yexception, "Cast error object '3 <dot> 1415926' to Float");
+    }
+
+    Y_UNIT_TEST(BadFromPythonLong) {
+        TPythonTestEngine engine;
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            engine.ToMiniKQL<ui64>(
+                "def Test():\n"
+                "    return -1",
+                [](const NUdf::TUnboxedValuePod& value) {
+                    Y_UNUSED(value);
+                    Y_UNREACHABLE();
+                }),
+            yexception, "Cast error object -1 to Long");
+    }
+
 }


### PR DESCRIPTION
The error indicator raised by the Python runtime, when the particular numeric cast fails, should be reset, when the exception is considered "handled" (e.g. rethrow of the unsuccessful cast error). `PyErr_Clear` had been lost since the very first commit, related to the Python bindings, i.e. 93acd0b ("Move YQL python UDFs in OS (#4139)"), though the similar exceptions are handled right in the "test" helpers (see `TRY_FROM_PYTHON_FLOAT` and `TRY_FROM_PYTHON_LONG`).

Considering the changes related to the Python integral types between 2.x and 3.x major releases, it's enough (almost) to provide only the one test for PyObject-to-int/long conversion.

Follows up #4139

### Changelog category

* Bugfix
