### PR TITLE
Fix merge artifact

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -92,10 +92,7 @@ TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTrans
         for (auto& indexChildItems : index.Base()->GetChildren()) {
             const auto& indexImplTableName = indexChildItems.first;
             const auto partId = NextPartId(nextId, result);
-            // TODO(mbkkt) it doesn't work for some reason
-            // if (NTableIndex::IsTmpImplTable(indexImplTableName)) {
-            //     result.push_back(DropIndexImplTable(context, index, nextId, partId, indexImplTableName, indexChildItems.second));
-            // } else 
+            // TODO(mbkkt) We should remove tmp tables, but it doesn't work for some reason
             {
                 result.push_back(FinalizeIndexImplTable(context, index, partId, indexImplTableName, indexChildItems.second));
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -92,9 +92,11 @@ TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTrans
         for (auto& indexChildItems : index.Base()->GetChildren()) {
             const auto& indexImplTableName = indexChildItems.first;
             const auto partId = NextPartId(nextId, result);
-            if (NTableIndex::IsTmpImplTable(indexImplTableName)) {
-                result.push_back(DropIndexImplTable(context, index, nextId, partId, indexImplTableName, indexChildItems.second));
-            } else {
+            // TODO(mbkkt) it doesn't work for some reason
+            // if (NTableIndex::IsTmpImplTable(indexImplTableName)) {
+            //     result.push_back(DropIndexImplTable(context, index, nextId, partId, indexImplTableName, indexChildItems.second));
+            // } else 
+            {
                 result.push_back(FinalizeIndexImplTable(context, index, partId, indexImplTableName, indexChildItems.second));
             }
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
@@ -530,9 +530,13 @@ public:
                 if (parent.Base()->IsTableIndex()) {
                     checks
                         .IsTableIndex()
-                        .IsInsideTableIndexPath()
-                        .IsUnderDeleting()
-                        .IsUnderTheSameOperation(OperationId.GetTxId()); //allow only as part of drop base table
+                        .IsInsideTableIndexPath();
+                    // Not tmp index impl tables can be dropped only as part of drop index
+                    if (!NTableIndex::IsTmpImplTable(name)) {
+                        checks
+                            .IsUnderDeleting()
+                            .IsUnderTheSameOperation(OperationId.GetTxId());
+                    }
                 } else {
                     checks
                         .IsLikeDirectory()

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1288,8 +1288,12 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
 
     auto indexPath = *PathsById.FindPtr(pathId);
     Y_ABORT_UNLESS(indexPath);
-    const ui8 expectedIndexImplTableCount = indexInfo->Type == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree ? 2 : 1;
-    Y_ABORT_UNLESS(indexPath->GetChildren().size() == expectedIndexImplTableCount);
+    if (indexInfo->Type == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree) {
+        // For vector index we have 4 impl tables on build stage and 2 impl tables when it's ready
+        Y_ABORT_UNLESS(indexPath->GetChildren().size() == 4 || indexPath->GetChildren().size() == 2);
+    } else {
+        Y_ABORT_UNLESS(indexPath->GetChildren().size() == 1);
+    }
 
     ui64 dataSize = 0;
     for (const auto& indexImplTablePathId : indexPath->GetChildren()) {


### PR DESCRIPTION
There was test that added in parallel with new tables was introduced

There was restriction that index impl tables can be dropped only when index dropped.
But it's not true for temporary index impl tables.