### PR TITLE
YQ-3345 support load cpu threshold

### DIFF
--- a/ydb/core/fq/libs/compute/ydb/control_plane/database_monitoring.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/database_monitoring.cpp
@@ -1,6 +1,8 @@
 #include <ydb/core/fq/libs/compute/ydb/events/events.h>
 #include <ydb/core/fq/libs/control_plane_storage/util.h>
 
+#include <ydb/core/kqp/workload_service/common/cpu_quota_manager.h>
+
 #include <ydb/library/services/services.pb.h>
 
 #include <ydb/library/security/ydb_credentials_provider_factory.h>
@@ -24,17 +26,9 @@ namespace NFq {
 class TComputeDatabaseMonitoringActor : public NActors::TActorBootstrapped<TComputeDatabaseMonitoringActor> {
     struct TCounters {
         ::NMonitoring::TDynamicCounterPtr Counters;
-        struct TCommonMetrics {
-            ::NMonitoring::TDynamicCounters::TCounterPtr Ok;
-            ::NMonitoring::TDynamicCounters::TCounterPtr Error;
-            ::NMonitoring::THistogramPtr LatencyMs;
-        };
+        ::NMonitoring::TDynamicCounterPtr SubComponent;
 
-        TCommonMetrics CpuLoadRequest;
-        ::NMonitoring::TDynamicCounters::TCounterPtr InstantLoadPercentage;
-        ::NMonitoring::TDynamicCounters::TCounterPtr AverageLoadPercentage;
-        ::NMonitoring::TDynamicCounters::TCounterPtr QuotedLoadPercentage;
-        ::NMonitoring::TDynamicCounters::TCounterPtr AvailableLoadPercentage;
+        ::NMonitoring::THistogramPtr CpuLoadRequestLatencyMs;
         ::NMonitoring::TDynamicCounters::TCounterPtr TargetLoadPercentage;
         ::NMonitoring::TDynamicCounters::TCounterPtr PendingQueueSize;
         ::NMonitoring::TDynamicCounters::TCounterPtr PendingQueueOverload;
@@ -48,21 +42,11 @@ class TComputeDatabaseMonitoringActor : public NActors::TActorBootstrapped<TComp
     private:
         void Register() {
             ::NMonitoring::TDynamicCounterPtr component = Counters->GetSubgroup("component", "ComputeDatabaseMonitoring");
-            auto subComponent = component->GetSubgroup("subcomponent", "CpuLoadRequest");
-            RegisterCommonMetrics(CpuLoadRequest, subComponent);
-            InstantLoadPercentage = subComponent->GetCounter("InstantLoadPercentage", false);
-            AverageLoadPercentage = subComponent->GetCounter("AverageLoadPercentage", false);
-            QuotedLoadPercentage = subComponent->GetCounter("QuotedLoadPercentage", false);
-            AvailableLoadPercentage = subComponent->GetCounter("AvailableLoadPercentage", false);
-            TargetLoadPercentage = subComponent->GetCounter("TargetLoadPercentage", false);
-            PendingQueueSize = subComponent->GetCounter("PendingQueueSize", false);
-            PendingQueueOverload = subComponent->GetCounter("PendingQueueOverload", true);
-        }
-
-        void RegisterCommonMetrics(TCommonMetrics& metrics, ::NMonitoring::TDynamicCounterPtr subComponent) {
-            metrics.Ok = subComponent->GetCounter("Ok", true);
-            metrics.Error = subComponent->GetCounter("Error", true);
-            metrics.LatencyMs = subComponent->GetHistogram("LatencyMs", GetLatencyHistogramBuckets());
+            SubComponent = component->GetSubgroup("subcomponent", "CpuLoadRequest");
+            CpuLoadRequestLatencyMs = SubComponent->GetHistogram("LatencyMs", GetLatencyHistogramBuckets());
+            TargetLoadPercentage = SubComponent->GetCounter("TargetLoadPercentage", false);
+            PendingQueueSize = SubComponent->GetCounter("PendingQueueSize", false);
+            PendingQueueOverload = SubComponent->GetCounter("PendingQueueOverload", true);
         }
 
         static ::NMonitoring::IHistogramCollectorPtr GetLatencyHistogramBuckets() {
@@ -75,15 +59,19 @@ public:
     TComputeDatabaseMonitoringActor(const TActorId& monitoringClientActorId, NFq::NConfig::TLoadControlConfig config, const ::NMonitoring::TDynamicCounterPtr& counters)
         : MonitoringClientActorId(monitoringClientActorId)
         , Counters(counters)
-        , MonitoringRequestDelay(GetDuration(config.GetMonitoringRequestDelay(), TDuration::Seconds(1)))
-        , AverageLoadInterval(std::max<TDuration>(GetDuration(config.GetAverageLoadInterval(), TDuration::Seconds(10)), TDuration::Seconds(1)))
         , MaxClusterLoad(std::min<ui32>(config.GetMaxClusterLoadPercentage(), 100) / 100.0)
-        , DefaultQueryLoad(config.GetDefaultQueryLoadPercentage() ? std::min<ui32>(config.GetDefaultQueryLoadPercentage(), 100) / 100.0 : 0.1)
         , PendingQueueSize(config.GetPendingQueueSize())
         , Strict(config.GetStrict())
-        , CpuNumber(config.GetCpuNumber())
+        , CpuQuotaManager(
+            GetDuration(config.GetMonitoringRequestDelay(), TDuration::Seconds(1)),
+            std::max<TDuration>(GetDuration(config.GetAverageLoadInterval(), TDuration::Seconds(10)), TDuration::Seconds(1)),
+            TDuration::Zero(),
+            config.GetDefaultQueryLoadPercentage() ? std::min<ui32>(config.GetDefaultQueryLoadPercentage(), 100) / 100.0 : 0.1,
+            config.GetStrict(),
+            config.GetCpuNumber(),
+            Counters.SubComponent
+        )
     {
-        *Counters.AvailableLoadPercentage = 100;
         *Counters.TargetLoadPercentage = static_cast<ui64>(MaxClusterLoad * 100);
     }
 
@@ -105,8 +93,8 @@ public:
     )
 
     void Handle(TEvYdbCompute::TEvCpuLoadRequest::TPtr& ev) {
-        auto response = std::make_unique<TEvYdbCompute::TEvCpuLoadResponse>(InstantLoad, AverageLoad);
-        if (!Ready) {
+        auto response = std::make_unique<TEvYdbCompute::TEvCpuLoadResponse>(CpuQuotaManager.GetInstantLoad(), CpuQuotaManager.GetAverageLoad());
+        if (!CpuQuotaManager.CheckLoadIsOutdated()) {
             response->Issues.AddIssue("CPU Load is unavailable");
         }
         Send(ev->Sender, response.release(), 0, ev->Cookie);
@@ -114,45 +102,20 @@ public:
 
     void Handle(TEvYdbCompute::TEvCpuLoadResponse::TPtr& ev) {
         const auto& response = *ev.Get()->Get();
-
-        auto now = TInstant::Now();
-        if (!response.Issues) {
-            auto delta = now - LastCpuLoad;
-            LastCpuLoad = now;
-
-            if (response.CpuNumber) {
-                CpuNumber = response.CpuNumber;
-            }
-
-            InstantLoad = response.InstantLoad;
-            // exponential moving average
-            if (!Ready || delta >= AverageLoadInterval) {
-                AverageLoad = InstantLoad;
-                QuotedLoad = InstantLoad;
-            } else {
-                auto ratio = static_cast<double>(delta.GetValue()) / AverageLoadInterval.GetValue();
-                AverageLoad = (1 - ratio) * AverageLoad + ratio * InstantLoad;
-                QuotedLoad = (1 - ratio) * QuotedLoad + ratio * InstantLoad;
-            }
-            Ready = true;
-            Counters.CpuLoadRequest.Ok->Inc();
-            *Counters.InstantLoadPercentage = static_cast<ui64>(InstantLoad * 100);
-            *Counters.AverageLoadPercentage = static_cast<ui64>(AverageLoad * 100);
-            CheckPendingQueue();
-            *Counters.QuotedLoadPercentage = static_cast<ui64>(QuotedLoad * 100);
-        } else {
+        if (response.Issues) {
             LOG_E("CPU Load Request FAILED: " << response.Issues.ToOneLineString());
-            Counters.CpuLoadRequest.Error->Inc();
-            CheckLoadIsOutdated();
         }
-        Counters.CpuLoadRequest.LatencyMs->Collect((now - StartCpuLoad).MilliSeconds());
+        Counters.CpuLoadRequestLatencyMs->Collect((TInstant::Now() - StartCpuLoad).MilliSeconds());
+
+        CpuQuotaManager.UpdateCpuLoad(response.InstantLoad, response.CpuNumber, !response.Issues);
+        CheckPendingQueue();
 
         // TODO: make load pulling reactive
         // 1. Long period (i.e. AverageLoadInterval/2) when idle (no requests)
         // 2. Active pulling when busy
 
-        if (MonitoringRequestDelay) {
-            Schedule(MonitoringRequestDelay, new NActors::TEvents::TEvWakeup());
+        if (auto delay = CpuQuotaManager.GetMonitoringRequestDelay()) {
+            Schedule(delay, new NActors::TEvents::TEvWakeup());
         } else {
             SendCpuLoadRequest();
         }
@@ -164,48 +127,24 @@ public:
         if (request.Quota > 1.0) {
             Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(-1, NYdb::EStatus::OVERLOADED, NYql::TIssues{NYql::TIssue{TStringBuilder{} << "Incorrect quota value (exceeds 1.0) " << request.Quota}}), 0, ev->Cookie);
         } else {
-            if (!request.Quota) {
-                request.Quota = DefaultQueryLoad;
-            }
-            CheckLoadIsOutdated();
-            if (MaxClusterLoad > 0.0 && ((!Ready && Strict) || QuotedLoad >= MaxClusterLoad)) {
-                if (PendingQueue.size() >= PendingQueueSize) {
-                    Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(-1, NYdb::EStatus::OVERLOADED, NYql::TIssues{
-                        NYql::TIssue{TStringBuilder{}
-                        << "Cluster is overloaded, current quoted load " << static_cast<ui64>(QuotedLoad * 100)
-                        << "%, average load " << static_cast<ui64>(AverageLoad * 100) << "%"
-                        }}), 0, ev->Cookie);
-                    Counters.PendingQueueOverload->Inc();
-                } else {
-                    PendingQueue.push(ev);
-                    Counters.PendingQueueSize->Inc();
-                }
+            auto response = CpuQuotaManager.RequestCpuQuota(request.Quota, MaxClusterLoad);
+            CheckPendingQueue();
+            if (response.Status == NYdb::EStatus::OVERLOADED && PendingQueue.size() < PendingQueueSize) {
+                PendingQueue.push(ev);
+                Counters.PendingQueueSize->Inc();
             } else {
-                QuotedLoad += request.Quota;
-                *Counters.QuotedLoadPercentage = static_cast<ui64>(QuotedLoad * 100);
-                Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(QuotedLoad * 100), 0, ev->Cookie);
+                if (response.Status == NYdb::EStatus::OVERLOADED) {
+                    Counters.PendingQueueOverload->Inc();
+                }
+                Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(response.CurrentLoad, response.Status, response.Issues), 0, ev->Cookie);
             }
         }
     }
 
     void Handle(TEvYdbCompute::TEvCpuQuotaAdjust::TPtr& ev) {
-        if (CpuNumber) {
-            auto& request = *ev.Get()->Get();
-            if (request.Duration && request.Duration < AverageLoadInterval / 2 && request.Quota <= 1.0) {
-                auto load = (request.CpuSecondsConsumed * 1000 / request.Duration.MilliSeconds()) / CpuNumber;
-                auto quota = request.Quota ? request.Quota : DefaultQueryLoad;
-                if (quota > load) {
-                    auto adjustment = (quota - load) / 2;
-                    if (QuotedLoad > adjustment) {
-                        QuotedLoad -= adjustment;
-                    } else {
-                        QuotedLoad = 0.0;
-                    }
-                    CheckPendingQueue();
-                    *Counters.QuotedLoadPercentage = static_cast<ui64>(QuotedLoad * 100);
-                }
-            }
-        }
+        auto& request = *ev.Get()->Get();
+        CpuQuotaManager.AdjustCpuQuota(request.Quota, request.Duration, request.CpuSecondsConsumed);
+        CheckPendingQueue();
     }
 
     void SendCpuLoadRequest() {
@@ -215,57 +154,51 @@ public:
 
     void CheckLoadIsOutdated() {
         // TODO: support timeout to decline quota after request pending time is over, not load info
-        if (TInstant::Now() - LastCpuLoad > AverageLoadInterval) {
-            Ready = false;
-            QuotedLoad = 0.0;
-            if (Strict) {
-                while (PendingQueue.size()) {
-                    auto& ev = PendingQueue.front();
-                    Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(-1, NYdb::EStatus::OVERLOADED, NYql::TIssues{NYql::TIssue{TStringBuilder{} << "Cluster load info is not available"}}), 0, ev->Cookie);
-                    PendingQueue.pop();
-                    Counters.PendingQueueSize->Dec();
-                }
+        if (Strict && !CpuQuotaManager.CheckLoadIsOutdated()) {
+            while (PendingQueue.size()) {
+                auto& ev = PendingQueue.front();
+                Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(-1, NYdb::EStatus::OVERLOADED, NYql::TIssues{NYql::TIssue{TStringBuilder{} << "Cluster load info is not available"}}), 0, ev->Cookie);
+                PendingQueue.pop();
+                Counters.PendingQueueSize->Dec();
             }
         }
     }
 
     void CheckPendingQueue() {
+        CheckLoadIsOutdated();
+
         auto now = TInstant::Now();
-        while (QuotedLoad < MaxClusterLoad && PendingQueue.size()) {
+        while (PendingQueue.size()) {
             auto& ev = PendingQueue.front();
             auto& request = *ev.Get()->Get();
             if (request.Deadline && now >= request.Deadline) {
                 Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(-1, NYdb::EStatus::CANCELLED, NYql::TIssues{
                     NYql::TIssue{TStringBuilder{} << "Deadline reached " << request.Deadline}}), 0, ev->Cookie);
             } else {
-                QuotedLoad += request.Quota;
-                Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(QuotedLoad * 100), 0, ev->Cookie);
+                auto response = CpuQuotaManager.RequestCpuQuota(request.Quota, MaxClusterLoad);
+                if (response.Status == NYdb::EStatus::OVERLOADED) {
+                    break;
+                }
+
+                Send(ev->Sender, new TEvYdbCompute::TEvCpuQuotaResponse(response.CurrentLoad, response.Status, response.Issues), 0, ev->Cookie);
             }
+
             PendingQueue.pop();
             Counters.PendingQueueSize->Dec();
         }
     }
 
 private:
-    TInstant StartCpuLoad;
-    TInstant LastCpuLoad;
     TActorId MonitoringClientActorId;
     TCounters Counters;
-
-    double InstantLoad = 0.0;
-    double AverageLoad = 0.0;
-    double QuotedLoad = 0.0;
-    bool Ready = false;
-
-    const TDuration MonitoringRequestDelay;
-    const TDuration AverageLoadInterval;
     const double MaxClusterLoad;
-    const double DefaultQueryLoad;
     const ui32 PendingQueueSize;
     const bool Strict;
-    ui32 CpuNumber = 0;
 
+    NKikimr::NKqp::NWorkload::TCpuQuotaManager CpuQuotaManager;
     TQueue<TEvYdbCompute::TEvCpuQuotaRequest::TPtr> PendingQueue;
+
+    TInstant StartCpuLoad;
 };
 
 std::unique_ptr<NActors::IActor> CreateDatabaseMonitoringActor(const NActors::TActorId& monitoringClientActorId, NFq::NConfig::TLoadControlConfig config, const ::NMonitoring::TDynamicCounterPtr& counters) {

--- a/ydb/core/fq/libs/compute/ydb/control_plane/ya.make
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     ydb/core/fq/libs/compute/ydb/synchronization_service
     ydb/core/fq/libs/control_plane_storage/proto
     ydb/core/fq/libs/quota_manager/proto
+    ydb/core/kqp/workload_service/common
     ydb/core/protos
     ydb/library/db_pool/protos
     ydb/library/yql/public/issue

--- a/ydb/core/kqp/common/events/workload_service.h
+++ b/ydb/core/kqp/common/events/workload_service.h
@@ -41,15 +41,19 @@ struct TEvContinueRequest : public NActors::TEventLocal<TEvContinueRequest, TKqp
 };
 
 struct TEvCleanupRequest : public NActors::TEventLocal<TEvCleanupRequest, TKqpWorkloadServiceEvents::EvCleanupRequest> {
-    TEvCleanupRequest(const TString& database, const TString& sessionId, const TString& poolId)
+    TEvCleanupRequest(const TString& database, const TString& sessionId, const TString& poolId, TDuration duration, TDuration cpuConsumed)
         : Database(database)
         , SessionId(sessionId)
         , PoolId(poolId)
+        , Duration(duration)
+        , CpuConsumed(cpuConsumed)
     {}
 
     const TString Database;
     const TString SessionId;
     const TString PoolId;
+    const TDuration Duration;
+    const TDuration CpuConsumed;
 };
 
 struct TEvCleanupResponse : public NActors::TEventLocal<TEvCleanupResponse, TKqpWorkloadServiceEvents::EvCleanupResponse> {

--- a/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
@@ -138,8 +138,14 @@ void FillResourcePoolDescription(NKikimrSchemeOp::TResourcePoolDescription& reso
     }
 
     if (settings.GetObjectId() == NResourcePool::DEFAULT_POOL_ID) {
-        if (properties.contains("concurrent_query_limit")) {
-            ythrow yexception() << "Can not change property concurrent_query_limit for default pool";
+        std::vector<TString> forbiddenProperties = {
+            "concurrent_query_limit",
+            "database_load_cpu_threshold"
+        };
+        for (const TString& property : forbiddenProperties) {
+            if (properties.contains(property)) {
+                ythrow yexception() << "Can not change property " << property << " for default pool";
+            }
         }
     }
 }

--- a/ydb/core/kqp/gateway/behaviour/resource_pool/manager.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool/manager.h
@@ -31,7 +31,7 @@ private:
     void PrepareDropResourcePool(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TDropObjectSettings& settings, TInternalModificationContext& context) const;
 
     TAsyncStatus ChainFeatures(TAsyncStatus lastFeature, std::function<TAsyncStatus()> callback) const;
-    TAsyncStatus ExecuteSchemeRequest(const NKikimrSchemeOp::TModifyScheme& schemeTx, const TExternalModificationContext& context, ui32 nodeId) const;
+    TAsyncStatus ExecuteSchemeRequest(const NKikimrSchemeOp::TModifyScheme& schemeTx, const TExternalModificationContext& context, ui32 nodeId, NKqpProto::TKqpSchemeOperation::OperationCase operationCase) const;
 };
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -6060,11 +6060,15 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         auto db = kikimr.GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
 
-        auto checkDisabled = [&session](const TString& query) {
+        auto checkQuery = [&session](const TString& query, EStatus status, const TString& error) {
             Cerr << "Check query:\n" << query << "\n";
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::UNSUPPORTED);
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Resource pools are disabled. Please contact your system administrator to enable it");
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), status);
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), error);
+        };
+
+        auto checkDisabled = [checkQuery](const TString& query) {
+            checkQuery(query, EStatus::UNSUPPORTED, "Resource pools are disabled. Please contact your system administrator to enable it");
         };
 
         // CREATE RESOURCE POOL
