### PR TITLE
YQL-18052: Implement Arrow IO spec for purecalc

### DIFF
--- a/ydb/library/yql/public/purecalc/common/interface.h
+++ b/ydb/library/yql/public/purecalc/common/interface.h
@@ -784,6 +784,8 @@ namespace NYql {
 
                 return AllVirtualColumns_;
             }
+
+            static constexpr bool ProvidesBlocks = false;
         };
 
         /**
@@ -827,6 +829,8 @@ namespace NYql {
             void SetOutputColumnsFilter(const TMaybe<THashSet<TString>>& outputColumnsFilter) {
                 OutputColumnsFilter_ = outputColumnsFilter;
             }
+
+            static constexpr bool AcceptsBlocks = false;
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -1,0 +1,1 @@
+#include "spec.h"

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -1,6 +1,230 @@
 #include "spec.h"
 
+#include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
+#include <ydb/library/yql/minikql/computation/mkql_custom_list.h>
+#include <ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h>
+#include <ydb/library/yql/utils/yql_panic.h>
+
 using namespace NYql::NPureCalc;
+using namespace NKikimr::NUdf;
+using namespace NKikimr::NMiniKQL;
+
+using IArrowIStream = typename TInputSpecTraits<TArrowInputSpec>::IInputStream;
+using InputItemType = typename TInputSpecTraits<TArrowInputSpec>::TInputItemType;
+using OutputItemType = typename TOutputSpecTraits<TArrowOutputSpec>::TOutputItemType;
+using PullListReturnType = typename TOutputSpecTraits<TArrowOutputSpec>::TPullListReturnType;
+
+namespace {
+
+class TArrowIStreamImpl : public IArrowIStream {
+private:
+    IArrowIStream* Underlying_;
+    // If we own Underlying_, than Owned_ == Underlying_;
+    // otherwise Owned_ is nullptr.
+    THolder<IArrowIStream> Owned_;
+
+    TArrowIStreamImpl(IArrowIStream* underlying, THolder<IArrowIStream> owned)
+        : Underlying_(underlying)
+        , Owned_(std::move(owned))
+    {
+    }
+
+public:
+    TArrowIStreamImpl(THolder<IArrowIStream> stream)
+        : TArrowIStreamImpl(stream.Get(), nullptr)
+    {
+        Owned_ = std::move(stream);
+    }
+
+    TArrowIStreamImpl(IArrowIStream* stream)
+        : TArrowIStreamImpl(stream, nullptr)
+    {
+    }
+
+    InputItemType Fetch() {
+        return Underlying_->Fetch();
+    }
+};
+
+
+/**
+ * Converts input Datums to unboxed values.
+ */
+class TArrowInputConverter {
+protected:
+    IWorker* Worker_;
+    const THolderFactory& Factory_;
+
+public:
+    explicit TArrowInputConverter(
+        const TArrowInputSpec& inputSpec,
+        IWorker* worker
+    )
+        : Worker_(worker)
+        , Factory_(Worker_->GetGraph().GetHolderFactory())
+    {
+        Y_UNUSED(inputSpec);
+    }
+
+    void DoConvert(arrow::compute::ExecBatch* batch, TUnboxedValue& result) {
+        ui64 nvalues = batch->num_values();
+        TUnboxedValue* datums = nullptr;
+        result = Factory_.CreateDirectArrayHolder(nvalues, datums);
+        for (ui64 i = 0; i < nvalues; i++) {
+            datums[i] = Factory_.CreateArrowBlock(std::move(batch->values[i]));
+        }
+    }
+};
+
+
+/**
+ * Converts unboxed values to output Datums (single-output program case).
+ */
+class TArrowOutputConverter {
+protected:
+    IWorker* Worker_;
+    const THolderFactory& Factory_;
+    const NYT::TNode& Schema_;
+    THolder<arrow::compute::ExecBatch> Batch_;
+
+public:
+    explicit TArrowOutputConverter(
+        const TArrowOutputSpec& outputSpec,
+        IWorker* worker
+    )
+        : Worker_(worker)
+        , Factory_(worker->GetGraph().GetHolderFactory())
+        , Schema_(outputSpec.GetSchema())
+    {
+        Batch_.Reset(new arrow::compute::ExecBatch);
+    }
+
+    OutputItemType DoConvert(TUnboxedValue value) {
+        OutputItemType batch = Batch_.Get();
+        ui64 nvalues = Schema_.Size();
+        TVector<arrow::Datum> datums(nvalues);
+        for (ui32 i = 0; i < nvalues; i++) {
+            datums[i] = TArrowBlock::From(value.GetElement(i)).GetDatum();
+        }
+        *batch = ARROW_RESULT(arrow::compute::ExecBatch::Make(datums));
+        return batch;
+    }
+};
+
+
+/**
+ * List (or, better, stream) of unboxed values.
+ * Used as an input value in pull workers.
+ */
+class TArrowListValue final: public TCustomListValue {
+private:
+    mutable bool HasIterator_ = false;
+    THolder<IArrowIStream> Underlying_;
+    IWorker* Worker_;
+    TArrowInputConverter Converter_;
+    TScopedAlloc& ScopedAlloc_;
+
+public:
+    TArrowListValue(
+        TMemoryUsageInfo* memInfo,
+        const TArrowInputSpec& inputSpec,
+        THolder<IArrowIStream> underlying,
+        IWorker* worker
+    )
+      : TCustomListValue(memInfo)
+      , Underlying_(std::move(underlying))
+      , Worker_(worker)
+      , Converter_(inputSpec, Worker_)
+      , ScopedAlloc_(Worker_->GetScopedAlloc())
+    {
+    }
+
+    ~TArrowListValue() override {
+        {
+            // This list value stored in the worker's computation graph and
+            // destroyed upon the computation graph's destruction. This brings
+            // us to an interesting situation: scoped alloc is acquired, worker
+            // and computation graph are half-way destroyed, and now it's our
+            // turn to die. The problem is, the underlying stream may own
+            // another worker. This happens when chaining programs. Now, to
+            // destroy that worker correctly, we need to release our scoped
+            // alloc (because that worker has its own computation graph and
+            // scoped alloc).
+            // By the way, note that we shouldn't interact with the worker here
+            // because worker is in the middle of its own destruction. So we're
+            // using our own reference to the scoped alloc. That reference is
+            // alive because scoped alloc destroyed after computation graph.
+            auto unguard = Unguard(ScopedAlloc_);
+            Underlying_.Destroy();
+        }
+    }
+
+    TUnboxedValue GetListIterator() const override {
+        YQL_ENSURE(!HasIterator_, "Only one pass over input is supported");
+        HasIterator_ = true;
+        return TUnboxedValuePod(const_cast<TArrowListValue*>(this));
+    }
+
+    bool Next(TUnboxedValue& result) override {
+        arrow::compute::ExecBatch* batch;
+        {
+            auto unguard = Unguard(ScopedAlloc_);
+            batch = Underlying_->Fetch();
+        }
+
+        if (!batch) {
+            return false;
+        }
+
+        Converter_.DoConvert(batch, result);
+        return true;
+    }
+
+    EFetchStatus Fetch(TUnboxedValue& result) override {
+        if (Next(result)) {
+            return EFetchStatus::Ok;
+        } else {
+            return EFetchStatus::Finish;
+        }
+    }
+};
+
+
+/**
+ * Arrow input stream for unboxed value lists.
+ */
+class TArrowListImpl final: public IStream<OutputItemType> {
+protected:
+    TWorkerHolder<IPullListWorker> WorkerHolder_;
+    TArrowOutputConverter Converter_;
+
+public:
+    explicit TArrowListImpl(
+        const TArrowOutputSpec& outputSpec,
+        TWorkerHolder<IPullListWorker> worker
+    )
+        : WorkerHolder_(std::move(worker))
+        , Converter_(outputSpec, WorkerHolder_.Get())
+    {
+    }
+
+    OutputItemType Fetch() override {
+        TBindTerminator bind(WorkerHolder_->GetGraph().GetTerminator());
+
+        with_lock(WorkerHolder_->GetScopedAlloc()) {
+            TUnboxedValue value;
+
+            if (!WorkerHolder_->GetOutputIterator().Next(value)) {
+                return TOutputSpecTraits<TArrowOutputSpec>::StreamSentinel;
+            }
+
+            return Converter_.DoConvert(value);
+        }
+    }
+};
+
+} // namespace
+
 
 TArrowInputSpec::TArrowInputSpec(const TVector<NYT::TNode>& schemas)
     : Schemas_(schemas)
