### PR TITLE
Fix PDisk FAULTY status in CMS UI

### DIFF
--- a/ydb/core/cms/ui/sentinel_state.js
+++ b/ydb/core/cms/ui/sentinel_state.js
@@ -22,15 +22,14 @@ TPDiskState[253] = "Timeout";
 TPDiskState[254] = "NodeDisconnected";
 TPDiskState[255] = "Unknown";
 
-const EPDiskStatus = [
-    "UNKNOWN",
-    "ACTIVE",
-    "INACTIVE",
-    "BROKEN",
-    "UNKNOWN", // deprecated status
-    "FAULTY",
-    "TO_BE_REMOVED",
-];
+const EPDiskStatus = {
+    0: "UNKNOWN",
+    1: "ACTIVE",
+    2: "INACTIVE",
+    3: "BROKEN",
+    5: "FAULTY",
+    6: "TO_BE_REMOVED",
+};
 
 const PDiskHeaders = [
     "PDiskId",

--- a/ydb/core/cms/ui/sentinel_state.js
+++ b/ydb/core/cms/ui/sentinel_state.js
@@ -27,6 +27,7 @@ const EPDiskStatus = [
     "ACTIVE",
     "INACTIVE",
     "BROKEN",
+    "UNKNOWN", // deprecated status
     "FAULTY",
     "TO_BE_REMOVED",
 ];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix that pdisk status `FAULTY` is shown as `TO_BE_REMOVED` in CMS UI.

### Changelog category <!-- remove all except one -->

* Bugfix 

