### PR TITLE
grace join spilling: fix reversed condition

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -1154,7 +1154,7 @@ bool TTable::TryToReduceMemoryAndWait() {
         }
     }
 
-    if (largestBucketSize) return false;
+    if (largestBucketSize == 0) return false;
 
     TableBucketsSpillers[largestBucketIndex].SpillBucket(std::move(TableBuckets[largestBucketIndex]));
     TableBuckets[largestBucketIndex] = TTableBucket{};


### PR DESCRIPTION
We want to spill largest block, not zero-sized block

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Only part of real fix (freezes execution somewhere afterwards, but main is not affected, this code is currently not enable/reachable)
