### PR TITLE
Fix infinite loop in Re2::FindAndConsume UDF

### DIFF
--- a/ydb/library/yql/udfs/common/re2/re2_udf.cpp
+++ b/ydb/library/yql/udfs/common/re2/re2_udf.cpp
@@ -216,7 +216,10 @@ namespace {
                     case FIND_AND_CONSUME: {
                         StringPiece text(piece);
                         std::vector<TUnboxedValue> matches;
-                        for (StringPiece w; RE2::FindAndConsume(&text, *Regexp, &w);) {
+                        for (StringPiece w; !text.empty() && RE2::FindAndConsume(&text, *Regexp, &w);) {
+                            if (w.size() == 0) {
+                                text.remove_prefix(1);
+                            }
                             matches.emplace_back(valueBuilder->SubString(args[0], std::distance(piece.begin(), w.begin()), w.size()));
                         }
                         return valueBuilder->NewList(matches.data(), matches.size());

--- a/ydb/library/yql/udfs/common/re2/test/canondata/result.json
+++ b/ydb/library/yql/udfs/common/re2/test/canondata/result.json
@@ -19,6 +19,11 @@
             "uri": "file://test.test_DefOptions_/results.txt"
         }
     ],
+    "test.test[FindAndConsumeEmpty]": [
+        {
+            "uri": "file://test.test_FindAndConsumeEmpty_/results.txt"
+        }
+    ],
     "test.test[LikeEscape]": [
         {
             "uri": "file://test.test_LikeEscape_/results.txt"

--- a/ydb/library/yql/udfs/common/re2/test/canondata/test.test_FindAndConsumeEmpty_/results.txt
+++ b/ydb/library/yql/udfs/common/re2/test/canondata/test.test_FindAndConsumeEmpty_/results.txt
@@ -1,0 +1,35 @@
+[
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "column0";
+                                [
+                                    "ListType";
+                                    [
+                                        "DataType";
+                                        "String"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            "a";
+                            "";
+                            "aa"
+                        ]
+                    ]
+                ]
+            }
+        ]
+    }
+]

--- a/ydb/library/yql/udfs/common/re2/test/cases/FindAndConsumeEmpty.sql
+++ b/ydb/library/yql/udfs/common/re2/test/cases/FindAndConsumeEmpty.sql
@@ -1,0 +1,4 @@
+/* syntax version 1 */
+$regexp = Re2::FindAndConsume("(a*)");
+
+SELECT $regexp("abaa");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixes infinite loop in queries where group matches empty string:
```
$regexp = Re2::FindAndConsume("(a*)");

SELECT $regexp("abaa");
```

### Changelog category <!-- remove all except one -->

* Bugfix

### Additional information

...
