### PR TITLE
Remove virtual calls in UDF Arrow Kernels

### DIFF
--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -349,7 +349,7 @@ TReader* CastToBlockReaderImpl(IBlockReader& reader) {
     return readerImpl;
 }
 
-template <typename TDerived, typename TBuilderImpl = IArrayBuilder, typename TReader = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, typename TArrayBuilderImpl = IArrayBuilder, typename TReader = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
 struct TUnaryKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
@@ -369,7 +369,7 @@ struct TUnaryKernelExec {
         else {
             auto& array = *arg.array();
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TArrayBuilderImpl>(builder);
 
             size_t maxBlockLength = builderImpl->MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -392,7 +392,7 @@ struct TUnaryKernelExec {
     }
 };
 
-template <typename TDerived, typename TBuilderImpl = IArrayBuilder, typename TReader1 = IBlockReader, typename TReader2 = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, typename TArrayBuilderImpl = IArrayBuilder, typename TReader1 = IBlockReader, typename TReader2 = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
 struct TBinaryKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
@@ -419,7 +419,7 @@ struct TBinaryKernelExec {
             auto item1 = reader1Impl->GetScalarItem(*arg1.scalar());
             auto& array2 = *arg2.array();
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TArrayBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -440,7 +440,7 @@ struct TBinaryKernelExec {
             auto& array1 = *arg1.array();            
             auto item2 = reader2Impl->GetScalarItem(*arg2.scalar());
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TArrayBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -462,7 +462,7 @@ struct TBinaryKernelExec {
             auto& array1 = *arg1.array();
             auto& array2 = *arg2.array();
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TArrayBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -487,7 +487,7 @@ struct TBinaryKernelExec {
     }
 };
 
-template <typename TDerived, size_t Argc, typename TBuilderImpl = IArrayBuilder, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, size_t Argc, typename TArrayBuilderImpl = IArrayBuilder, typename TScalarBuilderImpl = IScalarBuilder>
 struct TGenericKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
@@ -534,7 +534,7 @@ struct TGenericKernelExec {
             });
         } else {
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TArrayBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);

--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -48,7 +48,7 @@ public:
     IArrayBuilder& GetArrayBuilder() {
         Y_ENSURE(!OnlyScalars_);
         if (!ArrayBuilder_) {
-            ArrayBuilder_ = MakeArrayBuilder(*TypeInfoHelper_, OutputType_, *GetYqlMemoryPool(), TypeInfoHelper_->GetMaxBlockLength(OutputType_), &ValueBuilder_->GetPgBuilder());
+            ArrayBuilder_ = MakeArrayBuilder(*TypeInfoHelper_, OutputType_, *arrow::default_memory_pool(), TypeInfoHelper_->GetMaxBlockLength(OutputType_), &ValueBuilder_->GetPgBuilder());
         }
 
         return *ArrayBuilder_;
@@ -163,7 +163,7 @@ public:
             }
 
             TUdfKernelState kernelState(ArgTypes_, OutputType_, OnlyScalars_, TypeInfoHelper_.Get(), valueBuilder);
-            arrow::compute::ExecContext execContext(GetYqlMemoryPool());
+            arrow::compute::ExecContext execContext;
             arrow::compute::KernelContext kernelContext(&execContext);
             kernelContext.SetState(&kernelState);
 

--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -349,7 +349,7 @@ TReader* CastToBlockReaderImpl(IBlockReader& reader) {
     return readerImpl;
 }
 
-template <typename TDerived, typename TBuilder = IArrayBuilder, typename TReader = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, typename TBuilderImpl = IArrayBuilder, typename TReader = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
 struct TUnaryKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
@@ -369,7 +369,7 @@ struct TUnaryKernelExec {
         else {
             auto& array = *arg.array();
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilder>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
 
             size_t maxBlockLength = builderImpl->MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -392,7 +392,7 @@ struct TUnaryKernelExec {
     }
 };
 
-template <typename TDerived, typename TBuilder = IArrayBuilder, typename TReader1 = IBlockReader, typename TReader2 = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, typename TBuilderImpl = IArrayBuilder, typename TReader1 = IBlockReader, typename TReader2 = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
 struct TBinaryKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
@@ -419,7 +419,7 @@ struct TBinaryKernelExec {
             auto item1 = reader1Impl->GetScalarItem(*arg1.scalar());
             auto& array2 = *arg2.array();
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilder>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -440,7 +440,7 @@ struct TBinaryKernelExec {
             auto& array1 = *arg1.array();            
             auto item2 = reader2Impl->GetScalarItem(*arg2.scalar());
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilder>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -462,7 +462,7 @@ struct TBinaryKernelExec {
             auto& array1 = *arg1.array();
             auto& array2 = *arg2.array();
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilder>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);
@@ -487,7 +487,7 @@ struct TBinaryKernelExec {
     }
 };
 
-template <typename TDerived, size_t Argc, typename TBuilder = IArrayBuilder, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, size_t Argc, typename TBuilderImpl = IArrayBuilder, typename TScalarBuilderImpl = IScalarBuilder>
 struct TGenericKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
@@ -534,7 +534,7 @@ struct TGenericKernelExec {
             });
         } else {
             auto& builder = state.GetArrayBuilder();
-            auto* builderImpl = CastToArrayBuilderImpl<TBuilder>(builder);
+            auto* builderImpl = CastToArrayBuilderImpl<TBuilderImpl>(builder);
 
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);

--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -349,7 +349,7 @@ TReader* CastToBlockReaderImpl(IBlockReader& reader) {
     return readerImpl;
 }
 
-template <typename TDerived, typename TArrayBuilderImpl = IArrayBuilder, typename TReader = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, typename TReader = IBlockReader, typename TArrayBuilderImpl = IArrayBuilder, typename TScalarBuilderImpl = IScalarBuilder>
 struct TUnaryKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
@@ -392,7 +392,7 @@ struct TUnaryKernelExec {
     }
 };
 
