### PR TITLE
After restarting the PQ tablet, the service partition is empty

### DIFF
--- a/ydb/core/persqueue/key.cpp
+++ b/ydb/core/persqueue/key.cpp
@@ -10,4 +10,16 @@ std::pair<TKeyPrefix, TKeyPrefix> MakeKeyPrefixRange(TKeyPrefix::EType type, con
     return {std::move(from), std::move(to)};
 }
 
+TKey MakeKeyFromString(const TString& s, const TPartitionId& partition)
+{
+    TKey t(s);
+    return TKey(t.GetType(),
+                partition,
+                t.GetOffset(),
+                t.GetPartNo(),
+                t.GetCount(),
+                t.GetInternalPartsCount(),
+                t.IsHead());
+}
+
 }

--- a/ydb/core/persqueue/key.h
+++ b/ydb/core/persqueue/key.h
@@ -313,6 +313,8 @@ private:
     ui16 InternalPartsCount;
 };
 
+TKey MakeKeyFromString(const TString& s, const TPartitionId& partition);
+
 inline
 TString GetTxKey(ui64 txId)
 {

--- a/ydb/core/persqueue/partition_init.cpp
+++ b/ydb/core/persqueue/partition_init.cpp
@@ -199,7 +199,7 @@ void TInitConfigStep::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorCon
 // TInitInternalFieldsStep
 //
 TInitInternalFieldsStep::TInitInternalFieldsStep(TInitializer* initializer)
-    : TInitializerStep(initializer, "TInitializerStep", false) {
+    : TInitializerStep(initializer, "TInitInternalFieldsStep", false) {
 }
 
 void TInitInternalFieldsStep::Execute(const TActorContext &ctx) {
@@ -495,7 +495,7 @@ void TInitDataRangeStep::FillBlobsMetaData(const NKikimrClient::TKeyValueRespons
     for (ui32 i = 0; i < range.PairSize(); ++i) {
         auto pair = range.GetPair(i);
         Y_ABORT_UNLESS(pair.GetStatus() == NKikimrProto::OK); //this is readrange without keys, only OK could be here
-        TKey k(pair.GetKey());
+        TKey k = MakeKeyFromString(pair.GetKey(), PartitionId());
         if (dataKeysBody.empty()) { //no data - this is first pair of first range
             head.Offset = endOffset = startOffset = k.GetOffset();
             if (k.GetPartNo() > 0) ++startOffset;

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -936,7 +936,7 @@ void TPersQueue::CreateSupportivePartitionActor(const TPartitionId& partitionId,
     partition.Actor = ctx.Register(CreatePartitionActor(partitionId,
                                                         TopicConverter,
                                                         MakeSupportivePartitionConfig(),
-                                                        true,
+                                                        false,
                                                         ctx));
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

1. The actor of the service partition was created with the `newPartition` flag. As a result, I did not subtract the blobs.
2. Blobs were subtracted by keys with types for the main partition.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
