### PR TITLE
Bump workflows up to graph compare to run tests

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,6 +11,9 @@ inputs:
     required: false
     default: ""
     description: "extra compile flags will be added to the end of C_FLAGS and CXX_FLAGS"
+  ninja_target:
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -59,7 +62,7 @@ runs:
       export CCACHE_SLOPPINESS=locale
       export CCACHE_MAXSIZE=50G
       cd ../build
-      ninja
+      ninja ${{ inputs.ninja_target }}
       ccache -s
       df -h
   - name: report Build failed

--- a/.github/actions/build_and_test_ya/action.yml
+++ b/.github/actions/build_and_test_ya/action.yml
@@ -1,0 +1,117 @@
+name: Ya-Build-and-Test
+inputs:
+  build_target:
+    type: string
+    default: "ydb/"
+    description: "limit build and test to specific target"
+  build_preset:
+    type: string
+  run_build:
+    type: boolean
+    default: true
+    description: "run build"
+  run_tests:
+    type: boolean
+    default: true
+    description: "run tests"
+  test_threads:
+    type: string
+    default: 28
+    description: "Test threads count"
+  link_threads:
+    type: string
+    default: 8
+    description: "link threads count"
+  test_size:
+    type: string
+    default: "small,medium,large"
+  test_type:
+    type: string
+    default: "unittest,py3test,py2test,pytest"
+  folder_prefix:
+    type: string
+    default: "ya-"
+  cache_tests:
+    type: boolean
+    default: false
+    description: "Use cache for tests"
+  put_build_results_to_cache:
+    type: boolean
+    default: true
+  commit_sha:
+    type: string
+    default: ""
+  secs:
+    type: string
+    default: ""
+  vars:
+    type: string
+    default: ""
+defaults:
+  run:
+    shell: bash
+runs:
+  using: "composite"
+  steps:
+    - name: comment-build-start
+      if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+      shell: bash
+      env:
+        BUILD_PRESET: ${{ inputs.build_preset }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        jobs_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs"
+        # tricky: we are searching job with name that contains build_preset
+        check_url=$(curl -s $jobs_url | jq --arg n "$BUILD_PRESET" -r '.jobs[] | select(.name | contains($n)) | .html_url')
+        
+        echo "Pre-commit [check]($check_url) for ${{ inputs.commit_sha }} has started." | .github/scripts/tests/comment-pr.py --rewrite
+    
+    - name: Prepare s3cmd
+      uses: ./.github/actions/s3cmd
+      with:
+        s3_bucket: ${{ fromJSON( inputs.vars ).AWS_BUCKET }}
+        s3_endpoint: ${{ fromJSON( inputs.vars ).AWS_ENDPOINT }}
+        s3_key_id: ${{ fromJSON( inputs.secs ).AWS_KEY_ID }}
+        s3_key_secret: ${{ fromJSON( inputs.secs ).AWS_KEY_VALUE }}
+        folder_prefix: ya-
+        build_preset: ${{ inputs.build_preset }}
+
+    - name: Build
+      uses: ./.github/actions/build_ya
+      if: ${{ inputs.run_build == 'true' }}
+      with:
+        build_target: ${{ inputs.build_target }}
+        build_preset: ${{ inputs.build_preset }}
+        bazel_remote_uri: ${{  fromJSON( inputs.vars ).REMOTE_CACHE_URL || '' }}
+        bazel_remote_username: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_USERNAME || '' }}
+        bazel_remote_password: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
+        link_threads: ${{ inputs.link_threads }}
+
+    - name: debug1
+      shell: bash
+      run: echo "Run tests? ${{ inputs.run_tests }}"
+
+    - name: Run tests
+      uses: ./.github/actions/test_ya
+      if: ${{ inputs.run_tests == 'true' }}
+      with:
+        build_target: ${{ inputs.build_target }}
+        build_preset: ${{ inputs.build_preset }}
+        test_size: ${{ inputs.test_size }}
+        test_type: ${{ inputs.test_type }}
+        testman_token: ${{ fromJSON( inputs.secs ).TESTMO_TOKEN }}
+        testman_url: ${{  fromJSON( inputs.vars ).TESTMO_URL }}
+        testman_project_id: ${{  fromJSON( inputs.vars ).TESTMO_PROJECT_ID }}
+        bazel_remote_uri: ${{  fromJSON( inputs.vars ).REMOTE_CACHE_URL || '' }}
+        bazel_remote_username: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_USERNAME || '' }}
+        bazel_remote_password: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
+        link_threads: ${{ inputs.link_threads }}
+        test_threads: ${{ inputs.test_threads }}
+    
+    - name: comment-if-cancel
+      shell: bash
+      if: cancelled() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+      env:
+        BUILD_PRESET: ${{ inputs.build_preset }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run:  echo "Check cancelled" | .github/scripts/tests/comment-pr.py --color black

--- a/.github/actions/build_and_test_ya/action.yml
+++ b/.github/actions/build_and_test_ya/action.yml
@@ -31,19 +31,16 @@ inputs:
   test_type:
     type: string
     default: "unittest,py3test,py2test,pytest"
+  increment:
+    type: boolean
+    required: true
+    description: If true, compares build graphs between the current and previous commits to find a list of test suites to run. Otherwise, runs all tests.
   folder_prefix:
     type: string
     default: "ya-"
-  cache_tests:
-    type: boolean
-    default: false
-    description: "Use cache for tests"
   put_build_results_to_cache:
     type: boolean
     default: true
-  commit_sha:
-    type: string
-    default: ""
   secs:
     type: string
     default: ""
@@ -67,7 +64,7 @@ runs:
         # tricky: we are searching job with name that contains build_preset
         check_url=$(curl -s $jobs_url | jq --arg n "$BUILD_PRESET" -r '.jobs[] | select(.name | contains($n)) | .html_url')
         
-        echo "Pre-commit [check]($check_url) for ${{ inputs.commit_sha }} has started." | .github/scripts/tests/comment-pr.py --rewrite
+        echo "Pre-commit [check]($check_url) for $(git rev-parse HEAD) has started." | .github/scripts/tests/comment-pr.py --rewrite
     
     - name: Prepare s3cmd
       uses: ./.github/actions/s3cmd
@@ -91,24 +88,32 @@ runs:
         bazel_remote_password: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
         link_threads: ${{ inputs.link_threads }}
 
-    - name: debug1
+    - name: Generate ya.make with affected test suites list
+      if: inputs.run_tests == 'true' && inputs.increment == 'true'
+      uses: ./.github/actions/graph_compare
+ 
+    - name: Check if there's a list of tests to run
+      id: test_run_choice
       shell: bash
-      run: echo "Run tests? ${{ inputs.run_tests }}"
+      run: |
+        if [ -f ya.make ];then
+          echo "target='.'" >> $GITHUB_OUTPUT
+          echo "Listed test targets: "
+          cat ya.make
+        else
+          echo "target=${{ inputs.build_target }}" >> $GITHUB_OUTPUT
+        fi
 
     - name: Run tests
       uses: ./.github/actions/test_ya
       if: ${{ inputs.run_tests == 'true' &&  (steps.build.outputs.success == 'true' || inputs.run_tests_if_build_fails == 'true') }}
       with:
-        build_target: ${{ inputs.build_target }}
+        build_target: ${{ steps.test_run_choice.outputs.target }}
         build_preset: ${{ inputs.build_preset }}
         test_size: ${{ inputs.test_size }}
-        test_type: ${{ inputs.test_type }}
         testman_token: ${{ fromJSON( inputs.secs ).TESTMO_TOKEN }}
         testman_url: ${{  fromJSON( inputs.vars ).TESTMO_URL }}
         testman_project_id: ${{  fromJSON( inputs.vars ).TESTMO_PROJECT_ID }}
-        bazel_remote_uri: ${{  fromJSON( inputs.vars ).REMOTE_CACHE_URL || '' }}
-        bazel_remote_username: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_USERNAME || '' }}
-        bazel_remote_password: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
         link_threads: ${{ inputs.link_threads }}
         test_threads: ${{ inputs.test_threads }}
         