@@ -11,6 +235,28 @@ const TVector<NYT::TNode>& TArrowInputSpec::GetSchemas() const {
     return Schemas_;
 }
 
+
+void TInputSpecTraits<TArrowInputSpec>::PreparePullListWorker(
+    const TArrowInputSpec& inputSpec, IPullListWorker* worker,
+    IArrowIStream* stream
+) {
+    with_lock(worker->GetScopedAlloc()) {
+        worker->SetInput(worker->GetGraph().GetHolderFactory()
+            .Create<TArrowListValue>(inputSpec, MakeHolder<TArrowIStreamImpl>(stream), worker), 0);
+    }
+}
+
+void TInputSpecTraits<TArrowInputSpec>::PreparePullListWorker(
+    const TArrowInputSpec& inputSpec, IPullListWorker* worker,
+    THolder<IArrowIStream> stream
+) {
+    with_lock(worker->GetScopedAlloc()) {
+        worker->SetInput(worker->GetGraph().GetHolderFactory()
+            .Create<TArrowListValue>(inputSpec, std::move(stream), worker), 0);
+    }
+}
+
+
 TArrowOutputSpec::TArrowOutputSpec(const NYT::TNode& schema)
     : Schema_(schema)
 {
@@ -18,4 +264,11 @@ TArrowOutputSpec::TArrowOutputSpec(const NYT::TNode& schema)
 
 const NYT::TNode& TArrowOutputSpec::GetSchema() const {
     return Schema_;
+}
+
+
+PullListReturnType TOutputSpecTraits<TArrowOutputSpec>::ConvertPullListWorkerToOutputType(
+    const TArrowOutputSpec& outputSpec, TWorkerHolder<IPullListWorker> worker
+) {
+    return MakeHolder<TArrowListImpl>(outputSpec, std::move(worker));
 }

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -1,1 +1,21 @@
 #include "spec.h"
+
+using namespace NYql::NPureCalc;
+
+TArrowInputSpec::TArrowInputSpec(const TVector<NYT::TNode>& schemas)
+    : Schemas_(schemas)
+{
+}
+
+const TVector<NYT::TNode>& TArrowInputSpec::GetSchemas() const {
+    return Schemas_;
+}
+
+TArrowOutputSpec::TArrowOutputSpec(const NYT::TNode& schema)
+    : Schema_(schema)
+{
+}
+
+const NYT::TNode& TArrowOutputSpec::GetSchema() const {
+    return Schema_;
+}

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
@@ -36,6 +36,7 @@ private:
 public:
     explicit TArrowInputSpec(const TVector<NYT::TNode>& schemas);
     const TVector<NYT::TNode>& GetSchemas() const override;
+    const NYT::TNode& GetSchema(ui32) const;
     static constexpr bool ProvidesBlocks = true;
 };
 
