### PR TITLE
TTableHistogramBuilderBtreeIndex improvements

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -769,6 +769,7 @@ message TEvGetTableStats {
     optional uint64 DataSizeResolution = 2;
     optional uint64 RowCountResolution = 3;
     optional bool CollectKeySample = 4;
+    optional uint32 HistogramBucketsCount = 5;
 }
 
 message TEvGetTableStatsResult {

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -17,6 +17,7 @@
 #include <ydb/core/tablet_flat/test/libs/table/wrap_part.h>
 #include <ydb/core/tablet_flat/test/libs/table/test_steps.h>
 
+// ya test -r -D BENCHMARK_MAKE_LARGE_PART
 #ifndef BENCHMARK_MAKE_LARGE_PART
 #define BENCHMARK_MAKE_LARGE_PART 0
 #endif
@@ -233,7 +234,7 @@ BENCHMARK_DEFINE_F(TPartFixture, DoCharge)(benchmark::State& state) {
 BENCHMARK_DEFINE_F(TPartFixture, BuildStats)(benchmark::State& state) {
     for (auto _ : state) {
         TStats stats;
-        BuildStats(*Subset, stats, NDataShard::gDbStatsRowCountResolution, NDataShard::gDbStatsDataSizeResolution, &Env, [](){});
+        BuildStats(*Subset, stats, NDataShard::gDbStatsRowCountResolution, NDataShard::gDbStatsDataSizeResolution, NDataShard::gDbStatsHistogramKeysCount, &Env, [](){});
     }
 }
 

--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -234,7 +234,7 @@ BENCHMARK_DEFINE_F(TPartFixture, DoCharge)(benchmark::State& state) {
 BENCHMARK_DEFINE_F(TPartFixture, BuildStats)(benchmark::State& state) {
     for (auto _ : state) {
         TStats stats;
-        BuildStats(*Subset, stats, NDataShard::gDbStatsRowCountResolution, NDataShard::gDbStatsDataSizeResolution, NDataShard::gDbStatsHistogramKeysCount, &Env, [](){});
+        BuildStats(*Subset, stats, NDataShard::gDbStatsRowCountResolution, NDataShard::gDbStatsDataSizeResolution, NDataShard::gDbStatsHistogramBucketsCount, &Env, [](){});
     }
 }
 

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -7,7 +7,7 @@
 namespace NKikimr {
 namespace NTable {
 
-bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env, TBuildStatsYieldHandler yieldHandler) {
+bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramKeysCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
     stats.Clear();
 
     bool mixedIndex = false;
@@ -18,11 +18,11 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
     }
 
     // TODO: enable b-tree index after benchmarks
-    mixedIndex = true;
+    // mixedIndex = true;
 
     return mixedIndex
         ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)
-        : BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);
+        : BuildStatsBTreeIndex(subset, stats, histogramKeysCount, env, yieldHandler);
 }
 
 void GetPartOwners(const TSubset& subset, THashSet<ui64>& partOwners) {

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -18,7 +18,7 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
     }
 
     // TODO: enable b-tree index after benchmarks
-    // mixedIndex = true;
+    mixedIndex = true;
 
     return mixedIndex
         ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -7,7 +7,7 @@
 namespace NKikimr {
 namespace NTable {
 
-bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramKeysCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
+bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
     stats.Clear();
 
     bool mixedIndex = false;
@@ -22,7 +22,7 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
 
     return mixedIndex
         ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)
-        : BuildStatsBTreeIndex(subset, stats, histogramKeysCount, env, yieldHandler);
+        : BuildStatsBTreeIndex(subset, stats, histogramBucketsCount, env, yieldHandler);
 }
 
 void GetPartOwners(const TSubset& subset, THashSet<ui64>& partOwners) {

--- a/ydb/core/tablet_flat/flat_stat_table.h
+++ b/ydb/core/tablet_flat/flat_stat_table.h
@@ -190,7 +190,7 @@ private:
 
 using TBuildStatsYieldHandler = std::function<void()>;
 
-bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env, TBuildStatsYieldHandler yieldHandler);
+bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler);
 void GetPartOwners(const TSubset& subset, THashSet<ui64>& partOwners);
 
 }}

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.h
@@ -196,7 +196,7 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
 
 }
 
-inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramKeysCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
+inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
     stats.Clear();
 
     bool ready = true;
@@ -209,7 +209,7 @@ inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 hist
         return false;
     }
 
