### PR TITLE
Cancel existing Processor in OnConnect

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_persqueue_public/impl/write_session_impl.cpp
@@ -456,6 +456,10 @@ void TWriteSessionImpl::DoConnect(const TDuration& delay, const TString& endpoin
         Y_ASSERT(connectContext);
         Y_ASSERT(connectTimeoutContext);
 
+        if (Processor) {
+            Processor->Cancel();
+        }
+
         reqSettings = TRpcRequestSettings::Make(Settings);
 
         connectCallback = [cbContext = SelfContext,

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.ipp
@@ -277,6 +277,9 @@ bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::Reconnect(const TPlain
             Cancel(connectTimeoutContext);
             return false;
         }
+        if (Processor) {
+            Processor->Cancel();
+        }
         Processor = nullptr;
         WaitingReadResponse = false;
         ServerMessage = std::make_shared<TServerMessage<UseMigrationProtocol>>();

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.cpp
@@ -672,6 +672,9 @@ void TWriteSessionImpl::OnConnect(
             ConnectDelayContext = nullptr;
 
             if (st.Ok()) {
+                if (Processor) {
+                    Processor->Cancel();
+                }
                 Processor = std::move(processor);
                 InitImpl();
                 // Still should call ReadFromProcessor();

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.cpp
@@ -603,6 +603,10 @@ void TWriteSessionImpl::Connect(const TDuration& delay) {
         }
         Cancel(prevConnectTimeoutContext);
 
+        if (Processor) {
+            Processor->Cancel();
+        }
+
         reqSettings = TRpcRequestSettings::Make(Settings, PreferredPartitionLocation.Endpoint);
 
         connectCallback = [cbContext = SelfContext,
@@ -672,9 +676,6 @@ void TWriteSessionImpl::OnConnect(
             ConnectDelayContext = nullptr;
 
             if (st.Ok()) {
-                if (Processor) {
-                    Processor->Cancel();
-                }
                 Processor = std::move(processor);
                 InitImpl();
                 // Still should call ReadFromProcessor();


### PR DESCRIPTION
There is a memory leak wIthout canceling the previous processor.