### PR TITLE
Add allow unknown fields to CMS

### DIFF
--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -91,7 +91,10 @@ public:
             request.Owner = owner;
             request.Order = order;
             request.Priority = priority;
-            google::protobuf::TextFormat::ParseFromString(requestStr, &request.Request);
+
+            google::protobuf::TextFormat::Parser parser;
+            parser.AllowUnknownField(true);
+            parser.ParseFromString(requestStr, &request.Request);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded request %s owned by %s: %s",
                       id.data(), owner.data(), requestStr.data());
@@ -149,8 +152,11 @@ public:
             permission.PermissionId = id;
             permission.RequestId = requestId;
             permission.Owner = owner;
-            google::protobuf::TextFormat::ParseFromString(actionStr, &permission.Action);
             permission.Deadline = TInstant::MicroSeconds(deadline);
+
+            google::protobuf::TextFormat::Parser parser;
+            parser.AllowUnknownField(true);
+            parser.ParseFromString(actionStr, &permission.Action);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded permission %s owned by %s valid until %s: %s",
                       id.data(), owner.data(), TInstant::MicroSeconds(deadline).ToStringLocalUpToSeconds().data(), actionStr.data());
@@ -185,7 +191,10 @@ public:
             TNotificationInfo notification;
             notification.NotificationId = id;
             notification.Owner = owner;
-            google::protobuf::TextFormat::ParseFromString(notificationStr, &notification.Notification);
+            
+            google::protobuf::TextFormat::Parser parser;
+            parser.AllowUnknownField(true);
+            parser.ParseFromString(notificationStr, &notification.Notification);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded notification %s owned by %s: %s",
                       id.data(), owner.data(), notificationStr.data());

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -9,6 +9,21 @@
 
 namespace NKikimr::NCms {
 
+using namespace NKikimrCms;
+
+namespace {
+
+template<typename T>
+T ParseFromString(const TString& str) {
+    google::protobuf::TextFormat::Parser parser;
+    parser.AllowUnknownField(true);
+    T result;
+    parser.ParseFromString(str, &result);
+    return result;
+}
+
+} // anonymous namespace
+
 class TCms::TTxLoadState : public TTransactionBase<TCms> {
 public:
     TTxLoadState(TCms *self)
@@ -91,10 +106,7 @@ public:
             request.Owner = owner;
             request.Order = order;
             request.Priority = priority;
-
-            google::protobuf::TextFormat::Parser parser;
-            parser.AllowUnknownField(true);
-            parser.ParseFromString(requestStr, &request.Request);
+            request.Request = ParseFromString<TPermissionRequest>(requestStr);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded request %s owned by %s: %s",
                       id.data(), owner.data(), requestStr.data());
@@ -153,10 +165,7 @@ public:
             permission.RequestId = requestId;
             permission.Owner = owner;
             permission.Deadline = TInstant::MicroSeconds(deadline);
-
-            google::protobuf::TextFormat::Parser parser;
-            parser.AllowUnknownField(true);
-            parser.ParseFromString(actionStr, &permission.Action);
+            permission.Action = ParseFromString<TAction>(actionStr);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded permission %s owned by %s valid until %s: %s",
                       id.data(), owner.data(), TInstant::MicroSeconds(deadline).ToStringLocalUpToSeconds().data(), actionStr.data());
@@ -191,10 +200,7 @@ public:
             TNotificationInfo notification;
             notification.NotificationId = id;
             notification.Owner = owner;
-            
-            google::protobuf::TextFormat::Parser parser;
-            parser.AllowUnknownField(true);
-            parser.ParseFromString(notificationStr, &notification.Notification);
+            notification.Notification = ParseFromString<TNotification>(notificationStr);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded notification %s owned by %s: %s",
                       id.data(), owner.data(), notificationStr.data());

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -14,12 +14,10 @@ using namespace NKikimrCms;
 namespace {
 
 template<typename T>
-T ParseFromString(const TString& str) {
+bool ParseFromStringSafe(const TString& input, T* output) {
     google::protobuf::TextFormat::Parser parser;
     parser.AllowUnknownField(true);
-    T result;
-    parser.ParseFromString(str, &result);
-    return result;
+    return parser.ParseFromString(input, output);
 }
 
 } // anonymous namespace
@@ -106,7 +104,7 @@ public:
             request.Owner = owner;
             request.Order = order;
             request.Priority = priority;
-            request.Request = ParseFromString<TPermissionRequest>(requestStr);
+            ParseFromStringSafe<TPermissionRequest>(requestStr, &request.Request);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded request %s owned by %s: %s",
                       id.data(), owner.data(), requestStr.data());
@@ -164,8 +162,8 @@ public:
             permission.PermissionId = id;
             permission.RequestId = requestId;
             permission.Owner = owner;
+            ParseFromStringSafe<TAction>(actionStr, &permission.Action);
             permission.Deadline = TInstant::MicroSeconds(deadline);
-            permission.Action = ParseFromString<TAction>(actionStr);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded permission %s owned by %s valid until %s: %s",
                       id.data(), owner.data(), TInstant::MicroSeconds(deadline).ToStringLocalUpToSeconds().data(), actionStr.data());
@@ -200,7 +198,7 @@ public:
             TNotificationInfo notification;
             notification.NotificationId = id;
             notification.Owner = owner;
-            notification.Notification = ParseFromString<TNotification>(notificationStr);
+            ParseFromStringSafe<TNotification>(notificationStr, &notification.Notification);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded notification %s owned by %s: %s",
                       id.data(), owner.data(), notificationStr.data());

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -9,8 +9,6 @@
 
 namespace NKikimr::NCms {
 
-using namespace NKikimrCms;
-
 namespace {
 
 template<typename T>
@@ -104,7 +102,7 @@ public:
             request.Owner = owner;
             request.Order = order;
             request.Priority = priority;
-            ParseFromStringSafe<TPermissionRequest>(requestStr, &request.Request);
+            ParseFromStringSafe(requestStr, &request.Request);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded request %s owned by %s: %s",
                       id.data(), owner.data(), requestStr.data());
@@ -162,7 +160,7 @@ public:
             permission.PermissionId = id;
             permission.RequestId = requestId;
             permission.Owner = owner;
-            ParseFromStringSafe<TAction>(actionStr, &permission.Action);
+            ParseFromStringSafe(actionStr, &permission.Action);
             permission.Deadline = TInstant::MicroSeconds(deadline);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded permission %s owned by %s valid until %s: %s",
@@ -198,7 +196,7 @@ public:
             TNotificationInfo notification;
             notification.NotificationId = id;
             notification.Owner = owner;
-            ParseFromStringSafe<TNotification>(notificationStr, &notification.Notification);
+            ParseFromStringSafe(notificationStr, &notification.Notification);
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded notification %s owned by %s: %s",
                       id.data(), owner.data(), notificationStr.data());


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

This change allows CMS to ignore unknown fields when reading them from the local database. Overwriting the data will cause the unknown fields to be lost.