### PR TITLE
Use EvRead-based table reading in datashard_ut_write test

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -478,7 +478,7 @@ struct TTestHelper {
 
         return ::NKikimr::GetBaseReadRequest(
             table.TableId,
-            table.UserTable,
+            table.UserTable.GetDescription(),
             readId,
             format,
             readVersion

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -280,42 +280,6 @@ void CheckContinuationToken(
     CheckRow(lastKey.GetCells(), goldRow, types);
 }
 
-template <typename TKeyType>
-TVector<TCell> ToCells(const std::vector<TKeyType>& keys) {
-    TVector<TCell> cells;
-    for (auto& key: keys) {
-        cells.emplace_back(TCell::Make(key));
-    }
-    return cells;
-}
-
-void AddKeyQuery(
-    TEvDataShard::TEvRead& request,
-    const std::vector<ui32>& keys)
-{
-    // convertion is ugly, but for tests is OK
-    auto cells = ToCells(keys);
-    request.Keys.emplace_back(cells);
-}
-
-template <typename TCellType>
-void AddRangeQuery(
-    TEvDataShard::TEvRead& request,
-    std::vector<TCellType> from,
-    bool fromInclusive,
-    std::vector<TCellType> to,
-    bool toInclusive)
-{
-    auto fromCells = ToCells(from);
-    auto toCells = ToCells(to);
-
-    // convertion is ugly, but for tests is OK
-    auto fromBuf = TSerializedCellVec::Serialize(fromCells);
-    auto toBuf = TSerializedCellVec::Serialize(toCells);
-
-    request.Ranges.emplace_back(fromBuf, toBuf, fromInclusive, toInclusive);
-}
-
 struct TTableInfo {
     TString Name;
 
@@ -502,20 +466,6 @@ struct TTestHelper {
     {
         const auto& table = Tables[tableName];
 
-        std::unique_ptr<TEvDataShard::TEvRead> request(new TEvDataShard::TEvRead());
-        auto& record = request->Record;
-
-        record.SetReadId(readId);
-        record.MutableTableId()->SetOwnerId(table.TableId.PathId.OwnerId);
-        record.MutableTableId()->SetTableId(table.UserTable.GetPathId());
-
-        const auto& description = table.UserTable.GetDescription();
-        for (const auto& column: description.GetColumns()) {
-            record.AddColumns(column.GetId());
-        }
-
-        record.MutableTableId()->SetSchemaVersion(description.GetTableSchemaVersion());
-
         TRowVersion readVersion;
         if (!snapshot) {
             readVersion = CreateVolatileSnapshot(
@@ -526,12 +476,13 @@ struct TTestHelper {
             readVersion = snapshot;
         }
 
-        record.MutableSnapshot()->SetStep(readVersion.Step);
-        record.MutableSnapshot()->SetTxId(readVersion.TxId);
-
-        record.SetResultFormat(format);
-
-        return request;
+        return ::NKikimr::GetBaseReadRequest(
+            table.TableId,
+            table.UserTable,
+            readId,
+            format,
+            readVersion
+        );
     }
 
     std::unique_ptr<TEvDataShard::TEvRead> GetUserTablesRequest(
@@ -558,14 +509,7 @@ struct TTestHelper {
     }
 
     std::unique_ptr<TEvDataShard::TEvReadResult> WaitReadResult(TDuration timeout = TDuration::Max()) {
-        auto &runtime = *Server->GetRuntime();
-        TAutoPtr<IEventHandle> handle;
-        runtime.GrabEdgeEventRethrow<TEvDataShard::TEvReadResult>(handle, timeout);
-        if (!handle) {
-            return nullptr;
-        }
-        std::unique_ptr<TEvDataShard::TEvReadResult> event(handle->Release<TEvDataShard::TEvReadResult>().Release());
-        return event;
+        return ::NKikimr::WaitReadResult(Server, timeout);
     }
 
     void SendReadAsync(
@@ -579,14 +523,15 @@ struct TTestHelper {
         }
 
         const auto& table = Tables[tableName];
-        auto &runtime = *Server->GetRuntime();
-        runtime.SendToPipe(
+        ::NKikimr::SendReadAsync(
+            Server,
             table.TabletId,
-            sender,
             request,
+            sender,
             node,
             GetTestPipeConfig(),
-            table.ClientId);
+            table.ClientId
+        );
     }
 
     std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(
@@ -596,9 +541,21 @@ struct TTestHelper {
         TActorId sender = {},
         TDuration timeout = TDuration::Max())
     {
-        SendReadAsync(tableName, request, node, sender);
+        if (!sender) {
+            sender = Sender;
+        }
 
-        return WaitReadResult(timeout);
+        const auto& table = Tables[tableName];
+        return ::NKikimr::SendRead(
+            Server,
+            table.TabletId,
+            request,
+            sender,
+            node,
+            GetTestPipeConfig(),
+            table.ClientId,
+            timeout
+        );
     }
 
     void SendReadAck(

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -1,5 +1,4 @@
 #include "datashard_active_transaction.h"
-#include "datashard_ut_read_table.h"
 #include <ydb/core/tx/data_events/payload_helper.h>
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 #include <ydb/core/base/tablet_pipecache.h>
@@ -11,7 +10,6 @@ using namespace NKikimr::NDataShard;
 using namespace NKikimr::NDataShard::NKqpHelpers;
 using namespace NSchemeShard;
 using namespace Tests;
-using namespace NDataShardReadTableTest;
 
 Y_UNIT_TEST_SUITE(DataShardWrite) {
     const TString expectedTableState = "key = 0, value = 1\nkey = 2, value = 3\nkey = 4, value = 5\n";
@@ -52,7 +50,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -78,8 +76,8 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read tables =========\n";
         {
-            auto tableState1 = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
-            auto tableState2 = TReadTableState(server, MakeReadTableSettings("/Root/table-2")).All();
+            auto tableState1 = ReadTable(server, shards1.at(0), "table-1", tableId1, 1);
+            auto tableState2 = ReadTable(server, shards2.at(0), "table-2", tableId2, 2);
             UNIT_ASSERT_VALUES_EQUAL(tableState1, "key = 0, value = 1\n");
             UNIT_ASSERT_VALUES_EQUAL(tableState2, "key = 2, value = 3\n");
         }
@@ -111,7 +109,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -134,7 +132,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 0, key32 = 1, value64 = 2, value32 = 3, valueUtf8 = String_4\n"
                                                  "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
@@ -147,7 +145,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
         }
@@ -231,7 +229,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -252,7 +250,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -272,7 +270,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }   
@@ -303,7 +301,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -353,7 +351,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 0, value = NULL\n");
         }
     }
@@ -384,7 +382,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -396,7 +394,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -418,7 +416,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "");
         }         
 
@@ -429,7 +427,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -440,7 +438,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 3);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 0, value = 555\nkey = 2, value = 3\nkey = 4, value = 5\n");
         }
 
@@ -460,7 +458,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 4);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -522,7 +520,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/" + tableName)).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -629,9 +627,9 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read from tables" << Endl;
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/" + tableName1)).All();
+            auto tableState = ReadTable(server, shards1.at(0), tableName1, tableId1, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
-            tableState = TReadTableState(server, MakeReadTableSettings("/Root/"+ tableName2)).All();
+            tableState = ReadTable(server, shards2.at(0), tableName2, tableId2, 2);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -677,7 +675,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -702,7 +700,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+            auto tableState = ReadTable(server, shards.at(0), tableName, tableId, 1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -749,7 +747,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = TReadTableState(server, MakeReadTableSettings("/Root/" + tableName)).All();
+            auto tableState = ReadTable(server, shards.at(0), tableName, tableId, 2);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -50,7 +50,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -76,8 +76,8 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read tables =========\n";
         {
-            auto tableState1 = ReadTable(server, shards1, "table-1", tableId1, 1000);
-            auto tableState2 = ReadTable(server, shards2, "table-2", tableId2, 2000);
+            auto tableState1 = ReadTable(server, shards1, tableId1, 1000);
+            auto tableState2 = ReadTable(server, shards2, tableId2, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState1, "key = 0, value = 1\n");
             UNIT_ASSERT_VALUES_EQUAL(tableState2, "key = 2, value = 3\n");
         }
@@ -109,7 +109,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 0, key32 = 1, value64 = 2, value32 = 3, valueUtf8 = String_4\n"
                                                  "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
@@ -145,7 +145,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
         }
@@ -229,7 +229,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -250,7 +250,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -270,7 +270,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }   
@@ -301,7 +301,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -351,7 +351,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 0, value = NULL\n");
         }
     }
