### PR TITLE
Fix tests for purecalc Arrow IO spec

### DIFF
--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
@@ -53,7 +53,7 @@ using ExecBatchConsumerImpl = TVectorConsumer<arrow::compute::ExecBatch>;
 
 
 arrow::compute::ExecBatch MakeBatch(ui64 bsize, i64 value) {
-    TVector<ui64> data(bsize);
+    TVector<uint64_t> data(bsize);
     TVector<bool> valid(bsize);
     std::iota(data.begin(), data.end(), 1);
     std::fill(valid.begin(), valid.end(), true);


### PR DESCRIPTION
`ui64` is the platform dependent alias, that expands into `uint64_t` (i.e. `unsigned long long`) on Linux and into `unsigned long` on Darwin (see util/system/types.h). At the same time, `arrow::UInt64Type::c_type` is `uint64_t` on all platforms (see apache/arrow/cpp/src/arrow/type.h), so template instantiation of `UInt64Builder::AppendValues` failed due to the value_type mismatch.

Follows up #5079

### Changelog category

* Bugfix 