### PR TITLE
Create separate trace id for BlobStorage requests and link them to original traces

### DIFF
--- a/ydb/core/base/blobstorage.cpp
+++ b/ydb/core/base/blobstorage.cpp
@@ -1,4 +1,6 @@
 #include "blobstorage.h"
+#include <ydb/library/actors/wilson/wilson_span.h>
+#include <ydb/library/wilson_ids/wilson.h>
 
 namespace NKikimr {
 
@@ -44,11 +46,47 @@ bool operator<(const TPDiskCategory x, const TPDiskCategory y) {
     return std::make_tuple(x.Type(), x.Kind()) < std::make_tuple(y.Type(), y.Kind());
 }
 
+void TEvBlobStorage::TEvPut::ToSpan(NWilson::TSpan& span) const {
+    span
+        .Attribute("Id", Id.ToString())
+        .Attribute("PutHandleClass", NKikimrBlobStorage::EPutHandleClass_Name(HandleClass));
+}
+
 std::unique_ptr<TEvBlobStorage::TEvPutResult> TEvBlobStorage::TEvPut::MakeErrorResponse(
         NKikimrProto::EReplyStatus status, const TString& errorReason, TGroupId groupId) {
     auto res = std::make_unique<TEvPutResult>(status, Id, TStorageStatusFlags(), groupId, 0.0f);
     res->ErrorReason = errorReason;
     return res;
+}
+
+void TEvBlobStorage::TEvGet::ToSpan(NWilson::TSpan& span) const {
+    i64 totalSize = 0;
+    for (ui32 i = 0; i < QuerySize; ++i) {
+        const auto& q = Queries[i];
+        if (q.Shift < q.Id.BlobSize()) {
+            totalSize += Min<size_t>(q.Id.BlobSize() - q.Shift, q.Size ? q.Size : Max<size_t>());
+        }
+    }
+
+    span
+        .Attribute("TotalSize", totalSize)
+        .Attribute("GetHandleClass", NKikimrBlobStorage::EGetHandleClass_Name(GetHandleClass))
+        .Attribute("MustRestoreFirst", MustRestoreFirst)
+        .Attribute("IsIndexOnly", IsIndexOnly);
+
+    if (span.GetTraceId().GetVerbosity() >= TWilson::DsProxyInternals) {
+        NWilson::TArrayValue queries;
+        queries.reserve(QuerySize);
+        for (ui32 i = 0; i < QuerySize; ++i) {
+            const auto& q = Queries[i];
+            queries.emplace_back(NWilson::TKeyValueList{{
+                {"Id", q.Id.ToString()},
+                {"Shift", q.Shift},
+                {"Size", q.Size},
+            }});
+        }
+        span.Attribute("Queries", std::move(queries));
+    }
 }
 
 std::unique_ptr<TEvBlobStorage::TEvGetResult> TEvBlobStorage::TEvGet::MakeErrorResponse(
@@ -67,11 +105,24 @@ std::unique_ptr<TEvBlobStorage::TEvGetResult> TEvBlobStorage::TEvGet::MakeErrorR
     return res;
 }
 
+void TEvBlobStorage::TEvBlock::ToSpan(NWilson::TSpan& span) const {
+    span
+        .Attribute("TabletId", ::ToString(TabletId))
+        .Attribute("Generation", Generation);
+}
+
 std::unique_ptr<TEvBlobStorage::TEvBlockResult> TEvBlobStorage::TEvBlock::MakeErrorResponse(
         NKikimrProto::EReplyStatus status, const TString& errorReason, TGroupId /*groupId*/) {
     auto res = std::make_unique<TEvBlockResult>(status);
     res->ErrorReason = errorReason;
     return res;
+}
+
+void TEvBlobStorage::TEvPatch::ToSpan(NWilson::TSpan& span) const {
+    span
+        .Attribute("OriginalGroupId", OriginalGroupId)
+        .Attribute("OriginalId", OriginalId.ToString())
+        .Attribute("PatchedId", PatchedId.ToString());
 }
 
 std::unique_ptr<TEvBlobStorage::TEvPatchResult> TEvBlobStorage::TEvPatch::MakeErrorResponse(
@@ -81,11 +132,20 @@ std::unique_ptr<TEvBlobStorage::TEvPatchResult> TEvBlobStorage::TEvPatch::MakeEr
     return res;
 }
 
+void TEvBlobStorage::TEvInplacePatch::ToSpan(NWilson::TSpan& /*span*/) const {
+}
+
 std::unique_ptr<TEvBlobStorage::TEvInplacePatchResult> TEvBlobStorage::TEvInplacePatch::MakeErrorResponse(
         NKikimrProto::EReplyStatus status, const TString& errorReason) {
     auto res = std::make_unique<TEvInplacePatchResult>(status, PatchedId, TStorageStatusFlags(), 0.0f);
     res->ErrorReason = errorReason;
     return res;
+}
+
+void TEvBlobStorage::TEvDiscover::ToSpan(NWilson::TSpan& span) const {
+    span
+        .Attribute("TabletId", ::ToString(TabletId))
+        .Attribute("ReadBody", ReadBody);
 }
 
 std::unique_ptr<TEvBlobStorage::TEvDiscoverResult> TEvBlobStorage::TEvDiscover::MakeErrorResponse(
@@ -95,11 +155,56 @@ std::unique_ptr<TEvBlobStorage::TEvDiscoverResult> TEvBlobStorage::TEvDiscover::
     return res;
 }
 
+void TEvBlobStorage::TEvRange::ToSpan(NWilson::TSpan& span) const {
+    span
+        .Attribute("TabletId", ::ToString(TabletId))
+        .Attribute("From", From.ToString())
+        .Attribute("To", To.ToString())
+        .Attribute("MustRestoreFirst", MustRestoreFirst)
+        .Attribute("IsIndexOnly", IsIndexOnly);
+}
+
 std::unique_ptr<TEvBlobStorage::TEvRangeResult> TEvBlobStorage::TEvRange::MakeErrorResponse(
         NKikimrProto::EReplyStatus status, const TString& errorReason, TGroupId groupId) {
     auto res = std::make_unique<TEvRangeResult>(status, From, To, groupId);
     res->ErrorReason = errorReason;
     return res;
+}
+
+void TEvBlobStorage::TEvCollectGarbage::ToSpan(NWilson::TSpan& span) const {
+    span
+        .Attribute("TabletId", ::ToString(TabletId))
+        .Attribute("RecordGeneration", RecordGeneration)
+        .Attribute("PerGenerationCounter", PerGenerationCounter)
+        .Attribute("Channel", Channel);
+
+    if (Collect) {
+        span
+            .Attribute("CollectGeneration", CollectGeneration)
+            .Attribute("CollectStep", CollectStep);
+    }
+
+    if (span.GetTraceId().GetVerbosity() >= TWilson::DsProxyInternals) {
+        auto vector = [&](const auto& name, const auto& v) {
+            if (v) {
+                NWilson::TArrayValue items;
+                items.reserve(v->size());
+                for (const TLogoBlobID& id : *v) {
+                    items.emplace_back(id.ToString());
+                }
+                span.Attribute(name, std::move(items));
+            }
+        };
+        vector("Keep", Keep);
+        vector("DoNotKeep", DoNotKeep);
+    } else {
+        if (Keep) {
+            span.Attribute("NumKeep", static_cast<i64>(Keep->size()));
+        }
+        if (DoNotKeep) {
+            span.Attribute("NumDoNotKeep", static_cast<i64>(DoNotKeep->size()));
+        }
+    }
 }
 
 std::unique_ptr<TEvBlobStorage::TEvCollectGarbageResult> TEvBlobStorage::TEvCollectGarbage::MakeErrorResponse(
@@ -109,12 +214,18 @@ std::unique_ptr<TEvBlobStorage::TEvCollectGarbageResult> TEvBlobStorage::TEvColl
     return res;
 }
 
+void TEvBlobStorage::TEvStatus::ToSpan(NWilson::TSpan& /*span*/) const
+{}
+
 std::unique_ptr<TEvBlobStorage::TEvStatusResult> TEvBlobStorage::TEvStatus::MakeErrorResponse(
         NKikimrProto::EReplyStatus status, const TString& errorReason, TGroupId /*groupId*/) {
     auto res = std::make_unique<TEvStatusResult>(status, TStorageStatusFlags());
     res->ErrorReason = errorReason;
     return res;
 }
+
+void TEvBlobStorage::TEvAssimilate::ToSpan(NWilson::TSpan& /*span*/) const
+{}
 
 std::unique_ptr<TEvBlobStorage::TEvAssimilateResult> TEvBlobStorage::TEvAssimilate::MakeErrorResponse(
         NKikimrProto::EReplyStatus status, const TString& errorReason, TGroupId/*groupId*/) {

--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -25,6 +25,10 @@
 
 #include <optional>
 
+namespace NWilson {
+    class TSpan;
+} // NWilson
+
 namespace NKikimr {
 
 static constexpr ui32 MaxProtobufSize = 67108000;
@@ -993,6 +997,8 @@ struct TEvBlobStorage {
             return sizeof(*this) + Buffer.GetSize();
         }
 
+        void ToSpan(NWilson::TSpan& span) const;
+
         std::unique_ptr<TEvPutResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);
     };
@@ -1196,6 +1202,8 @@ struct TEvBlobStorage {
             return sizeof(*this) + QuerySize * sizeof(TQuery);
         }
 
+        void ToSpan(NWilson::TSpan& span) const;
+
         std::unique_ptr<TEvGetResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);
 
