### PR TITLE
Support metadata storage over pdisk

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -732,6 +732,7 @@ struct TEvBlobStorage {
         EvMinHugeBlobSizeUpdate,
         EvHugePreCompact,
         EvHugePreCompactResult,
+        EvPDiskMetadataLoaded,
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,
@@ -868,6 +869,10 @@ struct TEvBlobStorage {
         EvNodeWardenBaseConfig,
         EvNodeWardenDynamicConfigSubscribe,
         EvNodeWardenDynamicConfigPush,
+        EvNodeWardenReadMetadata,
+        EvNodeWardenReadMetadataResult,
+        EvNodeWardenWriteMetadata,
+        EvNodeWardenWriteMetadataResult,
 
         // Other
         EvRunActor = EvPut + 15 * 512,

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -220,6 +220,7 @@ namespace NKikimr::NStorage {
         std::deque<TAutoPtr<IEventHandle>> PendingEvents;
         std::vector<ui32> NodeIds;
         TNodeIdentifier SelfNode;
+        bool SelfBound = false;
 
         // scatter tasks
         ui64 NextScatterCookie = RandomNumber<ui64>();
@@ -265,15 +266,10 @@ namespace NKikimr::NStorage {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // PDisk configuration retrieval and storing
 
-        static void ReadConfig(TActorSystem *actorSystem, TActorId selfId, const std::vector<TString>& drives,
-            const TIntrusivePtr<TNodeWardenConfig>& cfg, ui64 cookie);
-
-        static void WriteConfig(TActorSystem *actorSystem, TActorId selfId, const std::vector<TString>& drives,
-            const TIntrusivePtr<TNodeWardenConfig>& cfg, const NKikimrBlobStorage::TPDiskMetadataRecord& record);
-
+        void ReadConfig(ui64 cookie = 0);
+        void WriteConfig(std::vector<TString> drives, NKikimrBlobStorage::TPDiskMetadataRecord record);
         void PersistConfig(TPersistCallback callback);
         void Handle(TEvPrivate::TEvStorageConfigStored::TPtr ev);
-
         void Handle(TEvPrivate::TEvStorageConfigLoaded::TPtr ev);
 
         static TString CalculateFingerprint(const NKikimrBlobStorage::TStorageConfig& config);

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -58,7 +58,8 @@ namespace NKikimr::NStorage {
         // issue updates
         NodeIds = std::move(nodeIds);
         BindQueue.Update(NodeIds);
-        if (NodeListObtained && StorageConfigLoaded) {
+        if (NodeListObtained && StorageConfigLoaded && !std::exchange(SelfBound, true)) {
+            UpdateBound(SelfNode.NodeId(), SelfNode, *StorageConfig, nullptr);
             IssueNextBindRequest();
         }
     }

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -328,8 +328,7 @@ namespace NKikimr::NStorage {
                 }
                 std::sort(drives.begin(), drives.end());
                 drives.erase(std::unique(drives.begin(), drives.end()), drives.end());
-                auto query = std::bind(&TThis::ReadConfig, TActivationContext::ActorSystem(), SelfId(), drives, Cfg, cookie);
-                Send(MakeIoDispatcherActorId(), new TEvInvokeQuery(std::move(query)));
+                ReadConfig(cookie);
                 ++task.AsyncOperationsPending;
                 break;
             }

--- a/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
@@ -1,60 +1,129 @@
 #include "distconf.h"
 #include <google/protobuf/util/json_util.h>
 
-
 namespace NKikimr::NStorage {
 
-    void TDistributedConfigKeeper::ReadConfig(TActorSystem *actorSystem, TActorId selfId,
-            const std::vector<TString>& drives, const TIntrusivePtr<TNodeWardenConfig>& cfg, ui64 cookie) {
-        auto ev = std::make_unique<TEvPrivate::TEvStorageConfigLoaded>();
-        for (const TString& path : drives) {
-            TRcBuf metadata;
-            std::optional<ui64> guid;
-            switch (auto status = ReadPDiskMetadata(path, cfg->PDiskKey, metadata, &guid)) {
-                case NPDisk::EPDiskMetadataOutcome::OK:
-                    if (NKikimrBlobStorage::TPDiskMetadataRecord m; m.ParseFromString(metadata.ExtractUnderlyingContainerOrCopy<TString>())) {
-                        auto& [p, config, g] = ev->MetadataPerPath.emplace_back();
-                        p = path;
-                        config.Swap(&m);
-                        g = guid;
-                    }
-                    break;
+    void TDistributedConfigKeeper::ReadConfig(ui64 cookie) {
+        class TReaderActor : public TActorBootstrapped<TReaderActor> {
+            const std::vector<TString> Paths;
+            const ui64 Cookie;
+            ui32 RepliesPending = 0;
+            std::unique_ptr<TEvPrivate::TEvStorageConfigLoaded> Response = std::make_unique<TEvPrivate::TEvStorageConfigLoaded>();
+            TActorId ParentId;
 
-                case NPDisk::EPDiskMetadataOutcome::NO_METADATA:
-                    ev->NoMetadata.emplace_back(path, guid);
-                    break;
+        public:
+            TReaderActor(std::vector<TString> paths, ui64 cookie)
+                : Paths(std::move(paths))
+                , Cookie(cookie)
+            {}
 
-                default:
-                    ev->Errors.emplace_back(path);
-                    STLOGX(*actorSystem, PRI_INFO, BS_NODE, NWDC40, "ReadConfig failed to read metadata", (Path, path),
-                        (Status, (int)status), (Cookie, cookie));
-                    break;
+            void Bootstrap(TActorId parentId) {
+                ParentId = parentId;
+
+                STLOG(PRI_DEBUG, BS_NODE, NWDC40, "TReaderActor bootstrap", (Paths, Paths));
+
+                const TActorId nodeWardenId = MakeBlobStorageNodeWardenID(SelfId().NodeId());
+                for (size_t index = 0; index < Paths.size(); ++index) {
+                    Send(nodeWardenId, new TEvNodeWardenReadMetadata(Paths[index]), 0, index);
+                    ++RepliesPending;
+                }
+
+                Become(&TThis::StateFunc);
+                CheckIfDone();
             }
-        }
-        actorSystem->Send(new IEventHandle(selfId, {}, ev.release(), 0, cookie));
+
+            void Handle(TEvNodeWardenReadMetadataResult::TPtr ev) {
+                auto *msg = ev->Get();
+                const size_t index = ev->Cookie;
+                Y_ABORT_UNLESS(index < Paths.size());
+                const TString& path = Paths[index];
+
+                STLOG(PRI_DEBUG, BS_NODE, NWDC50, "TReaderActor result", (Path, path), (Outcome, msg->Outcome),
+                    (Guid, msg->Guid), (Record, msg->Record));
+
+                switch (msg->Outcome) {
+                    case NPDisk::EPDiskMetadataOutcome::OK:
+                        Response->MetadataPerPath.emplace_back(path, std::move(msg->Record), msg->Guid);
+                        break;
+
+                    case NPDisk::EPDiskMetadataOutcome::NO_METADATA:
+                        Response->NoMetadata.emplace_back(path, msg->Guid);
+                        break;
+
+                    case NPDisk::EPDiskMetadataOutcome::ERROR:
+                        Response->Errors.push_back(path);
+                        break;
+                }
+                --RepliesPending;
+                CheckIfDone();
+            }
+
+            void CheckIfDone() {
+                if (!RepliesPending) {
+                    Send(ParentId, Response.release(), 0, Cookie);
+                    PassAway();
+                }
+            }
+
+            STRICT_STFUNC(StateFunc,
+                hFunc(TEvNodeWardenReadMetadataResult, Handle);
+            )
+        };
+        Register(new TReaderActor(DrivesToRead, cookie));
     }
 
-    void TDistributedConfigKeeper::WriteConfig(TActorSystem *actorSystem, TActorId selfId,
-            const std::vector<TString>& drives, const TIntrusivePtr<TNodeWardenConfig>& cfg,
-            const NKikimrBlobStorage::TPDiskMetadataRecord& record) {
-        THPTimer timer;
-        auto ev = std::make_unique<TEvPrivate::TEvStorageConfigStored>();
-        for (const TString& path : drives) {
-            TString data;
-            const bool success = record.SerializeToString(&data);
-            Y_ABORT_UNLESS(success);
-            std::optional<ui64> guid;
-            switch (WritePDiskMetadata(path, cfg->PDiskKey, TRcBuf(std::move(data)), &guid)) {
-                case NPDisk::EPDiskMetadataOutcome::OK:
-                    ev->StatusPerPath.emplace_back(path, true, guid);
-                    break;
+    void TDistributedConfigKeeper::WriteConfig(std::vector<TString> drives, NKikimrBlobStorage::TPDiskMetadataRecord record) {
+        class TWriterActor : public TActorBootstrapped<TWriterActor> {
+            const std::vector<TString> Drives;
+            const NKikimrBlobStorage::TPDiskMetadataRecord Record;
+            ui32 RepliesPending = 0;
+            std::unique_ptr<TEvPrivate::TEvStorageConfigStored> Response = std::make_unique<TEvPrivate::TEvStorageConfigStored>();
+            TActorId ParentId;
 
-                default:
-                    ev->StatusPerPath.emplace_back(path, false, std::nullopt);
-                    break;
+        public:
+            TWriterActor(std::vector<TString> drives, NKikimrBlobStorage::TPDiskMetadataRecord record)
+                : Drives(std::move(drives))
+                , Record(std::move(record))
+            {}
+
+            void Bootstrap(TActorId parentId) {
+                ParentId = parentId;
+
+                STLOG(PRI_DEBUG, BS_NODE, NWDC51, "TWriterActor bootstrap", (Drives, Drives), (Record, Record));
+
+                const TActorId nodeWardenId = MakeBlobStorageNodeWardenID(SelfId().NodeId());
+                for (size_t index = 0; index < Drives.size(); ++index) {
+                    Send(nodeWardenId, new TEvNodeWardenWriteMetadata(Drives[index], Record), 0, index);
+                    ++RepliesPending;
+                }
+
+                Become(&TThis::StateFunc);
+                CheckIfDone();
             }
-        }
-        actorSystem->Send(new IEventHandle(selfId, {}, ev.release()));
+
+            void Handle(TEvNodeWardenWriteMetadataResult::TPtr ev) {
+                const size_t index = ev->Cookie;
+                Y_ABORT_UNLESS(index < Drives.size());
+                const TString& path = Drives[index];
+                STLOG(PRI_DEBUG, BS_NODE, NWDC52, "TWriterActor result", (Path, path), (Outcome, ev->Get()->Outcome),
+                    (Guid, ev->Get()->Guid));
+                Response->StatusPerPath.emplace_back(path, ev->Get()->Outcome == NPDisk::EPDiskMetadataOutcome::OK, ev->Get()->Guid);
+                --RepliesPending;
+                CheckIfDone();
+            }
+
+            void CheckIfDone() {
+                if (!RepliesPending) {
+                    Send(ParentId, Response.release());
+                    PassAway();
+                }
+            }
+
+            STRICT_STFUNC(StateFunc,
+                hFunc(TEvNodeWardenWriteMetadataResult, Handle);
+            )
+        };
+        Register(new TWriterActor(std::move(drives), std::move(record)));
     }
 
     TString TDistributedConfigKeeper::CalculateFingerprint(const NKikimrBlobStorage::TStorageConfig& config) {
@@ -107,8 +176,7 @@ namespace NKikimr::NStorage {
         item.Callback = std::move(callback);
 
         if (PersistQ.size() == 1) {
-            auto query = std::bind(&TThis::WriteConfig, TActivationContext::ActorSystem(), SelfId(), item.Drives, Cfg, item.Record);
-            Send(MakeIoDispatcherActorId(), new TEvInvokeQuery(std::move(query)));
+            WriteConfig(item.Drives, item.Record);
         }
     }
 
@@ -132,9 +200,7 @@ namespace NKikimr::NStorage {
 
         if (!PersistQ.empty()) {
             auto& front = PersistQ.front();
-            auto query = std::bind(&TThis::WriteConfig, TActivationContext::ActorSystem(), SelfId(), front.Drives, Cfg,
-                front.Record);
-            Send(MakeIoDispatcherActorId(), new TEvInvokeQuery(std::move(query)));
+            WriteConfig(front.Drives, front.Record);
         }
     }
 
@@ -222,8 +288,7 @@ namespace NKikimr::NStorage {
             std::sort(drivesToRead.begin(), drivesToRead.end());
 
             if (DrivesToRead != drivesToRead) { // re-read configuration as it may cover additional drives
-                auto query = std::bind(&TThis::ReadConfig, TActivationContext::ActorSystem(), SelfId(), DrivesToRead, Cfg, 0);
-                Send(MakeIoDispatcherActorId(), new TEvInvokeQuery(std::move(query)));
+                ReadConfig();
             } else {
                 ApplyStorageConfig(InitialConfig);
                 Y_ABORT_UNLESS(DirectBoundNodes.empty()); // ensure we don't have to spread this config
@@ -234,150 +299,3 @@ namespace NKikimr::NStorage {
     }
 
 } // NKikimr::NStorage
-
-namespace NKikimr {
-
-    static const TString VaultLockFile = "/Berkanavt/kikimr/state/storage.lock";
-    static const TString VaultPath = "/Berkanavt/kikimr/state/storage.txt";
-    static TMutex VaultMutex;
-
-    static bool ReadVault(NKikimrBlobStorage::TStorageFileContent& vault) {
-        if (TFileHandle fh(VaultPath, OpenExisting | RdOnly); !fh.IsOpen()) {
-            return true;
-        } else if (TString buffer = TString::Uninitialized(fh.GetLength())) {
-            return fh.Read(buffer.Detach(), buffer.size()) == (i32)buffer.size() &&
-                google::protobuf::util::JsonStringToMessage(buffer, &vault).ok();
-        } else {
-            return true;
-        }
-    }
-
-    static bool WriteVault(NKikimrBlobStorage::TStorageFileContent& vault) {
-        TString buffer;
-        const bool success = google::protobuf::util::MessageToJsonString(vault, &buffer).ok();
-        Y_ABORT_UNLESS(success);
-
-        const TString tempPath = VaultPath + ".tmp";
-        if (TFileHandle fh(tempPath, CreateAlways | WrOnly); !fh.IsOpen()) {
-            return false;
-        } else if (fh.Flock(LOCK_EX | LOCK_NB)) {
-            Y_DEBUG_ABORT("unexpected lock race");
-            return false;
-        } else if (fh.Write(buffer.data(), buffer.size()) != (i32)buffer.size()) {
-            return false;
-        } else if (!NFs::Rename(tempPath, VaultPath)) {
-            return false;
-        }
-        return true;
-    }
-
-    NPDisk::EPDiskMetadataOutcome ReadPDiskMetadata(const TString& path, const NPDisk::TMainKey& key, TRcBuf& metadata,
-            std::optional<ui64> *pdiskGuid) {
-        TGuard<TMutex> guard(VaultMutex);
-        TFileHandle lock(VaultLockFile, OpenAlways);
-        if (!lock.IsOpen() || lock.Flock(LOCK_EX)) {
-            return NPDisk::EPDiskMetadataOutcome::ERROR;
-        }
-
-        NKikimrBlobStorage::TStorageFileContent vault;
-        if (!ReadVault(vault)) {
-            return NPDisk::EPDiskMetadataOutcome::ERROR;
-        }
-
-        NKikimrBlobStorage::TStorageFileContent::TRecord *it = nullptr;
-        for (NKikimrBlobStorage::TStorageFileContent::TRecord& item : *vault.MutableRecord()) {
-            if (item.GetPath() == path) {
-                it = &item;
-                break;
-            }
-        }
-
-        if (!it) {
-            // no metadata for this disk at all
-            return NPDisk::EPDiskMetadataOutcome::NO_METADATA;
-        } else if (std::find(key.Keys.begin(), key.Keys.end(), it->GetKey()) == key.Keys.end()) {
-            // incorrect key provided, <pretend> to unreadable format
-            return NPDisk::EPDiskMetadataOutcome::ERROR;
-        }
-
-        TPDiskInfo info;
-        const bool pdiskSuccess = ReadPDiskFormatInfo(path, key, info, false);
-
-        if (pdiskSuccess) {
-            pdiskGuid->emplace(info.DiskGuid);
-        } else {
-            pdiskGuid->reset();
-        }
-
-        if (it->GetUnformatted() && pdiskSuccess) {
-            it->SetPDiskGuid(info.DiskGuid);
-            it->SetTimestamp(info.Timestamp.GetValue());
-            it->ClearUnformatted();
-            if (!WriteVault(vault)) {
-                return NPDisk::EPDiskMetadataOutcome::ERROR;
-            }
-        }
-
-        const bool match = pdiskSuccess
-            ? it->GetPDiskGuid() == info.DiskGuid && TInstant::FromValue(it->GetTimestamp()) == info.Timestamp && !it->GetUnformatted()
-            : it->GetUnformatted();
-
-        if (match) {
-            TString s;
-            const bool success = it->GetMeta().SerializeToString(&s);
-            Y_ABORT_UNLESS(success);
-            metadata = TRcBuf(std::move(s));
-            return NPDisk::EPDiskMetadataOutcome::OK;
-        }
-
-        return NPDisk::EPDiskMetadataOutcome::NO_METADATA;
-    }
-
-    NPDisk::EPDiskMetadataOutcome WritePDiskMetadata(const TString& path, const NPDisk::TMainKey& key, TRcBuf&& metadata,
-            std::optional<ui64> *pdiskGuid) {
-        TGuard<TMutex> guard(VaultMutex);
-        TFileHandle lock(VaultLockFile, OpenAlways);
-        if (!lock.IsOpen() || lock.Flock(LOCK_EX)) {
-            return NPDisk::EPDiskMetadataOutcome::ERROR;
-        }
-
-        NKikimrBlobStorage::TStorageFileContent vault;
-        if (!ReadVault(vault)) {
-            return NPDisk::EPDiskMetadataOutcome::ERROR;
-        }
-
-        NKikimrBlobStorage::TStorageFileContent::TRecord *it = nullptr;
-        for (NKikimrBlobStorage::TStorageFileContent::TRecord& item : *vault.MutableRecord()) {
-            if (item.GetPath() == path) {
-                it = &item;
-                break;
-            }
-        }
-
-        if (!it) {
-            it = vault.AddRecord();
-            it->SetPath(path);
-        }
-
-        TPDiskInfo info;
-        const bool pdiskSuccess = ReadPDiskFormatInfo(path, key, info, false);
-
-        if (pdiskSuccess) {
-            it->SetPDiskGuid(info.DiskGuid);
-            it->SetTimestamp(info.Timestamp.GetValue());
-            it->ClearUnformatted();
-            pdiskGuid->emplace(info.DiskGuid);
-        } else {
-            it->SetUnformatted(true);
-            pdiskGuid->reset();
-        }
-        it->SetKey(key.Keys.back());
-        const bool success = it->MutableMeta()->ParseFromString(metadata.ExtractUnderlyingContainerOrCopy<TString>());
-        Y_ABORT_UNLESS(success);
-
-        return WriteVault(vault)
-            ? NPDisk::EPDiskMetadataOutcome::OK
-            : NPDisk::EPDiskMetadataOutcome::ERROR;
-    }
-
-}

--- a/ydb/core/blobstorage/nodewarden/node_warden_events.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_events.h
@@ -71,4 +71,45 @@ namespace NKikimr::NStorage {
         : TEventPB<TEvNodeWardenDynamicConfigPush, NKikimrBlobStorage::TEvNodeWardenDynamicConfigPush, TEvBlobStorage::EvNodeWardenDynamicConfigPush>
     {};
 
+    struct TEvNodeWardenReadMetadata : TEventLocal<TEvNodeWardenReadMetadata, TEvBlobStorage::EvNodeWardenReadMetadata> {
+        TString Path;
+
+        TEvNodeWardenReadMetadata(TString path)
+            : Path(std::move(path))
+        {}
+    };
+
+    struct TEvNodeWardenReadMetadataResult : TEventLocal<TEvNodeWardenReadMetadataResult, TEvBlobStorage::EvNodeWardenReadMetadataResult> {
+        std::optional<ui64> Guid;
+        NPDisk::EPDiskMetadataOutcome Outcome;
+        NKikimrBlobStorage::TPDiskMetadataRecord Record;
+
+        TEvNodeWardenReadMetadataResult(std::optional<ui64> guid, NPDisk::EPDiskMetadataOutcome outcome,
+                NKikimrBlobStorage::TPDiskMetadataRecord record)
+            : Guid(guid)
+            , Outcome(outcome)
+            , Record(std::move(record))
+        {}
+    };
+
+    struct TEvNodeWardenWriteMetadata : TEventLocal<TEvNodeWardenWriteMetadata, TEvBlobStorage::EvNodeWardenWriteMetadata> {
+        TString Path;
+        NKikimrBlobStorage::TPDiskMetadataRecord Record;
+
+        TEvNodeWardenWriteMetadata(TString path, NKikimrBlobStorage::TPDiskMetadataRecord record)
+            : Path(std::move(path))
+            , Record(std::move(record))
+        {}
+    };
+
+    struct TEvNodeWardenWriteMetadataResult : TEventLocal<TEvNodeWardenWriteMetadataResult, TEvBlobStorage::EvNodeWardenWriteMetadataResult> {
+        std::optional<ui64> Guid;
+        NPDisk::EPDiskMetadataOutcome Outcome;
+
+        TEvNodeWardenWriteMetadataResult(std::optional<ui64> guid, NPDisk::EPDiskMetadataOutcome outcome)
+            : Guid(guid)
+            , Outcome(outcome)
+        {}
+    };
+
 } // NKikimr::NStorage

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -64,6 +64,9 @@ namespace NKikimr::NStorage {
         TReplQuoter::TPtr ReplPDiskReadQuoter;
         TReplQuoter::TPtr ReplPDiskWriteQuoter;
 
+        ui32 RefCount = 0;
+        bool Temporary = false;
+
         TPDiskRecord(NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk record)
             : Record(std::move(record))
         {}
@@ -100,6 +103,12 @@ namespace NKikimr::NStorage {
         TIntrusiveList<TPDiskRecord, TUnreportedMetricTag> PDisksWithUnreportedMetrics;
         std::map<ui64, ui32> PDiskRestartRequests;
 
+        struct TPDiskByPathInfo {
+            TPDiskKey RunningPDiskId; // currently running PDiskId
+            std::optional<NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk> Pending; // pending
+        };
+        THashMap<TString, TPDiskByPathInfo> PDiskByPath;
+
         ui64 LastScrubCookie = RandomNumber<ui64>();
 
         ui32 AvailDomainId;
@@ -125,10 +134,16 @@ namespace NKikimr::NStorage {
                 EvReadCache,
                 EvGetGroup,
                 EvGroupPendingQueueTick,
+                EvDereferencePDisk,
             };
 
             struct TEvSendDiskMetrics : TEventLocal<TEvSendDiskMetrics, EvSendDiskMetrics> {};
             struct TEvUpdateNodeDrives : TEventLocal<TEvUpdateNodeDrives, EvUpdateNodeDrives> {};
+
+            struct TEvDereferencePDisk : TEventLocal<TEvDereferencePDisk, EvDereferencePDisk> {
+                TPDiskKey PDiskKey;
+                TEvDereferencePDisk(TPDiskKey pdiskKey) : PDiskKey(pdiskKey) {}
+            };
         };
 
         TControlWrapper EnablePutBatching;
@@ -144,6 +159,8 @@ namespace NKikimr::NStorage {
         TReplQuoter::TPtr ReplNodeResponseQuoter;
 
         TCostMetricsParametersByMedia CostMetricsParametersByMedia;
+
+        class TPDiskMetadataInteractionActor;
 
     public:
         struct TGroupRecord;
@@ -187,7 +204,7 @@ namespace NKikimr::NStorage {
         }
 
         TIntrusivePtr<TPDiskConfig> CreatePDiskConfig(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk);
-        void StartLocalPDisk(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk);
+        void StartLocalPDisk(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk, bool temporary);
         void AskBSCToRestartPDisk(ui32 pdiskId, ui64 requestCookie);
         void OnPDiskRestartFinished(ui32 pdiskId, NKikimrProto::EReplyStatus status);
         void DestroyLocalPDisk(ui32 pdiskId);
@@ -560,6 +577,11 @@ namespace NKikimr::NStorage {
 
         void Handle(TEvNodeWardenQueryBaseConfig::TPtr ev);
 
+        void Handle(TEvNodeWardenReadMetadata::TPtr ev);
+        void Handle(TEvNodeWardenWriteMetadata::TPtr ev);
+        TPDiskKey GetPDiskForMetadata(const TString& path);
+        void Handle(TEvPrivate::TEvDereferencePDisk::TPtr ev);
+
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ui64 NextInvokeCookie = 1;
@@ -660,6 +682,10 @@ namespace NKikimr::NStorage {
                 hFunc(TEvNodeConfigInvokeOnRootResult, Handle);
 
                 fFunc(TEvents::TSystem::Gone, HandleGone);
+
+                hFunc(TEvNodeWardenReadMetadata, Handle);
+                hFunc(TEvNodeWardenWriteMetadata, Handle);
+                hFunc(TEvPrivate::TEvDereferencePDisk, Handle);
 
                 default:
                     EnqueuePendingMessage(ev);

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -127,12 +127,32 @@ namespace NKikimr::NStorage {
         return pdiskConfig;
     }
 
-    void TNodeWarden::StartLocalPDisk(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk) {
+    void TNodeWarden::StartLocalPDisk(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk, bool temporary) {
+        const TString& path = pdisk.GetPath();
+        if (const auto it = PDiskByPath.find(path); it != PDiskByPath.end()) {
+            const auto jt = LocalPDisks.find(it->second.RunningPDiskId);
+            Y_ABORT_UNLESS(jt != LocalPDisks.end());
+            TPDiskRecord& record = jt->second;
+            if (record.Temporary) { // this is temporary PDisk spinning, have to wait for it to finish
+                it->second.Pending = pdisk;
+            } else { // incorrect configuration: we are trying to start two different PDisks with the same path
+                STLOG(PRI_ERROR, BS_NODE, NW48, "starting two PDisks with the same path", (Path, path),
+                    (ExistingPDiskId, jt->first.PDiskId), (NewPDiskId, pdisk.GetPDiskID()));
+            }
+            return;
+        }
+
         const TPDiskKey key(pdisk.GetNodeID(), pdisk.GetPDiskID());
         auto [it, inserted] = LocalPDisks.try_emplace(key, pdisk);
         TPDiskRecord& record = it->second;
-        if (!inserted) {
+        if (inserted) {
+            const auto [_, inserted] = PDiskByPath.emplace(path, TPDiskByPathInfo{key, std::nullopt});
+            Y_DEBUG_ABORT_UNLESS(inserted);
+            record.Temporary = temporary;
+        } else {
             Y_ABORT_UNLESS(record.Record.GetPDiskGuid() == pdisk.GetPDiskGuid());
+            Y_ABORT_UNLESS(!record.Temporary);
+            Y_ABORT_UNLESS(!temporary);
             return;
         }
 
@@ -163,26 +183,41 @@ namespace NKikimr::NStorage {
 
         STLOG(PRI_DEBUG, BS_NODE, NW04, "StartLocalPDisk", (NodeId, key.NodeId), (PDiskId, key.PDiskId),
             (Path, TString(TStringBuilder() << '"' << pdisk.GetPath() << '"')),
-            (PDiskCategory, TPDiskCategory(record.Record.GetPDiskCategory())));
+            (PDiskCategory, TPDiskCategory(record.Record.GetPDiskCategory())),
+            (Temporary, temporary));
 
         auto pdiskConfig = CreatePDiskConfig(pdisk);
+        if (temporary) {
+            pdiskConfig->MetadataOnly = true;
+        }
 
         const ui32 pdiskID = pdisk.GetPDiskID();
-        const TString& path = pdisk.GetPath();
         const ui64 pdiskGuid = pdisk.GetPDiskGuid();
         const ui64 pdiskCategory = pdisk.GetPDiskCategory();
         Cfg->PDiskKey.Initialize();
         Cfg->PDiskServiceFactory->Create(ActorContext(), pdiskID, pdiskConfig, Cfg->PDiskKey, AppData()->SystemPoolId, LocalNodeId);
-        Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate(pdiskID, path, pdiskGuid, pdiskCategory));
-        Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvSystemStateAddRole("Storage"));
+        if (!temporary) {
+            Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateUpdate(pdiskID, path, pdiskGuid, pdiskCategory));
+            Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvSystemStateAddRole("Storage"));
+        }
     }
 
     void TNodeWarden::DestroyLocalPDisk(ui32 pdiskId) {
+        std::optional<NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk> pending;
+
         STLOG(PRI_INFO, BS_NODE, NW36, "DestroyLocalPDisk", (PDiskId, pdiskId));
+
         if (auto it = LocalPDisks.find({LocalNodeId, pdiskId}); it != LocalPDisks.end()) {
             const TActorId actorId = MakeBlobStoragePDiskID(LocalNodeId, pdiskId);
             TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, actorId, {}, nullptr, 0));
             Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvPDiskStateDelete(pdiskId));
+            if (const auto jt = PDiskByPath.find(it->second.Record.GetPath()); jt != PDiskByPath.end() &&
+                    jt->second.RunningPDiskId == it->first) {
+                pending = std::move(jt->second.Pending);
+                PDiskByPath.erase(jt);
+            } else {
+                Y_DEBUG_ABORT("missing entry in PDiskByPath");
+            }
             LocalPDisks.erase(it);
             PDiskRestartInFlight.erase(pdiskId);
 
@@ -191,6 +226,10 @@ namespace NKikimr::NStorage {
                     it->first.NodeId == LocalNodeId && it->first.PDiskId == pdiskId; ++it) {
                 it->second.UnderlyingPDiskDestroyed = true;
             }
+        }
+
+        if (pending) {
+            StartLocalPDisk(*pending, false);
         }
     }
 
@@ -291,7 +330,7 @@ namespace NKikimr::NStorage {
 
             // This can happen if warden didn't handle pdisk's restart before node's restart.
             // In this case, PDisk has EntityStatus::RESTART instead of EntityStatus::INITIAL.
-            StartLocalPDisk(pdisk);
+            StartLocalPDisk(pdisk, false);
             SendPDiskReport(pdiskId, NKikimrBlobStorage::TEvControllerNodeReport::PD_RESTARTED);
             return;
         }
@@ -366,16 +405,25 @@ namespace NKikimr::NStorage {
 
     void TNodeWarden::ApplyServiceSetPDisks() {
         THashSet<TPDiskKey> pdiskToDelete;
+        THashSet<TString> pathsToResetPending;
         for (const auto& [key, value] : LocalPDisks) {
-            pdiskToDelete.insert(key);
+            if (!value.Temporary) { // ignore temporary disks, they are destroyed automatically
+                pdiskToDelete.insert(key);
+            }
+        }
+        for (const auto& [path, record] : PDiskByPath) {
+            if (record.Pending) {
+                pathsToResetPending.insert(path);
+            }
         }
 
         auto processDisk = [&](const TServiceSetPDisk& pdisk) {
             const TPDiskKey key(pdisk);
             if (!LocalPDisks.contains(key)) {
-                StartLocalPDisk(pdisk);
+                StartLocalPDisk(pdisk, false);
             }
             pdiskToDelete.erase(key);
+            pathsToResetPending.erase(pdisk.GetPath());
         };
 
         for (const auto& pdisk : StaticServices.GetPDisks()) {
@@ -391,6 +439,130 @@ namespace NKikimr::NStorage {
 
         for (const TPDiskKey& key : pdiskToDelete) {
             DestroyLocalPDisk(key.PDiskId);
+        }
+        for (const TString& path : pathsToResetPending) {
+            if (const auto it = PDiskByPath.find(path); it != PDiskByPath.end()) {
+                it->second.Pending.reset();
+            }
+        }
+    }
+
+    class TNodeWarden::TPDiskMetadataInteractionActor : public TActorBootstrapped<TPDiskMetadataInteractionActor> {
+        const TPDiskKey PDiskKey;
+        std::unique_ptr<IEventHandle> OriginalEv;
+        std::unique_ptr<IEventBase> ConvertedEv;
+        TActorId ParentId;
+
+    public:
+        TPDiskMetadataInteractionActor(TPDiskKey pdiskKey, TAutoPtr<IEventHandle> originalEv,
+                std::unique_ptr<IEventBase> convertedEv)
+            : PDiskKey(pdiskKey)
+            , OriginalEv(originalEv.Release())
+            , ConvertedEv(std::move(convertedEv))
+        {}
+
+        void Bootstrap(TActorId parentId) {
+            ParentId = parentId;
+            Y_ABORT_UNLESS(PDiskKey.NodeId == SelfId().NodeId());
+            Send(MakeBlobStoragePDiskID(PDiskKey.NodeId, PDiskKey.PDiskId), ConvertedEv.release(),
+                IEventHandle::FlagTrackDelivery);
+            Become(&TThis::StateFunc);
+        }
+
+        void Handle(TEvents::TEvUndelivered::TPtr ev) {
+            // send this event again, this may be a race with PDisk destruction
+            TActivationContext::Send(OriginalEv.release());
+            PassAway();
+        }
+
+        void Handle(NPDisk::TEvReadMetadataResult::TPtr ev) {
+            auto *msg = ev->Get();
+            NKikimrBlobStorage::TPDiskMetadataRecord record;
+            TRope rope(std::move(msg->Metadata));
+            TRopeStream stream(rope.begin(), rope.size());
+            STLOG(PRI_DEBUG, BS_NODE, NW59, "TEvReadMetadataResult", (PDiskId, PDiskKey.PDiskId),
+                (Outcome, msg->Outcome), (PDiskGuid, msg->PDiskGuid), (Metadata.size, rope.size()));
+            if (msg->Outcome == NPDisk::EPDiskMetadataOutcome::OK && !record.ParseFromZeroCopyStream(&stream)) {
+                STLOG(PRI_CRIT, BS_NODE, NW44, "ParseFromString failed for TPDiskMetadataRecord",
+                    (PDiskId, PDiskKey.PDiskId));
+                msg->Outcome = NPDisk::EPDiskMetadataOutcome::ERROR;
+            }
+            Send(OriginalEv->Sender, new TEvNodeWardenReadMetadataResult(msg->PDiskGuid, msg->Outcome, std::move(record)),
+                0, OriginalEv->Cookie);
+            PassAway();
+        }
+
+        void Handle(NPDisk::TEvWriteMetadataResult::TPtr ev) {
+            auto *msg = ev->Get();
+            STLOG(PRI_DEBUG, BS_NODE, NW60, "TEvWriteMetadataResult", (PDiskId, PDiskKey.PDiskId),
+                (Outcome, msg->Outcome), (PDiskGuid, msg->PDiskGuid));
+            Send(OriginalEv->Sender, new TEvNodeWardenWriteMetadataResult(msg->PDiskGuid, msg->Outcome), 0,
+                OriginalEv->Cookie);
+            PassAway();
+        }
+
+        void PassAway() override {
+            Send(ParentId, new TEvPrivate::TEvDereferencePDisk(PDiskKey));
+            TActorBootstrapped::PassAway();
+        }
+
+        STRICT_STFUNC(StateFunc,
+            hFunc(TEvents::TEvUndelivered, Handle);
+            hFunc(NPDisk::TEvReadMetadataResult, Handle);
+            hFunc(NPDisk::TEvWriteMetadataResult, Handle);
+        )
+    };
+
+    void TNodeWarden::Handle(TEvNodeWardenReadMetadata::TPtr ev) {
+        const TString& path = ev->Get()->Path;
+        STLOG(PRI_DEBUG, BS_NODE, NW56, "TEvNodeWardenReadMetadata", (Path, path));
+        Register(new TPDiskMetadataInteractionActor(GetPDiskForMetadata(path), ev.Release(),
+            std::make_unique<NPDisk::TEvReadMetadata>()));
+    }
+
+    void TNodeWarden::Handle(TEvNodeWardenWriteMetadata::TPtr ev) {
+        auto *msg = ev->Get();
+        TString data;
+        const bool success = msg->Record.SerializeToString(&data);
+        Y_ABORT_UNLESS(success);
+        const TString& path = msg->Path;
+        STLOG(PRI_DEBUG, BS_NODE, NW57, "TEvNodeWardenWriteMetadata", (Path, path), (Metadata.size, data.size()));
+        Register(new TPDiskMetadataInteractionActor(GetPDiskForMetadata(path), ev.Release(),
+            std::make_unique<NPDisk::TEvWriteMetadata>(TRcBuf(std::move(data)))));
+    }
+
+    TPDiskKey TNodeWarden::GetPDiskForMetadata(const TString& path) {
+        TPDiskKey key(LocalNodeId, Max<ui32>());
+        if (const auto it = PDiskByPath.find(path); it != PDiskByPath.end()) {
+            key = it->second.RunningPDiskId;
+        } else {
+            while (LocalPDisks.contains(key)) {
+                --key.PDiskId;
+            }
+
+            NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk pdisk;
+            pdisk.SetPath(path);
+            pdisk.SetNodeID(key.NodeId);
+            pdisk.SetPDiskID(key.PDiskId);
+            StartLocalPDisk(pdisk, true);
+        }
+
+        const auto it = LocalPDisks.find(key);
+        Y_ABORT_UNLESS(it != LocalPDisks.end());
+        TPDiskRecord& pdisk = it->second;
+        ++pdisk.RefCount;
+
+        return key;
+    }
+
+    void TNodeWarden::Handle(TEvPrivate::TEvDereferencePDisk::TPtr ev) {
+        STLOG(PRI_DEBUG, BS_NODE, NW58, "TEvDereferencePDisk", (PDiskId, ev->Get()->PDiskKey.PDiskId));
+        const auto it = LocalPDisks.find(ev->Get()->PDiskKey);
+        Y_ABORT_UNLESS(it != LocalPDisks.end());
+        TPDiskRecord& pdisk = it->second;
+        --pdisk.RefCount;
+        if (!pdisk.RefCount && pdisk.Temporary) {
+            DestroyLocalPDisk(it->first.PDiskId);
         }
     }
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -1525,8 +1525,9 @@ struct TEvReadMetadataResult : TEventLocal<TEvReadMetadataResult, TEvBlobStorage
     TRcBuf Metadata;
     std::optional<ui64> PDiskGuid;
 
-    TEvReadMetadataResult(EPDiskMetadataOutcome outcome)
+    TEvReadMetadataResult(EPDiskMetadataOutcome outcome, std::optional<ui64> pdiskGuid)
         : Outcome(outcome)
+        , PDiskGuid(pdiskGuid)
     {}
 
     TEvReadMetadataResult(TRcBuf&& metadata, std::optional<ui64> pdiskGuid)

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -39,15 +39,13 @@ namespace NPDisk {
 
 LWTRACE_USING(BLOBSTORAGE_PROVIDER);
 
-void CreatePDiskActor(
-        TGenericExecutorThread& executorThread,
+void CreatePDiskActor(TGenericExecutorThread& executorThread,
         const TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters,
         const TIntrusivePtr<TPDiskConfig> &cfg,
         const NPDisk::TMainKey &mainKey,
-        ui32 pDiskID, ui32 poolId, ui32 nodeId
-) {
-
-    TActorId actorId = executorThread.RegisterActor(CreatePDisk(cfg, mainKey, counters), TMailboxType::ReadAsFilled, poolId);
+        ui32 pDiskID, ui32 poolId, ui32 nodeId) {
+    TActorId actorId = executorThread.RegisterActor(CreatePDisk(cfg, mainKey, cfg->MetadataOnly
+        ? MakeIntrusive<NMonitoring::TDynamicCounters>() : counters), TMailboxType::ReadAsFilled, poolId);
 
     TActorId pDiskServiceId = MakeBlobStoragePDiskID(nodeId, pDiskID);
 
@@ -235,7 +233,7 @@ public:
     // Bootstrap state
     void Bootstrap(const TActorContext &ctx) {
         auto mon = AppData()->Mon;
-        if (mon) {
+        if (mon && !Cfg->MetadataOnly) {
             NMonitoring::TIndexMonPage *actorsMonPage = mon->RegisterIndexPage("actors", "Actors");
             NMonitoring::TIndexMonPage *pdisksMonPage = actorsMonPage->RegisterIndexPage("pdisks", "PDisks");
 
@@ -244,7 +242,9 @@ public:
             mon->RegisterActorPage(pdisksMonPage, path, name, false, ctx.ExecutorThread.ActorSystem,
                 SelfId());
         }
-        NodeWhiteboardServiceId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(SelfId().NodeId());
+        NodeWhiteboardServiceId = Cfg->MetadataOnly
+            ? TActorId()
+            : NNodeWhiteboard::MakeNodeWhiteboardServiceId(SelfId().NodeId());
         NodeWardenServiceId = MakeBlobStorageNodeWardenID(SelfId().NodeId());
 
         Schedule(TDuration::MilliSeconds(Cfg->StatisticsUpdateIntervalMs), new TEvents::TEvWakeup());
@@ -285,7 +285,7 @@ public:
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Init state
-    void InitError(const TString &errorReason) {
+    void InitError(const TString &errorReason, bool allowMetadataHandling = false) {
         Become(&TThis::StateError);
         for (TList<TInitQueueItem>::iterator it = InitQueue.begin(); it != InitQueue.end(); ++it) {
             Send(it->Sender, new NPDisk::TEvYardInitResult(NKikimrProto::CORRUPTED, errorReason));
@@ -299,8 +299,11 @@ public:
         StateErrorReason = str.Str();
         if (PDisk) {
             PDisk->ErrorStr = StateErrorReason;
-            auto* request = PDisk->ReqCreator.CreateFromArgs<TStopDevice>();
-            PDisk->InputRequest(request);
+            if (allowMetadataHandling) {
+                NeedToStopOnPoison = true;
+            } else {
+                PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TStopDevice>());
+            }
         }
 
         if (ControledStartResult) {
@@ -309,6 +312,8 @@ public:
             ev->ErrorReason = StateErrorReason;
             TlsActivationContext->Send(ControledStartResult.Release());
         }
+
+        StartHandlingMetadata(!allowMetadataHandling);
     }
 
     void InitHandle(NMon::TEvHttpInfo::TPtr &ev) {
@@ -332,6 +337,7 @@ public:
         FormattingThread->Join();
         IsFormattingNow = false;
         if (ev->Get()->IsSucceed) {
+            PDiskGuid.emplace(Cfg->PDiskGuid);
             StartPDiskThread();
             LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_PDISK,
                     "PDiskId# " << PDisk->PDiskId << " device formatting done");
@@ -356,58 +362,19 @@ public:
     }
 
     void CheckMagicSector(ui8 *magicData, ui32 magicDataSize) {
-        bool isFormatMagicValid = PDisk->IsFormatMagicValid(magicData, magicDataSize);
+        bool isFormatMagicValid = PDisk->IsFormatMagicValid(magicData, magicDataSize, MainKey);
         if (isFormatMagicValid) {
-            IsMagicAlreadyChecked = true;
-            IsFormattingNow = true;
-            // Stop PDiskThread but use PDisk object for creation of http pages
-            PDisk->Stop();
-            *PDisk->Mon.PDiskDetailedState = TPDiskMon::TPDisk::BootingDeviceFormattingAndTrimming;
-            PDisk->ErrorStr = "Magic sector is present on disk, now going to format device";
-            LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_PDISK, "PDiskId# " << PDisk->PDiskId << PDisk->ErrorStr);
-
-            // Is used to pass parameters into formatting thread, because TThread can pass only void*
-            using TCookieType = std::tuple<TPDiskActor*, TActorSystem*, TActorId>;
-            FormattingThread.Reset(new TThread(
-                    [] (void *cookie) -> void* {
-                        auto params = static_cast<TCookieType*>(cookie);
-                        TPDiskActor *actor = std::get<0>(*params);
-                        TActorSystem *actorSystem = std::get<1>(*params);
-                        TActorId pDiskActor = std::get<2>(*params);
-                        delete params;
-
-                        NPDisk::TKey chunkKey;
-                        NPDisk::TKey logKey;
-                        NPDisk::TKey sysLogKey;
-                        EntropyPool().Read(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
-                        EntropyPool().Read(&logKey, sizeof(NKikimr::NPDisk::TKey));
-                        EntropyPool().Read(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
-                        TPDiskConfig *cfg = actor->Cfg.Get();
-
-                        try {
-                            try {
-                                FormatPDisk(cfg->GetDevicePath(), 0, cfg->SectorSize, cfg->ChunkSize,
-                                    cfg->PDiskGuid, chunkKey, logKey, sysLogKey, actor->MainKey.Keys.back(), TString(), false,
-                                    cfg->FeatureFlags.GetTrimEntireDeviceOnStartup(), cfg->SectorMap,
-                                    cfg->FeatureFlags.GetEnableSmallDiskOptimization());
-                            } catch (NPDisk::TPDiskFormatBigChunkException) {
-                                FormatPDisk(cfg->GetDevicePath(), 0, cfg->SectorSize, NPDisk::SmallDiskMaximumChunkSize,
-                                    cfg->PDiskGuid, chunkKey, logKey, sysLogKey, actor->MainKey.Keys.back(), TString(), false,
-                                    cfg->FeatureFlags.GetTrimEntireDeviceOnStartup(), cfg->SectorMap,
-                                    cfg->FeatureFlags.GetEnableSmallDiskOptimization());
-                            }
-                            actorSystem->Send(pDiskActor, new TEvPDiskFormattingFinished(true, ""));
-                        } catch (yexception ex) {
-                            LOG_ERROR_S(*actorSystem, NKikimrServices::BS_PDISK, "Formatting error, what#" << ex.what());
-                            actorSystem->Send(pDiskActor, new TEvPDiskFormattingFinished(false, ex.what()));
-                        }
-                        return nullptr;
-                    },
-                    new TCookieType(this, TlsActivationContext->ActorSystem(), SelfId())));
-
-            FormattingThread->Start();
+            auto format = PDisk->CheckMetadataFormatSector(magicData, magicDataSize, MainKey);
+            PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TPushUnformattedMetadataSector>(format,
+                !Cfg->MetadataOnly));
+            if (Cfg->MetadataOnly) {
+                InitError("MetadataOnly is set to true, not formatting PDisk", true);
+            } else {
+                IsMagicAlreadyChecked = true;
+                IsFormattingNow = true;
+            }
         } else {
-            SecureWipeBuffer((ui8*)MainKey.Keys.data(), sizeof(NPDisk::TKey) * MainKey.Keys.size());
+            SecureWipeBuffer(reinterpret_cast<ui8*>(MainKey.Keys.data()), sizeof(NPDisk::TKey) * MainKey.Keys.size());
             *PDisk->Mon.PDiskState = NKikimrBlobStorage::TPDiskState::InitialFormatReadError;
             *PDisk->Mon.PDiskBriefState = TPDiskMon::TPDisk::Error;
             *PDisk->Mon.PDiskDetailedState = TPDiskMon::TPDisk::ErrorPDiskCannotBeInitialised;
@@ -426,6 +393,53 @@ public:
             str << " Config: " << Cfg->ToString();
             LOG_CRIT_S(*TlsActivationContext, NKikimrServices::BS_PDISK, str.Str());
         }
+    }
+
+    void InitHandle(TEvPDiskMetadataLoaded::TPtr ev) {
+        // Stop PDiskThread but use PDisk object for creation of http pages
+        PDisk->Stop();
+        *PDisk->Mon.PDiskDetailedState = TPDiskMon::TPDisk::BootingDeviceFormattingAndTrimming;
+        PDisk->ErrorStr = "Magic sector is present on disk, now going to format device";
+        LOG_WARN_S(*TlsActivationContext, NKikimrServices::BS_PDISK, "PDiskId# " << PDisk->PDiskId << ' ' << PDisk->ErrorStr);
+
+        // Is used to pass parameters into formatting thread, because TThread can pass only void*
+        using TCookieType = std::tuple<TPDiskActor*, TActorSystem*, TActorId, std::optional<TRcBuf>>;
+        FormattingThread.Reset(new TThread(
+                [] (void *cookie) -> void* {
+                    auto params = static_cast<TCookieType*>(cookie);
+                    auto [actor, actorSystem, pDiskActor, metadata] = *params;
+                    delete params;
+
+                    NPDisk::TKey chunkKey;
+                    NPDisk::TKey logKey;
+                    NPDisk::TKey sysLogKey;
+                    EntropyPool().Read(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
+                    EntropyPool().Read(&logKey, sizeof(NKikimr::NPDisk::TKey));
+                    EntropyPool().Read(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
+                    TPDiskConfig *cfg = actor->Cfg.Get();
+
+                    try {
+                        try {
+                            FormatPDisk(cfg->GetDevicePath(), 0, cfg->SectorSize, cfg->ChunkSize,
+                                cfg->PDiskGuid, chunkKey, logKey, sysLogKey, actor->MainKey.Keys.back(), TString(), false,
+                                cfg->FeatureFlags.GetTrimEntireDeviceOnStartup(), cfg->SectorMap,
+                                cfg->FeatureFlags.GetEnableSmallDiskOptimization(), metadata);
+                        } catch (NPDisk::TPDiskFormatBigChunkException) {
+                            FormatPDisk(cfg->GetDevicePath(), 0, cfg->SectorSize, NPDisk::SmallDiskMaximumChunkSize,
+                                cfg->PDiskGuid, chunkKey, logKey, sysLogKey, actor->MainKey.Keys.back(), TString(), false,
+                                cfg->FeatureFlags.GetTrimEntireDeviceOnStartup(), cfg->SectorMap,
+                                cfg->FeatureFlags.GetEnableSmallDiskOptimization(), metadata);
+                        }
+                        actorSystem->Send(pDiskActor, new TEvPDiskFormattingFinished(true, ""));
+                    } catch (yexception ex) {
+                        LOG_ERROR_S(*actorSystem, NKikimrServices::BS_PDISK, "Formatting error, what#" << ex.what());
+                        actorSystem->Send(pDiskActor, new TEvPDiskFormattingFinished(false, ex.what()));
+                    }
+                    return nullptr;
+                },
+                new TCookieType(this, TlsActivationContext->ActorSystem(), SelfId(), ev->Get()->Metadata)));
+
+        FormattingThread->Start();
     }
 
     void ReencryptDiskFormat(const TDiskFormat& format, const NPDisk::TKey& newMainKey) {
@@ -507,6 +521,7 @@ public:
             PDisk->ErrorStr = "Format chunks are not present on disk or corrupted, now checking for proper magic sector on disk";
             CheckMagicSector(formatSectors, formatSectorsSize);
         } else {
+            PDiskGuid.emplace(PDisk->Format.Guid);
             if (res.IsReencryptionRequired) {
                 // Format reencryption required
                 ReencryptDiskFormat(PDisk->Format, MainKey.Keys.back());
@@ -580,6 +595,7 @@ public:
         if (ControledStartResult) {
             TlsActivationContext->Send(ControledStartResult.Release());
         }
+        StartHandlingMetadata(false);
     }
 
     void InitHandle(NPDisk::TEvYardInit::TPtr &ev) {
@@ -772,7 +788,6 @@ public:
         Y_UNUSED(ev);
     }
 
-
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Online state
 
@@ -904,11 +919,64 @@ public:
         PDisk->InputRequest(request);
     }
 
+    std::optional<ui64> PDiskGuid;
+    std::deque<TAutoPtr<IEventHandle>> PendingMetadata;
+    enum class EMetadataHandlingState {
+        WAITING_FOR_STARTUP,
+        PROCESSING,
+        ERROR,
+    } MetadataHandlingState = EMetadataHandlingState::WAITING_FOR_STARTUP;
+    bool NeedToStopOnPoison = false;
+
+    void StartHandlingMetadata(bool error) {
+        MetadataHandlingState = error
+            ? EMetadataHandlingState::ERROR
+            : EMetadataHandlingState::PROCESSING;
+        for (auto& ev : std::exchange(PendingMetadata, {})) {
+            Receive(ev);
+        }
+    }
+
+    void Handle(TEvReadMetadata::TPtr& ev) {
+        switch (MetadataHandlingState) {
+            case EMetadataHandlingState::WAITING_FOR_STARTUP:
+                PendingMetadata.emplace_back(ev.Release());
+                break;
+
+            case EMetadataHandlingState::PROCESSING:
+                PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TReadMetadata>(ev->Sender, MainKey));
+                break;
+
+            case EMetadataHandlingState::ERROR:
+                Send(ev->Sender, new TEvReadMetadataResult(EPDiskMetadataOutcome::ERROR, PDiskGuid), 0, ev->Cookie);
+                break;
+        }
+    }
+
+    void Handle(TEvWriteMetadata::TPtr& ev) {
+        switch (MetadataHandlingState) {
+            case EMetadataHandlingState::WAITING_FOR_STARTUP:
+                PendingMetadata.emplace_back(ev.Release());
+                break;
+
+            case EMetadataHandlingState::PROCESSING:
+                PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TWriteMetadata>(ev->Sender,
+                    std::move(ev->Get()->Metadata), MainKey));
+                break;
+
+            case EMetadataHandlingState::ERROR:
+                Send(ev->Sender, new TEvWriteMetadataResult(EPDiskMetadataOutcome::ERROR, PDiskGuid), 0, ev->Cookie);
+                break;
+        }
+    }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // All states
 
     void HandlePoison() {
+        if (NeedToStopOnPoison && PDisk) {
+            PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TStopDevice>());
+        }
         ui32 pdiskId = PDisk->PDiskId;
         PDisk.Reset();
         PassAway();
@@ -1244,6 +1312,7 @@ public:
             hFunc(NPDisk::TEvLogInitResult, InitHandle);
             hFunc(TEvents::TEvUndelivered, Handle);
             hFunc(NPDisk::TEvPDiskFormattingFinished, InitHandle);
+            hFunc(NPDisk::TEvPDiskMetadataLoaded, InitHandle);
             hFunc(TEvReadFormatResult, InitHandle);
             hFunc(NPDisk::TEvReadLogResult, InitHandle);
             cFunc(NActors::TEvents::TSystem::PoisonPill, HandlePoison);
@@ -1252,6 +1321,9 @@ public:
             hFunc(NPDisk::TEvDeviceError, Handle);
             hFunc(TEvBlobStorage::TEvAskWardenRestartPDiskResult, Handle);
             hFunc(NPDisk::TEvFormatReencryptionFinish, InitHandle);
+
+            hFunc(TEvReadMetadata, Handle);
+            hFunc(TEvWriteMetadata, Handle);
     )
 
     STRICT_STFUNC(StateOnline,
@@ -1282,6 +1354,9 @@ public:
             cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
             hFunc(NPDisk::TEvDeviceError, Handle);
             hFunc(TEvBlobStorage::TEvAskWardenRestartPDiskResult, Handle);
+
+            hFunc(TEvReadMetadata, Handle);
+            hFunc(TEvWriteMetadata, Handle);
     )
 
     STRICT_STFUNC(StateError,
@@ -1309,6 +1384,9 @@ public:
             cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
             hFunc(NPDisk::TEvDeviceError, Handle);
             hFunc(TEvBlobStorage::TEvAskWardenRestartPDiskResult, Handle);
+
+            hFunc(TEvReadMetadata, Handle);
+            hFunc(TEvWriteMetadata, Handle);
     )
 };
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
@@ -1052,7 +1052,8 @@ protected:
             if (DriveData = ::NKikimr::NPDisk::GetDriveData(Path, &details)) {
                 if (ActorSystem) {
                     LOG_NOTICE_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
-                            << " Gathered DriveData, data# " << DriveData->ToString(false));
+                            << " Gathered DriveData, data# " << DriveData->ToString(false)
+                            << " Details# " << details.Str());
                 }
             } else {
                 if (ActorSystem) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -148,7 +148,11 @@ struct TPDiskConfig : public TThrRefBase {
     ui64 WarningLogChunksMultiplier = 4;
     ui64 YellowLogChunksMultiplier = 4;
 
+    ui32 MaxMetadataMegabytes = 32; // maximum size of raw metadata (in megabytes)
+
     NKikimrBlobStorage::TPDiskSpaceColor::E SpaceColorBorder = NKikimrBlobStorage::TPDiskSpaceColor::GREEN;
+
+    bool MetadataOnly = false;
 
     TPDiskConfig(ui64 pDiskGuid, ui32 pdiskId, ui64 pDiskCategory)
         : TPDiskConfig({}, pDiskGuid, pdiskId, pDiskCategory)
@@ -254,6 +258,7 @@ struct TPDiskConfig : public TThrRefBase {
         str << " PDiskGuid# " << PDiskGuid << x;
         str << " PDiskId# " << PDiskId << x;
         str << " PDiskCategory# " << PDiskCategory.ToString() << x;
+        str << " MetadataOnly# " << MetadataOnly << x;
         for (ui32 i = 0; i < HashedMainKey.size(); ++i) {
             str << " HashedMainKey[" << i << "]# " << HashedMainKey[i] << x;
         }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
@@ -24,6 +24,7 @@ const ui64 MagicSysLogChunkId = 0x5957095957095957;
 const ui64 MagicFormatChunkId = 0xF088A7F088A7F088;
 constexpr ui64 MagicIncompleteFormat = 0x5b48add808b31984;
 constexpr ui64 MagicIncompleteFormatSize = 512; // Bytes
+constexpr ui64 MagicMetadataFormatSector = 0xb5bf641dbca863d2;
 
 const ui64 Canary = 0x0123456789abcdef;
 constexpr ui32 CanarySize = 8;
@@ -397,6 +398,54 @@ struct TSysLogFirstNoncesToKeep {
         return str.Str();
     }
 };
+
+struct TMetadataHeader {
+    ui64 Nonce;
+    ui64 SequenceNumber; // of stored metadata
+    ui16 RecordIndex; // index of current record
+    ui16 TotalRecords; // total number of records for the this SequenceNumber
+    ui32 Length; // length of stored data, in bytes
+    THash DataHash; // of data only, not including header at all
+    THash HeaderHash; // of header only, not including HeaderHash
+
+    void Encrypt(TPDiskStreamCypher& cypher) {
+        cypher.StartMessage(Nonce);
+        cypher.InplaceEncrypt(&SequenceNumber, sizeof(TMetadataHeader) - sizeof(ui64));
+    }
+
+    void EncryptData(TPDiskStreamCypher& cypher) {
+        TMetadataHeader header = *this;
+        cypher.StartMessage(Nonce);
+        cypher.InplaceEncrypt(&SequenceNumber, sizeof(TMetadataHeader) - sizeof(ui64) + Length);
+        *this = header;
+    }
+
+    bool CheckHash() const {
+        TPDiskHashCalculator hasher;
+        hasher.Hash(this, sizeof(TMetadataHeader) - sizeof(THash));
+        return hasher.GetHashResult() == HeaderHash;
+    }
+
+    void SetHash() {
+        TPDiskHashCalculator hasher;
+        hasher.Hash(this, sizeof(TMetadataHeader) - sizeof(THash));
+        HeaderHash = hasher.GetHashResult();
+    }
+
+    bool CheckDataHash() const {
+        TPDiskHashCalculator hasher;
+        hasher.Hash(this + 1, Length);
+        return hasher.GetHashResult() == DataHash;
+    }
+};
+
+struct TMetadataFormatSector {
+    ui64 Magic; // MagicMetadataFormatSector
+    TKey DataKey; // data is encrypted with this key
+    ui64 Offset; // direct offset of latest stored metadata in this block device
+    ui64 Length; // length of stored metadata, including header
+    ui64 SequenceNumber; // sequence number of stored record
+};
 #pragma pack(pop)
 
 struct TChunkInfo {
@@ -514,6 +563,8 @@ struct TDiskFormat {
     ui64 DiskFormatSize;  // To determine Hash position for versions > 2
     ui64 TimestampUs;
     ui64 FormatFlags;     // Flags default to 0
+
+    TMetadataFormatSector MetadataFormat;
 
     THash Hash;
 
@@ -683,6 +734,11 @@ struct TDiskFormat {
             return size;
         }
         return DiskFormatSize;
+    }
+
+    ui64 RoundUpToSectorSize(ui64 size) const { // assuming SectorSize is a power of 2
+        Y_DEBUG_ABORT_UNLESS(IsPowerOf2(SectorSize));
+        return (size + SectorSize - 1) & ~ui64(SectorSize - 1);
     }
 
     bool IsHashOk(ui64 bufferSize) const {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_defs.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_defs.h
@@ -37,8 +37,6 @@ namespace NKikimr {
         enum class EPDiskMetadataOutcome {
             OK, // metadata was successfully read/written
             ERROR, // I/O, locking or some other kind of error has occured
-            UNFORMATTED, // pdisk is not formatted properly
-            METADATA_UNSUPPORTED, // metadata record is unsupported in this PDisk format
             NO_METADATA, // no metadata record available
         };
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -198,7 +198,7 @@ TCheckDiskFormatResult TPDisk::ReadChunk0Format(ui8* formatSectors, const NPDisk
     return TCheckDiskFormatResult(false, false);
 }
 
-bool TPDisk::IsFormatMagicValid(ui8 *magicData8, ui32 magicDataSize) {
+bool TPDisk::IsFormatMagicValid(ui8 *magicData8, ui32 magicDataSize, const TMainKey& mainKey) {
     Y_VERIFY_S(magicDataSize % sizeof(ui64) == 0, "Magic data size# "<< magicDataSize
             << " must be a multiple of sizeof(ui64)");
     Y_VERIFY_S(magicDataSize >= FormatSectorSize, "Magic data size# "<< magicDataSize
@@ -212,11 +212,15 @@ bool TPDisk::IsFormatMagicValid(ui8 *magicData8, ui32 magicDataSize) {
             isIncompleteFormatMagicPresent = false;
         }
     }
-    return magicOr == 0ull || isIncompleteFormatMagicPresent;
+    if (magicOr == 0ull || isIncompleteFormatMagicPresent) {
+        return true;
+    }
+    auto format = CheckMetadataFormatSector(magicData8, magicDataSize, mainKey);
+    return format.has_value();
 }
 
 bool TPDisk::CheckGuid(TString *outReason) {
-    const bool ok = Format.Guid == ExpectedDiskGuid;
+    const bool ok = Format.Guid == ExpectedDiskGuid || (Cfg->MetadataOnly && !ExpectedDiskGuid);
     if (!ok && outReason) {
         *outReason = TStringBuilder() << "expected# " << ExpectedDiskGuid << " on-disk# " << Format.Guid;
     }
@@ -241,7 +245,6 @@ void TPDisk::InitFreeChunks() {
         TrimAllUntrimmedChunks();
     }
 }
-
 
 TString TPDisk::StartupOwnerInfo() {
     TStringStream str;
@@ -1643,7 +1646,8 @@ void TPDisk::WriteApplyFormatRecord(TDiskFormat format, const TKey &mainKey) {
 
 void TPDisk::WriteDiskFormat(ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 userAccessibleChunkSizeBytes,
         const ui64 &diskGuid, const TKey &chunkKey, const TKey &logKey, const TKey &sysLogKey, const TKey &mainKey,
-        TString textMessage, const bool isErasureEncodeUserLog, const bool trimEntireDevice) {
+        TString textMessage, const bool isErasureEncodeUserLog, const bool trimEntireDevice,
+        std::optional<TRcBuf> metadata) {
     TGuard<TMutex> guard(StateMutex);
     // Prepare format record
     alignas(16) TDiskFormat format;
@@ -1692,6 +1696,12 @@ void TPDisk::WriteDiskFormat(ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 user
     format.SetFormatInProgress(true);
     format.SetHash();
     WriteApplyFormatRecord(format, mainKey);
+
+    if (metadata) {
+        // Prepare chunks for metadata, if needed.
+        InitFormattedMetadata();
+        WriteMetadataSync(std::move(*metadata));
+    }
 
     // Prepare initial SysLogRecord
     memset(&SysLogRecord, 0, sizeof(SysLogRecord));
@@ -2490,6 +2500,21 @@ void TPDisk::ProcessFastOperationsQueue() {
             case ERequestType::RequestReleaseChunks:
                 MarkChunksAsReleased(static_cast<TReleaseChunks&>(*req));
                 break;
+            case ERequestType::RequestReadMetadata:
+                ProcessReadMetadata(std::move(req));
+                break;
+            case ERequestType::RequestInitialReadMetadataResult:
+                ProcessInitialReadMetadataResult(static_cast<TInitialReadMetadataResult&>(*req));
+                break;
+            case ERequestType::RequestWriteMetadata:
+                ProcessWriteMetadata(std::move(req));
+                break;
+            case ERequestType::RequestWriteMetadataResult:
+                ProcessWriteMetadataResult(static_cast<TWriteMetadataResult&>(*req));
+                break;
+            case ERequestType::RequestPushUnformattedMetadataSector:
+                ProcessPushUnformattedMetadataSector(static_cast<TPushUnformattedMetadataSector&>(*req));
+                break;
             default:
                 Y_FAIL_S("Unexpected request type# " << (ui64)req->GetType());
                 break;
@@ -3078,30 +3103,28 @@ bool TPDisk::PreprocessRequest(TRequestBase *request) {
             return false;
         }
         case ERequestType::RequestAskForCutLog:
-            break;
         case ERequestType::RequestConfigureScheduler:
-            break;
         case ERequestType::RequestWhiteboartReport:
-            break;
         case ERequestType::RequestHttpInfo:
-            break;
         case ERequestType::RequestUndelivered:
-            break;
         case ERequestType::RequestCommitLogChunks:
-            break;
         case ERequestType::RequestLogCommitDone:
-            break;
         case ERequestType::RequestTryTrimChunk:
-            break;
         case ERequestType::RequestReleaseChunks:
+        case ERequestType::RequestInitialReadMetadataResult:
+        case ERequestType::RequestWriteMetadataResult:
+        case ERequestType::RequestPushUnformattedMetadataSector:
+        case ERequestType::RequestReadMetadata:
+        case ERequestType::RequestWriteMetadata:
             break;
         case ERequestType::RequestStopDevice:
             BlockDevice->Stop();
             delete request;
             return false;
-        default:
+        case ERequestType::RequestChunkReadPiece:
+        case ERequestType::RequestChunkWritePiece:
+        case ERequestType::RequestNop:
             Y_ABORT();
-            break;
     }
     return true;
 }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -18,6 +18,7 @@
 #include "blobstorage_pdisk_thread.h"
 #include "blobstorage_pdisk_util_countedqueuemanyone.h"
 #include "blobstorage_pdisk_writer.h"
+#include "blobstorage_pdisk_impl_metadata.h"
 
 #include <ydb/core/control/immediate_control_board_impl.h>
 #include <ydb/core/base/resource_profile.h>
@@ -196,12 +197,15 @@ public:
     // Debug
     std::function<TString()> DebugInfoGenerator;
 
+    // Metadata storage
+    NMeta::TInfo Meta;
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Initialization
     TPDisk(const TIntrusivePtr<TPDiskConfig> cfg, const TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters);
     TString DynamicStateToString(bool isMultiline);
     TCheckDiskFormatResult ReadChunk0Format(ui8* formatSectors, const TMainKey& mainKey); // Called by actor
-    bool IsFormatMagicValid(ui8 *magicData, ui32 magicDataSize); // Called by actor
+    bool IsFormatMagicValid(ui8 *magicData, ui32 magicDataSize, const TMainKey& mainKey); // Called by actor
     bool CheckGuid(TString *outReason); // Called by actor
     bool CheckFormatComplete(); // Called by actor
     void ReadSysLog(const TActorId &pDiskActor); // Called by actor
@@ -316,7 +320,8 @@ public:
     void WriteApplyFormatRecord(TDiskFormat format, const TKey &mainKey);
     void WriteDiskFormat(ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 userAccessibleChunkSizeBytes, const ui64 &diskGuid,
             const TKey &chunkKey, const TKey &logKey, const TKey &sysLogKey, const TKey &mainKey,
-            TString textMessage, const bool isErasureEncodeUserLog, const bool trimEntireDevice);
+            TString textMessage, const bool isErasureEncodeUserLog, const bool trimEntireDevice,
+            std::optional<TRcBuf> metadata);
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Owner initialization
     void ReplyErrorYardInitResult(TYardInit &evYardInit, const TString &str);
@@ -356,6 +361,31 @@ public:
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Drive info and write cache
     void OnDriveStartup();
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Metadata processing
+    void InitFormattedMetadata();
+    void ReadFormattedMetadataIfNeeded();
+    void ProcessInitialReadMetadataResult(TInitialReadMetadataResult& request);
+    void FinishReadingFormattedMetadata();
+
+    void ProcessPushUnformattedMetadataSector(TPushUnformattedMetadataSector& request);
+
+    void ProcessMetadataRequestQueue();
+    void ProcessReadMetadata(std::unique_ptr<TRequestBase> req);
+    void HandleNextReadMetadata();
+    void ProcessWriteMetadata(std::unique_ptr<TRequestBase> req);
+    void HandleNextWriteMetadata();
+    void ProcessWriteMetadataResult(TWriteMetadataResult& request);
+
+    TRcBuf CreateMetadataPayload(TRcBuf& metadata, size_t offset, size_t payloadSize, ui32 sectorSize, bool encryption,
+        const TKey& key, ui64 sequenceNumber, ui32 recordIndex, ui32 totalRecords);
+    bool WriteMetadataSync(TRcBuf&& metadata);
+
+    static std::optional<TMetadataFormatSector> CheckMetadataFormatSector(const ui8 *data, size_t len, const TMainKey& mainKey);
+    static void MakeMetadataFormatSector(ui8 *data, const TMainKey& mainKey, const TMetadataFormatSector& format);
+
+    NMeta::TFormatted& GetFormattedMeta();
+    NMeta::TUnformatted& GetUnformattedMeta();
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Internal interface
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_http.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_http.cpp
@@ -450,6 +450,8 @@ void TPDisk::OutputHtmlChunkLockUnlockInfo(TStringStream &str) {
                                             str << ",";
                                         } else if (chunk.OwnerId == OwnerLocked) {
                                             str << "X";
+                                        } else if (chunk.OwnerId == OwnerMetadata) {
+                                            str << 'M';
                                         } else {
                                             str << (ui32)chunk.OwnerId;
                                             if (chunk.CommitState != TChunkState::DATA_COMMITTED && chunk.CommitState != TChunkState::LOCKED) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -1389,6 +1389,8 @@ void TPDisk::ProcessReadLogResult(const NPDisk::TEvReadLogResult &evReadLogResul
                             "Error while parsing common log at booting state"));
                 return;
             }
+            // Initialize metadata.
+            InitFormattedMetadata();
             // Prepare the FreeChunks list
             InitFreeChunks();
             // Actualize LogChunks counters according to OwnerData
@@ -1498,6 +1500,9 @@ void TPDisk::ProcessReadLogResult(const NPDisk::TEvReadLogResult &evReadLogResul
             auto completion = MakeHolder<TCompletionEventSender>(this, pDiskActor, new TEvLogInitResult(true, "OK"));
             ReleaseUnusedLogChunks(completion.Get());
             WriteSysLogRestorePoint(completion.Release(), TReqId(TReqId::AfterInitCommonLoggerSysLog, 0), {});
+
+            // Start reading metadata.
+            ReadFormattedMetadataIfNeeded();
 
             // Output the fully initialized state for each owner and each chunk.
             LOG_NOTICE_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_metadata.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_metadata.cpp
@@ -1,0 +1,848 @@
+#include "blobstorage_pdisk_impl.h"
+#include "blobstorage_pdisk_completion_impl.h"
+
+namespace NKikimr::NPDisk {
+
+    namespace {
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // TCompletionReadMetadata handles single slot read during metadata loading on a formatted device
+
+        class TCompletionReadMetadata : public TCompletionAction {
+            TPDisk* const PDisk;
+            std::unique_ptr<TInitialReadMetadataResult> Req;
+            TRcBuf Buffer;
+
+        public:
+            TCompletionReadMetadata(TPDisk *pdisk, size_t bytesToRead, std::unique_ptr<TInitialReadMetadataResult> req)
+                : PDisk(pdisk)
+                , Req(std::move(req))
+                , Buffer(TRcBuf::UninitializedPageAligned(bytesToRead))
+            {}
+
+            void *GetBuffer() {
+                return Buffer.GetDataMut();
+            }
+
+            bool CanHandleResult() const override { return true; }
+
+            void Exec(TActorSystem *actorSystem) override {
+                if (Result != EIoResult::Ok) {
+                    Req->ErrorReason = std::move(ErrorReason);
+                    PDisk->InputRequest(Req.release());
+                    return Release(actorSystem);
+                }
+
+                Req->ErrorReason = "unspecified error"; // we assume error
+
+                TPDiskStreamCypher cypher(PDisk->Cfg->EnableSectorEncryption);
+                cypher.SetKey(PDisk->Format.ChunkKey);
+
+                // obtain the header and decrypt its encrypted part, then validate the hash
+                TMetadataHeader *header = reinterpret_cast<TMetadataHeader*>(GetBuffer());
+                header->Encrypt(cypher);
+                if (header->CheckHash()) {
+                    // check we have read it all
+                    const ui32 total = sizeof(TMetadataHeader) + header->Length;
+                    if (total <= Buffer.size()) {
+                        // already have all the buffer
+                        header->EncryptData(cypher);
+                        if (header->CheckDataHash()) {
+                            Req->ErrorReason = {}; 
+                            Req->Header = *header;
+                            Req->Payload = TRcBuf(TRcBuf::Piece, reinterpret_cast<const char*>(header + 1), header->Length, Buffer);
+                        } else {
+                            Req->ErrorReason = "metadata slot header passes validation, data does not -- corrupt data on disk";
+                        }
+                    } else {
+                        // have only the part of the buffer -- read more
+                        const size_t bytesToRead = PDisk->Format.RoundUpToSectorSize(sizeof(TMetadataHeader) + header->Length);
+                        Buffer = TRcBuf::UninitializedPageAligned(bytesToRead); // __header is not valid anymore__
+                        const ui64 offset = PDisk->Format.Offset(Req->Key.ChunkIdx, Req->Key.OffsetInSectors);
+                        PDisk->BlockDevice->PreadAsync(GetBuffer(), bytesToRead, offset, this, Req->ReqId, nullptr);
+                        return;
+                    }
+                } else {
+                    Req->ErrorReason = "header checksum does not pass validation";
+                }
+
+                PDisk->InputRequest(Req.release());
+                Release(actorSystem);
+            }
+
+            void Release(TActorSystem *actorSystem) override {
+                delete this;
+            }
+        };
+
+        class TCompletionWriteMetadata : public TCompletionAction {
+            TPDisk* const PDisk;
+            std::deque<std::tuple<NMeta::TSlotKey, TRcBuf>> WriteQueue;
+
+        public:
+            TCompletionWriteMetadata(TPDisk *pdisk)
+                : PDisk(pdisk)
+            {}
+
+            bool CanHandleResult() const override { return true; }
+
+            void AddQuery(NMeta::TSlotKey key, TRcBuf&& buffer) {
+                WriteQueue.emplace_back(key, std::move(buffer));
+            }
+
+            void IssueQuery() {
+                Y_ABORT_UNLESS(!WriteQueue.empty());
+                auto& [key, buffer] = WriteQueue.front();
+                const ui64 writeOffset = PDisk->Format.Offset(key.ChunkIdx, key.OffsetInSectors);
+                LOG_DEBUG_S(*PDisk->ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDisk->PDiskId
+                    << " TCompletionWriteMetadata::IssueQuery"
+                    << " Buffer.size# " << buffer.size()
+                    << " WriteOffset# " << writeOffset
+                    << " ChunkIdx# " << key.ChunkIdx
+                    << " OffsetInSectors# " << key.OffsetInSectors);
+                PDisk->BlockDevice->PwriteAsync(buffer.data(), buffer.size(), writeOffset, this, {}, nullptr);
+                WriteQueue.pop_front();
+            }
+
+            void Exec(TActorSystem *actorSystem) override {
+                LOG_DEBUG_S(*PDisk->ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDisk->PDiskId
+                    << " TCompletionWriteMetadata::Exec"
+                    << " Result# " << Result);
+                if (Result != EIoResult::Ok) {
+                    PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TWriteMetadataResult>(false));
+                } else if (WriteQueue.empty()) {
+                    PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TWriteMetadataResult>(true));
+                } else {
+                    return IssueQuery();
+                }
+                Release(actorSystem);
+            }
+
+            void Release(TActorSystem* /*actorSystem*/) override {
+                delete this;
+            }
+        };
+
+        class TCompletionReadUnformattedMetadata : public TCompletionAction {
+            TPDisk* const PDisk;
+            const TMetadataFormatSector Format;
+            const bool WantEvent;
+            TRcBuf Buffer;
+
+        public:
+            TCompletionReadUnformattedMetadata(TPDisk *pdisk, const TMetadataFormatSector& format, bool wantEvent)
+                : PDisk(pdisk)
+                , Format(format)
+                , WantEvent(wantEvent)
+            {}
+
+            bool CanHandleResult() const override { return true; }
+
+            void IssueQuery() {
+                const size_t bytesToRead = PDisk->Format.RoundUpToSectorSize(Format.Length);
+                Buffer = TRcBuf::UninitializedPageAligned(bytesToRead);
+                PDisk->BlockDevice->PreadAsync(Buffer.GetDataMut(), Buffer.size(), Format.Offset, this, {}, nullptr);
+            }
+
+            void Exec(TActorSystem *actorSystem) override {
+                std::unique_ptr<TInitialReadMetadataResult> req(
+                    PDisk->ReqCreator.CreateFromArgs<TInitialReadMetadataResult>(NMeta::TSlotKey()));
+                if (Result != EIoResult::Ok) {
+                    req->ErrorReason = "read failed";
+                } else if (Buffer.size() < sizeof(TMetadataHeader)) {
+                    req->ErrorReason = "buffer is too small to hold TMetadataHeader";
+                } else {
+                    TPDiskStreamCypher cypher(true);
+                    cypher.SetKey(Format.DataKey);
+
+                    auto *header = reinterpret_cast<TMetadataHeader*>(Buffer.GetDataMut());
+                    header->Encrypt(cypher);
+                    if (!header->CheckHash()) {
+                        req->ErrorReason = "header has is not valid";
+                    } else if (header->TotalRecords != 1 || header->RecordIndex != 0 || header->SequenceNumber != 0) {
+                        req->ErrorReason = "header fields are filled incorrectly";
+                    } else if (Buffer.size() < sizeof(TMetadataHeader) + header->Length) {
+                        req->ErrorReason = "payload does not fit";
+                    } else {
+                        header->EncryptData(cypher);
+                        if (!header->CheckDataHash()) {
+                            req->ErrorReason = "data hash is not valid";
+                        } else {
+                            req->Header = *header;
+                            req->Payload = {TRcBuf::Piece, reinterpret_cast<const char*>(header + 1), header->Length, Buffer};
+                        }
+                    }
+                }
+                if (WantEvent) {
+                    actorSystem->Send(PDisk->PDiskActor, new TEvPDiskMetadataLoaded(req->ErrorReason ? std::nullopt :
+                        std::make_optional(req->Payload)));
+                }
+                PDisk->InputRequest(req.release());
+                Release(actorSystem);
+            }
+
+            void Release(TActorSystem* /*actorSystem*/) override {
+                delete this;
+            }
+        };
+
+        class TCompletionWriteUnformattedMetadata : public TCompletionAction {
+            TPDisk* const PDisk;
+            const TMetadataFormatSector Format;
+            TRcBuf Payload;
+            const TMainKey MainKey;
+            int FormatIndex = -1; // -1 for payload
+            ui32 BadSectors = 0;
+
+        public:
+            TCompletionWriteUnformattedMetadata(TPDisk *pdisk, const TMetadataFormatSector& format, TRcBuf&& payload,
+                    const TMainKey& mainKey)
+                : PDisk(pdisk)
+                , Format(format)
+                , Payload(std::move(payload))
+                , MainKey(mainKey)
+            {}
+
+            void IssueQuery() {
+                const ui64 offset = FormatIndex == -1
+                    ? Format.Offset
+                    : FormatIndex * FormatSectorSize;
+
+                if (FormatIndex != -1) {
+                    Y_ABORT_UNLESS(static_cast<ui32>(FormatIndex) < ReplicationFactor);
+                    Payload = TRcBuf::UninitializedPageAligned(FormatSectorSize);
+                    TPDisk::MakeMetadataFormatSector(reinterpret_cast<ui8*>(Payload.GetDataMut()), MainKey, Format);
+                }
+
+                LOG_DEBUG_S(*PDisk->ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDisk->PDiskId
+                    << " TCompletionWriteUnformattedMetadata::IssueQuery"
+                    << " FormatIndex# " << FormatIndex
+                    << " Payload.size# " << Payload.size()
+                    << " Offset# " << offset);
+
+                PDisk->BlockDevice->PwriteAsync(Payload.data(), Payload.size(), offset, this, {}, nullptr);
+            }
+
+            bool CanHandleResult() const override { return true; }
+
+            void Exec(TActorSystem *actorSystem) override {
+                LOG_DEBUG_S(*PDisk->ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDisk->PDiskId
+                    << " TCompletionWriteUnformattedMetadata::Exec"
+                    << " Result# " << Result
+                    << " FormatIndex# " << FormatIndex
+                    << " BadSectors# " << BadSectors
+                    << " ReplicationFactor# " << ReplicationFactor);
+                if (Result != EIoResult::Ok) {
+                    if (FormatIndex == -1) {
+                        return Finish(false);
+                    } else {
+                        ++BadSectors;
+                    }
+                }
+                if (++FormatIndex == ReplicationFactor) { // finish query
+                    Finish(BadSectors < (ReplicationFactor + 1) / 2);
+                } else {
+                    IssueQuery();
+                }
+            }
+
+            void Release(TActorSystem* /*actorSystem*/) override {
+                delete this;
+            }
+
+            void Finish(bool success) {
+                PDisk->InputRequest(PDisk->ReqCreator.CreateFromArgs<TWriteMetadataResult>(success));
+                delete this;
+            }
+        };
+
+    } // anonymous
+
+    void TPDisk::InitFormattedMetadata() {
+        Y_ABORT_UNLESS(std::holds_alternative<std::monostate>(Meta.State));
+        auto& formatted = Meta.State.emplace<NMeta::TFormatted>();
+
+        std::vector<TChunkIdx> metadataChunks;
+
+        with_lock (StateMutex) {
+            // collect all existing metadata chunks
+            for (size_t chunkIdx = 0; chunkIdx < ChunkState.size(); ++chunkIdx) {
+                TChunkState& state = ChunkState[chunkIdx];
+                if (state.OwnerId == OwnerMetadata) {
+                    metadataChunks.push_back(chunkIdx);
+                }
+            }
+
+            // calculate amount of megabytes we need to have
+            const ui32 chunkSize = Format.ChunkSize;
+            ui64 metadataBytes = static_cast<ui64>(metadataChunks.size()) * chunkSize;
+            const ui64 requiredBytes = 2 * Cfg->MaxMetadataMegabytes * 1_MB; // double the number because we have to store old and current meta
+
+            // allocate more metadata chunks to satisfy config requirements
+            size_t chunkIdx = ChunkState.size();
+            while (chunkIdx > 0 && metadataBytes < requiredBytes) {
+                TChunkState& state = ChunkState[--chunkIdx];
+                if (state.OwnerId == OwnerUnallocated) {
+                    state.OwnerId = OwnerMetadata;
+                    state.CommitState = TChunkState::DATA_RESERVED;
+                    metadataChunks.push_back(chunkIdx);
+                    metadataBytes += chunkSize;
+                }
+            }
+        }
+
+        // prepare metadata slots for reading
+        const ui32 half = Format.ChunkSize / (2 * Format.SectorSize);
+        for (TChunkIdx chunk : metadataChunks) {
+            const NMeta::TSlotKey slot1(chunk, 0);
+            formatted.Slots.emplace(slot1, NMeta::ESlotState::READ_PENDING);
+            formatted.ReadPending.push_back(slot1);
+            const NMeta::TSlotKey slot2(chunk, half);
+            formatted.Slots.emplace(slot2, NMeta::ESlotState::READ_PENDING);
+            formatted.ReadPending.push_back(slot2);
+        }
+
+        LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId << " InitMetadata"
+            << " MetadataChunks# " << FormatList(metadataChunks));
+    }
+
+    void TPDisk::ReadFormattedMetadataIfNeeded() {
+        Y_ABORT_UNLESS(std::holds_alternative<NMeta::TScanInProgress>(Meta.StoredMetadata));
+        auto& formatted = GetFormattedMeta();
+
+        Y_ABORT_UNLESS(formatted.NumReadsInFlight < formatted.MaxReadsInFlight);
+
+        while (!formatted.ReadPending.empty()) {
+            // find the slot we have to read
+            const NMeta::TSlotKey& key = formatted.ReadPending.front();
+            const auto it = formatted.Slots.find(key);
+            Y_ABORT_UNLESS(it != formatted.Slots.end());
+            Y_ABORT_UNLESS(it->second == NMeta::ESlotState::READ_PENDING);
+
+            // make completion object and the request that will be pushed back to PDisk thread when the request is complete
+            const size_t bytesToRead = Format.RoundUpToSectorSize(sizeof(TMetadataHeader));
+            std::unique_ptr<TInitialReadMetadataResult> req(ReqCreator.CreateFromArgs<TInitialReadMetadataResult>(key));
+            const TReqId reqId = req->ReqId;
+            auto completion = std::make_unique<TCompletionReadMetadata>(this, bytesToRead, std::move(req));
+            completion->CostNs = DriveModel.TimeForSizeNs(bytesToRead, key.ChunkIdx, TDriveModel::OP_TYPE_READ);
+            void *buffer = completion->GetBuffer();
+            const ui64 readOffset = Format.Offset(key.ChunkIdx, key.OffsetInSectors);
+
+            LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+                << " ReadMetadataIfNeeded: initiating read"
+                << " ChunkIdx# " << key.ChunkIdx
+                << " OffsetInSectors# " << key.OffsetInSectors
+                << " ReadOffset# " << readOffset
+                << " BytesToRead# " << bytesToRead
+                << " ReqId# " << reqId);
+
+            // issue the request
+            BlockDevice->PreadAsync(buffer, bytesToRead, readOffset, completion.release(), reqId, nullptr);
+
+            // switch state and remove slot from the read pending queue
+            it->second = NMeta::ESlotState::READ_IN_PROGRESS;
+            formatted.ReadPending.pop_front();
+
+            if (++formatted.NumReadsInFlight == formatted.MaxReadsInFlight) { // at full capacity
+                return;
+            }
+        }
+
+        if (!formatted.NumReadsInFlight) {
+            FinishReadingFormattedMetadata();
+        }
+    }
+
+    void TPDisk::ProcessInitialReadMetadataResult(TInitialReadMetadataResult& request) {
+        std::visit(TOverloaded{
+            [](std::monostate&) { Y_ABORT("incorrect case"); },
+            [&](NMeta::TUnformatted&) {
+                LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+                    << " ProcessInitialReadMetadataResult (unformatted)"
+                    << " ErrorReason# " << request.ErrorReason
+                    << " Payload.size# " << request.Payload.size());
+
+                if (request.ErrorReason) {
+                    Meta.StoredMetadata = NMeta::TError{.Description = std::move(*request.ErrorReason)};
+                } else {
+                    Meta.StoredMetadata = std::move(request.Payload);
+                }
+                ProcessMetadataRequestQueue();
+            },
+            [&](NMeta::TFormatted& formatted) {
+                const auto it = formatted.Slots.find(request.Key);
+                Y_ABORT_UNLESS(it != formatted.Slots.end());
+                Y_ABORT_UNLESS(it->second == NMeta::ESlotState::READ_IN_PROGRESS);
+                Y_ABORT_UNLESS(formatted.NumReadsInFlight);
+                --formatted.NumReadsInFlight;
+
+                LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+                    << " ProcessInitialReadMetadataResult (formatted)"
+                    << " ChunkIdx# " << request.Key.ChunkIdx
+                    << " OffsetInSectors# " << request.Key.OffsetInSectors
+                    << " ErrorReason# " << request.ErrorReason
+                    << " Payload.size# " << request.Payload.size());
+
+                if (request.ErrorReason) { // we couldn't read the slot -- mark it as a free one
+                    it->second = NMeta::ESlotState::FREE;
+                } else {
+                    formatted.Parts.emplace_back(request.Key, request.Header, std::move(request.Payload));
+                    it->second = NMeta::ESlotState::PROCESSED;
+                }
+
+                ReadFormattedMetadataIfNeeded(); // issue next query
+            },
+        }, Meta.State);
+    }
+
+    void TPDisk::FinishReadingFormattedMetadata() {
+        auto& formatted = GetFormattedMeta();
+
+        Y_ABORT_UNLESS(formatted.ReadPending.empty());
+        for (auto& [_, state] : formatted.Slots) {
+            Y_ABORT_UNLESS(state == NMeta::ESlotState::FREE || state == NMeta::ESlotState::PROCESSED);
+        }
+
+        std::sort(formatted.Parts.begin(), formatted.Parts.end());
+        Meta.StoredMetadata.emplace<NMeta::TNoMetadata>(); // for the case when we find nothing
+        Meta.NextSequenceNumber = formatted.Parts.empty() ? 1 : formatted.Parts.back().Header.SequenceNumber + 1;
+
+        auto markSlots = [&](auto begin, auto end, NMeta::ESlotState newState) {
+            for (auto it = begin; it != end; ++it) {
+                const NMeta::ESlotState prev = std::exchange(formatted.Slots[it->Key], newState);
+                Y_ABORT_UNLESS(prev == NMeta::ESlotState::PROCESSED);
+            }
+        };
+
+        for (auto it = formatted.Parts.rbegin(); it != formatted.Parts.rend(); ) {
+            NMeta::TPart& part = *it;
+            const ui64 sequenceNumber = part.Header.SequenceNumber;
+
+            // find the ending range for this sequence number
+            decltype(it) endIt;
+            for (endIt = it; endIt != formatted.Parts.rend() && endIt->Header.SequenceNumber == sequenceNumber; ++endIt) {}
+
+            // check the validness
+            const ui32 totalParts = part.Header.TotalRecords;
+            TRope buffer;
+            ui32 expectedRecordIndex = totalParts - 1;
+            bool success = std::distance(it, endIt) == totalParts;
+            for (auto temp = it; temp != endIt; ++temp) {
+                Y_ABORT_UNLESS(temp->Header.SequenceNumber == sequenceNumber);
+                if (success && temp->Header.TotalRecords == totalParts && temp->Header.RecordIndex == expectedRecordIndex) {
+                    --expectedRecordIndex;
+                    buffer.Insert(buffer.Begin(), std::move(temp->Payload));
+                } else {
+                    success = false;
+                }
+            }
+            if (success) { // yes, the sequence is valid, we can apply it
+                markSlots(it, endIt, NMeta::ESlotState::OCCUPIED);
+                markSlots(endIt, formatted.Parts.rend(), NMeta::ESlotState::FREE);
+                Meta.StoredMetadata.emplace<TRcBuf>(buffer);
+                break;
+            } else { // no, we have to drop this sequence and proceed with the lower one
+                markSlots(it, endIt, NMeta::ESlotState::FREE);
+            }
+        }
+        formatted.Parts.clear();
+
+        // start processing any pending metadata requests
+        Y_ABORT_UNLESS(!Meta.WriteInFlight);
+        ProcessMetadataRequestQueue();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    void TPDisk::ProcessPushUnformattedMetadataSector(TPushUnformattedMetadataSector& request) {
+        Y_ABORT_UNLESS(std::holds_alternative<std::monostate>(Meta.State));
+        auto& unformatted = Meta.State.emplace<NMeta::TUnformatted>();
+        unformatted.Format = request.Format;
+        if (unformatted.Format) {
+            auto *completion = new TCompletionReadUnformattedMetadata(this, *unformatted.Format, request.WantEvent);
+            completion->IssueQuery();
+            Meta.NextSequenceNumber = unformatted.Format->SequenceNumber + 1;
+        } else {
+            Meta.StoredMetadata.emplace<NMeta::TNoMetadata>();
+            ProcessMetadataRequestQueue();
+            if (request.WantEvent) {
+                ActorSystem->Send(PDiskActor, new TEvPDiskMetadataLoaded(std::nullopt));
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    void TPDisk::ProcessMetadataRequestQueue() {
+        Y_ABORT_UNLESS(!std::holds_alternative<NMeta::TScanInProgress>(Meta.StoredMetadata));
+        while (!Meta.Requests.empty() && !Meta.WriteInFlight) {
+            const size_t sizeBefore = Meta.Requests.size();
+            switch (auto& front = Meta.Requests.front(); front->GetType()) {
+                case ERequestType::RequestReadMetadata:
+                    HandleNextReadMetadata();
+                    break;
+
+                case ERequestType::RequestWriteMetadata:
+                    HandleNextWriteMetadata();
+                    break;
+
+                default:
+                    Y_ABORT();
+            }
+            Y_ABORT_UNLESS(Meta.Requests.size() < sizeBefore || Meta.WriteInFlight);
+        }
+    }
+
+    void TPDisk::ProcessReadMetadata(std::unique_ptr<TRequestBase> req) {
+        LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+            << " ProcessReadMetadata: new request"
+            << " Sender# " << req->Sender
+            << " ScanInProgress# " << std::holds_alternative<NMeta::TScanInProgress>(Meta.StoredMetadata)
+            << " Requests.size# " << Meta.Requests.size());
+        Meta.Requests.push_back(std::move(req));
+        if (std::holds_alternative<NMeta::TScanInProgress>(Meta.StoredMetadata) || Meta.Requests.size() > 1) {
+            return;
+        }
+        HandleNextReadMetadata();
+    }
+
+    void TPDisk::HandleNextReadMetadata() {
+        auto& front = Meta.Requests.front();
+        Y_ABORT_UNLESS(front->GetType() == ERequestType::RequestReadMetadata);
+        Y_ABORT_UNLESS(!Meta.WriteInFlight);
+        auto guid = std::visit<std::optional<ui64>>(TOverloaded{
+            [](std::monostate&) -> std::nullopt_t { Y_ABORT("incorrect case"); },
+            [&](NMeta::TFormatted&) { return Format.Guid; },
+            [&](NMeta::TUnformatted&) { return std::nullopt; },
+        }, Meta.State);
+        LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+            << " HandleNextReadMetadata"
+            << " Guid# " << guid
+            << " Sender# " << front->Sender
+            << " StoredMetadata# " << NMeta::ToString(&Meta.StoredMetadata));
+        auto *response = std::visit<IEventBase*>(TOverloaded{
+            [](NMeta::TScanInProgress) -> std::nullptr_t { Y_ABORT("incorrect case"); },
+            [&](NMeta::TNoMetadata&) { return new TEvReadMetadataResult(EPDiskMetadataOutcome::NO_METADATA, guid); },
+            [&](NMeta::TError&) { return new TEvReadMetadataResult(EPDiskMetadataOutcome::ERROR, guid); },
+            [&](TRcBuf& buffer) { return new TEvReadMetadataResult(TRcBuf(buffer), guid); },
+        }, Meta.StoredMetadata);
+        ActorSystem->Send(front->Sender, response);
+        Meta.Requests.pop_front();
+    }
+
+    void TPDisk::ProcessWriteMetadata(std::unique_ptr<TRequestBase> req) {
+        LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+            << " ProcessWriteMetadata: new request"
+            << " Sender# " << req->Sender
+            << " ScanInProgress# " << std::holds_alternative<NMeta::TScanInProgress>(Meta.StoredMetadata)
+            << " Requests.size# " << Meta.Requests.size());
+        Meta.Requests.push_back(std::move(req));
+        if (std::holds_alternative<NMeta::TScanInProgress>(Meta.StoredMetadata) || Meta.Requests.size() > 1) {
+            return; // gonna handle incoming requests in order
+        }
+        HandleNextWriteMetadata();
+    }
+
+    void TPDisk::HandleNextWriteMetadata() {
+        Y_ABORT_UNLESS(!Meta.Requests.empty());
+        const auto& front = Meta.Requests.front();
+        Y_ABORT_UNLESS(front->GetType() == ERequestType::RequestWriteMetadata);
+        auto& write = static_cast<TWriteMetadata&>(*front);
+        Y_ABORT_UNLESS(!Meta.WriteInFlight);
+
+        LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+            << " HandleNextWriteMetadata"
+            << " Metadata.size# " << write.Metadata.size());
+
+        std::visit(TOverloaded{
+            [](std::monostate&) { Y_ABORT("incorrect case"); },
+            [&](NMeta::TFormatted& formatted) {
+                // calculate number of slots required to store provided meta
+                const ui64 metadataSize = write.Metadata.size();
+                const ui32 slotSize = Format.ChunkSize / (2 * Format.SectorSize) * Format.SectorSize - sizeof(TMetadataHeader);
+                const ui32 numSlotsRequired = Max<ui32>(1, (metadataSize + slotSize - 1) / slotSize);
+
+                // find free slots to store metadata
+                std::vector<NMeta::TSlotKey> freeSlotKeys;
+                for (const auto& [slotKey, state] : formatted.Slots) {
+                    if (state == NMeta::ESlotState::FREE) {
+                        freeSlotKeys.push_back(slotKey);
+                        if (freeSlotKeys.size() == numSlotsRequired) {
+                            break;
+                        }
+                    }
+                }
+
+                // check we have them enough
+                if (freeSlotKeys.size() < numSlotsRequired) {
+                    LOG_ERROR_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDisk# " << PDiskId
+                        << " ProcessWriteMetadata (formatted): not enough free slots"
+                        << " Required# " << numSlotsRequired
+                        << " Available# " << freeSlotKeys.size());
+                    ActorSystem->Send(write.Sender, new TEvWriteMetadataResult(EPDiskMetadataOutcome::ERROR, Format.Guid));
+                    Meta.Requests.pop_front();
+                    return;
+                }
+
+                // generate write queue
+                auto completion = std::make_unique<TCompletionWriteMetadata>(this);
+                size_t offset = 0;
+                for (ui32 i = 0; i < numSlotsRequired; ++i, offset += slotSize) {
+                    const NMeta::TSlotKey key = freeSlotKeys[i];
+
+                    const size_t payloadSize = Min<size_t>(slotSize, metadataSize - offset);
+                    TRcBuf payload = CreateMetadataPayload(write.Metadata, offset, payloadSize, Format.SectorSize,
+                        Cfg->EnableSectorEncryption, Format.ChunkKey, Meta.NextSequenceNumber, i, numSlotsRequired);
+
+                    completion->AddQuery(key, std::move(payload));
+                    completion->CostNs += DriveModel.TimeForSizeNs(payload.size(), key.ChunkIdx, TDriveModel::OP_TYPE_WRITE);
+
+                    const auto it = formatted.Slots.find(key);
+                    Y_ABORT_UNLESS(it != formatted.Slots.end());
+                    Y_ABORT_UNLESS(it->second == NMeta::ESlotState::FREE);
+                    it->second = NMeta::ESlotState::BEING_WRITTEN;
+                }
+
+                completion.release()->IssueQuery();
+            },
+            [&](NMeta::TUnformatted& unformatted) {
+                TMetadataFormatSector& fmt = unformatted.FormatInFlight;
+                memset(&fmt, 0, sizeof(fmt));
+
+                if (unformatted.Format) {
+                    fmt.DataKey = unformatted.Format->DataKey;
+                } else {
+                    fmt.DataKey = RandomNumber<TKey>();
+                }
+
+                TRcBuf payload = CreateMetadataPayload(write.Metadata, 0, write.Metadata.size(), DefaultSectorSize,
+                    true, fmt.DataKey, 0, 0, 1);
+                const size_t bytesToWrite = payload.size();
+
+                const ui64 deviceSizeInBytes = DriveData.Size & ~ui64(DefaultSectorSize - 1);
+                auto& cur = unformatted.Format;
+                const ui64 endOffset = !cur || cur->Offset + cur->Length + bytesToWrite <= deviceSizeInBytes
+                    ? deviceSizeInBytes
+                    : cur->Offset;
+
+                if (endOffset < bytesToWrite + FormatSectorSize * ReplicationFactor) { // way too large metadata
+                    LOG_ERROR_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDisk# " << PDiskId
+                        << " ProcessWriteMetadata (unformatted): not enough free space"
+                        << " EndOffset# " << endOffset
+                        << " RawDeviceSize# " << DriveData.Size
+                        << " DeviceSizeInBytes# " << deviceSizeInBytes
+                        << " BytesToWrite# " << bytesToWrite);
+                    ActorSystem->Send(write.Sender, new TEvWriteMetadataResult(EPDiskMetadataOutcome::ERROR, std::nullopt));
+                    Meta.Requests.pop_front();
+                    return;
+                }
+
+                fmt.Offset = endOffset - bytesToWrite;
+                fmt.Length = bytesToWrite;
+                fmt.SequenceNumber = Meta.NextSequenceNumber;
+
+                auto *completion = new TCompletionWriteUnformattedMetadata(this, fmt, std::move(payload), write.MainKey);
+                completion->IssueQuery();
+            },
+        }, Meta.State);
+
+        ++Meta.NextSequenceNumber;
+        Meta.WriteInFlight = true;
+    }
+
+    void TPDisk::ProcessWriteMetadataResult(TWriteMetadataResult& request) {
+        Y_ABORT_UNLESS(Meta.WriteInFlight);
+        Meta.WriteInFlight = false;
+
+        Y_ABORT_UNLESS(!Meta.Requests.empty());
+        auto& front = Meta.Requests.front();
+        Y_ABORT_UNLESS(front->GetType() == ERequestType::RequestWriteMetadata);
+        auto& write = static_cast<TWriteMetadata&>(*front);
+
+        std::optional<ui64> guid;
+
+        std::visit(TOverloaded{
+            [](std::monostate&) { Y_ABORT_UNLESS("incorrect case"); },
+            [&](NMeta::TFormatted& formatted) {
+                for (auto& [_, state] : formatted.Slots) {
+                    if (request.Success) {
+                        if (state == NMeta::ESlotState::BEING_WRITTEN) {
+                            state = NMeta::ESlotState::OCCUPIED;
+                        } else if (state == NMeta::ESlotState::OCCUPIED) {
+                            state = NMeta::ESlotState::FREE;
+                        }
+                    } else {
+                        if (state == NMeta::ESlotState::BEING_WRITTEN) {
+                            state = NMeta::ESlotState::FREE;
+                        }
+                    }
+                }
+                guid = Format.Guid;
+            },
+            [&](NMeta::TUnformatted& unformatted) {
+                if (request.Success) {
+                    unformatted.Format.emplace(unformatted.FormatInFlight);
+                }
+            },
+        }, Meta.State);
+
+        if (request.Success) { // update persisted metadata cache in memory
+            Meta.StoredMetadata.emplace<TRcBuf>(std::move(write.Metadata));
+        }
+
+        ActorSystem->Send(write.Sender, new TEvWriteMetadataResult(request.Success ? EPDiskMetadataOutcome::OK :
+            EPDiskMetadataOutcome::ERROR, guid));
+
+        Meta.Requests.pop_front();
+
+        ProcessMetadataRequestQueue();
+    }
+
+    TRcBuf TPDisk::CreateMetadataPayload(TRcBuf& metadata, size_t offset, size_t payloadSize, ui32 sectorSize,
+            bool encryption, const TKey& key, ui64 sequenceNumber, ui32 recordIndex, ui32 totalRecords) {
+        Y_ABORT_UNLESS(offset + payloadSize <= metadata.size());
+
+        Y_DEBUG_ABORT_UNLESS(IsPowerOf2(sectorSize));
+        const size_t dataSize = sizeof(TMetadataHeader) + payloadSize;
+        const size_t bytesToWrite = (dataSize + sectorSize - 1) & ~size_t(sectorSize - 1);
+
+        TPDiskStreamCypher cypher(encryption);
+        cypher.SetKey(key);
+
+        auto buffer = TRcBuf::UninitializedPageAligned(bytesToWrite);
+
+        Y_ABORT_UNLESS(recordIndex <= Max<ui16>());
+        Y_ABORT_UNLESS(totalRecords <= Max<ui16>());
+        Y_ABORT_UNLESS(payloadSize <= Max<ui32>());
+
+        auto *header = reinterpret_cast<TMetadataHeader*>(buffer.GetDataMut());
+        void *data = header + 1;
+        memcpy(data, metadata.data() + offset, payloadSize);
+        TPDiskHashCalculator dataHasher;
+        dataHasher.Hash(data, payloadSize);
+
+        *header = {
+            .Nonce = RandomNumber<ui64>(),
+            .SequenceNumber = sequenceNumber,
+            .RecordIndex = static_cast<ui16>(recordIndex),
+            .TotalRecords = static_cast<ui16>(totalRecords),
+            .Length = static_cast<ui32>(payloadSize),
+            .DataHash = dataHasher.GetHashResult(),
+        };
+
+        header->SetHash();
+        header->EncryptData(cypher);
+        header->Encrypt(cypher);
+
+        return buffer;
+    }
+
+    bool TPDisk::WriteMetadataSync(TRcBuf&& metadata) {
+        LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << PDiskId
+            << " WriteMetadataSync: transferring metadata"
+            << " Metadata.size# " << metadata.size());
+
+        // calculate number of slots required to store provided meta
+        const ui64 metadataSize = metadata.size();
+        const ui32 half = Format.ChunkSize / (2 * Format.SectorSize);
+        const ui32 slotSize = half * Format.SectorSize - sizeof(TMetadataHeader);
+        const ui32 numSlotsRequired = Max<ui32>(1, (metadataSize + slotSize - 1) / slotSize);
+
+        // find free slots to store metadata
+        std::vector<NMeta::TSlotKey> freeSlotKeys;
+        for (ui32 chunkIdx = 0; chunkIdx < ChunkState.size(); ++chunkIdx) {
+            if (ChunkState[chunkIdx].OwnerId == OwnerMetadata) {
+                freeSlotKeys.emplace_back(chunkIdx, 0);
+                if (freeSlotKeys.size() < numSlotsRequired) {
+                    freeSlotKeys.emplace_back(chunkIdx, half);
+                }
+                if (freeSlotKeys.size() == numSlotsRequired) {
+                    break;
+                }
+            }
+        }
+
+        // check we have them enough
+        if (freeSlotKeys.size() < numSlotsRequired) {
+            return false;
+        }
+
+        // generate write queue
+        size_t offset = 0;
+        for (ui32 i = 0; i < numSlotsRequired; ++i, offset += slotSize) {
+            const NMeta::TSlotKey key = freeSlotKeys[i];
+            const size_t payloadSize = Min<size_t>(slotSize, metadataSize - offset);
+            TRcBuf payload = CreateMetadataPayload(metadata, offset, payloadSize, Format.SectorSize,
+                Cfg->EnableSectorEncryption, Format.ChunkKey, 1, i, numSlotsRequired);
+            BlockDevice->PwriteSync(payload.data(), payload.size(), Format.Offset(key.ChunkIdx, key.OffsetInSectors), {}, nullptr);
+        }
+
+        return true;
+    }
+
+    std::optional<TMetadataFormatSector> TPDisk::CheckMetadataFormatSector(const ui8 *data, size_t len, const TMainKey& mainKey) {
+        if (len != FormatSectorSize * ReplicationFactor) {
+            Y_DEBUG_ABORT("unexpected metadata format sector size");
+            return {}; // definitely not correct
+        }
+
+        constexpr ui32 usefulDataSize = FormatSectorSize - sizeof(TDataSectorFooter);
+        static_assert(sizeof(TMetadataFormatSector) <= usefulDataSize);
+
+        TPDiskStreamCypher cypher(true);
+        auto decrypted = TRcBuf::Uninitialized(usefulDataSize);
+        auto& decryptedSector = *reinterpret_cast<TMetadataFormatSector*>(decrypted.GetDataMut());
+
+        std::optional<TMetadataFormatSector> winner;
+
+        for (ui32 i = 0; i < ReplicationFactor; ++i, data += FormatSectorSize) {
+            auto& footer = *reinterpret_cast<const TDataSectorFooter*>(data + usefulDataSize);
+            for (const auto& key : mainKey.Keys) {
+                cypher.SetKey(key);
+                cypher.StartMessage(footer.Nonce);
+                cypher.Encrypt(decrypted.GetDataMut(), data, decrypted.size());
+                TPDiskHashCalculator hasher;
+                hasher.Hash(decrypted.data(), decrypted.size());
+                if (hasher.GetHashResult() == footer.Hash && decryptedSector.Magic == MagicMetadataFormatSector) {
+                    if (!winner || winner->SequenceNumber < decryptedSector.SequenceNumber) {
+                        winner.emplace(decryptedSector);
+                    }
+                }
+            }
+        }
+
+        return winner;
+    }
+
+    void TPDisk::MakeMetadataFormatSector(ui8 *data, const TMainKey& mainKey, const TMetadataFormatSector& format) {
+        TReallyFastRng32 rng(RandomNumber<ui64>());
+        for (ui32 *p = reinterpret_cast<ui32*>(data); static_cast<void*>(p) < data + FormatSectorSize; ++p) {
+            *p = rng();
+        }
+
+        TMetadataFormatSector *p = reinterpret_cast<TMetadataFormatSector*>(data);
+        *p = format;
+        p->Magic = MagicMetadataFormatSector;
+
+        TPDiskHashCalculator hasher;
+        constexpr ui32 usefulDataSize = FormatSectorSize - sizeof(TDataSectorFooter);
+        hasher.Hash(data, usefulDataSize);
+
+        auto& footer = *reinterpret_cast<TDataSectorFooter*>(data + usefulDataSize);
+        memset(&footer, 0, sizeof(footer));
+        footer.Nonce = RandomNumber<ui64>();
+        footer.Version = PDISK_DATA_VERSION;
+        footer.Hash = hasher.GetHashResult();
+
+        TPDiskStreamCypher cypher(true);
+        cypher.SetKey(mainKey.Keys.back());
+        cypher.StartMessage(footer.Nonce);
+        cypher.InplaceEncrypt(data, usefulDataSize);
+    }
+
+    NMeta::TFormatted& TPDisk::GetFormattedMeta() {
+        Y_ABORT_UNLESS(std::holds_alternative<NMeta::TFormatted>(Meta.State));
+        return std::get<NMeta::TFormatted>(Meta.State);
+    }
+
+} // NKikimr::NPDisk

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_metadata.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_metadata.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include "defs.h"
+
+#include "blobstorage_pdisk_defs.h"
+#include "blobstorage_pdisk_data.h"
+
+// TODO:
+// 1. Нужно сделать механизм для чтения и записи метаданных в двух режимах:
+//    * когда PDisk отформатирован и работает
+//    * когда PDisk без форматирования
+// 2. Нужно сделать перенос метаданных при форматировании, причём так, чтобы при случайном перебое в процессе не вышло,
+//    что метаданные потерялись и их больше нет (NO_METADATA), хотя ERROR допустимо. Но нежелательно.
+// 3. Obliterate должен удалять метаданные тоже, даже если они были на неформатированном диске.
+// 4. Старый PDisk может не запускаться на новом PDisk'е с метаданными и без форматирования.
+
+namespace NKikimr::NPDisk {
+
+    class TRequestBase;
+
+} // NKikimr::NPDisk
+
+namespace NKikimr::NPDisk::NMeta {
+
+    enum class ESlotState {
+        READ_PENDING,
+        READ_IN_PROGRESS,
+        PROCESSED,
+        FREE,
+        OCCUPIED,
+        BEING_WRITTEN,
+    };
+
+    struct TSlotKey {
+        TChunkIdx ChunkIdx = 0;
+        ui32 OffsetInSectors = 0;
+
+        TSlotKey() = default;
+        TSlotKey(TChunkIdx chunkIdx, ui32 offsetInSectors) : ChunkIdx(chunkIdx), OffsetInSectors(offsetInSectors) {}
+
+        friend auto operator <=>(const TSlotKey&, const TSlotKey&) = default;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // TStoredMetadata variant -- different options describing what we have about metadata
+
+    struct TScanInProgress { // we are still reading the metadata
+    };
+
+    struct TNoMetadata { // no metadata stored yet
+    };
+
+    struct TError {
+        TString Description; // textual description of error happened when we loaded the metadata
+    };
+
+    using TStoredMetadata = std::variant<TScanInProgress, TNoMetadata, TError, TRcBuf>;
+
+    inline TString ToString(const TStoredMetadata *m) {
+        return std::visit<TString>(TOverloaded{
+            [](const TScanInProgress&) { return "ScanInProgress"; },
+            [](const TNoMetadata&) { return "NoMetadata"; },
+            [](const TError& e) { return TStringBuilder() << "Error{" << e.Description << '}'; },
+            [](const TRcBuf& meta) { return TStringBuilder() << "Metadata{" << meta.size() << "b}"; },
+        }, *m);
+    }
+
+    // TMetadataPart -- a fragment of metadata (half-chunk) that has been read into memory, but not processed yet. 
+    struct TPart {
+        TSlotKey Key;
+        TMetadataHeader Header;
+        TRcBuf Payload;
+
+        TPart(TSlotKey key, const TMetadataHeader& header, TRcBuf&& payload)
+            : Key(key)
+            , Header(header)
+            , Payload(std::move(payload))
+        {}
+
+        friend auto operator <=>(const TPart& x, const TPart& y) {
+            if (const auto diff = x.Header.SequenceNumber <=> y.Header.SequenceNumber; diff != 0) {
+                return diff;
+            } else if (const auto diff = x.Header.RecordIndex <=> y.Header.RecordIndex; diff != 0) {
+                return diff;
+            } else {
+                return std::strong_ordering::equal;
+            }
+        }
+    };
+
+    // TFormatted -- state record for formatted version of PDisk metadata storage
+    struct TFormatted {
+        static constexpr ui32 MaxReadsInFlight = 1;
+
+        std::map<TSlotKey, ESlotState> Slots;
+        std::deque<TSlotKey> ReadPending; // slots in READ_PENDING state
+        ui32 NumReadsInFlight = 0;
+        std::deque<TPart> Parts;
+    };
+
+    // TUnformatted -- state record for unformatted version of PDisk metadata storage
+    struct TUnformatted {
+        std::optional<TMetadataFormatSector> Format; // format value, if set
+        TMetadataFormatSector FormatInFlight; // being written
+    };
+
+    struct TInfo {
+        std::variant<std::monostate, TFormatted, TUnformatted> State; // metadata storage state
+        TStoredMetadata StoredMetadata; // the one that is persistently stored
+        std::deque<std::unique_ptr<TRequestBase>> Requests; // requests pending; the first one is in flight
+        bool WriteInFlight = false;
+        ui64 NextSequenceNumber = 1;
+    };
+
+} // NKikimr::NPDisk::NMeta

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_internal_interface.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_internal_interface.h
@@ -81,6 +81,13 @@ struct TEvPDiskFormattingFinished : public TEventLocal<TEvPDiskFormattingFinishe
     }
 };
 
+struct TEvPDiskMetadataLoaded : public TEventLocal<TEvPDiskMetadataLoaded, TEvBlobStorage::EvPDiskMetadataLoaded> {
+    std::optional<TRcBuf> Metadata;
+
+    TEvPDiskMetadataLoaded(std::optional<TRcBuf> metadata)
+        : Metadata(std::move(metadata))
+    {}
+};
 
 ////////////////////////////////////////////////////////////////////////////
 // This event is used for continuing log reading if it is not possible

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
@@ -83,6 +83,11 @@ struct TReqId {
         ReleaseChunks = 64,
         StopDevice = 65,
         ChunkForget = 66,
+        ReadMetadata = 67,
+        InitialReadMetadataResult = 68,
+        WriteMetadata = 69,
+        WriteMetadataResult = 70,
+        PushUnformattedMetadataSector = 71,
     };
 
     // 56 bit idx, 8 bit source
@@ -141,6 +146,11 @@ enum class ERequestType {
     RequestReleaseChunks,
     RequestStopDevice,
     RequestChunkForget,
+    RequestReadMetadata,
+    RequestInitialReadMetadataResult,
+    RequestWriteMetadata,
+    RequestWriteMetadataResult,
+    RequestPushUnformattedMetadataSector,
 };
 
 inline IOutputStream& operator <<(IOutputStream& out, const TReqId& reqId) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
@@ -7,6 +7,7 @@
 #include "blobstorage_pdisk_internal_interface.h"
 #include "blobstorage_pdisk_mon.h"
 #include "blobstorage_pdisk_request_id.h"
+#include "blobstorage_pdisk_impl_metadata.h"
 
 #include <ydb/core/blobstorage/base/vdisk_priorities.h>
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
@@ -1004,6 +1005,83 @@ public:
     }
 };
 
+class TReadMetadata : public TRequestBase {
+public:
+    const TMainKey MainKey;
+    std::optional<TMetadataFormatSector> Format;
+
+    TReadMetadata(TActorId sender, const TMainKey& mainKey, TAtomicBase reqIdx)
+        : TRequestBase(sender, TReqId(TReqId::ReadMetadata, reqIdx), OwnerSystem, 0, NPriInternal::Other)
+        , MainKey(mainKey)
+    {}
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestReadMetadata;
+    }
+};
+
+class TInitialReadMetadataResult : public TRequestBase {
+public:
+    const NMeta::TSlotKey Key;
+    std::optional<TString> ErrorReason;
+    TMetadataHeader Header;
+    TRcBuf Payload;
+
+    TInitialReadMetadataResult(NMeta::TSlotKey key, TAtomicBase reqIdx)
+        : TRequestBase({}, TReqId(TReqId::InitialReadMetadataResult, reqIdx), OwnerSystem, 0, NPriInternal::Other)
+        , Key(key)
+    {}
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestInitialReadMetadataResult;
+    }
+};
+
+class TWriteMetadata : public TRequestBase {
+public:
+    TRcBuf Metadata;
+    TMainKey MainKey;
+
+    TWriteMetadata(TActorId sender, TRcBuf&& metadata, const TMainKey& mainKey, TAtomicBase reqIdx)
+        : TRequestBase(sender, TReqId(TReqId::WriteMetadata, reqIdx), OwnerSystem, 0, NPriInternal::Other)
+        , Metadata(std::move(metadata))
+        , MainKey(mainKey)
+    {}
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestWriteMetadata;
+    }
+};
+
+class TWriteMetadataResult : public TRequestBase {
+public:
+    const bool Success;
+
+    TWriteMetadataResult(bool success, TAtomicBase reqIdx)
+        : TRequestBase({}, TReqId(TReqId::WriteMetadataResult, reqIdx), OwnerSystem, 0, NPriInternal::Other)
+        , Success(success)
+    {}
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestWriteMetadataResult;
+    }
+};
+
+class TPushUnformattedMetadataSector : public TRequestBase {
+public:
+    const std::optional<TMetadataFormatSector> Format;
+    const bool WantEvent;
+
+    TPushUnformattedMetadataSector(const std::optional<TMetadataFormatSector>& format, bool wantEvent, TAtomicBase reqIdx)
+        : TRequestBase({}, TReqId(TReqId::PushUnformattedMetadataSector, reqIdx), OwnerSystem, 0, NPriInternal::Other)
+        , Format(format)
+        , WantEvent(wantEvent)
+    {}
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestPushUnformattedMetadataSector;
+    }
+};
+
 } // NPDisk
 } // NKikimr
-

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
@@ -27,6 +27,7 @@ enum EOwner {
     OwnerUnallocated = 1, // Unallocated chunks, Trim scheduling, Slay commands
     OwnerBeginUser = 2,
     OwnerEndUser = 241,
+    OwnerMetadata = 250, // Metadata chunks, the real owner
     OwnerSystemLog = 251, // Not used to actually mark chunks, just for space tracking
     OwnerSystemReserve = 252, // Not used to actually mark chunks, just for space tracking, means "for static" in requests
     OwnerCommonStaticLog = 253, // Not used to actually mark chunks, just for space tracking

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
@@ -51,7 +51,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
 void FormatPDisk(TString path, ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 userAccessibleChunkSizeBytes,
     const ui64 &diskGuid, const NPDisk::TKey &chunkKey, const NPDisk::TKey &logKey, const NPDisk::TKey &sysLogKey,
     const NPDisk::TKey &mainKey, TString textMessage, const bool isErasureEncodeUserLog, bool trimEntireDevice,
-    TIntrusivePtr<NPDisk::TSectorMap> sectorMap, bool enableSmallDiskOptimization)
+    TIntrusivePtr<NPDisk::TSectorMap> sectorMap, bool enableSmallDiskOptimization, std::optional<TRcBuf> metadata)
 {
     TActorSystemCreator creator;
 
@@ -117,7 +117,8 @@ void FormatPDisk(TString path, ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 us
         ythrow yexception() << "Device with path# " << path << " is not good, info# " << pDisk->BlockDevice->DebugInfo();
     }
     pDisk->WriteDiskFormat(diskSizeBytes, sectorSizeBytes, userAccessibleChunkSizeBytes, diskGuid,
-        chunkKey, logKey, sysLogKey, mainKey, textMessage, isErasureEncodeUserLog, trimEntireDevice);
+        chunkKey, logKey, sysLogKey, mainKey, textMessage, isErasureEncodeUserLog, trimEntireDevice,
+        std::move(metadata));
 }
 
 bool ReadPDiskFormatInfo(const TString &path, const NPDisk::TMainKey &mainKey, TPDiskInfo &outInfo,

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.h
@@ -44,7 +44,8 @@ void FormatPDisk(TString path, ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 us
     const ui64 &diskGuid, const NPDisk::TKey &chunkKey, const NPDisk::TKey &logKey,
     const NPDisk::TKey &sysLogKey, const NPDisk::TKey &mainKey, TString textMessage,
     const bool isErasureEncodeUserLog = false, const bool trimEntireDevice = false,
-    TIntrusivePtr<NPDisk::TSectorMap> sectorMap = nullptr, bool enableSmallDiskOptimization = true);
+    TIntrusivePtr<NPDisk::TSectorMap> sectorMap = nullptr, bool enableSmallDiskOptimization = true,
+    std::optional<TRcBuf> metadata = std::nullopt);
 
 bool ReadPDiskFormatInfo(const TString &path, const NPDisk::TMainKey &mainKey, TPDiskInfo &outInfo,
     const bool doLock = false, TIntrusivePtr<NPDisk::TSectorMap> sectorMap = nullptr);

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -47,6 +47,7 @@ struct TPDiskMockState::TImpl {
     THashSet<ui32> ReadOnlyVDisks;
     TString StateErrorReason;
     NPDisk::EDeviceType DeviceType;
+    std::optional<TRcBuf> Metadata;
 
     TImpl(ui32 nodeId, ui32 pdiskId, ui64 pdiskGuid, ui64 size, ui32 chunkSize, NPDisk::EDeviceType deviceType)
         : NodeId(nodeId)
@@ -928,6 +929,27 @@ public:
         Y_UNUSED(ev);
     }
 
+    void ErrorHandle(NPDisk::TEvReadMetadata::TPtr& ev) {
+        Send(ev->Sender, new NPDisk::TEvReadMetadataResult(NPDisk::EPDiskMetadataOutcome::ERROR, std::nullopt), 0, ev->Cookie);
+    }
+
+    void ErrorHandle(NPDisk::TEvWriteMetadata::TPtr& ev) {
+        Send(ev->Sender, new NPDisk::TEvWriteMetadataResult(NPDisk::EPDiskMetadataOutcome::ERROR, std::nullopt), 0, ev->Cookie);
+    }
+
+    void Handle(NPDisk::TEvReadMetadata::TPtr& ev) {
+        if (Impl.Metadata) {
+            Send(ev->Sender, new NPDisk::TEvReadMetadataResult(TRcBuf(*Impl.Metadata), Impl.PDiskGuid), 0, ev->Cookie);
+        } else {
+            Send(ev->Sender, new NPDisk::TEvReadMetadataResult(NPDisk::EPDiskMetadataOutcome::NO_METADATA, Impl.PDiskGuid), 0, ev->Cookie);
+        }
+    }
+
+    void Handle(NPDisk::TEvWriteMetadata::TPtr& ev) {
+        Impl.Metadata.emplace(std::move(ev->Get()->Metadata));
+        Send(ev->Sender, new NPDisk::TEvWriteMetadataResult(NPDisk::EPDiskMetadataOutcome::OK, Impl.PDiskGuid), 0, ev->Cookie);
+    }
+
     void HandleMoveToErrorState() {
         Impl.StateErrorReason = "Some error reason";
         Become(&TThis::StateError);
@@ -954,6 +976,8 @@ public:
         hFunc(NPDisk::TEvConfigureScheduler, Handle);
         hFunc(TEvBlobStorage::TEvAskWardenRestartPDiskResult, Handle);
         cFunc(TEvents::TSystem::Wakeup, ReportMetrics);
+        hFunc(NPDisk::TEvReadMetadata, Handle);
+        hFunc(NPDisk::TEvWriteMetadata, Handle);
 
         cFunc(EvBecomeError, HandleMoveToErrorState);
     )
@@ -970,6 +994,8 @@ public:
         hFunc(NPDisk::TEvSlay, ErrorHandle);
         hFunc(NPDisk::TEvChunkReserve, ErrorHandle);
         hFunc(NPDisk::TEvChunkForget, ErrorHandle);
+        hFunc(NPDisk::TEvReadMetadata, ErrorHandle);
+        hFunc(NPDisk::TEvWriteMetadata, ErrorHandle);
 
         cFunc(TEvents::TSystem::Wakeup, ReportMetrics);
         cFunc(EvBecomeNormal, HandleMoveToNormalState);

--- a/ydb/core/blobstorage/pdisk/ya.make
+++ b/ydb/core/blobstorage/pdisk/ya.make
@@ -29,6 +29,7 @@ PEERDIR(
 )
 
 GENERATE_ENUM_SERIALIZATION(blobstorage_pdisk_state.h)
+GENERATE_ENUM_SERIALIZATION(blobstorage_pdisk_defs.h)
 
 SRCS(
     blobstorage_pdisk.cpp
@@ -41,6 +42,7 @@ SRCS(
     blobstorage_pdisk_impl.cpp
     blobstorage_pdisk_impl_http.cpp
     blobstorage_pdisk_impl_log.cpp
+    blobstorage_pdisk_impl_metadata.cpp
     blobstorage_pdisk_internal_interface.cpp
     blobstorage_pdisk_log_cache.cpp
     blobstorage_pdisk_logreader.cpp

--- a/ydb/library/actors/util/rc_buf.h
+++ b/ydb/library/actors/util/rc_buf.h
@@ -12,6 +12,7 @@
 #include <util/system/valgrind.h>
 #include <util/generic/array_ref.h>
 #include <util/system/sys_alloc.h>
+#include <util/system/info.h>
 
 #include "shared_data.h"
 #include "rc_buf_backend.h"
@@ -835,6 +836,13 @@ public:
 
         TInternalBackend res = TInternalBackend::Uninitialized(size, headroom, tailroom);
         return TRcBuf(res, res.data() + headroom, size);
+    }
+
+    static TRcBuf UninitializedPageAligned(size_t size) {
+        const size_t pageSize = NSystemInfo::GetPageSize();
+        TRcBuf res = Uninitialized(size + pageSize - 1);
+        const size_t misalign = (pageSize - reinterpret_cast<uintptr_t>(res.data())) & (pageSize - 1);
+        return TRcBuf(Piece, res.data() + misalign, size, res);
     }
 
     static TRcBuf Copy(TContiguousSpan data, size_t headroom = 0, size_t tailroom = 0) {

--- a/ydb/library/pdisk_io/drivedata.cpp
+++ b/ydb/library/pdisk_io/drivedata.cpp
@@ -16,6 +16,7 @@ TString TDriveData::ToString(bool isMultiline) const {
         << " SerialNumber# " << SerialNumber.Quote() << x
         << " FirmwareRevision# " << FirmwareRevision.Quote() << x
         << " DeviceType# " << NPDisk::DeviceTypeStr(DeviceType, true) << x
+        << " Size# " << Size << x
         << "}" << x;
     return str.Str();
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support metadata storage over pdisk

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Support of metadata storage in PDisk through NodeWarden.

#6344