@@ -88,6 +89,10 @@ struct TInputSpecTraits<TArrowInputSpec> {
         IInputStream*);
     static void PreparePullListWorker(const TArrowInputSpec&, IPullListWorker*,
         THolder<IInputStream>);
+    static void PreparePullListWorker(const TArrowInputSpec&, IPullListWorker*,
+        const TVector<IInputStream*>&);
+    static void PreparePullListWorker(const TArrowInputSpec&, IPullListWorker*,
+        TVector<THolder<IInputStream>>&&);
 
     static void PreparePullStreamWorker(const TArrowInputSpec&, IPullStreamWorker*,
         IInputStream*);

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
@@ -36,7 +36,7 @@ private:
 public:
     explicit TArrowInputSpec(const TVector<NYT::TNode>& schemas);
     const TVector<NYT::TNode>& GetSchemas() const override;
-    const NYT::TNode& GetSchema(ui32) const;
+    const NYT::TNode& GetSchema(ui32 index) const;
     static constexpr bool ProvidesBlocks = true;
 };
 

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
@@ -98,6 +98,10 @@ struct TInputSpecTraits<TArrowInputSpec> {
         IInputStream*);
     static void PreparePullStreamWorker(const TArrowInputSpec&, IPullStreamWorker*,
         THolder<IInputStream>);
