### PR TITLE
Leaking 'PartitionWriterCacheActor`

### DIFF
--- a/ydb/services/persqueue_v1/actors/partition_writer_cache_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_writer_cache_actor.cpp
@@ -204,6 +204,8 @@ void TPartitionWriterCacheActor::Handle(TEvents::TEvPoisonPill::TPtr& ev, const 
     for (auto& [_, writer] : Writers) {
         ctx.Send(writer->Actor, new TEvents::TEvPoisonPill());
     }
+
+    Die(ctx);
 }
 
 auto TPartitionWriterCacheActor::GetPartitionWriter(const TString& sessionId, const TString& txId,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The `Die` call was missing. As a result, the `TPartitionWriterCacheActor` destructor was not called

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
