### PR TITLE
Support dynamic node configuration updates through NodeWarden

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -845,6 +845,8 @@ struct TEvBlobStorage {
         EvNodeWardenStorageConfigConfirm,
         EvNodeWardenQueryBaseConfig,
         EvNodeWardenBaseConfig,
+        EvNodeWardenDynamicConfigSubscribe,
+        EvNodeWardenDynamicConfigPush,
 
         // Other
         EvRunActor = EvPut + 15 * 512,

--- a/ydb/core/blobstorage/nodewarden/bind_queue.h
+++ b/ydb/core/blobstorage/nodewarden/bind_queue.h
@@ -26,6 +26,10 @@ namespace NKikimr::NStorage {
 #endif
 
     public:
+        bool Empty() const {
+            return BindQueue.empty();
+        }
+
         void Disable(ui32 nodeId) {
 #ifndef NDEBUG
             Y_ABORT_UNLESS(Enabled.contains(nodeId));

--- a/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
@@ -1,0 +1,90 @@
+#include "distconf.h"
+
+namespace NKikimr::NStorage {
+
+    void TDistributedConfigKeeper::ApplyStaticNodeIds(const std::vector<ui32>& nodeIds) {
+        StaticBindQueue.Update(nodeIds);
+        ConnectToStaticNode();
+    }
+
+    void TDistributedConfigKeeper::ConnectToStaticNode() {
+        if (ConnectedToStaticNode) {
+            return;
+        }
+
+        const TMonotonic now = TActivationContext::Monotonic();
+        TMonotonic timestamp;
+        if (std::optional<ui32> nodeId = StaticBindQueue.Pick(now, &timestamp)) {
+            ConnectedToStaticNode = *nodeId;
+            TActivationContext::Send(new IEventHandle(TEvBlobStorage::EvNodeWardenDynamicConfigSubscribe,
+                IEventHandle::FlagSubscribeOnSession, MakeBlobStorageNodeWardenID(ConnectedToStaticNode), SelfId(),
+                nullptr, 0));
+        } else if (timestamp != TMonotonic::Max()) {
+            if (!ReconnectScheduled) {
+                TActivationContext::Schedule(timestamp, new IEventHandle(TEvPrivate::EvReconnect, 0, SelfId(), {}, nullptr, 0));
+                ReconnectScheduled = true;
+            }
+        }
+    }
+
+    void TDistributedConfigKeeper::HandleReconnect() {
+        Y_ABORT_UNLESS(ReconnectScheduled);
+        ReconnectScheduled = false;
+        ConnectToStaticNode();
+    }
+
+    void TDistributedConfigKeeper::OnStaticNodeConnected(ui32 nodeId, TActorId sessionId) {
+        Y_ABORT_UNLESS(nodeId == ConnectedToStaticNode);
+        Y_ABORT_UNLESS(!StaticNodeSessionId);
+        StaticNodeSessionId = sessionId;
+    }
+
+    void TDistributedConfigKeeper::OnStaticNodeDisconnected(ui32 nodeId, TActorId /*sessionId*/) {
+        Y_ABORT_UNLESS(nodeId == ConnectedToStaticNode);
+        ConnectedToStaticNode = 0;
+        StaticNodeSessionId = {};
+        ConnectToStaticNode();
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvNodeWardenDynamicConfigPush::TPtr ev) {
+        auto& record = ev->Get()->Record;
+        ApplyStorageConfig(record.GetConfig());
+    }
+
+    void TDistributedConfigKeeper::ApplyConfigUpdateToDynamicNodes() {
+        for (const auto& [sessionId, actorId] : DynamicConfigSubscribers) {
+            PushConfigToDynamicNode(actorId, sessionId);
+        }
+    }
+
+    void TDistributedConfigKeeper::OnDynamicNodeDisconnected(ui32 nodeId, TActorId sessionId) {
+        ConnectedDynamicNodes.erase(nodeId);
+        DynamicConfigSubscribers.erase(sessionId);
+    }
+
+    void TDistributedConfigKeeper::HandleDynamicConfigSubscribe(STATEFN_SIG) {
+        const TActorId sessionId = ev->InterconnectSession;
+        Y_ABORT_UNLESS(sessionId);
+        const ui32 peerNodeId = ev->Sender.NodeId();
+        if (const auto [it, inserted] = SubscribedSessions.try_emplace(peerNodeId); inserted) {
+            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Subscribe, IEventHandle::FlagTrackDelivery,
+                sessionId, SelfId(), nullptr, 0));
+        }
+        ConnectedDynamicNodes.insert(peerNodeId);
+        const auto [_, inserted] = DynamicConfigSubscribers.try_emplace(sessionId, ev->Sender);
+        Y_ABORT_UNLESS(inserted);
+
+        if (StorageConfig) {
+            PushConfigToDynamicNode(ev->Sender, sessionId);
+        }
+    }
+
+    void TDistributedConfigKeeper::PushConfigToDynamicNode(TActorId actorId, TActorId sessionId) {
+        auto ev = std::make_unique<TEvNodeWardenDynamicConfigPush>();
+        ev->Record.MutableConfig()->CopyFrom(*StorageConfig);
+        auto handle = std::make_unique<IEventHandle>(actorId, SelfId(), ev.release());
+        handle->Rewrite(TEvInterconnect::EvForward, sessionId);
+        TActivationContext::Send(handle.release());
+    }
+
+} // NKikimr::NStorage

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -200,6 +200,18 @@ namespace NKikimr::NStorage {
 
                 DIV_CLASS("panel panel-info") {
                     DIV_CLASS("panel-heading") {
+                        out << "Static <-> dynamic node interaction";
+                    }
+                    DIV_CLASS("panel-body") {
+                        out << "IsSelfStatic: " << (IsSelfStatic ? "true" : "false") << "<br/>";
+                        out << "ConnectedToStaticNode: " << ConnectedToStaticNode << "<br/>";
+                        out << "StaticNodeSessionId: " << StaticNodeSessionId << "<br/>";
+                        out << "ConnectedDynamicNodes: " << FormatList(ConnectedDynamicNodes) << "<br/>";
+                    }
+                }
+
+                DIV_CLASS("panel panel-info") {
+                    DIV_CLASS("panel-heading") {
                         out << "Incoming bindings";
                     }
                     DIV_CLASS("panel-body") {

--- a/ydb/core/blobstorage/nodewarden/node_warden_events.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_events.h
@@ -67,4 +67,8 @@ namespace NKikimr::NStorage {
         NKikimrBlobStorage::TBaseConfig BaseConfig;
     };
 
+    struct TEvNodeWardenDynamicConfigPush
+        : TEventPB<TEvNodeWardenDynamicConfigPush, NKikimrBlobStorage::TEvNodeWardenDynamicConfigPush, TEvBlobStorage::EvNodeWardenDynamicConfigPush>
+    {};
+
 } // NKikimr::NStorage

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -640,6 +640,8 @@ namespace NKikimr::NStorage {
                 fFunc(TEvBlobStorage::EvNodeConfigScatter, ForwardToDistributedConfigKeeper);
                 fFunc(TEvBlobStorage::EvNodeConfigGather, ForwardToDistributedConfigKeeper);
                 fFunc(TEvBlobStorage::EvNodeConfigInvokeOnRoot, ForwardToDistributedConfigKeeper);
+                fFunc(TEvBlobStorage::EvNodeWardenDynamicConfigSubscribe, ForwardToDistributedConfigKeeper);
+                fFunc(TEvBlobStorage::EvNodeWardenDynamicConfigPush, ForwardToDistributedConfigKeeper);
 
                 hFunc(TEvNodeWardenQueryBaseConfig, Handle);
                 hFunc(TEvNodeConfigInvokeOnRootResult, Handle);

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -7,6 +7,7 @@ SRCS(
     distconf.cpp
     distconf.h
     distconf_binding.cpp
+    distconf_dynamic.cpp
     distconf_generate.cpp
     distconf_fsm.cpp
     distconf_invoke.cpp

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -236,3 +236,7 @@ message TEvNodeConfigInvokeOnRootResult {
         TReassignStateStorageNode ReassignStateStorageNode = 9;
     }
 }
+
+message TEvNodeWardenDynamicConfigPush {
+    TStorageConfig Config = 1;
+}


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support dynamic node configuration updates through NodeWarden

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Dynamic nodes now have working distributed config keeper which provides information about storage configuration obtained from static nodes.
