### PR TITLE
Remove arm64 cmake nightly

### DIFF
--- a/.github/workflows/nightly_run.yaml
+++ b/.github/workflows/nightly_run.yaml
@@ -17,18 +17,6 @@ jobs:
       sanitizer: ${{matrix.sanitizer}}
     secrets: inherit
 
-  cmake_arm64:
-    name: Build/test ARM64
-    strategy:
-      matrix: ${{ fromJSON(vars.NIGHTLY_CMAKE_ARM64_MATRIX) }}
-      fail-fast: false
-    uses: ./.github/workflows/build_and_test_provisioned.yml
-    with:
-      runner_label: ARM64
-      sanitizer: ${{matrix.sanitizer}}
-      extra_compile_flags: "-DMKQL_DISABLE_CODEGEN"
-    secrets: inherit
-
   ya_x86_64:
     name: Build/test x86_64 using YA
     uses: ./.github/workflows/build_and_test_ya_provisioned.yml


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

I have no idea why do we need that

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
