### PR TITLE
Cleanup persistent locks on table rename

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -1,5 +1,6 @@
 #include "datashard_impl.h"
 #include "datashard_txs.h"
+#include "datashard_locks_db.h"
 #include "probes.h"
 
 #include <ydb/core/base/interconnect_channels.h>
@@ -1705,7 +1706,9 @@ TUserTable::TPtr TDataShard::MoveUserTable(TOperation::TPtr op, const NKikimrTxD
     newTableInfo->StatsUpdateInProgress = false;
     newTableInfo->StatsNeedUpdate = true;
 
-    RemoveUserTable(prevId);
+    TDataShardLocksDb locksDb(*this, txc);
+
+    RemoveUserTable(prevId, &locksDb);
     AddUserTable(newId, newTableInfo);
 
     for (auto& [_, record] : ChangesQueue) {

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1621,10 +1621,10 @@ public:
         return nullptr;
     }
 
-    void RemoveUserTable(const TPathId& tableId) {
-        TableInfos.erase(tableId.LocalPathId);
-        SysLocks.RemoveSchema(tableId);
+    void RemoveUserTable(const TPathId& tableId, ILocksDb* locksDb) {
+        SysLocks.RemoveSchema(tableId, locksDb);
         Pipeline.GetDepTracker().RemoveSchema(tableId);
+        TableInfos.erase(tableId.LocalPathId);
     }
 
     void AddUserTable(const TPathId& tableId, TUserTable::TPtr tableInfo) {

--- a/ydb/core/tx/datashard/datashard_locks_db.cpp
+++ b/ydb/core/tx/datashard/datashard_locks_db.cpp
@@ -2,4 +2,39 @@
 
 namespace NKikimr::NDataShard {
 
+void TDataShardLocksDb::PersistRemoveLock(ui64 lockId) {
+    // We remove lock changes unless it's managed by volatile tx manager
+    bool isVolatile = Self.GetVolatileTxManager().FindByCommitTxId(lockId);
+    if (!isVolatile) {
+        for (auto& pr : Self.GetUserTables()) {
+            auto tid = pr.second->LocalTid;
+            // Removing the lock also removes any uncommitted data
+            if (DB.HasOpenTx(tid, lockId)) {
+                DB.RemoveTx(tid, lockId);
+                Self.GetConflictsCache().GetTableCache(tid).RemoveUncommittedWrites(lockId, DB);
+            }
+        }
+    }
+
+    using Schema = TDataShard::Schema;
+    NIceDb::TNiceDb db(DB);
+    db.Table<typename Schema::Locks>().Key(lockId).Delete();
+    HasChanges_ = true;
+
+    if (!isVolatile) {
+        Self.ScheduleRemoveLockChanges(lockId);
+    }
+}
+
+bool TDataShardLocksDb::MayAddLock(ui64 lockId) {
+    for (auto& pr : Self.GetUserTables()) {
+        auto tid = pr.second->LocalTid;
+        // We cannot start a new lockId if it has any uncompacted data
+        if (DB.HasTxData(tid, lockId)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace NKikimr::NDataShard

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -591,7 +591,7 @@ public:
     }
 
     void UpdateSchema(const TPathId& tableId, const TVector<NScheme::TTypeInfo>& keyColumnTypes);
-    void RemoveSchema(const TPathId& tableId);
+    void RemoveSchema(const TPathId& tableId, ILocksDb* db);
     bool ForceShardLock(const TPathId& tableId) const;
     bool ForceShardLock(const TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables) const;
 
@@ -830,8 +830,8 @@ public:
         Locker.UpdateSchema(tableId, keyColumnTypes);
     }
 
-    void RemoveSchema(const TPathId& tableId) {
-        Locker.RemoveSchema(tableId);
+    void RemoveSchema(const TPathId& tableId, ILocksDb* db) {
+        Locker.RemoveSchema(tableId, db);
     }
 
     TVector<TLock> ApplyLocks();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Cleanup persistent locks on table rename.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Uncommitted changes may have lingered after a table is renamed. In the worst case persistent locks could become resurrected after a shard is restarted, causing an invariant assertion during a commit attempt.

Fixes #4782.