### PR TITLE
quota and consumption for hdd storage types

### DIFF
--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -344,6 +344,8 @@ message TStorageUsage {
     EType Type = 1;
     uint64 Size = 2;
     uint64 Limit = 3;
+    uint64 SoftQuota = 4;
+    uint64 HardQuota = 5;
 }
 
 message TTenant {
@@ -375,7 +377,6 @@ message TTenant {
     uint64 StorageAllocatedLimit = 41;
     Ydb.Cms.DatabaseQuotas DatabaseQuotas = 42;
     repeated TStorageUsage StorageUsage = 43;
-    repeated TStorageUsage QuotaUsage = 44;
 }
 
 message TTenants {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

https://github.com/ydb-platform/ydb/issues/4611#issuecomment-2141624326
I'm going to remove QuotaUsage field like before and combine info from it with StorageUsage instead
I would suggest that Size and Limit will go to the main Info card, and quotas will go to the details.

If there is information about size, return storage information.
If there are quotas, return limit and quotas.

The pool type is specified in the config. It's a String that don't have to be like SSD or HDD. So I added the block None in case the name is not parsed correctly - this usage and quotas will go to None.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
