### PR TITLE
[dq] Use separate precompute execution state for each running graph

### DIFF
--- a/ydb/library/yql/providers/dq/provider/exec/yql_dq_exectransformer.cpp
+++ b/ydb/library/yql/providers/dq/provider/exec/yql_dq_exectransformer.cpp
@@ -432,8 +432,8 @@ class TDqExecTransformer: public TExecTransformerBase, TCounters
 public:
     TDqExecTransformer(const TDqStatePtr& state, const ISkiffConverterPtr& skiffConverter)
         : State(state)
-        , ExecState(MakeIntrusive<TExecState>())
         , SkiffConverter(skiffConverter)
+        , UploadCache_(std::make_shared<TUploadCache>())
     {
         AddHandler({TStringBuf("Result")}, RequireNone(), Hndl(&TDqExecTransformer::HandleResult));
         AddHandler({TStringBuf("Pull")}, RequireNone(), Hndl(&TDqExecTransformer::HandlePull));
@@ -442,15 +442,14 @@ public:
     }
 
     void Rewind() override {
-        ExecState = MakeIntrusive<TExecState>();
-        FileLinks.clear();
-        ModulesMapping.clear();
+        UploadCache_ = std::make_shared<TUploadCache>();
+        ExecPrecomputeStates_.clear();
 
         TExecTransformerBase::Rewind();
     }
 
 private:
-    struct TExecState : public TThrRefBase {
+    struct TExecPrecomputeState : public TThrRefBase {
         TAdaptiveLock Lock;
 
         struct TItem : public TIntrusiveListItem<TItem> {
@@ -458,13 +457,13 @@ private:
             TAsyncTransformCallback Callback;
         };
 
-        using TQueueType = TIntrusiveListWithAutoDelete<TExecState::TItem, TDelete>;
+        using TQueueType = TIntrusiveListWithAutoDelete<TExecPrecomputeState::TItem, TDelete>;
         TQueueType Completed;
         NThreading::TPromise<void> Promise = NThreading::NewPromise();
         bool HasResult = false;
     };
 
-    using TExecStatePtr = TIntrusivePtr<TExecState>;
+    using TExecPrecomputeStatePtr = TIntrusivePtr<TExecPrecomputeState>;
 
     void GetResultType(TString* type, TVector<TString>* columns, const TExprNode& resOrPull, const TExprNode& resOrPullInput) const
     {
@@ -492,16 +491,16 @@ private:
         if (path.StartsWith(NKikimr::NMiniKQL::StaticModulePrefix)
             || !State->Settings->EnableStrip.Get() || !State->Settings->EnableStrip.Get().GetOrElse(false))
         {
-            ModulesMapping.emplace(objectId, path);
+            UploadCache_->ModulesMapping.emplace(objectId, path);
             return std::make_tuple(path, objectId);
         }
 
-        TFileLinkPtr& fileLink = FileLinks[objectId];
+        TFileLinkPtr& fileLink = UploadCache_->FileLinks[objectId];
         if (!fileLink) {
             fileLink = State->FileStorage->PutFileStripped(path, md5);
         }
 
-        ModulesMapping.emplace(objectId  + DqStrippedSuffied, path);
+        UploadCache_->ModulesMapping.emplace(objectId  + DqStrippedSuffied, path);
 
         return std::make_tuple(fileLink->GetPath(), objectId + DqStrippedSuffied);
     }
@@ -869,7 +868,7 @@ private:
         ui64 executionTimeout = State->Settings->_LiteralTimeout.Get().GetOrElse(TDqSettings::TDefault::LiteralTimeout);
 
         try {
-            auto result = TMaybeNode<TResult>(input).Cast();
+            auto result = TResult(input);
 
             THashMap<TString, TString> resSettings;
             for (auto s: result.Settings()) {
@@ -878,19 +877,9 @@ private:
                 }
             }
 
-            auto precomputes = FindIndependentPrecomputes(result.Input().Ptr());
-            if (!precomputes.empty()) {
-                auto status = HandlePrecomputes(precomputes, ctx, resSettings, executionTimeout);
-                if (status.Level != TStatus::Ok) {
-                    if (status == TStatus::Async) {
-                        return std::make_pair(status, ExecState->Promise.GetFuture().Apply([execState = ExecState](const TFuture<void>& completedFuture) {
-                            completedFuture.GetValue();
-                            return HandlePrecomputeAsyncComplete(execState);
-                        }));
-                    } else {
-                        return SyncStatus(status);
-                    }
-                }
+            auto statusPair = HandlePrecomputes(result, resSettings, executionTimeout, ctx);
+            if (statusPair.first.Level != TStatus::Ok) {
+                return statusPair;
             }
 
             IDataProvider::TFillSettings fillSettings = NCommon::GetFillSettings(result.Ref());
@@ -1009,7 +998,7 @@ private:
                     graphParams["Evaluation"] = ToString(!ctx.Step.IsDone(TExprStep::ExprEval));
                     future = State->ExecutePlan(
                         State->SessionId, executionPlanner->GetPlan(), columns, secureParams, graphParams,
-                        settings, progressWriter, ModulesMapping, fillSettings.Discard, executionTimeout);
+                        settings, progressWriter, UploadCache_->ModulesMapping, fillSettings.Discard, executionTimeout);
                 }
             }
 
