### PR TITLE
Fix flaky KqpOlapScheme.DropTable

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -22,7 +22,6 @@ ydb/core/kqp/ut/scheme KqpOlapScheme.TenThousandColumns
 ydb/core/kqp/ut/scheme KqpOlap.OlapRead_GenericQuerys
 ydb/core/kqp/ut/scheme KqpOlap.OlapRead_StreamGenericQuery
 ydb/core/kqp/ut/scheme KqpOlap.OlapRead_UsesGenericQueryOnJoinWithDataShardTable
-ydb/core/kqp/ut/scheme KqpOlapScheme.DropTable
 ydb/core/kqp/ut/scheme KqpScheme.AlterAsyncReplication
 ydb/core/kqp/ut/scheme KqpScheme.QueryWithAlter
 ydb/core/kqp/ut/scheme [14/50]*

--- a/ydb/core/kqp/ut/common/columnshard.cpp
+++ b/ydb/core/kqp/ut/common/columnshard.cpp
@@ -132,7 +132,7 @@ namespace NKqp {
 
     void TTestHelper::WaitTabletDeletionInHive(ui64 tabletId, TDuration duration) {
         auto deadline = TInstant::Now() + duration;
-        while (GetKikimr().GetTestClient().TabletExistsInHive(&GetRuntime(), tabletId) && deadline >= TInstant::Now()) {
+        while (GetKikimr().GetTestClient().TabletExistsInHive(&GetRuntime(), tabletId) && TInstant::Now() <= deadline) {
             Cerr << "WaitTabletDeletionInHive: wait until " << tabletId << " is deleted" << Endl;
             Sleep(TDuration::Seconds(1));
         }

--- a/ydb/core/kqp/ut/common/columnshard.cpp
+++ b/ydb/core/kqp/ut/common/columnshard.cpp
@@ -130,6 +130,14 @@ namespace NKqp {
         }
     }
 
+    void TTestHelper::WaitTabletDeletionInHive(ui64 tabletId, TDuration duration) {
+        auto deadline = TInstant::Now() + duration;
+        while (GetKikimr().GetTestClient().TabletExistsInHive(&GetRuntime(), tabletId) && deadline >= TInstant::Now()) {
+            Cerr << "WaitTabletDeletionInHive: wait until " << tabletId << " is deleted" << Endl;
+            Sleep(TDuration::Seconds(1));
+        }
+    }
+
     TString TTestHelper::TColumnSchema::BuildQuery() const {
         TStringBuilder str;
         str << Name << ' ';

--- a/ydb/core/kqp/ut/common/columnshard.h
+++ b/ydb/core/kqp/ut/common/columnshard.h
@@ -82,6 +82,7 @@ namespace NKqp {
         void BulkUpsert(const TColumnTable& table, std::shared_ptr<arrow::RecordBatch> batch, const Ydb::StatusIds_StatusCode& opStatus = Ydb::StatusIds::SUCCESS);
         void ReadData(const TString& query, const TString& expected, const NYdb::EStatus opStatus = NYdb::EStatus::SUCCESS);
         void RebootTablets(const TString& tableName);
+        void WaitTabletDeletionInHive(ui64 tabletId, TDuration duration);
     };
 
 }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -6425,6 +6425,10 @@ Y_UNIT_TEST_SUITE(KqpOlapScheme) {
         }
         testHelper.DropTable("/Root/ColumnTableTest");
         for (auto tablet: tabletIds) {
+            auto deadline = TInstant::Now() + TDuration::Seconds(1);
+            while (testHelper.GetKikimr().GetTestClient().TabletExistsInHive(&testHelper.GetRuntime(), tablet) && deadline >= TInstant::Now()) {
+                // do nothing
+            }
             UNIT_ASSERT_C(!testHelper.GetKikimr().GetTestClient().TabletExistsInHive(&testHelper.GetRuntime(), tablet), ToString(tablet) + " is alive");
         }
     }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -6425,10 +6425,7 @@ Y_UNIT_TEST_SUITE(KqpOlapScheme) {
         }
         testHelper.DropTable("/Root/ColumnTableTest");
         for (auto tablet: tabletIds) {
-            auto deadline = TInstant::Now() + TDuration::Seconds(1);
-            while (testHelper.GetKikimr().GetTestClient().TabletExistsInHive(&testHelper.GetRuntime(), tablet) && deadline >= TInstant::Now()) {
-                // do nothing
-            }
+            testHelper.WaitTabletDeletionInHive(tablet, TDuration::Seconds(5));
             UNIT_ASSERT_C(!testHelper.GetKikimr().GetTestClient().TabletExistsInHive(&testHelper.GetRuntime(), tablet), ToString(tablet) + " is alive");
         }
     }


### PR DESCRIPTION
Messages TEvDeleteTablet and TEvRequestHiveInfo are sent from unit test to a hive throught different pipes, so they can be handled out of order. Because of that, a tablet may be recognised as alive shortly after DropTable is finished.

- Fixed the unit test