### PR TITLE
Explicit devirtualize of GetOverloadFactor

### DIFF
--- a/ydb/core/tablet_flat/flat_comp.h
+++ b/ydb/core/tablet_flat/flat_comp.h
@@ -271,7 +271,7 @@ namespace NTable {
          * Overload factor must be in the [0, 1] range, where 0 means writes
          * are unrestricted and 1 means new writes must no longer be accepted
          */
-        virtual float GetOverloadFactor() = 0;
+        float GetOverloadFactor() { return OverloadFactor; }
 
         /**
          * Backing size returns total size of all currently active parts
@@ -376,6 +376,8 @@ namespace NTable {
          * Called to render current state as html
          */
         virtual void OutputHtml(IOutputStream& out) = 0;
+    protected:
+        float OverloadFactor = 0.0;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_comp_gen.cpp
+++ b/ydb/core/tablet_flat/flat_comp_gen.cpp
@@ -304,7 +304,6 @@ void TGenCompactionStrategy::Stop() {
     ForcedState = EForcedState::None;
     ForcedMemCompactionId = 0;
     ForcedGeneration = 0;
-    MaxOverloadFactor = 0.0;
 
     CurrentForcedGenCompactionId = 0;
     NextForcedGenCompactionId = 0;
@@ -343,10 +342,6 @@ void TGenCompactionStrategy::ReflectRemovedRowVersions() {
     if (Generations && MaybeAutoStartForceCompaction()) {
         CheckGeneration(1);
     }
-}
-
-float TGenCompactionStrategy::GetOverloadFactor() {
-    return MaxOverloadFactor;
 }
 
 ui64 TGenCompactionStrategy::GetBackingSize() {
@@ -1435,9 +1430,9 @@ void TGenCompactionStrategy::UpdateStats() {
 }
 
 void TGenCompactionStrategy::UpdateOverload() {
-    MaxOverloadFactor = 0.0;
+    OverloadFactor = 0.0;
     for (const auto& gen : Generations) {
-        MaxOverloadFactor = Max(MaxOverloadFactor, gen.OverloadFactor);
+        OverloadFactor = Max(OverloadFactor, gen.OverloadFactor);
     }
 }
 

--- a/ydb/core/tablet_flat/flat_comp_gen.h
+++ b/ydb/core/tablet_flat/flat_comp_gen.h
@@ -38,7 +38,6 @@ namespace NCompGen {
         void ReflectSchema() override;
         void ReflectRemovedRowVersions() override;
         void UpdateCompactions() override;
-        float GetOverloadFactor() override;
         ui64 GetBackingSize() override;
         ui64 GetBackingSize(ui64 ownerTabletId) override;
         ui64 BeginMemCompaction(TTaskId taskId, TSnapEdge edge, ui64 forcedCompactionId) override;
@@ -268,7 +267,6 @@ namespace NCompGen {
         EForcedState ForcedState = EForcedState::None;
         ui64 ForcedMemCompactionId = 0;
         ui32 ForcedGeneration = 0;
-        float MaxOverloadFactor = 0.0;
 
         ui64 CurrentForcedGenCompactionId = 0;
         ui64 NextForcedGenCompactionId = 0;


### PR DESCRIPTION
GetOverloadFactor() called from loop inside TCompactionLogic cause noticeable virtual call overhead.
