### PR TITLE
metadata cache keeps merged issues

### DIFF
--- a/ydb/core/grpc_services/db_metadata_cache.h
+++ b/ydb/core/grpc_services/db_metadata_cache.h
@@ -60,6 +60,7 @@ private:
         auto request = std::make_unique<NHealthCheck::TEvSelfCheckRequest>();
         request->Database = Path;
         request->Request.set_return_verbose_status(true);
+        request->Request.set_merge_records(true);
         Send(NHealthCheck::MakeHealthCheckID(), request.release());
         Counters->GetCounter(HEALTHCHECK_REQUESTS_MADE_COUNTER, true)->Inc();
     }

--- a/ydb/core/grpc_services/rpc_monitoring.cpp
+++ b/ydb/core/grpc_services/rpc_monitoring.cpp
@@ -44,7 +44,7 @@ public:
     }
 
     void Bootstrap() {
-        if (GetProtoRequest()->do_not_cache() || !Request->GetDatabaseName()) {
+        if (GetProtoRequest()->do_not_cache() || !Request->GetDatabaseName() || !GetProtoRequest()->merge_records()) {
             SendHealthCheckRequest();
         } else {
             RegisterWithSameMailbox(CreateBoardLookupActor(MakeDatabaseMetadataCacheBoardPath(Request->GetDatabaseName().GetRef()),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- cache keeps merged issues
- `SelfCheckRPC` skips cache if `merge_records=false`

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
