### PR TITLE
YDB FQ: disabling Python linter in tests

### DIFF
--- a/ydb/library/yql/providers/generic/connector/tests/common_test_cases/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/common_test_cases/ya.make
@@ -1,9 +1,7 @@
 PY3_LIBRARY()
 
-IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
-ENDIF()
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
 
 IF (OPENSOURCE)
     # YQ-3351: enabling python style checks only for opensource

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/conftest.py
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/conftest.py
@@ -7,7 +7,9 @@ from ydb.library.yql.providers.generic.connector.api.common.data_source_pb2 impo
 from ydb.library.yql.providers.generic.connector.tests.utils.settings import Settings
 from ydb.library.yql.providers.generic.connector.tests.utils.clients.clickhouse import Client, make_client
 
-docker_compose_dir: Final = pathlib.Path("ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse")
+docker_compose_dir: Final = pathlib.Path(
+    "ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse"
+)
 
 
 @pytest.fixture

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
@@ -12,9 +12,10 @@ DATA(
 
 ENV(COMPOSE_PROJECT_NAME=clickhouse)
 
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
+
 IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
     # Temporarily disable these tests due to infrastructure incompatibility
     SKIP_TEST("DEVTOOLSUPPORT-44637")
     # Split tests to chunks only when they're running on different machines with distbuild,

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/conftest.py
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/conftest.py
@@ -9,7 +9,9 @@ from ydb.library.yql.providers.generic.connector.tests.utils.settings import Set
 from ydb.library.yql.providers.generic.connector.tests.utils.clients.postgresql import Client
 
 
-docker_compose_dir: Final = pathlib.Path("ydb/library/yql/providers/generic/connector/tests/datasource/postgresql")
+docker_compose_dir: Final = pathlib.Path(
+    "ydb/library/yql/providers/generic/connector/tests/datasource/postgresql"
+)
 
 
 @pytest.fixture

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
@@ -12,9 +12,10 @@ DATA(
 
 ENV(COMPOSE_PROJECT_NAME=postgresql)
 
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
+
 IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
     # Temporarily disable these tests due to infrastructure incompatibility
     SKIP_TEST("DEVTOOLSUPPORT-44637")
     # Split tests to chunks only when they're running on different machines with distbuild,

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
@@ -12,9 +12,10 @@ DATA(
 
 ENV(COMPOSE_PROJECT_NAME=ydb)
 
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
+
 IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
     # Temporarily disable these tests due to infrastructure incompatibility
     SKIP_TEST("DEVTOOLSUPPORT-44637")
     # Split tests to chunks only when they're running on different machines with distbuild,

--- a/ydb/library/yql/providers/generic/connector/tests/join/conftest.py
+++ b/ydb/library/yql/providers/generic/connector/tests/join/conftest.py
@@ -9,7 +9,9 @@ from ydb.library.yql.providers.generic.connector.tests.utils.clients.clickhouse 
     make_client as make_clickhouse_client,
     Client as ClickHouseClient,
 )
-from ydb.library.yql.providers.generic.connector.tests.utils.clients.postgresql import Client as PostgreSQLClient
+from ydb.library.yql.providers.generic.connector.tests.utils.clients.postgresql import (
+    Client as PostgreSQLClient
+)
 from ydb.library.yql.providers.generic.connector.tests.utils.settings import Settings
 
 

--- a/ydb/library/yql/providers/generic/connector/tests/join/scenario.py
+++ b/ydb/library/yql/providers/generic/connector/tests/join/scenario.py
@@ -4,9 +4,13 @@ from ydb.library.yql.providers.generic.connector.tests.utils.log import make_log
 from ydb.library.yql.providers.generic.connector.tests.utils.settings import Settings
 from ydb.library.yql.providers.generic.connector.tests.utils.run.parent import Runner
 
-from ydb.library.yql.providers.generic.connector.tests.utils.clients.clickhouse import Client as ClickHouseClient
+from ydb.library.yql.providers.generic.connector.tests.utils.clients.clickhouse import (
+    Client as ClickHouseClient
+)
 import ydb.library.yql.providers.generic.connector.tests.utils.scenario.clickhouse as clickhouse_scenario
-from ydb.library.yql.providers.generic.connector.tests.utils.clients.postgresql import Client as PostgreSQLClient
+from ydb.library.yql.providers.generic.connector.tests.utils.clients.postgresql import (
+    Client as PostgreSQLClient
+)
 import ydb.library.yql.providers.generic.connector.tests.utils.scenario.postgresql as postgresql_scenario
 
 from test_case import TestCase

--- a/ydb/library/yql/providers/generic/connector/tests/join/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/join/ya.make
@@ -14,9 +14,10 @@ DATA(
 
 ENV(COMPOSE_PROJECT_NAME=join)
 
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
+
 IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
     # Temporarily disable these tests due to infrastructure incompatibility
     SKIP_TEST("DEVTOOLSUPPORT-44637")
     # Split tests to chunks only when they're running on different machines with distbuild,

--- a/ydb/library/yql/providers/generic/connector/tests/utils/clients/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/clients/ya.make
@@ -1,9 +1,7 @@
 PY3_LIBRARY()
 
-IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
-ENDIF()
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
 
 IF (OPENSOURCE) 
     # YQ-3351: enabling python style checks only for opensource

--- a/ydb/library/yql/providers/generic/connector/tests/utils/run/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/run/ya.make
@@ -1,9 +1,7 @@
 PY3_LIBRARY()
 
-IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
-ENDIF()
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
 
 IF (OPENSOURCE) 
     # YQ-3351: enabling python style checks only for opensource

--- a/ydb/library/yql/providers/generic/connector/tests/utils/scenario/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/scenario/ya.make
@@ -1,9 +1,7 @@
 PY3_LIBRARY()
 
-IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
-ENDIF()
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
 
 IF (OPENSOURCE) 
     # YQ-3351: enabling python style checks only for opensource

--- a/ydb/library/yql/providers/generic/connector/tests/utils/types/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/types/ya.make
@@ -1,9 +1,7 @@
 PY3_LIBRARY()
 
-IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
-ENDIF()
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
 
 IF (OPENSOURCE) 
     # YQ-3351: enabling python style checks only for opensource

--- a/ydb/library/yql/providers/generic/connector/tests/utils/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/utils/ya.make
@@ -13,10 +13,8 @@ PY_SRCS(
     sql.py
 )
 
-IF (AUTOCHECK)
-    # YQ-3351: enabling python style checks only for opensource
-    NO_LINT()
-ENDIF()
+# YQ-3351: enabling python style checks only for opensource
+NO_LINT()
 
 IF (OPENSOURCE) 
     # YQ-3351: enabling python style checks only for opensource


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

Moving NO_LINT() to global in ya.make for all .../connector/tets/\*
