### PR TITLE
Use the whole TTableDescription to describe an indexImplTable in TIndexDescription (#6280)

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_table.cpp
+++ b/ydb/core/grpc_services/rpc_describe_table.cpp
@@ -92,7 +92,14 @@ private:
                     return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
                 }
 
-                FillIndexDescription(describeTableResult, tableDescription, splitKeyType);
+                try {
+                    FillIndexDescription(describeTableResult, tableDescription);
+                } catch (const std::exception& ex) {
+                    LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, "Unable to fill index description: %s", ex.what());
+                    Request_->RaiseIssue(NYql::ExceptionToIssue(ex));
+                    return Reply(Ydb::StatusIds::INTERNAL_ERROR, ctx);
+                }
+
                 FillChangefeedDescription(describeTableResult, tableDescription);
 
                 if (GetProtoRequest()->include_table_stats()) {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -982,10 +982,6 @@ enum EIndexState {
     EIndexStateWriteOnly = 3;
 }
 
-message TExplicitPartitions {
-    repeated TSplitBoundary SplitBoundary = 1;
-}
-
 message TIndexDescription {
     optional string Name = 1;
     optional uint64 LocalPathId = 2;
@@ -1000,15 +996,10 @@ message TIndexDescription {
     optional uint64 PathOwnerId = 7;
 
     repeated string DataColumnNames = 8;
+
     // DataSize + IndexSize of indexImplTable
     optional uint64 DataSize = 9;
-
-    // indexImplTable settings
-    oneof Partitions {
-        uint32 UniformPartitions = 10;
-        TExplicitPartitions ExplicitPartitions = 11;
-    }
-    optional TPartitioningPolicy PartitioningPolicy = 12;
+    repeated TTableDescription IndexImplTableDescriptions = 10;
 }
 
 message TIndexCreationConfig {

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -55,11 +55,11 @@ TMaybe<Ydb::Table::CreateTableRequest> GenYdbScheme(
 
     try {
         FillTableBoundary(scheme, tableDesc, mkqlKeyType);
+        FillIndexDescription(scheme, tableDesc);
     } catch (const yexception&) {
         return Nothing();
     }
 
-    FillIndexDescription(scheme, tableDesc, mkqlKeyType);
     FillStorageSettings(scheme, tableDesc);
     FillColumnFamilies(scheme, tableDesc);
     FillAttributes(scheme, pathDesc);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_initiate_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_initiate_build_index.cpp
@@ -88,7 +88,9 @@ public:
             found = true;
 
             Y_ABORT_UNLESS(index->AlterData);
-            context.SS->DescribeTableIndex(childPathId, childName, index->AlterData, *initiate->MutableIndexDescription());
+            context.SS->DescribeTableIndex(childPathId, childName, index->AlterData, false, false,
+                *initiate->MutableIndexDescription()
+            );
         }
 
         txState->ClearShardsInProgress();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -6675,7 +6675,9 @@ void TSchemeShard::FillTableDescriptionForShardIdx(
             case NKikimrSchemeOp::EPathTypeTableIndex: {
                 Y_ABORT_UNLESS(Indexes.contains(childPathId));
                 auto info = Indexes.at(childPathId);
-                DescribeTableIndex(childPathId, childName, newTable ? info->AlterData : info, *tableDescr->MutableTableIndexes()->Add());
+                DescribeTableIndex(childPathId, childName, newTable ? info->AlterData : info, false, false,
+                    *tableDescr->MutableTableIndexes()->Add()
+                );
                 break;
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1016,8 +1016,12 @@ public:
 
     void DescribeTable(const TTableInfo::TPtr tableInfo, const NScheme::TTypeRegistry* typeRegistry,
                        bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TTableDescription* entry) const;
-    void DescribeTableIndex(const TPathId& pathId, const TString& name, NKikimrSchemeOp::TIndexDescription& entry);
-    void DescribeTableIndex(const TPathId& pathId, const TString& name, TTableIndexInfo::TPtr indexInfo, NKikimrSchemeOp::TIndexDescription& entry);
+    void DescribeTableIndex(const TPathId& pathId, const TString& name,
+        bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TIndexDescription& entry
+    ) const;
+    void DescribeTableIndex(const TPathId& pathId, const TString& name, TTableIndexInfo::TPtr indexInfo,
+        bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TIndexDescription& entry
+    ) const;
     void DescribeCdcStream(const TPathId& pathId, const TString& name, NKikimrSchemeOp::TCdcStreamDescription& desc);
     void DescribeCdcStream(const TPathId& pathId, const TString& name, TCdcStreamInfo::TPtr info, NKikimrSchemeOp::TCdcStreamDescription& desc);
     void DescribeSequence(const TPathId& pathId, const TString& name,

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -8,6 +8,16 @@
 
 #include <util/stream/format.h>
 
+namespace {
+
+void FillPartitionConfig(const NKikimrSchemeOp::TPartitionConfig& in, NKikimrSchemeOp::TPartitionConfig& out) {
+    out.CopyFrom(in);
+    NKikimr::NSchemeShard::TPartitionConfigMerger::DeduplicateColumnFamiliesById(out);
+    out.MutableStorageRooms()->Clear();
+}
+
+}
+
 namespace NKikimr {
 namespace NSchemeShard {
 
@@ -364,7 +374,7 @@ void TPathDescriber::DescribeTable(const TActorContext& ctx, TPathId pathId, TPa
 
         switch (childPath->PathType) {
         case NKikimrSchemeOp::EPathTypeTableIndex:
-            Self->DescribeTableIndex(childPathId, childName, *entry->AddTableIndexes());
+            Self->DescribeTableIndex(childPathId, childName, returnConfig, false, *entry->AddTableIndexes());
             break;
         case NKikimrSchemeOp::EPathTypeCdcStream:
             Self->DescribeCdcStream(childPathId, childName, *entry->AddCdcStreams());
@@ -586,8 +596,12 @@ void TPathDescriber::DescribeRtmrVolume(TPathId pathId, TPathElement::TPtr pathE
 }
 
 void TPathDescriber::DescribeTableIndex(const TPath& path) {
-    Self->DescribeTableIndex(path.Base()->PathId, path.Base()->Name,
-        *Result->Record.MutablePathDescription()->MutableTableIndex());
+    bool returnConfig = Params.GetReturnPartitionConfig();
+    bool returnBoundaries = Params.HasOptions() && Params.GetOptions().GetReturnBoundaries();
+
+    Self->DescribeTableIndex(path.Base()->PathId, path.Base()->Name, returnConfig, returnBoundaries,
+        *Result->Record.MutablePathDescription()->MutableTableIndex()
+    );
     DescribeChildren(path);
 }
 
@@ -1175,9 +1189,7 @@ void TSchemeShard::DescribeTable(const TTableInfo::TPtr tableInfo, const NScheme
     }
 
     if (fillConfig) {
-        entry->MutablePartitionConfig()->CopyFrom(tableInfo->PartitionConfig());
-        TPartitionConfigMerger::DeduplicateColumnFamiliesById(*entry->MutablePartitionConfig());
-        entry->MutablePartitionConfig()->MutableStorageRooms()->Clear();
+        FillPartitionConfig(tableInfo->PartitionConfig(), *entry->MutablePartitionConfig());
     }
 
     if (fillBoundaries) {
@@ -1196,17 +1208,17 @@ void TSchemeShard::DescribeTable(const TTableInfo::TPtr tableInfo, const NScheme
 }
 
 void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name,
-        NKikimrSchemeOp::TIndexDescription& entry)
+    bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TIndexDescription& entry) const
 {
     auto it = Indexes.FindPtr(pathId);
     Y_ABORT_UNLESS(it, "TableIndex is not found");
     TTableIndexInfo::TPtr indexInfo = *it;
 
-    DescribeTableIndex(pathId, name, indexInfo, entry);
+    DescribeTableIndex(pathId, name, indexInfo, fillConfig, fillBoundaries, entry);
 }
 
 void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name, TTableIndexInfo::TPtr indexInfo,
-        NKikimrSchemeOp::TIndexDescription& entry)
+    bool fillConfig, bool fillBoundaries, NKikimrSchemeOp::TIndexDescription& entry) const
 {
     Y_ABORT_UNLESS(indexInfo, "Empty index info");
 
@@ -1226,23 +1238,23 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
         *entry.MutableDataColumnNames()->Add() = dataColumns;
     }
 
-    Y_ABORT_UNLESS(PathsById.contains(pathId));
-    auto indexPath = PathsById.at(pathId);
+    auto* indexPath = PathsById.FindPtr(pathId);
+    Y_ABORT_UNLESS(indexPath);
+    Y_ABORT_UNLESS((*indexPath)->GetChildren().size() == 1);
+    const auto& indexImplTablePathId = (*indexPath)->GetChildren().begin()->second;
 
-    Y_ABORT_UNLESS(indexPath->GetChildren().size() == 1);
-    const auto& indexImplPathId = indexPath->GetChildren().begin()->second;
+    auto* tableInfo = Tables.FindPtr(indexImplTablePathId);
+    Y_ABORT_UNLESS(tableInfo);
 
-    Y_ABORT_UNLESS(Tables.contains(indexImplPathId));
-    auto indexImplTable = Tables.at(indexImplPathId);
-
-    const auto& tableStats = indexImplTable->GetStats().Aggregated;
+    const auto& tableStats = (*tableInfo)->GetStats().Aggregated;
     entry.SetDataSize(tableStats.DataSize + tableStats.IndexSize);
 
-    *entry.MutablePartitioningPolicy() = indexImplTable->PartitionConfig().GetPartitioningPolicy();
-    if (const auto& explicitPartitions = indexImplTable->TableDescription.GetSplitBoundary();
-        !explicitPartitions.empty()
-    ) {
-        *entry.MutableExplicitPartitions()->MutableSplitBoundary() = explicitPartitions;
+    auto* tableDescription = entry.AddIndexImplTableDescriptions();
+    if (fillConfig) {
+        FillPartitionConfig((*tableInfo)->PartitionConfig(), *tableDescription->MutablePartitionConfig());
+    }
+    if (fillBoundaries) {
+        FillTableBoundaries(*tableInfo, *tableDescription->MutableSplitBoundary());
     }
 }
 

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -48,7 +48,7 @@ namespace {
 
         scheme.mutable_primary_key()->CopyFrom(tableDesc.GetKeyColumnNames());
         FillColumnDescription(scheme, mkqlKeyType, tableDesc);
-        FillIndexDescription(scheme, tableDesc, mkqlKeyType);
+        FillIndexDescription(scheme, tableDesc);
         FillStorageSettings(scheme, tableDesc);
         FillColumnFamilies(scheme, tableDesc);
         FillAttributes(scheme, pathDesc);

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -719,10 +719,9 @@ bool FillColumnDescription(NKikimrSchemeOp::TColumnTableDescription& out,
 
 template <typename TYdbProto>
 void FillTableBoundaryImpl(TYdbProto& out,
-    const google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TSplitBoundary>& boundaries,
-    const NKikimrMiniKQL::TType& splitKeyType
-) {
-    for (const auto& boundary : boundaries) {
+        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
+
+    for (const auto& boundary : in.GetSplitBoundary()) {
         if (boundary.HasSerializedKeyPrefix()) {
             throw NYql::TErrorException(NKikimrIssues::TIssuesIds::DEFAULT_ERROR)
                 << "Unexpected serialized response from txProxy";
@@ -756,12 +755,12 @@ void FillTableBoundaryImpl(TYdbProto& out,
 
 void FillTableBoundary(Ydb::Table::DescribeTableResult& out,
         const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillTableBoundaryImpl<Ydb::Table::DescribeTableResult>(out, in.GetSplitBoundary(), splitKeyType);
+    FillTableBoundaryImpl<Ydb::Table::DescribeTableResult>(out, in, splitKeyType);
 }
 
 void FillTableBoundary(Ydb::Table::CreateTableRequest& out,
         const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillTableBoundaryImpl<Ydb::Table::CreateTableRequest>(out, in.GetSplitBoundary(), splitKeyType);
+    FillTableBoundaryImpl<Ydb::Table::CreateTableRequest>(out, in, splitKeyType);
 }
 
 template <typename TYdbProto>
@@ -802,38 +801,50 @@ void FillPartitioningSettings(TYdbProto& out, const NKikimrSchemeOp::TPartitioni
     }
 }
 
-void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
-        const NKikimrSchemeOp::TIndexDescription& tableIndex,
-        const NKikimrMiniKQL::TType& splitKeyType) {
+template <typename TYdbProto>
+void FillPartitioningSettingsImpl(TYdbProto& out,
+        const NKikimrSchemeOp::TTableDescription& in) {
 
-    switch (tableIndex.GetPartitionsCase()) {
-    case NKikimrSchemeOp::TIndexDescription::kUniformPartitions:
-        settings.set_uniform_partitions(tableIndex.GetUniformPartitions());
-        break;
-    case NKikimrSchemeOp::TIndexDescription::kExplicitPartitions:
-        FillTableBoundaryImpl(*settings.mutable_partition_at_keys(),
-            tableIndex.GetExplicitPartitions().GetSplitBoundary(),
+    auto& outPartSettings = *out.mutable_partitioning_settings();
+
+    if (!in.HasPartitionConfig()) {
+        FillDefaultPartitioningSettings(outPartSettings);
+        return;
+    }
+
+    const auto& partConfig = in.GetPartitionConfig();
+    if (!partConfig.HasPartitioningPolicy()) {
+        FillDefaultPartitioningSettings(outPartSettings);
+        return;
+    }
+
+    FillPartitioningSettings(outPartSettings, partConfig.GetPartitioningPolicy());
+}
+
+void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
+    const google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TTableDescription>& indexImplTables
+) {
+    if (indexImplTables.empty()) {
+        return;
+    }
+    const auto& indexImplTableDescription = indexImplTables.Get(0);
+
+    if (indexImplTableDescription.SplitBoundarySize()) {
+        NKikimrMiniKQL::TType splitKeyType;
+        Ydb::Table::DescribeTableResult unused;
+        FillColumnDescription(unused, splitKeyType, indexImplTableDescription);
+        FillTableBoundaryImpl(
+            *settings.mutable_partition_at_keys(),
+            indexImplTableDescription,
             splitKeyType
         );
-        break;
-    default:
-        break;
     }
 
-    auto& partitioningSettings = *settings.mutable_partitioning_settings();
-    if (tableIndex.HasPartitioningPolicy()) {
-        FillPartitioningSettings(
-            partitioningSettings,
-            tableIndex.GetPartitioningPolicy()
-        );
-    } else {
-        FillDefaultPartitioningSettings(partitioningSettings);
-    }
+    FillPartitioningSettingsImpl(settings, indexImplTableDescription);
 }
 
 template <typename TYdbProto>
-void FillIndexDescriptionImpl(TYdbProto& out,
-        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
+void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescription& in) {
 
     for (const auto& tableIndex : in.GetTableIndexes()) {
         auto index = out.add_indexes();
@@ -852,13 +863,22 @@ void FillIndexDescriptionImpl(TYdbProto& out,
 
         switch (tableIndex.GetType()) {
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobal:
-            FillGlobalIndexSettings(*index->mutable_global_index()->mutable_settings(), tableIndex, splitKeyType);
+            FillGlobalIndexSettings(
+                *index->mutable_global_index()->mutable_settings(),
+                tableIndex.GetIndexImplTableDescriptions()
+            );
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalAsync:
-            FillGlobalIndexSettings(*index->mutable_global_async_index()->mutable_settings(), tableIndex, splitKeyType);
+            FillGlobalIndexSettings(
+                *index->mutable_global_async_index()->mutable_settings(),
+                tableIndex.GetIndexImplTableDescriptions()
+            );
             break;
         case NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique:
-            FillGlobalIndexSettings(*index->mutable_global_unique_index()->mutable_settings(), tableIndex, splitKeyType);
+            FillGlobalIndexSettings(
+                *index->mutable_global_unique_index()->mutable_settings(),
+                tableIndex.GetIndexImplTableDescriptions()
+            );
             break;
         default:
             break;
@@ -876,13 +896,13 @@ void FillIndexDescriptionImpl(TYdbProto& out,
 }
 
 void FillIndexDescription(Ydb::Table::DescribeTableResult& out,
-        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillIndexDescriptionImpl(out, in, splitKeyType);
+        const NKikimrSchemeOp::TTableDescription& in) {
+    FillIndexDescriptionImpl(out, in);
 }
 
 void FillIndexDescription(Ydb::Table::CreateTableRequest& out,
-        const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType) {
-    FillIndexDescriptionImpl(out, in, splitKeyType);
+        const NKikimrSchemeOp::TTableDescription& in) {
+    FillIndexDescriptionImpl(out, in);
 }
 
 bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
@@ -1260,26 +1280,6 @@ void FillAttributes(Ydb::Table::DescribeTableResult& out,
 void FillAttributes(Ydb::Table::CreateTableRequest& out,
         const NKikimrSchemeOp::TPathDescription& in) {
     FillAttributesImpl(out, in);
-}
-
-template <typename TYdbProto>
-void FillPartitioningSettingsImpl(TYdbProto& out,
-        const NKikimrSchemeOp::TTableDescription& in) {
-
-    auto& outPartSettings = *out.mutable_partitioning_settings();
-
-    if (!in.HasPartitionConfig()) {
-        FillDefaultPartitioningSettings(outPartSettings);
-        return;
-    }
-
-    const auto& partConfig = in.GetPartitionConfig();
-    if (!partConfig.HasPartitioningPolicy()) {
-        FillDefaultPartitioningSettings(outPartSettings);
-        return;
-    }
-
-    FillPartitioningSettings(outPartSettings, partConfig.GetPartitioningPolicy());
 }
 
 void FillPartitioningSettings(Ydb::Table::DescribeTableResult& out,

--- a/ydb/core/ydb_convert/table_description.h
+++ b/ydb/core/ydb_convert/table_description.h
@@ -65,9 +65,9 @@ void FillTableBoundary(Ydb::Table::CreateTableRequest& out,
 
 // out
 void FillIndexDescription(Ydb::Table::DescribeTableResult& out,
-    const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType);
+    const NKikimrSchemeOp::TTableDescription& in);
 void FillIndexDescription(Ydb::Table::CreateTableRequest& out,
-    const NKikimrSchemeOp::TTableDescription& in, const NKikimrMiniKQL::TType& splitKeyType);
+    const NKikimrSchemeOp::TTableDescription& in);
 // in
 bool FillIndexDescription(NKikimrSchemeOp::TIndexedTableCreationConfig& out,
     const Ydb::Table::CreateTableRequest& in, Ydb::StatusIds::StatusCode& status, TString& error);


### PR DESCRIPTION
Relevant [ticket](https://github.com/ydb-platform/ydb/issues/4955)
[PR into main](https://github.com/ydb-platform/ydb/pull/6280)

The purpose of the change is to prepare for multiple indexImplTables for vector indices. Other changes are more or less cosmetic.

We need to merge these change in the stable-24-3 branch, before it starts to roll out on the actual clusters, because these changes are BREAKING (see [protobuf](https://github.com/ydb-platform/ydb/pull/6450/files#diff-a4a2759b643a34a33cd643bc6ca0e08c0348e1bbe83a17aeb5a1d8df9163379c)).