### PR TITLE
Disable RunOnOpt plan diff after FieldSubsetEnableMultiusage is enabled

### DIFF
--- a/ydb/library/yql/tests/sql/suites/pg-tpch/q11.sql
+++ b/ydb/library/yql/tests/sql/suites/pg-tpch/q11.sql
@@ -1,5 +1,6 @@
 --!syntax_pg
 --TPC-H Q11
+-- ignore runonopt plan diff
 
 
 select


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* [YQL-18585] Disable RunOnOpt plan diff after FieldSubsetEnableMultiusage is enabled

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
