### PR TITLE
Improve erase cache to better work with uncommitted changes

### DIFF
--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -84,8 +84,6 @@ TAutoPtr<TTableIter> TDatabase::Iterate(ui32 table, TRawVals key, TTagsRef tags,
         Y_ABORT("Don't know how to convert ELookup to ESeek mode");
     };
 
-    IteratedTables.insert(table);
-
     return Require(table)->Iterate(key, tags, Env, seekBy(key, mode), TRowVersion::Max());
 }
 
@@ -95,8 +93,6 @@ TAutoPtr<TTableIter> TDatabase::IterateExact(ui32 table, TRawVals key, TTagsRef 
         const ITransactionObserverPtr& observer) const noexcept
 {
     Y_ABORT_UNLESS(!NoMoreReadsFlag, "Trying to read after reads prohibited, table %u", table);
-
-    IteratedTables.insert(table);
 
     auto iter = Require(table)->Iterate(key, tags, Env, ESeek::Exact, snapshot, visible, observer);
 
@@ -153,8 +149,6 @@ TAutoPtr<TTableIter> TDatabase::IterateRange(ui32 table, const TKeyRange& range,
     Y_DEBUG_ABORT_UNLESS(!IsAmbiguousRange(range, Require(table)->GetScheme()->Keys->Size()),
         "%s", IsAmbiguousRangeReason(range, Require(table)->GetScheme()->Keys->Size()));
 
-    IteratedTables.insert(table);
-
     ESeek seek = !range.MinKey || range.MinInclusive ? ESeek::Lower : ESeek::Upper;
 
     auto iter = Require(table)->Iterate(range.MinKey, tags, Env, seek, snapshot, visible, observer);
@@ -181,8 +175,6 @@ TAutoPtr<TTableReverseIter> TDatabase::IterateRangeReverse(ui32 table, const TKe
 
     Y_DEBUG_ABORT_UNLESS(!IsAmbiguousRange(range, Require(table)->GetScheme()->Keys->Size()),
         "%s", IsAmbiguousRangeReason(range, Require(table)->GetScheme()->Keys->Size()));
-
-    IteratedTables.insert(table);
 
     ESeek seek = !range.MaxKey || range.MaxInclusive ? ESeek::Lower : ESeek::Upper;
 
@@ -699,18 +691,6 @@ TDatabase::TProd TDatabase::Commit(TTxStamp stamp, bool commit, TCookieAllocator
 
     TempIterators.clear();
 
-    if (IteratedTables) {
-        for (ui32 table : IteratedTables) {
-            if (auto& wrap = DatabaseImpl->Get(table, false)) {
-                if (auto* cache = wrap->GetErasedKeysCache()) {
-                    cache->CollectGarbage();
-                }
-            }
-        }
-
-        IteratedTables.clear();
-    }
-
     if (commit && HasChanges()) {
         Y_ABORT_UNLESS(stamp >= Change->Stamp);
         Y_ABORT_UNLESS(DatabaseImpl->Serial() == Change->Serial);
@@ -793,6 +773,8 @@ TDatabase::TProd TDatabase::Commit(TTxStamp stamp, bool commit, TCookieAllocator
     } else {
         DatabaseImpl->RollbackTransaction();
     }
+
+    DatabaseImpl->RunGC();
 
     Redo = nullptr;
     Annex = nullptr;

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -304,7 +304,6 @@ private:
     TVector<TUpdateOp> ModifiedOps;
 
     mutable TDeque<TPartIter> TempIterators; // Keeps the last result of Select() valid
-    mutable THashSet<ui32> IteratedTables;
 
     TVector<std::function<void()>> OnCommit_;
     TVector<std::function<void()>> OnRollback_;

--- a/ydb/core/tablet_flat/flat_mem_iter.h
+++ b/ydb/core/tablet_flat/flat_mem_iter.h
@@ -240,7 +240,8 @@ namespace NTable {
          */
         bool SkipToRowVersion(TRowVersion rowVersion, TIteratorStats& stats,
                               NTable::ITransactionMapSimplePtr committedTransactions,
-                              NTable::ITransactionObserverSimplePtr transactionObserver) noexcept
+                              NTable::ITransactionObserverSimplePtr transactionObserver,
+                              const NTable::ITransactionSet& decidedTransactions) noexcept
         {
             Y_DEBUG_ABORT_UNLESS(IsValid(), "Attempt to access an invalid row");
 
@@ -250,6 +251,10 @@ namespace NTable {
             // Skip uncommitted deltas
             while (chain->RowVersion.Step == Max<ui64>() && !committedTransactions.Find(chain->RowVersion.TxId)) {
                 transactionObserver.OnSkipUncommitted(chain->RowVersion.TxId);
+                if (chain->Rop != ERowOp::Erase && !decidedTransactions.Contains(chain->RowVersion.TxId)) {
+                    // This change may commit and change the iteration result
+                    stats.UncertainErase = true;
+                }
                 if (!(chain = chain->Next)) {
                     CurrentVersion = nullptr;
                     return false;
@@ -267,12 +272,20 @@ namespace NTable {
                 auto* commitVersion = committedTransactions.Find(chain->RowVersion.TxId);
                 Y_ABORT_UNLESS(commitVersion);
                 if (*commitVersion <= rowVersion) {
+                    if (!decidedTransactions.Contains(chain->RowVersion.TxId)) {
+                        // This change may rollback and change the iteration result
+                        stats.UncertainErase = true;
+                    }
                     return true;
                 }
                 transactionObserver.OnSkipCommitted(*commitVersion, chain->RowVersion.TxId);
             }
 
             stats.InvisibleRowSkips++;
+            if (chain->Rop != ERowOp::Erase) {
+                // We are skipping non-erase op, so any erase below cannot be trusted
+                stats.UncertainErase = true;
+            }
 
             while ((chain = chain->Next)) {
                 if (chain->RowVersion.Step != Max<ui64>()) {
@@ -286,6 +299,10 @@ namespace NTable {
                 } else {
                     auto* commitVersion = committedTransactions.Find(chain->RowVersion.TxId);
                     if (commitVersion && *commitVersion <= rowVersion) {
+                        if (!decidedTransactions.Contains(chain->RowVersion.TxId)) {
+                            // This change may rollback and change the iteration result
+                            stats.UncertainErase = true;
+                        }
                         CurrentVersion = chain;
                         return true;
                     }
@@ -295,7 +312,16 @@ namespace NTable {
                         stats.InvisibleRowSkips++;
                     } else {
                         transactionObserver.OnSkipUncommitted(chain->RowVersion.TxId);
+                        if (decidedTransactions.Contains(chain->RowVersion.TxId)) {
+                            // This is a decided uncommitted change and will never be committed
+                            // Make sure we don't mark possible erase below as uncertain
+                            continue;
+                        }
                     }
+                }
+                if (chain->Rop != ERowOp::Erase) {
+                    // We are skipping non-erase op, so any erase below cannot be trusted
+                    stats.UncertainErase = true;
                 }
             }
 

--- a/ydb/core/tablet_flat/flat_part_iter.h
+++ b/ydb/core/tablet_flat/flat_part_iter.h
@@ -923,7 +923,8 @@ namespace NTable {
 
         EReady SkipToRowVersion(TRowVersion rowVersion, TIteratorStats& stats,
                                 NTable::ITransactionMapSimplePtr committedTransactions,
-                                NTable::ITransactionObserverSimplePtr transactionObserver) noexcept
+                                NTable::ITransactionObserverSimplePtr transactionObserver,
+                                const NTable::ITransactionSet& decidedTransactions) noexcept
         {
             Y_DEBUG_ABORT_UNLESS(Main.IsValid(), "Attempt to use an invalid iterator");
 
@@ -948,6 +949,7 @@ namespace NTable {
                             transactionObserver.OnSkipCommitted(Part->MinRowVersion);
                         }
                         stats.InvisibleRowSkips++;
+                        stats.UncertainErase = true;
                     }
                     return EReady::Gone;
                 }
@@ -964,15 +966,27 @@ namespace NTable {
                     const auto* commitVersion = committedTransactions.Find(txId);
                     if (commitVersion && *commitVersion <= rowVersion) {
                         // Already committed and correct version
+                        if (!decidedTransactions.Contains(txId)) {
+                            // This change may rollback and change the iteration result
+                            stats.UncertainErase = true;
+                        }
                         return EReady::Data;
                     }
                     if (commitVersion) {
                         // Skipping a newer committed delta
                         transactionObserver.OnSkipCommitted(*commitVersion, txId);
                         stats.InvisibleRowSkips++;
+                        if (data->GetRop() != ERowOp::Erase) {
+                            // Skipping non-erase delta, so any erase below cannot be trusted
+                            stats.UncertainErase = true;
+                        }
                     } else {
                         // Skipping an uncommitted delta
                         transactionObserver.OnSkipUncommitted(txId);
+                        if (data->GetRop() != ERowOp::Erase && !decidedTransactions.Contains(txId)) {
+                            // This change may commit and change the iteration result
+                            stats.UncertainErase = true;
+                        }
                     }
                     data = Main.GetRecord()->GetAltRecord(++SkipMainDeltas);
                     if (!data) {
@@ -991,6 +1005,7 @@ namespace NTable {
                     SkipEraseVersion = true;
                     transactionObserver.OnSkipCommitted(current);
                     stats.InvisibleRowSkips++;
+                    stats.UncertainErase = true;
                 }
 
                 TRowVersion current = data->IsVersioned() ? data->GetMinVersion(info) : Part->MinRowVersion;
@@ -1001,6 +1016,7 @@ namespace NTable {
 
                 transactionObserver.OnSkipCommitted(current);
                 stats.InvisibleRowSkips++;
+                stats.UncertainErase = true;
 
                 if (!data->HasHistory()) {
                     // There is no history, reset
@@ -1661,10 +1677,11 @@ namespace NTable {
 
         EReady SkipToRowVersion(TRowVersion rowVersion, TIteratorStats& stats,
                                 NTable::ITransactionMapSimplePtr committedTransactions,
-                                NTable::ITransactionObserverSimplePtr transactionObserver) noexcept
+                                NTable::ITransactionObserverSimplePtr transactionObserver,
+                                const NTable::ITransactionSet& decidedTransactions) noexcept
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt);
-            auto ready = CurrentIt->SkipToRowVersion(rowVersion, stats, committedTransactions, transactionObserver);
+            auto ready = CurrentIt->SkipToRowVersion(rowVersion, stats, committedTransactions, transactionObserver, decidedTransactions);
             return ready;
         }
 

--- a/ydb/core/tablet_flat/flat_range_cache_ut.cpp
+++ b/ydb/core/tablet_flat/flat_range_cache_ut.cpp
@@ -235,7 +235,7 @@ Y_UNIT_TEST_SUITE(TFlatEraseCacheTest) {
             DB.Commit(8, true);
 
             // We touched an erased range, it should become invalidated
-            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ }");
+            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1, 2}, {2, 5}) }");
         }
 
         {
@@ -249,7 +249,7 @@ Y_UNIT_TEST_SUITE(TFlatEraseCacheTest) {
             DB.Commit(9, true);
 
             // We've seen all rows, expect correct erased ranges
-            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1, 2}, {2, 4}], [{2, 6}, {2, 31}] }");
+            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1, 2}, {2, 5}), [{2, 6}, {2, 31}] }");
         }
     }
 
@@ -423,7 +423,7 @@ Y_UNIT_TEST_SUITE(TFlatEraseCacheTest) {
             DB.Commit(8, true);
 
             // We touched an erased range, it should become invalidated
-            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ }");
+            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{2, 2}, {2, 28}) }");
         }
 
         {
@@ -437,7 +437,7 @@ Y_UNIT_TEST_SUITE(TFlatEraseCacheTest) {
             DB.Commit(9, true);
 
             // We've seen all rows, expect correct erased ranges
-            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{2, 2}, {2, 27}], [{2, 29}, {3, 31}] }");
+            UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{2, 2}, {2, 28}), [{2, 29}, {3, 31}] }");
         }
     }
 

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -16,7 +16,10 @@
 namespace NKikimr {
 namespace NTable {
 
-TTable::TTable(TEpoch epoch) : Epoch(epoch) { }
+TTable::TTable(TEpoch epoch, const TIntrusivePtr<TKeyRangeCacheNeedGCList>& gcList)
+    : Epoch(epoch)
+    , EraseCacheGCList(gcList)
+{ }
 
 TTable::~TTable() { }
 
@@ -30,12 +33,15 @@ void TTable::PrepareRollback()
     state.EraseCacheConfig = EraseCacheConfig;
     state.MutableExisted = bool(Mutable);
     state.MutableUpdated = false;
+    state.DisableEraseCache = false;
 }
 
 void TTable::RollbackChanges()
 {
     Y_ABORT_UNLESS(RollbackState, "PrepareRollback needed to rollback changes");
     auto& state = *RollbackState;
+
+    CommitOps.clear();
 
     while (!RollbackOps.empty()) {
         struct TApplyRollbackOp {
@@ -80,20 +86,12 @@ void TTable::RollbackChanges()
 
     if (Epoch != state.Epoch) {
         // We performed a snapshot, roll it back
-        if (Mutable) {
-            ErasedKeysCache.Reset();
-            Mutable = nullptr;
-        }
         Y_ABORT_UNLESS(MutableBackup, "Previous mem table missing");
         Mutable = std::move(MutableBackup);
     } else if (!state.MutableExisted) {
         // New memtable doesn't need rollback
-        if (Mutable) {
-            ErasedKeysCache.Reset();
-            Mutable = nullptr;
-        }
+        Mutable = nullptr;
     } else if (state.MutableUpdated) {
-        ErasedKeysCache.Reset();
         Y_ABORT_UNLESS(Mutable, "Mutable was updated, but it is missing");
         Mutable->RollbackChanges();
     }
@@ -103,7 +101,6 @@ void TTable::RollbackChanges()
     Annexed = state.Annexed;
     if (state.Scheme) {
         Levels.Reset();
-        ErasedKeysCache.Reset();
         Scheme = std::move(state.Scheme);
         EraseCacheEnabled = state.EraseCacheEnabled;
         EraseCacheConfig = state.EraseCacheConfig;
@@ -116,6 +113,19 @@ void TTable::CommitChanges(TArrayRef<const TMemGlob> blobs)
     Y_ABORT_UNLESS(RollbackState, "PrepareRollback needed to rollback changes");
     auto& state = *RollbackState;
 
+    for (auto& op : CommitOps) {
+        struct TApplyCommitOp {
+            TTable* Self;
+
+            void operator()(const TCommitAddDecidedTx& op) const {
+                Self->DecidedTransactions.Add(op.TxId);
+            }
+        };
+
+        std::visit(TApplyCommitOp{ this }, op);
+    }
+
+    CommitOps.clear();
     RollbackOps.clear();
 
     if (Epoch != state.Epoch) {
@@ -162,6 +172,11 @@ void TTable::SetScheme(const TScheme::TTableInfo &table)
 
     Y_ABORT_UNLESS(!Mutable && table.Columns);
 
+    if (RollbackState) {
+        // Make sure we don't populate erase cache with keys based on a schema
+        // which may end up rolling back.
+        RollbackState->DisableEraseCache = true;
+    }
     if (RollbackState && !RollbackState->Scheme) {
         RollbackState->Scheme = Scheme;
         RollbackState->EraseCacheEnabled = EraseCacheEnabled;
@@ -362,7 +377,8 @@ void TTable::ReplaceSlices(TBundleSlicesMap slices) noexcept
     }
     if (slices) {
         Levels.Reset();
-        ErasedKeysCache.Reset();
+        // Note: ReplaceSlices does not introduce any new rows, so we don't
+        // have to invalidate current erase cache.
     }
 }
 
@@ -383,9 +399,12 @@ void TTable::Replace(TArrayRef<const TPartView> partViews, const TSubset &subset
         Levels.Reset();
     }
 
+    bool removingOld = false;
+    bool addingNew = false;
     THashSet<ui64> checkNewTransactions;
 
     for (auto &memTable : subset.Frozen) {
+        removingOld = true;
         const auto found = Frozen.erase(memTable.MemTable);
 
         Y_ABORT_UNLESS(found == 1, "Got an unknown TMemTable table in TSubset");
@@ -406,6 +425,7 @@ void TTable::Replace(TArrayRef<const TPartView> partViews, const TSubset &subset
     }
 
     for (auto &part : subset.Flatten) {
+        removingOld = true;
         Y_ABORT_UNLESS(part.Slices && *part.Slices,
             "Got an empty TPart subset in TSubset");
 
@@ -454,12 +474,14 @@ void TTable::Replace(TArrayRef<const TPartView> partViews, const TSubset &subset
     }
 
     for (auto &part : subset.ColdParts) {
+        removingOld = true;
         auto it = ColdParts.find(part->Label);
         Y_ABORT_UNLESS(it != ColdParts.end(), "Got an unknown TColdPart in TSubset");
         ColdParts.erase(it);
     }
 
     for (const auto &partView : partViews) {
+        addingNew = true;
         if (Mutable && partView->Epoch >= Mutable->Epoch) {
             Y_Fail("Replace with " << NFmt::Do(*partView) << " after mutable epoch " << Mutable->Epoch);
         }
@@ -481,6 +503,7 @@ void TTable::Replace(TArrayRef<const TPartView> partViews, const TSubset &subset
             if (!ColdParts) {
                 CommittedTransactions.Remove(txId);
                 RemovedTransactions.Remove(txId);
+                DecidedTransactions.Remove(txId);
             } else {
                 CheckTransactions.insert(txId);
             }
@@ -491,7 +514,14 @@ void TTable::Replace(TArrayRef<const TPartView> partViews, const TSubset &subset
 
     ProcessCheckTransactions();
 
-    ErasedKeysCache.Reset();
+    if (!removingOld && addingNew) {
+        // Note: we invalidate erase cache when nothing old is removed,
+        // because followers always call Replace, even when leader called
+        // Merge. When something is removed we can assume it's a compaction
+        // and compactions don't add new rows to the table, keeping erase
+        // cache valid.
+        ErasedKeysCache.Reset();
+    }
 }
 
 void TTable::ReplaceTxStatus(TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>> newTxStatus, const TSubset &subset) noexcept
@@ -551,6 +581,8 @@ void TTable::Merge(TPartView partView) noexcept
         it->second.Slices = TSlices::Merge(it->second.Slices, partView.Slices);
     }
 
+    // Note: Merge is called when borrowing data, which may introduce new rows
+    // and invalidate current erase cache.
     ErasedKeysCache.Reset();
 }
 
@@ -579,8 +611,11 @@ void TTable::Merge(TIntrusiveConstPtr<TColdPart> part) noexcept
     Epoch = Max(Epoch, part->Epoch + 1);
     ColdParts.emplace(label, std::move(part));
 
-    ErasedKeysCache.Reset();
     Levels.Reset();
+
+    // Note: Merge is called when borrowing data, which may introduce new rows
+    // and invalidate current erase cache.
+    ErasedKeysCache.Reset();
 }
 
 void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept
@@ -601,6 +636,7 @@ void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept
         if (!TxRefs.contains(txId)) {
             CheckTransactions.insert(txId);
         }
+        DecidedTransactions.Add(txId);
         OpenTxs.erase(txId);
     }
     for (auto& item : txStatus->TxStatusPage->GetRemovedItems()) {
@@ -611,6 +647,7 @@ void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept
         if (!TxRefs.contains(txId)) {
             CheckTransactions.insert(txId);
         }
+        DecidedTransactions.Add(txId);
         OpenTxs.erase(txId);
     }
 
@@ -627,7 +664,9 @@ void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept
     auto res = TxStatus.emplace(txStatus->Label, txStatus);
     Y_ABORT_UNLESS(res.second, "Unexpected failure to add a new TTxStatusPart");
 
-    ErasedKeysCache.Reset();
+    // Note: Merge is called when borrowing data, but new tx status may commit
+    // or rollback some transactions, and erase cache already accounts for that
+    // eventuality, so doesn't need to be invalidated.
 }
 
 void TTable::ProcessCheckTransactions() noexcept
@@ -638,6 +677,7 @@ void TTable::ProcessCheckTransactions() noexcept
             if (it == TxRefs.end()) {
                 CommittedTransactions.Remove(txId);
                 RemovedTransactions.Remove(txId);
+                DecidedTransactions.Remove(txId);
             }
         }
         CheckTransactions.clear();
@@ -825,7 +865,7 @@ void TTable::Update(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMemG
         const TCelled cells(key, *Scheme->Keys, true);
         auto res = ErasedKeysCache->FindKey(cells);
         if (res.second) {
-            ErasedKeysCache->Invalidate(res.first);
+            ErasedKeysCache->InvalidateKey(res.first, cells);
         }
     }
 
@@ -842,6 +882,8 @@ void TTable::AddTxRef(ui64 txId)
     if (addOpenTx) {
         auto res = OpenTxs.insert(txId);
         Y_ABORT_UNLESS(res.second);
+        Y_DEBUG_ABORT_UNLESS(!DecidedTransactions.Contains(txId),
+            "Decided transaction %" PRIu64 " is both open and decided", txId);
     }
     if (RollbackState) {
         RollbackOps.emplace_back(TRollbackRemoveTxRef{ txId });
@@ -855,6 +897,14 @@ void TTable::UpdateTx(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMe
 {
     auto& memTable = MemTable();
     bool hadTxRef = memTable.GetTxIdStats().contains(txId);
+
+    if (ErasedKeysCache && rop != ERowOp::Erase) {
+        const TCelled cells(key, *Scheme->Keys, true);
+        auto res = ErasedKeysCache->FindKey(cells);
+        if (res.second) {
+            ErasedKeysCache->InvalidateKey(res.first, cells);
+        }
+    }
 
     // Use a special row version that marks this update as uncommitted
     TRowVersion rowVersion(Max<ui64>(), txId);
@@ -897,13 +947,15 @@ void TTable::CommitTx(ui64 txId, TRowVersion rowVersion)
         if (auto it = OpenTxs.find(txId); it != OpenTxs.end()) {
             if (RollbackState) {
                 RollbackOps.emplace_back(TRollbackAddOpenTx{ txId });
+                CommitOps.emplace_back(TCommitAddDecidedTx{ txId });
+            } else {
+                DecidedTransactions.Add(txId);
             }
             OpenTxs.erase(it);
         }
     }
 
-    // We don't know which keys have been commited, invalidate everything
-    ErasedKeysCache.Reset();
+    // Note: erase cache accounts for changes that may commit, no need to invalidate
 }
 
 void TTable::RemoveTx(ui64 txId)
@@ -922,6 +974,9 @@ void TTable::RemoveTx(ui64 txId)
         if (auto it = OpenTxs.find(txId); it != OpenTxs.end()) {
             if (RollbackState) {
                 RollbackOps.emplace_back(TRollbackAddOpenTx{ txId });
+                CommitOps.emplace_back(TCommitAddDecidedTx{ txId });
+            } else {
+                DecidedTransactions.Add(txId);
             }
             OpenTxs.erase(it);
         }
@@ -962,6 +1017,11 @@ TMemTable& TTable::MemTable()
 {
     if (!Mutable) {
         Mutable = new TMemTable(Scheme, Epoch, Annexed);
+    }
+    if (RollbackState) {
+        // MemTable() is only called when we want to apply updates
+        // Make sure we don't taint erase cache with changes that may rollback
+        RollbackState->DisableEraseCache = true;
     }
     if (RollbackState && Epoch == RollbackState->Epoch && RollbackState->MutableExisted) {
         if (!RollbackState->MutableUpdated) {
@@ -1009,11 +1069,12 @@ TAutoPtr<TTableIter> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, 
         }
     }
 
-    if (EraseCacheEnabled && !visible) {
+    if (EraseCacheEnabled && (!RollbackState || !RollbackState->DisableEraseCache)) {
         if (!ErasedKeysCache) {
-            ErasedKeysCache = new TKeyRangeCache(*Scheme->Keys, EraseCacheConfig);
+            ErasedKeysCache = new TKeyRangeCache(*Scheme->Keys, EraseCacheConfig, EraseCacheGCList);
         }
         dbIter->ErasedKeysCache = ErasedKeysCache;
+        dbIter->DecidedTransactions = DecidedTransactions;
     }
 
     return dbIter;
@@ -1056,11 +1117,12 @@ TAutoPtr<TTableReverseIter> TTable::IterateReverse(TRawVals key_, TTagsRef tags,
         }
     }
 
-    if (EraseCacheEnabled && !visible) {
+    if (EraseCacheEnabled && (!RollbackState || !RollbackState->DisableEraseCache)) {
         if (!ErasedKeysCache) {
-            ErasedKeysCache = new TKeyRangeCache(*Scheme->Keys, EraseCacheConfig);
+            ErasedKeysCache = new TKeyRangeCache(*Scheme->Keys, EraseCacheConfig, EraseCacheGCList);
         }
         dbIter->ErasedKeysCache = ErasedKeysCache;
+        dbIter->DecidedTransactions = DecidedTransactions;
     }
 
     return dbIter;
@@ -1098,7 +1160,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
     if (Mutable) {
         lastEpoch = Mutable->Epoch;
         if (auto it = TMemIter::Make(*Mutable, Mutable->Immediate(), key, ESeek::Exact, Scheme->Keys, &remap, env, EDirection::Forward)) {
-            if (it->IsValid() && (snapshotFound || it->SkipToRowVersion(snapshot, stats, committed, observer))) {
+            if (it->IsValid() && (snapshotFound || it->SkipToRowVersion(snapshot, stats, committed, observer, DecidedTransactions))) {
                 // N.B. stop looking for snapshot after the first hit
                 snapshotFound = true;
                 it->Apply(row, committed, observer);
@@ -1110,7 +1172,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
     if (MutableBackup && !row.IsFinalized()) {
         lastEpoch = MutableBackup->Epoch;
         if (auto it = TMemIter::Make(*MutableBackup, MutableBackup->Immediate(), key, ESeek::Exact, Scheme->Keys, &remap, env, EDirection::Forward)) {
-            if (it->IsValid() && (snapshotFound || it->SkipToRowVersion(snapshot, stats, committed, observer))) {
+            if (it->IsValid() && (snapshotFound || it->SkipToRowVersion(snapshot, stats, committed, observer, DecidedTransactions))) {
                 // N.B. stop looking for snapshot after the first hit
                 snapshotFound = true;
                 it->Apply(row, committed, observer);
@@ -1124,7 +1186,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
         Y_ABORT_UNLESS(lastEpoch > memTable->Epoch, "Ordering of epochs is incorrect");
         lastEpoch = memTable->Epoch;
         if (auto it = TMemIter::Make(*memTable, memTable->Immediate(), key, ESeek::Exact, Scheme->Keys, &remap, env, EDirection::Forward)) {
-            if (it->IsValid() && (snapshotFound || it->SkipToRowVersion(snapshot, stats, committed, observer))) {
+            if (it->IsValid() && (snapshotFound || it->SkipToRowVersion(snapshot, stats, committed, observer, DecidedTransactions))) {
                 // N.B. stop looking for snapshot after the first hit
                 snapshotFound = true;
                 it->Apply(row, committed, observer);
@@ -1150,7 +1212,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
                         Y_ABORT_UNLESS(lastEpoch > part->Epoch, "Ordering of epochs is incorrect");
                         lastEpoch = part->Epoch;
                         if (!snapshotFound) {
-                            res = it.SkipToRowVersion(snapshot, stats, committed, observer);
+                            res = it.SkipToRowVersion(snapshot, stats, committed, observer, DecidedTransactions);
                             if (res == EReady::Data) {
                                 // N.B. stop looking for snapshot after the first hit
                                 snapshotFound = true;

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -31,6 +31,7 @@ namespace NTable {
 
 class TTableEpochs;
 class TKeyRangeCache;
+class TKeyRangeCacheNeedGCList;
 
 class TTable: public TAtomicRefCount<TTable> {
 public:
@@ -64,7 +65,7 @@ public:
         TIteratorStats Stats;
     };
 
-    explicit TTable(TEpoch);
+    explicit TTable(TEpoch, const TIntrusivePtr<TKeyRangeCacheNeedGCList>& gcList = nullptr);
     ~TTable();
 
     void PrepareRollback();
@@ -351,6 +352,7 @@ private:
 
     bool EraseCacheEnabled = false;
     TKeyRangeCacheConfig EraseCacheConfig;
+    const TIntrusivePtr<TKeyRangeCacheNeedGCList> EraseCacheGCList;
 
     TRowVersionRanges RemovedRowVersions;
 
@@ -359,6 +361,7 @@ private:
     absl::flat_hash_set<ui64> CheckTransactions;
     TTransactionMap CommittedTransactions;
     TTransactionSet RemovedTransactions;
+    TTransactionSet DecidedTransactions;
     TIntrusivePtr<ITableObserver> TableObserver;
 
 private:
@@ -400,6 +403,13 @@ private:
         TRollbackAddOpenTx,
         TRollbackRemoveOpenTx>;
 
+    struct TCommitAddDecidedTx {
+        ui64 TxId;
+    };
+
+    using TCommitOp = std::variant<
+        TCommitAddDecidedTx>;
+
     struct TRollbackState {
         TEpoch Epoch;
         TIntrusiveConstPtr<TRowScheme> Scheme;
@@ -408,6 +418,7 @@ private:
         bool EraseCacheEnabled;
         bool MutableExisted;
         bool MutableUpdated;
+        bool DisableEraseCache;
 
         TRollbackState(TEpoch epoch)
             : Epoch(epoch)
@@ -415,6 +426,7 @@ private:
     };
 
     std::optional<TRollbackState> RollbackState;
+    std::vector<TCommitOp> CommitOps;
     std::vector<TRollbackOp> RollbackOps;
     TIntrusivePtr<TMemTable> MutableBackup;
 };

--- a/ydb/core/tablet_flat/flat_table_committed.cpp
+++ b/ydb/core/tablet_flat/flat_table_committed.cpp
@@ -1,0 +1,15 @@
+#include "flat_table_committed.h"
+
+namespace NKikimr::NTable {
+
+    class TEmptyTransactionSet : public ITransactionSet {
+    public:
+        bool Contains(ui64) const {
+            return false;
+        }
+    };
+
+    // Note: binding to reference extends the object lifetime
+    const ITransactionSet& ITransactionSet::None = TEmptyTransactionSet();
+
+} // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/flat_table_stats.h
+++ b/ydb/core/tablet_flat/flat_table_stats.h
@@ -34,6 +34,11 @@ namespace NTable {
     struct TIteratorStats {
         ui64 DeletedRowSkips = 0;
         ui64 InvisibleRowSkips = 0;
+        // When true an observed erase may possibly change due to undecided or
+        // skipped changes above. This is a special case to simplify erase
+        // cache updates, i.e. when UncertainErase is true observed erases
+        // cannot be cached, since it might change in a different query.
+        bool UncertainErase = false;
     };
 
     struct TSelectStats : TIteratorStats {

--- a/ydb/core/tablet_flat/test/libs/table/wrap_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_part.h
@@ -104,7 +104,8 @@ namespace NTest {
         EReady SkipToRowVersion(TRowVersion rowVersion) noexcept
         {
             TIteratorStats stats;
-            Ready = Iter->SkipToRowVersion(rowVersion, stats, /* committed */ nullptr, /* observer */ nullptr);
+            Ready = Iter->SkipToRowVersion(rowVersion, stats, /* committed */ nullptr, /* observer */ nullptr,
+                /* decided */ ITransactionSet::None);
 
             if (Ready == EReady::Data)
                 Ready = RollUp();

--- a/ydb/core/tablet_flat/ut/ut_db_iface.cpp
+++ b/ydb/core/tablet_flat/ut/ut_db_iface.cpp
@@ -821,7 +821,7 @@ Y_UNIT_TEST_SUITE(DBase) {
         me.WriteVer({4, 50}).Put(table, *me.SchemedCookRow(table).Col(9_u64, 9_u64));
         me.Commit();
 
-        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ }");
+        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {9}) }");
 
         // Verify we can only see 2 last rows at v3/50 (erased range shouldn't be cached incorrectly)
         me.To(24).ReadVer({3, 50}).IterData(table)
@@ -829,7 +829,7 @@ Y_UNIT_TEST_SUITE(DBase) {
             .Next().Is(*me.SchemedCookRow(table).Col(18_u64, 18_u64))
             .Next().Is(EReady::Gone);
 
-        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {8}], [{10}, {16}] }");
+        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {9}), [{10}, {16}] }");
 
         // Verify we can see all 3 rows at v5/50 (bug would cause as to skip over the key 9)
         me.To(25).ReadVer({5, 50}).IterData(table)
@@ -837,6 +837,106 @@ Y_UNIT_TEST_SUITE(DBase) {
             .Next().Is(*me.SchemedCookRow(table).Col(17_u64, 17_u64))
             .Next().Is(*me.SchemedCookRow(table).Col(18_u64, 18_u64))
             .Next().Is(EReady::Gone);
+    }
+
+    void TestEraseCacheWithUncommittedChanges(bool compact) {
+        TDbExec me;
+
+        const ui32 table = 1;
+        me.To(10)
+            .Begin()
+            .Apply(*TAlter()
+                .AddTable("me_1", table)
+                .AddColumn(table, "key", 1, ETypes::Uint64, false)
+                .AddColumn(table, "val", 2, ETypes::Uint64, false, Cimple(0_u64))
+                .AddColumnToKey(table, 1)
+                .SetEraseCache(table, true, 2, 8192))
+            .Commit();
+
+        auto dumpCache = [&]() -> TString {
+            if (auto* cache = me->DebugGetTableErasedKeysCache(table)) {
+                TStringStream stream;
+                stream << cache->DumpRanges();
+                return stream.Str();
+            } else {
+                return nullptr;
+            }
+        };
+
+        // Write a bunch of rows at v1/50
+        me.To(20).Begin();
+        for (ui64 i = 1; i <= 18; ++i) {
+            if (i != 9) {
+                me.WriteVer({1, 50}).Put(table, *me.SchemedCookRow(table).Col(i, i));
+            }
+        }
+        me.Commit();
+        if (compact) {
+            me.Compact(table, false);
+        }
+
+        // Erase a bunch of rows at v2/50
+        me.To(21).Begin();
+        for (ui64 i = 1; i <= 16; ++i) {
+            if (i != 9) {
+                me.WriteVer({2, 50}).Add(table, *me.SchemedCookRow(table).Col(i), ERowOp::Erase);
+            }
+        }
+        me.Commit();
+        if (compact) {
+            me.Compact(table, false);
+        }
+
+        // Verify we can only see 2 last rows at v3/50 (all other are deleted)
+        me.To(22).ReadVer({3, 50}).IterData(table)
+            .Seek({ }, ESeek::Lower).Is(*me.SchemedCookRow(table).Col(17_u64, 17_u64))
+            .Next().Is(*me.SchemedCookRow(table).Col(18_u64, 18_u64))
+            .Next().Is(EReady::Gone);
+
+        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {16}] }");
+
+        // Write an uncommitted row in tx 123
+        me.To(23).Begin();
+        me.WriteTx(123).Put(table, *me.SchemedCookRow(table).Col(9_u64, 9_u64));
+        me.Commit();
+        if (compact) {
+            me.Compact(table, false);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {9}) }");
+
+        // Verify we can only see all 3 rows in tx 123 and erase cache is correct
+        me.To(24).ReadTx(123).IterData(table)
+            .Seek({ }, ESeek::Lower).Is(*me.SchemedCookRow(table).Col(9_u64, 9_u64))
+            .Next().Is(*me.SchemedCookRow(table).Col(17_u64, 17_u64))
+            .Next().Is(*me.SchemedCookRow(table).Col(18_u64, 18_u64))
+            .Next().Is(EReady::Gone);
+
+        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {9}), [{10}, {16}] }");
+
+        // Rollback tx 123
+        me.To(25).Begin();
+        me.RemoveTx(table, 123);
+        me.Commit();
+        if (compact) {
+            me.Compact(table, false);
+        }
+
+        // Verify we can only see 2 last rows at v3/50 (all other are deleted)
+        me.To(26).ReadVer({3, 50}).IterData(table)
+            .Seek({ }, ESeek::Lower).Is(*me.SchemedCookRow(table).Col(17_u64, 17_u64))
+            .Next().Is(*me.SchemedCookRow(table).Col(18_u64, 18_u64))
+            .Next().Is(EReady::Gone);
+
+        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {16}] }");
+    }
+
+    Y_UNIT_TEST(EraseCacheWithUncommittedChanges) {
+        TestEraseCacheWithUncommittedChanges(false);
+    }
+
+    Y_UNIT_TEST(EraseCacheWithUncommittedChangesCompacted) {
+        TestEraseCacheWithUncommittedChanges(true);
     }
 
     Y_UNIT_TEST(AlterAndUpsertChangesVisibility) {

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -65,6 +65,8 @@ SRCS(
     flat_table_misc.cpp
     flat_table_observer.cpp
     flat_table_observer.h
+    flat_table_committed.cpp
+    flat_table_committed.h
     flat_update_op.h
     probes.cpp
     shared_handle.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Improve erase cache to better work with uncommitted changes.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Erase cache was invalidating too often when working with uncommitted changes, and wasn't used in the presence of custom transaction maps (e.g. when there are inflight volatile transactions). Erase cache now tries to cache erased ranges based on decided states, which makes it robust in the presence of uncommitted changes, volatile commits and transaction rollbacks.

Fixes #4984.