### PR TITLE
grace join: reduce hash collisions

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -244,7 +244,7 @@ void ResizeHashTable(KeysHashTable &t, ui64 newSlots){
         if ( *it == 0)
             continue;
         ui64 hash = *it;
-        ui64 newSlotNum = (hash / NumberOfBuckets) % (newSlots);
+        ui64 newSlotNum = hash % (newSlots);
         auto newIt = newTable.begin() + t.SlotSize * newSlotNum;
         while (*newIt != 0) {
             newIt += t.SlotSize;
@@ -359,7 +359,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             if (!HasBitSet(nullsPtr, 1))
             {
 
-                ui64 slotNum = (hash / NumberOfBuckets) % nSlots;
+                ui64 slotNum = hash % nSlots;
                 auto slotIt = joinSlots.begin() + slotNum * slotSize;
 
                 while (*slotIt != 0)
@@ -409,7 +409,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
                 continue;
             }
 
-            ui64 slotNum = (hash / NumberOfBuckets) % nSlots;
+            ui64 slotNum = hash % nSlots;
             auto slotIt = joinSlots.begin() + slotNum * slotSize;
             while (*slotIt != 0 && slotIt != joinSlots.end())
             {
@@ -679,7 +679,7 @@ inline bool TTable::AddKeysToHashTable(KeysHashTable& t, ui64* keys) {
         return false;
 
     ui64 hash = *keys;
-    ui64 slot = (hash / NumberOfBuckets) % t.NSlots;
+    ui64 slot = hash % t.NSlots;
     auto it = t.Table.begin() + slot * t.SlotSize;
 
     ui64 keyIntOffset = HashSize + NullsBitmapSize_;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -244,7 +244,7 @@ void ResizeHashTable(KeysHashTable &t, ui64 newSlots){
         if ( *it == 0)
             continue;
         ui64 hash = *it;
-        ui64 newSlotNum = hash % (newSlots);
+        ui64 newSlotNum = (hash / NumberOfBuckets) % (newSlots);
         auto newIt = newTable.begin() + t.SlotSize * newSlotNum;
         while (*newIt != 0) {
             newIt += t.SlotSize;
@@ -359,7 +359,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             if (!HasBitSet(nullsPtr, 1))
             {
 
-                ui64 slotNum = hash % nSlots;
+                ui64 slotNum = (hash / NumberOfBuckets) % nSlots;
                 auto slotIt = joinSlots.begin() + slotNum * slotSize;
 
                 while (*slotIt != 0)
@@ -409,7 +409,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
                 continue;
             }
 
-            ui64 slotNum = hash % nSlots;
+            ui64 slotNum = (hash / NumberOfBuckets) % nSlots;
             auto slotIt = joinSlots.begin() + slotNum * slotSize;
             while (*slotIt != 0 && slotIt != joinSlots.end())
             {
@@ -679,7 +679,7 @@ inline bool TTable::AddKeysToHashTable(KeysHashTable& t, ui64* keys) {
         return false;
 
     ui64 hash = *keys;
-    ui64 slot = hash % t.NSlots;
+    ui64 slot = (hash / NumberOfBuckets) % t.NSlots;
     auto it = t.Table.begin() + slot * t.SlotSize;
 
     ui64 keyIntOffset = HashSize + NullsBitmapSize_;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -336,7 +336,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
         }
 
         
-        ui64 nSlots = 3 * tuplesNum2 + 1;
+        ui64 nSlots = (3 * tuplesNum2 + 1) | 1;
         joinSlots.clear();
         spillSlots.clear();
         slotToIdx.clear();
@@ -672,7 +672,7 @@ inline bool TTable::AddKeysToHashTable(KeysHashTable& t, ui64* keys) {
     }
 
     if ( ( (t.NSlots - t.FillCount) * 100 ) / t.NSlots < 50 ) {
-        ResizeHashTable(t, 2 * t.NSlots);
+        ResizeHashTable(t, 2 * t.NSlots + 1);
     }
 
     if ( HasBitSet(keys + HashSize, 1)) // Keys with null value

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -15,7 +15,7 @@ class TTableBucketSpiller;
 const ui64 BitsForNumberOfBuckets = 5; // 2^5 = 32
 const ui64 BucketsMask = (0x00000001 << BitsForNumberOfBuckets)  - 1;
 const ui64 NumberOfBuckets = (0x00000001 << BitsForNumberOfBuckets);  // Number of hashed keys buckets to distribute incoming tables tuples
-const ui64 DefaultTuplesNum = 100; // Default initial number of tuples in one bucket to allocate memory
+const ui64 DefaultTuplesNum = 101; // Default initial number of tuples in one bucket to allocate memory
 const ui64 DefaultTupleBytes = 64; // Default size of all columns in table row for estimations
 const ui64 HashSize = 1; // Using ui64 hash size
 


### PR DESCRIPTION
Low bits of hash are already used as bucket index, so all low bits of hashes in single buckets is same. This results in higher collision rate and 6x to 7x number of comparision per access (simulated)

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Performance improvement
* Not for changelog (changelog entry is not required)

### Additional information

...
