### PR TITLE
Keep track of dynamic proxies too and broadcast messages to them

### DIFF
--- a/ydb/library/actors/core/actorsystem.cpp
+++ b/ydb/library/actors/core/actorsystem.cpp
@@ -125,6 +125,7 @@ namespace NActors {
                     if (!target) {
                         target = actorId;
                         ServiceMap->RegisterLocalService(recipient, target);
+                        DynamicProxies.push_back(target);
                     }
                 }
                 if (target != actorId) {
@@ -232,10 +233,21 @@ namespace NActors {
 
     ui32 TActorSystem::BroadcastToProxies(const std::function<IEventHandle*(const TActorId&)>& eventFabric) {
         // TODO: get rid of this method
+        ui32 res = 0;
         for (ui32 i = 0; i < InterconnectCount; ++i) {
             Send(eventFabric(Interconnect[i]));
+            ++res;
         }
-        return InterconnectCount;
+
+        auto guard = Guard(ProxyCreationLock);
+        for (size_t i = 0; i < DynamicProxies.size(); ++i) {
+            const TActorId actorId = DynamicProxies[i];
+            auto unguard = Unguard(guard);
+            Send(eventFabric(actorId));
+            ++res;
+        }
+
+        return res;
     }
 
     TActorId TActorSystem::LookupLocalService(const TActorId& x) const {

--- a/ydb/library/actors/core/actorsystem.h
+++ b/ydb/library/actors/core/actorsystem.h
@@ -161,6 +161,7 @@ namespace NActors {
         TIntrusivePtr<NLog::TSettings> LoggerSettings0;
         TProxyWrapperFactory ProxyWrapperFactory;
         TMutex ProxyCreationLock;
+        mutable std::vector<TActorId> DynamicProxies;
 
         bool StartExecuted;
         bool StopExecuted;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Keep track of dynamic proxies too and broadcast messages to them

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

This allows correct stopping of all proxies, including ones attached to dynamic nodes or to static nodes that were added online.
