### PR TITLE
24-2: Support arbiters feature flag for volatile transactions

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -131,4 +131,5 @@ message TFeatureFlags {
     optional bool EnableReplaceIfExistsForExternalEntities = 116 [ default = false];
     optional bool EnableCMSRequestPriorities = 117 [default = false];
     optional bool EnableStableNodeNames = 122 [default = false];
+    optional bool EnableVolatileTransactionArbiters = 124 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Partial merge of #4331 to support arbiters feature flag, which was intentionally omitted in #4371. This will make it possible to enable this feature flag internally.