### PR TITLE
Add ydb sql parameters support

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_command.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_command.cpp
@@ -33,6 +33,21 @@ TDriver TYdbCommand::CreateDriver(const TConfig& config, THolder<TLogBackend>&& 
     return TDriver(driverConfig);
 }
 
+NScripting::TExplainYqlResult TYdbCommand::ExplainQuery(TClientCommand::TConfig& config, const TString& queryText,
+        NScripting::ExplainYqlRequestMode mode) {
+    NScripting::TScriptingClient client(CreateDriver(config));
+
+    NScripting::TExplainYqlRequestSettings explainSettings;
+    explainSettings.Mode(mode);
+
+    auto result = client.ExplainYqlScript(
+        queryText,
+        explainSettings
+    ).GetValueSync();
+    ThrowOnError(result);
+    return result;
+}
+
 TYdbSimpleCommand::TYdbSimpleCommand(const TString& name, const std::initializer_list<TString>& aliases, const TString& description)
     :TYdbCommand(name, aliases, description)
 {}
@@ -56,21 +71,6 @@ void TYdbOperationCommand::Config(TConfig& config) {
     opts.AddLongOption("timeout", "Operation timeout. Operation should be executed on server within this timeout. "
             "There could also be a delay up to 200ms to receive timeout error from server.")
         .RequiredArgument("ms").StoreResult(&OperationTimeout);
-}
-
-NScripting::TExplainYqlResult TYdbOperationCommand::ExplainQuery(TClientCommand::TConfig& config, const TString& queryText,
-        NScripting::ExplainYqlRequestMode mode) {
-    NScripting::TScriptingClient client(CreateDriver(config));
-
-    NScripting::TExplainYqlRequestSettings explainSettings;
-    explainSettings.Mode(mode);
-
-    auto result = client.ExplainYqlScript(
-        queryText,
-        explainSettings
-    ).GetValueSync();
-    ThrowOnError(result);
-    return result;
 }
 
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_command.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_command.h
@@ -21,6 +21,10 @@ public:
     static TDriver CreateDriver(const TConfig& config);
     static TDriver CreateDriver(const TConfig& config, THolder<TLogBackend>&& loggingBackend);
 
+protected:
+    NScripting::TExplainYqlResult ExplainQuery(TClientCommand::TConfig& config, const TString& queryText,
+        NScripting::ExplainYqlRequestMode mode);
+
 private:
     static TDriverConfig CreateDriverConfig(const TConfig& config);
 };
@@ -65,9 +69,6 @@ protected:
         }
         return std::forward<TSettingsType>(settings);
     }