--- a/.github/actions/build_and_test_ya/action.yml
+++ b/.github/actions/build_and_test_ya/action.yml
@@ -14,6 +14,9 @@ inputs:
     type: boolean
     default: true
     description: "run tests"
+  run_tests_if_build_fails:
+    default: "true"
+    description: "run tests if build fails"
   test_threads:
     type: string
     default: 28
@@ -78,6 +81,7 @@ runs:
 
     - name: Build
       uses: ./.github/actions/build_ya
+      id: build
       if: ${{ inputs.run_build == 'true' }}
       with:
         build_target: ${{ inputs.build_target }}
@@ -93,7 +97,7 @@ runs:
 
     - name: Run tests
       uses: ./.github/actions/test_ya
-      if: ${{ inputs.run_tests == 'true' }}
+      if: ${{ inputs.run_tests == 'true' &&  (steps.build.outputs.success == 'true' || inputs.run_tests_if_build_fails == 'true') }}
       with:
         build_target: ${{ inputs.build_target }}
         build_preset: ${{ inputs.build_preset }}
@@ -107,6 +111,18 @@ runs:
         bazel_remote_password: ${{ inputs.put_build_results_to_cache &&  fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
         link_threads: ${{ inputs.link_threads }}
         test_threads: ${{ inputs.test_threads }}
+        
+    - name: Notify about failed build
+      if: ${{ steps.build.outputs.success != 'true' && inputs.run_tests == 'true' && inputs.run_tests_if_build_fails == 'false' }}
+      shell: bash
+      run: |
+        echo 'Build failed. See the [build log](${{ steps.build.outputs.log_url }}).' >> $GITHUB_STEP_SUMMARY
+        
+        if [[ "$GITHUB_EVENT_NAME" =~ ^pull_request ]]; then
+          echo "Tests run skipped." | .github/scripts/tests/comment-pr.py --fail
+        fi
+        
+        exit 1
     
     - name: comment-if-cancel
       shell: bash

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -70,7 +70,7 @@ runs:
           release)
             build_type=release
             ;;
-          release-cmake14)
+          release-clang14)
             build_type=release
             extra_params+=(--target-platform="CLANG14-LINUX-X86_64")
             extra_params+=(-DLLD_VERSION=16)

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -7,7 +7,7 @@ inputs:
   build_preset:
     required: true
     default: "relwithdebinfo"
-    description: "relwithdebinfo, release-asan, release-tsan"
+    description: "debug, relwithdebinfo, release-asan, release-tsan, release, release-cmake14"
   bazel_remote_uri:
     required: false
     description: "bazel-remote endpoint"
@@ -66,6 +66,14 @@ runs:
             ;;
           relwithdebinfo)
             build_type=relwithdebinfo
+            ;;
+          release)
+            build_type=release
+            ;;
+          release-cmake14)
+            build_type=release
+            extra_params+=(--target-platform="CLANG14-LINUX-X86_64")
+            extra_params+=(-DLLD_VERSION=16)
             ;;
           release-asan)
             build_type=release

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -21,7 +21,13 @@ inputs:
     required: false
     default: "8"
     description: "link threads count"
-
+outputs:
+  success:
+    value: ${{ steps.build.outputs.status }}
+    description: "build success"
+  log_url:
+    value: ${{ steps.init.outputs.log_url }}
+    description: "build log url"
 runs:
   using: "composite"
   steps:
@@ -34,10 +40,15 @@ runs:
         echo "SHELLOPTS=xtrace" >> $GITHUB_ENV
         export TMP_DIR=$(pwd)/tmp_build
         echo "TMP_DIR=$TMP_DIR" >> $GITHUB_ENV
+        
+        export log_url="$S3_URL_PREFIX/build_logs/ya_make.log"
+        
         rm -rf $TMP_DIR && mkdir $TMP_DIR
         
         echo "BUILD_PRESET=$build_preset" >> $GITHUB_ENV
         echo "GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV
+        echo "LOG_URL=$log_url" >> $GITHUB_ENV
+        echo "log_url=$log_url" >> $GITHUB_OUTPUT
 
     - name: build
       id: build
