### PR TITLE
OAuth2 token exchange in ydb cli

### DIFF
--- a/ydb/apps/ydb/commands/ydb_cloud_root.cpp
+++ b/ydb/apps/ydb/commands/ydb_cloud_root.cpp
@@ -30,6 +30,11 @@ void TClientCommandRoot::SetCredentialsGetter(TConfig& config) {
                 return CreateLoginCredentialsProviderFactory(config.StaticCredentials);
             }
         }
+        if (config.UseOauth2TokenExchange) {
+            if (config.Oauth2TokenExchangeParams) {
+                return CreateOauth2TokenExchangeCredentialsProviderFactory(config.BuildOauth2TokenExchangeParams());
+            }
+        }
         if (config.UseIamAuth) {
             if (config.YCToken) {
                 return CreateIamOAuthCredentialsProviderFactory(
@@ -99,6 +104,7 @@ int NewYCloudClient(int argc, char** argv) {
     settings.UseDefaultTokenFile = false;
     settings.UseIamAuth = true;
     settings.UseStaticCredentials = true;
+    settings.UseOauth2TokenExchange = true;
     settings.UseExportToYt = false;
     settings.MentionUserAccount = false;
     settings.YdbDir = "ydb";

--- a/ydb/apps/ydb/commands/ydb_cloud_root.cpp
+++ b/ydb/apps/ydb/commands/ydb_cloud_root.cpp
@@ -101,7 +101,7 @@ int TYCloudClientCommandRoot::Run(TConfig& config) {
 int NewYCloudClient(int argc, char** argv) {
     NYdb::NConsoleClient::TClientSettings settings;
     settings.EnableSsl = true;
-    settings.UseOAuthToken = true;
+    settings.UseAccessToken = true;
     settings.UseDefaultTokenFile = false;
     settings.UseIamAuth = true;
     settings.UseStaticCredentials = true;

--- a/ydb/apps/ydb/commands/ydb_cloud_root.cpp
+++ b/ydb/apps/ydb/commands/ydb_cloud_root.cpp
@@ -3,6 +3,7 @@
 #include "ydb_version.h"
 
 #include <ydb/public/sdk/cpp/client/iam/common/iam.h>
+#include <ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.h>
 #include <ydb/public/lib/ydb_cli/common/ydb_updater.h>
 
 #include <filesystem>
@@ -31,8 +32,8 @@ void TClientCommandRoot::SetCredentialsGetter(TConfig& config) {
             }
         }
         if (config.UseOauth2TokenExchange) {
-            if (config.Oauth2TokenExchangeParams) {
-                return CreateOauth2TokenExchangeCredentialsProviderFactory(config.BuildOauth2TokenExchangeParams());
+            if (config.Oauth2KeyFile) {
+                return CreateOauth2TokenExchangeFileCredentialsProviderFactory(config.Oauth2KeyFile, config.IamEndpoint);
             }
         }
         if (config.UseIamAuth) {

--- a/ydb/public/lib/ydb_cli/commands/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/ya.make
@@ -34,7 +34,6 @@ SRCS(
 
 PEERDIR(
     contrib/libs/fmt
-    contrib/libs/jwt-cpp
     contrib/restricted/patched/replxx
     library/cpp/histogram/hdr
     library/cpp/protobuf/json

--- a/ydb/public/lib/ydb_cli/commands/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/ya.make
@@ -34,6 +34,7 @@ SRCS(
 
 PEERDIR(
     contrib/libs/fmt
+    contrib/libs/jwt-cpp
     contrib/restricted/patched/replxx
     library/cpp/histogram/hdr
     library/cpp/protobuf/json

--- a/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
@@ -553,11 +553,11 @@ void TCommandProfileCommon::SetupProfileAuthentication(bool existingProfile, con
                 }
         );
     }
-    if (config.UseOAuthToken) {
+    if (config.UseAccessToken) {
         picker.AddOption(
-                "Set new OAuth token (ydb-token)",
+                "Set new access token (ydb-token)",
                 [&profile, &profileName]() {
-                    SetAuthMethod("ydb-token", "OAuth YDB token", profile, profileName);
+                    SetAuthMethod("ydb-token", "YDB token", profile, profileName);
                 }
         );
     }

--- a/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
@@ -198,7 +198,7 @@ namespace {
     }
 
     TString TryBlurValue(const TString& authMethod, const TString& value) {
-        if (!IsStdoutInteractive() || authMethod == "sa-key-file" || authMethod == "token-file" || authMethod == "yc-token-file") {
+        if (!IsStdoutInteractive() || authMethod == "sa-key-file" || authMethod == "token-file" || authMethod == "yc-token-file" || authMethod == "oauth2-key-file") {
             return value;
         }
         if (authMethod == "password") {
@@ -218,7 +218,7 @@ namespace {
             auto authValue = profile->GetValue(AuthNode);
             TString authMethod = authValue["method"].as<TString>();
             Cout << "  " << authMethod;
-            if (authMethod == "ydb-token" ||authMethod == "iam-token"
+            if (authMethod == "ydb-token" || authMethod == "oauth2-key-file" || authMethod == "iam-token"
                 || authMethod == "yc-token" || authMethod == "sa-key-file"
                 || authMethod == "token-file" || authMethod == "yc-token-file") {
                 Cout << ": " << TryBlurValue(authMethod, authValue["data"].as<TString>());
@@ -276,6 +276,11 @@ void TCommandConnectionInfo::PrintInfo(TConfig& config) {
     }
     if (config.SecurityToken) {
         Cout << "token: " << TryBlurValue("token", config.SecurityToken) << Endl;
+    }
+    if (config.UseOauth2TokenExchange) {
+        if (config.Oauth2KeyFile) {
+            Cout << "oauth2-key-file: " << config.Oauth2KeyFile << Endl;
+        }
     }
     if (config.UseIamAuth) {
         if (config.YCToken) {
@@ -370,6 +375,7 @@ void TCommandProfileCommon::GetOptionsFromStdin() {
     THashMap<TString, TString&> options {
         {"database", Database},
         {"token-file", TokenFile},
+        {"oauth2-key-file", Oauth2KeyFile},
         {"yc-token-file", YcTokenFile},
         {"iam-token-file", IamTokenFile},
         {"sa-key-file", SaKeyFile},
@@ -526,11 +532,17 @@ void TCommandProfileCommon::SetupProfileAuthentication(bool existingProfile, con
                 }
         );
         picker.AddOption(
+                "Use OAuth 2.0 RFC8693 token exchange credentials parameters json file.",
+                [&profile, &profileName]() {
+                    SetAuthMethod("oauth2-key-file", "OAuth 2.0 RFC8693 token exchange credentials parameters json file", profile, profileName);
+                }
+        );
+        picker.AddOption(
                 "Use metadata service on a virtual machine (use-metadata-credentials)"
                 " cloud.yandex.ru/docs/compute/operations/vm-connect/auth-inside-vm",
                 [&profile, &profileName]() {
                     Cout << "Setting metadata service usage for profile \"" << profileName << "\"" << Endl;
-                    PutAuthMethodWithoutPars( profile, "use-metadata-credentials" );
+                    PutAuthMethodWithoutPars(profile, "use-metadata-credentials");
                 }
         );
         picker.AddOption(
@@ -570,7 +582,7 @@ void TCommandProfileCommon::SetupProfileAuthentication(bool existingProfile, con
             description << "Use current settings with method \"" << method << "\"";
             if (method == "iam-token" || method == "yc-token" || method == "ydb-token") {
                 description << " and value \"" << BlurSecret(authValue["data"].as<TString>()) << "\"";
-            } else if (method == "sa-key-file" || method == "token-file" || method == "yc-token-file") {
+            } else if (method == "sa-key-file" || method == "token-file" || method == "yc-token-file" || method == "oauth2-key-file") {
                 description << " and value \"" << authValue["data"].as<TString>() << "\"";
             }
             picker.AddOption(
@@ -588,18 +600,20 @@ bool TCommandProfileCommon::SetAuthFromCommandLine(std::shared_ptr<IProfile> pro
         profile->SetValue("iam-endpoint", IamEndpoint);
     }
     if (TokenFile) {
-        PutAuthMethod( profile, "token-file", TokenFile);
+        PutAuthMethod(profile, "token-file", TokenFile);
+    } else if (Oauth2KeyFile) {
+        PutAuthMethod(profile, "oauth2-key-file", Oauth2KeyFile);
     } else if (IamTokenFile) {
         // no error here, we take the iam-token-file option as just a token-file authentication
-        PutAuthMethod( profile, "token-file", IamTokenFile);
-    }else if (YcTokenFile) {
-        PutAuthMethod( profile, "yc-token-file", YcTokenFile);
+        PutAuthMethod(profile, "token-file", IamTokenFile);
+    } else if (YcTokenFile) {
+        PutAuthMethod(profile, "yc-token-file", YcTokenFile);
     } else if (UseMetadataCredentials) {
-        PutAuthMethodWithoutPars( profile, "use-metadata-credentials");
+        PutAuthMethodWithoutPars(profile, "use-metadata-credentials");
     } else if (SaKeyFile) {
-        PutAuthMethod( profile, "sa-key-file", SaKeyFile);
+        PutAuthMethod(profile, "sa-key-file", SaKeyFile);
     } else if (User) {
-        PutAuthStatic( profile, User, PasswordFile, true );
+        PutAuthStatic(profile, User, PasswordFile, true);
     } else if (AnonymousAuth) {
         PutAuthMethodWithoutPars(profile, "anonymous-auth");
     } else {
@@ -610,7 +624,8 @@ bool TCommandProfileCommon::SetAuthFromCommandLine(std::shared_ptr<IProfile> pro
 
 void TCommandProfileCommon::ValidateAuth() {
     size_t authMethodCount =
-            (bool) (TokenFile) + (bool) (IamTokenFile) +
+            (bool) (TokenFile) + (bool) (Oauth2KeyFile) +
+            (bool) (IamTokenFile) +
             (bool) (YcTokenFile) + UseMetadataCredentials +
             (bool) (SaKeyFile) + AnonymousAuth +
             (User || PasswordFile);
@@ -624,6 +639,9 @@ void TCommandProfileCommon::ValidateAuth() {
         str << authMethodCount << " authentication methods were provided via options:";
         if (TokenFile) {
             str << " TokenFile (" << TokenFile << ")";
+        }
+        if (Oauth2KeyFile) {
+            str << " OAuth2KeyFile (" << Oauth2KeyFile << ")";
         }
         if (IamTokenFile) {
             str << " IamTokenFile (" << IamTokenFile << ")";
@@ -652,7 +670,7 @@ void TCommandProfileCommon::ValidateAuth() {
 }
 
 bool TCommandProfileCommon::AnyProfileOptionInCommandLine() {
-    return Endpoint || Database || TokenFile ||
+    return Endpoint || Database || TokenFile || Oauth2KeyFile ||
            IamTokenFile || YcTokenFile ||
            SaKeyFile || UseMetadataCredentials || User ||
            PasswordFile || IamEndpoint || AnonymousAuth || CaCertsFile;
@@ -673,6 +691,9 @@ void TCommandProfileCommon::Config(TConfig& config) {
     opts.AddLongOption('d', "database", "Database to save in the profile").RequiredArgument("PATH").StoreResult(&Database);
 
     opts.AddLongOption("token-file", "Access token file").RequiredArgument("PATH").StoreResult(&TokenFile);
+    if (config.UseOauth2TokenExchange) {
+        opts.AddLongOption("oauth2-key-file", "OAuth 2.0 RFC8693 token exchange credentials parameters json file").RequiredArgument("PATH").StoreResult(&Oauth2KeyFile);
+    }
     opts.AddLongOption("iam-token-file", "Access token file").RequiredArgument("PATH").Hidden().StoreResult(&IamTokenFile);
     opts.AddLongOption("anonymous-auth", "Anonymous authentication").Optional().StoreTrue(&AnonymousAuth);
     if (config.UseIamAuth) {
@@ -1049,7 +1070,8 @@ void TCommandUpdateProfile::Config(TConfig& config) {
 
 void TCommandUpdateProfile::ValidateNoOptions() {
     size_t authMethodCount =
-            (bool) (TokenFile) + (bool) (IamTokenFile) +
+            (bool) (TokenFile) + (bool) (Oauth2KeyFile) +
+            (bool) (IamTokenFile) +
             (bool) (YcTokenFile) + UseMetadataCredentials +
             (bool) (SaKeyFile) + AnonymousAuth +
             (User || PasswordFile);

--- a/ydb/public/lib/ydb_cli/commands/ydb_profile.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_profile.h
@@ -15,7 +15,7 @@ public:
 class TCommandConnectionInfo : public TClientCommand {
 public:
     TCommandConnectionInfo();
-		
+
     virtual void Config(TConfig& config) override;
     virtual int Run(TConfig& config) override;
 
@@ -42,7 +42,7 @@ protected:
     void ConfigureProfile(const TString& profileName, std::shared_ptr<IProfileManager> profileManager,
                      TConfig& config, bool interactive, bool cmdLine);
 
-    TString ProfileName, Endpoint, Database, TokenFile, YcTokenFile, SaKeyFile,
+    TString ProfileName, Endpoint, Database, TokenFile, Oauth2KeyFile, YcTokenFile, SaKeyFile,
             IamTokenFile, IamEndpoint, User, PasswordFile, CaCertsFile;
 
     bool UseMetadataCredentials = false;

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -259,13 +259,13 @@ void TClientCommandRootCommon::Config(TConfig& config) {
 
             oauth2TokenExchangeHelp
                 << "  Fields of json file:" << Endl
-                << FIELD("grant-type") "          " TYPE("string") "Grant type option" DEFAULT(defaultParams.GrantType_) << Endl
-                << FIELD("res") "                 " TYPE("string") "Resource option (optional)" << Endl
+                << FIELD("grant-type") "          " TYPE("string") "Grant type" DEFAULT(defaultParams.GrantType_) << Endl
+                << FIELD("res") "                 " TYPE("string") "Resource (optional)" << Endl
                 << FIELD("aud") "                 " TYPE2("string", "list of strings") "Audience option for token exchange request (optional)" << Endl
-                << FIELD("scope") "               " TYPE2("string", "list of strings") "Scope option (optional)" << Endl
-                << FIELD("requested-token-type") "" TYPE("string") "Requested token type option" DEFAULT(defaultParams.RequestedTokenType_) << Endl
-                << FIELD("subject-credentials") " " TYPE("creds_json") "Subject credentials options (optional)" << Endl
-                << FIELD("actor-credentials") "   " TYPE("creds_json") "Actor credentials options (optional)" << Endl
+                << FIELD("scope") "               " TYPE2("string", "list of strings") "Scope (optional)" << Endl
+                << FIELD("requested-token-type") "" TYPE("string") "Requested token type" DEFAULT(defaultParams.RequestedTokenType_) << Endl
+                << FIELD("subject-credentials") " " TYPE("creds_json") "Subject credentials (optional)" << Endl
+                << FIELD("actor-credentials") "   " TYPE("creds_json") "Actor credentials (optional)" << Endl
                 << Endl
                 << "  Fields of " << colors.BoldColor() << "creds_json" << colors.OldColor() << " (JWT):" << Endl
                 << FIELD("type") "                " TYPE("string") "Token source type. Set " << colors.BoldColor() << "JWT" << colors.OldColor() << Endl

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -913,24 +913,6 @@ void TClientCommandRootCommon::ParseCredentials(TConfig& config) {
             break;
         }
 
-        if (config.UseOauth2TokenExchange) {
-            TString envOauth2KeyFile = GetEnv("YDB_OAUTH2_KEY_FILE");
-            if (!envOauth2KeyFile.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using oauth2 key file from YDB_OAUTH2_KEY_FILE env variable" << Endl;
-                    }
-                    config.ChosenAuthMethod = "oauth2-key-file";
-                    config.Oauth2KeyFile = envOauth2KeyFile;
-                    IsAuthSet = true;
-                }
-                if (!IsVerbose()) {
-                    break;
-                }
-                config.ConnectionParams["oauth2-key-file"].push_back({envOauth2KeyFile, "YDB_OAUTH2_KEY_FILE enviroment variable"});
-            }
-        }
-
         // Priority 3. No auth methods from --profile either. Checking environment variables.
         if (config.UseIamAuth) {
             TString envIamToken = GetEnv("IAM_TOKEN");
@@ -1045,6 +1027,24 @@ void TClientCommandRootCommon::ParseCredentials(TConfig& config) {
             }
             if (!IsVerbose() && (!userName.empty() || !password.empty())) {
                 break;
+            }
+        }
+
+        if (config.UseOauth2TokenExchange) {
+            TString envOauth2KeyFile = GetEnv("YDB_OAUTH2_KEY_FILE");
+            if (!envOauth2KeyFile.empty()) {
+                if (!IsAuthSet) {
+                    if (IsVerbose()) {
+                        Cerr << "Using oauth2 key file from YDB_OAUTH2_KEY_FILE env variable" << Endl;
+                    }
+                    config.ChosenAuthMethod = "oauth2-key-file";
+                    config.Oauth2KeyFile = envOauth2KeyFile;
+                    IsAuthSet = true;
+                }
+                if (!IsVerbose()) {
+                    break;
+                }
+                config.ConnectionParams["oauth2-key-file"].push_back({envOauth2KeyFile, "YDB_OAUTH2_KEY_FILE enviroment variable"});
             }
         }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -68,7 +68,7 @@ void TClientCommandRootCommon::ValidateSettings() {
     } else if (!Settings.MentionUserAccount.Defined()) {
         Cerr << "Missing user account mentioning flag in client settings" << Endl;
     } else if (!Settings.UseOauth2TokenExchange.Defined()) {
-        Cerr << "Missing oauth 2.0 token exchange credentials usage flag in client settings" << Endl;
+        Cerr << "Missing OAuth 2.0 token exchange credentials usage flag in client settings" << Endl;
     } else if (!Settings.YdbDir) {
         Cerr << "Missing YDB directory in client settings" << Endl;
     } else {

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -55,8 +55,8 @@ TClientCommandRootCommon::TClientCommandRootCommon(const TString& name, const TC
 void TClientCommandRootCommon::ValidateSettings() {
     if (!Settings.EnableSsl.Defined()) {
         Cerr << "Missing ssl enabling flag in client settings" << Endl;
-    } else if (!Settings.UseOAuthToken.Defined()) {
-        Cerr << "Missing OAuth token usage flag in client settings" << Endl;
+    } else if (!Settings.UseAccessToken.Defined()) {
+        Cerr << "Missing access token usage flag in client settings" << Endl;
     } else if (!Settings.UseDefaultTokenFile.Defined()) {
         Cerr << "Missing default token file usage flag in client settings" << Endl;
     } else if (!Settings.UseIamAuth.Defined()) {
@@ -78,7 +78,7 @@ void TClientCommandRootCommon::ValidateSettings() {
 }
 
 void TClientCommandRootCommon::FillConfig(TConfig& config) {
-    config.UseOAuthToken = Settings.UseOAuthToken.GetRef();
+    config.UseAccessToken = Settings.UseAccessToken.GetRef();
     config.UseIamAuth = Settings.UseIamAuth.GetRef();
     config.UseStaticCredentials = Settings.UseStaticCredentials.GetRef();
     config.UseOauth2TokenExchange = Settings.UseOauth2TokenExchange.GetRef();
@@ -187,9 +187,9 @@ void TClientCommandRootCommon::Config(TConfig& config) {
         opts.AddLongOption("sa-key-file", saKeyHelp).RequiredArgument("PATH").StoreResult(&SaKeyFile);
     }
 
-    if (config.UseOAuthToken) {
+    if (config.UseAccessToken) {
         TStringBuilder tokenHelp;
-        tokenHelp << "OAuth token file" << Endl
+        tokenHelp << "Access token file" << Endl
             << "  Token search order:" << Endl
             << "    1. This option" << Endl
             << "    2. Profile specified with --profile option" << Endl
@@ -651,7 +651,7 @@ bool TClientCommandRootCommon::GetCredentialsFromProfile(std::shared_ptr<IProfil
         knownMethod |= (authMethod == "iam-token" || authMethod == "yc-token" || authMethod == "sa-key-file" ||
                         authMethod == "token-file" || authMethod == "yc-token-file");
     }
-    if (config.UseOAuthToken) {
+    if (config.UseAccessToken) {
         knownMethod |= (authMethod == "ydb-token" || authMethod == "token-file");
     }
     if (config.UseStaticCredentials) {
@@ -772,7 +772,7 @@ bool TClientCommandRootCommon::GetCredentialsFromProfile(std::shared_ptr<IProfil
     } else if (authMethod == "ydb-token") {
         if (!IsAuthSet && (explicitOption || !Profile)) {
             if (IsVerbose()) {
-                PrintSettingFromProfile("OAuth token (ydb-token)", profile, explicitOption);
+                PrintSettingFromProfile("Access token (ydb-token)", profile, explicitOption);
             }
             config.SecurityToken = authData.as<TString>();
             config.ChosenAuthMethod = "token";
@@ -993,12 +993,12 @@ void TClientCommandRootCommon::ParseCredentials(TConfig& config) {
                 config.ConnectionParams["sa-key-file"].push_back({envSaKeyFile, "SA_KEY_FILE enviroment variable"});
             }
         }
-        if (config.UseOAuthToken) {
+        if (config.UseAccessToken) {
             TString envYdbToken = GetEnv("YDB_TOKEN");
             if (!envYdbToken.empty()) {
                 if (!IsAuthSet) {
                     if (IsVerbose()) {
-                        Cerr << "Using OAuth token from YDB_TOKEN env variable" << Endl;
+                        Cerr << "Using access token from YDB_TOKEN env variable" << Endl;
                     }
                     config.ChosenAuthMethod = "token";
                     config.SecurityToken = envYdbToken;

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
@@ -78,8 +78,7 @@ private:
     const TClientSettings& Settings;
     TVector<TString> MisuseErrors;
 
-    TMaybe<TOauth2TokenExchangeParams> Oauth2TokenExchangeParams;
-    TString Oauth2TokenExchangeParamsJson;
+    TString Oauth2KeyFile;
 
     bool IsAddressSet = false;
     bool IsDatabaseSet = false;

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
@@ -9,8 +9,8 @@ namespace NConsoleClient {
 struct TClientSettings {
     // Whether to use secure connection or not
     TMaybe<bool> EnableSsl;
-    // Whether to use OAuth token in auth options or not
-    TMaybe<bool> UseOAuthToken;
+    // Whether to use access token in auth options or not
+    TMaybe<bool> UseAccessToken;
     // Whether to use default token file in auth options or not
     TMaybe<bool> UseDefaultTokenFile;
     // Whether to use IAM authentication (Yandex.Cloud) or not

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
@@ -17,6 +17,8 @@ struct TClientSettings {
     TMaybe<bool> UseIamAuth;
     // Whether to use static credentials (user/password) or not
     TMaybe<bool> UseStaticCredentials;
+    // Whether to use OAuth 2.0 token exchange credentials or not
+    TMaybe<bool> UseOauth2TokenExchange;
     // Whether to use export to YT command or not
     TMaybe<bool> UseExportToYt;
     // Whether to mention user account in --help command or not
@@ -75,6 +77,9 @@ private:
     TString IamEndpoint;
     const TClientSettings& Settings;
     TVector<TString> MisuseErrors;
+
+    TMaybe<TOauth2TokenExchangeParams> Oauth2TokenExchangeParams;
+    TString Oauth2TokenExchangeParamsJson;
 
     bool IsAddressSet = false;
     bool IsDatabaseSet = false;

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -127,6 +127,13 @@ ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriority(TClientComman
     }
 }
 
+TOauth2TokenExchangeParams TClientCommand::TConfig::BuildOauth2TokenExchangeParams() const {
+    Y_ASSERT(Oauth2TokenExchangeParams);
+    TOauth2TokenExchangeParams params = *Oauth2TokenExchangeParams;
+    params.TokenEndpoint(IamEndpoint);
+    return params;
+}
+
 TClientCommand::TOptsParseOneLevelResult::TOptsParseOneLevelResult(TConfig& config) {
     int _argc = 1;
     int levels = 1;

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -106,7 +106,7 @@ TClientCommand::TClientCommand(
 {
     HideOption("svnrevision");
     Opts.AddHelpOption('h');
-    ChangeOptionDescription("help", "Print usage");
+    ChangeOptionDescription("help", "Print usage, -hh for more detailed help");
     auto terminalWidth = GetTerminalWidth();
     size_t lineLength = terminalWidth ? *terminalWidth : Max<size_t>();
     Opts.SetWrap(Max(Opts.Wrap_, static_cast<ui32>(lineLength)));
@@ -127,11 +127,30 @@ ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriority(TClientComman
     }
 }
 
-TOauth2TokenExchangeParams TClientCommand::TConfig::BuildOauth2TokenExchangeParams() const {
-    Y_ASSERT(Oauth2TokenExchangeParams);
-    TOauth2TokenExchangeParams params = *Oauth2TokenExchangeParams;
-    params.TokenEndpoint(IamEndpoint);
-    return params;
+size_t TClientCommand::TConfig::ParseHelpCommandVerbosilty(int argc, char** argv) {
+    size_t cnt = 0;
+    for (int i = 0; i < argc; ++i) {
+        TStringBuf arg = argv[i];
+        if (arg == "--help") {
+            ++cnt;
+            continue;
+        }
+        if (arg.StartsWith("--")) { // other option
+            continue;
+        }
+        if (arg.StartsWith("-")) { // char options
+            for (size_t i = 1; i < arg.size(); ++i) {
+                if (arg[i] == 'h') {
+                    ++cnt;
+                }
+            }
+        }
+    }
+
+    if (!cnt) {
+        cnt = 1;
+    }
+    return cnt;
 }
 
 TClientCommand::TOptsParseOneLevelResult::TOptsParseOneLevelResult(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -106,7 +106,7 @@ TClientCommand::TClientCommand(
 {
     HideOption("svnrevision");
     Opts.AddHelpOption('h');
-    ChangeOptionDescription("help", "Print usage, -hh for more detailed help");
+    ChangeOptionDescription("help", "Print usage, -hh for detailed help");
     auto terminalWidth = GetTerminalWidth();
     size_t lineLength = terminalWidth ? *terminalWidth : Max<size_t>();
     Opts.SetWrap(Max(Opts.Wrap_, static_cast<ui32>(lineLength)));

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -127,7 +127,7 @@ public:
         TString ChosenAuthMethod;
 
         TString ProfileFile;
-        bool UseOAuthToken = true;
+        bool UseAccessToken = true;
         bool UseIamAuth = false;
         bool UseStaticCredentials = false;
         bool UseOauth2TokenExchange = false;

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -47,6 +47,7 @@ PEERDIR(
     ydb/public/sdk/cpp/client/ydb_topic
     ydb/public/sdk/cpp/client/ydb_types
     ydb/public/sdk/cpp/client/ydb_types/credentials
+    ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange
     ydb/library/arrow_parquet
 )
 

--- a/ydb/public/sdk/cpp/client/helpers/helpers.cpp
+++ b/ydb/public/sdk/cpp/client/helpers/helpers.cpp
@@ -4,6 +4,7 @@
 #include <ydb/public/sdk/cpp/client/resources/ydb_ca.h>
 #include <ydb/public/sdk/cpp/client/impl/ydb_internal/common/parser.h>
 #include <ydb/public/sdk/cpp/client/impl/ydb_internal/common/getenv.h>
+#include <ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.h>
 #include <util/stream/file.h>
 
 namespace NYdb {
@@ -37,7 +38,7 @@ TDriverConfig CreateFromEnvironment(const TStringType& connectionString) {
     }
 
     bool useMetadataCredentials = GetStrFromEnv("YDB_METADATA_CREDENTIALS", "0") == "1";
-    if (useMetadataCredentials){
+    if (useMetadataCredentials) {
         auto factory = CreateIamCredentialsProviderFactory();
         try {
             factory->CreateProvider();
@@ -49,8 +50,15 @@ TDriverConfig CreateFromEnvironment(const TStringType& connectionString) {
     }
 
     TStringType accessToken = GetStrFromEnv("YDB_ACCESS_TOKEN_CREDENTIALS", "");
-    if (accessToken != ""){
+    if (accessToken != "") {
         driverConfig.SetAuthToken(accessToken);
+        return driverConfig;
+    }
+
+    TStringType oauth2KeyFile = GetStrFromEnv("YDB_OAUTH2_KEY_FILE", "");
+    if (!saKeyFile.empty()) {
+        driverConfig.SetCredentialsProviderFactory(
+            CreateOauth2TokenExchangeFileCredentialsProviderFactory(oauth2KeyFile));
         return driverConfig;
     }
 
@@ -65,4 +73,3 @@ TDriverConfig CreateFromSaKeyFile(const TStringType& saKeyFile, const TStringTyp
 }
 
 } // namespace NYdb
-

--- a/ydb/public/sdk/cpp/client/helpers/helpers.h
+++ b/ydb/public/sdk/cpp/client/helpers/helpers.h
@@ -9,6 +9,7 @@ namespace NYdb {
 //! YDB_ANONYMOUS_CREDENTIALS="1" — uses anonymous access (used for test installation),
 //! YDB_METADATA_CREDENTIALS="1" — uses metadata service,
 //! YDB_ACCESS_TOKEN_CREDENTIALS=<access-token> — access token (for example, IAM-token).
+//! YDB_OAUTH2_KEY_FILE=<path-to-file> - OAuth 2.0 RFC8693 token exchange credentials parameters json file
 //! If grpcs protocol is given in endpoint (or protocol is empty), enables SSL and uses
 //! certificate from resourses and user cert from env variable "YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"
 TDriverConfig CreateFromEnvironment(const TStringType& connectionString = "");

--- a/ydb/public/sdk/cpp/client/helpers/ya.make
+++ b/ydb/public/sdk/cpp/client/helpers/ya.make
@@ -7,6 +7,7 @@ SRCS(
 PEERDIR(
     ydb/public/sdk/cpp/client/iam/common
     ydb/public/sdk/cpp/client/ydb_types/credentials
+    ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange
     ydb/library/yql/public/issue/protos
 )
 

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/credentials.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/credentials.cpp
@@ -141,13 +141,16 @@ public:
 
 private:
     void ParseTokenEndpoint() {
+        if (TokenEndpoint_.empty()) {
+            throw std::invalid_argument(INV_ARG "token endpoint not set");
+        }
         NUri::TUri url;
         NUri::TUri::TState::EParsed parseStatus = url.Parse(TokenEndpoint_, NUri::TFeature::FeaturesAll);
         if (parseStatus != NUri::TUri::TState::EParsed::ParsedOK) {
             throw std::invalid_argument(INV_ARG "failed to parse url");
         }
         if (url.IsNull(NUri::TUri::FieldScheme)) {
-            throw std::invalid_argument(INV_ARG "token url without scheme");
+            throw std::invalid_argument(TStringBuilder() << INV_ARG "token url without scheme: " << TokenEndpoint_);
         }
         TokenHost_ = TStringBuilder() << url.GetField(NUri::TUri::FieldScheme) << "://" << url.GetHost();
 

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.cpp
@@ -128,8 +128,8 @@ struct TJwtTokenSourceParamsForParsing : public TJwtTokenSourceParams {
 std::shared_ptr<ITokenSource> ParseFixedTokenSource(const NJson::TJsonValue& cfg) {
     const auto& map = cfg.GetMapSafe();
     TFixedTokenSourceParamsForParsing result;
-    PROCESS_JSON_STRING_PARAM("token", Token, true);
-    PROCESS_JSON_STRING_PARAM("token-type", TokenType, true);
+    PROCESS_JSON_STRING_PARAM("token", Token, true); // required
+    PROCESS_JSON_STRING_PARAM("token-type", TokenType, true); // required
     return CreateFixedTokenSource(result.Token_, result.TokenType_);
 }
 
@@ -144,8 +144,8 @@ std::shared_ptr<ITokenSource> ParseJwtTokenSource(const NJson::TJsonValue& cfg) 
 
     // special fields
     PROCESS_JSON_STRING_PARAM("ttl", TtlStr, false);
-    PROCESS_JSON_STRING_PARAM("alg", AlgStr, false);
-    PROCESS_JSON_STRING_PARAM("private-key", PrivateKeyStr, false);
+    PROCESS_JSON_STRING_PARAM("alg", AlgStr, true); // required
+    PROCESS_JSON_STRING_PARAM("private-key", PrivateKeyStr, true); // required
 
     try {
         if (result.TtlStr_) {
@@ -154,10 +154,6 @@ std::shared_ptr<ITokenSource> ParseJwtTokenSource(const NJson::TJsonValue& cfg) 
     } catch (const std::exception& ex) {
         throw std::runtime_error(TStringBuilder()
             << "Failed to parse \"ttl\": " << ex.what());
-    }
-
-    if (!result.AlgStr_ || !result.PrivateKeyStr_) {
-        throw std::runtime_error("\"alg\" and \"private-key\" params are required");
     }
 
     const auto jwtAlgIt = JwtAlgorithmsFactory.find(result.AlgStr_);
@@ -203,7 +199,7 @@ TOauth2TokenExchangeParams ReadOauth2ConfigJson(const TString& configJson, const
         if (tokenEndpoint) {
             result.TokenEndpoint(tokenEndpoint);
         } else {
-            PROCESS_JSON_STRING_PARAM("token-endpoint", TokenEndpoint, false);
+            PROCESS_JSON_STRING_PARAM("token-endpoint", TokenEndpoint, false); // there is an explicit check in provider params after parsing
         }
 
         PROCESS_JSON_STRING_PARAM("grant-type", GrantType, false);

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.cpp
@@ -1,0 +1,241 @@
+#include "from_file.h"
+#include "credentials.h"
+#include "jwt_token_source.h"
+
+#include <library/cpp/json/json_reader.h>
+
+#include <util/generic/map.h>
+#include <util/stream/file.h>
+#include <util/string/builder.h>
+#include <util/string/cast.h>
+
+#include <jwt-cpp/jwt.h>
+
+namespace NYdb {
+
+namespace {
+
+struct TLessNoCase {
+    bool operator()(TStringBuf l, TStringBuf r) const {
+        auto ll = l.length();
+        auto rl = r.length();
+        if (ll != rl) {
+            return ll < rl;
+        }
+        return strnicmp(l.data(), r.data(), ll) < 0;
+    }
+};
+
+template <class TAlg>
+void ApplyAsymmetricAlg(TJwtTokenSourceParams* params, const TString& privateKey) {
+    // Alg with first param as public key, second param as private key
+    params->SigningAlgorithm<TAlg>(std::string{}, privateKey);
+}
+
+template <class TAlg>
+void ApplyHmacAlg(TJwtTokenSourceParams* params, const TString& key) {
+    // Alg with first param as key
+    params->SigningAlgorithm<TAlg>(key);
+}
+
+const TMap<TString, void(*)(TJwtTokenSourceParams*, const TString& privateKey), TLessNoCase> JwtAlgorithmsFactory = {
+    {"RS256", &ApplyAsymmetricAlg<jwt::algorithm::rs256>},
+    {"RS384", &ApplyAsymmetricAlg<jwt::algorithm::rs384>},
+    {"RS512", &ApplyAsymmetricAlg<jwt::algorithm::rs512>},
+    {"ES256", &ApplyAsymmetricAlg<jwt::algorithm::es256>},
+    {"ES384", &ApplyAsymmetricAlg<jwt::algorithm::es384>},
+    {"ES512", &ApplyAsymmetricAlg<jwt::algorithm::es512>},
+    {"PS256", &ApplyAsymmetricAlg<jwt::algorithm::ps256>},
+    {"PS384", &ApplyAsymmetricAlg<jwt::algorithm::ps384>},
+    {"PS512", &ApplyAsymmetricAlg<jwt::algorithm::ps512>},
+    {"HS256", &ApplyHmacAlg<jwt::algorithm::hs256>},
+    {"HS384", &ApplyHmacAlg<jwt::algorithm::hs384>},
+    {"HS512", &ApplyHmacAlg<jwt::algorithm::hs512>},
+};
+
+bool IsAsciiEqualUpper(const TString& jsonParam, const TStringBuf& constantInUpperCase) {
+    if (jsonParam.size() != constantInUpperCase.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < constantInUpperCase.size(); ++i) {
+        char c = jsonParam[i];
+        if (c >= 'a' && c <= 'z') {
+            c += 'A' - 'a';
+        }
+        if (c != constantInUpperCase[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// throws if not string
+#define PROCESS_JSON_STRING_PARAM(jsonParamName, paramName, required)      \
+    try {                                                                  \
+        if (const NJson::TJsonValue* value = map.FindPtr(jsonParamName)) { \
+            result.paramName(value->GetStringSafe());                      \
+        } else if (required) {                                             \
+            throw std::runtime_error(                                      \
+                "No \"" jsonParamName "\" parameter");                     \
+        }                                                                  \
+    } catch (const std::exception& ex) {                                   \
+        throw std::runtime_error(TStringBuilder()                          \
+            << "Failed to parse \"" jsonParamName "\": " << ex.what());    \
+    }
+
+// throws if not string or array of strings
+#define PROCESS_JSON_ARRAY_PARAM(jsonParamName, paramName)                 \
+    try {                                                                  \
+        if (const NJson::TJsonValue* value = map.FindPtr(jsonParamName)) { \
+            if (value->IsArray()) {                                        \
+                for (const NJson::TJsonValue& v : value->GetArraySafe()) { \
+                    result.Append ## paramName(v.GetStringSafe());         \
+                }                                                          \
+            } else {                                                       \
+                result.paramName(value->GetStringSafe());                  \
+            }                                                              \
+        }                                                                  \
+    } catch (const std::exception& ex) {                                   \
+        throw std::runtime_error(TStringBuilder()                          \
+            << "Failed to parse \"" jsonParamName "\": " << ex.what());    \
+    }
+
+#define PROCESS_CREDS_PARAM(jsonParamName, paramName)                      \
+    try {                                                                  \
+        if (const NJson::TJsonValue* value = map.FindPtr(jsonParamName)) { \
+            result.paramName(ParseTokenSource(*value));                    \
+        }                                                                  \
+    } catch (const std::exception& ex) {                                   \
+        throw std::runtime_error(TStringBuilder()                          \
+            << "Failed to parse \"" jsonParamName "\": " << ex.what());    \
+    }
+
+// special struct to apply macros
+struct TFixedTokenSourceParamsForParsing {
+    using TSelf = TFixedTokenSourceParamsForParsing;
+
+    FLUENT_SETTING(TString, Token);
+    FLUENT_SETTING(TString, TokenType);
+};
+
+// special struct to apply macros
+struct TJwtTokenSourceParamsForParsing : public TJwtTokenSourceParams {
+    FLUENT_SETTING(TString, AlgStr);
+    FLUENT_SETTING(TString, PrivateKeyStr);
+    FLUENT_SETTING(TString, TtlStr);
+};
+
+std::shared_ptr<ITokenSource> ParseFixedTokenSource(const NJson::TJsonValue& cfg) {
+    const auto& map = cfg.GetMapSafe();
+    TFixedTokenSourceParamsForParsing result;
+    PROCESS_JSON_STRING_PARAM("token", Token, true);
+    PROCESS_JSON_STRING_PARAM("token-type", TokenType, true);
+    return CreateFixedTokenSource(result.Token_, result.TokenType_);
+}
+
+std::shared_ptr<ITokenSource> ParseJwtTokenSource(const NJson::TJsonValue& cfg) {
+    const auto& map = cfg.GetMapSafe();
+    TJwtTokenSourceParamsForParsing result;
+    PROCESS_JSON_STRING_PARAM("kid", KeyId, false);
+    PROCESS_JSON_STRING_PARAM("iss", Issuer, false);
+    PROCESS_JSON_STRING_PARAM("sub", Subject, false);
+    PROCESS_JSON_ARRAY_PARAM("aud", Audience);
+    PROCESS_JSON_STRING_PARAM("jti", Id, false);
+
+    // special fields
+    PROCESS_JSON_STRING_PARAM("ttl", TtlStr, false);
+    PROCESS_JSON_STRING_PARAM("alg", AlgStr, false);
+    PROCESS_JSON_STRING_PARAM("private-key", PrivateKeyStr, false);
+
+    try {
+        if (result.TtlStr_) {
+            result.TokenTtl(FromString<TDuration>(result.TtlStr_));
+        }
+    } catch (const std::exception& ex) {
+        throw std::runtime_error(TStringBuilder()
+            << "Failed to parse \"ttl\": " << ex.what());
+    }
+
+    if (!result.AlgStr_ || !result.PrivateKeyStr_) {
+        throw std::runtime_error("\"alg\" and \"private-key\" params are required");
+    }
+
+    const auto jwtAlgIt = JwtAlgorithmsFactory.find(result.AlgStr_);
+    if (jwtAlgIt == JwtAlgorithmsFactory.end()) {
+        TStringBuilder err;
+        err << "Algorithm \"" << result.AlgStr_ << "\" is not supported. Supported algorithms are: ";
+        bool first = true;
+        for (const TString& alg : GetSupportedOauth2TokenExchangeJwtAlgorithms()) {
+            if (!first) {
+                err << ", ";
+            }
+            first = false;
+            err << alg;
+        }
+        throw std::runtime_error(err);
+    }
+    jwtAlgIt->second(&result, result.PrivateKeyStr_);
+    return CreateJwtTokenSource(result);
+}
+
+std::shared_ptr<ITokenSource> ParseTokenSource(const NJson::TJsonValue& cfg) {
+    const auto& map = cfg.GetMapSafe();
+    const NJson::TJsonValue* type = map.FindPtr("type");
+    if (!type) {
+        throw std::runtime_error("No \"type\" parameter");
+    }
+    if (IsAsciiEqualUpper(type->GetStringSafe(), "JWT")) {
+        return ParseJwtTokenSource(cfg);
+    } else if (IsAsciiEqualUpper(type->GetStringSafe(), "FIXED")) {
+        return ParseFixedTokenSource(cfg);
+    } else {
+        throw std::runtime_error("Incorrect \"type\" parameter: only \"JWT\" and \"FIXED\" are supported");
+    }
+}
+
+TOauth2TokenExchangeParams ReadOauth2ConfigJson(const TString& configJson, const TString& tokenEndpoint) {
+    try {
+        NJson::TJsonValue cfg;
+        NJson::ReadJsonTree(configJson, &cfg, true);
+        const auto& map = cfg.GetMapSafe();
+
+        TOauth2TokenExchangeParams result;
+        if (tokenEndpoint) {
+            result.TokenEndpoint(tokenEndpoint);
+        } else {
+            PROCESS_JSON_STRING_PARAM("token-endpoint", TokenEndpoint, false);
+        }
+
+        PROCESS_JSON_STRING_PARAM("grant-type", GrantType, false);
+        PROCESS_JSON_STRING_PARAM("res", Resource, false);
+        PROCESS_JSON_STRING_PARAM("requested-token-type", RequestedTokenType, false);
+        PROCESS_JSON_ARRAY_PARAM("aud", Audience);
+        PROCESS_JSON_ARRAY_PARAM("scope", Scope);
+        PROCESS_CREDS_PARAM("subject-credentials", SubjectTokenSource);
+        PROCESS_CREDS_PARAM("actor-credentials", ActorTokenSource);
+        return result;
+    } catch (const std::exception& ex) {
+        throw std::runtime_error(TStringBuilder() << "Failed to parse config file for OAuth 2.0 token exchange: " << ex.what());
+    }
+}
+
+TOauth2TokenExchangeParams ReadOauth2ConfigFile(const TString& configFilePath, const TString& tokenEndpoint) {
+    return ReadOauth2ConfigJson(TFileInput(configFilePath).ReadAll(), tokenEndpoint);
+}
+
+} // namespace
+
+std::vector<TString> GetSupportedOauth2TokenExchangeJwtAlgorithms() {
+    std::vector<TString> result;
+    result.reserve(JwtAlgorithmsFactory.size());
+    for (const auto& [alg, _] : JwtAlgorithmsFactory) {
+        result.push_back(alg);
+    }
+    return result;
+}
+
+std::shared_ptr<ICredentialsProviderFactory> CreateOauth2TokenExchangeFileCredentialsProviderFactory(const TString& configFilePath, const TString& tokenEndpoint) {
+    return CreateOauth2TokenExchangeCredentialsProviderFactory(ReadOauth2ConfigFile(configFilePath, tokenEndpoint));
+}
+
+} // namespace NYdb

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.h
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/from_file.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <ydb/public/sdk/cpp/client/ydb_types/credentials/credentials.h>
+
+#include <util/generic/string.h>
+
+#include <vector>
+
+namespace NYdb {
+
+// Lists supported algorithms for creation of OAuth 2.0 token exchange provider via config file
+std::vector<TString> GetSupportedOauth2TokenExchangeJwtAlgorithms();
+
+// Creates OAuth 2.0 token exchange credentials provider factory that exchanges token using standard protocol
+// https://www.rfc-editor.org/rfc/rfc8693
+//
+// Config file must be a valid json file
+//
+// Fields of json file
+//     grant-type:           [string] Grant type option (default: see TOauth2TokenExchangeParams)
+//     res:                  [string] Resource option (optional)
+//     aud:                  [string | list of strings] Audience option for token exchange request (optional)
+//     scope:                [string | list of strings] Scope option (optional)
+//     requested-token-type: [string] Requested token type option (default: see TOauth2TokenExchangeParams)
+//     subject-credentials:  [creds_json] Subject credentials options (optional)
+//     actor-credentials:    [creds_json] Actor credentials options (optional)
+//     token-endpoint:       [string] Token endpoint. Can be overritten with tokenEndpoint param (if it is not empty)
+//
+// Fields of creds_json (JWT):
+//     type:                 [string] Token source type. Set JWT
+//     alg:                  [string] Algorithm for JWT signature. Supported algorithms can be listed with GetSupportedOauth2TokenExchangeJwtAlgorithms()
+//     private-key:          [string] (Private) key in PEM format for JWT signature
+//     kid:                  [string] Key id JWT standard claim (optional)
+//     iss:                  [string] Issuer JWT standard claim (optional)
+//     sub:                  [string] Subject JWT standard claim (optional)
+//     aud:                  [string | list of strings] Audience JWT standard claim (optional)
+//     jti:                  [string] JWT ID JWT standard claim (optional)
+//     ttl:                  [string] Token TTL (default: see TJwtTokenSourceParams)
+//
+// Fields of creds_json (FIXED):
+//     type:                 [string] Token source type. Set FIXED
+//     token:                [string] Token value
+//     token-type:           [string] Token type value. It will become subject_token_type/actor_token_type parameter in token exchange request (https://www.rfc-editor.org/rfc/rfc8693)
+//
+std::shared_ptr<ICredentialsProviderFactory> CreateOauth2TokenExchangeFileCredentialsProviderFactory(const TString& configFilePath, const TString& tokenEndpoint = {});
+
+} // namespace NYdb

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/jwt_token_source.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/jwt_token_source.cpp
@@ -1,6 +1,6 @@
 #include "jwt_token_source.h"
 
-#include <contrib/libs/jwt-cpp/include/jwt-cpp/jwt.h>
+#include <jwt-cpp/jwt.h>
 
 #include <chrono>
 #include <set>

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/credentials_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/credentials_ut.cpp
@@ -1,15 +1,23 @@
 #include "credentials.h"
+#include "from_file.h"
+#include <ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/jwt_check_helper.h>
 
 #include <library/cpp/cgiparam/cgiparam.h>
 #include <library/cpp/http/misc/parsed_request.h>
 #include <library/cpp/http/server/http.h>
 #include <library/cpp/http/server/response.h>
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/testing/unittest/tests_data.h>
 
+#include <util/stream/file.h>
 #include <util/string/builder.h>
+#include <util/system/tempfile.h>
 
 using namespace NYdb;
+
+extern const TString TestPrivateKeyContent;
+extern const TString TestPublicKeyContent;
 
 class TTestTokenExchangeServer: public THttpServer::ICallBack {
 public:
@@ -21,11 +29,36 @@ public:
         TString Response;
         TString ExpectedErrorPart;
         TString Error;
+        TMaybe<TJwtCheck> SubjectJwtCheck;
+        TMaybe<TJwtCheck> ActorJwtCheck;
 
         void Check() {
             UNIT_ASSERT(InputParams || !ExpectRequest);
             if (InputParams) {
-                UNIT_ASSERT_VALUES_EQUAL(ExpectedInputParams.Print(), InputParams->Print());
+                if (SubjectJwtCheck || ActorJwtCheck) {
+                    TCgiParameters inputParamsCopy = *InputParams;
+                    if (SubjectJwtCheck) {
+                        TString subjectJwt;
+                        UNIT_ASSERT(inputParamsCopy.Has("subject_token"));
+                        UNIT_ASSERT(inputParamsCopy.Has("subject_token_type", "urn:ietf:params:oauth:token-type:jwt"));
+                        subjectJwt = inputParamsCopy.Get("subject_token");
+                        inputParamsCopy.Erase("subject_token");
+                        inputParamsCopy.Erase("subject_token_type");
+                        SubjectJwtCheck->Check(subjectJwt);
+                    }
+                    if (ActorJwtCheck) {
+                        TString actorJwt;
+                        UNIT_ASSERT(inputParamsCopy.Has("actor_token"));
+                        UNIT_ASSERT(inputParamsCopy.Has("actor_token_type", "urn:ietf:params:oauth:token-type:jwt"));
+                        actorJwt = inputParamsCopy.Get("actor_token");
+                        inputParamsCopy.Erase("actor_token");
+                        inputParamsCopy.Erase("actor_token_type");
+                        ActorJwtCheck->Check(actorJwt);
+                    }
+                    UNIT_ASSERT_VALUES_EQUAL(ExpectedInputParams.Print(), inputParamsCopy.Print());
+                } else {
+                    UNIT_ASSERT_VALUES_EQUAL(ExpectedInputParams.Print(), InputParams->Print());
+                }
             }
 
             if (ExpectedErrorPart) {
@@ -109,6 +142,21 @@ public:
         }
     }
 
+    void RunFromConfig(const TString& fileName, const TString& expectedToken = {}, bool checkExpectations = true, const TString& explicitTokenEndpoint = {}) {
+        TString token;
+        Run([&]() {
+            auto factory = CreateOauth2TokenExchangeFileCredentialsProviderFactory(fileName, explicitTokenEndpoint);
+            if (expectedToken) {
+                token = factory->CreateProvider()->GetAuthInfo();
+            }
+        },
+        checkExpectations);
+
+        if (expectedToken) {
+            UNIT_ASSERT_VALUES_EQUAL(expectedToken, token);
+        }
+    }
+
     void CheckExpectations() {
         with_lock (Lock) {
             Check.Check();
@@ -129,8 +177,95 @@ public:
     TCheck Check;
 };
 
+template <class TParent>
+struct TJsonFillerArray {
+    TJsonFillerArray(TParent* parent, NJson::TJsonWriter* writer)
+        : Parent(parent)
+        , Writer(writer)
+    {
+        Writer->OpenArray();
+    }
+
+    TJsonFillerArray& Value(const TStringBuf& value) {
+        Writer->Write(value);
+        return *this;
+    }
+
+    TParent& Build() {
+        Writer->CloseArray();
+        return *Parent;
+    }
+
+    TParent* Parent = nullptr;
+    NJson::TJsonWriter* Writer = nullptr;
+};
+
+template <class TDerived>
+struct TJsonFiller {
+    TJsonFiller(NJson::TJsonWriter* writer)
+        : Writer(writer)
+    {}
+
+    TDerived& Field(const TStringBuf& key, const TStringBuf& value) {
+        Writer->WriteKey(key);
+        Writer->Write(value);
+        return *static_cast<TDerived*>(this);
+    }
+
+    TJsonFillerArray<TDerived> Array(const TStringBuf& key) {
+        Writer->WriteKey(key);
+        return TJsonFillerArray(static_cast<TDerived*>(this), Writer);
+    }
+
+    NJson::TJsonWriter* Writer = nullptr;
+};
+
+struct TTestConfigFile : public TJsonFiller<TTestConfigFile> {
+    struct TSubMap : public TJsonFiller<TSubMap> {
+        TSubMap(TTestConfigFile* parent, NJson::TJsonWriter* writer)
+            : TJsonFiller<TSubMap>(writer)
+            , Parent(parent)
+        {
+            Writer->OpenMap();
+        }
+
+        TTestConfigFile& Build() {
+            Writer->CloseMap();
+            return *Parent;
+        }
+
+        TTestConfigFile* Parent = nullptr;
+    };
+
+    TTestConfigFile()
+        : TJsonFiller<TTestConfigFile>(&Writer)
+        , Writer(&Result.Out, true)
+        , TmpFile(MakeTempName(nullptr, "oauth2_cfg"))
+    {
+        Writer.OpenMap();
+    }
+
+    TSubMap SubMap(const TStringBuf& key) {
+        Writer.WriteKey(key);
+        return TSubMap(this, &Writer);
+    }
+
+    TString Build() {
+        Writer.CloseMap();
+        Writer.Flush();
+
+        TUnbufferedFileOutput(TmpFile.Name()).Write(Result);
+
+        return TmpFile.Name();
+    }
+
+    TStringBuilder Result;
+    NJson::TJsonWriter Writer;
+    TTempFile TmpFile;
+};
+
 Y_UNIT_TEST_SUITE(TestTokenExchange) {
-    Y_UNIT_TEST(Exchanges) {
+    void Exchanges(bool fromConfig) {
         TTestTokenExchangeServer server;
         server.Check.ExpectedInputParams.emplace("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
         server.Check.ExpectedInputParams.emplace("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
@@ -139,77 +274,197 @@ Y_UNIT_TEST_SUITE(TestTokenExchange) {
         server.Check.ExpectedInputParams.emplace("audience", "test_aud");
         server.Check.ExpectedInputParams.emplace("scope", "s1 s2");
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "bEareR", "expires_in": 42})";
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint(server.GetEndpoint())
-                .Audience("test_aud")
-                .AppendScope("s1")
-                .AppendScope("s2")
-                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")),
-            "Bearer hello_token"
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", server.GetEndpoint())
+                    .Field("aud", "test_aud")
+                    .Array("scope")
+                        .Value("s1")
+                        .Value("s2")
+                        .Build()
+                    .SubMap("subject-credentials")
+                        .Field("type", "Fixed")
+                        .Field("token", "test_token")
+                        .Field("token-type", "test_token_type")
+                        .Build()
+                    .Build(),
+                "Bearer hello_token"
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint(server.GetEndpoint())
+                    .Audience("test_aud")
+                    .AppendScope("s1")
+                    .AppendScope("s2")
+                    .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")),
+                "Bearer hello_token"
+            );
+        }
 
         server.Check.ExpectedInputParams.emplace("audience", "test_aud_2");
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint(server.GetEndpoint())
-                .AppendAudience("test_aud")
-                .AppendAudience("test_aud_2")
-                .AppendScope("s1")
-                .AppendScope("s2")
-                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")),
-            "Bearer hello_token"
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", server.GetEndpoint())
+                    .Array("aud")
+                        .Value("test_aud")
+                        .Value("test_aud_2")
+                        .Build()
+                    .Array("scope")
+                        .Value("s1")
+                        .Value("s2")
+                        .Build()
+                    .SubMap("subject-credentials")
+                        .Field("type", "Fixed")
+                        .Field("token", "test_token")
+                        .Field("token-type", "test_token_type")
+                        .Build()
+                    .Build(),
+                "Bearer hello_token"
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint(server.GetEndpoint())
+                    .AppendAudience("test_aud")
+                    .AppendAudience("test_aud_2")
+                    .AppendScope("s1")
+                    .AppendScope("s2")
+                    .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")),
+                "Bearer hello_token"
+            );
+        }
 
         server.Check.ExpectedInputParams.erase("scope");
         server.Check.ExpectedInputParams.emplace("resource", "test_res");
         server.Check.ExpectedInputParams.emplace("actor_token", "act_token");
         server.Check.ExpectedInputParams.emplace("actor_token_type", "act_token_type");
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint(server.GetEndpoint())
-                .AppendAudience("test_aud")
-                .AppendAudience("test_aud_2")
-                .Resource("test_res")
-                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"))
-                .ActorTokenSource(CreateFixedTokenSource("act_token", "act_token_type")),
-            "Bearer hello_token"
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", server.GetEndpoint())
+                    .Array("aud")
+                        .Value("test_aud")
+                        .Value("test_aud_2")
+                        .Build()
+                    .Field("res", "test_res")
+                    .SubMap("subject-credentials")
+                        .Field("type", "Fixed")
+                        .Field("token", "test_token")
+                        .Field("token-type", "test_token_type")
+                        .Build()
+                    .SubMap("actor-credentials")
+                        .Field("type", "Fixed")
+                        .Field("token", "act_token")
+                        .Field("token-type", "act_token_type")
+                        .Build()
+                    .Build(),
+                "Bearer hello_token"
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint(server.GetEndpoint())
+                    .AppendAudience("test_aud")
+                    .AppendAudience("test_aud_2")
+                    .Resource("test_res")
+                    .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"))
+                    .ActorTokenSource(CreateFixedTokenSource("act_token", "act_token_type")),
+                "Bearer hello_token"
+            );
+        }
     }
 
-    Y_UNIT_TEST(BadParams) {
+    Y_UNIT_TEST(Exchanges) {
+        Exchanges(false);
+    }
+
+    Y_UNIT_TEST(ExchangesFromConfig) {
+        Exchanges(true);
+    }
+
+    void BadParams(bool fromConfig) {
         TTestTokenExchangeServer server;
         server.Check.ExpectRequest = false;
 
         server.Check.ExpectedErrorPart = "no token endpoint";
-        server.Run(
-            TOauth2TokenExchangeParams()
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Build()
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+            );
+        }
 
         server.Check.ExpectedErrorPart = "empty audience";
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint(server.GetEndpoint())
-                .AppendAudience("a")
-                .AppendAudience("")
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", server.GetEndpoint())
+                    .Array("aud")
+                        .Value("a")
+                        .Value("")
+                        .Build()
+                    .Build()
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint(server.GetEndpoint())
+                    .AppendAudience("a")
+                    .AppendAudience("")
+            );
+        }
 
         server.Check.ExpectedErrorPart = "empty scope";
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint(server.GetEndpoint())
-                .AppendScope("s")
-                .AppendScope("")
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", server.GetEndpoint())
+                    .Array("scope")
+                        .Value("s")
+                        .Value("")
+                        .Build()
+                    .Build()
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint(server.GetEndpoint())
+                    .AppendScope("s")
+                    .AppendScope("")
+            );
+        }
 
         server.Check.ExpectedErrorPart = "failed to parse url";
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint("not an url")
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", "not an url")
+                    .Build()
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint("not an url")
+            );
+        }
     }
 
-    Y_UNIT_TEST(BadResponse) {
+    Y_UNIT_TEST(BadParams) {
+        BadParams(false);
+    }
+
+    Y_UNIT_TEST(BadParamsFromConfig) {
+        BadParams(true);
+    }
+
+    void BadResponse(bool fromConfig) {
         TTestTokenExchangeServer server;
         server.Check.ExpectedInputParams.emplace("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
         server.Check.ExpectedInputParams.emplace("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
@@ -217,92 +472,147 @@ Y_UNIT_TEST_SUITE(TestTokenExchange) {
         server.Check.ExpectedInputParams.emplace("subject_token_type", "test_token_type");
 
         TOauth2TokenExchangeParams params;
-        params
-            .TokenEndpoint(server.GetEndpoint())
-            .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"));
+        TTestConfigFile cfg;
+        if (fromConfig) {
+            cfg
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                        .Field("type", "Fixed")
+                        .Field("token", "test_token")
+                        .Field("token-type", "test_token_type")
+                        .Build()
+                .Build();
+        } else {
+            params
+                .TokenEndpoint(server.GetEndpoint())
+                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"));
+        }
+
+        auto run = [&]() {
+            if (fromConfig) {
+                server.RunFromConfig(cfg.TmpFile.Name());
+            } else {
+                server.Run(params);
+            }
+        };
 
         server.Check.Response = R"(})";
         server.Check.ExpectedErrorPart = "json parsing error";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type1": "bearer", "expires_in": 42})";
         server.Check.ExpectedErrorPart = "no field \"token_type\" in response";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token1": "hello_token", "token_type": "bearer", "expires_in": 42})";
         server.Check.ExpectedErrorPart = "no field \"access_token\" in response";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "bearer", "expires_in1": 42})";
         server.Check.ExpectedErrorPart = "no field \"expires_in\" in response";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "abc", "expires_in": 42})";
         server.Check.ExpectedErrorPart = "unsupported token type: \"abc\"";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "bearer", "expires_in": 0})";
         server.Check.ExpectedErrorPart = "incorrect expiration time: 0";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "bearer", "expires_in": "hello"})";
         server.Check.ExpectedErrorPart = "incorrect expiration time: 0";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "bearer", "expires_in": -1})";
         server.Check.ExpectedErrorPart = "incorrect expiration time: -1";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "bearer", "expires_in": 1, "scope": "s"})";
         server.Check.ExpectedErrorPart = "different scope. Expected \"\", but got \"s\"";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "", "token_type": "bearer", "expires_in": 1})";
         server.Check.ExpectedErrorPart = "got empty token";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"access_token": "hello_token", "token_type": "bearer", "expires_in": 1, "scope": "s a"})";
         server.Check.ExpectedErrorPart = "different scope. Expected \"a\", but got \"s a\"";
         server.Check.ExpectedInputParams.emplace("scope", "a");
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint(server.GetEndpoint())
-                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"))
-                .Scope("a")
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", server.GetEndpoint())
+                    .SubMap("subject-credentials")
+                        .Field("type", "Fixed")
+                        .Field("token", "test_token")
+                        .Field("token-type", "test_token_type")
+                        .Build()
+                    .Field("scope", "a")
+                    .Build()
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint(server.GetEndpoint())
+                    .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"))
+                    .Scope("a")
+            );
+        }
         server.Check.ExpectedInputParams.erase("scope");
 
 
         server.Check.ExpectedErrorPart = "can not connect to";
         server.Check.ExpectRequest = false;
-        server.Run(
-            TOauth2TokenExchangeParams()
-                .TokenEndpoint("https://localhost:42/aaa")
-                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"))
-        );
+        if (fromConfig) {
+            server.RunFromConfig(
+                TTestConfigFile()
+                    .Field("token-endpoint", "https://localhost:42/aaa")
+                    .SubMap("subject-credentials")
+                        .Field("type", "Fixed")
+                        .Field("token", "test_token")
+                        .Field("token-type", "test_token_type")
+                        .Build()
+                    .Build()
+            );
+        } else {
+            server.Run(
+                TOauth2TokenExchangeParams()
+                    .TokenEndpoint("https://localhost:42/aaa")
+                    .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"))
+            );
+        }
         server.Check.ExpectRequest = true;
 
         // parsing response
         server.Check.StatusCode = HTTP_FORBIDDEN;
         server.Check.Response = R"(not json)";
         server.Check.ExpectedErrorPart = "Exchange token error in Oauth 2 token exchange credentials provider: 403 Forbidden, could not parse response: ";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"error": "smth"})";
         server.Check.ExpectedErrorPart = "Exchange token error in Oauth 2 token exchange credentials provider: 403 Forbidden, error: smth";
-        server.Run(params);
+        run();
 
         server.Check.Response = R"({"error": "smth", "error_description": "something terrible happened"})";
         server.Check.ExpectedErrorPart = "Exchange token error in Oauth 2 token exchange credentials provider: 403 Forbidden, error: smth, description: something terrible happened";
-        server.Run(params);
+        run();
 
         server.Check.StatusCode = HTTP_BAD_REQUEST;
         server.Check.Response = R"({"error_uri": "my_uri", "error_description": "something terrible happened"})";
         server.Check.ExpectedErrorPart = "Exchange token error in Oauth 2 token exchange credentials provider: 400 Bad request, description: something terrible happened, error_uri: my_uri";
-        server.Run(params);
+        run();
     }
 
-    Y_UNIT_TEST(UpdatesToken) {
+    Y_UNIT_TEST(BadResponse) {
+        BadResponse(false);
+    }
+
+    Y_UNIT_TEST(BadResponseFromConfig) {
+        BadResponse(true);
+    }
+
+    void UpdatesToken(bool fromConfig) {
         TCredentialsProviderFactoryPtr factory;
 
         TTestTokenExchangeServer server;
@@ -313,10 +623,22 @@ Y_UNIT_TEST_SUITE(TestTokenExchange) {
         server.Check.Response = R"({"access_token": "token_1", "token_type": "bearer", "expires_in": 1})";
         server.Run(
             [&]() {
-                factory = CreateOauth2TokenExchangeCredentialsProviderFactory(
-                    TOauth2TokenExchangeParams()
-                        .TokenEndpoint(server.GetEndpoint())
-                        .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")));
+                if (fromConfig) {
+                    factory = CreateOauth2TokenExchangeFileCredentialsProviderFactory(
+                        TTestConfigFile()
+                            .Field("token-endpoint", server.GetEndpoint())
+                            .SubMap("subject-credentials")
+                                .Field("type", "Fixed")
+                                .Field("token", "test_token")
+                                .Field("token-type", "test_token_type")
+                                .Build()
+                            .Build());
+                } else {
+                    factory = CreateOauth2TokenExchangeCredentialsProviderFactory(
+                        TOauth2TokenExchangeParams()
+                            .TokenEndpoint(server.GetEndpoint())
+                            .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")));
+                }
                 UNIT_ASSERT_VALUES_EQUAL(factory->CreateProvider()->GetAuthInfo(), "Bearer token_1");
             }
         );
@@ -333,6 +655,14 @@ Y_UNIT_TEST_SUITE(TestTokenExchange) {
                 UNIT_ASSERT_VALUES_EQUAL(factory->CreateProvider()->GetAuthInfo(), "Bearer token_2");
             }
         );
+    }
+
+    Y_UNIT_TEST(UpdatesToken) {
+        UpdatesToken(false);
+    }
+
+    Y_UNIT_TEST(UpdatesTokenFromConfig) {
+        UpdatesToken(true);
     }
 
     Y_UNIT_TEST(UsesCachedToken) {
@@ -560,5 +890,266 @@ Y_UNIT_TEST_SUITE(TestTokenExchange) {
         factory = nullptr;
         const TInstant shutdownStop = TInstant::Now();
         Cerr << "Shutdown: " << (shutdownStop - shutdownStart) << Endl;
+    }
+
+    Y_UNIT_TEST(ExchangesFromFileConfig) {
+        TTestTokenExchangeServer server;
+        server.Check.ExpectedInputParams.emplace("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+        server.Check.ExpectedInputParams.emplace("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+        server.Check.ExpectedInputParams.emplace("subject_token", "test_token");
+        server.Check.ExpectedInputParams.emplace("subject_token_type", "test_token_type");
+        server.Check.ExpectedInputParams.emplace("audience", "test_aud");
+        server.Check.ExpectedInputParams.emplace("scope", "s1 s2");
+        server.Check.Response = R"({"access_token": "hello_token", "token_type": "bEareR", "expires_in": 42})";
+        server.Run(
+            TOauth2TokenExchangeParams()
+                .TokenEndpoint(server.GetEndpoint())
+                .Audience("test_aud")
+                .AppendScope("s1")
+                .AppendScope("s2")
+                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")),
+            "Bearer hello_token"
+        );
+
+        server.Check.ExpectedInputParams.emplace("audience", "test_aud_2");
+        server.Run(
+            TOauth2TokenExchangeParams()
+                .TokenEndpoint(server.GetEndpoint())
+                .AppendAudience("test_aud")
+                .AppendAudience("test_aud_2")
+                .AppendScope("s1")
+                .AppendScope("s2")
+                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type")),
+            "Bearer hello_token"
+        );
+
+        server.Check.ExpectedInputParams.erase("scope");
+        server.Check.ExpectedInputParams.emplace("resource", "test_res");
+        server.Check.ExpectedInputParams.emplace("actor_token", "act_token");
+        server.Check.ExpectedInputParams.emplace("actor_token_type", "act_token_type");
+        server.Run(
+            TOauth2TokenExchangeParams()
+                .TokenEndpoint(server.GetEndpoint())
+                .AppendAudience("test_aud")
+                .AppendAudience("test_aud_2")
+                .Resource("test_res")
+                .SubjectTokenSource(CreateFixedTokenSource("test_token", "test_token_type"))
+                .ActorTokenSource(CreateFixedTokenSource("act_token", "act_token_type")),
+            "Bearer hello_token"
+        );
+    }
+
+    Y_UNIT_TEST(SkipsUnknownFieldsInConfig) {
+        TTestTokenExchangeServer server;
+        server.Check.ExpectedInputParams.emplace("grant_type", "test_grant_type");
+        server.Check.ExpectedInputParams.emplace("requested_token_type", "test_requested_token_type");
+        server.Check.ExpectedInputParams.emplace("subject_token", "test_token");
+        server.Check.ExpectedInputParams.emplace("subject_token_type", "test_token_type");
+        server.Check.Response = R"({"access_token": "received_token", "token_type": "bEareR", "expires_in": 42})";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", "bla-bla-bla") // use explicit endpoint via param
+                .Field("unknown", "unknown value")
+                .Field("grant-type", "test_grant_type")
+                .Field("requested-token-type", "test_requested_token_type")
+                .SubMap("subject-credentials")
+                    .Field("type", "Fixed")
+                    .Field("token", "test_token")
+                    .Field("token-type", "test_token_type")
+                    .Field("unknown", "unknown value")
+                    .Build()
+                .Build(),
+            "Bearer received_token",
+            true,
+            server.GetEndpoint()
+        );
+    }
+
+    Y_UNIT_TEST(JwtTokenSourceInConfig) {
+        TTestTokenExchangeServer server;
+        server.Check.ExpectedInputParams.emplace("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+        server.Check.ExpectedInputParams.emplace("requested_token_type", "urn:ietf:params:oauth:token-type:access_token");
+        server.Check.SubjectJwtCheck.ConstructInPlace()
+            .TokenTtl(TDuration::Hours(24))
+            .KeyId("test_key_id")
+            .Issuer("test_iss")
+            .Subject("test_sub")
+            .Audience("test_aud")
+            .Id("test_jti")
+            .Alg<jwt::algorithm::rs384>(TestPublicKeyContent);
+        server.Check.ActorJwtCheck.ConstructInPlace()
+            .AppendAudience("a1")
+            .AppendAudience("a2");
+        server.Check.Response = R"({"access_token": "received_token", "token_type": "bEareR", "expires_in": 42})";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "jwt")
+                    .Field("ttl", "24h")
+                    .Field("kid", "test_key_id")
+                    .Field("iss", "test_iss")
+                    .Field("sub", "test_sub")
+                    .Field("aud", "test_aud")
+                    .Field("jti", "test_jti")
+                    .Field("alg", "rs384")
+                    .Field("private-key", TestPrivateKeyContent)
+                    .Field("unknown", "unknown value")
+                    .Build()
+                .SubMap("actor-credentials")
+                    .Field("type", "JWT")
+                    .Array("aud")
+                        .Value("a1")
+                        .Value("a2")
+                        .Build()
+                    .Field("alg", "RS256")
+                    .Field("private-key", TestPrivateKeyContent)
+                    .Build()
+                .Build(),
+            "Bearer received_token"
+        );
+    }
+
+    Y_UNIT_TEST(BadConfigParams) {
+        TTestTokenExchangeServer server;
+        server.Check.ExpectRequest = false;
+
+        // wrong format
+        TTempFile cfg(MakeTempName(nullptr, "oauth2_cfg"));
+        TUnbufferedFileOutput(cfg.Name()).Write(""); // empty
+        server.Check.ExpectedErrorPart = "Failed to parse config file";
+        server.RunFromConfig(cfg.Name());
+
+        TUnbufferedFileOutput(cfg.Name()).Write("not a json");
+        server.Check.ExpectedErrorPart = "Failed to parse config file";
+        server.RunFromConfig(cfg.Name());
+
+        TUnbufferedFileOutput(cfg.Name()).Write("[\"not a map\"]");
+        server.Check.ExpectedErrorPart = "Not a map";
+        server.RunFromConfig(cfg.Name());
+
+        server.Check.ExpectedErrorPart = "No \"type\" parameter";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type1", "unknown")
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "Incorrect \"type\" parameter";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "unknown")
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "Failed to parse \"iss\""; // must be string
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "jwt")
+                    .Array("iss")
+                        .Value("1")
+                        .Build()
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "No \"token\" parameter";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "fixed")
+                    .Field("token-type", "test_token_type")
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "No \"token-type\" parameter";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "fixed")
+                    .Field("token", "test_token")
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "No \"alg\" parameter";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "jwt")
+                    .Field("private-key", TestPrivateKeyContent)
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "No \"private-key\" parameter";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "jwt")
+                    .Field("alg", "rs256")
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "Failed to parse \"ttl\"";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "jwt")
+                    .Field("alg", "rs256")
+                    .Field("private-key", TestPrivateKeyContent)
+                    .Field("ttl", "-1s")
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "Algorithm \"algorithm\" is not supported. Supported algorithms are: ";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "jwt")
+                    .Field("alg", "algorithm")
+                    .Field("private-key", TestPrivateKeyContent)
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "failed to load private key";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .SubMap("subject-credentials")
+                    .Field("type", "jwt")
+                    .Field("alg", "rs256")
+                    .Field("private-key", "not a key")
+                    .Build()
+                .Build()
+        );
+
+        server.Check.ExpectedErrorPart = "Not a map";
+        server.RunFromConfig(
+            TTestConfigFile()
+                .Field("token-endpoint", server.GetEndpoint())
+                .Array("subject-credentials")
+                    .Value("42")
+                    .Build()
+                .Build()
+        );
     }
 }

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/jwt_check_helper.h
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/jwt_check_helper.h
@@ -1,0 +1,86 @@
+#include "jwt_token_source.h"
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/string.h>
+
+#include <contrib/libs/jwt-cpp/include/jwt-cpp/jwt.h>
+
+extern const TString TestPrivateKeyContent;
+extern const TString TestPublicKeyContent;
+
+struct TJwtCheck {
+    using TSelf = TJwtCheck;
+
+    struct IAlgCheck {
+        virtual void Check(const jwt::decoded_jwt& decoded) const = 0;
+        virtual ~IAlgCheck() = default;
+    };
+
+    template <class TAlg>
+    struct TAlgCheck : public IAlgCheck {
+        TAlgCheck(const TString& publicKey)
+            : Alg(publicKey)
+        {}
+
+        void Check(const jwt::decoded_jwt& decoded) const override {
+            UNIT_ASSERT_VALUES_EQUAL(decoded.get_algorithm(), Alg.name());
+            const std::string data = decoded.get_header_base64() + "." + decoded.get_payload_base64();
+		    const std::string signature = decoded.get_signature();
+            Alg.verify(data, signature); // Throws
+        }
+
+        TAlg Alg;
+    };
+
+    template <class TAlg>
+    TSelf& Alg(const TString& publicKey) {
+        Alg_.Reset(new TAlgCheck<TAlg>(publicKey));
+        return *this;
+    }
+    THolder<IAlgCheck> Alg_ = MakeHolder<TAlgCheck<jwt::algorithm::rs256>>(TestPublicKeyContent);
+
+    FLUENT_SETTING_OPTIONAL(TString, KeyId);
+
+    FLUENT_SETTING_OPTIONAL(TString, Issuer);
+    FLUENT_SETTING_OPTIONAL(TString, Subject);
+    FLUENT_SETTING_OPTIONAL(TString, Id);
+    FLUENT_SETTING_VECTOR_OR_SINGLE(TString, Audience);
+    FLUENT_SETTING_DEFAULT(TDuration, TokenTtl, TDuration::Hours(1));
+
+    void Check(const TString& token) {
+        jwt::decoded_jwt decoded(token);
+        UNIT_ASSERT_VALUES_EQUAL(decoded.get_type(), "JWT");
+        Alg_->Check(decoded);
+
+        const auto now = std::chrono::system_clock::from_time_t(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
+        UNIT_ASSERT(decoded.get_issued_at() >= now - std::chrono::minutes(10));
+        UNIT_ASSERT(decoded.get_issued_at() <= now);
+        UNIT_ASSERT_EQUAL(decoded.get_expires_at() - decoded.get_issued_at(), std::chrono::seconds(TokenTtl_.Seconds()));
+
+#define CHECK_JWT_CLAIM(claim, option)                                  \
+        if (option) {                                                   \
+            UNIT_ASSERT(decoded.has_ ## claim());                       \
+            UNIT_ASSERT_VALUES_EQUAL(decoded.get_ ## claim(), *option); \
+        } else {                                                        \
+            UNIT_ASSERT(!decoded.has_ ## claim());                      \
+        }
+
+        CHECK_JWT_CLAIM(key_id, KeyId_);
+        CHECK_JWT_CLAIM(issuer, Issuer_);
+        CHECK_JWT_CLAIM(subject, Subject_);
+        CHECK_JWT_CLAIM(id, Id_);
+
+#undef CHECK_JWT_CLAIM
+
+        if (!Audience_.empty()) {
+            UNIT_ASSERT(decoded.has_audience());
+            const std::set<std::string> aud = decoded.get_audience();
+            UNIT_ASSERT_VALUES_EQUAL(aud.size(), Audience_.size());
+            for (const TString& a : Audience_) {
+                UNIT_ASSERT(aud.contains(a));
+            }
+        } else {
+            UNIT_ASSERT(!decoded.has_audience());
+        }
+    }
+};

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/jwt_token_source_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/jwt_token_source_ut.cpp
@@ -1,4 +1,5 @@
 #include "jwt_token_source.h"
+#include <ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/jwt_check_helper.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -6,8 +7,8 @@
 
 using namespace NYdb;
 
-const TString TestPrivateKeyContent = "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC75/JS3rMcLJxv\nFgpOzF5+2gH+Yig3RE2MTl9uwC0BZKAv6foYr7xywQyWIK+W1cBhz8R4LfFmZo2j\nM0aCvdRmNBdW0EDSTnHLxCsFhoQWLVq+bI5f5jzkcoiioUtaEpADPqwgVULVtN/n\nnPJiZ6/dU30C3jmR6+LUgEntUtWt3eq3xQIn5lG3zC1klBY/HxtfH5Hu8xBvwRQT\nJnh3UpPLj8XwSmriDgdrhR7o6umWyVuGrMKlLHmeivlfzjYtfzO1MOIMG8t2/zxG\nR+xb4Vwks73sH1KruH/0/JMXU97npwpe+Um+uXhpldPygGErEia7abyZB2gMpXqr\nWYKMo02NAgMBAAECggEAO0BpC5OYw/4XN/optu4/r91bupTGHKNHlsIR2rDzoBhU\nYLd1evpTQJY6O07EP5pYZx9mUwUdtU4KRJeDGO/1/WJYp7HUdtxwirHpZP0lQn77\nuccuX/QQaHLrPekBgz4ONk+5ZBqukAfQgM7fKYOLk41jgpeDbM2Ggb6QUSsJISEp\nzrwpI/nNT/wn+Hvx4DxrzWU6wF+P8kl77UwPYlTA7GsT+T7eKGVH8xsxmK8pt6lg\nsvlBA5XosWBWUCGLgcBkAY5e4ZWbkdd183o+oMo78id6C+PQPE66PLDtHWfpRRmN\nm6XC03x6NVhnfvfozoWnmS4+e4qj4F/emCHvn0GMywKBgQDLXlj7YPFVXxZpUvg/\nrheVcCTGbNmQJ+4cZXx87huqwqKgkmtOyeWsRc7zYInYgraDrtCuDBCfP//ZzOh0\nLxepYLTPk5eNn/GT+VVrqsy35Ccr60g7Lp/bzb1WxyhcLbo0KX7/6jl0lP+VKtdv\nmto+4mbSBXSM1Y5BVVoVgJ3T/wKBgQDsiSvPRzVi5TTj13x67PFymTMx3HCe2WzH\nJUyepCmVhTm482zW95pv6raDr5CTO6OYpHtc5sTTRhVYEZoEYFTM9Vw8faBtluWG\nBjkRh4cIpoIARMn74YZKj0C/0vdX7SHdyBOU3bgRPHg08Hwu3xReqT1kEPSI/B2V\n4pe5fVrucwKBgQCNFgUxUA3dJjyMES18MDDYUZaRug4tfiYouRdmLGIxUxozv6CG\nZnbZzwxFt+GpvPUV4f+P33rgoCvFU+yoPctyjE6j+0aW0DFucPmb2kBwCu5J/856\nkFwCx3blbwFHAco+SdN7g2kcwgmV2MTg/lMOcU7XwUUcN0Obe7UlWbckzQKBgQDQ\nnXaXHL24GGFaZe4y2JFmujmNy1dEsoye44W9ERpf9h1fwsoGmmCKPp90az5+rIXw\nFXl8CUgk8lXW08db/r4r+ma8Lyx0GzcZyplAnaB5/6j+pazjSxfO4KOBy4Y89Tb+\nTP0AOcCi6ws13bgY+sUTa/5qKA4UVw+c5zlb7nRpgwKBgGXAXhenFw1666482iiN\ncHSgwc4ZHa1oL6aNJR1XWH+aboBSwR+feKHUPeT4jHgzRGo/aCNHD2FE5I8eBv33\nof1kWYjAO0YdzeKrW0rTwfvt9gGg+CS397aWu4cy+mTI+MNfBgeDAIVBeJOJXLlX\nhL8bFAuNNVrCOp79TNnNIsh7\n-----END PRIVATE KEY-----\n";
-const TString TestPublicKeyContent = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu+fyUt6zHCycbxYKTsxe\nftoB/mIoN0RNjE5fbsAtAWSgL+n6GK+8csEMliCvltXAYc/EeC3xZmaNozNGgr3U\nZjQXVtBA0k5xy8QrBYaEFi1avmyOX+Y85HKIoqFLWhKQAz6sIFVC1bTf55zyYmev\n3VN9At45kevi1IBJ7VLVrd3qt8UCJ+ZRt8wtZJQWPx8bXx+R7vMQb8EUEyZ4d1KT\ny4/F8Epq4g4Ha4Ue6OrplslbhqzCpSx5nor5X842LX8ztTDiDBvLdv88RkfsW+Fc\nJLO97B9Sq7h/9PyTF1Pe56cKXvlJvrl4aZXT8oBhKxImu2m8mQdoDKV6q1mCjKNN\njQIDAQAB\n-----END PUBLIC KEY-----\n";
+extern const TString TestPrivateKeyContent = "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC75/JS3rMcLJxv\nFgpOzF5+2gH+Yig3RE2MTl9uwC0BZKAv6foYr7xywQyWIK+W1cBhz8R4LfFmZo2j\nM0aCvdRmNBdW0EDSTnHLxCsFhoQWLVq+bI5f5jzkcoiioUtaEpADPqwgVULVtN/n\nnPJiZ6/dU30C3jmR6+LUgEntUtWt3eq3xQIn5lG3zC1klBY/HxtfH5Hu8xBvwRQT\nJnh3UpPLj8XwSmriDgdrhR7o6umWyVuGrMKlLHmeivlfzjYtfzO1MOIMG8t2/zxG\nR+xb4Vwks73sH1KruH/0/JMXU97npwpe+Um+uXhpldPygGErEia7abyZB2gMpXqr\nWYKMo02NAgMBAAECggEAO0BpC5OYw/4XN/optu4/r91bupTGHKNHlsIR2rDzoBhU\nYLd1evpTQJY6O07EP5pYZx9mUwUdtU4KRJeDGO/1/WJYp7HUdtxwirHpZP0lQn77\nuccuX/QQaHLrPekBgz4ONk+5ZBqukAfQgM7fKYOLk41jgpeDbM2Ggb6QUSsJISEp\nzrwpI/nNT/wn+Hvx4DxrzWU6wF+P8kl77UwPYlTA7GsT+T7eKGVH8xsxmK8pt6lg\nsvlBA5XosWBWUCGLgcBkAY5e4ZWbkdd183o+oMo78id6C+PQPE66PLDtHWfpRRmN\nm6XC03x6NVhnfvfozoWnmS4+e4qj4F/emCHvn0GMywKBgQDLXlj7YPFVXxZpUvg/\nrheVcCTGbNmQJ+4cZXx87huqwqKgkmtOyeWsRc7zYInYgraDrtCuDBCfP//ZzOh0\nLxepYLTPk5eNn/GT+VVrqsy35Ccr60g7Lp/bzb1WxyhcLbo0KX7/6jl0lP+VKtdv\nmto+4mbSBXSM1Y5BVVoVgJ3T/wKBgQDsiSvPRzVi5TTj13x67PFymTMx3HCe2WzH\nJUyepCmVhTm482zW95pv6raDr5CTO6OYpHtc5sTTRhVYEZoEYFTM9Vw8faBtluWG\nBjkRh4cIpoIARMn74YZKj0C/0vdX7SHdyBOU3bgRPHg08Hwu3xReqT1kEPSI/B2V\n4pe5fVrucwKBgQCNFgUxUA3dJjyMES18MDDYUZaRug4tfiYouRdmLGIxUxozv6CG\nZnbZzwxFt+GpvPUV4f+P33rgoCvFU+yoPctyjE6j+0aW0DFucPmb2kBwCu5J/856\nkFwCx3blbwFHAco+SdN7g2kcwgmV2MTg/lMOcU7XwUUcN0Obe7UlWbckzQKBgQDQ\nnXaXHL24GGFaZe4y2JFmujmNy1dEsoye44W9ERpf9h1fwsoGmmCKPp90az5+rIXw\nFXl8CUgk8lXW08db/r4r+ma8Lyx0GzcZyplAnaB5/6j+pazjSxfO4KOBy4Y89Tb+\nTP0AOcCi6ws13bgY+sUTa/5qKA4UVw+c5zlb7nRpgwKBgGXAXhenFw1666482iiN\ncHSgwc4ZHa1oL6aNJR1XWH+aboBSwR+feKHUPeT4jHgzRGo/aCNHD2FE5I8eBv33\nof1kWYjAO0YdzeKrW0rTwfvt9gGg+CS397aWu4cy+mTI+MNfBgeDAIVBeJOJXLlX\nhL8bFAuNNVrCOp79TNnNIsh7\n-----END PRIVATE KEY-----\n";
+extern const TString TestPublicKeyContent = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu+fyUt6zHCycbxYKTsxe\nftoB/mIoN0RNjE5fbsAtAWSgL+n6GK+8csEMliCvltXAYc/EeC3xZmaNozNGgr3U\nZjQXVtBA0k5xy8QrBYaEFi1avmyOX+Y85HKIoqFLWhKQAz6sIFVC1bTf55zyYmev\n3VN9At45kevi1IBJ7VLVrd3qt8UCJ+ZRt8wtZJQWPx8bXx+R7vMQb8EUEyZ4d1KT\ny4/F8Epq4g4Ha4Ue6OrplslbhqzCpSx5nor5X842LX8ztTDiDBvLdv88RkfsW+Fc\nJLO97B9Sq7h/9PyTF1Pe56cKXvlJvrl4aZXT8oBhKxImu2m8mQdoDKV6q1mCjKNN\njQIDAQAB\n-----END PUBLIC KEY-----\n";
 
 Y_UNIT_TEST_SUITE(JwtTokenSourceTest) {
     Y_UNIT_TEST(Encodes) {
@@ -19,29 +20,17 @@ Y_UNIT_TEST_SUITE(JwtTokenSourceTest) {
                 .Subject("test_subject")
                 .Audience("test_audience")
         );
-        const auto now1 = std::chrono::system_clock::from_time_t(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
+
+        TJwtCheck check;
+        check
+            .KeyId("test_key_id")
+            .Issuer("test_issuer")
+            .Audience("test_audience")
+            .Subject("test_subject");
+
         auto t = source->GetToken();
-        const auto now2 = std::chrono::system_clock::from_time_t(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
         UNIT_ASSERT_VALUES_EQUAL(t.TokenType, "urn:ietf:params:oauth:token-type:jwt");
-
-        jwt::decoded_jwt decoded(t.Token);
-        UNIT_ASSERT_VALUES_EQUAL(decoded.get_type(), "JWT");
-        UNIT_ASSERT_VALUES_EQUAL(decoded.get_algorithm(), "RS256");
-        UNIT_ASSERT_VALUES_EQUAL(decoded.get_key_id(), "test_key_id");
-        UNIT_ASSERT(!decoded.has_id());
-        UNIT_ASSERT_VALUES_EQUAL(decoded.get_issuer(), "test_issuer");
-        UNIT_ASSERT_VALUES_EQUAL(decoded.get_subject(), "test_subject");
-        UNIT_ASSERT_VALUES_EQUAL(decoded.get_audience().size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(*decoded.get_audience().begin(), "test_audience");
-        UNIT_ASSERT(decoded.get_issued_at() >= now1);
-        UNIT_ASSERT(decoded.get_issued_at() <= now2);
-        UNIT_ASSERT(decoded.get_expires_at() >= now1 + std::chrono::hours(1));
-        UNIT_ASSERT(decoded.get_expires_at() <= now2 + std::chrono::hours(1));
-
-        const std::string data = decoded.get_header_base64() + "." + decoded.get_payload_base64();
-		const std::string signature = decoded.get_signature();
-        jwt::algorithm::rs256 alg(TestPublicKeyContent);
-        alg.verify(data, signature); // Throws
+        check.Check(t.Token);
     }
 
     Y_UNIT_TEST(BadParams) {

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/ya.make
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
 PEERDIR(
     contrib/libs/jwt-cpp
     library/cpp/http/server
+    library/cpp/json
 )
 
 END()

--- a/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ya.make
+++ b/ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     credentials.cpp
+    from_file.cpp
     jwt_token_source.cpp
 )
 

--- a/ydb/tests/functional/ydb_cli/canondata/test_ydb_scripting.TestScriptingServiceHelp.test_help/result.output
+++ b/ydb/tests/functional/ydb_cli/canondata/test_ydb_scripting.TestScriptingServiceHelp.test_help/result.output
@@ -3,11 +3,11 @@ Usage: ydb [global options...] scripting yql [options...]
 Description: Execute YQL script
 
 Global options:
-  {-e|--endpoint}, {-d|--database}, {-v|--verbose}, {-p|--profile}, --ca-file, --iam-token-file, --yc-token-file, --use-metadata-credentials, --sa-key-file, --token-file, --user, --password-file, --no-password, --iam-endpoint, --profile-file
+  {-e|--endpoint}, {-d|--database}, {-v|--verbose}, {-p|--profile}, --ca-file, --iam-token-file, --yc-token-file, --use-metadata-credentials, --sa-key-file, --token-file, --user, --password-file, --no-password, --oauth2-key-file, --iam-endpoint, --profile-file
   To get full description of these options run 'ydb --help'.
 
 Options:
-  {-?|-h|--help}           Print usage
+  {-?|-h|--help}           Print usage, -hh for detailed help
   --help-ex                Print usage with examples
   --timeout ms             Operation timeout. Operation should be executed on server within this timeout. There could also be a delay up to 200ms to receive timeout error from server.
   --stats [String]         Collect statistics mode [none, basic, full]

--- a/ydb/tests/functional/ydb_cli/canondata/test_ydb_scripting.TestScriptingServiceHelp.test_help_ex/result.output
+++ b/ydb/tests/functional/ydb_cli/canondata/test_ydb_scripting.TestScriptingServiceHelp.test_help_ex/result.output
@@ -3,11 +3,11 @@ Usage: ydb [global options...] scripting yql [options...]
 Description: Execute YQL script
 
 Global options:
-  {-e|--endpoint}, {-d|--database}, {-v|--verbose}, {-p|--profile}, --ca-file, --iam-token-file, --yc-token-file, --use-metadata-credentials, --sa-key-file, --token-file, --user, --password-file, --no-password, --iam-endpoint, --profile-file
+  {-e|--endpoint}, {-d|--database}, {-v|--verbose}, {-p|--profile}, --ca-file, --iam-token-file, --yc-token-file, --use-metadata-credentials, --sa-key-file, --token-file, --user, --password-file, --no-password, --oauth2-key-file, --iam-endpoint, --profile-file
   To get full description of these options run 'ydb --help'.
 
 Options:
-  {-?|-h|--help}           Print usage
+  {-?|-h|--help}           Print usage, -hh for detailed help
   --help-ex                Print usage with examples
   --timeout ms             Operation timeout. Operation should be executed on server within this timeout. There could also be a delay up to 200ms to receive timeout error from server.
   --stats [String]         Collect statistics mode [none, basic, full]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add a new credentials provider that exchanges tokens with OAuth 2.0 token exchange protocol to ydb cli
Protocol details: https://www.rfc-editor.org/rfc/rfc8693
Credentials provider: ydb/public/sdk/cpp/client/ydb_types/credentials/oauth2_token_exchange/credentials.h
RFC: https://github.com/ydb-platform/ydb-rfc/blob/main/cli_oauth2_token_exchange.md
Docs: https://ydb.tech/docs/en/reference/ydb-cli/connect

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
