### PR TITLE
Use yellow color for failed test not in last retry

### DIFF
--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -380,7 +380,7 @@ def main():
             event = json.load(fp)
 
         pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
-        text = get_comment_text(pr, summary, args.summary_links, is_last_retry=bool(args.is_last_retry))
+        color, text = get_comment_text(pr, summary, args.summary_links, is_last_retry=bool(args.is_last_retry))
 
         update_pr_comment_text(pr, args.build_preset, run_number, color, text='\n'.join(text), rewrite=False)
 

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -298,16 +298,20 @@ def gen_summary(public_dir, public_dir_url, paths, is_retry: bool):
     return summary
 
 
-def get_comment_text(pr: PullRequest, summary: TestSummary, summary_links: str, is_last_retry: bool):
+def get_comment_text(pr: PullRequest, summary: TestSummary, summary_links: str, is_last_retry: bool)->tuple[str, list[str]]:
+    color = "red"
     if summary.is_empty:
-        return [
+        color = "green"
+        return color, [
             f"Test run completed, no test results found for commit {pr.head.sha}. "
         ]
     elif summary.is_failed:
+        color = "red" if is_last_retry else "yellow"
         result = f"Some tests failed, follow the links below."
         if not is_last_retry:
             result += " Going to retry failed tests..."
     else:
+        color = "green"
         result = f"Tests successful."
 
     body = []
@@ -338,7 +342,7 @@ def get_comment_text(pr: PullRequest, summary: TestSummary, summary_links: str, 
     else:
         body.append("")
 
-    return body
+    return color, body
 
 
 def main():
@@ -364,10 +368,8 @@ def main():
     write_summary(summary)
 
     if summary.is_failed:
-        color = 'red'
         overall_status = "failure"
     else:
-        color = 'green'
         overall_status = "success"
 
     if os.environ.get("GITHUB_EVENT_NAME") in ("pull_request", "pull_request_target"):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Use yellow color instead of red for retriable tests
<img width="785" alt="image" src="https://github.com/user-attachments/assets/ad8ade7e-968b-4b77-9a5c-29d6c90cae55">

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Check: https://github.com/ydb-platform/ydb/pull/7059