### PR TITLE
Disable modification operations in CS by default

### DIFF
--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -274,7 +274,7 @@ message TTableServiceConfig {
 
     optional uint64 ExtractPredicateRangesLimit = 54 [default = 10000];
 
-    optional bool EnableOlapSink = 55 [default = true];
+    optional bool EnableOlapSink = 55 [default = false];
 
     optional bool EnablePerStatementQueryExecution = 56 [default = false];
     optional bool EnableCreateTableAs = 57 [default = true];


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Experimental feature

Выключаю флажок по-умолчанию, т.к., на мой взгляд, он был включен преждевременно.
Эта фича никогда не работала. Чтобы заработала требуется реализация локов в CS. Когда появится реализация локов, флажок можно будет включить обратно
