### PR TITLE
TKeyPrefix constructor

### DIFF
--- a/ydb/core/persqueue/key.cpp
+++ b/ydb/core/persqueue/key.cpp
@@ -22,6 +22,37 @@ TKey MakeKeyFromString(const TString& s, const TPartitionId& partition)
                 t.IsHead());
 }
 
+void TKeyPrefix::SetTypeImpl(EType type, bool isServicePartition)
+{
+    char c = type;
+
+    if (isServicePartition) {
+        switch (type) {
+        case TypeNone:
+            break;
+        case TypeData:
+            c = ServiceTypeData;
+            break;
+        case TypeTmpData:
+            c = ServiceTypeTmpData;
+            break;
+        case TypeInfo:
+            c = ServiceTypeInfo;
+            break;
+        case TypeMeta:
+            c = ServiceTypeMeta;
+            break;
+        case TypeTxMeta:
+            c = ServiceTypeTxMeta;
+            break;
+        default:
+            Y_ABORT();
+        }
+    }
+
+    *PtrType() = c;
+}
+
 bool TKeyPrefix::HasServiceType() const
 {
     switch (*PtrType()) {

--- a/ydb/core/persqueue/partition_log.h
+++ b/ydb/core/persqueue/partition_log.h
@@ -7,12 +7,12 @@ namespace NKikimr::NPQ {
 
 inline TString LogPrefix() { return {}; }
 
-#define PQ_LOG_T(stream) LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
-#define PQ_LOG_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
-#define PQ_LOG_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
-#define PQ_LOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
-#define PQ_LOG_NOTICE(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
-#define PQ_LOG_ERROR(stream) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
-#define PQ_LOG_CRIT(stream) LOG_CRIT_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
+#define PQ_LOG_T(stream) if (NActors::TlsActivationContext) { LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+#define PQ_LOG_D(stream) if (NActors::TlsActivationContext) { LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+#define PQ_LOG_I(stream) if (NActors::TlsActivationContext) { LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+#define PQ_LOG_W(stream) if (NActors::TlsActivationContext) { LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+#define PQ_LOG_NOTICE(stream) if (NActors::TlsActivationContext) { LOG_NOTICE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+#define PQ_LOG_ERROR(stream) if (NActors::TlsActivationContext) { LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+#define PQ_LOG_CRIT(stream) if (NActors::TlsActivationContext) { LOG_CRIT_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/partition_log.h
+++ b/ydb/core/persqueue/partition_log.h
@@ -7,12 +7,12 @@ namespace NKikimr::NPQ {
 
 inline TString LogPrefix() { return {}; }
 
-#define PQ_LOG_T(stream) if (NActors::TlsActivationContext) { LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
-#define PQ_LOG_D(stream) if (NActors::TlsActivationContext) { LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
-#define PQ_LOG_I(stream) if (NActors::TlsActivationContext) { LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
-#define PQ_LOG_W(stream) if (NActors::TlsActivationContext) { LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
-#define PQ_LOG_NOTICE(stream) if (NActors::TlsActivationContext) { LOG_NOTICE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
-#define PQ_LOG_ERROR(stream) if (NActors::TlsActivationContext) { LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
-#define PQ_LOG_CRIT(stream) if (NActors::TlsActivationContext) { LOG_CRIT_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream); }
+#define PQ_LOG_T(stream) LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
+#define PQ_LOG_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
+#define PQ_LOG_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
+#define PQ_LOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
+#define PQ_LOG_NOTICE(stream) LOG_NOTICE_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
+#define PQ_LOG_ERROR(stream) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
+#define PQ_LOG_CRIT(stream) LOG_CRIT_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE, LogPrefix() << stream)
 
 } // namespace NKikimr::NPQ


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The `TKeyPrefix` constructor used an uninitialized field. Because of this, various special effects took place. For example, a partition actor could delete all the keys of the tablet state.  Or the key list of the head of the main partition could contain the key for the service partition.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
