### PR TITLE
IGNIETFERRO-2059: Fix a couple of string-related use-after-free errors

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_http_request.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_http_request.h
@@ -27,7 +27,7 @@ struct THttpRequestMock : NMonitoring::IHttpRequest {
     }
 
     TStringBuf GetPostContent() const override {
-        return TString();
+        return TStringBuf();
     }
 
     HTTP_METHOD GetMethod() const override {

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -265,7 +265,7 @@ namespace {
 
     TString GetColumnTypeName(const TTypeAnnotationNode* type) {
         if (type->GetKind() == ETypeAnnotationKind::Data) {
-            return type->Cast<TDataExprType>()->GetName();
+            return ToString(type->Cast<TDataExprType>()->GetName());
         } else {
             auto pgTypeId = type->Cast<TPgExprType>()->GetId();
             auto typeDesc = NKikimr::NPg::TypeDescFromPgTypeId(pgTypeId);

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -263,7 +263,7 @@ namespace {
         return columnTypeError;
     }
 
-    TStringBuf GetColumnTypeName(const TTypeAnnotationNode* type) {
+    TString GetColumnTypeName(const TTypeAnnotationNode* type) {
         if (type->GetKind() == ETypeAnnotationKind::Data) {
             return type->Cast<TDataExprType>()->GetName();
         } else {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -2583,7 +2583,8 @@ namespace Tests {
             return TServerSetup("localhost", 0);
         }
 
-        TStringBuf str(GetEnv(ServerRedirectEnvVar));
+        const auto& envValue = GetEnv(ServerRedirectEnvVar);
+        TStringBuf str(envValue);
         TStringBuf address;
         TStringBuf port;
         str.Split('/', address, port);

--- a/ydb/library/yql/core/type_ann/type_ann_core.cpp
+++ b/ydb/library/yql/core/type_ann/type_ann_core.cpp
@@ -7583,7 +7583,7 @@ template <NKikimr::NUdf::EDataSlot DataSlot>
             }
 
             auto udfInfo = ctx.Types.UdfModules.FindPtr(moduleName);
-            TStringBuf fileAlias = udfInfo ? udfInfo->FileAlias : "";
+            TStringBuf fileAlias = udfInfo ? udfInfo->FileAlias : ""_sb;
             auto ret = ctx.Expr.Builder(input->Pos())
                 .Callable("Udf")
                     .Add(0, input->HeadPtr())

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -145,7 +145,7 @@ struct THttpRequest : NMonitoring::IHttpRequest {
     }
 
     TStringBuf GetPostContent() const override {
-        return TString();
+        return TStringBuf();
     }
 
     HTTP_METHOD GetMethod() const override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed access to freed memory when the original string is destroyed earlier than the TStringBuf constructed from it.

Also, the construction of empty TStringBuf from an empty string has been replaced with direct construction, since, firstly, it is faster, and secondly, it does not lead to invalid pointers, the comparison/copying of which may be problematic in hardened environments: 
> Some implementations might define that copying an invalid pointer value causes a system-generated runtime fault[.](https://timsong-cpp.github.io/cppwp/n4868/basic.stc#footnote-35.sentence-1) [⮥](https://timsong-cpp.github.io/cppwp/n4868/basic.stc#footnoteref-35)



### Changelog category <!-- remove all except one -->

* Bugfix 
