### PR TITLE
prioritise nodes with tablets on initial ping (#5654)

### DIFF
--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -469,10 +469,19 @@ void THive::Handle(TEvPrivate::TEvBootTablets::TPtr&) {
     SignalTabletActive(DEPRECATED_CTX);
     ReadyForConnections = true;
     RequestPoolsInformation();
+    std::vector<TNodeInfo*> unimportantNodes; // ping nodes with tablets first
+    unimportantNodes.reserve(Nodes.size());
     for (auto& [id, node] : Nodes) {
         if (node.IsUnknown() && node.Local) {
-            node.Ping();
+            if (node.GetTabletsTotal() > 0) {
+                node.Ping();
+            } else {
+                unimportantNodes.push_back(&node);
+            }
         }
+    }
+    for (auto* node : unimportantNodes) {
+        node->Ping();
     }
     TVector<TTabletId> tabletsToReleaseFromParent;
     TSideEffects sideEffects;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

On Hive restart, connect to nodes with tablets first

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

backport of https://github.com/ydb-platform/ydb/pull/5654