### PR TITLE
Support StateStorageBoard online reconfiguration through distconf

### DIFF
--- a/ydb/core/base/statestorage_impl.h
+++ b/ydb/core/base/statestorage_impl.h
@@ -124,9 +124,11 @@ struct TEvStateStorage::TEvResolveReplicas : public TEventLocal<TEvResolveReplic
 
 struct TEvStateStorage::TEvResolveBoard : public TEventLocal<TEvResolveBoard, EvResolveBoard> {
     const TString Path;
+    const bool Subscribe;
 
-    TEvResolveBoard(const TString &path)
+    TEvResolveBoard(const TString &path, bool subscribe = false)
         : Path(path)
+        , Subscribe(subscribe)
     {}
 };
 

--- a/ydb/core/base/statestorage_proxy.cpp
+++ b/ydb/core/base/statestorage_proxy.cpp
@@ -788,6 +788,10 @@ class TStateStorageProxy : public TActor<TStateStorageProxy> {
         const auto *msg = ev->Get();
         const ui64 pathHash = CityHash64(msg->Path);
 
+        if (msg->Subscribe) {
+            Subscriptions.try_emplace(std::make_tuple(ev->Sender, ev->Cookie), pathHash, &TThis::BoardInfo);
+        }
+
         ResolveReplicas(ev, pathHash, BoardInfo);
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support StateStorageBoard online reconfiguration through distconf

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

StateStorage board now can be reconfigured without restarting publishers.

#5768
