### PR TITLE
Fix grace join any spilling

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -87,7 +87,7 @@ void TTable::AddTuple(  ui64 * intColumns, char ** stringColumns, ui32 * strings
     std::vector<ui32, TMKQLAllocator<ui32>> & stringsOffsets = TableBuckets[bucket].StringsOffsets;
     std::vector<ui64, TMKQLAllocator<ui64>> & dataIntVals = TableBuckets[bucket].DataIntVals;
     std::vector<char, TMKQLAllocator<char>> & stringVals = TableBuckets[bucket].StringsValues;
-    KeysHashTable & kh = TableBuckets[bucket].AnyHashTable;
+    KeysHashTable & kh = TableBucketsStats[bucket].AnyHashTable;
 
     ui32 offset = keyIntVals.size();  // Offset of tuple inside the keyIntVals vector
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -68,11 +68,11 @@ struct TTableBucket {
 
     std::set<ui32> AllLeftMatchedIds;  // All row ids of left join table which have matching rows in right table. To process streaming join mode.
     std::set<ui32> AllRightMatchedIds; // All row ids of right join table which matching rows in left table. To process streaming join mode. 
-    KeysHashTable AnyHashTable; // Hash table to process join only for unique keys (any join attribute)
 
  };
 
  struct TTableBucketStats {
+    KeysHashTable AnyHashTable;      // Hash table to process join only for unique keys (any join attribute)
     ui64 TuplesNum = 0;             // Total number of tuples in bucket
     ui64 StringValuesTotalSize = 0; // Total size of StringsValues. Used to correctly calculate StringsOffsets.
     ui64 KeyIntValsTotalSize = 0;   // Total size of KeyIntVals. Used to correctly calculate StringsOffsets.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

AnyHashTable was clobbered/cleared by spilling code, rendering JOIN ANY result incorrect and prevented correct work of LEFT SEMI/ONLY optimization.
This is quick fix, proper fix should move this to separate DISTINCT stage and remove AnyHashTable from grace join.
v2: just moved AnyHashTable into TableBucketsStats that is preserved by spilling

...