@@ -1348,6 +1356,8 @@ struct TEvBlobStorage {
         ui32 CalculateSize() const {
             return sizeof(*this);
         }
+
+        void ToSpan(NWilson::TSpan& span) const;
 
         std::unique_ptr<TEvBlockResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);
@@ -1546,6 +1556,8 @@ struct TEvBlobStorage {
             return sizeof(*this) + sizeof(TDiff) * DiffCount;
         }
 
+        void ToSpan(NWilson::TSpan& span) const;
+
         std::unique_ptr<TEvPatchResult> MakeErrorResponse(NKikimrProto::EReplyStatus status,
                 const TString& errorReason, TGroupId groupId);
     };
@@ -1636,6 +1648,8 @@ struct TEvBlobStorage {
             return sizeof(*this) + sizeof(TDiff) * DiffCount;
         }
 
+        void ToSpan(NWilson::TSpan& span) const;
+
         std::unique_ptr<TEvInplacePatchResult> MakeErrorResponse(NKikimrProto::EReplyStatus status,
                 const TString& errorReason);
     };
@@ -1722,6 +1736,8 @@ struct TEvBlobStorage {
         ui32 CalculateSize() const {
             return sizeof(*this);
         }
+
+        void ToSpan(NWilson::TSpan& span) const;
 
         std::unique_ptr<TEvDiscoverResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);
