### PR TITLE
Update s3 artifacts more often

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -300,6 +300,8 @@ runs:
             CURRENT_MESSAGE="Failed tests rerun (try $RETRY) $CURRENT_MESSAGE"
             RERUN_FAILED_OPT="-X"
           fi
+
+          s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
           echo $CURRENT_MESSAGE | GITHUB_TOKEN="${{ github.token }}" .github/scripts/tests/comment-pr.py
 
           CURRENT_PUBLIC_DIR_RELATIVE=try_$RETRY
@@ -473,7 +475,7 @@ runs:
         echo "::group::s3-sync"
         .github/scripts/Indexer/indexer.py -r "$PUBLIC_DIR/"
         echo "00 [Workflow artifacts](${S3_URL_PREFIX}/index.html)" >> $SUMMARY_LINKS
-        s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"     
+        s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
         cat $SUMMARY_LINKS | python3 -c 'import sys; print(" | ".join([v for _, v in sorted([l.strip().split(" ", 1) for l in sys.stdin], key=lambda a: (int(a[0]), a))]))' >> $GITHUB_STEP_SUMMARY
         echo "::endgroup::"
 

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -14,6 +14,8 @@
 #include <library/cpp/deprecated/atomic/atomic.h>
 #include <util/system/rwlock.h>
 #include <util/system/hp_timer.h>
+#include <chrono>
+#include <thread>
 
 using namespace NActors;
 using namespace NActors::NTests;
@@ -598,6 +600,8 @@ Y_UNIT_TEST_SUITE(TestStateFunc) {
     };
 
     Y_UNIT_TEST(StateFuncWithExceptions) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000*30));
+        UNIT_ASSERT_VALUES_EQUAL(42, 420);
         TTestActorRuntimeBase runtime;
         runtime.Initialize();
         auto sender = runtime.AllocateEdgeActor();

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -14,8 +14,6 @@
 #include <library/cpp/deprecated/atomic/atomic.h>
 #include <util/system/rwlock.h>
 #include <util/system/hp_timer.h>
-#include <chrono>
-#include <thread>
 
 using namespace NActors;
 using namespace NActors::NTests;
@@ -600,8 +598,6 @@ Y_UNIT_TEST_SUITE(TestStateFunc) {
     };
 
     Y_UNIT_TEST(StateFuncWithExceptions) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000*30));
-        UNIT_ASSERT_VALUES_EQUAL(42, 420);
         TTestActorRuntimeBase runtime;
         runtime.Initialize();
         auto sender = runtime.AllocateEdgeActor();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
update s3 right before commenting PR (to ensure that all links are working)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Overhead is small, see https://github.com/ydb-platform/ydb/pull/7064

Total upload time is about 25 sec