@@ -6083,7 +6087,9 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             )");
 
         // DROP RESOURCE POOL
-        checkDisabled("DROP RESOURCE POOL MyResourcePool;");
+        checkQuery("DROP RESOURCE POOL MyResourcePool;",
+            EStatus::SCHEME_ERROR,
+            "Path does not exist");
     }
 
     Y_UNIT_TEST(ResourcePoolsValidation) {

--- a/ydb/core/kqp/workload_service/actors/actors.h
+++ b/ydb/core/kqp/workload_service/actors/actors.h
@@ -15,4 +15,7 @@ NActors::IActor* CreatePoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bo
 NActors::IActor* CreatePoolFetcherActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken);
 NActors::IActor* CreatePoolCreatorActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl);
 
+// Cpu load fetcher actor
+NActors::IActor* CreateCpuLoadFetcherActor(const NActors::TActorId& replyActorId);
+
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/actors/actors.h
+++ b/ydb/core/kqp/workload_service/actors/actors.h
@@ -9,10 +9,10 @@ namespace NKikimr::NKqp::NWorkload {
 NActors::IActor* CreatePoolHandlerActor(const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters);
 
 // Fetch pool and create default pool if needed
-NActors::IActor* CreatePoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaultPoolExists);
+NActors::IActor* CreatePoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaultPoolExists, bool enableOnServerless);
 
 // Fetch and create pool in scheme shard
-NActors::IActor* CreatePoolFetcherActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken);
+NActors::IActor* CreatePoolFetcherActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, bool enableOnServerless);
 NActors::IActor* CreatePoolCreatorActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl);
 
 // Cpu load fetcher actor

--- a/ydb/core/kqp/workload_service/actors/cpu_load_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/cpu_load_actors.cpp
@@ -1,0 +1,77 @@
+#include "actors.h"
+
+#include <ydb/core/kqp/workload_service/common/events.h>
+
+#include <ydb/library/query_actor/query_actor.h>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+namespace {
+
+class TCpuLoadFetcherActor : public NKikimr::TQueryBase {
+    using TBase = NKikimr::TQueryBase;
+
+public:
+    TCpuLoadFetcherActor()
+        : TBase(NKikimrServices::KQP_WORKLOAD_SERVICE)
+    {
+        SetOperationInfo(__func__, "");
+    }
+
+    void OnRunQuery() override {
+        TString sql = TStringBuilder() << R"(
+            -- TCpuLoadFetcherActor::OnRunQuery
+
+            SELECT
+                SUM(CpuThreads) AS ThreadsCount,
+                SUM(CpuThreads * (1.0 - CpuIdle)) AS TotalLoad
+            FROM `.sys/nodes`;
+        )";
+
+        RunDataQuery(sql);
+    }
+
+    void OnQueryResult() override {
+        if (ResultSets.size() != 1) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
+            return;
+        }
+
+        NYdb::TResultSetParser result(ResultSets[0]);
+        if (!result.TryNextRow()) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
+            return;
+        }
+
+        ThreadsCount = result.ColumnParser("ThreadsCount").GetOptionalUint64().GetOrElse(0);
+        TotalLoad = result.ColumnParser("TotalLoad").GetOptionalDouble().GetOrElse(0.0);
+
+        if (!ThreadsCount) {
+            Finish(Ydb::StatusIds::NOT_FOUND, "Cpu info not found");
+            return;
+        }
+
+        Finish();
+    }
+
+    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+        if (status == Ydb::StatusIds::SUCCESS) {
+            Send(Owner, new TEvPrivate::TEvCpuLoadResponse(Ydb::StatusIds::SUCCESS, TotalLoad / ThreadsCount, ThreadsCount, std::move(issues)));
+        } else {
+            Send(Owner, new TEvPrivate::TEvCpuLoadResponse(status, 0.0, 0, std::move(issues)));
+        }
+    }
+
+private:
+    double TotalLoad = 0.0;
+    ui64 ThreadsCount = 0;
+};
+
+}  // anonymous namespace
+
+IActor* CreateCpuLoadFetcherActor(const TActorId& replyActorId) {
+    return new TQueryRetryActor<TCpuLoadFetcherActor, TEvPrivate::TEvCpuLoadResponse>(replyActorId);
+}
+
+}  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/actors/pool_handlers_acors.cpp
+++ b/ydb/core/kqp/workload_service/actors/pool_handlers_acors.cpp
@@ -42,6 +42,9 @@ protected:
         EState State = EState::Pending;
         bool Started = false;  // after TEvContinueRequest success
         bool CleanupRequired = false;
+        bool UsedCpuQuota = false;
+        TDuration Duration;
+        TDuration CpuConsumed;
     };
 
 public:
@@ -54,7 +57,6 @@ public:
         , QueueSizeLimit(GetMaxQueueSize(poolConfig))
         , InFlightLimit(GetMaxInFlight(poolConfig))
         , PoolConfig(poolConfig)
-        , CancelAfter(poolConfig.QueryCancelAfter)
     {
         RegisterCounters();
     }
@@ -118,8 +120,8 @@ private:
         }
 
         LOG_D("Received new request, worker id: " << workerActorId << ", session id: " << sessionId);
-        if (CancelAfter) {
-            this->Schedule(CancelAfter, new TEvPrivate::TEvCancelRequest(sessionId));
+        if (auto cancelAfter = PoolConfig.QueryCancelAfter) {
+            this->Schedule(cancelAfter, new TEvPrivate::TEvCancelRequest(sessionId));
         }
 
         TRequest* request = &LocalSessions.insert({sessionId, TRequest(workerActorId, sessionId)}).first->second;
@@ -146,8 +148,10 @@ private:
             return;
         }
         request->State = TRequest::EState::Finishing;
