### PR TITLE
HDD and SSD used bytes counters

### DIFF
--- a/ydb/core/cms/console/console__create_tenant.cpp
+++ b/ydb/core/cms/console/console__create_tenant.cpp
@@ -276,19 +276,20 @@ public:
                 return Error(Ydb::StatusIds::BAD_REQUEST,
                     TStringBuilder() << "Overall data size soft quota (" << softQuota << ")"
                                      << " of the database " << path
-                                     << " must be smaller than the hard quota (" << hardQuota << ")",
+                                     << " must be less than or equal to the hard quota (" << hardQuota << ")",
                     ctx
                 );
             }
-            for (const auto& storageQuota : quotas.storage_quotas()) {
-                const auto unitHardQuota = storageQuota.data_size_hard_quota();
-                const auto unitSoftQuota = storageQuota.data_size_soft_quota();
+            for (const auto& storageUnitQuota : quotas.storage_quotas()) {
+                const auto unitHardQuota = storageUnitQuota.data_size_hard_quota();
+                const auto unitSoftQuota = storageUnitQuota.data_size_soft_quota();
                 if (unitHardQuota && unitSoftQuota && unitHardQuota < unitSoftQuota) {
                     return Error(Ydb::StatusIds::BAD_REQUEST,
                         TStringBuilder() << "Data size soft quota (" << unitSoftQuota << ")"
-                                         << " for a " << storageQuota.unit_kind() << " storage unit "
+                                         << " for a " << storageUnitQuota.unit_kind() << " storage unit "
                                          << " of the database " << path
-                                         << " must be smaller than the corresponding hard quota (" << unitHardQuota << ")",
+                                         << " must be less than or equal to"
+                                         << " the corresponding hard quota (" << unitHardQuota << ")",
                         ctx
                     );
                 }

--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -205,6 +205,13 @@ enum ESimpleCounters {
     COUNTER_IN_FLIGHT_OPS_TxCreateContinuousBackup = 162          [(CounterOpts) = {Name: "InFlightOps/CreateContinuousBackup"}];
     COUNTER_IN_FLIGHT_OPS_TxAlterContinuousBackup = 163          [(CounterOpts) = {Name: "InFlightOps/AlterContinuousBackup"}];
     COUNTER_IN_FLIGHT_OPS_TxDropContinuousBackup = 164           [(CounterOpts) = {Name: "InFlightOps/DropContinuousBackup"}];
+    
+    COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_SSD = 165     [(CounterOpts) = {Name: "DiskSpaceTablesDataBytesOnSsd"}];
+    COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_SSD = 166    [(CounterOpts) = {Name: "DiskSpaceTablesIndexBytesOnSsd"}];
+    COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_SSD = 167    [(CounterOpts) = {Name: "DiskSpaceTablesTotalBytesOnSsd"}];
+    COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_HDD = 168     [(CounterOpts) = {Name: "DiskSpaceTablesDataBytesOnHdd"}];
+    COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_HDD = 169    [(CounterOpts) = {Name: "DiskSpaceTablesIndexBytesOnHdd"}];
+    COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_HDD = 170    [(CounterOpts) = {Name: "DiskSpaceTablesTotalBytesOnHdd"}];
 }
 
 enum ECumulativeCounters {

--- a/ydb/core/sys_view/service/ext_counters.cpp
+++ b/ydb/core/sys_view/service/ext_counters.cpp
@@ -23,6 +23,8 @@ class TExtCountersUpdaterActor
     TCounterPtr MemoryUsedBytes;
     TCounterPtr MemoryLimitBytes;
     TCounterPtr StorageUsedBytes;
+    TCounterPtr StorageUsedBytesOnSsd;
+    TCounterPtr StorageUsedBytesOnHdd;
     TVector<TCounterPtr> CpuUsedCorePercents;
     TVector<TCounterPtr> CpuLimitCorePercents;
     THistogramPtr ExecuteLatencyMs;
@@ -54,6 +56,10 @@ public:
             "resources.memory.limit_bytes", false);
         StorageUsedBytes = ydbGroup->GetNamedCounter("name",
             "resources.storage.used_bytes", false);
+        StorageUsedBytesOnSsd = ydbGroup->GetNamedCounter("name",
+            "resources.storage.used_bytes.ssd", false);
+        StorageUsedBytesOnHdd = ydbGroup->GetNamedCounter("name",
+            "resources.storage.used_bytes.hdd", false);
 
         auto poolCount = Config.Pools.size();
         CpuUsedCorePercents.resize(poolCount);
@@ -109,6 +115,12 @@ private:
         }
         if (StorageUsedBytes->Val() != 0) {
             metrics->AddMetric("resources.storage.used_bytes", StorageUsedBytes->Val());
+        }
+        if (StorageUsedBytesOnSsd->Val() != 0) {
+            metrics->AddMetric("resources.storage.used_bytes.ssd", StorageUsedBytesOnSsd->Val());
+        }
+        if (StorageUsedBytesOnHdd->Val() != 0) {
+            metrics->AddMetric("resources.storage.used_bytes.hdd", StorageUsedBytesOnHdd->Val());
         }
         if (!Config.Pools.empty()) {
             double cpuUsage = 0;

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -770,8 +770,12 @@ private:
         TCounterPtr ColumnShardBulkUpsertRows_;
         TCounterPtr ColumnShardBulkUpsertBytes_;
         TCounterPtr ResourcesStorageUsedBytes;
+        TCounterPtr ResourcesStorageUsedBytesOnSsd;
+        TCounterPtr ResourcesStorageUsedBytesOnHdd;
         TCounterPtr ResourcesStorageLimitBytes;
         TCounterPtr ResourcesStorageTableUsedBytes;
+        TCounterPtr ResourcesStorageTableUsedBytesOnSsd;
+        TCounterPtr ResourcesStorageTableUsedBytesOnHdd;
         TCounterPtr ResourcesStorageTopicUsedBytes;
         TCounterPtr ResourcesStreamUsedShards;
         TCounterPtr ResourcesStreamLimitShards;
@@ -806,6 +810,8 @@ private:
         TCounterPtr ColumnShardUpsertBytesWritten_;
 
         TCounterPtr DiskSpaceTablesTotalBytes;
+        TCounterPtr DiskSpaceTablesTotalBytesOnSsd;
+        TCounterPtr DiskSpaceTablesTotalBytesOnHdd;
         TCounterPtr DiskSpaceTopicsTotalBytes;
         TCounterPtr DiskSpaceSoftQuotaBytes;
 
@@ -860,10 +866,18 @@ private:
 
             ResourcesStorageUsedBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.used_bytes", false);
+            ResourcesStorageUsedBytesOnSsd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.used_bytes.ssd", false);
+            ResourcesStorageUsedBytesOnHdd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.used_bytes.hdd", false);
             ResourcesStorageLimitBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.limit_bytes", false);
             ResourcesStorageTableUsedBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.table.used_bytes", false);
+            ResourcesStorageTableUsedBytesOnSsd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.table.used_bytes.ssd", false);
+            ResourcesStorageTableUsedBytesOnHdd = ydbGroup->GetNamedCounter("name",
+                "resources.storage.table.used_bytes.hdd", false);
             ResourcesStorageTopicUsedBytes = ydbGroup->GetNamedCounter("name",
                 "resources.storage.topic.used_bytes", false);
 
@@ -930,6 +944,8 @@ private:
                 auto appGroup = schemeshardGroup->GetSubgroup("category", "app");
 
                 DiskSpaceTablesTotalBytes = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTablesTotalBytes)");
+                DiskSpaceTablesTotalBytesOnSsd = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTablesTotalBytesOnSsd)");
+                DiskSpaceTablesTotalBytesOnHdd = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTablesTotalBytesOnHdd)");
                 DiskSpaceTopicsTotalBytes = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceTopicsTotalBytes)");
                 DiskSpaceSoftQuotaBytes = appGroup->GetCounter("SUM(SchemeShard/DiskSpaceSoftQuotaBytes)");
 