-
-    NScripting::TExplainYqlResult ExplainQuery(TClientCommand::TConfig& config, const TString& queryText,
-        NScripting::ExplainYqlRequestMode mode);
 
     TString OperationTimeout;
 };

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scripting.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scripting.cpp
@@ -44,7 +44,7 @@ void TCommandExecuteYqlScript::Config(TConfig& config) {
 
     AddParametersOption(config);
 
-    AddInputFormats(config, {
+    AddParamFormats(config, {
         EOutputFormat::JsonUnicode,
         EOutputFormat::JsonBase64
     });

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scripting.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scripting.cpp
@@ -99,6 +99,10 @@ void TCommandExecuteYqlScript::Parse(TConfig& config) {
         throw TMisuseException() << "FlameGraph path can not be empty.";
     }
     ParseParameters(config);
+    // For backward compatibility
+    if (!IsStdinInteractive()) {
+        ReadParametersFromStdin = true;
+    }
 }
 
 int TCommandExecuteYqlScript::Run(TConfig& config) {
@@ -122,7 +126,7 @@ int TCommandExecuteYqlScript::Run(TConfig& config) {
                                         + (CollectStatsMode.Empty() ? "none" : CollectStatsMode) + '.';
         }
 
-        if (!Parameters.empty() || !IsStdinInteractive()) {
+        if (!Parameters.empty() || ReadParametersFromStdin) {
             ValidateResult = MakeHolder<NScripting::TExplainYqlResult>(
                 ExplainQuery(config, Script, NScripting::ExplainYqlRequestMode::Validate));
             THolder<TParamsBuilder> paramBuilder;

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_table.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_table.cpp
@@ -378,7 +378,7 @@ void TCommandExecuteQuery::Config(TConfig& config) {
 
     AddParametersOption(config, "(for data & scan queries)");
 
-    AddInputFormats(config, {
+    AddParamFormats(config, {
         EOutputFormat::JsonUnicode,
         EOutputFormat::JsonBase64
     });

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_table.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_table.cpp
@@ -414,6 +414,10 @@ void TCommandExecuteQuery::Parse(TConfig& config) {
     CheckQueryOptions();
     CheckQueryFile();
     ParseParameters(config);
+    // For backward compatibility
+    if (!IsStdinInteractive()) {
+        ReadParametersFromStdin = true;
+    }
 }
 
 int TCommandExecuteQuery::Run(TConfig& config) {
@@ -456,7 +460,7 @@ int TCommandExecuteQuery::ExecuteDataQuery(TConfig& config) {
     NTable::TTableClient client(CreateDriver(config));
     NTable::TAsyncDataQueryResult asyncResult;
 
-    if (!Parameters.empty() || !IsStdinInteractive()) {
+    if (!Parameters.empty() || ReadParametersFromStdin) {
         ValidateResult = MakeHolder<NScripting::TExplainYqlResult>(
             ExplainQuery(config, Query, NScripting::ExplainYqlRequestMode::Validate));
         THolder<TParamsBuilder> paramBuilder;
@@ -685,7 +689,7 @@ int TCommandExecuteQuery::ExecuteQueryImpl(TConfig& config) {
 
     TAsyncPartIterator<TClient> asyncResult;
     SetInterruptHandlers();
-    if (!Parameters.empty() || !IsStdinInteractive()) {
+    if (!Parameters.empty() || ReadParametersFromStdin) {
         ValidateResult = MakeHolder<NScripting::TExplainYqlResult>(
             ExplainQuery(config, Query, NScripting::ExplainYqlRequestMode::Validate));
         THolder<TParamsBuilder> paramBuilder;

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -65,7 +65,9 @@ void TCommandSql::Config(TConfig& config) {
     AddInputFormats(config, {
         EOutputFormat::JsonUnicode,
         EOutputFormat::JsonBase64
-    });
+    },
+    EOutputFormat::JsonUnicode,
+    "param-format");
 
     AddStdinFormats(config, {
         EOutputFormat::JsonUnicode,
@@ -76,7 +78,8 @@ void TCommandSql::Config(TConfig& config) {
     }, {
         EOutputFormat::NoFraming,
         EOutputFormat::NewlineDelimited
-    });
+    },
+    "stdin-param-format");
 
     AddParametersStdinOption(config, "script");
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -60,8 +60,6 @@ void TCommandSql::Config(TConfig& config) {
 
     AddParametersOption(config);
 
-    AddExamplesOption(config);
-
     AddParamFormats(config, {
         EOutputFormat::JsonUnicode,
         EOutputFormat::JsonBase64
@@ -76,10 +74,11 @@ void TCommandSql::Config(TConfig& config) {
     }, {
         EOutputFormat::NoFraming,
         EOutputFormat::NewlineDelimited
-    },
-    "stdin-param-format");
+    });
 
     AddParametersStdinOption(config, "script");
+
+    CheckExamples(config);
 
     config.SetFreeArgsNum(0);
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -58,12 +58,35 @@ void TCommandSql::Config(TConfig& config) {
         EOutputFormat::Parquet,
     });
 
+    AddParametersOption(config);
+
+    AddExamplesOption(config);
+
+    AddInputFormats(config, {
+        EOutputFormat::JsonUnicode,
+        EOutputFormat::JsonBase64
+    });
+
+    AddStdinFormats(config, {
+        EOutputFormat::JsonUnicode,
+        EOutputFormat::JsonBase64,
+        EOutputFormat::Raw,
+        EOutputFormat::Csv,
+        EOutputFormat::Tsv
+    }, {
+        EOutputFormat::NoFraming,
+        EOutputFormat::NewlineDelimited
+    });
+
+    AddParametersStdinOption(config, "script");
+
     config.SetFreeArgsNum(0);
 }
 
 void TCommandSql::Parse(TConfig& config) {
     TClientCommand::Parse(config);
     ParseFormats();
+    ParseParameters(config);
     if (Query && QueryFile) {
         throw TMisuseException() << "Both mutually exclusive options \"Text of query\" (\"--query\", \"-q\") "
             << "and \"Path to file with query text\" (\"--file\", \"-f\") were provided.";

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.h
@@ -4,7 +4,6 @@
 #include "ydb_common.h"
 
 #include <ydb/public/sdk/cpp/client/ydb_query/client.h>
-#include <ydb/public/lib/ydb_cli/common/format.h>
 #include <ydb/public/lib/ydb_cli/common/interruptible.h>
 #include <ydb/public/lib/ydb_cli/common/parameters.h>
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.h
@@ -6,11 +6,12 @@
 #include <ydb/public/sdk/cpp/client/ydb_query/client.h>
 #include <ydb/public/lib/ydb_cli/common/format.h>
 #include <ydb/public/lib/ydb_cli/common/interruptible.h>
+#include <ydb/public/lib/ydb_cli/common/parameters.h>
 
 namespace NYdb {
 namespace NConsoleClient {
 
-class TCommandSql : public TYdbCommand, public TCommandWithFormat,
+class TCommandSql : public TYdbCommand, public TCommandWithParameters,
     public TInterruptibleCommand
 {
 public:

--- a/ydb/public/lib/ydb_cli/commands/ydb_yql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_yql.cpp
@@ -45,7 +45,7 @@ void TCommandYql::Config(TConfig& config) {
 
     AddParametersOption(config);
 
-    AddInputFormats(config, {
+    AddParamFormats(config, {
         EOutputFormat::JsonUnicode,
         EOutputFormat::JsonBase64
     });

--- a/ydb/public/lib/ydb_cli/commands/ydb_yql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_yql.cpp
@@ -83,6 +83,10 @@ void TCommandYql::Parse(TConfig& config) {
         throw TMisuseException() << "FlameGraph path can not be empty.";
     }
     ParseParameters(config);
+    // For backward compatibility
+    if (!IsStdinInteractive()) {
+        ReadParametersFromStdin = true;
+    }
 }
 
 int TCommandYql::Run(TConfig& config) {
@@ -104,7 +108,7 @@ int TCommandYql::RunCommand(TConfig& config, const TString& script) {
 
     SetInterruptHandlers();
 
-    if (!Parameters.empty() || !IsStdinInteractive()) {
+    if (!Parameters.empty() || ReadParametersFromStdin) {
         ValidateResult = MakeHolder<NScripting::TExplainYqlResult>(
             ExplainQuery(config, Script, NScripting::ExplainYqlRequestMode::Validate));
         THolder<TParamsBuilder> paramBuilder;

--- a/ydb/public/lib/ydb_cli/common/examples.cpp
+++ b/ydb/public/lib/ydb_cli/common/examples.cpp
@@ -80,7 +80,7 @@ namespace {
 }
 
 void TCommandWithExamples::CheckExamples(const TClientCommand::TConfig& config) {
-    if (!IsOptionCalled(config)) {
+    if (!IsOptionCalled(config) && config.HelpCommandVerbosiltyLevel <= 1) {
         return;
     }
 

--- a/ydb/public/lib/ydb_cli/common/examples.cpp
+++ b/ydb/public/lib/ydb_cli/common/examples.cpp
@@ -44,7 +44,7 @@ TExampleSet TExampleSetBuilder::Build() {
 /////////////////////////////////////////////////////////////////
 
 void TCommandWithExamples::AddExamplesOption(TClientCommand::TConfig& config) {
-    config.Opts->AddLongOption("help-ex", "Print usage with examples")
+    config.Opts->AddLongOption("help-ex", "Print usage examples")
         .HasArg(NLastGetopt::NO_ARGUMENT)
         .IfPresentDisableCompletion()
         .Handler(&NLastGetopt::PrintUsageAndExit);

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -207,7 +207,6 @@ void TCommandWithFormat::AddMessagingFormats(TClientCommand::TConfig& config, co
 }
 
 void TCommandWithFormat::ParseFormats() {
-    Cerr << "TCommandWithFormat::ParseFormats" << Endl;
     if ((InputFormat != EOutputFormat::Default)
             && std::find(AllowedInputFormats.begin(), AllowedInputFormats.end(), InputFormat) == AllowedInputFormats.end()) {
         throw TMisuseException() << "Input format " << InputFormat << " is not available for this command";
@@ -257,8 +256,6 @@ void TCommandWithFormat::ParseFormats() {
             && std::find(AllowedInputFormats.begin(), AllowedInputFormats.end(), ParamFormat) == AllowedInputFormats.end()) {
         throw TMisuseException() << "Param format " << ParamFormat << " is not available for this command";
     }
-    Cerr << "ParamFormat: " << ParamFormat << Endl
-        << "LegacyInputFormat: " << LegacyInputFormat << Endl;
 }
 
 void TCommandWithFormat::ParseMessagingFormats() {

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -132,8 +132,11 @@ void TCommandWithFormat::AddParamFormats(TClientCommand::TConfig& config, const 
             << "\n    " << findResult->second;
     }
     description << "\nDefault: " << colors.CyanColor() << "\"" << defaultFormat << "\"" << colors.OldColor() << ".";
-    config.Opts->AddLongOption("param-format", description.Str())
+    auto& paramFormatOption = config.Opts->AddLongOption("param-format", description.Str())
         .RequiredArgument("STRING").StoreResult(&ParamFormat);
+    if (config.HelpCommandVerbosiltyLevel <= 1) {
+        paramFormatOption.Hidden();
+    }
     config.Opts->AddLongOption("input-format", "For backward compatibility")
         .RequiredArgument("STRING").StoreResult(&LegacyInputFormat).Hidden();
     config.Opts->MutuallyExclusive("param-format", "input-format");
@@ -141,7 +144,7 @@ void TCommandWithFormat::AddParamFormats(TClientCommand::TConfig& config, const 
 }
 
 void TCommandWithFormat::AddStdinFormats(TClientCommand::TConfig &config, const TVector<EOutputFormat>& allowedStdinFormats,
-                                         const TVector<EOutputFormat>& allowedFramingFormats, const TString& optionName) {
+                                         const TVector<EOutputFormat>& allowedFramingFormats) {
     TStringStream description;
     description << "Stdin parameters format and framing. Specify this option twice to select both.\n"
                 << "1. Parameters format. Format of parameters expected on the stdin. Available options: ";
@@ -163,10 +166,17 @@ void TCommandWithFormat::AddStdinFormats(TClientCommand::TConfig &config, const 
                     << "\n    " << findResult->second;
     }
     description << "\nDefault: " << colors.CyanColor() << "\"no-framing\"" << colors.OldColor() << ".";
-    config.Opts->AddLongOption(optionName, description.Str())
+    auto& stdinParamFormat = config.Opts->AddLongOption("stdin-param-format", description.Str())
             .RequiredArgument("STRING").AppendTo(&StdinFormats);
+    config.Opts->AddLongOption("stdin-format", "For backward compatibility").RequiredArgument("STRING")
+        .AppendTo(&StdinFormats).Hidden();
+    config.Opts->MutuallyExclusive("stdin-param-format", "stdin-format");
+    if (config.HelpCommandVerbosiltyLevel <= 1) {
+        stdinParamFormat.Hidden();
+    }
     AllowedStdinFormats = allowedStdinFormats;
     AllowedFramingFormats = allowedFramingFormats;
+    
 }
 
 void TCommandWithFormat::AddFormats(TClientCommand::TConfig& config, 

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -98,7 +98,8 @@ void TCommandWithFormat::AddDeprecatedJsonOption(TClientCommand::TConfig& config
 }
 
 void TCommandWithFormat::AddInputFormats(TClientCommand::TConfig& config, 
-                                         const TVector<EOutputFormat>& allowedFormats, EOutputFormat defaultFormat) {
+                                         const TVector<EOutputFormat>& allowedFormats, EOutputFormat defaultFormat,
+                                         const TString& optionName) {
     TStringStream description;
     description << "Input format. Available options: ";
     NColorizer::TColors colors = NColorizer::AutoColors(Cout);
@@ -112,13 +113,13 @@ void TCommandWithFormat::AddInputFormats(TClientCommand::TConfig& config,
             << "\n    " << findResult->second;
     }
     description << "\nDefault: " << colors.CyanColor() << "\"" << defaultFormat << "\"" << colors.OldColor() << ".";
-    config.Opts->AddLongOption("input-format", description.Str())
+    config.Opts->AddLongOption(optionName, description.Str())
         .RequiredArgument("STRING").StoreResult(&InputFormat);
     AllowedInputFormats = allowedFormats;
 }
 
 void TCommandWithFormat::AddStdinFormats(TClientCommand::TConfig &config, const TVector<EOutputFormat>& allowedStdinFormats,
-                                         const TVector<EOutputFormat>& allowedFramingFormats) {
+                                         const TVector<EOutputFormat>& allowedFramingFormats, const TString& optionName) {
     TStringStream description;
     description << "Stdin parameters format and framing. Specify this option twice to select both.\n"
                 << "1. Parameters format. Available options: ";
@@ -140,7 +141,7 @@ void TCommandWithFormat::AddStdinFormats(TClientCommand::TConfig &config, const 
                     << "\n    " << findResult->second;
     }
     description << "\nDefault: " << colors.CyanColor() << "\"no-framing\"" << colors.OldColor() << ".";
-    config.Opts->AddLongOption("stdin-format", description.Str())
+    config.Opts->AddLongOption(optionName, description.Str())
             .RequiredArgument("STRING").AppendTo(&StdinFormats);
     AllowedStdinFormats = allowedStdinFormats;
     AllowedFramingFormats = allowedFramingFormats;

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -26,8 +26,8 @@ namespace {
         { EOutputFormat::Csv, "Parameter names and values in csv format" },
         { EOutputFormat::Tsv, "Parameter names and values in tsv format" },
         { EOutputFormat::NewlineDelimited, "Newline character delimits parameter sets on stdin and triggers "
-                                            "processing in accordance to \"batch\" option" },
-        { EOutputFormat::Raw, "Binary value with no transformations or parsing, parameter name is set by an \"stdin-par\" option" },
+                                            "processing in accordance to --param-batch option" },
+        { EOutputFormat::Raw, "Binary value with no transformations or parsing, parameter name is set by an --param-name-stdin option" },
         { EOutputFormat::NoFraming, "Data from stdin is taken as a single set of parameters" },
     };
 

--- a/ydb/public/lib/ydb_cli/common/format.h
+++ b/ydb/public/lib/ydb_cli/common/format.h
@@ -30,8 +30,10 @@ class TCommandWithFormat {
 protected:
     void AddInputFormats(TClientCommand::TConfig& config, 
                          const TVector<EOutputFormat>& allowedFormats,
-                         EOutputFormat defaultFormat = EOutputFormat::JsonUnicode,
-                         const TString& optionName = "input-format");
+                         EOutputFormat defaultFormat = EOutputFormat::JsonUnicode);
+    void AddParamFormats(TClientCommand::TConfig& config, 
+                         const TVector<EOutputFormat>& allowedFormats,
+                         EOutputFormat defaultFormat = EOutputFormat::JsonUnicode);
     void AddStdinFormats(TClientCommand::TConfig& config, const TVector<EOutputFormat>& allowedStdinFormats, 
                          const TVector<EOutputFormat>& allowedFramingFormats, const TString& optionName = "stdin-format");
     void AddFormats(TClientCommand::TConfig& config, 
@@ -48,6 +50,8 @@ protected:
 protected:
     EOutputFormat OutputFormat = EOutputFormat::Default;
     EOutputFormat InputFormat = EOutputFormat::Default;
+    EOutputFormat ParamFormat = EOutputFormat::Default;
+    EOutputFormat LegacyInputFormat = EOutputFormat::Default;
     EOutputFormat FramingFormat = EOutputFormat::Default;
     EOutputFormat StdinFormat = EOutputFormat::Default;
     TVector<EOutputFormat> StdinFormats;

--- a/ydb/public/lib/ydb_cli/common/format.h
+++ b/ydb/public/lib/ydb_cli/common/format.h
@@ -29,9 +29,11 @@ protected:
 class TCommandWithFormat {
 protected:
     void AddInputFormats(TClientCommand::TConfig& config, 
-                         const TVector<EOutputFormat>& allowedFormats, EOutputFormat defaultFormat = EOutputFormat::JsonUnicode);
+                         const TVector<EOutputFormat>& allowedFormats,
+                         EOutputFormat defaultFormat = EOutputFormat::JsonUnicode,
+                         const TString& optionName = "input-format");
     void AddStdinFormats(TClientCommand::TConfig& config, const TVector<EOutputFormat>& allowedStdinFormats, 
-                         const TVector<EOutputFormat>& allowedFramingFormats);
+                         const TVector<EOutputFormat>& allowedFramingFormats, const TString& optionName = "stdin-format");
     void AddFormats(TClientCommand::TConfig& config, 
                          const TVector<EOutputFormat>& allowedFormats, EOutputFormat defaultFormat = EOutputFormat::Pretty);
     void AddMessagingFormats(TClientCommand::TConfig& config, const TVector<EMessagingFormat>& allowedFormats);

--- a/ydb/public/lib/ydb_cli/common/format.h
+++ b/ydb/public/lib/ydb_cli/common/format.h
@@ -35,7 +35,7 @@ protected:
                          const TVector<EOutputFormat>& allowedFormats,
                          EOutputFormat defaultFormat = EOutputFormat::JsonUnicode);
     void AddStdinFormats(TClientCommand::TConfig& config, const TVector<EOutputFormat>& allowedStdinFormats, 
-                         const TVector<EOutputFormat>& allowedFramingFormats, const TString& optionName = "stdin-format");
+                         const TVector<EOutputFormat>& allowedFramingFormats);
     void AddFormats(TClientCommand::TConfig& config, 
                          const TVector<EOutputFormat>& allowedFormats, EOutputFormat defaultFormat = EOutputFormat::Pretty);
     void AddMessagingFormats(TClientCommand::TConfig& config, const TVector<EMessagingFormat>& allowedFormats);

--- a/ydb/public/lib/ydb_cli/common/parameters.cpp
+++ b/ydb/public/lib/ydb_cli/common/parameters.cpp
@@ -62,10 +62,10 @@ void TCommandWithParameters::ParseParameters(TClientCommand::TConfig& config) {
                 << "--param '$input=1'";
         }
         if (Parameters.find(paramName) != Parameters.end()) {
-            throw TMisuseException() << "Parameter $" << paramName << " value found in more than one source: \'--param\' option.";
+            throw TMisuseException() << "Parameter $" << paramName << " value found in more than one source: --param option.";
         }
         Parameters[paramName] = parameterOption.substr(equalPos + 1);
-        ParameterSources[paramName] = "\'--param\' option";
+        ParameterSources[paramName] = "--param option";
     }
 
     for (auto& file : ParameterFiles) {
@@ -95,13 +95,13 @@ void TCommandWithParameters::ParseParameters(TClientCommand::TConfig& config) {
     }
     if (StdinFormat != EOutputFormat::Csv && StdinFormat != EOutputFormat::Tsv && (!Columns.Empty() || config.ParseResult->Has("param-skip-rows")
             || config.ParseResult->Has("skip-rows"))) {
-        throw TMisuseException() << "Options \"--param-columns\" and  \"--param-skip-rows\" requires \"csv\" or \"tsv\" formats";
+        throw TMisuseException() << "Options --param-columns and  --param-skip-rows requires \"csv\" or \"tsv\" formats";
     }
     if (StdinParameters.empty() && StdinFormat == EOutputFormat::Raw) {
-        throw TMisuseException() << "For \"raw\" format \"--param-name-stdin\" option should be used.";
+        throw TMisuseException() << "For \"raw\" format --param-name-stdin option should be used.";
     }
     if (!StdinParameters.empty() && !ReadParametersFromStdin) {
-        throw TMisuseException() << "\"--param-name-stdin\" option is allowed only with non-interactive stdin.";
+        throw TMisuseException() << "--param-name-stdin option is allowed only with non-interactive stdin.";
     }
     if (BatchMode == EBatchMode::Full || BatchMode == EBatchMode::Adaptive) {
         if (StdinParameters.size() > 1) {
@@ -116,17 +116,17 @@ void TCommandWithParameters::ParseParameters(TClientCommand::TConfig& config) {
 
     for (auto it = StdinParameters.begin(); it != StdinParameters.end(); ++it) {
         if (std::find(StdinParameters.begin(), it, *it) != it) {
-            throw TMisuseException() << "Parameter $" << *it << " value found in more than one \'--param-name-stdin\' option.";
+            throw TMisuseException() << "Parameter $" << *it << " value found in more than one --param-name-stdin option.";
         }
         if (Parameters.find("$" + *it) != Parameters.end()) {
-            throw TMisuseException() << "Parameter $" << *it << " value found in more than one source: \'--param-name-stdin\' option, "
+            throw TMisuseException() << "Parameter $" << *it << " value found in more than one source: --param-name-stdin option, "
                 << ParameterSources["$" + *it] << ".";
         }
     }
     if (BatchMode != EBatchMode::Adaptive && (config.ParseResult->Has("param-batch-limit")
             || config.ParseResult->Has("param-batch-max-delay") || config.ParseResult->Has("batch-limit")
             || config.ParseResult->Has("batch-max-delay"))) {
-        throw TMisuseException() << "Options \"--param-batch-limit\" and \"--param-batch-max-delay\" are allowed only in \"adaptive\" batch mode.";
+        throw TMisuseException() << "Options --param-batch-limit and --param-batch-max-delay are allowed only in \"adaptive\" batch mode.";
     }
     if (DeprecatedSkipRows != 0) {
         SkipRows = DeprecatedSkipRows;
@@ -223,13 +223,13 @@ void TCommandWithParameters::AddParametersStdinOption(TClientCommand::TConfig& c
     descr << "Batching mode for stdin parameters processing. Available options:\n  "
         << colors.BoldColor() << "iterative" << colors.OldColor()
         << "\n    Executes " << requestString << " for each parameter set (exactly one execution "
-        "when no framing is specified in \"stdin-param-format\")\n  "
+        "when no framing is specified in --stdin-param-format option)\n  "
         << colors.BoldColor() << "full" << colors.OldColor()
         << "\n    Executes " << requestString << " once, with all parameter sets wrapped in json list, when EOF is reached on stdin\n  "
         << colors.BoldColor() << "adaptive" << colors.OldColor()
         << "\n    Executes " << requestString << " with a json list of parameter sets every time when its number reaches param-batch-limit, "
         "or the waiting time reaches param-batch-max-delay. An stdin parameter name must be specified via "
-        "\"--param-name-stdin\" option for \"adaptive\" batch mode."
+        "--param-name-stdin option for \"adaptive\" batch mode."
         "\nDefault: " << colors.CyanColor() << "\"iterative\"" << colors.OldColor() << ".";
 
     auto& paramBatch = config.Opts->AddLongOption("param-batch", descr.Str()).RequiredArgument("STRING")
@@ -269,7 +269,7 @@ void TCommandWithParameters::AddParams(TParamsBuilder& paramBuilder) {
             for (const auto&[name, value] : Parameters) {
                 auto paramIt = ParamTypes.find(name);
                 if (paramIt == ParamTypes.end()) {
-                    if (ParameterSources[name] == "\'--param\' option") {
+                    if (ParameterSources[name] == "--param option") {
                         throw TMisuseException() << "Query does not contain parameter \"" << name << "\".";
                     } else {
                         continue;

--- a/ydb/public/lib/ydb_cli/common/parameters.cpp
+++ b/ydb/public/lib/ydb_cli/common/parameters.cpp
@@ -14,7 +14,7 @@ namespace {
 }
 
 void TCommandWithParameters::ParseParameters(TClientCommand::TConfig& config) {
-    switch (InputFormat) {
+    switch (ParamFormat) {
         case EOutputFormat::Default:
         case EOutputFormat::JsonUnicode:
             InputEncoding = EBinaryStringEncoding::Unicode;
@@ -23,7 +23,7 @@ void TCommandWithParameters::ParseParameters(TClientCommand::TConfig& config) {
             InputEncoding = EBinaryStringEncoding::Base64;
             break;
         default:
-            throw TMisuseException() << "Unknown input format: " << InputFormat;
+            throw TMisuseException() << "Unknown param format: " << ParamFormat;
     }
 
     switch (StdinFormat) {
@@ -132,13 +132,14 @@ void TCommandWithParameters::AddParametersOption(TClientCommand::TConfig& config
     if (clarification) {
         descr << ' ' << clarification;
     }
-    descr << Endl << "Several parameter options can be specified. " << Endl
-        << "To change input format use --input-format option." << Endl
+    descr << Endl << "Several parameter options can be specified." << Endl
+        << "To change parameter input format use --param-format option." << Endl
         << "Escaping depends on operating system.";
     config.Opts->AddLongOption('p', "param", descr.Str())
         .RequiredArgument("$name=value").AppendTo(&ParameterOptions);
-    config.Opts->AddLongOption("param-file", "File name with parameter names and values "
-        "in json format. You may specify this option repeatedly.")
+    config.Opts->AddLongOption("param-file", "File name with parameter names and values.\n"
+        "This option may be specified several times.\n"
+        "To change parameter input format use --param-format option.")
         .RequiredArgument("PATH").AppendTo(&ParameterFiles);
 
     AddOptionExamples(
@@ -223,7 +224,7 @@ void TCommandWithParameters::AddParametersStdinOption(TClientCommand::TConfig& c
 }
 
 void TCommandWithParameters::AddParams(TParamsBuilder& paramBuilder) {
-     switch (InputFormat) {
+     switch (ParamFormat) {
         case EOutputFormat::Default:
         case EOutputFormat::JsonUnicode:
         case EOutputFormat::JsonBase64: {
@@ -242,7 +243,7 @@ void TCommandWithParameters::AddParams(TParamsBuilder& paramBuilder) {
             break;
         }
         default:
-            Y_ABORT_UNLESS(false, "Unexpected input format");
+            Y_ABORT_UNLESS(false, "Unexpected param format");
     }
 }
 

--- a/ydb/public/lib/ydb_cli/common/parameters.h
+++ b/ydb/public/lib/ydb_cli/common/parameters.h
@@ -55,6 +55,7 @@ protected:
     size_t BatchLimit;
     TDuration BatchMaxDelay;
     THolder<NScripting::TExplainYqlResult> ValidateResult;
+    bool ReadParametersFromStdin = false;
 };
 
 }

--- a/ydb/public/lib/ydb_cli/common/parameters.h
+++ b/ydb/public/lib/ydb_cli/common/parameters.h
@@ -41,8 +41,11 @@ private:
     THolder<IParamStream> Input;
     bool IsFirstEncounter = true;
     size_t SkipRows = 0;
+    size_t DeprecatedSkipRows = 0;
     char Delimiter;
     TCsvParser CsvParser;
+    size_t DeprecatedBatchLimit;
+    TDuration DeprecatedBatchMaxDelay;
 
 protected:
     TVector<TString> ParameterOptions, ParameterFiles, StdinParameters;


### PR DESCRIPTION
### Changelog entry
* Added parameters support for `ydb sql` command
* Renamed most option names related to parameters (with backward compatibility)

### Changelog category
* New feature
