### PR TITLE
Reset replication counters correctly to avoid data race on VDisk restart

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -48,6 +48,7 @@ namespace NKikimr::NStorage {
         vdisk.ScrubCookie = 0; // disable reception of Scrub messages from this disk
         vdisk.ScrubCookieForController = 0; // and from controller too
         vdisk.Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+        vdisk.ShutdownPending = true;
 
         SendDiskMetrics(false);
     }
@@ -67,6 +68,12 @@ namespace NKikimr::NStorage {
         }
 
         if (PDiskRestartInFlight.contains(vslotId.PDiskId)) {
+            return;
+        }
+
+        if (vdisk.ShutdownPending) {
+            vdisk.RestartAfterShutdown = true;
+            vdisk.YardInitDelay = Max(vdisk.YardInitDelay, yardInitDelay);
             return;
         }
 
@@ -206,8 +213,10 @@ namespace NKikimr::NStorage {
 
         // create an actor
         auto *as = TActivationContext::ActorSystem();
-        as->RegisterLocalService(vdiskServiceId, as->Register(CreateVDisk(vdiskConfig, groupInfo, AppData()->Counters),
-            TMailboxType::Revolving, AppData()->SystemPoolId));
+        TActorId actorId = as->Register(CreateVDisk(vdiskConfig, groupInfo, AppData()->Counters),
+            TMailboxType::Revolving, AppData()->SystemPoolId);
+        as->RegisterLocalService(vdiskServiceId, actorId);
+        VDiskIdByActor.try_emplace(actorId, vslotId);
 
         STLOG(PRI_DEBUG, BS_NODE, NW24, "StartLocalVDiskActor done", (VDiskId, vdisk.GetVDiskId()), (VSlotId, vslotId),
             (PDiskGuid, pdiskGuid));
@@ -231,6 +240,22 @@ namespace NKikimr::NStorage {
         vdisk.Status = NKikimrBlobStorage::EVDiskStatus::INIT_PENDING;
         vdisk.ReportedVDiskStatus.reset();
         vdisk.ScrubCookie = scrubCookie;
+    }
+
+    void TNodeWarden::HandleGone(STATEFN_SIG) {
+        if (const auto it = VDiskIdByActor.find(ev->Sender); it != VDiskIdByActor.end()) {
+            if (const auto jt = LocalVDisks.find(it->second); jt != LocalVDisks.end()) {
+                TVDiskRecord& vdisk = jt->second;
+                Y_ABORT_UNLESS(vdisk.ShutdownPending);
+                vdisk.ShutdownPending = false;
+                if (vdisk.RestartAfterShutdown) {
+                    StartLocalVDiskActor(vdisk, vdisk.YardInitDelay);
+                    vdisk.RestartAfterShutdown = false;
+                    vdisk.YardInitDelay = TDuration::Zero();
+                }
+            }
+            VDiskIdByActor.erase(it);
+        }
     }
 
     void TNodeWarden::ApplyServiceSetVDisks(const NKikimrBlobStorage::TNodeWardenServiceSet& serviceSet) {

--- a/ydb/core/blobstorage/ut_group/main.cpp
+++ b/ydb/core/blobstorage/ut_group/main.cpp
@@ -123,6 +123,7 @@ public:
         cFunc(TEvBlobStorage::EvDropDonor, Ignore);
         cFunc(TEvBlobStorage::EvGroupStatReport, Ignore);
         cFunc(TEvBlobStorage::EvNotifyVDiskGenerationChange, Ignore);
+        cFunc(TEvents::TSystem::Gone, Ignore);
 
         fFunc(TEvBlobStorage::EvPut, ForwardToProxy);
         fFunc(TEvBlobStorage::EvGet, ForwardToProxy);

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -2209,6 +2209,8 @@ namespace NKikimr {
 
         void PassAway() override {
             VDiskCountersBase->RemoveSubgroupChain(CountersChain);
+            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Gone, 0,
+                MakeBlobStorageNodeWardenID(SelfId().NodeId()), SelfId(), nullptr, 0));
             TActorBootstrapped::PassAway();
         }
     };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Reset replication counters correctly to avoid data race on VDisk restart

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Replication values are set correctly when VDisk is being terminated and restarted instantly.

#5568 