### PR TITLE
Change calculation of actorsytem pool usage

### DIFF
--- a/ydb/library/actors/helpers/pool_stats_collector.h
+++ b/ydb/library/actors/helpers/pool_stats_collector.h
@@ -362,7 +362,7 @@ private:
             double seconds = UsageTimer.PassedReset();
 
             // TODO[serxa]: It doesn't account for contention. Use 1 - parkedTicksDelta / seconds / numThreads KIKIMR-11916
-            const double currentThreadCount = poolStats.CurrentThreadCount;
+            const double currentThreadCount = poolStats.PotentialMaxThreadCount;
             const double elapsed = NHPTimer::GetSeconds(stats.ElapsedTicks);
             const double currentUsage = currentThreadCount > 0 ? ((elapsed - LastElapsedSeconds) / seconds / currentThreadCount) : 0;
             LastElapsedSeconds = elapsed;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Since Usage is calculated based on CurrentThreadCount, it can continuously display high values, even though there are still free cores available for thread pool expansion. We changed the calculation of usage to be based on PotentialMaxThreadCount.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
