### PR TITLE
channel spilling: unique names for files

### DIFF
--- a/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
@@ -50,7 +50,8 @@ public:
     {}
 
     void Bootstrap() {
-        auto spillingActor = CreateDqLocalFileSpillingActor(TxId_, TStringBuilder() << "ChannelId: " << ChannelId_,
+        static std::atomic<uint64_t> serial;
+        auto spillingActor = CreateDqLocalFileSpillingActor(TxId_, TStringBuilder() << "ChannelId: " << ChannelId_ << "__" << ++serial,
             SelfId(), true);
         SpillingActorId_ = Register(spillingActor);
         Become(&TDqChannelStorageActor::WorkState);

--- a/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
+++ b/ydb/library/yql/dq/actors/spilling/channel_storage_actor.cpp
@@ -11,6 +11,7 @@
 #include <ydb/library/actors/core/log.h>
 
 #include <util/generic/size_literals.h>
+#include <util/generic/guid.h>
 
 namespace NYql::NDq {
 
@@ -50,8 +51,7 @@ public:
     {}
 
     void Bootstrap() {
-        static std::atomic<uint64_t> serial;
-        auto spillingActor = CreateDqLocalFileSpillingActor(TxId_, TStringBuilder() << "ChannelId: " << ChannelId_ << "__" << ++serial,
+        auto spillingActor = CreateDqLocalFileSpillingActor(TxId_, TStringBuilder() << "ChannelId: " << ChannelId_ << "_" << CreateGuidAsString(),
             SelfId(), true);
         SpillingActorId_ = Register(spillingActor);
         Become(&TDqChannelStorageActor::WorkState);


### PR DESCRIPTION
There can be more than one scheduler per process, and channel ids may be not unique.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...