### PR TITLE
Make interconnect proxy retry timeout parameters configurable (merge from main #3748)

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -535,6 +535,16 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
     }
     result.SocketBacklogSize = config.GetSocketBacklogSize();
 
+    if (config.HasFirstErrorSleep()) {
+        result.FirstErrorSleep = DurationFromProto(config.GetFirstErrorSleep());
+    }
+    if (config.HasMaxErrorSleep()) {
+        result.MaxErrorSleep = DurationFromProto(config.GetMaxErrorSleep());
+    }
+    if (config.HasErrorSleepRetryMultiplier()) {
+        result.ErrorSleepRetryMultiplier = config.GetErrorSleepRetryMultiplier();
+    }
+
     return result;
 }
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -469,6 +469,10 @@ message TInterconnectConfig {
     optional NKikimrConfigUnits.TDuration LostConnectionDuration = 28;
     optional NKikimrConfigUnits.TDuration BatchPeriodDuration = 29;
 
+    optional NKikimrConfigUnits.TDuration FirstErrorSleep = 46;
+    optional NKikimrConfigUnits.TDuration MaxErrorSleep = 47;
+    optional double ErrorSleepRetryMultiplier = 48;
+
     optional uint32 OutgoingHandshakeInflightLimit = 43;
 }
 

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -51,6 +51,9 @@ namespace NActors {
         bool EnableExternalDataChannel = false;
         bool ValidateIncomingPeerViaDirectLookup = false;
         ui32 SocketBacklogSize = 0; // SOMAXCONN if zero
+        TDuration FirstErrorSleep = TDuration::MilliSeconds(10);
+        TDuration MaxErrorSleep = TDuration::Seconds(1);
+        double ErrorSleepRetryMultiplier = 4.0;
 
         ui32 GetSendBufferSize() const {
             ui32 res = 512 * 1024; // 512 kb is the default value for send buffer


### PR DESCRIPTION
hangelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make interconnect proxy retry timeout parameters configurable

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Added configuration parameters to customize error sleep timeout. Also default maximum timeout has been reduced to 1 second instead of 10.
