### PR TITLE
HugeKeeper API for the compaction

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -711,6 +711,9 @@ struct TEvBlobStorage {
         EvMinHugeBlobSizeUpdate,
         EvHugePreCompact,
         EvHugePreCompactResult,
+        EvHullHugeSlotsAllocate, 
+        EvHullHugeSlotsAllocated, 
+        EvHullHugeSlotsUsed,
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_huge.h
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_huge.h
@@ -6,3 +6,7 @@
 struct THugeModuleTest {
     void operator ()(TConfiguration *conf);
 };
+
+struct THugeAllocTest {
+    void operator ()(TConfiguration *conf);
+};

--- a/ydb/core/blobstorage/ut_vdisk/vdisk_test.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/vdisk_test.cpp
@@ -431,6 +431,11 @@ Y_UNIT_TEST_SUITE(TBsHuge) {
                                                            DefDisksInDomain,
                                                            NKikimr::TErasureType::ErasureNone);
     }
+
+    Y_UNIT_TEST(AllocateHugeSlots) {
+        THugeAllocTest test;
+        TestRun<THugeAllocTest, TFastVDiskSetupCompacted>(&test, TIMEOUT);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.h
@@ -61,6 +61,26 @@ namespace NKikimr {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    // TEvHullHugeSlotsAllocate
+    ////////////////////////////////////////////////////////////////////////////
+    class TEvHullHugeSlotsAllocate : public TEventLocal<TEvHullHugeSlotsAllocate, TEvBlobStorage::EvHullHugeSlotsAllocate> {
+        using TSlotSize = size_t;
+    public:
+        const std::map<TSlotSize, int> SlotSizes;
+
+        TEvHullHugeSlotsAllocate(const std::map<TSlotSize, int> &slotSizes)
+            : SlotSizes(slotSizes) {}
+    };
+
+    class TEvHullHugeSlotsAllocated : public TEventLocal<TEvHullHugeSlotsAllocated, TEvBlobStorage::EvHullHugeSlotsAllocated> {
+    public:
+        const std::vector<NHuge::THugeSlot> Slots;
+
+        TEvHullHugeSlotsAllocated(const std::vector<NHuge::THugeSlot>&& slots)
+            : Slots(std::move(slots)) {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     // TEvHullLogHugeBlob
     ////////////////////////////////////////////////////////////////////////////
     class TEvHullLogHugeBlob : public TEventLocal<TEvHullLogHugeBlob, TEvBlobStorage::EvHullLogHugeBlob> {
@@ -123,6 +143,28 @@ namespace NKikimr {
                 << " Lsn# " << RecLsn << " Used# " << SlotIsUsed << "}";
             return str.Str();
         }
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TEvHullHugeSlotsUsed
+    ////////////////////////////////////////////////////////////////////////////
+    class TEvHullHugeSlotsUsed : public TEventLocal<TEvHullHugeSlotsUsed, TEvBlobStorage::EvHullHugeSlotsUsed> {
+    public:
+        const std::vector<NHuge::THugeSlot> UsedSlots;
+        const std::vector<NHuge::THugeSlot> UnusedSlots;
+
+        const ui64 RecLsn;
+        const ui64 WriteId;
+
+        TEvHullHugeSlotsUsed(const std::vector<NHuge::THugeSlot>& UsedSlots, 
+                             const std::vector<NHuge::THugeSlot>& UnusedSlots, 
+                             ui64 recLsn, 
+                             ui64 writeId)
+            : UsedSlots(UsedSlots)
+            , UnusedSlots(UnusedSlots)
+            , RecLsn(recLsn)
+            , WriteId(writeId)
+        {}
     };
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge_ut.cpp
@@ -14,7 +14,29 @@ namespace NKikimr {
 
     Y_UNIT_TEST_SUITE(TBlobStorageHullHugeKeeperPersState) {
 
-        Y_UNIT_TEST(SerializeParse) {
+        Y_UNIT_TEST(SerializeDeserializeOldLogPos) {
+            THullHugeRecoveryLogPos logPos(0, 0, 100500, 50000, 70000, 56789, 39482, 0);
+            THullHugeRecoveryLogPos deserialized = THullHugeRecoveryLogPos::Default();
+            
+            TString serialized(logPos.Serialize());
+            deserialized.ParseFromString(serialized);
+
+            UNIT_ASSERT(THullHugeRecoveryLogPos::CheckEntryPoint(serialized));
+            UNIT_ASSERT_EQUAL(deserialized.HugeSlotsAllocationLsn, 0);
+        }
+
+        Y_UNIT_TEST(SerializeDeserializeLogPos) {
+            THullHugeRecoveryLogPos logPos(0, 0, 100500, 50000, 70000, 56789, 39482, 65431);
+            THullHugeRecoveryLogPos deserialized = THullHugeRecoveryLogPos::Default();
+            
+            TString serialized(logPos.Serialize());
+            deserialized.ParseFromString(serialized);
+
+            UNIT_ASSERT(THullHugeRecoveryLogPos::CheckEntryPoint(serialized));
+            UNIT_ASSERT_EQUAL(deserialized.HugeSlotsAllocationLsn, 65431);
+        }
+
+        Y_UNIT_TEST(SerializeOldParse) {
             ui32 chunkSize = 134274560u;
             ui32 appendBlockSize = 56896u;
             ui32 minHugeBlobInBytes = 512u << 10u;
@@ -33,12 +55,41 @@ namespace NKikimr {
                         minHugeBlobInBytes, milestoneHugeBlobInBytes, maxBlobInBytes,
                         overhead, freeChunksReservation, logf));
 
-            state->LogPos = THullHugeRecoveryLogPos(0, 0, 100500, 50000, 70000, 56789, 39482);
+            state->LogPos = THullHugeRecoveryLogPos(0, 0, 100500, 50000, 70000, 56789, 39482, 0);
             NHuge::THugeSlot hugeSlot(453, 0, 234);
             state->AllocatedSlots.insert(hugeSlot);
 
             TString serialized(state->Serialize());
             UNIT_ASSERT(THullHugeKeeperPersState::CheckEntryPoint(serialized));
+            state->ParseFromString(serialized);
+        }
+
+         Y_UNIT_TEST(SerializeParse) {
+            ui32 chunkSize = 134274560u;
+            ui32 appendBlockSize = 56896u;
+            ui32 minHugeBlobInBytes = 512u << 10u;
+            ui32 milestoneHugeBlobInBytes = 512u << 10u;
+            ui32 maxBlobInBytes = 10u << 20u;
+            ui32 overhead = 8;
+            ui32 freeChunksReservation = 2;
+
+            auto logf = [] (const TString &state) { STR << state; };
+            auto counters = MakeIntrusive<::NMonitoring::TDynamicCounters>();
+            auto info = MakeIntrusive<TBlobStorageGroupInfo>(TBlobStorageGroupType::Erasure4Plus2Block);
+            auto vctx = MakeIntrusive<TVDiskContext>(TActorId(), info->PickTopology(), counters, TVDiskID(0, 1, 0, 0, 0),
+                nullptr, NPDisk::DEVICE_TYPE_UNKNOWN);
+            std::unique_ptr<THullHugeKeeperPersState> state(
+                    new THullHugeKeeperPersState(vctx, chunkSize, appendBlockSize, appendBlockSize,
+                        minHugeBlobInBytes, milestoneHugeBlobInBytes, maxBlobInBytes,
+                        overhead, freeChunksReservation, logf));
+
+            state->LogPos = THullHugeRecoveryLogPos(0, 0, 100500, 50000, 70000, 56789, 39482, 54323);
+            NHuge::THugeSlot hugeSlot(453, 0, 234);
+            state->AllocatedSlots.insert(hugeSlot);
+
+            TString serialized(state->Serialize());
+            UNIT_ASSERT(THullHugeKeeperPersState::CheckEntryPoint(serialized));
+            state->ParseFromString(serialized);
         }
     }
 

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugerecovery.h
@@ -21,12 +21,15 @@ namespace NKikimr {
             ui64 BlocksDbSlotDelLsn = 0;
             ui64 BarriersDbSlotDelLsn = 0;
             ui64 EntryPointLsn = 0;
+            ui64 HugeSlotsAllocationLsn = 0;
 
-            static const ui32 SerializedSize = sizeof(ui64) * 7;
+            static const ui32 SerializedSize = sizeof(ui64) * 8;
+            static const ui32 OldSerializedSize = sizeof(ui64) * 7;
+
 
             THullHugeRecoveryLogPos(ui64 allocLsn, ui64 freeLsn, ui64 blobLoggedLsn,
                                     ui64 logoBlobsDelLsn, ui64 blocksDelLsn,
-                                    ui64 barriersDelLsn, ui64 entryLsn)
+                                    ui64 barriersDelLsn, ui64 entryLsn, ui64 hugeSlotsAllocationLsn)
                 : ChunkAllocationLsn(allocLsn)
                 , ChunkFreeingLsn(freeLsn)
                 , HugeBlobLoggedLsn(blobLoggedLsn)
@@ -34,13 +37,14 @@ namespace NKikimr {
                 , BlocksDbSlotDelLsn(blocksDelLsn)
                 , BarriersDbSlotDelLsn(barriersDelLsn)
                 , EntryPointLsn(entryLsn)
+                , HugeSlotsAllocationLsn(hugeSlotsAllocationLsn)
             {}
 
             THullHugeRecoveryLogPos(const THullHugeRecoveryLogPos &) = default;
             THullHugeRecoveryLogPos &operator=(const THullHugeRecoveryLogPos &) = default;
 
             static THullHugeRecoveryLogPos Default() {
-                return THullHugeRecoveryLogPos(0, 0, 0, 0, 0, 0, 0);
+                return THullHugeRecoveryLogPos(0, 0, 0, 0, 0, 0, 0, 0);
             }
 
             TString ToString() const;
@@ -73,6 +77,7 @@ namespace NKikimr {
         struct THullHugeKeeperPersState {
             typedef THashSet<NHuge::THugeSlot> TAllocatedSlots;
             static const ui32 Signature;
+            static const ui32 OldSignature;
 
             TIntrusivePtr<TVDiskContext> VCtx;
             // current pos
@@ -169,6 +174,10 @@ namespace NKikimr {
                         ui64 lsn,
                         const TDiskPartVec &rec,
                         ESlotDelDbType type);
+            TRlas ApplySlotsUsed(
+                        const TActorContext &ctx,
+                        ui64 lsn,
+                        const TDiskPartVec &parts);
             TRlas Apply(const TActorContext &ctx,
                         ui64 lsn,
                         const NHuge::TPutRecoveryLogRec &rec);

--- a/ydb/core/protos/blobstorage_vdisk_internal.proto
+++ b/ydb/core/protos/blobstorage_vdisk_internal.proto
@@ -75,6 +75,8 @@ message THullDbEntryPoint {
 
     // obsolete field
     repeated TUncommittedRemovedHugeBlob UncommittedRemovedHugeBlobs = 3;
+
+    optional TDiskPartVec AddedHugeBlobs = 4;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -675,24 +675,27 @@ private:
 
     void SwitchMode(EOperatingMode mode, TComputationContext& ctx) {
         switch(mode) {
-            case EOperatingMode::InMemory:
+            case EOperatingMode::InMemory: {
                 MKQL_ENSURE(false, "Internal logic error");
                 break;
-            case EOperatingMode::Spilling:
+            }
+            case EOperatingMode::Spilling: {
                 MKQL_ENSURE(EOperatingMode::InMemory == Mode, "Internal logic error");
                 SpilledBuckets.resize(SpilledBucketCount);
+                auto spiller = ctx.SpillerFactory->CreateSpiller();
                 for (auto &b: SpilledBuckets) {
-                    auto spiller = ctx.SpillerFactory->CreateSpiller();
                     b.SpilledState = std::make_unique<TWideUnboxedValuesSpillerAdapter>(spiller, KeyAndStateType, 5_MB);
                     b.SpilledData = std::make_unique<TWideUnboxedValuesSpillerAdapter>(spiller, UsedInputItemType, 5_MB);
                     b.InMemoryProcessingState = std::make_unique<TState>(MemInfo, KeyWidth, KeyAndStateType->GetElementsCount() - KeyWidth, Hasher, Equal);
                 }
                 SplitStateIntoBuckets();
                 break;
-            case EOperatingMode::ProcessSpilled:
+            }
+            case EOperatingMode::ProcessSpilled: {
                 MKQL_ENSURE(EOperatingMode::Spilling == Mode, "Internal logic error");
                 MKQL_ENSURE(SpilledBuckets.size() == SpilledBucketCount, "Internal logic error");
                 break;
+            }
 
         }
         Mode = mode;


### PR DESCRIPTION
This change introduces two new methods for huge slot allocations on the compaction:
* TEvHullHugeSlotsAllocate(map<SlotSize, count) to allocate new slots
* TEvHullHugeSlotsUsed(usedSlots, unusedSlots) to commit chunks related to the used slots 

This commit also introduces recovery mechanism for the huge keeper state to free up unused slots on failed compactions  