@@ -1273,19 +1262,9 @@ private:
         auto publicIds = GetPublicIds(pull.Ptr());
         YQL_ENSURE(!oneGraphPerQuery || publicIds->GraphsCount == 1, "Internal error: only one graph per query is allowed");
 
-        auto precomputes = FindIndependentPrecomputes(pull.Input().Ptr());
-        if (!precomputes.empty()) {
-            auto status = HandlePrecomputes(precomputes, ctx, pullSettings, executionTimeout);
-            if (status.Level != TStatus::Ok) {
-                if (status == TStatus::Async) {
-                    return std::make_pair(status, ExecState->Promise.GetFuture().Apply([execState = ExecState](const TFuture<void>& completedFuture) {
-                        completedFuture.GetValue();
-                        return HandlePrecomputeAsyncComplete(execState);
-                    }));
-                } else {
-                    return SyncStatus(status);
-                }
-            }
+        auto statusPair = HandlePrecomputes(pull, pullSettings, executionTimeout, ctx);
+        if (statusPair.first.Level != TStatus::Ok) {
+            return statusPair;
         }
 
         TString type;
@@ -1456,7 +1435,7 @@ private:
         IDqGateway::TDqProgressWriter progressWriter = MakeDqProgressWriter(publicIds);
 
         auto future = State->ExecutePlan(State->SessionId, executionPlanner->GetPlan(), columns, secureParams, graphParams,
-            settings, progressWriter, ModulesMapping, fillSettings.Discard, executionTimeout);
+            settings, progressWriter, UploadCache_->ModulesMapping, fillSettings.Discard, executionTimeout);
 
         future.Subscribe([publicIds, progressWriter = State->ProgressWriter](const NThreading::TFuture<IDqGateway::TResult>& completedFuture) {
             YQL_ENSURE(!completedFuture.HasException());
@@ -1756,8 +1735,8 @@ private:
         return hasPrecompute;
     }
 
-    static void CompleteNode(const TExecStatePtr& execState, TExprNode* node, const TAsyncTransformCallback& callback) {
-        auto item = MakeHolder<TExecState::TItem>();
+    static void CompleteNode(const TExecPrecomputeStatePtr& execState, TExprNode* node, const TAsyncTransformCallback& callback) {
+        auto item = MakeHolder<TExecPrecomputeState::TItem>();
         item->Node = node;
         item->Callback = callback;
 
@@ -1775,15 +1754,14 @@ private:
         }
     }
 
-    static TAsyncTransformCallback HandlePrecomputeAsyncComplete(TExecStatePtr execState) {
+    static TAsyncTransformCallback HandlePrecomputeAsyncComplete(TExecPrecomputeStatePtr execState) {
         return TAsyncTransformCallback([execState](const TExprNode::TPtr& input, TExprNode::TPtr& output, TExprContext& ctx) {
             output = input;
             input->SetState(TExprNode::EState::ExecutionRequired);
             TStatus combinedStatus = TStatus::Repeat;
-            TExecState::TQueueType completed;
+            TExecPrecomputeState::TQueueType completed;
             auto newPromise = NThreading::NewPromise();
-            {
-                TGuard<TAdaptiveLock> guard(execState->Lock);
+            with_lock(execState->Lock) {
                 completed.Swap(execState->Completed);
                 execState->Promise.Swap(newPromise);
                 execState->HasResult = false;
@@ -1802,7 +1780,7 @@ private:
         });
     }
 
-    IGraphTransformer::TStatus HandlePrecomputes(const TNodeOnNodeOwnedMap& precomputes, TExprContext& ctx, const THashMap<TString, TString>& providerParams, ui64 executionTimeout) {
+    IGraphTransformer::TStatus RunPrecomputes(const TNodeOnNodeOwnedMap& precomputes, TExecPrecomputeStatePtr execState, TExprContext& ctx, const THashMap<TString, TString>& providerParams, ui64 executionTimeout) {
 
         IDataProvider::TFillSettings fillSettings;
         fillSettings.AllResultsBytesLimit.Clear();
@@ -1852,7 +1830,7 @@ private:
                 }
                 YQL_CLOG(DEBUG, ProviderDq) << "Freezing files for " << input->Content();
                 if (filesRes.first.Level == TStatus::Async) {
-                    filesRes.second.Subscribe([execState = ExecState, node = input.Get(), logCtx](const TAsyncTransformCallbackFuture& future) {
+                    filesRes.second.Subscribe([execState, node = input.Get(), logCtx](const TAsyncTransformCallbackFuture& future) {
                         YQL_LOG_CTX_ROOT_SESSION_SCOPE(logCtx);
                         YQL_ENSURE(!future.HasException());
                         YQL_CLOG(DEBUG, ProviderDq) << "Finishing freezing files";
@@ -1970,12 +1948,12 @@ private:
             IDqGateway::TDqProgressWriter progressWriter = MakeDqProgressWriter(publicIds);
 
             auto future = State->ExecutePlan(State->SessionId, executionPlanner->GetPlan(), {}, secureParams, graphParams,
-                settings, progressWriter, ModulesMapping, false, executionTimeout);
+                settings, progressWriter, UploadCache_->ModulesMapping, false, executionTimeout);
 
             executionPlanner.Destroy();
 
             bool neverFallback = settings->FallbackPolicy.Get().GetOrElse(EFallbackPolicy::Default) == EFallbackPolicy::Never;
-            future.Subscribe([publicIds, state = State, startTime, execState = ExecState, node = input.Get(), neverFallback, logCtx](const NThreading::TFuture<IDqGateway::TResult>& completedFuture) {
+            future.Subscribe([publicIds, state = State, startTime, execState, node = input.Get(), neverFallback, logCtx](const NThreading::TFuture<IDqGateway::TResult>& completedFuture) {
                 YQL_LOG_CTX_ROOT_SESSION_SCOPE(logCtx);
                 YQL_ENSURE(!completedFuture.HasException());
                 const IDqGateway::TResult& res = completedFuture.GetValueSync();
@@ -2049,6 +2027,31 @@ private:
         return combinedStatus;
     }
 
+    TStatusCallbackPair HandlePrecomputes(const TResOrPullBase& resOrPull, const THashMap<TString, TString>& settings, ui64 executionTimeout, TExprContext& ctx) {
+        TStatus status = TStatus::Ok;
+        auto precomputes = FindIndependentPrecomputes(resOrPull.Input().Ptr());
+        if (!precomputes.empty()) {
+            auto& execPrecomputeState = ExecPrecomputeStates_[resOrPull.Raw()];
+            if (!execPrecomputeState) {
+                YQL_CLOG(TRACE, ProviderDq) << "Create exec state for #" << resOrPull.Raw()->UniqueId();
+                execPrecomputeState = MakeIntrusive<TExecPrecomputeState>();
+            } else {
+                YQL_CLOG(TRACE, ProviderDq) << "Reuse exec state for #" << resOrPull.Raw()->UniqueId();
+            }
+            status = RunPrecomputes(precomputes, execPrecomputeState, ctx, settings, executionTimeout);
+            YQL_CLOG(TRACE, ProviderDq) << "RunPrecomputes returns status " << status;
+            if (status == TStatus::Async) {
+                return std::make_pair(status, execPrecomputeState->Promise.GetFuture().Apply([execPrecomputeState](const TFuture<void>& completedFuture) {
+                    completedFuture.GetValue();
+                    return HandlePrecomputeAsyncComplete(execPrecomputeState);
+                }));
+            }
+        }
+        YQL_CLOG(TRACE, ProviderDq) << "Erase exec state for #" << resOrPull.Raw()->UniqueId();
+        ExecPrecomputeStates_.erase(resOrPull.Raw());
+        return SyncStatus(status);
+    }
+
     IGraphTransformer::TStatus PeepHole(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx,
         const THashMap<TString, TString>& providerParams, const TPublicIds::TPtr& publicIds) const
     {
@@ -2069,10 +2072,9 @@ private:
 
 private:
     TDqStatePtr State;
-    TExecStatePtr ExecState;
     ISkiffConverterPtr SkiffConverter;
-    mutable THashMap<TString, TFileLinkPtr> FileLinks;
-    mutable THashMap<TString, TString> ModulesMapping;
+    TUploadCache::TPtr UploadCache_;
+    TNodeMap<TExecPrecomputeStatePtr> ExecPrecomputeStates_;
 
     const ui64 MaxFileReadSize = 1_MB;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
