### PR TITLE
Fixes for multiple implementation tables in vector index

### DIFF
--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -147,4 +147,9 @@ bool IsImplTable(std::string_view tableName) {
     return Contains(ImplTables, tableName);
 }
 
+bool IsTmpImplTable(std::string_view tableName) {
+    // all impl tables that ends with "tmp" should be used only for index creation and dropped when index build is finished
+    return tableName.ends_with("tmp");
+}
+
 }

--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -41,9 +41,6 @@ TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const T
             result.Keys.push_back(ik);
             result.Columns.emplace(ik);
         }
-    } else {
-        result.Keys.push_back(NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn);
-        result.Columns.insert(NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn);
     }
 
     for (const auto& tk : table.Keys) {

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -24,5 +24,6 @@ inline constexpr const char* ImplTable = "indexImplTable";
 bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index, TString& explain);
 TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index);
 bool IsImplTable(std::string_view tableName);
+bool IsTmpImplTable(std::string_view tableName);
 
 }

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
-#include <ydb/core/base/table_vector_index.h>
 
 #include <util/generic/hash_set.h>
 #include <util/generic/vector.h>
@@ -21,7 +20,6 @@ struct TIndexColumns {
 };
 
 inline constexpr const char* ImplTable = "indexImplTable";
-inline constexpr std::string_view ImplTables[] = {ImplTable, NTableVectorKmeansTreeIndex::LevelTable, NTableVectorKmeansTreeIndex::PostingTable};
 
 bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index, TString& explain);
 TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index);

--- a/ydb/core/base/table_vector_index.h
+++ b/ydb/core/base/table_vector_index.h
@@ -14,6 +14,8 @@ inline constexpr const char* LevelTable_EmbeddingColumn = "-embedding";
 inline constexpr const char* PostingTable = "indexImplPostingTable";
 inline constexpr const char* PostingTable_ParentIdColumn = "-parent";
 
+inline constexpr const char* TmpPostingTableSuffix0 = "0tmp";
+inline constexpr const char* TmpPostingTableSuffix1 = "1tmp";
 
 }
 

--- a/ydb/core/base/ut/table_index_ut.cpp
+++ b/ydb/core/base/ut/table_index_ut.cpp
@@ -48,31 +48,31 @@ Y_UNIT_TEST_SUITE (TableIndex) {
         auto type = NKikimrSchemeOp::EIndexType::EIndexTypeGlobal;
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"NOT EXIST"}, {}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index key columns should be in table columns, index key column NOT EXIST is missed");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{}, {"NOT EXIST"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index data columns should be in table columns, index data column NOT EXIST is missed");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"NOT EXIST"}, {"NOT EXIST"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index key columns should be in table columns, index key column NOT EXIST is missed");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1", "DATA1"}, {}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index key columns should be unique, for example DATA1");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1"}, {"PK2"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "the same column can't be used as key and data column for one index, for example PK2");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1"}, {"DATA1"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "the same column can't be used as key and data column for one index, for example DATA1");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1"}, {"DATA3", "DATA3"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index data columns should be unique, for example DATA3");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{}, {}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "should be at least single index key column");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"PK2"}, {}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "index keys are prefix of table keys");
     }
 
     Y_UNIT_TEST (CompatibleVectorIndex) {
@@ -97,37 +97,37 @@ Y_UNIT_TEST_SUITE (TableIndex) {
         auto type = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree;
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"NOT EXIST"}, {}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index key columns should be in table columns, index key column NOT EXIST is missed");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{}, {"NOT EXIST"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index data columns should be in table columns, index data column NOT EXIST is missed");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"NOT EXIST"}, {"NOT EXIST"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index key columns should be in table columns, index key column NOT EXIST is missed");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1", "DATA1"}, {}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "all index key columns should be unique, for example DATA1");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1", "DATA2"}, {}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "only single key column is supported for vector index");
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1"}, {"PK2"}}, explain));
-        UNIT_ASSERT(!explain.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(explain, "the same column can't be used as key and data column for one index, for example PK2");
 
         {
             const TTableColumns Table2{{"PK", "DATA", NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}, {"PK"}};
 
             UNIT_ASSERT(!IsCompatibleIndex(type, Table2, {{NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}, {}}, explain));
-            UNIT_ASSERT(!explain.empty());
+            UNIT_ASSERT_STRINGS_EQUAL(explain, "index key column shouldn't have a reserved name: -parent");
 
             UNIT_ASSERT(!IsCompatibleIndex(type, Table2, {{"DATA"}, {NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}}, explain));
-            UNIT_ASSERT(!explain.empty());
+            UNIT_ASSERT_STRINGS_EQUAL(explain, "index data column shouldn't have a reserved name: -parent");
         }
         {
             const TTableColumns Table3{{"PK", "DATA", NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}, {NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}};
 
             UNIT_ASSERT(!IsCompatibleIndex(type, Table3, {{"DATA"}, {}}, explain));
-            UNIT_ASSERT(!explain.empty());
+            UNIT_ASSERT_STRINGS_EQUAL(explain, "table key column shouldn't have a reserved name: -parent");
         }
     }
 }