+    static void PreparePullStreamWorker(const TArrowInputSpec&, IPullStreamWorker*,
+        const TVector<IInputStream*>&);
+    static void PreparePullStreamWorker(const TArrowInputSpec&, IPullStreamWorker*,
+        TVector<THolder<IInputStream>>&&);
 
     static TConsumerType MakeConsumer(const TArrowInputSpec&, TWorkerHolder<IPushStreamWorker>);
 };

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
@@ -77,6 +77,7 @@ struct TInputSpecTraits<TArrowInputSpec> {
     static const constexpr bool IsPartial = false;
 
     static const constexpr bool SupportPullListMode = true;
+    static const constexpr bool SupportPullStreamMode = true;
 
     using TInputItemType = arrow::compute::ExecBatch*;
     using IInputStream = IStream<TInputItemType>;
@@ -85,6 +86,11 @@ struct TInputSpecTraits<TArrowInputSpec> {
         IInputStream*);
     static void PreparePullListWorker(const TArrowInputSpec&, IPullListWorker*,
         THolder<IInputStream>);
+
+    static void PreparePullStreamWorker(const TArrowInputSpec&, IPullStreamWorker*,
+        IInputStream*);
+    static void PreparePullStreamWorker(const TArrowInputSpec&, IPullStreamWorker*,
+        THolder<IInputStream>);
 };
 
 template <>
@@ -92,14 +98,17 @@ struct TOutputSpecTraits<TArrowOutputSpec> {
     static const constexpr bool IsPartial = false;
 
     static const constexpr bool SupportPullListMode = true;
+    static const constexpr bool SupportPullStreamMode = true;
 
     using TOutputItemType = arrow::compute::ExecBatch*;
     using IOutputStream = IStream<TOutputItemType>;
     using TPullListReturnType = THolder<IOutputStream>;
+    using TPullStreamReturnType = THolder<IOutputStream>;
 
     static const constexpr TOutputItemType StreamSentinel = nullptr;
 
     static TPullListReturnType ConvertPullListWorkerToOutputType(const TArrowOutputSpec&, TWorkerHolder<IPullListWorker>);
+    static TPullStreamReturnType ConvertPullStreamWorkerToOutputType(const TArrowOutputSpec&, TWorkerHolder<IPullStreamWorker>);
 };
 
 } // namespace NPureCalc

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
@@ -78,9 +78,11 @@ struct TInputSpecTraits<TArrowInputSpec> {
 
     static const constexpr bool SupportPullListMode = true;
     static const constexpr bool SupportPullStreamMode = true;
+    static const constexpr bool SupportPushStreamMode = true;
 
     using TInputItemType = arrow::compute::ExecBatch*;
     using IInputStream = IStream<TInputItemType>;
+    using TConsumerType = THolder<IConsumer<TInputItemType>>;
 
     static void PreparePullListWorker(const TArrowInputSpec&, IPullListWorker*,
         IInputStream*);
@@ -91,6 +93,8 @@ struct TInputSpecTraits<TArrowInputSpec> {
         IInputStream*);
     static void PreparePullStreamWorker(const TArrowInputSpec&, IPullStreamWorker*,
         THolder<IInputStream>);
+
+    static TConsumerType MakeConsumer(const TArrowInputSpec&, TWorkerHolder<IPushStreamWorker>);
 };
 
 template <>
