### PR TITLE
Fix put_build_results_to_cache=false

### DIFF
--- a/.github/actions/build_and_test_ya/action.yml
+++ b/.github/actions/build_and_test_ya/action.yml
@@ -112,8 +112,9 @@ runs:
         build_target: ${{ inputs.build_target }}
         build_preset: ${{ inputs.build_preset }}
         bazel_remote_uri: ${{  fromJSON( inputs.vars ).REMOTE_CACHE_URL || '' }}
-        bazel_remote_username: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_USERNAME || '' }}
-        bazel_remote_password: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
+        bazel_remote_username: ${{ fromJSON( inputs.secs ).REMOTE_CACHE_USERNAME || '' }}
+        bazel_remote_password: ${{ fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
+        put_build_results_to_cache: ${{ inputs.put_build_results_to_cache }}
         link_threads: ${{ inputs.link_threads }}
         additional_ya_make_args: ${{ inputs.additional_ya_make_args }}
 

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -65,7 +65,7 @@ runs:
         if [ ! -z "${{ inputs.build_target }}" ]; then
           extra_params+=(--target="${{ inputs.build_target }}")
         fi
-        
+
         if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
           extra_params+=(--bazel-remote-store)
           extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -66,7 +66,7 @@ runs:
           extra_params+=(--target="${{ inputs.build_target }}")
         fi
 
-        if [ "${{ inputs.put_build_results_to_cache }}" != "false" ]; then
+        if [ "${{ inputs.put_build_results_to_cache }}" = "true" ]; then
           extra_params+=(--bazel-remote-store)
           extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
         fi

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -8,6 +8,9 @@ inputs:
     required: true
     default: "relwithdebinfo"
     description: "debug, relwithdebinfo, release-asan, release-tsan, release, release-cmake14"
+  put_build_results_to_cache:
+    required: false
+    default: "true"
   bazel_remote_uri:
     required: false
     description: "bazel-remote endpoint"
@@ -63,7 +66,7 @@ runs:
           extra_params+=(--target="${{ inputs.build_target }}")
         fi
 
-        if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
+        if [ "${{ inputs.put_build_results_to_cache }}" != "false" ]; then
           extra_params+=(--bazel-remote-store)
           extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
         fi

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -65,13 +65,13 @@ runs:
         if [ ! -z "${{ inputs.build_target }}" ]; then
           extra_params+=(--target="${{ inputs.build_target }}")
         fi
-
-        if [ "${{ inputs.put_build_results_to_cache }}" = "true" ]; then
+        
+        if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
           extra_params+=(--bazel-remote-store)
           extra_params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
         fi
         
-        if [ ! -z "${{ inputs.bazel_remote_username }}" ]; then
+        if [ "${{ inputs.put_build_results_to_cache }}" = "true" ]; then
           extra_params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
           extra_params+=(--bazel-remote-password "${{ inputs.bazel_remote_password }}")
           extra_params+=(--bazel-remote-put --dist-cache-evict-bins --add-result .o --add-result .a)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

put_build_results_to_cache=false setting now has effect 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
