### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ list_result.log
 bin/config.json
 
 .vs/
+path.bash.inc


### PR DESCRIPTION
For some reason, the YDB CLI writes data to `~/ydb/path.bash.inc`, even though `~/ydb` might be a checkout of this repository.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