@@ -382,7 +382,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -394,7 +394,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -416,7 +416,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "");
         }         
 
@@ -427,7 +427,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -438,7 +438,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 3000);
+            auto tableState = ReadTable(server, shards, tableId, 3000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 0, value = 555\nkey = 2, value = 3\nkey = 4, value = 5\n");
         }
 
@@ -458,7 +458,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 4000);
+            auto tableState = ReadTable(server, shards, tableId, 4000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -520,7 +520,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -627,9 +627,9 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read from tables" << Endl;
         {
-            auto tableState = ReadTable(server, shards1, tableName1, tableId1, 1000);
+            auto tableState = ReadTable(server, shards1, tableId1, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
-            tableState = ReadTable(server, shards2, tableName2, tableId2, 2000);
+            tableState = ReadTable(server, shards2, tableId2, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -675,7 +675,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -700,7 +700,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableName, tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -747,7 +747,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableName, tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }
@@ -977,7 +977,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cerr << "========= Checking table =========" << Endl;
         {
-            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState,
                 "key = 1, value = 11\n"
                 "key = 11, value = 111\n"
@@ -1021,7 +1021,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cerr << "========= Checking table =========" << Endl;
         {
-            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "");
         }
     }
@@ -1062,7 +1062,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cerr << "========= Checking table =========" << Endl;
         {
-            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "");
         }
     }
