### PR TITLE
Drop deprecated OWNER macro from ya.make

### DIFF
--- a/ydb/tools/query_replay_yt/ya.make
+++ b/ydb/tools/query_replay_yt/ya.make
@@ -1,10 +1,5 @@
 PROGRAM(query_replay_yt)
 
-OWNER(
-    shumkovnd
-    g:kikimr
-)
-
 ALLOCATOR(LF)
 
 YQL_LAST_ABI_VERSION()


### PR DESCRIPTION
### Changelog entry
Drop deprecated OWNER from ya.make files

### Changelog category
* Not for changelog (changelog entry is not required)

Continuation of #4742