### PR TITLE
Keep track of dynamic proxies too and broadcast messages to them (merge from main #5826)

### DIFF
--- a/ydb/library/actors/core/actorsystem.h
+++ b/ydb/library/actors/core/actorsystem.h
@@ -161,6 +161,7 @@ namespace NActors {
         TIntrusivePtr<NLog::TSettings> LoggerSettings0;
         TProxyWrapperFactory ProxyWrapperFactory;
         TMutex ProxyCreationLock;
+        mutable std::vector<TActorId> DynamicProxies;
 
         bool StartExecuted;
         bool StopExecuted;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Keep track of dynamic proxies too and broadcast messages to them

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

This allows correct stopping of all proxies, including ones attached to dynamic nodes or to static nodes that were added online.
