### PR TITLE
Added method to enable memory yellow zone by force

### DIFF
--- a/ydb/library/yql/minikql/aligned_page_pool.cpp
+++ b/ydb/library/yql/minikql/aligned_page_pool.cpp
@@ -504,6 +504,7 @@ void TAlignedPagePoolImpl<T>::Free(void* ptr, size_t size) noexcept {
 template<typename T>
 void TAlignedPagePoolImpl<T>::UpdateMemoryYellowZone() {
     if (Limit == 0) return;
+    if (IsMemoryYellowZoneForcefullyChanged) return;
     if (IncreaseMemoryLimitCallback && !IsMaximumLimitValueReached) return;
 
     ui8 usedMemoryPercent = 100 * GetUsed() / Limit;

--- a/ydb/library/yql/minikql/aligned_page_pool.h
+++ b/ydb/library/yql/minikql/aligned_page_pool.h
@@ -222,6 +222,11 @@ public:
         return IsMemoryYellowZoneReached;
     }
 
+    void ForcefullySetMemoryYellowZone(bool isEnabled) noexcept {
+        IsMemoryYellowZoneReached = isEnabled;
+        IsMemoryYellowZoneForcefullyChanged = true;
+    }
+
 protected:
     void* Alloc(size_t size);
     void Free(void* ptr, size_t size) noexcept;
@@ -268,6 +273,10 @@ protected:
 
     // Indicates when memory limit is almost reached.
     bool IsMemoryYellowZoneReached = false;
+    // Indicates that memory yellow zone was enabled or disabled forcefully.
+    // If the value of this variable is true, then the limits specified below will not be applied and
+    // changing the value can only be done manually.
+    bool IsMemoryYellowZoneForcefullyChanged = false;
     // This theshold is used to determine is memory limit is almost reached.
     // If TIncreaseMemoryLimitCallback is set this thresholds should be ignored.
     // The yellow zone turns on when memory consumption reaches 80% and turns off when consumption drops below 50%.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Added method to enable memory yellow zone by force. This method will allow testing compute nodes with enabled spilling.



* Not for changelog (changelog entry is not required)

### Additional information

...
