### PR TITLE
24-2: Fix bugs in: change exchange split, removing schema snapshots & emitting of resolved timestamps

### DIFF
--- a/ydb/core/change_exchange/change_sender_common_ops.cpp
+++ b/ydb/core/change_exchange/change_sender_common_ops.cpp
@@ -351,7 +351,7 @@ bool TBaseChangeSender::AddBroadcastPartition(ui64 order, ui64 partitionId) {
     Y_ABORT_UNLESS(it != Broadcasting.end());
 
     auto& broadcast = it->second;
-    if (broadcast.Partitions.contains(partitionId)) {
+    if (broadcast.CompletedPartitions.contains(partitionId)) {
         return false;
     }
 

--- a/ydb/core/change_exchange/change_sender_common_ops.cpp
+++ b/ydb/core/change_exchange/change_sender_common_ops.cpp
@@ -197,7 +197,7 @@ void TBaseChangeSender::SendRecords() {
             EraseNodesIf(broadcast.PendingPartitions, [&](ui64 partitionId) {
                 if (Senders.contains(partitionId)) {
                     auto& sender = Senders.at(partitionId);
-                    sender.Prepared.push_back(std::move(it->second));
+                    sender.Prepared.push_back(it->second);
                     if (!sender.ActorId) {
                         Y_ABORT_UNLESS(!sender.Ready);
                         registrations.insert(partitionId);

--- a/ydb/core/persqueue/partition_sourcemanager.cpp
+++ b/ydb/core/persqueue/partition_sourcemanager.cpp
@@ -81,7 +81,8 @@ void TPartitionSourceManager::TModificationBatch::Cancel() {
 }
 
 bool TPartitionSourceManager::TModificationBatch::HasModifications() const {
-    return !SourceIdWriter.GetSourceIdsToWrite().empty();
+    return !SourceIdWriter.GetSourceIdsToWrite().empty()
+        || !SourceIdWriter.GetSourceIdsToDelete().empty();
 }
 
 void TPartitionSourceManager::TModificationBatch::FillRequest(TEvKeyValue::TEvRequest* request) {

--- a/ydb/core/persqueue/sourceid.h
+++ b/ydb/core/persqueue/sourceid.h
@@ -122,6 +122,10 @@ public:
         return Registrations;
     }
 
+    const THashSet<TString>& GetSourceIdsToDelete() const {
+        return Deregistrations;
+    }
+
     template <typename... Args>
     void RegisterSourceId(const TString& sourceId, Args&&... args) {
         Registrations[sourceId] = TSourceIdInfo(std::forward<Args>(args)...);

--- a/ydb/core/protos/counters_datashard.proto
+++ b/ydb/core/protos/counters_datashard.proto
@@ -486,4 +486,5 @@ enum ETxTypes {
     TXTYPE_CLEANUP_VOLATILE = 80                          [(TxTypeOpts) = {Name: "TxCleanupVolatile"}];
     TXTYPE_PLAN_PREDICTED_TXS = 81                        [(TxTypeOpts) = {Name: "TxPlanPredictedTxs"}];
     TXTYPE_WRITE = 82                                     [(TxTypeOpts) = {Name: "TxWrite"}];
+    TXTYPE_REMOVE_SCHEMA_SNAPSHOTS = 83                   [(TxTypeOpts) = {Name: "TxRemoveSchemaSnapshots"}];
 }

--- a/ydb/core/tx/datashard/datashard_change_sending.cpp
+++ b/ydb/core/tx/datashard/datashard_change_sending.cpp
@@ -340,15 +340,13 @@ public:
             Self->RemoveChangeRecordsInFly = false;
         }
 
-        if (!Self->ChangesQueue) { // double check queue
-            if (ChangeExchangeSplit) {
-                Self->KillChangeSender(ctx);
-                Self->ChangeExchangeSplitter.DoSplit(ctx);
-            }
+        if (ChangeExchangeSplit) {
+            Self->KillChangeSender(ctx);
+            Self->ChangeExchangeSplitter.DoSplit(ctx);
+        }
 
-            for (const auto dstTabletId : ActivationList) {
-                Self->ChangeSenderActivator.DoSend(dstTabletId, ctx);
-            }
+        for (const auto dstTabletId : ActivationList) {
+            Self->ChangeSenderActivator.DoSend(dstTabletId, ctx);
         }
 
         Self->CheckStateChange(ctx);

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -236,6 +236,7 @@ class TDataShard
     class TTxCdcStreamScanProgress;
     class TTxCdcStreamEmitHeartbeats;
     class TTxUpdateFollowerReadEdge;
+    class TTxRemoveSchemaSnapshots;
 
     template <typename T> friend class TTxDirectBase;
     class TTxUploadRows;
@@ -366,6 +367,7 @@ class TDataShard
             EvReadonlyLeaseConfirmation,
             EvPlanPredictedTxs,
             EvTableStatsError,
+            EvRemoveSchemaSnapshots,
             EvEnd
         };
 
@@ -585,6 +587,8 @@ class TDataShard
         struct TEvReadonlyLeaseConfirmation: public TEventLocal<TEvReadonlyLeaseConfirmation, EvReadonlyLeaseConfirmation> {};
 
         struct TEvPlanPredictedTxs : public TEventLocal<TEvPlanPredictedTxs, EvPlanPredictedTxs> {};
+
+        struct TEvRemoveSchemaSnapshots : public TEventLocal<TEvRemoveSchemaSnapshots, EvRemoveSchemaSnapshots> {};
     };
 
     struct Schema : NIceDb::Schema {
@@ -1368,6 +1372,8 @@ class TDataShard
 
     void Handle(TEvPrivate::TEvPlanPredictedTxs::TPtr& ev, const TActorContext& ctx);
 
+    void Handle(TEvPrivate::TEvRemoveSchemaSnapshots::TPtr& ev, const TActorContext& ctx);
+
     void HandleByReplicationSourceOffsetsServer(STATEFN_SIG);
 
     void DoPeriodicTasks(const TActorContext &ctx);
@@ -1864,7 +1870,8 @@ public:
     void MoveChangeRecord(NIceDb::TNiceDb& db, ui64 order, const TPathId& pathId);
     void MoveChangeRecord(NIceDb::TNiceDb& db, ui64 lockId, ui64 lockOffset, const TPathId& pathId);
     void RemoveChangeRecord(NIceDb::TNiceDb& db, ui64 order);
-    void EnqueueChangeRecords(TVector<IDataShardChangeCollector::TChange>&& records, ui64 cookie = 0);
+    // TODO(ilnaz): remove 'afterMove' after #6541
+    void EnqueueChangeRecords(TVector<IDataShardChangeCollector::TChange>&& records, ui64 cookie = 0, bool afterMove = false);
     ui32 GetFreeChangeQueueCapacity(ui64 cookie);
     ui64 ReserveChangeQueueCapacity(ui32 capacity);
     void UpdateChangeExchangeLag(TInstant now);
@@ -1878,6 +1885,8 @@ public:
     bool LoadChangeRecordCommits(NIceDb::TNiceDb& db, TVector<IDataShardChangeCollector::TChange>& records);
     void ScheduleRemoveLockChanges(ui64 lockId);
     void ScheduleRemoveAbandonedLockChanges();
+    void ScheduleRemoveSchemaSnapshot(const TSchemaSnapshotKey& key);
+    void ScheduleRemoveAbandonedSchemaSnapshots();
 
     static void PersistCdcStreamScanLastKey(NIceDb::TNiceDb& db, const TSerializedCellVec& value,
         const TPathId& tablePathId, const TPathId& streamPathId);
@@ -2740,24 +2749,29 @@ private:
         ui64 LockOffset;
         ui64 ReservationCookie;
 
-        explicit TEnqueuedRecord(ui64 bodySize, const TPathId& tableId,
-                ui64 schemaVersion, TInstant created, TInstant enqueued,
-                ui64 lockId = 0, ui64 lockOffset = 0, ui64 cookie = 0)
+        explicit TEnqueuedRecord(ui64 bodySize, const TPathId& tableId, ui64 schemaVersion,
+                TInstant created, ui64 lockId = 0, ui64 lockOffset = 0)
             : BodySize(bodySize)
             , TableId(tableId)
             , SchemaVersion(schemaVersion)
             , SchemaSnapshotAcquired(false)
             , CreatedAt(created)
-            , EnqueuedAt(enqueued)
+            , EnqueuedAt(TInstant::Zero())
             , LockId(lockId)
             , LockOffset(lockOffset)
-            , ReservationCookie(cookie)
+            , ReservationCookie(0)
         {
         }
 
-        explicit TEnqueuedRecord(const IDataShardChangeCollector::TChange& record, TInstant now, ui64 cookie)
-            : TEnqueuedRecord(record.BodySize, record.TableId, record.SchemaVersion, record.CreatedAt(), now,
-                record.LockId, record.LockOffset, cookie)
+        explicit TEnqueuedRecord(const IDataShardChangeCollector::TChange& record)
+            : TEnqueuedRecord(record.BodySize, record.TableId, record.SchemaVersion,
+                record.CreatedAt(), record.LockId, record.LockOffset)
+        {
+        }
+
+        explicit TEnqueuedRecord(const TChangeRecord& record)
+            : TEnqueuedRecord(record.GetBody().size(), record.GetTableId(), record.GetSchemaVersion(),
+                record.GetApproximateCreationDateTime(), record.GetLockId(), record.GetLockOffset())
         {
         }
     };
@@ -2798,9 +2812,11 @@ private:
         size_t Count = 0;
     };
 
+    TVector<ui64> CommittingChangeRecords;
     THashMap<ui64, TUncommittedLockChangeRecords> LockChangeRecords; // ui64 is lock id
     THashMap<ui64, TCommittedLockChangeRecords> CommittedLockChangeRecords; // ui64 is lock id
     TVector<ui64> PendingLockChangeRecordsToRemove;
+    TVector<TSchemaSnapshotKey> PendingSchemaSnapshotsToGc;
 
     // in
     THashMap<ui64, TInChangeSender> InChangeSenders; // ui64 is shard id
@@ -2896,6 +2912,16 @@ public:
         CommittedLockChangeRecords = std::move(committedLockChangeRecords);
     }
 
+    auto TakeChangesQueue() {
+        auto result = std::move(ChangesQueue);
+        ChangesQueue.clear();
+        return result;
+    }
+
+    void SetChangesQueue(THashMap<ui64, TEnqueuedRecord>&& changesQueue) {
+        ChangesQueue = std::move(changesQueue);
+    }
+
 protected:
     // Redundant init state required by flat executor implementation
     void StateInit(TAutoPtr<NActors::IEventHandle> &ev) {
@@ -2917,6 +2943,7 @@ protected:
             HFuncTraced(TEvMediatorTimecast::TEvNotifyPlanStep, Handle);
             HFuncTraced(TEvPrivate::TEvMediatorRestoreBackup, Handle);
             HFuncTraced(TEvPrivate::TEvRemoveLockChangeRecords, Handle);
+            HFuncTraced(TEvPrivate::TEvRemoveSchemaSnapshots, Handle);
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateInactive unhandled event type: " << ev->GetTypeRewrite()
@@ -3041,6 +3068,7 @@ protected:
             HFuncTraced(TEvPrivate::TEvRemoveLockChangeRecords, Handle);
             HFunc(TEvPrivate::TEvConfirmReadonlyLease, Handle);
             HFunc(TEvPrivate::TEvPlanPredictedTxs, Handle);
+            HFuncTraced(TEvPrivate::TEvRemoveSchemaSnapshots, Handle);
             default:
                 if (!HandleDefaultEvents(ev, SelfId())) {
                     ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateWork unhandled event type: " << ev->GetTypeRewrite() << " event: " << ev->ToString());

--- a/ydb/core/tx/datashard/datashard_schema_snapshots.h
+++ b/ydb/core/tx/datashard/datashard_schema_snapshots.h
@@ -23,6 +23,8 @@ struct TSchemaSnapshot {
 };
 
 class TSchemaSnapshotManager {
+    using TSnapshots = TMap<TSchemaSnapshotKey, TSchemaSnapshot, TLess<void>>;
+
 public:
     explicit TSchemaSnapshotManager(const TDataShard* self);
 
@@ -31,11 +33,13 @@ public:
 
     bool AddSnapshot(NTable::TDatabase& db, const TSchemaSnapshotKey& key, const TSchemaSnapshot& snapshot);
     const TSchemaSnapshot* FindSnapshot(const TSchemaSnapshotKey& key) const;
-    void RemoveShapshot(NIceDb::TNiceDb& db, const TSchemaSnapshotKey& key);
+    void RemoveShapshot(NTable::TDatabase& db, const TSchemaSnapshotKey& key);
     void RenameSnapshots(NTable::TDatabase& db, const TPathId& prevTableId, const TPathId& newTableId);
+    const TSnapshots& GetSnapshots() const;
 
     bool AcquireReference(const TSchemaSnapshotKey& key);
     bool ReleaseReference(const TSchemaSnapshotKey& key);
+    bool HasReference(const TSchemaSnapshotKey& key) const;
 
 private:
     void PersistAddSnapshot(NIceDb::TNiceDb& db, const TSchemaSnapshotKey& key, const TSchemaSnapshot& snapshot);
@@ -43,7 +47,7 @@ private:
 
 private:
     const TDataShard* Self;
-    TMap<TSchemaSnapshotKey, TSchemaSnapshot, TLess<void>> Snapshots;
+    TSnapshots Snapshots;
     THashMap<TSchemaSnapshotKey, size_t> References;
 
 }; // TSchemaSnapshotManager

--- a/ydb/core/tx/datashard/datashard_split_src.cpp
+++ b/ydb/core/tx/datashard/datashard_split_src.cpp
@@ -424,7 +424,7 @@ public:
     void Complete(const TActorContext &ctx) override {
         LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID() << " Sending snapshots from src for split OpId " << Self->SrcSplitOpId);
         Self->SplitSrcSnapshotSender.DoSend(ctx);
-        if (ChangeExchangeSplit && !Self->ChangesQueue) { // double check queue
+        if (ChangeExchangeSplit) {
             Self->KillChangeSender(ctx);
             Self->ChangeExchangeSplitter.DoSplit(ctx);
         }
@@ -488,7 +488,7 @@ public:
             }
         }
 
-        if (ActivateTabletId && !Self->ChangesQueue) { // double check queue
+        if (ActivateTabletId) {
             Self->ChangeSenderActivator.DoSend(ActivateTabletId, ctx);
         }
     }

--- a/ydb/core/tx/datashard/datashard_split_src.cpp
+++ b/ydb/core/tx/datashard/datashard_split_src.cpp
@@ -238,6 +238,8 @@ class TDataShard::TTxSplitSnapshotComplete : public NTabletFlatExecutor::TTransa
 private:
     TIntrusivePtr<TSplitSnapshotContext> SnapContext;
     bool ChangeExchangeSplit;
+    THashSet<ui64> ActivationList;
+    THashSet<ui64> SplitList;
 
 public:
     TTxSplitSnapshotComplete(TDataShard* ds, TIntrusivePtr<TSplitSnapshotContext> snapContext)
@@ -372,13 +374,11 @@ public:
                     proto->SetTimeoutMs(kv.second.Timeout.MilliSeconds());
                 }
 
-                if (Self->ChangesQueue || tableInfo.HasCdcStreams()) {
+                if (tableInfo.HasAsyncIndexes() || tableInfo.HasCdcStreams()) {
                     snapshot->SetWaitForActivation(true);
-                    Self->ChangeSenderActivator.AddDst(dstTablet);
-                    db.Table<Schema::SrcChangeSenderActivations>().Key(dstTablet).Update();
-
+                    ActivationList.insert(dstTablet);
                     if (tableInfo.HasCdcStreams()) {
-                        Self->ChangeExchangeSplitter.AddDst(dstTablet);
+                        SplitList.insert(dstTablet);
                     }
                 }
 
@@ -397,13 +397,22 @@ public:
             }
         }
 
-        ChangeExchangeSplit = !Self->ChangesQueue && !Self->ChangeExchangeSplitter.Done();
-
         if (needToReadPages) {
             LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID() << " BorrowSnapshot is restarting for split OpId " << opId);
             return false;
         } else {
             txc.Env.DropSnapshot(SnapContext);
+
+            for (ui64 dstTabletId : ActivationList) {
+                Self->ChangeSenderActivator.AddDst(dstTabletId);
+                db.Table<Schema::SrcChangeSenderActivations>().Key(dstTabletId).Update();
+            }
+
+            for (ui64 dstTabletId : SplitList) {
+                Self->ChangeExchangeSplitter.AddDst(dstTabletId);
+            }
+
+            ChangeExchangeSplit = !Self->ChangesQueue && !Self->ChangeExchangeSplitter.Done();
 
             Self->State = TShardState::SplitSrcSendingSnapshot;
             Self->PersistSys(db, Schema::Sys_State, Self->State);
@@ -415,7 +424,7 @@ public:
     void Complete(const TActorContext &ctx) override {
         LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, Self->TabletID() << " Sending snapshots from src for split OpId " << Self->SrcSplitOpId);
         Self->SplitSrcSnapshotSender.DoSend(ctx);
-        if (ChangeExchangeSplit) {
+        if (ChangeExchangeSplit && !Self->ChangesQueue) { // double check queue
             Self->KillChangeSender(ctx);
             Self->ChangeExchangeSplitter.DoSplit(ctx);
         }
@@ -432,14 +441,14 @@ class TDataShard::TTxSplitTransferSnapshotAck : public NTabletFlatExecutor::TTra
 private:
     TEvDataShard::TEvSplitTransferSnapshotAck::TPtr Ev;
     bool AllDstAcksReceived;
-    bool Activate;
+    ui64 ActivateTabletId;
 
 public:
     TTxSplitTransferSnapshotAck(TDataShard* ds, TEvDataShard::TEvSplitTransferSnapshotAck::TPtr& ev)
         : NTabletFlatExecutor::TTransactionBase<TDataShard>(ds)
         , Ev(ev)
         , AllDstAcksReceived(false)
-        , Activate(false)
+        , ActivateTabletId(0)
     {}
 
     TTxType GetTxType() const override { return TXTYPE_SPLIT_TRANSFER_SNAPSHOT_ACK; }
@@ -463,8 +472,8 @@ public:
         // Remove the row for acked snapshot
         db.Table<Schema::SplitSrcSnapshots>().Key(dstTabletId).Delete();
 
-        if (!Self->ChangesQueue && Self->ChangeExchangeSplitter.Done()) {
-            Activate = !Self->ChangeSenderActivator.Acked(dstTabletId);
+        if (!Self->ChangesQueue && Self->ChangeExchangeSplitter.Done() && !Self->ChangeSenderActivator.Acked(dstTabletId)) {
+            ActivateTabletId = dstTabletId;
         }
 
         return true;
@@ -479,11 +488,8 @@ public:
             }
         }
 
-        if (Activate) {
-            const ui64 dstTabletId = Ev->Get()->Record.GetTabletId();
-            if (!Self->ChangeSenderActivator.Acked(dstTabletId)) {
-                Self->ChangeSenderActivator.DoSend(dstTabletId, ctx);
-            }
+        if (ActivateTabletId && !Self->ChangesQueue) { // double check queue
+            Self->ChangeSenderActivator.DoSend(ActivateTabletId, ctx);
         }
     }
 };

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -3491,7 +3491,7 @@ Y_UNIT_TEST_SUITE(Cdc) {
         });
 
         ui32 splitResponses = 0;
-        auto countSplitResponses = runtime.AddObserver<TEvPersQueue::TEvResponse>([&](auto& ev) {
+        auto countSplitResponses = runtime.AddObserver<TEvPersQueue::TEvResponse>([&](auto&) {
             ++splitResponses;
         });
 

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -3434,6 +3434,94 @@ Y_UNIT_TEST_SUITE(Cdc) {
         MustNotLoseSchemaSnapshot(true);
     }
 
+    Y_UNIT_TEST(ResolvedTimestampsContinueAfterMerge) {
+        TPortManager portManager;
+        TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
+            .SetUseRealThreads(false)
+            .SetDomainName("Root")
+        );
+
+        auto& runtime = *server->GetRuntime();
+        const auto edgeActor = runtime.AllocateEdgeActor();
+
+        SetupLogging(runtime);
+        InitRoot(server, edgeActor);
+        SetSplitMergePartCountLimit(&runtime, -1);
+        CreateShardedTable(server, edgeActor, "/Root", "Table", SimpleTable());
+
+        WaitTxNotification(server, edgeActor, AsyncAlterAddStream(server, "/Root", "Table",
+            WithResolvedTimestamps(TDuration::Seconds(3), Updates(NKikimrSchemeOp::ECdcStreamFormatJson))));
+
+        Cerr << "... prepare" << Endl;
+        {
+            WaitForContent(server, edgeActor, "/Root/Table/Stream", {
+                R"({"resolved":"***"})",
+            });
+
+            auto tabletIds = GetTableShards(server, edgeActor, "/Root/Table");
+            UNIT_ASSERT_VALUES_EQUAL(tabletIds.size(), 1);
+
+            WaitTxNotification(server, edgeActor, AsyncSplitTable(server, edgeActor, "/Root/Table", tabletIds.at(0), 2));
+            WaitForContent(server, edgeActor, "/Root/Table/Stream", {
+                R"({"resolved":"***"})",
+                R"({"resolved":"***"})",
+            });
+        }
+
+        auto initialTabletIds = GetTableShards(server, edgeActor, "/Root/Table");
+        UNIT_ASSERT_VALUES_EQUAL(initialTabletIds.size(), 2);
+
+        std::vector<std::unique_ptr<IEventHandle>> blockedSplitRequests;
+        auto blockSplitRequests = runtime.AddObserver<TEvPersQueue::TEvRequest>([&](auto& ev) {
+            if (ev->Get()->Record.GetPartitionRequest().HasCmdSplitMessageGroup()) {
+                blockedSplitRequests.emplace_back(ev.Release());
+            }
+        });
+
+        Cerr << "... merge table" << Endl;
+        const auto mergeTxId = AsyncMergeTable(server, edgeActor, "/Root/Table", initialTabletIds);
+        WaitFor(runtime, [&]{ return blockedSplitRequests.size() == initialTabletIds.size(); }, "blocked split requests");
+        blockSplitRequests.Remove();
+
+        std::vector<std::unique_ptr<IEventHandle>> blockedRegisterRequests;
+        auto blockRegisterRequests = runtime.AddObserver<TEvPersQueue::TEvRequest>([&](auto& ev) {
+            if (ev->Get()->Record.GetPartitionRequest().HasCmdRegisterMessageGroup()) {
+                blockedRegisterRequests.emplace_back(ev.Release());
+            }
+        });
+
+        ui32 splitResponses = 0;
+        auto countSplitResponses = runtime.AddObserver<TEvPersQueue::TEvResponse>([&](auto& ev) {
+            ++splitResponses;
+        });
+
+        Cerr << "... release split requests" << Endl;
+        for (auto& ev : std::exchange(blockedSplitRequests, {})) {
+            runtime.Send(ev.release(), 0, true);
+            WaitFor(runtime, [prev = splitResponses, &splitResponses]{ return splitResponses > prev; }, "split response");
+        }
+
+        Cerr << "... reboot pq tablet" << Endl;
+        RebootTablet(runtime, ResolvePqTablet(runtime, edgeActor, "/Root/Table/Stream", 0), edgeActor);
+        countSplitResponses.Remove();
+
+        Cerr << "... release register requests" << Endl;
+        blockRegisterRequests.Remove();
+        for (auto& ev : std::exchange(blockedRegisterRequests, {})) {
+            runtime.Send(ev.release(), 0, true);
+        }
+
+        Cerr << "... wait for merge tx notification" << Endl;
+        WaitTxNotification(server, edgeActor, mergeTxId);
+
+        Cerr << "... wait for final heartbeat" << Endl;
+        WaitForContent(server, edgeActor, "/Root/Table/Stream", {
+            R"({"resolved":"***"})",
+            R"({"resolved":"***"})",
+            R"({"resolved":"***"})",
+        });
+    }
+
 } // Cdc
 
 } // NKikimr

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -3334,6 +3334,106 @@ Y_UNIT_TEST_SUITE(Cdc) {
         });
     }
 
