### PR TITLE
Enable volatile transaction arbiters by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -136,7 +136,7 @@ message TFeatureFlags {
     optional bool ExtendedPDiskSensors = 121 [default = true];
     optional bool EnableStableNodeNames = 122 [default = false];
     optional bool EnableBackupService = 123 [default = false];
-    optional bool EnableVolatileTransactionArbiters = 124 [default = false];
+    optional bool EnableVolatileTransactionArbiters = 124 [default = true];
     optional bool EnableGraphShard = 125 [default = false];
     optional bool EnableExternalSourceSchemaInference = 126 [default = false];
     optional bool EnableDbMetadataCache = 127 [default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Enable volatile transaction arbiters by default.

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Volatile transaction arbiters reduce the number of exchanged messages for transactions with the high number of participants.