@@ -107,7 +118,7 @@ runs:
         ./ya make -k --build "${build_type}" --force-build-depends -D'BUILD_LANGUAGES=CPP PY3 PY2 GO' -T --stat -DCONSISTENT_DEBUG \
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \
-          "${extra_params[@]}" |& tee $TMP_DIR/ya_make.log || (
+          "${extra_params[@]}" |& tee $TMP_DIR/ya_make.log && echo "status=true" >> $GITHUB_OUTPUT || (
               RC=$?
               echo "::debug::ya make RC=$RC"
               echo "status=failed" >> $GITHUB_OUTPUT
@@ -126,10 +137,8 @@ runs:
       if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
       shell: bash
       run: |
-        log_url="$S3_URL_PREFIX/build_logs/ya_make.log"
-
         if [ "${{ steps.build.outputs.status }}" == "failed" ]; then
-          echo "Build failed. see the [build logs]($log_url)." | .github/scripts/tests/comment-pr.py --fail
+          echo "Build failed. see the [build logs]($LOG_URL)." | .github/scripts/tests/comment-pr.py --fail
         else
           echo "Build successful." | .github/scripts/tests/comment-pr.py --ok
         fi

--- a/.github/actions/graph_compare/action.yml
+++ b/.github/actions/graph_compare/action.yml
@@ -1,0 +1,18 @@
+name: graph_compare
+description: Compare graphs between current and previous commits (merge commit base in case of a merge commit), and list affected tests in ya.make
+runs:
+  using: "composite"
+  steps:
+    - name: original_ref
+      id: oref
+      shell: bash
+      run: |
+        echo "value=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+    - name: generate_ya_make
+      shell: bash
+      run: |
+        ./.github/scripts/graph_compare.sh ${{ steps.oref.outputs.value }}~1 ${{ steps.oref.outputs.value }}
+    - name: restore_ref
+      shell: bash
+      run: |
+        git checkout ${{ steps.oref.outputs.value }}

--- a/.github/actions/s3cmd/action.yml
+++ b/.github/actions/s3cmd/action.yml
@@ -54,9 +54,10 @@ runs:
             exit 1
             ;;
         esac
-
         echo "S3_BUCKET_PATH=s3://${{ inputs.s3_bucket }}/${{ github.repository }}/${{github.workflow}}/${{ github.run_id }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
         echo "S3_URL_PREFIX=${{ inputs.s3_endpoint }}/${{ inputs.s3_bucket }}/${{ github.repository }}/${{ github.workflow }}/${{ github.run_id }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
+        echo "S3_TEST_ARTIFACTS_BUCKET_PATH=s3://${{ inputs.s3_bucket }}/testing_out_stuff/${{ github.repository }}/${{github.workflow}}/${{ github.run_id }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
+        echo "S3_TEST_ARTIFACTS_URL_PREFIX=${{ inputs.s3_endpoint }}/${{ inputs.s3_bucket }}/testing_out_stuff/${{ github.repository }}/${{ github.workflow }}/${{ github.run_id }}/${{ inputs.folder_prefix }}${folder}" >> $GITHUB_ENV
       env:
         s3_key_id: ${{ inputs.s3_key_id }}
         s3_secret_access_key: ${{ inputs.s3_key_secret }}

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -1,34 +1,24 @@
 name: Run tests (ya make)
-description: Run tests using ya make
+description: Run test targets listed in repository root ya.make (to be created previously)
 inputs:
   build_target:
-    required: false
-    description: "build target"
-
+    required: true
   build_preset:
     required: true
     default: "relwithdebinfo"
     description: "relwithdebinfo, release-asan, release-tsan"
-  
   test_size:
     required: false
     default: "small,medium,large"
     description: "small or small-medium or all"
-  
-  test_type:
-    required: false
-    default: "unittest,py3test,py2test,pytest"
-    description: "run "
-  
   test_threads:
     required: false
-    default: "28"
+    default: "56"
     description: "Test threads count"
   link_threads:
     required: false
-    default: "8"
+    default: "12"
     description: "link threads count"
-
   testman_token:
     required: false
     description: "test manager auth token"
@@ -38,15 +28,6 @@ inputs:
   testman_project_id:
     required: false
     description: "test manager project id"
-  bazel_remote_uri:
-    required: false
-    description: "bazel-remote endpoint"
-  bazel_remote_username:
-    required: false
-    description: "bazel-remote username"
-  bazel_remote_password:
-    required: false
-    description: "bazel-remote password"
 runs:
   using: "composite"
   steps:
@@ -161,13 +142,12 @@ runs:
       shell: bash
       run: |
         readarray -d ',' -t test_size < <(printf "%s" "${{ inputs.test_size }}")
-        readarray -d ',' -t test_type < <(printf "%s" "${{ inputs.test_type }}")
 
         params=(
-          -T -k -D'BUILD_LANGUAGES=CPP PY3 PY2 GO'
-          ${test_size[@]/#/--test-size=} ${test_type[@]/#/--test-type=}
+          -T -k
+          ${test_size[@]/#/--test-size=}
           --cache-size 512G --do-not-output-stderrs
-          --stat --canonization-backend=ydb-canondata.storage.yandexcloud.net
+          --stat
           --test-threads "${{ inputs.test_threads }}" --link-threads "${{ inputs.link_threads }}"
         )
         
@@ -203,36 +183,14 @@ runs:
             ;;
         esac
         
-        if [ ! -z "${{ inputs.build_target }}" ]; then
-          params+=(--target="${{ inputs.build_target }}")
-        fi
-
-        if [ ! -z "${{ inputs.bazel_remote_uri }}" ]; then
-          params+=(--bazel-remote-store)
-          params+=(--bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
-        fi
-        
         echo "::debug::get version"
         ./ya --version
         
         echo "Tests are running..." | .github/scripts/tests/comment-pr.py
-        
-        if [ ! -z "${{ inputs.bazel_remote_username }}" ]; then
-          echo "::debug::start tests"
 
-          ./ya test "${params[@]}" \
-            --bazel-remote-put --bazel-remote-username "${{ inputs.bazel_remote_username }}" --bazel-remote-password "${{ inputs.bazel_remote_password }}" -DCONSISTENT_DEBUG \
-            --log-file "$LOG_DIR/ya_log_prewarm.txt" --evlog-file "$LOG_DIR/ya_evlog_prewarm.jsonl" \
-            --dist-cache-evict-bins --cache-tests --no-dir-outputs --test-node-output-limit 1000000 --drop-graph-result-before-tests || (
-              RC=$?
-              echo "::debug::ya test RC=$RC"
-            )
-        fi
-        
-        echo "::debug::save tests reports"
-        ./ya test "${params[@]}" \
+        ./ya test ${{ inputs.build_target }} "${params[@]}" \
           --stat --log-file "$LOG_DIR/ya_log.txt" --evlog-file "$LOG_DIR/ya_evlog.jsonl" -DCONSISTENT_DEBUG \
-          --cache-tests --dist-cache-evict-bins --no-dir-outputs --test-node-output-limit 1000000 --drop-graph-result-before-tests \
+          --no-dir-outputs \
           --junit "$JUNIT_REPORT_XML" --output "$OUT_DIR" || (
             RC=$?
             if [ $RC -ne 0 ]; then

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -60,6 +60,7 @@ runs:
         echo "LOG_DIR=$TMP_DIR/logs" >> $GITHUB_ENV
         echo "OUT_DIR=$TMP_DIR/out" >> $GITHUB_ENV
         echo "ARTIFACTS_DIR=$TMP_DIR/artifacts" >> $GITHUB_ENV
+        echo "TEST_ARTIFACTS_DIR=$TMP_DIR/test_artifacts" >> $GITHUB_ENV
         echo "REPORTS_ARTIFACTS_DIR=$TMP_DIR/artifacts/test_reports" >> $GITHUB_ENV
         echo "JUNIT_REPORT_XML=$TMP_DIR/junit.xml" >> $GITHUB_ENV
         echo "JUNIT_REPORT_PARTS=$TMP_DIR/junit-split" >> $GITHUB_ENV
@@ -73,7 +74,7 @@ runs:
       shell: bash
       run: |
         rm -rf $TMP_DIR $JUNIT_REPORT_XML $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR
-        mkdir -p $TMP_DIR $OUT_DIR $ARTIFACTS_DIR $LOG_DIR $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR
+        mkdir -p $TMP_DIR $OUT_DIR $ARTIFACTS_DIR $TEST_ARTIFACTS_DIR $LOG_DIR $JUNIT_REPORT_PARTS $REPORTS_ARTIFACTS_DIR
     
     - name: Install Node required for Testmo CLI
       uses: actions/setup-node@v3
@@ -222,7 +223,7 @@ runs:
           ./ya test "${params[@]}" \
             --bazel-remote-put --bazel-remote-username "${{ inputs.bazel_remote_username }}" --bazel-remote-password "${{ inputs.bazel_remote_password }}" -DCONSISTENT_DEBUG \
             --log-file "$LOG_DIR/ya_log_prewarm.txt" --evlog-file "$LOG_DIR/ya_evlog_prewarm.jsonl" \
-            --dist-cache-evict-bins --cache-tests --no-dir-outputs --test-node-output-limit 100000 --drop-graph-result-before-tests || (
+            --dist-cache-evict-bins --cache-tests --no-dir-outputs --test-node-output-limit 1000000 --drop-graph-result-before-tests || (
               RC=$?
               echo "::debug::ya test RC=$RC"
             )
@@ -231,7 +232,7 @@ runs:
         echo "::debug::save tests reports"
         ./ya test "${params[@]}" \
           --stat --log-file "$LOG_DIR/ya_log.txt" --evlog-file "$LOG_DIR/ya_evlog.jsonl" -DCONSISTENT_DEBUG \
-          --cache-tests --dist-cache-evict-bins --no-dir-outputs --test-node-output-limit 100000 --drop-graph-result-before-tests \
+          --cache-tests --dist-cache-evict-bins --no-dir-outputs --test-node-output-limit 1000000 --drop-graph-result-before-tests \
           --junit "$JUNIT_REPORT_XML" --output "$OUT_DIR" || (
             RC=$?
             if [ $RC -ne 0 ]; then
@@ -259,7 +260,8 @@ runs:
           -m .github/config/muted_ya.txt \
           --ya-out "$OUT_DIR" \
           --log-url-prefix "$S3_URL_PREFIX/logs/" \
-          --log-out-dir "$ARTIFACTS_DIR/logs/" \
+          --test-stuff-out "$TEST_ARTIFACTS_DIR/" \
+          --test-stuff-prefix "$S3_TEST_ARTIFACTS_URL_PREFIX/" \
           "$JUNIT_REPORT_XML"
     
         .github/scripts/tests/split-junit.py -o "$JUNIT_REPORT_PARTS" "$JUNIT_REPORT_XML"
@@ -321,6 +323,7 @@ runs:
       run: |
         echo "::group::s3-sync"
         s3cmd sync -r --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$ARTIFACTS_DIR/" "$S3_BUCKET_PATH/"
+        s3cmd sync -r --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$TEST_ARTIFACTS_DIR/" "$S3_TEST_ARTIFACTS_BUCKET_PATH/"
         echo "::endgroup::"
     
     - name: sync logs results to s3

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -260,6 +260,7 @@ runs:
           -m .github/config/muted_ya.txt \
           --ya-out "$OUT_DIR" \
           --log-url-prefix "$S3_URL_PREFIX/logs/" \
+          --log-out-dir "$ARTIFACTS_DIR/logs/" \
           --test-stuff-out "$TEST_ARTIFACTS_DIR/" \
           --test-stuff-prefix "$S3_TEST_ARTIFACTS_URL_PREFIX/" \
           "$JUNIT_REPORT_XML"

--- a/.github/scripts/graph_compare.sh
+++ b/.github/scripts/graph_compare.sh
@@ -1,0 +1,40 @@
+
+# Compares build graphs for two given refs in the current directory git repo
+# Creates ya.make in the current directory listing affected ydb test suites
+# Parameters: base_commit_sha head_commit_sha
+
+set -e
+
+workdir=$(mktemp -d)
+echo Workdir: $workdir
+echo Checkout base commit...
+git checkout $1
+echo Build graph for base commit...
+./ya make -Gj0 -ttt ydb --build release -k --cache-tests | jq '.graph[] | select( ."node-type"=="test")' > $workdir/graph_base
+
+echo Checkout head commit...
+git checkout $2
+echo Build graph for head commit...
+./ya make -Gj0 -ttt ydb --build release -k --cache-tests | jq '.graph[] | select( ."node-type"=="test")' > $workdir/graph_head
+
+echo Generate lists of uids for base and head...
+cat $workdir/graph_base | jq '.uid' > $workdir/uid_base
+cat $workdir/graph_head | jq '.uid' > $workdir/uid_head
+
+echo Create a list of changed uids in the head graph...
+(cat $workdir/uid_head;(cat $workdir/uid_base;cat $workdir/uid_head) | sort | uniq -u) | sort | uniq -d > $workdir/uids_new
+
+echo Generate list of test shard names from the head graph based on the list of uids...
+cat $workdir/graph_head | jq -r --slurpfile uids $workdir/uids_new 'select( any( .uid; .==$uids[] )) | .kv.path' | sort | uniq > $workdir/testsuites
+
+echo Number of test suites:
+cat $workdir/testsuites | wc -l
+
+echo Removing test suite name from the list to get target names...
+sed -E 's/\/[^/]*$//g;/^null$/d' $workdir/testsuites > $workdir/ts2
+
+echo Generating temp ya.make with recurses to all required tests...
+cat $workdir/ts2 | (echo 'RECURSE_FOR_TESTS(';cat;echo ')') > ya.make
+
+# echo Running ya test...
+# ./ya make -A -R --build relwithdebinfo .

--- a/.github/workflows/build_and_test_provisioned.yml
+++ b/.github/workflows/build_and_test_provisioned.yml
@@ -24,6 +24,9 @@ on:
       extra_compile_flags:
         required: false
         type: string
+      checkout_ref:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       runner_label:
@@ -47,6 +50,9 @@ on:
       extra_compile_flags:
         required: false
         type: string
+      checkout_ref:
+        required: false
+        type: string
 
 jobs:
   main:
@@ -56,7 +62,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        ref: cmakebuild
+        ref: ${{ inputs.checkout_ref }}
     - name: Build
       uses: ./.github/actions/build
       if: inputs.run_build

--- a/.github/workflows/build_and_test_provisioned.yml
+++ b/.github/workflows/build_and_test_provisioned.yml
@@ -27,6 +27,9 @@ on:
       checkout_ref:
         required: false
         type: string
+      ninja_target:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       runner_label:
@@ -53,6 +56,9 @@ on:
       checkout_ref:
         required: false
         type: string
+      ninja_target:
+        required: false
+        type: string
 
 jobs:
   main:
@@ -70,6 +76,7 @@ jobs:
         sanitizer: ${{ inputs.sanitizer }}
         ccache_remote_path: ${{ vars.REMOTE_CACHE_URL && format('http://{0}{1}', secrets.REMOTE_CACHE_AUTH, vars.REMOTE_CACHE_URL) || ''}}
         extra_compile_flags: ${{ inputs.extra_compile_flags }}
+        ninja_target: ${{ inputs.ninja_target }}
     - name: Run tests
       uses: ./.github/actions/test
       with:

--- a/.github/workflows/build_and_test_ya.yml
+++ b/.github/workflows/build_and_test_ya.yml
@@ -27,11 +27,11 @@ on:
         description: "run tests"
       test_threads:
         type: string
-        default: 28
+        default: 56
         description: "Test threads count"
       link_threads:
         type: string
-        default: 8
+        default: 12
         description: "link threads count"
       test_size:
         type: string
@@ -65,60 +65,18 @@ jobs:
       with:
         ref: ${{ inputs.commit_sha }}
 
-    - name: comment-build-start
-      if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-      shell: bash
-      env:
-        BUILD_PRESET: ${{ inputs.build_preset }}
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        jobs_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs"
-        # tricky: we are searching job with name that contains build_preset
-        check_url=$(curl -s $jobs_url | jq --arg n "$BUILD_PRESET" -r '.jobs[] | select(.name | contains($n)) | .html_url')
-        
-        echo "Pre-commit [check]($check_url) for ${{ inputs.commit_sha }} has started." | .github/scripts/tests/comment-pr.py --rewrite
-    
-    - name: Prepare s3cmd
-      uses: ./.github/actions/s3cmd
+    - name: Build and test
+      uses: ./.github/actions/build_and_test_ya
       with:
-        s3_bucket: ${{ vars.AWS_BUCKET }}
-        s3_endpoint: ${{ vars.AWS_ENDPOINT }}
-        s3_key_id: ${{ secrets.AWS_KEY_ID }}
-        s3_key_secret: ${{ secrets.AWS_KEY_VALUE }}
-        folder_prefix: ya-
         build_preset: ${{ inputs.build_preset }}
-
-    - name: Build
-      uses: ./.github/actions/build_ya
-      if: inputs.run_build
-      with:
         build_target: ${{ inputs.build_target }}
-        build_preset: ${{ inputs.build_preset }}
-        bazel_remote_uri: ${{ vars.REMOTE_CACHE_URL_YA || '' }}
-        bazel_remote_username: ${{ inputs.put_build_results_to_cache && secrets.REMOTE_CACHE_USERNAME || '' }}
-        bazel_remote_password: ${{ inputs.put_build_results_to_cache && secrets.REMOTE_CACHE_PASSWORD || '' }}
-        link_threads: ${{ inputs.link_threads }}
-
-    - name: Run tests
-      uses: ./.github/actions/test_ya
-      if: inputs.run_tests
-      with:
-        build_target: ${{ inputs.build_target }}
-        build_preset: ${{ inputs.build_preset }}
+        increment: false
+        run_tests: ${{ inputs.run_tests }}
         test_size: ${{ inputs.test_size }}
         test_type: ${{ inputs.test_type }}
-        testman_token: ${{ secrets.TESTMO_TOKEN }}
-        testman_url: ${{ vars.TESTMO_URL }}
-        testman_project_id: ${{ vars.TESTMO_PROJECT_ID }}
-        bazel_remote_uri: ${{ vars.REMOTE_CACHE_URL_YA || '' }}
-        bazel_remote_username: ${{ inputs.put_build_results_to_cache && secrets.REMOTE_CACHE_USERNAME || '' }}
-        bazel_remote_password: ${{ inputs.put_build_results_to_cache && secrets.REMOTE_CACHE_PASSWORD || '' }}
-        link_threads: ${{ inputs.link_threads }}
         test_threads: ${{ inputs.test_threads }}
-    
-    - name: comment-if-cancel
-      if: cancelled() && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
-      env:
-        BUILD_PRESET: ${{ inputs.build_preset }}
-        GITHUB_TOKEN: ${{ github.token }}
-      run:  echo "Check cancelled" | .github/scripts/tests/comment-pr.py --color black
+        put_build_results_to_cache: ${{ inputs.put_build_results_to_cache }}
+        secs: ${{ format('{{"TESTMO_TOKEN":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}', 
+          secrets.TESTMO_TOKEN, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
+        vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',
+          vars.AWS_BUCKET, vars.AWS_ENDPOINT, vars.REMOTE_CACHE_URL_YA, vars.TESTMO_URL, vars.TESTMO_PROJECT_ID ) }}

--- a/.github/workflows/build_and_test_ya_provisioned.yml
+++ b/.github/workflows/build_and_test_ya_provisioned.yml
@@ -45,11 +45,11 @@ on:
         description: "run tests"
       test_threads:
         type: string
-        default: "28"
+        default: "56"
         description: "Test threads count"
       link_threads:
         type: string
-        default: "8"
+        default: "12"
         description: "link threads count"
       runner_label:
         type: string
@@ -80,11 +80,11 @@ on:
         default: true
       test_threads:
         type: string
-        default: 28
+        default: 56
         description: "Test threads count"
       link_threads:
         type: string
-        default: 8
+        default: 12
         description: "link threads count"
       runner_label:
         type: string

--- a/.github/workflows/build_and_test_ya_provisioned.yml
+++ b/.github/workflows/build_and_test_ya_provisioned.yml
@@ -101,8 +101,7 @@ jobs:
     with:
       # FIXME: always use auto-provisioned here?
       runner_label: ${{ inputs.runner_label }}
-      # naive check for -asan, -tsan, -msan
-      runner_additional_label: ${{ contains(inputs.build_preset, '-') && format('build-preset-{0}', inputs.build_preset) || '' }}
+      runner_additional_label: ${{ format('build-preset-{0}', inputs.build_preset) }}
       build_target: ${{ inputs.build_target }}
       build_preset: ${{ inputs.build_preset }}
       run_build: ${{ inputs.run_build }}

--- a/.github/workflows/build_and_test_ya_provisioned.yml
+++ b/.github/workflows/build_and_test_ya_provisioned.yml
@@ -13,10 +13,12 @@ on:
         description: "Build preset"
         options:
           - debug
+          - release
           - relwithdebinfo
           - release-asan
           - release-tsan
           - release-msan
+          - release-cmake14
       test_size:
         type: choice
         default: "small,medium,large"

--- a/.github/workflows/libs_create_pr.yml
+++ b/.github/workflows/libs_create_pr.yml
@@ -1,0 +1,61 @@
+name: Create PR to import libraries to main
+on:
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+env:
+  REPO: ${{ github.repository }}
+  TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=dtm::$(date +'%y%m%d-%H%M')"
+    - name: Sync
+      run: |
+        currsha=$(curl -s -H "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/$REPO/commits/rightlib)
+        echo "Current rightlib sha: ${currsha}"
+        lastsha=$(curl -s https://raw.githubusercontent.com/$REPO/main/ydb/ci/rightlib.txt)
+        echo "Last imported rightlib sha: ${lastsha}"
+        if [ "${currsha}" == "${lastsha}" ];then
+          echo "No new commits on the rightlib branch to merge, exiting"
+          exit 0
+        fi
+        echo "Git clone..."
+        git clone https://$TOKEN@github.com/$REPO.git ydb
+        git config --global user.email "alex@ydb.tech"
+        git config --global user.name "Alexander Smirnov"
+        cd ydb
+        # git fetch --depth `expr $(git rev-list --count HEAD) + 1`
+        # echo "Commits in rightlib: $(git rev-list --count HEAD)"
+        # echo "Fetch main..."
+        # git fetch origin main:main --shallow-exclude rightlib 
+        # git fetch --depth `expr $(git rev-list --count main) + 1`
+        # echo "Commits in main: $(git rev-list --count main)"
+        git checkout rightlib
+        libsha=$(git rev-parse HEAD)
+        echo "Libs sha: $libsha"
+        echo "Dev branch..."
+        git checkout main
+        devbranch="mergelibs-${{ steps.date.outputs.dtm }}"
+        git checkout -b ${devbranch}
+        prevsha=$(git rev-parse HEAD)
+        git merge rightlib --no-edit
+        currsha=$(git rev-parse HEAD)
+        if [ ${prevsha} == ${currsha} ];then
+          echo "Merge did not bring any changes, exiting"
+          exit
+        fi
+        echo ${mainsha} > ydb/ci/rightlib.txt
+        git add .
+        git commit -m "Import libraries ${{ steps.date.outputs.dtm }}"
+        git push --set-upstream origin mergelibs-${{ steps.date.outputs.dtm }}
+        curl -L -X POST --fail-with-body \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $TOKEN" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/$REPO/pulls \
+          -d '{"title":"Library import ${{ steps.date.outputs.dtm }}","body":"","head":"'${devbranch}'","base":"main"}'

--- a/.github/workflows/libs_create_pr.yml
+++ b/.github/workflows/libs_create_pr.yml
@@ -49,7 +49,7 @@ jobs:
           echo "Merge did not bring any changes, exiting"
           exit
         fi
-        echo ${mainsha} > ydb/ci/rightlib.txt
+        echo ${libsha} > ydb/ci/rightlib.txt
         git add .
         git commit -m "Import libraries ${{ steps.date.outputs.dtm }}"
         git push --set-upstream origin mergelibs-${{ steps.date.outputs.dtm }}

--- a/.github/workflows/postcommit_asan.yml
+++ b/.github/workflows/postcommit_asan.yml
@@ -13,14 +13,25 @@ on:
 jobs:
   build_and_test:
     if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).postcommit_asan == true}}
+    runs-on: [ self-hosted, auto-provisioned, build-preset-release-asan ]
     name: Build and test release-asan
-    uses: ./.github/workflows/build_and_test_ya_provisioned.yml
-    with:
-      build_preset: "release-asan"
-      build_target: "ydb/"
-      test_size: "small,medium"
-      test_type: "unittest,py3test,py2test,pytest"
-      test_threads: 52
-      runner_label: auto-provisioned
-      put_build_results_to_cache: true
-    secrets: inherit
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Build and test
+      uses: ./.github/actions/build_and_test_ya
+      with:
+        build_preset: "release-asan"
+        build_target: "ydb/"
+        increment: true
+        run_tests: true
+        test_size: "small,medium"
+        test_type: "unittest,py3test,py2test,pytest"
+        test_threads: 52
+        put_build_results_to_cache: true
+        secs: ${{ format('{{"TESTMO_TOKEN":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}', 
+          secrets.TESTMO_TOKEN, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
+        vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',
+          vars.AWS_BUCKET, vars.AWS_ENDPOINT, vars.REMOTE_CACHE_URL_YA, vars.TESTMO_URL, vars.TESTMO_PROJECT_ID ) }}

--- a/.github/workflows/postcommit_asan.yml
+++ b/.github/workflows/postcommit_asan.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+      - 'stream-nb-*'
     paths-ignore:
       - 'ydb/docs/**'
       - '.github/**'

--- a/.github/workflows/postcommit_cmakebuild.yml
+++ b/.github/workflows/postcommit_cmakebuild.yml
@@ -1,0 +1,22 @@
+name: Postcommit_cmake
+on: 
+  push:
+    branches:
+      - 'cmakebuild'
+    paths-ignore:
+      - 'ydb/docs/**'
+      - '.github/**'
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  build_and_test:
+    if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).postcommit_cmake == true}}
+    name: Build and test cmake
+    uses: ./.github/workflows/build_and_test_provisioned.yml
+    with:
+      runner_label: auto-provisioned
+      run_unit_tests: false
+      run_functional_tests: false
+    secrets: inherit
+

--- a/.github/workflows/postcommit_cmakebuild.yml
+++ b/.github/workflows/postcommit_cmakebuild.yml
@@ -3,12 +3,8 @@ on:
   push:
     branches:
       - 'cmakebuild'
-    paths-ignore:
-      - 'ydb/docs/**'
-      - '.github/**'
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+    paths:
+      - 'ydb/ci/cmakegen.txt'
 jobs:
   build_and_test:
     if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).postcommit_cmake == true}}

--- a/.github/workflows/postcommit_relwithdebinfo.yml
+++ b/.github/workflows/postcommit_relwithdebinfo.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+      - 'stream-nb-*'
     paths-ignore:
       - 'ydb/docs/**'
       - '.github/**'

--- a/.github/workflows/postcommit_relwithdebinfo.yml
+++ b/.github/workflows/postcommit_relwithdebinfo.yml
@@ -12,14 +12,25 @@ on:
 jobs:
   build_and_test:
     if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).postcommit_relwithdebinfo == true}}
