### PR TITLE
Use persistent pipe cache for readset exchanges

### DIFF
--- a/ydb/core/base/tablet_pipecache.h
+++ b/ydb/core/base/tablet_pipecache.h
@@ -74,13 +74,23 @@ struct TEvPipeCache {
 
     struct TEvDeliveryProblem : public TEventLocal<TEvDeliveryProblem, EvDeliveryProblem> {
         const ui64 TabletId;
+        const bool Connected;
         const bool NotDelivered;
         const bool IsDeleted;
 
-        TEvDeliveryProblem(ui64 tabletId, bool notDelivered, bool isDeleted = false)
+        TEvDeliveryProblem(ui64 tabletId, bool connected, bool notDelivered, bool isDeleted)
             : TabletId(tabletId)
+            , Connected(connected)
             , NotDelivered(notDelivered)
             , IsDeleted(isDeleted)
+        {}
+
+        // For compatibility with existing tests
+        TEvDeliveryProblem(ui64 tabletId, bool notDelivered)
+            : TabletId(tabletId)
+            , Connected(notDelivered ? false : true)
+            , NotDelivered(notDelivered)
+            , IsDeleted(false)
         {}
     };
 

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -223,6 +223,7 @@ namespace NActors {
             return true;
         case NKikimr::TEvBlobStorage::EvNotReadyRetryTimeout:
         case NKikimr::TEvTabletPipe::EvClientRetry:
+        case NKikimr::TEvTabletPipe::EvClientCheckDelay:
         case NKikimr::TEvTabletBase::EvFollowerRetry:
         case NKikimr::TEvTabletBase::EvTryBuildFollowerGraph:
         case NKikimr::TEvTabletBase::EvTrySyncFollower:

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -102,9 +102,7 @@ public:
 TDataShard::TDataShard(const TActorId &tablet, TTabletStorageInfo *info)
     : TActor(&TThis::StateInit)
     , TTabletExecutedFlat(info, tablet, new TDataShardMiniKQLFactory(this))
-    , PipeClientCacheConfig(new NTabletPipe::TBoundedClientCacheConfig())
-    , PipeClientCache(NTabletPipe::CreateBoundedClientCache(PipeClientCacheConfig, GetPipeClientConfig()))
-    , ResendReadSetPipeTracker(*PipeClientCache)
+    , PersistentPipeCache(MakePipePeNodeCacheID(EPipePeNodeCache::Persistent))
     , SchemeShardPipeRetryPolicy({})
     , PathOwnerId(INVALID_TABLET_ID)
     , CurrentSchemeShardId(INVALID_TABLET_ID)
@@ -169,18 +167,6 @@ TDataShard::TDataShard(const TActorId &tablet, TTabletStorageInfo *info)
     TabletCounters = TabletCountersPtr.Get();
 
     RegisterDataShardProbes();
-}
-
-NTabletPipe::TClientConfig TDataShard::GetPipeClientConfig() {
-    NTabletPipe::TClientConfig config;
-    config.CheckAliveness = true;
-    config.RetryPolicy = {
-        .RetryLimitCount = 30,
-        .MinRetryTime = TDuration::MilliSeconds(10),
-        .MaxRetryTime = TDuration::MilliSeconds(500),
-        .BackoffMultiplier = 2,
-    };
-    return config;
 }
 
 void TDataShard::OnDetach(const TActorContext &ctx) {
@@ -258,7 +244,6 @@ void TDataShard::OnTabletDead(TEvTablet::TEvTabletDead::TPtr &ev, const TActorCo
 }
 
 void TDataShard::Cleanup(const TActorContext& ctx) {
-    //PipeClientCache->Detach(ctx);
     if (RegistrationSended) {
         ctx.Send(MakeMediatorTimecastProxyID(), new TEvMediatorTimecast::TEvUnsubscribeReadStep());
         ctx.Send(MakeMediatorTimecastProxyID(), new TEvMediatorTimecast::TEvUnregisterTablet(TabletID()));
@@ -272,6 +257,37 @@ void TDataShard::Cleanup(const TActorContext& ctx) {
             tx->KillAsyncJobActor(ctx);
         }
     }
+}
+
+void TDataShard::Die(const TActorContext& ctx) {
+    NTabletPipe::CloseAndForgetClient(SelfId(), SchemeShardPipe);
+    NTabletPipe::CloseAndForgetClient(SelfId(), StateReportPipe);
+    NTabletPipe::CloseAndForgetClient(SelfId(), DbStatsReportPipe);
+    NTabletPipe::CloseAndForgetClient(SelfId(), TableResolvePipe);
+
+    if (ReplicationSourceOffsetsServer) {
+        InvokeOtherActor(*ReplicationSourceOffsetsServer, &TReplicationSourceOffsetsServer::PassAway);
+    }
+
+    for (const TActorId& actorId : Actors) {
+        Send(actorId, new TEvents::TEvPoison);
+    }
+    Actors.clear();
+
+    KillChangeSender(ctx);
+    ChangeSenderActivator.Shutdown(ctx);
+    ChangeExchangeSplitter.Shutdown(ctx);
+
+    StopFindSubDomainPathId();
+    StopWatchingSubDomainPathId();
+    UnsubscribeReadIteratorSessions(ctx);
+
+    LoanReturnTracker.Shutdown(ctx);
+    Y_ABORT_UNLESS(LoanReturnTracker.Empty());
+    SplitSrcSnapshotSender.Shutdown(ctx);
+
+    Send(PersistentPipeCache, new TEvPipeCache::TEvUnlink(0));
+    return IActor::Die(ctx);
 }
 
 void TDataShard::IcbRegister() {
@@ -393,8 +409,6 @@ void TDataShard::SwitchToWork(const TActorContext &ctx) {
 }
 
 void TDataShard::SyncConfig() {
-    PipeClientCacheConfig->ClientPoolLimit = PipeClientCachePoolLimit();
-    PipeClientCache->PopWhileOverflow();
     // TODO[serxa]: dynamic prepared in fly
     //3=SetDynamicPreparedInFly(Config.GetFlowControl().GetPreparedInFlyMax());
 }
@@ -3282,17 +3296,6 @@ void TDataShard::Handle(TEvTabletPipe::TEvClientConnected::TPtr &ev, const TActo
         }
         return;
     }
-
-    if (!PipeClientCache->OnConnect(ev)) {
-        if (ev->Get()->Dead) {
-            AckRSToDeletedTablet(ev->Get()->TabletId, ctx);
-        } else {
-            LOG_NOTICE(ctx, NKikimrServices::TX_DATASHARD, "Failed to connect to tablet %" PRIu64 " from tablet %" PRIu64, ev->Get()->TabletId, TabletID());
-            RestartPipeRS(ev->Get()->TabletId, ctx);
-        }
-    } else {
-        LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "Connected to tablet %" PRIu64 " from tablet %" PRIu64, ev->Get()->TabletId, TabletID());
-    }
 }
 
 void TDataShard::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr &ev, const TActorContext &ctx) {
@@ -3335,35 +3338,55 @@ void TDataShard::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr &ev, const TActo
         ChangeSenderActivator.DoSend(ev->Get()->TabletId, ctx);
         return;
     }