-    ready &= BuildStatsHistogramsBTreeIndex(subset, stats, histogramKeysCount, env, yieldHandler);
+    ready &= BuildStatsHistogramsBTreeIndex(subset, stats, histogramBucketsCount, env, yieldHandler);
 
     return ready;
 }

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.h
@@ -196,7 +196,7 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
 
 }
 
-inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env, TBuildStatsYieldHandler yieldHandler) {
+inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramKeysCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
     stats.Clear();
 
     bool ready = true;
@@ -209,7 +209,7 @@ inline bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui64 rowC
         return false;
     }
 
-    ready &= BuildStatsHistogramsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler);
+    ready &= BuildStatsHistogramsBTreeIndex(subset, stats, histogramKeysCount, env, yieldHandler);
 
     return ready;
 }

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -1014,7 +1014,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     // this test uses same data as benchmark::TPartFixture/BuildStats/*, but may be debugged and prints result histograms
     Y_UNIT_TEST(Benchmark)
     {
-        const ui32 partsCount = 15;
+        const ui32 partsCount = 4;
         const bool groups = false;
         const bool history = false;
         ui64 rowsCount = history ? 300000 : 1000000;

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -571,7 +571,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         ui64 dataSizeResolution = totalBytes / histogramBucketsCount;
 
         TTouchEnv env;
-        env.Faulty = false; // uncomment for debug
+        // env.Faulty = false; // uncomment for debug
         TStats stats;
         auto buildStats = [&]() {
             if (mode == BTreeIndex) {

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -92,13 +92,13 @@ namespace {
         UNIT_ASSERT_VALUES_EQUAL(stats.IndexSize.Size, expectedIndex);
     }
 
-    void CheckBTreeIndex(const TSubset& subset, ui64 expectedRows, ui64 expectedData, ui64 expectedIndex, ui64 rowCountResolution = 531, ui64 dataSizeResolution = 53105) {
+    void CheckBTreeIndex(const TSubset& subset, ui64 expectedRows, ui64 expectedData, ui64 expectedIndex, ui32 histogramKeysCount = 10) {
         TStats stats;
         TTouchEnv env;
 
         const ui32 attempts = 25;
         for (ui32 attempt : xrange(attempts)) {
-            if (NTable::BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){})) {
+            if (NTable::BuildStatsBTreeIndex(subset, stats, histogramKeysCount, &env, [](){})) {
                 break;
             }
             UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");
@@ -554,7 +554,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         }
     }
 
-    void Check(const TSubset& subset, TMode mode, ui32 buckets = 10, bool verifyPercents = true) {
+    void Check(const TSubset& subset, TMode mode, ui32 histogramKeysCount = 10, bool verifyPercents = true) {
         if (mode == 0) {
             Dump(subset);
         }
@@ -567,21 +567,21 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             CalcDataBefore(subset, TSerializedCellVec(emptyKey), totalBytes, totalRows);
         }
 
-        ui64 rowCountResolution = totalRows / buckets;
-        ui64 dataSizeResolution = totalBytes / buckets;
+        ui64 rowCountResolution = totalRows / (histogramKeysCount + 1);
+        ui64 dataSizeResolution = totalBytes / (histogramKeysCount + 1);
 
         TTouchEnv env;
-        // env.Faulty = false; // uncomment for debug
+        env.Faulty = false; // uncomment for debug
         TStats stats;
         auto buildStats = [&]() {
             if (mode == BTreeIndex) {
-                return NTable::BuildStatsBTreeIndex(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){});
+                return NTable::BuildStatsBTreeIndex(subset, stats, histogramKeysCount, &env, [](){});
             } else {
                 return NTable::BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){});
             }
         };
 
-        const ui32 attempts = 25;
+        const ui32 attempts = 35;
         for (ui32 attempt : xrange(attempts)) {
             if (buildStats()) {
                 break;
@@ -1008,6 +1008,29 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             TMixerSeq mixer(4, Mass1.Saved.Size());
             auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), mode)).Mixed(0, 4, mixer, 0.3);
             Check(*subset, mode);