+    void MustNotLoseSchemaSnapshot(bool enableVolatileTx) {
+        TPortManager portManager;
+        TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
+            .SetUseRealThreads(false)
+            .SetDomainName("Root")
+            .SetEnableDataShardVolatileTransactions(enableVolatileTx)
+        );
+
+        auto& runtime = *server->GetRuntime();
+        const auto edgeActor = runtime.AllocateEdgeActor();
+
+        SetupLogging(runtime);
+        InitRoot(server, edgeActor);
+        CreateShardedTable(server, edgeActor, "/Root", "Table", SimpleTable());
+
+        WaitTxNotification(server, edgeActor, AsyncAlterAddStream(server, "/Root", "Table",
+            Updates(NKikimrSchemeOp::ECdcStreamFormatJson)));
+
+        auto tabletIds = GetTableShards(server, edgeActor, "/Root/Table");
+        UNIT_ASSERT_VALUES_EQUAL(tabletIds.size(), 1);
+
+        std::vector<std::unique_ptr<IEventHandle>> blockedRemoveRecords;
+        auto blockRemoveRecords = runtime.AddObserver<NChangeExchange::TEvChangeExchange::TEvRemoveRecords>([&](auto& ev) {
+            Cerr << "... blocked remove record" << Endl;
+            blockedRemoveRecords.emplace_back(ev.Release());
+        });
+
+        Cerr << "... execute first query" << Endl;
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES (1, 10);
+        )");
+
+        WaitFor(runtime, [&]{ return blockedRemoveRecords.size() == 1; }, "blocked remove records");
+        blockRemoveRecords.Remove();
+
+        std::vector<std::unique_ptr<IEventHandle>> blockedPlans;
+        auto blockPlans = runtime.AddObserver<TEvTxProxy::TEvProposeTransaction>([&](auto& ev) {
+            blockedPlans.emplace_back(ev.Release());
+        });
+
+        Cerr << "... execute scheme query" << Endl;
+        const auto alterTxId = AsyncAlterAddExtraColumn(server, "/Root", "Table");
+
+        WaitFor(runtime, [&]{ return blockedPlans.size() > 0; }, "blocked plans");
+        blockPlans.Remove();
+
+        std::vector<std::unique_ptr<IEventHandle>> blockedPutResponses;
+        auto blockPutResponses = runtime.AddObserver<TEvBlobStorage::TEvPutResult>([&](auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Id.TabletID() == tabletIds[0]) {
+                Cerr << "... blocked put response:" << msg->Id << Endl;
+                blockedPutResponses.emplace_back(ev.Release());
+            }
+        });
+
+        Cerr << "... execute second query" << Endl;
+        SendSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES (2, 20);
+        )");
+
+        WaitFor(runtime, [&]{ return blockedPutResponses.size() > 0; }, "blocked put responses");
+        auto wasBlockedPutResponses = blockedPutResponses.size();
+
+        Cerr << "... release blocked plans" << Endl;
+        for (auto& ev : std::exchange(blockedPlans, {})) {
+            runtime.Send(ev.release(), 0, true);
+        }
+
+        WaitFor(runtime, [&]{ return blockedPutResponses.size() > wasBlockedPutResponses; }, "blocked put responses");
+        wasBlockedPutResponses = blockedPutResponses.size();
+
+        Cerr << "... release blocked remove records" << Endl;
+        for (auto& ev : std::exchange(blockedRemoveRecords, {})) {
+            runtime.Send(ev.release(), 0, true);
+        }
+
+        WaitFor(runtime, [&]{ return blockedPutResponses.size() > wasBlockedPutResponses; }, "blocked put responses");
+        blockPutResponses.Remove();
+
+        Cerr << "... release blocked put responses" << Endl;
+        for (auto& ev : std::exchange(blockedPutResponses, {})) {
+            runtime.Send(ev.release(), 0, true);
+        }
+
+        Cerr << "... finalize" << Endl;
+        WaitTxNotification(server, edgeActor, alterTxId);
+        WaitForContent(server, edgeActor, "/Root/Table/Stream", {
+            R"({"update":{"value":10},"key":[1]})",
+            R"({"update":{"value":20},"key":[2]})",
+        });
+    }
+
+    Y_UNIT_TEST(MustNotLoseSchemaSnapshot) {
+        MustNotLoseSchemaSnapshot(false);
+    }
+
+    Y_UNIT_TEST(MustNotLoseSchemaSnapshotWithVolatileTx) {
+        MustNotLoseSchemaSnapshot(true);
+    }
+
 } // Cdc
 
 } // NKikimr