@@ -99,6 +103,7 @@ struct TOutputSpecTraits<TArrowOutputSpec> {
 
     static const constexpr bool SupportPullListMode = true;
     static const constexpr bool SupportPullStreamMode = true;
+    static const constexpr bool SupportPushStreamMode = true;
 
     using TOutputItemType = arrow::compute::ExecBatch*;
     using IOutputStream = IStream<TOutputItemType>;
@@ -109,6 +114,7 @@ struct TOutputSpecTraits<TArrowOutputSpec> {
 
     static TPullListReturnType ConvertPullListWorkerToOutputType(const TArrowOutputSpec&, TWorkerHolder<IPullListWorker>);
     static TPullStreamReturnType ConvertPullStreamWorkerToOutputType(const TArrowOutputSpec&, TWorkerHolder<IPullStreamWorker>);
+    static void SetConsumerToWorker(const TArrowOutputSpec&, IPushStreamWorker*, THolder<IConsumer<TOutputItemType>>);
 };
 
 } // namespace NPureCalc

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace NYql {
+namespace NPureCalc {
+} // namespace NPureCalc
+} // namespace NYql

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
@@ -1,0 +1,104 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/library/yql/public/purecalc/common/interface.h>
+#include <ydb/library/yql/public/purecalc/io_specs/arrow/spec.h>
+#include <ydb/library/yql/public/purecalc/ut/lib/helpers.h>
+
+#include <ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h>
+#include <arrow/array/builder_primitive.h>
+
+namespace {
+
+template <typename T>
+struct TVectorStream: public NYql::NPureCalc::IStream<T*> {
+    TVector<T> Data_;
+    size_t Index_ = 0;
+
+public:
+    TVectorStream(TVector<T> items)
+        : Data_(std::move(items))
+    {
+    }
+
+    T* Fetch() override {
+        return Index_ < Data_.size() ? &Data_[Index_++] : nullptr;
+    }
+};
+
+
+using ExecBatchStreamImpl = TVectorStream<arrow::compute::ExecBatch>;
+
+
+static constexpr i64 value = 19;
+static constexpr ui64 bsize = 9;
+
+arrow::compute::ExecBatch MakeBatch() {
+    TVector<ui64> data(bsize);
+    TVector<bool> valid(bsize);
+    std::iota(data.begin(), data.end(), 1);
+    std::fill(valid.begin(), valid.end(), true);
+
+    arrow::UInt64Builder builder;
+    ARROW_OK(builder.Reserve(bsize));
+    ARROW_OK(builder.AppendValues(data, valid));
+
+    arrow::Datum array(ARROW_RESULT(builder.Finish()));
+    arrow::Datum scalar(std::make_shared<arrow::Int64Scalar>(value));
+
+    TVector<arrow::Datum> batchArgs = {array, scalar};
+    return arrow::compute::ExecBatch(std::move(batchArgs), bsize);
+}
+
+void AssertBatch(const arrow::compute::ExecBatch* batch) {
+    arrow::Datum first = batch->values[0];
+    arrow::Datum second = batch->values[1];
+
+    UNIT_ASSERT(first.is_array());
+    const auto& array = *first.array();
+    UNIT_ASSERT_EQUAL(array.length, bsize);
+    UNIT_ASSERT_EQUAL(array.GetNullCount(), 0);
+    UNIT_ASSERT_EQUAL(array.buffers.size(), 2);
+
+    TVector<ui64> data(bsize);
+    std::iota(data.begin(), data.end(), 1);
+    ui8* expected = reinterpret_cast<ui8*>(data.data());
+    const ui8* got = array.buffers[1]->data();
+    UNIT_ASSERT(std::memcpy(expected, got, bsize * sizeof(i64)));
+
+    UNIT_ASSERT(second.is_scalar());
+    const auto& scalar = arrow::internal::checked_cast<const arrow::Int64Scalar&>(*second.scalar());
+    UNIT_ASSERT_EQUAL(scalar.value, value);
+}
+
+} // namespace
+
+
+Y_UNIT_TEST_SUITE(TestSimplePullListArrowIO) {
+    Y_UNIT_TEST(TestSingleInput) {
+        using namespace NYql::NPureCalc;
+
+        TVector<TString> fields = {"uint64", "int64"};
+        auto schema = NYql::NPureCalc::NPrivate::GetSchema(fields);
+
+        auto factory = MakeProgramFactory();
+
+        {
+            auto program = factory->MakePullListProgram(
+                TArrowInputSpec({schema}),
+                TArrowOutputSpec(schema),
+                "SELECT * FROM Input",
+                ETranslationMode::SQL
+            );
+
+            ExecBatchStreamImpl items({MakeBatch()});
+
+            auto stream = program->Apply(&items);
+
+            arrow::compute::ExecBatch* batch;
+
+            UNIT_ASSERT(batch = stream->Fetch());
+            AssertBatch(batch);
+            UNIT_ASSERT(!stream->Fetch());
+        }
+    }
+}

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
@@ -91,8 +91,10 @@ void AssertBatch(const arrow::compute::ExecBatch* batch) {
     UNIT_ASSERT(std::memcpy(expected, got, bsize * sizeof(i64)));
 
     UNIT_ASSERT(second.is_scalar());
-    const auto& scalar = arrow::internal::checked_cast<const arrow::Int64Scalar&>(*second.scalar());
-    UNIT_ASSERT_VALUES_EQUAL(scalar.value, value);
+    const auto& scalar = second.scalar();
+    UNIT_ASSERT(scalar->is_valid);
+    const auto& i64scalar = arrow::internal::checked_cast<const arrow::Int64Scalar&>(*scalar);
+    UNIT_ASSERT_VALUES_EQUAL(i64scalar.value, value);
 }
 
 } // namespace

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
@@ -80,9 +80,9 @@ void AssertBatch(const arrow::compute::ExecBatch* batch) {
 
     UNIT_ASSERT(first.is_array());
     const auto& array = *first.array();
-    UNIT_ASSERT_EQUAL(array.length, bsize);
-    UNIT_ASSERT_EQUAL(array.GetNullCount(), 0);
-    UNIT_ASSERT_EQUAL(array.buffers.size(), 2);
+    UNIT_ASSERT_VALUES_EQUAL(array.length, bsize);
+    UNIT_ASSERT_VALUES_EQUAL(array.GetNullCount(), 0);
+    UNIT_ASSERT_VALUES_EQUAL(array.buffers.size(), 2);
 
     TVector<ui64> data(bsize);
     std::iota(data.begin(), data.end(), 1);
@@ -92,7 +92,7 @@ void AssertBatch(const arrow::compute::ExecBatch* batch) {
 
     UNIT_ASSERT(second.is_scalar());
     const auto& scalar = arrow::internal::checked_cast<const arrow::Int64Scalar&>(*second.scalar());
-    UNIT_ASSERT_EQUAL(scalar.value, value);
+    UNIT_ASSERT_VALUES_EQUAL(scalar.value, value);
 }
 
 } // namespace

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/ya.make
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/ya.make
@@ -1,0 +1,20 @@
+UNITTEST()
+
+SIZE(MEDIUM)
+
+TIMEOUT(300)
+
+PEERDIR(
+    ydb/library/yql/public/udf/service/exception_policy
+    ydb/library/yql/public/purecalc
+    ydb/library/yql/public/purecalc/io_specs/arrow
+    ydb/library/yql/public/purecalc/ut/lib
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    test_spec.cpp
+)
+
+END()

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ya.make
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ya.make
@@ -1,0 +1,13 @@
+LIBRARY()
+
+PEERDIR(
+    ydb/library/yql/public/purecalc/common
+)
+
+INCLUDE(ya.make.inc)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ya.make.inc
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ya.make.inc
@@ -1,0 +1,13 @@
+SRCDIR(
+    ydb/library/yql/public/purecalc/io_specs/arrow
+)
+
+ADDINCL(
+    ydb/library/yql/public/purecalc/io_specs/arrow
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    spec.cpp
+)

