### PR TITLE
add funcName to the "UDF implementation is not set" error message

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_udf.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_udf.cpp
@@ -179,7 +179,7 @@ IComputationNode* WrapUdf(TCallable& callable, const TComputationNodeFactoryCont
     MKQL_ENSURE(funcInfo.FunctionType->IsConvertableTo(*callable.GetType()->GetReturnType(), true),
                 "Function '" << funcName << "' type mismatch, expected return type: " << PrintNode(callable.GetType()->GetReturnType(), true) <<
                 ", actual:" << PrintNode(funcInfo.FunctionType, true));
-    MKQL_ENSURE(funcInfo.Implementation, "UDF implementation is not set");
+    MKQL_ENSURE(funcInfo.Implementation, "UDF implementation is not set for function " << funcName);
 
     const auto runConfigType = funcInfo.RunConfigType;
     const bool typesMatch = runConfigType->IsSameType(*runCfgNode.GetStaticType());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Adds the `funcName` when UDF fails with a missing implementation.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Not sure if a changelog entry is required.

This change helps debugging huge yql pipelines with generated code.