```
2024-07-24T18:36:50.3157262Z + s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 /home/runner/actions_runner/_work/ydb/ydb/tmp/results/ s3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/
2024-07-24T18:36:50.4765613Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/summary_links.txt' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/summary_links.txt' (204 bytes in 0.0 seconds, 10.59 KB/s) [1 of 1]
2024-07-24T18:36:50.4767191Z Done. Uploaded 204 bytes in 1.0 seconds, 204.00 B/s.
2024-07-24T18:36:50.4767797Z Stats: Number of files: 1 (204 bytes) 
2024-07-24T18:36:50.4768394Z Stats: Number of files transferred: 1 (204 bytes) 


2024-07-24T21:35:00.6700260Z + s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 /home/runner/actions_runner/_work/ydb/ydb/tmp/results/ s3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/
2024-07-24T21:35:00.9719931Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/junit_parts.xml.tar.gz' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/junit_parts.xml.tar.gz' (1415292 bytes in 0.1 seconds, 19.92 MB/s) [1 of 45]
2024-07-24T21:35:01.3851257Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/last_junit.xml' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/last_junit.xml' (12971652 bytes in 0.4 seconds, 30.74 MB/s) [2 of 45]
2024-07-24T21:35:01.4151060Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadHuge.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadHuge.err' (1033 bytes in 0.0 seconds, 51.30 KB/s) [3 of 45]
2024-07-24T21:35:01.4466195Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadSmall.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadSmall.err' (1034 bytes in 0.0 seconds, 36.86 KB/s) [4 of 45]
2024-07-24T21:35:01.4776831Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteHuge.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteHuge.err' (1144 bytes in 0.0 seconds, 41.75 KB/s) [5 of 45]
2024-07-24T21:35:01.5481769Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteSmall.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteSmall.err' (1145 bytes in 0.1 seconds, 16.76 KB/s) [6 of 45]
2024-07-24T21:35:01.5818223Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' (6311 bytes in 0.0 seconds, 214.07 KB/s) [7 of 45]
2024-07-24T21:35:01.6039392Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.out' (100 bytes in 0.0 seconds, 5.14 KB/s) [8 of 45]
2024-07-24T21:35:01.6363562Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' (10529 bytes in 0.0 seconds, 365.83 KB/s) [9 of 45]
2024-07-24T21:35:01.6751402Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.out' (100 bytes in 0.0 seconds, 2.72 KB/s) [10 of 45]
2024-07-24T21:35:01.7073237Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/KqpScheme.AlterTableAddExplicitSyncVectorKMeansTreeIndex.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/KqpScheme.AlterTableAddExplicitSyncVectorKMeansTreeIndex.err' (6846 bytes in 0.0 seconds, 248.55 KB/s) [11 of 45]
2024-07-24T21:35:01.7299430Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/KqpScheme.AlterTableAddExplicitSyncVectorKMeansTreeIndex.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/KqpScheme.AlterTableAddExplicitSyncVectorKMeansTreeIndex.out' (100 bytes in 0.0 seconds, 4.97 KB/s) [12 of 45]
2024-07-24T21:35:01.7594651Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/KqpService.CloseSessionsWithLoad.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/KqpService.CloseSessionsWithLoad.err' (1063 bytes in 0.0 seconds, 40.59 KB/s) [13 of 45]
2024-07-24T21:35:01.8184777Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/Balancing.Simple.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/Balancing.Simple.err' (1513886 bytes in 0.1 seconds, 27.63 MB/s) [14 of 45]
2024-07-24T21:35:01.8475578Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/Balancing.Simple.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/Balancing.Simple.out' (400 bytes in 0.0 seconds, 15.26 KB/s) [15 of 45]
2024-07-24T21:35:01.8748226Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/QuoterWithKesusTest.PrefetchCoefficient.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/QuoterWithKesusTest.PrefetchCoefficient.err' (26932 bytes in 0.0 seconds, 1220.19 KB/s) [16 of 45]
2024-07-24T21:35:01.8961396Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/QuoterWithKesusTest.PrefetchCoefficient.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/QuoterWithKesusTest.PrefetchCoefficient.out' (100 bytes in 0.0 seconds, 5.44 KB/s) [17 of 45]
2024-07-24T21:35:01.9292711Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' (243868 bytes in 0.0 seconds, 8.48 MB/s) [18 of 45]
2024-07-24T21:35:01.9511653Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/TestStateFunc.StateFuncWithExceptions.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/TestStateFunc.StateFuncWithExceptions.err' (951 bytes in 0.0 seconds, 53.06 KB/s) [19 of 45]
2024-07-24T21:35:02.5275039Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/BasicUsage.ReadSessionCorrectClose.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/BasicUsage.ReadSessionCorrectClose.err' (23627574 bytes in 0.6 seconds, 39.58 MB/s) [20 of 45]
2024-07-24T21:35:02.5556185Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/BasicUsage.ReadSessionCorrectClose.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/BasicUsage.ReadSessionCorrectClose.out' (400 bytes in 0.0 seconds, 15.65 KB/s) [21 of 45]
2024-07-24T21:35:02.5936738Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/TPersQueueTest.DirectReadCleanCache.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/TPersQueueTest.DirectReadCleanCache.err' (403682 bytes in 0.0 seconds, 12.03 MB/s) [22 of 45]
2024-07-24T21:35:02.6137747Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/TPersQueueTest.DirectReadCleanCache.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/TPersQueueTest.DirectReadCleanCache.out' (400 bytes in 0.0 seconds, 22.70 KB/s) [23 of 45]
2024-07-24T21:35:02.6334944Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/failed_count.txt' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/failed_count.txt' (1 bytes in 0.0 seconds, 51.20 B/s) [24 of 45]
2024-07-24T21:35:02.9304889Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/junit.xml' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/junit.xml' (12971652 bytes in 0.3 seconds, 42.52 MB/s) [25 of 45]
2024-07-24T21:35:02.9871560Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/orig_junit.xml.gz' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/orig_junit.xml.gz' (1279281 bytes in 0.1 seconds, 22.39 MB/s) [26 of 45]
2024-07-24T21:35:03.0276136Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-keyvalue-ut_trace.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-keyvalue-ut_trace.zip' (9459 bytes in 0.0 seconds, 235.36 KB/s) [27 of 45]
2024-07-24T21:35:03.8327392Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-kqp-ut-olap.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-kqp-ut-olap.zip' (25685647 bytes in 0.8 seconds, 30.49 MB/s) [28 of 45]
2024-07-24T21:35:03.8800915Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-kqp-ut-scan.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-kqp-ut-scan.zip' (418149 bytes in 0.0 seconds, 8.66 MB/s) [29 of 45]
2024-07-24T21:35:03.9314097Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-kqp-ut-scheme.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-kqp-ut-scheme.zip' (805363 bytes in 0.1 seconds, 15.32 MB/s) [30 of 45]
2024-07-24T21:35:03.9699671Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-kqp-ut-service.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-kqp-ut-service.zip' (447315 bytes in 0.0 seconds, 11.44 MB/s) [31 of 45]
2024-07-24T21:35:04.2703044Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-persqueue-ut-ut_with_sdk.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-persqueue-ut-ut_with_sdk.zip' (8715669 bytes in 0.3 seconds, 27.86 MB/s) [32 of 45]
2024-07-24T21:35:04.3066494Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-quoter-ut.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-quoter-ut.zip' (194771 bytes in 0.0 seconds, 5.33 MB/s) [33 of 45]
2024-07-24T21:35:04.3532964Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-core-tx-datashard-ut_incremental_backup.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-core-tx-datashard-ut_incremental_backup.zip' (237749 bytes in 0.0 seconds, 5.03 MB/s) [34 of 45]
2024-07-24T21:35:04.3769353Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-library-actors-core-ut.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-library-actors-core-ut.zip' (81587 bytes in 0.0 seconds, 3.43 MB/s) [35 of 45]
2024-07-24T21:35:04.4079127Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-library-actors-http-ut.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-library-actors-http-ut.zip' (13296 bytes in 0.0 seconds, 431.45 KB/s) [36 of 45]
2024-07-24T21:35:04.6629849Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-public-sdk-cpp-client-ydb_topic-ut.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-public-sdk-cpp-client-ydb_topic-ut.zip' (9304770 bytes in 0.3 seconds, 34.98 MB/s) [37 of 45]
2024-07-24T21:35:05.0081424Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-services-persqueue_v1-ut.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-services-persqueue_v1-ut.zip' (9075827 bytes in 0.3 seconds, 25.20 MB/s) [38 of 45]
2024-07-24T21:35:05.0878392Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-tests-fq-mem_alloc.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-tests-fq-mem_alloc.zip' (1538706 bytes in 0.1 seconds, 18.85 MB/s) [39 of 45]
2024-07-24T21:35:05.4765399Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-tests-fq-yds.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-tests-fq-yds.zip' (11344279 bytes in 0.4 seconds, 27.95 MB/s) [40 of 45]
2024-07-24T21:35:05.5429518Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/ydb-tests-fq-yt-kqp_yt_file-part18.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/ydb-tests-fq-yt-kqp_yt_file-part18.zip' (806364 bytes in 0.1 seconds, 11.88 MB/s) [41 of 45]
2024-07-24T21:35:06.3069992Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/ya-test.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/ya-test.html' (32445453 bytes in 0.8 seconds, 40.70 MB/s) [42 of 45]
2024-07-24T21:35:08.0780418Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_evlog.jsonl' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_evlog.jsonl' (65595923 bytes in 1.8 seconds, 35.41 MB/s) [43 of 45]
2024-07-24T21:35:08.8565004Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_log.log' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_log.log' (32287250 bytes in 0.8 seconds, 39.79 MB/s) [44 of 45]
2024-07-24T21:35:10.6547507Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_make_output.log' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_make_output.log' (55857892 bytes in 1.8 seconds, 29.77 MB/s) [45 of 45]
2024-07-24T21:35:10.6549328Z Done. Uploaded 309350945 bytes in 9.8 seconds, 30.21 MB/s.
2024-07-24T21:35:10.6550079Z Stats: Number of files: 46 (309351149 bytes) 
2024-07-24T21:35:10.6550847Z Stats: Number of files transferred: 45 (309350945 bytes) 


2024-07-24T21:50:30.1788775Z + s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 /home/runner/actions_runner/_work/ydb/ydb/tmp/results/ s3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/
2024-07-24T21:50:30.4865956Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadHuge.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadHuge.err' (1033 bytes in 0.0 seconds, 34.81 KB/s) [1 of 35]
2024-07-24T21:50:30.5131863Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadSmall.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadSmall.err' (1034 bytes in 0.0 seconds, 46.07 KB/s) [2 of 35]
2024-07-24T21:50:30.5377552Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteHuge.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteHuge.err' (1144 bytes in 0.0 seconds, 55.55 KB/s) [3 of 35]
2024-07-24T21:50:30.5672379Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteSmall.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteSmall.err' (1145 bytes in 0.0 seconds, 44.47 KB/s) [4 of 35]
2024-07-24T21:50:30.5917499Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' (6547 bytes in 0.0 seconds, 324.97 KB/s) [5 of 35]
2024-07-24T21:50:30.6164470Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.out' (100 bytes in 0.0 seconds, 4.55 KB/s) [6 of 35]
2024-07-24T21:50:30.6449158Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' (9245 bytes in 0.0 seconds, 384.94 KB/s) [7 of 35]
2024-07-24T21:50:30.6751616Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.out' (100 bytes in 0.0 seconds, 3.61 KB/s) [8 of 35]
2024-07-24T21:50:30.6993517Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/KqpService.CloseSessionsWithLoad.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/KqpService.CloseSessionsWithLoad.err' (1063 bytes in 0.0 seconds, 52.54 KB/s) [9 of 35]
2024-07-24T21:50:30.7397032Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' (243867 bytes in 0.0 seconds, 6.82 MB/s) [10 of 35]
2024-07-24T21:50:30.7626952Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/TestStateFunc.StateFuncWithExceptions.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/TestStateFunc.StateFuncWithExceptions.err' (951 bytes in 0.0 seconds, 49.11 KB/s) [11 of 35]
2024-07-24T21:50:30.7818220Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/failed_count.txt' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/failed_count.txt' (1 bytes in 0.0 seconds, 54.53 B/s) [12 of 35]
2024-07-24T21:50:30.8087742Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/junit.xml' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/junit.xml' (38225 bytes in 0.0 seconds, 1793.22 KB/s) [13 of 35]
2024-07-24T21:50:30.8438354Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/orig_junit.xml.gz' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/orig_junit.xml.gz' (4901 bytes in 0.0 seconds, 141.31 KB/s) [14 of 35]
2024-07-24T21:50:30.8640103Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/ydb-core-keyvalue-ut_trace.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/ydb-core-keyvalue-ut_trace.zip' (9572 bytes in 0.0 seconds, 487.30 KB/s) [15 of 35]
2024-07-24T21:50:30.8839585Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/ydb-core-kqp-ut-olap.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/ydb-core-kqp-ut-olap.zip' (30691 bytes in 0.0 seconds, 1571.61 KB/s) [16 of 35]
2024-07-24T21:50:30.9111285Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/ydb-core-kqp-ut-scan.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/ydb-core-kqp-ut-scan.zip' (18540 bytes in 0.0 seconds, 688.42 KB/s) [17 of 35]
2024-07-24T21:50:30.9376060Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/ydb-core-kqp-ut-service.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/ydb-core-kqp-ut-service.zip' (15222 bytes in 0.0 seconds, 579.98 KB/s) [18 of 35]
2024-07-24T21:50:30.9601184Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/ydb-core-tx-datashard-ut_incremental_backup.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/ydb-core-tx-datashard-ut_incremental_backup.zip' (91282 bytes in 0.0 seconds, 4.11 MB/s) [19 of 35]
2024-07-24T21:50:30.9772248Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/ydb-library-actors-core-ut.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/ydb-library-actors-core-ut.zip' (7394 bytes in 0.0 seconds, 443.84 KB/s) [20 of 35]
2024-07-24T21:50:31.0051789Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/ydb-tests-fq-yt-kqp_yt_file-part18.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/ydb-tests-fq-yt-kqp_yt_file-part18.zip' (17502 bytes in 0.0 seconds, 630.36 KB/s) [21 of 35]
2024-07-24T21:50:31.0238452Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/ya-test.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/ya-test.html' (15917 bytes in 0.0 seconds, 937.59 KB/s) [22 of 35]
2024-07-24T21:50:31.0689795Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/junit_parts.xml.tar.gz' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/junit_parts.xml.tar.gz' (1422204 bytes in 0.0 seconds, 31.60 MB/s) [23 of 35]
2024-07-24T21:50:31.1376450Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/last_junit.xml' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/last_junit.xml' (38225 bytes in 0.1 seconds, 595.91 KB/s) [24 of 35]
2024-07-24T21:50:31.1627555Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' (6547 bytes in 0.0 seconds, 326.38 KB/s) [25 of 35]
2024-07-24T21:50:31.2005194Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' (9245 bytes in 0.0 seconds, 275.86 KB/s) [26 of 35]
2024-07-24T21:50:31.2341968Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/KqpScheme.AlterTableAddExplicitSyncVectorKMeansTreeIndex.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/KqpScheme.AlterTableAddExplicitSyncVectorKMeansTreeIndex.err' (8169 bytes in 0.0 seconds, 276.93 KB/s) [27 of 35]
2024-07-24T21:50:31.3008376Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/Balancing.Simple.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/Balancing.Simple.err' (1764086 bytes in 0.1 seconds, 28.26 MB/s) [28 of 35]
2024-07-24T21:50:31.3264007Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/QuoterWithKesusTest.PrefetchCoefficient.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/QuoterWithKesusTest.PrefetchCoefficient.err' (34004 bytes in 0.0 seconds, 1658.10 KB/s) [29 of 35]
2024-07-24T21:50:31.3590469Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' (243867 bytes in 0.0 seconds, 8.82 MB/s) [30 of 35]
2024-07-24T21:50:31.9195716Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/BasicUsage.ReadSessionCorrectClose.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/BasicUsage.ReadSessionCorrectClose.err' (24634621 bytes in 0.6 seconds, 42.45 MB/s) [31 of 35]
2024-07-24T21:50:31.9647394Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/TPersQueueTest.DirectReadCleanCache.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/TPersQueueTest.DirectReadCleanCache.err' (444060 bytes in 0.0 seconds, 10.87 MB/s) [32 of 35]
2024-07-24T21:50:32.0526824Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_evlog.jsonl' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_evlog.jsonl' (1720459 bytes in 0.1 seconds, 18.99 MB/s) [33 of 35]
2024-07-24T21:50:33.1392107Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_log.log' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_log.log' (34372109 bytes in 1.1 seconds, 30.21 MB/s) [34 of 35]
2024-07-24T21:50:34.8290196Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_make_output.log' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_make_output.log' (56150581 bytes in 1.7 seconds, 31.82 MB/s) [35 of 35]
2024-07-24T21:50:34.8292038Z Done. Uploaded 121363653 bytes in 4.4 seconds, 26.44 MB/s.
2024-07-24T21:50:34.8292806Z Stats: Number of files: 68 (236747165 bytes) 
2024-07-24T21:50:34.8293582Z Stats: Number of files transferred: 35 (121363653 bytes) 


2024-07-24T22:04:43.4939801Z + s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 /home/runner/actions_runner/_work/ydb/ydb/tmp/results/ s3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/
2024-07-24T22:04:43.4942172Z file-symlink /home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/TestStateFunc.StateFuncWithExceptions.err
2024-07-24T22:04:43.7399109Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/index.html' (16550 bytes in 0.0 seconds, 795.21 KB/s) [1 of 179]
2024-07-24T22:04:43.7630220Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/index.html' (12218 bytes in 0.0 seconds, 547.34 KB/s) [2 of 179]
2024-07-24T22:04:43.7930264Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/index.html' (12211 bytes in 0.0 seconds, 418.79 KB/s) [3 of 179]
2024-07-24T22:04:43.8129722Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/index.html' (14353 bytes in 0.0 seconds, 762.28 KB/s) [4 of 179]
2024-07-24T22:04:43.8385199Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/index.html' (12225 bytes in 0.0 seconds, 497.00 KB/s) [5 of 179]
2024-07-24T22:04:43.8590521Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/index.html' (12233 bytes in 0.0 seconds, 619.54 KB/s) [6 of 179]
2024-07-24T22:04:43.8868612Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/index.html' (12229 bytes in 0.0 seconds, 446.70 KB/s) [7 of 179]
2024-07-24T22:04:43.9071927Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 642.63 KB/s) [8 of 179]
2024-07-24T22:04:43.9262672Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/index.html' (14039 bytes in 0.0 seconds, 780.57 KB/s) [9 of 179]
2024-07-24T22:04:43.9475568Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/index.html' (12208 bytes in 0.0 seconds, 593.97 KB/s) [10 of 179]
2024-07-24T22:04:43.9651017Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/index.html' (13814 bytes in 0.0 seconds, 819.07 KB/s) [11 of 179]
2024-07-24T22:04:43.9955156Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/index.html' (12229 bytes in 0.0 seconds, 416.84 KB/s) [12 of 179]
2024-07-24T22:04:44.0234345Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/index.html' (12229 bytes in 0.0 seconds, 452.39 KB/s) [13 of 179]
2024-07-24T22:04:44.0521756Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 439.73 KB/s) [14 of 179]
2024-07-24T22:04:44.0883495Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/index.html' (12891 bytes in 0.0 seconds, 368.07 KB/s) [15 of 179]
2024-07-24T22:04:44.1077849Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/index.html' (12229 bytes in 0.0 seconds, 665.03 KB/s) [16 of 179]
2024-07-24T22:04:44.1304120Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/index.html' (12229 bytes in 0.0 seconds, 563.44 KB/s) [17 of 179]
2024-07-24T22:04:44.1589324Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 445.61 KB/s) [18 of 179]
2024-07-24T22:04:44.1798076Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/index.html' (12907 bytes in 0.0 seconds, 651.56 KB/s) [19 of 179]
2024-07-24T22:04:44.2026707Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/index.html' (12231 bytes in 0.0 seconds, 555.58 KB/s) [20 of 179]
2024-07-24T22:04:44.2229292Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/index.html' (12229 bytes in 0.0 seconds, 635.36 KB/s) [21 of 179]
2024-07-24T22:04:44.2422525Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 667.95 KB/s) [22 of 179]
2024-07-24T22:04:44.2625141Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scheme/test-results/unittest/testing_out_stuff/index.html' (12975 bytes in 0.0 seconds, 684.20 KB/s) [23 of 179]
2024-07-24T22:04:44.2888623Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/service/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/service/index.html' (12232 bytes in 0.0 seconds, 471.48 KB/s) [24 of 179]
2024-07-24T22:04:44.3161655Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/index.html' (12229 bytes in 0.0 seconds, 459.66 KB/s) [25 of 179]
2024-07-24T22:04:44.3373213Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 610.38 KB/s) [26 of 179]
2024-07-24T22:04:44.3713692Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/index.html' (12285 bytes in 0.0 seconds, 368.41 KB/s) [27 of 179]
2024-07-24T22:04:44.3909888Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/index.html' (12214 bytes in 0.0 seconds, 651.01 KB/s) [28 of 179]
2024-07-24T22:04:44.4202315Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/index.html' (12225 bytes in 0.0 seconds, 431.89 KB/s) [29 of 179]
2024-07-24T22:04:44.4480858Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/index.html' (12236 bytes in 0.0 seconds, 453.37 KB/s) [30 of 179]
2024-07-24T22:04:44.4757459Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/index.html' (12229 bytes in 0.0 seconds, 455.04 KB/s) [31 of 179]
2024-07-24T22:04:44.4939587Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 711.08 KB/s) [32 of 179]
2024-07-24T22:04:44.5182190Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/persqueue/ut/ut_with_sdk/test-results/unittest/testing_out_stuff/index.html' (12818 bytes in 0.0 seconds, 548.08 KB/s) [33 of 179]
2024-07-24T22:04:44.5392686Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/index.html' (12211 bytes in 0.0 seconds, 602.50 KB/s) [34 of 179]
2024-07-24T22:04:44.5675930Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/ut/index.html' (12227 bytes in 0.0 seconds, 442.47 KB/s) [35 of 179]
2024-07-24T22:04:44.5887494Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/index.html' (12229 bytes in 0.0 seconds, 613.01 KB/s) [36 of 179]
2024-07-24T22:04:44.6172859Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 441.69 KB/s) [37 of 179]
2024-07-24T22:04:44.6364115Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/quoter/ut/test-results/unittest/testing_out_stuff/index.html' (12909 bytes in 0.0 seconds, 710.18 KB/s) [38 of 179]
2024-07-24T22:04:44.6575837Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/index.html' (12252 bytes in 0.0 seconds, 608.37 KB/s) [39 of 179]
2024-07-24T22:04:44.6758518Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/index.html' (12246 bytes in 0.0 seconds, 713.48 KB/s) [40 of 179]
2024-07-24T22:04:44.6948531Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/index.html' (12229 bytes in 0.0 seconds, 680.80 KB/s) [41 of 179]
2024-07-24T22:04:44.7156527Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 609.58 KB/s) [42 of 179]
2024-07-24T22:04:44.7358097Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/index.html' (12287 bytes in 0.0 seconds, 642.17 KB/s) [43 of 179]
2024-07-24T22:04:44.7650786Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/index.html' (12221 bytes in 0.0 seconds, 427.15 KB/s) [44 of 179]
2024-07-24T22:04:44.7941746Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/index.html' (13823 bytes in 0.0 seconds, 488.93 KB/s) [45 of 179]
2024-07-24T22:04:44.8238827Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/actors/core/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/actors/core/index.html' (12209 bytes in 0.0 seconds, 426.69 KB/s) [46 of 179]
2024-07-24T22:04:44.8520819Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/actors/core/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/actors/core/ut/index.html' (12227 bytes in 0.0 seconds, 446.69 KB/s) [47 of 179]
2024-07-24T22:04:44.8735091Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/index.html' (12229 bytes in 0.0 seconds, 601.46 KB/s) [48 of 179]
2024-07-24T22:04:44.8920280Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 695.55 KB/s) [49 of 179]
2024-07-24T22:04:44.9124260Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/index.html' (12299 bytes in 0.0 seconds, 630.65 KB/s) [50 of 179]
2024-07-24T22:04:44.9424802Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/actors/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/actors/index.html' (12215 bytes in 0.0 seconds, 415.52 KB/s) [51 of 179]
2024-07-24T22:04:44.9685577Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/library/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/library/index.html' (12220 bytes in 0.0 seconds, 485.44 KB/s) [52 of 179]
2024-07-24T22:04:44.9905472Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/index.html' (12213 bytes in 0.0 seconds, 582.36 KB/s) [53 of 179]
2024-07-24T22:04:45.0091447Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/index.html' (12225 bytes in 0.0 seconds, 700.88 KB/s) [54 of 179]
2024-07-24T22:04:45.0702517Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/index.html' (12214 bytes in 0.1 seconds, 200.55 KB/s) [55 of 179]
2024-07-24T22:04:45.1140210Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/index.html' (12227 bytes in 0.0 seconds, 286.14 KB/s) [56 of 179]
2024-07-24T22:04:45.1360058Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/index.html' (12229 bytes in 0.0 seconds, 596.25 KB/s) [57 of 179]
2024-07-24T22:04:45.1567180Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 633.62 KB/s) [58 of 179]
2024-07-24T22:04:45.1762371Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_topic/ut/test-results/unittest/testing_out_stuff/index.html' (12892 bytes in 0.0 seconds, 703.62 KB/s) [59 of 179]
2024-07-24T22:04:45.1958566Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/cpp/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/cpp/index.html' (12216 bytes in 0.0 seconds, 654.04 KB/s) [60 of 179]
2024-07-24T22:04:45.2283591Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/public/sdk/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/public/sdk/index.html' (12210 bytes in 0.0 seconds, 383.76 KB/s) [61 of 179]
2024-07-24T22:04:45.2509783Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/index.html' (12233 bytes in 0.0 seconds, 572.97 KB/s) [62 of 179]
2024-07-24T22:04:45.2718218Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/index.html' (12217 bytes in 0.0 seconds, 625.57 KB/s) [63 of 179]
2024-07-24T22:04:45.2942330Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/index.html' (12227 bytes in 0.0 seconds, 569.07 KB/s) [64 of 179]
2024-07-24T22:04:45.3266306Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/index.html' (12229 bytes in 0.0 seconds, 387.30 KB/s) [65 of 179]
2024-07-24T22:04:45.3491921Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 570.69 KB/s) [66 of 179]
2024-07-24T22:04:45.3785863Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/services/persqueue_v1/ut/test-results/unittest/testing_out_stuff/index.html' (12895 bytes in 0.0 seconds, 452.41 KB/s) [67 of 179]
2024-07-24T22:04:45.4100303Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/index.html' (14931 bytes in 0.0 seconds, 486.83 KB/s) [68 of 179]
2024-07-24T22:04:45.4346872Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/test_artifacts/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/test_artifacts/index.html' (20287 bytes in 0.0 seconds, 882.91 KB/s) [69 of 179]
2024-07-24T22:04:45.4680872Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/index.html' (12218 bytes in 0.0 seconds, 375.37 KB/s) [70 of 179]
2024-07-24T22:04:45.4938569Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/index.html' (12211 bytes in 0.0 seconds, 498.51 KB/s) [71 of 179]
2024-07-24T22:04:45.5170425Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/index.html' (13277 bytes in 0.0 seconds, 602.22 KB/s) [72 of 179]
2024-07-24T22:04:45.5401742Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/index.html' (12225 bytes in 0.0 seconds, 547.18 KB/s) [73 of 179]
2024-07-24T22:04:45.5719626Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/index.html' (12233 bytes in 0.0 seconds, 394.24 KB/s) [74 of 179]
2024-07-24T22:04:45.6072234Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/index.html' (12229 bytes in 0.0 seconds, 354.39 KB/s) [75 of 179]
2024-07-24T22:04:45.6336047Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 483.73 KB/s) [76 of 179]
2024-07-24T22:04:45.6540220Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/index.html' (14039 bytes in 0.0 seconds, 713.11 KB/s) [77 of 179]
2024-07-24T22:04:45.7231202Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/index.html' (12208 bytes in 0.1 seconds, 177.01 KB/s) [78 of 179]
2024-07-24T22:04:45.7444541Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/index.html' (13279 bytes in 0.0 seconds, 665.54 KB/s) [79 of 179]
2024-07-24T22:04:45.7718381Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/olap/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/olap/index.html' (12229 bytes in 0.0 seconds, 463.14 KB/s) [80 of 179]
2024-07-24T22:04:45.7991886Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/index.html' (12229 bytes in 0.0 seconds, 464.75 KB/s) [81 of 179]
2024-07-24T22:04:45.8235656Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 526.49 KB/s) [82 of 179]
2024-07-24T22:04:45.8518128Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/index.html' (12891 bytes in 0.0 seconds, 473.76 KB/s) [83 of 179]
2024-07-24T22:04:45.8749725Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/scan/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/scan/index.html' (12229 bytes in 0.0 seconds, 556.23 KB/s) [84 of 179]
2024-07-24T22:04:45.9097603Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/index.html' (12229 bytes in 0.0 seconds, 360.37 KB/s) [85 of 179]
2024-07-24T22:04:45.9365834Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 474.69 KB/s) [86 of 179]
2024-07-24T22:04:45.9650966Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/index.html' (12907 bytes in 0.0 seconds, 471.47 KB/s) [87 of 179]
2024-07-24T22:04:45.9851040Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/service/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/service/index.html' (12232 bytes in 0.0 seconds, 641.92 KB/s) [88 of 179]
2024-07-24T22:04:46.0062594Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/index.html' (12229 bytes in 0.0 seconds, 606.19 KB/s) [89 of 179]
2024-07-24T22:04:46.0335350Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 461.51 KB/s) [90 of 179]
2024-07-24T22:04:46.0534075Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/index.html' (12285 bytes in 0.0 seconds, 654.51 KB/s) [91 of 179]
2024-07-24T22:04:46.0817937Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/datashard/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/datashard/index.html' (12252 bytes in 0.0 seconds, 443.34 KB/s) [92 of 179]
2024-07-24T22:04:46.1087655Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/index.html' (12246 bytes in 0.0 seconds, 470.91 KB/s) [93 of 179]
2024-07-24T22:04:46.1290123Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/index.html' (12229 bytes in 0.0 seconds, 641.57 KB/s) [94 of 179]
2024-07-24T22:04:46.1553012Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 479.77 KB/s) [95 of 179]
2024-07-24T22:04:46.1818011Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/index.html' (12287 bytes in 0.0 seconds, 482.35 KB/s) [96 of 179]
2024-07-24T22:04:46.2088824Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/index.html' (12221 bytes in 0.0 seconds, 463.06 KB/s) [97 of 179]
2024-07-24T22:04:46.2326967Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/index.html' (12749 bytes in 0.0 seconds, 561.38 KB/s) [98 of 179]
2024-07-24T22:04:46.2520503Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/actors/core/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/actors/core/index.html' (12209 bytes in 0.0 seconds, 663.84 KB/s) [99 of 179]
2024-07-24T22:04:46.2698825Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/actors/core/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/actors/core/ut/index.html' (12227 bytes in 0.0 seconds, 728.11 KB/s) [100 of 179]
2024-07-24T22:04:46.3929775Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/index.html' (12229 bytes in 0.1 seconds, 98.17 KB/s) [101 of 179]
2024-07-24T22:04:46.4122995Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 689.44 KB/s) [102 of 179]
2024-07-24T22:04:46.4410041Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/index.html' (12299 bytes in 0.0 seconds, 441.39 KB/s) [103 of 179]
2024-07-24T22:04:46.4591521Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/actors/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/actors/index.html' (12215 bytes in 0.0 seconds, 712.89 KB/s) [104 of 179]
2024-07-24T22:04:46.4870096Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/library/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/library/index.html' (12220 bytes in 0.0 seconds, 451.27 KB/s) [105 of 179]
2024-07-24T22:04:46.5076834Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/index.html' (14922 bytes in 0.0 seconds, 761.96 KB/s) [106 of 179]
2024-07-24T22:04:46.5285161Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/test_artifacts/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/test_artifacts/index.html' (15705 bytes in 0.0 seconds, 790.12 KB/s) [107 of 179]
2024-07-24T22:04:46.5495835Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/index.html' (12218 bytes in 0.0 seconds, 607.18 KB/s) [108 of 179]
2024-07-24T22:04:46.5732297Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/index.html' (12211 bytes in 0.0 seconds, 539.03 KB/s) [109 of 179]
2024-07-24T22:04:46.5935452Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/index.html' (13277 bytes in 0.0 seconds, 686.06 KB/s) [110 of 179]
2024-07-24T22:04:46.6299121Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/index.html' (12225 bytes in 0.0 seconds, 343.33 KB/s) [111 of 179]
2024-07-24T22:04:46.6581427Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/index.html' (12233 bytes in 0.0 seconds, 448.86 KB/s) [112 of 179]
2024-07-24T22:04:46.6783424Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/index.html' (12229 bytes in 0.0 seconds, 641.94 KB/s) [113 of 179]
2024-07-24T22:04:46.6981011Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 652.23 KB/s) [114 of 179]
2024-07-24T22:04:46.7275110Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadHuge.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadHuge.err' (1033 bytes in 0.0 seconds, 40.08 KB/s) [115 of 179]
2024-07-24T22:04:46.7493784Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadSmall.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.ReadSmall.err' (1034 bytes in 0.0 seconds, 56.54 KB/s) [116 of 179]
2024-07-24T22:04:46.7788175Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteHuge.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteHuge.err' (1144 bytes in 0.0 seconds, 43.33 KB/s) [117 of 179]
2024-07-24T22:04:46.8009343Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteSmall.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/TKeyValueTracingTest.WriteSmall.err' (1145 bytes in 0.0 seconds, 61.48 KB/s) [118 of 179]
2024-07-24T22:04:46.8292106Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/keyvalue/ut_trace/test-results/unittest/testing_out_stuff/index.html' (14039 bytes in 0.0 seconds, 507.72 KB/s) [119 of 179]
2024-07-24T22:04:46.8507791Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/index.html' (12208 bytes in 0.0 seconds, 596.19 KB/s) [120 of 179]
2024-07-24T22:04:46.8701186Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/index.html' (13279 bytes in 0.0 seconds, 718.52 KB/s) [121 of 179]
2024-07-24T22:04:46.8900330Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/olap/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/olap/index.html' (12229 bytes in 0.0 seconds, 642.02 KB/s) [122 of 179]
2024-07-24T22:04:46.9089925Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/index.html' (12229 bytes in 0.0 seconds, 686.36 KB/s) [123 of 179]
2024-07-24T22:04:46.9277370Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 687.45 KB/s) [124 of 179]
2024-07-24T22:04:46.9566229Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' (6311 bytes in 0.0 seconds, 250.16 KB/s) [125 of 179]
﻿2024-07-24T22:04:46.9927671Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.out' (100 bytes in 0.0 seconds, 2.93 KB/s) [126 of 179]
2024-07-24T22:04:47.0130731Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/index.html' (12891 bytes in 0.0 seconds, 673.50 KB/s) [127 of 179]
2024-07-24T22:04:47.0314938Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/scan/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/scan/index.html' (12229 bytes in 0.0 seconds, 694.71 KB/s) [128 of 179]
2024-07-24T22:04:47.0532973Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/index.html' (12229 bytes in 0.0 seconds, 584.26 KB/s) [129 of 179]
2024-07-24T22:04:47.0736356Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 629.72 KB/s) [130 of 179]
2024-07-24T22:04:47.0992495Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' (9242 bytes in 0.0 seconds, 427.02 KB/s) [131 of 179]
2024-07-24T22:04:47.1292192Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.out' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.out' (100 bytes in 0.0 seconds, 3.59 KB/s) [132 of 179]
2024-07-24T22:04:47.1483323Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/index.html' (12907 bytes in 0.0 seconds, 711.03 KB/s) [133 of 179]
2024-07-24T22:04:47.1688035Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/service/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/service/index.html' (12232 bytes in 0.0 seconds, 630.20 KB/s) [134 of 179]
2024-07-24T22:04:47.2065111Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/index.html' (12229 bytes in 0.0 seconds, 327.82 KB/s) [135 of 179]
2024-07-24T22:04:47.2285886Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 589.10 KB/s) [136 of 179]
2024-07-24T22:04:47.2747415Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/KqpService.CloseSessionsWithLoad.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/KqpService.CloseSessionsWithLoad.err' (1063 bytes in 0.0 seconds, 24.70 KB/s) [137 of 179]
2024-07-24T22:04:47.2942774Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/kqp/ut/service/test-results/unittest/testing_out_stuff/index.html' (12285 bytes in 0.0 seconds, 672.37 KB/s) [138 of 179]
2024-07-24T22:04:47.3134236Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/tx/datashard/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/datashard/index.html' (12252 bytes in 0.0 seconds, 668.69 KB/s) [139 of 179]
2024-07-24T22:04:47.3431598Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/index.html' (12246 bytes in 0.0 seconds, 417.94 KB/s) [140 of 179]
2024-07-24T22:04:47.3641464Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/index.html' (12229 bytes in 0.0 seconds, 620.41 KB/s) [141 of 179]
2024-07-24T22:04:47.3841624Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 649.01 KB/s) [142 of 179]
2024-07-24T22:04:47.4153030Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' (243868 bytes in 0.0 seconds, 9.10 MB/s) [143 of 179]
2024-07-24T22:04:47.4419116Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/index.html' (12287 bytes in 0.0 seconds, 475.65 KB/s) [144 of 179]
2024-07-24T22:04:47.4683724Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/core/tx/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/index.html' (12221 bytes in 0.0 seconds, 473.22 KB/s) [145 of 179]
2024-07-24T22:04:47.4860197Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/index.html' (12749 bytes in 0.0 seconds, 776.90 KB/s) [146 of 179]
2024-07-24T22:04:47.5147424Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/core/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/actors/core/index.html' (12209 bytes in 0.0 seconds, 436.09 KB/s) [147 of 179]
2024-07-24T22:04:47.5333360Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/core/ut/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/actors/core/ut/index.html' (12227 bytes in 0.0 seconds, 698.17 KB/s) [148 of 179]
2024-07-24T22:04:47.5533322Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/index.html' (12229 bytes in 0.0 seconds, 643.04 KB/s) [149 of 179]
2024-07-24T22:04:47.5787672Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/index.html' (12243 bytes in 0.0 seconds, 495.73 KB/s) [150 of 179]
2024-07-24T22:04:47.6119938Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/TestStateFunc.StateFuncWithExceptions.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/TestStateFunc.StateFuncWithExceptions.err' (951 bytes in 0.0 seconds, 31.64 KB/s) [151 of 179]
2024-07-24T22:04:47.6321261Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/actors/core/ut/test-results/unittest/testing_out_stuff/index.html' (12299 bytes in 0.0 seconds, 647.00 KB/s) [152 of 179]
2024-07-24T22:04:47.6502311Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/actors/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/actors/index.html' (12215 bytes in 0.0 seconds, 714.01 KB/s) [153 of 179]
2024-07-24T22:04:47.6681466Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/artifacts/logs/ydb/library/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/artifacts/logs/ydb/library/index.html' (12220 bytes in 0.0 seconds, 710.83 KB/s) [154 of 179]
2024-07-24T22:04:47.6924209Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/failed_count.txt' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/failed_count.txt' (1 bytes in 0.0 seconds, 42.13 B/s) [155 of 179]
2024-07-24T22:04:47.7133415Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/index.html' (14922 bytes in 0.0 seconds, 747.30 KB/s) [156 of 179]
2024-07-24T22:04:47.7366813Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/junit.xml' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/junit.xml' (36749 bytes in 0.0 seconds, 1986.22 KB/s) [157 of 179]
2024-07-24T22:04:47.7545915Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/orig_junit.xml.gz' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/orig_junit.xml.gz' (4549 bytes in 0.0 seconds, 257.35 KB/s) [158 of 179]
2024-07-24T22:04:47.7818041Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/index.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/index.html' (15705 bytes in 0.0 seconds, 593.68 KB/s) [159 of 179]
2024-07-24T22:04:47.7992334Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/ydb-core-keyvalue-ut_trace.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/ydb-core-keyvalue-ut_trace.zip' (9571 bytes in 0.0 seconds, 553.81 KB/s) [160 of 179]
2024-07-24T22:04:47.8171974Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/ydb-core-kqp-ut-olap.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/ydb-core-kqp-ut-olap.zip' (30421 bytes in 0.0 seconds, 1740.21 KB/s) [161 of 179]
2024-07-24T22:04:47.8367047Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/ydb-core-kqp-ut-scan.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/ydb-core-kqp-ut-scan.zip' (18463 bytes in 0.0 seconds, 950.28 KB/s) [162 of 179]
2024-07-24T22:04:47.8565055Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/ydb-core-kqp-ut-service.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/ydb-core-kqp-ut-service.zip' (15161 bytes in 0.0 seconds, 770.64 KB/s) [163 of 179]
2024-07-24T22:04:47.8893402Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/ydb-core-tx-datashard-ut_incremental_backup.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/ydb-core-tx-datashard-ut_incremental_backup.zip' (90853 bytes in 0.0 seconds, 2.70 MB/s) [164 of 179]
2024-07-24T22:04:47.9221751Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/ydb-library-actors-core-ut.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/ydb-library-actors-core-ut.zip' (7379 bytes in 0.0 seconds, 223.76 KB/s) [165 of 179]
2024-07-24T22:04:47.9422817Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/test_artifacts/ydb-tests-fq-yt-kqp_yt_file-part18.zip' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/test_artifacts/ydb-tests-fq-yt-kqp_yt_file-part18.zip' (17417 bytes in 0.0 seconds, 888.21 KB/s) [166 of 179]
2024-07-24T22:04:47.9627039Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_3/ya-test.html' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_3/ya-test.html' (13203 bytes in 0.0 seconds, 691.46 KB/s) [167 of 179]
2024-07-24T22:04:48.0248438Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/junit_parts.xml.tar.gz' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/junit_parts.xml.tar.gz' (1423639 bytes in 0.1 seconds, 22.67 MB/s) [168 of 179]
2024-07-24T22:04:48.0591156Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/last_junit.xml' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/last_junit.xml' (36749 bytes in 0.0 seconds, 1258.63 KB/s) [169 of 179]
2024-07-24T22:04:48.0829724Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/summary_links.txt' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/summary_links.txt' (332 bytes in 0.0 seconds, 15.29 KB/s) [170 of 179]
2024-07-24T22:04:48.1087235Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' (6311 bytes in 0.0 seconds, 291.95 KB/s) [171 of 179]
2024-07-24T22:04:48.1456277Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' (9242 bytes in 0.0 seconds, 279.18 KB/s) [172 of 179]
2024-07-24T22:04:48.1792490Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' (243868 bytes in 0.0 seconds, 8.23 MB/s) [173 of 179]
2024-07-24T22:04:48.2041073Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/olap/test-results/unittest/testing_out_stuff/KqpOlapStatistics.StatsUsageWithTTL.err' (6311 bytes in 0.0 seconds, 306.95 KB/s) [174 of 179]
2024-07-24T22:04:48.2395306Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/kqp/ut/scan/test-results/unittest/testing_out_stuff/KqpRequestContext.TraceIdInErrorMessage.err' (9242 bytes in 0.0 seconds, 295.19 KB/s) [175 of 179]
2024-07-24T22:04:48.2819401Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/datashard/ut_incremental_backup/test-results/unittest/testing_out_stuff/IncrementalBackup.BackupRestore.err' (243868 bytes in 0.0 seconds, 6.29 MB/s) [176 of 179]
2024-07-24T22:04:48.3619958Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_evlog.jsonl' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_evlog.jsonl' (1498952 bytes in 0.1 seconds, 18.12 MB/s) [177 of 179]
2024-07-24T22:04:49.6015762Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_log.log' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_log.log' (36470626 bytes in 1.2 seconds, 28.09 MB/s) [178 of 179]
2024-07-24T22:04:51.1374434Z upload: '/home/runner/actions_runner/_work/ydb/ydb/tmp/results/ya_make_output.log' -> 's3://ydb-gh-logs/ydb-platform/ydb/PR-check/10082089177/ya-x86-64/ya_make_output.log' (56329663 bytes in 1.5 seconds, 35.12 MB/s) [179 of 179]
2024-07-24T22:04:51.1376062Z Done. Uploaded 98613103 bytes in 7.4 seconds, 12.67 MB/s.
2024-07-24T22:04:51.1376749Z Stats: Number of files: 235 (241137168 bytes) 
2024-07-24T22:04:51.1377431Z Stats: Number of files transferred: 179 (98613103 bytes) 



```