@@ -1827,6 +1843,8 @@ struct TEvBlobStorage {
         ui32 CalculateSize() const {
             return sizeof(*this);
         }
+
+        void ToSpan(NWilson::TSpan& span) const;
 
         std::unique_ptr<TEvRangeResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);
@@ -2023,6 +2041,8 @@ struct TEvBlobStorage {
             return sizeof(*this) + ((Keep ? Keep->size() : 0) + (DoNotKeep ? DoNotKeep->size() : 0)) * sizeof(TLogoBlobID);
         }
 
+        void ToSpan(NWilson::TSpan& span) const;
+
         std::unique_ptr<TEvCollectGarbageResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);
     };
@@ -2090,6 +2110,8 @@ struct TEvBlobStorage {
         ui32 CalculateSize() const {
             return sizeof(*this);
         }
+
+        void ToSpan(NWilson::TSpan& span) const;
 
         std::unique_ptr<TEvStatusResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);
@@ -2165,6 +2187,8 @@ struct TEvBlobStorage {
         ui32 CalculateSize() const {
             return sizeof(*this);
         }
+
+        void ToSpan(NWilson::TSpan& span) const;
 
         std::unique_ptr<TEvAssimilateResult> MakeErrorResponse(NKikimrProto::EReplyStatus status, const TString& errorReason,
             TGroupId groupId);

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -175,18 +175,20 @@ public:
         return NKikimrServices::TActivity::BS_GROUP_REQUEST;
     }
 
