### PR TITLE
Use the whole TTableDescription to describe an indexImplTable in TIndexDescription

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_table.cpp
+++ b/ydb/core/grpc_services/rpc_describe_table.cpp
@@ -92,7 +92,14 @@ private:
                     return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
                 }
 
-                FillIndexDescription(describeTableResult, tableDescription, splitKeyType);
+                try {
+                    FillIndexDescription(describeTableResult, tableDescription);
+                } catch (const std::exception& ex) {
+                    LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, "Unable to fill index description: %s", ex.what());
+                    Request_->RaiseIssue(NYql::ExceptionToIssue(ex));
+                    return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
+                }
+
                 FillChangefeedDescription(describeTableResult, tableDescription);
 
                 if (GetProtoRequest()->include_table_stats()) {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -999,7 +999,7 @@ message TIndexDescription {
 
     // DataSize + IndexSize of indexImplTable
     optional uint64 DataSize = 9;
-    repeated TTableDescription IndexImplTableDescription = 10;
+    repeated TTableDescription IndexImplTableDescriptions = 10;
 }
 
 message TIndexCreationConfig {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -982,10 +982,6 @@ enum EIndexState {
     EIndexStateWriteOnly = 3;
 }
 
-message TExplicitPartitions {
-    repeated TSplitBoundary SplitBoundary = 1;
-}
-
 message TIndexDescription {
     optional string Name = 1;
     optional uint64 LocalPathId = 2;
@@ -1000,15 +996,10 @@ message TIndexDescription {
     optional uint64 PathOwnerId = 7;
 
     repeated string DataColumnNames = 8;
+
     // DataSize + IndexSize of indexImplTable
     optional uint64 DataSize = 9;
-
-    // indexImplTable settings
-    oneof Partitions {
-        uint32 UniformPartitions = 10;
-        TExplicitPartitions ExplicitPartitions = 11;
-    }
-    optional TPartitioningPolicy PartitioningPolicy = 12;
+    repeated TTableDescription IndexImplTableDescription = 10;
 }
 
 message TIndexCreationConfig {

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -55,11 +55,6 @@ TMaybe<Ydb::Table::CreateTableRequest> GenYdbScheme(
 
     try {
         FillTableBoundary(scheme, tableDesc, mkqlKeyType);
-    } catch (const yexception&) {
-        return Nothing();
-    }
-
-    try {
         FillIndexDescription(scheme, tableDesc);
     } catch (const yexception&) {
         return Nothing();

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -59,7 +59,12 @@ TMaybe<Ydb::Table::CreateTableRequest> GenYdbScheme(
         return Nothing();
     }
 
-    FillIndexDescription(scheme, tableDesc, mkqlKeyType);
+    try {
+        FillIndexDescription(scheme, tableDesc);
+    } catch (const yexception&) {
+        return Nothing();
+    }
+
     FillStorageSettings(scheme, tableDesc);
     FillColumnFamilies(scheme, tableDesc);
     FillAttributes(scheme, pathDesc);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_initiate_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_initiate_build_index.cpp
@@ -88,7 +88,9 @@ public:
             found = true;
 
             Y_ABORT_UNLESS(index->AlterData);
-            context.SS->DescribeTableIndex(childPathId, childName, index->AlterData, *initiate->MutableIndexDescription());
+            context.SS->DescribeTableIndex(childPathId, childName, index->AlterData, false, false,
+                *initiate->MutableIndexDescription()
+            );
         }
 
         txState->ClearShardsInProgress();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -6675,7 +6675,9 @@ void TSchemeShard::FillTableDescriptionForShardIdx(
             case NKikimrSchemeOp::EPathTypeTableIndex: {
                 Y_ABORT_UNLESS(Indexes.contains(childPathId));
                 auto info = Indexes.at(childPathId);
-                DescribeTableIndex(childPathId, childName, newTable ? info->AlterData : info, *tableDescr->MutableTableIndexes()->Add());
+                DescribeTableIndex(childPathId, childName, newTable ? info->AlterData : info, false, false,
+                    *tableDescr->MutableTableIndexes()->Add()
+                );
                 break;
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1016,8 +1016,12 @@ public:
 
     void DescribeTable(const TTableInfo::TPtr tableInfo, const NScheme::TTypeRegistry* typeRegistry,
                        bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TTableDescription* entry) const;
-    void DescribeTableIndex(const TPathId& pathId, const TString& name, NKikimrSchemeOp::TIndexDescription& entry);
-    void DescribeTableIndex(const TPathId& pathId, const TString& name, TTableIndexInfo::TPtr indexInfo, NKikimrSchemeOp::TIndexDescription& entry);
+    void DescribeTableIndex(const TPathId& pathId, const TString& name,
+        bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TIndexDescription& entry
+    ) const;
+    void DescribeTableIndex(const TPathId& pathId, const TString& name, TTableIndexInfo::TPtr indexInfo,
+        bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TIndexDescription& entry
+    ) const;
     void DescribeCdcStream(const TPathId& pathId, const TString& name, NKikimrSchemeOp::TCdcStreamDescription& desc);
     void DescribeCdcStream(const TPathId& pathId, const TString& name, TCdcStreamInfo::TPtr info, NKikimrSchemeOp::TCdcStreamDescription& desc);
     void DescribeSequence(const TPathId& pathId, const TString& name,

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -374,7 +374,7 @@ void TPathDescriber::DescribeTable(const TActorContext& ctx, TPathId pathId, TPa
 
         switch (childPath->PathType) {
         case NKikimrSchemeOp::EPathTypeTableIndex:
-            Self->DescribeTableIndex(childPathId, childName, returnConfig, returnBoundaries, *entry->AddTableIndexes());
+            Self->DescribeTableIndex(childPathId, childName, returnConfig, false, *entry->AddTableIndexes());
             break;
         case NKikimrSchemeOp::EPathTypeCdcStream:
             Self->DescribeCdcStream(childPathId, childName, *entry->AddCdcStreams());

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1238,12 +1238,7 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
     const auto& tableStats = indexImplTable->GetStats().Aggregated;
     entry.SetDataSize(tableStats.DataSize + tableStats.IndexSize);
 
-    *entry.MutablePartitioningPolicy() = indexImplTable->PartitionConfig().GetPartitioningPolicy();
-    if (const auto& explicitPartitions = indexImplTable->TableDescription.GetSplitBoundary();
-        !explicitPartitions.empty()
-    ) {
-        *entry.MutableExplicitPartitions()->MutableSplitBoundary() = explicitPartitions;
-    }
+    *entry.AddIndexImplTableDescription() = indexImplTable->TableDescription;
 }
 
 void TSchemeShard::DescribeCdcStream(const TPathId& pathId, const TString& name,

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1238,7 +1238,7 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
     const auto& tableStats = indexImplTable->GetStats().Aggregated;
     entry.SetDataSize(tableStats.DataSize + tableStats.IndexSize);
 
-    *entry.AddIndexImplTableDescription() = indexImplTable->TableDescription;
+    *entry.AddIndexImplTableDescriptions() = indexImplTable->TableDescription;
 }
 
 void TSchemeShard::DescribeCdcStream(const TPathId& pathId, const TString& name,

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -48,7 +48,7 @@ namespace {
 
         scheme.mutable_primary_key()->CopyFrom(tableDesc.GetKeyColumnNames());
         FillColumnDescription(scheme, mkqlKeyType, tableDesc);
-        FillIndexDescription(scheme, tableDesc, mkqlKeyType);
+        FillIndexDescription(scheme, tableDesc);
         FillStorageSettings(scheme, tableDesc);
         FillColumnFamilies(scheme, tableDesc);
         FillAttributes(scheme, pathDesc);

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -829,9 +829,6 @@ void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
     }
     const auto& indexImplTableDescription = indexImplTables.Get(0);
 
-    if (indexImplTableDescription.HasUniformPartitionsCount()) {
-        settings.set_uniform_partitions(indexImplTableDescription.GetUniformPartitionsCount());
-    }
     if (indexImplTableDescription.SplitBoundarySize()) {
         NKikimrMiniKQL::TType splitKeyType;
         Ydb::Table::DescribeTableResult unused;

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -719,10 +719,9 @@ bool FillColumnDescription(NKikimrSchemeOp::TColumnTableDescription& out,
 
 template <typename TYdbProto>
 void FillTableBoundaryImpl(TYdbProto& out,
-    const google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TSplitBoundary>& boundaries,
-    const NKikimrMiniKQL::TType& splitKeyType
-) {
-    for (const auto& boundary : boundaries) {
+        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
+
+    for (const auto& boundary : in.GetSplitBoundary()) {
         if (boundary.HasSerializedKeyPrefix()) {
             throw NYql::TErrorException(NKikimrIssues::TIssuesIds::DEFAULT_ERROR)
                 << "Unexpected serialized response from txProxy";
@@ -756,12 +755,12 @@ void FillTableBoundaryImpl(TYdbProto& out,
 
 void FillTableBoundary(Ydb::Table::DescribeTableResult& out,
         const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillTableBoundaryImpl<Ydb::Table::DescribeTableResult>(out, in.GetSplitBoundary(), splitKeyType);
+    FillTableBoundaryImpl<Ydb::Table::DescribeTableResult>(out, in, splitKeyType);
 }
 
 void FillTableBoundary(Ydb::Table::CreateTableRequest& out,
         const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillTableBoundaryImpl<Ydb::Table::CreateTableRequest>(out, in.GetSplitBoundary(), splitKeyType);
+    FillTableBoundaryImpl<Ydb::Table::CreateTableRequest>(out, in, splitKeyType);
 }
 
 template <typename TYdbProto>
@@ -802,38 +801,53 @@ void FillPartitioningSettings(TYdbProto& out, const NKikimrSchemeOp::TPartitioni
     }
 }
 
-void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
-        const NKikimrSchemeOp::TIndexDescription& tableIndex,
-        const NKikimrMiniKQL::TType& splitKeyType) {
+template <typename TYdbProto>
+void FillPartitioningSettingsImpl(TYdbProto& out,
+        const NKikimrSchemeOp::TTableDescription& in) {
 
-    switch (tableIndex.GetPartitionsCase()) {
-    case NKikimrSchemeOp::TIndexDescription::kUniformPartitions:
-        settings.set_uniform_partitions(tableIndex.GetUniformPartitions());
-        break;
-    case NKikimrSchemeOp::TIndexDescription::kExplicitPartitions:
-        FillTableBoundaryImpl(*settings.mutable_partition_at_keys(),
-            tableIndex.GetExplicitPartitions().GetSplitBoundary(),
+    auto& outPartSettings = *out.mutable_partitioning_settings();
+
+    if (!in.HasPartitionConfig()) {
+        FillDefaultPartitioningSettings(outPartSettings);
+        return;
+    }
+
+    const auto& partConfig = in.GetPartitionConfig();
+    if (!partConfig.HasPartitioningPolicy()) {
+        FillDefaultPartitioningSettings(outPartSettings);
+        return;
+    }
+
+    FillPartitioningSettings(outPartSettings, partConfig.GetPartitioningPolicy());
+}
+
+void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
+    const google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TTableDescription>& indexImplTables
+) {
+    if (indexImplTables.empty()) {
+        return;
+    }
+    const auto& indexImplTableDescription = indexImplTables.Get(0);
+
+    if (indexImplTableDescription.HasUniformPartitionsCount()) {
+        settings.set_uniform_partitions(indexImplTableDescription.GetUniformPartitionsCount());
+    }
+    if (indexImplTableDescription.SplitBoundarySize()) {
+        NKikimrMiniKQL::TType splitKeyType;
+        Ydb::Table::DescribeTableResult unused;
+        FillColumnDescription(unused, splitKeyType, indexImplTableDescription);
+        FillTableBoundaryImpl(
+            *settings.mutable_partition_at_keys(),
+            indexImplTableDescription,
             splitKeyType
         );
-        break;
-    default:
-        break;
     }
 
-    auto& partitioningSettings = *settings.mutable_partitioning_settings();
-    if (tableIndex.HasPartitioningPolicy()) {
-        FillPartitioningSettings(
-            partitioningSettings,
-            tableIndex.GetPartitioningPolicy()
-        );
-    } else {
-        FillDefaultPartitioningSettings(partitioningSettings);
-    }
+    FillPartitioningSettingsImpl(settings, indexImplTableDescription);
 }
 
 template <typename TYdbProto>
-void FillIndexDescriptionImpl(TYdbProto& out,
-        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
+void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescription& in) {
 
     for (const auto& tableIndex : in.GetTableIndexes()) {
         auto index = out.add_indexes();
@@ -852,13 +866,22 @@ void FillIndexDescriptionImpl(TYdbProto& out,
 
         switch (tableIndex.GetType()) {
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobal:
-            FillGlobalIndexSettings(*index->mutable_global_index()->mutable_settings(), tableIndex, splitKeyType);
+            FillGlobalIndexSettings(
+                *index->mutable_global_index()->mutable_settings(),
+                tableIndex.GetIndexImplTableDescription()
+            );
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalAsync:
-            FillGlobalIndexSettings(*index->mutable_global_async_index()->mutable_settings(), tableIndex, splitKeyType);
+            FillGlobalIndexSettings(
+                *index->mutable_global_async_index()->mutable_settings(),
+                tableIndex.GetIndexImplTableDescription()
+            );
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique:
-            FillGlobalIndexSettings(*index->mutable_global_unique_index()->mutable_settings(), tableIndex, splitKeyType);
+            FillGlobalIndexSettings(
+                *index->mutable_global_unique_index()->mutable_settings(),
+                tableIndex.GetIndexImplTableDescription()
+            );
             break;
         default:
             break;
@@ -876,13 +899,13 @@ void FillIndexDescriptionImpl(TYdbProto& out,
 }
 
 void FillIndexDescription(Ydb::Table::DescribeTableResult& out,
-        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillIndexDescriptionImpl(out, in, splitKeyType);
+        const NKikimrSchemeOp::TTableDescription& in) {
+    FillIndexDescriptionImpl(out, in);
 }
 
 void FillIndexDescription(Ydb::Table::CreateTableRequest& out,
-        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillIndexDescriptionImpl(out, in, splitKeyType);
+        const NKikimrSchemeOp::TTableDescription& in) {
+    FillIndexDescriptionImpl(out, in);
 }
 
 bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
@@ -1260,26 +1283,6 @@ void FillAttributes(Ydb::Table::DescribeTableResult& out,
 void FillAttributes(Ydb::Table::CreateTableRequest& out,
         const NKikimrSchemeOp::TPathDescription& in) {
     FillAttributesImpl(out, in);
-}
-
-template <typename TYdbProto>
-void FillPartitioningSettingsImpl(TYdbProto& out,
-        const NKikimrSchemeOp::TTableDescription& in) {
-
-    auto& outPartSettings = *out.mutable_partitioning_settings();
-
-    if (!in.HasPartitionConfig()) {
-        FillDefaultPartitioningSettings(outPartSettings);
-        return;
-    }
-
-    const auto& partConfig = in.GetPartitionConfig();
-    if (!partConfig.HasPartitioningPolicy()) {
-        FillDefaultPartitioningSettings(outPartSettings);
-        return;
-    }
-
-    FillPartitioningSettings(outPartSettings, partConfig.GetPartitioningPolicy());
 }
 
 void FillPartitioningSettings(Ydb::Table::DescribeTableResult& out,

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -868,19 +868,19 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobal:
             FillGlobalIndexSettings(
                 *index->mutable_global_index()->mutable_settings(),
-                tableIndex.GetIndexImplTableDescription()
+                tableIndex.GetIndexImplTableDescriptions()
             );
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalAsync:
             FillGlobalIndexSettings(
                 *index->mutable_global_async_index()->mutable_settings(),
-                tableIndex.GetIndexImplTableDescription()
+                tableIndex.GetIndexImplTableDescriptions()
             );
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique:
             FillGlobalIndexSettings(
                 *index->mutable_global_unique_index()->mutable_settings(),
-                tableIndex.GetIndexImplTableDescription()
+                tableIndex.GetIndexImplTableDescriptions()
             );
             break;
         default:

--- a/ydb/core/ydb_convert/table_description.h
+++ b/ydb/core/ydb_convert/table_description.h
@@ -65,9 +65,9 @@ void FillTableBoundary(Ydb::Table::CreateTableRequest& out,
 
 // out
 void FillIndexDescription(Ydb::Table::DescribeTableResult& out,
-    const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType);
+    const NKikimrSchemeOp::TTableDescription& in);
 void FillIndexDescription(Ydb::Table::CreateTableRequest& out,
-    const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType);
+    const NKikimrSchemeOp::TTableDescription& in);
 // in
 bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
     const Ydb::Table::CreateTableRequest& in, Ydb::StatusIds::StatusCode& status, TString& error);


### PR DESCRIPTION
It would be better (more future proof) to keep all the necessary settings of the indexImplTable in one message. I would not like to reinvent the bicycle, so the best option I see here is to reuse TTableDescription.

Additionally, I have added options `fillConfig` and `fillBoundaries` to control what parts of the whole TTableDescription would be return on DescribeTableIndex request. It should prevent the unnecessary use of CPU for parsing big protobufs (TableBoundaries can be big). We would need to enable `fillBoundaries` explicitly for backups, but this would be done in scope of https://github.com/ydb-platform/ydb/issues/4955.

And the last change is to make IndexImplTableDescription field a repeated field. The motivation is to prepare `flat_scheme_op.proto` for multiple indexImplTables which are said to be coming soon to implement vector indices. It is a breaking change, but there are no instances of YDB that have been using the new TIndexDescriptions with PartitionConfig and PartitionBoundaries, so it should be ok.