### PR TITLE
add config option to specify TTL for user logins

### DIFF
--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -34,6 +34,7 @@ message TAuthConfig {
     optional string UserAccountDomain = 43 [default = "passport"];
     optional string ServiceDomain = 44 [default = "service"];
     optional bool DomainLoginOnly = 45 [default = true];
+    optional string LoginTokenExpireTime = 46 [default = "12h"];
     optional string RefreshPeriod = 50 [default = "1s"]; // how often we check for tickets freshness/expiration
     optional string RefreshTime = 51 [default = "1h"]; // we will try to refresh valid ticket within RefreshTime/2 and RefreshTime randomly
     optional string LifeTime = 52 [default = "1h"]; // for how long ticket will remain in the cache after last access

--- a/ydb/core/protos/flat_tx_scheme.proto
+++ b/ydb/core/protos/flat_tx_scheme.proto
@@ -146,6 +146,7 @@ message TEvLogin {
     optional string User = 1;
     optional string Password = 2;
     optional string ExternalAuth = 3;
+    optional uint64 ExpiresAfterMs = 4;
 }
 
 message TEvLoginResult {

--- a/ydb/core/security/login_shared_func.cpp
+++ b/ydb/core/security/login_shared_func.cpp
@@ -38,6 +38,9 @@ NKikimrScheme::TEvLogin CreateLoginRequest(const TAuthCredentials& credentials, 
         }
         default: {}
     }
+    if (config.HasLoginTokenExpireTime()) {
+        record.SetExpiresAfterMs(TDuration::Parse(config.GetLoginTokenExpireTime()).MilliSeconds());
+    }
     return record;
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -19,10 +19,16 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
     TTxType GetTxType() const override { return TXTYPE_LOGIN; }
 
     NLogin::TLoginProvider::TLoginUserRequest GetLoginRequest() const {
+        const auto& record(Request->Get()->Record);
         return {
-            .User = Request->Get()->Record.GetUser(),
-            .Password = Request->Get()->Record.GetPassword(),
-            .ExternalAuth = Request->Get()->Record.GetExternalAuth()
+            .User = record.GetUser(),
+            .Password = record.GetPassword(),
+            .Options = {
+                .ExpiresAfter = record.HasExpiresAfterMs()
+                    ? std::chrono::milliseconds(record.GetExpiresAfterMs())
+                    : std::chrono::system_clock::duration::zero()
+                },
+            .ExternalAuth = record.GetExternalAuth(),
             };
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

add config option to specify TTL for user logins
closes #7035 

### Changelog category <!-- remove all except one -->

* New feature
* Improvement