-template <typename TDerived, typename TArrayBuilderImpl = IArrayBuilder, typename TReader1 = IBlockReader, typename TReader2 = IBlockReader, typename TScalarBuilderImpl = IScalarBuilder>
+template <typename TDerived, typename TReader1 = IBlockReader, typename TReader2 = IBlockReader, typename TArrayBuilderImpl = IArrayBuilder, typename TScalarBuilderImpl = IScalarBuilder>
 struct TBinaryKernelExec {
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());

--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -27,12 +27,12 @@ using TExec = arrow::Status(*)(arrow::compute::KernelContext*, const arrow::comp
 
 class TUdfKernelState : public arrow::compute::KernelState {
 public:
-    TUdfKernelState(const TVector<const TType*>& argTypes, const TType* outputType, bool onlyScalars, const ITypeInfoHelper* typeInfoHelper, const IPgBuilder& pgBuilder)
+    TUdfKernelState(const TVector<const TType*>& argTypes, const TType* outputType, bool onlyScalars, const ITypeInfoHelper* typeInfoHelper, const IValueBuilder* valueBuilder)
         : ArgTypes_(argTypes)
         , OutputType_(outputType)
         , OnlyScalars_(onlyScalars)
         , TypeInfoHelper_(typeInfoHelper)
-        , PgBuilder_(pgBuilder)
+        , ValueBuilder_(valueBuilder)
     {
         Readers_.resize(ArgTypes_.size());
     }
@@ -48,7 +48,7 @@ public:
     IArrayBuilder& GetArrayBuilder() {
         Y_ENSURE(!OnlyScalars_);
         if (!ArrayBuilder_) {
-            ArrayBuilder_ = MakeArrayBuilder(*TypeInfoHelper_, OutputType_, *GetYqlMemoryPool(), TypeInfoHelper_->GetMaxBlockLength(OutputType_), &PgBuilder_);
+            ArrayBuilder_ = MakeArrayBuilder(*TypeInfoHelper_, OutputType_, *arrow::default_memory_pool(), TypeInfoHelper_->GetMaxBlockLength(OutputType_), &ValueBuilder_->GetPgBuilder());
         }
 
         return *ArrayBuilder_;
@@ -62,13 +62,18 @@ public:
 
         return *ScalarBuilder_;
     }
+    
+    const IValueBuilder& GetValueBuilder() {
+        Y_ENSURE(ValueBuilder_);
+        return *ValueBuilder_;
+    }
 
 private:
     const TVector<const TType*> ArgTypes_;
     const TType* OutputType_;
     const bool OnlyScalars_;
     const ITypeInfoHelper* TypeInfoHelper_;
-    const IPgBuilder& PgBuilder_;  
+    const IValueBuilder* ValueBuilder_;
     TVector<std::unique_ptr<IBlockReader>> Readers_;
     std::unique_ptr<IArrayBuilder> ArrayBuilder_;
     std::unique_ptr<IScalarBuilder> ScalarBuilder_;
@@ -157,8 +162,8 @@ public:
                 }
             }
 