+    runs-on: [ self-hosted, auto-provisioned, build-preset-relwithdebinfo ]
     name: Build and test relwithdebinfo
-    uses: ./.github/workflows/build_and_test_ya_provisioned.yml
-    with:
-      build_preset: "relwithdebinfo"
-      build_target: "ydb/"
-      test_size: "small,medium"
-      test_type: "unittest,py3test,py2test,pytest"
-      test_threads: 52
-      runner_label: auto-provisioned
-      put_build_results_to_cache: true
-    secrets: inherit
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Build and test
+      uses: ./.github/actions/build_and_test_ya
+      with:
+        build_preset: relwithdebinfo
+        build_target: "ydb/"
+        increment: true
+        run_tests: true
+        test_size: "small,medium"
+        test_type: "unittest,py3test,py2test,pytest"
+        test_threads: 52
+        put_build_results_to_cache: true
+        secs: ${{ format('{{"TESTMO_TOKEN":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}', 
+          secrets.TESTMO_TOKEN, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
+        vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',
+          vars.AWS_BUCKET, vars.AWS_ENDPOINT, vars.REMOTE_CACHE_URL_YA, vars.TESTMO_URL, vars.TESTMO_PROJECT_ID ) }}

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -214,6 +214,7 @@ jobs:
         test_type: "unittest,py3test,py2test,pytest"
         test_threads: 52
         put_build_results_to_cache: true