--- a/ydb/core/base/ut/table_index_ut.cpp
+++ b/ydb/core/base/ut/table_index_ut.cpp
@@ -1,4 +1,5 @@
 #include "table_index.h"
+#include "table_vector_index.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -40,13 +41,6 @@ Y_UNIT_TEST_SUITE (TableIndex) {
             UNIT_ASSERT(IsCompatibleIndex(type, Table3, {{"DATA"}, {}}, explain));
             UNIT_ASSERT(explain.empty());
         }
-
-        // will be fixed:
-        UNIT_ASSERT(IsCompatibleIndex(type, Table, {{}, {}}, explain));
-        UNIT_ASSERT(explain.empty());
-
-        UNIT_ASSERT(IsCompatibleIndex(type, Table, {{"PK2"}, {}}, explain));
-        UNIT_ASSERT(explain.empty());
     }
 
     Y_UNIT_TEST (NotCompatibleSecondaryIndex) {
@@ -73,6 +67,12 @@ Y_UNIT_TEST_SUITE (TableIndex) {
 
         UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"DATA1"}, {"DATA3", "DATA3"}}, explain));
         UNIT_ASSERT(!explain.empty());
+
+        UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{}, {}}, explain));
+        UNIT_ASSERT(!explain.empty());
+
+        UNIT_ASSERT(!IsCompatibleIndex(type, Table, {{"PK2"}, {}}, explain));
+        UNIT_ASSERT(!explain.empty());
     }
 
     Y_UNIT_TEST (CompatibleVectorIndex) {
@@ -90,14 +90,6 @@ Y_UNIT_TEST_SUITE (TableIndex) {
 
         UNIT_ASSERT(IsCompatibleIndex(type, Table, {{"DATA1"}, {"DATA1"}}, explain));
         UNIT_ASSERT(explain.empty());
-
-        // will be fixed:
-        {
-            const TTableColumns Table3{{"PK", "DATA", NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}, {NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}};
-
-            UNIT_ASSERT(IsCompatibleIndex(type, Table3, {{"DATA"}, {}}, explain));
-            UNIT_ASSERT(explain.empty());
-        }
     }
 
     Y_UNIT_TEST (NotCompatibleVectorIndex) {
@@ -129,6 +121,12 @@ Y_UNIT_TEST_SUITE (TableIndex) {
             UNIT_ASSERT(!explain.empty());
 
             UNIT_ASSERT(!IsCompatibleIndex(type, Table2, {{"DATA"}, {NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}}, explain));
+            UNIT_ASSERT(!explain.empty());
+        }
+        {
+            const TTableColumns Table3{{"PK", "DATA", NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}, {NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn}};
+
+            UNIT_ASSERT(!IsCompatibleIndex(type, Table3, {{"DATA"}, {}}, explain));
             UNIT_ASSERT(!explain.empty());
         }
     }

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
@@ -120,6 +120,7 @@ void IKikimrGateway::BuildIndexMetadata(TTableMetadataResult& loadTableMetadataR
 
         TString error;
         auto indexType = TIndexDescription::ConvertIndexType(index.Type);
+        YQL_ENSURE(indexType != NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree);
         YQL_ENSURE(IsCompatibleIndex(indexType, tableColumns, indexColumns, error), "Index is not compatible: " << error);
 
         auto indexTableColumns = NKikimr::NTableIndex::CalcTableImplDescription(indexType, tableColumns, indexColumns);

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
@@ -120,7 +120,6 @@ void IKikimrGateway::BuildIndexMetadata(TTableMetadataResult& loadTableMetadataR
 
         TString error;
         auto indexType = TIndexDescription::ConvertIndexType(index.Type);
-        YQL_ENSURE(indexType != NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree);
         YQL_ENSURE(IsCompatibleIndex(indexType, tableColumns, indexColumns, error), "Index is not compatible: " << error);
 
         auto indexTableColumns = NKikimr::NTableIndex::CalcTableImplDescription(indexType, tableColumns, indexColumns);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -92,8 +92,7 @@ TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTrans
         for (auto& indexChildItems : index.Base()->GetChildren()) {
             const auto& indexImplTableName = indexChildItems.first;
             const auto partId = NextPartId(nextId, result);
-            // all impl tables that ends with "tmp" should be used only for index creation and dropped when index build is finished
-            if (indexImplTableName.EndsWith("tmp")) {
+            if (NTableIndex::IsTmpImplTable(indexImplTableName)) {
                 result.push_back(DropIndexImplTable(context, index, nextId, partId, indexImplTableName, indexChildItems.second));
             } else {
                 result.push_back(FinalizeIndexImplTable(context, index, partId, indexImplTableName, indexChildItems.second));

--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -13,6 +13,43 @@
 
 namespace NKikimr {
 namespace NSchemeShard {
+namespace {
+
+ISubOperation::TPtr FinalizeIndexImplTable(TOperationContext& context, const TPath& index, const TOperationId& partId, const TString& name, const TPathId& pathId) {
+    Y_ABORT_UNLESS(index.Child(name)->PathId == pathId);
+    Y_ABORT_UNLESS(index.Child(name).LeafName() == name);
+    TTableInfo::TPtr table = context.SS->Tables.at(pathId);
+    auto transaction = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexImplTable);
+    auto operation = transaction.MutableAlterTable();
+    operation->SetName(name);
+    operation->MutablePartitionConfig()->MutableCompactionPolicy()->CopyFrom(table->PartitionConfig().GetCompactionPolicy());
+    operation->MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(false);
+    operation->MutablePartitionConfig()->SetShadowData(false);
+    return CreateFinalizeBuildIndexImplTable(partId, transaction);
+}
+
+ISubOperation::TPtr DropIndexImplTable(TOperationContext& context, const TPath& index, const TOperationId& nextId, const TOperationId& partId, const TString& name, const TPathId& pathId) {
+    TPath implTable = index.Child(name);
+    Y_ABORT_UNLESS(implTable->PathId == pathId);
+    Y_ABORT_UNLESS(implTable.LeafName() == name);
+    auto checks = implTable.Check();
+    checks.NotEmpty()
+        .IsResolved()
+        .NotDeleted()
+        .IsTable()
+        .IsInsideTableIndexPath()
+        .NotUnderDeleting()
+        .NotUnderOperation();
+    if (!checks) {
+        return {CreateReject(nextId, checks.GetStatus(), checks.GetError())};
+    }
+    auto transaction = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpDropTable);
+    auto operation = transaction.MutableDrop();
+    operation->SetName(name);
+    return CreateDropTable(partId, transaction);
+}
+
+}
 
 TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTransaction& tx, TOperationContext& context) {
     Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpApplyIndexBuild);
@@ -50,24 +87,16 @@ TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTrans
     }
 
     if (!indexName.empty()) {
-        auto alterImplTableTransactionTemplate = [] (TPath index, TPath implIndexTable, TTableInfo::TPtr implIndexTableInfo) {
-            auto indexImplTableAltering = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexImplTable);
-            auto alterTable = indexImplTableAltering.MutableAlterTable();
-            alterTable->SetName(implIndexTable.LeafName());
-            alterTable->MutablePartitionConfig()->MutableCompactionPolicy()->CopyFrom(implIndexTableInfo->PartitionConfig().GetCompactionPolicy());
-            alterTable->MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(false);
-            alterTable->MutablePartitionConfig()->SetShadowData(false);
-            return indexImplTableAltering;
-        };
-
         TPath index = table.Child(indexName);
-        for (const std::string_view implTable : NTableIndex::ImplTables) {
-            TPath implIndexTable = index.Child(implTable.data());
-            if (!implIndexTable.IsResolved()) {
-                continue;
+        Y_ABORT_UNLESS(index.Base()->GetChildren().size() >= 1);
+        for (auto& indexChildItems : index.Base()->GetChildren()) {
+            const auto& indexImplTableName = indexChildItems.first;
+            const auto partId = NextPartId(nextId, result);
+            if (indexImplTableName.EndsWith("tmp")) {
+                result.push_back(DropIndexImplTable(context, index, nextId, partId, indexImplTableName, indexChildItems.second));
+            } else {
+                result.push_back(FinalizeIndexImplTable(context, index, partId, indexImplTableName, indexChildItems.second));
             }
-            TTableInfo::TPtr implIndexTableInfo = context.SS->Tables.at(implIndexTable.Base()->PathId);
-            result.push_back(CreateFinalizeBuildIndexImplTable(NextPartId(nextId, result), alterImplTableTransactionTemplate(index, implIndexTable, implIndexTableInfo)));
         }
     }
 
@@ -113,33 +142,8 @@ TVector<ISubOperation::TPtr> CancelBuildIndex(TOperationId nextId, const TTxTran
         TPath index = table.Child(indexName);
         Y_ABORT_UNLESS(index.Base()->GetChildren().size() >= 1);
         for (auto& indexChildItems : index.Base()->GetChildren()) {
-            const TString& implTableName = indexChildItems.first;
-            Y_ABORT_UNLESS(NTableIndex::IsImplTable(implTableName), "unexpected name %s", implTableName.c_str());
-
-            TPath implTable = index.Child(implTableName);
-            {
-                TPath::TChecker checks = implTable.Check();
-                checks.NotEmpty()
-                    .IsResolved()
-                    .NotDeleted()
-                    .IsTable()
-                    .IsInsideTableIndexPath()
-                    .NotUnderDeleting()
-                    .NotUnderOperation();
-
-                if (!checks) {
-                    return {CreateReject(nextId, checks.GetStatus(), checks.GetError())};
-                }
-            }
-            Y_ABORT_UNLESS(implTable.Base()->PathId == indexChildItems.second);
-
-            {
-                auto implTableDropping = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpDropTable);
-                auto operation = implTableDropping.MutableDrop();
-                operation->SetName(ToString(implTable.Base()->Name));
-
-                result.push_back(CreateDropTable(NextPartId(nextId,result), implTableDropping));
-            }
+            const auto partId = NextPartId(nextId, result);
+            result.push_back(DropIndexImplTable(context, index, nextId, partId, indexChildItems.first, indexChildItems.second));
         }
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -92,6 +92,7 @@ TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTrans
         for (auto& indexChildItems : index.Base()->GetChildren()) {
             const auto& indexImplTableName = indexChildItems.first;
             const auto partId = NextPartId(nextId, result);
+            // all impl tables that ends with "tmp" should be used only for index creation and dropped when index build is finished
             if (indexImplTableName.EndsWith("tmp")) {
                 result.push_back(DropIndexImplTable(context, index, nextId, partId, indexImplTableName, indexChildItems.second));
             } else {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -131,6 +131,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
         result.push_back(createImplTable(CalcVectorKmeansTreeLevelImplTableDesc(tableInfo->PartitionConfig(), indexLevelTableDesc)));
         result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc)));
         // TODO Maybe better to use partition from main table
+        // This tables are temporary and handled differently in apply_build_index
         result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, "0tmp")));
         result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, "1tmp")));
     } else {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -114,7 +114,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
 
     auto createImplTable = [&](NKikimrSchemeOp::TTableDescription&& implTableDesc) {
         auto outTx = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexImplTable);
-        *outTx.MutableCreateTable() = implTableDesc;
+        *outTx.MutableCreateTable() = std::move(implTableDesc);
 
         implTableDesc.MutablePartitionConfig()->SetShadowData(true);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -114,10 +114,10 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
     }
 
     auto createImplTable = [&](NKikimrSchemeOp::TTableDescription&& implTableDesc) {
+        implTableDesc.MutablePartitionConfig()->SetShadowData(true);
+
         auto outTx = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexImplTable);
         *outTx.MutableCreateTable() = std::move(implTableDesc);
