### PR TITLE
Extend index tables' partitioning settings to be able to restore them from a backup with the same partitioning as before

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_table.cpp
+++ b/ydb/core/grpc_services/rpc_describe_table.cpp
@@ -92,7 +92,7 @@ private:
                     return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
                 }
 
-                FillIndexDescription(describeTableResult, tableDescription);
+                FillIndexDescription(describeTableResult, tableDescription, splitKeyType);
                 FillChangefeedDescription(describeTableResult, tableDescription);
 
                 if (GetProtoRequest()->include_table_stats()) {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -974,7 +974,7 @@ enum EIndexState {
 }
 
 message TExplicitPartitions {
-    repeated TSplitBoundary SplitBoundary = 1;
+    repeated TSplitBoundary SplitBoundaries = 1;
 }
 
 message TIndexDescription {
@@ -997,7 +997,7 @@ message TIndexDescription {
     // indexImplTable settings
     oneof Partitions {
         uint32 UniformPartitions = 10;
-        TExplicitPartitions PartitionAtKeys = 11;
+        TExplicitPartitions ExplicitPartitions = 11;
     }
     optional TPartitioningPolicy PartitioningPolicy = 12;
 }

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -974,7 +974,7 @@ enum EIndexState {
 }
 
 message TExplicitPartitions {
-    repeated TSplitBoundary SplitBoundaries = 1;
+    repeated TSplitBoundary SplitBoundary = 1;
 }
 
 message TIndexDescription {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -973,6 +973,10 @@ enum EIndexState {
     EIndexStateWriteOnly = 3;
 }
 
+message TExplicitPartitions {
+    repeated TSplitBoundary SplitBoundary = 1;
+}
+
 message TIndexDescription {
     optional string Name = 1;
     optional uint64 LocalPathId = 2;
@@ -989,6 +993,13 @@ message TIndexDescription {
     repeated string DataColumnNames = 8;
     // DataSize + IndexSize of indexImplTable
     optional uint64 DataSize = 9;
+
+    // indexImplTable settings
+    oneof Partitions {
+        uint32 UniformPartitions = 10;
+        TExplicitPartitions PartitionAtKeys = 11;
+    }
+    optional TPartitioningPolicy PartitioningPolicy = 12;
 }
 
 message TIndexCreationConfig {

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -59,7 +59,7 @@ TMaybe<Ydb::Table::CreateTableRequest> GenYdbScheme(
         return Nothing();
     }
 
-    FillIndexDescription(scheme, tableDesc);
+    FillIndexDescription(scheme, tableDesc, mkqlKeyType);
     FillStorageSettings(scheme, tableDesc);
     FillColumnFamilies(scheme, tableDesc);
     FillAttributes(scheme, pathDesc);

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -4,6 +4,8 @@
 #include "schemeshard_impl.h"
 #include "schemeshard_utils.h"
 
+#include <ydb/core/ydb_convert/table_settings.h>
+
 namespace NKikimr::NSchemeShard {
 
 using namespace NTabletFlatExecutor;
@@ -214,7 +216,9 @@ private:
         }
 
         if (settings.has_index()) {
-            switch (settings.index().type_case()) {
+            const auto& index = settings.index();
+
+            switch (index.type_case()) {
             case Ydb::Table::TableIndex::TypeCase::kGlobalIndex:
                 buildInfo->IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobal;
                 break;
@@ -229,9 +233,14 @@ private:
                 return false;
             };
 
-            buildInfo->IndexName = settings.index().name();
-            buildInfo->IndexColumns.assign(settings.index().index_columns().begin(), settings.index().index_columns().end());
-            buildInfo->DataColumns.assign(settings.index().data_columns().begin(), settings.index().data_columns().end());
+            buildInfo->IndexName = index.name();
+            buildInfo->IndexColumns.assign(index.index_columns().begin(), index.index_columns().end());
+            buildInfo->DataColumns.assign(index.data_columns().begin(), index.data_columns().end());
+
+            Ydb::StatusIds::StatusCode status;
+            if (!FillIndexTablePartitioning(buildInfo->ImplTableDescription, index, status, explain)) {
+                return false;
+            } 
         }
         return true;
     }

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2113,6 +2113,8 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
     for (const auto& x : DataColumns) {
         *index.AddDataColumnNames() = x;
     }
+
+    *index.MutableIndexImplTableDescription() = ImplTableDescription;
 }
 
 void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrIndexBuilder::TColumnBuildSettings* result) const {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2887,6 +2887,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
     TString ImplTablePath;
     NTableIndex::TTableColumns ImplTableColumns;
+    NKikimrSchemeOp::TTableDescription ImplTableDescription;
 
     EState State = EState::Invalid;
     TString Issue;

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1227,7 +1227,7 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
     if (const auto& explicitPartitions = indexImplTable->TableDescription.GetSplitBoundary();
         !explicitPartitions.empty()
     ) {
-        *entry.MutableExplicitPartitions()->MutableSplitBoundaries() = explicitPartitions;
+        *entry.MutableExplicitPartitions()->MutableSplitBoundary() = explicitPartitions;
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1227,7 +1227,7 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
     if (const auto& explicitPartitions = indexImplTable->TableDescription.GetSplitBoundary();
         !explicitPartitions.empty()
     ) {
-        *entry.MutablePartitionAtKeys()->MutableSplitBoundary() = explicitPartitions;
+        *entry.MutableExplicitPartitions()->MutableSplitBoundaries() = explicitPartitions;
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1222,6 +1222,13 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
 
     const auto& tableStats = indexImplTable->GetStats().Aggregated;
     entry.SetDataSize(tableStats.DataSize + tableStats.IndexSize);
+
+    *entry.MutablePartitioningPolicy() = indexImplTable->PartitionConfig().GetPartitioningPolicy();
+    if (const auto& explicitPartitions = indexImplTable->TableDescription.GetSplitBoundary();
+        !explicitPartitions.empty()
+    ) {
+        *entry.MutablePartitionAtKeys()->MutableSplitBoundary() = explicitPartitions;
+    }
 }
 
 void TSchemeShard::DescribeCdcStream(const TPathId& pathId, const TString& name,

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -2589,6 +2589,126 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         });
     }
 
+    void ShouldRestoreIndexTableSettings(const TString& schemeAdditions, auto&& tableDescriptionChecker) {
+        TTestBasicRuntime runtime;
+
+        const auto empty = TTestData("", EmptyYsonStr);
+        const auto data = TTestDataWithScheme(TStringBuilder() << R"(
+                columns {
+                    name: "key"
+                    type { optional_type { item { type_id: UTF8 } } }
+                }
+                columns {
+                    name: "value"
+                    type { optional_type { item { type_id: UINT32 } } }
+                }
+                primary_key: "key"
+            )" << schemeAdditions,
+            {empty}
+        );
+
+        Run(runtime, ConvertTestData(data), R"(
+            ImportFromS3Settings {
+                endpoint: "localhost:%d"
+                scheme: HTTP
+                items {
+                    source_prefix: ""
+                    destination_path: "/MyRoot/User/Table"
+                }
+            }
+        )", Ydb::StatusIds::SUCCESS, "/MyRoot/User");
+
+        ui64 schemeshardId = 0;
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/User"), {
+            NLs::PathExist,
+            NLs::ExtractTenantSchemeshard(&schemeshardId)
+        });
+
+        tableDescriptionChecker(
+            DescribePath(runtime, schemeshardId, "/MyRoot/User/Table/ByValue/indexImplTable", true, true, true)
+        );
+    }
+
+    Y_UNIT_TEST(ShouldRestoreIndexTableSplitPoints) {
+        ShouldRestoreIndexTableSettings(R"(
+                indexes {
+                    name: "ByValue"
+                    index_columns: "value"
+                    global_index {
+                        settings {
+                            partition_at_keys {
+                                split_points {
+                                    type { tuple_type { elements { optional_type { item { type_id: UINT32 } } } } }
+                                    value { items { uint32_value: 1 } }
+                                }
+                            }
+                        }
+                    }
+                }
+            )",
+            [](const NKikimrScheme::TEvDescribeSchemeResult& tableDescription) {
+                TestDescribeResult(
+                    tableDescription,
+                    {NLs::CheckBoundaries}
+                );
+            }
+        );
+    }
+
+    Y_UNIT_TEST(ShouldRestoreIndexTableUniformPartitionsCount) {
+        ShouldRestoreIndexTableSettings(R"(
+                indexes {
+                    name: "ByValue"
+                    index_columns: "value"
+                    global_index {
+                        settings {
+                            uniform_partitions: 10
+                        }
+                    }
+                }
+            )",
+            [](const NKikimrScheme::TEvDescribeSchemeResult& tableDescription) {
+                const auto& pathDescription = tableDescription.GetPathDescription();
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    pathDescription.TablePartitionsSize(), 10,
+                    pathDescription.ShortDebugString()
+                );
+            }
+        );
+    }
+
+    Y_UNIT_TEST(ShouldRestoreIndexTablePartitioningSettings) {
+        ShouldRestoreIndexTableSettings(R"(
+                indexes {
+                    name: "ByValue"
+                    index_columns: "value"
+                    global_index {
+                        settings {
+                            partitioning_settings {
+                                partitioning_by_size: ENABLED
+                                partition_size_mb: 1024
+                                partitioning_by_load: ENABLED
+                                min_partitions_count: 2
+                                max_partitions_count: 3
+                            }
+                        }
+                    }
+                }
+            )",
+            [](const NKikimrScheme::TEvDescribeSchemeResult& tableDescription) {
+                TestDescribeResult(
+                    tableDescription,
+                    {
+                        NLs::SizeToSplitEqual(1 << 30),
+                        NLs::PartitioningByLoadStatus(true),
+                        NLs::MinPartitionsCountEqual(2),
+                        NLs::MaxPartitionsCountEqual(3)
+                    }
+                );
+            }
+        );
+    }
+
     Y_UNIT_TEST(ShouldFailOnInvalidSchema) {
         TTestBasicRuntime runtime;
 

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -42,7 +42,7 @@ namespace {
 
         scheme.mutable_primary_key()->CopyFrom(tableDesc.GetKeyColumnNames());
         FillColumnDescription(scheme, mkqlKeyType, tableDesc);
-        FillIndexDescription(scheme, tableDesc);
+        FillIndexDescription(scheme, tableDesc, mkqlKeyType);
         FillStorageSettings(scheme, tableDesc);
         FillColumnFamilies(scheme, tableDesc);
         FillAttributes(scheme, pathDesc);

--- a/ydb/core/wrappers/ut_helpers/s3_mock.cpp
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.cpp
@@ -392,6 +392,10 @@ bool TS3Mock::Start() {
     return HttpServer.Start();
 }
 
+const char* TS3Mock::GetError() {
+    return HttpServer.GetError();
+}
+
 TS3Mock::TS3Mock(const TSettings& settings)
     : Settings(settings)
     , HttpServer(this, settings.HttpOptions)

--- a/ydb/core/wrappers/ut_helpers/s3_mock.h
+++ b/ydb/core/wrappers/ut_helpers/s3_mock.h
@@ -67,6 +67,7 @@ public:
 
     TClientRequest* CreateClient();
     bool Start();
+    const char* GetError();
 
     const THashMap<TString, TString>& GetData() const { return Data; }
 

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -810,9 +810,9 @@ void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
     case NKikimrSchemeOp::TIndexDescription::kUniformPartitions:
         settings.set_uniform_partitions(tableIndex.GetUniformPartitions());
         break;
-    case NKikimrSchemeOp::TIndexDescription::kPartitionAtKeys:
+    case NKikimrSchemeOp::TIndexDescription::kExplicitPartitions:
         FillTableBoundaryImpl(*settings.mutable_partition_at_keys(),
-            tableIndex.GetPartitionAtKeys().GetSplitBoundary(),
+            tableIndex.GetExplicitPartitions().GetSplitBoundaries(),
             splitKeyType
         );
         break;
@@ -935,25 +935,6 @@ bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
         if (!FillIndexTablePartitioning(*indexDesc->MutableIndexImplTableDescription(), index, status, error)) {
             return false;
         }
-
-        //Disabled for a while. Probably we need to allow set this profile to user
-/*
-        auto indexTableDesc = indexDesc->MutableIndexImplTableDescription();
-        if (index.has_global_index() && index.global_index().has_table_profile()) {
-            auto indexTableProfile = index.global_index().table_profile();
-            // Copy to common table profile to reuse common ApplyTableProfile method
-            Ydb::Table::TableProfile profile;
-            profile.mutable_partitioning_policy()->CopyFrom(indexTableProfile.partitioning_policy());
-
-            StatusIds::StatusCode code;
-            TString error;
-            if (!Profiles.ApplyTableProfile(profile, *indexTableDesc, code, error)) {
-                NYql::TIssues issues;
-                issues.AddIssue(NYql::TIssue(error));
-                return Reply(code, issues, ctx);
-            }
-        }
-*/
     }
 
     return true;

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -812,7 +812,7 @@ void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
         break;
     case NKikimrSchemeOp::TIndexDescription::kExplicitPartitions:
         FillTableBoundaryImpl(*settings.mutable_partition_at_keys(),
-            tableIndex.GetExplicitPartitions().GetSplitBoundaries(),
+            tableIndex.GetExplicitPartitions().GetSplitBoundary(),
             splitKeyType
         );
         break;

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -862,6 +862,10 @@ bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
             break;
         }
 
