### PR TITLE
Simplier Y_ABORT in event local

### DIFF
--- a/ydb/library/actors/core/event_local.h
+++ b/ydb/library/actors/core/event_local.h
@@ -14,7 +14,7 @@ namespace NActors {
         }
 
         bool SerializeToArcadiaStream(TChunkSerializer* /*serializer*/) const override {
-            Y_ABORT("Serialization of local event %s type %" PRIu32, TypeName<TEv>().data(), TEventType);
+            Y_ABORT("Serialization of local event");
         }
 
         bool IsSerializable() const override {
@@ -22,7 +22,7 @@ namespace NActors {
         }
 
         static IEventBase* Load(TEventSerializedData*) {
-            Y_ABORT("Loading of local event %s type %" PRIu32, TypeName<TEv>().data(), TEventType);
+            Y_ABORT("Loading of local event");
         }
     };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Custom ABORTs are bloating code.

TEventLocal has a lot of instantiations. 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