+        }
+    }
+
+    // this test uses same data as benchmark::TPartFixture/BuildStats/*, but may be debugged and prints result histograms
+    Y_UNIT_TEST(Benchmark)
+    {
+        const ui32 partsCount = 15;
+        const bool groups = false;
+        const bool history = false;
+        ui64 rowsCount = history ? 300000 : 1000000;
+
+        rowsCount /= 100; // to be faster
+
+        TAutoPtr<TMass> mass = new NTest::TMass(new NTest::TModelStd(groups), rowsCount);
+
+        for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
+            NPage::TConf conf;
+            conf.Groups.resize(mass->Model->Scheme->Families.size());
+            conf.WriteBTreeIndex = (mode == FlatIndex ? false : true);
+
+            TAutoPtr<TSubset> subset = TMake(*mass, conf).Mixed(0, partsCount, TMixerRnd(partsCount), history ? 0.7 : 0);
+            
+            Check(*subset, mode, 10, false);
         }
     }
 }

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -92,13 +92,13 @@ namespace {
         UNIT_ASSERT_VALUES_EQUAL(stats.IndexSize.Size, expectedIndex);
     }
 
-    void CheckBTreeIndex(const TSubset& subset, ui64 expectedRows, ui64 expectedData, ui64 expectedIndex, ui32 histogramKeysCount = 10) {
+    void CheckBTreeIndex(const TSubset& subset, ui64 expectedRows, ui64 expectedData, ui64 expectedIndex, ui32 histogramBucketsCount = 10) {
         TStats stats;
         TTouchEnv env;
 
         const ui32 attempts = 25;
         for (ui32 attempt : xrange(attempts)) {
-            if (NTable::BuildStatsBTreeIndex(subset, stats, histogramKeysCount, &env, [](){})) {
+            if (NTable::BuildStatsBTreeIndex(subset, stats, histogramBucketsCount, &env, [](){})) {
                 break;
             }
             UNIT_ASSERT_C(attempt + 1 < attempts, "Too many attempts");
@@ -554,7 +554,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         }
     }
 
-    void Check(const TSubset& subset, TMode mode, ui32 histogramKeysCount = 10, bool verifyPercents = true) {
+    void Check(const TSubset& subset, TMode mode, ui32 histogramBucketsCount = 10, bool verifyPercents = true) {
         if (mode == 0) {
             Dump(subset);
         }
@@ -567,15 +567,15 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             CalcDataBefore(subset, TSerializedCellVec(emptyKey), totalBytes, totalRows);
         }
 
-        ui64 rowCountResolution = totalRows / (histogramKeysCount + 1);
-        ui64 dataSizeResolution = totalBytes / (histogramKeysCount + 1);
+        ui64 rowCountResolution = totalRows / histogramBucketsCount;
+        ui64 dataSizeResolution = totalBytes / histogramBucketsCount;
 
         TTouchEnv env;
         env.Faulty = false; // uncomment for debug
         TStats stats;
         auto buildStats = [&]() {
             if (mode == BTreeIndex) {
-                return NTable::BuildStatsBTreeIndex(subset, stats, histogramKeysCount, &env, [](){});
+                return NTable::BuildStatsBTreeIndex(subset, stats, histogramBucketsCount, &env, [](){});
             } else {
                 return NTable::BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, &env, [](){});
             }

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -37,7 +37,7 @@ bool gAllowLogBatchingDefaultValue = true;
 TDuration gDbStatsReportInterval = TDuration::Seconds(10);
 ui64 gDbStatsDataSizeResolution = 10*1024*1024;
 ui64 gDbStatsRowCountResolution = 100000;
-ui32 gDbStatsHistogramKeysCount = 10;
+ui32 gDbStatsHistogramBucketsCount = 10;
 
 // The first byte is 0x01 so it would fail to parse as an internal tablet protobuf
 TStringBuf SnapshotTransferReadSetMagic("\x01SRS", 4);

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -37,6 +37,7 @@ bool gAllowLogBatchingDefaultValue = true;
 TDuration gDbStatsReportInterval = TDuration::Seconds(10);
 ui64 gDbStatsDataSizeResolution = 10*1024*1024;
 ui64 gDbStatsRowCountResolution = 100000;
+ui32 gDbStatsHistogramKeysCount = 10;
 
 // The first byte is 0x01 so it would fail to parse as an internal tablet protobuf
 TStringBuf SnapshotTransferReadSetMagic("\x01SRS", 4);

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -151,7 +151,7 @@ namespace NDataShard {
     extern TDuration gDbStatsReportInterval;
     extern ui64 gDbStatsDataSizeResolution;
     extern ui64 gDbStatsRowCountResolution;
-    extern ui32 gDbStatsHistogramKeysCount;
+    extern ui32 gDbStatsHistogramBucketsCount;
 
     // This SeqNo is used to discard outdated schema Tx requests on datashards.
     // In case of tablet restart on network disconnects SS can resend same Propose for the same schema Tx.
@@ -830,10 +830,11 @@ struct TEvDataShard {
                                                         NKikimrTxDataShard::TEvGetTableStats,
                                                         TEvDataShard::EvGetTableStats> {
         TEvGetTableStats() = default;
-        explicit TEvGetTableStats(ui64 tableId, ui64 dataSizeResolution = 0, ui64 rowCountResolution = 0, bool collectKeySample = false) {
+        explicit TEvGetTableStats(ui64 tableId, ui64 dataSizeResolution = 0, ui64 rowCountResolution = 0, ui32 histogramBucketsCount = 0, bool collectKeySample = false) {
             Record.SetTableId(tableId);
             Record.SetDataSizeResolution(dataSizeResolution);
             Record.SetRowCountResolution(rowCountResolution);
+            Record.SetHistogramBucketsCount(histogramBucketsCount);
             Record.SetCollectKeySample(collectKeySample);
         }
     };

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -830,12 +830,8 @@ struct TEvDataShard {
                                                         NKikimrTxDataShard::TEvGetTableStats,
                                                         TEvDataShard::EvGetTableStats> {
         TEvGetTableStats() = default;
-        explicit TEvGetTableStats(ui64 tableId, ui64 dataSizeResolution = 0, ui64 rowCountResolution = 0, ui32 histogramBucketsCount = 0, bool collectKeySample = false) {
+        explicit TEvGetTableStats(ui64 tableId) {
             Record.SetTableId(tableId);
-            Record.SetDataSizeResolution(dataSizeResolution);
-            Record.SetRowCountResolution(rowCountResolution);
-            Record.SetHistogramBucketsCount(histogramBucketsCount);
-            Record.SetCollectKeySample(collectKeySample);
         }
     };
 

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -151,6 +151,7 @@ namespace NDataShard {
     extern TDuration gDbStatsReportInterval;
     extern ui64 gDbStatsDataSizeResolution;
     extern ui64 gDbStatsRowCountResolution;
+    extern ui32 gDbStatsHistogramKeysCount;
 
     // This SeqNo is used to discard outdated schema Tx requests on datashards.
     // In case of tablet restart on network disconnects SS can resend same Propose for the same schema Tx.

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -41,7 +41,7 @@ private:
 public:
     TTableStatsCoroBuilder(TActorId replyTo, ui64 tabletId, ui64 tableId, TActorId executorId, ui64 indexSize,
                             const TAutoPtr<TSubset> subset, ui64 memRowCount, ui64 memDataSize,
-                            ui64 rowCountResolution, ui64 dataSizeResolution, ui64 searchHeight, TInstant statsUpdateTime)
+                            ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramBucketsCount, ui64 searchHeight, TInstant statsUpdateTime)
         : TActorCoroImpl(/* stackSize */ 64_KB, /* allowUnhandledDtor */ true)
         , ReplyTo(replyTo)
         , TabletId(tabletId)
@@ -54,6 +54,7 @@ public:
         , MemDataSize(memDataSize)
         , RowCountResolution(rowCountResolution)
         , DataSizeResolution(dataSizeResolution)
+        , HistogramBucketsCount(histogramBucketsCount)
         , SearchHeight(searchHeight)
     {}
 
@@ -139,7 +140,7 @@ private:
 
         Subset->ColdParts.clear(); // stats won't include cold parts, if any
 
-        BuildStats(*Subset, ev->Stats, RowCountResolution, DataSizeResolution, this, [this](){
+        BuildStats(*Subset, ev->Stats, RowCountResolution, DataSizeResolution, HistogramBucketsCount, this, [this](){
             const auto now = GetCycleCountFast();
     
             if (now > CoroutineDeadline) {
@@ -222,6 +223,7 @@ private:
     ui64 MemDataSize;
     ui64 RowCountResolution;
     ui64 DataSizeResolution;
+    ui32 HistogramBucketsCount;
     ui64 SearchHeight;
     THashMap<const TPart*, THashMap<TPageId, TSharedData>> Pages;
     ui64 CoroutineDeadline;
@@ -273,6 +275,7 @@ public:
 
         tableInfo.Stats.DataSizeResolution = Ev->Get()->Record.GetDataSizeResolution();
         tableInfo.Stats.RowCountResolution = Ev->Get()->Record.GetRowCountResolution();
+        tableInfo.Stats.HistogramBucketsCount = Ev->Get()->Record.GetHistogramBucketsCount();
 
         // Check if first stats update has been completed
         bool ready = (tableInfo.Stats.StatsUpdateTime != TInstant());
@@ -480,11 +483,13 @@ public:
                 continue;
             }
 
+            const ui32 MaxBuckets = 500;
+
             ui64 tableId = ti.first;
             ui64 rowCountResolution = gDbStatsRowCountResolution;
             ui64 dataSizeResolution = gDbStatsDataSizeResolution;
+            ui32 histogramBucketsCount = gDbStatsHistogramBucketsCount;
 
-            const ui64 MaxBuckets = 500;
 
             if (ti.second->Stats.DataSizeResolution &&
                 ti.second->Stats.DataStats.DataSize.Size / ti.second->Stats.DataSizeResolution <= MaxBuckets)
@@ -496,6 +501,10 @@ public:
                 ti.second->Stats.DataStats.RowCount / ti.second->Stats.RowCountResolution <= MaxBuckets)
             {
                 rowCountResolution = ti.second->Stats.RowCountResolution;
+            }
+
+            if (ti.second->Stats.HistogramBucketsCount) {
+                histogramBucketsCount = Min(MaxBuckets, ti.second->Stats.HistogramBucketsCount);
             }
 
             ti.second->StatsUpdateInProgress = true;
@@ -536,6 +545,7 @@ public:
                 memDataSize,
                 rowCountResolution,
                 dataSizeResolution,
+                histogramBucketsCount,
                 searchHeight,
                 AppData(ctx)->TimeProvider->Now()), NKikimrServices::TActivity::DATASHARD_STATS_BUILDER);
 

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -352,6 +352,7 @@ struct TUserTable : public TThrRefBase {
         TInstant StatsUpdateTime;
         ui64 DataSizeResolution = 0;
         ui64 RowCountResolution = 0;
+        ui32 HistogramBucketsCount = 0;
         ui64 BackgroundCompactionRequests = 0;
         ui64 BackgroundCompactionCount = 0;
         ui64 CompactBorrowedCount = 0;

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -433,8 +433,10 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
         return true;
     }
 
-    ui64 dataSizeResolution = 0; // Datashard will use default resolution
-    ui64 rowCountResolution = 0; // Datashard will use default resolution
+    const ui64 dataSizeResolution = 0; // Datashard will use default resolution
+    const ui64 rowCountResolution = 0; // Datashard will use default resolution
+    const ui64 histogramBucketsCount = 0; // Datashard will use default resolution
+
     bool collectKeySample = false;
     if (table->ShouldSplitBySize(dataSize, forceShardSplitSettings)) {
         // We would like to split by size and do this no matter how many partitions there are
@@ -481,6 +483,7 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
             pathId.LocalPathId,
             dataSizeResolution,
             rowCountResolution,
+            histogramBucketsCount,
             collectKeySample));
 
     return true;

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -473,7 +473,7 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     // Request histograms from the datashard
     LOG_DEBUG(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
              "Requesting full stats from datashard %" PRIu64, rec.GetDatashardId());
-    TAutoPtr<TEvDataShard::TEvGetTableStats> request = new TEvDataShard::TEvGetTableStats(pathId.LocalPathId);
+    auto request = new TEvDataShard::TEvGetTableStats(pathId.LocalPathId);
     request->Record.SetCollectKeySample(collectKeySample);
     PendingMessages.emplace_back(item.Ev->Sender, request);
 

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -433,10 +433,6 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
         return true;
     }
 
-    const ui64 dataSizeResolution = 0; // Datashard will use default resolution
-    const ui64 rowCountResolution = 0; // Datashard will use default resolution
-    const ui64 histogramBucketsCount = 0; // Datashard will use default resolution
-
     bool collectKeySample = false;
     if (table->ShouldSplitBySize(dataSize, forceShardSplitSettings)) {
         // We would like to split by size and do this no matter how many partitions there are
@@ -477,14 +473,9 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     // Request histograms from the datashard
     LOG_DEBUG(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
              "Requesting full stats from datashard %" PRIu64, rec.GetDatashardId());
-    PendingMessages.emplace_back(
-        item.Ev->Sender,
-        new TEvDataShard::TEvGetTableStats(
-            pathId.LocalPathId,
-            dataSizeResolution,
-            rowCountResolution,
-            histogramBucketsCount,
-            collectKeySample));
+    TAutoPtr<TEvDataShard::TEvGetTableStats> request = new TEvDataShard::TEvGetTableStats(pathId.LocalPathId);
+    request->Record.SetCollectKeySample(collectKeySample);
+    PendingMessages.emplace_back(item.Ev->Sender, request);
 
     return true;
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- Add benchmark part count param
- Search for 10 histogram buckets instead of fixed resolution
- Measure TSpent for BuildStats
