### PR TITLE
Fix conversions in purecalc Arrow IO spec

### DIFF
--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -95,7 +95,7 @@ public:
     }
 
     void DoConvert(arrow::compute::ExecBatch* batch, TUnboxedValue& result) {
-        size_t nvalues = Schema_.Size();
+        size_t nvalues = DatumToMemberIDMap_.size();
         Y_ENSURE(nvalues == static_cast<size_t>(batch->num_values()));
 
         TUnboxedValue* datums = nullptr;
@@ -153,7 +153,7 @@ public:
 
     OutputItemType DoConvert(TUnboxedValue value) {
         OutputItemType batch = Batch_.Get();
-        size_t nvalues = Schema_.Size();
+        size_t nvalues = MemberToDatumIDMap_.size();
 
         const auto& sizeDatum = TArrowBlock::From(value.GetElement(nvalues)).GetDatum();
         Y_ENSURE(sizeDatum.is_scalar());

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
 #include <ydb/library/yql/minikql/computation/mkql_custom_list.h>
+#include <ydb/library/yql/minikql/mkql_node_cast.h>
 #include <ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h>
 #include <ydb/library/yql/utils/yql_panic.h>
 
@@ -65,6 +66,7 @@ protected:
     IWorker* Worker_;
     const THolderFactory& Factory_;
     const NYT::TNode& Schema_;
+    TVector<ui32> DatumToMemberIDMap_;
 
 public:
     explicit TArrowInputConverter(
@@ -76,6 +78,20 @@ public:
         , Factory_(Worker_->GetGraph().GetHolderFactory())
         , Schema_(inputSpec.GetSchema(index))
     {
+        DatumToMemberIDMap_.resize(Schema_.Size());
+
+        const auto* type = Worker_->GetInputType(index, true);
+
+        Y_ENSURE(type->IsStruct());
+        Y_ENSURE(Schema_.ChildAsString(0) == "StructType");
+
+        const auto& members = Schema_.ChildAsList(1);
+        for (size_t i = 0; i < DatumToMemberIDMap_.size(); i++) {
+            const auto& name = members[i].ChildAsString(0);
+            const auto& memberIndex = type->FindMemberIndex(name);
+            Y_ENSURE(memberIndex);
+            DatumToMemberIDMap_[i] = *memberIndex;
+        }
     }
 
     void DoConvert(arrow::compute::ExecBatch* batch, TUnboxedValue& result) {
@@ -85,7 +101,8 @@ public:
         TUnboxedValue* datums = nullptr;
         result = Factory_.CreateDirectArrayHolder(nvalues + 1, datums);
         for (size_t i = 0; i < nvalues; i++) {
-            datums[i] = Factory_.CreateArrowBlock(std::move(batch->values[i]));
+            const ui32 id = DatumToMemberIDMap_[i];
+            datums[id] = Factory_.CreateArrowBlock(std::move(batch->values[i]));
         }
 
         arrow::Datum length(std::make_shared<arrow::UInt64Scalar>(batch->length));
@@ -102,6 +119,7 @@ protected:
     IWorker* Worker_;
     const THolderFactory& Factory_;
     const NYT::TNode& Schema_;
+    TVector<ui32> MemberToDatumIDMap_;
     THolder<arrow::compute::ExecBatch> Batch_;
 
 public:
@@ -114,6 +132,22 @@ public:
         , Schema_(outputSpec.GetSchema())
     {
         Batch_.Reset(new arrow::compute::ExecBatch);
+        MemberToDatumIDMap_.resize(Schema_.Size());
+
+        const auto* type = Worker_->GetOutputType();
+
+        Y_ENSURE(type->IsStruct());
+        Y_ENSURE(Schema_.ChildAsString(0) == "StructType");
+
+        const auto* stype = AS_TYPE(NKikimr::NMiniKQL::TStructType, type);
+
+        const auto& members = Schema_.ChildAsList(1);
+        for (size_t i = 0; i < MemberToDatumIDMap_.size(); i++) {
+            const auto& name = members[i].ChildAsString(0);
+            const auto& memberIndex = stype->FindMemberIndex(name);
+            Y_ENSURE(memberIndex);
+            MemberToDatumIDMap_[*memberIndex] = i;
+        }
     }
 
     OutputItemType DoConvert(TUnboxedValue value) {
@@ -129,7 +163,7 @@ public:
         TVector<arrow::Datum> datums(nvalues);
         for (size_t i = 0; i < nvalues; i++) {
             const auto& datum = TArrowBlock::From(value.GetElement(i)).GetDatum();
-            datums[i] = datum;
+            datums[MemberToDatumIDMap_[i]] = datum;
             if (datum.is_scalar()) {
                 continue;
             }

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -79,12 +79,12 @@ public:
     }
 
     void DoConvert(arrow::compute::ExecBatch* batch, TUnboxedValue& result) {
-        ui64 nvalues = Schema_.Size();
+        size_t nvalues = Schema_.Size();
         Y_ENSURE(nvalues == static_cast<size_t>(batch->num_values()));
 
         TUnboxedValue* datums = nullptr;
         result = Factory_.CreateDirectArrayHolder(nvalues, datums);
-        for (ui64 i = 0; i < nvalues; i++) {
+        for (size_t i = 0; i < nvalues; i++) {
             datums[i] = Factory_.CreateArrowBlock(std::move(batch->values[i]));
         }
     }
@@ -115,9 +115,9 @@ public:
 
     OutputItemType DoConvert(TUnboxedValue value) {
         OutputItemType batch = Batch_.Get();
-        ui64 nvalues = Schema_.Size();
+        size_t nvalues = Schema_.Size();
         TVector<arrow::Datum> datums(nvalues);
-        for (ui32 i = 0; i < nvalues; i++) {
+        for (size_t i = 0; i < nvalues; i++) {
             datums[i] = TArrowBlock::From(value.GetElement(i)).GetDatum();
         }
         *batch = ARROW_RESULT(arrow::compute::ExecBatch::Make(datums));

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -78,14 +78,14 @@ public:
         , Factory_(Worker_->GetGraph().GetHolderFactory())
         , Schema_(inputSpec.GetSchema(index))
     {
-        DatumToMemberIDMap_.resize(Schema_.Size());
-
         const auto* type = Worker_->GetInputType(index, true);
 
         Y_ENSURE(type->IsStruct());
         Y_ENSURE(Schema_.ChildAsString(0) == "StructType");
 
         const auto& members = Schema_.ChildAsList(1);
+        DatumToMemberIDMap_.resize(members.size());
+
         for (size_t i = 0; i < DatumToMemberIDMap_.size(); i++) {
             const auto& name = members[i].ChildAsString(0);
             const auto& memberIndex = type->FindMemberIndex(name);
@@ -132,7 +132,6 @@ public:
         , Schema_(outputSpec.GetSchema())
     {
         Batch_.Reset(new arrow::compute::ExecBatch);
-        MemberToDatumIDMap_.resize(Schema_.Size());
 
         const auto* type = Worker_->GetOutputType();
 
@@ -142,6 +141,8 @@ public:
         const auto* stype = AS_TYPE(NKikimr::NMiniKQL::TStructType, type);
 
         const auto& members = Schema_.ChildAsList(1);
+        MemberToDatumIDMap_.resize(members.size());
+
         for (size_t i = 0; i < MemberToDatumIDMap_.size(); i++) {
             const auto& name = members[i].ChildAsString(0);
             const auto& memberIndex = stype->FindMemberIndex(name);


### PR DESCRIPTION
This patchset fixes the following bugs in ExecBatch to UnboxedValue conversion:
* The first patch just puts all iterator types in order
* The second patch adds the missing system column with ExecBatch length
* The third patch implements the proper mapping from ExecBatch Datums to MKQL Struct members and vice versa

Follows up #5079

### Changelog category

* Bugfix 