### PR TITLE
Grammar changes for antlr4 migration

### DIFF
--- a/ydb/library/yql/sql/v1/SQLv1.g.in
+++ b/ydb/library/yql/sql/v1/SQLv1.g.in
@@ -111,7 +111,7 @@ con_subexpr: unary_subexpr | unary_op unary_subexpr;
 
 unary_op: PLUS | MINUS | TILDA | NOT;
 
-unary_subexpr_suffix: (key_expr | invoke_expr |(DOT (bind_parameter | DIGITS | an_id_or_type)))* (COLLATE an_id)?;
+unary_subexpr_suffix: ((key_expr | invoke_expr | DOT (bind_parameter | DIGITS | an_id_or_type)))* (COLLATE an_id)?;
 
 unary_casual_subexpr: (id_expr | atom_expr) unary_subexpr_suffix;
 
@@ -171,7 +171,7 @@ exists_expr: EXISTS LPAREN (select_stmt | values_stmt) RPAREN;
 
 case_expr: CASE expr? when_expr+ (ELSE expr)? END;
 
-lambda: smart_parenthesis (ARROW ((LPAREN expr RPAREN) | (LBRACE_CURLY lambda_body RBRACE_CURLY)) )?;
+lambda: smart_parenthesis (ARROW (LPAREN expr RPAREN | LBRACE_CURLY lambda_body RBRACE_CURLY) )?;
 
 in_expr: in_unary_subexpr;
 
@@ -188,7 +188,7 @@ json_variables: json_variable (COMMA json_variable)*;
 
 json_common_args: expr COMMA jsonpath_spec (PASSING json_variables)?;
 
-json_case_handler: ERROR | NULL | (DEFAULT expr);
+json_case_handler: ERROR | NULL | DEFAULT expr;
 
 json_value: JSON_VALUE LPAREN
   json_common_args
@@ -203,7 +203,7 @@ json_exists: JSON_EXISTS LPAREN
   json_exists_handler?
 RPAREN;
 
-json_query_wrapper: (WITHOUT ARRAY?) | (WITH (CONDITIONAL | UNCONDITIONAL)? ARRAY?);
+json_query_wrapper: (WITHOUT ARRAY?) | WITH (CONDITIONAL | UNCONDITIONAL)? ARRAY?;
 json_query_handler: ERROR | NULL | (EMPTY ARRAY) | (EMPTY OBJECT);
 
 json_query: JSON_QUERY LPAREN
@@ -224,7 +224,7 @@ pure_column_or_named: bind_parameter | an_id;
 pure_column_or_named_list: LPAREN pure_column_or_named (COMMA pure_column_or_named)* RPAREN;
 
 column_name: opt_id_prefix an_id;
-without_column_name: (an_id DOT an_id) | an_id_without;
+without_column_name: an_id DOT an_id | an_id_without;
 
 column_list: column_name (COMMA column_name)* COMMA?;
 without_column_list: without_column_name (COMMA without_column_name)* COMMA?;
@@ -241,7 +241,7 @@ invoke_expr_tail:
     (null_treatment | filter_clause)? (OVER window_name_or_specification)?
 ;
 
-using_call_expr: ((an_id_or_type NAMESPACE an_id_or_type) | an_id_expr | bind_parameter | (EXTERNAL FUNCTION)) invoke_expr;
+using_call_expr: (an_id_or_type NAMESPACE an_id_or_type | an_id_expr | bind_parameter | (EXTERNAL FUNCTION)) invoke_expr;
 
 key_expr: LBRACE_SQUARE expr RBRACE_SQUARE;
 
@@ -519,7 +519,7 @@ hopping_window_specification: HOP LPAREN expr COMMA expr COMMA expr COMMA expr R
 
 result_column:
     opt_id_prefix ASTERISK
-  | expr ((AS an_id_or_type) | an_id_as_compat)?
+  | expr (AS an_id_or_type | an_id_as_compat)?
 ;
 
 join_source: ANY? flatten_source (join_op ANY? flatten_source join_constraint?)*;
@@ -533,7 +533,7 @@ flatten_by_arg:
 
 flatten_source: named_single_source (FLATTEN ((OPTIONAL|LIST|DICT)? BY flatten_by_arg | COLUMNS))?;
 
-named_single_source: single_source row_pattern_recognition_clause? (((AS an_id) | an_id_as_compat) pure_column_list?)? (sample_clause | tablesample_clause)?;
+named_single_source: single_source row_pattern_recognition_clause? ((AS an_id | an_id_as_compat) pure_column_list?)? (sample_clause | tablesample_clause)?;
 
 single_source:
     table_ref

