### PR TITLE
Allow skipping service set in blobstorage configuration

### DIFF
--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -910,7 +910,9 @@ namespace NKikimr::NYaml {
         }
 
         auto* bsConfig = config.MutableBlobStorageConfig();
-        Y_ENSURE_BT(bsConfig->HasServiceSet(), "service_set field in blob_storage_config must be json map.");
+        if (!bsConfig->HasServiceSet()) {
+            return;
+        }
 
         auto* serviceSet = bsConfig->MutableServiceSet();
         if (!serviceSet->AvailabilityDomainsSize()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Allow skipping service set in blobstorage configuration

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Allow skipping ServiceSet and AvailableDomains inside BlobStorageConfig to make configuration even better.

#2010
