### PR TITLE
KqpRun fixed performance and backtrace printing

### DIFF
--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -170,7 +170,7 @@ namespace NActors {
             }
 
             if (NeedMonitoring && !SingleSysEnv) {
-                ui16 port = GetPortManager().GetPort();
+                ui16 port = MonitoringPortOffset ? MonitoringPortOffset + nodeIndex : GetPortManager().GetPort();
                 node->Mon.Reset(new NActors::TSyncHttpMon({
                     .Port = port,
                     .Threads = 10,

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -227,7 +227,7 @@ namespace Tests {
 
         NKikimr::SetupChannelProfiles(app);
 
-        Runtime->SetupMonitoring();
+        Runtime->SetupMonitoring(Settings->MonitoringPortOffset);
         Runtime->SetLogBackend(Settings->LogBackend);
 
         Runtime->AddAppDataInit([this](ui32 nodeIdx, NKikimr::TAppData& appData) {

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -105,6 +105,7 @@ namespace Tests {
         ui16 Port;
         ui16 GrpcPort = 0;
         int GrpcMaxMessageSize = 0;  // 0 - default (4_MB), -1 - no limit
+        ui16 MonitoringPortOffset = 0;
         NKikimrProto::TAuthConfig AuthConfig;
         NKikimrPQ::TPQConfig PQConfig;
         NKikimrPQ::TPQClusterDiscoveryConfig PQClusterDiscoveryConfig;
@@ -157,6 +158,7 @@ namespace Tests {
 
         TServerSettings& SetGrpcPort(ui16 value) { GrpcPort = value; return *this; }
         TServerSettings& SetGrpcMaxMessageSize(int value) { GrpcMaxMessageSize = value; return *this; }
+        TServerSettings& SetMonitoringPortOffset(ui16 value) { MonitoringPortOffset = value; return *this; }
         TServerSettings& SetSupportsRedirect(bool value) { SupportsRedirect = value; return *this; }
         TServerSettings& SetTracePath(const TString& value) { TracePath = value; return *this; }
         TServerSettings& SetDomain(ui32 value) { Domain = value; return *this; }

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1594,8 +1594,9 @@ namespace NActors {
         return node->DynamicCounters;
     }
 
-    void TTestActorRuntimeBase::SetupMonitoring() {
+    void TTestActorRuntimeBase::SetupMonitoring(ui16 monitoringPortOffset) {
         NeedMonitoring = true;
+        MonitoringPortOffset = monitoringPortOffset;
     }
 
     void TTestActorRuntimeBase::SendInternal(TAutoPtr<IEventHandle> ev, ui32 nodeIndex, bool viaActorSystem) {

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -295,7 +295,7 @@ namespace NActors {
         void EnableScheduleForActor(const TActorId& actorId, bool allow = true);
         bool IsScheduleForActorEnabled(const TActorId& actorId) const;
         TIntrusivePtr<NMonitoring::TDynamicCounters> GetDynamicCounters(ui32 nodeIndex = 0);
-        void SetupMonitoring();
+        void SetupMonitoring(ui16 monitoringPortOffset = 0);
 
         using TEventObserverCollection = std::list<std::function<void(TAutoPtr<IEventHandle>& event)>>;
         class TEventObserverHolder {
@@ -655,6 +655,7 @@ namespace NActors {
         TIntrusivePtr<IRandomProvider> DispatcherRandomProvider;
         TAutoPtr<TLogBackend> LogBackend;
         bool NeedMonitoring;
+        ui16 MonitoringPortOffset = 0;
 
         TIntrusivePtr<IRandomProvider> RandomProvider;
         TIntrusivePtr<ITimeProvider> TimeProvider;

--- a/ydb/tests/fq/yt/kqprun.py
+++ b/ydb/tests/fq/yt/kqprun.py
@@ -37,7 +37,7 @@ class KqpRun(object):
 
         cmd += '--emulate-yt ' \
             '--exclude-linked-udfs ' \
-            '--clear-execution query ' \
+            '--execution-case query ' \
             '--app-config=%(config_file)s ' \
             '--script-query=%(program_file)s ' \
             '--scheme-query=%(scheme_file)s ' \

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -81,7 +81,8 @@ void RunScript(const TExecutionOptions& executionOptions, const NKqpRun::TRunner
             Sleep(executionOptions.LoopDelay);
         }
 
-        if (executionOptions.GetExecutionCase(id) != TExecutionOptions::EExecutionCase::AsyncQuery) {
+        const auto executionCase = executionOptions.GetExecutionCase(id);
+        if (executionCase != TExecutionOptions::EExecutionCase::AsyncQuery) {
             Cout << colors.Yellow() << TInstant::Now().ToIsoStringLocal() << " Executing script";
             if (numberQueries > 1) {
                 Cout << " " << id;
@@ -92,7 +93,7 @@ void RunScript(const TExecutionOptions& executionOptions, const NKqpRun::TRunner
             Cout << "..." << colors.Default() << Endl;
         }
 
-        switch (executionOptions.GetExecutionCase(id)) {
+        switch (executionCase) {
         case TExecutionOptions::EExecutionCase::GenericScript:
             if (!runner.ExecuteScript(executionOptions.ScriptQueries[id], executionOptions.ScriptQueryAction, executionOptions.TraceId)) {
                 ythrow yexception() << TInstant::Now().ToIsoStringLocal() << " Script execution failed";
@@ -381,8 +382,8 @@ protected:
             });
         options.AddLongOption("inflight-limit", "In flight limit for async queries (use 0 for unlimited)")
             .RequiredArgument("uint")
-            .DefaultValue(RunnerOptions.InFlightLimit)
-            .StoreResult(&RunnerOptions.InFlightLimit);
+            .DefaultValue(RunnerOptions.YdbSettings.InFlightLimit)
+            .StoreResult(&RunnerOptions.YdbSettings.InFlightLimit);
 
         TChoices<NKikimrKqp::EQueryAction> scriptAction({
             {"execute", NKikimrKqp::QUERY_ACTION_EXECUTE},

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -6,21 +6,23 @@
 
 #include <library/cpp/colorizer/colors.h>
 #include <library/cpp/getopt/last_getopt.h>
+#include <library/cpp/getopt/small/modchooser.h>
 
 #include <util/stream/file.h>
 #include <util/system/env.h>
+
+#include <ydb/core/base/backtrace.h>
 
 #include <ydb/library/yql/minikql/invoke_builtins/mkql_builtins.h>
 #include <ydb/library/yql/providers/yt/gateway/file/yql_yt_file.h>
 #include <ydb/library/yql/providers/yt/gateway/file/yql_yt_file_comp_nodes.h>
 #include <ydb/library/yql/providers/yt/lib/yt_download/yt_download.h>
 #include <ydb/library/yql/public/udf/udf_static_registry.h>
-#include <ydb/library/yql/utils/backtrace/backtrace.h>
 
 
 struct TExecutionOptions {
-    enum class EClearExecutionCase {
-        Disabled,
+    enum class EExecutionCase {
+        GenericScript,
         GenericQuery,
         YqlScript
     };
@@ -29,10 +31,10 @@ struct TExecutionOptions {
     TString SchemeQuery;
 
     bool ForgetExecution = false;
-    EClearExecutionCase ClearExecution = EClearExecutionCase::Disabled;
+    EExecutionCase ExecutionCase = EExecutionCase::GenericScript;
     NKikimrKqp::EQueryAction ScriptQueryAction = NKikimrKqp::QUERY_ACTION_EXECUTE;
 
-    TString TraceId = "kqprun_" + CreateGuidAsString();
+    const TString TraceId = "kqprun_" + CreateGuidAsString();
 
     bool HasResults() const {
         return !ScriptQueries.empty() && ScriptQueryAction == NKikimrKqp::QUERY_ACTION_EXECUTE;
@@ -55,8 +57,8 @@ void RunScript(const TExecutionOptions& executionOptions, const NKqpRun::TRunner
 
     for (size_t id = 0; id < executionOptions.ScriptQueries.size(); ++id) {
         Cout << colors.Yellow() << TInstant::Now().ToIsoStringLocal() << " Executing script" << (executionOptions.ScriptQueries.size() > 1 ? TStringBuilder() << " " << id : TString()) << "..." << colors.Default() << Endl;
-        switch (executionOptions.ClearExecution) {
-        case TExecutionOptions::EClearExecutionCase::Disabled:
+        switch (executionOptions.ExecutionCase) {
+        case TExecutionOptions::EExecutionCase::GenericScript:
             if (!runner.ExecuteScript(executionOptions.ScriptQueries[id], executionOptions.ScriptQueryAction, executionOptions.TraceId)) {
                 ythrow yexception() << TInstant::Now().ToIsoStringLocal() << " Script execution failed";
             }
@@ -72,13 +74,13 @@ void RunScript(const TExecutionOptions& executionOptions, const NKqpRun::TRunner
             }
             break;
 
-        case TExecutionOptions::EClearExecutionCase::GenericQuery:
+        case TExecutionOptions::EExecutionCase::GenericQuery:
             if (!runner.ExecuteQuery(executionOptions.ScriptQueries[id], executionOptions.ScriptQueryAction, executionOptions.TraceId)) {
                 ythrow yexception() << TInstant::Now().ToIsoStringLocal() << " Query execution failed";
             }
             break;
 
-        case TExecutionOptions::EClearExecutionCase::YqlScript:
+        case TExecutionOptions::EExecutionCase::YqlScript:
             if (!runner.ExecuteYqlScript(executionOptions.ScriptQueries[id], executionOptions.ScriptQueryAction, executionOptions.TraceId)) {
                 ythrow yexception() << TInstant::Now().ToIsoStringLocal() << " Yql script execution failed";
             }
@@ -111,37 +113,6 @@ void RunScript(const TExecutionOptions& executionOptions, const NKqpRun::TRunner
 }
 
 
-THolder<TFileOutput> SetupDefaultFileOutput(const TString& filePath, IOutputStream*& stream) {
-    THolder<TFileOutput> fileHolder;
-    if (filePath == "-") {
-        stream = &Cout;
-    } else if (filePath) {
-        fileHolder.Reset(new TFileOutput(filePath));
-        stream = fileHolder.Get();
-    }
-    return fileHolder;
-}
-
-
-template <typename EnumType>
-EnumType GetCaseVariant(const TString& optionName, const TString& caseName, const std::map<TString, EnumType>& casesMap) {
-    auto it = casesMap.find(caseName);
-    if (it == casesMap.end()) {
-        ythrow yexception() << "Option '" << optionName << "' has no case '" << caseName << "'";
-    }
-    return it->second;
-}
-
-
-void ReplaceTemplate(const TString& variableName, const TString& variableValue, TString& query) {
-    TString variableTemplate = TStringBuilder() << "${" << variableName << "}";
-    for (size_t position = query.find(variableTemplate); position != TString::npos; position = query.find(variableTemplate, position)) {
-        query.replace(position, variableTemplate.size(), variableValue);
-        position += variableValue.size();
-    }
-}
-
-
 TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> CreateFunctionRegistry(const TString& udfsDirectory, TVector<TString> udfsPaths, bool excludeLinkedUdfs) {
     if (!udfsDirectory.empty() || !udfsPaths.empty()) {
         NColorizer::TColors colors = NColorizer::AutoColors(Cout);
@@ -149,7 +120,7 @@ TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> CreateFunctionRegistr
     }
 
     NKikimr::NMiniKQL::FindUdfsInDir(udfsDirectory, &udfsPaths);
-    auto functionRegistry = NKikimr::NMiniKQL::CreateFunctionRegistry(&NYql::NBacktrace::KikimrBackTrace, NKikimr::NMiniKQL::CreateBuiltinRegistry(), false, udfsPaths)->Clone();
+    auto functionRegistry = NKikimr::NMiniKQL::CreateFunctionRegistry(&PrintBackTrace, NKikimr::NMiniKQL::CreateBuiltinRegistry(), false, udfsPaths)->Clone();
 
     if (excludeLinkedUdfs) {
         for (const auto& wrapper : NYql::NUdf::GetStaticUdfModuleWrapperList()) {
@@ -166,253 +137,281 @@ TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> CreateFunctionRegistr
 }
 
 
-void RunMain(int argc, const char* argv[]) {
-    TExecutionOptions executionOptions;
-    NKqpRun::TRunnerOptions runnerOptions;
+class TMain : public TMainClassArgs {
+    inline static const TString YqlToken = GetEnv(NKqpRun::YQL_TOKEN_VARIABLE);
+    inline static TVector<std::unique_ptr<TFileOutput>> FileHolders;
 
-    std::vector<TString> scriptQueryFiles;
-    TString schemeQueryFile;
-    TString resultOutputFile = "-";
-    TString schemeQueryAstFile;
-    TString scriptQueryAstFile;
-    TString scriptQueryPlanFile;
-    TString inProgressStatisticsFile;
-    TString logFile = "-";
-    TString appConfigFile = "./configuration/app_config.conf";
-    std::vector<TString> tablesMappingList;
+    TExecutionOptions ExecutionOptions;
+    NKqpRun::TRunnerOptions RunnerOptions;
 
-    TString clearExecutionType = "disabled";
-    TString traceOptType = "disabled";
-    TString scriptQueryAction = "execute";
-    TString planOutputFormat = "pretty";
-    TString resultOutputFormat = "rows";
-    i64 resultsRowsLimit = 1000;
-    bool emulateYt = false;
+    THashMap<TString, TString> TablesMapping;
+    TVector<TString> UdfsPaths;
+    TString UdfsDirectory;
+    bool ExcludeLinkedUdfs = false;
+    ui64 ResultsRowsLimit = 1000;
+    bool EmulateYt = false;
 
-    TVector<TString> udfsPaths;
-    TString udfsDirectory;
-    bool excludeLinkedUdfs = false;
-
-    NLastGetopt::TOpts options = NLastGetopt::TOpts::Default();
-    options.AddLongOption('p', "script-query", "Script query to execute")
-        .Optional()
-        .RequiredArgument("FILE")
-        .AppendTo(&scriptQueryFiles);
-    options.AddLongOption('s', "scheme-query", "Scheme query to execute")
-        .Optional()
-        .RequiredArgument("FILE")
-        .StoreResult(&schemeQueryFile);
-    options.AddLongOption('c', "app-config", "File with app config (TAppConfig)")
-        .Optional()
-        .RequiredArgument("FILE")
-        .DefaultValue(appConfigFile)
-        .StoreResult(&appConfigFile);
-    options.AddLongOption('t', "table", "File with table (can be used by YT with -E flag), table@file")
-        .Optional()
-        .RequiredArgument("FILE")
-        .AppendTo(&tablesMappingList);
-
-    options.AddLongOption("log-file", "File with execution logs (use '-' to write in stderr)")
-        .Optional()
-        .RequiredArgument("FILE")
-        .StoreResult(&logFile);
-    options.AddLongOption("result-file", "File with script execution results (use '-' to write in stdout)")
-        .Optional()
-        .RequiredArgument("FILE")
-        .StoreResult(&resultOutputFile);
-    options.AddLongOption("scheme-ast-file", "File with scheme query ast (use '-' to write in stdout)")
-        .Optional()
-        .RequiredArgument("FILE")
-        .StoreResult(&schemeQueryAstFile);
-    options.AddLongOption("script-ast-file", "File with script query ast (use '-' to write in stdout)")
-        .Optional()
-        .RequiredArgument("FILE")
-        .StoreResult(&scriptQueryAstFile);
-    options.AddLongOption("script-plan-file", "File with script query plan (use '-' to write in stdout)")
-        .Optional()
-        .RequiredArgument("FILE")
-        .StoreResult(&scriptQueryPlanFile);
-    options.AddLongOption("in-progress-statistics", "File with script inprogress statistics")
-        .Optional()
-        .RequiredArgument("FILE")
-        .StoreResult(&inProgressStatisticsFile);
-
-    options.AddLongOption('C', "clear-execution", "Execute script query without creating additional tables, one of { query | yql-script }")
-        .Optional()
-        .RequiredArgument("STR")
-        .DefaultValue(clearExecutionType)
-        .StoreResult(&clearExecutionType);
-    options.AddLongOption('F', "forget", "Forget script execution operation after fetching results, cannot be used with -C")
-        .Optional()
-        .NoArgument()
-        .DefaultValue(executionOptions.ForgetExecution)
-        .SetFlag(&executionOptions.ForgetExecution);
-    options.AddLongOption('T', "trace-opt", "print AST in the begin of each transformation, one of { scheme | script | all }")
-        .Optional()
-        .RequiredArgument("STR")
-        .DefaultValue(traceOptType)
-        .StoreResult(&traceOptType);
-    options.AddLongOption('A', "script-action", "Script query execute action, one of { execute | explain }")
-        .Optional()
-        .RequiredArgument("STR")
-        .DefaultValue(scriptQueryAction)
-        .StoreResult(&scriptQueryAction);
-    options.AddLongOption('P', "plan-format", "Script query plan format, one of { pretty | table | json }")
-        .Optional()
-        .RequiredArgument("STR")
-        .DefaultValue(planOutputFormat)
-        .StoreResult(&planOutputFormat);
-    options.AddLongOption('R', "result-format", "Script query result format, one of { rows | full-json | full-proto }")
-        .Optional()
-        .RequiredArgument("STR")
-        .DefaultValue(resultOutputFormat)
-        .StoreResult(&resultOutputFormat);
-    options.AddLongOption('L', "result-rows-limit", "Rows limit for script execution results")
-        .Optional()
-        .RequiredArgument("INT")
-        .DefaultValue(resultsRowsLimit)
-        .StoreResult(&resultsRowsLimit);
-    options.AddLongOption('E', "emulate-yt", "Emulate YT tables")
-        .Optional()
-        .NoArgument()
-        .DefaultValue(emulateYt)
-        .SetFlag(&emulateYt);
-    options.AddLongOption('N', "node-count", "Number of nodes to create")
-        .Optional()
-        .RequiredArgument("INT")
-        .DefaultValue(runnerOptions.YdbSettings.NodeCount)
-        .StoreResult(&runnerOptions.YdbSettings.NodeCount);
-    options.AddLongOption('M', "monitoring", "Enable embedded UI access and run kqprun as deamon")
-        .Optional()
-        .NoArgument()
-        .DefaultValue(runnerOptions.YdbSettings.MonitoringEnabled)
-        .SetFlag(&runnerOptions.YdbSettings.MonitoringEnabled);
-
-    options.AddLongOption('u', "udf", "Load shared library with UDF by given path")
-        .Optional()
-        .RequiredArgument("FILE")
-        .AppendTo(&udfsPaths);
-    options.AddLongOption("udfs-dir", "Load all shared libraries with UDFs found in given directory")
-        .Optional()
-        .RequiredArgument("PATH")
-        .StoreResult(&udfsDirectory);
-    options.AddLongOption("exclude-linked-udfs", "Exclude linked udfs when same udf passed from -u or --udfs-dir")
-        .Optional()
-        .NoArgument()
-        .DefaultValue(excludeLinkedUdfs)
-        .SetFlag(&excludeLinkedUdfs);
-
-    NLastGetopt::TOptsParseResult parsedOptions(&options, argc, argv);
-
-    // Environment variables
-
-    const TString& yqlToken = GetEnv(NKqpRun::YQL_TOKEN_VARIABLE);
-
-    // Execution options
-
-    if (!schemeQueryFile && scriptQueryFiles.empty() && !runnerOptions.YdbSettings.MonitoringEnabled) {
-        ythrow yexception() << "Nothing to execute";
+    static TString LoadFile(const TString& file) {
+        return TFileInput(file).ReadAll();
     }
 
-    if (schemeQueryFile) {
-        executionOptions.SchemeQuery = TFileInput(schemeQueryFile).ReadAll();
-        ReplaceTemplate(NKqpRun::YQL_TOKEN_VARIABLE, yqlToken, executionOptions.SchemeQuery);
+    static void ReplaceTemplate(const TString& variableName, const TString& variableValue, TString& query) {
+        TString variableTemplate = TStringBuilder() << "${" << variableName << "}";
+        for (size_t position = query.find(variableTemplate); position != TString::npos; position = query.find(variableTemplate, position)) {
+            query.replace(position, variableTemplate.size(), variableValue);
+            position += variableValue.size();
+        }
     }
 
-    executionOptions.ScriptQueries.reserve(scriptQueryFiles.size());
-    for (const TString& scriptQueryFile : scriptQueryFiles) {
-        executionOptions.ScriptQueries.emplace_back(TFileInput(scriptQueryFile).ReadAll());
+    static IOutputStream* GetDefaultOutput(const TString& file) {
+        if (file == "-") {
+            return &Cout;
+        }
+        if (file) {
+            FileHolders.emplace_back(new TFileOutput(file));
+            return FileHolders.back().get();
+        }
+        return nullptr;
     }
 
-    executionOptions.ClearExecution = GetCaseVariant<TExecutionOptions::EClearExecutionCase>("clear-execution", clearExecutionType, {
-        {"query", TExecutionOptions::EClearExecutionCase::GenericQuery},
-        {"yql-script", TExecutionOptions::EClearExecutionCase::YqlScript},
-        {"disabled", TExecutionOptions::EClearExecutionCase::Disabled}
-    });
+    template <typename TResult>
+    class TChoices {
+    public:
+        explicit TChoices(std::map<TString, TResult> choicesMap)
+            : ChoicesMap(std::move(choicesMap))
+        {}
 
-    executionOptions.ScriptQueryAction = GetCaseVariant<NKikimrKqp::EQueryAction>("script-action", scriptQueryAction, {
-        {"execute", NKikimrKqp::QUERY_ACTION_EXECUTE},
-        {"explain", NKikimrKqp::QUERY_ACTION_EXPLAIN}
-    });
-
-    // Runner options
-
-    THolder<TFileOutput> resultFileHolder = SetupDefaultFileOutput(resultOutputFile, runnerOptions.ResultOutput);
-    THolder<TFileOutput> schemeQueryAstFileHolder = SetupDefaultFileOutput(schemeQueryAstFile, runnerOptions.SchemeQueryAstOutput);
-    THolder<TFileOutput> scriptQueryAstFileHolder = SetupDefaultFileOutput(scriptQueryAstFile, runnerOptions.ScriptQueryAstOutput);
-    THolder<TFileOutput> scriptQueryPlanFileHolder = SetupDefaultFileOutput(scriptQueryPlanFile, runnerOptions.ScriptQueryPlanOutput);
-
-    if (inProgressStatisticsFile) {
-        runnerOptions.InProgressStatisticsOutputFile = inProgressStatisticsFile;
-    }
-
-    runnerOptions.TraceOptType = GetCaseVariant<NKqpRun::TRunnerOptions::ETraceOptType>("trace-opt", traceOptType, {
-        {"all", NKqpRun::TRunnerOptions::ETraceOptType::All},
-        {"scheme", NKqpRun::TRunnerOptions::ETraceOptType::Scheme},
-        {"script", NKqpRun::TRunnerOptions::ETraceOptType::Script},
-        {"disabled", NKqpRun::TRunnerOptions::ETraceOptType::Disabled}
-    });
-    runnerOptions.YdbSettings.TraceOptEnabled = runnerOptions.TraceOptType != NKqpRun::TRunnerOptions::ETraceOptType::Disabled;
-
-    runnerOptions.ResultOutputFormat = GetCaseVariant<NKqpRun::TRunnerOptions::EResultOutputFormat>("result-format", resultOutputFormat, {
-        {"rows", NKqpRun::TRunnerOptions::EResultOutputFormat::RowsJson},
-        {"full-json", NKqpRun::TRunnerOptions::EResultOutputFormat::FullJson},
-        {"full-proto", NKqpRun::TRunnerOptions::EResultOutputFormat::FullProto}
-    });
-
-    runnerOptions.PlanOutputFormat = GetCaseVariant<NYdb::NConsoleClient::EOutputFormat>("plan-format", planOutputFormat, {
-        {"pretty", NYdb::NConsoleClient::EOutputFormat::Pretty},
-        {"table", NYdb::NConsoleClient::EOutputFormat::PrettyTable},
-        {"json", NYdb::NConsoleClient::EOutputFormat::JsonUnicode},
-    });
-
-    // Ydb settings
-
-    if (runnerOptions.YdbSettings.NodeCount < 1) {
-        ythrow yexception() << "Number of nodes less than one";
-    }
-
-    if (logFile != "-") {
-        runnerOptions.YdbSettings.LogOutputFile = logFile;
-        std::remove(logFile.c_str());
-    }
-
-    runnerOptions.YdbSettings.YqlToken = yqlToken;
-    runnerOptions.YdbSettings.FunctionRegistry = CreateFunctionRegistry(udfsDirectory, udfsPaths, excludeLinkedUdfs).Get();
-
-    TString appConfigData = TFileInput(appConfigFile).ReadAll();
-    if (!google::protobuf::TextFormat::ParseFromString(appConfigData, &runnerOptions.YdbSettings.AppConfig)) {
-        ythrow yexception() << "Bad format of app configuration";
-    }
-
-    if (resultsRowsLimit < 0) {
-        ythrow yexception() << "Results rows limit less than zero";
-    }
-    runnerOptions.YdbSettings.AppConfig.MutableQueryServiceConfig()->SetScriptResultRowsLimit(resultsRowsLimit);
-
-    if (emulateYt) {
-        THashMap<TString, TString> tablesMapping;
-        for (const auto& tablesMappingItem: tablesMappingList) {
-            TStringBuf tableName;
-            TStringBuf filePath;
-            TStringBuf(tablesMappingItem).Split('@', tableName, filePath);
-            if (tableName.empty() || filePath.empty()) {
-                ythrow yexception() << "Incorrect table mapping, expected form table@file, e.g. yt.Root/plato.Input@input.txt";
-            }
-            tablesMapping[tableName] = filePath;
+        TResult operator()(const TString& choice) const {
+            return ChoicesMap.at(choice);
         }
 
-        const auto& fileStorageConfig = runnerOptions.YdbSettings.AppConfig.GetQueryServiceConfig().GetFileStorage();
-        auto fileStorage = WithAsync(CreateFileStorage(fileStorageConfig, {MakeYtDownloader(fileStorageConfig)}));
-        auto ytFileServices = NYql::NFile::TYtFileServices::Make(runnerOptions.YdbSettings.FunctionRegistry.Get(), tablesMapping, fileStorage);
-        runnerOptions.YdbSettings.YtGateway = NYql::CreateYtFileGateway(ytFileServices);
-        runnerOptions.YdbSettings.ComputationFactory = NYql::NFile::GetYtFileFactory(ytFileServices);
-    } else if (!tablesMappingList.empty()) {
-        ythrow yexception() << "Tables mapping is not supported without emulate YT mode";
+        TVector<TString> GetChoices() const {
+            TVector<TString> choices;
+            choices.reserve(ChoicesMap.size());
+            for (const auto& [choice, _] : ChoicesMap) {
+                choices.emplace_back(choice);
+            }
+            return choices;
+        }
+
+    private:
+        const std::map<TString, TResult> ChoicesMap;
+    };
+
+protected:
+    void RegisterOptions(NLastGetopt::TOpts& options) override {
+        options.SetTitle("KqpRun -- tool to execute queries by using kikimr provider (instead of dq provider in DQrun tool)");
+        options.AddHelpOption('h');
+        options.SetFreeArgsNum(0);
+
+        // Inputs
+
+        options.AddLongOption('s', "scheme-query", "Scheme query to execute (typically DDL/DCL query)")
+            .RequiredArgument("file")
+            .Handler1([this](const NLastGetopt::TOptsParser* option) {
+                ExecutionOptions.SchemeQuery = LoadFile(option->CurVal());
+                ReplaceTemplate(NKqpRun::YQL_TOKEN_VARIABLE, YqlToken, ExecutionOptions.SchemeQuery);
+            });
+        options.AddLongOption('p', "script-query", "Script query to execute (typically DML query)")
+            .RequiredArgument("file")
+            .Handler1([this](const NLastGetopt::TOptsParser* option) {
+                ExecutionOptions.ScriptQueries.emplace_back(LoadFile(option->CurVal()));
+            });
+
+        options.AddLongOption('t', "table", "File with table (can be used by YT with -E flag), table@file")
+            .RequiredArgument("table@file")
+            .Handler1([this](const NLastGetopt::TOptsParser* option) {
+                TStringBuf tableName;
+                TStringBuf filePath;
+                TStringBuf(option->CurVal()).Split('@', tableName, filePath);
+                if (tableName.empty() || filePath.empty()) {
+                    ythrow yexception() << "Incorrect table mapping, expected form table@file, e.g. yt.Root/plato.Input@input.txt";
+                }
+                if (TablesMapping.contains(tableName)) {
+                    ythrow yexception() << "Got duplicate table name: " << tableName;
+                }
+                TablesMapping[tableName] = filePath;
+            });
+
+        options.AddLongOption('c', "app-config", "File with app config (TAppConfig for ydb tennant)")
+            .RequiredArgument("file")
+            .DefaultValue("./configuration/app_config.conf")
+            .Handler1([this](const NLastGetopt::TOptsParser* option) {
+                TString file(option->CurValOrDef());
+                if (!google::protobuf::TextFormat::ParseFromString(LoadFile(file), &RunnerOptions.YdbSettings.AppConfig)) {
+                    ythrow yexception() << "Bad format of app configuration";
+                }
+            });
+
+        options.AddLongOption('u', "udf", "Load shared library with UDF by given path")
+            .RequiredArgument("file")
+            .EmplaceTo(&UdfsPaths);
+        options.AddLongOption("udfs-dir", "Load all shared libraries with UDFs found in given directory")
+            .RequiredArgument("directory")
+            .StoreResult(&UdfsDirectory);
+        options.AddLongOption("exclude-linked-udfs", "Exclude linked udfs when same udf passed from -u or --udfs-dir")
+            .NoArgument()
+            .SetFlag(&ExcludeLinkedUdfs);
+
+        // Outputs
+
+        options.AddLongOption("log-file", "File with execution logs (write in stderr if empty)")
+            .RequiredArgument("file")
+            .StoreResult(&RunnerOptions.YdbSettings.LogOutputFile)
+            .Handler1([](const NLastGetopt::TOptsParser* option) {
+                if (const TString& file = option->CurVal()) {
+                    std::remove(file.c_str());
+                }
+            });
+        TChoices<NKqpRun::TRunnerOptions::ETraceOptType> traceOpt({
+            {"all", NKqpRun::TRunnerOptions::ETraceOptType::All},
+            {"scheme", NKqpRun::TRunnerOptions::ETraceOptType::Scheme},
+            {"script", NKqpRun::TRunnerOptions::ETraceOptType::Script},
+            {"disabled", NKqpRun::TRunnerOptions::ETraceOptType::Disabled}
+        });
+        options.AddLongOption('T', "trace-opt", "print AST in the begin of each transformation")
+            .RequiredArgument("trace-opt-query")
+            .DefaultValue("disabled")
+            .Choices(traceOpt.GetChoices())
+            .StoreMappedResultT<TString>(&RunnerOptions.TraceOptType, [this, traceOpt](const TString& choise) {
+                auto traceOptType = traceOpt(choise);
+                RunnerOptions.YdbSettings.TraceOptEnabled = traceOptType != NKqpRun::TRunnerOptions::ETraceOptType::Disabled;
+                return traceOptType;
+            });
+
+        options.AddLongOption("result-file", "File with script execution results (use '-' to write in stdout)")
+            .RequiredArgument("file")
+            .DefaultValue("-")
+            .StoreMappedResultT<TString>(&RunnerOptions.ResultOutput, &GetDefaultOutput);
+        options.AddLongOption('L', "result-rows-limit", "Rows limit for script execution results")
+            .RequiredArgument("uint")
+            .DefaultValue(ResultsRowsLimit)
+            .StoreResult(&ResultsRowsLimit);
+        TChoices<NKqpRun::TRunnerOptions::EResultOutputFormat> resultFormat({
+            {"rows", NKqpRun::TRunnerOptions::EResultOutputFormat::RowsJson},
+            {"full-json", NKqpRun::TRunnerOptions::EResultOutputFormat::FullJson},
+            {"full-proto", NKqpRun::TRunnerOptions::EResultOutputFormat::FullProto}
+        });
+        options.AddLongOption('R', "result-format", "Script query result format")
+            .RequiredArgument("result-format")
+            .DefaultValue("rows")
+            .Choices(resultFormat.GetChoices())
+            .StoreMappedResultT<TString>(&RunnerOptions.ResultOutputFormat, resultFormat);
+
+        options.AddLongOption("scheme-ast-file", "File with scheme query ast (use '-' to write in stdout)")
+            .RequiredArgument("file")
+            .StoreMappedResultT<TString>(&RunnerOptions.SchemeQueryAstOutput, &GetDefaultOutput);
+
+        options.AddLongOption("script-ast-file", "File with script query ast (use '-' to write in stdout)")
+            .RequiredArgument("file")
+            .StoreMappedResultT<TString>(&RunnerOptions.ScriptQueryAstOutput, &GetDefaultOutput);
+
+        options.AddLongOption("script-plan-file", "File with script query plan (use '-' to write in stdout)")
+            .RequiredArgument("file")
+            .StoreMappedResultT<TString>(&RunnerOptions.ScriptQueryPlanOutput, &GetDefaultOutput);
+        options.AddLongOption("script-statistics", "File with script inprogress statistics")
+            .RequiredArgument("file")
+            .StoreResult(&RunnerOptions.InProgressStatisticsOutputFile);
+        TChoices<NYdb::NConsoleClient::EOutputFormat> planFormat({
+            {"pretty", NYdb::NConsoleClient::EOutputFormat::Pretty},
+            {"table", NYdb::NConsoleClient::EOutputFormat::PrettyTable},
+            {"json", NYdb::NConsoleClient::EOutputFormat::JsonUnicode},
+        });
+        options.AddLongOption('P', "plan-format", "Script query plan format")
+            .RequiredArgument("plan-format")
+            .DefaultValue("pretty")
+            .Choices(planFormat.GetChoices())
+            .StoreMappedResultT<TString>(&RunnerOptions.PlanOutputFormat, planFormat);
+
+        // Pipeline settings
+
+        TChoices<TExecutionOptions::EExecutionCase> executionCase({
+            {"script", TExecutionOptions::EExecutionCase::GenericScript},
+            {"query", TExecutionOptions::EExecutionCase::GenericQuery},
+            {"yql-script", TExecutionOptions::EExecutionCase::YqlScript}
+        });
+        options.AddLongOption('C', "execution-case", "Type of query for -p argument")
+            .RequiredArgument("query-type")
+            .DefaultValue("script")
+            .Choices(executionCase.GetChoices())
+            .StoreMappedResultT<TString>(&ExecutionOptions.ExecutionCase, executionCase);
+
+        TChoices<NKikimrKqp::EQueryAction> scriptAction({
+            {"execute", NKikimrKqp::QUERY_ACTION_EXECUTE},
+            {"explain", NKikimrKqp::QUERY_ACTION_EXPLAIN}
+        });
+        options.AddLongOption('A', "script-action", "Script query execute action")
+            .RequiredArgument("script-action")
+            .DefaultValue("execute")
+            .Choices(scriptAction.GetChoices())
+            .StoreMappedResultT<TString>(&ExecutionOptions.ScriptQueryAction, scriptAction);
+
+        options.AddLongOption('F', "forget", "Forget script execution operation after fetching results")
+            .NoArgument()
+            .SetFlag(&ExecutionOptions.ForgetExecution);
+
+        // Cluster settings
+
+        options.AddLongOption('N', "node-count", "Number of nodes to create")
+            .RequiredArgument("uint")
+            .DefaultValue(RunnerOptions.YdbSettings.NodeCount)
+            .StoreMappedResultT<ui32>(&RunnerOptions.YdbSettings.NodeCount, [](ui32 nodeCount) {
+                if (nodeCount < 1) {
+                    ythrow yexception() << "Number of nodes less than one";
+                }
+                return nodeCount;
+            });
+
+        options.AddLongOption('M', "monitoring", "Embedded UI port (use 0 to start on random free port), if used kqprun will be runs as daemon")
+            .RequiredArgument("uint")
+            .Handler1([this](const NLastGetopt::TOptsParser* option) {
+                if (const TString& port = option->CurVal()) {
+                    RunnerOptions.YdbSettings.MonitoringEnabled = true;
+                    RunnerOptions.YdbSettings.MonitoringPortOffset = FromString(port.c_str());
+                }
+            });
+
+        options.AddLongOption('E', "emulate-yt", "Emulate YT tables (use file gateway instead of native gateway)")
+            .NoArgument()
+            .SetFlag(&EmulateYt);
+
+        TChoices<std::function<void()>> backtrace({
+            {"heavy", &NKikimr::EnableYDBBacktraceFormat},
+            {"light", []() { SetFormatBackTraceFn(FormatBackTrace); }}
+        });
+        options.AddLongOption("backtrace", "Default backtrace format function")
+            .RequiredArgument("backtrace-type")
+            .DefaultValue("heavy")
+            .Choices(backtrace.GetChoices())
+            .Handler1([backtrace](const NLastGetopt::TOptsParser* option) {
+                TString choice(option->CurValOrDef());
+                backtrace(choice)();
+            });
     }
 
-    RunScript(executionOptions, runnerOptions);
-}
+    int DoRun(NLastGetopt::TOptsParseResult&&) override {
+        if (!ExecutionOptions.SchemeQuery && ExecutionOptions.ScriptQueries.empty() && !RunnerOptions.YdbSettings.MonitoringEnabled) {
+            ythrow yexception() << "Nothing to execute";
+        }
+
+        RunnerOptions.YdbSettings.YqlToken = YqlToken;
+        RunnerOptions.YdbSettings.FunctionRegistry = CreateFunctionRegistry(UdfsDirectory, UdfsPaths, ExcludeLinkedUdfs).Get();
+        RunnerOptions.YdbSettings.AppConfig.MutableQueryServiceConfig()->SetScriptResultRowsLimit(ResultsRowsLimit);
+
+        if (EmulateYt) {
+            const auto& fileStorageConfig = RunnerOptions.YdbSettings.AppConfig.GetQueryServiceConfig().GetFileStorage();
+            auto fileStorage = WithAsync(CreateFileStorage(fileStorageConfig, {MakeYtDownloader(fileStorageConfig)}));
+            auto ytFileServices = NYql::NFile::TYtFileServices::Make(RunnerOptions.YdbSettings.FunctionRegistry.Get(), TablesMapping, fileStorage);
+            RunnerOptions.YdbSettings.YtGateway = NYql::CreateYtFileGateway(ytFileServices);
+            RunnerOptions.YdbSettings.ComputationFactory = NYql::NFile::GetYtFileFactory(ytFileServices);
+        } else if (!TablesMapping.empty()) {
+            ythrow yexception() << "Tables mapping is not supported without emulate YT mode";
+        }
+
+        RunScript(ExecutionOptions, RunnerOptions);
+        return 0;
+    }
+};
 
 
 void KqprunTerminateHandler() {
@@ -442,7 +441,7 @@ int main(int argc, const char* argv[]) {
     signal(SIGSEGV, &SegmentationFaultHandler);
 
     try {
-        RunMain(argc, argv);
+        TMain().Run(argc, argv);
     } catch (...) {
         NColorizer::TColors colors = NColorizer::AutoColors(Cerr);
 

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -424,7 +424,7 @@ protected:
             .Handler1([this](const NLastGetopt::TOptsParser* option) {
                 if (const TString& port = option->CurVal()) {
                     RunnerOptions.YdbSettings.MonitoringEnabled = true;
-                    RunnerOptions.YdbSettings.MonitoringPortOffset = FromString(port.c_str());
+                    RunnerOptions.YdbSettings.MonitoringPortOffset = FromString(port);
                 }
             });
 

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -180,7 +180,7 @@ TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> CreateFunctionRegistr
 
 class TMain : public TMainClassArgs {
     inline static const TString YqlToken = GetEnv(NKqpRun::YQL_TOKEN_VARIABLE);
-    inline static TVector<std::unique_ptr<TFileOutput>> FileHolders;
+    inline static std::vector<std::unique_ptr<TFileOutput>> FileHolders;
 
     TExecutionOptions ExecutionOptions;
     NKqpRun::TRunnerOptions RunnerOptions;
@@ -259,7 +259,7 @@ protected:
                 ExecutionOptions.ScriptQueries.emplace_back(LoadFile(option->CurVal()));
             });
 
-        options.AddLongOption('t', "table", "File with table (can be used by YT with -E flag), table@file")
+        options.AddLongOption('t', "table", "File with input table (can be used by YT with -E flag), table@file")
             .RequiredArgument("table@file")
             .Handler1([this](const NLastGetopt::TOptsParser* option) {
                 TStringBuf tableName;
@@ -296,7 +296,7 @@ protected:
 
         // Outputs
 
-        options.AddLongOption("log-file", "File with execution logs (write in stderr if empty)")
+        options.AddLongOption("log-file", "File with execution logs (writes in stderr if empty)")
             .RequiredArgument("file")
             .StoreResult(&RunnerOptions.YdbSettings.LogOutputFile)
             .Handler1([](const NLastGetopt::TOptsParser* option) {

--- a/ydb/tests/tools/kqprun/src/actors.cpp
+++ b/ydb/tests/tools/kqprun/src/actors.cpp
@@ -1,5 +1,7 @@
 #include "actors.h"
 
+#include <library/cpp/colorizer/colors.h>
+
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
 
@@ -10,26 +12,25 @@ namespace {
 
 class TRunScriptActorMock : public NActors::TActorBootstrapped<TRunScriptActorMock> {
 public:
-    TRunScriptActorMock(THolder<NKikimr::NKqp::TEvKqp::TEvQueryRequest> request,
-        NThreading::TPromise<TQueryResponse> promise, ui64 resultRowsLimit, ui64 resultSizeLimit,
-        TProgressCallback progressCallback)
-        : Request_(std::move(request))
+    TRunScriptActorMock(TQueryRequest request, NThreading::TPromise<TQueryResponse> promise, TProgressCallback progressCallback)
+        : TargetNode(request.TargetNode)
+        , Request_(std::move(request.Event))
         , Promise_(promise)
         , ResultRowsLimit_(std::numeric_limits<ui64>::max())
         , ResultSizeLimit_(std::numeric_limits<i64>::max())
         , ProgressCallback_(progressCallback)
     {
-        if (resultRowsLimit) {
-            ResultRowsLimit_ = resultRowsLimit;
+        if (request.ResultRowsLimit) {
+            ResultRowsLimit_ = request.ResultRowsLimit;
         }
-        if (resultSizeLimit) {
-            ResultSizeLimit_ = resultSizeLimit;
+        if (request.ResultSizeLimit) {
+            ResultSizeLimit_ = request.ResultSizeLimit;
         }
     }
 
     void Bootstrap() {
         NActors::ActorIdToProto(SelfId(), Request_->Record.MutableRequestActorId());
-        Send(NKikimr::NKqp::MakeKqpProxyID(SelfId().NodeId()), std::move(Request_));
+        Send(NKikimr::NKqp::MakeKqpProxyID(TargetNode), std::move(Request_));
 
         Become(&TRunScriptActorMock::StateFunc);
     }
@@ -88,7 +89,8 @@ public:
     }
 
 private:
-    THolder<NKikimr::NKqp::TEvKqp::TEvQueryRequest> Request_;
+    ui32 TargetNode = 0;
+    std::unique_ptr<NKikimr::NKqp::TEvKqp::TEvQueryRequest> Request_;
     NThreading::TPromise<TQueryResponse> Promise_;
     ui64 ResultRowsLimit_;
     ui64 ResultSizeLimit_;
@@ -97,25 +99,104 @@ private:
     std::vector<ui64> ResultSetSizes_;
 };
 
+class TAsyncQueryRunnerActor : public NActors::TActor<TAsyncQueryRunnerActor> {
+    using TBase = NActors::TActor<TAsyncQueryRunnerActor>;
+
+public:
+    TAsyncQueryRunnerActor(ui64 inFlightLimit)
+        : TBase(&TAsyncQueryRunnerActor::StateFunc)
+        , InFlightLimit_(inFlightLimit)
+    {}
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvPrivate::TEvStartAsyncQuery, Handle);
+        hFunc(TEvPrivate::TEvAsyncQueryFinished, Handle);
+        hFunc(TEvPrivate::TEvFinalizeAsyncQueryRunner, Handle);
+    )
+
+    void Handle(TEvPrivate::TEvStartAsyncQuery::TPtr& ev) {
+        DelayedRequests_.emplace(std::move(ev));
+        StartDelayedRequests();
+    }
+
+    void Handle(TEvPrivate::TEvAsyncQueryFinished::TPtr& ev) {
+        const ui64 requestId = ev->Get()->RequestId;
+        RunningRequests_.erase(requestId);
+
+        const auto& response = ev->Get()->Result.Response->Get()->Record.GetRef();
+        const auto status = response.GetYdbStatus();
+
+        if (status == Ydb::StatusIds::SUCCESS) {
+            Completed_++;
+            Cout << CoutColors_.Green() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " completed. " << CoutColors_.Yellow() << GetInfoString() << CoutColors_.Default() << Endl;
+        } else {
+            Failed_++;
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(response.GetResponse().GetQueryIssues(), issues);
+            Cout << CoutColors_.Red() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " failed " << status << ". " << CoutColors_.Yellow() << GetInfoString() << "\n" << CoutColors_.Red() << "Issues:\n" << issues.ToString() << CoutColors_.Default();
+        }
+
+        StartDelayedRequests();
+        TryFinalize();
+    }
+
+    void Handle(TEvPrivate::TEvFinalizeAsyncQueryRunner::TPtr& ev) {
+        FinalizePromise_ = ev->Get()->FinalizePromise;
+        if (!TryFinalize()) {
+            Cout << CoutColors_.Yellow() << TInstant::Now().ToIsoStringLocal() << " Waiting for " << DelayedRequests_.size() + RunningRequests_.size() << " async queries..." << CoutColors_.Default() << Endl;
+        }
+    }
+
+private:
+    void StartDelayedRequests() {
+        while (!DelayedRequests_.empty() && (!InFlightLimit_ || RunningRequests_.size() < InFlightLimit_)) {
+            auto request = std::move(DelayedRequests_.front());
+            DelayedRequests_.pop();
+
+            auto promise = NThreading::NewPromise<TQueryResponse>();
+            Register(CreateRunScriptActorMock(std::move(request->Get()->Request), promise, nullptr));
+            RunningRequests_[RequestId_] = promise.GetFuture().Subscribe([id = RequestId_, this](const NThreading::TFuture<TQueryResponse>& f) {
+                Send(SelfId(), new TEvPrivate::TEvAsyncQueryFinished(id, std::move(f.GetValue())));
+            });
+
+            MaxInFlight_ = std::max(MaxInFlight_, RunningRequests_.size());
+            Cout << TStringBuilder() << CoutColors_.Cyan() << TInstant::Now().ToIsoStringLocal() << " Request #" << RequestId_ << " started. " << CoutColors_.Yellow() << GetInfoString() << CoutColors_.Default() << "\n";
+
+            RequestId_++;
+            request->Get()->StartPromise.SetValue();
+        }
+    }
+
+    bool TryFinalize() {
+        if (!FinalizePromise_ || !RunningRequests_.empty()) {
+            return false;
+        }
+
+        FinalizePromise_->SetValue();
+        PassAway();
+        return true;
+    }
+
+    TString GetInfoString() const {
+        return TStringBuilder() << "completed: " << Completed_ << ", failed: " << Failed_ << ", in flight: " << RunningRequests_.size() << ", max in flight: " << MaxInFlight_ << ", spend time: " << TInstant::Now() - StartTime_;
+    }
+
+private:
+    const ui64 InFlightLimit_;
+    const TInstant StartTime_ = TInstant::Now();
+    const NColorizer::TColors CoutColors_ = NColorizer::AutoColors(Cout);
+
+    std::optional<NThreading::TPromise<void>> FinalizePromise_;
+    std::queue<TEvPrivate::TEvStartAsyncQuery::TPtr> DelayedRequests_;
+    std::unordered_map<ui64, NThreading::TFuture<TQueryResponse>> RunningRequests_;
+
+    ui64 RequestId_ = 1;
+    ui64 MaxInFlight_ = 0;
+    ui64 Completed_ = 0;
+    ui64 Failed_ = 0;
+};
+
 class TResourcesWaiterActor : public NActors::TActorBootstrapped<TResourcesWaiterActor> {
-    struct TEvPrivate {
-        enum EEv : ui32 {
-            EvResourcesInfo = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
-
-            EvEnd
-        };
-
-        static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
-
-        struct TEvResourcesInfo : public NActors::TEventLocal<TEvResourcesInfo, EvResourcesInfo> {
-            explicit TEvResourcesInfo(i32 nodeCount)
-                : NodeCount(nodeCount)
-            {}
-
-            const i32 NodeCount;
-        };
-    };
-
     static constexpr TDuration REFRESH_PERIOD = TDuration::MilliSeconds(10);
 
 public:
@@ -183,10 +264,12 @@ private:
 
 }  // anonymous namespace
 
-NActors::IActor* CreateRunScriptActorMock(THolder<NKikimr::NKqp::TEvKqp::TEvQueryRequest> request,
-    NThreading::TPromise<TQueryResponse> promise, ui64 resultRowsLimit, ui64 resultSizeLimit,
-    TProgressCallback progressCallback) {
-    return new TRunScriptActorMock(std::move(request), promise, resultRowsLimit, resultSizeLimit, progressCallback);
+NActors::IActor* CreateRunScriptActorMock(TQueryRequest request, NThreading::TPromise<TQueryResponse> promise, TProgressCallback progressCallback) {
+    return new TRunScriptActorMock(std::move(request), promise, progressCallback);
+}
+
+NActors::IActor* CreateAsyncQueryRunnerActor(ui64 inFlightLimit) {
+    return new TAsyncQueryRunnerActor(inFlightLimit);
 }
 
 NActors::IActor* CreateResourcesWaiterActor(NThreading::TPromise<void> promise, i32 expectedNodeCount) {

--- a/ydb/tests/tools/kqprun/src/actors.cpp
+++ b/ydb/tests/tools/kqprun/src/actors.cpp
@@ -13,7 +13,7 @@ namespace {
 class TRunScriptActorMock : public NActors::TActorBootstrapped<TRunScriptActorMock> {
 public:
     TRunScriptActorMock(TQueryRequest request, NThreading::TPromise<TQueryResponse> promise, TProgressCallback progressCallback)
-        : TargetNode(request.TargetNode)
+        : TargetNode_(request.TargetNode)
         , Request_(std::move(request.Event))
         , Promise_(promise)
         , ResultRowsLimit_(std::numeric_limits<ui64>::max())
@@ -30,7 +30,7 @@ public:
 
     void Bootstrap() {
         NActors::ActorIdToProto(SelfId(), Request_->Record.MutableRequestActorId());
-        Send(NKikimr::NKqp::MakeKqpProxyID(TargetNode), std::move(Request_));
+        Send(NKikimr::NKqp::MakeKqpProxyID(TargetNode_), std::move(Request_));
 
         Become(&TRunScriptActorMock::StateFunc);
     }
@@ -89,7 +89,7 @@ public:
     }
 
 private:
-    ui32 TargetNode = 0;
+    ui32 TargetNode_ = 0;
     std::unique_ptr<NKikimr::NKqp::TEvKqp::TEvQueryRequest> Request_;
     NThreading::TPromise<TQueryResponse> Promise_;
     ui64 ResultRowsLimit_;

--- a/ydb/tests/tools/kqprun/src/actors.cpp
+++ b/ydb/tests/tools/kqprun/src/actors.cpp
@@ -106,7 +106,9 @@ public:
     TAsyncQueryRunnerActor(ui64 inFlightLimit)
         : TBase(&TAsyncQueryRunnerActor::StateFunc)
         , InFlightLimit_(inFlightLimit)
-    {}
+    {
+        RunningRequests_.reserve(InFlightLimit_);
+    }
 
     STRICT_STFUNC(StateFunc,
         hFunc(TEvPrivate::TEvStartAsyncQuery, Handle);

--- a/ydb/tests/tools/kqprun/src/actors.h
+++ b/ydb/tests/tools/kqprun/src/actors.h
@@ -42,7 +42,7 @@ struct TEvPrivate {
     struct TEvAsyncQueryFinished : public NActors::TEventLocal<TEvAsyncQueryFinished, EvAsyncQueryFinished> {
         TEvAsyncQueryFinished(ui64 requestId, TQueryResponse result)
             : RequestId(requestId)
-            , Result(result)
+            , Result(std::move(result))
         {}
 
         const ui64 RequestId;

--- a/ydb/tests/tools/kqprun/src/actors.h
+++ b/ydb/tests/tools/kqprun/src/actors.h
@@ -4,11 +4,15 @@
 
 namespace NKqpRun {
 
+struct TQueryResponse {
+    NKikimr::NKqp::TEvKqp::TEvQueryResponse::TPtr Response;
+    std::vector<Ydb::ResultSet> ResultSets;
+};
+
 using TProgressCallback = std::function<void(const NKikimrKqp::TEvExecuterProgress&)>;
 
 NActors::IActor* CreateRunScriptActorMock(THolder<NKikimr::NKqp::TEvKqp::TEvQueryRequest> request,
-    NThreading::TPromise<NKikimr::NKqp::TEvKqp::TEvQueryResponse::TPtr> promise,
-    ui64 resultRowsLimit, ui64 resultSizeLimit, std::vector<Ydb::ResultSet>& resultSets,
+    NThreading::TPromise<TQueryResponse> promise, ui64 resultRowsLimit, ui64 resultSizeLimit,
     TProgressCallback progressCallback);
 
 NActors::IActor* CreateResourcesWaiterActor(NThreading::TPromise<void> promise, i32 expectedNodeCount);

--- a/ydb/tests/tools/kqprun/src/actors.h
+++ b/ydb/tests/tools/kqprun/src/actors.h
@@ -9,11 +9,68 @@ struct TQueryResponse {
     std::vector<Ydb::ResultSet> ResultSets;
 };
 
+struct TQueryRequest {
+    std::unique_ptr<NKikimr::NKqp::TEvKqp::TEvQueryRequest> Event;
+    ui32 TargetNode;
+    ui64 ResultRowsLimit;
+    ui64 ResultSizeLimit;
+};
+
+struct TEvPrivate {
+    enum EEv : ui32 {
+        EvStartAsyncQuery = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+        EvAsyncQueryFinished,
+        EvFinalizeAsyncQueryRunner,
+
+        EvResourcesInfo,
+
+        EvEnd
+    };
+
+    static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+
+    struct TEvStartAsyncQuery : public NActors::TEventLocal<TEvStartAsyncQuery, EvStartAsyncQuery> {
+        TEvStartAsyncQuery(TQueryRequest request, NThreading::TPromise<void> startPromise)
+            : Request(std::move(request))
+            , StartPromise(startPromise)
+        {}
+
+        TQueryRequest Request;
+        NThreading::TPromise<void> StartPromise;
+    };
+
+    struct TEvAsyncQueryFinished : public NActors::TEventLocal<TEvAsyncQueryFinished, EvAsyncQueryFinished> {
+        TEvAsyncQueryFinished(ui64 requestId, TQueryResponse result)
+            : RequestId(requestId)
+            , Result(result)
+        {}
+
+        const ui64 RequestId;
+        const TQueryResponse Result;
+    };
+
+    struct TEvFinalizeAsyncQueryRunner : public NActors::TEventLocal<TEvFinalizeAsyncQueryRunner, EvFinalizeAsyncQueryRunner> {
+        explicit TEvFinalizeAsyncQueryRunner(NThreading::TPromise<void> finalizePromise)
+            : FinalizePromise(finalizePromise)
+        {}
+
+        NThreading::TPromise<void> FinalizePromise;
+    };
+
+    struct TEvResourcesInfo : public NActors::TEventLocal<TEvResourcesInfo, EvResourcesInfo> {
+        explicit TEvResourcesInfo(i32 nodeCount)
+            : NodeCount(nodeCount)
+        {}
+
+        const i32 NodeCount;
+    };
+};
+
 using TProgressCallback = std::function<void(const NKikimrKqp::TEvExecuterProgress&)>;
 
-NActors::IActor* CreateRunScriptActorMock(THolder<NKikimr::NKqp::TEvKqp::TEvQueryRequest> request,
-    NThreading::TPromise<TQueryResponse> promise, ui64 resultRowsLimit, ui64 resultSizeLimit,
-    TProgressCallback progressCallback);
+NActors::IActor* CreateRunScriptActorMock(TQueryRequest request, NThreading::TPromise<TQueryResponse> promise, TProgressCallback progressCallback);
+
+NActors::IActor* CreateAsyncQueryRunnerActor(ui64 inFlightLimit);
 
 NActors::IActor* CreateResourcesWaiterActor(NThreading::TPromise<void> promise, i32 expectedNodeCount);
 

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -14,13 +14,14 @@ namespace NKqpRun {
 constexpr char YQL_TOKEN_VARIABLE[] = "YQL_TOKEN";
 
 struct TYdbSetupSettings {
-    i32 NodeCount = 1;
+    ui32 NodeCount = 1;
     TString DomainName = "Root";
     TDuration InitializationTimeout = TDuration::Seconds(10);
 
     bool MonitoringEnabled = false;
+    ui16 MonitoringPortOffset = 0;
     bool TraceOptEnabled = false;
-    TMaybe<TString> LogOutputFile;
+    TString LogOutputFile;
 
     TString YqlToken;
     TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> FunctionRegistry;
@@ -44,11 +45,11 @@ struct TRunnerOptions {
         FullProto,  // Columns, rows and types in proto string format
     };
 
-    IOutputStream* ResultOutput = &Cout;
+    IOutputStream* ResultOutput = nullptr;
     IOutputStream* SchemeQueryAstOutput = nullptr;
     IOutputStream* ScriptQueryAstOutput = nullptr;
     IOutputStream* ScriptQueryPlanOutput = nullptr;
-    TMaybe<TString> InProgressStatisticsOutputFile;
+    TString InProgressStatisticsOutputFile;
 
     EResultOutputFormat ResultOutputFormat = EResultOutputFormat::RowsJson;
     NYdb::NConsoleClient::EOutputFormat PlanOutputFormat = NYdb::NConsoleClient::EOutputFormat::Default;

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -55,6 +55,8 @@ struct TRunnerOptions {
     NYdb::NConsoleClient::EOutputFormat PlanOutputFormat = NYdb::NConsoleClient::EOutputFormat::Default;
     ETraceOptType TraceOptType = ETraceOptType::Disabled;
 
+    ui64 InFlightLimit = 0;
+
     TYdbSetupSettings YdbSettings;
 };
 

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -28,6 +28,8 @@ struct TYdbSetupSettings {
     NKikimr::NMiniKQL::TComputationNodeFactory ComputationFactory;
     TIntrusivePtr<NYql::IYtGateway> YtGateway;
     NKikimrConfig::TAppConfig AppConfig;
+
+    ui64 InFlightLimit = 0;
 };
 
 
@@ -54,8 +56,6 @@ struct TRunnerOptions {
     EResultOutputFormat ResultOutputFormat = EResultOutputFormat::RowsJson;
     NYdb::NConsoleClient::EOutputFormat PlanOutputFormat = NYdb::NConsoleClient::EOutputFormat::Default;
     ETraceOptType TraceOptType = ETraceOptType::Disabled;
-
-    ui64 InFlightLimit = 0;
 
     TYdbSetupSettings YdbSettings;
 };

--- a/ydb/tests/tools/kqprun/src/kqp_runner.cpp
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.cpp
@@ -4,8 +4,6 @@
 #include <library/cpp/colorizer/colors.h>
 #include <library/cpp/json/json_reader.h>
 
-#include <util/system/condvar.h>
-
 #include <ydb/core/blob_depot/mon_main.h>
 #include <ydb/core/fq/libs/compute/common/utils.h>
 

--- a/ydb/tests/tools/kqprun/src/kqp_runner.cpp
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.cpp
@@ -295,7 +295,7 @@ private:
 
     void PrintScriptProgress(const TString& plan) const {
         if (Options_.InProgressStatisticsOutputFile) {
-            TFileOutput outputStream(*Options_.InProgressStatisticsOutputFile);
+            TFileOutput outputStream(Options_.InProgressStatisticsOutputFile);
             outputStream << TInstant::Now().ToIsoStringLocal() << " Script in progress statistics" << Endl;
 
             auto convertedPlan = plan;

--- a/ydb/tests/tools/kqprun/src/kqp_runner.cpp
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.cpp
@@ -4,6 +4,8 @@
 #include <library/cpp/colorizer/colors.h>
 #include <library/cpp/json/json_reader.h>
 
+#include <util/system/condvar.h>
+
 #include <ydb/core/blob_depot/mon_main.h>
 #include <ydb/core/fq/libs/compute/common/utils.h>
 
@@ -86,6 +88,34 @@ void PrintStatistics(const TString& fullStat, const THashMap<TString, i64>& flat
 //// TKqpRunner::TImpl
 
 class TKqpRunner::TImpl {
+    struct TAsyncState {
+        ui64 OnStartRequest() {
+            InFlight++;
+            MaxInFlight = std::max(MaxInFlight, InFlight);
+            return RequestId++;
+        }
+
+        void OnRequestFinished(bool success) {
+            InFlight--;
+            if (success) {
+                Completed++;
+            } else {
+                Failed++;
+            }
+        }
+
+        TString GetInfoString() const {
+            return TStringBuilder() << "completed: " << Completed << ", failed: " << Failed << ", in flight: " << InFlight << ", max in flight: " << MaxInFlight << ", spend time: " << TInstant::Now() - Start;
+        }
+
+        const TInstant Start = TInstant::Now();
+        ui64 RequestId = 1;
+        ui64 MaxInFlight = 0;
+        ui64 InFlight = 0;
+        ui64 Completed = 0;
+        ui64 Failed = 0;
+    };
+
 public:
     enum class EQueryType {
         ScriptQuery,
@@ -161,6 +191,45 @@ public:
         }
 
         return true;
+    }
+
+    void ExecuteQueryAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) {
+        TGuard<TMutex> lock(Mutex_);
+
+        if (Options_.InFlightLimit && AsyncState_.InFlight >= Options_.InFlightLimit) {
+            AwaitInFlight_.WaitI(Mutex_);
+        }
+
+        ui64 requestId = AsyncState_.OnStartRequest();
+        RunningQueries_[requestId] = YdbSetup_.QueryRequestAsync(query, action, traceId, nullptr).Subscribe([this, requestId](const NThreading::TFuture<NKqpRun::TQueryResult>& f) {
+            TGuard<TMutex> lock(Mutex_);
+
+            auto response = f.GetValue().Response;
+            AsyncState_.OnRequestFinished(response.IsSuccess());
+            if (response.IsSuccess()) {
+                Cout << CoutColors_.Green() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " completed. " << CoutColors_.Yellow() << AsyncState_.GetInfoString() << CoutColors_.Default() << "\n";
+            } else {
+                Cout << CoutColors_.Red() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " failed " << response.Status << ". " << CoutColors_.Yellow() << AsyncState_.GetInfoString() << "\n" << CoutColors_.Red() << "Issues:\n" << response.Issues.ToString() << CoutColors_.Default();
+            }
+
+            if (AsyncState_.InFlight < Options_.InFlightLimit) {
+                AwaitInFlight_.Signal();
+            }
+            if (!AsyncState_.InFlight) {
+                AwaitFinish_.Signal();
+            }
+            RunningQueries_.erase(requestId);
+        }).IgnoreResult();
+        Cout << TStringBuilder() << CoutColors_.Cyan() << TInstant::Now().ToIsoStringLocal() << " Request #" << requestId << " started. " << CoutColors_.Yellow() << AsyncState_.GetInfoString() << CoutColors_.Default() << "\n";
+    }
+
+    void WaitAsyncQueries() {
+        TGuard<TMutex> lock(Mutex_);
+
+        if (AsyncState_.InFlight) {
+            Cout << CoutColors_.Yellow() << TInstant::Now().ToIsoStringLocal() << " Waiting for async queries..." << CoutColors_.Default() << Endl;
+            AwaitFinish_.WaitI(Mutex_);
+        }
     }
 
     bool FetchScriptResults() {
@@ -373,6 +442,12 @@ private:
     TString ExecutionOperation_;
     TExecutionMeta ExecutionMeta_;
     std::vector<Ydb::ResultSet> ResultSets_;
+
+    TMutex Mutex_;
+    TCondVar AwaitInFlight_;
+    TCondVar AwaitFinish_;
+    TAsyncState AsyncState_;
+    std::unordered_map<ui64, NThreading::TFuture<void>> RunningQueries_;
 };
 
 
@@ -394,8 +469,16 @@ bool TKqpRunner::ExecuteQuery(const TString& query, NKikimrKqp::EQueryAction act
     return Impl_->ExecuteQuery(query, action, traceId, TImpl::EQueryType::ScriptQuery);
 }
 
+void TKqpRunner::ExecuteQueryAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const {
+    Impl_->ExecuteQueryAsync(query, action, traceId);
+}
+
 bool TKqpRunner::ExecuteYqlScript(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const {
     return Impl_->ExecuteQuery(query, action, traceId, TImpl::EQueryType::YqlScriptQuery);
+}
+
+void TKqpRunner::WaitAsyncQueries() {
+    Impl_->WaitAsyncQueries();
 }
 
 bool TKqpRunner::FetchScriptResults() {

--- a/ydb/tests/tools/kqprun/src/kqp_runner.h
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.h
@@ -16,11 +16,11 @@ public:
 
     bool ExecuteQuery(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
 
-    void ExecuteQueryAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
-
     bool ExecuteYqlScript(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
 
-    void WaitAsyncQueries();
+    void ExecuteQueryAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
+
+    void WaitAsyncQueries() const;
 
     bool FetchScriptResults();
 

--- a/ydb/tests/tools/kqprun/src/kqp_runner.h
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.h
@@ -16,7 +16,11 @@ public:
 
     bool ExecuteQuery(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
 
+    void ExecuteQueryAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
+
     bool ExecuteYqlScript(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
+
+    void WaitAsyncQueries();
 
     bool FetchScriptResults();
 

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -198,7 +198,9 @@ public:
         WaitResourcesPublishing();
 
         if (Settings_.MonitoringEnabled) {
-            Cout << CoutColors_.Cyan() << "Monitoring port: " << CoutColors_.Default() << Server_->GetRuntime()->GetMonPort() << Endl;
+            for (ui32 nodeIndex = 0; nodeIndex < Settings_.NodeCount; ++nodeIndex) {
+                Cout << CoutColors_.Cyan() << "Monitoring port" << (Settings_.NodeCount > 1 ? TStringBuilder() << " for node " << nodeIndex + 1 : TString()) << ": " << CoutColors_.Default() << Server_->GetRuntime()->GetMonPort(nodeIndex) << Endl;
+            }
         }
     }
 

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -69,7 +69,7 @@ class TYdbSetup::TImpl {
 private:
     TAutoPtr<TLogBackend> CreateLogBackend() const {
         if (Settings_.LogOutputFile) {
-            return NActors::CreateFileBackend(*Settings_.LogOutputFile);
+            return NActors::CreateFileBackend(Settings_.LogOutputFile);
         } else {
             return NActors::CreateStderrBackend();
         }
@@ -138,6 +138,7 @@ private:
 
         if (Settings_.MonitoringEnabled) {
             serverSettings.InitKikimrRunConfig();
+            serverSettings.SetMonitoringPortOffset(Settings_.MonitoringPortOffset);
         }
 
         return serverSettings;

--- a/ydb/tests/tools/kqprun/src/ydb_setup.h
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.h
@@ -47,13 +47,6 @@ struct TRequestResult {
 };
 
 
-struct TQueryResult {
-    TRequestResult Response;
-    TQueryMeta Meta;
-    std::vector<Ydb::ResultSet> ResultSets;
-};
-
-
 class TYdbSetup {
 public:
     explicit TYdbSetup(const TYdbSetupSettings& settings);

--- a/ydb/tests/tools/kqprun/src/ydb_setup.h
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.h
@@ -64,8 +64,6 @@ public:
 
     TRequestResult QueryRequest(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId, TQueryMeta& meta, std::vector<Ydb::ResultSet>& resultSets, TProgressCallback progressCallback) const;
 
-    NThreading::TFuture<TQueryResult> QueryRequestAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId, TProgressCallback progressCallback) const;
-
     TRequestResult YqlScriptRequest(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId, TQueryMeta& meta, std::vector<Ydb::ResultSet>& resultSets) const;
 
     TRequestResult GetScriptExecutionOperationRequest(const TString& operation, TExecutionMeta& meta) const;
@@ -73,6 +71,10 @@ public:
     TRequestResult FetchScriptExecutionResultsRequest(const TString& operation, i32 resultSetId, Ydb::ResultSet& resultSet) const;
 
     TRequestResult ForgetScriptExecutionOperationRequest(const TString& operation) const;
+
+    void QueryRequestAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId) const;
+
+    void WaitAsyncQueries() const;
 
     void StartTraceOpt() const;
 

--- a/ydb/tests/tools/kqprun/src/ydb_setup.h
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.h
@@ -47,6 +47,13 @@ struct TRequestResult {
 };
 
 
+struct TQueryResult {
+    TRequestResult Response;
+    TQueryMeta Meta;
+    std::vector<Ydb::ResultSet> ResultSets;
+};
+
+
 class TYdbSetup {
 public:
     explicit TYdbSetup(const TYdbSetupSettings& settings);
@@ -56,6 +63,8 @@ public:
     TRequestResult ScriptRequest(const TString& script, NKikimrKqp::EQueryAction action, const TString& traceId, TString& operation) const;
 
     TRequestResult QueryRequest(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId, TQueryMeta& meta, std::vector<Ydb::ResultSet>& resultSets, TProgressCallback progressCallback) const;
+
+    NThreading::TFuture<TQueryResult> QueryRequestAsync(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId, TProgressCallback progressCallback) const;
 
     TRequestResult YqlScriptRequest(const TString& query, NKikimrKqp::EQueryAction action, const TString& traceId, TQueryMeta& meta, std::vector<Ydb::ResultSet>& resultSets) const;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

KqpRun fixed performance and backtrace printing

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

* Fixed performance for `-C query`
* Refactored arguments parsing 
* Added new backtrace format by default
* Added fixed monitoring port option
* Added execution case option for each request 
* Added async query execution
* Added loop options