### PR TITLE
Support dynamic node configuration updates from node quorum only

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -70,7 +70,7 @@ namespace NKikimr::NStorage {
                 ProposedStorageConfig ? &ProposedStorageConfig.value() : nullptr));
             if (IsSelfStatic) {
                 PersistConfig({});
-                ApplyConfigUpdateToDynamicNodes();
+                ApplyConfigUpdateToDynamicNodes(false);
             }
             return true;
         } else if (StorageConfig->GetGeneration() && StorageConfig->GetGeneration() == config.GetGeneration() &&

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -305,6 +305,7 @@ namespace NKikimr::NStorage {
         void Handle(TEvNodeConfigUnbind::TPtr ev);
         void UnbindNode(ui32 nodeId, const char *reason);
         ui32 GetRootNodeId() const;
+        bool PartOfNodeQuorum() const;
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Root node operation
@@ -381,7 +382,7 @@ namespace NKikimr::NStorage {
         void Handle(TEvNodeWardenDynamicConfigPush::TPtr ev);
 
         // these are used on the static nodes
-        void ApplyConfigUpdateToDynamicNodes();
+        void ApplyConfigUpdateToDynamicNodes(bool drop);
         void OnDynamicNodeDisconnected(ui32 nodeId, TActorId sessionId);
         void HandleDynamicConfigSubscribe(STATEFN_SIG);
         void PushConfigToDynamicNode(TActorId actorId, TActorId sessionId);

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -194,6 +194,8 @@ namespace NKikimr::NStorage {
 
             AbortAllScatterTasks(binding);
 
+            ApplyConfigUpdateToDynamicNodes(true);
+
             IssueNextBindRequest();
 
             for (const auto& [nodeId, info] : DirectBoundNodes) {
@@ -441,6 +443,10 @@ namespace NKikimr::NStorage {
 
     ui32 TDistributedConfigKeeper::GetRootNodeId() const {
         return Binding && Binding->RootNodeId ? Binding->RootNodeId : SelfId().NodeId();
+    }
+
+    bool TDistributedConfigKeeper::PartOfNodeQuorum() const {
+        return Scepter || GetRootNodeId() != SelfId().NodeId();
     }
 
 } // NKikimr::NStorage

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -46,6 +46,7 @@ namespace NKikimr::NStorage {
         CurrentProposedStorageConfig.reset();
         const TDuration timeout = TDuration::FromValue(ErrorTimeout.GetValue() * (25 + RandomNumber(51u)) / 50);
         TActivationContext::Schedule(timeout, new IEventHandle(TEvPrivate::EvErrorTimeout, 0, SelfId(), {}, nullptr, 0));
+        ApplyConfigUpdateToDynamicNodes(true);
     }
 
     void TDistributedConfigKeeper::HandleErrorTimeout() {

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -239,4 +239,5 @@ message TEvNodeConfigInvokeOnRootResult {
 
 message TEvNodeWardenDynamicConfigPush {
     TStorageConfig Config = 1;
+    bool NoQuorum = 2;
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support dynamic node configuration updates from node quorum only

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Dynamic node can only obtain new configuration through a static node which is a part of quorum now. Otherwise it could lead to configuration stalling if dynamic node was connected to partitioned static node.

#5807 