### PR TITLE
Support block IO in purecalc

### DIFF
--- a/ydb/library/yql/public/purecalc/common/compile_mkql.cpp
+++ b/ydb/library/yql/public/purecalc/common/compile_mkql.cpp
@@ -98,6 +98,7 @@ NKikimr::NMiniKQL::TRuntimeNode CompileMkql(const TExprNode::TPtr& exprRoot, TEx
     NCommon::TMkqlCommonCallableCompiler compiler;
 
     compiler.AddCallable(PurecalcInputCallableName, MakeSelfCallableCompiler());
+    compiler.AddCallable(PurecalcBlockInputCallableName, MakeSelfCallableCompiler());
     compiler.OverrideCallable("FileContent", MakeFileContentCallableCompiler(userData));
     compiler.OverrideCallable("FilePath", MakeFilePathCallableCompiler(userData));
     compiler.OverrideCallable("FolderPath", MakeFolderPathCallableCompiler(userData));

--- a/ydb/library/yql/public/purecalc/common/interface.h
+++ b/ydb/library/yql/public/purecalc/common/interface.h
@@ -592,10 +592,26 @@ namespace NYql {
             virtual const NKikimr::NMiniKQL::TStructType* GetInputType(bool original = false) const = 0;
 
             /**
+             * MiniKQL input struct type of the specified input for this program.
+             * The returned type is the actual type of the specified input node.
+             */
+            virtual const NKikimr::NMiniKQL::TStructType* GetRawInputType(ui32) const = 0;
+            /**
+             * Overload for single-input programs.
+             */
+            virtual const NKikimr::NMiniKQL::TStructType* GetRawInputType() const = 0;
+
+            /**
              * MiniKQL output struct type for this program. The returned type is equivalent to the deduced output
              * schema (see IWorker::MakeFullOutputSchema()).
              */
             virtual const NKikimr::NMiniKQL::TType* GetOutputType() const = 0;
+
+            /**
+             * MiniKQL output struct type for this program. The returned type is
+             * the actual type of the root node.
+             */
+            virtual const NKikimr::NMiniKQL::TType* GetRawOutputType() const = 0;
 
             /**
              * Make input type schema for specified input as deduced by program optimizer. This schema is equivalent

--- a/ydb/library/yql/public/purecalc/common/interface.h
+++ b/ydb/library/yql/public/purecalc/common/interface.h
@@ -795,7 +795,7 @@ namespace NYql {
                 return AllVirtualColumns_;
             }
 
-            static constexpr bool ProvidesBlocks = false;
+            virtual bool ProvidesBlocks() const { return false; }
         };
 
         /**
@@ -840,7 +840,7 @@ namespace NYql {
                 OutputColumnsFilter_ = outputColumnsFilter;
             }
 
-            static constexpr bool AcceptsBlocks = false;
+            virtual bool AcceptsBlocks() const { return false; }
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/library/yql/public/purecalc/common/names.cpp
+++ b/ydb/library/yql/public/purecalc/common/names.cpp
@@ -5,6 +5,7 @@
 namespace NYql::NPureCalc {
     const TStringBuf PurecalcSysColumnsPrefix = "_yql_sys_";
     const TStringBuf PurecalcSysColumnTablePath = "_yql_sys_tablepath";
+    const TStringBuf PurecalcBlockColumnLength = "_yql_block_length";
 
     const TStringBuf PurecalcDefaultCluster = "view";
     const TStringBuf PurecalcDefaultService = "data";

--- a/ydb/library/yql/public/purecalc/common/names.cpp
+++ b/ydb/library/yql/public/purecalc/common/names.cpp
@@ -12,5 +12,7 @@ namespace NYql::NPureCalc {
     const TStringBuf PurecalcInputCallableName = "Self";
     const TStringBuf PurecalcInputTablePrefix = "Input";
 
+    const TStringBuf PurecalcBlockInputCallableName = "BlockSelf";
+
     const TStringBuf PurecalcUdfModulePrefix = "<purecalc>::";
 }

--- a/ydb/library/yql/public/purecalc/common/names.h
+++ b/ydb/library/yql/public/purecalc/common/names.h
@@ -12,5 +12,7 @@ namespace NYql::NPureCalc {
     extern const TStringBuf PurecalcInputCallableName;
     extern const TStringBuf PurecalcInputTablePrefix;
 
+    extern const TStringBuf PurecalcBlockInputCallableName;
+
     extern const TStringBuf PurecalcUdfModulePrefix;
 }

--- a/ydb/library/yql/public/purecalc/common/names.h
+++ b/ydb/library/yql/public/purecalc/common/names.h
@@ -5,6 +5,7 @@
 namespace NYql::NPureCalc {
     extern const TStringBuf PurecalcSysColumnsPrefix;
     extern const TStringBuf PurecalcSysColumnTablePath;
+    extern const TStringBuf PurecalcBlockColumnLength;
 
     extern const TStringBuf PurecalcDefaultCluster;
     extern const TStringBuf PurecalcDefaultService;

--- a/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.cpp
@@ -78,8 +78,12 @@ namespace {
             auto actualType = MakeActualType(input);
             switch (actualType->GetKind()) {
                 case ETypeAnnotationKind::Stream:
+                    Y_ENSURE(ProcessorMode_ != EProcessorMode::PullList,
+                             "processor mode mismatches the actual container type");
                     return actualType->Cast<TStreamExprType>()->GetItemType();
                 case ETypeAnnotationKind::List:
+                    Y_ENSURE(ProcessorMode_ == EProcessorMode::PullList,
+                             "processor mode mismatches the actual container type");
                     return actualType->Cast<TListExprType>()->GetItemType();
                 default:
                     Y_ABORT("unexpected return type");

--- a/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.cpp
@@ -43,6 +43,9 @@ namespace {
                 const auto originalMembers = actualItemType->Cast<TStructExprType>()->GetItems();
                 TVector<const TItemExprType*> newMembers;
                 for (auto originalItem : originalMembers) {
+                    if (originalItem->GetName() == "_yql_block_length") {
+                        continue;
+                    }
                     bool isScalarUnused;
                     const auto blockItemType = GetBlockItemType(*originalItem->GetItemType(), isScalarUnused);
                     newMembers.push_back(ctx.MakeType<TItemExprType>(originalItem->GetName(), blockItemType));

--- a/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.cpp
@@ -1,5 +1,6 @@
 #include "align_output_schema.h"
 
+#include <ydb/library/yql/public/purecalc/common/names.h>
 #include <ydb/library/yql/public/purecalc/common/type_from_schema.h>
 
 #include <ydb/library/yql/core/yql_expr_type_annotation.h>
@@ -43,7 +44,7 @@ namespace {
                 const auto originalMembers = actualItemType->Cast<TStructExprType>()->GetItems();
                 TVector<const TItemExprType*> newMembers;
                 for (auto originalItem : originalMembers) {
-                    if (originalItem->GetName() == "_yql_block_length") {
+                    if (originalItem->GetName() == PurecalcBlockColumnLength) {
                         continue;
                     }
                     bool isScalarUnused;

--- a/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/align_output_schema.h
@@ -11,10 +11,14 @@ namespace NYql {
          * A transformer which converts an output type of the expression to the given type or reports an error.
          *
          * @param outputStruct destination output struct type.
+         * @param acceptsBlocks indicates, whether the output type need to be
+         *        preprocessed.
+         * @param processorMode specifies the top-most container of the result.
          * @return a graph transformer for type alignment.
          */
         TAutoPtr<IGraphTransformer> MakeOutputAligner(
             const TTypeAnnotationNode* outputStruct,
+            bool acceptsBlocks,
             EProcessorMode processorMode
         );
     }

--- a/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.cpp
@@ -13,21 +13,21 @@ namespace {
     private:
         ui32 InputsNumber_;
         bool UseSystemColumns_;
-        TString TablePrefix_;
         TString CallableName_;
+        TString TablePrefix_;
         bool Complete_ = false;
 
     public:
         explicit TTableReadsReplacer(
             ui32 inputsNumber,
             bool useSystemColumns,
-            TString tablePrefix,
-            TString inputNodeName
+            TString inputNodeName,
+            TString tablePrefix
         )
             : InputsNumber_(inputsNumber)
             , UseSystemColumns_(useSystemColumns)
-            , TablePrefix_(std::move(tablePrefix))
             , CallableName_(std::move(inputNodeName))
+            , TablePrefix_(std::move(tablePrefix))
         {
         }
 
@@ -228,8 +228,8 @@ namespace {
 TAutoPtr<IGraphTransformer> NYql::NPureCalc::MakeTableReadsReplacer(
     ui32 inputsNumber,
     bool useSystemColumns,
-    TString tablePrefix,
-    TString callableName
+    TString callableName,
+    TString tablePrefix
 ) {
-    return new TTableReadsReplacer(inputsNumber, useSystemColumns, std::move(tablePrefix), std::move(callableName));
+    return new TTableReadsReplacer(inputsNumber, useSystemColumns, std::move(callableName), std::move(tablePrefix));
 }

--- a/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.cpp
@@ -142,25 +142,8 @@ namespace {
             if (inputNode->IsCallable(PurecalcBlockInputCallableName)) {
                 const auto inputStruct = InputStructs_[inputIndex]->Cast<TStructExprType>();
                 const auto blocksLambda = NodeFromBlocks(replacePos, inputStruct, ctx);
-                if (ProcessorMode_ == EProcessorMode::PullList) {
-                    inputNode = ctx.Builder(replacePos)
-                        .Callable("LMap")
-                            .Add(0, inputNode)
-                            .Lambda(1)
-                                .Param("stream")
-                                .Apply(blocksLambda)
-                                    .With(0, "stream")
-                                .Seal()
-                            .Seal()
-                        .Seal()
-                        .Build();
-                } else {
-                    inputNode = ctx.Builder(replacePos)
-                        .Apply(blocksLambda)
-                            .With(0, inputNode)
-                        .Seal()
-                        .Build();
-                }
+                bool wrapLMap = ProcessorMode_ == EProcessorMode::PullList;
+                inputNode = ApplyToIterable(replacePos, inputNode, blocksLambda, wrapLMap, ctx);
             }
 
             if (UseSystemColumns_) {

--- a/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/library/yql/public/purecalc/common/names.h>
+#include <ydb/library/yql/public/purecalc/common/processor_mode.h>
 
 #include <ydb/library/yql/core/yql_graph_transformer.h>
 
@@ -22,6 +23,7 @@ namespace NYql::NPureCalc {
     TAutoPtr<IGraphTransformer> MakeTableReadsReplacer(
         const TVector<const TStructExprType*>& inputStructs,
         bool useSystemColumns,
+        EProcessorMode processorMode,
         TString callableName = TString{PurecalcInputCallableName},
         TString tablePrefix = TString{PurecalcInputTablePrefix}
     );

--- a/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.h
@@ -20,7 +20,7 @@ namespace NYql::NPureCalc {
      * @param return a graph transformer for replacing table reads.
      */
     TAutoPtr<IGraphTransformer> MakeTableReadsReplacer(
-        ui32 inputsNumber,
+        const TVector<const TStructExprType*>& inputStructs,
         bool useSystemColumns,
         TString callableName = TString{PurecalcInputCallableName},
         TString tablePrefix = TString{PurecalcInputTablePrefix}

--- a/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/replace_table_reads.h
@@ -15,14 +15,14 @@ namespace NYql::NPureCalc {
      *
      * @param inputStructs types of each input.
      * @param useSystemColumns whether to allow special system columns in input structs.
-     * @param tablePrefix required prefix for all table names (e.g. `Input`).
      * @param callableName name of the special callable used to get input data (e.g. `Self`).
+     * @param tablePrefix required prefix for all table names (e.g. `Input`).
      * @param return a graph transformer for replacing table reads.
      */
     TAutoPtr<IGraphTransformer> MakeTableReadsReplacer(
         ui32 inputsNumber,
         bool useSystemColumns,
-        TString tablePrefix = TString{PurecalcInputTablePrefix},
-        TString callableName = TString{PurecalcInputCallableName}
+        TString callableName = TString{PurecalcInputCallableName},
+        TString tablePrefix = TString{PurecalcInputTablePrefix}
     );
 }

--- a/ydb/library/yql/public/purecalc/common/transformations/root_to_blocks.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/root_to_blocks.cpp
@@ -46,26 +46,8 @@ public:
         Y_ENSURE(returnItemType->GetKind() == ETypeAnnotationKind::Struct);
         const TStructExprType* structType = returnItemType->Cast<TStructExprType>();
         const auto blocksLambda = NodeToBlocks(input->Pos(), structType, ctx);
-
-        if (ProcessorMode_ == EProcessorMode::PullList) {
-            output = ctx.Builder(input->Pos())
-                .Callable("LMap")
-                    .Add(0, input)
-                    .Lambda(1)
-                        .Param("stream")
-                        .Apply(blocksLambda)
-                            .With(0, "stream")
-                        .Seal()
-                    .Seal()
-                .Seal()
-                .Build();
-        } else {
-            output = ctx.Builder(input->Pos())
-                .Apply(blocksLambda)
-                    .With(0, input)
-                .Seal()
-                .Build();
-        }
+        bool wrapLMap = ProcessorMode_ == EProcessorMode::PullList;
+        output = ApplyToIterable(input->Pos(), input, blocksLambda, wrapLMap, ctx);
 
         Wrapped_ = true;
 

--- a/ydb/library/yql/public/purecalc/common/transformations/root_to_blocks.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/root_to_blocks.cpp
@@ -1,0 +1,83 @@
+#include "root_to_blocks.h"
+
+#include <ydb/library/yql/public/purecalc/common/transformations/utils.h>
+
+#include <ydb/library/yql/core/yql_expr_type_annotation.h>
+
+using namespace NYql;
+using namespace NYql::NPureCalc;
+
+namespace {
+
+class TRootToBlocks: public TSyncTransformerBase {
+private:
+    bool AcceptsBlocks_;
+    EProcessorMode ProcessorMode_;
+    bool Wrapped_;
+
+public:
+    explicit TRootToBlocks(bool acceptsBlocks, EProcessorMode processorMode)
+        : AcceptsBlocks_(acceptsBlocks)
+        , ProcessorMode_(processorMode)
+        , Wrapped_(false)
+    {
+    }
+
+public:
+    void Rewind() override {
+        Wrapped_ = false;
+    }
+
+    TStatus DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) final {
+        if (Wrapped_ || !AcceptsBlocks_) {
+            return IGraphTransformer::TStatus::Ok;
+        }
+
+        const TTypeAnnotationNode* returnItemType;
+        const TTypeAnnotationNode* returnType = input->GetTypeAnn();
+        if (ProcessorMode_ == EProcessorMode::PullList) {
+            Y_ENSURE(returnType->GetKind() == ETypeAnnotationKind::List);
+            returnItemType = returnType->Cast<TListExprType>()->GetItemType();
+        } else {
+            Y_ENSURE(returnType->GetKind() == ETypeAnnotationKind::Stream);
+            returnItemType = returnType->Cast<TStreamExprType>()->GetItemType();
+        }
+
+        Y_ENSURE(returnItemType->GetKind() == ETypeAnnotationKind::Struct);
+        const TStructExprType* structType = returnItemType->Cast<TStructExprType>();
+        const auto blocksLambda = NodeToBlocks(input->Pos(), structType, ctx);
+
+        if (ProcessorMode_ == EProcessorMode::PullList) {
+            output = ctx.Builder(input->Pos())
+                .Callable("LMap")
+                    .Add(0, input)
+                    .Lambda(1)
+                        .Param("stream")
+                        .Apply(blocksLambda)
+                            .With(0, "stream")
+                        .Seal()
+                    .Seal()
+                .Seal()
+                .Build();
+        } else {
+            output = ctx.Builder(input->Pos())
+                .Apply(blocksLambda)
+                    .With(0, input)
+                .Seal()
+                .Build();
+        }
+
+        Wrapped_ = true;
+
+        return IGraphTransformer::TStatus(IGraphTransformer::TStatus::Repeat, true);
+    }
+};
+
+} // namespace
+
+TAutoPtr<IGraphTransformer> NYql::NPureCalc::MakeRootToBlocks(
+    bool acceptsBlocks,
+    EProcessorMode processorMode
+) {
+    return new TRootToBlocks(acceptsBlocks, processorMode);
+}

--- a/ydb/library/yql/public/purecalc/common/transformations/root_to_blocks.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/root_to_blocks.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <ydb/library/yql/public/purecalc/common/processor_mode.h>
+
+#include <ydb/library/yql/core/yql_graph_transformer.h>
+
+namespace NYql {
+    namespace NPureCalc {
+        /**
+         * A transformer which rewrite the root to respect block types.
+         *
+         * @param acceptsBlock allows using this transformer in pipeline and
+         *        skip this phase if no block output is required.
+         * @param processorMode specifies the top-most container of the result.
+         * @return a graph transformer for rewriting the root node.
+         */
+        TAutoPtr<IGraphTransformer> MakeRootToBlocks(
+            bool acceptsBlocks,
+            EProcessorMode processorMode
+        );
+    }
+}

--- a/ydb/library/yql/public/purecalc/common/transformations/type_annotation.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/type_annotation.cpp
@@ -3,6 +3,7 @@
 #include <ydb/library/yql/public/purecalc/common/interface.h>
 #include <ydb/library/yql/public/purecalc/common/inspect_input.h>
 #include <ydb/library/yql/public/purecalc/common/names.h>
+#include <ydb/library/yql/public/purecalc/common/transformations/utils.h>
 
 #include <ydb/library/yql/core/type_ann/type_ann_core.h>
 #include <ydb/library/yql/core/yql_expr_type_annotation.h>
@@ -112,15 +113,7 @@ namespace {
             // 1. Add "_yql_block_length" attribute for internal usage.
             // 2. Add block container to wrap the actual item type.
             if (input->IsCallable(PurecalcBlockInputCallableName)) {
-                const auto inputItems = itemType->GetItems();
-                TVector<const TItemExprType*> members;
-                for (const auto& item : inputItems) {
-                    const auto blockItemType = ctx.MakeType<TBlockExprType>(item->GetItemType());
-                    members.push_back(ctx.MakeType<TItemExprType>(item->GetName(), blockItemType));
-                }
-                const auto scalarItemType = ctx.MakeType<TScalarExprType>(ctx.MakeType<TDataExprType>(EDataSlot::Uint64));
-                members.push_back(ctx.MakeType<TItemExprType>(PurecalcBlockColumnLength, scalarItemType));
-                itemType = ctx.MakeType<TStructExprType>(members);
+                itemType = WrapBlockStruct(itemType, ctx);
             }
 
             RawInputTypes_[inputIndex] = itemType;

--- a/ydb/library/yql/public/purecalc/common/transformations/type_annotation.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/type_annotation.cpp
@@ -119,7 +119,7 @@ namespace {
                     members.push_back(ctx.MakeType<TItemExprType>(item->GetName(), blockItemType));
                 }
                 const auto scalarItemType = ctx.MakeType<TScalarExprType>(ctx.MakeType<TDataExprType>(EDataSlot::Uint64));
-                members.push_back(ctx.MakeType<TItemExprType>("_yql_block_length", scalarItemType));
+                members.push_back(ctx.MakeType<TItemExprType>(PurecalcBlockColumnLength, scalarItemType));
                 itemType = ctx.MakeType<TStructExprType>(members);
             }
 

--- a/ydb/library/yql/public/purecalc/common/transformations/type_annotation.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/type_annotation.h
@@ -13,6 +13,7 @@ namespace NYql {
          *
          * @param typeAnnotationContext current context.
          * @param inputStructs types of each input.
+         * @param rawInputStructs container to store the resulting input item type.
          * @param processorMode current processor mode. This will affect generated input type,
          *                      e.g. list node or struct node.
          * @param nodeName name of the callable used to get input data, e.g. `Self`.
@@ -21,6 +22,7 @@ namespace NYql {
         TAutoPtr<IGraphTransformer> MakeTypeAnnotationTransformer(
             TTypeAnnotationContextPtr typeAnnotationContext,
             const TVector<const TStructExprType*>& inputStructs,
+            TVector<const TStructExprType*>& rawInputStructs,
             EProcessorMode processorMode,
             const TString& nodeName = TString{PurecalcInputCallableName}
         );

--- a/ydb/library/yql/public/purecalc/common/transformations/utils.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/utils.cpp
@@ -1,5 +1,7 @@
 #include "utils.h"
 
+#include <ydb/library/yql/public/purecalc/common/names.h>
+
 using namespace NYql;
 using namespace NYql::NPureCalc;
 
@@ -32,7 +34,7 @@ TExprNode::TPtr NYql::NPureCalc::NodeFromBlocks(
                                     }
                                     lambda.Callable(i, "Member")
                                         .Arg(0, "item")
-                                        .Atom(1, "_yql_block_length")
+                                        .Atom(1, PurecalcBlockColumnLength)
                                     .Seal();
                                     return lambda;
                                 })
@@ -104,7 +106,7 @@ TExprNode::TPtr NYql::NPureCalc::NodeToBlocks(
                                     .Seal();
                                 }
                                 parent.List(i)
-                                    .Atom(0, "_yql_block_length")
+                                    .Atom(0, PurecalcBlockColumnLength)
                                     .Arg(1, "fields", i)
                                 .Seal();
                                 return parent;

--- a/ydb/library/yql/public/purecalc/common/transformations/utils.cpp
+++ b/ydb/library/yql/public/purecalc/common/transformations/utils.cpp
@@ -1,0 +1,70 @@
+#include "utils.h"
+
+using namespace NYql;
+using namespace NYql::NPureCalc;
+
+TExprNode::TPtr NYql::NPureCalc::NodeFromBlocks(
+    const TPositionHandle& pos,
+    const TStructExprType* structType,
+    TExprContext& ctx
+) {
+    const auto items = structType->GetItems();
+    Y_ENSURE(items.size() > 1);
+    const auto blockLengthValue = structType->FindItem("_yql_block_length");
+    Y_ENSURE(blockLengthValue);
+    const ui32 blockLengthIndex = *blockLengthValue;
+    return ctx.Builder(pos)
+        .Lambda()
+            .Param("stream")
+            .Callable(0, "FromFlow")
+                .Callable(0, "NarrowMap")
+                    .Callable(0, "WideFromBlocks")
+                        .Callable(0, "ExpandMap")
+                            .Callable(0, "ToFlow")
+                                .Arg(0, "stream")
+                            .Seal()
+                            .Lambda(1)
+                                .Param("item")
+                                .Do([&](TExprNodeBuilder& lambda) -> TExprNodeBuilder& {
+                                    ui32 i = 0;
+                                    for (ui32 j = 0; j < items.size(); j++) {
+                                        if (j == blockLengthIndex) {
+                                            continue;
+                                        }
+                                        lambda.Callable(i++, "Member")
+                                            .Arg(0, "item")
+                                            .Atom(1, items[j]->GetName())
+                                        .Seal();
+                                    }
+                                    lambda.Callable(i, "Member")
+                                        .Arg(0, "item")
+                                        .Atom(1, items[blockLengthIndex]->GetName())
+                                    .Seal();
+                                    return lambda;
+                                })
+                            .Seal()
+                        .Seal()
+                    .Seal()
+                    .Lambda(1)
+                        .Params("fields", items.size() - 1)
+                        .Callable("AsStruct")
+                            .Do([&](TExprNodeBuilder& parent) -> TExprNodeBuilder& {
+                                    ui32 i = 0;
+                                    for (ui32 j = 0; j < items.size(); j++) {
+                                        if (j == blockLengthIndex) {
+                                            continue;
+                                        }
+                                        parent.List(i)
+                                            .Atom(0, items[j]->GetName())
+                                            .Arg(1, "fields", i++)
+                                        .Seal();
+                                    }
+                                    return parent;
+                                })
+                        .Seal()
+                    .Seal()
+                .Seal()
+            .Seal()
+        .Seal()
+        .Build();
+}

--- a/ydb/library/yql/public/purecalc/common/transformations/utils.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/utils.h
@@ -33,5 +33,51 @@ namespace NYql {
             const TStructExprType* structType,
             TExprContext& ctx
         );
+
+        /**
+         * A transformer to apply the given lambda to the given iterable (either
+         * list or stream). If the iterable is list, the lambda should be passed
+         * to the <LMap> callable; if the iterable is stream, the lambda should
+         * be applied right to the iterable.
+         *
+         * @param pos the position of the given node to be rewritten.
+         * @param iterable the node, that provides the iterable to be processed.
+         * @param lambda the node, that provides lambda to be applied.
+         * @param wrapLMap indicator to wrap the result with LMap callable.
+         * @oaram ctx the context to make ExprNode rewrites.
+         */
+        TExprNode::TPtr ApplyToIterable(
+            const TPositionHandle& pos,
+            const TExprNode::TPtr iterable,
+            const TExprNode::TPtr lambda,
+            bool wrapLMap,
+            TExprContext& ctx
+        );
+
+        /**
+         * A helper which wraps the items of the given struct with the block
+         * type container and appends the new item for _yql_block_length column.
+         *
+         * @param structType original struct to be wrapped.
+         * @param ctx the context to make ExprType rewrite.
+         * @return the new struct with block items.
+         */
+        const TStructExprType* WrapBlockStruct(
+            const TStructExprType* structType,
+            TExprContext& ctx
+        );
+
+        /**
+         * A helper which unwraps the block container from the items of the
+         * given struct and removes the item for _yql_block_length column.
+         *
+         * @param structType original struct to be unwrapped.
+         * @param ctx the context to make ExprType rewrite.
+         * @return the new struct without block items.
+         */
+        const TStructExprType* UnwrapBlockStruct(
+            const TStructExprType* structType,
+            TExprContext& ctx
+        );
     }
 }

--- a/ydb/library/yql/public/purecalc/common/transformations/utils.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/utils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <ydb/library/yql/core/yql_graph_transformer.h>
+
+namespace NYql {
+    namespace NPureCalc {
+        /**
+         * A transformer which wraps the given input node with the pipeline
+         * converting the input type to the block one.
+         *
+         * @param pos the position of the given node to be rewritten.
+         * @param structType the item type of the container provided by the node.
+         * @param ctx the context to make ExprNode rewrites.
+         * @return the resulting ExprNode.
+         */
+        TExprNode::TPtr NodeFromBlocks(
+            const TPositionHandle& pos,
+            const TStructExprType* structType,
+            TExprContext& ctx
+        );
+    }
+}

--- a/ydb/library/yql/public/purecalc/common/transformations/utils.h
+++ b/ydb/library/yql/public/purecalc/common/transformations/utils.h
@@ -18,5 +18,20 @@ namespace NYql {
             const TStructExprType* structType,
             TExprContext& ctx
         );
+
+        /**
+         * A transformer which wraps the given root node with the pipeline
+         * converting the output type to the block one.
+         *
+         * @param pos the position of the given node to be rewritten.
+         * @param structType the item type of the container provided by the node.
+         * @param ctx the context to make ExprNode rewrites.
+         * @return the resulting ExprNode.
+         */
+        TExprNode::TPtr NodeToBlocks(
+            const TPositionHandle& pos,
+            const TStructExprType* structType,
+            TExprContext& ctx
+        );
     }
 }

--- a/ydb/library/yql/public/purecalc/common/worker.cpp
+++ b/ydb/library/yql/public/purecalc/common/worker.cpp
@@ -38,7 +38,9 @@ TWorkerGraph::TWorkerGraph(
     const TUserDataTable& userData,
     const TVector<const TStructExprType*>& inputTypes,
     const TVector<const TStructExprType*>& originalInputTypes,
+    const TVector<const TStructExprType*>& rawInputTypes,
     const TTypeAnnotationNode* outputType,
+    const TTypeAnnotationNode* rawOutputType,
     const TString& LLVMSettings,
     NKikimr::NUdf::ICountersProvider* countersProvider,
     ui64 nativeYtTypeFlags,
@@ -79,6 +81,7 @@ TWorkerGraph::TWorkerGraph(
     for (ui32 i = 0; i < inputsCount; ++i) {
         const auto* type = static_cast<NKikimr::NMiniKQL::TStructType*>(NCommon::BuildType(TPositionHandle(), *inputTypes[i], pgmBuilder));
         const auto* originalType = type;
+        const auto* rawType = static_cast<NKikimr::NMiniKQL::TStructType*>(NCommon::BuildType(TPositionHandle(), *rawInputTypes[i], pgmBuilder));
         if (inputTypes[i] != originalInputTypes[i]) {
             YQL_ENSURE(inputTypes[i]->GetSize() >= originalInputTypes[i]->GetSize());
             originalType = static_cast<NKikimr::NMiniKQL::TStructType*>(NCommon::BuildType(TPositionHandle(), *originalInputTypes[i], pgmBuilder));
@@ -86,11 +89,16 @@ TWorkerGraph::TWorkerGraph(
 
         InputTypes_.push_back(type);
         OriginalInputTypes_.push_back(originalType);
+        RawInputTypes_.push_back(rawType);
     }
 
     if (outputType) {
         OutputType_ = NCommon::BuildType(TPositionHandle(), *outputType, pgmBuilder);
     }
+    if (rawOutputType) {
+        RawOutputType_ = NCommon::BuildType(TPositionHandle(), *rawOutputType, pgmBuilder);
+    }
+
     if (!exprRoot) {
         auto outMkqlType = rootNode.GetStaticType();
         if (outMkqlType->GetKind() == NKikimr::NMiniKQL::TType::EKind::List) {
@@ -106,6 +114,7 @@ TWorkerGraph::TWorkerGraph(
             }
         } else {
             OutputType_ = outMkqlType;
+            RawOutputType_ = outMkqlType;
         }
     }
 
@@ -181,15 +190,18 @@ TWorker<TBase>::TWorker(
     const TUserDataTable& userData,
     const TVector<const TStructExprType*>& inputTypes,
     const TVector<const TStructExprType*>& originalInputTypes,
+    const TVector<const TStructExprType*>& rawInputTypes,
     const TTypeAnnotationNode* outputType,
+    const TTypeAnnotationNode* rawOutputType,
     const TString& LLVMSettings,
     NKikimr::NUdf::ICountersProvider* countersProvider,
     ui64 nativeYtTypeFlags,
     TMaybe<ui64> deterministicTimeProviderSeed
 )
     : WorkerFactory_(std::move(factory))
-    , Graph_(exprRoot, exprCtx, serializedProgram, funcRegistry, userData, inputTypes, originalInputTypes, outputType, LLVMSettings,
-        countersProvider, nativeYtTypeFlags, deterministicTimeProviderSeed)
+    , Graph_(exprRoot, exprCtx, serializedProgram, funcRegistry, userData,
+         inputTypes, originalInputTypes, rawInputTypes, outputType, rawOutputType,
+         LLVMSettings, countersProvider, nativeYtTypeFlags, deterministicTimeProviderSeed)
 {
 }
 
@@ -217,8 +229,27 @@ inline const NKikimr::NMiniKQL::TStructType* TWorker<TBase>::GetInputType(bool o
 }
 
 template <typename TBase>
+inline const NKikimr::NMiniKQL::TStructType* TWorker<TBase>::GetRawInputType(ui32 inputIndex) const {
+    const auto& container = Graph_.RawInputTypes_;
+    YQL_ENSURE(inputIndex < container.size(), "invalid input index (" << inputIndex << ") in GetInputType call");
+    return container[inputIndex];
+}
+
+template <typename TBase>
+inline const NKikimr::NMiniKQL::TStructType* TWorker<TBase>::GetRawInputType() const {
+    const auto& container = Graph_.RawInputTypes_;
+    YQL_ENSURE(container.size() == 1, "GetInputType() can be used only for single-input programs");
+    return container[0];
+}
+
+template <typename TBase>
 inline const NKikimr::NMiniKQL::TType* TWorker<TBase>::GetOutputType() const {
     return Graph_.OutputType_;
+}
+
+template <typename TBase>
+inline const NKikimr::NMiniKQL::TType* TWorker<TBase>::GetRawOutputType() const {
+    return Graph_.RawOutputType_;
 }
 
 template <typename TBase>

--- a/ydb/library/yql/public/purecalc/common/worker.cpp
+++ b/ydb/library/yql/public/purecalc/common/worker.cpp
@@ -111,7 +111,10 @@ TWorkerGraph::TWorkerGraph(
 
     // Compile computation pattern
 
-    auto selfCallableName = Env_.InternName(PurecalcInputCallableName);
+    const THashSet<NKikimr::NMiniKQL::TInternName> selfCallableNames = {
+        Env_.InternName(PurecalcInputCallableName),
+        Env_.InternName(PurecalcBlockInputCallableName)
+    };
 
     NKikimr::NMiniKQL::TExploringNodeVisitor explorer;
     explorer.Walk(rootNode.GetNode(), Env_);
@@ -123,7 +126,7 @@ TWorkerGraph::TWorkerGraph(
     auto nodeFactory = [&](
         NKikimr::NMiniKQL::TCallable& callable, const NKikimr::NMiniKQL::TComputationNodeFactoryContext& ctx
         ) -> NKikimr::NMiniKQL::IComputationNode* {
-        if (callable.GetType()->GetNameStr() == selfCallableName) {
+        if (selfCallableNames.contains(callable.GetType()->GetNameStr())) {
             YQL_ENSURE(callable.GetInputsCount() == 1, "Self takes exactly 1 argument");
             const auto inputIndex = AS_VALUE(NKikimr::NMiniKQL::TDataLiteral, callable.GetInput(0))->AsValue().Get<ui32>();
             YQL_ENSURE(inputIndex < inputsCount, "Self index is out of range");

--- a/ydb/library/yql/public/purecalc/common/worker.h
+++ b/ydb/library/yql/public/purecalc/common/worker.h
@@ -24,7 +24,9 @@ namespace NYql {
                 const TUserDataTable& userData,
                 const TVector<const TStructExprType*>& inputTypes,
                 const TVector<const TStructExprType*>& originalInputTypes,
+                const TVector<const TStructExprType*>& rawInputTypes,
                 const TTypeAnnotationNode* outputType,
+                const TTypeAnnotationNode* rawOutputType,
                 const TString& LLVMSettings,
                 NKikimr::NUdf::ICountersProvider* countersProvider,
                 ui64 nativeYtTypeFlags,
@@ -44,9 +46,11 @@ namespace NYql {
             ui64 NativeYtTypeFlags_;
             TMaybe<TString> TimestampColumn_;
             const NKikimr::NMiniKQL::TType* OutputType_;
+            const NKikimr::NMiniKQL::TType* RawOutputType_;
             TVector<NKikimr::NMiniKQL::IComputationExternalNode*> SelfNodes_;
             TVector<const NKikimr::NMiniKQL::TStructType*> InputTypes_;
             TVector<const NKikimr::NMiniKQL::TStructType*> OriginalInputTypes_;
+            TVector<const NKikimr::NMiniKQL::TStructType*> RawInputTypes_;
         };
 
         template <typename TBase>
@@ -70,7 +74,9 @@ namespace NYql {
                 const TUserDataTable& userData,
                 const TVector<const TStructExprType*>& inputTypes,
                 const TVector<const TStructExprType*>& originalInputTypes,
+                const TVector<const TStructExprType*>& rawInputTypes,
                 const TTypeAnnotationNode* outputType,
+                const TTypeAnnotationNode* rawOutputType,
                 const TString& LLVMSettings,
                 NKikimr::NUdf::ICountersProvider* countersProvider,
                 ui64 nativeYtTypeFlags,
@@ -81,7 +87,10 @@ namespace NYql {
             ui32 GetInputsCount() const override;
             const NKikimr::NMiniKQL::TStructType* GetInputType(ui32, bool) const override;
             const NKikimr::NMiniKQL::TStructType* GetInputType(bool) const override;
+            const NKikimr::NMiniKQL::TStructType* GetRawInputType(ui32) const override;
+            const NKikimr::NMiniKQL::TStructType* GetRawInputType() const override;
             const NKikimr::NMiniKQL::TType* GetOutputType() const override;
+            const NKikimr::NMiniKQL::TType* GetRawOutputType() const override;
             NYT::TNode MakeInputSchema() const override;
             NYT::TNode MakeInputSchema(ui32) const override;
             NYT::TNode MakeOutputSchema() const override;

--- a/ydb/library/yql/public/purecalc/common/worker_factory.cpp
+++ b/ydb/library/yql/public/purecalc/common/worker_factory.cpp
@@ -119,7 +119,7 @@ TWorkerFactory<TBase>::TWorkerFactory(TWorkerFactoryOptions options, EProcessorM
                 const auto originalMembers = OutputType_->Cast<TStructExprType>()->GetItems();
                 TVector<const TItemExprType*> newMembers;
                 for (auto originalItem : originalMembers) {
-                    if (originalItem->GetName() == "_yql_block_length") {
+                    if (originalItem->GetName() == PurecalcBlockColumnLength) {
                         continue;
                     }
                     bool isScalarUnused;

--- a/ydb/library/yql/public/purecalc/common/worker_factory.cpp
+++ b/ydb/library/yql/public/purecalc/common/worker_factory.cpp
@@ -192,6 +192,9 @@ TExprNode::TPtr TWorkerFactory<TBase>::Compile(
         settings.ModuleMapping = modules;
         settings.EnableGenericUdfs = true;
         settings.File = "generated.sql";
+        if (BlockEngineMode_ != EBlockEngineMode::Disable) {
+            settings.Flags = {"EmitAggApply"};
+        }
         for (const auto& [key, block] : UserData_) {
             TStringBuf alias(key.Alias());
             if (block.Usage.Test(EUserDataBlockUsage::Library) && !alias.StartsWith("/lib")) {

--- a/ydb/library/yql/public/purecalc/common/worker_factory.cpp
+++ b/ydb/library/yql/public/purecalc/common/worker_factory.cpp
@@ -246,7 +246,7 @@ TExprNode::TPtr TWorkerFactory<TBase>::Compile(
 
     TTransformationPipeline pipeline(typeContext);
 
-    pipeline.Add(MakeTableReadsReplacer(InputTypes_.size(), UseSystemColumns_),
+    pipeline.Add(MakeTableReadsReplacer(InputTypes_, UseSystemColumns_),
                  "ReplaceTableReads", EYqlIssueCode::TIssuesIds_EIssueCode_DEFAULT_ERROR,
                  "Replace reads from tables");
     pipeline.AddServiceTransformers();

--- a/ydb/library/yql/public/purecalc/common/worker_factory.cpp
+++ b/ydb/library/yql/public/purecalc/common/worker_factory.cpp
@@ -11,6 +11,7 @@
 #include <ydb/library/yql/core/peephole_opt/yql_opt_peephole_physical.h>
 #include <ydb/library/yql/providers/common/codec/yql_codec.h>
 #include <ydb/library/yql/providers/common/udf_resolve/yql_simple_udf_resolver.h>
+#include <ydb/library/yql/providers/common/arrow_resolve/yql_simple_arrow_resolver.h>
 #include <ydb/library/yql/providers/common/schema/expr/yql_expr_schema.h>
 #include <ydb/library/yql/providers/common/provider/yql_provider.h>
 #include <ydb/library/yql/providers/common/provider/yql_provider_names.h>
@@ -136,6 +137,7 @@ TExprNode::TPtr TWorkerFactory<TBase>::Compile(
         CreateDeterministicTimeProvider(*DeterministicTimeProviderSeed_) :
         CreateDefaultTimeProvider();
     typeContext->UdfResolver = NCommon::CreateSimpleUdfResolver(FuncRegistry_.Get());
+    typeContext->ArrowResolver = MakeSimpleArrowResolver(*FuncRegistry_.Get());
     typeContext->UserDataStorage = MakeIntrusive<TUserDataStorage>(nullptr, UserData_, nullptr, nullptr);
     typeContext->Modules = moduleResolver;
     typeContext->BlockEngineMode = BlockEngineMode_;

--- a/ydb/library/yql/public/purecalc/common/worker_factory.h
+++ b/ydb/library/yql/public/purecalc/common/worker_factory.h
@@ -88,7 +88,9 @@ namespace NYql {
             TString SerializedProgram_;
             TVector<const TStructExprType*> InputTypes_;
             TVector<const TStructExprType*> OriginalInputTypes_;
+            TVector<const TStructExprType*> RawInputTypes_;
             const TTypeAnnotationNode* OutputType_;
+            const TTypeAnnotationNode* RawOutputType_;
             TVector<THashSet<TString>> AllColumns_;
             TVector<THashSet<TString>> UsedColumns_;
             TString LLVMSettings_;

--- a/ydb/library/yql/public/purecalc/common/worker_factory.h
+++ b/ydb/library/yql/public/purecalc/common/worker_factory.h
@@ -125,6 +125,7 @@ namespace NYql {
                 IModuleResolver::TPtr moduleResolver,
                 ui16 syntaxVersion,
                 const THashMap<TString, TString>& modules,
+                const TInputSpecBase& inputSpec,
                 const TOutputSpecBase& outputSpec,
                 EProcessorMode processorMode);
         };

--- a/ydb/library/yql/public/purecalc/common/ya.make.inc
+++ b/ydb/library/yql/public/purecalc/common/ya.make.inc
@@ -44,6 +44,7 @@ PEERDIR(
     ydb/library/yql/providers/common/provider
     ydb/library/yql/providers/common/schema/expr
     ydb/library/yql/providers/common/udf_resolve
+    ydb/library/yql/providers/common/arrow_resolve
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/library/yql/public/purecalc/common/ya.make.inc
+++ b/ydb/library/yql/public/purecalc/common/ya.make.inc
@@ -20,6 +20,7 @@ SRCS(
     transformations/output_columns_filter.cpp
     transformations/replace_table_reads.cpp
     transformations/type_annotation.cpp
+    transformations/utils.cpp
     type_from_schema.cpp
     worker.cpp
     worker_factory.cpp

--- a/ydb/library/yql/public/purecalc/common/ya.make.inc
+++ b/ydb/library/yql/public/purecalc/common/ya.make.inc
@@ -19,6 +19,7 @@ SRCS(
     transformations/extract_used_columns.cpp
     transformations/output_columns_filter.cpp
     transformations/replace_table_reads.cpp
+    transformations/root_to_blocks.cpp
     transformations/type_annotation.cpp
     transformations/utils.cpp
     type_from_schema.cpp

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -95,7 +95,7 @@ public:
     }
 
     void DoConvert(arrow::compute::ExecBatch* batch, TUnboxedValue& result) {
-        size_t nvalues = Schema_.Size();
+        size_t nvalues = DatumToMemberIDMap_.size();
         Y_ENSURE(nvalues == static_cast<size_t>(batch->num_values()));
 
         TUnboxedValue* datums = nullptr;
@@ -153,7 +153,7 @@ public:
 
     OutputItemType DoConvert(TUnboxedValue value) {
         OutputItemType batch = Batch_.Get();
-        size_t nvalues = Schema_.Size();
+        size_t nvalues = DatumToMemberIDMap_.size();
 
         const auto& sizeDatum = TArrowBlock::From(value.GetElement(nvalues)).GetDatum();
         Y_ENSURE(sizeDatum.is_scalar());

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -1,5 +1,7 @@
 #include "spec.h"
 
+#include <ydb/library/yql/public/purecalc/common/names.h>
+
 #include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
 #include <ydb/library/yql/minikql/computation/mkql_custom_list.h>
 #include <ydb/library/yql/minikql/mkql_node_cast.h>
@@ -96,7 +98,7 @@ public:
             Y_ENSURE(memberIndex);
             DatumToMemberIDMap_[i] = *memberIndex;
         }
-        const auto& batchLengthID = type->FindMemberIndex("_yql_block_length");
+        const auto& batchLengthID = type->FindMemberIndex(PurecalcBlockColumnLength);
         Y_ENSURE(batchLengthID);
         BatchLengthID_ = *batchLengthID;
     }
@@ -159,7 +161,7 @@ public:
             Y_ENSURE(memberIndex);
             DatumToMemberIDMap_[i] = *memberIndex;
         }
-        const auto& batchLengthID = stype->FindMemberIndex("_yql_block_length");
+        const auto& batchLengthID = stype->FindMemberIndex(PurecalcBlockColumnLength);
         Y_ENSURE(batchLengthID);
         BatchLengthID_ = *batchLengthID;
     }

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -82,7 +82,7 @@ public:
                                  ? worker->MakeInputSchema(index)
                                  : inputSchema;
 
-        const auto* type = worker->GetInputType(index, true);
+        const auto* type = worker->GetRawInputType(index);
 
         Y_ENSURE(type->IsStruct());
         Y_ENSURE(schema.ChildAsString(0) == "StructType");
@@ -143,7 +143,7 @@ public:
                                  ? worker->MakeOutputSchema()
                                  : outputSchema;
 
-        const auto* type = worker->GetOutputType();
+        const auto* type = worker->GetRawOutputType();
 
         Y_ENSURE(type->IsStruct());
         Y_ENSURE(schema.ChildAsString(0) == "StructType");

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -79,12 +79,12 @@ public:
     }
 
     void DoConvert(arrow::compute::ExecBatch* batch, TUnboxedValue& result) {
-        ui64 nvalues = Schema_.Size();
+        size_t nvalues = Schema_.Size();
         Y_ENSURE(nvalues == static_cast<size_t>(batch->num_values()));
 
         TUnboxedValue* datums = nullptr;
         result = Factory_.CreateDirectArrayHolder(nvalues, datums);
-        for (ui64 i = 0; i < nvalues; i++) {
+        for (size_t i = 0; i < nvalues; i++) {
             datums[i] = Factory_.CreateArrowBlock(std::move(batch->values[i]));
         }
     }
@@ -115,9 +115,9 @@ public:
 
     OutputItemType DoConvert(TUnboxedValue value) {
         OutputItemType batch = Batch_.Get();
-        ui64 nvalues = Schema_.Size();
+        size_t nvalues = Schema_.Size();
         TVector<arrow::Datum> datums(nvalues);
-        for (ui32 i = 0; i < nvalues; i++) {
+        for (size_t i = 0; i < nvalues; i++) {
             datums[i] = TArrowBlock::From(value.GetElement(i)).GetDatum();
         }
         *batch = ARROW_RESULT(arrow::compute::ExecBatch::Make(datums));

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -78,14 +78,14 @@ public:
         , Factory_(Worker_->GetGraph().GetHolderFactory())
         , Schema_(inputSpec.GetSchema(index))
     {
-        DatumToMemberIDMap_.resize(Schema_.Size());
-
         const auto* type = Worker_->GetInputType(index, true);
 
         Y_ENSURE(type->IsStruct());
         Y_ENSURE(Schema_.ChildAsString(0) == "StructType");
 
         const auto& members = Schema_.ChildAsList(1);
+        DatumToMemberIDMap_.resize(members.size());
+
         for (size_t i = 0; i < DatumToMemberIDMap_.size(); i++) {
             const auto& name = members[i].ChildAsString(0);
             const auto& memberIndex = type->FindMemberIndex(name);
@@ -132,7 +132,6 @@ public:
         , Schema_(outputSpec.GetSchema())
     {
         Batch_.Reset(new arrow::compute::ExecBatch);
-        DatumToMemberIDMap_.resize(Schema_.Size());
 
         const auto* type = Worker_->GetOutputType();
 
@@ -142,6 +141,8 @@ public:
         const auto* stype = AS_TYPE(NKikimr::NMiniKQL::TStructType, type);
 
         const auto& members = Schema_.ChildAsList(1);
+        DatumToMemberIDMap_.resize(members.size());
+
         for (size_t i = 0; i < DatumToMemberIDMap_.size(); i++) {
             const auto& name = members[i].ChildAsString(0);
             const auto& memberIndex = stype->FindMemberIndex(name);

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.h
@@ -37,7 +37,7 @@ public:
     explicit TArrowInputSpec(const TVector<NYT::TNode>& schemas);
     const TVector<NYT::TNode>& GetSchemas() const override;
     const NYT::TNode& GetSchema(ui32 index) const;
-    static constexpr bool ProvidesBlocks = true;
+    bool ProvidesBlocks() const override { return true; }
 };
 
 /**
@@ -70,7 +70,7 @@ private:
 public:
     explicit TArrowOutputSpec(const NYT::TNode& schema);
     const NYT::TNode& GetSchema() const override;
-    static constexpr bool AcceptsBlocks = true;
+    bool AcceptsBlocks() const override { return true; }
 };
 
 template <>

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
@@ -156,7 +156,7 @@ Y_UNIT_TEST_SUITE(TestSimplePullListArrowIO) {
 
         auto factory = MakeProgramFactory(TestOptions(BlockEngineMode));
 
-        {
+        try {
             auto program = factory->MakePullListProgram(
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
@@ -176,6 +176,8 @@ Y_UNIT_TEST_SUITE(TestSimplePullListArrowIO) {
             }
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInput, canonOutput);
+        } catch (const TCompileError& error) {
+            Cerr << error.GetIssues() << "\n";
         }
     }
 
@@ -187,7 +189,7 @@ Y_UNIT_TEST_SUITE(TestSimplePullListArrowIO) {
 
         auto factory = MakeProgramFactory(TestOptions(BlockEngineMode));
 
-        {
+        try {
             auto program = factory->MakePullListProgram(
                 TArrowInputSpec({schema, schema}),
                 TArrowOutputSpec(schema),
@@ -218,6 +220,8 @@ Y_UNIT_TEST_SUITE(TestSimplePullListArrowIO) {
             }
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInputs, canonOutput);
+        } catch (const TCompileError& error) {
+            Cerr << error.GetIssues() << "\n";
         }
     }
 }
@@ -232,7 +236,7 @@ Y_UNIT_TEST_SUITE(TestMorePullListArrowIO) {
 
         auto factory = MakeProgramFactory(TestOptions(BlockEngineMode));
 
-        {
+        try {
             auto program = factory->MakePullListProgram(
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
@@ -257,6 +261,8 @@ Y_UNIT_TEST_SUITE(TestMorePullListArrowIO) {
             const TVector<arrow::compute::ExecBatch> check({MakeBatch(9, 17, 2)});
             const auto canonCheck = CanonBatches(check);
             UNIT_ASSERT_EQUAL(canonCheck, canonOutput);
+        } catch (const TCompileError& error) {
+            Cerr << error.GetIssues() << "\n";
         }
     }
 }
@@ -271,7 +277,7 @@ Y_UNIT_TEST_SUITE(TestSimplePullStreamArrowIO) {
 
         auto factory = MakeProgramFactory(TestOptions(BlockEngineMode));
 
-        {
+        try {
             auto program = factory->MakePullStreamProgram(
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
@@ -291,6 +297,8 @@ Y_UNIT_TEST_SUITE(TestSimplePullStreamArrowIO) {
             }
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInput, canonOutput);
+        } catch (const TCompileError& error) {
+            Cerr << error.GetIssues() << "\n";
         }
     }
 }
@@ -305,7 +313,7 @@ Y_UNIT_TEST_SUITE(TestMorePullStreamArrowIO) {
 
         auto factory = MakeProgramFactory(TestOptions(BlockEngineMode));
 
-        {
+        try {
             auto program = factory->MakePullStreamProgram(
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
@@ -330,6 +338,8 @@ Y_UNIT_TEST_SUITE(TestMorePullStreamArrowIO) {
             const TVector<arrow::compute::ExecBatch> check({MakeBatch(9, 17, 2)});
             const auto canonCheck = CanonBatches(check);
             UNIT_ASSERT_EQUAL(canonCheck, canonOutput);
+        } catch (const TCompileError& error) {
+            Cerr << error.GetIssues() << "\n";
         }
     }
 }
@@ -344,7 +354,7 @@ Y_UNIT_TEST_SUITE(TestPushStreamArrowIO) {
 
         auto factory = MakeProgramFactory(TestOptions(BlockEngineMode));
 
-        {
+        try {
             auto program = factory->MakePushStreamProgram(
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
@@ -363,6 +373,8 @@ Y_UNIT_TEST_SUITE(TestPushStreamArrowIO) {
 
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInput, canonOutput);
+        } catch (const TCompileError& error) {
+            Cerr << error.GetIssues() << "\n";
         }
     }
 }
@@ -376,7 +388,7 @@ Y_UNIT_TEST_SUITE(TestMorePushStreamArrowIO) {
 
         auto factory = MakeProgramFactory(TestOptions(BlockEngineMode));
 
-        {
+        try {
             auto program = factory->MakePushStreamProgram(
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
@@ -400,6 +412,8 @@ Y_UNIT_TEST_SUITE(TestMorePushStreamArrowIO) {
             const TVector<arrow::compute::ExecBatch> check({MakeBatch(9, 17, 2)});
             const auto canonCheck = CanonBatches(check);
             UNIT_ASSERT_EQUAL(canonCheck, canonOutput);
+        } catch (const TCompileError& error) {
+            Cerr << error.GetIssues() << "\n";
         }
     }
 }

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
@@ -177,7 +177,7 @@ Y_UNIT_TEST_SUITE(TestSimplePullListArrowIO) {
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInput, canonOutput);
         } catch (const TCompileError& error) {
-            Cerr << error.GetIssues() << "\n";
+            UNIT_FAIL(error.GetIssues());
         }
     }
 
@@ -221,7 +221,7 @@ Y_UNIT_TEST_SUITE(TestSimplePullListArrowIO) {
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInputs, canonOutput);
         } catch (const TCompileError& error) {
-            Cerr << error.GetIssues() << "\n";
+            UNIT_FAIL(error.GetIssues());
         }
     }
 }
@@ -262,7 +262,7 @@ Y_UNIT_TEST_SUITE(TestMorePullListArrowIO) {
             const auto canonCheck = CanonBatches(check);
             UNIT_ASSERT_EQUAL(canonCheck, canonOutput);
         } catch (const TCompileError& error) {
-            Cerr << error.GetIssues() << "\n";
+            UNIT_FAIL(error.GetIssues());
         }
     }
 }
@@ -298,7 +298,7 @@ Y_UNIT_TEST_SUITE(TestSimplePullStreamArrowIO) {
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInput, canonOutput);
         } catch (const TCompileError& error) {
-            Cerr << error.GetIssues() << "\n";
+            UNIT_FAIL(error.GetIssues());
         }
     }
 }
@@ -339,7 +339,7 @@ Y_UNIT_TEST_SUITE(TestMorePullStreamArrowIO) {
             const auto canonCheck = CanonBatches(check);
             UNIT_ASSERT_EQUAL(canonCheck, canonOutput);
         } catch (const TCompileError& error) {
-            Cerr << error.GetIssues() << "\n";
+            UNIT_FAIL(error.GetIssues());
         }
     }
 }
@@ -374,7 +374,7 @@ Y_UNIT_TEST_SUITE(TestPushStreamArrowIO) {
             const auto canonOutput = CanonBatches(output);
             UNIT_ASSERT_EQUAL(canonInput, canonOutput);
         } catch (const TCompileError& error) {
-            Cerr << error.GetIssues() << "\n";
+            UNIT_FAIL(error.GetIssues());
         }
     }
 }
@@ -413,7 +413,7 @@ Y_UNIT_TEST_SUITE(TestMorePushStreamArrowIO) {
             const auto canonCheck = CanonBatches(check);
             UNIT_ASSERT_EQUAL(canonCheck, canonOutput);
         } catch (const TCompileError& error) {
-            Cerr << error.GetIssues() << "\n";
+            UNIT_FAIL(error.GetIssues());
         }
     }
 }


### PR DESCRIPTION
This changeset implements block IO support in purecalc.

Strictly saying the first half of the patchset fixes several issues related to #5079. All of them should be fixed in scope of #6494 and #6588, however a couple of the patches require wide enhancements in purecalc, so everything is implemented in this PR.

Alongside with some block-related graph rewrites and type tweaks, this PR introduces:
* `purecalc/common/transformation/utils.cpp` with auxiliary routines to emit to-blocks/from-blocks wrappert for both nodes and types.
* `GetRawInputType` and `GetRawOutputType` methods for `IWorker` interface to obtain the actual MKQL node type to be used in the Arrow IO converters.

### Changelog category

* New feature