### PR TITLE
Fix yql translation for INTERSECT in TPC DS queries

### DIFF
--- a/ydb/library/benchmarks/queries/tpcds/yql/q14.sql
+++ b/ydb/library/benchmarks/queries/tpcds/yql/q14.sql
@@ -32,6 +32,7 @@ $bla3 = (select iws.i_brand_id brand_id
 $cross_items = (select i_item_sk ss_item_sk
  from {{item}} as item cross join
  (select bla1.brand_id as brand_id, bla1.class_id as class_id, bla1.category_id as category_id from
+ any
  $bla1 bla1 left semi join $bla2 bla2 on (bla1.brand_id = bla2.brand_id and bla1.class_id = bla2.class_id and bla1.category_id = bla2.category_id)
             left semi join $bla3 bla3 on (bla1.brand_id = bla3.brand_id and bla1.class_id = bla3.class_id and bla1.category_id = bla3.category_id)
  ) x

--- a/ydb/library/benchmarks/queries/tpcds/yql/q8.sql
+++ b/ydb/library/benchmarks/queries/tpcds/yql/q8.sql
@@ -102,7 +102,7 @@ select  store.s_store_name
      cross join
      (select A2.ca_zip as ca_zip
      from (
-     select ca_zip from $bla1 bla1 left semi join $bla2 bla2 using (ca_zip)
+     select ca_zip from $bla1 bla1 right semi join $bla2 bla2 using (ca_zip)
       )A2) V1
  where ss_store_sk = s_store_sk
   and ss_sold_date_sk = d_date_sk


### PR DESCRIPTION
When left side contains duplicates, `INTERSECT` produces only distinct rows, `LEFT SEMI JOIN` is not.

q8: `$bla2` is distinct (`GROUP BY`), `$bla1` is not. Just replace `LEFT SEMI` with `RIGHT SEMI`; note that this changes result of this query in S10+ (for S1 result is empty).
q14: add `ANY` qualifier to left side
q38: joined tables already distinct

#6186

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
