### PR TITLE
Allow shorter drive listing in config.yaml

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -112,6 +112,11 @@ namespace NKikimr::NStorage {
                     invoke(disk);
                 }
             }
+            for (const auto& item : res->GetProposedConfigs()) {
+                for (const auto& disk : item.GetDisks()) {
+                    invoke(disk);
+                }
+            }
             for (const auto& disk : res->GetNoMetadata()) {
                 invoke(disk);
             }

--- a/ydb/core/mind/bscontroller/cmds_host_config.cpp
+++ b/ydb/core/mind/bscontroller/cmds_host_config.cpp
@@ -34,8 +34,30 @@ namespace NKikimr::NBsController {
             }
 
             Schema::HostConfigDrive::TKey::Type key(id, drive.GetPath());
-            config.Drives.emplace(std::move(key), std::move(driveInfo));
+            const auto [it, inserted] = config.Drives.emplace(std::move(key), std::move(driveInfo));
+            if (!inserted) {
+                throw TExError() << "duplicate path# " << drive.GetPath();
+            }
         }
+
+        auto addDrives = [&](const auto& field, NKikimrBlobStorage::EPDiskType type) {
+            THostConfigInfo::TDriveInfo driveInfo;
+            driveInfo.Type = type;
+            driveInfo.SharedWithOs = false;
+            driveInfo.ReadCentric = false;
+            driveInfo.Kind = 0;
+            driveInfo.PDiskConfig = defaultPDiskConfig;
+
+            for (const auto& path : field) {
+                const auto [it, inserted] = config.Drives.emplace(Schema::HostConfigDrive::TKey::Type(id, path), driveInfo);
+                if (!inserted) {
+                    throw TExError() << "duplicate path# " << path;
+                }
+            }
+        };
+        addDrives(cmd.GetRot(), NKikimrBlobStorage::EPDiskType::ROT);
+        addDrives(cmd.GetSsd(), NKikimrBlobStorage::EPDiskType::SSD);
+        addDrives(cmd.GetNvme(), NKikimrBlobStorage::EPDiskType::NVME);
 
         auto &hostConfigs = HostConfigs.Unshare();
         hostConfigs[id] = std::move(config);

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -35,6 +35,11 @@ message TDefineHostConfig {
     // host-wide default configuration for every PDisk
     NKikimrBlobStorage.TPDiskConfig DefaultHostPDiskConfig = 4;
 
+    // some syntactic sugar -- one drive type per path
+    repeated string Rot = 5;
+    repeated string Ssd = 6;
+    repeated string Nvme = 7;
+
     // item's generation to prevent concurrent modification
     uint64 ItemConfigGeneration = 100;
 }

--- a/ydb/library/yaml_config/protos/config.proto
+++ b/ydb/library/yaml_config/protos/config.proto
@@ -134,6 +134,10 @@ message TExtendedDefineHostConfig {
 
     optional NKikimrBlobStorage.TPDiskConfig DefaultHostPDiskConfig = 4 [(NMarkers.CopyTo) = "TDefineHostConfig"];
 
+    repeated string Rot = 5 [(NMarkers.CopyTo) = "TDefineHostConfig"];
+    repeated string Ssd = 6 [(NMarkers.CopyTo) = "TDefineHostConfig"];
+    repeated string Nvme = 7 [(NMarkers.CopyTo) = "TDefineHostConfig"];
+
     optional uint64 ItemConfigGeneration = 100 [(NMarkers.CopyTo) = "TDefineHostConfig"];
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Allow shorter drive listing in config.yaml

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Added shorter form of specifying available devices through config.yaml

#2010