+        run_tests_if_build_fails: false
         commit_sha: ${{ needs.check-running-allowed.outputs.commit_sha }}
         secs: ${{ format('{{"TESTMO_TOKEN":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}', 
           secrets.TESTMO_TOKEN, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -199,3 +199,21 @@ jobs:
       put_build_results_to_cache: true
       commit_sha: ${{ needs.check-running-allowed.outputs.commit_sha }}
     secrets: inherit
+  build:
+    needs:
+      - check-running-allowed
+    if: needs.check-running-allowed.outputs.result == 'true' && needs.check-running-allowed.outputs.commit_sha != ''
+    strategy:
+      fail-fast: false
+      matrix:
+        build_preset: ["release-cmake14"]
+    name: Build and test ${{ matrix.build_preset }}
+    uses: ./.github/workflows/build_and_test_ya_provisioned.yml
+    with:
+      build_preset: ${{ matrix.build_preset }}
+      build_target: "ydb/"
+      run_tests: false
+      runner_label: auto-provisioned
+      put_build_results_to_cache: true
+      commit_sha: ${{ needs.check-running-allowed.outputs.commit_sha }}
+    secrets: inherit

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -204,18 +204,19 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ needs.check-running-allowed.outputs.commit_sha }}
+        fetch-depth: 2
     - name: Build and test
       uses: ./.github/actions/build_and_test_ya
       with:
         build_preset: ${{ matrix.build_preset }}
         build_target: "ydb/"
+        increment: true
         run_tests: ${{ contains(fromJSON('["relwithdebinfo", "release-asan"]'), matrix.build_preset) }}
         test_size: "small,medium"
         test_type: "unittest,py3test,py2test,pytest"
         test_threads: 52
         put_build_results_to_cache: true
         run_tests_if_build_fails: false
-        commit_sha: ${{ needs.check-running-allowed.outputs.commit_sha }}
         secs: ${{ format('{{"TESTMO_TOKEN":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}', 
           secrets.TESTMO_TOKEN, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
         vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -196,34 +196,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_preset: ["relwithdebinfo", "release-asan"]
+        build_preset: ["relwithdebinfo", "release-asan", "release-clang14"]
+    runs-on: [ self-hosted, auto-provisioned, "${{ format('build-preset-{0}', matrix.build_preset) }}" ]
     name: Build and test ${{ matrix.build_preset }}
-    uses: ./.github/workflows/build_and_test_ya_provisioned.yml
-    with:
-      build_preset: ${{ matrix.build_preset }}
-      build_target: "ydb/"
-      test_size: "small,medium"
-      test_type: "unittest,py3test,py2test,pytest"
-      test_threads: 52
-      runner_label: auto-provisioned
-      put_build_results_to_cache: true
-      commit_sha: ${{ needs.check-running-allowed.outputs.commit_sha }}
-    secrets: inherit
-  build:
-    needs:
-      - check-running-allowed
-    if: needs.check-running-allowed.outputs.result == 'true' && needs.check-running-allowed.outputs.commit_sha != ''
-    strategy:
-      fail-fast: false
-      matrix:
-        build_preset: ["release-cmake14"]
-    name: Build and test ${{ matrix.build_preset }}
-    uses: ./.github/workflows/build_and_test_ya_provisioned.yml
-    with:
-      build_preset: ${{ matrix.build_preset }}
-      build_target: "ydb/"
-      run_tests: false
-      runner_label: auto-provisioned
-      put_build_results_to_cache: true
-      commit_sha: ${{ needs.check-running-allowed.outputs.commit_sha }}
-    secrets: inherit
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ needs.check-running-allowed.outputs.commit_sha }}
+    - name: Build and test
+      uses: ./.github/actions/build_and_test_ya
+      with:
+        build_preset: ${{ matrix.build_preset }}
+        build_target: "ydb/"
+        run_tests: ${{ contains(fromJSON('["relwithdebinfo", "release-asan"]'), matrix.build_preset) }}
+        test_size: "small,medium"
+        test_type: "unittest,py3test,py2test,pytest"
+        test_threads: 52
+        put_build_results_to_cache: true
+        commit_sha: ${{ needs.check-running-allowed.outputs.commit_sha }}
+        secs: ${{ format('{{"TESTMO_TOKEN":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}', 
+          secrets.TESTMO_TOKEN, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
+        vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',
+          vars.AWS_BUCKET, vars.AWS_ENDPOINT, vars.REMOTE_CACHE_URL_YA, vars.TESTMO_URL, vars.TESTMO_PROJECT_ID ) }}

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+      - 'stream-nb-*'
     paths-ignore:
       - 'ydb/docs/**'
       - '*'

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -79,12 +79,21 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            let externalContributorLabel = 'external';
+            
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Hi! Thank you for contributing!\nThe tests on this PR will run after a maintainer adds an `ok-to-test` label to this PR manually. Thank you for your patience!'
             });
