### PR TITLE
Add start and end times to Operations API

### DIFF
--- a/ydb/core/grpc_services/rpc_export_base.h
+++ b/ydb/core/grpc_services/rpc_export_base.h
@@ -45,6 +45,13 @@ struct TExportConv {
             operation.mutable_issues()->CopyFrom(exprt.GetIssues());
         }
 
+        if (exprt.HasStartTime()) {
+            *operation.mutable_start_time() = exprt.GetStartTime();
+        }
+        if (exprt.HasEndTime()) {
+            *operation.mutable_end_time() = exprt.GetEndTime();
+        }
+
         using namespace Ydb::Export;
         switch (exprt.GetSettingsCase()) {
         case NKikimrExport::TExport::kExportToYtSettings:

--- a/ydb/core/grpc_services/rpc_import_base.h
+++ b/ydb/core/grpc_services/rpc_import_base.h
@@ -42,6 +42,13 @@ struct TImportConv {
             operation.mutable_issues()->CopyFrom(import.GetIssues());
         }
 
+        if (import.HasStartTime()) {
+            *operation.mutable_start_time() = import.GetStartTime();
+        }
+        if (import.HasEndTime()) {
+            *operation.mutable_end_time() = import.GetEndTime();
+        }
+
         using namespace Ydb::Import;
         switch (import.GetSettingsCase()) {
         case NKikimrImport::TImport::kImportFromS3Settings:

--- a/ydb/core/tx/schemeshard/schemeshard_export.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export.cpp
@@ -84,7 +84,9 @@ void TSchemeShard::FromXxportInfo(NKikimrExport::TExport& exprt, const TExportIn
     exprt.SetId(exportInfo->Id);
     exprt.SetStatus(Ydb::StatusIds::SUCCESS);
     
-    *exprt.MutableStartTime() = SecondsToProtoTimeStamp(exportInfo->StartTime.Seconds());
+    if (exportInfo->StartTime != TInstant::Zero()) {
+        *exprt.MutableStartTime() = SecondsToProtoTimeStamp(exportInfo->StartTime.Seconds());
+    }
     if (exportInfo->EndTime != TInstant::Zero()) {
         *exprt.MutableEndTime() = SecondsToProtoTimeStamp(exportInfo->EndTime.Seconds());
     }

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -48,7 +48,9 @@ void TSchemeShard::FromXxportInfo(NKikimrImport::TImport& import, const TImportI
     import.SetId(importInfo->Id);
     import.SetStatus(Ydb::StatusIds::SUCCESS);
 
-    *import.MutableStartTime() = SecondsToProtoTimeStamp(importInfo->StartTime.Seconds());
+    if (importInfo->StartTime != TInstant::Zero()) {
+        *import.MutableStartTime() = SecondsToProtoTimeStamp(importInfo->StartTime.Seconds());
+    }
     if (importInfo->EndTime != TInstant::Zero()) {
         *import.MutableEndTime() = SecondsToProtoTimeStamp(importInfo->EndTime.Seconds());
     }

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -1506,9 +1506,8 @@ partitioning_settings {
 
     Y_UNIT_TEST(ExportStartTime) {
         TTestBasicRuntime runtime;
-        runtime.UpdateCurrentTime(TInstant::Now());
-
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
@@ -1545,9 +1544,8 @@ partitioning_settings {
 
     Y_UNIT_TEST(CompletedExportEndTime) {
         TTestBasicRuntime runtime;
-        runtime.UpdateCurrentTime(TInstant::Now());
-
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
@@ -1589,9 +1587,8 @@ partitioning_settings {
 
     Y_UNIT_TEST(CancelledExportEndTime) {
         TTestBasicRuntime runtime;
-        runtime.UpdateCurrentTime(TInstant::Now());
-
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -1506,6 +1506,8 @@ partitioning_settings {
 
     Y_UNIT_TEST(ExportStartTime) {
         TTestBasicRuntime runtime;
+        runtime.UpdateCurrentTime(TInstant::Now());
+
         TTestEnv env(runtime);
         ui64 txId = 100;
 
@@ -1543,6 +1545,8 @@ partitioning_settings {
 
     Y_UNIT_TEST(CompletedExportEndTime) {
         TTestBasicRuntime runtime;
+        runtime.UpdateCurrentTime(TInstant::Now());
+
         TTestEnv env(runtime);
         ui64 txId = 100;
 
@@ -1585,6 +1589,8 @@ partitioning_settings {
 
     Y_UNIT_TEST(CancelledExportEndTime) {
         TTestBasicRuntime runtime;
+        runtime.UpdateCurrentTime(TInstant::Now());
+
         TTestEnv env(runtime);
         ui64 txId = 100;
 

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -2952,7 +2952,9 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(ImportStartTime) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions());
+        runtime.UpdateCurrentTime(TInstant::Now());
+
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(
@@ -2993,7 +2995,9 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(CompletedImportEndTime) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions());
+        runtime.UpdateCurrentTime(TInstant::Now());
+
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(
@@ -3039,7 +3043,9 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(CancelledImportEndTime) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions());
+        runtime.UpdateCurrentTime(TInstant::Now());
+
+        TTestEnv env(runtime);
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -2952,9 +2952,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(ImportStartTime) {
         TTestBasicRuntime runtime;
-        runtime.UpdateCurrentTime(TInstant::Now());
-
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(
@@ -2995,9 +2994,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(CompletedImportEndTime) {
         TTestBasicRuntime runtime;
-        runtime.UpdateCurrentTime(TInstant::Now());
-
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(
@@ -3043,9 +3041,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(CancelledImportEndTime) {
         TTestBasicRuntime runtime;
-        runtime.UpdateCurrentTime(TInstant::Now());
-
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(

--- a/ydb/public/api/protos/ydb_operation.proto
+++ b/ydb/public/api/protos/ydb_operation.proto
@@ -122,11 +122,9 @@ message Operation {
     // For operations in progress, it might indicate the current cost of the operation (if supported).
     CostInfo cost_info = 7;
 
-    // The time at which this operation was started and the time at which
-    // this operation was completed (doesn't matter successful or not).
-    // Currently filled for:
-    // - Export;
-    // - Import.
+    // The time at which this operation was started (if supported).
     google.protobuf.Timestamp start_time = 8;
+
+    // The time at which this operation was completed, doesn't matter successful or not (if supported).
     google.protobuf.Timestamp end_time = 9;
 }

--- a/ydb/public/api/protos/ydb_operation.proto
+++ b/ydb/public/api/protos/ydb_operation.proto
@@ -3,6 +3,7 @@ option cc_enable_arenas = true;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 import "ydb/public/api/protos/annotations/validation.proto";
 import "ydb/public/api/protos/ydb_common.proto";
@@ -103,7 +104,7 @@ message Operation {
     // not created in the first place, as in SYNC operation mode).
     string id = 1;
 
-    // true - this operation has beed finished (doesn't matter successful or not),
+    // true - this operation has been completed (doesn't matter successful or not),
     // so Status field has status code, and Result field can contains result data.
     // false - this operation still running. You can repeat request using operation Id.
     bool ready = 2;
@@ -120,4 +121,12 @@ message Operation {
     // For completed operations, it shows the final cost of the operation.
     // For operations in progress, it might indicate the current cost of the operation (if supported).
     CostInfo cost_info = 7;
+
+    // The time at which this operation was started and the time at which
+    // this operation was completed (doesn't matter successful or not).
+    // Currently filled for:
+    // - Export;
+    // - Import.
+    google.protobuf.Timestamp start_time = 8;
+    google.protobuf.Timestamp end_time = 9;
 }

--- a/ydb/public/lib/ydb_cli/common/print_operation.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_operation.cpp
@@ -36,6 +36,14 @@ namespace {
                 freeText << "  - " << issue << Endl;
             }
         }
+        
+        if (operation.StartTime() != TInstant::Zero()) {
+            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        }
+
+        if (operation.EndTime() != TInstant::Zero()) {
+            freeText << "End time: " << operation.EndTime().ToStringUpToSeconds() << Endl;
+        }
 
         row.FreeText(freeText);
     }
@@ -114,6 +122,14 @@ namespace {
 
         freeText << "TypeV3: " << (settings.UseTypeV3_ ? "true" : "false") << Endl;
 
+        if (operation.StartTime() != TInstant::Zero()) {
+            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        }
+
+        if (operation.EndTime() != TInstant::Zero()) {
+            freeText << "End time: " << operation.EndTime().ToStringUpToSeconds() << Endl;
+        }
+
         row.FreeText(freeText);
     }
 
@@ -166,6 +182,14 @@ namespace {
 
         if (settings.NumberOfRetries_) {
             freeText << "Number of retries: " << settings.NumberOfRetries_.GetRef() << Endl;
+        }
+
+        if (operation.StartTime() != TInstant::Zero()) {
+            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        }
+
+        if (operation.EndTime() != TInstant::Zero()) {
+            freeText << "End time: " << operation.EndTime().ToStringUpToSeconds() << Endl;
         }
 
         row.FreeText(freeText);

--- a/ydb/public/sdk/cpp/client/ydb_export/export.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_export/export.cpp
@@ -24,12 +24,6 @@ using namespace Ydb::Export;
 /// Common
 namespace {
 
-TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp) {
-    ui64 us = timestamp.seconds() * 1000000;
-    us += timestamp.nanos() / 1000;
-    return TInstant::MicroSeconds(us);
-}
-
 TVector<TExportItemProgress> ItemsProgressFromProto(const google::protobuf::RepeatedPtrField<ExportItemProgress>& proto) {
     TVector<TExportItemProgress> result(Reserve(proto.size()));
 

--- a/ydb/public/sdk/cpp/client/ydb_import/import.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_import/import.cpp
@@ -19,12 +19,6 @@ using namespace Ydb::Import;
 /// Common
 namespace {
 
-TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp) {
-    ui64 us = timestamp.seconds() * 1000000;
-    us += timestamp.nanos() / 1000;
-    return TInstant::MicroSeconds(us);
-}
-
 TVector<TImportItemProgress> ItemsProgressFromProto(const google::protobuf::RepeatedPtrField<Ydb::Import::ImportItemProgress>& proto) {
     TVector<TImportItemProgress> result(Reserve(proto.size()));
 

--- a/ydb/public/sdk/cpp/client/ydb_types/operation/operation.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/operation/operation.cpp
@@ -17,6 +17,8 @@ public:
         : Id_(operation.id(), true /* allowEmpty */)
         , Status_(std::move(status))
         , Ready_(operation.ready())
+        , StartTime_(ProtoTimestampToInstant(operation.start_time()))
+        , EndTime_(ProtoTimestampToInstant(operation.end_time()))
         , Operation_(std::move(operation))
     {
     }
@@ -33,6 +35,14 @@ public:
         return Status_;
     }
 
+    TInstant StartTime() const {
+        return StartTime_;
+    }
+
+    TInstant EndTime() const {
+        return EndTime_;
+    }
+
     const Ydb::Operations::Operation& GetProto() const {
         return Operation_;
     }
@@ -41,6 +51,8 @@ private:
     const TOperationId Id_;
     const TStatus Status_;
     const bool Ready_;
+    const TInstant StartTime_;
+    const TInstant EndTime_;
     const Ydb::Operations::Operation Operation_;
 };
 
@@ -62,6 +74,14 @@ bool TOperation::Ready() const {
 
 const TStatus& TOperation::Status() const {
     return Impl_->Status();
+}
+
+TInstant TOperation::StartTime() const {
+    return Impl_->StartTime();
+}
+
+TInstant TOperation::EndTime() const {
+    return Impl_->EndTime();
 }
 
 TString TOperation::ToString() const {
@@ -86,6 +106,12 @@ TString TOperation::ToJsonString() const {
 
 const Ydb::Operations::Operation& TOperation::GetProto() const {
     return Impl_->GetProto();
+}
+
+TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp) {
+    ui64 us = timestamp.seconds() * 1000000;
+    us += timestamp.nanos() / 1000;
+    return TInstant::MicroSeconds(us);
 }
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/client/ydb_types/operation/operation.h
+++ b/ydb/public/sdk/cpp/client/ydb_types/operation/operation.h
@@ -5,6 +5,7 @@
 #include <library/cpp/threading/future/future.h>
 
 #include <google/protobuf/stubs/status.h>
+#include <google/protobuf/timestamp.pb.h>
 #include <google/protobuf/util/json_util.h>
 
 namespace Ydb {
@@ -31,6 +32,8 @@ public:
     const TOperationId& Id() const;
     bool Ready() const;
     const TStatus& Status() const;
+    TInstant StartTime() const;
+    TInstant EndTime() const;
 
     TString ToString() const;
     TString ToJsonString() const;
@@ -45,5 +48,7 @@ private:
 };
 
 using TAsyncOperation = NThreading::TFuture<TOperation>;
+
+TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp);
 
 } // namespace NYdb


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add start and end times for long-running operations (export, import). 

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

```
$ ydb export s3
┌───────────────────────────────────────────┬───────┬─────────┬───────────┬───────────┬────────┐
│ id                                        │ ready │ status  │ progress  │ endpoint  │ bucket │
├───────────────────────────────────────────┼───────┼─────────┼───────────┼───────────┼────────┤
│ ydb://export/6?id=844425031076972&kind=s3 │ false │ SUCCESS │ Preparing │ localhost │ 1      │
├╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴┤
│ StorageClass: NOT_SET                                                                        │
│ Items:                                                                                       │
│   - source: /Root/pixcc-slice-db/users                                                       │
│     destination: 1                                                                           │
│ Description:                                                                                 │
│ Number of retries: 10                                                                        │
│ Start time: 2024-06-10T23:55:57Z                                                             │
└──────────────────────────────────────────────────────────────────────────────────────────────┘

$ ydb operation cancel "ydb://export/6?id=844425031076972&kind=s3"

$ ydb operation get "ydb://export/6?id=844425031076972&kind=s3"
┌───────────────────────────────────────────┬───────┬───────────┬───────────┬───────────┬────────┐
│ id                                        │ ready │ status    │ progress  │ endpoint  │ bucket │
├───────────────────────────────────────────┼───────┼───────────┼───────────┼───────────┼────────┤
│ ydb://export/6?id=844425031076972&kind=s3 │ true  │ CANCELLED │ Cancelled │ localhost │ 1      │
├╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴┤
│ StorageClass: NOT_SET                                                                          │
│ Issues:                                                                                        │
│   - <main>: Error: Cancelled manually                                                          │
│ Items:                                                                                         │
│   - source: /Root/pixcc-slice-db/users                                                         │
│     destination: 1                                                                             │
│ Description:                                                                                   │
│ Number of retries: 10                                                                          │
│ Start time: 2024-06-10T23:55:57Z                                                               │
│ End time: 2024-06-10T23:57:30Z                                                                 │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
```
