### PR TITLE
Support put tracing with sampling in TestShard

### DIFF
--- a/ydb/core/protos/msgbus.proto
+++ b/ydb/core/protos/msgbus.proto
@@ -717,6 +717,8 @@ message TTestShardControlRequest {
         repeated TTimeInterval WritePeriods = 7; // time between two events
         repeated TTimeInterval RestartPeriods = 8; // time between automatic restarts
         optional uint32 PatchRequestsFractionPPM = 12;
+        optional uint32 PutTraceFractionPPM = 13;
+        optional uint32 PutTraceVerbosity = 14 [default = 15];
     }
 
     optional uint64 TabletId = 1;

--- a/ydb/core/test_tablet/load_actor_impl.h
+++ b/ydb/core/test_tablet/load_actor_impl.h
@@ -22,6 +22,7 @@ namespace NKikimr::NTestShard {
             ::NTestShard::TStateServer::EEntityState ConfirmedState = ::NTestShard::TStateServer::ABSENT;
             ::NTestShard::TStateServer::EEntityState PendingState = ::NTestShard::TStateServer::ABSENT;
             std::unique_ptr<TEvKeyValue::TEvRequest> Request;
+            NWilson::TTraceId TraceId;
             size_t ConfirmedKeyIndex = Max<size_t>();
 
             TKeyInfo(ui32 len)
@@ -174,7 +175,8 @@ namespace NKikimr::NTestShard {
         std::deque<TKey*> TransitionInFlight;
 
         void RegisterTransition(TKey& key, ::NTestShard::TStateServer::EEntityState from,
-            ::NTestShard::TStateServer::EEntityState to, std::unique_ptr<TEvKeyValue::TEvRequest> ev = nullptr);
+            ::NTestShard::TStateServer::EEntityState to, std::unique_ptr<TEvKeyValue::TEvRequest> ev = nullptr,
+            NWilson::TTraceId traceId = {});
         void Handle(TEvStateServerWriteResult::TPtr ev);
 
         void MakeConfirmed(TKey& key);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support put tracing with sampling in TestShard

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Put request tracing can now be enabled through sampling when initiating the load.
