### PR TITLE
Added spiller factory to sync compute actor

### DIFF
--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -1015,6 +1015,10 @@ public:
     std::function<void()> GetWakeupCallback() const override {
         return {};
     }
+
+    NDq::TTxId GetTxId() const override {
+        return {};
+    }
 };
 
 }  // anonymous namespace

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -213,8 +213,7 @@ protected:
         TaskRunner->Prepare(this->Task, limits, execCtx);
 
         if (this->Task.GetEnableSpilling()) {
-            auto wakeUpCallback = execCtx.GetWakeupCallback();
-            TaskRunner->SetSpillerFactory(std::make_shared<TDqSpillerFactory>(execCtx.GetTxId(), NActors::TActivationContext::ActorSystem(), wakeUpCallback));
+            TaskRunner->SetSpillerFactory(std::make_shared<TDqSpillerFactory>(execCtx.GetTxId(), NActors::TActivationContext::ActorSystem(), execCtx.GetWakeupCallback()));
         }
 
         for (auto& [channelId, channel] : this->InputChannelsMap) {

--- a/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.cpp
@@ -28,5 +28,9 @@ std::function<void()> TDqTaskRunnerExecutionContext::GetWakeupCallback() const {
     return WakeUp_;
 }
 
+TTxId TDqTaskRunnerExecutionContext::GetTxId() const {
+    return TxId_;
+}
+
 } // namespace NDq
 } // namespace NYql

--- a/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.h
+++ b/ydb/library/yql/dq/actors/compute/dq_task_runner_exec_ctx.h
@@ -15,6 +15,7 @@ public:
     IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem) const override;
 
     std::function<void()> GetWakeupCallback() const override;
+    TTxId GetTxId() const override;
 
 private:
     const TTxId TxId_;

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.h
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.h
@@ -139,6 +139,7 @@ public:
     virtual IDqChannelStorage::TPtr CreateChannelStorage(ui64 channelId, bool withSpilling, NActors::TActorSystem* actorSystem) const = 0;
 
     virtual std::function<void()> GetWakeupCallback() const = 0;
+    virtual TTxId GetTxId() const = 0;
 };
 
 class TDqTaskRunnerExecutionContextBase : public IDqTaskRunnerExecutionContext {
@@ -161,6 +162,10 @@ public:
     };
 
     std::function<void()> GetWakeupCallback() const override {
+        return {};
+    }
+
+    TTxId GetTxId() const override {
         return {};
     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -729,8 +729,6 @@ private:
     }
 
     EFetchResult DoCalculateInMemory(TComputationContext& ctx, NUdf::TUnboxedValue*const* output) {
-
-        std::cerr << "MISHA spiller factory: " << (bool)ctx.SpillerFactory << std::endl;
         // Collecting data for join and perform join (batch or full)
         while (!*JoinCompleted ) {
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -729,6 +729,8 @@ private:
     }
 
     EFetchResult DoCalculateInMemory(TComputationContext& ctx, NUdf::TUnboxedValue*const* output) {
+
+        std::cerr << "MISHA spiller factory: " << (bool)ctx.SpillerFactory << std::endl;
         // Collecting data for join and perform join (batch or full)
         while (!*JoinCompleted ) {
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Spiller factory is added to TDqSyncComputeActorBase. So, it will be used in KQP, because KQP don't use async compute actor.

### Changelog category <!-- remove all except one -->

* New feature


### Additional information

...