+        request->Duration = ev->Get()->Duration;
+        request->CpuConsumed = ev->Get()->CpuConsumed;
 
-        LOG_D("Received cleanup request, worker id: " << workerActorId << ", session id: " << sessionId);
+        LOG_D("Received cleanup request, worker id: " << workerActorId << ", session id: " << sessionId << ", duration: " << request->Duration << ", cpu consumed: " << request->CpuConsumed);
         OnCleanupRequest(request);
     }
 
@@ -213,7 +217,7 @@ public:
                 ContinueError->Inc();
                 LOG_W("Reply continue error " << status << " to " << request->WorkerActorId << ", session id: " << request->SessionId << ", issues: " << issues.ToOneLineString());
             }
-            RemoveRequest(request->SessionId);
+            RemoveRequest(request);
         }
 
         LocalDelayedRequests->Dec();
@@ -246,7 +250,7 @@ public:
             ReplyCleanup(request, status, issues);
         }
 
-        RemoveRequest(request->SessionId);
+        RemoveRequest(request);
     }
 
 protected:
@@ -273,9 +277,13 @@ protected:
         return nullptr;
     }
 
-    void RemoveRequest(const TString& sessionId) {
-        LocalSessions.erase(sessionId);
-        this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvFinishRequestInPool(Database, PoolId));
+    void RemoveRequest(TRequest* request) {
+        auto event = std::make_unique<TEvPrivate::TEvFinishRequestInPool>(
+            Database, PoolId, request->Duration, request->CpuConsumed, request->UsedCpuQuota
+        );
+        this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), event.release());
+
+        LocalSessions.erase(request->SessionId);
         if (StopHandler && LocalSessions.empty()) {
             LOG_I("All requests finished, stop handler");
             PassAway();
@@ -291,10 +299,17 @@ protected:
     }
 
     TMaybe<TInstant> GetWaitDeadline(TInstant startTime) const {
-        if (!CancelAfter) {
+        if (auto cancelAfter = PoolConfig.QueryCancelAfter) {
+            return startTime + cancelAfter;
+        }
+        return Nothing();
+    }
+
+    TMaybe<double> GetLoadCpuThreshold() const {
+        if (PoolConfig.DatabaseLoadCpuThreshold < 0.0) {
             return Nothing();
         }
-        return startTime + CancelAfter;
+        return PoolConfig.DatabaseLoadCpuThreshold;
     }
 
     TString LogPrefix() const {
@@ -349,7 +364,6 @@ private:
         LOG_D("Pool config has changed, queue size: " << poolConfig.QueueSize << ", in flight limit: " << poolConfig.ConcurrentQueryLimit);
 
         PoolConfig = poolConfig;
-        CancelAfter = poolConfig.QueryCancelAfter;
         QueueSizeLimit = GetMaxQueueSize(poolConfig);
         InFlightLimit = GetMaxInFlight(poolConfig);
         RefreshState(true);
@@ -398,7 +412,6 @@ protected:
 
 private:
     NResourcePool::TPoolSettings PoolConfig;
-    TDuration CancelAfter;
 
     // Scheme board settings
     std::unique_ptr<TPathId> WatchPathId;
@@ -436,7 +449,7 @@ public:
 
 protected:
     bool ShouldResign() const override {
-        return 0 < InFlightLimit && InFlightLimit < std::numeric_limits<ui64>::max();
+        return 0 < InFlightLimit && (InFlightLimit < std::numeric_limits<ui64>::max() || GetLoadCpuThreshold());
     }
 
     void OnScheduleRequest(TRequest* request) override {
@@ -452,6 +465,11 @@ protected:
 class TFifoPoolHandlerActor : public TPoolHandlerActorBase<TFifoPoolHandlerActor> {
     using TBase = TPoolHandlerActorBase<TFifoPoolHandlerActor>;
 
+    enum class EStartRequestCase {
+        Pending,
+        Delayed
+    };
+
     static constexpr ui64 MAX_PENDING_REQUESTS = 1000;
 
 public:
@@ -466,6 +484,7 @@ public:
         switch (ev->GetTypeRewrite()) {
             sFunc(TEvents::TEvWakeup, HandleRefreshState);
             sFunc(TEvPrivate::TEvRefreshPoolState, HandleExternalRefreshState);
+            hFunc(TEvPrivate::TEvCpuQuotaResponse, Handle);
 
             hFunc(TEvPrivate::TEvTablesCreationFinished, Handle);
             hFunc(TEvPrivate::TEvRefreshPoolStateResponse, Handle);
@@ -486,7 +505,7 @@ public:
 
 protected:
     bool ShouldResign() const override {
-        return InFlightLimit == 0 || InFlightLimit == std::numeric_limits<ui64>::max();
+        return InFlightLimit == 0 || (InFlightLimit == std::numeric_limits<ui64>::max() && !GetLoadCpuThreshold());
     }
 
     void OnScheduleRequest(TRequest* request) override {
@@ -594,7 +613,7 @@ private:
         RemoveFinishedRequests();
 
         size_t delayedRequestsCount = DelayedRequests.size();
-        DoStartPendingRequest();
+        DoStartPendingRequest(GetLoadCpuThreshold());
 
         if (GlobalState.DelayedRequests + PendingRequests.size() > QueueSizeLimit) {
             RemoveBackRequests(PendingRequests, std::min(GlobalState.DelayedRequests + PendingRequests.size() - QueueSizeLimit, PendingRequests.size()), [this](TRequest* request) {
@@ -611,7 +630,7 @@ private:
         }
 
         DoDelayRequest();
-        DoStartDelayedRequest();
+        DoStartDelayedRequest(GetLoadCpuThreshold());
         RefreshState();
     };
 
@@ -633,9 +652,43 @@ private:
         GlobalDelayedRequests->Inc();
         LOG_D("succefully delayed request, session id: " << ev->Get()->SessionId);
 
-        DoStartDelayedRequest();
+        DoStartDelayedRequest(GetLoadCpuThreshold());
         RefreshState();
     };
+
+    void Handle(TEvPrivate::TEvCpuQuotaResponse::TPtr& ev) {
+        RunningOperation = false;
+
+        if (!ev->Get()->QuotaAccepted) {
+            LOG_D("Skipped request start due to load cpu threshold");
+            if (static_cast<EStartRequestCase>(ev->Cookie) == EStartRequestCase::Pending) {
+                ForEachUnfinished(DelayedRequests.begin(), DelayedRequests.end(), [this](TRequest* request) {
+                    AddFinishedRequest(request->SessionId);
+                    ReplyContinue(request, Ydb::StatusIds::OVERLOADED, TStringBuilder() << "Too many pending requests for pool " << PoolId);
+                });
+            }
+            RefreshState();
+            return;
+        }
+
+        RemoveFinishedRequests();
+        switch (static_cast<EStartRequestCase>(ev->Cookie)) {
+            case EStartRequestCase::Pending:
+                if (!RunningOperation && !DelayedRequests.empty()) {
+                    RunningOperation = true;
+                    const TString& sessionId = DelayedRequests.front();
+                    this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, sessionId, LEASE_DURATION, CountersSubgroup));
+                    GetRequest(sessionId)->CleanupRequired = true;
+                }
+                break;
+
+            case EStartRequestCase::Delayed:
+                DoStartDelayedRequest(Nothing());
+                break;
+        }
+
+        RefreshState();
+    }
 
     void Handle(TEvPrivate::TEvStartRequestResponse::TPtr& ev) {
         RunningOperation = false;
@@ -668,6 +721,7 @@ private:
         while (!DelayedRequests.empty() && !requestFound) {
             ForUnfinished(DelayedRequests.front(), [this, sessionId, &requestFound](TRequest* request) {
                 if (request->SessionId == sessionId) {
+                    request->UsedCpuQuota = !!GetLoadCpuThreshold();
                     requestFound = true;
                     GlobalState.RunningRequests++;
                     GlobalInFly->Inc();
@@ -706,7 +760,7 @@ private:
     };
 
 private:
-    void DoStartPendingRequest() {
+    void DoStartPendingRequest(TMaybe<double> loadCpuThreshold) {
         RemoveFinishedRequests();
         if (RunningOperation) {
             return;
@@ -715,13 +769,17 @@ private:
         if (!PendingRequests.empty() && QueueSizeLimit == 0 && GlobalState.RunningRequests < InFlightLimit) {
             RunningOperation = true;
             const TString& sessionId = PopPendingRequest();
-            this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, sessionId, LEASE_DURATION, CountersSubgroup));
             DelayedRequests.emplace_front(sessionId);
-            GetRequest(sessionId)->CleanupRequired = true;
+            if (loadCpuThreshold) {
+                RequestCpuQuota(*loadCpuThreshold, EStartRequestCase::Pending);
+            } else {
+                this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, sessionId, LEASE_DURATION, CountersSubgroup));
+                GetRequest(sessionId)->CleanupRequired = true;
+            }
         }
     }
 
-    void DoStartDelayedRequest() {
+    void DoStartDelayedRequest(TMaybe<double> loadCpuThreshold) {
         RemoveFinishedRequests();
         if (RunningOperation) {
             return;
@@ -729,7 +787,11 @@ private:
 
         if ((!DelayedRequests.empty() || GlobalState.DelayedRequests) && GlobalState.RunningRequests < InFlightLimit) {
             RunningOperation = true;
-            this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, std::nullopt, LEASE_DURATION, CountersSubgroup));
+            if (loadCpuThreshold) {
+                RequestCpuQuota(*loadCpuThreshold, EStartRequestCase::Delayed);
+            } else {
+                this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, std::nullopt, LEASE_DURATION, CountersSubgroup));
+            }
         }
     }
 
@@ -768,6 +830,10 @@ private:
         }
         RefreshScheduled = true;
         this->Schedule(LEASE_DURATION / 2, new TEvents::TEvWakeup());
+    }
+
+    void RequestCpuQuota(double loadCpuThreshold, EStartRequestCase requestCase) const {
+        this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvCpuQuotaRequest(loadCpuThreshold / 100.0), 0, static_cast<ui64>(requestCase));
     }
 
 private:
@@ -859,7 +925,7 @@ private:
 }  // anonymous namespace
 
 IActor* CreatePoolHandlerActor(const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters) {
-    if (poolConfig.ConcurrentQueryLimit <= 0) {
+    if (poolConfig.ConcurrentQueryLimit == 0 || (poolConfig.ConcurrentQueryLimit == -1 && poolConfig.DatabaseLoadCpuThreshold < 0.0)) {
         return new TUnlimitedPoolHandlerActor(database, poolId, poolConfig, counters);
     }
     return new TFifoPoolHandlerActor(database, poolId, poolConfig, counters);

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -1,11 +1,13 @@
 #include "actors.h"
 
 #include <ydb/core/base/path.h>
+#include <ydb/core/base/tablet_pipe.h>
 
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/workload_service/common/events.h>
 #include <ydb/core/kqp/workload_service/common/helpers.h>
 
+#include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 
 #include <ydb/library/table_creator/table_creator.h>
@@ -64,7 +66,13 @@ public:
         for (const TString& usedSid : AppData()->AdministrationAllowedSIDs) {
             diffAcl.AddAccess(NACLib::EAccessType::Allow, NACLib::EAccessRights::GenericFull, usedSid);
         }
-        diffAcl.AddAccess(NACLib::EAccessType::Allow, NACLib::EAccessRights::SelectRow | NACLib::EAccessRights::DescribeSchema, AppData()->AllAuthenticatedUsers);
+
+        auto useAccess = NACLib::EAccessRights::SelectRow | NACLib::EAccessRights::DescribeSchema;
+        for (const auto& userSID : AppData()->DefaultUserSIDs) {
+            diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, userSID);
+        }
+        diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, AppData()->AllAuthenticatedUsers);
+        diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, BUILTIN_ACL_ROOT);
 
         auto token = MakeIntrusive<NACLib::TUserToken>(BUILTIN_ACL_METADATA, TVector<NACLib::TSID>{});
         Register(CreatePoolCreatorActor(SelfId(), Event->Get()->Database, Event->Get()->PoolId, NResourcePool::TPoolSettings(), token, diffAcl));
@@ -116,7 +124,7 @@ private:
 
 class TPoolFetcherActor : public TSchemeActorBase<TPoolFetcherActor> {
 public:
-    TPoolFetcherActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, bool enableOnServerless)
+    TPoolFetcherActor(const TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, bool enableOnServerless)
         : ReplyActorId(replyActorId)
         , Database(database)
         , PoolId(poolId)
