### PR TITLE
Handle empty GC commands correctly

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/gc.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/gc.cpp
@@ -1,0 +1,22 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+
+Y_UNIT_TEST_SUITE(GarbageCollection) {
+    Y_UNIT_TEST(EmptyGcCmd) {
+        TEnvironmentSetup env({
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        });
+        auto& runtime = env.Runtime;
+
+        env.CreateBoxAndPool(1, 1);
+        auto info = env.GetGroupInfo(env.GetGroups().front());
+
+        auto ev = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(1u, 1u, 1u, 0u, false, 0u, 0u, nullptr, nullptr,
+            TInstant::Max(), true);
+        const TActorId edge = runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
+        runtime->WrapInActorContext(edge, [&] {
+            SendToBSProxy(edge, info->GroupID, ev.release());
+        });
+        auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvCollectGarbageResult>(edge);
+        UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::ERROR);
+    }
+}

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -22,6 +22,7 @@ SRCS(
     ds_proxy_lwtrace.cpp
     encryption.cpp
     extra_block_checks.cpp
+    gc.cpp
     gc_quorum_3dc.cpp
     get.cpp
     group_reconfiguration.cpp

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hull.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hull.cpp
@@ -413,6 +413,13 @@ namespace NKikimr {
         if (!CheckGC(ctx, record))
             return {NKikimrProto::ERROR, 0, false}; // record has duplicates
 
+        if (!collect && !record.KeepSize() && !record.DoNotKeepSize()) {
+            LOG_ERROR_S(ctx, NKikimrServices::BS_HULLRECS, HullDs->HullCtx->VCtx->VDiskLogPrefix
+                << "Db# Barriers ValidateGCCmd: empty garbage collection command"
+                << " TabletId# " << tabletID);
+            return {NKikimrProto::ERROR, "empty garbage collection command"};
+        }
+
         auto blockStatus = THullDbRecovery::IsBlocked(record);
         switch (blockStatus.Status) {
             case TBlocksCache::EStatus::OK:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Handle empty GC commands correctly

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

VDisk now can handle correctly empty GC command (returning ERROR status instead of an assertion failure).
