### PR TITLE
Fix Aws::InitAPI memory leak

### DIFF
--- a/ydb/core/driver_lib/run/main.cpp
+++ b/ydb/core/driver_lib/run/main.cpp
@@ -29,6 +29,25 @@
 
 #include <filesystem>
 
+#include <contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/Aws.h>
+
+namespace {
+
+struct TApiInitializer {
+    TApiInitializer() {
+        Aws::InitAPI(Options);
+    }
+
+    ~TApiInitializer() {
+        Aws::ShutdownAPI(Options);
+    }
+
+private:
+    Aws::SDKOptions Options;
+};
+
+}
+
 namespace NKikimr {
 
 int MainRun(const TKikimrRunConfig& runConfig, std::shared_ptr<TModuleFactories> factories) {
@@ -43,6 +62,7 @@ int MainRun(const TKikimrRunConfig& runConfig, std::shared_ptr<TModuleFactories>
 
     TIntrusivePtr<TKikimrRunner> runner = TKikimrRunner::CreateKikimrRunner(runConfig, std::move(factories));
     if (runner) {
+        TApiInitializer awsApi;
         runner->KikimrStart();
         runner->BusyLoop();
         // exit busy loop by a signal

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -21,6 +21,7 @@ SRCS(
 
 PEERDIR(
     contrib/libs/protobuf
+    contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3
     ydb/library/actors/core
     ydb/library/actors/dnsresolver
     ydb/library/actors/interconnect

--- a/ydb/core/wrappers/s3_storage_config.cpp
+++ b/ydb/core/wrappers/s3_storage_config.cpp
@@ -24,58 +24,6 @@ using namespace Aws::Utils::Stream;
 
 namespace {
 
-struct TCurlInitializer {
-    TCurlInitializer() {
-        curl_global_init(CURL_GLOBAL_ALL);
-    }
-
-    ~TCurlInitializer() {
-        curl_global_cleanup();
-    }
-};
-
-struct TApiInitializer {
-    TApiInitializer() {
-        Options.httpOptions.initAndCleanupCurl = false;
-        InitAPI(Options);
-
-        Internal::CleanupEC2MetadataClient(); // speeds up config construction
-    }
-
-    ~TApiInitializer() {
-        ShutdownAPI(Options);
-    }
-
-private:
-    SDKOptions Options;
-};
-
-class TApiOwner {
-public:
-    void Ref() {
-        auto guard = Guard(Mutex);
-        if (!RefCount++) {
-            if (!CurlInitializer) {
-                CurlInitializer.Reset(new TCurlInitializer);
-            }
-            ApiInitializer.Reset(new TApiInitializer);
-        }
-    }
-
-    void UnRef() {
-        auto guard = Guard(Mutex);
-        if (!--RefCount) {
-            ApiInitializer.Destroy();
-        }
-    }
-
-private:
-    ui64 RefCount = 0;
-    TMutex Mutex;
-    THolder<TCurlInitializer> CurlInitializer;
-    THolder<TApiInitializer> ApiInitializer;
-};
-
 namespace NPrivate {
 
 template <class TSettings>
@@ -114,20 +62,10 @@ Aws::Auth::AWSCredentials CredentialsFromSettings(const TSettings& settings) {
 
 } // anonymous
 
-TS3User::TS3User(const TS3User& /*baseObject*/) {
-    Singleton<TApiOwner>()->Ref();
-}
-
-TS3User::TS3User(TS3User& /*baseObject*/) {
-    Singleton<TApiOwner>()->Ref();
-}
-
 TS3User::TS3User() {
-    Singleton<TApiOwner>()->Ref();
 }
 
 TS3User::~TS3User() {
-    Singleton<TApiOwner>()->UnRef();
 }
 
 class TS3ThreadsPoolByEndpoint {

--- a/ydb/core/wrappers/s3_storage_config.h
+++ b/ydb/core/wrappers/s3_storage_config.h
@@ -19,8 +19,6 @@ namespace NKikimr::NWrappers::NExternalStorage {
 
 struct TS3User {
     TS3User();
-    TS3User(const TS3User& baseObject);
-    TS3User(TS3User& baseObject);
     ~TS3User();
 };
 

--- a/ydb/services/ydb/ydb_import_ut.cpp
+++ b/ydb/services/ydb/ydb_import_ut.cpp
@@ -1,8 +1,12 @@
 #include "ydb_common_ut.h"
 
+#include <ydb/core/wrappers/ut_helpers/s3_mock.h>
+
 #include <ydb/public/sdk/cpp/client/ydb_result/result.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_import/import.h>
+#include <ydb/public/sdk/cpp/client/ydb_export/export.h>
+#include <ydb/public/sdk/cpp/client/ydb_operation/operation.h>
 #include <ydb/public/lib/ydb_cli/dump/dump.h>
 #include <ydb/public/lib/yson_value/ydb_yson_value.h>
 
@@ -134,6 +138,7 @@ Y_UNIT_TEST_SUITE(YdbImport) {
 Y_UNIT_TEST_SUITE(BackupRestore) {
 
     using namespace NYdb::NTable;
+    using NKikimr::NWrappers::NTestHelpers::TS3Mock;
 
     void ExecuteDataDefinitionQuery(TSession& session, const TString& script) {
         const auto result = session.ExecuteSchemeQuery(script).ExtractValueSync();
@@ -185,6 +190,108 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
         UNIT_ASSERT_C(
             checker(tableDescription),
             descriptionProto.DebugString()
+        );
+    }
+
+    class TS3TestEnv {
+        TKikimrWithGrpcAndRootSchema server;
+        TDriver driver;
+        TTableClient tableClient;
+        TSession session;
+        ui16 s3Port;
+        TS3Mock s3Mock;
+        // required for exports to function
+        TDataShardExportFactory dataShardExportFactory;
+
+    public:
+        TS3TestEnv()
+            : driver(TDriverConfig().SetEndpoint(Sprintf("localhost:%d", server.GetPort())))
+            , tableClient(driver)
+            , session(tableClient.CreateSession().ExtractValueSync().GetSession())
+            , s3Port(server.GetPortManager().GetPort())
+            , s3Mock({}, TS3Mock::TSettings(s3Port))
+        {
+            UNIT_ASSERT_C(s3Mock.Start(), s3Mock.GetError());
+
+            auto& runtime = *server.GetRuntime();
+            runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::EPriority::PRI_DEBUG);
+            runtime.GetAppData().DataShardExportFactory = &dataShardExportFactory;
+        }
+
+        TKikimrWithGrpcAndRootSchema& GetServer() {
+            return server;
+        }
+
+        const TDriver& GetDriver() const {
+            return driver;
+        }
+
+        TSession& GetSession() {
+            return session;
+        }
+
+        ui16 GetS3Port() const {
+            return s3Port;
+        }
+    };
+
+    template <typename TOperation>
+    bool WaitForOperation(NOperation::TOperationClient& client, NOperationId::TOperationId id,
+        int retries = 10, TDuration sleepDuration = TDuration::MilliSeconds(100)
+    ) {
+        for (int retry = 0; retry <= retries; ++retry) {
+            auto result = client.Get<TOperation>(id).ExtractValueSync();
+            if (result.Ready()) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    result.Status().GetStatus(), EStatus::SUCCESS,
+                    result.Status().GetIssues().ToString()
+                );
+                return true;
+            }
+            Sleep(sleepDuration *= 2);
+        }
+        return false;
+    }
+
+    void ExportToS3(NExport::TExportClient& exportClient, ui16 s3Port, NOperation::TOperationClient& operationClient,
+        const TString& source, const TString& destination
+   ) {
+        // The exact values for Bucket, AccessKey and SecretKey do not matter if the S3 backend is TS3Mock.
+        // Any non-empty strings should do.
+        const auto exportSettings = NExport::TExportToS3Settings()
+            .Endpoint(Sprintf("localhost:%d", s3Port))
+            .Scheme(ES3Scheme::HTTP)
+            .Bucket("test_bucket")
+            .AccessKey("test_key")
+            .SecretKey("test_secret")
+            .AppendItem(NExport::TExportToS3Settings::TItem{.Src = source, .Dst = destination});
+
+        auto response = exportClient.ExportToS3(exportSettings).ExtractValueSync();
+        UNIT_ASSERT_C(WaitForOperation<NExport::TExportToS3Response>(operationClient, response.Id()),
+            Sprintf("The export from %s to %s did not complete within the allocated time.",
+                source.c_str(), destination.c_str()
+            )
+        );
+    }
+
+    void ImportFromS3(NImport::TImportClient& importClient, ui16 s3Port, NOperation::TOperationClient& operationClient,
+        const TString& source, const TString& destination
+    ) {
+        // The exact values for Bucket, AccessKey and SecretKey do not matter if the S3 backend is TS3Mock. 
+        // Any non-empty strings should do.
+        const auto importSettings = NImport::TImportFromS3Settings()
+            .Endpoint(Sprintf("localhost:%d", s3Port))
+            .Scheme(ES3Scheme::HTTP)
+            .Bucket("test_bucket")
+            .AccessKey("test_key")
+            .SecretKey("test_secret")
+            .AppendItem(NImport::TImportFromS3Settings::TItem{.Src = source, .Dst = destination});
+
+        auto response = importClient.ImportFromS3(importSettings).ExtractValueSync();
+        UNIT_ASSERT_C(WaitForOperation<NImport::TImportFromS3Response>(operationClient, response.Id()),
+            Sprintf("The import from %s to %s did not complete within the allocated time.",
+                source.c_str(), destination.c_str()
+            )
         );
     }
 
@@ -339,6 +446,136 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
         ));
         Restore(backupClient, pathToBackup, "/Root");
         CheckTableDescription(session, indexTablePath, CreateMinPartitionsChecker(minPartitions));
+    }
+
+    Y_UNIT_TEST(BasicS3) {
+        TS3TestEnv testEnv;
+
+        constexpr const char* table = "/Root/table";
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Utf8,
+                    PRIMARY KEY (Key)
+                );
+            )",
+            table
+        ));
+        ExecuteDataModificationQuery(testEnv.GetSession(), Sprintf(R"(
+                UPSERT INTO `%s` (
+                    Key,
+                    Value
+                )
+                VALUES
+                    (1, "one"),
+                    (2, "two"),
+                    (3, "three"),
+                    (4, "four"),
+                    (5, "five");
+            )",
+            table
+        ));
+
+        NExport::TExportClient exportClient(testEnv.GetDriver());
+        NImport::TImportClient importClient(testEnv.GetDriver());
+        NOperation::TOperationClient operationClient(testEnv.GetDriver());
+
+        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
+
+        // The table needs to be dropped before importing from S3 can proceed successfully.
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+
+        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
+        {
+            auto result = ExecuteDataModificationQuery(testEnv.GetSession(), Sprintf(R"(
+                    SELECT COUNT(*) FROM `%s`;
+                )", table
+            ));
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(GetSingleResult(result)), 5ull);
+        }
+    }
+
+    Y_UNIT_TEST(RestoreTablePartitioningSettingsS3) {
+        TS3TestEnv testEnv;
+
+        constexpr const char* table = "/Root/table";
+        constexpr int minPartitions = 10;
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Utf8,
+                    PRIMARY KEY (Key)
+                )
+                WITH (
+                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
+                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
+                );
+            )",
+            table, minPartitions
+        ));
+
+        CheckTableDescription(testEnv.GetSession(), table, CreateMinPartitionsChecker(minPartitions));
+
+        NExport::TExportClient exportClient(testEnv.GetDriver());
+        NImport::TImportClient importClient(testEnv.GetDriver());
+        NOperation::TOperationClient operationClient(testEnv.GetDriver());
+
+        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
+
+        // The table needs to be dropped before importing from S3 can proceed successfully.
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+
+        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
+        CheckTableDescription(testEnv.GetSession(), table, CreateMinPartitionsChecker(minPartitions));
+    }
+
+    Y_UNIT_TEST(RestoreIndexTablePartitioningSettingsS3) {
+        TS3TestEnv testEnv;
+
+        constexpr const char* table = "/Root/table";
+        constexpr const char* index = "byValue";
+        const TString indexTablePath = JoinFsPaths(table, index, "indexImplTable");
+        constexpr int minPartitions = 10;
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                CREATE TABLE `%s` (
+                    Key Uint32,
+                    Value Uint32,
+                    PRIMARY KEY (Key),
+                    INDEX %s GLOBAL ON (Value)
+                );
+            )",
+            table, index
+        ));
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                ALTER TABLE `%s` ALTER INDEX %s SET (
+                    AUTO_PARTITIONING_BY_LOAD = ENABLED,
+                    AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = %d
+                );
+            )", table, index, minPartitions
+        ));
+
+        CheckTableDescription(testEnv.GetSession(), indexTablePath, CreateMinPartitionsChecker(minPartitions));
+
+        NExport::TExportClient exportClient(testEnv.GetDriver());
+        NImport::TImportClient importClient(testEnv.GetDriver());
+        NOperation::TOperationClient operationClient(testEnv.GetDriver());
+
+        ExportToS3(exportClient, testEnv.GetS3Port(), operationClient, table, "table");
+
+        // The table needs to be dropped before importing from S3 can proceed successfully.
+        ExecuteDataDefinitionQuery(testEnv.GetSession(), Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+
+        ImportFromS3(importClient, testEnv.GetS3Port(), operationClient, "table", table);
+        CheckTableDescription(testEnv.GetSession(), indexTablePath, CreateMinPartitionsChecker(minPartitions));
     }
 
 }


### PR DESCRIPTION
Put InitAPI into the main function like is advised in the docs (it seems static is bad)