@@ -1147,7 +1147,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cerr << "========= Checking table =========" << Endl;
         {
-            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState,
                 "key = 1, value = 11\n"
                 "key = 11, value = 111\n"
@@ -1237,7 +1237,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cerr << "========= Checking table =========" << Endl;
         {
-            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "");
         }
     }

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -76,8 +76,8 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read tables =========\n";
         {
-            auto tableState1 = ReadTable(server, shards1, tableId1, 1000);
-            auto tableState2 = ReadTable(server, shards2, tableId2, 2000);
+            auto tableState1 = ReadTable(server, shards1, tableId1);
+            auto tableState2 = ReadTable(server, shards2, tableId2);
             UNIT_ASSERT_VALUES_EQUAL(tableState1, "key = 0, value = 1\n");
             UNIT_ASSERT_VALUES_EQUAL(tableState2, "key = 2, value = 3\n");
         }
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 0, key32 = 1, value64 = 2, value32 = 3, valueUtf8 = String_4\n"
                                                  "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
@@ -145,7 +145,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
         }
@@ -250,7 +250,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -270,7 +270,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }   
@@ -382,7 +382,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -394,7 +394,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -416,7 +416,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "");
         }         
 
@@ -427,7 +427,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -438,7 +438,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 3000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 0, value = 555\nkey = 2, value = 3\nkey = 4, value = 5\n");
         }
 
@@ -458,7 +458,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 4000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -627,9 +627,9 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read from tables" << Endl;
         {
-            auto tableState = ReadTable(server, shards1, tableId1, 1000);
+            auto tableState = ReadTable(server, shards1, tableId1);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
-            tableState = ReadTable(server, shards2, tableId2, 2000);
+            tableState = ReadTable(server, shards2, tableId2);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -700,7 +700,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 1000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -747,7 +747,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards, tableId, 2000);
+            auto tableState = ReadTable(server, shards, tableId);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -50,7 +50,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -76,8 +76,8 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read tables =========\n";
         {
-            auto tableState1 = ReadTable(server, shards1.at(0), "table-1", tableId1, 1);
-            auto tableState2 = ReadTable(server, shards2.at(0), "table-2", tableId2, 2);
+            auto tableState1 = ReadTable(server, shards1, "table-1", tableId1, 1000);
+            auto tableState2 = ReadTable(server, shards2, "table-2", tableId2, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState1, "key = 0, value = 1\n");
             UNIT_ASSERT_VALUES_EQUAL(tableState2, "key = 2, value = 3\n");
         }
@@ -109,7 +109,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -132,7 +132,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 0, key32 = 1, value64 = 2, value32 = 3, valueUtf8 = String_4\n"
                                                  "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
@@ -145,7 +145,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key64 = 5, key32 = 6, value64 = 7, value32 = 8, valueUtf8 = String_9\n"
                                                  "key64 = 10, key32 = 11, value64 = 12, value32 = 13, valueUtf8 = String_14\n");
         }
@@ -229,7 +229,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -250,7 +250,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -270,7 +270,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table with 1th row deleted =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }   
@@ -301,7 +301,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -351,7 +351,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 0, value = NULL\n");
         }
     }
@@ -382,7 +382,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -394,7 +394,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }    
@@ -416,7 +416,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "");
         }         
 
@@ -427,7 +427,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 2);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -438,7 +438,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 3);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 3000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 0, value = 555\nkey = 2, value = 3\nkey = 4, value = 5\n");
         }
 