@@ -255,38 +263,67 @@ public:
     }
 
     void Handle(TEvTxUserProxy::TEvProposeTransactionStatus::TPtr& ev) {
-        const auto ssStatus = ev->Get()->Record.GetSchemeShardStatus();
-        switch (ev->Get()->Status()) {
+        const auto& response = ev->Get()->Record;
+        const auto ssStatus = response.GetSchemeShardStatus();
+        const auto status = ev->Get()->Status();
+        switch (status) {
             case NTxProxy::TResultStatus::ExecComplete:
             case NTxProxy::TResultStatus::ExecAlready:
                 if (ssStatus == NKikimrScheme::EStatus::StatusSuccess || ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists) {
                     Reply(Ydb::StatusIds::SUCCESS);
                 } else {
-                    Reply(Ydb::StatusIds::SCHEME_ERROR, TStringBuilder() << "Invalid creation status: " << static_cast<NKikimrScheme::EStatus>(ssStatus));
+                    Reply(Ydb::StatusIds::SCHEME_ERROR, ExtractIssues(response, TStringBuilder() << "Invalid creation status: " << static_cast<NKikimrScheme::EStatus>(ssStatus)));
                 }
                 return;
             case NTxProxy::TResultStatus::ExecError:
-                if (ssStatus == NKikimrScheme::EStatus::StatusMultipleModifications || ssStatus == NKikimrScheme::EStatus::StatusInvalidParameter) {
-                    ScheduleRetry(ssStatus, "Retry execution error", true);
+                if (ssStatus == NKikimrScheme::EStatus::StatusMultipleModifications) {
+                    SubscribeOnTransactionOrRetry(status, response);
                 } else {
-                    Reply(Ydb::StatusIds::SCHEME_ERROR, TStringBuilder() << "Execution error: " << static_cast<NKikimrScheme::EStatus>(ssStatus));
+                    Reply(Ydb::StatusIds::SCHEME_ERROR, ExtractIssues(response, TStringBuilder() << "Execution error: " << static_cast<NKikimrScheme::EStatus>(ssStatus)));
                 }
                 return;
             case NTxProxy::TResultStatus::ExecInProgress:
-                ScheduleRetry(ssStatus, "Retry execution in progress error", true);
+                SubscribeOnTransactionOrRetry(status, response);
                 return;
             case NTxProxy::TResultStatus::ProxyShardNotAvailable:
-                ScheduleRetry(ssStatus, "Retry shard unavailable error");
+                ScheduleRetry(response, "Retry shard unavailable error");
                 return;
             default:
-                Reply(Ydb::StatusIds::SCHEME_ERROR, TStringBuilder() << "Failed to create resource pool: " << static_cast<NKikimrScheme::EStatus>(ssStatus));
+                Reply(Ydb::StatusIds::SCHEME_ERROR, ExtractIssues(response, TStringBuilder() << "Failed to create resource pool: " << static_cast<NKikimrScheme::EStatus>(ssStatus)));
                 return;
         }
+    }
+
+    void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
+        if (ev->Get()->Status == NKikimrProto::OK) {
+            LOG_T("Tablet to pipe successfully connected");
+            return;
+        }
+
+        ClosePipeClient();
+        ScheduleRetry(TStringBuilder() << "Tablet to pipe not connected: " << NKikimrProto::EReplyStatus_Name(ev->Get()->Status));
+    }
+
+    void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+        const TActorId clientId = ev->Get()->ClientId;
+        if (!ClosedSchemePipeActors.contains(clientId)) {
+            ClosePipeClient();
+            ScheduleRetry("Tablet to pipe destroyed");
+        }
+    }
+
+    void Handle(NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult::TPtr& ev) {
+        ScheduleRetry(TStringBuilder() << "Transaction " << ev->Get()->Record.GetTxId() << " completed, doublechecking");
     }
 
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvTxUserProxy::TEvProposeTransactionStatus, Handle)
+            hFunc(TEvTabletPipe::TEvClientConnected, Handle)
+            hFunc(TEvTabletPipe::TEvClientDestroyed, Handle)
+            hFunc(NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult, Handle)
+            IgnoreFunc(NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionRegistered)
+
             default:
                 StateFuncBase(ev);
         }
@@ -301,13 +338,12 @@ protected:
         schemeTx.SetWorkingDir(JoinPath({Database, ".resource_pools"}));
         schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateResourcePool);
         schemeTx.SetInternal(true);
-        schemeTx.SetAllowAccessToPrivatePaths(true);
 
         BuildCreatePoolRequest(*schemeTx.MutableCreateResourcePool());
         BuildModifyAclRequest(*schemeTx.MutableModifyACL());
 
         if (UserToken) {
-            event->Record.SetUserToken(UserToken->GetSerializedToken());
+            event->Record.SetUserToken(UserToken->SerializeAsString());
         }
 
         Send(MakeTxProxyID(), std::move(event));
@@ -322,10 +358,42 @@ protected:
     }
 
 private:
-    void ScheduleRetry(ui32 status, const TString& message, bool longDelay = false) {
-        auto ssStatus = static_cast<NKikimrScheme::EStatus>(status);
-        if (!TBase::ScheduleRetry(TStringBuilder() << message << ", status: " << ssStatus, longDelay)) {
-            Reply(Ydb::StatusIds::UNAVAILABLE, TStringBuilder() << "Retry limit exceeded on status: " << ssStatus);
+    void SubscribeOnTransactionOrRetry(NTxProxy::TResultStatus::EStatus status, const NKikimrTxUserProxy::TEvProposeTransactionStatus& response) {
+        const ui64 txId = status == NTxProxy::TResultStatus::ExecInProgress ? response.GetTxId() : response.GetPathCreateTxId();
+        if (txId == 0) {
+            ScheduleRetry(response, "Unable to subscribe to concurrent transaction", true);
+            return;
+        }
+
+        SchemePipeActorId = Register(NTabletPipe::CreateClient(SelfId(), response.GetSchemeShardTabletId()));
+
+        auto request = MakeHolder<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletion>();
+        request->Record.SetTxId(txId);
+        NTabletPipe::SendData(SelfId(), SchemePipeActorId, std::move(request));
+        LOG_D("Subscribe on create pool tx: " << txId);
+    }
+
+    void ClosePipeClient() {
+        if (SchemePipeActorId) {
+            ClosedSchemePipeActors.insert(SchemePipeActorId);
+            NTabletPipe::CloseClient(SelfId(), SchemePipeActorId);
+            SchemePipeActorId = {};
+        }
+    }
+
+    void ScheduleRetry(const NKikimrTxUserProxy::TEvProposeTransactionStatus& response, const TString& message, bool longDelay = false) {
+        ClosePipeClient();
+
+        auto ssStatus = static_cast<NKikimrScheme::EStatus>(response.GetSchemeShardStatus());
+        if (!TBase::ScheduleRetry(ExtractIssues(response, TStringBuilder() << message << ", status: " << ssStatus), longDelay)) {
+            Reply(Ydb::StatusIds::UNAVAILABLE, ExtractIssues(response, TStringBuilder() << "Retry limit exceeded on status: " << ssStatus));
+        }
+    }
+
+    void ScheduleRetry(const TString& message, bool longDelay = false) {
+        ClosePipeClient();
+        if (!TBase::ScheduleRetry(message, longDelay)) {
+            Reply(Ydb::StatusIds::UNAVAILABLE, TStringBuilder() << "Retry limit exceeded on error: " << message);
         }
     }
 
@@ -358,9 +426,17 @@ private:
             LOG_W("Failed to create pool, " << status << ", issues: " << issues.ToOneLineString());
         }
 
+        ClosePipeClient();
+
         Issues.AddIssues(std::move(issues));
         Send(ReplyActorId, new TEvPrivate::TEvCreatePoolResponse(status, std::move(Issues)));
         PassAway();
+    }
+
+    static NYql::TIssues ExtractIssues(const NKikimrTxUserProxy::TEvProposeTransactionStatus& response, const TString& message) {
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(response.GetIssues(), issues);
+        return GroupIssues(issues, message);
     }
 
 private:
@@ -370,6 +446,9 @@ private:
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     const NACLibProto::TDiffACL DiffAcl;
     NResourcePool::TPoolSettings PoolConfig;
+
+    std::unordered_set<TActorId> ClosedSchemePipeActors;
+    TActorId SchemePipeActorId;
 };
 
 }  // anonymous namespace

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -20,8 +20,9 @@ using namespace NActors;
 
 class TPoolResolverActor : public TActorBootstrapped<TPoolResolverActor> {
 public:
-    TPoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaultPoolExists)
+    TPoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaultPoolExists, bool enableOnServerless)
         : Event(std::move(event))
