### PR TITLE
move pool_stats_collector

### DIFF
--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -32,8 +32,6 @@ SRCS(
     memobserver.h
     nameservice.h
     path.cpp
-    pool_stats_collector.cpp
-    pool_stats_collector.h
     resource_profile.h
     row_version.cpp
     row_version.h
@@ -96,7 +94,6 @@ PEERDIR(
     ydb/library/pretty_types_print/protobuf
     ydb/library/ydb_issue
     ydb/public/api/protos/out
-    ydb/library/yql/minikql
     library/cpp/deprecated/atomic
 )
 

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -16,7 +16,6 @@
 #include <ydb/core/base/feature_flags.h>
 #include <ydb/core/base/hive.h>
 #include <ydb/core/base/location.h>
-#include <ydb/core/base/pool_stats_collector.h>
 #include <ydb/core/base/statestorage_impl.h>
 #include <ydb/core/base/tablet_resolver.h>
 #include <ydb/core/base/tablet_pipecache.h>
@@ -168,6 +167,8 @@
 
 #include <ydb/library/folder_service/folder_service.h>
 #include <ydb/library/folder_service/proto/config.pb.h>
+
+#include <ydb/library/pool_stats_collector/pool_stats_collector.h>
 
 #include <ydb/library/yql/minikql/comp_nodes/mkql_factories.h>
 #include <ydb/library/yql/parser/pg_wrapper/interface/comp_factory.h>

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -133,6 +133,7 @@ PEERDIR(
     ydb/library/folder_service
     ydb/library/folder_service/proto
     ydb/library/pdisk_io
+    ydb/library/pool_stats_collector
     ydb/library/security
     ydb/library/yql/minikql/comp_nodes/llvm14
     ydb/library/yql/providers/yt/codec/codegen

--- a/ydb/core/kqp/query_data/ya.make
+++ b/ydb/core/kqp/query_data/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
     ydb/core/kqp/common/simple
     ydb/library/yql/dq/expr_nodes
     ydb/library/yql/dq/proto
+    ydb/library/yql/minikql
     ydb/core/kqp/expr_nodes
 )
 

--- a/ydb/core/log_backend/log_backend.h
+++ b/ydb/core/log_backend/log_backend.h
@@ -19,4 +19,3 @@ TMap<NKikimrConfig::TAuditConfig::EFormat, TVector<THolder<TLogBackend>>> Create
     NMonitoring::TDynamicCounterPtr counters);
 
 } // NKikimr
-

--- a/ydb/core/log_backend/ya.make
+++ b/ydb/core/log_backend/ya.make
@@ -8,8 +8,11 @@ SRCS(
 )
 
 PEERDIR(
-    library/cpp/unified_agent_client
     ydb/core/base
+    ydb/core/driver_lib/cli_config_base
+
+    library/cpp/messagebus/monitoring
+    library/cpp/unified_agent_client
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/tx/columnshard/counters/ya.make
+++ b/ydb/core/tx/columnshard/counters/ya.make
@@ -14,6 +14,7 @@ SRCS(
 PEERDIR(
     library/cpp/monlib/dynamic_counters
     ydb/core/tx/columnshard/counters/common
+    ydb/core/tx/columnshard/engines/portions
     ydb/core/base
 )
 

--- a/ydb/core/tx/schemeshard/olap/indexes/ya.make
+++ b/ydb/core/tx/schemeshard/olap/indexes/ya.make
@@ -7,6 +7,7 @@ SRCS(
 
 PEERDIR(
     ydb/services/bg_tasks/abstract
+    ydb/core/tx/columnshard/engines/scheme/indexes/abstract
 )
 
 END()

--- a/ydb/core/tx/schemeshard/olap/statistics/ya.make
+++ b/ydb/core/tx/schemeshard/olap/statistics/ya.make
@@ -6,6 +6,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/tx/columnshard/engines/scheme/statistics/abstract
     ydb/services/bg_tasks/abstract
 )
 

--- a/ydb/library/pool_stats_collector/pool_stats_collector.cpp
+++ b/ydb/library/pool_stats_collector/pool_stats_collector.cpp
@@ -1,6 +1,6 @@
 #include "pool_stats_collector.h"
 
-#include "counters.h"
+#include <ydb/core/base/counters.h>
 
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 

--- a/ydb/library/pool_stats_collector/pool_stats_collector.h
+++ b/ydb/library/pool_stats_collector/pool_stats_collector.h
@@ -1,5 +1,6 @@
 #pragma once
-#include "defs.h"
+
+#include <ydb/core/base/defs.h>
 #include <ydb/library/actors/core/actorsystem.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 

--- a/ydb/library/pool_stats_collector/ya.make
+++ b/ydb/library/pool_stats_collector/ya.make
@@ -1,0 +1,19 @@
+LIBRARY()
+
+SRCS(
+    pool_stats_collector.cpp
+    pool_stats_collector.h
+)
+
+PEERDIR(
+    ydb/library/actors/core
+    ydb/library/yql/minikql
+
+    ydb/core/base
+    ydb/core/graph/api
+    ydb/core/node_whiteboard
+
+    library/cpp/monlib/dynamic_counters
+)
+
+END()

--- a/ydb/library/ya.make
+++ b/ydb/library/ya.make
@@ -21,6 +21,7 @@ RECURSE(
     ncloud
     pdisk_io
     persqueue
+    pool_stats_collector
     pretty_types_print
     protobuf_printer
     query_actor

--- a/ydb/library/yql/providers/dq/stats_collector/pool_stats_collector.h
+++ b/ydb/library/yql/providers/dq/stats_collector/pool_stats_collector.h
@@ -7,7 +7,7 @@ namespace NActors {
     struct TActorSystemSetup;
 }
 
-// copy from kikimr/core/base/pool_stats_collector.h
+// copy from ydb/library/pool_stats_collector/pool_stats_collector.h
 
 namespace NYql {
 

--- a/ydb/services/metadata/abstract/ya.make
+++ b/ydb/services/metadata/abstract/ya.make
@@ -14,6 +14,7 @@ SRCS(
 GENERATE_ENUM_SERIALIZATION(kqp_common.h)
 
 PEERDIR(
+    contrib/libs/apache/arrow
     ydb/core/base
     ydb/library/accessor
     ydb/library/actors/core

--- a/ydb/services/metadata/manager/ya.make
+++ b/ydb/services/metadata/manager/ya.make
@@ -17,6 +17,7 @@ SRCS(
 )
 
 PEERDIR(
+    contrib/libs/apache/arrow
     ydb/library/accessor
     ydb/library/actors/core
     ydb/public/api/protos


### PR DESCRIPTION
move pool_stats_collector to ydb/library

the goal: remove ydb/core/base -> ydb/library/yql PEERDIR dependency