### PR TITLE
grace join/spilling: try to free memory more often

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -836,15 +836,19 @@ private:
 void DoCalculateWithSpilling(TComputationContext& ctx) {
     UpdateSpilling();
 
-    if (!HasMemoryForProcessing() && !IsSpillingFinalized) {
-        bool isWaitingForReduce = TryToReduceMemoryAndWait();
-        if (isWaitingForReduce) return;
-    }
-
+    ui64 cntrows = 0;
     while (*HaveMoreLeftRows || *HaveMoreRightRows) {
+        if (0 == (cntrows++ % CheckMemoryRowLimit)) { // checks before first loop and
+                                                      // every CheckMemoryRowLimit rows
+            if (!HasMemoryForProcessing() && !IsSpillingFinalized) {
+                bool isWaitingForReduce = TryToReduceMemoryAndWait();
+                if (isWaitingForReduce) break;
+            }
+        }
         bool isYield = FetchAndPackData(ctx);
-        if (isYield) return;
+        if (isYield) break;
     }
+    YQL_LOG_IF(TRACE, cntrows > 0) << "chunk " << cntrows;
 
     if (!*HaveMoreLeftRows && !*HaveMoreRightRows) {
         if (!IsSpillingFinished()) return;
@@ -951,6 +955,8 @@ private:
     bool IsSpillingFinalized = false;
 
     ui32 NextBucketToJoin = 0;
+
+    static constexpr ui64 CheckMemoryRowLimit = 0x10000;
 };
 
 class TGraceJoinWrapper : public TStatefulWideFlowCodegeneratorNode<TGraceJoinWrapper> {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -836,19 +836,14 @@ private:
 void DoCalculateWithSpilling(TComputationContext& ctx) {
     UpdateSpilling();
 
-    ui64 cntrows = 0;
     while (*HaveMoreLeftRows || *HaveMoreRightRows) {
-        if (0 == (cntrows++ % CheckMemoryRowLimit)) { // checks before first loop and
-                                                      // every CheckMemoryRowLimit rows
-            if (!HasMemoryForProcessing() && !IsSpillingFinalized) {
-                bool isWaitingForReduce = TryToReduceMemoryAndWait();
-                if (isWaitingForReduce) break;
-            }
+        if (!HasMemoryForProcessing() && !IsSpillingFinalized) {
+            bool isWaitingForReduce = TryToReduceMemoryAndWait();
+            if (isWaitingForReduce) return;
         }
         bool isYield = FetchAndPackData(ctx);
-        if (isYield) break;
+        if (isYield) return;
     }
-    YQL_LOG_IF(TRACE, cntrows > 0) << "chunk " << cntrows;
 
     if (!*HaveMoreLeftRows && !*HaveMoreRightRows) {
         if (!IsSpillingFinished()) return;
@@ -955,8 +950,6 @@ private:
     bool IsSpillingFinalized = false;
 
     ui32 NextBucketToJoin = 0;
-
-    static constexpr ui64 CheckMemoryRowLimit = 0x10000;
 };
 
 class TGraceJoinWrapper : public TStatefulWideFlowCodegeneratorNode<TGraceJoinWrapper> {


### PR DESCRIPTION
number of rows per one loop may be large, try to free memory once in a while (0x10000 constant is somewhat arbitrary)

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...