### PR TITLE
Remove __func__ usage in templates

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
@@ -365,7 +365,7 @@ public:
     private:
         // copypaste to resolve -Woverloaded-virtual
         bool Next(NUdf::TUnboxedValue&) override {
-            this->ThrowNotSupported();
+            this->ThrowNotSupported(__FILE__, __LINE__);;
             return false;
         }
 
@@ -781,7 +781,7 @@ public:
     private:
         // copypaste to resolve -Woverloaded-virtual
         bool Next(NUdf::TUnboxedValue&) override {
-            this->ThrowNotSupported();
+            this->ThrowNotSupported(__FILE__, __LINE__);;
             return false;
         }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
@@ -365,7 +365,7 @@ public:
     private:
         // copypaste to resolve -Woverloaded-virtual
         bool Next(NUdf::TUnboxedValue&) override {
-            this->ThrowNotSupported(__func__);
+            this->ThrowNotSupported();
             return false;
         }
 
@@ -781,7 +781,7 @@ public:
     private:
         // copypaste to resolve -Woverloaded-virtual
         bool Next(NUdf::TUnboxedValue&) override {
-            this->ThrowNotSupported(__func__);
+            this->ThrowNotSupported();
             return false;
         }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_replicate.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_replicate.cpp
@@ -29,10 +29,10 @@ public:
                 if (Current < End) {
                     switch (Mode) {
                     case EDictItems::Payloads:
-                        this->ThrowNotSupported();
+                        this->ThrowNotSupported(__FILE__, __LINE__);;
                         break;
                     case EDictItems::Keys:
-                        this->ThrowNotSupported();
+                        this->ThrowNotSupported(__FILE__, __LINE__);;
                         break;
                     case EDictItems::Both:
                         key = NUdf::TUnboxedValuePod(ui64(Current));
@@ -57,7 +57,7 @@ public:
                         value = NUdf::TUnboxedValuePod(ui64(Current));
                         break;
                     case EDictItems::Both:
-                        this->ThrowNotSupported();
+                        this->ThrowNotSupported(__FILE__, __LINE__);;
                         break;
                     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_replicate.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_replicate.cpp
@@ -29,10 +29,10 @@ public:
                 if (Current < End) {
                     switch (Mode) {
                     case EDictItems::Payloads:
-                        this->ThrowNotSupported(__func__);
+                        this->ThrowNotSupported();
                         break;
                     case EDictItems::Keys:
-                        this->ThrowNotSupported(__func__);
+                        this->ThrowNotSupported();
                         break;
                     case EDictItems::Both:
                         key = NUdf::TUnboxedValuePod(ui64(Current));
@@ -57,7 +57,7 @@ public:
                         value = NUdf::TUnboxedValuePod(ui64(Current));
                         break;
                     case EDictItems::Both:
-                        this->ThrowNotSupported(__func__);
+                        this->ThrowNotSupported();
                         break;
                     }
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_impl.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_impl.cpp
@@ -5,9 +5,9 @@
 namespace NKikimr {
 namespace NMiniKQL {
 
-void ThrowNotSupportedImplForClass(const TString& className, const char *func) {
-    THROW yexception() << "Unsupported access to '" << func << "' method of: " << className;
-} 
+[[noreturn]] void ThrowNotSupportedImpl(const char *file, int line){
+    THROW yexception() << "Unsupported access " << file << ":" << line;
+}
 
 template <class IComputationNodeInterface>
 void TRefCountedComputationNode<IComputationNodeInterface>::Ref() {

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
@@ -1099,7 +1099,7 @@ public:
     }
 
 protected:
-    [[noreturn]] void ThrowNotSupported(const char* func) const {
+    [[noreturn]] void ThrowNotSupported() const {
 
         THROW yexception() << "Unsupported access";
     }

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
@@ -853,8 +853,7 @@ protected:
     }
 };
 
-[[noreturn]]
-void ThrowNotSupportedImplForClass(const TString& className, const char *func);
+[[noreturn]] void ThrowNotSupportedImpl(const char *file, int line);
 
 template <typename TDerived, typename TBaseExt = NYql::NUdf::IBoxedValue>
 class TComputationValueBase: public TBaseExt
@@ -873,22 +872,22 @@ public:
 
 private:
     bool HasFastListLength() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
     ui64 GetListLength() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return 0;
     }
 
     ui64 GetEstimatedListLength() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return 0;
     }
 
     bool HasListItems() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
@@ -919,22 +918,22 @@ private:
     }
 
     ui64 GetDictLength() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return 0;
     }
 
     bool HasDictItems() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
     NUdf::TStringRef GetResourceTag() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return NUdf::TStringRef();
     }
 
     void* GetResource() override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return nullptr;
     }
 