--- a/ydb/library/yql/sql/v1/format/sql_format.cpp
+++ b/ydb/library/yql/sql/v1/format/sql_format.cpp
@@ -359,8 +359,8 @@ private:
     void VisitUnaryCasualSubexpr(const TRule_unary_casual_subexpr& msg) {
         bool invoke = false;
         for (auto& b : msg.GetRule_unary_subexpr_suffix2().GetBlock1()) {
-            switch (b.Alt_case()) {
-            case TRule_unary_subexpr_suffix::TBlock1::kAlt2: {
+            switch (b.GetBlock1().Alt_case()) {
+            case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt2: {
                 invoke = true;
                 break;
             }
@@ -385,8 +385,8 @@ private:
     void VisitInUnaryCasualSubexpr(const TRule_in_unary_casual_subexpr& msg) {
         bool invoke = false;
         for (auto& b : msg.GetRule_unary_subexpr_suffix2().GetBlock1()) {
-            switch (b.Alt_case()) {
-            case TRule_unary_subexpr_suffix::TBlock1::kAlt2: {
+            switch (b.GetBlock1().Alt_case()) {
+            case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt2: {
                 invoke = true;
                 break;
             }

--- a/ydb/library/yql/sql/v1/sql_call_expr.cpp
+++ b/ydb/library/yql/sql/v1/sql_call_expr.cpp
@@ -203,7 +203,7 @@ bool TSqlCallExpr::Init(const TRule_using_call_expr& node) {
     const auto& block = node.GetBlock1();
     switch (block.Alt_case()) {
         case TRule_using_call_expr::TBlock1::kAlt1: {
-            auto& subblock = block.GetAlt1().GetBlock1();
+            auto& subblock = block.GetAlt1();
             Module = Id(subblock.GetRule_an_id_or_type1(), *this);
             Func = Id(subblock.GetRule_an_id_or_type3(), *this);
             break;

--- a/ydb/library/yql/sql/v1/sql_expression.cpp
+++ b/ydb/library/yql/sql/v1/sql_expression.cpp
@@ -561,7 +561,7 @@ TNodePtr TSqlExpression::JsonValueCaseHandler(const TRule_json_case_handler& nod
         }
         case TRule_json_case_handler::kAltJsonCaseHandler3:
             mode = EJsonValueHandlerMode::DefaultValue;
-            return Build(node.GetAlt_json_case_handler3().GetBlock1().GetRule_expr2());
+            return Build(node.GetAlt_json_case_handler3().GetRule_expr2());
         case TRule_json_case_handler::ALT_NOT_SET:
             Y_ABORT("You should change implementation according to grammar changes");
     }
@@ -718,7 +718,7 @@ EJsonQueryWrap TSqlExpression::JsonQueryWrapper(const TRule_json_query& node) {
     }
 
     // WITH (CONDITIONAL | UNCONDITIONAL)? ARRAY? - wrapping depends on 2nd token. Default is UNCONDITIONAL
-    const auto& withWrapperRule = wrapperRule.GetAlt_json_query_wrapper2().GetBlock1();
+    const auto& withWrapperRule = wrapperRule.GetAlt_json_query_wrapper2();
     if (!withWrapperRule.HasBlock2()) {
         return EJsonQueryWrap::Wrap;
     }
@@ -838,13 +838,13 @@ TNodePtr MatchRecognizeVarAccess(TTranslation& ctx, const TString& var, const TR
     return BuildMatchRecognizeVarAccess(TPosition{}, var, column, theSameVar);
 }
 
-TNodePtr TSqlExpression::RowPatternVarAccess(const TString& alias, const TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2 block) {
+TNodePtr TSqlExpression::RowPatternVarAccess(const TString& alias, const TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2 block) {
     switch (block.GetAltCase()) {
-        case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::kAlt1:
+        case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::kAlt1:
             break;
-        case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::kAlt2:
+        case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::kAlt2:
             break;
-        case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::kAlt3:
+        case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::kAlt3:
             switch (block.GetAlt3().GetRule_an_id_or_type1().GetAltCase()) {
                 case TRule_an_id_or_type::kAltAnIdOrType1: {
                     const auto &idOrType = block.GetAlt3().GetRule_an_id_or_type1().GetAlt_an_id_or_type1().GetRule_id_or_type1();
@@ -869,7 +869,7 @@ TNodePtr TSqlExpression::RowPatternVarAccess(const TString& alias, const TRule_u
                     break;
             }
             break;
-        case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::ALT_NOT_SET:
+        case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::ALT_NOT_SET:
             Y_ABORT("You should change implementation according to grammar changes");
     }
     return TNodePtr{};
@@ -932,14 +932,15 @@ TNodePtr TSqlExpression::UnaryCasualExpr(const TUnaryCasualExprRule& node, const
     bool isColumnRef = !expr;
     bool isFirstElem = true;
 
-    for (auto& b : suffix.GetBlock1()) {
+    for (auto& _b : suffix.GetBlock1()) {
+        auto& b = _b.GetBlock1();
         switch (b.Alt_case()) {
-        case TRule_unary_subexpr_suffix::TBlock1::kAlt1: {
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt1: {
             // key_expr
             // onlyDots = false;
             break;
         }
-        case TRule_unary_subexpr_suffix::TBlock1::kAlt2: {
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt2: {
             // invoke_expr - cannot be a column, function name
             if (isFirstElem) {
                 isColumnRef = false;
@@ -948,20 +949,20 @@ TNodePtr TSqlExpression::UnaryCasualExpr(const TUnaryCasualExprRule& node, const
             // onlyDots = false;
             break;
         }
-        case TRule_unary_subexpr_suffix::TBlock1::kAlt3: {
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt3: {
             // In case of MATCH_RECOGNIZE lambdas
             // X.Y is treated as Var.Column access
             if (isColumnRef && EColumnRefState::MatchRecognize == Ctx.GetColumnReferenceState()) {
                 if (auto rowPatternVarAccess = RowPatternVarAccess(
                     name,
-                    b.GetAlt3().GetBlock1().GetBlock2())
+                    b.GetAlt3().GetBlock2())
                 ) {
                     return rowPatternVarAccess;
                 }
             }
             break;
         }
-        case TRule_unary_subexpr_suffix::TBlock1::ALT_NOT_SET:
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::ALT_NOT_SET:
             AltNotImplemented("unary_subexpr_suffix", b);
             return nullptr;
         }
@@ -1008,9 +1009,10 @@ TNodePtr TSqlExpression::UnaryCasualExpr(const TUnaryCasualExprRule& node, const
     }
 
     TPosition pos(Ctx.Pos());
-    for (auto& b : suffix.GetBlock1()) {
+    for (auto& _b : suffix.GetBlock1()) {
+        auto& b = _b.GetBlock1();
         switch (b.Alt_case()) {
-        case TRule_unary_subexpr_suffix::TBlock1::kAlt1: {
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt1: {
             // key_expr
             auto keyExpr = KeyExpr(b.GetAlt1().GetRule_key_expr1());
             if (!keyExpr) {
@@ -1029,7 +1031,7 @@ TNodePtr TSqlExpression::UnaryCasualExpr(const TUnaryCasualExprRule& node, const
             ids.clear();
             break;
         }
-        case TRule_unary_subexpr_suffix::TBlock1::kAlt2: {
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt2: {
             // invoke_expr - cannot be a column, function name
             TSqlCallExpr call(Ctx, Mode);
             if (isFirstElem && !name.Empty()) {
@@ -1055,15 +1057,15 @@ TNodePtr TSqlExpression::UnaryCasualExpr(const TUnaryCasualExprRule& node, const
 
             break;
         }
-        case TRule_unary_subexpr_suffix::TBlock1::kAlt3: {
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::kAlt3: {
             // dot
             if (lastExpr) {
                 ids.push_back(lastExpr);
             }
 
-            auto bb = b.GetAlt3().GetBlock1().GetBlock2();
+            auto bb = b.GetAlt3().GetBlock2();
             switch (bb.Alt_case()) {
-                case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::kAlt1: {
+                case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::kAlt1: {
                     TString named;
                     if (!NamedNodeImpl(bb.GetAlt1().GetRule_bind_parameter1(), named, *this)) {
                         return nullptr;
@@ -1077,16 +1079,16 @@ TNodePtr TSqlExpression::UnaryCasualExpr(const TUnaryCasualExprRule& node, const
                     ids.back().Expr = namedNode;
                     break;
                 }
-                case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::kAlt2: {
+                case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::kAlt2: {
                     const TString str(Token(bb.GetAlt2().GetToken1()));
                     ids.push_back(str);
                     break;
                 }
-                case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::kAlt3: {
+                case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::kAlt3: {
                     ids.push_back(Id(bb.GetAlt3().GetRule_an_id_or_type1(), *this));
                     break;
                 }
-                case TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2::ALT_NOT_SET:
+                case TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2::ALT_NOT_SET:
                     Y_ABORT("You should change implementation according to grammar changes");
             }
 
@@ -1097,7 +1099,7 @@ TNodePtr TSqlExpression::UnaryCasualExpr(const TUnaryCasualExprRule& node, const
 
             break;
         }
-        case TRule_unary_subexpr_suffix::TBlock1::ALT_NOT_SET:
+        case TRule_unary_subexpr_suffix::TBlock1::TBlock1::ALT_NOT_SET:
             AltNotImplemented("unary_subexpr_suffix", b);
             return nullptr;
         }
@@ -1175,9 +1177,9 @@ TNodePtr TSqlExpression::LambdaRule(const TRule_lambda& rule) {
     TColumnRefScope scope(Ctx, EColumnRefState::Deny);
     scope.SetNoColumnErrContext("in lambda function");
     if (bodyBlock.GetBlock2().HasAlt1()) {
-        ret = SqlLambdaExprBody(Ctx, bodyBlock.GetBlock2().GetAlt1().GetBlock1().GetRule_expr2(), exprSeq);
+        ret = SqlLambdaExprBody(Ctx, bodyBlock.GetBlock2().GetAlt1().GetRule_expr2(), exprSeq);
     } else {
-        ret = SqlLambdaExprBody(Ctx, bodyBlock.GetBlock2().GetAlt2().GetBlock1().GetRule_lambda_body2(), exprSeq);
+        ret = SqlLambdaExprBody(Ctx, bodyBlock.GetBlock2().GetAlt2().GetRule_lambda_body2(), exprSeq);
     }
 
     TVector<TString> argNames;

--- a/ydb/library/yql/sql/v1/sql_expression.h
+++ b/ydb/library/yql/sql/v1/sql_expression.h
@@ -108,7 +108,7 @@ private:
 
     TNodePtr BinOperList(const TString& opName, TVector<TNodePtr>::const_iterator begin, TVector<TNodePtr>::const_iterator end) const;
 
-    TNodePtr RowPatternVarAccess(const TString& alias, const TRule_unary_subexpr_suffix_TBlock1_TAlt3_TBlock1_TBlock2 block);
+    TNodePtr RowPatternVarAccess(const TString& alias, const TRule_unary_subexpr_suffix_TBlock1_TBlock1_TAlt3_TBlock2 block);
 
     struct TCaseBranch {
         TNodePtr Pred;

--- a/ydb/library/yql/sql/v1/sql_select.cpp
+++ b/ydb/library/yql/sql/v1/sql_select.cpp
@@ -410,7 +410,7 @@ bool TSqlSelect::SelectTerm(TVector<TNodePtr>& terms, const TRule_result_column&
                 bool implicitLabel = false;
                 switch (alt.GetBlock2().Alt_case()) {
                     case TRule_result_column_TAlt2_TBlock2::kAlt1:
-                        label = Id(alt.GetBlock2().GetAlt1().GetBlock1().GetRule_an_id_or_type2(), *this);
+                        label = Id(alt.GetBlock2().GetAlt1().GetRule_an_id_or_type2(), *this);
                         break;
                     case TRule_result_column_TAlt2_TBlock2::kAlt2:
                         label = Id(alt.GetBlock2().GetAlt2().GetRule_an_id_as_compat1(), *this);
@@ -564,7 +564,7 @@ TSourcePtr TSqlSelect::NamedSingleSource(const TRule_named_single_source& node, 
         TString label;
         switch (node.GetBlock3().GetBlock1().Alt_case()) {
             case TRule_named_single_source_TBlock3_TBlock1::kAlt1:
-                label = Id(node.GetBlock3().GetBlock1().GetAlt1().GetBlock1().GetRule_an_id2(), *this);
+                label = Id(node.GetBlock3().GetBlock1().GetAlt1().GetRule_an_id2(), *this);
                 break;
             case TRule_named_single_source_TBlock3_TBlock1::kAlt2:
                 label = Id(node.GetBlock3().GetBlock1().GetAlt2().GetRule_an_id_as_compat1(), *this);
@@ -663,8 +663,8 @@ bool TSqlSelect::ColumnName(TVector<TNodePtr>& keys, const TRule_without_column_
     TString columnName;
     switch (node.Alt_case()) {
         case TRule_without_column_name::kAltWithoutColumnName1:
-            sourceName = Id(node.GetAlt_without_column_name1().GetBlock1().GetRule_an_id1(), *this);
-            columnName = Id(node.GetAlt_without_column_name1().GetBlock1().GetRule_an_id3(), *this);
+            sourceName = Id(node.GetAlt_without_column_name1().GetRule_an_id1(), *this);
+            columnName = Id(node.GetAlt_without_column_name1().GetRule_an_id3(), *this);
             break;
         case TRule_without_column_name::kAltWithoutColumnName2:
             columnName = Id(node.GetAlt_without_column_name2().GetRule_an_id_without1(), *this);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Few changes in grammar for better antlr4 backward compatibility.

### Changelog category <!-- remove all except one -->

* Backward incompatible change

### Additional information

Related issue: #6797
