### PR TITLE
Use StateStorage proxy stub to prevent incorrect replies while initially configuring

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -166,13 +166,8 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
     const bool changedStateStorage = !StateStorageProxyConfigured || changed(*StateStorageInfo, *stateStorageInfo);
     const bool changedBoard = !StateStorageProxyConfigured || changed(*BoardInfo, *boardInfo);
     const bool changedSchemeBoard = !StateStorageProxyConfigured || changed(*SchemeBoardInfo, *schemeBoardInfo);
-    if (changedStateStorage || changedBoard || changedSchemeBoard) { // reconfigure proxy
-        STLOG(PRI_INFO, BS_NODE, NW50, "updating state storage proxy configuration");
-        Send(MakeStateStorageProxyID(), new TEvStateStorage::TEvUpdateGroupConfig(stateStorageInfo, boardInfo,
-            schemeBoardInfo));
-        StateStorageProxyConfigured = true;
-    } else { // no changes
-        return;
+    if (!changedStateStorage && !changedBoard && !changedSchemeBoard) {
+        return; // no changes
     }
 
     // start new replicas if needed
@@ -224,6 +219,19 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
         STLOG(PRI_INFO, BS_NODE, NW43, "terminating useless state storage replica", (ReplicaId, replicaId));
         const TActorId actorId = as->RegisterLocalService(actorId, TActorId());
         TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, actorId, SelfId(), nullptr, 0));
+    }
+
+    // reconfigure proxy
+    STLOG(PRI_INFO, BS_NODE, NW50, "updating state storage proxy configuration");
+    if (StateStorageProxyConfigured) {
+        Send(MakeStateStorageProxyID(), new TEvStateStorage::TEvUpdateGroupConfig(StateStorageInfo, BoardInfo,
+            SchemeBoardInfo));
+    } else {
+        const TActorId newInstance = as->Register(CreateStateStorageProxy(StateStorageInfo, BoardInfo, SchemeBoardInfo),
+            TMailboxType::ReadAsFilled, AppData()->SystemPoolId);
+        const TActorId stubInstance = as->RegisterLocalService(MakeStateStorageProxyID(), newInstance);
+        TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, stubInstance, newInstance, nullptr, 0));
+        StateStorageProxyConfigured = true;
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Use StateStorage proxy stub to prevent incorrect replies while initially configuring

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Now StateStorage proxy holds pending requests and sends them to the real proxy after it is configured initially.
