### PR TITLE
Fix github outage (postcommit checks are stuck)

### DIFF
--- a/.github/workflows/gate_postcommits.yml
+++ b/.github/workflows/gate_postcommits.yml
@@ -17,7 +17,8 @@ jobs:
           jq '[.workflow_runs[] | {name,status,id,updated_at,"waiting_seconds":(now - (.updated_at | fromdate)), html_url}]' | \
           jq '[.[] | select(.waiting_seconds > 600)] | length')
         echo "Queue size: $queue_size"
-        if (( queue_size > 0 ));then
+        # temporary solution for https://www.githubstatus.com/incidents/m70hk23gx3nx (some workflows are uncancellable stuck)
+        if (( queue_size > 10 ));then
           echo "Close gate for postcommits"
           query='.runners[] | select(.labels[].name=="ghrun") | select( any([.labels[].name][]; .=="postcommit")) | .id'
         else


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
temporary solution for https://www.githubstatus.com/incidents/m70hk23gx3nx (some workflows are uncancellable stuck)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
