### PR TITLE
Refactor indexes handling in datashard

### DIFF
--- a/ydb/core/tx/datashard/change_collector_async_index.cpp
+++ b/ydb/core/tx/datashard/change_collector_async_index.cpp
@@ -105,11 +105,7 @@ bool TAsyncIndexChangeCollector::Collect(const TTableId& tableId, ERowOp rop,
     const auto tagToPos = MakeTagToPos(tagsToSelect, [](const auto tag) { return tag; });
     const auto updatedTagToPos = MakeTagToPos(updates, [](const TUpdateOp& op) { return op.Tag; });
 
-    for (const auto& [pathId, index] : userTable->Indexes) {
-        if (index.Type != TUserTable::TTableIndex::EType::EIndexTypeGlobalAsync) {
-            continue;
-        }
-
+    userTable->ForEachAsyncIndex([&] (const auto& pathId, const auto& index) {
         if (generateDeletions) {
             bool needDeletion = rop == ERowOp::Erase || rop == ERowOp::Reset;
 
@@ -191,7 +187,7 @@ bool TAsyncIndexChangeCollector::Collect(const TTableId& tableId, ERowOp rop,
 
             Clear();
         }
-    }
+    });
 
     return true;
 }
@@ -202,14 +198,10 @@ auto TAsyncIndexChangeCollector::CacheTags(const TTableId& tableId) const {
 
     TCachedTagsBuilder builder;
 
-    for (const auto& [_, index] : userTable->Indexes) {
-        if (index.Type != TUserTable::TTableIndex::EType::EIndexTypeGlobalAsync) {
-            continue;
-        }
-
+    userTable->ForEachAsyncIndex([&] (const auto&, const auto& index) {
         builder.AddIndexTags(index.KeyColumnIds);
         builder.AddDataTags(index.DataColumnIds);
-    }
+    });
 
     return CachedTags.emplace(tableId, builder.Build()).first;
 }

--- a/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
+++ b/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
@@ -372,6 +372,7 @@ class TDynamoDBStreamsJsonSerializer: public TJsonSerializer {
                 for (const auto& [_, index] : schema->Indexes) {
                     Y_ABORT_UNLESS(index.KeyColumnIds.size() >= 1);
                     if (index.KeyColumnIds.at(0) == tag) {
+                        Y_ABORT_UNLESS(index.Type == TUserTable::TTableIndex::EType::EIndexTypeGlobalAsync);
                         indexed = true;
                         break;
                     }

--- a/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
+++ b/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
@@ -372,7 +372,6 @@ class TDynamoDBStreamsJsonSerializer: public TJsonSerializer {
                 for (const auto& [_, index] : schema->Indexes) {
                     Y_ABORT_UNLESS(index.KeyColumnIds.size() >= 1);
                     if (index.KeyColumnIds.at(0) == tag) {
-                        Y_ABORT_UNLESS(index.Type == TUserTable::TTableIndex::EType::EIndexTypeGlobalAsync);
                         indexed = true;
                         break;
                     }

--- a/ydb/core/tx/datashard/change_sender.cpp
+++ b/ydb/core/tx/datashard/change_sender.cpp
@@ -275,13 +275,9 @@ public:
         for (const auto& [tableId, tableInfo] : self->GetUserTables()) {
             const auto fullTableId = TTableId(self->GetPathOwnerId(), tableId);
 
-            for (const auto& [indexPathId, indexInfo] : tableInfo->Indexes) {
-                if (indexInfo.Type != TUserTable::TTableIndex::EType::EIndexTypeGlobalAsync) {
-                    continue;
-                }
-
+            tableInfo->ForEachAsyncIndex([&] (const auto& indexPathId, const auto&) {
                 AddChangeSender(indexPathId, fullTableId, ESenderType::AsyncIndex);
-            }
+            });
 
             for (const auto& [streamPathId, _] : tableInfo->CdcStreams) {
                 AddChangeSender(streamPathId, fullTableId, ESenderType::CdcStream);

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -67,11 +67,12 @@ void TUserTable::AddIndex(const NKikimrSchemeOp::TIndexDescription& indexDesc) {
     Y_ABORT_UNLESS(indexDesc.HasPathOwnerId() && indexDesc.HasLocalPathId());
     const auto addIndexPathId = TPathId(indexDesc.GetPathOwnerId(), indexDesc.GetLocalPathId());
 
-    if (Indexes.contains(addIndexPathId)) {
+    auto it = Indexes.lower_bound(addIndexPathId);
+    if (it != Indexes.end() && it->first == addIndexPathId) {
         return;
     }
 
-    Indexes.emplace(addIndexPathId, TTableIndex(indexDesc, Columns));
+    Indexes.emplace_hint(it, addIndexPathId, TTableIndex(indexDesc, Columns));
     AsyncIndexCount += ui32(indexDesc.GetType() == TTableIndex::EType::EIndexTypeGlobalAsync);
 
     NKikimrSchemeOp::TTableDescription schema;
@@ -117,15 +118,13 @@ void TUserTable::DropIndex(const TPathId& indexPathId) {
     NKikimrSchemeOp::TTableDescription schema;
     GetSchema(schema);
 
-    for (auto it = schema.GetTableIndexes().begin(); it != schema.GetTableIndexes().end(); ++it) {
-        if (indexPathId != TPathId(it->GetPathOwnerId(), it->GetLocalPathId())) {
-            continue;
+    auto& indexes = *schema.MutableTableIndexes();
+    for (auto it = indexes.begin(); it != indexes.end(); ++it) {
+        if (indexPathId == TPathId(it->GetPathOwnerId(), it->GetLocalPathId())) {
+            indexes.erase(it);
+            SetSchema(schema);
+            return;
         }
-
-        schema.MutableTableIndexes()->erase(it);
-        SetSchema(schema);
-
-        return;
     }
 
     Y_ABORT("unreachable");

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -396,6 +396,30 @@ struct TUserTable : public TThrRefBase {
     bool IsBackup = false;
 
     TMap<TPathId, TTableIndex> Indexes;
+
+    template <typename TCallback>
+    void ForAsyncIndex(const TPathId& pathId, TCallback&& callback) const {
+        if (AsyncIndexCount == 0) {
+            return;
+        }
+        auto it = Indexes.find(pathId);
+        if (it != Indexes.end() && it->second.Type == TTableIndex::EType::EIndexTypeGlobalAsync) {
+            callback(it->second);
+        }
+    }
+
+    template <typename TCallback>
+    void ForEachAsyncIndex(TCallback&& callback) const {
+        if (AsyncIndexCount == 0) {
+            return;
+        }
+        for (const auto& [pathId, index] : Indexes) {
+            if (index.Type == TTableIndex::EType::EIndexTypeGlobalAsync) {
+                callback(pathId, index);
+            }
+        }
+    }
+
     TMap<TPathId, TCdcStream> CdcStreams;
     ui32 AsyncIndexCount = 0;
     ui32 JsonCdcStreamCount = 0;

--- a/ydb/core/tx/datashard/drop_index_notice_unit.cpp
+++ b/ydb/core/tx/datashard/drop_index_notice_unit.cpp
@@ -38,16 +38,13 @@ public:
 
         TUserTable::TPtr tableInfo;
         if (params.HasIndexPathId()) {
+            const auto indexPathId = PathIdFromPathId(params.GetIndexPathId());
+
             const auto& userTables = DataShard.GetUserTables();
             Y_ABORT_UNLESS(userTables.contains(pathId.LocalPathId));
-            const auto& indexes = userTables.at(pathId.LocalPathId)->Indexes;
-
-            const auto indexPathId = PathIdFromPathId(params.GetIndexPathId());
-            auto it = indexes.find(indexPathId);
-
-            if (it != indexes.end() && it->second.Type == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalAsync) {
+            userTables.at(pathId.LocalPathId)->ForAsyncIndex(indexPathId, [&](const auto&) {
                 RemoveSender.Reset(new TEvChangeExchange::TEvRemoveSender(indexPathId));
-            }
+            });
 
             tableInfo = DataShard.AlterTableDropIndex(ctx, txc, pathId, version, indexPathId);
         } else {

--- a/ydb/core/tx/datashard/drop_table_unit.cpp
+++ b/ydb/core/tx/datashard/drop_table_unit.cpp
@@ -80,11 +80,9 @@ EExecutionStatus TDropTableUnit::Execute(TOperation::TPtr op,
     auto it = DataShard.GetUserTables().find(tableId);
     Y_ABORT_UNLESS(it != DataShard.GetUserTables().end());
     {
-        for (const auto& [indexPathId, indexInfo] : it->second->Indexes) {
-            if (indexInfo.Type == TUserTable::TTableIndex::EType::EIndexTypeGlobalAsync) {
-                RemoveSenders.emplace_back(new TEvChangeExchange::TEvRemoveSender(indexPathId));
-            }
-        }
+        it->second->ForEachAsyncIndex([&] (const auto& indexPathId, const auto&) {
+            RemoveSenders.emplace_back(new TEvChangeExchange::TEvRemoveSender(indexPathId));
+        });
         for (const auto& [streamPathId, _] : it->second->CdcStreams) {
             RemoveSenders.emplace_back(new TEvChangeExchange::TEvRemoveSender(streamPathId));
         }

--- a/ydb/core/tx/datashard/finalize_build_index_unit.cpp
+++ b/ydb/core/tx/datashard/finalize_build_index_unit.cpp
@@ -46,11 +46,9 @@ public:
 
             const auto& userTables = DataShard.GetUserTables();
             Y_ABORT_UNLESS(userTables.contains(pathId.LocalPathId));
-            const auto& indexes = userTables.at(pathId.LocalPathId)->Indexes;
-            auto it = indexes.find(indexPathId);
-            if (it != indexes.end() && it->second.Type == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalAsync) {
+            userTables.at(pathId.LocalPathId)->ForAsyncIndex(indexPathId, [&] (const auto&) {
                 RemoveSender.Reset(new TEvChangeExchange::TEvRemoveSender(indexPathId));
-            }
+            });
 
             tableInfo = DataShard.AlterTableDropIndex(ctx, txc, pathId, version, indexPathId);
         } else {


### PR DESCRIPTION
* We don't need to iterate over Indexes when there are no async indexes
* extract node from map instead of insert + erase
* use lower_bound + emplace_hint instead of find + erase