### PR TITLE
grace_join/spilling: fix inflation of memory 

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -835,10 +835,14 @@ private:
 void DoCalculateWithSpilling(TComputationContext& ctx) {
     UpdateSpilling();
 
+    ui32 cnt = 0;
     while (*HaveMoreLeftRows || *HaveMoreRightRows) {
-        if (!HasMemoryForProcessing() && !IsSpillingFinalized) {
-            bool isWaitingForReduce = TryToReduceMemoryAndWait();
-            if (isWaitingForReduce) return;
+        if ((cnt++ % GraceJoin::SpillingRowLimit) == 0) {
+            if (!HasMemoryForProcessing() && !IsSpillingFinalized) {
+                bool isWaitingForReduce = TryToReduceMemoryAndWait();
+     
+                if (isWaitingForReduce) return;
+            }
         }
         bool isYield = FetchAndPackData(ctx);
         if (isYield) return;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -1162,7 +1162,7 @@ bool TTable::TryToReduceMemoryAndWait() {
         }
     }
 
-    if (!largestBucketSize) return false;
+    if (largestBucketSize < SpillingSizeLimit/NumberOfBuckets) return false;
     TableBucketsSpillers[largestBucketIndex].SpillBucket(std::move(TableBuckets[largestBucketIndex]));
     TableBuckets[largestBucketIndex] = TTableBucket{};
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -1136,7 +1136,7 @@ void TTable::ShrinkBucket(ui64 bucket) {
 
 void TTable::InitializeBucketSpillers(ISpiller::TPtr spiller) {
     for (size_t i = 0; i < NumberOfBuckets; ++i) {
-        TableBucketsSpillers.emplace_back(spiller, 5_MB);
+        TableBucketsSpillers.emplace_back(spiller, 1_MB);
     }
 }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -1136,7 +1136,7 @@ void TTable::ShrinkBucket(ui64 bucket) {
 
 void TTable::InitializeBucketSpillers(ISpiller::TPtr spiller) {
     for (size_t i = 0; i < NumberOfBuckets; ++i) {
-        TableBucketsSpillers.emplace_back(spiller, 1_MB);
+        TableBucketsSpillers.emplace_back(spiller, 5_MB);
     }
 }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -19,7 +19,7 @@ const ui64 DefaultTuplesNum = 100; // Default initial number of tuples in one bu
 const ui64 DefaultTupleBytes = 64; // Default size of all columns in table row for estimations
 const ui64 HashSize = 1; // Using ui64 hash size
 const ui64 SpillingSizeLimit = 1_MB; // Don't try to spill if net effect is lower than this size
-const ui32 SpillingRowLimit = 8192; // Don't try to invoke spilling more often than 1 in this number of rows
+const ui32 SpillingRowLimit = 1000; // Don't try to invoke spilling more often than 1 in this number of rows
 
 /*
 Table data stored in buckets. Table columns are interpreted either as integers, strings or some interface-based type,

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -18,6 +18,8 @@ const ui64 NumberOfBuckets = (0x00000001 << BitsForNumberOfBuckets);  // Number 
 const ui64 DefaultTuplesNum = 100; // Default initial number of tuples in one bucket to allocate memory
 const ui64 DefaultTupleBytes = 64; // Default size of all columns in table row for estimations
 const ui64 HashSize = 1; // Using ui64 hash size
+const ui64 SpillingSizeLimit = 1_MB; // Don't try to spill if net effect is lower than this size
+const ui32 SpillingRowLimit = 8192; // Don't try to invoke spilling more often than 1 in this number of rows
 
 /*
 Table data stored in buckets. Table columns are interpreted either as integers, strings or some interface-based type,

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -19,7 +19,7 @@ const ui64 DefaultTuplesNum = 100; // Default initial number of tuples in one bu
 const ui64 DefaultTupleBytes = 64; // Default size of all columns in table row for estimations
 const ui64 HashSize = 1; // Using ui64 hash size
 const ui64 SpillingSizeLimit = 1_MB; // Don't try to spill if net effect is lower than this size
-const ui32 SpillingRowLimit = 1000; // Don't try to invoke spilling more often than 1 in this number of rows
+const ui32 SpillingRowLimit = 1024; // Don't try to invoke spilling more often than 1 in this number of rows
 
 /*
 Table data stored in buckets. Table columns are interpreted either as integers, strings or some interface-based type,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

With certain RSS limits and grace join spilling enabled TPC H 100 q13 use more memory than without spilling,
YQL-18701. Problem is triggered by starting grace join with allocator in yellow zone, so spilling immediately triggered,
but there are almost no state in grace_join collected. Then spilling code triggers on each row and move short chunks to TRope buffers (overblowing actual memory use), Yellow Zone condition is not fixed, and loop continues.

...