+    template<typename TEv>
     TBlobStorageGroupRequestActor(TIntrusivePtr<TBlobStorageGroupInfo> info, TIntrusivePtr<TGroupQueues> groupQueues,
             TIntrusivePtr<TBlobStorageGroupProxyMon> mon, const TActorId& source, ui64 cookie,
             NKikimrServices::EServiceKikimr logComponent, bool logAccEnabled, TMaybe<TGroupStat::EKind> latencyQueueKind,
             TInstant now, TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters, ui32 restartCounter,
-            NWilson::TSpan&& span, std::shared_ptr<TEvBlobStorage::TExecutionRelay> executionRelay)
+            NWilson::TTraceId&& traceId, const char *name, const TEv *event,
+            std::shared_ptr<TEvBlobStorage::TExecutionRelay> executionRelay)
         : TActor<TDerived>(&TThis::InitialStateFunc, TDerived::ActorActivityType())
         , Info(std::move(info))
         , GroupQueues(std::move(groupQueues))
         , Mon(std::move(mon))
         , PoolCounters(storagePoolCounters)
         , LogCtx(logComponent, logAccEnabled)
-        , Span(std::move(span))
+        , ParentSpan(TWilson::BlobStorage, std::move(traceId), name)
         , RestartCounter(restartCounter)
         , CostModel(GroupQueues->CostModel)
         , Source(source)
@@ -197,9 +199,16 @@ public:
         , ExecutionRelay(std::move(executionRelay))
     {
         TDerived::ActiveCounter(Mon)->Inc();
-        Span
-            .Attribute("GroupId", Info->GroupID.GetRawId())
-            .Attribute("RestartCounter", RestartCounter);
+
+        if (ParentSpan) {
+            const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
+            Span = NWilson::TSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(parentTraceId.GetVerbosity(),
+                parentTraceId.GetTimeToLive()), ParentSpan.GetName());
+            ParentSpan.Link(Span.GetTraceId());
+            Span.Attribute("GroupId", Info->GroupID.GetRawId());
+            Span.Attribute("RestartCounter", RestartCounter);
+            event->ToSpan(Span);
+        }
 
         Y_ABORT_UNLESS(CostModel);
     }
@@ -561,8 +570,10 @@ public:
 
         if (term) {
             if (status == NKikimrProto::OK) {
+                ParentSpan.EndOk();
                 Span.EndOk();
             } else {
+                ParentSpan.EndError(errorReason);
                 Span.EndError(std::move(errorReason));
             }
         }
@@ -608,6 +619,7 @@ protected:
     TIntrusivePtr<TBlobStorageGroupProxyMon> Mon;
     TIntrusivePtr<TStoragePoolCounters> PoolCounters;
     TLogContext LogCtx;
+    NWilson::TSpan ParentSpan;
     NWilson::TSpan Span;
     TStackVec<std::pair<TDiskResponsivenessTracker::TDiskId, TDuration>, 16> Responsiveness;
     TString ErrorReason;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_assimilate.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_assimilate.cpp
