### PR TITLE
Do not use YQL_LOG during YQL plugin initialization

### DIFF
--- a/ydb/library/yql/yt/native/plugin.cpp
+++ b/ydb/library/yql/yt/native/plugin.cpp
@@ -351,7 +351,9 @@ public:
             ProgramFactory_->SetFileStorage(FileStorage_);
             ProgramFactory_->SetUrlPreprocessing(MakeIntrusive<NYql::TUrlPreprocessing>(GatewaysConfig_));
         } catch (const std::exception& ex) {
-            YQL_LOG(FATAL) << "Unexpected exception while initializing YQL plugin: " << ex.what();
+            // NB: YQL_LOG may be not initialized yet (for example, during singletons config parse),
+            // so we use std::cerr instead of it.
+            std::cerr << "Unexpected exception while initializing YQL plugin: " << ex.what() << std::endl;
             exit(1);
         }
         YQL_LOG(INFO) << "YQL plugin initialized";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
