### PR TITLE
Prepare flat_scheme_op.proto for multiple indexImplTables. 

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1015,7 +1015,7 @@ message TIndexCreationConfig {
     optional string Name = 1;
     repeated string KeyColumnNames = 2;
     optional EIndexType Type = 3;
-    optional TTableDescription IndexImplTableDescription = 4; //description for index impl table
+    repeated TTableDescription IndexImplTableDescriptions = 4; //description for index impl tables
     optional EIndexState State = 5; //state of index at the creation time
     repeated string DataColumnNames = 6; //columns to be denormalized to read data just from index
 }

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1672,7 +1672,7 @@ namespace Tests {
             }
 
             indexDesc->SetType(type);
-            indexDesc->MutableIndexImplTableDescription()->SetUniformPartitionsCount(16);
+            indexDesc->AddIndexImplTableDescriptions()->SetUniformPartitionsCount(16);
         }
 
         TAutoPtr<NBus::TBusMessage> reply;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -116,7 +116,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
         auto& indexImplTableDescription = *outTx.MutableCreateTable();
 
         // This description provided by user to override partition policy
-        const auto& userIndexDesc = indexDesc.GetIndexImplTableDescription();
+        const auto& userIndexDesc = indexDesc.GetIndexImplTableDescriptions(0);
         indexImplTableDescription = CalcImplTableDesc(tableInfo, implTableColumns, userIndexDesc);
 
         indexImplTableDescription.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2114,7 +2114,7 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
         *index.AddDataColumnNames() = x;
     }
 
-    *index.MutableIndexImplTableDescription() = ImplTableDescription;
+    *index.AddIndexImplTableDescriptions() = ImplTableDescription;
 }
 
 void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrIndexBuilder::TColumnBuildSettings* result) const {

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -1779,7 +1779,7 @@ partitioning_settings {
             IndexDescription {
                 Name: "ByValue"
                 KeyColumnNames: ["value"]
-                IndexImplTableDescription {
+                IndexImplTableDescriptions: [ {
                     PartitionConfig {
                         PartitioningPolicy {
                             MinPartitionsCount: 10
@@ -1788,7 +1788,7 @@ partitioning_settings {
                             }
                         }
                     }
-                }
+                } ]
             }
         )");
         env.TestWaitNotification(runtime, txId);

--- a/ydb/core/tx/schemeshard/ut_index/ut_async_index.cpp
+++ b/ydb/core/tx/schemeshard/ut_index/ut_async_index.cpp
@@ -399,7 +399,7 @@ Y_UNIT_TEST_SUITE(TAsyncIndexTests) {
                   Name: "UserDefinedIndex"
                   KeyColumnNames: ["indexed"]
                   Type: EIndexTypeGlobalAsync
-                  IndexImplTableDescription {
+                  IndexImplTableDescriptions: [ {
                     SplitBoundary {
                       KeyPrefix {
                         Tuple { Optional { Uint32: 50 } }
@@ -410,7 +410,7 @@ Y_UNIT_TEST_SUITE(TAsyncIndexTests) {
                         MinPartitionsCount: 1
                       }
                     }
-                  }
+                  } ]
                 }
             )");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
@@ -440,7 +440,7 @@ Y_UNIT_TEST_SUITE(TAsyncIndexTests) {
                   Name: "UserDefinedIndex"
                   KeyColumnNames: ["indexed"]
                   Type: EIndexTypeGlobalAsync
-                  IndexImplTableDescription {
+                  IndexImplTableDescriptions: [ {
                     SplitBoundary {
                       KeyPrefix {
                         Tuple { Optional { Uint32: 50 } }
@@ -451,7 +451,7 @@ Y_UNIT_TEST_SUITE(TAsyncIndexTests) {
                         MinPartitionsCount: 1
                       }
                     }
-                  }
+                  } ]
                 }
             )");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -453,7 +453,7 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
                     auto& tx = *msg->Record.MutableTransaction(0);
                     auto& config = *tx.MutableInitiateIndexBuild();
                     NKikimrSchemeOp::TIndexCreationConfig& indexConfig = *config.MutableIndex();
-                    NKikimrSchemeOp::TTableDescription& indexTableDescr = *indexConfig.MutableIndexImplTableDescription();
+                    NKikimrSchemeOp::TTableDescription& indexTableDescr = indexConfig.MutableIndexImplTableDescriptions()->at(0);
 
                     indexTableDescr.MutablePartitionConfig()->MutablePartitioningPolicy()->SetSizeToSplit(10);
                     indexTableDescr.MutablePartitionConfig()->MutablePartitioningPolicy()->SetMaxPartitionsCount(10);

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -932,7 +932,7 @@ bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
             break;
         }
 
-        if (!FillIndexTablePartitioning(*indexDesc->MutableIndexImplTableDescription(), index, status, error)) {
+        if (!FillIndexTablePartitioning(*indexDesc->AddIndexImplTableDescriptions(), index, status, error)) {
             return false;
         }
     }


### PR DESCRIPTION
Future features require multiple indexImplTables. We would like to prepare flat_scheme_op.proto for the future changes.

...

This change `optional`->`repeated` is wire compatible.
> For ... message fields, optional is [compatible](https://protobuf.dev/programming-guides/proto3/#updating) with repeated)

...

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
