### PR TITLE
Federated write session: fix deadlock

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.cpp
@@ -115,13 +115,11 @@ void TFederatedWriteSessionImpl::OpenSubsessionImpl(std::shared_ptr<TDbInfo> db)
         // Therefore, we temporarily release the lock here,
         // which allows the handler to finish and release its shared lock,
         // after which the TWriteSession destructor can also complete its work.
-        std::shared_ptr<NTopic::IWriteSession> old;
+        auto old = std::exchange(OldSubsession, Subsession);
         {
-            old = std::exchange(OldSubsession, {});
             auto unguard = Unguard(Lock);
-            old = std::move(Subsession);
+            old = nullptr;  // old subsession dtor is called here
         }
-        OldSubsession = old;
         OldSubsession->Close(TDuration::Zero());
     }
 

--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.h
@@ -123,6 +123,7 @@ private:
     TAdaptiveLock Lock;
 
     std::shared_ptr<NTopic::IWriteSession> Subsession;
+    std::shared_ptr<NTopic::IWriteSession> OldSubsession;
 
     std::shared_ptr<NTopic::TWriteSessionEventsQueue> ClientEventsQueue;
 

--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/ut/basic_usage_ut.cpp
@@ -1074,7 +1074,9 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         auto driver = NYdb::TDriver(driverConfig);
         auto topicClient = NYdb::NFederatedTopic::TFederatedTopicClient(driver);
 
-        auto writeSettings = NTopic::TWriteSessionSettings()
+        auto writeSettings = NTopic::TFederatedWriteSessionSettings()
+            .PreferredDatabase("dc1")
+            .AllowFallback(true)
             .DirectWriteToPartition(false)
             .RetryPolicy(NPersQueue::IRetryPolicy::GetNoRetryPolicy())
             .Path(setup->GetTestTopic())


### PR DESCRIPTION
Destroy the previous write subsession outside of the TFederatedWriteSession::Lock.

Ignore TSessionClosedEvent(SUCCESS) events in the SessionClosedHandler, because these events are emitted after the subsession is closed by the federated subsession, i.e. it's an expected event that should not be propagated further. A TSessionClosedEvent with another code is passed to the CloseImpl method to shutdown the federated session.