### PR TITLE
Do not ignore configure errors

### DIFF
--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -125,9 +125,9 @@ runs:
         # to be sure
         set -o pipefail
         
-        # check that there are no configure errors configure errors are hidden then '-k' is used, 
+        # check that there are no configure errors configure errors are hidden if '-k' is used, 
         # see https://github.com/yandex/yatool/issues/7
-        ./ya make --build "${build_type}" --force-build-depends -j0
+        ./ya make --build "${build_type}" --force-build-depends -j0 ydb
 
         ./ya make -k --build "${build_type}" --force-build-depends -T --stat -DCONSISTENT_DEBUG \
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -125,6 +125,10 @@ runs:
         # to be sure
         set -o pipefail
         
+        # check that there are no configure errors configure errors are hidden then '-k' is used, 
+        # see https://github.com/yandex/yatool/issues/7
+        ./ya make --build "${build_type}" --force-build-depends -j0
+
         ./ya make -k --build "${build_type}" --force-build-depends -T --stat -DCONSISTENT_DEBUG \
           --log-file "$TMP_DIR/ya_log.txt" --evlog-file "$TMP_DIR/ya_evlog.jsonl" \
           --cache-size 512G --link-threads "${{ inputs.link_threads }}" \

--- a/.github/actions/build_ya/action.yml
+++ b/.github/actions/build_ya/action.yml
@@ -125,7 +125,7 @@ runs:
         # to be sure
         set -o pipefail
         
-        # check that there are no configure errors configure errors are hidden if '-k' is used, 
+        # Check that there are no configure errors. Configure errors are hidden if '-k' is used, 
         # see https://github.com/yandex/yatool/issues/7
         ./ya make --build "${build_type}" --force-build-depends -j0 ydb
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Configure errors are ignored if `-k` specified.

Additional call without any compilation was added to handle that situation.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Check is here: https://github.com/ydb-platform/ydb/pull/6076