@@ -943,40 +942,40 @@ private:
     }
 
     NUdf::TUnboxedValue GetListIterator() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
     NUdf::TUnboxedValue GetDictIterator() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
     NUdf::TUnboxedValue GetKeysIterator() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
     NUdf::TUnboxedValue GetPayloadsIterator() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
     bool Contains(const NUdf::TUnboxedValuePod& key) const override {
         Y_UNUSED(key);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
     NUdf::TUnboxedValue Lookup(const NUdf::TUnboxedValuePod& key) const override {
         Y_UNUSED(key);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return NUdf::TUnboxedValuePod();
     }
 
     NUdf::TUnboxedValue GetElement(ui32 index) const override {
         Y_UNUSED(index);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
@@ -990,7 +989,7 @@ private:
     {
         Y_UNUSED(valueBuilder);
         Y_UNUSED(args);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
@@ -1000,96 +999,96 @@ private:
     }
 
     bool Next(NUdf::TUnboxedValue&) override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
     bool NextPair(NUdf::TUnboxedValue&, NUdf::TUnboxedValue&) override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
     ui32 GetVariantIndex() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return 0;
     }
 
     NUdf::TUnboxedValue GetVariantItem() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
     NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) override {
         Y_UNUSED(result);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return NUdf::EFetchStatus::Finish;
     }
 
     ui32 GetTraverseCount() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return 0;
     }
 
     NUdf::TUnboxedValue GetTraverseItem(ui32 index) const override {
         Y_UNUSED(index);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return {};
     }
 
     NUdf::TUnboxedValue Save() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return NUdf::TUnboxedValue::Zero();
     }
 
     void Load(const NUdf::TStringRef& state) override {
         Y_UNUSED(state);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     bool Load2(const NUdf::TUnboxedValue& state) override {
         Y_UNUSED(state);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
     void Push(const NUdf::TUnboxedValuePod& value) override {
         Y_UNUSED(value);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     bool IsSortedDict() const override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return false;
     }
 
     void Unused1() override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     void Unused2() override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     void Unused3() override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     void Unused4() override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     void Unused5() override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     void Unused6() override {
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
     }
 
     NUdf::EFetchStatus WideFetch(NUdf::TUnboxedValue* result, ui32 width) override {
         Y_UNUSED(result);
         Y_UNUSED(width);
-        ThrowNotSupported();
+        ThrowNotSupported(__FILE__, __LINE__);
         return NUdf::EFetchStatus::Finish;
     }
 
@@ -1099,9 +1098,8 @@ public:
     }
 
 protected:
-    [[noreturn]] void ThrowNotSupported() const {
-
-        THROW yexception() << "Unsupported access";
+    [[noreturn]] void ThrowNotSupported(const char *file, int line) const {
+        ThrowNotSupportedImpl(file, line);
     }
 };
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
@@ -873,22 +873,22 @@ public:
 
 private:
     bool HasFastListLength() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
     ui64 GetListLength() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return 0;
     }
 
     ui64 GetEstimatedListLength() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return 0;
     }
 
     bool HasListItems() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
@@ -919,22 +919,22 @@ private:
     }
 
     ui64 GetDictLength() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return 0;
     }
 
     bool HasDictItems() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
     NUdf::TStringRef GetResourceTag() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return NUdf::TStringRef();
     }
 
     void* GetResource() override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return nullptr;
     }
 
@@ -943,40 +943,40 @@ private:
     }
 
     NUdf::TUnboxedValue GetListIterator() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
     NUdf::TUnboxedValue GetDictIterator() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
     NUdf::TUnboxedValue GetKeysIterator() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
     NUdf::TUnboxedValue GetPayloadsIterator() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
     bool Contains(const NUdf::TUnboxedValuePod& key) const override {
         Y_UNUSED(key);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
     NUdf::TUnboxedValue Lookup(const NUdf::TUnboxedValuePod& key) const override {
         Y_UNUSED(key);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return NUdf::TUnboxedValuePod();
     }
 
     NUdf::TUnboxedValue GetElement(ui32 index) const override {
         Y_UNUSED(index);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
@@ -990,7 +990,7 @@ private:
     {
         Y_UNUSED(valueBuilder);
         Y_UNUSED(args);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
@@ -1000,96 +1000,96 @@ private:
     }
 
     bool Next(NUdf::TUnboxedValue&) override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
     bool NextPair(NUdf::TUnboxedValue&, NUdf::TUnboxedValue&) override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
     ui32 GetVariantIndex() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return 0;
     }
 
     NUdf::TUnboxedValue GetVariantItem() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
     NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) override {
         Y_UNUSED(result);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return NUdf::EFetchStatus::Finish;
     }
 
     ui32 GetTraverseCount() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return 0;
     }
 
     NUdf::TUnboxedValue GetTraverseItem(ui32 index) const override {
         Y_UNUSED(index);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return {};
     }
 
     NUdf::TUnboxedValue Save() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return NUdf::TUnboxedValue::Zero();
     }
 
     void Load(const NUdf::TStringRef& state) override {
         Y_UNUSED(state);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     bool Load2(const NUdf::TUnboxedValue& state) override {
         Y_UNUSED(state);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
     void Push(const NUdf::TUnboxedValuePod& value) override {
         Y_UNUSED(value);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     bool IsSortedDict() const override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return false;
     }
 
     void Unused1() override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     void Unused2() override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     void Unused3() override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     void Unused4() override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     void Unused5() override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     void Unused6() override {
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
     }
 
     NUdf::EFetchStatus WideFetch(NUdf::TUnboxedValue* result, ui32 width) override {
         Y_UNUSED(result);
         Y_UNUSED(width);
-        ThrowNotSupported(__func__);
+        ThrowNotSupported("foo");
         return NUdf::EFetchStatus::Finish;
     }
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
@@ -873,22 +873,22 @@ public:
 
 private:
     bool HasFastListLength() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
     ui64 GetListLength() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return 0;
     }
 
     ui64 GetEstimatedListLength() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return 0;
     }
 
     bool HasListItems() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