+        , EnableOnServerless(enableOnServerless)
     {
         if (!Event->Get()->PoolId) {
             Event->Get()->PoolId = NResourcePool::DEFAULT_POOL_ID;
@@ -36,7 +37,7 @@ public:
 
     void StartPoolFetchRequest() const {
         LOG_D("Start pool fetching");
-        Register(CreatePoolFetcherActor(SelfId(), Event->Get()->Database, Event->Get()->PoolId, Event->Get()->UserToken));
+        Register(CreatePoolFetcherActor(SelfId(), Event->Get()->Database, Event->Get()->PoolId, Event->Get()->UserToken, EnableOnServerless));
     }
 
     void Handle(TEvPrivate::TEvFetchPoolResponse::TPtr& ev) {
@@ -107,6 +108,7 @@ private:
 
 private:
     TEvPlaceRequestIntoPool::TPtr Event;
+    const bool EnableOnServerless;
     bool CanCreatePool = false;
     bool DefaultPoolCreated = false;
 };
@@ -114,11 +116,12 @@ private:
 
 class TPoolFetcherActor : public TSchemeActorBase<TPoolFetcherActor> {
 public:
-    TPoolFetcherActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
+    TPoolFetcherActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, bool enableOnServerless)
         : ReplyActorId(replyActorId)
         , Database(database)
         , PoolId(poolId)
         , UserToken(userToken)
+        , EnableOnServerless(enableOnServerless)
     {}
 
     void DoBootstrap() {
@@ -133,6 +136,11 @@ public:
         }
 
         const auto& result = results[0];
+        if (!EnableOnServerless && result.DomainInfo && result.DomainInfo->IsServerless()) {
+            Reply(Ydb::StatusIds::UNSUPPORTED, "Resource pools are disabled for serverless domains. Please contact your system administrator to enable it");
+            return;
+        }
+
         switch (result.Status) {
             case EStatus::Unknown:
             case EStatus::PathNotTable:
@@ -222,6 +230,7 @@ private:
     const TString Database;
     const TString PoolId;
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    const bool EnableOnServerless;
 
     NResourcePool::TPoolSettings PoolConfig;
     NKikimrProto::TPathID PathId;
@@ -365,12 +374,12 @@ private:
 
 }  // anonymous namespace
 
-IActor* CreatePoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaultPoolExists) {
-    return new TPoolResolverActor(std::move(event), defaultPoolExists);
+IActor* CreatePoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaultPoolExists, bool enableOnServerless) {
+    return new TPoolResolverActor(std::move(event), defaultPoolExists, enableOnServerless);
 }
 
-IActor* CreatePoolFetcherActor(const TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken) {
-    return new TPoolFetcherActor(replyActorId, database, poolId, userToken);
+IActor* CreatePoolFetcherActor(const TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, bool enableOnServerless) {
+    return new TPoolFetcherActor(replyActorId, database, poolId, userToken, enableOnServerless);
 }
 
 IActor* CreatePoolCreatorActor(const TActorId& replyActorId, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl) {

--- a/ydb/core/kqp/workload_service/actors/ya.make
+++ b/ydb/core/kqp/workload_service/actors/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    cpu_load_actors.cpp
     pool_handlers_acors.cpp
     scheme_actors.cpp
 )

--- a/ydb/core/kqp/workload_service/common/cpu_quota_manager.cpp
+++ b/ydb/core/kqp/workload_service/common/cpu_quota_manager.cpp
@@ -1,0 +1,156 @@
+#include "cpu_quota_manager.h"
+
+#include <util/string/builder.h>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+//// TCpuQuotaManager::TCounters
+
+TCpuQuotaManager::TCounters::TCounters(const ::NMonitoring::TDynamicCounterPtr& subComponent)
+    : SubComponent(subComponent)
+{
+    Register();
+}
+
+void TCpuQuotaManager::TCounters::Register() {
+    RegisterCommonMetrics(CpuLoadRequest);
+    InstantLoadPercentage = SubComponent->GetCounter("InstantLoadPercentage", false);
+    AverageLoadPercentage = SubComponent->GetCounter("AverageLoadPercentage", false);
+    QuotedLoadPercentage = SubComponent->GetCounter("QuotedLoadPercentage", false);
+}
+
+void TCpuQuotaManager::TCounters::RegisterCommonMetrics(TCommonMetrics& metrics) const {
+    metrics.Ok = SubComponent->GetCounter("Ok", true);
+    metrics.Error = SubComponent->GetCounter("Error", true);
+}
+
+//// TCpuQuotaManager::TCpuQuotaResponse
+
+TCpuQuotaManager::TCpuQuotaResponse::TCpuQuotaResponse(int32_t currentLoad, NYdb::EStatus status, NYql::TIssues issues)
+    : CurrentLoad(currentLoad)
+    , Status(status)
+    , Issues(std::move(issues))
+{}
+
+//// TCpuQuotaManager
+
+TCpuQuotaManager::TCpuQuotaManager(TDuration monitoringRequestDelay, TDuration averageLoadInterval, TDuration idleTimeout, double defaultQueryLoad, bool strict, ui64 cpuNumber, const ::NMonitoring::TDynamicCounterPtr& subComponent)
+    : Counters(subComponent)
+    , MonitoringRequestDelay(monitoringRequestDelay)
+    , AverageLoadInterval(averageLoadInterval)
+    , IdleTimeout(idleTimeout)
+    , DefaultQueryLoad(defaultQueryLoad)
+    , Strict(strict)
+    , CpuNumber(cpuNumber)
+{}
+
+double TCpuQuotaManager::GetInstantLoad() const {
+    return InstantLoad;
+}
+
+double TCpuQuotaManager::GetAverageLoad() const {
+    return AverageLoad;
+}
+
+TDuration TCpuQuotaManager::GetMonitoringRequestDelay() const {
+    return GetMonitoringRequestTime() - TInstant::Now();
+}
+
+TInstant TCpuQuotaManager::GetMonitoringRequestTime() const {
+    TDuration delay = MonitoringRequestDelay;
+    if (IdleTimeout && TInstant::Now() - LastRequestCpuQuota > IdleTimeout) {
+        delay = AverageLoadInterval / 2;
+    }
+
+    return LastUpdateCpuLoad ? LastUpdateCpuLoad + delay : TInstant::Now();
+}
+
+void TCpuQuotaManager::UpdateCpuLoad(double instantLoad, ui64 cpuNumber, bool success) {
+    auto now = TInstant::Now();
+    LastUpdateCpuLoad = now;
+
+    if (!success) {
+        Counters.CpuLoadRequest.Error->Inc();
+        CheckLoadIsOutdated();
+        return;
+    }
+
+    auto delta = now - LastCpuLoad;
+    LastCpuLoad = now;
+
+    if (cpuNumber) {
+        CpuNumber = cpuNumber;
+    }
+
+    InstantLoad = instantLoad;
+    // exponential moving average
+    if (!Ready || delta >= AverageLoadInterval) {
+        AverageLoad = InstantLoad;
+        QuotedLoad = InstantLoad;
+    } else {
+        auto ratio = static_cast<double>(delta.GetValue()) / AverageLoadInterval.GetValue();
+        AverageLoad = (1 - ratio) * AverageLoad + ratio * InstantLoad;
+        QuotedLoad = (1 - ratio) * QuotedLoad + ratio * InstantLoad;
+    }
+    Ready = true;
+    Counters.CpuLoadRequest.Ok->Inc();
+    Counters.InstantLoadPercentage->Set(static_cast<ui64>(InstantLoad * 100));
+    Counters.AverageLoadPercentage->Set(static_cast<ui64>(AverageLoad * 100));
+    Counters.QuotedLoadPercentage->Set(static_cast<ui64>(QuotedLoad * 100));
+}
+
+bool TCpuQuotaManager::CheckLoadIsOutdated() {
+    if (TInstant::Now() - LastCpuLoad > AverageLoadInterval) {
+        Ready = false;
+        QuotedLoad = 0.0;
+        Counters.QuotedLoadPercentage->Set(0);
+    }
+    return Ready;
+}
+
+bool TCpuQuotaManager::HasCpuQuota(double maxClusterLoad) {
+    LastRequestCpuQuota = TInstant::Now();
+    return maxClusterLoad == 0.0 || ((Ready || !Strict) && QuotedLoad < maxClusterLoad);
+}
+
+TCpuQuotaManager::TCpuQuotaResponse TCpuQuotaManager::RequestCpuQuota(double quota, double maxClusterLoad) {
+    if (quota < 0.0 || quota > 1.0) {
+        return TCpuQuotaResponse(-1, NYdb::EStatus::OVERLOADED, {NYql::TIssue(TStringBuilder() << "Incorrect quota value (exceeds 1.0 or less than 0.0) " << quota)});
+    }
+    quota = quota ? quota : DefaultQueryLoad;
+
+    CheckLoadIsOutdated();
+    if (!HasCpuQuota(maxClusterLoad)) {
+        return TCpuQuotaResponse(-1, NYdb::EStatus::OVERLOADED, {NYql::TIssue(TStringBuilder()
+            << "Cluster is overloaded, current quoted load " << static_cast<ui64>(QuotedLoad * 100)
+            << "%, average load " << static_cast<ui64>(AverageLoad * 100) << "%"
+        )});
+    }
+
+    QuotedLoad += quota;
+    Counters.QuotedLoadPercentage->Set(static_cast<ui64>(QuotedLoad * 100));
+    return TCpuQuotaResponse(QuotedLoad * 100);
+}
+
+void TCpuQuotaManager::AdjustCpuQuota(double quota, TDuration duration, double cpuSecondsConsumed) {
+    if (!CpuNumber) {
+        return;
+    }
+
+    if (duration && duration < AverageLoadInterval / 2 && quota <= 1.0) {
+        quota = quota ? quota : DefaultQueryLoad;
+        auto load = (cpuSecondsConsumed * 1000.0 / duration.MilliSeconds()) / CpuNumber;
+        if (quota > load) {
+            auto adjustment = (quota - load) / 2;
+            if (QuotedLoad > adjustment) {
+                QuotedLoad -= adjustment;
+            } else {
+                QuotedLoad = 0.0;
+            }
+            Counters.QuotedLoadPercentage->Set(static_cast<ui64>(QuotedLoad * 100));
+        }
+    }
+}
+
+}  // namespace NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/common/cpu_quota_manager.h
+++ b/ydb/core/kqp/workload_service/common/cpu_quota_manager.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+
+#include <ydb/library/yql/public/issue/yql_issue.h>
+
+#include <ydb/public/sdk/cpp/client/ydb_types/status_codes.h>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+class TCpuQuotaManager {
+    struct TCounters {
+        const ::NMonitoring::TDynamicCounterPtr SubComponent;
+        struct TCommonMetrics {
+            ::NMonitoring::TDynamicCounters::TCounterPtr Ok;
+            ::NMonitoring::TDynamicCounters::TCounterPtr Error;
+        };
+
+        TCommonMetrics CpuLoadRequest;
+        ::NMonitoring::TDynamicCounters::TCounterPtr InstantLoadPercentage;
+        ::NMonitoring::TDynamicCounters::TCounterPtr AverageLoadPercentage;
+        ::NMonitoring::TDynamicCounters::TCounterPtr QuotedLoadPercentage;
+
+        explicit TCounters(const ::NMonitoring::TDynamicCounterPtr& subComponent);
+
+    private:
+        void Register();
+        void RegisterCommonMetrics(TCommonMetrics& metrics) const;
+    };
+
+public:
+    struct TCpuQuotaResponse {
+        explicit TCpuQuotaResponse(int32_t currentLoad, NYdb::EStatus status = NYdb::EStatus::SUCCESS, NYql::TIssues issues = {});
+
+        const int32_t CurrentLoad;
+        const NYdb::EStatus Status;
+        const NYql::TIssues Issues;
+    };
+
+public:
+    TCpuQuotaManager(TDuration monitoringRequestDelay, TDuration averageLoadInterval, TDuration idleTimeout, double defaultQueryLoad, bool strict, ui64 cpuNumber, const ::NMonitoring::TDynamicCounterPtr& subComponent);
+
+    double GetInstantLoad() const;
+    double GetAverageLoad() const;
+    TDuration GetMonitoringRequestDelay() const;
+    TInstant GetMonitoringRequestTime() const;
+
+    void UpdateCpuLoad(double instantLoad, ui64 cpuNumber, bool success);
+    bool CheckLoadIsOutdated();
+
+    bool HasCpuQuota(double maxClusterLoad);
+    TCpuQuotaResponse RequestCpuQuota(double quota, double maxClusterLoad);
+    void AdjustCpuQuota(double quota, TDuration duration, double cpuSecondsConsumed);
+
+private:
+    TCounters Counters;
+
+    const TDuration MonitoringRequestDelay;
+    const TDuration AverageLoadInterval;
+    const TDuration IdleTimeout;
+    const double DefaultQueryLoad;
+    const bool Strict;
+    ui64 CpuNumber = 0;
+
+    TInstant LastCpuLoad;
+    TInstant LastUpdateCpuLoad;
+    TInstant LastRequestCpuQuota;
+
+    double InstantLoad = 0.0;
+    double AverageLoad = 0.0;
+    double QuotedLoad = 0.0;
+    bool Ready = false;
+};
+
+}  // namespace NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -33,6 +33,8 @@ struct TEvPrivate {
         EvCpuQuotaRequest,
         EvCpuQuotaResponse,
         EvCpuLoadResponse,
+        EvNodesInfoRequest,
+        EvNodesInfoResponse,
 
         EvTablesCreationFinished,
         EvCleanupTableResponse,
@@ -181,6 +183,17 @@ struct TEvPrivate {
         const double InstantLoad;
         const ui64 CpuNumber;
         const NYql::TIssues Issues;
+    };
+
+    struct TEvNodesInfoRequest : public NActors::TEventLocal<TEvNodesInfoRequest, EvNodesInfoRequest> {
+    };
+
+    struct TEvNodesInfoResponse : public NActors::TEventLocal<TEvNodesInfoResponse, EvNodesInfoResponse> {
+        explicit TEvNodesInfoResponse(ui32 nodeCount)
+            : NodeCount(nodeCount)
+        {}
+
+        const ui32 NodeCount;
     };
 
     // Tables queries events

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -30,6 +30,10 @@ struct TEvPrivate {
         EvStopPoolHandler,
         EvCancelRequest,
 
+        EvCpuQuotaRequest,
+        EvCpuQuotaResponse,
+        EvCpuLoadResponse,
+
         EvTablesCreationFinished,
         EvCleanupTableResponse,
         EvCleanupTablesFinished,
@@ -110,13 +114,19 @@ struct TEvPrivate {
     };
 
     struct TEvFinishRequestInPool : public NActors::TEventLocal<TEvFinishRequestInPool, EvFinishRequestInPool> {
-        TEvFinishRequestInPool(const TString& database, const TString& poolId)
+        TEvFinishRequestInPool(const TString& database, const TString& poolId, TDuration duration, TDuration cpuConsumed, bool adjustCpuQuota)
             : Database(database)
             , PoolId(poolId)
+            , Duration(duration)
+            , CpuConsumed(cpuConsumed)
+            , AdjustCpuQuota(adjustCpuQuota)
         {}
 
         const TString Database;
         const TString PoolId;
+        const TDuration Duration;
+        const TDuration CpuConsumed;
+        const bool AdjustCpuQuota;
     };
 
     struct TEvResignPoolHandler : public NActors::TEventLocal<TEvResignPoolHandler, EvResignPoolHandler> {
@@ -140,6 +150,37 @@ struct TEvPrivate {
         {}
 
         const TString SessionId;
+    };
+
+    // Cpu load requests
+    struct TEvCpuQuotaRequest : public NActors::TEventLocal<TEvCpuQuotaRequest, EvCpuQuotaRequest> {
+        explicit TEvCpuQuotaRequest(double maxClusterLoad)
+            : MaxClusterLoad(maxClusterLoad)
+        {}
+
+        const double MaxClusterLoad;
+    };
+
+    struct TEvCpuQuotaResponse : public NActors::TEventLocal<TEvCpuQuotaResponse, EvCpuQuotaResponse> {
+        explicit TEvCpuQuotaResponse(bool quotaAccepted)
+            : QuotaAccepted(quotaAccepted)
+        {}
+
+        const bool QuotaAccepted;
+    };
+
+    struct TEvCpuLoadResponse : public NActors::TEventLocal<TEvCpuLoadResponse, EvCpuLoadResponse> {
+        TEvCpuLoadResponse(Ydb::StatusIds::StatusCode status, double instantLoad, ui64 cpuNumber, NYql::TIssues issues)
+            : Status(status)
+            , InstantLoad(instantLoad)
+            , CpuNumber(cpuNumber)
+            , Issues(std::move(issues))
+        {}
+
+        const Ydb::StatusIds::StatusCode Status;
+        const double InstantLoad;
+        const ui64 CpuNumber;
+        const NYql::TIssues Issues;
     };
 
     // Tables queries events

--- a/ydb/core/kqp/workload_service/common/helpers.cpp
+++ b/ydb/core/kqp/workload_service/common/helpers.cpp
@@ -20,4 +20,8 @@ void ParsePoolSettings(const NKikimrSchemeOp::TResourcePoolDescription& descript
     }
 }
 
+ui64 SaturationSub(ui64 x, ui64 y) {
+    return (x > y) ? x - y : 0;
+}
+
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/common/helpers.h
+++ b/ydb/core/kqp/workload_service/common/helpers.h
@@ -62,19 +62,23 @@ protected:
     virtual TString LogPrefix() const = 0;
 
 protected:
-    bool ScheduleRetry(const TString& message, bool longDelay = false) {
+    bool ScheduleRetry(NYql::TIssues issues, bool longDelay = false) {
         if (!RetryState) {
             RetryState = CreateRetryState();
         }
 
         if (const auto delay = RetryState->GetNextRetryDelay(longDelay)) {
-            Issues.AddIssue(message);
+            Issues.AddIssues(issues);
             this->Schedule(*delay, new TEvents::TEvWakeup());
-            LOG_W("Scheduled retry for error: " << message);
+            LOG_W("Scheduled retry for error: " << issues.ToOneLineString());
             return true;
         }
 
         return false;
+    }
+
+    bool ScheduleRetry(const TString& message, bool longDelay = false) {
+        return ScheduleRetry({NYql::TIssue(message)}, longDelay);
     }
 
 private:

--- a/ydb/core/kqp/workload_service/common/helpers.h
+++ b/ydb/core/kqp/workload_service/common/helpers.h
@@ -99,4 +99,6 @@ NYql::TIssues GroupIssues(const NYql::TIssues& issues, const TString& message);
 
 void ParsePoolSettings(const NKikimrSchemeOp::TResourcePoolDescription& description, NResourcePool::TPoolSettings& poolConfig);
 
+ui64 SaturationSub(ui64 x, ui64 y);
+
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/common/ya.make
+++ b/ydb/core/kqp/workload_service/common/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    cpu_quota_manager.cpp
     events.cpp
     helpers.cpp
 )
@@ -13,6 +14,8 @@ PEERDIR(
     ydb/core/tx/scheme_cache
 
     ydb/library/actors/core
+
+    ydb/public/sdk/cpp/client/ydb_types
 
     library/cpp/retry
 )

--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -132,9 +132,6 @@ public:
             return;
         }
 
