### PR TITLE
merge to stable-24-2

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -1825,6 +1825,7 @@ private:
             case NKikimrKqp::ISOLATION_LEVEL_READ_UNCOMMITTED:
                 YQL_ENSURE(ReadOnlyTx);
                 YQL_ENSURE(!VolatileTx);
+                TasksGraph.GetMeta().AllowInconsistentReads = true;
                 ImmediateTx = true;
                 break;
 

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -1103,9 +1103,14 @@ void FillInputDesc(const TKqpTasksGraph& tasksGraph, NYql::NDqProto::TTaskInput&
         transformProto->SetOutputType(input.Transform->OutputType);
         if (input.Meta.StreamLookupSettings) {
             YQL_ENSURE(input.Meta.StreamLookupSettings);
-            YQL_ENSURE(snapshot.IsValid(), "stream lookup cannot be performed without the snapshot.");
-            input.Meta.StreamLookupSettings->MutableSnapshot()->SetStep(snapshot.Step);
-            input.Meta.StreamLookupSettings->MutableSnapshot()->SetTxId(snapshot.TxId);
+            if (snapshot.IsValid()) {
+                input.Meta.StreamLookupSettings->MutableSnapshot()->SetStep(snapshot.Step);
+                input.Meta.StreamLookupSettings->MutableSnapshot()->SetTxId(snapshot.TxId);
+            } else {
+                YQL_ENSURE(tasksGraph.GetMeta().AllowInconsistentReads, "Expected valid snapshot or enabled inconsistent read mode");
+                input.Meta.StreamLookupSettings->SetAllowInconsistentReads(true);
+            }
+
             if (lockTxId) {
                 input.Meta.StreamLookupSettings->SetLockTxId(*lockTxId);
             }

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -92,6 +92,7 @@ struct TGraphMeta {
     std::unordered_map<ui64, TActorId> ResultChannelProxies;
     TActorId ExecuterId;
     bool UseFollowers = false;
+    bool AllowInconsistentReads = false;
     TIntrusivePtr<TProtoArenaHolder> Arena;
     TString Database;
     NKikimrConfig::TTableServiceConfig::EChannelTransportVersion ChannelTransportVersion;

--- a/ydb/core/kqp/node_service/kqp_node_service.cpp
+++ b/ydb/core/kqp/node_service/kqp_node_service.cpp
@@ -13,6 +13,7 @@
 #include <ydb/core/kqp/rm_service/kqp_resource_estimation.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
 #include <ydb/core/kqp/runtime/kqp_read_actor.h>
+#include <ydb/core/kqp/runtime/kqp_read_iterator_common.h>
 #include <ydb/core/kqp/common/kqp_resolve.h>
 
 #include <ydb/library/wilson_ids/wilson.h>

--- a/ydb/core/kqp/runtime/kqp_read_actor.h
+++ b/ydb/core/kqp/runtime/kqp_read_actor.h
@@ -12,42 +12,7 @@ class TEvReadAck;
 namespace NKikimr {
 namespace NKqp {
 
-struct TIteratorReadBackoffSettings : TAtomicRefCount<TIteratorReadBackoffSettings> {
-    TDuration StartRetryDelay = TDuration::MilliSeconds(5);
-    size_t MaxShardAttempts = 10;
-    size_t MaxShardResolves = 3;
-    double UnsertaintyRatio = 0.5;
-    double Multiplier = 2.0;
-    TDuration MaxRetryDelay = TDuration::Seconds(1);
-
-    TMaybe<size_t> MaxTotalRetries;
-    TMaybe<TDuration> ReadResponseTimeout;
-
-    TDuration CalcShardDelay(size_t attempt, bool allowInstantRetry) {
-        if (allowInstantRetry && attempt == 1) {
-            return TDuration::Zero();
-        }
-
-        auto delay = StartRetryDelay;
-        for (size_t i = 0; i < attempt; ++i) {
-            delay *= Multiplier;
-            delay = Min(delay, MaxRetryDelay);
-        }
-
-        delay *= (1 - UnsertaintyRatio * RandomNumber<double>());
-
-        return delay;
-    }
-};
-
-void SetReadIteratorBackoffSettings(TIntrusivePtr<TIteratorReadBackoffSettings>);
-void SetDefaultIteratorQuotaSettings(ui32 rows, ui32 bytes);
-
 void RegisterKqpReadActor(NYql::NDq::TDqAsyncIoFactory&, TIntrusivePtr<TKqpCounters>);
-
-void InjectRangeEvReadSettings(const NKikimrTxDataShard::TEvRead&);
-void InjectRangeEvReadAckSettings(const NKikimrTxDataShard::TEvReadAck&);
-
 void InterceptReadActorPipeCache(NActors::TActorId);
 
 } // namespace NKqp

--- a/ydb/core/kqp/runtime/kqp_read_iterator_common.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_iterator_common.cpp
@@ -1,0 +1,107 @@
+#include "kqp_read_iterator_common.h"
+
+#include <library/cpp/threading/hot_swap/hot_swap.h>
+
+namespace NKikimr {
+namespace NKqp {
+
+struct TBackoffStorage {
+    THotSwap<NKikimr::NKqp::TIteratorReadBackoffSettings> SettingsPtr;
+
+    TBackoffStorage() {
+        SettingsPtr.AtomicStore(new NKikimr::NKqp::TIteratorReadBackoffSettings());
+    }
+};
+
+struct TEvReadDefaultSettings {
+    THotSwap<TEvReadSettings> Settings;
+
+    TEvReadDefaultSettings() {
+        Settings.AtomicStore(MakeIntrusive<TEvReadSettings>());
+    }
+
+};
+
+void SetDefaultIteratorQuotaSettings(ui32 rows, ui32 bytes) {
+    TEvReadSettings settings;
+
+    settings.Read.SetMaxRows(rows);
+    settings.Ack.SetMaxRows(rows);
+
+    settings.Read.SetMaxBytes(bytes);
+    settings.Ack.SetMaxBytes(bytes);
+
+    SetDefaultReadSettings(settings.Read);
+    SetDefaultReadAckSettings(settings.Ack);
+}
+
+THolder<NKikimr::TEvDataShard::TEvRead> GetDefaultReadSettings() {
+    auto result = MakeHolder<NKikimr::TEvDataShard::TEvRead>();
+    auto ptr = Singleton<TEvReadDefaultSettings>()->Settings.AtomicLoad();
+    result->Record.MergeFrom(ptr->Read);
+    return result;
+}
+
+void SetDefaultReadSettings(const NKikimrTxDataShard::TEvRead& read) {
+    auto ptr = Singleton<TEvReadDefaultSettings>()->Settings.AtomicLoad();
+    TEvReadSettings settings = *ptr;
+    settings.Read.MergeFrom(read);
+    Singleton<TEvReadDefaultSettings>()->Settings.AtomicStore(MakeIntrusive<TEvReadSettings>(settings));
+}
+
+THolder<NKikimr::TEvDataShard::TEvReadAck> GetDefaultReadAckSettings() {
+    auto result = MakeHolder<NKikimr::TEvDataShard::TEvReadAck>();
+    auto ptr = Singleton<TEvReadDefaultSettings>()->Settings.AtomicLoad();
+    result->Record.MergeFrom(ptr->Ack);
+    return result;
+}
+
+void SetDefaultReadAckSettings(const NKikimrTxDataShard::TEvReadAck& ack) {
+    auto ptr = Singleton<TEvReadDefaultSettings>()->Settings.AtomicLoad();
+    TEvReadSettings settings = *ptr;
+    settings.Ack.MergeFrom(ack);
+    Singleton<TEvReadDefaultSettings>()->Settings.AtomicStore(MakeIntrusive<TEvReadSettings>(settings));
+}
+
+TDuration TIteratorReadBackoffSettings::CalcShardDelay(size_t attempt, bool allowInstantRetry) {
+    if (allowInstantRetry && attempt == 1) {
+        return TDuration::Zero();
+    }
+
+    auto delay = StartRetryDelay;
+    for (size_t i = 0; i < attempt; ++i) {
+        delay *= Multiplier;
+        delay = Min(delay, MaxRetryDelay);
+    }
+
+    delay *= (1 - UnsertaintyRatio * RandomNumber<double>());
+
+    return delay;
+}
+
+void SetReadIteratorBackoffSettings(TIntrusivePtr<TIteratorReadBackoffSettings> ptr) {
+    Singleton<TBackoffStorage>()->SettingsPtr.AtomicStore(ptr);
+}
+
+TDuration CalcDelay(size_t attempt, bool allowInstantRetry) {
+    return Singleton<TBackoffStorage>()->SettingsPtr.AtomicLoad()->CalcShardDelay(attempt, allowInstantRetry);
+}
+
+size_t MaxShardResolves() {
+    return Singleton<TBackoffStorage>()->SettingsPtr.AtomicLoad()->MaxShardResolves;
+}
+
+size_t MaxShardRetries() {  
+    return Singleton<TBackoffStorage>()->SettingsPtr.AtomicLoad()->MaxShardAttempts;
+}
+
+TMaybe<size_t> MaxTotalRetries() {
+    return Singleton<TBackoffStorage>()->SettingsPtr.AtomicLoad()->MaxTotalRetries;
+}
+
+TMaybe<TDuration> ShardTimeout() {
+    return Singleton<TBackoffStorage>()->SettingsPtr.AtomicLoad()->ReadResponseTimeout;
+}
+
+} // namespace NKqp
+} // namespace NKikimr

--- a/ydb/core/kqp/runtime/kqp_read_iterator_common.h
+++ b/ydb/core/kqp/runtime/kqp_read_iterator_common.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <ydb/core/tx/datashard/datashard.h>
+
+namespace NKikimr {
+namespace NKqp {
+
+struct TIteratorReadBackoffSettings : TAtomicRefCount<TIteratorReadBackoffSettings> {
+    TDuration CalcShardDelay(size_t attempt, bool allowInstantRetry);
+
+    TDuration StartRetryDelay = TDuration::MilliSeconds(5);
+    size_t MaxShardAttempts = 10;
+    size_t MaxShardResolves = 3;
+    double UnsertaintyRatio = 0.5;
+    double Multiplier = 2.0;
+    TDuration MaxRetryDelay = TDuration::Seconds(1);
+
+    TMaybe<size_t> MaxTotalRetries;
+    TMaybe<TDuration> ReadResponseTimeout;
+};
+
+struct TEvReadSettings : public TAtomicRefCount<TEvReadSettings> {
+    TEvReadSettings() {
+        Read.SetMaxRows(32767);
+        Read.SetMaxBytes(5_MB);
+
+        Ack.SetMaxRows(32767);
+        Ack.SetMaxBytes(5_MB);
+    }
+
+    NKikimrTxDataShard::TEvRead Read;
+    NKikimrTxDataShard::TEvReadAck Ack;
+};
+
+void SetReadIteratorBackoffSettings(TIntrusivePtr<TIteratorReadBackoffSettings>);
+TDuration CalcDelay(size_t attempt, bool allowInstantRetry);
+size_t MaxShardResolves();
+size_t MaxShardRetries();
+TMaybe<size_t> MaxTotalRetries();
+TMaybe<TDuration> ShardTimeout();
+
+void SetDefaultIteratorQuotaSettings(ui32 rows, ui32 bytes);
+THolder<NKikimr::TEvDataShard::TEvRead> GetDefaultReadSettings();
+void SetDefaultReadSettings(const NKikimrTxDataShard::TEvRead&);
+THolder<NKikimr::TEvDataShard::TEvReadAck> GetDefaultReadAckSettings();
+void SetDefaultReadAckSettings(const NKikimrTxDataShard::TEvReadAck&);
+
+} // namespace NKqp
+} // namespace NKikimr

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/kqp/common/kqp_event_ids.h>
 #include <ydb/core/kqp/gateway/kqp_gateway.h>
 #include <ydb/core/kqp/runtime/kqp_scan_data.h>
+#include <ydb/core/kqp/runtime/kqp_read_iterator_common.h>
 #include <ydb/core/kqp/runtime/kqp_stream_lookup_worker.h>
 #include <ydb/core/protos/kqp_stats.pb.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
@@ -22,7 +23,7 @@ namespace NKqp {
 namespace {
 
 static constexpr TDuration SCHEME_CACHE_REQUEST_TIMEOUT = TDuration::Seconds(10);
-static constexpr ui64 MAX_SHARD_RETRIES = 10;
+NActors::TActorId MainPipeCacheId = NKikimr::MakePipePeNodeCacheID(false);
 
 class TKqpStreamLookupActor : public NActors::TActorBootstrapped<TKqpStreamLookupActor>, public NYql::NDq::IDqComputeActorAsyncInput {
 public:
@@ -133,6 +134,7 @@ private:
         EReadState State;
         TMaybe<TOwnedCellVec> LastProcessedKey;
         ui32 FirstUnprocessedQuery = 0;
+        ui64 LastSeqNo = 0;
     };
 
     struct TShardState {
@@ -142,11 +144,23 @@ private:
 
     struct TEvPrivate {
         enum EEv {
-            EvRetryReadTimeout = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
-            EvSchemeCacheRequestTimeout,
+            EvRetryRead = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
+            EvSchemeCacheRequestTimeout
         };
 
         struct TEvSchemeCacheRequestTimeout : public TEventLocal<TEvSchemeCacheRequestTimeout, EvSchemeCacheRequestTimeout> {
+        };
+
+        struct TEvRetryRead : public TEventLocal<TEvRetryRead, EvRetryRead> {
+            explicit TEvRetryRead(ui64 readId, ui64 lastSeqNo, bool instantStart = false) 
+                : ReadId(readId)
+                , LastSeqNo(lastSeqNo)
+                , InstantStart(instantStart) {
+            }
+
+            const ui64 ReadId;
+            const ui64 LastSeqNo;
+            const bool InstantStart;
         };
     };
 
@@ -173,11 +187,11 @@ private:
                 Counters->SentIteratorCancels->Inc();
                 auto cancel = MakeHolder<TEvDataShard::TEvReadCancel>();
                 cancel->Record.SetReadId(id);
-                Send(MakePipePeNodeCacheID(false), new TEvPipeCache::TEvForward(cancel.Release(), state.ShardId, false));
+                Send(MainPipeCacheId, new TEvPipeCache::TEvForward(cancel.Release(), state.ShardId, false));
             }
         }
 
-        Send(MakePipePeNodeCacheID(false), new TEvPipeCache::TEvUnlink(0));
+        Send(MainPipeCacheId, new TEvPipeCache::TEvUnlink(0));
         TActorBootstrapped<TKqpStreamLookupActor>::PassAway();
 
         LookupActorSpan.End();
@@ -228,6 +242,7 @@ private:
                 hFunc(TEvDataShard::TEvReadResult, Handle);
                 hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
                 hFunc(TEvPrivate::TEvSchemeCacheRequestTimeout, Handle);
+                hFunc(TEvPrivate::TEvRetryRead, Handle);
                 IgnoreFunc(TEvTxProxySchemeCache::TEvInvalidateTableResult);
                 default:
                     RuntimeError(TStringBuilder() << "Unexpected event: " << ev->GetTypeRewrite(),
@@ -264,12 +279,12 @@ private:
             ", readId: " << record.GetReadId() << ", finished: " << record.GetFinished());
 
         auto readIt = Reads.find(record.GetReadId());
-        YQL_ENSURE(readIt != Reads.end(), "Unexpected readId: " << record.GetReadId());
-        auto& read = readIt->second;
-
-        if (read.State != EReadState::Running) {
+        if (readIt == Reads.end() || readIt->second.State != EReadState::Running) {
+            CA_LOG_D("Drop read with readId: " << record.GetReadId() << ", because it's already completed");
             return;
         }
+
+        auto& read = readIt->second;
 
         for (auto& lock : record.GetBrokenTxLocks()) {
             BrokenLocks.push_back(lock);
@@ -291,8 +306,14 @@ private:
         switch (record.GetStatus().GetCode()) {
             case Ydb::StatusIds::SUCCESS:
                 break;
-            case Ydb::StatusIds::NOT_FOUND:
-            case Ydb::StatusIds::OVERLOADED:
+            case Ydb::StatusIds::NOT_FOUND: {
+                StreamLookupWorker->ResetRowsProcessing(read.Id, read.FirstUnprocessedQuery, read.LastProcessedKey);
+                read.SetFinished();
+                return ResolveTableShards();
+            }
+            case Ydb::StatusIds::OVERLOADED: {
+                return RetryTableRead(read, /*allowInstantRetry = */false);
+            }
             case Ydb::StatusIds::INTERNAL_ERROR: {
                 return RetryTableRead(read);
             }
@@ -302,6 +323,8 @@ private:
                 return RuntimeError("Read request aborted", NYql::NDqProto::StatusIds::ABORTED, issues);
             }
         }
+
+        read.LastSeqNo = record.GetSeqNo();
 
         if (record.GetFinished()) {
             read.SetFinished();
@@ -321,12 +344,21 @@ private:
             THolder<TEvDataShard::TEvReadAck> request(new TEvDataShard::TEvReadAck());
             request->Record.SetReadId(record.GetReadId());
             request->Record.SetSeqNo(record.GetSeqNo());
-            request->Record.SetMaxRows(Max<ui16>());
-            request->Record.SetMaxBytes(5_MB);
-            Send(MakePipePeNodeCacheID(false), new TEvPipeCache::TEvForward(request.Release(), read.ShardId, true),
+
+            auto defaultSettings = GetDefaultReadAckSettings()->Record;
+            request->Record.SetMaxRows(defaultSettings.GetMaxRows());
+            request->Record.SetMaxBytes(defaultSettings.GetMaxBytes());
+
+            Send(MainPipeCacheId, new TEvPipeCache::TEvForward(request.Release(), read.ShardId, true),
                 IEventHandle::FlagTrackDelivery);
 
             CA_LOG_D("TEvReadAck was sent to shard: " << read.ShardId);
+
+            if (auto delay = ShardTimeout()) {
+                TlsActivationContext->Schedule(
+                    *delay, new IEventHandle(SelfId(), SelfId(), new TEvPrivate::TEvRetryRead(read.Id, read.LastSeqNo))
+                );
+            }
         }
 
         StreamLookupWorker->AddResult(TKqpStreamLookupWorker::TShardReadResult{
@@ -345,12 +377,9 @@ private:
         for (auto* read : shardIt->second.Reads) {
             if (read->State == EReadState::Running) {
                 Counters->IteratorDeliveryProblems->Inc();
-                StreamLookupWorker->ResetRowsProcessing(read->Id, read->FirstUnprocessedQuery, read->LastProcessedKey);
-                read->SetFinished();
+                RetryTableRead(*read);
             }
         }
-
-        ResolveTableShards();
     }
 
     void Handle(TEvPrivate::TEvSchemeCacheRequestTimeout::TPtr&) {
@@ -358,11 +387,27 @@ private:
             << " was resolved: " << !!Partitioning);
 
         if (!Partitioning) {
-            TString errorMsg = TStringBuilder() << "Failed to resolve shards for table: " << StreamLookupWorker->GetTablePath()
-                << " (request timeout exceeded)";
-            LookupActorStateSpan.EndError(errorMsg);
+            LookupActorStateSpan.EndError("timeout exceeded");
+            CA_LOG_D("Retry attempt to resolve shards for table: " << StreamLookupWorker->GetTablePath());
+            ResolveTableShards();
+        }
+    }
 
-            RuntimeError(errorMsg, NYql::NDqProto::StatusIds::TIMEOUT);
+    void Handle(TEvPrivate::TEvRetryRead::TPtr& ev) {
+        auto readIt = Reads.find(ev->Get()->ReadId);
+        YQL_ENSURE(readIt != Reads.end(), "Unexpected readId: " << ev->Get()->ReadId);
+        auto& read = readIt->second;
+        
+        if (read.LastSeqNo <= ev->Get()->LastSeqNo) {
+            if (ev->Get()->InstantStart) {
+                read.SetFinished();
+                auto requests = StreamLookupWorker->RebuildRequest(read.Id, read.FirstUnprocessedQuery, read.LastProcessedKey, ReadId);
+                for (auto& request : requests) {
+                    StartTableRead(read.ShardId, std::move(request));
+                }
+            } else {
+                RetryTableRead(read);
+            }
         }
     }
 
@@ -389,7 +434,7 @@ private:
         }
     }
 
-    TReadState& StartTableRead(ui64 shardId, THolder<TEvDataShard::TEvRead> request) {
+    void StartTableRead(ui64 shardId, THolder<TEvDataShard::TEvRead> request) {
         Counters->CreatedIterators->Inc();
         auto& record = request->Record;
 
@@ -409,41 +454,69 @@ private:
             record.SetLockTxId(*LockTxId);
         }
 
-        record.SetMaxRows(Max<ui16>());
-        record.SetMaxBytes(5_MB);
+        auto defaultSettings = GetDefaultReadSettings()->Record;
+        record.SetMaxRows(defaultSettings.GetMaxRows());
+        record.SetMaxBytes(defaultSettings.GetMaxBytes());
         record.SetResultFormat(NKikimrDataEvents::FORMAT_CELLVEC);
 
-        Send(MakePipePeNodeCacheID(false), new TEvPipeCache::TEvForward(request.Release(), shardId, true),
+        Send(MainPipeCacheId, new TEvPipeCache::TEvForward(request.Release(), shardId, true),
             IEventHandle::FlagTrackDelivery, 0, LookupActorSpan.GetTraceId());
 
         read.State = EReadState::Running;
 
         auto readId = read.Id;
+        auto lastSeqNo = read.LastSeqNo;
         const auto [readIt, succeeded] = Reads.insert({readId, std::move(read)});
         YQL_ENSURE(succeeded);
         ReadsPerShard[shardId].Reads.push_back(&readIt->second);
 
-        return readIt->second;
+        if (auto delay = ShardTimeout()) {
+            TlsActivationContext->Schedule(
+                *delay, new IEventHandle(SelfId(), SelfId(), new TEvPrivate::TEvRetryRead(readId, lastSeqNo))
+            );
+        }
     }
 
-    void RetryTableRead(TReadState& failedRead) {
+    void RetryTableRead(TReadState& failedRead, bool allowInstantRetry = true) {
         CA_LOG_D("Retry reading of table: " << StreamLookupWorker->GetTablePath() << ", readId: " << failedRead.Id
             << ", shardId: " << failedRead.ShardId);
 
-        StreamLookupWorker->ResetRowsProcessing(failedRead.Id, failedRead.FirstUnprocessedQuery, failedRead.LastProcessedKey);
-        failedRead.SetFinished();
+        ++TotalRetryAttempts;
+        auto totalRetriesLimit = MaxTotalRetries();
+        if (totalRetriesLimit && TotalRetryAttempts > *totalRetriesLimit) {
+            return RuntimeError(TStringBuilder() << "Table '" << StreamLookupWorker->GetTablePath() << "' retry limit exceeded",
+                NYql::NDqProto::StatusIds::UNAVAILABLE);
+        }
 
         auto& shardState = ReadsPerShard[failedRead.ShardId];
-        if (shardState.RetryAttempts > MAX_SHARD_RETRIES) {
-            RuntimeError(TStringBuilder() << "Retry limit exceeded for shard: " << failedRead.ShardId,
-                NYql::NDqProto::StatusIds::ABORTED);
+        ++shardState.RetryAttempts;
+        if (shardState.RetryAttempts > MaxShardRetries()) {
+            StreamLookupWorker->ResetRowsProcessing(failedRead.Id, failedRead.FirstUnprocessedQuery, failedRead.LastProcessedKey);
+            failedRead.SetFinished();
+            return ResolveTableShards();
+        }
+
+        auto delay = CalcDelay(shardState.RetryAttempts, allowInstantRetry);
+        if (delay == TDuration::Zero()) {
+            failedRead.SetFinished();
+            auto requests = StreamLookupWorker->RebuildRequest(failedRead.Id, failedRead.FirstUnprocessedQuery, failedRead.LastProcessedKey, ReadId);
+            for (auto& request : requests) {
+                StartTableRead(failedRead.ShardId, std::move(request));
+            }
         } else {
-            ++shardState.RetryAttempts;
-            ResolveTableShards();
+            CA_LOG_D("Schedule retry atempt for readId: " << failedRead.Id << " after " << delay);
+            TlsActivationContext->Schedule(
+                delay, new IEventHandle(SelfId(), SelfId(), new TEvPrivate::TEvRetryRead(failedRead.Id, failedRead.LastSeqNo, /*instantStart = */ true))
+            );
         }
     }
 
     void ResolveTableShards() {
+        if (++TotalResolveShardsAttempts > MaxShardResolves()) {
+            return RuntimeError(TStringBuilder() << "Table '" << StreamLookupWorker->GetTablePath() << "' resolve attempts limit exceeded",
+                NYql::NDqProto::StatusIds::UNAVAILABLE);
+        }
+
         CA_LOG_D("Resolve shards for table: " << StreamLookupWorker->GetTablePath());
 
         Partitioning.reset();
@@ -520,6 +593,8 @@ private:
     TVector<NKikimrDataEvents::TLock> BrokenLocks;
     std::unique_ptr<TKqpStreamLookupWorker> StreamLookupWorker;
     ui64 ReadId = 0;
+    size_t TotalRetryAttempts = 0;
+    size_t TotalResolveShardsAttempts = 0;
 
     // stats
     ui64 ReadRowsCount = 0;
@@ -536,6 +611,10 @@ std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateStreamL
     NKikimrKqp::TKqpStreamLookupSettings&& settings, TIntrusivePtr<TKqpCounters> counters) {
     auto actor = new TKqpStreamLookupActor(std::move(args), std::move(settings), counters);
     return {actor, actor};
+}
+
+void InterceptStreamLookupActorPipeCache(NActors::TActorId id) {
+    MainPipeCacheId = id;
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -398,7 +398,7 @@ private:
         YQL_ENSURE(readIt != Reads.end(), "Unexpected readId: " << ev->Get()->ReadId);
         auto& read = readIt->second;
         
-        if (read.LastSeqNo <= ev->Get()->LastSeqNo) {
+        if (read.State == EReadState::Running && read.LastSeqNo <= ev->Get()->LastSeqNo) {
             if (ev->Get()->InstantStart) {
                 read.SetFinished();
                 auto requests = StreamLookupWorker->RebuildRequest(read.Id, read.FirstUnprocessedQuery, read.LastProcessedKey, ReadId);

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -35,6 +35,7 @@ public:
         , TypeEnv(args.TypeEnv)
         , Alloc(args.Alloc)
         , Snapshot(settings.GetSnapshot().GetStep(), settings.GetSnapshot().GetTxId())
+        , AllowInconsistentReads(settings.GetAllowInconsistentReads())
         , LockTxId(settings.HasLockTxId() ? settings.GetLockTxId() : TMaybe<ui64>())
         , SchemeCacheRequestTimeout(SCHEME_CACHE_REQUEST_TIMEOUT)
         , StreamLookupWorker(CreateStreamLookupWorker(std::move(settings), args.TypeEnv, args.HolderFactory, args.InputDesc))
@@ -278,6 +279,10 @@ private:
             Locks.push_back(lock);
         }
 
+        if (!Snapshot.IsValid()) {
+            Snapshot = IKqpGateway::TKqpSnapshot(record.GetSnapshot().GetStep(), record.GetSnapshot().GetTxId());
+        }
+
         Counters->DataShardIteratorMessages->Inc();
         if (record.GetStatus().GetCode() != Ydb::StatusIds::SUCCESS) {
             Counters->DataShardIteratorFails->Inc();
@@ -393,9 +398,12 @@ private:
 
         TReadState read(record.GetReadId(), shardId);
 
-        YQL_ENSURE(Snapshot.IsValid(), "Invalid snapshot value");
-        record.MutableSnapshot()->SetStep(Snapshot.Step);
-        record.MutableSnapshot()->SetTxId(Snapshot.TxId);
+        if (Snapshot.IsValid()) {
+            record.MutableSnapshot()->SetStep(Snapshot.Step);
+            record.MutableSnapshot()->SetTxId(Snapshot.TxId);
+        } else {
+            YQL_ENSURE(AllowInconsistentReads, "Expected valid snapshot or enabled inconsistent read mode");
+        }
 
         if (LockTxId && BrokenLocks.empty()) {
             record.SetLockTxId(*LockTxId);
@@ -501,6 +509,7 @@ private:
     const NMiniKQL::TTypeEnvironment& TypeEnv;
     std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
     IKqpGateway::TKqpSnapshot Snapshot;
+    const bool AllowInconsistentReads;
     const TMaybe<ui64> LockTxId;
     std::unordered_map<ui64, TReadState> Reads;
     std::unordered_map<ui64, TShardState> ReadsPerShard;

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.h
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.h
@@ -10,5 +10,7 @@ namespace NKqp {
 std::pair<NYql::NDq::IDqComputeActorAsyncInput*, NActors::IActor*> CreateStreamLookupActor(NYql::NDq::IDqAsyncIoFactory::TInputTransformArguments&& args,
     NKikimrKqp::TKqpStreamLookupSettings&& settings, TIntrusivePtr<TKqpCounters>);
 
+void InterceptStreamLookupActorPipeCache(NActors::TActorId);
+
 } // namespace NKqp
 } // namespace NKikimr

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -244,7 +244,9 @@ public:
         TMaybe<TOwnedCellVec> lastProcessedKey, ui64& newReadId) final {
 
         auto it = PendingKeysByReadId.find(prevReadId);
-        YQL_ENSURE(it != PendingKeysByReadId.end());
+        if (it == PendingKeysByReadId.end()) {
+            return {};
+        }
 
         std::vector<TOwnedTableRange> unprocessedRanges;
         std::vector<TOwnedTableRange> unprocessedPoints;
@@ -405,7 +407,9 @@ public:
 
     void ResetRowsProcessing(ui64 readId, ui32 firstUnprocessedQuery, TMaybe<TOwnedCellVec> lastProcessedKey) final {
         auto it = PendingKeysByReadId.find(readId);
-        YQL_ENSURE(it != PendingKeysByReadId.end());
+        if (it == PendingKeysByReadId.end()) {
+            return;
+        }
 
         if (lastProcessedKey) {
             YQL_ENSURE(firstUnprocessedQuery < it->second.size());
@@ -501,7 +505,9 @@ public:
         TMaybe<TOwnedCellVec> lastProcessedKey, ui64& newReadId) final {
 
         auto readIt = PendingKeysByReadId.find(prevReadId);
-        YQL_ENSURE(readIt != PendingKeysByReadId.end());
+        if (readIt == PendingKeysByReadId.end()) {
+            return {};
+        }
 
         std::vector<TOwnedTableRange> unprocessedRanges;
         std::vector<TOwnedTableRange> unprocessedPoints;
@@ -678,7 +684,10 @@ public:
 
     void ResetRowsProcessing(ui64 readId, ui32 firstUnprocessedQuery, TMaybe<TOwnedCellVec> lastProcessedKey) final {
         auto readIt = PendingKeysByReadId.find(readId);
-        YQL_ENSURE(readIt != PendingKeysByReadId.end());
+        if (readIt == PendingKeysByReadId.end()) {
+            return;
+        }
+
         auto& ranges = readIt->second;
 
         if (lastProcessedKey) {

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -240,6 +240,57 @@ public:
         }
     }
 
+    std::vector<THolder<TEvDataShard::TEvRead>> RebuildRequest(const ui64& prevReadId, ui32 firstUnprocessedQuery, 
+        TMaybe<TOwnedCellVec> lastProcessedKey, ui64& newReadId) final {
+
+        auto it = PendingKeysByReadId.find(prevReadId);
+        YQL_ENSURE(it != PendingKeysByReadId.end());
+
+        std::vector<TOwnedTableRange> unprocessedRanges;
+        std::vector<TOwnedTableRange> unprocessedPoints;
+
+        auto& ranges = it->second;
+
+        if (lastProcessedKey) {
+            YQL_ENSURE(firstUnprocessedQuery < ranges.size());
+            auto unprocessedRange = ranges[firstUnprocessedQuery];
+            YQL_ENSURE(!unprocessedRange.Point);
+
+            unprocessedRanges.emplace_back(*lastProcessedKey, false,
+                unprocessedRange.GetOwnedTo(), unprocessedRange.InclusiveTo);
+            ++firstUnprocessedQuery;
+        }
+
+        for (ui32 i = firstUnprocessedQuery; i < ranges.size(); ++i) {
+            if (ranges[i].Point) {
+                unprocessedPoints.emplace_back(std::move(ranges[i]));
+            } else {
+                unprocessedRanges.emplace_back(std::move(ranges[i]));
+            }
+        }
+
+        PendingKeysByReadId.erase(it);
+
+        std::vector<THolder<TEvDataShard::TEvRead>> requests;
+        requests.reserve(unprocessedPoints.size() + unprocessedRanges.size());
+
+        if (!unprocessedPoints.empty()) {
+            THolder<TEvDataShard::TEvRead> request(new TEvDataShard::TEvRead());
+            FillReadRequest(++newReadId, request, unprocessedPoints);
+            requests.emplace_back(std::move(request));
+            PendingKeysByReadId.insert({newReadId, std::move(unprocessedPoints)});
+        }
+
+        if (!unprocessedRanges.empty()) {
+            THolder<TEvDataShard::TEvRead> request(new TEvDataShard::TEvRead());
+            FillReadRequest(++newReadId, request, unprocessedRanges);
+            requests.emplace_back(std::move(request));
+            PendingKeysByReadId.insert({newReadId, std::move(unprocessedRanges)});
+        }
+        
+        return requests;
+    }
+
     TReadList BuildRequests(const TPartitionInfo& partitioning, ui64& readId) final {
         YQL_ENSURE(partitioning);
 
@@ -444,6 +495,74 @@ public:
         }
 
         UnprocessedRows.emplace_back(std::make_pair(TOwnedCellVec(joinKeyCells), std::move(inputRow.GetElement(1))));
+    }
+
+    std::vector<THolder<TEvDataShard::TEvRead>> RebuildRequest(const ui64& prevReadId, ui32 firstUnprocessedQuery, 
+        TMaybe<TOwnedCellVec> lastProcessedKey, ui64& newReadId) final {
+
+        auto readIt = PendingKeysByReadId.find(prevReadId);
+        YQL_ENSURE(readIt != PendingKeysByReadId.end());
+
+        std::vector<TOwnedTableRange> unprocessedRanges;
+        std::vector<TOwnedTableRange> unprocessedPoints;
+
+        auto& ranges = readIt->second;
+
+        if (lastProcessedKey) {
+            YQL_ENSURE(firstUnprocessedQuery < ranges.size());
+            auto unprocessedRange = ranges[firstUnprocessedQuery];
+            YQL_ENSURE(!unprocessedRange.Point);
+
+            unprocessedRanges.emplace_back(*lastProcessedKey, false,
+                unprocessedRange.GetOwnedTo(), unprocessedRange.InclusiveTo);
+            ++firstUnprocessedQuery;
+        }
+
+        for (ui32 i = firstUnprocessedQuery; i < ranges.size(); ++i) {
+            auto leftRowIt = PendingLeftRowsByKey.find(ExtractKeyPrefix(ranges[i]));
+            YQL_ENSURE(leftRowIt != PendingLeftRowsByKey.end());
+            leftRowIt->second.PendingReads.erase(prevReadId);
+
+            if (ranges[i].Point) {
+                unprocessedPoints.emplace_back(std::move(ranges[i]));
+            } else {
+                unprocessedRanges.emplace_back(std::move(ranges[i]));
+            }
+        }
+
+        PendingKeysByReadId.erase(readIt);
+
+        std::vector<THolder<TEvDataShard::TEvRead>> readRequests;
+
+        if (!unprocessedPoints.empty()) {
+            THolder<TEvDataShard::TEvRead> request(new TEvDataShard::TEvRead());
+            FillReadRequest(++newReadId, request, unprocessedPoints);
+            readRequests.emplace_back(std::move(request));
+
+            for (const auto& point : unprocessedPoints) {
+                auto rowIt = PendingLeftRowsByKey.find(point.From);
+                YQL_ENSURE(rowIt != PendingLeftRowsByKey.end());
+                rowIt->second.PendingReads.insert(newReadId);
+            }
+
+            PendingKeysByReadId.insert({newReadId, std::move(unprocessedPoints)});
+        }
+
+        if (!unprocessedRanges.empty()) {
+            THolder<TEvDataShard::TEvRead> request(new TEvDataShard::TEvRead());
+            FillReadRequest(++newReadId, request, unprocessedRanges);
+            readRequests.emplace_back(std::move(request));
+
+            for (const auto& range : unprocessedRanges) {
+                auto rowIt = PendingLeftRowsByKey.find(ExtractKeyPrefix(range));
+                YQL_ENSURE(rowIt != PendingLeftRowsByKey.end());
+                rowIt->second.PendingReads.insert(newReadId);
+            }
+
+            PendingKeysByReadId.insert({newReadId, std::move(unprocessedRanges)});
+        }
+
+        return readRequests;
     }
 
     TReadList BuildRequests(const TPartitionInfo& partitioning, ui64& readId) final {

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
@@ -53,6 +53,8 @@ public:
     virtual std::vector<NScheme::TTypeInfo> GetKeyColumnTypes() const;
 
     virtual void AddInputRow(NUdf::TUnboxedValue inputRow) = 0;
+    virtual std::vector<THolder<TEvDataShard::TEvRead>> RebuildRequest(const ui64& prevReadId, ui32 firstUnprocessedQuery, 
+        TMaybe<TOwnedCellVec> lastProcessedKey, ui64& newReadId) = 0;
     virtual TReadList BuildRequests(const TPartitionInfo& partitioning, ui64& readId) = 0;
     virtual void AddResult(TShardReadResult result) = 0;
     virtual TReadResultStats ReplyResult(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, i64 freeSpace) = 0;

--- a/ydb/core/kqp/runtime/ya.make
+++ b/ydb/core/kqp/runtime/ya.make
@@ -6,6 +6,7 @@ SRCS(
     kqp_output_stream.cpp
     kqp_program_builder.cpp
     kqp_read_actor.cpp
+    kqp_read_iterator_common.cpp
     kqp_read_table.cpp
     kqp_runtime_impl.h
     kqp_scan_data.cpp

--- a/ydb/core/kqp/ut/opt/kqp_ne_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_ne_ut.cpp
@@ -2106,20 +2106,38 @@ Y_UNIT_TEST_SUITE(KqpNewEngine) {
 
         kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::KQP_EXECUTER, NActors::NLog::PRI_INFO);
 
-        auto result = session.ExecuteDataQuery(R"(
-            SELECT Value1, Value2, Key FROM `/Root/TwoShard` WHERE Value2 != 0 ORDER BY Key DESC;
-        )", TTxControl::BeginTx(TTxSettings::OnlineRO(TTxOnlineSettings().AllowInconsistentReads(true))).CommitTx())
+        {
+            auto result = session.ExecuteDataQuery(R"(
+                SELECT Value1, Value2, Key FROM `/Root/TwoShard` WHERE Value2 != 0 ORDER BY Key DESC;
+            )", TTxControl::BeginTx(TTxSettings::OnlineRO(TTxOnlineSettings().AllowInconsistentReads(true))).CommitTx())
             .ExtractValueSync();
-        AssertSuccessResult(result);
+            AssertSuccessResult(result);
 
-        CompareYson(R"(
-            [
-                [["BigThree"];[1];[4000000003u]];
-                [["BigOne"];[-1];[4000000001u]];
-                [["Three"];[1];[3u]];
-                [["One"];[-1];[1u]]
-            ]
-        )", FormatResultSetYson(result.GetResultSet(0)));
+            CompareYson(R"(
+                [
+                    [["BigThree"];[1];[4000000003u]];
+                    [["BigOne"];[-1];[4000000001u]];
+                    [["Three"];[1];[3u]];
+                    [["One"];[-1];[1u]]
+                ]
+            )", FormatResultSetYson(result.GetResultSet(0)));
+        }
+
+        {  // stream lookup query
+            auto result = session.ExecuteDataQuery(R"(
+                $list = SELECT Key FROM `/Root/TwoShard`;
+                SELECT Value, Key FROM `/Root/KeyValue` WHERE Key IN $list ORDER BY Key;
+            )", TTxControl::BeginTx(TTxSettings::OnlineRO(TTxOnlineSettings().AllowInconsistentReads(true))).CommitTx())
+            .ExtractValueSync();
+            AssertSuccessResult(result);
+
+            CompareYson(R"(
+                [
+                    [["One"];[1u]];
+                    [["Two"];[2u]]
+                ]
+            )", FormatResultSetYson(result.GetResultSet(0)));
+        }
     }
 
     Y_UNIT_TEST(StaleRO) {

--- a/ydb/core/kqp/ut/opt/kqp_ne_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_ne_ut.cpp
@@ -2,6 +2,8 @@
 
 #include <ydb/public/sdk/cpp/client/ydb_proto/accessor.h>
 #include <ydb/core/kqp/runtime/kqp_read_actor.h>
+#include <ydb/core/kqp/runtime/kqp_read_iterator_common.h>
+#include <ydb/core/tx/datashard/datashard_impl.h>
 
 namespace NKikimr::NKqp {
 
@@ -3648,11 +3650,11 @@ Y_UNIT_TEST_SUITE(KqpNewEngine) {
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(1);
         evread.SetMaxRows(2);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         NKikimrTxDataShard::TEvReadAck evreadack;
         evreadack.SetMaxRows(2);
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         {
             auto result = session.ExecuteDataQuery(R"(
@@ -3730,10 +3732,10 @@ Y_UNIT_TEST_SUITE(KqpNewEngine) {
 
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(2);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         NKikimrTxDataShard::TEvReadAck evreadack;
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         {
             auto result = session.ExecuteDataQuery(R"(
@@ -3758,10 +3760,10 @@ Y_UNIT_TEST_SUITE(KqpNewEngine) {
 
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(2);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         NKikimrTxDataShard::TEvReadAck evreadack;
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         {
             auto result = session.ExecuteDataQuery(R"(

--- a/ydb/core/kqp/ut/opt/kqp_sqlin_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_sqlin_ut.cpp
@@ -1016,11 +1016,7 @@ Y_UNIT_TEST_SUITE(KqpSqlIn) {
             CompareYson(R"([[[1u];["One"]]])", FormatResultSetYson(result.GetResultSet(0)));
 
             const Ydb::TableStats::QueryStats stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
-            if (serverSettings.AppConfig.GetTableServiceConfig().GetEnableKqpDataQueryStreamLookup()) {
-                UNIT_ASSERT_EQUAL_C(1, stats.query_phases_size(), stats.DebugString());
-            } else {
-                UNIT_ASSERT_EQUAL_C(2, stats.query_phases_size(), stats.DebugString());
-            }
+            UNIT_ASSERT_EQUAL_C(2, stats.query_phases_size(), stats.DebugString());
         }
 
         // complex (tuple) key
@@ -1058,11 +1054,7 @@ Y_UNIT_TEST_SUITE(KqpSqlIn) {
             CompareYson(R"([[[3500u];["None"];[1u];["Anna"]]])", FormatResultSetYson(result.GetResultSet(0)));
 
             const Ydb::TableStats::QueryStats stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
-            if (serverSettings.AppConfig.GetTableServiceConfig().GetEnableKqpDataQueryStreamLookup()) {
-                UNIT_ASSERT_EQUAL_C(1, stats.query_phases_size(), stats.DebugString());
-            } else {
-                UNIT_ASSERT_EQUAL_C(2, stats.query_phases_size(), stats.DebugString());
-            }
+            UNIT_ASSERT_EQUAL_C(2, stats.query_phases_size(), stats.DebugString());
         }
     }
 }

--- a/ydb/core/kqp/ut/scan/kqp_split_ut.cpp
+++ b/ydb/core/kqp/ut/scan/kqp_split_ut.cpp
@@ -3,7 +3,9 @@
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 
 #include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/kqp/runtime/kqp_read_iterator_common.h>
 #include <ydb/core/kqp/runtime/kqp_read_actor.h>
+#include <ydb/core/kqp/runtime/kqp_stream_lookup_actor.h>
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor.h>
 
@@ -291,13 +293,12 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
         runtime.Send(new IEventHandle(NKqp::MakeKqpProxyID(runtime.GetNodeId()), sender, request.Release()));
     }
 
-    void ExecSQL(Tests::TServer::TPtr server,
+    void ExecSQL(NActors::TTestActorRuntime& runtime,
                  TActorId sender,
                  const TString &sql,
                  bool dml = true,
                  Ydb::StatusIds::StatusCode code = Ydb::StatusIds::SUCCESS)
     {
-        auto &runtime = *server->GetRuntime();
         TAutoPtr<IEventHandle> handle;
 
         auto request = MakeSQLRequest(sql, dml);
@@ -385,19 +386,28 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
     template <SortOrder OPT>                                                                                            \
     void TTestCase##N<OPT>::Execute_(NUnitTest::TTestContext& ut_context Y_DECLARE_UNUSED)
 
+    enum class ETestActorType {
+        SorceRead,
+        StreamLookup
+    };
+
     struct TTestSetup {
-        TTestSetup(TString table = "/Root/KeyValueLargePartition", Tests::TServer* providedServer = nullptr)
+        TTestSetup(ETestActorType testActorType, TString table = "/Root/KeyValueLargePartition", Tests::TServer* providedServer = nullptr)
             : Table(table)
         {
-            InterceptReadActorPipeCache(MakePipePeNodeCacheID(false));
+            if (testActorType == ETestActorType::SorceRead) {
+                InterceptReadActorPipeCache(MakePipePeNodeCacheID(false));
+            } else if (testActorType == ETestActorType::StreamLookup) {
+                InterceptStreamLookupActorPipeCache(MakePipePeNodeCacheID(false));
+            }
+            
             if (providedServer) {
                 Server = providedServer;
             } else {
                 TKikimrSettings settings;
                 NKikimrConfig::TAppConfig appConfig;
-                appConfig.MutableTableServiceConfig()->SetEnableKqpScanQuerySourceRead(true);
-                appConfig.MutableTableServiceConfig()->SetEnableKqpScanQueryStreamLookup(false);
-                appConfig.MutableTableServiceConfig()->SetEnablePredicateExtractForScanQueries(true);
+                appConfig.MutableTableServiceConfig()->SetEnableKqpScanQuerySourceRead(testActorType == ETestActorType::SorceRead);
+                appConfig.MutableTableServiceConfig()->SetEnableKqpScanQueryStreamLookup(testActorType == ETestActorType::StreamLookup);
                 settings.SetDomainRoot(KikimrDefaultUtDomainRoot);
                 settings.SetAppConfig(appConfig);
 
@@ -456,7 +466,7 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
     };
 
     Y_UNIT_TEST_SORT(AfterResolve, Order) {
-        TTestSetup s;
+        TTestSetup s(ETestActorType::SorceRead);
 
         auto shards = s.Shards();
         auto* shim = new TReadActorPipeCacheStub();
@@ -476,17 +486,17 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
     }
 
     Y_UNIT_TEST_SORT(AfterResult, Order) {
-        TTestSetup s;
+        TTestSetup s(ETestActorType::SorceRead);
         auto shards = s.Shards();
 
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(8);
         evread.SetMaxRows(8);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         NKikimrTxDataShard::TEvReadAck evreadack;
         evreadack.SetMaxRows(8);
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         auto* shim = new TReadActorPipeCacheStub();
         shim->SetupCapture(1, 1);
@@ -518,17 +528,17 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
             ";
 
     Y_UNIT_TEST_SORT(AfterResultMultiRange, Order) {
-        TTestSetup s;
+        TTestSetup s(ETestActorType::SorceRead);
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(5);
         evread.SetMaxRows(5);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         auto shards = s.Shards();
 
         NKikimrTxDataShard::TEvReadAck evreadack;
         evreadack.SetMaxRows(5);
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         auto* shim = new TReadActorPipeCacheStub();
         shim->SetupCapture(1, 1);
@@ -549,17 +559,17 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
     }
 
     Y_UNIT_TEST_SORT(AfterResultMultiRangeSegmentPartition, Order) {
-        TTestSetup s;
+        TTestSetup s(ETestActorType::SorceRead);
         auto shards = s.Shards();
 
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(5);
         evread.SetMaxRows(5);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         NKikimrTxDataShard::TEvReadAck evreadack;
         evreadack.SetMaxRows(5);
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         auto* shim = new TReadActorPipeCacheStub();
         shim->SetupCapture(1, 1);
@@ -580,17 +590,17 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
     }
 
     Y_UNIT_TEST_SORT(ChoosePartition, Order) {
-        TTestSetup s;
+        TTestSetup s(ETestActorType::SorceRead);
         auto shards = s.Shards();
 
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(8);
         evread.SetMaxRows(8);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         NKikimrTxDataShard::TEvReadAck evreadack;
         evreadack.SetMaxRows(8);
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         auto* shim = new TReadActorPipeCacheStub();
         shim->SetupCapture(2, 1);
@@ -612,17 +622,17 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
 
 
     Y_UNIT_TEST_SORT(BorderKeys, Order) {
-        TTestSetup s;
+        TTestSetup s(ETestActorType::SorceRead);
         auto shards = s.Shards();
 
         NKikimrTxDataShard::TEvRead evread;
         evread.SetMaxRowsInResult(12);
         evread.SetMaxRows(12);
-        InjectRangeEvReadSettings(evread);
+        SetDefaultReadSettings(evread);
 
         NKikimrTxDataShard::TEvReadAck evreadack;
         evreadack.SetMaxRows(12);
-        InjectRangeEvReadAckSettings(evreadack);
+        SetDefaultReadAckSettings(evreadack);
 
         auto* shim = new TReadActorPipeCacheStub();
         shim->SetupCapture(1, 1);
@@ -647,7 +657,7 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
     }
 
     Y_UNIT_TEST_SORT(IntersectionLosesRange, Order) {
-        TTestSetup s;
+        TTestSetup s(ETestActorType::SorceRead);
         auto shards = s.Shards();
 
         auto* shim = new TReadActorPipeCacheStub();
@@ -680,7 +690,7 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
 
         server->GetRuntime()->SetLogPriority(NKikimrServices::KQP_YQL, NActors::NLog::PRI_DEBUG);
         server->GetRuntime()->SetLogPriority(NKikimrServices::KQP_COMPUTE, NActors::NLog::PRI_DEBUG);
-        TTestSetup s("/Root/Test", server.Get());
+        TTestSetup s(ETestActorType::SorceRead, "/Root/Test", server.Get());
 
         NThreading::TPromise<bool> captured = NThreading::NewPromise<bool>();
         TVector<THolder<IEventHandle>> evts;
@@ -703,7 +713,7 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
                 return TTestActorRuntime::EEventAction::PROCESS;
             });
 
-        ExecSQL(server, s.Sender, R"(
+        ExecSQL(*server->GetRuntime(), s.Sender, R"(
             CREATE TABLE `/Root/Test` (
                 Key Uint64,
                 Value String,
@@ -712,7 +722,7 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
             )",
             false);
 
-        ExecSQL(server, s.Sender, R"(
+        ExecSQL(*server->GetRuntime(), s.Sender, R"(
             REPLACE INTO `/Root/Test` (Key, Value) VALUES
                 (201u, "Value1"),
                 (202u, "Value2"),
@@ -742,6 +752,149 @@ Y_UNIT_TEST_SUITE(KqpSplit) {
 
         s.AssertSuccess();
         UNIT_ASSERT_VALUES_EQUAL(Format(s.CollectedKeys), ",202");
+    }
+
+    Y_UNIT_TEST(StreamLookupSplitBeforeReading) {
+        TTestSetup s(ETestActorType::StreamLookup, "/Root/TestIndex");
+
+        ExecSQL(*s.Runtime, s.Sender, R"(
+            CREATE TABLE `/Root/TestIndex` (
+                Key Uint64,
+                Fk Uint64,
+                Value String,
+                PRIMARY KEY (Key),
+                INDEX Index GLOBAL ON (Fk)
+            );
+        )", false);
+
+        ExecSQL(*s.Runtime, s.Sender, R"(
+            REPLACE INTO `/Root/TestIndex` (Key, Fk, Value) VALUES
+                (1u, 10u, "Value1"),
+                (2u, 10u, "Value2"),
+                (3u, 10u, "Value3"),
+                (4u, 11u, "Value4"),
+                (5u, 12u, "Value5");
+        )", true);
+
+        auto shards = s.Shards();
+        auto* shim = new TReadActorPipeCacheStub();
+
+        InterceptStreamLookupActorPipeCache(s.Runtime->Register(shim));
+        shim->SetupCapture(0, 1);
+        s.SendScanQuery(
+            "SELECT Key, Value FROM `/Root/TestIndex` VIEW Index where Fk in (10, 11) ORDER BY Key"
+        );
+
+        shim->ReadsReceived.WaitI();
+        Cerr << "starting split -----------------------------------------------------------" << Endl;
+        s.Split(shards.at(0), 3);
+        Cerr << "resume evread -----------------------------------------------------------" << Endl;
+        shim->SkipAll();
+        shim->SendCaptured(s.Runtime);
+
+        s.AssertSuccess();
+        UNIT_ASSERT_VALUES_EQUAL(Format(Canonize(s.CollectedKeys, SortOrder::Ascending)), ",1,2,3,4");
+    }
+
+    Y_UNIT_TEST(StreamLookupSplitAfterFirstResult) {
+        TTestSetup s(ETestActorType::StreamLookup, "/Root/TestIndex");
+
+        ExecSQL(*s.Runtime, s.Sender, R"(
+            CREATE TABLE `/Root/TestIndex` (
+                Key Uint64,
+                Fk Uint64,
+                Value String,
+                PRIMARY KEY (Key),
+                INDEX Index GLOBAL ON (Fk)
+            );
+        )", false);
+
+        ExecSQL(*s.Runtime, s.Sender, R"(
+            REPLACE INTO `/Root/TestIndex` (Key, Fk, Value) VALUES
+                (1u, 10u, "Value1"),
+                (2u, 10u, "Value2"),
+                (3u, 10u, "Value3"),
+                (4u, 11u, "Value4"),
+                (5u, 12u, "Value5");
+        )", true);
+
+        auto shards = s.Shards();
+
+        NKikimrTxDataShard::TEvRead evread;
+        evread.SetMaxRowsInResult(2);
+        evread.SetMaxRows(2);
+        SetDefaultReadSettings(evread);
+
+        NKikimrTxDataShard::TEvReadAck evreadack;
+        evreadack.SetMaxRows(2);
+        SetDefaultReadAckSettings(evreadack);
+
+        auto* shim = new TReadActorPipeCacheStub();
+        shim->SetupCapture(1, 1);
+        shim->SetupResultsCapture(1);
+        InterceptStreamLookupActorPipeCache(s.Runtime->Register(shim));
+        s.SendScanQuery(
+            "SELECT Key, Value FROM `/Root/TestIndex` VIEW Index where Fk in (10, 11) ORDER BY Key"
+        );
+
+        shim->ReadsReceived.WaitI();
+        Cerr << "starting split -----------------------------------------------------------" << Endl;
+        s.Split(shards.at(0), 3);
+        Cerr << "resume evread -----------------------------------------------------------" << Endl;
+        shim->SkipAll();
+        shim->AllowResults();
+        shim->SendCaptured(s.Runtime);
+
+        s.AssertSuccess();
+        UNIT_ASSERT_VALUES_EQUAL(Format(Canonize(s.CollectedKeys, SortOrder::Ascending)), ",1,2,3,4");
+    }
+
+    Y_UNIT_TEST(StreamLookupDeliveryProblem) {
+        TTestSetup s(ETestActorType::StreamLookup, "/Root/TestIndex");
+
+        ExecSQL(*s.Runtime, s.Sender, R"(
+            CREATE TABLE `/Root/TestIndex` (
+                Key Uint64,
+                Fk Uint64,
+                Value String,
+                PRIMARY KEY (Key),
+                INDEX Index GLOBAL ON (Fk)
+            );
+        )", false);
+
+        ExecSQL(*s.Runtime, s.Sender, R"(
+            REPLACE INTO `/Root/TestIndex` (Key, Fk, Value) VALUES
+                (1u, 10u, "Value1"),
+                (2u, 10u, "Value2"),
+                (3u, 10u, "Value3"),
+                (4u, 11u, "Value4"),
+                (5u, 12u, "Value5");
+        )", true);
+
+        auto shards = s.Shards();
+        auto* shim = new TReadActorPipeCacheStub();
+
+        InterceptStreamLookupActorPipeCache(s.Runtime->Register(shim));
+        shim->SetupCapture(0, 1);
+
+        s.SendScanQuery(
+            "SELECT Key, Value FROM `/Root/TestIndex` VIEW Index where Fk in (10, 11) ORDER BY Key"
+        );
+
+        shim->ReadsReceived.WaitI();
+        
+        UNIT_ASSERT_EQUAL(shards.size(), 1);
+        auto undelivery = MakeHolder<TEvPipeCache::TEvDeliveryProblem>(shards[0], true);
+
+        UNIT_ASSERT_EQUAL(shim->Captured.size(), 1);
+        s.Runtime->Send(shim->Captured[0]->Sender, s.Sender, undelivery.Release());
+
+        shim->SkipAll();
+        shim->SendCaptured(s.Runtime);
+
+        s.AssertSuccess();
+        UNIT_ASSERT_VALUES_EQUAL(Format(Canonize(s.CollectedKeys, SortOrder::Ascending)), ",1,2,3,4");
+
     }
 
     // TODO: rework test for stream lookups

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -668,6 +668,7 @@ message TKqpStreamLookupSettings {
      optional bool ImmediateTx = 6;
      repeated string LookupKeyColumns = 7;
      optional NKqpProto.EStreamLookupStrategy LookupStrategy = 8;
+     optional bool AllowInconsistentReads = 9 [default = false];
 }
 
 message TKqpSequencerSettings {

--- a/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
@@ -484,8 +484,8 @@ NNodes::TExprBase DqPeepholeRewriteJoinDict(const NNodes::TExprBase& node, TExpr
                 << "(" << *leftKeyType << ") and " << rightKeys[i]->Content() << "(" << *rightKeyType << ")";
             break;
         }
-        castKeyLeft = (!IsSameAnnotation(*leftDryType, *commonType) || optKeyLeft);
-        castKeyRight = (!IsSameAnnotation(*rightDryType, *commonType) || optKeyRight);
+        castKeyLeft = castKeyLeft || (!IsSameAnnotation(*leftDryType, *commonType) || optKeyLeft);
+        castKeyRight = castKeyRight || (!IsSameAnnotation(*rightDryType, *commonType) || optKeyRight);
         keyTypeItems.emplace_back(commonType);
     }
 


### PR DESCRIPTION
These commits are needed for enabling KqpDataQueryStreamLookup:

fix(kqp): allow inconsistent reads for stream lookup
fix(kqp): use retry settings form table_service_config for stream lookup
fix(kqp): reject retry attempts for finished reads in stream lookup actor 

Fix test KqpJoin.FullOuterJoinNotNullJoinKey:
[fix(dq): add cast for all optional join keys