+
+            github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: context.issue.number,
+                labels: [externalContributorLabel]
+            });
+
       - name: cleanup-test-label
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/sync_cmakebuild.yml
+++ b/.github/workflows/sync_cmakebuild.yml
@@ -28,7 +28,9 @@ jobs:
         git config --global user.name "Alexander Smirnov"
         cd ydb
         git fetch --depth `expr $(git rev-list --count HEAD) + 1`
-        git fetch origin cmakebuild:cmakebuild --depth 3 # 1st with cmake generation, 2nd with previous merge, 3rd is common between main and cmakebuild
+        # Depth 10: 1st with cmake generation, 2nd with previous merge, 3rd is common between main and cmakebuild,
+        # others for possible commits directly on cmakebuild branch
+        git fetch origin cmakebuild:cmakebuild --depth 10 
         mainsha=$(git rev-parse HEAD)
         git checkout cmakebuild
         prevsha=$(git rev-parse HEAD)

--- a/.github/workflows/sync_cmakebuild.yml
+++ b/.github/workflows/sync_cmakebuild.yml
@@ -1,0 +1,23 @@
+name: Sync cmakebuild with main
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      test_label_regexp:
+        required: false
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: cmakebuild
+    - name: Sync
+      run: |
+        git checkout main -- ydb/ci/sync_cmakebuild.sh
+        cp ydb/ci/sync_cmakebuild.sh ~
+        git restore ydb/ci/sync_cmakebuild.sh
+        ~/sync_cmakebuild.sh
+        git push