@@ -919,22 +919,22 @@ private:
     }
 
     ui64 GetDictLength() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return 0;
     }
 
     bool HasDictItems() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
     NUdf::TStringRef GetResourceTag() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return NUdf::TStringRef();
     }
 
     void* GetResource() override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return nullptr;
     }
 
@@ -943,40 +943,40 @@ private:
     }
 
     NUdf::TUnboxedValue GetListIterator() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
     NUdf::TUnboxedValue GetDictIterator() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
     NUdf::TUnboxedValue GetKeysIterator() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
     NUdf::TUnboxedValue GetPayloadsIterator() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
     bool Contains(const NUdf::TUnboxedValuePod& key) const override {
         Y_UNUSED(key);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
     NUdf::TUnboxedValue Lookup(const NUdf::TUnboxedValuePod& key) const override {
         Y_UNUSED(key);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return NUdf::TUnboxedValuePod();
     }
 
     NUdf::TUnboxedValue GetElement(ui32 index) const override {
         Y_UNUSED(index);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
@@ -990,7 +990,7 @@ private:
     {
         Y_UNUSED(valueBuilder);
         Y_UNUSED(args);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
@@ -1000,96 +1000,96 @@ private:
     }
 
     bool Next(NUdf::TUnboxedValue&) override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
     bool NextPair(NUdf::TUnboxedValue&, NUdf::TUnboxedValue&) override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
     ui32 GetVariantIndex() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return 0;
     }
 
     NUdf::TUnboxedValue GetVariantItem() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
     NUdf::EFetchStatus Fetch(NUdf::TUnboxedValue& result) override {
         Y_UNUSED(result);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return NUdf::EFetchStatus::Finish;
     }
 
     ui32 GetTraverseCount() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return 0;
     }
 
     NUdf::TUnboxedValue GetTraverseItem(ui32 index) const override {
         Y_UNUSED(index);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return {};
     }
 
     NUdf::TUnboxedValue Save() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return NUdf::TUnboxedValue::Zero();
     }
 
     void Load(const NUdf::TStringRef& state) override {
         Y_UNUSED(state);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     bool Load2(const NUdf::TUnboxedValue& state) override {
         Y_UNUSED(state);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
     void Push(const NUdf::TUnboxedValuePod& value) override {
         Y_UNUSED(value);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     bool IsSortedDict() const override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return false;
     }
 
     void Unused1() override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     void Unused2() override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     void Unused3() override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     void Unused4() override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     void Unused5() override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     void Unused6() override {
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
     }
 
     NUdf::EFetchStatus WideFetch(NUdf::TUnboxedValue* result, ui32 width) override {
         Y_UNUSED(result);
         Y_UNUSED(width);
-        ThrowNotSupported("foo");
+        ThrowNotSupported();
         return NUdf::EFetchStatus::Finish;
     }
 
@@ -1100,7 +1100,8 @@ public:
 
 protected:
     [[noreturn]] void ThrowNotSupported(const char* func) const {
-        ThrowNotSupportedImplForClass(TypeName(*this), func);
+
+        THROW yexception() << "Unsupported access;
     }
 };
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_impl.h
@@ -1101,7 +1101,7 @@ public:
 protected:
     [[noreturn]] void ThrowNotSupported(const char* func) const {
 
-        THROW yexception() << "Unsupported access;
+        THROW yexception() << "Unsupported access";
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Using `__func__` in templates bloats code in case of a lot of instantiations

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
