### PR TITLE
Make DS proxy startup though distconf a bit smooth

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -253,6 +253,8 @@ void TNodeWarden::Bootstrap() {
     StartInvalidGroupProxy();
 
     StartDistributedConfigKeeper();
+
+    HandleGroupPendingQueueTick();
 }
 
 void TNodeWarden::HandleReadCache() {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -124,6 +124,7 @@ namespace NKikimr::NStorage {
                 EvUpdateNodeDrives,
                 EvReadCache,
                 EvGetGroup,
+                EvGroupPendingQueueTick,
             };
 
             struct TEvSendDiskMetrics : TEventLocal<TEvSendDiskMetrics, EvSendDiskMetrics> {};
@@ -450,6 +451,9 @@ namespace NKikimr::NStorage {
 
         std::unordered_map<ui32, TGroupRecord> Groups;
         std::unordered_set<ui32> EjectedGroups;
+        using TGroupPendingQueue = THashMap<ui32, std::deque<std::tuple<TMonotonic, std::unique_ptr<IEventHandle>>>>;
+        TGroupPendingQueue GroupPendingQueue;
+        std::set<std::tuple<TMonotonic, TGroupPendingQueue::value_type*>> TimeoutToQueue;
 
         // this function returns group info if possible, or otherwise starts requesting group info and/or proposing key
         // if needed
@@ -522,6 +526,7 @@ namespace NKikimr::NStorage {
         void FillInVDiskStatus(google::protobuf::RepeatedPtrField<NKikimrBlobStorage::TVDiskStatus> *pb, bool initial);
 
         void HandleForwarded(TAutoPtr<::NActors::IEventHandle> &ev);
+        void HandleGroupPendingQueueTick();
         void HandleIncrHugeInit(NIncrHuge::TEvIncrHugeInit::TPtr ev);
 
         void Handle(TEvBlobStorage::TEvControllerScrubQueryStartQuantum::TPtr ev); // from VDisk
@@ -590,6 +595,8 @@ namespace NKikimr::NStorage {
                 fFunc(TEvBlobStorage::TEvAssimilate::EventType, HandleForwarded);
                 fFunc(TEvBlobStorage::TEvBunchOfEvents::EventType, HandleForwarded);
                 fFunc(TEvRequestProxySessionsState::EventType, HandleForwarded);
+
+                cFunc(TEvPrivate::EvGroupPendingQueueTick, HandleGroupPendingQueueTick);
 
                 hFunc(NIncrHuge::TEvIncrHugeInit, HandleIncrHugeInit);
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_pipe.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pipe.cpp
@@ -30,6 +30,9 @@ void TNodeWarden::Handle(TEvTabletPipe::TEvClientConnected::TPtr ev) {
             (ClientId, msg->ClientId), (ServerId, msg->ServerId), (TabletId, msg->TabletId),
             (PipeClientId, PipeClientId));
         OnPipeError();
+    } else {
+        STLOG(PRI_DEBUG, BS_NODE, NW05, "TEvTabletPipe::TEvClientConnected OK", (ClientId, msg->ClientId),
+            (ServerId, msg->ServerId), (TabletId, msg->TabletId), (PipeClientId, PipeClientId));
     }
 }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
@@ -85,7 +85,7 @@ void TNodeWarden::HandleForwarded(TAutoPtr<::NActors::IEventHandle> &ev) {
     const TGroupID groupId(GroupIDFromBlobStorageProxyID(ev->GetForwardOnNondeliveryRecipient()));
     const ui32 id = groupId.GetRaw();
 
-    const bool noGroup = (groupId.ConfigurationType() == EGroupConfigurationType::Static && !Groups.count(id)) || EjectedGroups.count(id);
+    const bool noGroup = EjectedGroups.count(id);
     STLOG(PRI_DEBUG, BS_NODE, NW46, "HandleForwarded", (GroupId, id), (EnableProxyMock, EnableProxyMock), (NoGroup, noGroup));
 
     if (id == Max<ui32>()) {
@@ -95,6 +95,15 @@ void TNodeWarden::HandleForwarded(TAutoPtr<::NActors::IEventHandle> &ev) {
         TActivationContext::Forward(ev, errorProxy);
         TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, errorProxy, {}, nullptr, 0));
         return;
+    } else if (groupId.ConfigurationType() == EGroupConfigurationType::Static && !Groups.count(id)) {
+        const auto [it, inserted] = GroupPendingQueue.try_emplace(id);
+        auto& queue = it->second;
+        TMonotonic expiration = TActivationContext::Monotonic() + TDuration::Seconds(5);
+        if (queue.empty()) {
+            TimeoutToQueue.emplace(expiration, &*it);
+        }
+        queue.emplace_back(expiration, std::unique_ptr<IEventHandle>(ev.Release()));
+        return;
     } else if (TGroupRecord& group = Groups[id]; !group.ProxyId) {
         if (TGroupID(id).ConfigurationType() == EGroupConfigurationType::Virtual) {
             StartVirtualGroupAgent(id);
@@ -103,6 +112,43 @@ void TNodeWarden::HandleForwarded(TAutoPtr<::NActors::IEventHandle> &ev) {
         }
     }
     TActivationContext::Forward(ev, ev->GetForwardOnNondeliveryRecipient());
+}
+
+void TNodeWarden::HandleGroupPendingQueueTick() {
+    const TMonotonic now = TActivationContext::Monotonic();
+
+    std::set<std::tuple<TMonotonic, TGroupPendingQueue::value_type*>>::iterator it;
+    for (it = TimeoutToQueue.begin(); it != TimeoutToQueue.end(); ++it) {
+        const auto& [timestamp, ptr] = *it;
+        if (now < timestamp) {
+            break;
+        }
+
+        auto& [groupId, queue] = *ptr;
+        Y_ABORT_UNLESS(!queue.empty());
+
+        const TActorId errorProxy = StartEjectedProxy(groupId);
+        for (;;) {
+            auto& [timestamp, ev] = queue.front();
+            if (now < timestamp) {
+                TimeoutToQueue.emplace(timestamp, ptr);
+                break;
+            } else {
+                THolder<IEventHandle> tmp(ev.release());
+                TActivationContext::Forward(tmp, errorProxy);
+                queue.pop_front();
+                if (queue.empty()) {
+                    GroupPendingQueue.erase(groupId);
+                    break;
+                }
+            }
+        }
+        TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, errorProxy, {}, nullptr, 0));
+    }
+    TimeoutToQueue.erase(TimeoutToQueue.begin(), it);
+
+    TActivationContext::Schedule(TDuration::Seconds(1), new IEventHandle(TEvPrivate::EvGroupPendingQueueTick, 0,
+        SelfId(), {}, nullptr, 0));
 }
 
 void TNodeWarden::Handle(NNodeWhiteboard::TEvWhiteboard::TEvBSGroupStateUpdate::TPtr ev) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make DS proxy startup though distconf a bit smooth

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

DS proxy requests for static group that has not been configured yet are now enqueued in a timeout-based queue and processed as soon as timeout hits or group gets configured.
