### PR TITLE
Support block IO in purebench

### DIFF
--- a/ydb/library/yql/public/udf/arrow/util.h
+++ b/ydb/library/yql/public/udf/arrow/util.h
@@ -4,6 +4,7 @@
 
 #include <util/generic/vector.h>
 
+#include <arrow/compute/api.h>
 #include <arrow/datum.h>
 #include <arrow/memory_pool.h>
 #include <arrow/util/bit_util.h>
@@ -41,6 +42,7 @@ inline bool IsNull(const arrow::ArrayData& data, size_t index) {
 }
 
 ui64 GetSizeOfArrowBatchInBytes(const arrow::RecordBatch& batch);
+ui64 GetSizeOfArrowExecBatchInBytes(const arrow::compute::ExecBatch& batch);
 
 class TResizeableBuffer : public arrow::ResizableBuffer {
 public:

--- a/ydb/library/yql/tools/purebench/purebench.cpp
+++ b/ydb/library/yql/tools/purebench/purebench.cpp
@@ -22,6 +22,17 @@
 using namespace NYql;
 using namespace NYql::NPureCalc;
 
+TStringStream MakeGenInput(ui64 count) {
+    TStringStream stream;
+    NSkiff::TUncheckedSkiffWriter writer{&stream};
+    for (ui64 i = 0; i < count; ++i) {
+        writer.WriteVariant16Tag(0);
+        writer.WriteInt64(i);
+    }
+    writer.Finish();
+    return stream;
+}
+
 int Main(int argc, const char *argv[])
 {
     Y_UNUSED(NUdf::GetStaticSymbols());
@@ -89,14 +100,7 @@ int Main(int argc, const char *argv[])
         genSql,
         res.Has("pg") ? ETranslationMode::PG : ETranslationMode::SQL);
 
-    TStringStream stream;
-    NSkiff::TUncheckedSkiffWriter writer{&stream};
-    for (ui64 i = 0; i < count; ++i) {
-        writer.WriteVariant16Tag(0);
-        writer.WriteInt64(i);
-    }
-    writer.Finish();
-    auto input1 = TStringStream(stream);
+    auto input1 = MakeGenInput(count);
     Cerr << "Input data size: " << input1.Size() << "\n";
     auto handle1 = genProgram->Apply(&input1);
     TStringStream output1;

--- a/ydb/library/yql/tools/purebench/purebench.cpp
+++ b/ydb/library/yql/tools/purebench/purebench.cpp
@@ -8,6 +8,7 @@
 
 #include <ydb/library/yql/utils/log/log.h>
 #include <ydb/library/yql/utils/backtrace/backtrace.h>
+#include <ydb/library/yql/public/udf/arrow/util.h>
 #include <ydb/library/yql/public/udf/udf_registrator.h>
 #include <ydb/library/yql/public/udf/udf_version.h>
 
@@ -225,7 +226,9 @@ int Main(int argc, const char *argv[])
 
         ui64 outputGenSize = std::transform_reduce(
             outputGenStream.cbegin(), outputGenStream.cend(),
-            0l, std::plus{}, [](auto t) { return t.length; });
+            0l, std::plus{}, [](const auto& b) {
+                return NYql::NUdf::GetSizeOfArrowExecBatchInBytes(b);
+            });
 
         Cerr << "Generated data size: " << outputGenSize << "\n";
 

--- a/ydb/library/yql/tools/purebench/ya.make
+++ b/ydb/library/yql/tools/purebench/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     library/cpp/skiff
     library/cpp/yson
     ydb/library/yql/public/purecalc/io_specs/mkql
+    ydb/library/yql/public/purecalc/io_specs/arrow
     ydb/library/yql/public/purecalc
 )
 


### PR DESCRIPTION
This patchset follows up the one implementing block IO support in purecalc (#7016), and uses the new Arrow IO spec for running the benchmarks via purebench util.

It also contains a small partial refactoring to make the code more unified, though there are still an area for improvement.

### Changelog category

* New feature