--- a/ydb/core/tx/datashard/move_index_unit.cpp
+++ b/ydb/core/tx/datashard/move_index_unit.cpp
@@ -60,20 +60,27 @@ public:
         NIceDb::TNiceDb db(txc.DB);
 
         ChangeRecords.clear();
-        if (!DataShard.LoadChangeRecords(db, ChangeRecords)) {
-            return EExecutionStatus::Restart;
-        }
 
+        auto changesQueue = DataShard.TakeChangesQueue();
         auto lockChangeRecords = DataShard.TakeLockChangeRecords();
         auto committedLockChangeRecords = DataShard.TakeCommittedLockChangeRecords();
 
+        if (!DataShard.LoadChangeRecords(db, ChangeRecords)) {
+            DataShard.SetChangesQueue(std::move(changesQueue));
+            DataShard.SetLockChangeRecords(std::move(lockChangeRecords));
+            DataShard.SetCommittedLockChangeRecords(std::move(committedLockChangeRecords));
+            return EExecutionStatus::Restart;
+        }
+
         if (!DataShard.LoadLockChangeRecords(db)) {
+            DataShard.SetChangesQueue(std::move(changesQueue));
             DataShard.SetLockChangeRecords(std::move(lockChangeRecords));
             DataShard.SetCommittedLockChangeRecords(std::move(committedLockChangeRecords));
             return EExecutionStatus::Restart;
         }
 
         if (!DataShard.LoadChangeRecordCommits(db, ChangeRecords)) {
+            DataShard.SetChangesQueue(std::move(changesQueue));
             DataShard.SetLockChangeRecords(std::move(lockChangeRecords));
             DataShard.SetCommittedLockChangeRecords(std::move(committedLockChangeRecords));
             return EExecutionStatus::Restart;
@@ -99,7 +106,7 @@ public:
     void Complete(TOperation::TPtr, const TActorContext& ctx) override {
         DataShard.CreateChangeSender(ctx);
         DataShard.MaybeActivateChangeSender(ctx);
-        DataShard.EnqueueChangeRecords(std::move(ChangeRecords));
+        DataShard.EnqueueChangeRecords(std::move(ChangeRecords), 0, true);
     }
 };
 