+        if (!FillIndexTablePartitioning(*indexDesc->MutableIndexImplTableDescription(), index, status, error)) {
+            return false;
+        }
+
         //Disabled for a while. Probably we need to allow set this profile to user
 /*
         auto indexTableDesc = indexDesc->MutableIndexImplTableDescription();

--- a/ydb/core/ydb_convert/table_description.h
+++ b/ydb/core/ydb_convert/table_description.h
@@ -65,9 +65,9 @@ void FillTableBoundary(Ydb::Table::CreateTableRequest& out,
 
 // out
 void FillIndexDescription(Ydb::Table::DescribeTableResult& out,
-    const NKikimrSchemeOp::TTableDescription& in);
+    const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType);
 void FillIndexDescription(Ydb::Table::CreateTableRequest& out,
-    const NKikimrSchemeOp::TTableDescription& in);
+    const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType);
 // in
 bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
     const Ydb::Table::CreateTableRequest& in, Ydb::StatusIds::StatusCode& status, TString& error);

--- a/ydb/core/ydb_convert/table_settings.cpp
+++ b/ydb/core/ydb_convert/table_settings.cpp
@@ -18,16 +18,131 @@ namespace {
     const ui32 defaultMinPartitions = 1;
     const ui64 defaultSizeToSplit = 2ul << 30; // 2048 Mb
 
-    ui32 CalculateDefaultMinPartitions(const Ydb::Table::CreateTableRequest& proto) {
+    template <typename TYdbProto>
+    ui32 CalculateDefaultMinPartitions(const TYdbProto& proto) {
         switch (proto.partitions_case()) {
-        case Ydb::Table::CreateTableRequest::kUniformPartitions:
+        case TYdbProto::kUniformPartitions:
             return static_cast<ui32>(proto.uniform_partitions());
-        case Ydb::Table::CreateTableRequest::kPartitionAtKeys:
+        case TYdbProto::kPartitionAtKeys:
             return proto.partition_at_keys().split_points().size() + 1;
         default:
             return defaultMinPartitions;
         }
     }
+}
+
+template <class TYdbProto>
+bool FillPartitioningPolicy(
+    NKikimrSchemeOp::TPartitionConfig& partitionConfig,
+    const TYdbProto& proto,
+    Ydb::StatusIds::StatusCode& code, TString& error
+) {
+    const auto& partitioningSettings = proto.partitioning_settings();
+
+    switch (partitioningSettings.partitioning_by_size()) {
+    case Ydb::FeatureFlag::STATUS_UNSPECIFIED:
+    {
+        if (partitioningSettings.partition_size_mb()) {
+            auto &policy = *partitionConfig.MutablePartitioningPolicy();
+            policy.SetSizeToSplit((1 << 20) * partitioningSettings.partition_size_mb());
+            if (!partitioningSettings.min_partitions_count()) {
+                policy.SetMinPartitionsCount(CalculateDefaultMinPartitions(proto));
+            }
+        }
+        break;
+    }
+    case Ydb::FeatureFlag::ENABLED:
+    {
+        auto &policy = *partitionConfig.MutablePartitioningPolicy();
+        if (partitioningSettings.partition_size_mb()) {
+            policy.SetSizeToSplit((1 << 20) * partitioningSettings.partition_size_mb());
+        } else {
+            policy.SetSizeToSplit(defaultSizeToSplit);
+        }
+        if (!partitioningSettings.min_partitions_count()) {
+            policy.SetMinPartitionsCount(CalculateDefaultMinPartitions(proto));
+        }
+        break;
+    }
+    case Ydb::FeatureFlag::DISABLED:
+    {
+        if (partitioningSettings.partition_size_mb()) {
+            code = Ydb::StatusIds::BAD_REQUEST;
+            error = TStringBuilder() << "Auto partitioning partition size is set while "
+                "auto partitioning by size is disabled";
+            return false;
+        }
+        auto &policy = *partitionConfig.MutablePartitioningPolicy();
+        policy.SetSizeToSplit(0);
+        break;
+    }
+    default:
+        code = Ydb::StatusIds::BAD_REQUEST;
+        error = TStringBuilder() << "Unknown auto partitioning by size feature flag status: '"
+            << (ui32)partitioningSettings.partitioning_by_size() << "'";
+        return false;
+    }
+
+    switch (partitioningSettings.partitioning_by_load()) {
+    case Ydb::FeatureFlag::STATUS_UNSPECIFIED:
+    {
+        break;
+    }
+    case Ydb::FeatureFlag::ENABLED:
+    {
+        auto &policy = *partitionConfig.MutablePartitioningPolicy();
+        policy.MutableSplitByLoadSettings()->SetEnabled(true);
+        if (!partitioningSettings.min_partitions_count()) {
+            policy.SetMinPartitionsCount(CalculateDefaultMinPartitions(proto));
+        }
+        break;
+    }
+    case Ydb::FeatureFlag::DISABLED:
+    {
+        auto &policy = *partitionConfig.MutablePartitioningPolicy();
+        policy.MutableSplitByLoadSettings()->SetEnabled(false);
+        break;
+    }
+    default:
+        code = Ydb::StatusIds::BAD_REQUEST;
+        error = TStringBuilder() << "Unknown auto partitioning by load feature flag status: '"
+            << (ui32)partitioningSettings.partitioning_by_load() << "'";
+        return false;
+    }
+
+    if (partitioningSettings.min_partitions_count()) {
+        auto &policy = *partitionConfig.MutablePartitioningPolicy();
+        policy.SetMinPartitionsCount(partitioningSettings.min_partitions_count());
+    }
+
+    if (partitioningSettings.max_partitions_count()) {
+        auto &policy = *partitionConfig.MutablePartitioningPolicy();
+        policy.SetMaxPartitionsCount(partitioningSettings.max_partitions_count());
+    }
+
+    return true;
+}
+
+template <typename TYdbProto>
+bool FillPartitions(
+    NKikimrSchemeOp::TTableDescription& tableDesc,
+    const TYdbProto& proto,
+    Ydb::StatusIds::StatusCode& code, TString& error
+) {
+    switch (proto.partitions_case()) {
+    case TYdbProto::kUniformPartitions:
+        tableDesc.SetUniformPartitionsCount(proto.uniform_partitions());
+        break;
+    case TYdbProto::kPartitionAtKeys:
+        if (!CopyExplicitPartitions(tableDesc, proto.partition_at_keys(), code, error)) {
+            return false;
+        }
+        break;
+    default:
+        break;
+    }
+
+    return true;
 }
 
 bool FillCreateTableSettingsDesc(NKikimrSchemeOp::TTableDescription& tableDesc,
@@ -40,104 +155,18 @@ bool FillCreateTableSettingsDesc(NKikimrSchemeOp::TTableDescription& tableDesc,
         if (tableProfileSet) {
             MEWarning("PartitioningSettings", warnings);
         }
-        auto& partitioningSettings = proto.partitioning_settings();
-
-        switch (partitioningSettings.partitioning_by_size()) {
-        case Ydb::FeatureFlag::STATUS_UNSPECIFIED:
-        {
-            if (partitioningSettings.partition_size_mb()) {
-                auto &policy = *partitionConfig.MutablePartitioningPolicy();
-                policy.SetSizeToSplit((1 << 20) * partitioningSettings.partition_size_mb());
-                if (!partitioningSettings.min_partitions_count()) {
-                    policy.SetMinPartitionsCount(CalculateDefaultMinPartitions(proto));
-                }
-            }
-        }
-            break;
-        case Ydb::FeatureFlag::ENABLED:
-        {
-            auto &policy = *partitionConfig.MutablePartitioningPolicy();
-            if (partitioningSettings.partition_size_mb()) {
-                policy.SetSizeToSplit((1 << 20) * partitioningSettings.partition_size_mb());
-            } else {
-                policy.SetSizeToSplit(defaultSizeToSplit);
-            }
-            if (!partitioningSettings.min_partitions_count()) {
-                policy.SetMinPartitionsCount(CalculateDefaultMinPartitions(proto));
-            }
-            break;
-        }
-        case Ydb::FeatureFlag::DISABLED:
-        {
-            if (partitioningSettings.partition_size_mb()) {
-                code = Ydb::StatusIds::BAD_REQUEST;
-                error = TStringBuilder() << "Auto partitioning partition size is set while "
-                    "auto partitioning by size is disabled";
-                return false;
-            }
-            auto &policy = *partitionConfig.MutablePartitioningPolicy();
-            policy.SetSizeToSplit(0);
-            break;
-        }
-        default:
-            code = Ydb::StatusIds::BAD_REQUEST;
-            error = TStringBuilder() << "Unknown auto partitioning by size feature flag status: '"
-                << (ui32)partitioningSettings.partitioning_by_size() << "'";
+        if (!FillPartitioningPolicy(partitionConfig, proto, code, error)) {
             return false;
-        }
-
-        switch (partitioningSettings.partitioning_by_load()) {
-        case Ydb::FeatureFlag::STATUS_UNSPECIFIED:
-        {
-            break;
-        }
-        case Ydb::FeatureFlag::ENABLED:
-        {
-            auto &policy = *partitionConfig.MutablePartitioningPolicy();
-            policy.MutableSplitByLoadSettings()->SetEnabled(true);
-            if (!partitioningSettings.min_partitions_count()) {
-                policy.SetMinPartitionsCount(CalculateDefaultMinPartitions(proto));
-            }
-            break;
-        }
-        case Ydb::FeatureFlag::DISABLED:
-        {
-            auto &policy = *partitionConfig.MutablePartitioningPolicy();
-            policy.MutableSplitByLoadSettings()->SetEnabled(false);
-            break;
-        }
-        default:
-            code = Ydb::StatusIds::BAD_REQUEST;
-            error = TStringBuilder() << "Unknown auto partitioning by load feature flag status: '"
-                << (ui32)partitioningSettings.partitioning_by_load() << "'";
-            return false;
-        }
-
-        if (partitioningSettings.min_partitions_count()) {
-            auto &policy = *partitionConfig.MutablePartitioningPolicy();
-            policy.SetMinPartitionsCount(partitioningSettings.min_partitions_count());
-        }
-
-        if (partitioningSettings.max_partitions_count()) {
-            auto &policy = *partitionConfig.MutablePartitioningPolicy();
-            policy.SetMaxPartitionsCount(partitioningSettings.max_partitions_count());
         }
     }
 
-    if (proto.partitions_case() != Ydb::Table::CreateTableRequest::PARTITIONS_NOT_SET && tableProfileSet) {
-        MEWarning("Partitions", warnings);
-    }
-    switch (proto.partitions_case()) {
-    case Ydb::Table::CreateTableRequest::kUniformPartitions:
-        tableDesc.SetUniformPartitionsCount(proto.uniform_partitions());
-        break;
-    case Ydb::Table::CreateTableRequest::kPartitionAtKeys:
-        if (!CopyExplicitPartitions(tableDesc, proto.partition_at_keys(), code, error)) {
+    if (proto.partitions_case() != Ydb::Table::CreateTableRequest::PARTITIONS_NOT_SET) {
+        if (tableProfileSet) {
+            MEWarning("Partitions", warnings);
+        }
+        if (!FillPartitions(tableDesc, proto, code, error)) {
             return false;
         }
-        break;
-    default:
-        break;
     }
 
     if (proto.key_bloom_filter() != Ydb::FeatureFlag::STATUS_UNSPECIFIED && tableProfileSet) {

--- a/ydb/core/ydb_convert/table_settings.h
+++ b/ydb/core/ydb_convert/table_settings.h
@@ -69,4 +69,9 @@ bool FillTtlSettings(TTtlSettingsEnabled& out, const Ydb::Table::TtlSettings& in
     return true;
 }
 
+bool FillIndexTablePartitioning(
+    NKikimrSchemeOp::TTableDescription& out,
+    const Ydb::Table::TableIndex& index,
+    Ydb::StatusIds::StatusCode& code, TString& error);
+
 } // namespace NKikimr

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -43,6 +43,14 @@ static constexpr i64 READ_TABLE_RETRIES = 100;
 //                               Util
 ////////////////////////////////////////////////////////////////////////////////
 
+void TYdbErrorException::LogToStderr() const {
+    LOG_ERR("Ydb error, status# " << Status.GetStatus());
+    if (what()) {
+        LOG_ERR("\t" << "What# " << what());
+    }
+    LOG_ERR("\t" << Status.GetIssues().ToString());
+}
+
 static void VerifyStatus(TStatus status, TString explain = "") {
     if (status.IsSuccess()) {
         if (status.GetIssues()) {

--- a/ydb/library/backup/backup.h
+++ b/ydb/library/backup/backup.h
@@ -11,8 +11,6 @@
 #include <util/stream/output.h>
 #include <util/system/file.h>
 
-#include "util.h"
-
 namespace NYdb {
 namespace NBackup {
 
@@ -23,13 +21,7 @@ public:
     TYdbErrorException(const TStatus& status)
         : Status(status) {}
 
-    void LogToStderr() const {
-        LOG_ERR("Ydb error, status# " << Status.GetStatus());
-        if (what()) {
-            LOG_ERR("\t" << "What# " << what());
-        }
-        LOG_ERR("\t" << Status.GetIssues().ToString());
-    }
+    void LogToStderr() const;
 };
 
 void BackupFolder(TDriver driver, const TString& database, const TString& relDbPath, TFsPath folderPath,

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -46,13 +46,29 @@ message DeleteSessionResponse {
     Ydb.Operations.Operation operation = 1;
 }
 
+message GlobalIndexSettings {
+    oneof partitions {
+        // Enable uniform partitioning of the table that implements the index using the specified partition count.
+        // Note that the index columns must be of type Uint32 or Uint64.
+        uint64 uniform_partitions = 1;
+        // Explicitly specify the key values of the index columns that define the partition boundaries
+        // for the table implementing the index.
+        ExplicitPartitions partition_at_keys = 2;
+    }
+    // Partitioning settings for the table that implements the index.
+    PartitioningSettings partitioning_settings = 3;
+}
+
 message GlobalIndex {
+    GlobalIndexSettings settings = 1;
 }
 
 message GlobalAsyncIndex {
+    GlobalIndexSettings settings = 1;
 }
 
 message GlobalUniqueIndex {
+    GlobalIndexSettings settings = 1;
 }
 
 // Represent secondary index

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -173,11 +173,23 @@ struct TExplicitPartitions {
     using TSelf = TExplicitPartitions;
 
     FLUENT_SETTING_VECTOR(TValue, SplitPoints);
-
+    
     template <typename TProto>
     static TExplicitPartitions FromProto(const TProto& proto);
-
+    
     void SerializeTo(Ydb::Table::ExplicitPartitions& proto) const;
+};
+
+struct TGlobalIndexSettings {
+    using TUniformOrExplicitPartitions = std::variant<std::monostate, ui64, TExplicitPartitions>;
+
+    TPartitioningSettings PartitioningSettings;
+    TUniformOrExplicitPartitions Partitions;
+
+    template <typename TProto>
+    static TGlobalIndexSettings FromProto(const TProto& proto);
+
+    void SerializeTo(Ydb::Table::GlobalIndexSettings& proto) const;
 };
 
 //! Represents index description
@@ -189,13 +201,15 @@ public:
         const TString& name,
         EIndexType type,
         const TVector<TString>& indexColumns,
-        const TVector<TString>& dataColumns = {}
+        const TVector<TString>& dataColumns = {},
+        const TGlobalIndexSettings& settings = {}
     );
 
     TIndexDescription(
         const TString& name,
         const TVector<TString>& indexColumns,
-        const TVector<TString>& dataColumns = {}
+        const TVector<TString>& dataColumns = {},
+        const TGlobalIndexSettings& settings = {}
     );
 
     const TString& GetIndexName() const;
@@ -220,6 +234,7 @@ private:
     EIndexType IndexType_;
     TVector<TString> IndexColumns_;
     TVector<TString> DataColumns_;
+    TGlobalIndexSettings GlobalIndexSettings_;
     ui64 SizeBytes = 0;
 };
 

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -23,6 +23,8 @@ class CreateTableRequest;
 class Changefeed;
 class ChangefeedDescription;
 class DescribeTableResult;
+class ExplicitPartitions;
+class GlobalIndexSettings;
 class PartitioningSettings;
 class DateTypeColumnModeSettings;
 class TtlSettings;
@@ -148,17 +150,53 @@ struct TAlterTableColumn {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! Represents table partitioning settings
+class TPartitioningSettings {
+public:
+    TPartitioningSettings();
+    explicit TPartitioningSettings(const Ydb::Table::PartitioningSettings& proto);
+
+    const Ydb::Table::PartitioningSettings& GetProto() const;
+
+    TMaybe<bool> GetPartitioningBySize() const;
+    TMaybe<bool> GetPartitioningByLoad() const;
+    ui64 GetPartitionSizeMb() const;
+    ui64 GetMinPartitionsCount() const;
+    ui64 GetMaxPartitionsCount() const;
+
+private:
+    class TImpl;
+    std::shared_ptr<TImpl> Impl_;
+};
+
+struct TExplicitPartitions {
+    using TSelf = TExplicitPartitions;
+
+    FLUENT_SETTING_VECTOR(TValue, SplitPoints);
+
+    template <typename TProto>
+    static TExplicitPartitions FromProto(const TProto& proto);
+
+    void SerializeTo(Ydb::Table::ExplicitPartitions& proto) const;
+};
+
 //! Represents index description
 class TIndexDescription {
     friend class NYdb::TProtoAccessor;
 
 public:
     TIndexDescription(
-        const TString& name, EIndexType type,
+        const TString& name,
+        EIndexType type,
         const TVector<TString>& indexColumns,
-        const TVector<TString>& dataColumns = TVector<TString>());
+        const TVector<TString>& dataColumns = {}
+    );
 
-    TIndexDescription(const TString& name, const TVector<TString>& indexColumns, const TVector<TString>& dataColumns = TVector<TString>());
+    TIndexDescription(
+        const TString& name,
+        const TVector<TString>& indexColumns,
+        const TVector<TString>& dataColumns = {}
+    );
 
     const TString& GetIndexName() const;
     EIndexType GetIndexType() const;
@@ -419,25 +457,6 @@ public:
     TMaybe<TString> GetData() const;
     TMaybe<EColumnFamilyCompression> GetCompression() const;
     TMaybe<bool> GetKeepInMemory() const;
-
-private:
-    class TImpl;
-    std::shared_ptr<TImpl> Impl_;
-};
-
-//! Represents table partitioning settings
-class TPartitioningSettings {
-public:
-    TPartitioningSettings();
-    explicit TPartitioningSettings(const Ydb::Table::PartitioningSettings& proto);
-
-    const Ydb::Table::PartitioningSettings& GetProto() const;
-
-    TMaybe<bool> GetPartitioningBySize() const;
-    TMaybe<bool> GetPartitioningByLoad() const;
-    ui64 GetPartitionSizeMb() const;
-    ui64 GetMinPartitionsCount() const;
-    ui64 GetMaxPartitionsCount() const;
 
 private:
     class TImpl;
@@ -1219,12 +1238,6 @@ struct TStoragePolicy {
     FLUENT_SETTING_OPTIONAL(TString, External);
 
     FLUENT_SETTING_VECTOR(TColumnFamilyPolicy, ColumnFamilies);
-};
-
-struct TExplicitPartitions {
-    using TSelf = TExplicitPartitions;
-
-    FLUENT_SETTING_VECTOR(TValue, SplitPoints);
 };
 
 struct TPartitioningPolicy {

--- a/ydb/services/ydb/ut/ya.make
+++ b/ydb/services/ydb/ut/ya.make
@@ -42,6 +42,8 @@ PEERDIR(
     ydb/core/grpc_services/base
     ydb/core/testlib
     ydb/core/security
+    ydb/core/wrappers/ut_helpers
+    ydb/library/backup
     ydb/library/yql/minikql/dom
     ydb/library/yql/minikql/jsonpath
     ydb/library/testlib/service_mocks/ldap_mock
@@ -50,6 +52,7 @@ PEERDIR(
     ydb/public/lib/yson_value
     ydb/public/lib/ut_helpers
     ydb/public/lib/ydb_cli/commands
+    ydb/public/lib/ydb_cli/dump
     ydb/public/sdk/cpp/client/draft
     ydb/public/sdk/cpp/client/ydb_coordination
     ydb/public/sdk/cpp/client/ydb_export

--- a/ydb/services/ydb/ydb_common_ut.h
+++ b/ydb/services/ydb/ydb_common_ut.h
@@ -357,4 +357,11 @@ using TKikimrWithGrpcAndRootSchemaWithAuth = TBasicKikimrWithGrpcAndRootSchema<T
 using TKikimrWithGrpcAndRootSchemaWithAuthAndSsl = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestWithAuthAndSsl>;
 using TKikimrWithGrpcAndRootSchemaNoSystemViews = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestNoSystemViews>;
 
+Ydb::StatusIds::StatusCode WaitForStatus(
+    std::shared_ptr<grpc::Channel> channel, const TString& opId,
+    TString* error = nullptr,
+    int retries = 10,
+    TDuration sleepDuration = NYdb::ITERATION_DURATION
+);
+
 }

--- a/ydb/services/ydb/ydb_import_ut.cpp
+++ b/ydb/services/ydb/ydb_import_ut.cpp
@@ -1,12 +1,8 @@
 #include "ydb_common_ut.h"
 
-#include <ydb/core/wrappers/ut_helpers/s3_mock.h>
-
 #include <ydb/public/sdk/cpp/client/ydb_result/result.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_import/import.h>
-#include <ydb/public/sdk/cpp/client/ydb_export/export.h>
-#include <ydb/public/sdk/cpp/client/ydb_operation/operation.h>
 #include <ydb/public/lib/ydb_cli/dump/dump.h>
 #include <ydb/public/lib/yson_value/ydb_yson_value.h>
 
@@ -138,7 +134,6 @@ Y_UNIT_TEST_SUITE(YdbImport) {
 Y_UNIT_TEST_SUITE(BackupRestore) {
 
     using namespace NYdb::NTable;
-    using NKikimr::NWrappers::NTestHelpers::TS3Mock;
 
     void ExecuteDataDefinitionQuery(TSession& session, const TString& script) {
         const auto result = session.ExecuteSchemeQuery(script).ExtractValueSync();
@@ -190,108 +185,6 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
         UNIT_ASSERT_C(
             checker(tableDescription),
             descriptionProto.DebugString()
-        );
-    }
-
-    class TS3TestEnv {
-        TKikimrWithGrpcAndRootSchema server;
-        TDriver driver;
-        TTableClient tableClient;
-        TSession session;
-        ui16 s3Port;
-        TS3Mock s3Mock;
-        // required for exports to function
-        TDataShardExportFactory dataShardExportFactory;
-
-    public:
-        TS3TestEnv()
-            : driver(TDriverConfig().SetEndpoint(Sprintf("localhost:%d", server.GetPort())))
-            , tableClient(driver)
-            , session(tableClient.CreateSession().ExtractValueSync().GetSession())
-            , s3Port(server.GetPortManager().GetPort())
-            , s3Mock({}, TS3Mock::TSettings(s3Port))
-        {
-            UNIT_ASSERT_C(s3Mock.Start(), s3Mock.GetError());
-
-            auto& runtime = *server.GetRuntime();
-            runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::EPriority::PRI_DEBUG);
-            runtime.GetAppData().DataShardExportFactory = &dataShardExportFactory;
-        }
-
-        TKikimrWithGrpcAndRootSchema& GetServer() {
-            return server;
-        }
-
-        const TDriver& GetDriver() const {
-            return driver;
-        }
-
-        TSession& GetSession() {
-            return session;
-        }
-
-        ui16 GetS3Port() const {
-            return s3Port;
-        }
-    };
-
-    template <typename TOperation>
-    bool WaitForOperation(NOperation::TOperationClient& client, NOperationId::TOperationId id,
-        int retries = 10, TDuration sleepDuration = TDuration::MilliSeconds(100)
-    ) {
-        for (int retry = 0; retry <= retries; ++retry) {
-            auto result = client.Get<TOperation>(id).ExtractValueSync();
-            if (result.Ready()) {
-                UNIT_ASSERT_VALUES_EQUAL_C(
-                    result.Status().GetStatus(), EStatus::SUCCESS,
-                    result.Status().GetIssues().ToString()
-                );
-                return true;
-            }
-            Sleep(sleepDuration *= 2);
-        }
-        return false;
-    }
-
-    void ExportToS3(NExport::TExportClient& exportClient, ui16 s3Port, NOperation::TOperationClient& operationClient,
-        const TString& source, const TString& destination
-   ) {
-        // The exact values for Bucket, AccessKey and SecretKey do not matter if the S3 backend is TS3Mock.
-        // Any non-empty strings should do.
-        const auto exportSettings = NExport::TExportToS3Settings()
-            .Endpoint(Sprintf("localhost:%d", s3Port))
-            .Scheme(ES3Scheme::HTTP)
-            .Bucket("test_bucket")
-            .AccessKey("test_key")
-            .SecretKey("test_secret")
-            .AppendItem(NExport::TExportToS3Settings::TItem{.Src = source, .Dst = destination});
-
-        auto response = exportClient.ExportToS3(exportSettings).ExtractValueSync();
-        UNIT_ASSERT_C(WaitForOperation<NExport::TExportToS3Response>(operationClient, response.Id()),
-            Sprintf("The export from %s to %s did not complete within the allocated time.",
-                source.c_str(), destination.c_str()
-            )
-        );
-    }
-
-    void ImportFromS3(NImport::TImportClient& importClient, ui16 s3Port, NOperation::TOperationClient& operationClient,
-        const TString& source, const TString& destination
-    ) {
-        // The exact values for Bucket, AccessKey and SecretKey do not matter if the S3 backend is TS3Mock. 
-        // Any non-empty strings should do.
-        const auto importSettings = NImport::TImportFromS3Settings()
-            .Endpoint(Sprintf("localhost:%d", s3Port))
-            .Scheme(ES3Scheme::HTTP)
-            .Bucket("test_bucket")
-            .AccessKey("test_key")
-            .SecretKey("test_secret")
-            .AppendItem(NImport::TImportFromS3Settings::TItem{.Src = source, .Dst = destination});
-
-        auto response = importClient.ImportFromS3(importSettings).ExtractValueSync();
-        UNIT_ASSERT_C(WaitForOperation<NImport::TImportFromS3Response>(operationClient, response.Id()),
-            Sprintf("The import from %s to %s did not complete within the allocated time.",
-                source.c_str(), destination.c_str()
-            )
         );
     }
 
@@ -446,136 +339,6 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
         ));
         Restore(backupClient, pathToBackup, "/Root");
         CheckTableDescription(session, indexTablePath, CreateMinPartitionsChecker(minPartitions));
-    }
-
-    Y_UNIT_TEST(BasicS3) {
-        TS3TestEnv testEnv;
-
-        constexpr const char* table = "/Root/table";
-        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
-                CREATE TABLE `%s` (
-                    Key Uint32,
-                    Value Utf8,
-                    PRIMARY KEY (Key)
-                );
-            )",
-            table
-        ));
-        ExecuteDataModificationQuery(testEnv.GetSession(), Sprintf(R"(
-                UPSERT INTO `%s` (
-                    Key,
-                    Value
-                )
-                VALUES
-                    (1, "one"),
-                    (2, "two"),
-                    (3, "three"),
-                    (4, "four"),
-                    (5, "five");
-            )",
-            table
-        ));
-
-        NExport::TExportClient exportClient(testEnv.GetDriver());
-        NImport::TImportClient importClient(testEnv.GetDriver());
-        NOperation::TOperationClient operationClient(testEnv.GetDriver());
-
-        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
-
-        // The table needs to be dropped before importing from S3 can proceed successfully.
-        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
-                DROP TABLE `%s`;
-            )", table
-        ));
-
-        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
-        {
-            auto result = ExecuteDataModificationQuery(testEnv.GetSession(), Sprintf(R"(
-                    SELECT COUNT(*) FROM `%s`;
-                )", table
-            ));
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(GetSingleResult(result)), 5ull);
-        }
-    }
-
-    Y_UNIT_TEST(RestoreTablePartitioningSettingsS3) {
-        TS3TestEnv testEnv;
-
-        constexpr const char* table = "/Root/table";
-        constexpr int minPartitions = 10;
-        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
-                CREATE TABLE `%s` (
-                    Key Uint32,
-                    Value Utf8,
-                    PRIMARY KEY (Key)
-                )
-                WITH (
-                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
-                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
-                );
-            )",
-            table, minPartitions
-        ));
-
-        CheckTableDescription(testEnv.GetSession(), table, CreateMinPartitionsChecker(minPartitions));
-
-        NExport::TExportClient exportClient(testEnv.GetDriver());
-        NImport::TImportClient importClient(testEnv.GetDriver());
-        NOperation::TOperationClient operationClient(testEnv.GetDriver());
-
-        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
-
-        // The table needs to be dropped before importing from S3 can proceed successfully.
-        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
-                DROP TABLE `%s`;
-            )", table
-        ));
-
-        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
-        CheckTableDescription(testEnv.GetSession(), table, CreateMinPartitionsChecker(minPartitions));
-    }
-
-    Y_UNIT_TEST(RestoreIndexTablePartitioningSettingsS3) {
-        TS3TestEnv testEnv;
-
-        constexpr const char* table = "/Root/table";
-        constexpr const char* index = "byValue";
-        const TString indexTablePath = JoinFsPaths(table, index, "indexImplTable");
-        constexpr int minPartitions = 10;
-        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
-                CREATE TABLE `%s` (
-                    Key Uint32,
-                    Value Uint32,
-                    PRIMARY KEY (Key),
-                    INDEX %s GLOBAL ON (Value)
-                );
-            )",
-            table, index
-        ));
-        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
-                ALTER TABLE `%s` ALTER INDEX %s SET (
-                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
-                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
-                );
-            )", table, index, minPartitions
-        ));
-
-        CheckTableDescription(testEnv.GetSession(), indexTablePath, CreateMinPartitionsChecker(minPartitions));
-
-        NExport::TExportClient exportClient(testEnv.GetDriver());
-        NImport::TImportClient importClient(testEnv.GetDriver());
-        NOperation::TOperationClient operationClient(testEnv.GetDriver());
-
-        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
-
-        // The table needs to be dropped before importing from S3 can proceed successfully.
-        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
-                DROP TABLE `%s`;
-            )", table
-        ));
-
-        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
-        CheckTableDescription(testEnv.GetSession(), indexTablePath, CreateMinPartitionsChecker(minPartitions));
     }
 
 }

--- a/ydb/services/ydb/ydb_import_ut.cpp
+++ b/ydb/services/ydb/ydb_import_ut.cpp
@@ -1,10 +1,16 @@
 #include "ydb_common_ut.h"
 
+#include <ydb/core/wrappers/ut_helpers/s3_mock.h>
+
 #include <ydb/public/sdk/cpp/client/ydb_result/result.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_import/import.h>
+#include <ydb/public/sdk/cpp/client/ydb_export/export.h>
+#include <ydb/public/sdk/cpp/client/ydb_operation/operation.h>
+#include <ydb/public/lib/ydb_cli/dump/dump.h>
 #include <ydb/public/lib/yson_value/ydb_yson_value.h>
 
+#include <ydb/library/backup/backup.h>
 #include <ydb/library/yql/public/issue/yql_issue.h>
 #include <ydb/library/yql/public/issue/yql_issue_message.h>
 
@@ -125,6 +131,451 @@ Y_UNIT_TEST_SUITE(YdbImport) {
             auto result = client.ImportData("/Root/Table", "", settings).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
         }
+    }
+
+}
+
+Y_UNIT_TEST_SUITE(BackupRestore) {
+
+    using namespace NYdb::NTable;
+    using NKikimr::NWrappers::NTestHelpers::TS3Mock;
+
+    void ExecuteDataDefinitionQuery(TSession& session, const TString& script) {
+        const auto result = session.ExecuteSchemeQuery(script).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), "script:\n" << script << "\nissues:\n" << result.GetIssues().ToString());
+    }
+
+    TDataQueryResult ExecuteDataModificationQuery(TSession& session,
+                                                  const TString& script,
+                                                  const TExecDataQuerySettings& settings = {}
+    ) {
+        const auto result = session.ExecuteDataQuery(
+            script,
+            TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx(),
+            settings
+        ).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), "script:\n" << script << "\nissues:\n" << result.GetIssues().ToString());
+
+        return result;
+    }
+
+    TValue GetSingleResult(const TDataQueryResult& rawResults) {
+        auto resultSetParser = rawResults.GetResultSetParser(0);
+        UNIT_ASSERT(resultSetParser.TryNextRow());
+        return resultSetParser.GetValue(0);
+    }
+
+    ui64 GetUint64(const TValue& value) {
+        return TValueParser(value).GetUint64();
+    }
+        
+    void Restore(NDump::TClient& client, const TFsPath& sourceFile, const TString& dbPath) {
+        auto result = client.Restore(sourceFile, dbPath);
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+    }
+
+    auto CreateMinPartitionsChecker(ui64 expectedMinPartitions) {
+        return [=](const TTableDescription& tableDescription) {
+            return tableDescription.GetPartitioningSettings().GetMinPartitionsCount() == expectedMinPartitions;
+        };
+    }
+
+    void CheckTableDescription(TSession& session, const TString& path, auto&& checker) {
+        auto describeResult = session.DescribeTable(path).ExtractValueSync();
+        UNIT_ASSERT_C(describeResult.IsSuccess(), describeResult.GetIssues().ToString());
+        auto tableDescription = describeResult.GetTableDescription();
+        Ydb::Table::CreateTableRequest descriptionProto;
+        // The purpose of translating to CreateTableRequest is solely to produce a clearer error message.
+        tableDescription.SerializeTo(descriptionProto);
+        UNIT_ASSERT_C(
+            checker(tableDescription),
+            descriptionProto.DebugString()
+        );
+    }
+
+    class TS3TestEnv {
+        TKikimrWithGrpcAndRootSchema server;
+        TDriver driver;
+        TTableClient tableClient;
+        TSession session;
+        ui16 s3Port;
+        TS3Mock s3Mock;
+        // required for exports to function
+        TDataShardExportFactory dataShardExportFactory;
+
+    public:
+        TS3TestEnv()
+            : driver(TDriverConfig().SetEndpoint(Sprintf("localhost:%d", server.GetPort())))
+            , tableClient(driver)
+            , session(tableClient.CreateSession().ExtractValueSync().GetSession())
+            , s3Port(server.GetPortManager().GetPort())
+            , s3Mock({}, TS3Mock::TSettings(s3Port))
+        {
+            UNIT_ASSERT_C(s3Mock.Start(), s3Mock.GetError());
+
+            auto& runtime = *server.GetRuntime();
+            runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::EPriority::PRI_DEBUG);
+            runtime.GetAppData().DataShardExportFactory = &dataShardExportFactory;
+        }
+
+        TKikimrWithGrpcAndRootSchema& GetServer() {
+            return server;
+        }
+
+        const TDriver& GetDriver() const {
+            return driver;
+        }
+
+        TSession& GetSession() {
+            return session;
+        }
+
+        ui16 GetS3Port() const {
+            return s3Port;
+        }
+    };
+
+    template <typename TOperation>
+    bool WaitForOperation(NOperation::TOperationClient& client, NOperationId::TOperationId id,
+        int retries = 10, TDuration sleepDuration = TDuration::MilliSeconds(100)
+    ) {
+        for (int retry = 0; retry <= retries; ++retry) {
+            auto result = client.Get<TOperation>(id).ExtractValueSync();
+            if (result.Ready()) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    result.Status().GetStatus(), EStatus::SUCCESS,
+                    result.Status().GetIssues().ToString()
+                );
+                return true;
+            }
+            Sleep(sleepDuration *= 2);
+        }
+        return false;
+    }
+
+    void ExportToS3(NExport::TExportClient& exportClient, ui16 s3Port, NOperation::TOperationClient& operationClient,
+        const TString& source, const TString& destination
+   ) {
+        // The exact values for Bucket, AccessKey and SecretKey do not matter if the S3 backend is TS3Mock.
+        // Any non-empty strings should do.
+        const auto exportSettings = NExport::TExportToS3Settings()
+            .Endpoint(Sprintf("localhost:%d", s3Port))
+            .Scheme(ES3Scheme::HTTP)
+            .Bucket("test_bucket")
+            .AccessKey("test_key")
+            .SecretKey("test_secret")
+            .AppendItem(NExport::TExportToS3Settings::TItem{.Src = source, .Dst = destination});
+
+        auto response = exportClient.ExportToS3(exportSettings).ExtractValueSync();
+        UNIT_ASSERT_C(WaitForOperation<NExport::TExportToS3Response>(operationClient, response.Id()),
+            Sprintf("The export from %s to %s did not complete within the allocated time.",
+                source.c_str(), destination.c_str()
+            )
+        );
+    }
+
+    void ImportFromS3(NImport::TImportClient& importClient, ui16 s3Port, NOperation::TOperationClient& operationClient,
+        const TString& source, const TString& destination
+    ) {
+        // The exact values for Bucket, AccessKey and SecretKey do not matter if the S3 backend is TS3Mock. 
+        // Any non-empty strings should do.
+        const auto importSettings = NImport::TImportFromS3Settings()
+            .Endpoint(Sprintf("localhost:%d", s3Port))
+            .Scheme(ES3Scheme::HTTP)
+            .Bucket("test_bucket")
+            .AccessKey("test_key")
+            .SecretKey("test_secret")
+            .AppendItem(NImport::TImportFromS3Settings::TItem{.Src = source, .Dst = destination});
+
+        auto response = importClient.ImportFromS3(importSettings).ExtractValueSync();
+        UNIT_ASSERT_C(WaitForOperation<NImport::TImportFromS3Response>(operationClient, response.Id()),
+            Sprintf("The import from %s to %s did not complete within the allocated time.",
+                source.c_str(), destination.c_str()
+            )
+        );
+    }
+
+    Y_UNIT_TEST(Basic) {
+        TKikimrWithGrpcAndRootSchema server;
+        auto driver = TDriver(TDriverConfig().SetEndpoint(Sprintf("localhost:%d", server.GetPort())));
+        TTableClient tableClient(driver);
+        auto session = tableClient.GetSession().ExtractValueSync().GetSession();
+
+        constexpr const char* table = "/Root/table";
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Utf8,
+                    PRIMARY KEY (Key)
+                );
+            )",
+            table
+        ));
+        ExecuteDataModificationQuery(session, Sprintf(R"(
+                UPSERT INTO `%s` (
+                    Key,
+                    Value
+                )
+                VALUES
+                    (1, "one"),
+                    (2, "two"),
+                    (3, "three"),
+                    (4, "four"),
+                    (5, "five");
+            )",
+            table
+        ));
+
+        TTempDir tempDir;
+        const auto& pathToBackup = tempDir.Path();
+        // TO DO: implement NDump::TClient::Dump and call it instead of BackupFolder
+        NYdb::NBackup::BackupFolder(driver, "/Root", ".", pathToBackup, {}, false, false);
+        
+        NDump::TClient backupClient(driver);
+
+        // restore deleted rows in an existing table
+        ExecuteDataModificationQuery(session, Sprintf(R"(
+                DELETE FROM `%s` WHERE Key > 3;
+            )", table
+        ));
+        Restore(backupClient, pathToBackup, "/Root");
+        {
+            auto result = ExecuteDataModificationQuery(session, Sprintf(R"(
+                    SELECT COUNT(*) FROM `%s`;
+                )", table
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(GetSingleResult(result)), 5ull);
+        }
+
+        // restore deleted table
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+        Restore(backupClient, pathToBackup, "/Root");
+        {
+            auto result = ExecuteDataModificationQuery(session, Sprintf(R"(
+                    SELECT COUNT(*) FROM `%s`;
+                )", table
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(GetSingleResult(result)), 5ull);
+        }
+    }
+    
+    Y_UNIT_TEST(RestoreTablePartitioningSettings) {
+        TKikimrWithGrpcAndRootSchema server;
+        auto driver = TDriver(TDriverConfig().SetEndpoint(Sprintf("localhost:%d", server.GetPort())));
+        TTableClient tableClient(driver);
+        auto session = tableClient.GetSession().ExtractValueSync().GetSession();
+
+        constexpr const char* table = "/Root/table";
+        constexpr int minPartitions = 10;
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Utf8,
+                    PRIMARY KEY (Key)
+                )
+                WITH (
+                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
+                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
+                );
+            )",
+            table, minPartitions
+        ));
+
+        CheckTableDescription(session, table, CreateMinPartitionsChecker(minPartitions));
+
+        TTempDir tempDir;
+        const auto& pathToBackup = tempDir.Path();
+        // TO DO: implement NDump::TClient::Dump and call it instead of BackupFolder
+        NYdb::NBackup::BackupFolder(driver, "/Root", ".", pathToBackup, {}, false, false);
+        
+        NDump::TClient backupClient(driver);
+
+        // restore deleted table
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+        Restore(backupClient, pathToBackup, "/Root");
+        CheckTableDescription(session, table, CreateMinPartitionsChecker(minPartitions));
+    }
+
+    Y_UNIT_TEST(RestoreIndexTablePartitioningSettings) {
+        TKikimrWithGrpcAndRootSchema server;
+        auto driver = TDriver(TDriverConfig().SetEndpoint(Sprintf("localhost:%d", server.GetPort())));
+        TTableClient tableClient(driver);
+        auto session = tableClient.GetSession().ExtractValueSync().GetSession();
+
+        constexpr const char* table = "/Root/table";
+        constexpr const char* index = "byValue";
+        const TString indexTablePath = JoinFsPaths(table, index, "indexImplTable");
+        constexpr int minPartitions = 10;
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Uint32,
+                    PRIMARY KEY (Key),
+                    INDEX %s GLOBAL ON (Value)
+                );
+            )",
+            table, index
+        ));
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                ALTER TABLE `%s` ALTER INDEX %s SET (
+                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
+                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
+                );
+            )", table, index, minPartitions
+        ));
+
+        CheckTableDescription(session, indexTablePath, CreateMinPartitionsChecker(minPartitions));
+                
+        TTempDir tempDir;
+        const auto& pathToBackup = tempDir.Path();
+        // TO DO: implement NDump::TClient::Dump and call it instead of BackupFolder
+        NYdb::NBackup::BackupFolder(driver, "/Root", ".", pathToBackup, {}, false, false);
+        
+        NDump::TClient backupClient(driver);
+
+        // restore deleted table
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+        Restore(backupClient, pathToBackup, "/Root");
+        CheckTableDescription(session, indexTablePath, CreateMinPartitionsChecker(minPartitions));
+    }
+
+    Y_UNIT_TEST(BasicS3) {
+        TS3TestEnv testEnv;
+
+        constexpr const char* table = "/Root/table";
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Utf8,
+                    PRIMARY KEY (Key)
+                );
+            )",
+            table
+        ));
+        ExecuteDataModificationQuery(testEnv.GetSession(), Sprintf(R"(
+                UPSERT INTO `%s` (
+                    Key,
+                    Value
+                )
+                VALUES
+                    (1, "one"),
+                    (2, "two"),
+                    (3, "three"),
+                    (4, "four"),
+                    (5, "five");
+            )",
+            table
+        ));
+
+        NExport::TExportClient exportClient(testEnv.GetDriver());
+        NImport::TImportClient importClient(testEnv.GetDriver());
+        NOperation::TOperationClient operationClient(testEnv.GetDriver());
+
+        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
+
+        // The table needs to be dropped before importing from S3 can proceed successfully.
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+
+        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
+        {
+            auto result = ExecuteDataModificationQuery(testEnv.GetSession(), Sprintf(R"(
+                    SELECT COUNT(*) FROM `%s`;
+                )", table
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(GetSingleResult(result)), 5ull);
+        }
+    }
+
+    Y_UNIT_TEST(RestoreTablePartitioningSettingsS3) {
+        TS3TestEnv testEnv;
+
+        constexpr const char* table = "/Root/table";
+        constexpr int minPartitions = 10;
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Utf8,
+                    PRIMARY KEY (Key)
+                )
+                WITH (
+                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
+                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
+                );
+            )",
+            table, minPartitions
+        ));
+
+        CheckTableDescription(testEnv.GetSession(), table, CreateMinPartitionsChecker(minPartitions));
+
+        NExport::TExportClient exportClient(testEnv.GetDriver());
+        NImport::TImportClient importClient(testEnv.GetDriver());
+        NOperation::TOperationClient operationClient(testEnv.GetDriver());
+
+        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
+
+        // The table needs to be dropped before importing from S3 can proceed successfully.
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+
+        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
+        CheckTableDescription(testEnv.GetSession(), table, CreateMinPartitionsChecker(minPartitions));
+    }
+
+    Y_UNIT_TEST(RestoreIndexTablePartitioningSettingsS3) {
+        TS3TestEnv testEnv;
+
+        constexpr const char* table = "/Root/table";
+        constexpr const char* index = "byValue";
+        const TString indexTablePath = JoinFsPaths(table, index, "indexImplTable");
+        constexpr int minPartitions = 10;
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Uint32,
+                    PRIMARY KEY (Key),
+                    INDEX %s GLOBAL ON (Value)
+                );
+            )",
+            table, index
+        ));
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                ALTER TABLE `%s` ALTER INDEX %s SET (
+                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
+                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
+                );
+            )", table, index, minPartitions
+        ));
+
+        CheckTableDescription(testEnv.GetSession(), indexTablePath, CreateMinPartitionsChecker(minPartitions));
+
+        NExport::TExportClient exportClient(testEnv.GetDriver());
+        NImport::TImportClient importClient(testEnv.GetDriver());
+        NOperation::TOperationClient operationClient(testEnv.GetDriver());
+
+        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
+
+        // The table needs to be dropped before importing from S3 can proceed successfully.
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+
+        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
+        CheckTableDescription(testEnv.GetSession(), indexTablePath, CreateMinPartitionsChecker(minPartitions));
     }
 
 }

--- a/ydb/services/ydb/ydb_index_table_ut.cpp
+++ b/ydb/services/ydb/ydb_index_table_ut.cpp
@@ -173,7 +173,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
                     index_columns: "Value"
                     global_index {
                         settings {
-                            uniform_partitions: 10
+                            uniform_partitions: 5
                             partitioning_settings {
                                 partitioning_by_load: ENABLED
                                 min_partitions_count: 5
@@ -217,7 +217,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
             );
 
             const auto& tableStats = result.table_stats();
-            UNIT_ASSERT_VALUES_EQUAL_C(tableStats.partitions(), 10, tableStats.DebugString());
+            UNIT_ASSERT_VALUES_EQUAL_C(tableStats.partitions(), 5, tableStats.DebugString());
         }
     }
 
@@ -252,7 +252,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
                     index_columns: "Value"
                     global_index {
                         settings {
-                            uniform_partitions: 10
+                            uniform_partitions: 5
                             partitioning_settings {
                                 partitioning_by_load: ENABLED
                                 min_partitions_count: 5
@@ -298,7 +298,7 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
             );
 
             const auto& tableStats = result.table_stats();
-            UNIT_ASSERT_VALUES_EQUAL_C(tableStats.partitions(), 10, tableStats.DebugString());
+            UNIT_ASSERT_VALUES_EQUAL_C(tableStats.partitions(), 5, tableStats.DebugString());
         }
     }
 }

--- a/ydb/services/ydb/ydb_index_table_ut.cpp
+++ b/ydb/services/ydb/ydb_index_table_ut.cpp
@@ -13,6 +13,7 @@
 
 #include <ydb/public/api/grpc/ydb_table_v1.grpc.pb.h>
 
+using namespace NKikimr;
 using namespace NYdb;
 using namespace NYdb::NTable;
 
@@ -151,6 +152,153 @@ Y_UNIT_TEST_SUITE(YdbIndexTable) {
             )", "root@builtin");
             UNIT_ASSERT_VALUES_EQUAL_C(result->Record.GetStatus(), NMsgBusProxy::MSTATUS_ERROR, "Super user must not be able to alter coloumns");
             UNIT_ASSERT_VALUES_EQUAL(result->Record.GetErrorReason(), "Adding or dropping columns in index table is not supported");
+        }
+    }
+
+    Y_UNIT_TEST(CreateTableAddIndex) {
+        TKikimrWithGrpcAndRootSchema server;
+
+        auto channel = grpc::CreateChannel("localhost:" + ToString(server.GetPort()), grpc::InsecureChannelCredentials());
+        auto tableService = Ydb::Table::V1::TableService::NewStub(channel);
+        {
+            grpc::ClientContext context;
+            Ydb::Table::CreateTableRequest request;
+            UNIT_ASSERT(::google::protobuf::TextFormat::ParseFromString(R"(
+                path: "/Root/TheTable"
+                columns { name: "Key"   type { optional_type { item { type_id: UINT32 } } } }
+                columns { name: "Value" type { optional_type { item { type_id: UINT32 } } } }
+                primary_key: ["Key"]
+                indexes {
+                    name: "ByValue"
+                    index_columns: "Value"
+                    global_index {
+                        settings {
+                            uniform_partitions: 10
+                            partitioning_settings {
+                                partitioning_by_load: ENABLED
+                                min_partitions_count: 5
+                            }
+                        }
+                    }
+                }
+            )", &request));
+
+            Ydb::Table::CreateTableResponse response;
+            auto grpcStatus = tableService->CreateTable(&context, request, &response);
+
+            UNIT_ASSERT(grpcStatus.ok());
+            UNIT_ASSERT(response.operation().ready());
+        }
+        {
+            grpc::ClientContext context;
+            Ydb::Table::DescribeTableRequest request;
+            UNIT_ASSERT(::google::protobuf::TextFormat::ParseFromString(R"(
+                path: "/Root/TheTable/ByValue/indexImplTable"
+                include_table_stats: true
+                include_partition_stats: true
+            )", &request));
+
+            Ydb::Table::DescribeTableResponse response;
+            auto grpcStatus = tableService->DescribeTable(&context, request, &response);
+
+            UNIT_ASSERT(grpcStatus.ok());
+            const auto& operation = response.operation();
+            UNIT_ASSERT(operation.ready());
+            UNIT_ASSERT_VALUES_EQUAL(operation.status(), Ydb::StatusIds::SUCCESS);
+
+            Ydb::Table::DescribeTableResult result;
+            operation.result().UnpackTo(&result);
+
+            auto partitioning = result.partitioning_settings().ShortDebugString();
+            UNIT_ASSERT_STRINGS_EQUAL(partitioning, 
+                "partitioning_by_size: DISABLED "
+                "partitioning_by_load: ENABLED "
+                "min_partitions_count: 5"
+            );
+
+            const auto& tableStats = result.table_stats();
+            UNIT_ASSERT_VALUES_EQUAL_C(tableStats.partitions(), 10, tableStats.DebugString());
+        }
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndex) {
+        TKikimrWithGrpcAndRootSchema server;
+
+        auto channel = grpc::CreateChannel("localhost:" + ToString(server.GetPort()), grpc::InsecureChannelCredentials());
+        auto tableService = Ydb::Table::V1::TableService::NewStub(channel);
+        {
+            grpc::ClientContext context;
+            Ydb::Table::CreateTableRequest request;
+            UNIT_ASSERT(::google::protobuf::TextFormat::ParseFromString(R"(
+                path: "/Root/TheTable"
+                columns { name: "Key"   type { optional_type { item { type_id: UINT32 } } } }
+                columns { name: "Value" type { optional_type { item { type_id: UINT32 } } } }
+                primary_key: ["Key"]
+            )", &request));
+
+            Ydb::Table::CreateTableResponse response;
+            auto grpcStatus = tableService->CreateTable(&context, request, &response);
+
+            UNIT_ASSERT(grpcStatus.ok());
+            UNIT_ASSERT(response.operation().ready());
+        }
+        {
+            grpc::ClientContext context;
+            Ydb::Table::AlterTableRequest request;
+            UNIT_ASSERT(::google::protobuf::TextFormat::ParseFromString(R"(
+                path: "/Root/TheTable"
+                add_indexes {
+                    name: "ByValue"
+                    index_columns: "Value"
+                    global_index {
+                        settings {
+                            uniform_partitions: 10
+                            partitioning_settings {
+                                partitioning_by_load: ENABLED
+                                min_partitions_count: 5
+                            }
+                        }
+                    }
+                }
+            )", &request));
+
+            Ydb::Table::AlterTableResponse response;
+            auto grpcStatus = tableService->AlterTable(&context, request, &response);
+
+            UNIT_ASSERT(grpcStatus.ok());
+            const auto& id = response.operation().id();
+            TString error;
+            UNIT_ASSERT_VALUES_EQUAL_C(WaitForStatus(channel, id, &error), Ydb::StatusIds::SUCCESS, error);
+        }
+        {
+            grpc::ClientContext context;
+            Ydb::Table::DescribeTableRequest request;
+            UNIT_ASSERT(::google::protobuf::TextFormat::ParseFromString(R"(
+                path: "/Root/TheTable/ByValue/indexImplTable"
+                include_table_stats: true
+                include_partition_stats: true
+            )", &request));
+
+            Ydb::Table::DescribeTableResponse response;
+            auto grpcStatus = tableService->DescribeTable(&context, request, &response);
+
+            UNIT_ASSERT(grpcStatus.ok());
+            const auto& operation = response.operation();
+            UNIT_ASSERT(operation.ready());
+            UNIT_ASSERT_VALUES_EQUAL(operation.status(), Ydb::StatusIds::SUCCESS);
+
+            Ydb::Table::DescribeTableResult result;
+            operation.result().UnpackTo(&result);
+
+            auto partitioning = result.partitioning_settings().ShortDebugString();
+            UNIT_ASSERT_STRINGS_EQUAL(partitioning, 
+                "partitioning_by_size: DISABLED "
+                "partitioning_by_load: ENABLED "
+                "min_partitions_count: 5"
+            );
+
+            const auto& tableStats = result.table_stats();
+            UNIT_ASSERT_VALUES_EQUAL_C(tableStats.partitions(), 10, tableStats.DebugString());
         }
     }
 }

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -42,6 +42,35 @@
 
 #include <util/generic/ymath.h>
 
+namespace NYdb {
+
+Ydb::StatusIds::StatusCode WaitForStatus(
+    std::shared_ptr<grpc::Channel> channel, const TString& opId, TString* error, int retries, TDuration sleepDuration
+) {
+    std::unique_ptr<Ydb::Operation::V1::OperationService::Stub> stub;
+    stub = Ydb::Operation::V1::OperationService::NewStub(channel);
+    Ydb::Operations::GetOperationRequest request;
+    request.set_id(opId);
+    Ydb::Operations::GetOperationResponse response;
+    for (int retry = 0; retry <= retries; ++retry) {
+        grpc::ClientContext context;
+        auto grpcStatus = stub->GetOperation(&context, request, &response);
+        UNIT_ASSERT_C(grpcStatus.ok(), grpcStatus.error_message());
+        if (response.operation().ready()) {
+            break;
+        }
+        Sleep(sleepDuration *= 2);
+    }
+    if (error && response.operation().issues_size() > 0) {
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(response.operation().issues(), issues);
+        *error = issues.ToString();
+    }
+    return response.operation().status();
+}
+
+}
+
 namespace NKikimr {
 
 using namespace Tests;
@@ -97,26 +126,6 @@ Ydb::Table::DescribeTableResult DescribeTable(std::shared_ptr<grpc::Channel> cha
 
 
 Ydb::Table::ExecuteQueryResult ExecYql(std::shared_ptr<grpc::Channel> channel, const TString &sessionId, const TString &yql, bool withStat = false);
-
-static Ydb::StatusIds::StatusCode WaitForStatus(std::shared_ptr<grpc::Channel> channel, const TString& opId) {
-    std::unique_ptr<Ydb::Operation::V1::OperationService::Stub> stub;
-    stub = Ydb::Operation::V1::OperationService::NewStub(channel);
-    Ydb::Operations::GetOperationRequest request;
-    request.set_id(opId);
-    Ydb::Operations::GetOperationResponse response;
-    bool run = true;
-    while (run) {
-        grpc::ClientContext context;
-        auto status = stub->GetOperation(&context, request, &response);
-        UNIT_ASSERT(status.ok());  //GRpc layer - OK
-        if (response.operation().ready() == false) {
-            Sleep(ITERATION_DURATION);
-        } else {
-            run = false;
-        }
-    }
-    return response.operation().status();
-}
 
 struct TKikimrTestSettings {
     static constexpr bool SSL = false;

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -1630,6 +1630,14 @@ indexes {
   name: "IndexedValue"
   index_columns: "IValue"
   global_index {
+    settings {
+      partitioning_settings {
+        partitioning_by_size: ENABLED
+        partition_size_mb: 2048
+        partitioning_by_load: DISABLED
+        min_partitions_count: 1
+      }
+    }
   }
   status: STATUS_READY
 }


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/4955

There are 3 major commits in this PR, whose purposes are the following:
- 90162f55be34706f7b08797aa3a0fa1703d29eca Extend `ydb_table.proto` to be able to specify partitioning settings of the `indexImplTable` and explicit partition boundaries (or uniform partition count) of the index table at the moment of its creation. There is also a functional test using GRPC calls that shows that it becomes possible to create a table with extended index partitioning settings.
- c96c24f11babd322026f7f5e9860ba7cdf8c6142 Changes in cpp SDK to be able to describe extended partitioning settings and explicit partition boundaries (if any) of secondary indexes of the table. This is necessary to be able to dump and restore the table with the extended index partitioning info.
- 49321ece51d08509414e40ff7ba089a0691d9078 Unit tests and functional tests of the feature.

Note: each major commit is preceded by a minor refactoring change. For the best reviewing experience, please review these changes separately.