### PR TITLE
The partition actor did not restore transactions after restarting the PQ tablet (#6831)

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -82,7 +82,7 @@ TString TPartition::LogPrefix() const {
     } else {
         state = "Unknown";
     }
-    return TStringBuilder() << "[Partition:" << Partition << ", State:" << state << "] ";
+    return TStringBuilder() << "[PQ: " << TabletID << ", Partition:" << Partition << ", State:" << state << "] ";
 }
 
 bool TPartition::IsActive() const {
@@ -913,6 +913,10 @@ void TPartition::Handle(TEvPersQueue::TEvProposeTransaction::TPtr& ev, const TAc
 
 void TPartition::Handle(TEvPQ::TEvProposePartitionConfig::TPtr& ev, const TActorContext& ctx)
 {
+    PQ_LOG_D("Handle TEvPQ::TEvProposePartitionConfig" <<
+             " Step " << ev->Get()->Step <<
+             ", TxId " << ev->Get()->TxId);
+
     PushBackDistrTx(ev->Release());
 
     ProcessTxsAndUserActs(ctx);
@@ -925,6 +929,10 @@ void TPartition::HandleOnInit(TEvPQ::TEvTxCalcPredicate::TPtr& ev, const TActorC
 
 void TPartition::HandleOnInit(TEvPQ::TEvTxCommit::TPtr& ev, const TActorContext&)
 {
+    PQ_LOG_D("HandleOnInit TEvPQ::TEvTxCommit" <<
+             " Step " << ev->Get()->Step <<
+             ", TxId " << ev->Get()->TxId);
+
     PendingEvents.emplace_back(ev->ReleaseBase().Release());
 }
 
@@ -935,6 +943,10 @@ void TPartition::HandleOnInit(TEvPQ::TEvTxRollback::TPtr& ev, const TActorContex
 
 void TPartition::HandleOnInit(TEvPQ::TEvProposePartitionConfig::TPtr& ev, const TActorContext&)
 {
+    PQ_LOG_D("HandleOnInit TEvPQ::TEvProposePartitionConfig" <<
+             " Step " << ev->Get()->Step <<
+             ", TxId " << ev->Get()->TxId);
+
     PendingEvents.emplace_back(ev->ReleaseBase().Release());
 }
 
@@ -947,8 +959,15 @@ void TPartition::Handle(TEvPQ::TEvTxCalcPredicate::TPtr& ev, const TActorContext
 
 void TPartition::Handle(TEvPQ::TEvTxCommit::TPtr& ev, const TActorContext& ctx)
 {
+    PQ_LOG_D("Handle TEvPQ::TEvTxCommit" <<
+             " Step " << ev->Get()->Step <<
+             ", TxId " << ev->Get()->TxId);
+
     if (PlanStep.Defined() && TxId.Defined()) {
         if (GetStepAndTxId(*ev->Get()) < GetStepAndTxId(*PlanStep, *TxId)) {
+            PQ_LOG_D("Send TEvTxCommitDone" <<
+                     " Step " << ev->Get()->Step <<
+                     ", TxId " << ev->Get()->TxId);
             ctx.Send(Tablet, MakeCommitDone(ev->Get()->Step, ev->Get()->TxId).Release());
             return;
         }
@@ -956,11 +975,20 @@ void TPartition::Handle(TEvPQ::TEvTxCommit::TPtr& ev, const TActorContext& ctx)
 
     auto txIter = TransactionsInflight.begin();
     if (ChangeConfig) {
-        Y_ABORT_UNLESS(TransactionsInflight.size() == 1);
+        Y_ABORT_UNLESS(TransactionsInflight.size() == 1,
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
+                       TabletID, Partition.OriginalPartitionId,
+                       ev->Get()->Step, ev->Get()->TxId);
     } else {
-        Y_ABORT_UNLESS(!TransactionsInflight.empty());
+        Y_ABORT_UNLESS(!TransactionsInflight.empty(),
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
+                       TabletID, Partition.OriginalPartitionId,
+                       ev->Get()->Step, ev->Get()->TxId);
         txIter = TransactionsInflight.find(ev->Get()->TxId);
-        Y_ABORT_UNLESS(!txIter.IsEnd());
+        Y_ABORT_UNLESS(!txIter.IsEnd(),
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
+                       TabletID, Partition.OriginalPartitionId,
+                       ev->Get()->Step, ev->Get()->TxId);
     }
     Y_ABORT_UNLESS(txIter->second->State == ECommitState::Pending);
 
@@ -973,18 +1001,29 @@ void TPartition::Handle(TEvPQ::TEvTxRollback::TPtr& ev, const TActorContext& ctx
     auto* event = ev->Get();
     if (PlanStep.Defined() && TxId.Defined()) {
         if (GetStepAndTxId(*event) < GetStepAndTxId(*PlanStep, *TxId)) {
+            PQ_LOG_D("Rollback for" <<
+                     " Step " << ev->Get()->Step <<
+                     ", TxId " << ev->Get()->TxId);
             return;
         }
     }
 
     auto txIter = TransactionsInflight.begin();
     if (ChangeConfig) {
-        Y_ABORT_UNLESS(TransactionsInflight.size() == 1);
+        Y_ABORT_UNLESS(TransactionsInflight.size() == 1,
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32,
+                       TabletID, Partition.OriginalPartitionId);
     } else {
+        Y_ABORT_UNLESS(!TransactionsInflight.empty(),
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32,
+                       TabletID, Partition.OriginalPartitionId);
         txIter = TransactionsInflight.find(ev->Get()->TxId);
-        Y_ABORT_UNLESS(!txIter.IsEnd());
+        Y_ABORT_UNLESS(!txIter.IsEnd(),
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32,
+                       TabletID, Partition.OriginalPartitionId);
     }
     Y_ABORT_UNLESS(txIter->second->State == ECommitState::Pending);
+
     txIter->second->State = ECommitState::Aborted;
     ProcessTxsAndUserActs(ctx);
 }
@@ -1109,19 +1148,20 @@ void TPartition::Handle(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActorConte
 void TPartition::ReplyToProposeOrPredicate(TSimpleSharedPtr<TTransaction>& tx, bool isPredicate) {
 
     if (isPredicate) {
-        auto insRes = TransactionsInflight.insert(std::make_pair(tx->Tx->TxId, tx));
-        Y_ABORT_UNLESS(insRes.second);
-        Send(Tablet, MakeHolder<TEvPQ::TEvTxCalcPredicateResult>(tx->Tx->Step,
-                                                                tx->Tx->TxId,
-                                                                Partition,
-                                                                *tx->Predicate).Release());
-    } else {
-        auto insRes = TransactionsInflight.insert(std::make_pair(tx->ProposeConfig->TxId, tx));
+        auto insRes = TransactionsInflight.emplace(tx->Tx->TxId, tx);
         Y_ABORT_UNLESS(insRes.second);
         Send(Tablet,
-                MakeHolder<TEvPQ::TEvProposePartitionConfigResult>(tx->ProposeConfig->Step,
-                                                                    tx->ProposeConfig->TxId,
-                                                                    Partition).Release());
+             MakeHolder<TEvPQ::TEvTxCalcPredicateResult>(tx->Tx->Step,
+                                                         tx->Tx->TxId,
+                                                         Partition,
+                                                         *tx->Predicate).Release());
+    } else {
+        auto insRes = TransactionsInflight.emplace(tx->ProposeConfig->TxId, tx);
+        Y_ABORT_UNLESS(insRes.second);
+        Send(Tablet,
+             MakeHolder<TEvPQ::TEvProposePartitionConfigResult>(tx->ProposeConfig->Step,
+                                                                tx->ProposeConfig->TxId,
+                                                                Partition).Release());
     }
 }
 
@@ -3314,20 +3354,25 @@ void TPartition::ScheduleNegativeReplies()
 {
     auto processQueue = [&](std::deque<TUserActionAndTransactionEvent>& queue) {
         for (auto& event : queue) {
-            if (auto* setInfo = std::get_if<0>(&event.Event)) {
-                ScheduleNegativeReply(*setInfo->Get());
-            } else if (auto* tx = std::get_if<1>(&event.Event)) {
-                if (tx->Get()->ProposeTransaction) {
-                    ScheduleNegativeReply(*tx->Get()->ProposeTransaction);
-                } else {
-                    ScheduleNegativeReply(*tx->Get());
+            std::visit(TOverloaded{
+                [this](TSimpleSharedPtr<TEvPQ::TEvSetClientInfo>& v) {
+                    ScheduleNegativeReply(*v);
+                },
+                [this](TSimpleSharedPtr<TTransaction>& v) {
+                    if (v->ProposeTransaction) {
+                        ScheduleNegativeReply(*v->ProposeTransaction);
+                    } else {
+                        ScheduleNegativeReply(*v);
+                    }
+                },
+                [this](TMessage& v) {
+                    ScheduleNegativeReply(v);
                 }
-            } else {
-                ScheduleNegativeReply(*(std::get_if<2>(&event.Event)));
-            }
+            }, event.Event);
         }
         queue.clear();
     };
+
     processQueue(UserActionAndTransactionEvents);
     processQueue(UserActionAndTxPendingCommit);
 }

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -66,7 +66,6 @@ struct TTransaction {
     explicit TTransaction(TSimpleSharedPtr<TEvPQ::TEvProposePartitionConfig> proposeConfig)
         : ProposeConfig(proposeConfig)
     {
-
         Y_ABORT_UNLESS(ProposeConfig);
     }
 

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -907,7 +907,7 @@ void TPersQueue::CreateOriginalPartition(const NKikimrPQ::TPQTabletConfig& confi
     ++OriginalPartitionsCount;
 }
 
-void TPersQueue:MoveTopTxToCalculating(TDistributedTransaction& tx,
+void TPersQueue::MoveTopTxToCalculating(TDistributedTransaction& tx,
                                         const TActorContext& ctx)
 {
     std::tie(ExecStep, ExecTxId) = TxQueue.front();

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -907,6 +907,57 @@ void TPersQueue::CreateOriginalPartition(const NKikimrPQ::TPQTabletConfig& confi
     ++OriginalPartitionsCount;
 }
 
+void TPersQueue:MoveTopTxToCalculating(TDistributedTransaction& tx,
+                                        const TActorContext& ctx)
+{
+    std::tie(ExecStep, ExecTxId) = TxQueue.front();
+    PQ_LOG_D("New ExecStep " << ExecStep << ", ExecTxId " << ExecTxId);
+
+    switch (tx.Kind) {
+    case NKikimrPQ::TTransaction::KIND_DATA:
+        SendEvTxCalcPredicateToPartitions(ctx, tx);
+        break;
+    case NKikimrPQ::TTransaction::KIND_CONFIG: {
+        NPersQueue::TConverterFactoryPtr converterFactory;
+        CreateTopicConverter(tx.TabletConfig,
+                             converterFactory,
+                             tx.TopicConverter,
+                             ctx);
+        if (InitCompleted) {
+            CreateNewPartitions(tx.TabletConfig,
+                                tx.TopicConverter,
+                                ctx);
+        }
+        SendEvProposePartitionConfig(ctx, tx);
+        break;
+    }
+    case NKikimrPQ::TTransaction::KIND_UNKNOWN:
+        Y_ABORT_UNLESS(false);
+    }
+
+    tx.State = NKikimrPQ::TTransaction::CALCULATING;
+    PQ_LOG_D("TxId " << tx.TxId <<
+             ", NewState " << NKikimrPQ::TTransaction_EState_Name(tx.State));
+}
+
+void TPersQueue::UpdateTopTxState(const TActorContext& ctx)
+{
+    Y_ABORT_UNLESS(!InitCompleted);
+
+    if (TxQueue.empty()) {
+        return;
+    }
+
+    Y_ABORT_UNLESS(Txs.contains(TxQueue.front().second));
+    auto& tx = Txs.at(TxQueue.front().second);
+
+    if (tx.State <= NKikimrPQ::TTransaction::PLANNED) {
+        return;
+    }
+
+    MoveTopTxToCalculating(tx, ctx);
+}
+
 void TPersQueue::AddSupportivePartition(const TPartitionId& partitionId)
 {
     Partitions.emplace(partitionId,
@@ -1045,6 +1096,8 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
                                 false,
                                 ctx);
     }
+
+    UpdateTopTxState(ctx);
 
     ConfigInited = true;
 
@@ -3348,6 +3401,8 @@ void TPersQueue::Handle(TEvPQ::TEvTxCalcPredicateResult::TPtr& ev, const TActorC
         return;
     }
 
+    Y_ABORT_UNLESS(tx->State == NKikimrPQ::TTransaction::CALCULATING);
+
     tx->OnTxCalcPredicateResult(event);
 
     CheckTxState(ctx, *tx);
@@ -4041,30 +4096,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
                  ", (!TxQueue.empty())=" << !TxQueue.empty());
 
         if (!TxQueue.empty() && (TxQueue.front().second == tx.TxId)) {
-            std::tie(ExecStep, ExecTxId) = TxQueue.front();
-            PQ_LOG_D("ExecStep " << ExecStep << ", ExecTxId " << ExecTxId);
-
-            switch (tx.Kind) {
-            case NKikimrPQ::TTransaction::KIND_DATA:
-                SendEvTxCalcPredicateToPartitions(ctx, tx);
-                break;
-            case NKikimrPQ::TTransaction::KIND_CONFIG: {
-                NPersQueue::TConverterFactoryPtr converterFactory;
-                CreateTopicConverter(tx.TabletConfig,
-                                     converterFactory,
-                                     tx.TopicConverter,
-                                     ctx);
-                CreateNewPartitions(tx.TabletConfig,
-                                    tx.TopicConverter,
-                                    ctx);
-                SendEvProposePartitionConfig(ctx, tx);
-                break;
-            }
-            case NKikimrPQ::TTransaction::KIND_UNKNOWN:
-                Y_ABORT_UNLESS(false);
-            }
-
-            tx.State = NKikimrPQ::TTransaction::CALCULATING;
+            MoveTopTxToCalculating(tx, ctx);
         }
 
         break;

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -503,6 +503,9 @@ private:
     bool CheckTxWriteOperation(const NKikimrPQ::TPartitionOperation& operation,
                                const TWriteId& writeId) const;
     bool CheckTxWriteOperations(const NKikimrPQ::TDataTransaction& txBody) const;
+
+    void UpdateTopTxState(const TActorContext& ctx);
+    void MoveTopTxToCalculating(TDistributedTransaction& tx, const TActorContext& ctx);
 };
 
 

--- a/ydb/core/persqueue/ut/make_config.cpp
+++ b/ydb/core/persqueue/ut/make_config.cpp
@@ -6,22 +6,38 @@
 
 namespace NKikimr::NPQ::NHelpers {
 
-NKikimrPQ::TPQTabletConfig MakeConfig(ui64 version,
-                                      const TVector<TCreateConsumerParams>& consumers,
-                                      ui32 partitionsCount,
-                                      NKikimrPQ::TPQTabletConfig::EMeteringMode meteringMode)
+NKikimrPQ::TPQTabletConfig MakeConfig(const TMakeConfigParams& params)
 {
     NKikimrPQ::TPQTabletConfig config;
 
-    config.SetVersion(version);
+    config.SetVersion(params.Version);
 
-    for (auto& c : consumers) {
+    for (auto& c : params.Consumers) {
         config.AddReadRules(c.Consumer);
         config.AddReadRuleGenerations(c.Generation);
     }
 
-    for (ui32 id = 0; id < partitionsCount; ++id) {
-        config.AddPartitionIds(id);
+    for (const auto& e : params.AllPartitions) {
+        auto* p = config.AddAllPartitions();
+        p->SetPartitionId(e.Id);
+        p->SetTabletId(e.TabletId);
+        for (auto t : e.Children) {
+            p->AddChildPartitionIds(t);
+        }
+        for (auto t : e.Parents) {
+            p->AddParentPartitionIds(t);
+        }
+    }
+
+    for (const auto& e : params.Partitions) {
+        auto* p = config.AddPartitions();
+        p->SetPartitionId(e.Id);
+    }
+
+    if (params.AllPartitions.empty() && params.Partitions.empty()) {
+        for (ui32 id = 0; id < params.PartitionsCount; ++id) {
+            config.AddPartitionIds(id);
+        }
     }
 
     config.SetTopicName("rt3.dc1--account--topic");
@@ -30,13 +46,26 @@ NKikimrPQ::TPQTabletConfig MakeConfig(ui64 version,
     config.SetLocalDC(true);
     config.SetYdbDatabasePath("");
 
-    config.SetMeteringMode(meteringMode);
+    config.SetMeteringMode(params.MeteringMode);
     config.MutablePartitionConfig()->SetLifetimeSeconds(TDuration::Hours(24).Seconds());
     config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(10 << 20);
 
     Migrate(config);
 
     return config;
+}
+
+NKikimrPQ::TPQTabletConfig MakeConfig(ui64 version,
+                                      const TVector<TCreateConsumerParams>& consumers,
+                                      ui32 partitionsCount,
+                                      NKikimrPQ::TPQTabletConfig::EMeteringMode meteringMode)
+{
+    TMakeConfigParams params;
+    params.Version = version;
+    params.Consumers = consumers;
+    params.PartitionsCount = partitionsCount;
+    params.MeteringMode = meteringMode;
+    return MakeConfig(params);
 }
 
 NKikimrPQ::TBootstrapConfig MakeBootstrapConfig()

--- a/ydb/core/persqueue/ut/make_config.h
+++ b/ydb/core/persqueue/ut/make_config.h
@@ -18,6 +18,24 @@ struct TCreateConsumerParams {
     ui64 ReadRuleGeneration = 0;
 };
 
+struct TPartitionParams {
+    ui32 Id = Max<ui32>();
+    ui64 TabletId = Max<ui64>();
+    TVector<ui32> Children;
+    TVector<ui32> Parents;
+};
+
+struct TMakeConfigParams {
+    ui64 Version = 0;
+    TVector<TCreateConsumerParams> Consumers;
+    TVector<TPartitionParams> Partitions;
+    TVector<TPartitionParams> AllPartitions;
+    ui32 PartitionsCount = 1;
+    NKikimrPQ::TPQTabletConfig::EMeteringMode MeteringMode = NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS;
+};
+
+NKikimrPQ::TPQTabletConfig MakeConfig(const TMakeConfigParams& params);
+
 NKikimrPQ::TPQTabletConfig MakeConfig(ui64 version,
                                       const TVector<TCreateConsumerParams>& consumers,
                                       ui32 partitionsCount = 1,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The PQ tablet performed the transaction. I received the value of the predicate from the partition and waited for RS from other tablets. At this time, Hive was restarting it on another node. After the restart, the tablet restored the transaction and continued to execute it. I received all RS and sent the message `TEvTxCommit` to the partition. As a result, the program crashed, since the partition did not know anything about this transaction after the restart.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