-
-    LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "Client pipe to tablet %" PRIu64 " from %" PRIu64 " is reset", ev->Get()->TabletId, TabletID());
-    PipeClientCache->OnDisconnect(ev);
-    RestartPipeRS(ev->Get()->TabletId, ctx);
 }
 
-void TDataShard::RestartPipeRS(ui64 tabletId, const TActorContext& ctx) {
-    for (auto seqno : ResendReadSetPipeTracker.FindTx(tabletId)) {
-        if (seqno == Max<ui64>()) {
-            OutReadSets.ResendExpectations(tabletId, ctx);
-            continue;
-        }
+bool TDataShard::TPersistentTablet::IsEmpty() const {
+    return !Subscribed && OutReadSets.empty();
+}
 
-        LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "Pipe reset to tablet %" PRIu64 " caused resend of readset %" PRIu64
-            " at tablet %" PRIu64, tabletId, seqno, TabletID());
+TDataShard::TPersistentTablet& TDataShard::SendPersistent(ui64 tabletId, IEventBase* event, ui64 cookie) {
+    auto& state = PersistentTablets[tabletId];
+    Send(PersistentPipeCache,
+        new TEvPipeCache::TEvForward(event, tabletId, {
+                .AutoConnect = !state.Subscribed,
+                .Subscribe = !state.Subscribed,
+            }),
+        0, cookie);
+    state.Subscribed = true;
+    return state;
+}
 
-        ResendReadSetQueue.Progress(seqno, ctx);
+void TDataShard::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev, const TActorContext& ctx) {
+    auto* msg = ev->Get();
+
+    if (!msg->Connected) {
+        LOG_NOTICE_S(ctx, NKikimrServices::TX_DATASHARD, "Client pipe to tablet " << msg->TabletId
+            << " from " << TabletID() << " failed to connect (IsDeleted=" << (msg->IsDeleted ? "true" : "false") << ")");
+    } else {
+        LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, "Client pipe to tablet " << msg->TabletId
+            << " from " << TabletID() << " is reset");
     }
