### PR TITLE
refactor cli: don't implicitly convert YAML::Node to bool

### DIFF
--- a/ydb/public/lib/ydb_cli/common/profile_manager.cpp
+++ b/ydb/public/lib/ydb_cli/common/profile_manager.cpp
@@ -27,7 +27,7 @@ public:
     }
 
     bool Has(const TString& key) const noexcept override {
-        return YamlProfile[key];
+        return static_cast<bool>(YamlProfile[key]);
     }
 
     void SetValue(const TString& key, const YAML::Node& value) override {


### PR DESCRIPTION
### Changelog entry

yaml-cpp 0.8.0 has made `YAML::Node` explicitly convertible to `bool`.
This commit fixes YDB build with modern versions of yaml-cpp library.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
