### PR TITLE
fix(docs): wrong syntax in example `DROP OBJECT` command

### DIFF
--- a/ydb/docs/ru/core/yql/reference/yql-core/syntax/drop-object-type-secret.md
+++ b/ydb/docs/ru/core/yql/reference/yql-core/syntax/drop-object-type-secret.md
@@ -14,6 +14,6 @@
 **Пример**
 
 ```yql
-DROP OBJECT (TYPE SECRET) my_secret;
+DROP OBJECT my_secret (TYPE SECRET);
 ```
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Current documentation states that in order to delete object of type secret one can use the following query:
`DROP OBJECT (TYPE SECRET) my_secret;`

However, it is incorrect as of 22.06.2024. Attempt to execute it gives errors like
```
error1:12 Unexpected token '(' : cannot match to any predicted input...
error1:26 Unexpected token 'my_secret' : cannot match to any predicted input...
```

The correct syntax is `DROP OBJECT my_secret (TYPE SECRET);`

### Changelog category <!-- remove all except one -->
* Documentation (changelog entry is not required)
