### PR TITLE
Strip clang14 binaries in order to reduce build size

### DIFF
--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -90,6 +90,7 @@ runs:
             build_type=release
             extra_params+=(--target-platform="CLANG14-LINUX-X86_64")
             extra_params+=(-DLLD_VERSION=16)
+            extra_params+=(-DSTRIP)
             ;;
           release-asan)
             build_type=release


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

We have a lot of problems with broken clang14 build due to its size

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

