### PR TITLE
Change build_docs trigger to pull_request_target

### DIFF
--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -1,7 +1,7 @@
 name: Build documentation
 
 on:
-  pull_request:
+  pull_request_target:
     paths: 
     - 'ydb/docs/**'
 


### PR DESCRIPTION
To ensure workflow is taken from the main, and therefore GITHUB_TOKEN receives enough privileges to write statuses even if pull request is made from a fork.