### PR TITLE
Fix non-ASCIIZ input for pcreposix

### DIFF
--- a/ydb/library/yql/udfs/common/hyperscan/hyperscan_udf.cpp
+++ b/ydb/library/yql/udfs/common/hyperscan/hyperscan_udf.cpp
@@ -201,7 +201,10 @@ namespace {
             }
 
             if (args[0]) {
-                const std::string_view input(args[0].AsStringRef());
+                // XXX: StringRef data might not be a NTBS, though the function
+                // <TRegExMatch::Match> expects ASCIIZ string. Explicitly copy
+                // the given argument string and append the NUL terminator to it.
+                const TString input(args[0].AsStringRef());
                 if (Y_UNLIKELY(Mode == THyperscanMatch::EMode::MULTI)) {
                     auto callback = [items] (TOptions id, ui64 /* from */, ui64 /* to */) {
                         items[id] = TUnboxedValuePod(true);

--- a/ydb/library/yql/udfs/common/hyperscan/test/canondata/test.test_Basic_/results.txt
+++ b/ydb/library/yql/udfs/common/hyperscan/test/canondata/test.test_Basic_/results.txt
@@ -156,6 +156,13 @@
                                         "String"
                                     ]
                                 ]
+                            ];
+                            [
+                                "backtracking";
+                                [
+                                    "DataType";
+                                    "Bool"
+                                ]
                             ]
                         ]
                     ]
@@ -190,7 +197,8 @@
                         #;
                         [
                             ""
-                        ]
+                        ];
+                        %false
                     ];
                     [
                         "a";
@@ -221,7 +229,8 @@
                         #;
                         [
                             "a"
-                        ]
+                        ];
+                        %false
                     ];
                     [
                         "aax";
@@ -254,7 +263,8 @@
                         #;
                         [
                             "aax"
-                        ]
+                        ];
+                        %true
                     ];
                     [
                         "xaax";
@@ -289,7 +299,8 @@
                         ];
                         [
                             "bax"
-                        ]
+                        ];
+                        %false
                     ];
                     [
                         "xaaxaaxaa";
@@ -324,7 +335,8 @@
                         ];
                         [
                             "bababa"
-                        ]
+                        ];
+                        %false
                     ];
                     [
                         "XAXA";
@@ -355,7 +367,8 @@
                         #;
                         [
                             "XAXA"
-                        ]
+                        ];
+                        %false
                     ];
                     [
                         "7";
@@ -386,7 +399,8 @@
                         #;
                         [
                             "7"
-                        ]
+                        ];
+                        %false
                     ];
                     [
                         "QC transfer task JAVA";
@@ -417,7 +431,8 @@
                         #;
                         [
                             "QC transfer task JAVA"
-                        ]
+                        ];
+                        %false
                     ]
                 ]
             }

--- a/ydb/library/yql/udfs/common/hyperscan/test/cases/Basic.sql
+++ b/ydb/library/yql/udfs/common/hyperscan/test/cases/Basic.sql
@@ -13,6 +13,7 @@ QC.*
 $capture = Hyperscan::Capture(".*a{2}.*");
 $capture_many = Hyperscan::Capture(".*x(a+).*");
 $replace = Hyperscan::Replace("xa");
+$backtracking_grep = Hyperscan::BacktrackingGrep("(?<!xa)ax");
 
 SELECT
     value,
@@ -27,5 +28,6 @@ SELECT
     $multi_match2(value).2 AS some_multi_match2c,
     $capture(value) AS capture,
     $capture_many(value) AS capture_many,
-    $replace(value, "b") AS replace
+    $replace(value, "b") AS replace,
+    $backtracking_grep(value) as backtracking
 FROM Input;


### PR DESCRIPTION
StringRef data might not be a NTBS, though the function `<TRegExMatch::Match>` expects ASCIIZ string. As a result of the patch the given argument string is explicitly copied and NUL terminator is appended to it.

Unfortunately, several existing tests reveals the error, but the canon results were invalid.

### Changelog category

* Bugfix