@@ -458,7 +458,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 4);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 4000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -520,7 +520,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -627,9 +627,9 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read from tables" << Endl;
         {
-            auto tableState = ReadTable(server, shards1.at(0), tableName1, tableId1, 1);
+            auto tableState = ReadTable(server, shards1, tableName1, tableId1, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
-            tableState = ReadTable(server, shards2.at(0), tableName2, tableId2, 2);
+            tableState = ReadTable(server, shards2, tableName2, tableId2, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
     }
@@ -675,7 +675,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), "table-1", tableId, 1);
+            auto tableState = ReadTable(server, shards, "table-1", tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -700,7 +700,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), tableName, tableId, 1);
+            auto tableState = ReadTable(server, shards, tableName, tableId, 1000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, expectedTableState);
         }
 
@@ -747,7 +747,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
 
         Cout << "========= Read table =========\n";
         {
-            auto tableState = ReadTable(server, shards.at(0), tableName, tableId, 2);
+            auto tableState = ReadTable(server, shards, tableName, tableId, 2000);
             UNIT_ASSERT_VALUES_EQUAL(tableState, "key = 2, value = 3\nkey = 4, value = 5\n");
         }
     }
@@ -976,15 +976,14 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
             /* expectedReadSets */ 6 + 3 * 2);
 
         Cerr << "========= Checking table =========" << Endl;
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table`
-                ORDER BY key;
-            )"),
-            "{ items { int32_value: 1 } items { int32_value: 11 } }, "
-            "{ items { int32_value: 11 } items { int32_value: 111 } }, "
-            "{ items { int32_value: 21 } items { int32_value: 211 } }, "
-            "{ items { int32_value: 31 } items { int32_value: 311 } }");
+        {
+            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            UNIT_ASSERT_VALUES_EQUAL(tableState,
+                "key = 1, value = 11\n"
+                "key = 11, value = 111\n"
+                "key = 21, value = 211\n"
+                "key = 31, value = 311\n");
+        }
     }
 
     Y_UNIT_TEST(UpsertLostPrepareArbiter) {
@@ -1021,12 +1020,10 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         }
 
         Cerr << "========= Checking table =========" << Endl;
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table`
-                ORDER BY key;
-            )"),
-            "");
+        {
+            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            UNIT_ASSERT_VALUES_EQUAL(tableState, "");
+        }
     }
 
     Y_UNIT_TEST(UpsertBrokenLockArbiter) {
@@ -1064,12 +1061,10 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         }
 
         Cerr << "========= Checking table =========" << Endl;
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table`
-                ORDER BY key;
-            )"),
-            "");
+        {
+            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            UNIT_ASSERT_VALUES_EQUAL(tableState, "");
+        }
     }
 
     Y_UNIT_TEST(UpsertNoLocksArbiterRestart) {
@@ -1151,15 +1146,14 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         runtime.SimulateSleep(TDuration::Seconds(1));
 
         Cerr << "========= Checking table =========" << Endl;
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table`
-                ORDER BY key;
-            )"),
-            "{ items { int32_value: 1 } items { int32_value: 11 } }, "
-            "{ items { int32_value: 11 } items { int32_value: 111 } }, "
-            "{ items { int32_value: 21 } items { int32_value: 211 } }, "
-            "{ items { int32_value: 31 } items { int32_value: 311 } }");
+        {
+            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            UNIT_ASSERT_VALUES_EQUAL(tableState,
+                "key = 1, value = 11\n"
+                "key = 11, value = 111\n"
+                "key = 21, value = 211\n"
+                "key = 31, value = 311\n");
+        }
     }
 
     Y_UNIT_TEST(UpsertLostPrepareArbiterRestart) {
@@ -1242,12 +1236,10 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         runtime.SimulateSleep(TDuration::Seconds(1));
 
         Cerr << "========= Checking table =========" << Endl;
-        UNIT_ASSERT_VALUES_EQUAL(
-            KqpSimpleExec(runtime, R"(
-                SELECT key, value FROM `/Root/table`
-                ORDER BY key;
-            )"),
-            "");
+        {
+            auto tableState = ReadTable(server, shards, "table", tableId, 1000);
+            UNIT_ASSERT_VALUES_EQUAL(tableState, "");
+        }
     }
 
 } // Y_UNIT_TEST_SUITE

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -536,9 +536,13 @@ NKikimrTxDataShard::TEvCompactBorrowedResult CompactBorrowed(
     TTestActorRuntime& runtime, ui64 shardId, const TTableId& tableId);
 
 using TTableInfoMap = THashMap<TString, NKikimrTxDataShard::TEvGetInfoResponse::TUserTable>;
+using TTableInfoByPathIdMap = THashMap<TPathId, NKikimrTxDataShard::TEvGetInfoResponse::TUserTable>;
 
 std::pair<TTableInfoMap, ui64> GetTables(Tests::TServer::TPtr server,
                                          ui64 tabletId);
