### PR TITLE
Fix loop variable shadowing

### DIFF
--- a/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
+++ b/ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h
@@ -142,11 +142,11 @@ public:
                     argDatums[i] = scalar;
                 } else {
                     TVector<std::shared_ptr<arrow::Array>> imported(chunkCount);
-                    for (ui32 i = 0; i < chunkCount; ++i) {
+                    for (ui32 k = 0; k < chunkCount; ++k) {
                         ArrowArray a;
-                        valueBuilder->ExportArrowBlock(args[i], i, &a);
+                        valueBuilder->ExportArrowBlock(args[i], k, &a);
                         auto arr = ARROW_RESULT(arrow::ImportArray(&a, ArgArrowTypes_[i]));
-                        imported[i] = arr;
+                        imported[k] = arr;
                     }
 
                     if (chunkCount == 1) {


### PR DESCRIPTION
The patch fixes the typo leading to the mislookup in the TUnboxedValue vector while accumulating the blocks into the resulting chunked array.

### Changelog category

* Bugfix