-        // Add AllAuthenticatedUsers group SID into user token
-        ev->Get()->UserToken = GetUserToken(ev->Get()->UserToken);
-
         LOG_D("Recieved new request from " << workerActorId << ", Database: " << ev->Get()->Database << ", PoolId: " << ev->Get()->PoolId << ", SessionId: " << ev->Get()->SessionId);
         bool hasDefaultPool = DatabasesWithDefaultPool.contains(CanonizePath(ev->Get()->Database));
         Register(CreatePoolResolverActor(std::move(ev), hasDefaultPool, EnabledResourcePoolsOnServerless));
@@ -473,25 +470,6 @@ private:
     void ReplyCleanupError(const TActorId& replyActorId, Ydb::StatusIds::StatusCode status, const TString& message) const {
         LOG_W("Reply cleanup error " << status << " to " << replyActorId << ": " << message);
         Send(replyActorId, new TEvCleanupResponse(status, {NYql::TIssue(message)}));
-    }
-
-    static TIntrusivePtr<NACLib::TUserToken> GetUserToken(TIntrusiveConstPtr<NACLib::TUserToken> userToken) {
-        auto token = MakeIntrusive<NACLib::TUserToken>(userToken ? userToken->GetUserSID() : NACLib::TSID(), TVector<NACLib::TSID>{});
-
-        bool hasAllAuthenticatedUsersSID = false;
-        const auto& allAuthenticatedUsersSID = AppData()->AllAuthenticatedUsers;
-        if (userToken) {
-            for (const auto& groupSID : userToken->GetGroupSIDs()) {
-                token->AddGroupSID(groupSID);
-                hasAllAuthenticatedUsersSID = hasAllAuthenticatedUsersSID || groupSID == allAuthenticatedUsersSID;
-            }
-        }
-
-        if (!hasAllAuthenticatedUsersSID) {
-            token->AddGroupSID(allAuthenticatedUsersSID);
-        }
-
-        return token;
     }
 
     TPoolState* GetPoolState(const TString& database, const TString& poolId) {

--- a/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
+++ b/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <queue>
+
+#include <ydb/core/kqp/workload_service/common/cpu_quota_manager.h>
+#include <ydb/core/kqp/workload_service/common/events.h>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+constexpr TDuration IDLE_DURATION = TDuration::Seconds(60);
+
+struct TPoolState {
+    NActors::TActorId PoolHandler;
+    NActors::TActorContext ActorContext;
+
+    std::queue<TEvPrivate::TEvResolvePoolResponse::TPtr> PendingRequests = {};
+    bool WaitingInitialization = false;
+    bool PlaceRequestRunning = false;
+    std::optional<TActorId> NewPoolHandler = std::nullopt;
+
+    ui64 InFlightRequests = 0;
+    TInstant LastUpdateTime = TInstant::Now();
+
+    void UpdateHandler() {
+        if (PlaceRequestRunning || WaitingInitialization || !NewPoolHandler) {
+            return;
+        }
+
+        ActorContext.Send(PoolHandler, new TEvPrivate::TEvStopPoolHandler());
+        PoolHandler = *NewPoolHandler;
+        NewPoolHandler = std::nullopt;
+        InFlightRequests = 0;
+    }
+
+    void StartPlaceRequest() {
+        if (PlaceRequestRunning || PendingRequests.empty()) {
+            return;
+        }
+
+        PlaceRequestRunning = true;
+        InFlightRequests++;
+        ActorContext.Send(PendingRequests.front()->Forward(PoolHandler));
+        PendingRequests.pop();
+    }
+
+    void OnRequestFinished() {
+        Y_ENSURE(InFlightRequests);
+        InFlightRequests--;
+        LastUpdateTime = TInstant::Now();
+    }
+};
+
+struct TCpuQuotaManagerState {
+    TCpuQuotaManager CpuQuotaManager;
+    NActors::TActorContext ActorContext;
+    bool CpuLoadRequestRunning = false;
+    TInstant CpuLoadRequestTime = TInstant::Zero();
+
+    TCpuQuotaManagerState(NActors::TActorContext actorContext, NMonitoring::TDynamicCounterPtr subComponent)
+        : CpuQuotaManager(TDuration::Seconds(1), TDuration::Seconds(10), IDLE_DURATION, 0.1, true, 0, subComponent)
+        , ActorContext(actorContext)
+    {}
+
+    void RequestCpuQuota(TActorId poolHandler, double maxClusterLoad, ui64 coockie) {
+        auto response = CpuQuotaManager.RequestCpuQuota(0.0, maxClusterLoad);
+
+        bool quotaAccepted = response.Status == NYdb::EStatus::SUCCESS;
+        ActorContext.Send(poolHandler, new TEvPrivate::TEvCpuQuotaResponse(quotaAccepted), 0, coockie);
+
+        // Schedule notification
+        if (!quotaAccepted) {
+            if (auto it = HandlersLimits.find(poolHandler); it != HandlersLimits.end()) {
+                PendingHandlers[it->second].erase(poolHandler);
+            }
+            HandlersLimits[poolHandler] = maxClusterLoad;
+            PendingHandlers[maxClusterLoad].insert(poolHandler);
+        }
+    }
+
+    void UpdateCpuLoad(double instantLoad, ui64 cpuNumber, bool success) {
+        CpuQuotaManager.UpdateCpuLoad(instantLoad, cpuNumber, success);
+        CheckPendingQueue();
+    }
+
+    void AdjustCpuQuota(TDuration duration, double cpuSecondsConsumed) {
+        CpuQuotaManager.AdjustCpuQuota(0.0, duration, cpuSecondsConsumed);
+        CheckPendingQueue();
+    }
+
+    std::optional<TDuration> GetCpuLoadRequestDelay() {
+        if (CpuLoadRequestRunning) {
+            return std::nullopt;
+        }
+
+        auto requestTime = CpuQuotaManager.GetMonitoringRequestTime();
+        if (!CpuLoadRequestTime || CpuLoadRequestTime > requestTime) {
+            CpuLoadRequestTime = requestTime;
+            return CpuLoadRequestTime - TInstant::Now();
+        }
+        return std::nullopt;
+    }
+
+    void CleanupHandler(TActorId poolHandler) {
+        if (auto it = HandlersLimits.find(poolHandler); it != HandlersLimits.end()) {
+            PendingHandlers[it->second].erase(poolHandler);
+            HandlersLimits.erase(it);
+        }
+    }
+
+private:
+    void CheckPendingQueue() {
+        while (!PendingHandlers.empty()) {
+            const auto& [maxClusterLoad, poolHandlers] = *PendingHandlers.begin();
+            if (!CpuQuotaManager.HasCpuQuota(maxClusterLoad)) {
+                break;
+            }
+
+            for (const TActorId& poolHandler : poolHandlers) {
+                ActorContext.Send(poolHandler, new TEvPrivate::TEvRefreshPoolState());
+                HandlersLimits.erase(poolHandler);
+            }
+            PendingHandlers.erase(PendingHandlers.begin());
+        }
+    }
+
+private:
+    std::map<double, std::unordered_set<TActorId>> PendingHandlers;
+    std::unordered_map<TActorId, double> HandlersLimits;
+};
+
+}  // namespace NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -307,8 +307,8 @@ public:
 
     // Cluster helpers
     void UpdateNodeCpuInfo(double usage, ui32 threads, ui64 nodeIndex = 0) override {
-        TVector<std::tuple<TString, double, ui32, ui32>> pools;
-        pools.emplace_back("User", usage, threads, threads);
+        TVector<std::tuple<TString, double, ui32>> pools;
+        pools.emplace_back("User", usage, threads);
 
         auto edgeActor = GetRuntime()->AllocateEdgeActor(nodeIndex);
         GetRuntime()->Send(

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -453,9 +453,10 @@ public:
             auto subgroup = GetWorkloadManagerCounters(nodeIndex)
                 ->GetSubgroup("pool", CanonizePath(TStringBuilder() << Settings_.DomainName_ << "/" << (poolId ? poolId : Settings_.PoolId_)));
 
-            CheckCommonCounters(subgroup);
+            const TString description = TStringBuilder() << "Node index: " << nodeIndex;
+            CheckCommonCounters(subgroup, description);
             if (checkTableCounters) {
-                CheckTableCounters(subgroup);
+                CheckTableCounters(subgroup, description);
             }
         }
     }
@@ -497,21 +498,21 @@ private:
             ->GetSubgroup("subsystem", "workload_manager");
     }
 
-    static void CheckCommonCounters(NMonitoring::TDynamicCounterPtr subgroup) {
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("LocalInFly", false)->Val(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("LocalDelayedRequests", false)->Val(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("ContinueOverloaded", true)->Val(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("ContinueError", true)->Val(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("CleanupError", true)->Val(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("Cancelled", true)->Val(), 0);
+    static void CheckCommonCounters(NMonitoring::TDynamicCounterPtr subgroup, const TString& description) {
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("LocalInFly", false)->Val(), 0, description);
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("LocalDelayedRequests", false)->Val(), 0, description);
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("ContinueOverloaded", true)->Val(), 0, description);
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("ContinueError", true)->Val(), 0, description);
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("CleanupError", true)->Val(), 0, description);
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("Cancelled", true)->Val(), 0, description);
 
-        UNIT_ASSERT_GE(subgroup->GetCounter("ContinueOk", true)->Val(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("ContinueOk", true)->Val(), subgroup->GetCounter("CleanupOk", true)->Val());
+        UNIT_ASSERT_GE_C(subgroup->GetCounter("ContinueOk", true)->Val(), 1, description);
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("ContinueOk", true)->Val(), subgroup->GetCounter("CleanupOk", true)->Val(), description);
     }
 
