### PR TITLE
YQ-3439 added retries for CURLE_COULDNT_RESOLVE_HOST

### DIFF
--- a/ydb/core/external_sources/object_storage.cpp
+++ b/ydb/core/external_sources/object_storage.cpp
@@ -304,7 +304,8 @@ struct TObjectStorageExternalSource : public IExternalSource {
         }
 
         auto httpGateway = NYql::IHTTPGateway::Make();
-        auto s3Lister = NYql::NS3Lister::MakeS3Lister(httpGateway, NYql::NS3Lister::TListingRequest{
+        auto httpRetryPolicy = NYql::GetHTTPDefaultRetryPolicy(NYql::THttpRetryPolicyOptions{.RetriedCurlCodes = NYql::FqRetriedCurlCodes()});
+        auto s3Lister = NYql::NS3Lister::MakeS3Lister(httpGateway, httpRetryPolicy, NYql::NS3Lister::TListingRequest{
             .Url = meta->DataSourceLocation,
             .AuthInfo = authInfo,
             .Pattern = meta->TableLocation,

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1518,6 +1518,7 @@ private:
         state->Configuration->AllowAtomicUploadCommit = queryType == EKikimrQueryType::Script;
         state->Configuration->Init(FederatedQuerySetup->S3GatewayConfig, TypesCtx);
         state->Gateway = FederatedQuerySetup->HttpGateway;
+        state->GatewayRetryPolicy = NYql::GetHTTPDefaultRetryPolicy(NYql::THttpRetryPolicyOptions{.RetriedCurlCodes = NYql::FqRetriedCurlCodes()});
         state->ExecutorPoolId = AppData()->UserPoolId;
 
         auto dataSource = NYql::CreateS3DataSource(state);

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -29,7 +29,8 @@ std::unordered_set<CURLcode> FqRetriedCurlCodes() {
         CURLE_SEND_ERROR,
         CURLE_RECV_ERROR,
         CURLE_NO_CONNECTION_AVAILABLE,
-        CURLE_GOT_NOTHING
+        CURLE_GOT_NOTHING,
+        CURLE_COULDNT_RESOLVE_HOST
     };
 }
 

--- a/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_raw_read_actor.cpp
@@ -111,6 +111,7 @@ public:
                 FileQueueBatchSizeLimit,
                 FileQueueBatchObjectCountLimit,
                 Gateway,
+                RetryPolicy,
                 Url,
                 AuthInfo,
                 Pattern,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -1315,6 +1315,7 @@ public:
                 FileQueueBatchSizeLimit,
                 FileQueueBatchObjectCountLimit,
                 Gateway,
+                RetryPolicy,
                 Url,
                 AuthInfo,
                 Pattern,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.h
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.h
@@ -25,6 +25,7 @@ NActors::IActor* CreateS3FileQueueActor(
         ui64 batchSizeLimit,
         ui64 batchObjectCountLimit,
         IHTTPGateway::TPtr gateway,
+        IHTTPGateway::TRetryPolicy::TPtr retryPolicy,
         TString url,
         TS3Credentials::TAuthInfo authInfo,
         TString pattern,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.cpp
@@ -171,6 +171,7 @@ public:
         ui64 batchSizeLimit,
         ui64 batchObjectCountLimit,
         IHTTPGateway::TPtr gateway,
+        IHTTPGateway::TRetryPolicy::TPtr retryPolicy,
         TString url,
         TS3Credentials::TAuthInfo authInfo,
         TString pattern,
@@ -186,6 +187,7 @@ public:
         , BatchSizeLimit(batchSizeLimit)
         , BatchObjectCountLimit(batchObjectCountLimit)
         , Gateway(std::move(gateway))
+        , RetryPolicy(std::move(retryPolicy))
         , Url(std::move(url))
         , AuthInfo(std::move(authInfo))
         , Pattern(std::move(pattern))
@@ -488,6 +490,7 @@ private:
             CurrentDirectoryPathIndex = object.GetPathIndex();
             MaybeLister = NS3Lister::MakeS3Lister(
                 Gateway,
+                RetryPolicy,
                 NS3Lister::TListingRequest{
                     Url,
                     AuthInfo,
@@ -611,6 +614,7 @@ private:
     THashSet<NActors::TActorId> UpdatedConsumers;
 
     const IHTTPGateway::TPtr Gateway;
+    const IHTTPGateway::TRetryPolicy::TPtr RetryPolicy;
     const TString Url;
     const TS3Credentials::TAuthInfo AuthInfo;
     const TString Pattern;
@@ -632,6 +636,7 @@ NActors::IActor* CreateS3FileQueueActor(
         ui64 batchSizeLimit,
         ui64 batchObjectCountLimit,
         IHTTPGateway::TPtr gateway,
+        IHTTPGateway::TRetryPolicy::TPtr retryPolicy,
         TString url,
         TS3Credentials::TAuthInfo authInfo,
         TString pattern,
@@ -648,6 +653,7 @@ NActors::IActor* CreateS3FileQueueActor(
         batchSizeLimit,
         batchObjectCountLimit,
         gateway,
+        retryPolicy,
         url,
         authInfo,
         pattern,

--- a/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.h
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.h
@@ -22,6 +22,7 @@ NActors::IActor* CreateS3FileQueueActor(
         ui64 batchSizeLimit,
         ui64 batchObjectCountLimit,
         IHTTPGateway::TPtr gateway,
+        IHTTPGateway::TRetryPolicy::TPtr retryPolicy,
         TString url,
         TS3Credentials::TAuthInfo authInfo,
         TString pattern,

--- a/ydb/library/yql/providers/s3/object_listers/yql_s3_list.h
+++ b/ydb/library/yql/providers/s3/object_listers/yql_s3_list.h
@@ -165,6 +165,7 @@ public:
 
 IS3Lister::TPtr MakeS3Lister(
     const IHTTPGateway::TPtr& httpGateway,
+    const IHTTPGateway::TRetryPolicy::TPtr& retryPolicy,
     const TListingRequest& listingRequest,
     const TMaybe<TString>& delimiter,
     bool allowLocalFiles,
@@ -176,6 +177,7 @@ public:
 
     virtual NThreading::TFuture<NS3Lister::IS3Lister::TPtr> Make(
         const IHTTPGateway::TPtr& httpGateway,
+        const IHTTPGateway::TRetryPolicy::TPtr& retryPolicy,
         const NS3Lister::TListingRequest& listingRequest,
         const TMaybe<TString>& delimiter,
         bool allowLocalFiles) = 0;

--- a/ydb/library/yql/providers/s3/provider/yql_s3_dq_integration.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_dq_integration.cpp
@@ -511,6 +511,7 @@ public:
                         fileQueueBatchSizeLimit,
                         fileQueueBatchObjectCountLimit,
                         State_->Gateway,
+                        State_->GatewayRetryPolicy,
                         connect.Url,
                         GetAuthInfo(State_->CredentialsFactory, State_->Configuration->Tokens.at(cluster)),
                         pathPattern,

--- a/ydb/library/yql/providers/s3/provider/yql_s3_io_discovery.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_io_discovery.cpp
@@ -88,6 +88,7 @@ public:
               State_->Configuration->RegexpCacheSize))
         , ListingStrategy_(MakeS3ListingStrategy(
               State_->Gateway,
+              State_->GatewayRetryPolicy,
               ListerFactory_,
               State_->Configuration->MinDesiredDirectoriesOfFilesPerQuery,
               State_->Configuration->MaxInflightListsPerQuery,

--- a/ydb/library/yql/providers/s3/provider/yql_s3_listing_strategy.h
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_listing_strategy.h
@@ -31,6 +31,7 @@ public:
 
 IS3ListingStrategy::TPtr MakeS3ListingStrategy(
     const IHTTPGateway::TPtr& httpGateway,
+    const IHTTPGateway::TRetryPolicy::TPtr& retryPolicy,
     const NS3Lister::IS3ListerFactory::TPtr& listerFactory,
     ui64 minDesiredDirectoriesOfFilesPerQuery,
     size_t maxParallelOps,

--- a/ydb/library/yql/providers/s3/provider/yql_s3_provider.h
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_provider.h
@@ -2,6 +2,7 @@
 
 #include <ydb/library/yql/core/yql_data_provider.h>
 #include <ydb/library/yql/providers/common/token_accessor/client/factory.h>
+#include <ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 
 #include "yql_s3_settings.h"
@@ -28,6 +29,7 @@ struct TS3State : public TThrRefBase
     const NKikimr::NMiniKQL::IFunctionRegistry* FunctionRegistry = nullptr;
     ISecuredServiceAccountCredentialsFactory::TPtr CredentialsFactory;
     IHTTPGateway::TPtr Gateway;
+    IHTTPGateway::TRetryPolicy::TPtr GatewayRetryPolicy = GetHTTPDefaultRetryPolicy();
     ui32 ExecutorPoolId = 0;
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Added retries for CURLE_COULDNT_RESOLVE_HOST

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

* Added retries for CURLE_COULDNT_RESOLVE_HOST into fq retry policy
* Passed fq retry policy into s3 listers
