### PR TITLE
Correct PDisk/VDisk metrics reporting

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -338,7 +338,6 @@ void TNodeWarden::Handle(NPDisk::TEvSlayResult::TPtr ev) {
                 SendVDiskReport(vslotId, msg.VDiskId, NKikimrBlobStorage::TEvControllerNodeReport::WIPED);
                 TVDiskRecord& vdisk = vdiskIt->second;
                 StartLocalVDiskActor(vdisk); // restart actor after successful wiping
-                SendDiskMetrics(false);
             }
             break;
 
@@ -540,6 +539,8 @@ void TNodeWarden::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatus::TPtr ev)
 
     auto& record = ev->Get()->Record;
 
+    std::unique_ptr<TEvBlobStorage::TEvControllerUpdateDiskStatus> updateDiskStatus;
+
     for (const NKikimrBlobStorage::TVDiskMetrics& m : record.GetVDisksMetrics()) {
         Y_ABORT_UNLESS(m.HasVSlotId());
         const TVSlotId vslotId(m.GetVSlotId());
@@ -554,8 +555,11 @@ void TNodeWarden::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatus::TPtr ev)
                     VDisksWithUnreportedMetrics.PushBack(&vdisk);
                 }
             } else {
+                if (!updateDiskStatus) {
+                    updateDiskStatus.reset(new TEvBlobStorage::TEvControllerUpdateDiskStatus);
+                }
+                updateDiskStatus->Record.AddVDisksMetrics()->CopyFrom(m);
                 vdisk.VDiskMetrics.emplace(m);
-                VDisksWithUnreportedMetrics.PushBack(&vdisk);
             }
         }
     }
@@ -571,10 +575,17 @@ void TNodeWarden::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatus::TPtr ev)
                     PDisksWithUnreportedMetrics.PushBack(&pdisk);
                 }
             } else {
+                if (!updateDiskStatus) {
+                    updateDiskStatus.reset(new TEvBlobStorage::TEvControllerUpdateDiskStatus);
+                }
+                updateDiskStatus->Record.AddPDisksMetrics()->CopyFrom(m);
                 pdisk.PDiskMetrics.emplace(m);
-                PDisksWithUnreportedMetrics.PushBack(&pdisk);
             }
         }
+    }
+
+    if (updateDiskStatus) {
+        SendToController(std::move(updateDiskStatus));
     }
 }
 
@@ -637,7 +648,7 @@ void TNodeWarden::Handle(TEvStatusUpdate::TPtr ev) {
         auto& vdisk = it->second;
         vdisk.Status = msg->Status;
         vdisk.OnlyPhantomsRemain = msg->OnlyPhantomsRemain;
-        SendDiskMetrics(false);
+        VDiskStatusChanged = true;
 
         if (msg->Status == NKikimrBlobStorage::EVDiskStatus::READY && vdisk.WhiteboardVDiskId) {
             Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvVDiskDropDonors(*vdisk.WhiteboardVDiskId,

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -582,6 +582,8 @@ namespace NKikimr::NStorage {
         IActor *CreateGroupResolverActor(ui32 groupId);
         void Handle(TEvNodeWardenQueryGroupInfo::TPtr ev);
 
+        bool VDiskStatusChanged = false;
+
         STATEFN(StateOnline) {
             switch (ev->GetTypeRewrite()) {
                 fFunc(TEvBlobStorage::TEvPut::EventType, HandleForwarded);
@@ -662,6 +664,11 @@ namespace NKikimr::NStorage {
                 default:
                     EnqueuePendingMessage(ev);
                     break;
+            }
+
+            if (VDiskStatusChanged) {
+                SendDiskMetrics(false);
+                VDiskStatusChanged = false;
             }
         }
     };

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -254,7 +254,6 @@ namespace NKikimr::NStorage {
                     StartLocalVDiskActor(value);
                 }
             }
-            SendDiskMetrics(false);
 
             vdisks << "}";
             STLOG(PRI_NOTICE, BS_NODE, NW74, "RestartLocalPDisk has finished",

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -49,8 +49,7 @@ namespace NKikimr::NStorage {
         vdisk.ScrubCookieForController = 0; // and from controller too
         vdisk.Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
         vdisk.ShutdownPending = true;
-
-        SendDiskMetrics(false);
+        VDiskStatusChanged = true;
     }
 
     void TNodeWarden::StartLocalVDiskActor(TVDiskRecord& vdisk) {
@@ -239,6 +238,7 @@ namespace NKikimr::NStorage {
         vdisk.Status = NKikimrBlobStorage::EVDiskStatus::INIT_PENDING;
         vdisk.ReportedVDiskStatus.reset();
         vdisk.ScrubCookie = scrubCookie;
+        VDiskStatusChanged = true;
     }
 
     void TNodeWarden::HandleGone(STATEFN_SIG) {
@@ -259,7 +259,6 @@ namespace NKikimr::NStorage {
         for (const auto& vdisk : serviceSet.GetVDisks()) {
             ApplyLocalVDiskInfo(vdisk);
         }
-        SendDiskMetrics(false);
     }
 
     void TNodeWarden::ApplyLocalVDiskInfo(const NKikimrBlobStorage::TNodeWardenServiceSet::TVDisk& vdisk) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Correct PDisk/VDisk metrics reporting

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

VDisk/PDisk metrics are reported now without delay when respective entries has been created, also excessive PDisk restarts due to serial number discovery have been eliminated.