-    static void CheckTableCounters(NMonitoring::TDynamicCounterPtr subgroup) {
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("PendingRequestsCount", false)->Val(), 0);
-        UNIT_ASSERT_VALUES_EQUAL(subgroup->GetCounter("FinishingRequestsCount", false)->Val(), 0);
+    static void CheckTableCounters(NMonitoring::TDynamicCounterPtr subgroup, const TString& description) {
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("PendingRequestsCount", false)->Val(), 0, description);
+        UNIT_ASSERT_VALUES_EQUAL_C(subgroup->GetCounter("FinishingRequestsCount", false)->Val(), 0, description);
 
         const std::vector<std::pair<TString, bool>> tableQueries = {
             {"TCleanupTablesQuery", false},
@@ -524,9 +525,9 @@ private:
         for (const auto& [operation, runExpected] : tableQueries) {
             auto operationSubgroup = subgroup->GetSubgroup("operation", operation);
 
-            UNIT_ASSERT_VALUES_EQUAL_C(operationSubgroup->GetCounter("FinishError", true)->Val(), 0, TStringBuilder() << "Unexpected vaule for operation " << operation);
+            UNIT_ASSERT_VALUES_EQUAL_C(operationSubgroup->GetCounter("FinishError", true)->Val(), 0, TStringBuilder() << description << ", unexpected vaule for operation " << operation);
             if (runExpected) {
-                UNIT_ASSERT_GE_C(operationSubgroup->GetCounter("FinishOk", true)->Val(), 1, TStringBuilder() << "Unexpected vaule for operation " << operation);
+                UNIT_ASSERT_GE_C(operationSubgroup->GetCounter("FinishOk", true)->Val(), 1, TStringBuilder() << description << ", unexpected vaule for operation " << operation);
             }
         }
     }

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -460,6 +460,7 @@ public:
         }
     }
 
+    // Coomon helpers
     TTestActorRuntime* GetRuntime() const override {
         return Server_->GetRuntime();
     }
@@ -489,19 +490,6 @@ private:
         request->SetPoolId(settings.PoolId_);
 
         return event;
-    }
-
-    static void WaitFor(TDuration timeout, TString description, std::function<bool(TString&)> callback) {
-        TInstant start = TInstant::Now();
-        while (TInstant::Now() - start <= timeout) {
-            TString errorString;
-            if (callback(errorString)) {
-                return;
-            }
-            Cerr << "Wait " << description << " " << TInstant::Now() - start << ": " << errorString << "\n";
-            Sleep(TDuration::Seconds(1));
-        }
-        UNIT_ASSERT_C(false, "Waiting " << description << " timeout");
     }
 
     NMonitoring::TDynamicCounterPtr GetWorkloadManagerCounters(ui32 nodeIndex) const {
@@ -596,6 +584,21 @@ bool TQueryRunnerResultAsync::HasValue() const {
 
 TIntrusivePtr<IYdbSetup> TYdbSetupSettings::Create() const {
     return MakeIntrusive<TWorkloadServiceYdbSetup>(*this);
+}
+
+//// IYdbSetup
+
+void IYdbSetup::WaitFor(TDuration timeout, TString description, std::function<bool(TString&)> callback) {
+    TInstant start = TInstant::Now();
+    while (TInstant::Now() - start <= timeout) {
+        TString errorString;
+        if (callback(errorString)) {
+            return;
+        }
+        Cerr << "Wait " << description << " " << TInstant::Now() - start << ": " << errorString << "\n";
+        Sleep(TDuration::Seconds(1));
+    }
+    UNIT_ASSERT_C(false, "Waiting " << description << " timeout. Spent time " << TInstant::Now() - start << " exceeds limit " << timeout);
 }
 
 //// TSampleQueriess

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -8,8 +8,9 @@
 #include <ydb/core/kqp/executer_actor/kqp_executer.h>
 #include <ydb/core/kqp/workload_service/actors/actors.h>
 #include <ydb/core/kqp/workload_service/tables/table_queries.h>
-
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+#include <ydb/core/node_whiteboard/node_whiteboard.h>
 
 
 namespace NKikimr::NKqp::NWorkload {
@@ -287,6 +288,7 @@ private:
         poolConfig.QueueSize = Settings_.QueueSize_;
         poolConfig.QueryCancelAfter = Settings_.QueryCancelAfter_;
         poolConfig.QueryMemoryLimitPercentPerNode = Settings_.QueryMemoryLimitPercentPerNode_;
+        poolConfig.DatabaseLoadCpuThreshold = Settings_.DatabaseLoadCpuThreshold_;
 
         TActorId edgeActor = GetRuntime()->AllocateEdgeActor();
         GetRuntime()->Register(CreatePoolCreatorActor(edgeActor, Settings_.DomainName_, Settings_.PoolId_, poolConfig, nullptr, {}));
@@ -301,6 +303,41 @@ public:
         EnableYDBBacktraceFormat();
         InitializeServer();
         CreateSamplePool();
+    }
+
+    // Cluster helpers
+    void UpdateNodeCpuInfo(double usage, ui32 threads, ui64 nodeIndex = 0) override {
+        TVector<std::tuple<TString, double, ui32, ui32>> pools;
+        pools.emplace_back("User", usage, threads, threads);
+
+        auto edgeActor = GetRuntime()->AllocateEdgeActor(nodeIndex);
+        GetRuntime()->Send(
+            NNodeWhiteboard::MakeNodeWhiteboardServiceId(GetRuntime()->GetNodeId(nodeIndex)), edgeActor,
+            new NNodeWhiteboard::TEvWhiteboard::TEvSystemStateUpdate(pools), nodeIndex
+        );
+
+        WaitFor(FUTURE_WAIT_TIMEOUT, "node cpu usage", [this, usage, threads, nodeIndex, edgeActor](TString& errorString) {
+            GetRuntime()->Send(
+                NNodeWhiteboard::MakeNodeWhiteboardServiceId(GetRuntime()->GetNodeId(nodeIndex)), edgeActor,
+                new NNodeWhiteboard::TEvWhiteboard::TEvSystemStateRequest(), nodeIndex
+            );
+            auto response = GetRuntime()->GrabEdgeEvent<NNodeWhiteboard::TEvWhiteboard::TEvSystemStateResponse>(edgeActor, FUTURE_WAIT_TIMEOUT);
+            
+            if (!response->Get()->Record.SystemStateInfoSize()) {
+                errorString = "empty system state info";
+                return false;
+            }
+            const auto& systemStateInfo = response->Get()->Record.GetSystemStateInfo()[0];
+
+            if (!systemStateInfo.PoolStatsSize()) {
+                errorString = "empty pool stats";
+                return false;
+            }
+            const auto& poolStat = systemStateInfo.GetPoolStats()[0];
+
+            errorString = TStringBuilder() << "usage: " << poolStat.GetUsage() << ", threads: " << poolStat.GetThreads();
+            return poolStat.GetUsage() == usage && threads == poolStat.GetThreads();
+        });
     }
 
     // Scheme queries helpers
@@ -323,21 +360,17 @@ public:
     void WaitPoolAccess(const TString& userSID, ui32 access, const TString& poolId = "") const override {
         auto token = NACLib::TUserToken(userSID, {});
 
-        TInstant start = TInstant::Now();
-        while (TInstant::Now() - start <= FUTURE_WAIT_TIMEOUT) {
-            if (auto response = Navigate(TStringBuilder() << ".resource_pools/" << (poolId ? poolId : Settings_.PoolId_))) {
-                const auto& result = response->ResultSet.at(0);
-                bool resourcePool = result.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool;
-                if (resourcePool && (!result.SecurityObject || result.SecurityObject->CheckAccess(access, token))) {
-                    return;
-                }
-                Cerr << "WaitPoolAccess " << TInstant::Now() - start << ": " << (resourcePool ? TStringBuilder() << "access denied" : TStringBuilder() << "unexpected kind " << result.Kind) << "\n";
-            } else {
-                Cerr << "WaitPoolAccess " << TInstant::Now() - start << ": empty response\n";
+        WaitFor(FUTURE_WAIT_TIMEOUT, "pool acl", [this, token, access, poolId](TString& errorString) {
+            auto response = Navigate(TStringBuilder() << ".resource_pools/" << (poolId ? poolId : Settings_.PoolId_));
+            if (!response) {
+                errorString = "empty response";
+                return false;
             }
-            Sleep(TDuration::Seconds(1));
-        }
-        UNIT_ASSERT_C(false, "Pool version waiting timeout");
+            const auto& result = response->ResultSet.at(0);
+            bool resourcePool = result.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool;
+            errorString = (resourcePool ? TStringBuilder() << "access denied" : TStringBuilder() << "unexpected kind " << result.Kind);
+            return resourcePool && (!result.SecurityObject || result.SecurityObject->CheckAccess(access, token));
+        });
     }
 
     // Generic query helpers
@@ -390,17 +423,11 @@ public:
     }
 
     void WaitPoolState(const TPoolStateDescription& state, const TString& poolId = "") const override {
-        TInstant start = TInstant::Now();
-        while (TInstant::Now() - start <= FUTURE_WAIT_TIMEOUT) {
+        WaitFor(FUTURE_WAIT_TIMEOUT, "pool state", [this, state, poolId](TString& errorString) {
             auto description = GetPoolDescription(TDuration::Zero(), poolId);
-            if (description.DelayedRequests == state.DelayedRequests && description.RunningRequests == state.RunningRequests) {
-                return;
-            }
-
-            Cerr << "WaitPoolState " << TInstant::Now() - start << ": delayed = " << description.DelayedRequests << ", running = " << description.RunningRequests << "\n";
-            Sleep(TDuration::Seconds(1));
-        }
-        UNIT_ASSERT_C(false, "Pool state waiting timeout");
+            errorString = TStringBuilder() << "delayed = " << description.DelayedRequests << ", running = " << description.RunningRequests;
+            return description.DelayedRequests == state.DelayedRequests && description.RunningRequests == state.RunningRequests;
+        });
     }
 
     void WaitPoolHandlersCount(i64 finalCount, std::optional<i64> initialCount = std::nullopt, TDuration timeout = FUTURE_WAIT_TIMEOUT) const override {
@@ -410,16 +437,10 @@ public:
             UNIT_ASSERT_VALUES_EQUAL_C(counter->Val(), *initialCount, "Unexpected pool handlers count");
         }
 
-        TInstant start = TInstant::Now();
-        while (TInstant::Now() - start < timeout) {
-            if (counter->Val() == finalCount) {
-                return;
-            }
-
-            Cerr << "WaitPoolHandlersCount " << TInstant::Now() - start << ": number handlers = " << counter->Val() << "\n";
-            Sleep(TDuration::Seconds(1));
-        }
-        UNIT_ASSERT_C(false, "Pool handlers count wait timeout");
+        WaitFor(timeout, "pool handlers", [counter, finalCount](TString& errorString) {
+            errorString = TStringBuilder() << "number handlers = " << counter->Val();
+            return counter->Val() == finalCount;
+        });
     }
 
     void StopWorkloadService(ui64 nodeIndex = 0) const override {
@@ -468,6 +489,19 @@ private:
         request->SetPoolId(settings.PoolId_);
 
         return event;
+    }
+
+    static void WaitFor(TDuration timeout, TString description, std::function<bool(TString&)> callback) {
+        TInstant start = TInstant::Now();
+        while (TInstant::Now() - start <= timeout) {
+            TString errorString;
+            if (callback(errorString)) {
+                return;
+            }
+            Cerr << "Wait " << description << " " << TInstant::Now() - start << ": " << errorString << "\n";
+            Sleep(TDuration::Seconds(1));
+        }
+        UNIT_ASSERT_C(false, "Waiting " << description << " timeout");
     }
 
     NMonitoring::TDynamicCounterPtr GetWorkloadManagerCounters(ui32 nodeIndex) const {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -74,12 +74,16 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(i32, QueueSize, -1);
     FLUENT_SETTING_DEFAULT(TDuration, QueryCancelAfter, FUTURE_WAIT_TIMEOUT);
     FLUENT_SETTING_DEFAULT(double, QueryMemoryLimitPercentPerNode, -1);
+    FLUENT_SETTING_DEFAULT(double, DatabaseLoadCpuThreshold, -1);
 
     TIntrusivePtr<IYdbSetup> Create() const;
 };
 
 class IYdbSetup : public TThrRefBase {
 public:
+    // Cluster helpers
+    virtual void UpdateNodeCpuInfo(double usage, ui32 threads, ui64 nodeIndex = 0) = 0;
+
     // Scheme queries helpers
     virtual NYdb::NScheme::TSchemeClient GetSchemeClient() const = 0;
     virtual void ExecuteSchemeQuery(const TString& query, NYdb::EStatus expectedStatus = NYdb::EStatus::SUCCESS, const TString& expectedMessage = "") const = 0;

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -106,8 +106,10 @@ public:
     virtual void StopWorkloadService(ui64 nodeIndex = 0) const = 0;
     virtual void ValidateWorkloadServiceCounters(bool checkTableCounters = true, const TString& poolId = "") const = 0;
 
+    // Coomon helpers
     virtual TTestActorRuntime* GetRuntime() const = 0;
     virtual const TYdbSetupSettings& GetSettings() const = 0;
+    static void WaitFor(TDuration timeout, TString description, std::function<bool(TString&)> callback);
 };
 
 // Test queries

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
@@ -16,7 +16,7 @@ TEvPrivate::TEvFetchPoolResponse::TPtr FetchPool(TIntrusivePtr<IYdbSetup> ydb, c
     auto runtime = ydb->GetRuntime();
     const auto& edgeActor = runtime->AllocateEdgeActor();
 
-    runtime->Register(CreatePoolFetcherActor(edgeActor, settings.DomainName_, poolId ? poolId : settings.PoolId_, MakeIntrusive<NACLib::TUserToken>(userSID, TVector<NACLib::TSID>{})));
+    runtime->Register(CreatePoolFetcherActor(edgeActor, settings.DomainName_, poolId ? poolId : settings.PoolId_, MakeIntrusive<NACLib::TUserToken>(userSID, TVector<NACLib::TSID>{}), true));
     return runtime->GrabEdgeEvent<TEvPrivate::TEvFetchPoolResponse>(edgeActor, FUTURE_WAIT_TIMEOUT);
 }
 

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -123,6 +123,36 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
         TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
     }
 
