### PR TITLE
Do not hide configure errors

### DIFF
--- a/build/internal/ya.conf
+++ b/build/internal/ya.conf
@@ -4,6 +4,8 @@ bazel_remote_baseuri = "http://cachesrv.ydb.tech:8081"
 bazel_remote_client_decompress = true
 test_fakeid = "r13102898"
 
+ignore_configure_errors = false  # Not synced with Arcadia yet, will be synced in YA-1456
+
 [host_platform_flags]
 OPENSOURCE = "yes"
 USE_PREBUILT_TOOLS = "no"

--- a/ya.conf
+++ b/ya.conf
@@ -19,7 +19,6 @@ tools_cache_master = true
 use_atd_revisions_info = true
 use_jstyle_server = true
 use_command_file_in_testtool = true
-ignore_configure_errors = false  # Not synced with Arcadia yet, will be synced in YA-1456
 
 # ===== opensource only table params =====
 

--- a/ya.conf
+++ b/ya.conf
@@ -19,6 +19,7 @@ tools_cache_master = true
 use_atd_revisions_info = true
 use_jstyle_server = true
 use_command_file_in_testtool = true
+ignore_configure_errors = false  # Not synced with Arcadia yet, will be synced in YA-1456
 
 # ===== opensource only table params =====
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Configure errors could be hidden with `-k` option, see https://github.com/yandex/yatool/issues/7 

We need to set variable to fix it 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

