### PR TITLE
Revert "Add base class for simple stateless wide nodes (#5183)"

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_skip.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_skip.cpp
@@ -118,8 +118,8 @@ private:
     IComputationNode* const Count;
 };
 
-class TWideSkipWrapper : public TSimpleStatefulWideFlowCodegeneratorNode<TWideSkipWrapper> {
-using TBaseComputation = TSimpleStatefulWideFlowCodegeneratorNode<TWideSkipWrapper>;
+class TWideSkipWrapper : public TSimpleStatefulWideFlowCodegeneratorNode<TWideSkipWrapper, ui64> {
+using TBaseComputation = TSimpleStatefulWideFlowCodegeneratorNode<TWideSkipWrapper, ui64>;
 public:
      TWideSkipWrapper(TComputationMutables& mutables, IComputationWideFlowNode* flow, IComputationNode* count, ui32 size)
         : TBaseComputation(mutables, flow, size, size)

--- a/ydb/library/yql/minikql/computation/mkql_simple_codegen.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_simple_codegen.cpp
@@ -5,7 +5,7 @@ namespace NKikimr {
 namespace NMiniKQL {
 
 #ifndef MKQL_DISABLE_CODEGEN
-ICodegeneratorInlineWideNode::TGenerateResult TSimpleWideFlowCodegeneratorNodeLLVMBase::DoGenGetValuesBase(const NKikimr::NMiniKQL::TCodegenContext& ctx, llvm::Value* statePtrVal, llvm::BasicBlock*& genToBlock) const  {
+ICodegeneratorInlineWideNode::TGenerateResult TSimpleStatefulWideFlowCodegeneratorNodeLLVMBase::DoGenGetValues(const NKikimr::NMiniKQL::TCodegenContext &ctx, llvm::Value *statePtrVal, llvm::BasicBlock *&genToBlock) const  {
     // init stuff (mainly in global entry block)
 
     auto& context = ctx.Codegen.GetContext();
@@ -19,14 +19,12 @@ ICodegeneratorInlineWideNode::TGenerateResult TSimpleWideFlowCodegeneratorNodeLL
     const auto done = BasicBlock::Create(context, "done", ctx.Func);
     const auto entryPos = &ctx.Func->getEntryBlock().back();
 
-    const bool hasState = statePtrVal != nullptr;
-
     const auto thisType = StructType::get(context)->getPointerTo();
     const auto thisRawVal = ConstantInt::get(Type::getInt64Ty(context), PtrTable.ThisPtr);
     const auto thisVal = CastInst::Create(Instruction::IntToPtr, thisRawVal, thisType, "this", entryPos);
     const auto valuePtrType = PointerType::getUnqual(valueType);
     const auto valuePtrsPtrType = PointerType::getUnqual(valuePtrType);
-    const auto statePtrType = hasState ? statePtrVal->getType() : nullptr;
+    const auto statePtrType = statePtrVal->getType();
     const auto ctxType = ctx.Ctx->getType();
     const auto i32Type = Type::getInt32Ty(context);
     const auto valueNullptrVal = ConstantPointerNull::get(valuePtrType);
@@ -46,32 +44,26 @@ ICodegeneratorInlineWideNode::TGenerateResult TSimpleWideFlowCodegeneratorNodeLL
 
     auto block = genToBlock; // >>> start of main code chunk
 
-    const auto stateVal = hasState ? new LoadInst(valueType, statePtrVal, "state", block) : nullptr;
-    BranchInst::Create(init, loop, hasState ? IsInvalid(stateVal, block) : ConstantInt::get(Type::getInt1Ty(context), 0), block);
+    const auto stateVal = new LoadInst(valueType, statePtrVal, "state", block);
+    BranchInst::Create(init, loop, IsInvalid(stateVal, block), block);
 
     block = init; // state initialization block:
 
-    if (hasState) {
-        const auto initFuncType = FunctionType::get(Type::getVoidTy(context), {thisType, statePtrType, ctxType}, false);
-        const auto initFuncRawVal = ConstantInt::get(Type::getInt64Ty(context), PtrTable.InitStateMethPtr);
-        const auto initFuncVal = CastInst::Create(Instruction::IntToPtr, initFuncRawVal, PointerType::getUnqual(initFuncType), "init_func", block);
-        CallInst::Create(initFuncType, initFuncVal, {thisVal, statePtrVal, ctx.Ctx}, "", block);
-    }
+    const auto initFuncType = FunctionType::get(Type::getVoidTy(context), {thisType, statePtrType, ctxType}, false);
+    const auto initFuncRawVal = ConstantInt::get(Type::getInt64Ty(context), PtrTable.InitStateMethPtr);
+    const auto initFuncVal = CastInst::Create(Instruction::IntToPtr, initFuncRawVal, PointerType::getUnqual(initFuncType), "init_func", block);
+    CallInst::Create(initFuncType, initFuncVal, {thisVal, statePtrVal, ctx.Ctx}, "", block);
     BranchInst::Create(loop, block);
 
     block = loop; // loop head block: (prepare inputs and decide whether to calculate row or not)
 
-    const auto generated = DispatchGenFetchProcess(statePtrVal, ctx, std::bind_front(GetNodeValues, SourceFlow), block);
+    const auto generated = GenFetchProcess(statePtrVal, ctx, std::bind_front(GetNodeValues, SourceFlow), block);
     auto processResVal = generated.first;
     if (processResVal == nullptr) {
-        const auto prepareFuncType = hasState
-            ? FunctionType::get(valuePtrsPtrType, {thisType, statePtrType, ctxType, valuePtrsPtrType}, false)
-            : FunctionType::get(valuePtrsPtrType, {thisType, ctxType, valuePtrsPtrType}, false);
+        const auto prepareFuncType = FunctionType::get(valuePtrsPtrType, {thisType, statePtrType, ctxType, valuePtrsPtrType}, false);
         const auto prepareFuncRawVal = ConstantInt::get(Type::getInt64Ty(context), PtrTable.PrepareInputMethPtr);
         const auto prepareFuncVal = CastInst::Create(Instruction::IntToPtr, prepareFuncRawVal, PointerType::getUnqual(prepareFuncType), "prepare_func", block);
-        const auto inputPtrsVal = hasState
-            ? CallInst::Create(prepareFuncType, prepareFuncVal, {thisVal, statePtrVal, ctx.Ctx, outputPtrsVal}, "input_ptrs", block)
-            : CallInst::Create(prepareFuncType, prepareFuncVal, {thisVal, ctx.Ctx, outputPtrsVal}, "input_ptrs", block);
+        const auto inputPtrsVal = CallInst::Create(prepareFuncType, prepareFuncVal, {thisVal, statePtrVal, ctx.Ctx, outputPtrsVal}, "input_ptrs", block);
         const auto skipFetchCond = CmpInst::Create(Instruction::ICmp, ICmpInst::ICMP_EQ, inputPtrsVal, valuePtrNullptrVal, "skip_fetch", block);
         BranchInst::Create(loopTail, loopFetch, skipFetchCond, block);
 
@@ -117,14 +109,10 @@ ICodegeneratorInlineWideNode::TGenerateResult TSimpleWideFlowCodegeneratorNodeLL
         maybeFetchResVal->addIncoming(noneVal, loop);
         maybeFetchResVal->addIncoming(fetchResExtVal, fetchSourceBlock);
         maybeFetchResVal->addIncoming(fetchResExtVal, calcSourceBlock);
-        const auto processFuncType = hasState 
-            ? FunctionType::get(maybeResType, {thisType, statePtrType, ctxType, maybeResType, valuePtrsPtrType}, false)
-            : FunctionType::get(maybeResType, {thisType, ctxType, maybeResType, valuePtrsPtrType}, false);
+        const auto processFuncType = FunctionType::get(maybeResType, {thisType, statePtrType, ctxType, maybeResType, valuePtrsPtrType}, false);
         const auto processFuncRawVal = ConstantInt::get(Type::getInt64Ty(context), PtrTable.DoProcessMethPtr);
         const auto processFuncVal = CastInst::Create(Instruction::IntToPtr, processFuncRawVal, PointerType::getUnqual(processFuncType), "process_func", block);
-        processResVal = hasState
-            ? CallInst::Create(processFuncType, processFuncVal, {thisVal, statePtrVal, ctx.Ctx, maybeFetchResVal, outputPtrsVal}, "process_res", block)
-            : CallInst::Create(processFuncType, processFuncVal, {thisVal, ctx.Ctx, maybeFetchResVal, outputPtrsVal}, "process_res", block);
+        processResVal = CallInst::Create(processFuncType, processFuncVal, {thisVal, statePtrVal, ctx.Ctx, maybeFetchResVal, outputPtrsVal}, "process_res", block);
     } else {
         BranchInst::Create(loopFetch, loopFetch);
         BranchInst::Create(loopCalc, loopCalc);
@@ -155,7 +143,6 @@ ICodegeneratorInlineWideNode::TGenerateResult TSimpleWideFlowCodegeneratorNodeLL
     }
     return {processResTruncVal, std::move(new_getters)};
 }
-
 #endif
 
 }

--- a/ydb/library/yql/minikql/computation/mkql_simple_codegen.h
+++ b/ydb/library/yql/minikql/computation/mkql_simple_codegen.h
@@ -34,7 +34,7 @@ public:
         return Type::getInt64Ty(context);
     }
 
-    static Value* LLVMFromFetchResult(Value* fetchRes, const Twine& name, BasicBlock* block) {
+    static Value* LLVMFromFetchResult(Value *fetchRes, const Twine& name, BasicBlock* block) {
         return new ZExtInst(fetchRes, LLVMType(fetchRes->getContext()), name, block);
     }
 
@@ -48,7 +48,7 @@ public:
 using TResultCodegenerator = std::function<ICodegeneratorInlineWideNode::TGenerateResult(const TCodegenContext&, BasicBlock*&)>;
 #endif
 
-class TSimpleWideFlowCodegeneratorNodeLLVMBase {
+class TSimpleStatefulWideFlowCodegeneratorNodeLLVMBase {
 public:
     struct TMethPtrTable {
         uintptr_t ThisPtr;
@@ -57,39 +57,10 @@ public:
         uintptr_t DoProcessMethPtr;
     };
 
-    TSimpleWideFlowCodegeneratorNodeLLVMBase(IComputationWideFlowNode* source, ui32 inWidth, ui32 outWidth, TMethPtrTable ptrTable)
+    TSimpleStatefulWideFlowCodegeneratorNodeLLVMBase(IComputationWideFlowNode* source, ui32 inWidth, ui32 outWidth, TMethPtrTable ptrTable)
         : SourceFlow(source), InWidth(inWidth), OutWidth(outWidth)
         , PtrTable(ptrTable) {}
 
-protected:
-#ifndef MKQL_DISABLE_CODEGEN
-    virtual ICodegeneratorInlineWideNode::TGenerateResult DispatchGenFetchProcess(Value* statePtrVal, const TCodegenContext& ctx, const TResultCodegenerator& fetchGenerator, BasicBlock*& block) const = 0;
-
-    ICodegeneratorInlineWideNode::TGenerateResult DoGenGetValuesBase(const NKikimr::NMiniKQL::TCodegenContext& ctx, llvm::Value* statePtrVal, llvm::BasicBlock*& genToBlock) const;
-#endif
-
-    IComputationWideFlowNode* const SourceFlow;
-    const ui32 InWidth, OutWidth;
-    const TMethPtrTable PtrTable;
-};
-
-template<typename TDerived, EValueRepresentation StateKind = EValueRepresentation::Embedded>
-class TSimpleStatefulWideFlowCodegeneratorNode
-        : public TStatefulWideFlowCodegeneratorNode<TSimpleStatefulWideFlowCodegeneratorNode<TDerived, StateKind>>
-        , public TSimpleWideFlowCodegeneratorNodeLLVMBase {
-    using TBase = TStatefulWideFlowCodegeneratorNode<TSimpleStatefulWideFlowCodegeneratorNode>;
-    using TLLVMBase = TSimpleWideFlowCodegeneratorNodeLLVMBase;
-
-protected:
-    TSimpleStatefulWideFlowCodegeneratorNode(TComputationMutables& mutables, IComputationWideFlowNode* source, ui32 inWidth, ui32 outWidth)
-        : TBase(mutables, source, StateKind)
-        , TLLVMBase(source, inWidth, outWidth, {
-            .ThisPtr = reinterpret_cast<uintptr_t>(this),
-            .InitStateMethPtr = GetMethodPtr(&TDerived::InitState),
-            .PrepareInputMethPtr = GetMethodPtr(&TDerived::PrepareInput),
-            .DoProcessMethPtr = GetMethodPtr(&TDerived::DoProcess)
-        }) {}
-    
 #ifndef MKQL_DISABLE_CODEGEN
     virtual ICodegeneratorInlineWideNode::TGenerateResult GenFetchProcess(Value* statePtrVal, const TCodegenContext& ctx, const TResultCodegenerator& fetchGenerator, BasicBlock*& block) const {
         Y_UNUSED(statePtrVal);
@@ -99,10 +70,31 @@ protected:
         return {nullptr, {}};
     }
 
-    virtual ICodegeneratorInlineWideNode::TGenerateResult DispatchGenFetchProcess(Value* statePtrVal, const TCodegenContext& ctx, const TResultCodegenerator& fetchGenerator, BasicBlock*& block) const override final {
-        return GenFetchProcess(statePtrVal, ctx, fetchGenerator, block);
-    }
+    ICodegeneratorInlineWideNode::TGenerateResult DoGenGetValues(const TCodegenContext& ctx, Value* statePtrVal, BasicBlock*& genToBlock) const;
 #endif
+
+protected:
+    IComputationWideFlowNode* const SourceFlow;
+    const ui32 InWidth, OutWidth;
+    const TMethPtrTable PtrTable;
+};
+
+template<typename TDerived, typename TState, EValueRepresentation StateKind = EValueRepresentation::Embedded>
+class TSimpleStatefulWideFlowCodegeneratorNode
+        : public TStatefulWideFlowCodegeneratorNode<TSimpleStatefulWideFlowCodegeneratorNode<TDerived, TState, StateKind>>
+        , public TSimpleStatefulWideFlowCodegeneratorNodeLLVMBase {
+    using TBase = TStatefulWideFlowCodegeneratorNode<TSimpleStatefulWideFlowCodegeneratorNode>;
+    using TLLVMBase = TSimpleStatefulWideFlowCodegeneratorNodeLLVMBase;
+
+protected:
+    TSimpleStatefulWideFlowCodegeneratorNode(TComputationMutables& mutables, IComputationWideFlowNode* source, ui32 inWidth, ui32 outWidth)
+            : TBase(mutables, source, StateKind)
+            , TLLVMBase(source, inWidth, outWidth, {
+                .ThisPtr = reinterpret_cast<uintptr_t>(this),
+                .InitStateMethPtr = GetMethodPtr(&TDerived::InitState),
+                .PrepareInputMethPtr = GetMethodPtr(&TDerived::PrepareInput),
+                .DoProcessMethPtr = GetMethodPtr(&TDerived::DoProcess)
+            }) {}
 
 public:
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
@@ -122,65 +114,6 @@ public:
         }
         return result.Get();
     }
-
-#ifndef MKQL_DISABLE_CODEGEN
-    ICodegeneratorInlineWideNode::TGenerateResult DoGenGetValues(const NKikimr::NMiniKQL::TCodegenContext& ctx, llvm::Value* statePtrVal, llvm::BasicBlock*& genToBlock) const {
-        return DoGenGetValuesBase(ctx, statePtrVal, genToBlock);
-    }
-#endif
-};
-
-template<typename TDerived>
-class TSimpleStatelessWideFlowCodegeneratorNode
-        : public TStatelessWideFlowCodegeneratorNode<TSimpleStatelessWideFlowCodegeneratorNode<TDerived>> 
-        , public TSimpleWideFlowCodegeneratorNodeLLVMBase {
-    using TBase = TStatelessWideFlowCodegeneratorNode<TSimpleStatelessWideFlowCodegeneratorNode<TDerived>>;
-    using TLLVMBase = TSimpleWideFlowCodegeneratorNodeLLVMBase;
-
-protected:
-    TSimpleStatelessWideFlowCodegeneratorNode(IComputationWideFlowNode* source, ui32 inWidth, ui32 outWidth)
-        : TBase (source)
-        , TLLVMBase(source, inWidth, outWidth, {
-            .ThisPtr = reinterpret_cast<uintptr_t>(this),
-            .InitStateMethPtr = 0,
-            .PrepareInputMethPtr = GetMethodPtr(&TDerived::PrepareInput),
-            .DoProcessMethPtr = GetMethodPtr(&TDerived::DoProcess)
-        }) {}
-
-#ifndef MKQL_DISABLE_CODEGEN
-    virtual ICodegeneratorInlineWideNode::TGenerateResult GenFetchProcess(const TCodegenContext& ctx, const TResultCodegenerator& fetchGenerator, BasicBlock*& block) const {
-        Y_UNUSED(ctx);
-        Y_UNUSED(fetchGenerator);
-        Y_UNUSED(block);
-        return {nullptr, {}};
-    }
-
-    virtual ICodegeneratorInlineWideNode::TGenerateResult DispatchGenFetchProcess(Value* statePtrVal, const TCodegenContext& ctx, const TResultCodegenerator& fetchGenerator, BasicBlock*& block) const override final {
-        Y_UNUSED(statePtrVal);
-        return GenFetchProcess(ctx, fetchGenerator, block);
-    }
-#endif
-
-public:
-    EFetchResult DoCalculate(TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        NUdf::TUnboxedValue *const stub = nullptr;
-        if (!output && !OutWidth) {
-            output = &stub;
-        }
-        auto result = TMaybeFetchResult::None();
-        while (result.Empty()) {
-            NUdf::TUnboxedValue*const* input = static_cast<const TDerived*>(this)->PrepareInput(ctx, output);
-            TMaybeFetchResult fetchResult = input ? SourceFlow->FetchValues(ctx, input) : TMaybeFetchResult::None();
-            result = static_cast<const TDerived*>(this)->DoProcess(ctx, fetchResult, output);
-        }
-        return result.Get();
-    }
-
-#ifndef MKQL_DISABLE_CODEGEN
-    ICodegeneratorInlineWideNode::TGenerateResult DoGenGetValues(const NKikimr::NMiniKQL::TCodegenContext& ctx, llvm::BasicBlock*& genToBlock) const {
-        return DoGenGetValuesBase(ctx, nullptr, genToBlock);
-    }
-#endif
 };
 
 }


### PR DESCRIPTION
This reverts commit 5b2264954da2ff5c8d861877db109ab2532c81ff because of coredump inside Clickbench q25 in PG syntax.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Additional information

...
