### PR TITLE
Add sleep to fix a test

### DIFF
--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -2468,6 +2468,12 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             );
             auto result = adminSession.ExecuteSchemeQuery(grantQuery).ExtractValueSync();
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            
+            // It was discovered that TModifyACL scheme operation returns successfully without waiting for
+            // SchemeBoard replicas to acknowledge the path updates. This can cause the SchemeCache to reply
+            // with outdated entries, even if the SyncVersion flag is enabled.
+            // For more details, please refer to the PR description of this change.
+            Sleep(TDuration::MilliSeconds(300));
         };
 
         // a user which does not have any implicit permissions


### PR DESCRIPTION
Original issue: https://github.com/ydb-platform/ydb/issues/5744
Follow-up issue that will be fixed separately: https://github.com/ydb-platform/ydb/issues/5963

Due to a bug in Modify ACL scheme operation (please refer to the follow-up issue for details on the root cause), we need to insert an ugly sleep in a failing test. Somehow, no users (as far as I know) have noticed the lag in ACL propogation to SchemeCache yet.