--- a/ydb/core/tx/datashard/move_table_unit.cpp
+++ b/ydb/core/tx/datashard/move_table_unit.cpp
@@ -60,20 +60,27 @@ public:
         NIceDb::TNiceDb db(txc.DB);
 
         ChangeRecords.clear();
-        if (!DataShard.LoadChangeRecords(db, ChangeRecords)) {
-            return EExecutionStatus::Restart;
-        }
 
+        auto changesQueue = DataShard.TakeChangesQueue();
         auto lockChangeRecords = DataShard.TakeLockChangeRecords();
         auto committedLockChangeRecords = DataShard.TakeCommittedLockChangeRecords();
 
+        if (!DataShard.LoadChangeRecords(db, ChangeRecords)) {
+            DataShard.SetChangesQueue(std::move(changesQueue));
+            DataShard.SetLockChangeRecords(std::move(lockChangeRecords));
+            DataShard.SetCommittedLockChangeRecords(std::move(committedLockChangeRecords));
+            return EExecutionStatus::Restart;
+        }
+
         if (!DataShard.LoadLockChangeRecords(db)) {
+            DataShard.SetChangesQueue(std::move(changesQueue));
             DataShard.SetLockChangeRecords(std::move(lockChangeRecords));
             DataShard.SetCommittedLockChangeRecords(std::move(committedLockChangeRecords));
             return EExecutionStatus::Restart;
         }
 
         if (!DataShard.LoadChangeRecordCommits(db, ChangeRecords)) {
+            DataShard.SetChangesQueue(std::move(changesQueue));
             DataShard.SetLockChangeRecords(std::move(lockChangeRecords));
             DataShard.SetCommittedLockChangeRecords(std::move(committedLockChangeRecords));
             return EExecutionStatus::Restart;
@@ -99,7 +106,7 @@ public:
     void Complete(TOperation::TPtr, const TActorContext& ctx) override {
         DataShard.CreateChangeSender(ctx);
         DataShard.MaybeActivateChangeSender(ctx);
-        DataShard.EnqueueChangeRecords(std::move(ChangeRecords));
+        DataShard.EnqueueChangeRecords(std::move(ChangeRecords), 0, true);
     }
 };
 