@@ -973,12 +989,18 @@ private:
             if (DiskSpaceTablesTotalBytes) {
                 ResourcesStorageLimitBytes->Set(DiskSpaceSoftQuotaBytes->Val());
                 ResourcesStorageTableUsedBytes->Set(DiskSpaceTablesTotalBytes->Val());
+                ResourcesStorageTableUsedBytesOnSsd->Set(DiskSpaceTablesTotalBytesOnSsd->Val());
+                ResourcesStorageTableUsedBytesOnHdd->Set(DiskSpaceTablesTotalBytesOnHdd->Val());
                 ResourcesStorageTopicUsedBytes->Set(DiskSpaceTopicsTotalBytes->Val());
 
                 if (AppData()->FeatureFlags.GetEnableTopicDiskSubDomainQuota()) {
                     ResourcesStorageUsedBytes->Set(ResourcesStorageTableUsedBytes->Val() + ResourcesStorageTopicUsedBytes->Val());
+                    ResourcesStorageUsedBytesOnSsd->Set(ResourcesStorageTableUsedBytesOnSsd->Val());
+                    ResourcesStorageUsedBytesOnHdd->Set(ResourcesStorageTableUsedBytesOnHdd->Val());
                 } else {
                     ResourcesStorageUsedBytes->Set(ResourcesStorageTableUsedBytes->Val());
+                    ResourcesStorageUsedBytesOnSsd->Set(ResourcesStorageTableUsedBytesOnSsd->Val());
+                    ResourcesStorageUsedBytesOnHdd->Set(ResourcesStorageTableUsedBytesOnHdd->Val());
                 }
 
                 auto quota = StreamShardsQuota->Val();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
@@ -279,7 +279,7 @@ VerifyParams(TParamsDelta* delta, const TPathId pathId, const TSubDomainInfo::TP
         if (const auto& effectivePools = requestedPools.empty()
                 ? actualPools
                 : requestedPools;
-            !CheckStorageQuotasKinds(input.GetDatabaseQuotas(), effectivePools, pathId.ToString(), error)
+            !CheckStoragePoolsInQuotas(input.GetDatabaseQuotas(), effectivePools, input.GetName(), error)
         ) {
             return paramError(error);
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
@@ -290,7 +290,7 @@ public:
             if (const auto& effectivePools = requestedPools.empty()
                     ? actualPools
                     : requestedPools;
-                !CheckStorageQuotasKinds(settings.GetDatabaseQuotas(), effectivePools, path.PathString(), errStr)
+                !CheckStoragePoolsInQuotas(settings.GetDatabaseQuotas(), effectivePools, path.PathString(), errStr)
             ) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                 return result;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
@@ -6,10 +6,11 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
-inline bool CheckStoragePoolsInQuotas(const Ydb::Cms::DatabaseQuotas& quotas,
-                                      const TVector<TStoragePool>& pools,
-                                      const TString& path,
-                                      TString& error
+inline bool CheckStoragePoolsInQuotas(
+    const Ydb::Cms::DatabaseQuotas& quotas,
+    const TVector<TStoragePool>& pools,
+    const TString& path,
+    TString& error
 ) {
     TVector<TString> quotedKinds;
     quotedKinds.reserve(quotas.storage_quotas_size());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
@@ -6,33 +6,43 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
-inline bool CheckStorageQuotasKinds(const Ydb::Cms::DatabaseQuotas& quotas,
-                                    const TVector<TStoragePool>& pools,
-                                    const TString& path,
-                                    TString& error
+inline bool CheckStoragePoolsInQuotas(const Ydb::Cms::DatabaseQuotas& quotas,
+                                      const TVector<TStoragePool>& pools,
+                                      const TString& path,
+                                      TString& error
 ) {
     TVector<TString> quotedKinds;
+    quotedKinds.reserve(quotas.storage_quotas_size());
     for (const auto& storageQuota : quotas.storage_quotas()) {
         quotedKinds.emplace_back(storageQuota.unit_kind());
     }
     Sort(quotedKinds);
-    const auto uniqueEnd = Unique(quotedKinds.begin(), quotedKinds.end());
-    if (uniqueEnd != quotedKinds.end()) {
+    if (const auto equalKinds = AdjacentFind(quotedKinds);
+        equalKinds != quotedKinds.end()
+    ) {
         error = TStringBuilder()
-            << "Malformed subdomain request: storage quotas' unit kinds must be unique, but "
-            << *uniqueEnd << " appears twice in the storage quotas definition of the " << path << " subdomain.";
+            << "Malformed subdomain request: storage kinds in DatabaseQuotas must be unique, but "
+            << *equalKinds << " appears twice in the quotas definition of the " << path << " subdomain.";
         return false;
     }
 
-    for (const auto& quotedKind : quotedKinds) {
-        if (!AnyOf(pools, [&quotedKind](const TStoragePool& pool) {
-            return pool.GetKind() == quotedKind;
-        })) {
-            error = TStringBuilder()
-                << "Malformed subdomain request: cannot set a " << quotedKind << " storage quota, "
-                << "because no storage pool in the subdomain " << path << " has the specified kind.";
-            return false;
-        }
+    TVector<TString> existingKinds;
+    existingKinds.reserve(pools.size());
+    for (const auto& pool : pools) {
+        existingKinds.emplace_back(pool.GetKind());
+    }
+    Sort(existingKinds);
+    TVector<TString> unknownKinds;
+    SetDifference(quotedKinds.begin(), quotedKinds.end(),
+                  existingKinds.begin(), existingKinds.end(),
+                  std::back_inserter(unknownKinds)
+    );
+    if (!unknownKinds.empty()) {
+        error = TStringBuilder()
+            << "Malformed subdomain request: cannot set storage quotas of the following kinds: " << JoinSeq(", ", unknownKinds)
+            << ", because no storage pool in the subdomain " << path << " has the specified kinds. "
+            << "Existing storage kinds are: " << JoinSeq(", ", existingKinds);
+        return false;
     }
     return true;
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
@@ -295,7 +295,7 @@ public:
 
         if (settings.HasDatabaseQuotas()) {
             if (!requestedStoragePools.empty()
-                    && !CheckStorageQuotasKinds(settings.GetDatabaseQuotas(), requestedStoragePools, dstPath.PathString(), errStr)
+                    && !CheckStoragePoolsInQuotas(settings.GetDatabaseQuotas(), requestedStoragePools, dstPath.PathString(), errStr)
             ) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                 return result;

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -173,8 +173,8 @@ TPartitionStats TTxStoreTableStats::PrepareStats(const TActorContext& ctx,
             indexSize += channelStats.GetIndexSize();
         } else {
             LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-                        "PrepareStats: the subdomain has no info about the datashard's channel "
-                            << channelStats.GetChannel()
+                        "PrepareStats: SchemeShard has no info on DataShard "
+                            << rec.GetDatashardId() << " channel " << channelStats.GetChannel() << " binding"
             );
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -7216,6 +7216,18 @@ void TSchemeShard::ChangeDiskSpaceTablesTotalBytes(i64 delta) {
     TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES].Add(delta);
 }
 
+void TSchemeShard::ChangeDiskSpaceTables(EUserFacingStorageType storageType, i64 dataDelta, i64 indexDelta) {
+    if (storageType == EUserFacingStorageType::Ssd) {
+        TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_SSD].Add(dataDelta);
+        TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_SSD].Add(indexDelta);
+        TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_SSD].Add(dataDelta + indexDelta);
+    } else if (storageType == EUserFacingStorageType::Hdd) {
+        TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_DATA_BYTES_ON_HDD].Add(dataDelta);
+        TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_INDEX_BYTES_ON_HDD].Add(indexDelta);
+        TabletCounters->Simple()[COUNTER_DISK_SPACE_TABLES_TOTAL_BYTES_ON_HDD].Add(dataDelta + indexDelta);
+    }
+}
+
 void TSchemeShard::ChangeDiskSpaceTopicsTotalBytes(ui64 value) {
     TabletCounters->Simple()[COUNTER_DISK_SPACE_TOPICS_TOTAL_BYTES].Set(value);
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1380,6 +1380,7 @@ public:
     void ChangeDiskSpaceTablesDataBytes(i64 delta) override;
     void ChangeDiskSpaceTablesIndexBytes(i64 delta) override;
     void ChangeDiskSpaceTablesTotalBytes(i64 delta) override;
+    void ChangeDiskSpaceTables(EUserFacingStorageType storageType, i64 dataDelta, i64 indexDelta) override;
     void ChangeDiskSpaceTopicsTotalBytes(ui64 value) override;
     void ChangeDiskSpaceQuotaExceeded(i64 delta) override;
     void ChangeDiskSpaceHardQuotaBytes(i64 delta) override;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -51,6 +51,12 @@ EDiskUsageStatus CheckStoragePoolsQuotas(const THashMap<TString, TStoragePoolUsa
             : EDiskUsageStatus::BelowSoftQuota;
 }
 
+/*
+This is a workaround!
+It makes sense only in the specific case where:
+    - there are no multiple storage pools of the same kind
+    - all storage pool kinds belong to the set {ssh*, hdd*, rot*, nvme*}
+*/
 EUserFacingStorageType GetUserFacingStorageType(const TString& poolKind) {
     if (poolKind.StartsWith("ssd") || poolKind.StartsWith("nvme")) {
         return EUserFacingStorageType::Ssd;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -52,10 +52,10 @@ EDiskUsageStatus CheckStoragePoolsQuotas(const THashMap<TString, TStoragePoolUsa
 }
 
 EUserFacingStorageType GetUserFacingStorageType(const TString& poolKind) {
-    if (poolKind.StartsWith("ssd")) {
+    if (poolKind.StartsWith("ssd") || poolKind.StartsWith("nvme")) {
         return EUserFacingStorageType::Ssd;
     }
-    if (poolKind.StartsWith("hdd")) {
+    if (poolKind.StartsWith("hdd") || poolKind.StartsWith("rot")) {
         return EUserFacingStorageType::Hdd;
     }
     return EUserFacingStorageType::Ignored;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1581,19 +1581,21 @@ void TAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartition
     Aggregated.IndexSize += (newStats.IndexSize - oldStats.IndexSize);
     for (const auto& [poolKind, newStoragePoolStats] : newStats.StoragePoolsStats) {
         auto* aggregatedStoragePoolStats = Aggregated.StoragePoolsStats.FindPtr(poolKind);
+        const auto* oldStoragePoolStats = oldStats.StoragePoolsStats.FindPtr(poolKind);
         if (aggregatedStoragePoolStats) {
-            const auto* oldStoragePoolStats = oldStats.StoragePoolsStats.FindPtr(poolKind);
-
             // Missing old stats for a particular storage pool are interpreted as if this data
             // has just been written to the datashard and we need to increment the aggregate by the entire new stats' sizes.
             aggregatedStoragePoolStats->DataSize += newStoragePoolStats.DataSize - (oldStoragePoolStats ? oldStoragePoolStats->DataSize : 0u);
             aggregatedStoragePoolStats->IndexSize += newStoragePoolStats.IndexSize - (oldStoragePoolStats ? oldStoragePoolStats->IndexSize : 0u);
         } else {
+            Y_ABORT_UNLESS(!oldStoragePoolStats, "Old stats are present, but they haven't been aggregated.");
             Aggregated.StoragePoolsStats.emplace(poolKind, newStoragePoolStats);
         }
     }
     for (const auto& [poolKind, oldStoragePoolStats] : oldStats.StoragePoolsStats) {
-        if (const auto* newStoragePoolStats = newStats.StoragePoolsStats.FindPtr(poolKind); !newStoragePoolStats) {
+        if (const auto* newStoragePoolStats = newStats.StoragePoolsStats.FindPtr(poolKind);
+            !newStoragePoolStats
+        ) {
             auto* aggregatedStoragePoolStats = Aggregated.StoragePoolsStats.FindPtr(poolKind);
             Y_ABORT_UNLESS(aggregatedStoragePoolStats, "Old stats are present, but they haven't been aggregated.");
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -1281,6 +1281,12 @@ struct TSchemeQuotas : public TVector<TSchemeQuota> {
     mutable size_t LastKnownSize = 0;
 };
 
+enum class EUserFacingStorageType {
+    Ssd,
+    Hdd,
+    Ignored
+};
+
 struct IQuotaCounters {
     virtual void ChangeStreamShardsCount(i64 delta) = 0;
     virtual void ChangeStreamShardsQuota(i64 delta) = 0;
@@ -1289,6 +1295,7 @@ struct IQuotaCounters {
     virtual void ChangeDiskSpaceTablesDataBytes(i64 delta) = 0;
     virtual void ChangeDiskSpaceTablesIndexBytes(i64 delta) = 0;
     virtual void ChangeDiskSpaceTablesTotalBytes(i64 delta) = 0;
+    virtual void ChangeDiskSpaceTables(EUserFacingStorageType storageType, i64 dataDelta, i64 indexDelta) = 0;
     virtual void ChangeDiskSpaceTopicsTotalBytes(ui64 value) = 0;
     virtual void ChangeDiskSpaceQuotaExceeded(i64 delta) = 0;
     virtual void ChangeDiskSpaceHardQuotaBytes(i64 delta) = 0;

--- a/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
+++ b/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
@@ -601,7 +601,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsStatsPersistence) {
         TTestBasicRuntime runtime;
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
 
         TTestEnvOptions opts;
         opts.DisableStatsBatching(true);
@@ -662,7 +662,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsStatsPersistence) {
         UNIT_ASSERT_VALUES_EQUAL(NKikimr::CompactTable(runtime, datashard, ResolveTableId(runtime, "/MyRoot/SomeTable")).GetStatus(),
                                  NKikimrTxDataShard::TEvCompactTableResult::OK
         );
-        // we wait for at least 1 part count, because it means that the table has been compacted
+        // we wait for at least 1 part count, because it signals that the stats have been recalculated after compaction
         WaitTableStats(runtime, datashard, 1, rowsCount).GetTableStats();
 
         auto checkUsage = [&poolsKinds](ui64 totalUsage, const auto& poolUsage) {

--- a/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
@@ -3364,7 +3364,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
 
     Y_UNIT_TEST_FLAG(DisableWritesToDatabase, IsExternalSubdomain) {
         TTestBasicRuntime runtime;
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
 
         TTestEnvOptions opts;
         opts.DisableStatsBatching(true);
@@ -3486,7 +3486,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
 
     Y_UNIT_TEST_FLAG(QuoteNonexistentPool, IsExternalSubdomain) {
         TTestBasicRuntime runtime;
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
 
         TTestEnvOptions opts;
         TTestEnv env(runtime, opts);
@@ -3535,7 +3535,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
     // To fix the test you need to update canonical quotas and / or batch sizes.
     Y_UNIT_TEST_FLAG(DifferentQuotasInteraction, IsExternalSubdomain) {
         TTestBasicRuntime runtime;
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
 
         TTestEnvOptions opts;
         opts.DisableStatsBatching(true);

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -5574,7 +5574,7 @@ Y_UNIT_TEST(DisableWritesToDatabase) {
     auto sender = runtime.AllocateEdgeActor();
     InitRoot(server, sender);
 
-    runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
+    runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
     NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
     NDataShard::gDbStatsDataSizeResolution = 1;
     NDataShard::gDbStatsRowCountResolution = 1;


### PR DESCRIPTION
#3275

In this PR two new counters are added:
- `resources.storage.used_bytes.ssd`
- `resources.storage.used_bytes.hdd`

Necessary subcounters like `resources.storage.used_bytes.table.ssd` (note the added `table` part) are also added. These counters are needed to monitor SSD and HDD storage usage separately. 

In the follow-up [PR](https://github.com/ydb-platform/ydb/pull/4765) `.ssd` and `.hdd` versions of `resources.storage.limit_bytes` are added too.

Probably the most interesting part of this PR is the "hacky" [mapping](https://github.com/ydb-platform/ydb/blob/4fca557e2646a1de873613694c2adfd10c780b2f/ydb/core/tx/schemeshard/schemeshard_info_types.cpp#L54) of storage pool kinds to `ssd` and `hdd` counters. It is discussed in more detail in these comments:
- https://github.com/ydb-platform/ydb/pull/4727#discussion_r1608650304
- https://github.com/ydb-platform/ydb/pull/4727#discussion_r1608656793

The data for the `used_bytes` counters is sourced from the SchemeShard's counters:
- `SchemeShard/DiskSpaceTablesTotalBytesOnSsd`
- `SchemeShard/DiskSpaceTablesTotalBytesOnHdd`

which are updated each time the SchemeShard receives TEvPeriodicTableStats from DataShards.

Currently, only row-oriented tables report disk space usage separately by channels, so effectively:
- `resources.storage.used_bytes.ssd` is equal to `resources.storage.table.used_bytes.ssd` (note the added `table` part)
- `resources.storage.used_bytes.hdd` is equal to `resources.storage.table.used_bytes.hdd` (note the added `table` part)

In the future, we will start accounting for HDD and SSD usage separately for both column-oriented tables and topics. Consequently, `resources.storage.used_bytes.ssd` will more accurately represent the total SSD space used by all entities in the database.

P.S. For the best reviewing experience, I recommend reviewing the [commits](https://github.com/ydb-platform/ydb/pull/4727/commits) individually.