### PR TITLE
Tablet pipe client. Sending messages only for local tablets.

### DIFF
--- a/ydb/core/base/tablet_pipe.h
+++ b/ydb/core/base/tablet_pipe.h
@@ -32,6 +32,7 @@ namespace NKikimr {
             EvClientCheckDelay,
             EvClientShuttingDown,
             EvMessage, // replacement for EvSend
+            EvNonLocalTablet,
 
             EvEnd
         };
@@ -287,6 +288,18 @@ namespace NKikimr {
             TIntrusivePtr<TEventSerializedData> Buffer;
             ui64 SeqNo = 0;
         };
+
+        struct TEvNonLocalTablet : public TEventLocal<TEvNonLocalTablet, EvNonLocalTablet> {
+            TEvNonLocalTablet(ui32 nodeId, ui64 tabletId, const TActorId& clientId)
+                : NodeId(nodeId)
+                , TabletId(tabletId)
+                , ClientId(clientId)
+            {}
+
+            const ui32 NodeId;
+            const ui64 TabletId;
+            const TActorId ClientId;
+        };
     };
 
     namespace NTabletPipe {
@@ -365,6 +378,7 @@ namespace NKikimr {
             bool PreferLocal = false;
             bool CheckAliveness = false;
             bool ExpectShutdown = false;
+            bool SendForLocalOnly = false;
             TClientRetryPolicy RetryPolicy;
 
             TClientConfig()

--- a/ydb/core/tablet/tablet_pipe_client.cpp
+++ b/ydb/core/tablet/tablet_pipe_client.cpp
@@ -598,6 +598,12 @@ namespace NTabletPipe {
         void Push(const TActorContext& ctx, TAutoPtr<IEventHandle>& ev) {
             BLOG_D("push event to server");
 
+            if (Config.SendForLocalOnly && !IsLocalNode(ctx)) {
+                auto nodeId = GetTabletLeader().NodeId();
+                ctx.Send(Owner, new TEvTabletPipe::TEvNonLocalTablet(nodeId, TabletId, ctx.SelfID));
+                return;
+            }
+
             if (!InterconnectSessionId) {
                 switch (ev->GetTypeRewrite()) {
                     case TEvTabletPipe::EvMessage: {


### PR DESCRIPTION
### Changelog entry

Added the flag "SendForLocalOnly" for tablet pipe client.  Used for sending messages only for local tablets. If a tablet is not local, a message "TEvNonLocalTablet" is returned.

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

