### PR TITLE
Support SchemeBoard online reconfiguration

### DIFF
--- a/ydb/core/base/statestorage_impl.h
+++ b/ydb/core/base/statestorage_impl.h
@@ -158,6 +158,11 @@ struct TEvStateStorage::TEvResolveReplicasList : public TEventLocal<TEvResolveRe
 };
 
 struct TEvStateStorage::TEvListSchemeBoard : public TEventLocal<TEvListSchemeBoard, EvListSchemeBoard> {
+    const bool Subscribe = false;
+
+    TEvListSchemeBoard(bool subscribe)
+        : Subscribe(subscribe)
+    {}
 };
 
 struct TEvStateStorage::TEvListSchemeBoardResult : public TEventLocal<TEvListSchemeBoardResult, EvListSchemeBoardResult> {

--- a/ydb/core/base/statestorage_proxy.cpp
+++ b/ydb/core/base/statestorage_proxy.cpp
@@ -337,8 +337,9 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
                 ReplyAndSig(NKikimrProto::OK);
                 return;
             case TStateStorageInfo::TSelection::StatusNoInfo:
-                if (RepliesMerged == Replicas) // for negative response always waits for full reply set to avoid herding of good replicas by fast retry cycle
+                if (RepliesMerged == Replicas) { // for negative response always waits for full reply set to avoid herding of good replicas by fast retry cycle
                     ReplyAndSig(NKikimrProto::ERROR);
+                }
                 return;
             case TStateStorageInfo::TSelection::StatusOutdated:
                 ReplyAndSig(NKikimrProto::RACE);
@@ -743,6 +744,7 @@ class TStateStorageProxy : public TActor<TStateStorageProxy> {
     TMap<TActorId, TActorId> ReplicaProbes;
 
     THashMap<std::tuple<TActorId, ui64>, ui64> Subscriptions;
+    THashSet<std::tuple<TActorId, ui64>> SchemeBoardSubscriptions;
 
     void Handle(TEvStateStorage::TEvRequestReplicasDumps::TPtr &ev) {
         TActivationContext::Register(new TStateStorageDumpRequest(ev->Sender, Info));
@@ -772,7 +774,9 @@ class TStateStorageProxy : public TActor<TStateStorageProxy> {
     }
 
     void HandleUnsubscribe(STATEFN_SIG) {
-        Subscriptions.erase(std::make_tuple(ev->Sender, ev->Cookie));
+        const auto key = std::make_tuple(ev->Sender, ev->Cookie);
+        Subscriptions.erase(key);
+        SchemeBoardSubscriptions.erase(key);
     }
 
     void Handle(TEvStateStorage::TEvResolveBoard::TPtr &ev) {
@@ -813,20 +817,13 @@ class TStateStorageProxy : public TActor<TStateStorageProxy> {
     }
 
     void Handle(TEvStateStorage::TEvListSchemeBoard::TPtr &ev) {
-        if (!SchemeBoardInfo) {
-            Send(ev->Sender, new TEvStateStorage::TEvListSchemeBoardResult(nullptr), 0, ev->Cookie);
-            return;
+        if (ev->Get()->Subscribe) {
+            SchemeBoardSubscriptions.emplace(std::make_tuple(ev->Sender, ev->Cookie));
         }
-
         Send(ev->Sender, new TEvStateStorage::TEvListSchemeBoardResult(SchemeBoardInfo), 0, ev->Cookie);
     }
 
     void Handle(TEvStateStorage::TEvListStateStorage::TPtr &ev) {
-        if (!Info) {
-            Send(ev->Sender, new TEvStateStorage::TEvListStateStorageResult(nullptr), 0, ev->Cookie);
-            return;
-        }
-
         Send(ev->Sender, new TEvStateStorage::TEvListStateStorageResult(Info), 0, ev->Cookie);
     }
 
@@ -873,6 +870,9 @@ class TStateStorageProxy : public TActor<TStateStorageProxy> {
             const auto& [sender, cookie] = key;
             struct { TActorId Sender; ui64 Cookie; } ev{sender, cookie};
             ResolveReplicas(&ev, tabletId, Info);
+        }
+        for (const auto& [sender, cookie] : SchemeBoardSubscriptions) {
+            Send(sender, new TEvStateStorage::TEvListSchemeBoardResult(SchemeBoardInfo), 0, cookie);
         }
     }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -188,7 +188,7 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
         for (const auto& ring : info->Rings) {
             for (ui32 index = 0; index < ring.Replicas.size(); ++index) {
                 if (const TActorId& replicaId = ring.Replicas[index]; replicaId.NodeId() == LocalNodeId) {
-                    if (const auto [it, inserted] = localActorIds.insert(replicaId); inserted) {
+                    if (!localActorIds.erase(replicaId)) {
                         STLOG(PRI_INFO, BS_NODE, NW08, "starting new state storage replica",
                             (Component, comp), (ReplicaId, replicaId), (Index, index), (Config, *info));
                         as->RegisterLocalService(replicaId, as->Register(factory(info, index), TMailboxType::ReadAsFilled,

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -312,7 +312,7 @@ void TTablet::HandleStateStorageLeaderResolve(TEvStateStorage::TEvInfo::TPtr &ev
     }
 
     StateStorageInfo.KnownGeneration = msg->CurrentGeneration;
-    StateStorageInfo.Signature.Reset(msg->Signature.Release());
+    StateStorageInfo.KnownStep = msg->CurrentStep;
 
     if (msg->Status == NKikimrProto::OK && msg->CurrentLeader) {
         FollowerInfo.KnownLeaderID = msg->CurrentLeader;

--- a/ydb/core/tx/scheme_board/load_test.cpp
+++ b/ydb/core/tx/scheme_board/load_test.cpp
@@ -184,7 +184,7 @@ class TLoadProducer: public TActorBootstrapped<TLoadProducer> {
 
     void Boot() {
         const TActorId proxy = MakeStateStorageProxyID();
-        Send(proxy, new TEvStateStorage::TEvListSchemeBoard(), IEventHandle::FlagTrackDelivery);
+        Send(proxy, new TEvStateStorage::TEvListSchemeBoard(false), IEventHandle::FlagTrackDelivery);
 
         Become(&TThis::StateBoot);
     }

--- a/ydb/core/tx/scheme_board/monitoring.cpp
+++ b/ydb/core/tx/scheme_board/monitoring.cpp
@@ -1124,7 +1124,7 @@ class TMonitoring: public TActorBootstrapped<TMonitoring> {
 
     class TReplicaEnumerator: public TBaseRequester<TReplicaEnumerator, TEvStateStorage::TEvListSchemeBoardResult> {
         IEventBase* MakeRequest() const override {
-            return new TEvStateStorage::TEvListSchemeBoard();
+            return new TEvStateStorage::TEvListSchemeBoard(false);
         }
 
         void ProcessResponse(TEvStateStorage::TEvListSchemeBoardResult::TPtr& ev) override {

--- a/ydb/core/tx/scheme_board/populator.cpp
+++ b/ydb/core/tx/scheme_board/populator.cpp
@@ -758,15 +758,30 @@ class TPopulator: public TMonitorableActor<TPopulator> {
         const auto& info = ev->Get()->Info;
 
         if (!info) {
+            Y_ABORT_UNLESS(!GroupInfo);
             SBP_LOG_E("Publish on unconfigured SchemeBoard");
             Become(&TThis::StateCalm);
             return;
         }
 
+        THashSet<TActorId> neededReplicas;
+
         GroupInfo = info;
         for (auto& replica : info->SelectAllReplicas()) {
-            IActor* replicaPopulator = new TReplicaPopulator(SelfId(), replica, Owner, Generation);
-            ReplicaToReplicaPopulator.emplace(replica, Register(replicaPopulator, TMailboxType::ReadAsFilled));
+            neededReplicas.insert(replica);
+            if (!ReplicaToReplicaPopulator.contains(replica)) {
+                IActor* replicaPopulator = new TReplicaPopulator(SelfId(), replica, Owner, Generation);
+                ReplicaToReplicaPopulator.emplace(replica, Register(replicaPopulator, TMailboxType::ReadAsFilled));
+            }
+        }
+
+        for (auto it = ReplicaToReplicaPopulator.begin(); it != ReplicaToReplicaPopulator.end(); ) {
+            if (neededReplicas.contains(it->first)) {
+                ++it;
+            } else {
+                TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, it->second, SelfId(), nullptr, 0));
+                ReplicaToReplicaPopulator.erase(it++);
+            }
         }
 
         Become(&TThis::StateWork);
@@ -844,6 +859,8 @@ class TPopulator: public TMonitorableActor<TPopulator> {
         for (const auto& x : ReplicaToReplicaPopulator) {
             Send(x.second, new TEvents::TEvPoisonPill());
         }
+        TActivationContext::Send(new IEventHandle(TEvents::TSystem::Unsubscribe, 0, MakeStateStorageProxyID(), SelfId(),
+            nullptr, 0));
 
         TMonitorableActor::PassAway();
     }
@@ -878,7 +895,7 @@ public:
         TMonitorableActor::Bootstrap();
 
         const TActorId proxy = MakeStateStorageProxyID();
-        Send(proxy, new TEvStateStorage::TEvListSchemeBoard(), IEventHandle::FlagTrackDelivery);
+        Send(proxy, new TEvStateStorage::TEvListSchemeBoard(true), IEventHandle::FlagTrackDelivery);
         Become(&TThis::StateResolve);
     }
 
@@ -898,6 +915,8 @@ public:
 
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
+            hFunc(TEvStateStorage::TEvListSchemeBoardResult, Handle);
+
             hFunc(NInternalEvents::TEvRequestDescribe, Handle);
             hFunc(NInternalEvents::TEvRequestUpdate, Handle);
 

--- a/ydb/core/tx/scheme_board/subscriber_ut.cpp
+++ b/ydb/core/tx/scheme_board/subscriber_ut.cpp
@@ -21,7 +21,7 @@ class TSubscriberTest: public NUnitTest::TTestBase {
         const TActorId proxy = MakeStateStorageProxyID();
         const TActorId edge = Context->AllocateEdgeActor();
 
-        Context->Send(proxy, edge, new TEvStateStorage::TEvListSchemeBoard());
+        Context->Send(proxy, edge, new TEvStateStorage::TEvListSchemeBoard(false));
         auto ev = Context->GrabEdgeEvent<TEvStateStorage::TEvListSchemeBoardResult>(edge);
 
         Y_ABORT_UNLESS(ev->Get()->Info);
@@ -253,7 +253,7 @@ class TSubscriberCombinationsTest: public NUnitTest::TTestBase {
         const TActorId proxy = MakeStateStorageProxyID();
         const TActorId edge = context.AllocateEdgeActor();
 
-        context.Send(proxy, edge, new TEvStateStorage::TEvListSchemeBoard());
+        context.Send(proxy, edge, new TEvStateStorage::TEvListSchemeBoard(false));
         auto ev = context.GrabEdgeEvent<TEvStateStorage::TEvListSchemeBoardResult>(edge);
 
         Y_ABORT_UNLESS(ev->Get()->Info);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support SchemeBoard online reconfiguration

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Support subscription for SchemeBoardPopulator allowing it to handle situation when set of replicas change online.
