### PR TITLE
tpc ds q32: fix yql translation

### DIFF
--- a/ydb/library/benchmarks/queries/tpcds/yql/q32.sql
+++ b/ydb/library/benchmarks/queries/tpcds/yql/q32.sql
@@ -12,6 +12,7 @@ $avg_discount_by_item = (
          where cast (d_date as date) between cast('2002-03-29' as date) and
                              (cast('2002-03-29' as date) + DateTime::IntervalFromDays(90))
           and d_date_sk = cs_sold_date_sk
+          and i_manufact_id = 66
           group by item.i_item_sk
       );
 


### PR DESCRIPTION
Original query contains correlated subqueries, which process only `item` rows with specified `i_manufacture_id`.
In YQL translation they are replaced by JOIN with aggregate, and this aggregate is built over much bigger (unfiltered) table.

Fixes #7006

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

It would be nice to teach query optimizer to push such condition into joins automatically, but I think that would be separate issue.