### PR TITLE
fix neighbours count (#6409)

### DIFF
--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -132,7 +132,11 @@ public:
     ui32 GetTabletNeighboursCount(const TTabletInfo& tablet) const {
         auto it = TabletsOfObject.find(tablet.GetObjectId());
         if (it != TabletsOfObject.end()) {
-            return it->second.size();
+            auto count = it->second.size();
+            if (tablet.IsAliveOnLocal(Local)) {
+                --count;
+            }
+            return count;
         } else {
             return 0;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

fix a bug where a tablet was considered its own "neighbour", which made the current node always less favorable and could lead to unnecessary tablet moves

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Backport of https://github.com/ydb-platform/ydb/pull/6409