--- a/ydb/library/yql/public/purecalc/io_specs/ut/ya.make
+++ b/ydb/library/yql/public/purecalc/io_specs/ut/ya.make
@@ -1,4 +1,5 @@
 RECURSE(
+    ../arrow/ut
     ../mkql/ut
     ../protobuf/ut
 )

--- a/ydb/library/yql/public/purecalc/io_specs/ya.make
+++ b/ydb/library/yql/public/purecalc/io_specs/ya.make
@@ -1,4 +1,5 @@
 RECURSE(
+    arrow
     mkql
     protobuf
     protobuf_raw

--- a/ydb/library/yql/public/purecalc/ut/lib/ya.make
+++ b/ydb/library/yql/public/purecalc/ut/lib/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 PEERDIR(
+    contrib/libs/apache/arrow
     library/cpp/yson
     library/cpp/yson/node
 )


### PR DESCRIPTION
This patches introduces the new purecalc IO spec to process Apache Arrow ExecBatches. The spec implements all working modes provided by the public purecalc interface:

* Modes to process Arrow Input:
    * `... TPullListProgram::Apply(IStream<arrow::compute::ExecBatch*>*);`
    * `... TPullListProgram::Apply(TVector<IStream<arrow::compute::ExecBatch*>*>);`
    * `... TPullStreamProgram::Apply(IStream<arrow::compute::ExecBatch*>*);`
    * `... TPullStreamProgram::Apply(TVector<IStream<arrow::compute::ExecBatch*>*>);`
    * `TConsumer<arrow::compute::ExecBatch*> TPushStreamProgram::Apply(...);`

* Modes to process Arrow Output:
    * `IStream<arrow::compute::ExecBatch*> TPullStreamProgram::Apply(...);`
    * `IStream<arrow::compute::ExecBatch*> TPullListProgram::Apply(...);`
    * `... TPushStreamProgram::Apply(TConsumer<arrow::compute::ExecBatch*>);`

### Changelog category

* New feature