### PR TITLE
Fix VDisk chunks leaking in runtime

### DIFF
--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
@@ -139,14 +139,10 @@ namespace NKikimr {
 
             // notify delayed deleter when log record is actually written; we MUST ensure that updates are coming in
             // order of increasing LSN's; this is achieved automatically as all actors reside on the same mailbox
-            if (WId) {
-                LevelIndex->DelayedCompactionDeleterInfo->Update(LsnSeg.Last, std::move(Metadata.RemovedHugeBlobs),
-                    CommitRecord.DeleteToDecommitted ? CommitRecord.DeleteChunks : TVector<TChunkIdx>(),
-                    PDiskSignatureForHullDbKey<TKey>(), WId, ctx, Ctx->HugeKeeperId, Ctx->SkeletonId, Ctx->PDiskCtx,
-                    Ctx->HullCtx->VCtx);
-            } else {
-                Y_ABORT_UNLESS(Metadata.RemovedHugeBlobs.Empty());
-            }
+            LevelIndex->DelayedCompactionDeleterInfo->Update(LsnSeg.Last, std::move(Metadata.RemovedHugeBlobs),
+                CommitRecord.DeleteToDecommitted ? CommitRecord.DeleteChunks : TVector<TChunkIdx>(),
+                PDiskSignatureForHullDbKey<TKey>(), WId, ctx, Ctx->HugeKeeperId, Ctx->SkeletonId, Ctx->PDiskCtx,
+                Ctx->HullCtx->VCtx);
 
             NPDisk::TEvLogResult* msg = ev->Get();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix VDisk chunks leaking in runtime

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fixed incorrect delayed deleter invocation filter leading to loss of chunks in runtime.