+
+    auto& state = PersistentTablets[msg->TabletId];
+    Y_DEBUG_ABORT_UNLESS(state.Subscribed);
+    state.Subscribed = false;
+
+    if (msg->IsDeleted) {
+        AckRSToDeletedTablet(msg->TabletId, state, ctx);
+    } else {
+        RestartPipeRS(msg->TabletId, state, ctx);
+    }
+
+    if (state.IsEmpty()) {
+        // Nothing left to track for this tablet
+        PersistentTablets.erase(msg->TabletId);
+    }
+
+    CheckStateChange(ctx);
 }
 
-void TDataShard::AckRSToDeletedTablet(ui64 tabletId, const TActorContext& ctx) {
-    bool detachExpectations = false;
-    for (auto seqno : ResendReadSetPipeTracker.FindTx(tabletId)) {
-        if (seqno == Max<ui64>()) {
-            AbortExpectationsFromDeletedTablet(tabletId, OutReadSets.RemoveExpectations(tabletId));
-            detachExpectations = true;
-            continue;
-        }
-
+void TDataShard::AckRSToDeletedTablet(ui64 tabletId, TPersistentTablet& state, const TActorContext& ctx) {
+    for (ui64 seqno : state.OutReadSets) {
         LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "Pipe reset to dead tablet %" PRIu64 " caused ack of readset %" PRIu64
             " at tablet %" PRIu64, tabletId, seqno, TabletID());
 
@@ -3376,12 +3399,11 @@ void TDataShard::AckRSToDeletedTablet(ui64 tabletId, const TActorContext& ctx) {
             PlanQueue.Progress(ctx);
         }
     }
+    state.OutReadSets.clear();
 
-    if (detachExpectations) {
-        ResendReadSetPipeTracker.DetachTablet(Max<ui64>(), tabletId, 0, ctx);
+    if (OutReadSets.HasExpectations(tabletId)) {
+        AbortExpectationsFromDeletedTablet(tabletId, OutReadSets.RemoveExpectations(tabletId));
     }
-
-    CheckStateChange(ctx);
 }
 
 void TDataShard::AbortExpectationsFromDeletedTablet(ui64 tabletId, THashMap<ui64, ui64>&& expectations) {
@@ -3390,6 +3412,24 @@ void TDataShard::AbortExpectationsFromDeletedTablet(ui64 tabletId, THashMap<ui64
         if (info && info->State == EVolatileTxState::Waiting && info->Participants.contains(tabletId)) {
             VolatileTxManager.AbortWaitingTransaction(info);
         }
+    }
+}
+
+void TDataShard::RestartPipeRS(ui64 tabletId, TPersistentTablet& state, const TActorContext& ctx) {
+    for (auto seqno : state.OutReadSets) {
+        if (seqno == Max<ui64>()) {
+            OutReadSets.ResendExpectations(tabletId, ctx);
+            continue;
+        }
+
+        LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "Pipe reset to tablet %" PRIu64 " caused resend of readset %" PRIu64
+            " at tablet %" PRIu64, tabletId, seqno, TabletID());
+
+        ResendReadSetQueue.Progress(seqno, ctx);
+    }
+
+    if (OutReadSets.HasExpectations(tabletId)) {
+        OutReadSets.ResendExpectations(tabletId, ctx);
     }
 }
 
@@ -3689,17 +3729,19 @@ void TDataShard::SendReadSet(
         const TActorContext& ctx,
         THolder<TEvTxProcessing::TEvReadSet>&& rs)
 {
+    ui64 seqno = rs->Record.GetSeqno();
     ui64 txId = rs->Record.GetTxId();
     ui64 source = rs->Record.GetTabletSource();
     ui64 target = rs->Record.GetTabletDest();
 
     LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD,
-                "Send RS at " << TabletID() << " from " << source << " to " << target << " txId " << txId);
+                "Send RS " << seqno << " at " << TabletID() << " from " << source << " to " << target << " txId " << txId);
 
     IncCounter(COUNTER_READSET_SENT_COUNT);
     IncCounter(COUNTER_READSET_SENT_SIZE, rs->Record.GetReadSet().size());
 