-
-        implTableDesc.MutablePartitionConfig()->SetShadowData(true);
 
         return CreateInitializeBuildIndexImplTable(NextPartId(opId, result), outTx);
     };

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -130,6 +130,9 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
         }
         result.push_back(createImplTable(CalcVectorKmeansTreeLevelImplTableDesc(tableInfo->PartitionConfig(), indexLevelTableDesc)));
         result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc)));
+        // TODO Maybe better to use partition from main table
+        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, "0tmp")));
+        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, "1tmp")));
     } else {
         NKikimrSchemeOp::TTableDescription indexTableDesc;
         // TODO After IndexImplTableDescriptions are persisted, this should be replaced with Y_ABORT_UNLESS
@@ -137,6 +140,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             indexTableDesc = indexDesc.GetIndexImplTableDescriptions(0);
         }
         auto implTableDesc = CalcImplTableDesc(tableInfo, implTableColumns, indexTableDesc);
+        // TODO if keep erase markers also speedup compaction or something else we can enable it for other impl tables too
         implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
         result.push_back(createImplTable(std::move(implTableDesc)));
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -4,6 +4,7 @@
 #include "schemeshard_path_element.h"
 #include "schemeshard_utils.h"
 
+#include <ydb/core/base/table_vector_index.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/ydb_convert/table_description.h>
@@ -132,8 +133,8 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
         result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc)));
         // TODO Maybe better to use partition from main table
         // This tables are temporary and handled differently in apply_build_index
