### PR TITLE
Hotfix: disable PDisk serial number management

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -89,6 +89,9 @@ void TNodeWarden::RemoveDrivesWithBadSerialsAndReport(TVector<NPDisk::TDriveData
 }
 
 TVector<NPDisk::TDriveData> TNodeWarden::ListLocalDrives() {
+    return {};
+
+#if 0
     TStringStream details;
     TVector<NPDisk::TDriveData> drives = ListDevicesWithPartlabel(details);
 
@@ -114,6 +117,7 @@ TVector<NPDisk::TDriveData> TNodeWarden::ListLocalDrives() {
     RemoveDrivesWithBadSerialsAndReport(drives, details);
 
     return drives;
+#endif
 }
 
 void TNodeWarden::StartInvalidGroupProxy() {

--- a/ydb/core/mind/bscontroller/cmds_drive_status.cpp
+++ b/ydb/core/mind/bscontroller/cmds_drive_status.cpp
@@ -85,7 +85,7 @@ namespace NKikimr::NBsController {
                 item->SetPath(pdiskInfo.Path);
                 item->SetStatus(pdiskInfo.Status);
                 item->SetPDiskId(pdiskId.PDiskId);
-                item->SetSerial(pdiskInfo.ExpectedSerial);
+                //item->SetSerial(pdiskInfo.ExpectedSerial);
                 item->SetStatusChangeTimestamp(pdiskInfo.StatusTimestamp.GetValue());
             }
             return true;

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -97,7 +97,7 @@ namespace NKikimr::NBsController {
                 }
                 pdisk->SetPDiskGuid(pdiskInfo.Guid);
                 pdisk->SetPDiskCategory(pdiskInfo.Kind.GetRaw());
-                pdisk->SetExpectedSerial(pdiskInfo.ExpectedSerial);
+                //pdisk->SetExpectedSerial(pdiskInfo.ExpectedSerial);
                 pdisk->SetManagementStage(Self->SerialManagementStage);
                 if (pdiskInfo.PDiskConfig && !pdisk->MutablePDiskConfig()->ParseFromString(pdiskInfo.PDiskConfig)) {
                     // TODO(alexvru): report this somehow
@@ -896,8 +896,8 @@ namespace NKikimr::NBsController {
             pb->SetDecommitStatus(pdisk.DecommitStatus);
             pb->MutablePDiskMetrics()->CopyFrom(pdisk.Metrics);
             pb->MutablePDiskMetrics()->ClearPDiskId();
-            pb->SetExpectedSerial(pdisk.ExpectedSerial);
-            pb->SetLastSeenSerial(pdisk.LastSeenSerial);
+            //pb->SetExpectedSerial(pdisk.ExpectedSerial);
+            //pb->SetLastSeenSerial(pdisk.LastSeenSerial);
         }
 
         void TBlobStorageController::Serialize(NKikimrBlobStorage::TVSlotId *pb, TVSlotId id) {

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -418,7 +418,7 @@ void TBlobStorageController::ReadPDisk(const TPDiskId& pdiskId, const TPDiskInfo
                 (PDiskId, pdiskId.PDiskId));
         }
     }
-    pDisk->SetExpectedSerial(pdisk.ExpectedSerial);
+    //pDisk->SetExpectedSerial(pdisk.ExpectedSerial);
     pDisk->SetManagementStage(SerialManagementStage);
     pDisk->SetSpaceColorBorder(PDiskSpaceColorBorder);
     pDisk->SetEntityStatus(entityStatus);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Hotfix: disable PDisk serial number management

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Disabled PDisk serial number management.