--- a/ydb/core/tx/datashard/remove_schema_snapshots.cpp
+++ b/ydb/core/tx/datashard/remove_schema_snapshots.cpp
@@ -1,0 +1,54 @@
+#include "datashard_impl.h"
+
+namespace NKikimr::NDataShard {
+
+class TDataShard::TTxRemoveSchemaSnapshots: public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+public:
+    TTxRemoveSchemaSnapshots(TDataShard* self)
+        : TBase(self)
+    { }
+
+    TTxType GetTxType() const override { return TXTYPE_REMOVE_SCHEMA_SNAPSHOTS; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        while (!Self->PendingSchemaSnapshotsToGc.empty()) {
+            const auto key = Self->PendingSchemaSnapshotsToGc.back();
+            const auto* snapshot = Self->GetSchemaSnapshotManager().FindSnapshot(key);
+
+            if (!snapshot) {
+                Self->PendingSchemaSnapshotsToGc.pop_back();
+                continue;
+            }
+
+            if (Self->GetSchemaSnapshotManager().HasReference(key)) {
+                Self->PendingSchemaSnapshotsToGc.pop_back();
+                continue;
+            }
+
+            auto table = Self->FindUserTable(TPathId(key.OwnerId, key.PathId));
+            if (!table) {
+                Self->PendingSchemaSnapshotsToGc.pop_back();
+                continue;
+            }
+
+            if (snapshot->Schema->GetTableSchemaVersion() >= table->GetTableSchemaVersion()) {
+                Self->PendingSchemaSnapshotsToGc.pop_back();
+                continue;
+            }
+
+            Self->GetSchemaSnapshotManager().RemoveShapshot(txc.DB, key);
+            Self->PendingSchemaSnapshotsToGc.pop_back();
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext&) override {
+    }
+};
+
+void TDataShard::Handle(TEvPrivate::TEvRemoveSchemaSnapshots::TPtr&, const TActorContext& ctx) {
+    Execute(new TTxRemoveSchemaSnapshots(this), ctx);
+}
+
+} // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -185,6 +185,7 @@ SRCS(
     remove_lock_change_records.cpp
     remove_locks.cpp
     range_avl_tree.cpp
