### PR TITLE
Enable COUNT in view queries

### DIFF
--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1775,7 +1775,7 @@ private:
 
         auto queryExecutor = MakeIntrusive<TKqpQueryExecutor>(Gateway, Cluster, SessionCtx, KqpRunner);
         auto kikimrDataSource = CreateKikimrDataSource(*FuncRegistry, *TypesCtx, gatewayProxy, SessionCtx,
-            ExternalSourceFactory, IsInternalCall);
+            ExternalSourceFactory, IsInternalCall, GUCSettings);
         auto kikimrDataSink = CreateKikimrDataSink(*FuncRegistry, *TypesCtx, gatewayProxy, SessionCtx, ExternalSourceFactory, queryExecutor);
 
         FillSettings.AllResultsBytesLimit = Nothing();

--- a/ydb/core/kqp/host/kqp_translate.cpp
+++ b/ydb/core/kqp/host/kqp_translate.cpp
@@ -1,6 +1,8 @@
 #include "kqp_translate.h"
 
+#include <ydb/core/kqp/provider/yql_kikimr_results.h>
 #include <ydb/library/yql/sql/sql.h>
+#include <ydb/public/api/protos/ydb_query.pb.h>
 
 
 namespace NKikimr {

--- a/ydb/core/kqp/host/kqp_translate.h
+++ b/ydb/core/kqp/host/kqp_translate.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <ydb/core/kqp/provider/yql_kikimr_results.h>
-#include <ydb/core/kqp/common/kqp.h>
+#include <ydb/core/kqp/common/simple/query_ast.h>
+#include <ydb/core/kqp/provider/yql_kikimr_provider.h>
+#include <ydb/core/protos/table_service_config.pb.h>
 #include <ydb/library/yql/core/pg_settings/guc_settings.h>
 
 namespace NKikimr {

--- a/ydb/core/kqp/provider/rewrite_io_utils.h
+++ b/ydb/core/kqp/provider/rewrite_io_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/kqp/host/kqp_translate.h>
 #include <ydb/library/yql/ast/yql_expr.h>
 
 namespace NYql {
@@ -10,7 +11,8 @@ TExprNode::TPtr RewriteReadFromView(
     const TExprNode::TPtr& node,
     TExprContext& ctx,
     const TString& query,
-    const TString& cluster
+    NKikimr::NKqp::TKqpTranslationSettingsBuilder& settingsBuilder,
+    IModuleResolver::TPtr moduleResolver
 );
 
 }

--- a/ydb/core/kqp/provider/yql_kikimr_provider.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.h
@@ -548,7 +548,8 @@ TIntrusivePtr<IDataProvider> CreateKikimrDataSource(
     TIntrusivePtr<IKikimrGateway> gateway,
     TIntrusivePtr<TKikimrSessionContext> sessionCtx,
     const NKikimr::NExternalSource::IExternalSourceFactory::TPtr& sourceFactory,
-    bool isInternalCall);
+    bool isInternalCall,
+    TGUCSettings::TPtr gucSettings);
 
 TIntrusivePtr<IDataProvider> CreateKikimrDataSink(
     const NKikimr::NMiniKQL::IFunctionRegistry& functionRegistry,

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/create_view.sql
@@ -1,0 +1,43 @@
+CREATE VIEW `/Root/aggregates_and_window` WITH (security_invoker = TRUE) AS
+    SELECT
+        series.title AS series,
+        series_stats.seasons_with_episode_count_greater_than_average AS seasons_with_episode_count_greater_than_average
+    FROM (
+        SELECT
+            series_id,
+            SUM(
+                CASE
+                    WHEN episode_count > average_episodes_in_season
+                        THEN 1
+                    ELSE 0
+                END
+            ) AS seasons_with_episode_count_greater_than_average
+        FROM (
+            SELECT
+                series_id,
+                season_id,
+                episode_count,
+                AVG(episode_count) OVER average_episodes_in_season_window AS average_episodes_in_season
+            FROM (
+                SELECT
+                    series_id,
+                    season_id,
+                    COUNT(*) AS episode_count
+                FROM `/Root/episodes`
+                GROUP BY
+                    series_id,
+                    season_id
+            )
+            WINDOW
+                average_episodes_in_season_window AS (
+                    PARTITION BY
+                        series_id
+                )
+        )
+        GROUP BY
+            series_id
+    )
+        AS series_stats
+    JOIN `/Root/series`
+        AS series
+    USING (series_id);

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/aggregates_and_window`;

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/etalon_query.sql
@@ -1,0 +1,46 @@
+SELECT
+    *
+FROM (
+    SELECT
+        series.title AS series,
+        series_stats.seasons_with_episode_count_greater_than_average AS seasons_with_episode_count_greater_than_average
+    FROM (
+        SELECT
+            series_id,
+            SUM(
+                CASE
+                    WHEN episode_count > average_episodes_in_season
+                        THEN 1
+                    ELSE 0
+                END
+            ) AS seasons_with_episode_count_greater_than_average
+        FROM (
+            SELECT
+                series_id,
+                season_id,
+                episode_count,
+                AVG(episode_count) OVER average_episodes_in_season_window AS average_episodes_in_season
+            FROM (
+                SELECT
+                    series_id,
+                    season_id,
+                    COUNT(*) AS episode_count
+                FROM `/Root/episodes`
+                GROUP BY
+                    series_id,
+                    season_id
+            )
+            WINDOW
+                average_episodes_in_season_window AS (
+                    PARTITION BY
+                        series_id
+                )
+        )
+        GROUP BY
+            series_id
+    )
+        AS series_stats
+    JOIN `/Root/series`
+        AS series
+    USING (series_id)
+);

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/aggregates_and_window`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/create_view.sql
@@ -1,0 +1,9 @@
+CREATE VIEW `/Root/count_episodes` WITH (security_invoker = TRUE) AS
+    SELECT
+        series_id,
+        season_id,
+        COUNT(*)
+    FROM `/Root/episodes`
+    GROUP BY
+        series_id,
+        season_id;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/count_episodes`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/etalon_query.sql
@@ -1,0 +1,12 @@
+SELECT
+    *
+FROM (
+    SELECT
+        series_id,
+        season_id,
+        COUNT(*)
+    FROM `/Root/episodes`
+    GROUP BY
+        series_id,
+        season_id
+);

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/count_episodes`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/create_view.sql
@@ -1,0 +1,22 @@
+CREATE VIEW `/Root/count_episodes_with_titles` WITH (security_invoker = TRUE) AS
+    SELECT
+        series.title AS series,
+        seasons.title AS season,
+        episodes.episode_count AS episode_count
+    FROM (
+        SELECT
+            series_id,
+            season_id,
+            COUNT(*) AS episode_count
+        FROM `/Root/episodes`
+        GROUP BY
+            series_id,
+            season_id
+    )
+        AS episodes
+    JOIN `/Root/series`
+        AS series
+    ON episodes.series_id == series.series_id
+    JOIN `/Root/seasons`
+        AS seasons
+    ON episodes.series_id == seasons.series_id AND episodes.season_id == seasons.season_id;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/count_episodes_with_titles`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/etalon_query.sql
@@ -1,0 +1,25 @@
+SELECT
+    *
+FROM (
+    SELECT
+        series.title AS series,
+        seasons.title AS season,
+        episodes.episode_count AS episode_count
+    FROM (
+        SELECT
+            series_id,
+            season_id,
+            COUNT(*) AS episode_count
+        FROM `/Root/episodes`
+        GROUP BY
+            series_id,
+            season_id
+    )
+        AS episodes
+    JOIN `/Root/series`
+        AS series
+    ON episodes.series_id == series.series_id
+    JOIN `/Root/seasons`
+        AS seasons
+    ON episodes.series_id == seasons.series_id AND episodes.season_id == seasons.season_id
+);

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/count_episodes_with_titles`;

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/create_view.sql
@@ -1,0 +1,4 @@
+CREATE VIEW `/Root/count_rows` WITH (security_invoker = TRUE) AS
+    SELECT
+        COUNT(*)
+    FROM `/Root/episodes`;

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/count_rows`;

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/etalon_query.sql
@@ -1,0 +1,7 @@
+SELECT
+    *
+FROM (
+    SELECT
+        COUNT(*)
+    FROM `/Root/episodes`
+);

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/count_rows`;


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/6394
KIKIMR-21731

- Add ModuleResolver from KQP host.
    
    It seems that `COUNT` and other aggregate functions are implemented as imported modules. See, for example, [AST](https://gist.github.com/jepett0/1429d788390b52a618804e7c1955c42d) of the following query:
    ```sql
    SELECT COUNT(*) FROM `/Root/episodes`
    ```
    Note the following line:
    > (import aggregate_module '"/lib/yql/aggregate.yql")

    Aggregate module `count_traits_factory` is implemented [here](https://github.com/ydb-platform/ydb/blob/31ea815dbf71fb690ebea594e04097d0f221e56d/ydb/library/yql/mount/lib/yql/aggregate.yql#L670).

- Add `ExpandApplyForLambdas` transformation step after `RewriteReadFromView`.

    The same is [done](https://github.com/ydb-platform/ydb/blob/31ea815dbf71fb690ebea594e04097d0f221e56d/ydb/library/yql/providers/yt/provider/yql_yt_datasource.cpp#L859) to rewrite reads from views in YT. The necessity could be well understood by studying the differences in:
    - [transformations](https://gist.github.com/jepett0/1328e860f5b061a3c01b79ceb3ea831a) of
        ```sql
        SELECT COUNT(*) FROM `/Root/episodes`
        ```
    
        (Note how `Apply` of a lambda disappears due to some graph transformation between the first and the second debug printout of the TExprNode graph of the pure `SELECT`.)
    - [transformations](https://gist.github.com/jepett0/50a585504490a0299df6785a274a5e94) of the same query written inside a view
    


Both (ModuleResolver addition and ExpandApplyForLambdas step repetition) are necessary to enable aggregate functions in views.

Copying default KQP host's translation settings is done to make view compilation more similar to a pure `SELECT` compilation. It is not a necessary part of the fix.
