### PR TITLE
Add some default and automatically derived values to config.yaml

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -327,6 +327,7 @@ namespace NKikimr::NStorage {
         void AllocateStaticGroup(NKikimrBlobStorage::TStorageConfig *config, ui32 groupId, ui32 groupGeneration,
             TBlobStorageGroupType gtype, const NKikimrBlobStorage::TGroupGeometry& geometry,
             const NProtoBuf::RepeatedPtrField<NKikimrBlobStorage::TPDiskFilter>& pdiskFilters,
+            std::optional<NKikimrBlobStorage::EPDiskType> pdiskType,
             THashMap<TVDiskIdShort, NBsController::TPDiskId> replacedDisks,
             const NBsController::TGroupMapper::TForbiddenPDisks& forbid,
             i64 requiredSpace, NKikimrBlobStorage::TBaseConfig *baseConfig,

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
@@ -378,7 +378,9 @@ namespace NKikimr::NStorage {
                     try {
                         Self->AllocateStaticGroup(&config, vdiskId.GroupID.GetRawId(), vdiskId.GroupGeneration + 1,
                             TBlobStorageGroupType((TBlobStorageGroupType::EErasureSpecies)group.GetErasureSpecies()),
-                            settings.GetGeometry(), settings.GetPDiskFilter(), replacedDisks, forbid, maxSlotSize,
+                            settings.GetGeometry(), settings.GetPDiskFilter(),
+                            settings.HasPDiskType() ? std::make_optional(settings.GetPDiskType()) : std::nullopt,
+                            replacedDisks, forbid, maxSlotSize,
                             &BaseConfig.value(), cmd.GetConvertToDonor(), cmd.GetIgnoreVSlotQuotaCheck(),
                             cmd.GetIsSelfHealReasonDecommit());
                     } catch (const TExConfigError& ex) {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -279,6 +279,7 @@ message TBlobStorageConfig {
         optional string ErasureSpecies = 1;
         optional NKikimrBlobStorage.TGroupGeometry Geometry = 2;
         repeated NKikimrBlobStorage.TPDiskFilter PDiskFilter = 3;
+        optional NKikimrBlobStorage.EPDiskType PDiskType = 7;
 
         // some extra settings
         optional bool AutomaticBoxManagement = 4; // invoke BSC DefineHostConfig/DefineBox automatically

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/block-4-2.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/block-4-2.yaml.result.json
@@ -171,14 +171,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -249,7 +241,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
@@ -110,14 +110,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -190,7 +182,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],
@@ -1465,6 +1456,10 @@
               }
           }
         ]
+    },
+  "GRpcConfig":
+    {
+      "Port":2135
     },
   "TableServiceConfig":
     {

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes.yaml.result.json
@@ -111,14 +111,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -191,7 +183,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-9-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-9-nodes.yaml.result.json
@@ -186,14 +186,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -265,7 +257,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/nvme.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/nvme.yaml.result.json
@@ -182,10 +182,6 @@
               [
                 1
               ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -256,7 +252,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ]

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/simple.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/simple.yaml.result.json
@@ -176,14 +176,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -254,7 +246,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-in-memory.yaml.result.json
@@ -86,14 +86,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -157,7 +149,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-with-file.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-with-file.yaml.result.json
@@ -86,14 +86,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -157,7 +149,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/block-4-2.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/block-4-2.yaml.result.json
@@ -120,14 +120,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -198,7 +190,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/disk.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/disk.yaml.result.json
@@ -32,14 +32,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -102,7 +94,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/drive.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/drive.yaml.result.json
@@ -32,14 +32,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -102,7 +94,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
@@ -60,14 +60,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -140,7 +132,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],
@@ -1418,6 +1409,7 @@
     },
   "GRpcConfig":
     {
+      "Port":2135,
       "CA":"/opt/ydb/certs/ca.crt",
       "Cert":"/opt/ydb/certs/node.crt",
       "Key":"/opt/ydb/certs/node.key"

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes.yaml.result.json
@@ -60,14 +60,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -140,7 +132,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-9-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-9-nodes.yaml.result.json
@@ -132,14 +132,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -211,7 +203,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/ram.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/ram.yaml.result.json
@@ -32,14 +32,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -102,7 +94,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-in-memory.yaml.result.json
@@ -32,14 +32,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -102,7 +94,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-with-file.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-with-file.yaml.result.json
@@ -32,14 +32,6 @@
           {
             "DomainId":1,
             "SchemeRoot":72057594046678944,
-            "SSId":
-              [
-                1
-              ],
-            "HiveUid":
-              [
-                1
-              ],
             "PlanResolution":10,
             "Name":"Root",
             "StoragePoolTypes":
@@ -102,7 +94,6 @@
       "HiveConfig":
         [
           {
-            "HiveUid":1,
             "Hive":72057594037968897
           }
         ],


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add some default and automatically derived values to config.yaml

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Some of the fields in config.yaml can be omitted now, they are calculated automatically. Also it is possible to specify drives of a host a bit shorter.

#2010