### PR TITLE
fix(http_proxy): actually perform DNS resolution when entry is stale

### DIFF
--- a/ydb/library/actors/http/http_proxy.cpp
+++ b/ydb/library/actors/http/http_proxy.cpp
@@ -127,59 +127,73 @@ protected:
     void Handle(TEvHttpProxy::TEvResolveHostRequest::TPtr event, const NActors::TActorContext& ctx) {
         const TString& host(event->Get()->Host);
         auto it = Hosts.find(host);
-        if (it == Hosts.end() || it->second.DeadlineTime > ctx.Now()) {
+        if (it == Hosts.end() || it->second.DeadlineTime < ctx.Now()) {
             TString addressPart;
             TIpPort portPart = 0;
             CrackAddress(host, addressPart, portPart);
-            // TODO(xenoxeno): move to another, possible blocking actor
-            try {
-                TNetworkAddress addr(addressPart, portPart);
-                auto pAddr = addr.Begin();
-                while (pAddr != addr.End() && pAddr->ai_family != AF_INET && pAddr->ai_family != AF_INET6) {
-                    ++pAddr;
+            if (IsIPv6(addressPart)) {
+                if (it == Hosts.end()) {
+                    it = Hosts.emplace(host, THostEntry()).first;
                 }
-                if (pAddr == addr.End()) {
-                    ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse("Invalid address family resolved"));
-                    return;
+                it->second.Address = std::make_shared<TSockAddrInet6>(addressPart.data(), portPart);
+                it->second.DeadlineTime = ctx.Now() + HostsTimeToLive;
+            } else if (IsIPv4(addressPart)) {
+                if (it == Hosts.end()) {
+                    it = Hosts.emplace(host, THostEntry()).first;
                 }
-                THttpConfig::SocketAddressType address;
-                switch (pAddr->ai_family) {
-                    case AF_INET:
-                        address = std::make_shared<TSockAddrInet>();
-                        break;
-                    case AF_INET6:
-                        address = std::make_shared<TSockAddrInet6>();
-                        break;
-                }
-                if (address) {
-                    memcpy(address->SockAddr(), pAddr->ai_addr, pAddr->ai_addrlen);
-                    LOG_DEBUG_S(ctx, HttpLog, "Host " << host << " resolved to " << address->ToString());
-                    if (it == Hosts.end()) {
-                        it = Hosts.emplace(host, THostEntry()).first;
+                it->second.Address = std::make_shared<TSockAddrInet>(addressPart.data(), portPart);
+                it->second.DeadlineTime = ctx.Now() + HostsTimeToLive;
+            } else {
+                // TODO(xenoxeno): move to another, possible blocking actor
+                try {
+                    TNetworkAddress addr(addressPart, portPart);
+                    auto pAddr = addr.Begin();
+                    while (pAddr != addr.End() && pAddr->ai_family != AF_INET && pAddr->ai_family != AF_INET6) {
+                        ++pAddr;
                     }
-                    it->second.Address = address;
-                    it->second.DeadlineTime = ctx.Now() + HostsTimeToLive;
+                    if (pAddr == addr.End()) {
+                        ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse("Invalid address family resolved"));
+                        return;
+                    }
+                    THttpConfig::SocketAddressType address;
+                    switch (pAddr->ai_family) {
+                        case AF_INET:
+                            address = std::make_shared<TSockAddrInet>();
+                            break;
+                        case AF_INET6:
+                            address = std::make_shared<TSockAddrInet6>();
+                            break;
+                    }
+                    if (address) {
+                        memcpy(address->SockAddr(), pAddr->ai_addr, pAddr->ai_addrlen);
+                        LOG_DEBUG_S(ctx, HttpLog, "Host " << host << " resolved to " << address->ToString());
+                        if (it == Hosts.end()) {
+                            it = Hosts.emplace(host, THostEntry()).first;
+                        }
+                        it->second.Address = address;
+                        it->second.DeadlineTime = ctx.Now() + HostsTimeToLive;
+                    }
                 }
-            }
-            catch (const TNetworkResolutionError& e) {
-                if (it != Hosts.end()) {
-                    ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse(it->first, it->second.Address));
-                    return;
-                } else {
-                    ctx.Send(event->Sender,
-                        new TEvHttpProxy::TEvResolveHostResponse(
-                            TStringBuilder()
-                                << "Resolution failed and no stale cached value has been found to fallback.\n"
-                                << "Resolution error: "
-                                << e.what()
-                        )
-                    );
+                catch (const TNetworkResolutionError& e) {
+                    if (it != Hosts.end()) {
+                        ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse(it->first, it->second.Address));
+                        return;
+                    } else {
+                        ctx.Send(event->Sender,
+                            new TEvHttpProxy::TEvResolveHostResponse(
+                                TStringBuilder() 
+                                    << "Resolution failed and no stale cached value has been found to fallback.\n" 
+                                    << "Resolution error: " 
+                                    << e.what()
+                            )
+                        );
+                        return;
+                    }
+                }
+                catch (const yexception& e) {
+                    ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse(e.what()));
                     return;
                 }
-            }
-            catch (const yexception& e) {
-                ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse(e.what()));
-                return;
             }
         }
         ctx.Send(event->Sender, new TEvHttpProxy::TEvResolveHostResponse(it->first, it->second.Address));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- fixed: http_proxy actor performed DNS resolution effectively only once upon startup for each FQDN

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Now, http_proxy actor performs DNS resolution whenever the host FQDN is not found in local cache, as well as when the entry is stale in the local cache. If the DNS resolution fails for some reason, http_proxy actor tries to fallback to the stale entry in the local cache, if it exists. Only if this fallback fails as well, the error is returned.