-    PipeClientCache->Send(ctx, target, rs.Release());
+    auto& state = SendPersistent(target, rs.Release());
+    state.OutReadSets.insert(seqno);
 }
 
 void TDataShard::SendReadSet(const TActorContext& ctx, ui64 step,
@@ -3711,20 +3753,11 @@ void TDataShard::SendReadSet(const TActorContext& ctx, ui64 step,
 }
 
 bool TDataShard::AddExpectation(ui64 target, ui64 step, ui64 txId) {
-    bool hadExpectations = OutReadSets.HasExpectations(target);
-    bool added = OutReadSets.AddExpectation(target, step, txId);
-    if (!hadExpectations) {
-        ResendReadSetPipeTracker.AttachTablet(Max<ui64>(), target);
-    }
-    return added;
+    return OutReadSets.AddExpectation(target, step, txId);
 }
 
 bool TDataShard::RemoveExpectation(ui64 target, ui64 txId) {
     bool removed = OutReadSets.RemoveExpectation(target, txId);
-    if (removed && !OutReadSets.HasExpectations(target)) {
-        auto ctx = ActorContext();
-        ResendReadSetPipeTracker.DetachTablet(Max<ui64>(), target, 0, ctx);
-    }
 
     // progress one more tx to force delayed schema operations
     if (removed && OutReadSets.Empty() && Pipeline.HasSchemaOperation()) {
@@ -3737,11 +3770,11 @@ bool TDataShard::RemoveExpectation(ui64 target, ui64 txId) {
     return removed;
 }
 
-void TDataShard::SendReadSetExpectation(const TActorContext& ctx, ui64 step, ui64 txId,
+void TDataShard::SendReadSetExpectation(const TActorContext&, ui64 step, ui64 txId,
                                         ui64 source, ui64 target)
 {
     auto ev = PrepareReadSetExpectation(step, txId, source, target);
-    PipeClientCache->Send(ctx, target, ev.Release());
+    SendPersistent(target, ev.Release());
 }
 
 std::unique_ptr<IEventHandle> TDataShard::GenerateReadSetNoData(const TActorId& recipient, ui64 step, ui64 txId, ui64 source, ui64 target)
@@ -3802,17 +3835,10 @@ bool TDataShard::ProcessReadSetExpectation(TEvTxProcessing::TEvReadSet::TPtr& ev
 void TDataShard::SendReadSets(const TActorContext& ctx,
                                      TVector<THolder<TEvTxProcessing::TEvReadSet>> &&readsets)
 {
-    TPendingPipeTrackerCommands pendingPipeTrackerCommands;
-
     for (auto &rs : readsets) {
-        ui64 target = rs->Record.GetTabletDest();
-        ui64 seqno = rs->Record.GetSeqno();
-
-        pendingPipeTrackerCommands.AttachTablet(seqno, target);
         SendReadSet(ctx, std::move(rs));
     }
 
-    pendingPipeTrackerCommands.Apply(ResendReadSetPipeTracker, ctx);
     readsets.clear();
 }
 
@@ -3823,7 +3849,6 @@ void TDataShard::ResendReadSet(const TActorContext& ctx, ui64 step, ui64 txId, u
                "Resend RS at " << TabletID() << " from " << source << " to " << target << " txId " << txId);
 
     SendReadSet(ctx, step, txId, source, target, body, seqNo);
-    ResendReadSetPipeTracker.AttachTablet(seqNo, target);
 }
 
 void TDataShard::UpdateLastSchemeOpSeqNo(const TSchemeOpSeqNo &newSeqNo,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Using the per-node pipe cache allows multiple shards to reuse the same connection to other shards.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Part of #4643.