@@ -270,7 +270,7 @@ public:
             NWilson::TTraceId traceId, TInstant now, TIntrusivePtr<TStoragePoolCounters>& storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
             NKikimrServices::BS_PROXY_ASSIMILATE, false, {}, now, storagePoolCounters, ev->RestartCounter,
-            NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.Assimilate"), std::move(ev->ExecutionRelay))
+            std::move(traceId), "DSProxy.Assimilate", ev, std::move(ev->ExecutionRelay))
         , SkipBlocksUpTo(ev->SkipBlocksUpTo)
         , SkipBarriersUpTo(ev->SkipBarriersUpTo)
         , SkipBlobsUpTo(ev->SkipBlobsUpTo)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_block.cpp
@@ -135,11 +135,11 @@ public:
     TBlobStorageGroupBlockRequest(const TIntrusivePtr<TBlobStorageGroupInfo> &info,
             const TIntrusivePtr<TGroupQueues> &state, const TActorId &source,
             const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvBlock *ev,
-            ui64 cookie, NWilson::TSpan&& span, TInstant now,
+            ui64 cookie, NWilson::TTraceId&& traceId, TInstant now,
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_BLOCK, false, {}, now, storagePoolCounters, ev->RestartCounter,
-                std::move(span), std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.Block", ev, std::move(ev->ExecutionRelay))
         , TabletId(ev->TabletId)
         , Generation(ev->Generation)
         , Deadline(ev->Deadline)
@@ -179,12 +179,7 @@ IActor* CreateBlobStorageGroupBlockRequest(const TIntrusivePtr<TBlobStorageGroup
         const TIntrusivePtr<TGroupQueues> &state, const TActorId &source,
         const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvBlock *ev,
         ui64 cookie, NWilson::TTraceId traceId, TInstant now, TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters) {
-    NWilson::TSpan span(TWilson::BlobStorage, std::move(traceId), "DSProxy.Block");
-    if (span) {
-        span.Attribute("event", ev->ToString());
-    }
-
-    return new TBlobStorageGroupBlockRequest(info, state, source, mon, ev, cookie, std::move(span), now, storagePoolCounters);
+    return new TBlobStorageGroupBlockRequest(info, state, source, mon, ev, cookie, std::move(traceId), now, storagePoolCounters);
 }
 
 } // NKikimr

--- a/ydb/core/blobstorage/dsproxy/dsproxy_collect.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_collect.cpp
@@ -147,7 +147,7 @@ public:
             NWilson::TTraceId traceId, TInstant now, TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_COLLECT, false, {}, now, storagePoolCounters, ev->RestartCounter,
-                NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.CollectGarbage"), std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.CollectGarbage", ev, std::move(ev->ExecutionRelay))
         , TabletId(ev->TabletId)
         , RecordGeneration(ev->RecordGeneration)
         , PerGenerationCounter(ev->PerGenerationCounter)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover.cpp
@@ -884,8 +884,7 @@ public:
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_DISCOVER, true, {}, now, storagePoolCounters, ev->RestartCounter,
-                NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.Discover"),
-                std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.Discover", ev, std::move(ev->ExecutionRelay))
         , TabletId(ev->TabletId)
         , MinGeneration(ev->MinGeneration)
         , ReadBody(ev->ReadBody)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3dc.cpp