+    Y_UNIT_TEST(TestZeroQueueSizeManyQueries) {
+        const i32 inFlight = 10;
+        auto ydb = TYdbSetupSettings()
+            .ConcurrentQueryLimit(inFlight)
+            .QueueSize(0)
+            .QueryCancelAfter(FUTURE_WAIT_TIMEOUT * inFlight)
+            .Create();
+
+        auto settings = TQueryRunnerSettings().HangUpDuringExecution(true);
+
+        std::vector<TQueryRunnerResultAsync> asyncResults;
+        for (size_t i = 0; i < inFlight; ++i) {
+            asyncResults.emplace_back(ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, settings));
+        }
+
+        for (const auto& asyncResult : asyncResults) {
+            ydb->WaitQueryExecution(asyncResult);
+        }
+
+        TSampleQueries::CheckOverloaded(
+            ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, TQueryRunnerSettings().ExecutionExpected(false)),
+            ydb->GetSettings().PoolId_
+        );
+
+        for (const auto& asyncResult : asyncResults) {
+            ydb->ContinueQueryExecution(asyncResult);
+            TSampleQueries::TSelect42::CheckResult(asyncResult.GetResult());
+        }
+    }
+
     Y_UNIT_TEST(TestQueryCancelAfterUnlimitedPool) {
         auto ydb = TYdbSetupSettings()
             .QueryCancelAfter(TDuration::Seconds(10))

--- a/ydb/core/kqp/workload_service/ya.make
+++ b/ydb/core/kqp/workload_service/ya.make
@@ -10,6 +10,8 @@ PEERDIR(
     ydb/core/fq/libs/compute/common
 
     ydb/core/kqp/workload_service/actors
+
+    ydb/library/actors/interconnect
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/kqp/workload_service/ya.make
+++ b/ydb/core/kqp/workload_service/ya.make
@@ -7,6 +7,8 @@ SRCS(
 PEERDIR(
     ydb/core/cms/console
 
+    ydb/core/fq/libs/compute/common
+
     ydb/core/kqp/workload_service/actors
 )
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -141,7 +141,8 @@ message TFeatureFlags {
     optional bool EnableExternalSourceSchemaInference = 126 [default = false];
     optional bool EnableDbMetadataCache = 127 [default = false];
     optional bool EnableTableDatetime64 = 128 [default = false];
-    optional bool EnableResourcePools  = 129 [default = false];
+    optional bool EnableResourcePools = 129 [default = false];
     optional bool EnableColumnStatistics = 130 [default = false];
     optional bool EnableSingleCompositeActionGroup = 131 [default = false];
+    optional bool EnableResourcePoolsOnServerless = 132 [default = false];
 }

--- a/ydb/core/resource_pools/resource_pool_settings.cpp
+++ b/ydb/core/resource_pools/resource_pool_settings.cpp
@@ -7,7 +7,8 @@ std::unordered_map<TString, TProperty> GetPropertiesMap(TPoolSettings& settings,
     std::unordered_map<TString, TProperty> properties = {
         {"concurrent_query_limit", &settings.ConcurrentQueryLimit},
         {"queue_size", &settings.QueueSize},
-        {"query_memory_limit_percent_per_node", &settings.QueryMemoryLimitPercentPerNode}
+        {"query_memory_limit_percent_per_node", &settings.QueryMemoryLimitPercentPerNode},
+        {"database_load_cpu_threshold", &settings.DatabaseLoadCpuThreshold}
     };
     if (!restricted) {
         properties.insert({"query_cancel_after_seconds", &settings.QueryCancelAfter});

--- a/ydb/core/resource_pools/resource_pool_settings.h
+++ b/ydb/core/resource_pools/resource_pool_settings.h
@@ -17,6 +17,8 @@ struct TPoolSettings {
 
     TPercent QueryMemoryLimitPercentPerNode = -1;  // Percent from node memory capacity, -1 = disabled
 
+    TPercent DatabaseLoadCpuThreshold = -1;  // -1 = disabled
+
     bool operator==(const TPoolSettings& other) const = default;
 };
 

--- a/ydb/core/tx/replication/controller/util.h
+++ b/ydb/core/tx/replication/controller/util.h
@@ -32,6 +32,7 @@ inline TMaybe<TReplication::ETargetKind> TryTargetKindFromEntryType(NYdb::NSchem
     case NYdb::NScheme::ESchemeEntryType::ExternalTable:
     case NYdb::NScheme::ESchemeEntryType::ExternalDataSource:
     case NYdb::NScheme::ESchemeEntryType::View:
+    case NYdb::NScheme::ESchemeEntryType::ResourcePool:
         return Nothing();
     }
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
@@ -129,6 +129,13 @@ public:
                                                    static_cast<ui64>(OperationId.GetTxId()),
                                                    static_cast<ui64>(context.SS->SelfTabletId()));
 
+        if (context.SS->IsServerlessDomain(TPath::Init(context.SS->RootPathId(), context.SS))) {
+            if (!context.SS->EnableResourcePoolsOnServerless) {
+                result->SetError(NKikimrScheme::StatusPreconditionFailed, "Resource pools are disabled for serverless domains. Please contact your system administrator to enable it");
+                return result;
+            }
+        }
+
         const TPath& parentPath = TPath::Resolve(parentPathStr, context.SS);
         RETURN_RESULT_UNLESS(NResourcePool::IsParentPathValid(result, parentPath));
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
@@ -155,6 +155,13 @@ public:
                                                    static_cast<ui64>(OperationId.GetTxId()),
                                                    static_cast<ui64>(context.SS->SelfTabletId()));
 
+        if (context.SS->IsServerlessDomain(TPath::Init(context.SS->RootPathId(), context.SS))) {
+            if (!context.SS->EnableResourcePoolsOnServerless) {
+                result->SetError(NKikimrScheme::StatusPreconditionFailed, "Resource pools are disabled for serverless domains. Please contact your system administrator to enable it");
+                return result;
+            }
+        }
+
         const TPath& parentPath = TPath::Resolve(parentPathStr, context.SS);
         RETURN_RESULT_UNLESS(NResourcePool::IsParentPathValid(result, parentPath));
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -7009,6 +7009,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TFeatureFlags& featu
     EnableTempTables = featureFlags.GetEnableTempTables();
     EnableReplaceIfExistsForExternalEntities = featureFlags.GetEnableReplaceIfExistsForExternalEntities();
     EnableTableDatetime64 = featureFlags.GetEnableTableDatetime64();
+    EnableResourcePoolsOnServerless = featureFlags.GetEnableResourcePoolsOnServerless();
 }
 
 void TSchemeShard::ConfigureStatsBatching(const NKikimrConfig::TSchemeShardConfig& config, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -326,6 +326,7 @@ public:
     bool EnableReplaceIfExistsForExternalEntities = false;
     bool EnableTempTables = false;
     bool EnableTableDatetime64 = false;
+    bool EnableResourcePoolsOnServerless = false;
 
     TShardDeleter ShardDeleter;
 

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -392,7 +392,9 @@ THolder<NSchemeCache::TSchemeCacheNavigate> BuildSchemeCacheNavigateRequest(cons
     auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
     auto databasePath = SplitPath(database);
     request->DatabaseName = CanonizePath(databasePath);
-    request->UserToken = userToken;
+    if (userToken && !userToken->GetSerializedToken().empty()) {
+        request->UserToken = userToken;
+    }
 
     for (const auto& pathComponents : pathsComponents) {
         auto& entry = request->ResultSet.emplace_back();

--- a/ydb/mvp/core/core_ydb_impl.h
+++ b/ydb/mvp/core/core_ydb_impl.h
@@ -519,7 +519,8 @@ struct THandlerActorYdb {
             {"CoordinationNode", "coordination"},
             {"ColumnStore", "column-store"},
             {"ExternalTable", "external-table"},
-            {"ExternalDataSource", "external-data-source"}
+            {"ExternalDataSource", "external-data-source"},
+            {"ResourcePool", "resource-pool"}
         };
         if (const auto* mapping = specialCases.FindPtr(schemeEntry)) {
             return *mapping;

--- a/ydb/public/api/protos/ydb_scheme.proto
+++ b/ydb/public/api/protos/ydb_scheme.proto
@@ -64,6 +64,7 @@ message Entry {
         EXTERNAL_TABLE = 18;
         EXTERNAL_DATA_SOURCE = 19;
         VIEW = 20;
+        RESOURCE_POOL = 21;
     }
 
     // Name of scheme entry (dir2 of /dir1/dir2)

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -39,6 +39,9 @@ void PrintSchemeEntry(IOutputStream& o, const NScheme::TSchemeEntry& entry, NCol
     case NScheme::ESchemeEntryType::ExternalDataSource:
         o << colors.LightWhite();
         break;
+    case NScheme::ESchemeEntryType::ResourcePool:
+        o << colors.LightWhite();
+        break;
     default:
         o << colors.RedColor();
     }
@@ -106,6 +109,8 @@ TString EntryTypeToString(NScheme::ESchemeEntryType entry) {
         return "view";
     case NScheme::ESchemeEntryType::Replication:
         return "replication";
+    case NScheme::ESchemeEntryType::ResourcePool:
+        return "resource-pool";
     case NScheme::ESchemeEntryType::Unknown:
     case NScheme::ESchemeEntryType::Sequence:
         return "unknown";

--- a/ydb/public/sdk/cpp/client/ydb_scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_scheme/scheme.cpp
@@ -95,6 +95,8 @@ static ESchemeEntryType ConvertProtoEntryType(::Ydb::Scheme::Entry::Type entry) 
         return ESchemeEntryType::ExternalDataSource;
     case ::Ydb::Scheme::Entry::VIEW:
         return ESchemeEntryType::View;
+    case ::Ydb::Scheme::Entry::RESOURCE_POOL:
+        return ESchemeEntryType::ResourcePool;
     default:
         return ESchemeEntryType::Unknown;
     }

--- a/ydb/public/sdk/cpp/client/ydb_scheme/scheme.h
+++ b/ydb/public/sdk/cpp/client/ydb_scheme/scheme.h
@@ -42,7 +42,8 @@ enum class ESchemeEntryType : i32 {
     Topic = 17,
     ExternalTable = 18,
     ExternalDataSource = 19,
-    View = 20
+    View = 20,
+    ResourcePool = 21
 };
 
 struct TVirtualTimestamp {


### PR DESCRIPTION
- **YQ-3345 support load cpu threshold (#6360)**
- **YQ-3345 fixed WM counters and unit test (#6643)**
- **YQ-3445 added feature flag for resource pools on sls (#6808)**
- **YQ-3458 fix requests starts for queue size zero (#6949)**
- **YQ-3447 support ydb scheme ls for resource pools (#6956)**
- **YQ-3459 fix resource pools permissions (#6989)**

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support load cpu threshold

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Эти изменения нужны в пределах задачи [YQ-3222](https://st.yandex-team.ru/YQ-3222): workload manager v1 (YDB DWH к скейлу), все фичи которые должны быть к скейлу согласовали с @fomichev3000 в этой дельте:
https://delta.yandex-team.ru/page/epad/page/oq95gk1890527ptp

Ещё нужно будет доделать изменения по этим тикетам:
* [YQ-3442](https://st.yandex-team.ru/YQ-3442): Оптимизировать default pool
* [YQ-3444](https://st.yandex-team.ru/YQ-3444): Пробросить pool id из connection string
* [YQ-3446](https://st.yandex-team.ru/YQ-3446): Добавить время ожидания в очереди в статистику 
