### PR TITLE
Make remaining group amount calculator consider decommission (merge from main #4942)

### DIFF
--- a/ydb/core/mind/bscontroller/storage_stats_calculator.cpp
+++ b/ydb/core/mind/bscontroller/storage_stats_calculator.cpp
@@ -136,16 +136,17 @@ public:
                         const auto readCentric = pdisk.HasReadCentric() ? MakeMaybe(pdisk.GetReadCentric()) : Nothing();
                         if (filter.MatchPDisk(pdisk.GetCategory(), sharedWithOs, readCentric)) {
                             const TNodeLocation& location = HostRecordMap->GetLocation(pdiskId.NodeId);
+                            const bool usable = pdisk.GetDecommitStatus() == "DECOMMIT_NONE";
                             const bool ok = mapper.RegisterPDisk({
                                 .PDiskId = pdiskId,
                                 .Location = location,
-                                .Usable = true,
+                                .Usable = usable,
                                 .NumSlots = pdisk.GetNumActiveSlots(),
                                 .MaxSlots = pdisk.GetExpectedSlotCount(),
                                 .Groups = {},
                                 .SpaceAvailable = 0,
                                 .Operational = true,
-                                .Decommitted = false,
+                                .Decommitted = false, // this flag applies only to group reconfiguration
                             });
                             Y_ABORT_UNLESS(ok);
                             break;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make remaining group amount calculator consider decommission

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Decommission status is taken into account too while calculating AvailableGroupsToCreate.
