### PR TITLE
allow module config customizations

### DIFF
--- a/ydb/core/driver_lib/run/config_parser.cpp
+++ b/ydb/core/driver_lib/run/config_parser.cpp
@@ -369,4 +369,10 @@ void TRunCommandConfigParser::ApplyParsedOptions() {
     Config.AppConfig.MutableRestartsCountConfig()->SetRestartsCountFile(RunOpts.RestartsCountFile);
 }
 
+void TRunCommandConfigParser::ApplyModuleDefaults(std::shared_ptr<TModuleFactories> factories) {
+    if (factories && factories->ModuleDefaults) {
+        factories->ModuleDefaults(Config);
+    }
+}
+
 } // namespace NKikimr

--- a/ydb/core/driver_lib/run/config_parser.h
+++ b/ydb/core/driver_lib/run/config_parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config.h"
+#include "factories.h"
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/driver_lib/cli_config_base/config_base.h>
 
@@ -23,6 +24,7 @@ public:
     virtual void SetupLastGetOptForConfigFiles(NLastGetopt::TOpts& opts);
     virtual void ParseConfigFiles(const NLastGetopt::TOptsParseResult& res);
     virtual void ApplyParsedOptions();
+    void ApplyModuleDefaults(std::shared_ptr<TModuleFactories> factories);
 
 protected:
     struct TGlobalOpts {

--- a/ydb/core/driver_lib/run/factories.h
+++ b/ydb/core/driver_lib/run/factories.h
@@ -25,6 +25,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "config.h"
+
 namespace NKikimr {
 
 // A way to parameterize YDB binary, we do it via a set of factories
@@ -57,6 +59,8 @@ struct TModuleFactories {
     std::vector<NKikimr::NMiniKQL::TComputationNodeFactory> AdditionalComputationNodeFactories;
 
     std::unique_ptr<NWilson::IGrpcSigner>(*WilsonGrpcSignerFactory)(const NKikimrConfig::TTracingConfig::TBackendConfig::TAuthConfig&);
+
+    std::function<void (TKikimrRunConfig& config)> ModuleDefaults;
 
     ~TModuleFactories();
 };

--- a/ydb/core/driver_lib/run/main.cpp
+++ b/ydb/core/driver_lib/run/main.cpp
@@ -132,6 +132,7 @@ int MainRun(const TKikimrRunConfig& runConfig, std::shared_ptr<TModuleFactories>
         {
             configParser.ParseRunOpts(argc, argv);
             configParser.ApplyParsedOptions();
+            configParser.ApplyModuleDefaults(factories);
             return MainRun(runConfig, factories);
         }
         case EDM_ADMIN:


### PR DESCRIPTION
The idea is to give an ability for every customized module, based on open-source version YDB, to specify it's own defaults for different config options. For example, specifiy different defaults for feature flags.

* New feature