-        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, "0tmp")));
-        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, "1tmp")));
+        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, NTableVectorKmeansTreeIndex::TmpPostingTableSuffix0)));
+        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, NTableVectorKmeansTreeIndex::TmpPostingTableSuffix1)));
     } else {
         NKikimrSchemeOp::TTableDescription indexTableDesc;
         // TODO After IndexImplTableDescriptions are persisted, this should be replaced with Y_ABORT_UNLESS

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -238,14 +238,14 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
             result.push_back(CreateNewTableIndex(NextPartId(nextId, result), scheme));
         }
 
-        auto createIndexImplTable = [&] (const NKikimrSchemeOp::TTableDescription&& implTableDesc) {
+        auto createIndexImplTable = [&] (NKikimrSchemeOp::TTableDescription&& implTableDesc) {
             auto scheme = TransactionTemplate(
                 tx.GetWorkingDir() + "/" + baseTableDescription.GetName() + "/" + indexDescription.GetName(),
                 NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable);
             scheme.SetFailOnExist(tx.GetFailOnExist());
             scheme.SetAllowCreateInTempDir(tx.GetAllowCreateInTempDir());
 
-            *scheme.MutableCreateTable() = implTableDesc;
+            *scheme.MutableCreateTable() = std::move(implTableDesc);
 
             return CreateNewTable(NextPartId(nextId, result), scheme);    
         };

--- a/ydb/core/tx/schemeshard/schemeshard_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.cpp
@@ -356,6 +356,8 @@ void FillIndexImplTableColumns(
     const TTableColumns& implTableColumns,
     NKikimrSchemeOp::TTableDescription& implTableDesc)
 {
+    // The function that calls this may have already added some columns
+    // and we want to add new columns after those that have already been added
     const auto was = implTableDesc.ColumnsSize();
 
     THashMap<TString, ui32> implKeyToImplColumn;
@@ -363,6 +365,9 @@ void FillIndexImplTableColumns(
         implKeyToImplColumn[implTableColumns.Keys[keyId]] = keyId;
     }
 
+    // We want data columns order in index table same as in indexed table,
+    // so we use counter to keep this order in the std::sort
+    // Counter starts with Max/2 to avoid intersection with key columns counter
     for (ui32 i = Max<ui32>() / 2; auto& columnIt: baseTableColumns) {
         NKikimrSchemeOp::TColumnDescription* column = nullptr;
         using TColumn = std::decay_t<decltype(columnIt)>;

--- a/ydb/core/tx/schemeshard/schemeshard_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.cpp
@@ -256,6 +256,8 @@ TTableColumns ExtractInfo(const NSchemeShard::TTableInfo::TPtr &tableInfo) {
     return result;
 }
 
+namespace {
+
 NKikimrSchemeOp::TPartitionConfig PartitionConfigForIndexes(
         const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
         const NKikimrSchemeOp::TTableDescription& indexTableDesc)
@@ -350,36 +352,48 @@ void SetImplTablePartitionConfig(
 }
 
 void FillIndexImplTableColumns(
-    const THashMap<ui32, struct NSchemeShard::TTableInfo::TColumn>& baseTableColumns,
+    const auto& baseTableColumns,
     const TTableColumns& implTableColumns,
     NKikimrSchemeOp::TTableDescription& implTableDesc)
 {
+    const auto was = implTableDesc.ColumnsSize();
 
     THashMap<TString, ui32> implKeyToImplColumn;
     for (ui32 keyId = 0; keyId < implTableColumns.Keys.size(); ++keyId) {
         implKeyToImplColumn[implTableColumns.Keys[keyId]] = keyId;
     }
 
-    for (auto& iter: baseTableColumns) {
-        const NSchemeShard::TTableInfo::TColumn& column = iter.second;
-        if (column.IsDropped()) {
-            continue;
+    for (ui32 i = Max<ui32>() / 2; auto& iter: baseTableColumns) {
+        NKikimrSchemeOp::TColumnDescription* item = nullptr;
+        if constexpr (std::is_same_v<const std::pair<const ui32, NSchemeShard::TTableInfo::TColumn>&, decltype(iter)>) {
+            const auto& column = iter.second;
+            if (!column.IsDropped() && implTableColumns.Columns.contains(column.Name)) {
+                item = implTableDesc.AddColumns();
+                item->SetName(column.Name);
+                item->SetType(NScheme::TypeName(column.PType, column.PTypeMod));
+                item->SetNotNull(column.NotNull);
+            }
+        } else if constexpr (std::is_same_v<const NKikimrSchemeOp::TColumnDescription&, decltype(iter)>) {
+            if (implTableColumns.Columns.contains(iter.GetName())) {
+                item = implTableDesc.AddColumns();
+                *item = iter;
+                item->ClearFamily();
+                item->ClearFamilyName();
+                item->ClearDefaultValue();
+            }
+        } else {
+            static_assert(dependent_false<decltype(iter)>::value);
         }
-
-        if (implTableColumns.Columns.contains(column.Name)) {
-            auto item = implTableDesc.AddColumns();
-            item->SetName(column.Name);
-            item->SetType(NScheme::TypeName(column.PType, column.PTypeMod));
-            item->SetNotNull(column.NotNull);
-            ui32 order = Max<ui32>();
-            if (implKeyToImplColumn.contains(column.Name)) {
-                order = implKeyToImplColumn.at(column.Name);
+        if (item) {
+            ui32 order = i++;
+            if (const auto* id = implKeyToImplColumn.FindPtr(item->GetName())) {
+                order = *id;
             }
             item->SetId(order);
         }
     }
 
-    std::sort(implTableDesc.MutableColumns()->begin(),
+    std::sort(implTableDesc.MutableColumns()->begin() + was,
               implTableDesc.MutableColumns()->end(),
               [] (auto& left, auto& right) {
                   return left.GetId() < right.GetId();
@@ -394,53 +408,55 @@ void FillIndexImplTableColumns(
     }
 }
 
-void FillIndexImplTableColumns(
-    const ::google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TColumnDescription>& baseTableColumns,
-    const NTableIndex::TTableColumns& implTableColumns,
-    NKikimrSchemeOp::TTableDescription& implTableDesc)
+const auto& GetPartitionConfig(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
+    return tableInfo->PartitionConfig();
+}
+
+const auto& GetColumns(const NSchemeShard::TTableInfo::TPtr& tableInfo) {
+    return tableInfo->Columns;
+}
+
+const auto& GetPartitionConfig(const NKikimrSchemeOp::TTableDescription& tableDescr) {
+    return tableDescr.GetPartitionConfig();
+}
+
+const auto& GetColumns(const NKikimrSchemeOp::TTableDescription& tableDescr) {
+    return tableDescr.GetColumns();
+}
+
+auto CalcImplTableDescImpl(
+    const auto& baseTable,
+    const TTableColumns& implTableColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
 {
-    //Columns and KeyColumnNames order is really important
-    //the order of implTableColumns.Keys is the right one
+    NKikimrSchemeOp::TTableDescription implTableDesc;
+    implTableDesc.SetName(NTableIndex::ImplTable);
+    SetImplTablePartitionConfig(GetPartitionConfig(baseTable), indexTableDesc, implTableDesc);
+    FillIndexImplTableColumns(GetColumns(baseTable), implTableColumns, implTableDesc);
+    return implTableDesc;
+}
 
-    THashMap<TString, ui32> implKeyToImplColumn;
-    for (ui32 keyId = 0; keyId < implTableColumns.Keys.size(); ++keyId) {
-        implKeyToImplColumn[implTableColumns.Keys[keyId]] = keyId;
+auto CalcVectorKmeansTreePostingImplTableDescImpl(
+    const auto& baseTable,
+    const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
+    const TTableColumns& implTableColumns,
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    std::string_view suffix)
+{
+    NKikimrSchemeOp::TTableDescription implTableDesc;
+    implTableDesc.SetName(TString::Join(NTableVectorKmeansTreeIndex::PostingTable, suffix));
+    SetImplTablePartitionConfig(baseTablePartitionConfig, indexTableDesc, implTableDesc);
+    {
+        auto parentColumn = implTableDesc.AddColumns();
+        parentColumn->SetName(NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn);
+        parentColumn->SetType("Uint32");
+        parentColumn->SetTypeId(NScheme::NTypeIds::Uint32);
     }
+    implTableDesc.AddKeyColumnNames(NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn);
+    FillIndexImplTableColumns(GetColumns(baseTable), implTableColumns, implTableDesc);
+    return implTableDesc;
+}
 
-    for (auto& column: baseTableColumns) {
-        auto& columnName = column.GetName();
-        if (implTableColumns.Columns.contains(columnName)) {
-            auto item = implTableDesc.AddColumns();
-            *item = column;
-
-            // Indexes don't use column families
-            item->ClearFamily();
-            item->ClearFamilyName();
-
-            // Indexes can't have a default value
-            item->ClearDefaultValue();
-
-            ui32 order = Max<ui32>();
-            if (implKeyToImplColumn.contains(columnName)) {
-                order = implKeyToImplColumn.at(columnName);
-            }
-            item->SetId(order);
-        }
-    }
-
-    std::sort(implTableDesc.MutableColumns()->begin(),
-              implTableDesc.MutableColumns()->end(),
-              [] (auto& left, auto& right) {
-                  return left.GetId() < right.GetId();
-              });
-
-    for (auto& column: *implTableDesc.MutableColumns()) {
-        column.ClearId();
-    }
-
-    for (auto& keyName: implTableColumns.Keys) {
-        implTableDesc.AddKeyColumnNames(keyName);
-    }
 }
 
 NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
@@ -448,15 +464,7 @@ NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
     const TTableColumns& implTableColumns,
     const NKikimrSchemeOp::TTableDescription& indexTableDesc)
 {
-    NKikimrSchemeOp::TTableDescription implTableDesc;
-
-    implTableDesc.SetName(NTableIndex::ImplTable);
-
-    SetImplTablePartitionConfig(baseTableInfo->PartitionConfig(), indexTableDesc, implTableDesc);
-
-    FillIndexImplTableColumns(baseTableInfo->Columns, implTableColumns, implTableDesc);
-
-    return implTableDesc;
+    return CalcImplTableDescImpl(baseTableInfo, implTableColumns, indexTableDesc);
 }
 
 NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
@@ -464,15 +472,7 @@ NKikimrSchemeOp::TTableDescription CalcImplTableDesc(
     const TTableColumns& implTableColumns,
     const NKikimrSchemeOp::TTableDescription& indexTableDesc)
 {
-    NKikimrSchemeOp::TTableDescription implTableDesc;
-
-    implTableDesc.SetName(NTableIndex::ImplTable);
-
-    SetImplTablePartitionConfig(baseTableDescr.GetPartitionConfig(), indexTableDesc, implTableDesc);
-
-    FillIndexImplTableColumns(baseTableDescr.GetColumns(), implTableColumns, implTableDesc);
-
-    return implTableDesc;
+    return CalcImplTableDescImpl(baseTableDescr, implTableColumns, indexTableDesc);
 }
 
 NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreeLevelImplTableDesc(
@@ -490,21 +490,18 @@ NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreeLevelImplTableDesc(
         parentColumn->SetName(NTableVectorKmeansTreeIndex::LevelTable_ParentIdColumn);
         parentColumn->SetType("Uint32");
         parentColumn->SetTypeId(NScheme::NTypeIds::Uint32);
-        parentColumn->SetId(0);
     }
     {
         auto idColumn = implTableDesc.AddColumns();
         idColumn->SetName(NTableVectorKmeansTreeIndex::LevelTable_IdColumn);
         idColumn->SetType("Uint32");
         idColumn->SetTypeId(NScheme::NTypeIds::Uint32);
-        idColumn->SetId(1);
     }
     {
         auto centroidColumn = implTableDesc.AddColumns();
         centroidColumn->SetName(NTableVectorKmeansTreeIndex::LevelTable_EmbeddingColumn);
         centroidColumn->SetType("String");
         centroidColumn->SetTypeId(NScheme::NTypeIds::String);
-        centroidColumn->SetId(2);
     }
 
     implTableDesc.AddKeyColumnNames(NTableVectorKmeansTreeIndex::LevelTable_ParentIdColumn);
@@ -517,53 +514,21 @@ NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreePostingImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    std::string_view suffix)
 {
-    NKikimrSchemeOp::TTableDescription implTableDesc;
-
-    implTableDesc.SetName(NTableVectorKmeansTreeIndex::PostingTable);
-
-    SetImplTablePartitionConfig(baseTablePartitionConfig, indexTableDesc, implTableDesc);
-
-    {
-        auto parentIdColumn = implTableDesc.AddColumns();
-        parentIdColumn->SetName(NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn);
-        parentIdColumn->SetType("Uint32");
-        parentIdColumn->SetTypeId(NScheme::NTypeIds::Uint32);
-        parentIdColumn->SetId(0);
-    }
-
-    FillIndexImplTableColumns(baseTableInfo->Columns, implTableColumns, implTableDesc);
-
-    return implTableDesc;
+    return CalcVectorKmeansTreePostingImplTableDescImpl(baseTableInfo, baseTablePartitionConfig, implTableColumns, indexTableDesc, suffix);
 }
 
 NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreePostingImplTableDesc(
     const NKikimrSchemeOp::TTableDescription& baseTableDescr,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc)
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    std::string_view suffix)
 {
-    NKikimrSchemeOp::TTableDescription implTableDesc;
-
-    implTableDesc.SetName(NTableVectorKmeansTreeIndex::PostingTable);
-
-    SetImplTablePartitionConfig(baseTablePartitionConfig, indexTableDesc, implTableDesc);
-
-    {
-        auto parentIdColumn = implTableDesc.AddColumns();
-        parentIdColumn->SetName(NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn);
-        parentIdColumn->SetType("Uint32");
-        parentIdColumn->SetTypeId(NScheme::NTypeIds::Uint32);
-        parentIdColumn->SetId(0);
-    }
-
-    FillIndexImplTableColumns(baseTableDescr.GetColumns(), implTableColumns, implTableDesc);
-
-    return implTableDesc;
+    return CalcVectorKmeansTreePostingImplTableDescImpl(baseTableDescr, baseTablePartitionConfig, implTableColumns, indexTableDesc, suffix);
 }
-
-
 
 bool ExtractTypes(const NKikimrSchemeOp::TTableDescription& baseTableDescr, TColumnTypes& columnTypes, TString& explain) {
     const NScheme::TTypeRegistry* typeRegistry = AppData()->TypeRegistry;

--- a/ydb/core/tx/schemeshard/schemeshard_utils.h
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.h
@@ -154,13 +154,15 @@ NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreePostingImplTableDesc(
     const NSchemeShard::TTableInfo::TPtr& baseTableInfo,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc);
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    std::string_view suffix = {});
 
 NKikimrSchemeOp::TTableDescription CalcVectorKmeansTreePostingImplTableDesc(
     const NKikimrSchemeOp::TTableDescription& baseTableDescr,
     const NKikimrSchemeOp::TPartitionConfig& baseTablePartitionConfig,
     const TTableColumns& implTableColumns,
-    const NKikimrSchemeOp::TTableDescription& indexTableDesc);    
+    const NKikimrSchemeOp::TTableDescription& indexTableDesc,
+    std::string_view suffix = {});
 
 TTableColumns ExtractInfo(const NSchemeShard::TTableInfo::TPtr& tableInfo);
 TTableColumns ExtractInfo(const NKikimrSchemeOp::TTableDescription& tableDesc);

--- a/ydb/core/tx/schemeshard/ut_index/ut_vector_index.cpp
+++ b/ydb/core/tx/schemeshard/ut_index/ut_vector_index.cpp
@@ -2,6 +2,7 @@
 #include <ydb/core/base/table_vector_index.h>
 #include <ydb/core/change_exchange/change_exchange.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
+#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
 #include <ydb/core/testlib/tablet_helpers.h>
@@ -154,6 +155,33 @@ Y_UNIT_TEST_SUITE(TVectorIndexTests) {
               NLs::CheckColumns(PostingTable, {PostingTable_ParentIdColumn, "id1", "id2", "covered1", "covered2"}, {}, {PostingTable_ParentIdColumn, "id1", "id2"}, true) });
     } 
 
+    Y_UNIT_TEST(VectorKmeansTreePostingImplTable) {
+      // partition
+      NKikimrSchemeOp::TPartitionConfig baseTablePartitionConfig;
+      NKikimrSchemeOp::TTableDescription indexTableDesc;
+      // columns
+      NKikimrSchemeOp::TTableDescription baseTableDescr;
+      {
+        auto* embedding = baseTableDescr.AddColumns();
+        *embedding->MutableName() = "embedding";
+      }
+      {
+        auto* data1 = baseTableDescr.AddColumns();
+        *data1->MutableName() = "data1";
+      }
+      {
+        auto* data2 = baseTableDescr.AddColumns();
+        *data2->MutableName() = "data2";
+
+      }
+      NTableIndex::TTableColumns implTableColumns = {{"data2", "data1"}, {}};
+      auto desc = CalcVectorKmeansTreePostingImplTableDesc(baseTableDescr, baseTablePartitionConfig, implTableColumns, indexTableDesc, "something");
+      std::string_view expected[] = {NTableIndex::NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn, "data1", "data2"};
+      for (size_t i = 0; auto& column : desc.GetColumns()) {
+        UNIT_ASSERT_STRINGS_EQUAL(column.GetName(), expected[i]);
+        ++i;
+      }
+    }
 
     Y_UNIT_TEST(CreateTableWithError) {
         TTestBasicRuntime runtime;

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/base/table_index.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/schemeshard_billing_helpers.h>
 #include <ydb/core/testlib/tablet_helpers.h>
@@ -375,10 +376,19 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         }
 
         TVector<TString> billRecords;
-        runtime.SetObserverFunc([&billRecords](TAutoPtr<IEventHandle>& ev) {
+        TVector<bool> shadowData;
+        TVector<bool> keepEraseMarkers;
+        runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
             if (ev->Type == NMetering::TEvMetering::TEvWriteMeteringJson::EventType) {
                 auto* msg = ev->Get<NMetering::TEvMetering::TEvWriteMeteringJson>();
                 billRecords.push_back(msg->MeteringJson);
+            } else if (ev->Type == TSchemeBoardEvents::TEvNotifyUpdate::EventType) {
+                auto* msg = ev->Get<TSchemeBoardEvents::TEvNotifyUpdate>();
+                if (msg->Path.EndsWith(NTableIndex::ImplTable)) {
+                    auto& desc = msg->DescribeSchemeResult.GetPathDescription().GetTable().GetPartitionConfig();
+                    shadowData.push_back(desc.GetShadowData());
+                    keepEraseMarkers.push_back(desc.GetCompactionPolicy().GetKeepEraseMarkers());
+                }
             }
 
             return TTestActorRuntime::EEventAction::PROCESS;
@@ -396,6 +406,14 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         Y_ASSERT(descr.GetIndexBuild().GetState() == Ydb::Table::IndexBuildState::STATE_DONE);
 
         UNIT_ASSERT(billRecords.empty());
+
+        UNIT_ASSERT_VALUES_EQUAL(shadowData.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(shadowData[0], true);
+        UNIT_ASSERT_VALUES_EQUAL(shadowData[1], false);
+
+        UNIT_ASSERT_VALUES_EQUAL(keepEraseMarkers.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(keepEraseMarkers[0], true);
+        UNIT_ASSERT_VALUES_EQUAL(keepEraseMarkers[1], false);
     }
 
     Y_UNIT_TEST(CancellationNotEnoughRetries) {


### PR DESCRIPTION
[1](https://github.com/ydb-platform/ydb/pull/6854/commits/bd6f35bc45c029c40ce9b2ce34645580c60302a7). Fix IsCompatibleIndex, now we're avoiding some error cases.

~~[2](https://github.com/ydb-platform/ydb/pull/6854/commits/10589618d510c0e89172df6437922edf4adb477e). Add yql_ensure to avoid incorrect work with non-secondary indexes, this code works only for secondary indexes.~~ done in another PR

[3](https://github.com/ydb-platform/ydb/pull/6854/commits/0dc5b829acef201fd9f9a946c6d7c954118025ef). Make order of columns stable, non-dependent of std::sort implementation. Add ability to create posting impl table with suffix in the name (needed for 4). Make `-parent` column addition more local to improve readability.

[4](https://github.com/ydb-platform/ydb/pull/6854/commits/9f06af10ea5539fd2356d8331082afa37159f942). Add temporary tables for index building
