### PR TITLE
PQ test: Wait for changed DescribePath result after modifying ACL

### DIFF
--- a/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
@@ -223,7 +223,7 @@ public:
         const TString validToken = "test_user@" BUILTIN_ACL_DOMAIN;
         // TODO: Why test fails with 'BUILTIN_ACL_DOMAIN' as domain in invalid token?
         TVector<TString> invalidTokens = {TString(), "test_user", "test_user@invalid_domain"};
-        server.ModifyTopicACL(server.GetFullTopicPath(), {{validToken, {"ydb.generic.write"}}});
+        server.ModifyTopicACLAndWait(server.GetFullTopicPath(), {{validToken, {"ydb.generic.write"}}});
 
         for (const auto &invalidToken : invalidTokens) {
             Cerr << "Invalid token under test is '" << invalidToken << "'" << Endl;


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/5691

Hopefully fixes test TPersQueueCommonTest.Auth_WriteUpdateTokenRequestWithInvalidToken_SessionClosedWithUnauthenticatedError.

It didn't fail in 4000 runs on my machine.

I will check the CI results in a week and if there are no fails,
I'll unmute it and replace ModifyTopicACL with ModifyTopicACLAndWait in all other tests.
