### PR TITLE
Make multiproto.py compatible with protobuf 3.20.0

### DIFF
--- a/ydb/library/yql/parser/proto_ast/gen/multiproto.py
+++ b/ydb/library/yql/parser/proto_ast/gen/multiproto.py
@@ -48,6 +48,8 @@ def main(argv):
                     out_file.write(line)
                 for line in in_file:
                     line=line.replace("inline ","")
+                    if 'Generated::' in line and line.endswith('_default_instance_._instance,\n'):
+                        line = f'reinterpret_cast<const ::_pb::Message*>({line.removesuffix('._instance,\n')}),'
                     if line.startswith("#"):
                         out_file.write(line)
                         continue
@@ -66,7 +68,8 @@ def main(argv):
                            in_class_def=False
                         continue
                     if line.startswith("PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT"):
-                        type_name=line.split(" ")[2]
+                        # MOD1 MOD2 MOD3 ... type_name varibale_name;
+                        type_name=line.split(" ")[-2]
                         if type_name in current_types:
                             out_file.write(line)
                         continue


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

```
$(BUILD_ROOT)/contrib/ydb/library/yql/parser/proto_ast/gen/v0_proto_split/SQLParser.pb.data.cc:5625:46: error: member access into incomplete type 'TTokenDefaultTypeInternal'
  &::NSQLGenerated::_TToken_default_instance_._instance,
                                             ^
$(BUILD_ROOT)/contrib/ydb/library/yql/parser/proto_ast/gen/v0_proto_split/SQLParser.pb.main.h:1709:8: note: forward declaration of 'NSQLGenerated::TTokenDefaultTypeInternal'
struct TTokenDefaultTypeInternal;
```
...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
