### PR TITLE
[yt provider] Add initial column group support

### DIFF
--- a/ydb/library/yql/providers/yt/common/yql_yt_settings.h
+++ b/ydb/library/yql/providers/yt/common/yql_yt_settings.h
@@ -64,6 +64,10 @@ enum class EInferSchemaMode {
     RPC        = 2ULL  /* "rpc" */,
 };
 
+enum class EColumnGroupMode {
+    Disable     /* "disable" */,
+    Single      /* "single" */
+};
 
 struct TYtSettings {
     using TConstPtr = std::shared_ptr<const TYtSettings>;
@@ -198,6 +202,7 @@ struct TYtSettings {
     NCommon::TConfSetting<TDuration, true> DQRPCReaderTimeout;
     NCommon::TConfSetting<TSet<TString>, true> BlockReaderSupportedTypes;
     NCommon::TConfSetting<TSet<NUdf::EDataSlot>, true> BlockReaderSupportedDataTypes;
+    NCommon::TConfSetting<EColumnGroupMode, true> ColumnGroupMode;
 
     // Optimizers
     NCommon::TConfSetting<bool, true> _EnableDq;

--- a/ydb/library/yql/providers/yt/gateway/native/yql_yt_native.cpp
+++ b/ydb/library/yql/providers/yt/gateway/native/yql_yt_native.cpp
@@ -1930,7 +1930,7 @@ private:
         }
 
         SortBy(rangeRes.Tables, [] (const TCanonizedPath& path) { return path.Path; });
-        
+
         return rangeRes;
     }
 
@@ -1996,7 +1996,7 @@ private:
         }
 
         SortBy(rangeRes.Tables, [] (const TCanonizedPath& path) { return path.Path; });
-        
+
         return rangeRes;
     }
 
@@ -5001,7 +5001,8 @@ private:
 
         if (createTable) {
             const auto nativeTypeCompat = execCtx->Options_.Config()->NativeYtTypeCompatibility.Get(cluster).GetOrElse(NTCF_LEGACY);
-            attrs["schema"] = RowSpecToYTSchema(out.Spec[YqlRowSpecAttribute], nativeTypeCompat).ToNode();
+            const bool useColumnGroups = execCtx->Options_.Config()->ColumnGroupMode.Get(cluster).GetOrElse(EColumnGroupMode::Disable) == EColumnGroupMode::Single;
+            attrs["schema"] = RowSpecToYTSchema(out.Spec[YqlRowSpecAttribute], nativeTypeCompat, useColumnGroups).ToNode();
         }
     }
 

--- a/ydb/library/yql/providers/yt/lib/schema/schema.cpp
+++ b/ydb/library/yql/providers/yt/lib/schema/schema.cpp
@@ -940,7 +940,9 @@ NYT::TNode RowSpecYqlTypeToYtNativeType(const NYT::TNode& rowSpecType, ui64 nati
     YQL_ENSURE(false, "Not supported type: " << (*type)[0].AsString());
 }
 
-NYT::TTableSchema RowSpecToYTSchema(const NYT::TNode& rowSpec, ui64 nativeTypeCompatibility) {
+NYT::TTableSchema RowSpecToYTSchema(const NYT::TNode& rowSpec, ui64 nativeTypeCompatibility, bool useColumnGroups) {
+    static TString DEFAULT_GROUP = "default";
+
     NYT::TTableSchema schema;
     const auto& rowSpecMap = rowSpec.AsMap();
 
@@ -992,6 +994,10 @@ NYT::TTableSchema RowSpecToYTSchema(const NYT::TNode& rowSpec, ui64 nativeTypeCo
             auto columnNode = NYT::TColumnSchema()
                 .Name(columnString);
 
+            if (useColumnGroups) {
+                columnNode.Group(DEFAULT_GROUP);
+            }
+
             bool auxField = false;
             if (useNativeTypes) {
                 auto ytType = RowSpecYqlTypeToYtNativeType(*sortedByType, nativeYtTypeFlags);
@@ -1014,19 +1020,21 @@ NYT::TTableSchema RowSpecToYTSchema(const NYT::TNode& rowSpec, ui64 nativeTypeCo
         if (keyColumns.contains(column)) {
             continue;
         }
+        auto columnNode = NYT::TColumnSchema().Name(column);
+        if (useColumnGroups) {
+            columnNode.Group(DEFAULT_GROUP);
+        }
         if (useNativeTypes) {
             auto field = fieldNativeTypes.find(column);
             YQL_ENSURE(field != fieldNativeTypes.end());
-            schema.AddColumn(NYT::TColumnSchema()
-                .Name(field->first)
-                .RawTypeV3(field->second));
+            columnNode.RawTypeV3(field->second);
+
         } else {
             auto field = fieldTypes.find(column);
             YQL_ENSURE(field != fieldTypes.end());
-            schema.AddColumn(NYT::TColumnSchema()
-                .Name(field->first)
-                .Type(field->second.first, /*required*/ field->second.second));
+            columnNode.Type(field->second.first, /*required*/ field->second.second);
         }
+        schema.AddColumn(std::move(columnNode));
     }
 
     // add fake column to avoid slow 0-columns YT schema

--- a/ydb/library/yql/providers/yt/lib/schema/schema.h
+++ b/ydb/library/yql/providers/yt/lib/schema/schema.h
@@ -7,6 +7,7 @@
 #include <library/cpp/yson/node/node.h>
 
 #include <util/generic/maybe.h>
+#include <util/generic/hash.h>
 #include <util/generic/vector.h>
 #include <util/generic/string.h>
 
@@ -28,7 +29,7 @@ NYT::TNode GetSchemaFromAttributes(const NYT::TNode& attributes, bool onlySystem
 TYTSortInfo KeyColumnsFromSchema(const NYT::TNode& schema);
 bool ValidateTableSchema(const TString& tableName, const NYT::TNode& attributes, bool ignoreYamrDsv, bool ignoreWeakSchema = false);
 void MergeInferredSchemeWithSort(NYT::TNode& schema, TYTSortInfo& sortInfo);
-NYT::TTableSchema RowSpecToYTSchema(const NYT::TNode& rowSpec, ui64 nativeTypeCompatibility);
+NYT::TTableSchema RowSpecToYTSchema(const NYT::TNode& rowSpec, ui64 nativeTypeCompatibility, bool useColumnGroups = false);
 NYT::TSortColumns ToYTSortColumns(const TVector<std::pair<TString, bool>>& sortColumns);
 TString GetTypeV3String(const TTypeAnnotationNode& type, ui64 nativeTypeCompatibility = NTCF_ALL);
 

--- a/ydb/library/yql/providers/yt/provider/yql_yt_op_hash.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_op_hash.cpp
@@ -173,6 +173,12 @@ TString TYtNodeHashCalculator::GetOutTableHash(const TExprNode& node, TArgIndex&
         if (auto replicationFactor = Configuration->TemporaryReplicationFactor.Get(Cluster)) {
             builder << *replicationFactor;
         }
+        if (auto optimizeFor = Configuration->OptimizeFor.Get(Cluster)) {
+            builder << *optimizeFor;
+        }
+        if (auto columnGroup = Configuration->ColumnGroupMode.Get(Cluster)) {
+            builder << *columnGroup;
+        }
     }
 
     return builder.Finish();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Initial column group support. When setting yt.ColumnGroupMode="single", all columns in temporary tables will be added to a single "default" column group.

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