+    remove_schema_snapshots.cpp
     range_ops.cpp
     range_treap.cpp
     read_iterator.h

--- a/ydb/core/tx/schemeshard/ut_cdc_stream_reboots/ut_cdc_stream_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_cdc_stream_reboots/ut_cdc_stream_reboots.cpp
@@ -518,68 +518,77 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithRebootsTests) {
         });
     }
 
+    bool CheckRegistrations(TTestActorRuntime& runtime, NKikimrPQ::TMessageGroupInfo::EState expectedState,
+            const google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TTablePartition>& tablePartitions,
+            const google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TPersQueueGroupDescription::TPartition>& topicPartitions)
+    {
+        for (const auto& topicPartition : topicPartitions) {
+            auto request = MakeHolder<TEvPersQueue::TEvRequest>();
+            {
+                auto& record = *request->Record.MutablePartitionRequest();
+                record.SetPartition(topicPartition.GetPartitionId());
+                auto& cmd = *record.MutableCmdGetMaxSeqNo();
+                for (const auto& tablePartition : tablePartitions) {
+                    cmd.AddSourceId(NPQ::NSourceIdEncoding::EncodeSimple(ToString(tablePartition.GetDatashardId())));
+                }
+            }
+
+            const auto& sender = runtime.AllocateEdgeActor();
+            ForwardToTablet(runtime, topicPartition.GetTabletId(), sender, request.Release());
+
+            auto response = runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(sender);
+            {
+                const auto& record = response->Get()->Record.GetPartitionResponse();
+                const auto& result = record.GetCmdGetMaxSeqNoResult().GetSourceIdInfo();
+
+                UNIT_ASSERT_VALUES_EQUAL(result.size(), tablePartitions.size());
+                for (const auto& item: result) {
+                    if (item.GetState() != expectedState) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
     struct TItem {
         TString Path;
-        ui32 nPartitions;
+        ui32 ExpectedPartitionCount;
     };
 
-    void CheckRegistrations(TTestActorRuntime& runtime, const TItem& table, const TItem& topic) {
+    void CheckRegistrations(TTestActorRuntime& runtime, const TItem& table, const TItem& topic,
+            const google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TTablePartition>* initialTablePartitions = nullptr)
+    {
         auto tableDesc = DescribePath(runtime, table.Path, true, true);
         const auto& tablePartitions = tableDesc.GetPathDescription().GetTablePartitions();
-        UNIT_ASSERT_VALUES_EQUAL(tablePartitions.size(), table.nPartitions);
+        UNIT_ASSERT_VALUES_EQUAL(tablePartitions.size(), table.ExpectedPartitionCount);
 
         auto topicDesc = DescribePrivatePath(runtime, topic.Path);
         const auto& topicPartitions = topicDesc.GetPathDescription().GetPersQueueGroup().GetPartitions();
-        UNIT_ASSERT_VALUES_EQUAL(topicPartitions.size(), topic.nPartitions);
+        UNIT_ASSERT_VALUES_EQUAL(topicPartitions.size(), topic.ExpectedPartitionCount);
 
         while (true) {
             runtime.SimulateSleep(TDuration::Seconds(1));
-            bool done = true;
-
-            for (ui32 i = 0; i < topic.nPartitions; ++i) {
-                auto request = MakeHolder<TEvPersQueue::TEvRequest>();
-                {
-                    auto& record = *request->Record.MutablePartitionRequest();
-                    record.SetPartition(topicPartitions[i].GetPartitionId());
-                    auto& cmd = *record.MutableCmdGetMaxSeqNo();
-                    for (const auto& tablePartition : tablePartitions) {
-                        cmd.AddSourceId(NPQ::NSourceIdEncoding::EncodeSimple(ToString(tablePartition.GetDatashardId())));
-                    }
-                }
-
-                const auto& sender = runtime.AllocateEdgeActor();
-                ForwardToTablet(runtime, topicPartitions[i].GetTabletId(), sender, request.Release());
-
-                auto response = runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(sender);
-                {
-                    const auto& record = response->Get()->Record.GetPartitionResponse();
-                    const auto& result = record.GetCmdGetMaxSeqNoResult().GetSourceIdInfo();
-
-                    UNIT_ASSERT_VALUES_EQUAL(result.size(), table.nPartitions);
-                    for (const auto& item: result) {
-                        done &= item.GetState() == NKikimrPQ::TMessageGroupInfo::STATE_REGISTERED;
-                        if (!done) {
-                            break;
-                        }
-                    }
-                }
-
-                if (!done) {
-                    break;
-                }
-            }
-
-            if (done) {
+            if (CheckRegistrations(runtime, NKikimrPQ::TMessageGroupInfo::STATE_REGISTERED, tablePartitions, topicPartitions)) {
                 break;
             }
         }
+
+        if (initialTablePartitions) {
+            UNIT_ASSERT(CheckRegistrations(runtime, NKikimrPQ::TMessageGroupInfo::STATE_UNKNOWN, *initialTablePartitions, topicPartitions));
+        }
     }
 
-    Y_UNIT_TEST_WITH_REBOOTS(SplitTable) {
+    template <typename T>
+    void SplitTable(const TString& cdcStreamDesc) {
         T t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            NKikimrScheme::TEvDescribeSchemeResult initialTableDesc;
             {
                 TInactiveZone inactive(activeZone);
+
                 TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
                     Name: "Table"
                     Columns { Name: "key" Type: "Uint32" }
@@ -587,15 +596,9 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithRebootsTests) {
                     KeyColumnNames: ["key"]
                 )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                initialTableDesc = DescribePath(runtime, "/MyRoot/Table", true, true);
 
-                TestCreateCdcStream(runtime, ++t.TxId, "/MyRoot", R"(
-                    TableName: "Table"
-                    StreamDescription {
-                      Name: "Stream"
-                      Mode: ECdcStreamModeKeysOnly
-                      Format: ECdcStreamFormatProto
-                    }
-                )");
+                TestCreateCdcStream(runtime, ++t.TxId, "/MyRoot", cdcStreamDesc);
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
@@ -613,16 +616,43 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithRebootsTests) {
                 TInactiveZone inactive(activeZone);
                 UploadRows(runtime, "/MyRoot/Table", 0, {1}, {2}, {1});
                 UploadRows(runtime, "/MyRoot/Table", 1, {1}, {2}, {Max<ui32>()});
-                CheckRegistrations(runtime, {"/MyRoot/Table", 2}, {"/MyRoot/Table/Stream/streamImpl", 1});
+                CheckRegistrations(runtime, {"/MyRoot/Table", 2}, {"/MyRoot/Table/Stream/streamImpl", 1},
+                    &initialTableDesc.GetPathDescription().GetTablePartitions());
             }
         });
     }
 
-    Y_UNIT_TEST_WITH_REBOOTS(MergeTable) {
+    Y_UNIT_TEST_WITH_REBOOTS(SplitTable) {
+        SplitTable<T>(R"(
+            TableName: "Table"
+            StreamDescription {
+              Name: "Stream"
+              Mode: ECdcStreamModeKeysOnly
+              Format: ECdcStreamFormatProto
+            }
+        )");
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS(SplitTableResolvedTimestamps) {
+        SplitTable<T>(R"(
+            TableName: "Table"
+            StreamDescription {
+              Name: "Stream"
+              Mode: ECdcStreamModeKeysOnly
+              Format: ECdcStreamFormatProto
+              ResolvedTimestampsIntervalMs: 1000
+            }
+        )");
+    }
+
+    template <typename T>
+    void MergeTable(const TString& cdcStreamDesc) {
         T t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            NKikimrScheme::TEvDescribeSchemeResult initialTableDesc;
             {
                 TInactiveZone inactive(activeZone);
+
                 TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
                     Name: "Table"
                     Columns { Name: "key" Type: "Uint32" }
@@ -636,15 +666,9 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithRebootsTests) {
                     }
                 )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                initialTableDesc = DescribePath(runtime, "/MyRoot/Table", true, true);
 
-                TestCreateCdcStream(runtime, ++t.TxId, "/MyRoot", R"(
-                    TableName: "Table"
-                    StreamDescription {
-                      Name: "Stream"
-                      Mode: ECdcStreamModeKeysOnly
-                      Format: ECdcStreamFormatProto
-                    }
-                )");
+                TestCreateCdcStream(runtime, ++t.TxId, "/MyRoot", cdcStreamDesc);
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
@@ -657,9 +681,33 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithRebootsTests) {
             {
                 TInactiveZone inactive(activeZone);
                 UploadRows(runtime, "/MyRoot/Table", 0, {1}, {2}, {1, Max<ui32>()});
-                CheckRegistrations(runtime, {"/MyRoot/Table", 1}, {"/MyRoot/Table/Stream/streamImpl", 2});
+                CheckRegistrations(runtime, {"/MyRoot/Table", 1}, {"/MyRoot/Table/Stream/streamImpl", 2},
+                    &initialTableDesc.GetPathDescription().GetTablePartitions());
             }
         });
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS(MergeTable) {
+        MergeTable<T>(R"(
+            TableName: "Table"
+            StreamDescription {
+              Name: "Stream"
+              Mode: ECdcStreamModeKeysOnly
+              Format: ECdcStreamFormatProto
+            }
+        )");
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS(MergeTableResolvedTimestamps) {
+        MergeTable<T>(R"(
+            TableName: "Table"
+            StreamDescription {
+              Name: "Stream"
+              Mode: ECdcStreamModeKeysOnly
+              Format: ECdcStreamFormatProto
+              ResolvedTimestampsIntervalMs: 1000
+            }
+        )");
     }
 
     Y_UNIT_TEST_WITH_REBOOTS(RacySplitTableAndCreateStream) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- Fill change exchange split & activation lists just before commit.
- Add records to change queue at Execute() stage.
- Fix bug with broadcasting records.
- Continue to emit resolved timestamp after table merge.

### Changelog category <!-- remove all except one -->

* Bugfix

### Additional information

...
