### PR TITLE
Fix getting oauth2 key file credentials from environment

### DIFF
--- a/ydb/public/sdk/cpp/client/helpers/helpers.cpp
+++ b/ydb/public/sdk/cpp/client/helpers/helpers.cpp
@@ -56,7 +56,7 @@ TDriverConfig CreateFromEnvironment(const TStringType& connectionString) {
     }
 
     TStringType oauth2KeyFile = GetStrFromEnv("YDB_OAUTH2_KEY_FILE", "");
-    if (!saKeyFile.empty()) {
+    if (!oauth2KeyFile.empty()) {
         driverConfig.SetCredentialsProviderFactory(
             CreateOauth2TokenExchangeFileCredentialsProviderFactory(oauth2KeyFile));
         return driverConfig;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix getting oauth2 key file credentials from environment. Silly error.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
