### PR TITLE
YQL-17072: fix Coalesce optimization on nested Optional

### DIFF
--- a/ydb/library/yql/minikql/mkql_opt_literal.cpp
+++ b/ydb/library/yql/minikql/mkql_opt_literal.cpp
@@ -240,10 +240,14 @@ TRuntimeNode OptimizeCoalesce(TCallable& callable, const TTypeEnvironment& env) 
 
     auto optionalInput = callable.GetInput(0);
     auto defaultInput = callable.GetInput(1);
+
+    bool isDefaultNonOptional = optionalInput.GetStaticType()
+        ->IsSameType(*TOptionalType::Create(defaultInput.GetStaticType(), env));
+
     if (optionalInput.HasValue()) {
         auto optionalData = AS_VALUE(TOptionalLiteral, optionalInput);
         if (optionalData->HasItem()) {
-            return optionalInput.GetStaticType()->IsSameType(*defaultInput.GetStaticType())  ? optionalInput : optionalData->GetItem();
+            return isDefaultNonOptional ? optionalData->GetItem() : optionalInput;
         } else {
             return defaultInput;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Coalesce has one of the following signatures:
```
COALESCE(T?, T)->T
COALESCE(T?, T?)->T?
```
It is incorrect to guess it's signature from checking if the last type is Optional. We have to compare argument types

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