--- a/.github/workflows/sync_cmakebuild.yml
+++ b/.github/workflows/sync_cmakebuild.yml
@@ -19,7 +19,7 @@ jobs:
         echo "Main sha: ${mainsha}"
         lastsha=$(curl -s https://raw.githubusercontent.com/$REPO/cmakebuild/ydb/ci/cmakegen.txt)
         echo "Last sha: ${lastsha}"
-        if [ ${mainsha} == ${lastsha} ];then
+        if [ "${mainsha}" == "${lastsha}" ];then
           echo "No new commits on the main branch to merge, exiting"
           exit 0
         fi

--- a/.github/workflows/sync_cmakebuild.yml
+++ b/.github/workflows/sync_cmakebuild.yml
@@ -3,21 +3,43 @@ on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch:
-    inputs:
-      test_label_regexp:
-        required: false
-        type: string
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+env:
+  REPO: ${{ github.repository }}
+  TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: cmakebuild
     - name: Sync
       run: |
-        git checkout main -- ydb/ci/sync_cmakebuild.sh
-        cp ydb/ci/sync_cmakebuild.sh ~
-        git restore ydb/ci/sync_cmakebuild.sh
-        ~/sync_cmakebuild.sh
-        git push
+        mainsha=$(curl -s -H "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/$REPO/commits/main)
+        echo "Main sha: ${mainsha}"
+        lastsha=$(curl -s https://raw.githubusercontent.com/$REPO/cmakebuild/ydb/ci/cmakegen.txt)
+        echo "Last sha: ${lastsha}"
+        if [ ${mainsha} == ${lastsha} ];then
+          echo "No new commits on the main branch to merge, exiting"
+          exit 0
+        fi
+        git clone -b main --shallow-exclude cmakebuild https://$TOKEN@github.com/$REPO.git ydb
+        git config --global user.email "alex@ydb.tech"
+        git config --global user.name "Alexander Smirnov"
+        cd ydb
+        git fetch --depth `expr $(git rev-list --count HEAD) + 1`
+        git fetch origin cmakebuild:cmakebuild --depth 3 # 1st with cmake generation, 2nd with previous merge, 3rd is common between main and cmakebuild
+        mainsha=$(git rev-parse HEAD)
+        git checkout cmakebuild
+        prevsha=$(git rev-parse HEAD)
+        git merge main --no-edit
+        currsha=$(git rev-parse HEAD)
+        if [ ${prevsha} == ${currsha} ];then
+          echo "Merge did not bring any changes, exiting"
+          exit
+        fi
+        ./generate_cmake -k
+        echo ${mainsha} > ydb/ci/cmakegen.txt
+        git add .
+        git commit -m "Generate cmake for ${mainsha}"
+        git push --set-upstream origin cmakebuild


### PR DESCRIPTION
- **Update build_and_test_provisioned.yml**
- **Enable cmake workflow to build a specified target (#1533)**
- **Add cmake check workflow (#1725)**
- **Fix cmake postcommit (#1739)**
- **Create sync_cmakebuild.yml (#1747)**
- **CMake regeneration workflow (#1774)**
- **Update sync_cmakebuild.yml (#1776)**
- **Increase commits depth on sync cmake workflow**
- **ci: save test artifacts for fail tests (#1501)**
- **ci: fix single file logs saving (#2077)**
- **CMake14 build (#2207)**
- **ci: run relwithdebinfo and debug with build-preset labels too (#2245)**
- **ci: add "external" label for PRs made by external contributors (#2488)**
- **Add workflow to create a Pull Request to import libraries update (#2575)**
- **Update libs_create_pr.yml**
- **Update GitHub workflows to include stream-nb-* branches (#2669)**
- **Remove reduntant call levels when running PR checks (#2778)**
- **ci: pr-checks: run tests only if build is success (#2954)**
- **Run tests based on build graph analysis**