-            TUdfKernelState kernelState(ArgTypes_, OutputType_, OnlyScalars_, TypeInfoHelper_.Get(), valueBuilder->GetPgBuilder());
-            arrow::compute::ExecContext execContext(GetYqlMemoryPool());
+            TUdfKernelState kernelState(ArgTypes_, OutputType_, OnlyScalars_, TypeInfoHelper_.Get(), valueBuilder);
+            arrow::compute::ExecContext execContext;
             arrow::compute::KernelContext kernelContext(&execContext);
             kernelContext.SetState(&kernelState);
 
@@ -322,33 +327,54 @@ inline void PrepareSimpleArrowUdf(IFunctionTypeInfoBuilder& builder, TType* sign
     }
 }
 
-template <typename TDerived>
+template <typename TDerived, typename TReader = IBlockReader, typename TBuilder = IArrayBuilder>
 struct TUnaryKernelExec {
-    static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
+
+static_assert(std::is_base_of_v<IBlockReader, TReader>);
+static_assert(std::is_base_of_v<IArrayBuilder, TBuilder>);
+
+template<typename TSink>
+static void Process(const TBlockItem& arg, TUdfKernelState& state, const TSink& sink) {
+    if constexpr (std::is_invocable_v<decltype(&TDerived::template Process<TSink>), TBlockItem, TUdfKernelState&, TSink&>) {
+        TDerived::Process(arg, state, sink);
+    } else {
+        TDerived::Process(arg, sink);
+    }
+}
+
+static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
         auto& reader = state.GetReader(0);
+
+        auto* readerImpl = dynamic_cast<TReader*>(&reader);
+        Y_ENSURE(readerImpl, TStringBuilder() << "Got " << typeid(reader).name() << " as BlockReader");
+
         const auto& arg = batch.values[0];
         if (arg.is_scalar()) {
             auto& builder = state.GetScalarBuilder();
-            auto item = reader.GetScalarItem(*arg.scalar());
-            TDerived::Process(item, [&](TBlockItem out) {
+            auto item = readerImpl->GetScalarItem(*arg.scalar());
+            Process(item, state, [&](auto out) {
                 *res = builder.Build(out);
             });
         }
         else {
             auto& array = *arg.array();
             auto& builder = state.GetArrayBuilder();
-            size_t maxBlockLength = builder.MaxLength();
+
+            auto* builderImpl = dynamic_cast<TBuilder*>(&builder);
+            Y_ENSURE(builderImpl, TStringBuilder() << "Got " << typeid(builder).name() << " as ArrayBuilder");
+
+            size_t maxBlockLength = builderImpl->MaxLength();
             Y_ENSURE(maxBlockLength > 0);
             TVector<std::shared_ptr<arrow::ArrayData>> outputArrays;
             for (int64_t i = 0; i < array.length;) {
                 for (size_t j = 0; j < maxBlockLength && i < array.length; ++j, ++i) {
-                    auto item = reader.GetItem(array, i);
-                    TDerived::Process(item, [&](TBlockItem out) {
-                        builder.Add(out);
+                    auto item = readerImpl->GetItem(array, i);
+                    Process(item, state, [&](auto out) {
+                        builderImpl->Add(out);
                     });
                 }
-                auto outputDatum = builder.Build(false);
+                auto outputDatum = builderImpl->Build(false);
                 ForEachArrayData(outputDatum, [&](const auto& arr) { outputArrays.push_back(arr); });
             }
 
@@ -359,24 +385,40 @@ struct TUnaryKernelExec {
     }
 };
 
-template <typename TDerived>
+template <typename TDerived, typename TReader1 = IBlockReader, typename TReader2 = IBlockReader, typename TBuilder = IArrayBuilder>
 struct TBinaryKernelExec {
+    template<typename TSink>
+    static void Process(const TBlockItem& arg1, const TBlockItem& arg2, TUdfKernelState& state, const TSink& sink) {
+        if constexpr (std::is_invocable_v<decltype(&TDerived::template Process<TSink>), TBlockItem, TBlockItem, TUdfKernelState&, TSink&>) {
+            TDerived::Process(arg1, arg2, state, sink);
+        } else {
+            TDerived::Process(arg1, arg2, sink);
+        }
+    }
+
     static arrow::Status Do(arrow::compute::KernelContext* ctx, const arrow::compute::ExecBatch& batch, arrow::Datum* res) {
         auto& state = dynamic_cast<TUdfKernelState&>(*ctx->state());
+
         auto& reader1 = state.GetReader(0);
+        auto* reader1Impl = dynamic_cast<TReader1*>(&reader1);
+        Y_ENSURE(reader1Impl, TStringBuilder() << "Got " << typeid(reader1).name() << " as BlockReader");
+
         auto& reader2 = state.GetReader(1);
+        auto* reader2Impl = dynamic_cast<TReader2*>(&reader2);
+        Y_ENSURE(reader2Impl, TStringBuilder() << "Got " << typeid(reader2).name() << " as BlockReader");
+
         const auto& arg1 = batch.values[0];
         const auto& arg2 = batch.values[1];
         if (arg1.is_scalar() && arg2.is_scalar()) {
             auto& builder = state.GetScalarBuilder();
-            auto item1 = reader1.GetScalarItem(*arg1.scalar());
-            auto item2 = reader2.GetScalarItem(*arg2.scalar());
-            TDerived::Process(item1, item2, [&](TBlockItem out) {
+            auto item1 = reader1Impl->GetScalarItem(*arg1.scalar());
+            auto item2 = reader2Impl->GetScalarItem(*arg2.scalar());
+            Process(item1, item2, state, [&](TBlockItem out) {
                 *res = builder.Build(out);
             });
         }
         else if (arg1.is_scalar() && arg2.is_array()) {
-            auto item1 = reader1.GetScalarItem(*arg1.scalar());
+            auto item1 = reader1Impl->GetScalarItem(*arg1.scalar());
             auto& array2 = *arg2.array();
             auto& builder = state.GetArrayBuilder();
             size_t maxBlockLength = builder.MaxLength();
@@ -384,8 +426,8 @@ struct TBinaryKernelExec {
             TVector<std::shared_ptr<arrow::ArrayData>> outputArrays;
             for (int64_t i = 0; i < array2.length;) {
                 for (size_t j = 0; j < maxBlockLength && i < array2.length; ++j, ++i) {
-                    auto item2 = reader2.GetItem(array2, i);
-                    TDerived::Process(item1, item2, [&](TBlockItem out) {
+                    auto item2 = reader2Impl->GetItem(array2, i);
+                    Process(item1, item2, state, [&](TBlockItem out) {
                         builder.Add(out);
                     });
                 }
@@ -396,15 +438,15 @@ struct TBinaryKernelExec {
             *res = MakeArray(outputArrays);
         } else if (arg1.is_array() && arg2.is_scalar()) {
             auto& array1 = *arg1.array();            
-            auto item2 = reader2.GetScalarItem(*arg2.scalar());
+            auto item2 = reader2Impl->GetScalarItem(*arg2.scalar());
             auto& builder = state.GetArrayBuilder();
             size_t maxBlockLength = builder.MaxLength();
             Y_ENSURE(maxBlockLength > 0);
             TVector<std::shared_ptr<arrow::ArrayData>> outputArrays;
             for (int64_t i = 0; i < array1.length;) {
                 for (size_t j = 0; j < maxBlockLength && i < array1.length; ++j, ++i) {
-                    auto item1 = reader1.GetItem(array1, i);
-                    TDerived::Process(item1, item2, [&](TBlockItem out) {
+                    auto item1 = reader1Impl->GetItem(array1, i);
+                    Process(item1, item2, state, [&](TBlockItem out) {
                         builder.Add(out);
                     });
                 }
@@ -426,7 +468,7 @@ struct TBinaryKernelExec {
                 for (size_t j = 0; j < maxBlockLength && i < array1.length; ++j, ++i) {
                     auto item1 = reader1.GetItem(array1, i);
                     auto item2 = reader2.GetItem(array2, i);
-                    TDerived::Process(item1, item2, [&](TBlockItem out) {
+                    Process(item1, item2, state, [&](TBlockItem out) {
                         builder.Add(out);
                     });
                 }
@@ -567,7 +609,7 @@ struct TUnaryUnsafeFixedSizeFilterKernel {
         auto& outArray = res->array();
         auto* outValues = outArray->GetMutableValues<TOutput>(1);
 
-        TTypedBufferBuilder<uint8_t> nullBuilder(GetYqlMemoryPool());
+        TTypedBufferBuilder<uint8_t> nullBuilder(arrow::default_memory_pool());
         nullBuilder.Reserve(length);
 
         bool isAllNull = inArray->GetNullCount() == length;
@@ -581,11 +623,11 @@ struct TUnaryUnsafeFixedSizeFilterKernel {
             nullBuilder.UnsafeAppend(length, 0);
         }
         auto validMask = nullBuilder.Finish();
-        validMask = MakeDenseBitmap(validMask->data(), length, GetYqlMemoryPool());
+        validMask = MakeDenseBitmap(validMask->data(), length, arrow::default_memory_pool());
         
         auto inMask = inArray->buffers[0];
         if (inMask) {
-            outArray->buffers[0] = AllocateBitmapWithReserve(length, GetYqlMemoryPool());
+            outArray->buffers[0] = AllocateBitmapWithReserve(length, arrow::default_memory_pool());
             arrow::internal::BitmapAnd(validMask->data(), 0, inArray->buffers[0]->data(), inArray->offset, outArray->length, outArray->offset, outArray->buffers[0]->mutable_data());
         } else {
             outArray->buffers[0] = std::move(validMask);
@@ -643,11 +685,11 @@ public:
 
 #define BEGIN_SIMPLE_ARROW_UDF_WITH_OPTIONAL_ARGS(udfName, signatureFunc, optArgc) \
     BEGIN_ARROW_UDF_IMPL(udfName##_BlocksImpl, signatureFunc, optArgc, false) \
-    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().SupportsBlocks().OptionalArgs(optArgc);, ;, ;, "", "", udfName##_BlocksImpl)
+    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().OptionalArgs(optArgc).SupportsBlocks();, ;, ;, "", "", udfName##_BlocksImpl)
 
 #define BEGIN_SIMPLE_STRICT_ARROW_UDF_WITH_OPTIONAL_ARGS(udfName, signatureFunc, optArgc) \
     BEGIN_ARROW_UDF_IMPL(udfName##_BlocksImpl, signatureFunc, optArgc, true) \
-    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().SupportsBlocks().IsStrict().OptionalArgs(optArgc);, ;, ;, "", "", udfName##_BlocksImpl)
+    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().OptionalArgs(optArgc).SupportsBlocks().IsStrict();, ;, ;, "", "", udfName##_BlocksImpl)
 
 #define END_ARROW_UDF(udfNameBlocks, exec) \
     inline bool udfNameBlocks::DeclareSignature(\

--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -609,7 +609,7 @@ struct TUnaryUnsafeFixedSizeFilterKernel {
         auto& outArray = res->array();
         auto* outValues = outArray->GetMutableValues<TOutput>(1);
 
-        TTypedBufferBuilder<uint8_t> nullBuilder(arrow::default_memory_pool());
+        TTypedBufferBuilder<uint8_t> nullBuilder(GetYqlMemoryPool());
         nullBuilder.Reserve(length);
 
         bool isAllNull = inArray->GetNullCount() == length;
@@ -623,11 +623,11 @@ struct TUnaryUnsafeFixedSizeFilterKernel {
             nullBuilder.UnsafeAppend(length, 0);
         }
         auto validMask = nullBuilder.Finish();
-        validMask = MakeDenseBitmap(validMask->data(), length, arrow::default_memory_pool());
+        validMask = MakeDenseBitmap(validMask->data(), length, GetYqlMemoryPool());
         
         auto inMask = inArray->buffers[0];
         if (inMask) {
-            outArray->buffers[0] = AllocateBitmapWithReserve(length, arrow::default_memory_pool());
+            outArray->buffers[0] = AllocateBitmapWithReserve(length, GetYqlMemoryPool());
             arrow::internal::BitmapAnd(validMask->data(), 0, inArray->buffers[0]->data(), inArray->offset, outArray->length, outArray->offset, outArray->buffers[0]->mutable_data());
         } else {
             outArray->buffers[0] = std::move(validMask);
@@ -685,11 +685,11 @@ public:
 
 #define BEGIN_SIMPLE_ARROW_UDF_WITH_OPTIONAL_ARGS(udfName, signatureFunc, optArgc) \
     BEGIN_ARROW_UDF_IMPL(udfName##_BlocksImpl, signatureFunc, optArgc, false) \
-    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().OptionalArgs(optArgc).SupportsBlocks();, ;, ;, "", "", udfName##_BlocksImpl)
+    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().SupportsBlocks().OptionalArgs(optArgc);, ;, ;, "", "", udfName##_BlocksImpl)
 
 #define BEGIN_SIMPLE_STRICT_ARROW_UDF_WITH_OPTIONAL_ARGS(udfName, signatureFunc, optArgc) \
     BEGIN_ARROW_UDF_IMPL(udfName##_BlocksImpl, signatureFunc, optArgc, true) \
-    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().OptionalArgs(optArgc).SupportsBlocks().IsStrict();, ;, ;, "", "", udfName##_BlocksImpl)
+    UDF_IMPL(udfName, builder.SimpleSignature<signatureFunc>().SupportsBlocks().IsStrict().OptionalArgs(optArgc);, ;, ;, "", "", udfName##_BlocksImpl)
 
 #define END_ARROW_UDF(udfNameBlocks, exec) \
     inline bool udfNameBlocks::DeclareSignature(\

--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -48,7 +48,7 @@ public:
     IArrayBuilder& GetArrayBuilder() {
         Y_ENSURE(!OnlyScalars_);
         if (!ArrayBuilder_) {
-            ArrayBuilder_ = MakeArrayBuilder(*TypeInfoHelper_, OutputType_, *arrow::default_memory_pool(), TypeInfoHelper_->GetMaxBlockLength(OutputType_), &ValueBuilder_->GetPgBuilder());
+            ArrayBuilder_ = MakeArrayBuilder(*TypeInfoHelper_, OutputType_, *GetYqlMemoryPool(), TypeInfoHelper_->GetMaxBlockLength(OutputType_), &ValueBuilder_->GetPgBuilder());
         }
 
         return *ArrayBuilder_;
@@ -163,7 +163,7 @@ public:
             }
 
             TUdfKernelState kernelState(ArgTypes_, OutputType_, OnlyScalars_, TypeInfoHelper_.Get(), valueBuilder);
-            arrow::compute::ExecContext execContext;
+            arrow::compute::ExecContext execContext(GetYqlMemoryPool());
             arrow::compute::KernelContext kernelContext(&execContext);
             kernelContext.SetState(&kernelState);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Allow to pass reader and builder types to UnaryKernelExec and BinaryKernelExec to avoid virtual calls and enable autovectorization.

### Changelog category <!-- remove all except one -->

* Performance improvement