@@ -464,8 +464,7 @@ public:
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(std::move(info), std::move(state), std::move(mon), source, cookie,
                 NKikimrServices::BS_PROXY_DISCOVER, false, {}, now, storagePoolCounters, ev->RestartCounter,
-                NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.Discover(mirror-3-dc)"),
-                std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.Discover", ev, std::move(ev->ExecutionRelay))
         , TabletId(ev->TabletId)
         , MinGeneration(ev->MinGeneration)
         , StartTime(now)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3of4.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_discover_m3of4.cpp
@@ -36,8 +36,7 @@ public:
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(std::move(info), std::move(state), std::move(mon), source, cookie,
                 NKikimrServices::BS_PROXY_DISCOVER, false, {}, now, storagePoolCounters, ev->RestartCounter,
-                NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.Discover(mirror-3of4)"),
-                std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.Discover", ev, std::move(ev->ExecutionRelay))
         , TabletId(ev->TabletId)
         , MinGeneration(ev->MinGeneration)
         , StartTime(now)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_get.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get.cpp
@@ -395,11 +395,11 @@ public:
     TBlobStorageGroupGetRequest(const TIntrusivePtr<TBlobStorageGroupInfo> &info,
             const TIntrusivePtr<TGroupQueues> &state, const TActorId &source,
             const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvGet *ev, ui64 cookie,
-            NWilson::TSpan&& span, TNodeLayoutInfoPtr&& nodeLayout, TMaybe<TGroupStat::EKind> latencyQueueKind,
+            NWilson::TTraceId&& traceId, TNodeLayoutInfoPtr&& nodeLayout, TMaybe<TGroupStat::EKind> latencyQueueKind,
             TInstant now, TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_GET, ev->IsVerboseNoDataEnabled || ev->CollectDebugInfo,
-                latencyQueueKind, now, storagePoolCounters, ev->RestartCounter, std::move(span),
+                latencyQueueKind, now, storagePoolCounters, ev->RestartCounter, std::move(traceId), "DSProxy.Get", ev,
                 std::move(ev->ExecutionRelay))
         , GetImpl(info, state, ev, std::move(nodeLayout), LogCtx.RequestPrefix)
         , Orbit(std::move(ev->Orbit))
@@ -472,12 +472,7 @@ IActor* CreateBlobStorageGroupGetRequest(const TIntrusivePtr<TBlobStorageGroupIn
         ui64 cookie, NWilson::TTraceId traceId, TNodeLayoutInfoPtr&& nodeLayout,
         TMaybe<TGroupStat::EKind> latencyQueueKind, TInstant now,
         TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters) {
-    NWilson::TSpan span(TWilson::BlobStorage, std::move(traceId), "DSProxy.Get");
-    if (span) {
-        span.Attribute("event", ev->ToString());
-    }
-
-    return new TBlobStorageGroupGetRequest(info, state, source, mon, ev, cookie, std::move(span),
+    return new TBlobStorageGroupGetRequest(info, state, source, mon, ev, cookie, std::move(traceId),
             std::move(nodeLayout), latencyQueueKind, now, storagePoolCounters);
 }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_indexrestoreget.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_indexrestoreget.cpp
@@ -269,11 +269,11 @@ public:
     TBlobStorageGroupIndexRestoreGetRequest(const TIntrusivePtr<TBlobStorageGroupInfo> &info,
             const TIntrusivePtr<TGroupQueues> &state, const TActorId &source,
             const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvGet *ev, ui64 cookie,
-            NWilson::TSpan&& span, TMaybe<TGroupStat::EKind> latencyQueueKind, TInstant now,
+            NWilson::TTraceId&& traceId, TMaybe<TGroupStat::EKind> latencyQueueKind, TInstant now,
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_INDEXRESTOREGET, false, latencyQueueKind, now, storagePoolCounters,
-                ev->RestartCounter, std::move(span), std::move(ev->ExecutionRelay))
+                ev->RestartCounter, std::move(traceId), "DSProxy.IndexRestoreGet", ev, std::move(ev->ExecutionRelay))
         , QuerySize(ev->QuerySize)
         , Queries(ev->Queries.Release())
         , Deadline(ev->Deadline)
@@ -399,12 +399,7 @@ IActor* CreateBlobStorageGroupIndexRestoreGetRequest(const TIntrusivePtr<TBlobSt
         const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvGet *ev,
         ui64 cookie, NWilson::TTraceId traceId, TMaybe<TGroupStat::EKind> latencyQueueKind, TInstant now,
         TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters) {
-    NWilson::TSpan span(TWilson::BlobStorage, std::move(traceId), "DSProxy.IndexRestoreGet");
-    if (span) {
-        span.Attribute("event", ev->ToString());
-    }
-
-    return new TBlobStorageGroupIndexRestoreGetRequest(info, state, source, mon, ev, cookie, std::move(span),
+    return new TBlobStorageGroupIndexRestoreGetRequest(info, state, source, mon, ev, cookie, std::move(traceId),
         latencyQueueKind, now, storagePoolCounters);
 }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_multicollect.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_multicollect.cpp
@@ -99,7 +99,7 @@ public:
             NWilson::TTraceId traceId, TInstant now, TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_MULTICOLLECT, false, {}, now, storagePoolCounters, 0,
-                NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.MultiCollect"), std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.MultiCollect", ev, std::move(ev->ExecutionRelay))
         , Iterations(ev->PerGenerationCounterStepSize())
         , TabletId(ev->TabletId)
         , RecordGeneration(ev->RecordGeneration)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_multiget.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_multiget.cpp
@@ -98,11 +98,11 @@ public:
     TBlobStorageGroupMultiGetRequest(const TIntrusivePtr<TBlobStorageGroupInfo> &info,
             const TIntrusivePtr<TGroupQueues> &state, const TActorId &source,
             const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvGet *ev, ui64 cookie,
-            NWilson::TSpan&& span, TMaybe<TGroupStat::EKind> latencyQueueKind, TInstant now,
+            NWilson::TTraceId&& traceId, TMaybe<TGroupStat::EKind> latencyQueueKind, TInstant now,
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_MULTIGET, false, latencyQueueKind, now, storagePoolCounters, 0,
-                std::move(span), std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.MultiGet", ev, std::move(ev->ExecutionRelay))
         , QuerySize(ev->QuerySize)
         , Queries(ev->Queries.Release())
         , Deadline(ev->Deadline)
@@ -213,12 +213,7 @@ IActor* CreateBlobStorageGroupMultiGetRequest(const TIntrusivePtr<TBlobStorageGr
         const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvGet *ev,
         ui64 cookie, NWilson::TTraceId traceId, TMaybe<TGroupStat::EKind> latencyQueueKind,
         TInstant now, TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters) {
-    NWilson::TSpan span(TWilson::BlobStorage, std::move(traceId), "DSProxy.MultiGet");
-    if (span) {
-        span.Attribute("event", ev->ToString());
-    }
-
-    return new TBlobStorageGroupMultiGetRequest(info, state, source, mon, ev, cookie, std::move(span),
+    return new TBlobStorageGroupMultiGetRequest(info, state, source, mon, ev, cookie, std::move(traceId),
         latencyQueueKind, now, storagePoolCounters);
 }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -104,12 +104,12 @@ public:
     TBlobStorageGroupPatchRequest(const TIntrusivePtr<TBlobStorageGroupInfo> &info,
             const TIntrusivePtr<TGroupQueues> &state, const TActorId &source,
             const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvPatch *ev,
-            ui64 cookie, NWilson::TSpan&& span, TInstant now,
+            ui64 cookie, NWilson::TTraceId&& traceId, TInstant now,
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters,
             bool useVPatch = false)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_PATCH, false, {}, now, storagePoolCounters,
-                ev->RestartCounter, std::move(span), std::move(ev->ExecutionRelay))
+                ev->RestartCounter, std::move(traceId), "DSProxy.Patch", ev, std::move(ev->ExecutionRelay))
         , OriginalGroupId(TGroupId::FromValue(ev->OriginalGroupId))
         , OriginalId(ev->OriginalId)
         , PatchedId(ev->PatchedId)
@@ -869,12 +869,7 @@ IActor* CreateBlobStorageGroupPatchRequest(const TIntrusivePtr<TBlobStorageGroup
         ui64 cookie, NWilson::TTraceId traceId, TInstant now,
         TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters,
         bool useVPatch) {
-    NWilson::TSpan span(TWilson::BlobStorage, std::move(traceId), "DSProxy.Patch");
-    if (span) {
-        span.Attribute("event", ev->ToString());
-    }
-
-    return new TBlobStorageGroupPatchRequest(info, state, source, mon, ev, cookie, std::move(span), now,
+    return new TBlobStorageGroupPatchRequest(info, state, source, mon, ev, cookie, std::move(traceId), now,
         storagePoolCounters, useVPatch);
 }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_range.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_range.cpp
@@ -342,11 +342,11 @@ public:
     TBlobStorageGroupRangeRequest(const TIntrusivePtr<TBlobStorageGroupInfo> &info,
             const TIntrusivePtr<TGroupQueues> &state, const TActorId &source,
             const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvRange *ev,
-            ui64 cookie, NWilson::TSpan&& span, TInstant now,
+            ui64 cookie, NWilson::TTraceId&& traceId, TInstant now,
             TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_RANGE, false, {}, now, storagePoolCounters,
-                ev->RestartCounter, std::move(span), std::move(ev->ExecutionRelay))
+                ev->RestartCounter, std::move(traceId), "DSProxy.Range", ev, std::move(ev->ExecutionRelay))
         , TabletId(ev->TabletId)
         , From(ev->From)
         , To(ev->To)
@@ -407,8 +407,7 @@ IActor* CreateBlobStorageGroupRangeRequest(const TIntrusivePtr<TBlobStorageGroup
         const TIntrusivePtr<TBlobStorageGroupProxyMon> &mon, TEvBlobStorage::TEvRange *ev,
         ui64 cookie, NWilson::TTraceId traceId, TInstant now,
         TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters) {
-    NWilson::TSpan span(TWilson::BlobStorage, std::move(traceId), "DSProxy.Range");
-    return new TBlobStorageGroupRangeRequest(info, state, source, mon, ev, cookie, std::move(span), now,
+    return new TBlobStorageGroupRangeRequest(info, state, source, mon, ev, cookie, std::move(traceId), now,
             storagePoolCounters);
 }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_status.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_status.cpp
@@ -90,7 +90,7 @@ public:
             ui64 cookie, NWilson::TTraceId traceId, TInstant now, TIntrusivePtr<TStoragePoolCounters> &storagePoolCounters)
         : TBlobStorageGroupRequestActor(info, state, mon, source, cookie,
                 NKikimrServices::BS_PROXY_STATUS, false, {}, now, storagePoolCounters, ev->RestartCounter,
-                NWilson::TSpan(TWilson::BlobStorage, std::move(traceId), "DSProxy.Status"), std::move(ev->ExecutionRelay))
+                std::move(traceId), "DSProxy.Status", ev, std::move(ev->ExecutionRelay))
         , Deadline(ev->Deadline)
         , Requests(0)
         , Responses(0)

--- a/ydb/library/actors/wilson/wilson_span.h
+++ b/ydb/library/actors/wilson/wilson_span.h
@@ -252,6 +252,10 @@ namespace NWilson {
             return TSpan(verbosity, GetTraceId(), std::move(name), flags, GetActorSystem());
         }
 
+        TString GetName() const {
+            return *this ? Data->Span.name() : TString();
+        }
+
         static const TSpan Empty;
 
     private:

--- a/ydb/library/actors/wilson/wilson_trace.h
+++ b/ydb/library/actors/wilson/wilson_trace.h
@@ -208,6 +208,10 @@ namespace NWilson {
             return Verbosity;
         }
 
+        ui32 GetTimeToLive() const {
+            return TimeToLive;
+        }
+
         const void *GetTraceIdPtr() const { return TraceId.data(); }
         static constexpr size_t GetTraceIdSize() { return sizeof(TTrace); }
         const void *GetSpanIdPtr() const { return &SpanId; }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Create separate trace id for BlobStorage requests and link them to original traces

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Now separate traces are created for the BlobStorage requests to keep details out of the main request tracing tree.
