### PR TITLE
Add DUMP_LINKER_MAP and COMPILER_TIME_TRACE

### DIFF
--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -112,6 +112,12 @@ runs:
         
         echo "Build **{platform_name}-${BUILD_PRESET}** is running..." | .github/scripts/tests/comment-pr.py
         
+        # ya bloat support
+        extra_params+=(-DDUMP_LINKER_MAP)
+
+        # compiler profiling support
+        extra_params+=(-DCOMPILER_TIME_TRACE --add-result .json)
+
         # to be sure
         set -o pipefail
         

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -194,6 +194,13 @@ runs:
         # Also build targets which are not in tests' dependencies
         params+=(--no-strip-idle-build-results)
 
+
+        # ya bloat support
+        extra_params+=(-DDUMP_LINKER_MAP)
+
+        # compiler profiling support
+        extra_params+=(-DCOMPILER_TIME_TRACE --add-result .json)
+
         echo "::debug::get version"
         ./ya --version
         


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Add DUMP_LINKER_MAP for ya tool bloat usage and add COMPILER_TIME_TRACE for analyzing compilation time 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Difference in ydbd compilation time and build dir size:
Without new flags:
```
maxim-yurchuk@yurchuk-github:~/ydb$ date; ya make --build=relwithdebinfo ydb/apps/ydbd/ --rebuild ; date
Sun May 26 12:26:09 UTC 2024
<...>
Sun May 26 14:50:44 UTC 2024

maxim-yurchuk@yurchuk-github:~/ydb$ du -sh ~/.ya
55G     /home/maxim-yurchuk/.ya

maxim-yurchuk@yurchuk-github:~/ydb$ cat ydb/apps/ydbd/ydbd | wc -c
9153326336
```

With new flags:
```
maxim-yurchuk@yurchuk-github:~/ydb$ date; ya make --build=relwithdebinfo ydb/apps/ydbd/ --rebuild -DDUMP_LINKER_MAP -DCOMPILER_TIME_TRACE --add-result .json ; date
Sun May 26 14:53:23 UTC 2024
<...>
Sun May 26 17:30:55 UTC 2024

maxim-yurchuk@yurchuk-github:~$ du -sh .ya/
80G     .ya/

maxim-yurchuk@yurchuk-github:~/ydb$ cat ydb/apps/ydbd/ydbd | wc -c
9153326336

```
