### PR TITLE
Use data() for getting pointer instead of begin()

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -256,7 +256,7 @@ static TCpuMask ParseAffinity(const TConfig& cfg) {
     if (cfg.GetCpuList()) {
         result = TCpuMask(cfg.GetCpuList());
     } else if (cfg.GetX().size() > 0) {
-        result = TCpuMask(cfg.GetX().begin(), cfg.GetX().size());
+        result = TCpuMask(cfg.GetX().data(), cfg.GetX().size());
     } else { // use all processors
         TAffinity available;
         available.Current();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Avoid this type of errors on upcoming protobuf
```
$(SOURCE_ROOT)/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp:261:18: error: no matching constructor for initialization of 'TCpuMask'
        result = TCpuMask(cfg.GetX().begin(), cfg.GetX().size());
                 ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$(SOURCE_ROOT)/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp:314:26: note: in instantiation of function template specialization 'NKikimr::NKikimrServicesInitializers::ParseAffinity<NKikimrConfig::TAffinity>' requested here
        basic.Affinity = ParseAffinity(poolConfig.GetAffinity());
                         ^
$(SOURCE_ROOT)/contrib/ydb/library/actors/util/cpumask.h:26:5: note: candidate template ignored: could not match 'const T *' against 'const_iterator' (aka 'RepeatedIterator<const unsigned int>')
    TCpuMask(const T* cpus, TCpuId size) {
    ^
$(SOURCE_ROOT)/contrib/ydb/library/actors/util/cpumask.h:20:14: note: candidate constructor not viable: requires single argument 'cpuId', but 2 arguments were provided
    explicit TCpuMask(TCpuId cpuId) {
             ^
$(SOURCE_ROOT)/contrib/ydb/library/actors/util/cpumask.h:34:14: note: candidate constructor not viable: requires single argument 'cpuList', but 2 arguments were provided
    explicit TCpuMask(const TString& cpuList) {
             ^
$(SOURCE_ROOT)/contrib/ydb/library/actors/util/cpumask.h:13:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
struct TCpuMask {
       ^
$(SOURCE_ROOT)/contrib/ydb/library/actors/util/cpumask.h:13:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
$(SOURCE_ROOT)/contrib/ydb/library/actors/util/cpumask.h:17:5: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
    TCpuMask() {}
    ^
1 error generated.
```
...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Additional information

...
