### PR TITLE
wait for succesful tablet start before persistently cutting history

### DIFF
--- a/ydb/core/mind/hive/leader_tablet_info.h
+++ b/ydb/core/mind/hive/leader_tablet_info.h
@@ -50,6 +50,17 @@ public:
         }
     };
 
+    struct TChannelHistoryEntry {
+        ui32 Channel;
+        TTabletChannelInfo::THistoryEntry Entry;
+
+        TChannelHistoryEntry(ui32 channel, const TTabletChannelInfo::THistoryEntry& entry)
+            : Channel(channel)
+            , Entry(entry)
+        {
+        }
+    };
+
     TTabletId Id;
     ETabletState State;
     TTabletTypes::EType Type;
@@ -60,6 +71,8 @@ public:
     TIntrusivePtr<TTabletStorageInfo> TabletStorageInfo;
     TChannelsBindings BoundChannels;
     std::bitset<MAX_TABLET_CHANNELS> ChannelProfileNewGroup;
+    std::vector<TChannelHistoryEntry> DeletedHistory;
+    bool WasAliveSinceCutHistory = false;
     NKikimrHive::TEvReassignTablet::EHiveReassignReason ChannelProfileReassignReason;
     ui32 KnownGeneration;
     TTabletCategoryInfo* Category;
@@ -339,6 +352,7 @@ public:
     TString GetChannelStoragePoolName(const TChannelProfiles::TProfile::TChannel& channel) const;
     TString GetChannelStoragePoolName(ui32 channelId) const;
     TStoragePoolInfo& GetStoragePool(ui32 channelId) const;
+    void RestoreDeletedHistory();
 
     void SetType(TTabletTypes::EType type);
 };

--- a/ydb/core/mind/hive/tx__cut_tablet_history.cpp
+++ b/ydb/core/mind/hive/tx__cut_tablet_history.cpp
@@ -14,7 +14,7 @@ public:
 
     TTxType GetTxType() const override { return NHive::TXTYPE_CUT_TABLET_HISTORY; }
 
-    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+    bool Execute(TTransactionContext&, const TActorContext&) override {
         TEvHive::TEvCutTabletHistory* msg = Event->Get();
         auto tabletId = msg->Record.GetTabletID();
         BLOG_D("THive::TTxCutTabletHistory::Execute(" << tabletId << ")");
@@ -30,9 +30,11 @@ public:
                         channelInfo.History.end(),
                         TTabletChannelInfo::THistoryEntry(fromGeneration, groupId));
             if (it != channelInfo.History.end()) {
+                tablet->DeletedHistory.emplace_back(channel, *it);
                 channelInfo.History.erase(it);
+                /* to be safe, don't do it just yet
                 NIceDb::TNiceDb db(txc.DB);
-                db.Table<Schema::TabletChannelGen>().Key(tabletId, channel, fromGeneration).Delete();
+                db.Table<Schema::TabletChannelGen>().Key(tabletId, channel, fromGeneration).Delete();*/
             }
         }
         return true;

--- a/ydb/core/mind/hive/tx__start_tablet.cpp
+++ b/ydb/core/mind/hive/tx__start_tablet.cpp
@@ -49,6 +49,14 @@ public:
             if (tablet->IsLeader()) {
                 TLeaderTabletInfo& leader = tablet->AsLeader();
                 if (leader.IsStartingOnNode(Local.NodeId()) || leader.IsBootingSuppressed() && External) {
+                    if (!leader.DeletedHistory.empty()) {
+                        if (!leader.WasAliveSinceCutHistory) {
+                            BLOG_ERROR("THive::TTxStartTablet::Execute Tablet " << TabletId << " failed to start after cutting history - will restore history");
+                            leader.RestoreDeletedHistory();
+                        } else {
+                            leader.WasAliveSinceCutHistory = false;
+                        }
+                    }
                     BLOG_D("THive::TTxStartTablet::Execute, Sending TEvBootTablet(" << leader.ToString() << ")"
                             << " to node " << Local.NodeId()
                             << " storage " << leader.TabletStorageInfo->ToString());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
