### PR TITLE
Fix lock in Immediate Control Board #5290

### DIFF
--- a/ydb/core/control/immediate_control_board_ut.cpp
+++ b/ydb/core/control/immediate_control_board_ut.cpp
@@ -111,15 +111,17 @@ Y_UNIT_TEST_SUITE(ControlImplementationTests) {
 
     Y_UNIT_TEST(TestParallelRegisterSharedControl) {
         void* (*parallelJob)(void*) = [](void *controlBoard) -> void *{
-            TControlBoard *Icb = reinterpret_cast<TControlBoard *>(controlBoard);
-            TControlWrapper control1(1, 1, 1);
-            Icb->RegisterSharedControl(control1, "sharedControl");
-            // Useless because running this test with --sanitize=thread cannot reveal
-            // race condition in Icb->RegisterLocalControl(...) without mutex
-            TControlWrapper control2(2, 2, 2);
-            TControlWrapper control2_origin(control2);
-            Icb->RegisterLocalControl(control2, "localControl");
-            UNIT_ASSERT_EQUAL(control2, control2_origin);
+            for (ui64 i = 0; i < 10000; ++i) {
+                TControlBoard *Icb = reinterpret_cast<TControlBoard *>(controlBoard);
+                TControlWrapper control1(1, 1, 1);
+                Icb->RegisterSharedControl(control1, "sharedControl");
+                // Useless because running this test with --sanitize=thread cannot reveal
+                // race condition in Icb->RegisterLocalControl(...) without mutex
+                TControlWrapper control2(2, 2, 2);
+                TControlWrapper control2_origin(control2);
+                Icb->RegisterLocalControl(control2, "localControl");
+                UNIT_ASSERT_EQUAL(control2, control2_origin);
+            }
             return nullptr;
         };
         TIntrusivePtr<TControlBoard> Icb(new TControlBoard);

--- a/ydb/core/util/concurrent_rw_hash.h
+++ b/ydb/core/util/concurrent_rw_hash.h
@@ -49,6 +49,20 @@ public:
         bucket.Map[key] = value;
     }
 
+    bool Swap(const K& key, const V& value, V& out_prev_value) {
+        TBucket& bucket = GetBucketForKey(key);
+        TWriteGuard guard(bucket.RWLock);
+
+        typename TActualMap::iterator it = bucket.Map.find(key);
+        if (it != bucket.Map.end()) {
+            out_prev_value = it->second;
+            it->second = value;
+            return true;
+        }
+        bucket.Map.insert(std::make_pair(key, value));
+        return false;
+    }
+
     V& InsertIfAbsent(const K& key, const V& value) {
         TBucket& bucket = GetBucketForKey(key);
         TWriteGuard guard(bucket.RWLock);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Do not use write lock in ICB when read lock is enough. Use swap to prevent read-check-write races.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

This may fix some latency issues.