+
+std::pair<TTableInfoByPathIdMap, ui64> GetTablesByPathId(Tests::TServer::TPtr server,
+                                                         ui64 tabletId);
 
 TTableId ResolveTableId(
         Tests::TServer::TPtr server,
@@ -936,8 +940,7 @@ std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(
 TString ReadTable(
     Tests::TServer::TPtr server,
     std::span<const ui64> tabletIds,
-    const TString& tableName,
     const TTableId& tableId,
-    ui64 startReadId);
+    ui64 startReadId = 1000);
 
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -870,11 +870,74 @@ void SendViaPipeCache(
     std::unique_ptr<IEventBase> msg,
     const TSendViaPipeCacheOptions& options = {});
 
-TString ReadTable(
+template <typename TKeyType>
+TVector<TCell> ToCells(const std::vector<TKeyType>& keys) {
+    TVector<TCell> cells;
+    for (auto& key: keys) {
+        cells.emplace_back(TCell::Make(key));
+    }
+    return cells;
+}
+
+void AddKeyQuery(
+    TEvDataShard::TEvRead& request,
+    const std::vector<ui32>& keys);
+
+template <typename TCellType>
+void AddRangeQuery(
+    TEvDataShard::TEvRead& request,
+    std::vector<TCellType> from,
+    bool fromInclusive,
+    std::vector<TCellType> to,
+    bool toInclusive)
+{
+    auto fromCells = ToCells(from);
+    auto toCells = ToCells(to);
+
+    // convertion is ugly, but for tests is OK
+    auto fromBuf = TSerializedCellVec::Serialize(fromCells);
+    auto toBuf = TSerializedCellVec::Serialize(toCells);
+
+    request.Ranges.emplace_back(fromBuf, toBuf, fromInclusive, toInclusive);
+}
+
+void AddFullRangeQuery(TEvDataShard::TEvRead& request);
+
+std::unique_ptr<TEvDataShard::TEvRead> GetBaseReadRequest(
+    const TTableId& tableId,
+    const NKikimrTxDataShard::TEvGetInfoResponse::TUserTable& userTable,
+    ui64 readId,
+    NKikimrDataEvents::EDataFormat format = NKikimrDataEvents::FORMAT_ARROW,
+    const TRowVersion& readVersion = {});
+
+std::unique_ptr<TEvDataShard::TEvReadResult> WaitReadResult(
+    Tests::TServer::TPtr server,
+    TDuration timeout = TDuration::Max());
+
+void SendReadAsync(
     Tests::TServer::TPtr server,
     ui64 tabletId,
+    TEvDataShard::TEvRead* request,
+    TActorId sender,
+    ui32 node = 0,
+    const NTabletPipe::TClientConfig& clientConfig = GetPipeConfigWithRetries(),
+    TActorId clientId = {});
+
+std::unique_ptr<TEvDataShard::TEvReadResult> SendRead(
+    Tests::TServer::TPtr server,
+    ui64 tabletId,
+    TEvDataShard::TEvRead* request,
+    TActorId sender,
+    ui32 node = 0,
+    const NTabletPipe::TClientConfig& clientConfig = GetPipeConfigWithRetries(),
+    TActorId clientId = {},
+    TDuration timeout = TDuration::Max());
+
+TString ReadTable(
+    Tests::TServer::TPtr server,
+    std::span<const ui64> tabletIds,
     const TString& tableName,
     const TTableId& tableId,
-    ui64 readId);
+    ui64 startReadId);
 
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -909,7 +909,7 @@ void AddFullRangeQuery(TEvDataShard::TEvRead& request);
 
 std::unique_ptr<TEvDataShard::TEvRead> GetBaseReadRequest(
     const TTableId& tableId,
-    const NKikimrTxDataShard::TEvGetInfoResponse::TUserTable& userTable,
+    const NKikimrSchemeOp::TTableDescription& description,
     ui64 readId,
     NKikimrDataEvents::EDataFormat format = NKikimrDataEvents::FORMAT_ARROW,
     const TRowVersion& readVersion = {});

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -870,4 +870,11 @@ void SendViaPipeCache(
     std::unique_ptr<IEventBase> msg,
     const TSendViaPipeCacheOptions& options = {});
 
+TString ReadTable(
+    Tests::TServer::TPtr server,
+    ui64 tabletId,
+    const TString& tableName,
+    const TTableId& tableId,
+    ui64 readId);
+
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Use EvRead in datashard_ut_write test instead of old TReadTableState.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
