### PR TITLE
Temporary hide indexes from replicator

### DIFF
--- a/ydb/core/tx/replication/controller/dst_creator.cpp
+++ b/ydb/core/tx/replication/controller/dst_creator.cpp
@@ -165,6 +165,8 @@ class TDstCreator: public TActorBootstrapped<TDstCreator> {
 
         Ydb::Table::CreateTableRequest scheme;
         result.GetTableDescription().SerializeTo(scheme);
+        // Disable index support until other replicator code be ready to process index replication
+        scheme.mutable_indexes()->Clear();
 
         Ydb::StatusIds::StatusCode status;
         TString error;

--- a/ydb/core/tx/replication/controller/dst_creator_ut.cpp
+++ b/ydb/core/tx/replication/controller/dst_creator_ut.cpp
@@ -116,7 +116,7 @@ Y_UNIT_TEST_SUITE(DstCreator) {
     Y_UNIT_TEST(WithIntermediateDir) {
         Basic("/Root/Dir/Replicated");
     }
-
+/*
     Y_UNIT_TEST(WithSyncIndex) {
         WithSyncIndex("/Root/Replicated");
     }
@@ -124,7 +124,7 @@ Y_UNIT_TEST_SUITE(DstCreator) {
     Y_UNIT_TEST(WithSyncIndexWithIntermediateDir) {
         WithSyncIndex("/Root/Dir/Replicated");
     }
-
+*/
 
     Y_UNIT_TEST(SameOwner) {
         TEnv env;


### PR DESCRIPTION
Replicator code should be ready to create stream for index, othervice it cause error.
The simplest wordaround jut to disable indexes for a while.

