### PR TITLE
add missing table stats for column shards

### DIFF
--- a/ydb/core/protos/counters_columnshard.proto
+++ b/ydb/core/protos/counters_columnshard.proto
@@ -135,6 +135,8 @@ enum ECumulativeCounters {
     COUNTER_READING_EXPORTED_BLOBS = 79                     [(CounterOpts) = {Name: "ReadingExportedBlobs"}];
     COUNTER_READING_EXPORTED_BYTES = 80                     [(CounterOpts) = {Name: "ReadingExportedBytes"}];
     COUNTER_READING_EXPORTED_RANGES = 81                    [(CounterOpts) = {Name: "ReadingExportedRanges"}];
+    COUNTER_PLANNED_TX_COMPLETED = 82                       [(CounterOpts) = {Name: "PlannedTxCompleted"}];
+    COUNTER_IMMEDIATE_TX_COMPLETED = 83                     [(CounterOpts) = {Name: "ImmediateTxCompleted"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/tx/columnshard/background_controller.cpp
+++ b/ydb/core/tx/columnshard/background_controller.cpp
@@ -27,21 +27,11 @@ void TBackgroundController::CheckDeadlinesIndexation() {
 }
 
 TInstant TBackgroundController::GetLastCompactionFinishInstant(ui64 pathId) const {
-    auto findInstant = LastCompactionFinishInstants.find(pathId);
+    auto findInstant = LastCompactionFinishByPathId.find(pathId);
     if (findInstant.IsEnd()) {
         return TInstant::Zero();
     }
     return findInstant->second;
-}
-
-TInstant TBackgroundController::GetLastCompactionFinishInstant() const {
-    TInstant maxInstant = TInstant::Zero();
-    for (const auto& [pathId, instant] : LastCompactionFinishInstants) {
-        if (maxInstant < instant) {
-            maxInstant = instant;
-        }
-    }
-    return maxInstant;
 }
 
 void TBackgroundController::StartIndexing(const NOlap::TColumnEngineChanges& changes) {

--- a/ydb/core/tx/columnshard/background_controller.cpp
+++ b/ydb/core/tx/columnshard/background_controller.cpp
@@ -26,14 +26,6 @@ void TBackgroundController::CheckDeadlinesIndexation() {
     }
 }
 
-TInstant TBackgroundController::GetLastCompactionFinishInstant(ui64 pathId) const {
-    auto findInstant = LastCompactionFinishByPathId.find(pathId);
-    if (findInstant.IsEnd()) {
-        return TInstant::Zero();
-    }
-    return findInstant->second;
-}
-
 void TBackgroundController::StartIndexing(const NOlap::TColumnEngineChanges& changes) {
     LastIndexationInstant = TMonotonic::Now();
     Y_ABORT_UNLESS(ActiveIndexationTasks.emplace(changes.GetTaskIdentifier(), TMonotonic::Now()).second);

--- a/ydb/core/tx/columnshard/background_controller.cpp
+++ b/ydb/core/tx/columnshard/background_controller.cpp
@@ -26,6 +26,24 @@ void TBackgroundController::CheckDeadlinesIndexation() {
     }
 }
 
+TInstant TBackgroundController::GetLastCompactionFinishInstant(ui64 pathId) const {
+    auto findInstant = LastCompactionFinishInstants.find(pathId);
+    if (findInstant.IsEnd()) {
+        return TInstant::Zero();
+    }
+    return findInstant->second;
+}
+
+TInstant TBackgroundController::GetLastCompactionFinishInstant() const {
+    TInstant maxInstant = TInstant::Zero();
+    for (const auto& [pathId, instant] : LastCompactionFinishInstants) {
+        if (maxInstant < instant) {
+            maxInstant = instant;
+        }
+    }
+    return maxInstant;
+}
+
 void TBackgroundController::StartIndexing(const NOlap::TColumnEngineChanges& changes) {
     LastIndexationInstant = TMonotonic::Now();
     Y_ABORT_UNLESS(ActiveIndexationTasks.emplace(changes.GetTaskIdentifier(), TMonotonic::Now()).second);

--- a/ydb/core/tx/columnshard/background_controller.h
+++ b/ydb/core/tx/columnshard/background_controller.h
@@ -14,6 +14,7 @@ private:
 
     using TCurrentCompaction = THashMap<ui64, NOlap::TPlanCompactionInfo>;
     TCurrentCompaction ActiveCompactionInfo;
+    THashMap<ui64, TInstant> LastCompactionFinishInstants; // pathId to finish time
 
     bool ActiveCleanupPortions = false;
     bool ActiveCleanupTables = false;
@@ -29,6 +30,8 @@ public:
     bool StartCompaction(const NOlap::TPlanCompactionInfo& info);
     void FinishCompaction(const NOlap::TPlanCompactionInfo& info) {
         Y_ABORT_UNLESS(ActiveCompactionInfo.erase(info.GetPathId()));
+        TInstant& lastFinishInstant = LastCompactionFinishInstants[info.GetPathId()];
+        lastFinishInstant = std::max(lastFinishInstant, TInstant::Now());
     }
     const TCurrentCompaction& GetActiveCompaction() const {
         return ActiveCompactionInfo;
@@ -36,6 +39,8 @@ public:
     ui32 GetCompactionsCount() const {
         return ActiveCompactionInfo.size();
     }
+    TInstant GetLastCompactionFinishInstant(ui64 pathId) const;
+    TInstant GetLastCompactionFinishInstant() const;
 
     void StartIndexing(const NOlap::TColumnEngineChanges& changes);
     void FinishIndexing(const NOlap::TColumnEngineChanges& changes);

--- a/ydb/core/tx/columnshard/background_controller.h
+++ b/ydb/core/tx/columnshard/background_controller.h
@@ -2,7 +2,6 @@
 #include "engines/changes/abstract/compaction_info.h"
 #include "engines/portions/meta.h"
 #include <ydb/core/tx/columnshard/counters/statistics_store.h>
-#include <ydb/core/base/appdata.h>
 
 namespace NKikimr::NOlap {
 class TColumnEngineChanges;
@@ -23,7 +22,8 @@ private:
     bool ActiveCleanupInsertTable = false;
     YDB_READONLY(TMonotonic, LastIndexationInstant, TMonotonic::Zero());
 public:
-    TBackgroundController(TBackgroundControllerCounters& stats) : Stats(stats) {
+    TBackgroundController(TBackgroundControllerCounters& stats)
+        : Stats(stats) {
     }
 
     THashSet<NOlap::TPortionAddress> GetConflictTTLPortions() const;
@@ -43,7 +43,6 @@ public:
     ui32 GetCompactionsCount() const {
         return ActiveCompactionInfo.size();
     }
-    TInstant GetLastCompactionFinishInstant(ui64 pathId) const;
 
     void StartIndexing(const NOlap::TColumnEngineChanges& changes);
     void FinishIndexing(const NOlap::TColumnEngineChanges& changes);

--- a/ydb/core/tx/columnshard/background_controller.h
+++ b/ydb/core/tx/columnshard/background_controller.h
@@ -16,14 +16,14 @@ private:
     using TCurrentCompaction = THashMap<ui64, NOlap::TPlanCompactionInfo>;
     TCurrentCompaction ActiveCompactionInfo;
 
-    TBackgroundControllerCounters& Counters;
+    std::shared_ptr<TBackgroundControllerCounters> Counters;
     bool ActiveCleanupPortions = false;
     bool ActiveCleanupTables = false;
     bool ActiveCleanupInsertTable = false;
     YDB_READONLY(TMonotonic, LastIndexationInstant, TMonotonic::Zero());
 public:
-    TBackgroundController(TBackgroundControllerCounters& counters)
-        : Counters(counters) {
+    TBackgroundController(std::shared_ptr<TBackgroundControllerCounters> counters)
+        : Counters(std::move(counters)) {
     }
 
     THashSet<NOlap::TPortionAddress> GetConflictTTLPortions() const;
@@ -35,7 +35,7 @@ public:
     bool StartCompaction(const NOlap::TPlanCompactionInfo& info);
     void FinishCompaction(const NOlap::TPlanCompactionInfo& info) {
         Y_ABORT_UNLESS(ActiveCompactionInfo.erase(info.GetPathId()));
-        Counters.OnCompactionFinish(info.GetPathId());
+        Counters->OnCompactionFinish(info.GetPathId());
     }
     const TCurrentCompaction& GetActiveCompaction() const {
         return ActiveCompactionInfo;

--- a/ydb/core/tx/columnshard/background_controller.h
+++ b/ydb/core/tx/columnshard/background_controller.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "engines/changes/abstract/compaction_info.h"
 #include "engines/portions/meta.h"
-#include <ydb/core/tx/columnshard/counters/statistics_store.h>
+#include <ydb/core/tx/columnshard/counters/counters_manager.h>
 
 namespace NKikimr::NOlap {
 class TColumnEngineChanges;

--- a/ydb/core/tx/columnshard/background_controller.h
+++ b/ydb/core/tx/columnshard/background_controller.h
@@ -16,14 +16,14 @@ private:
     using TCurrentCompaction = THashMap<ui64, NOlap::TPlanCompactionInfo>;
     TCurrentCompaction ActiveCompactionInfo;
 
-    TBackgroundControllerCounters& Stats;
+    TBackgroundControllerCounters& Counters;
     bool ActiveCleanupPortions = false;
     bool ActiveCleanupTables = false;
     bool ActiveCleanupInsertTable = false;
     YDB_READONLY(TMonotonic, LastIndexationInstant, TMonotonic::Zero());
 public:
-    TBackgroundController(TBackgroundControllerCounters& stats)
-        : Stats(stats) {
+    TBackgroundController(TBackgroundControllerCounters& counters)
+        : Counters(counters) {
     }
 
     THashSet<NOlap::TPortionAddress> GetConflictTTLPortions() const;
@@ -35,7 +35,7 @@ public:
     bool StartCompaction(const NOlap::TPlanCompactionInfo& info);
     void FinishCompaction(const NOlap::TPlanCompactionInfo& info) {
         Y_ABORT_UNLESS(ActiveCompactionInfo.erase(info.GetPathId()));
-        Stats.OnCompactionFinish(info.GetPathId());
+        Counters.OnCompactionFinish(info.GetPathId());
     }
     const TCurrentCompaction& GetActiveCompaction() const {
         return ActiveCompactionInfo;

--- a/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
@@ -15,13 +15,13 @@ void TWriteAction::DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, co
     ui64 blobsWritten = BlobBatch.GetBlobCount();
     ui64 bytesWritten = BlobBatch.GetTotalSize();
     if (blobsWroteSuccessfully) {
-        self.IncCounter(NColumnShard::COUNTER_UPSERT_BLOBS_WRITTEN, blobsWritten);
-        self.IncCounter(NColumnShard::COUNTER_UPSERT_BYTES_WRITTEN, bytesWritten);
-        //    self.IncCounter(NColumnShard::COUNTER_RAW_BYTES_UPSERTED, insertedBytes);
-        self.IncCounter(NColumnShard::COUNTER_WRITE_SUCCESS);
+        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_UPSERT_BLOBS_WRITTEN, blobsWritten);
+        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_UPSERT_BYTES_WRITTEN, bytesWritten);
+        //    self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_UPSERTED, insertedBytes);
+        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_WRITE_SUCCESS);
         Manager->SaveBlobBatchOnComplete(std::move(BlobBatch));
     } else {
-        self.IncCounter(NColumnShard::COUNTER_WRITE_FAIL);
+        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_WRITE_FAIL);
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
@@ -15,13 +15,10 @@ void TWriteAction::DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, co
     ui64 blobsWritten = BlobBatch.GetBlobCount();
     ui64 bytesWritten = BlobBatch.GetTotalSize();
     if (blobsWroteSuccessfully) {
-        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_UPSERT_BLOBS_WRITTEN, blobsWritten);
-        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_UPSERT_BYTES_WRITTEN, bytesWritten);
-        //    self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_UPSERTED, insertedBytes);
-        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_WRITE_SUCCESS);
+        self.Stats.GetTabletCounters().OnWriteSuccess(blobsWritten, bytesWritten);
         Manager->SaveBlobBatchOnComplete(std::move(BlobBatch));
     } else {
-        self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_WRITE_FAIL);
+        self.Stats.GetTabletCounters().OnWriteFailure();
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
@@ -15,10 +15,10 @@ void TWriteAction::DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, co
     ui64 blobsWritten = BlobBatch.GetBlobCount();
     ui64 bytesWritten = BlobBatch.GetTotalSize();
     if (blobsWroteSuccessfully) {
-        self.Stats.GetTabletCounters().OnWriteSuccess(blobsWritten, bytesWritten);
+        self.Counters.GetTabletCounters().OnWriteSuccess(blobsWritten, bytesWritten);
         Manager->SaveBlobBatchOnComplete(std::move(BlobBatch));
     } else {
-        self.Stats.GetTabletCounters().OnWriteFailure();
+        self.Counters.GetTabletCounters().OnWriteFailure();
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/write.cpp
@@ -15,10 +15,10 @@ void TWriteAction::DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, co
     ui64 blobsWritten = BlobBatch.GetBlobCount();
     ui64 bytesWritten = BlobBatch.GetTotalSize();
     if (blobsWroteSuccessfully) {
-        self.Counters.GetTabletCounters().OnWriteSuccess(blobsWritten, bytesWritten);
+        self.Counters.GetTabletCounters()->OnWriteSuccess(blobsWritten, bytesWritten);
         Manager->SaveBlobBatchOnComplete(std::move(BlobBatch));
     } else {
-        self.Counters.GetTabletCounters().OnWriteFailure();
+        self.Counters.GetTabletCounters()->OnWriteFailure();
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
@@ -143,7 +143,7 @@ void TTxWrite::Complete(const TActorContext& ctx) {
         Self->CSCounters.OnWriteTxComplete(now - writeMeta.GetWriteStartInstant());
         Self->CSCounters.OnSuccessWriteResponse();
     }
-
+    Self->IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
 }
 
 }

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
@@ -70,7 +70,7 @@ bool TTxWrite::Execute(TTransactionContext& txc, const TActorContext&) {
 
             if (!InsertOneBlob(txc, i, writeId)) {
                 LOG_S_DEBUG(TxPrefix() << "duplicate writeId " << (ui64)writeId << TxSuffix());
-                Self->IncCounter(COUNTER_WRITE_DUPLICATE);
+                Self->Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_DUPLICATE);
             }
         }
     }
@@ -140,10 +140,10 @@ void TTxWrite::Complete(const TActorContext& ctx) {
     }
     for (ui32 i = 0; i < buffer.GetAggregations().size(); ++i) {
         const auto& writeMeta = buffer.GetAggregations()[i]->GetWriteMeta();
-        Self->CSCounters.OnWriteTxComplete(now - writeMeta.GetWriteStartInstant());
-        Self->CSCounters.OnSuccessWriteResponse();
+        Self->Stats.GetCSCounters().OnWriteTxComplete(now - writeMeta.GetWriteStartInstant());
+        Self->Stats.GetCSCounters().OnSuccessWriteResponse();
     }
-    Self->IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
+    Self->Stats.GetTabletCounters().IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
 }
 
 }

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
@@ -70,7 +70,7 @@ bool TTxWrite::Execute(TTransactionContext& txc, const TActorContext&) {
 
             if (!InsertOneBlob(txc, i, writeId)) {
                 LOG_S_DEBUG(TxPrefix() << "duplicate writeId " << (ui64)writeId << TxSuffix());
-                Self->Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_DUPLICATE);
+                Self->Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_DUPLICATE);
             }
         }
     }
@@ -143,7 +143,7 @@ void TTxWrite::Complete(const TActorContext& ctx) {
         Self->Counters.GetCSCounters().OnWriteTxComplete(now - writeMeta.GetWriteStartInstant());
         Self->Counters.GetCSCounters().OnSuccessWriteResponse();
     }
-    Self->Counters.GetTabletCounters().IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
+    Self->Counters.GetTabletCounters()->IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
 }
 
 }

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_write.cpp
@@ -70,7 +70,7 @@ bool TTxWrite::Execute(TTransactionContext& txc, const TActorContext&) {
 
             if (!InsertOneBlob(txc, i, writeId)) {
                 LOG_S_DEBUG(TxPrefix() << "duplicate writeId " << (ui64)writeId << TxSuffix());
-                Self->Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_DUPLICATE);
+                Self->Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_DUPLICATE);
             }
         }
     }
@@ -140,10 +140,10 @@ void TTxWrite::Complete(const TActorContext& ctx) {
     }
     for (ui32 i = 0; i < buffer.GetAggregations().size(); ++i) {
         const auto& writeMeta = buffer.GetAggregations()[i]->GetWriteMeta();
-        Self->Stats.GetCSCounters().OnWriteTxComplete(now - writeMeta.GetWriteStartInstant());
-        Self->Stats.GetCSCounters().OnSuccessWriteResponse();
+        Self->Counters.GetCSCounters().OnWriteTxComplete(now - writeMeta.GetWriteStartInstant());
+        Self->Counters.GetCSCounters().OnSuccessWriteResponse();
     }
-    Self->Stats.GetTabletCounters().IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
+    Self->Counters.GetTabletCounters().IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
 }
 
 }

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -149,8 +149,8 @@ void TColumnShard::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr& ev, const 
 void TColumnShard::Handle(TEvPrivate::TEvScanStats::TPtr& ev, const TActorContext &ctx) {
     Y_UNUSED(ctx);
 
-    Counters.GetTabletCounters().IncCounter(COUNTER_SCANNED_ROWS, ev->Get()->Rows);
-    Counters.GetTabletCounters().IncCounter(COUNTER_SCANNED_BYTES, ev->Get()->Bytes);
+    Counters.GetTabletCounters()->IncCounter(COUNTER_SCANNED_ROWS, ev->Get()->Rows);
+    Counters.GetTabletCounters()->IncCounter(COUNTER_SCANNED_BYTES, ev->Get()->Bytes);
 }
 
 void TColumnShard::Handle(TEvPrivate::TEvReadFinished::TPtr& ev, const TActorContext &ctx) {
@@ -166,10 +166,10 @@ void TColumnShard::Handle(TEvPrivate::TEvReadFinished::TPtr& ev, const TActorCon
     ui64 txId = ev->Get()->TxId;
     if (ScanTxInFlight.contains(txId)) {
         TDuration duration = TAppData::TimeProvider->Now() - ScanTxInFlight[txId];
-        Counters.GetTabletCounters().IncCounter(COUNTER_SCAN_LATENCY, duration);
+        Counters.GetTabletCounters()->IncCounter(COUNTER_SCAN_LATENCY, duration);
         ScanTxInFlight.erase(txId);
-        Counters.GetTabletCounters().SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
-        Counters.GetTabletCounters().IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
+        Counters.GetTabletCounters()->SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
+        Counters.GetTabletCounters()->IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
     }
 }
 
@@ -219,10 +219,10 @@ void TColumnShard::UpdateInsertTableCounters() {
     auto& prepared = InsertTable->GetCountersPrepared();
     auto& committed = InsertTable->GetCountersCommitted();
 
-    Counters.GetTabletCounters().SetCounter(COUNTER_PREPARED_RECORDS, prepared.Rows);
-    Counters.GetTabletCounters().SetCounter(COUNTER_PREPARED_BYTES, prepared.Bytes);
-    Counters.GetTabletCounters().SetCounter(COUNTER_COMMITTED_RECORDS, committed.Rows);
-    Counters.GetTabletCounters().SetCounter(COUNTER_COMMITTED_BYTES, committed.Bytes);
+    Counters.GetTabletCounters()->SetCounter(COUNTER_PREPARED_RECORDS, prepared.Rows);
+    Counters.GetTabletCounters()->SetCounter(COUNTER_PREPARED_BYTES, prepared.Bytes);
+    Counters.GetTabletCounters()->SetCounter(COUNTER_COMMITTED_RECORDS, committed.Rows);
+    Counters.GetTabletCounters()->SetCounter(COUNTER_COMMITTED_BYTES, committed.Bytes);
 
     LOG_S_TRACE("InsertTable. Prepared: " << prepared.Bytes << " in " << prepared.Rows
         << " records, committed: " << committed.Bytes << " in " << committed.Rows
@@ -235,34 +235,34 @@ void TColumnShard::UpdateIndexCounters() {
     }
 
     auto& stats = TablesManager.MutablePrimaryIndex().GetTotalStats();
-    const TTabletCountersHandle& counters = Counters.GetTabletCounters();
-    counters.SetCounter(COUNTER_INDEX_TABLES, stats.Tables);
-    counters.SetCounter(COUNTER_INDEX_COLUMN_RECORDS, stats.ColumnRecords);
-    counters.SetCounter(COUNTER_INSERTED_PORTIONS, stats.GetInsertedStats().Portions);
-    counters.SetCounter(COUNTER_INSERTED_BLOBS, stats.GetInsertedStats().Blobs);
-    counters.SetCounter(COUNTER_INSERTED_ROWS, stats.GetInsertedStats().Rows);
-    counters.SetCounter(COUNTER_INSERTED_BYTES, stats.GetInsertedStats().Bytes);
-    counters.SetCounter(COUNTER_INSERTED_RAW_BYTES, stats.GetInsertedStats().RawBytes);
-    counters.SetCounter(COUNTER_COMPACTED_PORTIONS, stats.GetCompactedStats().Portions);
-    counters.SetCounter(COUNTER_COMPACTED_BLOBS, stats.GetCompactedStats().Blobs);
-    counters.SetCounter(COUNTER_COMPACTED_ROWS, stats.GetCompactedStats().Rows);
-    counters.SetCounter(COUNTER_COMPACTED_BYTES, stats.GetCompactedStats().Bytes);
-    counters.SetCounter(COUNTER_COMPACTED_RAW_BYTES, stats.GetCompactedStats().RawBytes);
-    counters.SetCounter(COUNTER_SPLIT_COMPACTED_PORTIONS, stats.GetSplitCompactedStats().Portions);
-    counters.SetCounter(COUNTER_SPLIT_COMPACTED_BLOBS, stats.GetSplitCompactedStats().Blobs);
-    counters.SetCounter(COUNTER_SPLIT_COMPACTED_ROWS, stats.GetSplitCompactedStats().Rows);
-    counters.SetCounter(COUNTER_SPLIT_COMPACTED_BYTES, stats.GetSplitCompactedStats().Bytes);
-    counters.SetCounter(COUNTER_SPLIT_COMPACTED_RAW_BYTES, stats.GetSplitCompactedStats().RawBytes);
-    counters.SetCounter(COUNTER_INACTIVE_PORTIONS, stats.GetInactiveStats().Portions);
-    counters.SetCounter(COUNTER_INACTIVE_BLOBS, stats.GetInactiveStats().Blobs);
-    counters.SetCounter(COUNTER_INACTIVE_ROWS, stats.GetInactiveStats().Rows);
-    counters.SetCounter(COUNTER_INACTIVE_BYTES, stats.GetInactiveStats().Bytes);
-    counters.SetCounter(COUNTER_INACTIVE_RAW_BYTES, stats.GetInactiveStats().RawBytes);
-    counters.SetCounter(COUNTER_EVICTED_PORTIONS, stats.GetEvictedStats().Portions);
-    counters.SetCounter(COUNTER_EVICTED_BLOBS, stats.GetEvictedStats().Blobs);
-    counters.SetCounter(COUNTER_EVICTED_ROWS, stats.GetEvictedStats().Rows);
-    counters.SetCounter(COUNTER_EVICTED_BYTES, stats.GetEvictedStats().Bytes);
-    counters.SetCounter(COUNTER_EVICTED_RAW_BYTES, stats.GetEvictedStats().RawBytes);
+    const std::shared_ptr<const TTabletCountersHandle>& counters = Counters.GetTabletCounters();
+    counters->SetCounter(COUNTER_INDEX_TABLES, stats.Tables);
+    counters->SetCounter(COUNTER_INDEX_COLUMN_RECORDS, stats.ColumnRecords);
+    counters->SetCounter(COUNTER_INSERTED_PORTIONS, stats.GetInsertedStats().Portions);
+    counters->SetCounter(COUNTER_INSERTED_BLOBS, stats.GetInsertedStats().Blobs);
+    counters->SetCounter(COUNTER_INSERTED_ROWS, stats.GetInsertedStats().Rows);
+    counters->SetCounter(COUNTER_INSERTED_BYTES, stats.GetInsertedStats().Bytes);
+    counters->SetCounter(COUNTER_INSERTED_RAW_BYTES, stats.GetInsertedStats().RawBytes);
+    counters->SetCounter(COUNTER_COMPACTED_PORTIONS, stats.GetCompactedStats().Portions);
+    counters->SetCounter(COUNTER_COMPACTED_BLOBS, stats.GetCompactedStats().Blobs);
+    counters->SetCounter(COUNTER_COMPACTED_ROWS, stats.GetCompactedStats().Rows);
+    counters->SetCounter(COUNTER_COMPACTED_BYTES, stats.GetCompactedStats().Bytes);
+    counters->SetCounter(COUNTER_COMPACTED_RAW_BYTES, stats.GetCompactedStats().RawBytes);
+    counters->SetCounter(COUNTER_SPLIT_COMPACTED_PORTIONS, stats.GetSplitCompactedStats().Portions);
+    counters->SetCounter(COUNTER_SPLIT_COMPACTED_BLOBS, stats.GetSplitCompactedStats().Blobs);
+    counters->SetCounter(COUNTER_SPLIT_COMPACTED_ROWS, stats.GetSplitCompactedStats().Rows);
+    counters->SetCounter(COUNTER_SPLIT_COMPACTED_BYTES, stats.GetSplitCompactedStats().Bytes);
+    counters->SetCounter(COUNTER_SPLIT_COMPACTED_RAW_BYTES, stats.GetSplitCompactedStats().RawBytes);
+    counters->SetCounter(COUNTER_INACTIVE_PORTIONS, stats.GetInactiveStats().Portions);
+    counters->SetCounter(COUNTER_INACTIVE_BLOBS, stats.GetInactiveStats().Blobs);
+    counters->SetCounter(COUNTER_INACTIVE_ROWS, stats.GetInactiveStats().Rows);
+    counters->SetCounter(COUNTER_INACTIVE_BYTES, stats.GetInactiveStats().Bytes);
+    counters->SetCounter(COUNTER_INACTIVE_RAW_BYTES, stats.GetInactiveStats().RawBytes);
+    counters->SetCounter(COUNTER_EVICTED_PORTIONS, stats.GetEvictedStats().Portions);
+    counters->SetCounter(COUNTER_EVICTED_BLOBS, stats.GetEvictedStats().Blobs);
+    counters->SetCounter(COUNTER_EVICTED_ROWS, stats.GetEvictedStats().Rows);
+    counters->SetCounter(COUNTER_EVICTED_BYTES, stats.GetEvictedStats().Bytes);
+    counters->SetCounter(COUNTER_EVICTED_RAW_BYTES, stats.GetEvictedStats().RawBytes);
 
     LOG_S_DEBUG("Index: tables " << stats.Tables
         << " inserted " << stats.GetInsertedStats().DebugString()
@@ -281,8 +281,8 @@ ui64 TColumnShard::MemoryUsage() const {
         LongTxWrites.size() * (sizeof(TWriteId) + sizeof(TLongTxWriteInfo)) +
         LongTxWritesByUniqueId.size() * (sizeof(TULID) + sizeof(void*)) +
         (WaitingScans.size()) * (sizeof(NOlap::TSnapshot) + sizeof(void*)) +
-        Counters.GetTabletCounters().GetValue(COUNTER_PREPARED_RECORDS) * sizeof(NOlap::TInsertedData) +
-        Counters.GetTabletCounters().GetValue(COUNTER_COMMITTED_RECORDS) * sizeof(NOlap::TInsertedData);
+        Counters.GetTabletCounters()->GetValue(COUNTER_PREPARED_RECORDS) * sizeof(NOlap::TInsertedData) +
+        Counters.GetTabletCounters()->GetValue(COUNTER_COMMITTED_RECORDS) * sizeof(NOlap::TInsertedData);
     memory += TablesManager.GetMemoryUsage();
     return memory;
 }
@@ -293,12 +293,12 @@ void TColumnShard::UpdateResourceMetrics(const TActorContext& ctx, const TUsage&
         return;
     }
 
-    ui64 storageBytes = Counters.GetTabletCounters().GetValue(COUNTER_PREPARED_BYTES) +
-                        Counters.GetTabletCounters().GetValue(COUNTER_COMMITTED_BYTES) +
-                        Counters.GetTabletCounters().GetValue(COUNTER_INSERTED_BYTES) +
-                        Counters.GetTabletCounters().GetValue(COUNTER_COMPACTED_BYTES) +
-                        Counters.GetTabletCounters().GetValue(COUNTER_SPLIT_COMPACTED_BYTES) +
-                        Counters.GetTabletCounters().GetValue(COUNTER_INACTIVE_BYTES);
+    ui64 storageBytes = Counters.GetTabletCounters()->GetValue(COUNTER_PREPARED_BYTES) +
+                        Counters.GetTabletCounters()->GetValue(COUNTER_COMMITTED_BYTES) +
+                        Counters.GetTabletCounters()->GetValue(COUNTER_INSERTED_BYTES) +
+                        Counters.GetTabletCounters()->GetValue(COUNTER_COMPACTED_BYTES) +
+                        Counters.GetTabletCounters()->GetValue(COUNTER_SPLIT_COMPACTED_BYTES) +
+                        Counters.GetTabletCounters()->GetValue(COUNTER_INACTIVE_BYTES);
 
     ui64 memory = MemoryUsage();
 
@@ -328,9 +328,9 @@ void TColumnShard::FillOlapStats(
     }
 
     TTableStatsBuilder statsBuilder(*ev->Record.MutableTableStats());
-    statsBuilder.FillColumnTableStats(Counters.GetColumnTableCounters());
-    statsBuilder.FillTabletStats(Counters.GetTabletCounters());
-    statsBuilder.FillBackgroundControllerStats(Counters.GetBackgroundControllerCounters());
+    statsBuilder.FillColumnTableStats(*Counters.GetColumnTablesCounters());
+    statsBuilder.FillTabletStats(*Counters.GetTabletCounters());
+    statsBuilder.FillBackgroundControllerStats(*Counters.GetBackgroundControllerCounters());
     statsBuilder.FillScanCountersStats(Counters.GetScanCounters());
     statsBuilder.FillExecutorStats(*Executor());
     if (TablesManager.HasPrimaryIndex()) {
@@ -361,9 +361,9 @@ void TColumnShard::FillColumnTableStats(
         }
 
         TTableStatsBuilder statsBuilder(*periodicTableStats->MutableTableStats());
-        statsBuilder.FillColumnTableStats(Counters.GetColumnTableCounters().GetPathIdCounter(pathId));
-        statsBuilder.FillTabletStats(Counters.GetTabletCounters());
-        statsBuilder.FillBackgroundControllerStats(Counters.GetBackgroundControllerCounters(), pathId);
+        statsBuilder.FillColumnTableStats(*Counters.GetColumnTablesCounters()->GetPathIdCounter(pathId));
+        statsBuilder.FillTabletStats(*Counters.GetTabletCounters());
+        statsBuilder.FillBackgroundControllerStats(*Counters.GetBackgroundControllerCounters(), pathId);
         statsBuilder.FillScanCountersStats(Counters.GetScanCounters());
         statsBuilder.FillExecutorStats(*Executor());
         if (TablesManager.HasPrimaryIndex()) {

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -369,7 +369,6 @@ std::optional<TColumnShard::TAggregatedTableStats> TColumnShard::CollectTableSta
         if (resultStats.TotalStats.LastFullCompaction < tableStats.LastFullCompaction) {
             resultStats.TotalStats.LastFullCompaction = tableStats.LastFullCompaction;
         }
-        // TODO: When dataStats are included, don't aggregate rowCount and dataSize from individual pathIds.
         resultStats.TotalStats.RowCount += tableStats.RowCount;
         resultStats.TotalStats.DataSize += tableStats.DataSize;
     }

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -63,12 +63,12 @@ void TColumnShard::SwitchToWork(const TActorContext& ctx) {
     ctx.Send(SelfId(), new TEvPrivate::TEvPeriodicWakeup());
     NYDBTest::TControllers::GetColumnShardController()->OnSwitchToWork(TabletID());
     AFL_VERIFY(!!StartInstant);
-    CSCounters.Initialization.OnSwitchToWork(TMonotonic::Now() - *StartInstant, TMonotonic::Now() - CreateInstant);
+    Counters.GetCSCounters().Initialization.OnSwitchToWork(TMonotonic::Now() - *StartInstant, TMonotonic::Now() - CreateInstant);
 }
 
 void TColumnShard::OnActivateExecutor(const TActorContext& ctx) {
     StartInstant = TMonotonic::Now();
-    CSCounters.Initialization.OnActivateExecutor(TMonotonic::Now() - CreateInstant);
+    Counters.GetCSCounters().Initialization.OnActivateExecutor(TMonotonic::Now() - CreateInstant);
     const TLogContextGuard gLogging = NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD)("tablet_id", TabletID())("self_id", SelfId());
     AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("event", "initialize_shard")("step", "OnActivateExecutor");
     Executor()->RegisterExternalTabletCounters(TabletCountersHolder.release());

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -168,6 +168,7 @@ void TColumnShard::Handle(TEvPrivate::TEvReadFinished::TPtr& ev, const TActorCon
         IncCounter(COUNTER_SCAN_LATENCY, duration);
         ScanTxInFlight.erase(txId);
         SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
+        IncCounter(COUNTER_IMMEDIATE_TX_COMPLETED);
     }
 }
 
@@ -336,8 +337,11 @@ void TColumnShard::ConfigureStats(const NOlap::TColumnEngineStats& indexStats,
 }
 
 void TColumnShard::FillTxTableStats(::NKikimrTableStats::TTableStats* tableStats) const {
+    tableStats->SetImmediateTxCompleted(TabletCounters->Cumulative()[COUNTER_IMMEDIATE_TX_COMPLETED].Get());
     tableStats->SetTxRejectedByOverload(TabletCounters->Cumulative()[COUNTER_WRITE_OVERLOAD].Get());
     tableStats->SetTxRejectedBySpace(TabletCounters->Cumulative()[COUNTER_OUT_OF_SPACE].Get());
+    tableStats->SetPlannedTxCompleted(TabletCounters->Cumulative()[COUNTER_PLANNED_TX_COMPLETED].Get());
+    tableStats->SetTxCompleteLagMsec(GetTxCompleteLag().MilliSeconds());
     tableStats->SetInFlightTxCount(Executor()->GetStats().TxInFly);
 }
 

--- a/ydb/core/tx/columnshard/columnshard__init.cpp
+++ b/ydb/core/tx/columnshard/columnshard__init.cpp
@@ -168,9 +168,9 @@ bool TTxInit::ReadEverything(TTransactionContext& txc, const TActorContext& ctx)
         }
         Self->TablesManager = std::move(tManagerLocal);
 
-        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TABLES, Self->TablesManager.GetTables().size());
-        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TABLE_PRESETS, Self->TablesManager.GetSchemaPresets().size());
-        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TABLE_TTLS, Self->TablesManager.GetTtl().PathsCount());
+        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TABLES, Self->TablesManager.GetTables().size());
+        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TABLE_PRESETS, Self->TablesManager.GetSchemaPresets().size());
+        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TABLE_TTLS, Self->TablesManager.GetTtl().PathsCount());
         ACFL_DEBUG("step", "TTablesManager::Load_Finish");
     }
 

--- a/ydb/core/tx/columnshard/columnshard__init.cpp
+++ b/ydb/core/tx/columnshard/columnshard__init.cpp
@@ -168,9 +168,9 @@ bool TTxInit::ReadEverything(TTransactionContext& txc, const TActorContext& ctx)
         }
         Self->TablesManager = std::move(tManagerLocal);
 
-        Self->SetCounter(COUNTER_TABLES, Self->TablesManager.GetTables().size());
-        Self->SetCounter(COUNTER_TABLE_PRESETS, Self->TablesManager.GetSchemaPresets().size());
-        Self->SetCounter(COUNTER_TABLE_TTLS, Self->TablesManager.GetTtl().PathsCount());
+        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TABLES, Self->TablesManager.GetTables().size());
+        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TABLE_PRESETS, Self->TablesManager.GetSchemaPresets().size());
+        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TABLE_TTLS, Self->TablesManager.GetTtl().PathsCount());
         ACFL_DEBUG("step", "TTablesManager::Load_Finish");
     }
 

--- a/ydb/core/tx/columnshard/columnshard__init.cpp
+++ b/ydb/core/tx/columnshard/columnshard__init.cpp
@@ -253,7 +253,7 @@ bool TTxInit::Execute(TTransactionContext& txc, const TActorContext& ctx) {
 }
 
 void TTxInit::Complete(const TActorContext& ctx) {
-    Self->CSCounters.Initialization.OnTxInitFinished(TMonotonic::Now() - StartInstant);
+    Self->Counters.GetCSCounters().Initialization.OnTxInitFinished(TMonotonic::Now() - StartInstant);
     Self->ProgressTxController->OnTabletInit();
     Self->SwitchToWork(ctx);
     NYDBTest::TControllers::GetColumnShardController()->OnTabletInitCompleted(*Self);
@@ -301,7 +301,7 @@ bool TTxUpdateSchema::Execute(TTransactionContext& txc, const TActorContext&) {
 
 void TTxUpdateSchema::Complete(const TActorContext& ctx) {
     AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("step", "TTxUpdateSchema.Complete");
-    Self->CSCounters.Initialization.OnTxUpdateSchemaFinished(TMonotonic::Now() - StartInstant);
+    Self->Counters.GetCSCounters().Initialization.OnTxUpdateSchemaFinished(TMonotonic::Now() - StartInstant);
     if (NormalizerTasks.empty()) {
         AFL_VERIFY(Self->NormalizerController.IsNormalizationFinished())("details", Self->NormalizerController.DebugString());
         Self->Execute(new TTxInit(Self), ctx);
@@ -432,7 +432,7 @@ bool TTxInitSchema::Execute(TTransactionContext& txc, const TActorContext&) {
 }
 
 void TTxInitSchema::Complete(const TActorContext& ctx) {
-    Self->CSCounters.Initialization.OnTxInitSchemaFinished(TMonotonic::Now() - StartInstant);
+    Self->Counters.GetCSCounters().Initialization.OnTxInitSchemaFinished(TMonotonic::Now() - StartInstant);
     LOG_S_DEBUG("TxInitSchema.Complete at tablet " << Self->TabletID(););
     Self->Execute(new TTxUpdateSchema(Self), ctx);
 }

--- a/ydb/core/tx/columnshard/columnshard__init.cpp
+++ b/ydb/core/tx/columnshard/columnshard__init.cpp
@@ -168,9 +168,9 @@ bool TTxInit::ReadEverything(TTransactionContext& txc, const TActorContext& ctx)
         }
         Self->TablesManager = std::move(tManagerLocal);
 
-        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TABLES, Self->TablesManager.GetTables().size());
-        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TABLE_PRESETS, Self->TablesManager.GetSchemaPresets().size());
-        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TABLE_TTLS, Self->TablesManager.GetTtl().PathsCount());
+        Self->Counters.GetTabletCounters()->SetCounter(COUNTER_TABLES, Self->TablesManager.GetTables().size());
+        Self->Counters.GetTabletCounters()->SetCounter(COUNTER_TABLE_PRESETS, Self->TablesManager.GetSchemaPresets().size());
+        Self->Counters.GetTabletCounters()->SetCounter(COUNTER_TABLE_TTLS, Self->TablesManager.GetTtl().PathsCount());
         ACFL_DEBUG("step", "TTablesManager::Load_Finish");
     }
 

--- a/ydb/core/tx/columnshard/columnshard__plan_step.cpp
+++ b/ydb/core/tx/columnshard/columnshard__plan_step.cpp
@@ -102,7 +102,7 @@ bool TTxPlanStep::Execute(TTransactionContext& txc, const TActorContext& ctx) {
 
     Result = std::make_unique<TEvTxProcessing::TEvPlanStepAccepted>(Self->TabletID(), step);
 
-    Self->IncCounter(COUNTER_PLAN_STEP_ACCEPTED);
+    Self->Stats.GetTabletCounters().IncCounter(COUNTER_PLAN_STEP_ACCEPTED);
 
     if (plannedCount > 0 || Self->ProgressTxController->HaveOutdatedTxs()) {
         Self->EnqueueProgressTx(ctx);

--- a/ydb/core/tx/columnshard/columnshard__plan_step.cpp
+++ b/ydb/core/tx/columnshard/columnshard__plan_step.cpp
@@ -102,7 +102,7 @@ bool TTxPlanStep::Execute(TTransactionContext& txc, const TActorContext& ctx) {
 
     Result = std::make_unique<TEvTxProcessing::TEvPlanStepAccepted>(Self->TabletID(), step);
 
-    Self->Stats.GetTabletCounters().IncCounter(COUNTER_PLAN_STEP_ACCEPTED);
+    Self->Counters.GetTabletCounters().IncCounter(COUNTER_PLAN_STEP_ACCEPTED);
 
     if (plannedCount > 0 || Self->ProgressTxController->HaveOutdatedTxs()) {
         Self->EnqueueProgressTx(ctx);

--- a/ydb/core/tx/columnshard/columnshard__plan_step.cpp
+++ b/ydb/core/tx/columnshard/columnshard__plan_step.cpp
@@ -102,7 +102,7 @@ bool TTxPlanStep::Execute(TTransactionContext& txc, const TActorContext& ctx) {
 
     Result = std::make_unique<TEvTxProcessing::TEvPlanStepAccepted>(Self->TabletID(), step);
 
-    Self->Counters.GetTabletCounters().IncCounter(COUNTER_PLAN_STEP_ACCEPTED);
+    Self->Counters.GetTabletCounters()->IncCounter(COUNTER_PLAN_STEP_ACCEPTED);
 
     if (plannedCount > 0 || Self->ProgressTxController->HaveOutdatedTxs()) {
         Self->EnqueueProgressTx(ctx);

--- a/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
+++ b/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
@@ -18,7 +18,7 @@ public:
     bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
         NActors::TLogContextGuard logGuard = NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD)("tablet_id", Self->TabletID())("tx_state", "execute");
         Y_ABORT_UNLESS(Self->ProgressTxInFlight);
-        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TX_COMPLETE_LAG, Self->GetTxCompleteLag().MilliSeconds());
+        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TX_COMPLETE_LAG, Self->GetTxCompleteLag().MilliSeconds());
 
         const size_t removedCount = Self->ProgressTxController->CleanExpiredTxs(txc);
         if (removedCount > 0) {
@@ -43,7 +43,7 @@ public:
             TxOperator = Self->ProgressTxController->GetVerifiedTxOperator(txId);
             AFL_VERIFY(TxOperator->ProgressOnExecute(*Self, NOlap::TSnapshot(step, txId), txc));
             Self->ProgressTxController->FinishPlannedTx(txId, txc);
-            Self->Stats.GetTabletCounters().IncCounter(COUNTER_PLANNED_TX_COMPLETED);
+            Self->Counters.GetTabletCounters().IncCounter(COUNTER_PLANNED_TX_COMPLETED);
         }
         return true;
     }

--- a/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
+++ b/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
@@ -18,7 +18,7 @@ public:
     bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
         NActors::TLogContextGuard logGuard = NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD)("tablet_id", Self->TabletID())("tx_state", "execute");
         Y_ABORT_UNLESS(Self->ProgressTxInFlight);
-        Self->Counters.GetTabletCounters().SetCounter(COUNTER_TX_COMPLETE_LAG, Self->GetTxCompleteLag().MilliSeconds());
+        Self->Counters.GetTabletCounters()->SetCounter(COUNTER_TX_COMPLETE_LAG, Self->GetTxCompleteLag().MilliSeconds());
 
         const size_t removedCount = Self->ProgressTxController->CleanExpiredTxs(txc);
         if (removedCount > 0) {
@@ -43,7 +43,7 @@ public:
             TxOperator = Self->ProgressTxController->GetVerifiedTxOperator(txId);
             AFL_VERIFY(TxOperator->ProgressOnExecute(*Self, NOlap::TSnapshot(step, txId), txc));
             Self->ProgressTxController->FinishPlannedTx(txId, txc);
-            Self->Counters.GetTabletCounters().IncCounter(COUNTER_PLANNED_TX_COMPLETED);
+            Self->Counters.GetTabletCounters()->IncCounter(COUNTER_PLANNED_TX_COMPLETED);
         }
         return true;
     }

--- a/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
+++ b/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
@@ -18,7 +18,7 @@ public:
     bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
         NActors::TLogContextGuard logGuard = NActors::TLogContextBuilder::Build(NKikimrServices::TX_COLUMNSHARD)("tablet_id", Self->TabletID())("tx_state", "execute");
         Y_ABORT_UNLESS(Self->ProgressTxInFlight);
-        Self->TabletCounters->Simple()[COUNTER_TX_COMPLETE_LAG].Set(Self->GetTxCompleteLag().MilliSeconds());
+        Self->Stats.GetTabletCounters().SetCounter(COUNTER_TX_COMPLETE_LAG, Self->GetTxCompleteLag().MilliSeconds());
 
         const size_t removedCount = Self->ProgressTxController->CleanExpiredTxs(txc);
         if (removedCount > 0) {
@@ -43,7 +43,7 @@ public:
             TxOperator = Self->ProgressTxController->GetVerifiedTxOperator(txId);
             AFL_VERIFY(TxOperator->ProgressOnExecute(*Self, NOlap::TSnapshot(step, txId), txc));
             Self->ProgressTxController->FinishPlannedTx(txId, txc);
-            Self->IncCounter(COUNTER_PLANNED_TX_COMPLETED);
+            Self->Stats.GetTabletCounters().IncCounter(COUNTER_PLANNED_TX_COMPLETED);
         }
         return true;
     }

--- a/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
+++ b/ydb/core/tx/columnshard/columnshard__progress_tx.cpp
@@ -43,6 +43,7 @@ public:
             TxOperator = Self->ProgressTxController->GetVerifiedTxOperator(txId);
             AFL_VERIFY(TxOperator->ProgressOnExecute(*Self, NOlap::TSnapshot(step, txId), txc));
             Self->ProgressTxController->FinishPlannedTx(txId, txc);
+            Self->IncCounter(COUNTER_PLANNED_TX_COMPLETED);
         }
         return true;
     }

--- a/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
+++ b/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
@@ -25,7 +25,7 @@ public:
         txc.DB.NoMoreReadsForTx();
         NIceDb::TNiceDb db(txc.DB);
 
-        Self->Stats.GetTabletCounters().IncCounter(COUNTER_PREPARE_REQUEST);
+        Self->Counters.GetTabletCounters().IncCounter(COUNTER_PREPARE_REQUEST);
 
         auto& record = Proto(Ev->Get());
         const auto txKind = record.GetTxKind();

--- a/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
+++ b/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
@@ -25,7 +25,7 @@ public:
         txc.DB.NoMoreReadsForTx();
         NIceDb::TNiceDb db(txc.DB);
 
-        Self->Counters.GetTabletCounters().IncCounter(COUNTER_PREPARE_REQUEST);
+        Self->Counters.GetTabletCounters()->IncCounter(COUNTER_PREPARE_REQUEST);
 
         auto& record = Proto(Ev->Get());
         const auto txKind = record.GetTxKind();

--- a/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
+++ b/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
@@ -25,7 +25,7 @@ public:
         txc.DB.NoMoreReadsForTx();
         NIceDb::TNiceDb db(txc.DB);
 
-        Self->IncCounter(COUNTER_PREPARE_REQUEST);
+        Self->Stats.GetTabletCounters().IncCounter(COUNTER_PREPARE_REQUEST);
 
         auto& record = Proto(Ev->Get());
         const auto txKind = record.GetTxKind();

--- a/ydb/core/tx/columnshard/columnshard__scan.cpp
+++ b/ydb/core/tx/columnshard/columnshard__scan.cpp
@@ -30,9 +30,9 @@ void TColumnShard::Handle(TEvColumnShard::TEvScan::TPtr& ev, const TActorContext
         return;
     }
 
-    Stats.GetColumnTableCounters().GetPathIdCounter(record.GetLocalPathId()).OnAccess();
+    Counters.GetColumnTableCounters().GetPathIdCounter(record.GetLocalPathId()).OnAccess();
     ScanTxInFlight.insert({txId, TAppData::TimeProvider->Now()});
-    Stats.GetTabletCounters().SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
+    Counters.GetTabletCounters().SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
     Execute(new NOlap::NReader::TTxScan(this, ev), ctx);
 }
 

--- a/ydb/core/tx/columnshard/columnshard__scan.cpp
+++ b/ydb/core/tx/columnshard/columnshard__scan.cpp
@@ -5,6 +5,7 @@
 #include "engines/reader/transaction/tx_internal_scan.h"
 
 #include <ydb/core/protos/kqp.pb.h>
+#include <ydb/core/base/appdata_fwd.h>
 
 namespace NKikimr::NColumnShard {
 
@@ -29,9 +30,9 @@ void TColumnShard::Handle(TEvColumnShard::TEvScan::TPtr& ev, const TActorContext
         return;
     }
 
-    TablesManager.RegisterAccess(record.GetLocalPathId());
-    ScanTxInFlight.insert({txId, LastAccessTime});
-    SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
+    Stats.GetColumnTableCounters().GetPathIdCounter(record.GetLocalPathId()).OnAccess();
+    ScanTxInFlight.insert({txId, TAppData::TimeProvider->Now()});
+    Stats.GetTabletCounters().SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
     Execute(new NOlap::NReader::TTxScan(this, ev), ctx);
 }
 

--- a/ydb/core/tx/columnshard/columnshard__scan.cpp
+++ b/ydb/core/tx/columnshard/columnshard__scan.cpp
@@ -29,7 +29,7 @@ void TColumnShard::Handle(TEvColumnShard::TEvScan::TPtr& ev, const TActorContext
         return;
     }
 
-    LastAccessTime = TAppData::TimeProvider->Now();
+    TablesManager.RegisterAccess(record.GetLocalPathId());
     ScanTxInFlight.insert({txId, LastAccessTime});
     SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
     Execute(new NOlap::NReader::TTxScan(this, ev), ctx);

--- a/ydb/core/tx/columnshard/columnshard__scan.cpp
+++ b/ydb/core/tx/columnshard/columnshard__scan.cpp
@@ -30,9 +30,9 @@ void TColumnShard::Handle(TEvColumnShard::TEvScan::TPtr& ev, const TActorContext
         return;
     }
 
-    Counters.GetColumnTableCounters().GetPathIdCounter(record.GetLocalPathId()).OnAccess();
+    Counters.GetColumnTablesCounters()->GetPathIdCounter(record.GetLocalPathId())->OnAccess();
     ScanTxInFlight.insert({txId, TAppData::TimeProvider->Now()});
-    Counters.GetTabletCounters().SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
+    Counters.GetTabletCounters()->SetCounter(COUNTER_SCAN_IN_FLY, ScanTxInFlight.size());
     Execute(new NOlap::NReader::TTxScan(this, ev), ctx);
 }
 

--- a/ydb/core/tx/columnshard/columnshard__write.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write.cpp
@@ -16,27 +16,21 @@ void TColumnShard::OverloadWriteFail(const EOverloadStatus overloadReason, const
     Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_FAIL);
     switch (overloadReason) {
         case EOverloadStatus::Disk:
-            Counters.GetTabletCounters()->IncCounter(COUNTER_OUT_OF_SPACE);
+            Counters.GetCSCounters().OnWriteOverloadDisk(writeData.GetSize());
             break;
         case EOverloadStatus::InsertTable:
-            // TODO: Move all IncCounter's below under OnWriteOverload*
-            Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_OVERLOAD);
             Counters.GetCSCounters().OnWriteOverloadInsertTable(writeData.GetSize());
             break;
         case EOverloadStatus::OverloadMetadata:
-            Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_OVERLOAD);
             Counters.GetCSCounters().OnWriteOverloadMetadata(writeData.GetSize());
             break;
         case EOverloadStatus::ShardTxInFly:
-            Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_OVERLOAD);
             Counters.GetCSCounters().OnWriteOverloadShardTx(writeData.GetSize());
             break;
         case EOverloadStatus::ShardWritesInFly:
-            Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_OVERLOAD);
             Counters.GetCSCounters().OnWriteOverloadShardWrites(writeData.GetSize());
             break;
         case EOverloadStatus::ShardWritesSizeInFly:
-            Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_OVERLOAD);
             Counters.GetCSCounters().OnWriteOverloadShardWritesSize(writeData.GetSize());
             break;
         case EOverloadStatus::None:

--- a/ydb/core/tx/columnshard/columnshard__write.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write.cpp
@@ -19,24 +19,25 @@ void TColumnShard::OverloadWriteFail(const EOverloadStatus overloadReason, const
             Stats.GetTabletCounters().IncCounter(COUNTER_OUT_OF_SPACE);
             break;
         case EOverloadStatus::InsertTable:
+            // TODO: Move all IncCounter's below under OnWriteOverload*
             Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnOverloadInsertTable(writeData.GetSize());
+            Stats.GetCSCounters().OnWriteOverloadInsertTable(writeData.GetSize());
             break;
         case EOverloadStatus::OverloadMetadata:
             Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnOverloadMetadata(writeData.GetSize());
+            Stats.GetCSCounters().OnWriteOverloadMetadata(writeData.GetSize());
             break;
         case EOverloadStatus::ShardTxInFly:
             Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnOverloadShardTx(writeData.GetSize());
+            Stats.GetCSCounters().OnWriteOverloadShardTx(writeData.GetSize());
             break;
         case EOverloadStatus::ShardWritesInFly:
             Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnOverloadShardWrites(writeData.GetSize());
+            Stats.GetCSCounters().OnWriteOverloadShardWrites(writeData.GetSize());
             break;
         case EOverloadStatus::ShardWritesSizeInFly:
             Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnOverloadShardWritesSize(writeData.GetSize());
+            Stats.GetCSCounters().OnWriteOverloadShardWritesSize(writeData.GetSize());
             break;
         case EOverloadStatus::None:
             Y_ABORT("invalid function usage");

--- a/ydb/core/tx/columnshard/columnshard__write.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write.cpp
@@ -16,7 +16,7 @@ void TColumnShard::OverloadWriteFail(const EOverloadStatus overloadReason, const
     Counters.GetTabletCounters()->IncCounter(COUNTER_WRITE_FAIL);
     switch (overloadReason) {
         case EOverloadStatus::Disk:
-            Counters.GetCSCounters().OnWriteOverloadDisk(writeData.GetSize());
+            Counters.GetCSCounters().OnWriteOverloadDisk();
             break;
         case EOverloadStatus::InsertTable:
             Counters.GetCSCounters().OnWriteOverloadInsertTable(writeData.GetSize());

--- a/ydb/core/tx/columnshard/columnshard__write.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write.cpp
@@ -153,7 +153,6 @@ void TColumnShard::Handle(TEvPrivate::TEvWriteDraft::TPtr& ev, const TActorConte
 
 void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContext& ctx) {
     CSCounters.OnStartWriteRequest();
-    LastAccessTime = TAppData::TimeProvider->Now();
 
     const auto& record = Proto(ev->Get());
     const ui64 tableId = record.GetTableId();
@@ -161,6 +160,9 @@ void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContex
     const ui64 cookie = ev->Cookie;
     const TString dedupId = record.GetDedupId();
     const auto source = ev->Sender;
+
+    TablesManager.RegisterAccess(tableId);
+    TablesManager.RegisterUpdate(tableId);
 
     std::optional<ui32> granuleShardingVersion;
     if (record.HasGranuleShardingVersion()) {

--- a/ydb/core/tx/columnshard/columnshard__write.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write.cpp
@@ -13,31 +13,31 @@ namespace NKikimr::NColumnShard {
 using namespace NTabletFlatExecutor;
 
 void TColumnShard::OverloadWriteFail(const EOverloadStatus overloadReason, const NEvWrite::TWriteData& writeData, const ui64 cookie, std::unique_ptr<NActors::IEventBase>&& event, const TActorContext& ctx) {
-    Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+    Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
     switch (overloadReason) {
         case EOverloadStatus::Disk:
-            Stats.GetTabletCounters().IncCounter(COUNTER_OUT_OF_SPACE);
+            Counters.GetTabletCounters().IncCounter(COUNTER_OUT_OF_SPACE);
             break;
         case EOverloadStatus::InsertTable:
             // TODO: Move all IncCounter's below under OnWriteOverload*
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnWriteOverloadInsertTable(writeData.GetSize());
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
+            Counters.GetCSCounters().OnWriteOverloadInsertTable(writeData.GetSize());
             break;
         case EOverloadStatus::OverloadMetadata:
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnWriteOverloadMetadata(writeData.GetSize());
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
+            Counters.GetCSCounters().OnWriteOverloadMetadata(writeData.GetSize());
             break;
         case EOverloadStatus::ShardTxInFly:
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnWriteOverloadShardTx(writeData.GetSize());
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
+            Counters.GetCSCounters().OnWriteOverloadShardTx(writeData.GetSize());
             break;
         case EOverloadStatus::ShardWritesInFly:
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnWriteOverloadShardWrites(writeData.GetSize());
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
+            Counters.GetCSCounters().OnWriteOverloadShardWrites(writeData.GetSize());
             break;
         case EOverloadStatus::ShardWritesSizeInFly:
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
-            Stats.GetCSCounters().OnWriteOverloadShardWritesSize(writeData.GetSize());
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_OVERLOAD);
+            Counters.GetCSCounters().OnWriteOverloadShardWritesSize(writeData.GetSize());
             break;
         case EOverloadStatus::None:
             Y_ABORT("invalid function usage");
@@ -58,7 +58,7 @@ TColumnShard::EOverloadStatus TColumnShard::CheckOverloaded(const ui64 tableId) 
         return EOverloadStatus::InsertTable;
     }
 
-    Stats.GetCSCounters().OnIndexMetadataLimit(NOlap::IColumnEngine::GetMetadataLimit());
+    Counters.GetCSCounters().OnIndexMetadataLimit(NOlap::IColumnEngine::GetMetadataLimit());
     if (TablesManager.GetPrimaryIndex() && TablesManager.GetPrimaryIndex()->IsOverloadedByMetadata(NOlap::IColumnEngine::GetMetadataLimit())) {
         return EOverloadStatus::OverloadMetadata;
     }
@@ -70,12 +70,12 @@ TColumnShard::EOverloadStatus TColumnShard::CheckOverloaded(const ui64 tableId) 
         AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "shard_overload")("reason", "tx_in_fly")("sum", Executor()->GetStats().TxInFly)("limit", txLimit);
         return EOverloadStatus::ShardTxInFly;
     }
-    if (writesLimit && Stats.GetWritesMonitor().GetWritesInFlight() > writesLimit) {
-        AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "shard_overload")("reason", "writes_in_fly")("sum", Stats.GetWritesMonitor().GetWritesInFlight())("limit", writesLimit);
+    if (writesLimit && Counters.GetWritesMonitor().GetWritesInFlight() > writesLimit) {
+        AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "shard_overload")("reason", "writes_in_fly")("sum", Counters.GetWritesMonitor().GetWritesInFlight())("limit", writesLimit);
         return EOverloadStatus::ShardWritesInFly;
     }
-    if (writesSizeLimit && Stats.GetWritesMonitor().GetWritesSizeInFlight() > writesSizeLimit) {
-        AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "shard_overload")("reason", "writes_size_in_fly")("sum", Stats.GetWritesMonitor().GetWritesSizeInFlight())("limit", writesSizeLimit);
+    if (writesSizeLimit && Counters.GetWritesMonitor().GetWritesSizeInFlight() > writesSizeLimit) {
+        AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "shard_overload")("reason", "writes_size_in_fly")("sum", Counters.GetWritesMonitor().GetWritesSizeInFlight())("limit", writesSizeLimit);
         return EOverloadStatus::ShardWritesSizeInFly;
     }
     return EOverloadStatus::None;
@@ -90,25 +90,25 @@ void TColumnShard::Handle(TEvPrivate::TEvWriteBlobsResult::TPtr& ev, const TActo
     auto baseAggregations = wBuffer.GetAggregations();
     wBuffer.InitReplyReceived(TMonotonic::Now());
 
-    auto wg = Stats.GetWritesMonitor().OnFinishWrite(wBuffer.GetSumSize(), wBuffer.GetAggregations().size());
+    auto wg = Counters.GetWritesMonitor().OnFinishWrite(wBuffer.GetSumSize(), wBuffer.GetAggregations().size());
 
     for (auto&& aggr : baseAggregations) {
         const auto& writeMeta = aggr->GetWriteMeta();
 
         if (!TablesManager.IsReadyForWrite(writeMeta.GetTableId())) {
             ACFL_ERROR("event", "absent_pathId")("path_id", writeMeta.GetTableId())("has_index", TablesManager.HasPrimaryIndex());
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
 
             auto result = std::make_unique<TEvColumnShard::TEvWriteResult>(TabletID(), writeMeta, NKikimrTxColumnShard::EResultStatus::ERROR);
             ctx.Send(writeMeta.GetSource(), result.release());
-            Stats.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::NoTable);
+            Counters.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::NoTable);
             wBuffer.RemoveData(aggr, StoragesManager->GetInsertOperator());
             continue;
         }
 
         if (putResult.GetPutStatus() != NKikimrProto::OK) {
-            Stats.GetCSCounters().OnWritePutBlobsFail(TMonotonic::Now() - writeMeta.GetWriteStartInstant());
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+            Counters.GetCSCounters().OnWritePutBlobsFail(TMonotonic::Now() - writeMeta.GetWriteStartInstant());
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
 
             auto errCode = NKikimrTxColumnShard::EResultStatus::STORAGE_ERROR;
             if (putResult.GetPutStatus() == NKikimrProto::TIMEOUT || putResult.GetPutStatus() == NKikimrProto::DEADLINE) {
@@ -129,17 +129,17 @@ void TColumnShard::Handle(TEvPrivate::TEvWriteBlobsResult::TPtr& ev, const TActo
                     ev->Get()->GetErrorMessage() ? ev->Get()->GetErrorMessage() : "put data fails");
                 ctx.Send(writeMeta.GetSource(), result.release(), 0, operation->GetCookie());
             }
-            Stats.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::PutBlob);
+            Counters.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::PutBlob);
             wBuffer.RemoveData(aggr, StoragesManager->GetInsertOperator());
         } else {
             const TMonotonic now = TMonotonic::Now();
-            Stats.GetCSCounters().OnWritePutBlobsSuccess(now - writeMeta.GetWriteStartInstant());
-            Stats.GetCSCounters().OnWriteMiddle1PutBlobsSuccess(now - writeMeta.GetWriteMiddle1StartInstant());
-            Stats.GetCSCounters().OnWriteMiddle2PutBlobsSuccess(now - writeMeta.GetWriteMiddle2StartInstant());
-            Stats.GetCSCounters().OnWriteMiddle3PutBlobsSuccess(now - writeMeta.GetWriteMiddle3StartInstant());
-            Stats.GetCSCounters().OnWriteMiddle4PutBlobsSuccess(now - writeMeta.GetWriteMiddle4StartInstant());
-            Stats.GetCSCounters().OnWriteMiddle5PutBlobsSuccess(now - writeMeta.GetWriteMiddle5StartInstant());
-            Stats.GetCSCounters().OnWriteMiddle6PutBlobsSuccess(now - writeMeta.GetWriteMiddle6StartInstant());
+            Counters.GetCSCounters().OnWritePutBlobsSuccess(now - writeMeta.GetWriteStartInstant());
+            Counters.GetCSCounters().OnWriteMiddle1PutBlobsSuccess(now - writeMeta.GetWriteMiddle1StartInstant());
+            Counters.GetCSCounters().OnWriteMiddle2PutBlobsSuccess(now - writeMeta.GetWriteMiddle2StartInstant());
+            Counters.GetCSCounters().OnWriteMiddle3PutBlobsSuccess(now - writeMeta.GetWriteMiddle3StartInstant());
+            Counters.GetCSCounters().OnWriteMiddle4PutBlobsSuccess(now - writeMeta.GetWriteMiddle4StartInstant());
+            Counters.GetCSCounters().OnWriteMiddle5PutBlobsSuccess(now - writeMeta.GetWriteMiddle5StartInstant());
+            Counters.GetCSCounters().OnWriteMiddle6PutBlobsSuccess(now - writeMeta.GetWriteMiddle6StartInstant());
             LOG_S_DEBUG("Write (record) into pathId " << writeMeta.GetTableId()
                 << (writeMeta.GetWriteId() ? (" writeId " + ToString(writeMeta.GetWriteId())).c_str() : "") << " at tablet " << TabletID());
 
@@ -153,7 +153,7 @@ void TColumnShard::Handle(TEvPrivate::TEvWriteDraft::TPtr& ev, const TActorConte
 }
 
 void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContext& ctx) {
-    Stats.GetCSCounters().OnStartWriteRequest();
+    Counters.GetCSCounters().OnStartWriteRequest();
 
     const auto& record = Proto(ev->Get());
     const ui64 tableId = record.GetTableId();
@@ -162,7 +162,7 @@ void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContex
     const TString dedupId = record.GetDedupId();
     const auto source = ev->Sender;
 
-    Stats.GetColumnTableCounters().GetPathIdCounter(tableId).OnUpdate();
+    Counters.GetColumnTableCounters().GetPathIdCounter(tableId).OnUpdate();
 
     std::optional<ui32> granuleShardingVersion;
     if (record.HasGranuleShardingVersion()) {
@@ -179,7 +179,7 @@ void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContex
     writeMeta.SetWritePartId(record.GetWritePartId());
 
     const auto returnFail = [&](const NColumnShard::ECumulativeCounters signalIndex) {
-        Stats.GetTabletCounters().IncCounter(signalIndex);
+        Counters.GetTabletCounters().IncCounter(signalIndex);
 
         ctx.Send(source, std::make_unique<TEvColumnShard::TEvWriteResult>(TabletID(), writeMeta, NKikimrTxColumnShard::EResultStatus::ERROR));
         return;
@@ -187,7 +187,7 @@ void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContex
 
     if (!AppDataVerified().ColumnShardConfig.GetWritingEnabled()) {
         AFL_WARN(NKikimrServices::TX_COLUMNSHARD)("event", "skip_writing")("reason", "disabled");
-        Stats.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::Disabled);
+        Counters.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::Disabled);
         return returnFail(COUNTER_WRITE_FAIL);
     }
 
@@ -195,7 +195,7 @@ void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContex
         LOG_S_NOTICE("Write (fail) into pathId:" << writeMeta.GetTableId() << (TablesManager.HasPrimaryIndex()? "": " no index")
             << " at tablet " << TabletID());
 
-        Stats.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::NoTable);
+        Counters.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::NoTable);
         return returnFail(COUNTER_WRITE_FAIL);
     }
 
@@ -204,7 +204,7 @@ void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContex
     if (!arrowData->ParseFromProto(record)) {
         LOG_S_ERROR("Write (fail) " << record.GetData().size() << " bytes into pathId " << writeMeta.GetTableId()
             << " at tablet " << TabletID());
-        Stats.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::IncorrectSchema);
+        Counters.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::IncorrectSchema);
         return returnFail(COUNTER_WRITE_FAIL);
     }
 
@@ -214,27 +214,27 @@ void TColumnShard::Handle(TEvColumnShard::TEvWrite::TPtr& ev, const TActorContex
     if (overloadStatus != EOverloadStatus::None) {
         std::unique_ptr<NActors::IEventBase> result = std::make_unique<TEvColumnShard::TEvWriteResult>(TabletID(), writeData.GetWriteMeta(), NKikimrTxColumnShard::EResultStatus::OVERLOADED);
         OverloadWriteFail(overloadStatus, writeData, cookie, std::move(result), ctx);
-        Stats.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::Overload);
+        Counters.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::Overload);
     } else {
         if (ui64 writeId = (ui64)HasLongTxWrite(writeMeta.GetLongTxIdUnsafe(), writeMeta.GetWritePartId())) {
             LOG_S_DEBUG("Write (duplicate) into pathId " << writeMeta.GetTableId()
                 << " longTx " << writeMeta.GetLongTxIdUnsafe().ToString()
                 << " at tablet " << TabletID());
 
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_DUPLICATE);
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_DUPLICATE);
 
             auto result = std::make_unique<TEvColumnShard::TEvWriteResult>(
                 TabletID(), writeMeta, writeId, NKikimrTxColumnShard::EResultStatus::SUCCESS);
             ctx.Send(writeMeta.GetSource(), result.release());
-            Stats.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::LongTxDuplication);
+            Counters.GetCSCounters().OnFailedWriteResponse(EWriteFailReason::LongTxDuplication);
             return;
         }
 
-        Stats.GetWritesMonitor().OnStartWrite(writeData.GetSize());
+        Counters.GetWritesMonitor().OnStartWrite(writeData.GetSize());
 
         LOG_S_DEBUG("Write (blob) " << writeData.GetSize() << " bytes into pathId " << writeMeta.GetTableId()
             << (writeMeta.GetWriteId()? (" writeId " + ToString(writeMeta.GetWriteId())).c_str() : " ")
-            << Stats.GetWritesMonitor().DebugString()
+            << Counters.GetWritesMonitor().DebugString()
             << " at tablet " << TabletID());
         writeData.MutableWriteMeta().SetWriteMiddle1StartInstant(TMonotonic::Now());
         std::shared_ptr<NConveyor::ITask> task = std::make_shared<NOlap::TBuildBatchesTask>(TabletID(), SelfId(), BufferizationWriteActorId, std::move(writeData),
@@ -306,7 +306,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     const auto behaviour = TOperationsManager::GetBehaviour(*ev->Get());
 
     if (behaviour == EOperationBehaviour::Undefined) {
-        Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+        Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
         auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, "invalid write event");
         ctx.Send(source, result.release(), 0, cookie);
         return;
@@ -315,7 +315,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     if (behaviour == EOperationBehaviour::CommitWriteLock) {
         auto commitOperation = std::make_shared<TCommitOperation>();
         if (!commitOperation->Parse(*ev->Get())) {
-            Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+            Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
             auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, "invalid commit event");
             ctx.Send(source, result.release(), 0, cookie);
         }
@@ -326,7 +326,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     const ui64 lockId = (behaviour == EOperationBehaviour::InTxWrite) ? record.GetTxId() : record.GetLockTxId();
 
     if (record.GetOperations().size() != 1) {
-        Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+        Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
         auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, "only single operation is supported");
         ctx.Send(source, result.release(), 0, cookie);
         return;
@@ -335,7 +335,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     const auto& operation = record.GetOperations()[0];
     const std::optional<NEvWrite::EModificationType> mType = TEnumOperator<NEvWrite::EModificationType>::DeserializeFromProto(operation.GetType());
     if (!mType) {
-        Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+        Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
         auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, 
             "operation " + NKikimrDataEvents::TEvWrite::TOperation::EOperationType_Name(operation.GetType()) + " is not supported");
         ctx.Send(source, result.release(), 0, cookie);
@@ -343,7 +343,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     }
 
     if (!operation.GetTableId().HasSchemaVersion()) {
-        Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+        Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
         auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, "schema version not set");
         ctx.Send(source, result.release(), 0, cookie);
         return;
@@ -351,7 +351,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
 
     auto schema = TablesManager.GetPrimaryIndex()->GetVersionedIndex().GetSchema(operation.GetTableId().GetSchemaVersion());
     if (!schema) {
-        Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+        Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
         auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, "unknown schema version");
         ctx.Send(source, result.release(), 0, cookie);
         return;
@@ -360,7 +360,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
     const auto tableId = operation.GetTableId().GetTableId();
 
     if (!TablesManager.IsReadyForWrite(tableId)) {
-        Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+        Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
         auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR, "table not writable");
         ctx.Send(source, result.release(), 0, cookie);
         return;
@@ -368,7 +368,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
 
     auto arrowData = std::make_shared<TArrowData>(schema);
     if (!arrowData->Parse(operation, NEvWrite::TPayloadReader<NEvents::TDataEvents::TEvWrite>(*ev->Get()))) {
-        Stats.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
+        Counters.GetTabletCounters().IncCounter(COUNTER_WRITE_FAIL);
         auto result = NEvents::TDataEvents::TEvWriteResult::BuildError(TabletID(), 0, NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST, "parsing data error");
         ctx.Send(source, result.release(), 0, cookie);
     }
@@ -381,7 +381,7 @@ void TColumnShard::Handle(NEvents::TDataEvents::TEvWrite::TPtr& ev, const TActor
         return;
     }
 
-    auto wg = Stats.GetWritesMonitor().OnStartWrite(arrowData->GetSize());
+    auto wg = Counters.GetWritesMonitor().OnStartWrite(arrowData->GetSize());
 
     std::optional<ui32> granuleShardingVersionId;
     if (record.HasGranuleShardingVersionId()) {

--- a/ydb/core/tx/columnshard/columnshard__write_index.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write_index.cpp
@@ -41,7 +41,7 @@ void TColumnShard::Handle(TEvPrivate::TEvWriteIndex::TPtr& ev, const TActorConte
         if (IsAnyChannelYellowStop()) {
             ACFL_ERROR("event", "TEvWriteIndex failed")("reason", "channel yellow stop");
 
-            Stats.GetTabletCounters().IncCounter(COUNTER_OUT_OF_SPACE);
+            Counters.GetTabletCounters().IncCounter(COUNTER_OUT_OF_SPACE);
             ev->Get()->SetPutStatus(NKikimrProto::TRYLATER);
             NOlap::TChangesFinishContext context("out of disk space");
             ev->Get()->IndexChanges->Abort(*this, context);

--- a/ydb/core/tx/columnshard/columnshard__write_index.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write_index.cpp
@@ -41,7 +41,7 @@ void TColumnShard::Handle(TEvPrivate::TEvWriteIndex::TPtr& ev, const TActorConte
         if (IsAnyChannelYellowStop()) {
             ACFL_ERROR("event", "TEvWriteIndex failed")("reason", "channel yellow stop");
 
-            Counters.GetTabletCounters().IncCounter(COUNTER_OUT_OF_SPACE);
+            Counters.GetTabletCounters()->IncCounter(COUNTER_OUT_OF_SPACE);
             ev->Get()->SetPutStatus(NKikimrProto::TRYLATER);
             NOlap::TChangesFinishContext context("out of disk space");
             ev->Get()->IndexChanges->Abort(*this, context);

--- a/ydb/core/tx/columnshard/columnshard__write_index.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write_index.cpp
@@ -41,7 +41,7 @@ void TColumnShard::Handle(TEvPrivate::TEvWriteIndex::TPtr& ev, const TActorConte
         if (IsAnyChannelYellowStop()) {
             ACFL_ERROR("event", "TEvWriteIndex failed")("reason", "channel yellow stop");
 
-            IncCounter(COUNTER_OUT_OF_SPACE);
+            Stats.GetTabletCounters().IncCounter(COUNTER_OUT_OF_SPACE);
             ev->Get()->SetPutStatus(NKikimrProto::TRYLATER);
             NOlap::TChangesFinishContext context("out of disk space");
             ev->Get()->IndexChanges->Abort(*this, context);

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -68,26 +68,16 @@ TColumnShard::TColumnShard(TTabletStorageInfo* info, const TActorId& tablet)
     , ProgressTxController(std::make_unique<TTxController>(*this))
     , StoragesManager(std::make_shared<NOlap::TStoragesManager>(*this))
     , DataLocksManager(std::make_shared<NOlap::NDataLocks::TManager>())
-    , PeriodicWakeupActivationPeriod(
-          NYDBTest::TControllers::GetColumnShardController()->GetPeriodicWakeupActivationPeriod(
-              TSettings::DefaultPeriodicWakeupActivationPeriod
-          )
-      )
-    , StatsReportInterval(NYDBTest::TControllers::GetColumnShardController()->GetStatsReportInterval(
-          TSettings::DefaultStatsReportInterval
-      ))
-    , TabletCountersHolder(new TProtobufTabletCounters<
-                           ESimpleCounters_descriptor,
-                           ECumulativeCounters_descriptor,
-                           EPercentileCounters_descriptor,
-                           ETxTypes_descriptor>())
+    , PeriodicWakeupActivationPeriod(NYDBTest::TControllers::GetColumnShardController()->GetPeriodicWakeupActivationPeriod(
+          TSettings::DefaultPeriodicWakeupActivationPeriod))
+    , StatsReportInterval(NYDBTest::TControllers::GetColumnShardController()->GetStatsReportInterval(TSettings::DefaultStatsReportInterval))
+    , TabletCountersHolder(new TProtobufTabletCounters<ESimpleCounters_descriptor, ECumulativeCounters_descriptor,
+          EPercentileCounters_descriptor, ETxTypes_descriptor>())
     , Stats(*TabletCountersHolder)
     , InFlightReadsTracker(StoragesManager)
     , TablesManager(StoragesManager, info->TabletID)
     , Subscribers(std::make_shared<NSubscriber::TManager>(*this))
-    , PipeClientCache(
-          NTabletPipe::CreateBoundedClientCache(new NTabletPipe::TBoundedClientCacheConfig(), GetPipeClientConfig())
-      )
+    , PipeClientCache(NTabletPipe::CreateBoundedClientCache(new NTabletPipe::TBoundedClientCacheConfig(), GetPipeClientConfig()))
     , InsertTable(std::make_unique<NOlap::TInsertTable>())
     , InsertTaskSubscription(NOlap::TInsertColumnEngineChanges::StaticTypeName(), Stats.GetSubscribeCounters())
     , CompactTaskSubscription(NOlap::TCompactColumnEngineChanges::StaticTypeName(), Stats.GetSubscribeCounters())

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -416,9 +416,9 @@ void TColumnShard::RunEnsureTable(const NKikimrTxColumnShard::TCreateTable& tabl
 
     TablesManager.AddTableVersion(pathId, version, tableVerProto, db, Tiers);
 
-    Counters.GetTabletCounters().SetCounter(COUNTER_TABLES, TablesManager.GetTables().size());
-    Counters.GetTabletCounters().SetCounter(COUNTER_TABLE_PRESETS, TablesManager.GetSchemaPresets().size());
-    Counters.GetTabletCounters().SetCounter(COUNTER_TABLE_TTLS, TablesManager.GetTtl().PathsCount());
+    Counters.GetTabletCounters()->SetCounter(COUNTER_TABLES, TablesManager.GetTables().size());
+    Counters.GetTabletCounters()->SetCounter(COUNTER_TABLE_PRESETS, TablesManager.GetSchemaPresets().size());
+    Counters.GetTabletCounters()->SetCounter(COUNTER_TABLE_TTLS, TablesManager.GetTtl().PathsCount());
 }
 
 void TColumnShard::RunAlterTable(const NKikimrTxColumnShard::TAlterTable& alterProto, const NOlap::TSnapshot& version,

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -440,7 +440,7 @@ private:
         TInstant LastFullCompaction;
     };
 
-    struct TAggregatedTableStats {
+    struct TTableStatsCollection {
         TColumnTableStats TotalStats;
         THashMap<ui64, TColumnTableStats> StatsByPathId;
     };
@@ -605,10 +605,10 @@ private:
     void UpdateResourceMetrics(const TActorContext& ctx, const TUsage& usage);
     ui64 MemoryUsage() const;
 
-    std::optional<TAggregatedTableStats> CollectTableStats() const;
+    std::optional<TTableStatsCollection> CollectTableStats() const;
     void SendPeriodicStats();
-    void FillOlapStats(const TActorContext& ctx, const std::optional<TAggregatedTableStats>& tableStats, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
-    void FillColumnTableStats(const TActorContext& ctx, const std::optional<TAggregatedTableStats>& tableStats, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
+    void FillOlapStats(const TActorContext& ctx, const std::optional<TTableStatsCollection>& tableStats, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
+    void FillColumnTableStats(const TActorContext& ctx, const std::optional<TTableStatsCollection>& tableStats, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
     void ConfigureStats(const TColumnTableStats& inputStats, ::NKikimrTableStats::TTableStats* outputStats);
     void FillTxTableStats(::NKikimrTableStats::TTableStats* tableStats) const;
 

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -292,15 +292,15 @@ public:
 
     // For syslocks
     void IncCounter(NDataShard::ECumulativeCounters counter, ui64 num = 1) const {
-        Counters.GetTabletCounters().IncCounter(counter, num);
+        Counters.GetTabletCounters()->IncCounter(counter, num);
     }
 
     void IncCounter(NDataShard::EPercentileCounters counter, ui64 num) const {
-        Counters.GetTabletCounters().IncCounter(counter, num);
+        Counters.GetTabletCounters()->IncCounter(counter, num);
     }
 
     void IncCounter(NDataShard::EPercentileCounters counter, const TDuration& latency) const {
-        Counters.GetTabletCounters().IncCounter(counter, latency);
+        Counters.GetTabletCounters()->IncCounter(counter, latency);
     }
 
     inline TRowVersion LastCompleteTxVersion() const {

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -434,6 +434,7 @@ private:
     struct TColumnTableStats {
         ui64 RowCount = 0;
         ui64 DataSize = 0;
+        ui64 Portions = 0;
         TInstant AccessTime;
         TInstant UpdateTime;
         TInstant LastFullCompaction;

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -13,7 +13,7 @@
 #include "transactions/tx_controller.h"
 #include "inflight_request_tracker.h"
 #include "counters/columnshard.h"
-#include "counters/statistics_store.h"
+#include "counters/counters_manager.h"
 #include "resource_subscriber/counters.h"
 #include "resource_subscriber/task.h"
 #include "normalizer/abstract/abstract.h"
@@ -292,15 +292,15 @@ public:
 
     // For syslocks
     void IncCounter(NDataShard::ECumulativeCounters counter, ui64 num = 1) const {
-        Stats.GetTabletCounters().IncCounter(counter, num);
+        Counters.GetTabletCounters().IncCounter(counter, num);
     }
 
     void IncCounter(NDataShard::EPercentileCounters counter, ui64 num) const {
-        Stats.GetTabletCounters().IncCounter(counter, num);
+        Counters.GetTabletCounters().IncCounter(counter, num);
     }
 
     void IncCounter(NDataShard::EPercentileCounters counter, const TDuration& latency) const {
-        Stats.GetTabletCounters().IncCounter(counter, latency);
+        Counters.GetTabletCounters().IncCounter(counter, latency);
     }
 
     inline TRowVersion LastCompleteTxVersion() const {
@@ -442,7 +442,7 @@ private:
     TActorId StatsReportPipe;
 
     std::unique_ptr<TTabletCountersBase> TabletCountersHolder;
-    TStatisticsStore Stats;
+    TCountersManager Counters;
 
     TInFlightReadsTracker InFlightReadsTracker;
     TTablesManager TablesManager;

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -431,6 +431,19 @@ private:
         std::optional<ui32> GranuleShardingVersionId;
     };
 
+    struct TColumnTableStats {
+        ui64 RowCount = 0;
+        ui64 DataSize = 0;
+        TInstant AccessTime;
+        TInstant UpdateTime;
+        TInstant LastFullCompaction;
+    };
+
+    struct TAggregatedTableStats {
+        TColumnTableStats TotalStats;
+        THashMap<ui64, TColumnTableStats> StatsByPathId;
+    };
+
     class TWritesMonitor {
     private:
         TColumnShard& Owner;
@@ -591,10 +604,11 @@ private:
     void UpdateResourceMetrics(const TActorContext& ctx, const TUsage& usage);
     ui64 MemoryUsage() const;
 
+    std::optional<TAggregatedTableStats> CollectTableStats() const;
     void SendPeriodicStats();
-    void FillOlapStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
-    void FillColumnTableStats(const TActorContext& ctx, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
-    void ConfigureStats(const NOlap::TColumnEngineStats& indexStats, ::NKikimrTableStats::TTableStats* tabletStats);
+    void FillOlapStats(const TActorContext& ctx, const std::optional<TAggregatedTableStats>& tableStats, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
+    void FillColumnTableStats(const TActorContext& ctx, const std::optional<TAggregatedTableStats>& tableStats, std::unique_ptr<TEvDataShard::TEvPeriodicTableStats>& ev);
+    void ConfigureStats(const TColumnTableStats& inputStats, ::NKikimrTableStats::TTableStats* outputStats);
     void FillTxTableStats(::NKikimrTableStats::TTableStats* tableStats) const;
 
 public:

--- a/ydb/core/tx/columnshard/columnshard_private_events.h
+++ b/ydb/core/tx/columnshard/columnshard_private_events.h
@@ -141,13 +141,13 @@ struct TEvPrivate {
     };
 
     struct TEvReadFinished : public TEventLocal<TEvReadFinished, EvReadFinished> {
-        explicit TEvReadFinished(ui64 requestCookie, ui64 txId, bool success)
-            : RequestCookie(requestCookie), TxId(txId), Success(success)
-        {}
+        explicit TEvReadFinished(ui64 requestCookie, ui64 txId)
+            : RequestCookie(requestCookie)
+            , TxId(txId) {
+        }
 
         ui64 RequestCookie;
         ui64 TxId;
-        bool Success;
     };
 
     struct TEvPeriodicWakeup : public TEventLocal<TEvPeriodicWakeup, EvPeriodicWakeup> {

--- a/ydb/core/tx/columnshard/columnshard_private_events.h
+++ b/ydb/core/tx/columnshard/columnshard_private_events.h
@@ -141,7 +141,7 @@ struct TEvPrivate {
     };
 
     struct TEvReadFinished : public TEventLocal<TEvReadFinished, EvReadFinished> {
-        explicit TEvReadFinished(ui64 requestCookie, ui64 txId)
+        explicit TEvReadFinished(ui64 requestCookie, ui64 txId = 0)
             : RequestCookie(requestCookie)
             , TxId(txId) {
         }

--- a/ydb/core/tx/columnshard/columnshard_private_events.h
+++ b/ydb/core/tx/columnshard/columnshard_private_events.h
@@ -141,12 +141,13 @@ struct TEvPrivate {
     };
 
     struct TEvReadFinished : public TEventLocal<TEvReadFinished, EvReadFinished> {
-        explicit TEvReadFinished(ui64 requestCookie, ui64 txId = 0)
-            : RequestCookie(requestCookie), TxId(txId)
+        explicit TEvReadFinished(ui64 requestCookie, ui64 txId, bool success)
+            : RequestCookie(requestCookie), TxId(txId), Success(success)
         {}
 
         ui64 RequestCookie;
         ui64 TxId;
+        bool Success;
     };
 
     struct TEvPeriodicWakeup : public TEventLocal<TEvPeriodicWakeup, EvPeriodicWakeup> {

--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.cpp
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.cpp
@@ -22,13 +22,13 @@ void TTableStatsBuilder::FillBackgroundControllerStats(const TBackgroundControll
     stats.FillTotalStats(TableStats);
 }
 
+void TTableStatsBuilder::FillScanCountersStats(const TScanCounters& stats) {
+    stats.FillStats(TableStats);
+}
+
 void TTableStatsBuilder::FillExecutorStats(const NTabletFlatExecutor::NFlatExecutorSetup::IExecutor& executor) {
     TableStats.SetInFlightTxCount(executor.GetStats().TxInFly);
     TableStats.SetHasLoanedParts(executor.HasLoanedParts());
-}
-
-void TTableStatsBuilder::FillTxCompleteLag(TDuration txCompleteLag) {
-    TableStats.SetTxCompleteLagMsec(txCompleteLag.MilliSeconds());
 }
 
 void TTableStatsBuilder::FillColumnEngineStats(const NOlap::TColumnEngineStats& stats) {

--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.cpp
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.cpp
@@ -1,0 +1,41 @@
+#include "table_stats.h"
+
+namespace NKikimr::NColumnShard {
+
+void TTableStatsBuilder::FillColumnTableStats(const TSingleColumnTableCounters& stats) {
+    stats.FillStats(TableStats);
+}
+
+void TTableStatsBuilder::FillColumnTableStats(const TColumnTablesCounters& stats) {
+    stats.FillStats(TableStats);
+}
+
+void TTableStatsBuilder::FillTabletStats(const TTabletCountersHandle& stats) {
+    stats.FillStats(TableStats);
+}
+
+void TTableStatsBuilder::FillBackgroundControllerStats(const TBackgroundControllerCounters& stats, ui64 pathId) {
+    stats.FillStats(pathId, TableStats);
+}
+
+void TTableStatsBuilder::FillBackgroundControllerStats(const TBackgroundControllerCounters& stats) {
+    stats.FillTotalStats(TableStats);
+}
+
+void TTableStatsBuilder::FillExecutorStats(const NTabletFlatExecutor::NFlatExecutorSetup::IExecutor& executor) {
+    TableStats.SetInFlightTxCount(executor.GetStats().TxInFly);
+    TableStats.SetHasLoanedParts(executor.HasLoanedParts());
+}
+
+void TTableStatsBuilder::FillTxCompleteLag(TDuration txCompleteLag) {
+    TableStats.SetTxCompleteLagMsec(txCompleteLag.MilliSeconds());
+}
+
+void TTableStatsBuilder::FillColumnEngineStats(const NOlap::TColumnEngineStats& stats) {
+    auto activeStats = stats.Active(); // data stats excluding inactive and evicted
+    TableStats.SetRowCount(activeStats.Rows);
+    TableStats.SetDataSize(activeStats.Bytes);
+    TableStats.SetPartCount(activeStats.Portions);
+}
+
+} // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ydb/core/tablet_flat/tablet_flat_executor.h>
+#include <ydb/core/tx/columnshard/counters/column_tables.h>
+#include <ydb/core/tx/columnshard/counters/tablet_counters.h>
+#include <ydb/core/tx/columnshard/counters/background_controller.h>
+#include <ydb/core/tx/columnshard/engines/column_engine.h>
+#include <ydb/core/protos/table_stats.pb.h>
+
+namespace NKikimr::NColumnShard {
+
+class TTableStatsBuilder {
+private:
+    ::NKikimrTableStats::TTableStats& TableStats;
+
+public:
+    TTableStatsBuilder(::NKikimrTableStats::TTableStats& tableStats)
+        : TableStats(tableStats) {
+    }
+
+    void FillColumnTableStats(const TSingleColumnTableCounters& stats);
+    void FillColumnTableStats(const TColumnTablesCounters& stats);
+
+    void FillTabletStats(const TTabletCountersHandle& stats);
+
+    void FillBackgroundControllerStats(const TBackgroundControllerCounters& stats, ui64 pathId);
+    void FillBackgroundControllerStats(const TBackgroundControllerCounters& stats);
+
+    void FillExecutorStats(const NTabletFlatExecutor::NFlatExecutorSetup::IExecutor& executor);
+
+    void FillTxCompleteLag(TDuration txCompleteLag);
+
+    void FillColumnEngineStats(const NOlap::TColumnEngineStats& stats);
+};
+
+} // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/tx/columnshard/counters/scan.h>
 #include <ydb/core/tablet_flat/tablet_flat_executor.h>
 #include <ydb/core/tx/columnshard/counters/column_tables.h>
 #include <ydb/core/tx/columnshard/counters/tablet_counters.h>
@@ -26,9 +27,9 @@ public:
     void FillBackgroundControllerStats(const TBackgroundControllerCounters& stats, ui64 pathId);
     void FillBackgroundControllerStats(const TBackgroundControllerCounters& stats);
 
-    void FillExecutorStats(const NTabletFlatExecutor::NFlatExecutorSetup::IExecutor& executor);
+    void FillScanCountersStats(const TScanCounters& stats);
 
-    void FillTxCompleteLag(TDuration txCompleteLag);
+    void FillExecutorStats(const NTabletFlatExecutor::NFlatExecutorSetup::IExecutor& executor);
 
     void FillColumnEngineStats(const NOlap::TColumnEngineStats& stats);
 };

--- a/ydb/core/tx/columnshard/counters/aggregation/ya.make
+++ b/ydb/core/tx/columnshard/counters/aggregation/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    table_stats.cpp
+)
+
+PEERDIR(
+    ydb/core/protos
+    ydb/core/base
+)
+
+END()

--- a/ydb/core/tx/columnshard/counters/background_controller.cpp
+++ b/ydb/core/tx/columnshard/counters/background_controller.cpp
@@ -1,0 +1,18 @@
+#include "background_controller.h"
+
+#include <ydb/core/base/appdata_fwd.h>
+#include <library/cpp/time_provider/time_provider.h>
+
+namespace NKikimr::NColumnShard {
+
+void TBackgroundControllerCounters::OnCompactionFinish(ui64 pathId) {
+    TInstant now = TAppData::TimeProvider->Now();
+    TInstant& lastFinish = LastCompactionFinishByPathId[pathId];
+    lastFinish = std::max(lastFinish, now);
+
+    if (LastCompactionFinish < now) {
+        LastCompactionFinish = now;
+    }
+}
+
+} // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/background_controller.h
+++ b/ydb/core/tx/columnshard/counters/background_controller.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <ydb/core/protos/table_stats.pb.h>
+#include <ydb/core/base/appdata_fwd.h>
+#include <library/cpp/time_provider/time_provider.h>
+
+namespace NKikimr::NColumnShard {
+
+class TBackgroundControllerCounters {
+private:
+    THashMap<ui64, TInstant> LastCompactionFinishByPathId;
+    TInstant LastCompactionFinish;
+
+public:
+    void OnCompactionFinish(ui64 pathId) {
+        TInstant now = TAppData::TimeProvider->Now();
+        TInstant& lastFinish = LastCompactionFinishByPathId[pathId];
+        lastFinish = std::max(lastFinish, now);
+
+        if (LastCompactionFinish < now) {
+            LastCompactionFinish = now;
+        }
+    }
+
+    TInstant GetLastCompactionFinishInstant(ui64 pathId) const {
+        auto findInstant = LastCompactionFinishByPathId.FindPtr(pathId);
+        if (!findInstant) {
+            return TInstant::Zero();
+        }
+        return *findInstant;
+    }
+
+    void FillStats(ui64 pathId, ::NKikimrTableStats::TTableStats& output) const {
+        output.SetLastFullCompactionTs(GetLastCompactionFinishInstant(pathId).Seconds());
+    }
+
+    void FillTotalStats(::NKikimrTableStats::TTableStats& output) const {
+        output.SetLastFullCompactionTs(LastCompactionFinish.Seconds());
+    }
+};
+
+} // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/column_tables.cpp
+++ b/ydb/core/tx/columnshard/counters/column_tables.cpp
@@ -2,8 +2,12 @@
 
 namespace NKikimr::NColumnShard {
 
-TSingleColumnTableCounters& TColumnTablesCounters::GetPathIdCounter(ui64 pathId) {
-    return PathIdCounters.try_emplace(pathId, *this).first->second;
+std::shared_ptr<TSingleColumnTableCounters> TColumnTablesCounters::GetPathIdCounter(ui64 pathId) {
+    auto findCounter = PathIdCounters.FindPtr(pathId);
+    if (findCounter) {
+        return *findCounter;
+    }
+    return PathIdCounters.emplace(pathId, std::make_shared<TSingleColumnTableCounters>(*this)).first->second;
 }
 
 } // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/column_tables.cpp
+++ b/ydb/core/tx/columnshard/counters/column_tables.cpp
@@ -1,0 +1,9 @@
+#include "column_tables.h"
+
+namespace NKikimr::NColumnShard {
+
+TSingleColumnTableCounters& TColumnTablesCounters::GetPathIdCounter(ui64 pathId) {
+    return PathIdCounters.try_emplace(pathId, *this).first->second;
+}
+
+} // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/column_tables.h
+++ b/ydb/core/tx/columnshard/counters/column_tables.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <ydb/core/protos/table_stats.pb.h>
+#include <util/datetime/base.h>
+#include <ydb/core/base/appdata_fwd.h>
+#include <library/cpp/time_provider/time_provider.h>
+#include <ydb/library/accessor/accessor.h>
+
+namespace NKikimr::NColumnShard {
+
+class TColumnTablesCounters {
+private:
+    YDB_READONLY(TInstant, LastAccessTime, TInstant::Zero());
+    YDB_READONLY(TInstant, LastUpdateTime, TInstant::Zero());
+
+    THashMap<ui64, class TSingleColumnTableCounters> PathIdCounters;
+
+    friend class TSingleColumnTableCounters;
+
+public:
+    void FillStats(::NKikimrTableStats::TTableStats& output) const {
+        output.SetLastAccessTime(LastAccessTime.MilliSeconds());
+        output.SetLastUpdateTime(LastUpdateTime.MilliSeconds());
+    }
+
+    TSingleColumnTableCounters& GetPathIdCounter(ui64 pathId);
+};
+
+class TSingleColumnTableCounters {
+private:
+    YDB_READONLY(TInstant, PathIdLastAccessTime, TInstant::Zero());
+    YDB_READONLY(TInstant, PathIdLastUpdateTime, TInstant::Zero());
+
+    TInstant& TotalLastAccessTime;
+    TInstant& TotalLastUpdateTime;
+
+public:
+    TSingleColumnTableCounters(TColumnTablesCounters& owner)
+        : TotalLastAccessTime(owner.LastAccessTime)
+        , TotalLastUpdateTime(owner.LastUpdateTime) {
+    }
+
+    void OnAccess() {
+        UpdateLastAccessTime(TAppData::TimeProvider->Now());
+    }
+
+    void OnUpdate() {
+        TInstant now = TAppData::TimeProvider->Now();
+        UpdateLastUpdateTime(now);
+        UpdateLastAccessTime(now);
+    }
+
+    void FillStats(::NKikimrTableStats::TTableStats& output) const {
+        output.SetLastAccessTime(PathIdLastAccessTime.MilliSeconds());
+        output.SetLastUpdateTime(PathIdLastUpdateTime.MilliSeconds());
+    }
+
+private:
+    void UpdateLastAccessTime(TInstant value) {
+        if (PathIdLastAccessTime < value) {
+            PathIdLastAccessTime = value;
+        }
+        if (TotalLastAccessTime < value) {
+            TotalLastAccessTime = value;
+        }
+    }
+
+    void UpdateLastUpdateTime(TInstant value) {
+        if (PathIdLastUpdateTime < value) {
+            PathIdLastUpdateTime = value;
+        }
+        if (TotalLastUpdateTime < value) {
+            TotalLastUpdateTime = value;
+        }
+    }
+};
+
+} // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/columnshard.cpp
+++ b/ydb/core/tx/columnshard/counters/columnshard.cpp
@@ -6,9 +6,12 @@
 
 namespace NKikimr::NColumnShard {
 
-TCSCounters::TCSCounters()
+TCSCounters::TCSCounters(std::shared_ptr<const TTabletCountersHandle> tabletCounters)
     : TBase("CS")
+    , TabletCounters(std::move(tabletCounters))
     , Initialization(*this) {
+    Y_ABORT_UNLESS(TabletCounters);
+
     StartBackgroundCount = TBase::GetDeriviative("StartBackground/Count");
     TooEarlyBackgroundCount = TBase::GetDeriviative("TooEarlyBackground/Count");
     SetupCompactionCount = TBase::GetDeriviative("SetupCompaction/Count");

--- a/ydb/core/tx/columnshard/counters/columnshard.h
+++ b/ydb/core/tx/columnshard/counters/columnshard.h
@@ -70,7 +70,7 @@ class TCSCounters: public TCommonCountersOwner {
 private:
     using TBase = TCommonCountersOwner;
 
-    std::shared_ptr<TTabletCountersHandle> TabletCounters;
+    std::shared_ptr<const TTabletCountersHandle> TabletCounters;
 
     NMonitoring::TDynamicCounters::TCounterPtr StartBackgroundCount;
     NMonitoring::TDynamicCounters::TCounterPtr TooEarlyBackgroundCount;
@@ -186,7 +186,7 @@ public:
         SplitCompactionGranulePortionsCount->SetValue(portionsCount);
     }
 
-    void OnWriteOverloadDisk(const ui64 /*size*/) const {
+    void OnWriteOverloadDisk() const {
         TabletCounters->IncCounter(COUNTER_OUT_OF_SPACE);
     }
 
@@ -266,7 +266,7 @@ public:
         SetupCleanupCount->Add(1);
     }
 
-    TCSCounters();
+    TCSCounters(std::shared_ptr<const TTabletCountersHandle> tabletCounters);
 };
 
 }

--- a/ydb/core/tx/columnshard/counters/columnshard.h
+++ b/ydb/core/tx/columnshard/counters/columnshard.h
@@ -183,27 +183,27 @@ public:
         SplitCompactionGranulePortionsCount->SetValue(portionsCount);
     }
 
-    void OnOverloadInsertTable(const ui64 size) const {
+    void OnWriteOverloadInsertTable(const ui64 size) const {
         OverloadInsertTableBytes->Add(size);
         OverloadInsertTableCount->Add(1);
     }
 
-    void OnOverloadMetadata(const ui64 size) const {
+    void OnWriteOverloadMetadata(const ui64 size) const {
         OverloadMetadataBytes->Add(size);
         OverloadMetadataCount->Add(1);
     }
 
-    void OnOverloadShardTx(const ui64 size) const {
+    void OnWriteOverloadShardTx(const ui64 size) const {
         OverloadShardTxBytes->Add(size);
         OverloadShardTxCount->Add(1);
     }
 
-    void OnOverloadShardWrites(const ui64 size) const {
+    void OnWriteOverloadShardWrites(const ui64 size) const {
         OverloadShardWritesBytes->Add(size);
         OverloadShardWritesCount->Add(1);
     }
 
-    void OnOverloadShardWritesSize(const ui64 size) const {
+    void OnWriteOverloadShardWritesSize(const ui64 size) const {
         OverloadShardWritesSizeBytes->Add(size);
         OverloadShardWritesSizeCount->Add(1);
     }

--- a/ydb/core/tx/columnshard/counters/columnshard.h
+++ b/ydb/core/tx/columnshard/counters/columnshard.h
@@ -4,6 +4,7 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
 #include <util/generic/hash_set.h>
+#include <ydb/core/tx/columnshard/counters/tablet_counters.h>
 
 namespace NKikimr::NColumnShard {
 
@@ -68,6 +69,8 @@ public:
 class TCSCounters: public TCommonCountersOwner {
 private:
     using TBase = TCommonCountersOwner;
+
+    std::shared_ptr<TTabletCountersHandle> TabletCounters;
 
     NMonitoring::TDynamicCounters::TCounterPtr StartBackgroundCount;
     NMonitoring::TDynamicCounters::TCounterPtr TooEarlyBackgroundCount;
@@ -183,27 +186,36 @@ public:
         SplitCompactionGranulePortionsCount->SetValue(portionsCount);
     }
 
+    void OnWriteOverloadDisk(const ui64 /*size*/) const {
+        TabletCounters->IncCounter(COUNTER_OUT_OF_SPACE);
+    }
+
     void OnWriteOverloadInsertTable(const ui64 size) const {
+        TabletCounters->IncCounter(COUNTER_WRITE_OVERLOAD);
         OverloadInsertTableBytes->Add(size);
         OverloadInsertTableCount->Add(1);
     }
 
     void OnWriteOverloadMetadata(const ui64 size) const {
+        TabletCounters->IncCounter(COUNTER_WRITE_OVERLOAD);
         OverloadMetadataBytes->Add(size);
         OverloadMetadataCount->Add(1);
     }
 
     void OnWriteOverloadShardTx(const ui64 size) const {
+        TabletCounters->IncCounter(COUNTER_WRITE_OVERLOAD);
         OverloadShardTxBytes->Add(size);
         OverloadShardTxCount->Add(1);
     }
 
     void OnWriteOverloadShardWrites(const ui64 size) const {
+        TabletCounters->IncCounter(COUNTER_WRITE_OVERLOAD);
         OverloadShardWritesBytes->Add(size);
         OverloadShardWritesCount->Add(1);
     }
 
     void OnWriteOverloadShardWritesSize(const ui64 size) const {
+        TabletCounters->IncCounter(COUNTER_WRITE_OVERLOAD);
         OverloadShardWritesSizeBytes->Add(size);
         OverloadShardWritesSizeCount->Add(1);
     }

--- a/ydb/core/tx/columnshard/counters/counters_manager.h
+++ b/ydb/core/tx/columnshard/counters/counters_manager.h
@@ -19,7 +19,7 @@
 
 namespace NKikimr::NColumnShard {
 
-class TStatisticsStore {
+class TCountersManager {
 private:
     YDB_READONLY(TCSCounters, CSCounters, {});
     YDB_READONLY(TIndexationCounters, EvictionCounters, TIndexationCounters("Eviction"));
@@ -35,7 +35,7 @@ private:
     TWritesMonitor WritesMonitor;
 
 public:
-    TStatisticsStore(TTabletCountersBase& tabletCounters)
+    TCountersManager(TTabletCountersBase& tabletCounters)
         : SubscribeCounters(std::make_shared<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters>())
         , TabletCounters(tabletCounters)
         , WritesMonitor(tabletCounters) {

--- a/ydb/core/tx/columnshard/counters/counters_manager.h
+++ b/ydb/core/tx/columnshard/counters/counters_manager.h
@@ -21,26 +21,26 @@ namespace NKikimr::NColumnShard {
 
 class TCountersManager {
 private:
-    YDB_READONLY(TCSCounters, CSCounters, TCSCounters());
+    YDB_READONLY_DEF(std::shared_ptr<const TTabletCountersHandle>, TabletCounters);
+    YDB_READONLY_DEF(std::shared_ptr<TWritesMonitor>, WritesMonitor);
+
+    YDB_READONLY_DEF(std::shared_ptr<TBackgroundControllerCounters>, BackgroundControllerCounters);
+    YDB_READONLY_DEF(std::shared_ptr<TColumnTablesCounters>, ColumnTablesCounters);
+
+    YDB_READONLY(TCSCounters, CSCounters, TCSCounters(TabletCounters));
     YDB_READONLY(TIndexationCounters, EvictionCounters, TIndexationCounters("Eviction"));
     YDB_READONLY(TIndexationCounters, IndexationCounters, TIndexationCounters("Indexation"));
     YDB_READONLY(TIndexationCounters, CompactionCounters, TIndexationCounters("GeneralCompaction"));
     YDB_READONLY(TScanCounters, ScanCounters, TScanCounters("Scan"));
     YDB_READONLY_DEF(std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters>, SubscribeCounters);
 
-    YDB_READONLY_DEF(std::shared_ptr<TBackgroundControllerCounters>, BackgroundControllerCounters);
-    YDB_READONLY_DEF(std::shared_ptr<TColumnTablesCounters>, ColumnTablesCounters);
-
-    YDB_READONLY_DEF(std::shared_ptr<const TTabletCountersHandle>, TabletCounters);
-    YDB_READONLY_DEF(std::shared_ptr<TWritesMonitor>, WritesMonitor);
-
 public:
     TCountersManager(TTabletCountersBase& tabletCounters)
-        : SubscribeCounters(std::make_shared<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters>())
+        : TabletCounters(std::make_shared<const TTabletCountersHandle>(tabletCounters))
+        , WritesMonitor(std::make_shared<TWritesMonitor>(tabletCounters))
         , BackgroundControllerCounters(std::make_shared<TBackgroundControllerCounters>())
         , ColumnTablesCounters(std::make_shared<TColumnTablesCounters>())
-        , TabletCounters(std::make_shared<const TTabletCountersHandle>(tabletCounters))
-        , WritesMonitor(std::make_shared<TWritesMonitor>(tabletCounters)) {
+        , SubscribeCounters(std::make_shared<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters>()) {
     }
 };
 

--- a/ydb/core/tx/columnshard/counters/counters_manager.h
+++ b/ydb/core/tx/columnshard/counters/counters_manager.h
@@ -21,48 +21,26 @@ namespace NKikimr::NColumnShard {
 
 class TCountersManager {
 private:
-    YDB_READONLY(TCSCounters, CSCounters, {});
+    YDB_READONLY(TCSCounters, CSCounters, TCSCounters());
     YDB_READONLY(TIndexationCounters, EvictionCounters, TIndexationCounters("Eviction"));
     YDB_READONLY(TIndexationCounters, IndexationCounters, TIndexationCounters("Indexation"));
     YDB_READONLY(TIndexationCounters, CompactionCounters, TIndexationCounters("GeneralCompaction"));
     YDB_READONLY(TScanCounters, ScanCounters, TScanCounters("Scan"));
-    std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters> SubscribeCounters;
+    YDB_READONLY_DEF(std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters>, SubscribeCounters);
 
-    TBackgroundControllerCounters BackgroundControllerCounters;
-    TColumnTablesCounters ColumnTablesCounters;
+    YDB_READONLY_DEF(std::shared_ptr<TBackgroundControllerCounters>, BackgroundControllerCounters);
+    YDB_READONLY_DEF(std::shared_ptr<TColumnTablesCounters>, ColumnTablesCounters);
 
-    const TTabletCountersHandle TabletCounters;
-    TWritesMonitor WritesMonitor;
+    YDB_READONLY_DEF(std::shared_ptr<const TTabletCountersHandle>, TabletCounters);
+    YDB_READONLY_DEF(std::shared_ptr<TWritesMonitor>, WritesMonitor);
 
 public:
     TCountersManager(TTabletCountersBase& tabletCounters)
         : SubscribeCounters(std::make_shared<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters>())
-        , TabletCounters(tabletCounters)
-        , WritesMonitor(tabletCounters) {
-    }
-
-    const TTabletCountersHandle& GetTabletCounters() const {
-        return TabletCounters;
-    }
-
-    TWritesMonitor& GetWritesMonitor() {
-        return WritesMonitor;
-    }
-
-    const TWritesMonitor& GetWritesMonitor() const {
-        return WritesMonitor;
-    }
-
-    std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters> GetSubscribeCounters() {
-        return SubscribeCounters;
-    }
-
-    TColumnTablesCounters& GetColumnTableCounters() {
-        return ColumnTablesCounters;
-    }
-
-    TBackgroundControllerCounters& GetBackgroundControllerCounters() {
-        return BackgroundControllerCounters;
+        , BackgroundControllerCounters(std::make_shared<TBackgroundControllerCounters>())
+        , ColumnTablesCounters(std::make_shared<TColumnTablesCounters>())
+        , TabletCounters(std::make_shared<const TTabletCountersHandle>(tabletCounters))
+        , WritesMonitor(std::make_shared<TWritesMonitor>(tabletCounters)) {
     }
 };
 

--- a/ydb/core/tx/columnshard/counters/scan.cpp
+++ b/ydb/core/tx/columnshard/counters/scan.cpp
@@ -95,7 +95,7 @@ TScanCounters::TScanCounters(const TString& module)
             continue;
         }
         ScanDurationByStatus[(ui32)i] = TBase::GetHistogram("ScanDuration/" + ::ToString(i) + "/Milliseconds", NMonitoring::ExponentialHistogram(18, 2, 1));
-        ScansFinishedByStatus[(ui32)i] = TBase::GetDeriviative("ScansFinised/" + ::ToString(i));
+        ScansFinishedByStatus[(ui32)i] = TBase::GetDeriviative("ScansFinished/" + ::ToString(i));
         AFL_VERIFY(idx == (ui32)i);
         ++idx;
     }

--- a/ydb/core/tx/columnshard/counters/scan.h
+++ b/ydb/core/tx/columnshard/counters/scan.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "common/owner.h"
 #include "common/histogram.h"
+#include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/tx/columnshard/resources/memory.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/counters.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/task.h>
@@ -127,6 +128,7 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr AckWaitingDuration;
 
     std::vector<NMonitoring::THistogramPtr> ScanDurationByStatus;
+    std::vector<NMonitoring::TDynamicCounters::TCounterPtr> ScansFinishedByStatus;
 
     NMonitoring::TDynamicCounters::TCounterPtr NoScanRecords;
     NMonitoring::TDynamicCounters::TCounterPtr NoScanIntervals;
@@ -212,9 +214,10 @@ public:
         LogScanIntervals->Add(1);
     }
 
-    void OnScanDuration(const EStatusFinish status, const TDuration d) const {
+    void OnScanFinished(const EStatusFinish status, const TDuration d) const {
         AFL_VERIFY((ui32)status < ScanDurationByStatus.size());
         ScanDurationByStatus[(ui32)status]->Collect(d.MilliSeconds());
+        ScansFinishedByStatus[(ui32)status]->Add(1);
     }
 
     void AckWaitingInfo(const TDuration d) const {
@@ -257,6 +260,8 @@ public:
     }
 
     TScanAggregations BuildAggregations();
+
+    void FillStats(::NKikimrTableStats::TTableStats& output) const;
 };
 
 class TCounterGuard: TNonCopyable {

--- a/ydb/core/tx/columnshard/counters/statistics_store.h
+++ b/ydb/core/tx/columnshard/counters/statistics_store.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "columnshard.h"
+#include "indexation.h"
+#include "scan.h"
+#include "column_tables.h"
+#include "writes_monitor.h"
+#include "tablet_counters.h"
+#include "background_controller.h"
+
+#include <ydb/core/tx/columnshard/engines/column_engine.h>
+#include <ydb/core/tablet_flat/tablet_flat_executor.h>
+#include <ydb/core/protos/table_stats.pb.h>
+#include <ydb/core/tablet/tablet_counters.h>
+#include <ydb/core/protos/counters_columnshard.pb.h>
+#include <ydb/core/protos/counters_datashard.pb.h>
+#include <ydb/core/base/appdata_fwd.h>
+#include <library/cpp/time_provider/time_provider.h>
+
+namespace NKikimr::NColumnShard {
+
+class TStatisticsStore {
+private:
+    YDB_READONLY(TCSCounters, CSCounters, {});
+    YDB_READONLY(TIndexationCounters, EvictionCounters, TIndexationCounters("Eviction"));
+    YDB_READONLY(TIndexationCounters, IndexationCounters, TIndexationCounters("Indexation"));
+    YDB_READONLY(TIndexationCounters, CompactionCounters, TIndexationCounters("GeneralCompaction"));
+    YDB_READONLY(TScanCounters, ScanCounters, TScanCounters("Scan"));
+    std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters> SubscribeCounters;
+
+    TBackgroundControllerCounters BackgroundControllerCounters;
+    TColumnTablesCounters ColumnTablesCounters;
+
+    const TTabletCountersHandle TabletCounters;
+    TWritesMonitor WritesMonitor;
+
+public:
+    TStatisticsStore(TTabletCountersBase& tabletCounters)
+        : SubscribeCounters(std::make_shared<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters>())
+        , TabletCounters(tabletCounters)
+        , WritesMonitor(tabletCounters) {
+    }
+
+    const TTabletCountersHandle& GetTabletCounters() const {
+        return TabletCounters;
+    }
+
+    TWritesMonitor& GetWritesMonitor() {
+        return WritesMonitor;
+    }
+
+    const TWritesMonitor& GetWritesMonitor() const {
+        return WritesMonitor;
+    }
+
+    std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TSubscriberCounters> GetSubscribeCounters() {
+        return SubscribeCounters;
+    }
+
+    TColumnTablesCounters& GetColumnTableCounters() {
+        return ColumnTablesCounters;
+    }
+
+    TBackgroundControllerCounters& GetBackgroundControllerCounters() {
+        return BackgroundControllerCounters;
+    }
+};
+
+} // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/counters/tablet_counters.h
+++ b/ydb/core/tx/columnshard/counters/tablet_counters.h
@@ -4,6 +4,8 @@
 #include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/protos/counters_columnshard.pb.h>
 #include <ydb/core/protos/counters_datashard.pb.h>
+#include <ydb/core/tx/columnshard/engines/column_engine.h>
+#include <ydb/core/tx/columnshard/engines/insert_table/rt_insertion.h>
 
 namespace NKikimr::NColumnShard {
 
@@ -77,6 +79,19 @@ public:
 
     void OnWriteFailure() const {
         IncCounter(NColumnShard::COUNTER_WRITE_FAIL);
+    }
+
+    void OnScanStarted(const NOlap::TSelectInfo::TStats& countersDelta) {
+        IncCounter(NColumnShard::COUNTER_READ_INDEX_PORTIONS, countersDelta.Portions);
+        IncCounter(NColumnShard::COUNTER_READ_INDEX_BLOBS, countersDelta.Blobs);
+        IncCounter(NColumnShard::COUNTER_READ_INDEX_ROWS, countersDelta.Rows);
+        IncCounter(NColumnShard::COUNTER_READ_INDEX_BYTES, countersDelta.Bytes);
+    }
+
+    void OnWriteCommitted(const NOlap::TInsertionSummary::TCounters& countersDelta) {
+        IncCounter(COUNTER_BLOBS_COMMITTED, countersDelta.Rows);
+        IncCounter(COUNTER_BYTES_COMMITTED, countersDelta.Bytes);
+        IncCounter(COUNTER_RAW_BYTES_COMMITTED, countersDelta.RawBytes);
     }
 
     void FillStats(::NKikimrTableStats::TTableStats& output) const {

--- a/ydb/core/tx/columnshard/counters/tablet_counters.h
+++ b/ydb/core/tx/columnshard/counters/tablet_counters.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <ydb/core/tablet/tablet_counters.h>
+#include <ydb/core/protos/table_stats.pb.h>
+#include <ydb/core/protos/counters_columnshard.pb.h>
+#include <ydb/core/protos/counters_datashard.pb.h>
+
+namespace NKikimr::NColumnShard {
+
+class TTabletCountersHandle {
+private:
+    TTabletCountersBase& TabletCounters;
+
+public:
+    TTabletCountersHandle(TTabletCountersBase& stats)
+        : TabletCounters(stats) {
+    }
+
+    void SetCounter(NColumnShard::ESimpleCounters counter, ui64 num) const {
+        TabletCounters.Simple()[counter].Set(num);
+    }
+
+    void IncCounter(NColumnShard::ECumulativeCounters counter, ui64 num = 1) const {
+        TabletCounters.Cumulative()[counter].Increment(num);
+    }
+
+    void IncCounter(NColumnShard::EPercentileCounters counter, const TDuration& latency) const {
+        TabletCounters.Percentile()[counter].IncrementFor(latency.MicroSeconds());
+    }
+
+    void IncCounter(NDataShard::ESimpleCounters counter, ui64 num = 1) const {
+        TabletCounters.Simple()[counter].Add(num);
+    }
+
+    void IncCounter(NDataShard::ECumulativeCounters counter, ui64 num = 1) const {
+        TabletCounters.Cumulative()[counter].Increment(num);
+    }
+
+    void IncCounter(NDataShard::EPercentileCounters counter, ui64 num) const {
+        TabletCounters.Percentile()[counter].IncrementFor(num);
+    }
+
+    void IncCounter(NDataShard::EPercentileCounters counter, const TDuration& latency) const {
+        TabletCounters.Percentile()[counter].IncrementFor(latency.MilliSeconds());
+    }
+
+    ui64 GetValue(NColumnShard::ESimpleCounters counter) const {
+        return TabletCounters.Simple()[counter].Get();
+    }
+
+    ui64 GetValue(NColumnShard::ECumulativeCounters counter) const {
+        return TabletCounters.Cumulative()[counter].Get();
+    }
+
+    const TTabletPercentileCounter& GetValue(NColumnShard::EPercentileCounters counter) const {
+        return TabletCounters.Percentile()[counter];
+    }
+
+    ui64 GetValue(NDataShard::ESimpleCounters counter) const {
+        return TabletCounters.Simple()[counter].Get();
+    }
+
+    ui64 GetValue(NDataShard::ECumulativeCounters counter) const {
+        return TabletCounters.Cumulative()[counter].Get();
+    }
+
+    const TTabletPercentileCounter& GetCounter(NDataShard::EPercentileCounters counter) const {
+        return TabletCounters.Percentile()[counter];
+    }
+
+    void FillStats(::NKikimrTableStats::TTableStats& output) const {
+        output.SetRowUpdates(GetValue(COUNTER_WRITE_SUCCESS));
+        output.SetRowDeletes(0); // manual deletes are not supported
+        output.SetRowReads(0);   // all reads are range reads
+        output.SetRangeReads(GetValue(COUNTER_READ_SUCCESS));
+        output.SetRangeReadRows(GetValue(COUNTER_READ_INDEX_ROWS));
+
+        output.SetImmediateTxCompleted(GetValue(COUNTER_IMMEDIATE_TX_COMPLETED));
+        output.SetTxRejectedByOverload(GetValue(COUNTER_WRITE_OVERLOAD));
+        output.SetTxRejectedBySpace(GetValue(COUNTER_OUT_OF_SPACE));
+        output.SetPlannedTxCompleted(GetValue(COUNTER_PLANNED_TX_COMPLETED));
+    }
+};
+
+}

--- a/ydb/core/tx/columnshard/counters/tablet_counters.h
+++ b/ydb/core/tx/columnshard/counters/tablet_counters.h
@@ -68,6 +68,17 @@ public:
         return TabletCounters.Percentile()[counter];
     }
 
+    void OnWriteSuccess(const ui64 blobsWritten, const ui64 bytesWritten) const {
+        IncCounter(NColumnShard::COUNTER_UPSERT_BLOBS_WRITTEN, blobsWritten);
+        IncCounter(NColumnShard::COUNTER_UPSERT_BYTES_WRITTEN, bytesWritten);
+        //    self.Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_UPSERTED, insertedBytes);
+        IncCounter(NColumnShard::COUNTER_WRITE_SUCCESS);
+    }
+
+    void OnWriteFailure() const {
+        IncCounter(NColumnShard::COUNTER_WRITE_FAIL);
+    }
+
     void FillStats(::NKikimrTableStats::TTableStats& output) const {
         output.SetRowUpdates(GetValue(COUNTER_WRITE_SUCCESS));
         output.SetRowDeletes(0); // manual deletes are not supported

--- a/ydb/core/tx/columnshard/counters/tablet_counters.h
+++ b/ydb/core/tx/columnshard/counters/tablet_counters.h
@@ -81,17 +81,29 @@ public:
         IncCounter(NColumnShard::COUNTER_WRITE_FAIL);
     }
 
-    void OnScanStarted(const NOlap::TSelectInfo::TStats& countersDelta) {
+    void OnScanStarted(const NOlap::TSelectInfo::TStats& countersDelta) const {
         IncCounter(NColumnShard::COUNTER_READ_INDEX_PORTIONS, countersDelta.Portions);
         IncCounter(NColumnShard::COUNTER_READ_INDEX_BLOBS, countersDelta.Blobs);
         IncCounter(NColumnShard::COUNTER_READ_INDEX_ROWS, countersDelta.Rows);
         IncCounter(NColumnShard::COUNTER_READ_INDEX_BYTES, countersDelta.Bytes);
     }
 
-    void OnWriteCommitted(const NOlap::TInsertionSummary::TCounters& countersDelta) {
+    void OnWriteCommitted(const NOlap::TInsertionSummary::TCounters& countersDelta) const {
         IncCounter(COUNTER_BLOBS_COMMITTED, countersDelta.Rows);
         IncCounter(COUNTER_BYTES_COMMITTED, countersDelta.Bytes);
         IncCounter(COUNTER_RAW_BYTES_COMMITTED, countersDelta.RawBytes);
+    }
+
+    void OnCompactionWriteIndexCompleted(bool success, const ui64 blobsWritten, const ui64 bytesWritten) const {
+        IncCounter(success ? NColumnShard::COUNTER_SPLIT_COMPACTION_SUCCESS : NColumnShard::COUNTER_SPLIT_COMPACTION_FAIL);
+        IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BLOBS_WRITTEN, blobsWritten);
+        IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BYTES_WRITTEN, bytesWritten);
+    }
+
+    void OnInsertionWriteIndexCompleted(const ui64 blobsWritten, const ui64 bytesWritten, const TDuration duration) const {
+        IncCounter(NColumnShard::COUNTER_INDEXING_BLOBS_WRITTEN, blobsWritten);
+        IncCounter(NColumnShard::COUNTER_INDEXING_BYTES_WRITTEN, bytesWritten);
+        IncCounter(NColumnShard::COUNTER_INDEXING_TIME, duration.MilliSeconds());
     }
 
     void FillStats(::NKikimrTableStats::TTableStats& output) const {

--- a/ydb/core/tx/columnshard/counters/tablet_counters.h
+++ b/ydb/core/tx/columnshard/counters/tablet_counters.h
@@ -72,13 +72,13 @@ public:
         output.SetRowUpdates(GetValue(COUNTER_WRITE_SUCCESS));
         output.SetRowDeletes(0); // manual deletes are not supported
         output.SetRowReads(0);   // all reads are range reads
-        output.SetRangeReads(GetValue(COUNTER_READ_SUCCESS));
         output.SetRangeReadRows(GetValue(COUNTER_READ_INDEX_ROWS));
 
         output.SetImmediateTxCompleted(GetValue(COUNTER_IMMEDIATE_TX_COMPLETED));
         output.SetTxRejectedByOverload(GetValue(COUNTER_WRITE_OVERLOAD));
         output.SetTxRejectedBySpace(GetValue(COUNTER_OUT_OF_SPACE));
         output.SetPlannedTxCompleted(GetValue(COUNTER_PLANNED_TX_COMPLETED));
+        output.SetTxCompleteLagMsec(GetValue(COUNTER_TX_COMPLETE_LAG));
     }
 };
 

--- a/ydb/core/tx/columnshard/counters/writes_monitor.h
+++ b/ydb/core/tx/columnshard/counters/writes_monitor.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <ydb/core/protos/counters_columnshard.pb.h>
+#include <ydb/core/tablet/tablet_counters.h>
+#include <ydb/library/accessor/accessor.h>
+
+namespace NKikimr::NColumnShard {
+
+class TWritesMonitor {
+private:
+    TTabletCountersBase& Stats;
+    
+    YDB_READONLY(ui64, WritesInFlight, 0);
+    YDB_READONLY(ui64, WritesSizeInFlight, 0);
+
+public:
+    class TGuard: public TNonCopyable {
+        friend class TWritesMonitor;
+
+    private:
+        TWritesMonitor& Owner;
+
+        explicit TGuard(TWritesMonitor& owner)
+            : Owner(owner) {
+        }
+
+    public:
+        ~TGuard() {
+            Owner.UpdateCounters();
+        }
+    };
+
+    TWritesMonitor(TTabletCountersBase& stats)
+        : Stats(stats) {
+    }
+
+    TGuard OnStartWrite(const ui64 dataSize) {
+        ++WritesInFlight;
+        WritesSizeInFlight += dataSize;
+        return TGuard(*this);
+    }
+
+    TGuard OnFinishWrite(const ui64 dataSize, const ui32 writesCount = 1) {
+        Y_ABORT_UNLESS(WritesInFlight > 0);
+        Y_ABORT_UNLESS(WritesSizeInFlight >= dataSize);
+        WritesInFlight -= writesCount;
+        WritesSizeInFlight -= dataSize;
+        return TGuard(*this);
+    }
+
+    TString DebugString() const {
+        return TStringBuilder() << "{object=write_monitor;count=" << WritesInFlight << ";size=" << WritesSizeInFlight
+                                << "}";
+    }
+
+private:
+    void UpdateCounters() {
+        Stats.Simple()[COUNTER_WRITES_IN_FLY].Set(WritesInFlight);
+    }
+};
+
+}

--- a/ydb/core/tx/columnshard/counters/ya.make
+++ b/ydb/core/tx/columnshard/counters/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    background_controller.cpp
     column_tables.cpp
     indexation.cpp
     scan.cpp

--- a/ydb/core/tx/columnshard/counters/ya.make
+++ b/ydb/core/tx/columnshard/counters/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    column_tables.cpp
     indexation.cpp
     scan.cpp
     engine_logs.cpp
@@ -13,6 +14,7 @@ SRCS(
 
 PEERDIR(
     library/cpp/monlib/dynamic_counters
+    ydb/core/tx/columnshard/counters/aggregation
     ydb/core/tx/columnshard/counters/common
     ydb/core/base
 )

--- a/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
@@ -46,7 +46,7 @@ void TColumnEngineChanges::WriteIndexOnComplete(NColumnShard::TColumnShard* self
     DoWriteIndexOnComplete(self, context);
     if (self) {
         OnFinish(*self, context);
-        self->Stats.GetTabletCounters().IncCounter(GetCounterIndex(context.FinishedSuccessfully));
+        self->Counters.GetTabletCounters().IncCounter(GetCounterIndex(context.FinishedSuccessfully));
     }
 
 }

--- a/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
@@ -46,7 +46,7 @@ void TColumnEngineChanges::WriteIndexOnComplete(NColumnShard::TColumnShard* self
     DoWriteIndexOnComplete(self, context);
     if (self) {
         OnFinish(*self, context);
-        self->Counters.GetTabletCounters().IncCounter(GetCounterIndex(context.FinishedSuccessfully));
+        self->Counters.GetTabletCounters()->IncCounter(GetCounterIndex(context.FinishedSuccessfully));
     }
 
 }

--- a/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
@@ -46,7 +46,7 @@ void TColumnEngineChanges::WriteIndexOnComplete(NColumnShard::TColumnShard* self
     DoWriteIndexOnComplete(self, context);
     if (self) {
         OnFinish(*self, context);
-        self->IncCounter(GetCounterIndex(context.FinishedSuccessfully));
+        self->Stats.GetTabletCounters().IncCounter(GetCounterIndex(context.FinishedSuccessfully));
     }
 
 }

--- a/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
@@ -41,9 +41,9 @@ void TCleanupPortionsColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::T
         }
     }
     if (self) {
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_ERASED, PortionsToDrop.size());
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_ERASED, PortionsToDrop.size());
         for (auto&& p : PortionsToDrop) {
-            self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_ERASED, p.GetTotalRawBytes());
+            self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_ERASED, p.GetTotalRawBytes());
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
@@ -41,9 +41,9 @@ void TCleanupPortionsColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::T
         }
     }
     if (self) {
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_ERASED, PortionsToDrop.size());
+        self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_PORTIONS_ERASED, PortionsToDrop.size());
         for (auto&& p : PortionsToDrop) {
-            self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_ERASED, p.GetTotalRawBytes());
+            self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_RAW_BYTES_ERASED, p.GetTotalRawBytes());
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/cleanup_portions.cpp
@@ -41,9 +41,9 @@ void TCleanupPortionsColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::T
         }
     }
     if (self) {
-        self->IncCounter(NColumnShard::COUNTER_PORTIONS_ERASED, PortionsToDrop.size());
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_ERASED, PortionsToDrop.size());
         for (auto&& p : PortionsToDrop) {
-            self->IncCounter(NColumnShard::COUNTER_RAW_BYTES_ERASED, p.GetTotalRawBytes());
+            self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_ERASED, p.GetTotalRawBytes());
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction.cpp
@@ -53,7 +53,7 @@ void TCompactColumnEngineChanges::DoStart(NColumnShard::TColumnShard& self) {
 void TCompactColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context) {
     TBase::DoWriteIndexOnComplete(self, context);
     if (self) {
-        self->IncCounter(NColumnShard::COUNTER_COMPACTION_TIME, context.Duration.MilliSeconds());
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_TIME, context.Duration.MilliSeconds());
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction.cpp
@@ -53,7 +53,7 @@ void TCompactColumnEngineChanges::DoStart(NColumnShard::TColumnShard& self) {
 void TCompactColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context) {
     TBase::DoWriteIndexOnComplete(self, context);
     if (self) {
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_TIME, context.Duration.MilliSeconds());
+        self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_COMPACTION_TIME, context.Duration.MilliSeconds());
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction.cpp
@@ -53,7 +53,7 @@ void TCompactColumnEngineChanges::DoStart(NColumnShard::TColumnShard& self) {
 void TCompactColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context) {
     TBase::DoWriteIndexOnComplete(self, context);
     if (self) {
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_TIME, context.Duration.MilliSeconds());
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_TIME, context.Duration.MilliSeconds());
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
@@ -192,7 +192,7 @@ TConclusionStatus TGeneralCompactColumnEngineChanges::DoConstructBlobs(TConstruc
 void TGeneralCompactColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context) {
     TBase::DoWriteIndexOnComplete(self, context);
     if (self) {
-        self->Counters.GetTabletCounters().OnCompactionWriteIndexCompleted(
+        self->Counters.GetTabletCounters()->OnCompactionWriteIndexCompleted(
             context.FinishedSuccessfully, context.BlobsWritten, context.BytesWritten);
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
@@ -192,10 +192,8 @@ TConclusionStatus TGeneralCompactColumnEngineChanges::DoConstructBlobs(TConstruc
 void TGeneralCompactColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context) {
     TBase::DoWriteIndexOnComplete(self, context);
     if (self) {
-        self->Counters.GetTabletCounters().IncCounter(
-            context.FinishedSuccessfully ? NColumnShard::COUNTER_SPLIT_COMPACTION_SUCCESS : NColumnShard::COUNTER_SPLIT_COMPACTION_FAIL);
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BLOBS_WRITTEN, context.BlobsWritten);
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BYTES_WRITTEN, context.BytesWritten);
+        self->Counters.GetTabletCounters().OnCompactionWriteIndexCompleted(
+            context.FinishedSuccessfully, context.BlobsWritten, context.BytesWritten);
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
@@ -192,17 +192,17 @@ TConclusionStatus TGeneralCompactColumnEngineChanges::DoConstructBlobs(TConstruc
 void TGeneralCompactColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context) {
     TBase::DoWriteIndexOnComplete(self, context);
     if (self) {
-        self->IncCounter(
+        self->Stats.GetTabletCounters().IncCounter(
             context.FinishedSuccessfully ? NColumnShard::COUNTER_SPLIT_COMPACTION_SUCCESS : NColumnShard::COUNTER_SPLIT_COMPACTION_FAIL);
-        self->IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BLOBS_WRITTEN, context.BlobsWritten);
-        self->IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BYTES_WRITTEN, context.BytesWritten);
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BLOBS_WRITTEN, context.BlobsWritten);
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BYTES_WRITTEN, context.BytesWritten);
     }
 }
 
 void TGeneralCompactColumnEngineChanges::DoStart(NColumnShard::TColumnShard& self) {
     TBase::DoStart(self);
     auto& g = *GranuleMeta;
-    self.CSCounters.OnSplitCompactionInfo(
+    self.Stats.GetCSCounters().OnSplitCompactionInfo(
         g.GetAdditiveSummary().GetCompacted().GetTotalPortionsSize(), g.GetAdditiveSummary().GetCompacted().GetPortionsCount());
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
@@ -192,17 +192,17 @@ TConclusionStatus TGeneralCompactColumnEngineChanges::DoConstructBlobs(TConstruc
 void TGeneralCompactColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context) {
     TBase::DoWriteIndexOnComplete(self, context);
     if (self) {
-        self->Stats.GetTabletCounters().IncCounter(
+        self->Counters.GetTabletCounters().IncCounter(
             context.FinishedSuccessfully ? NColumnShard::COUNTER_SPLIT_COMPACTION_SUCCESS : NColumnShard::COUNTER_SPLIT_COMPACTION_FAIL);
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BLOBS_WRITTEN, context.BlobsWritten);
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BYTES_WRITTEN, context.BytesWritten);
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BLOBS_WRITTEN, context.BlobsWritten);
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_BYTES_WRITTEN, context.BytesWritten);
     }
 }
 
 void TGeneralCompactColumnEngineChanges::DoStart(NColumnShard::TColumnShard& self) {
     TBase::DoStart(self);
     auto& g = *GranuleMeta;
-    self.Stats.GetCSCounters().OnSplitCompactionInfo(
+    self.Counters.GetCSCounters().OnSplitCompactionInfo(
         g.GetAdditiveSummary().GetCompacted().GetTotalPortionsSize(), g.GetAdditiveSummary().GetCompacted().GetPortionsCount());
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/indexation.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/indexation.cpp
@@ -36,9 +36,9 @@ void TInsertColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnSha
         if (!DataToIndex.empty()) {
             self->UpdateInsertTableCounters();
         }
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BLOBS_WRITTEN, context.BlobsWritten);
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BYTES_WRITTEN, context.BytesWritten);
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_TIME, context.Duration.MilliSeconds());
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BLOBS_WRITTEN, context.BlobsWritten);
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BYTES_WRITTEN, context.BytesWritten);
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_TIME, context.Duration.MilliSeconds());
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/indexation.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/indexation.cpp
@@ -36,7 +36,7 @@ void TInsertColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnSha
         if (!DataToIndex.empty()) {
             self->UpdateInsertTableCounters();
         }
-        self->Counters.GetTabletCounters().OnInsertWriteIndexCompleted(context);
+        self->Counters.GetTabletCounters().OnInsertionWriteIndexCompleted(context.BlobsWritten, context.BytesWritten, context.Duration);
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/indexation.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/indexation.cpp
@@ -36,9 +36,7 @@ void TInsertColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnSha
         if (!DataToIndex.empty()) {
             self->UpdateInsertTableCounters();
         }
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BLOBS_WRITTEN, context.BlobsWritten);
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BYTES_WRITTEN, context.BytesWritten);
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_TIME, context.Duration.MilliSeconds());
+        self->Counters.GetTabletCounters().OnInsertWriteIndexCompleted(context);
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/indexation.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/indexation.cpp
@@ -36,7 +36,7 @@ void TInsertColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnSha
         if (!DataToIndex.empty()) {
             self->UpdateInsertTableCounters();
         }
-        self->Counters.GetTabletCounters().OnInsertionWriteIndexCompleted(context.BlobsWritten, context.BytesWritten, context.Duration);
+        self->Counters.GetTabletCounters()->OnInsertionWriteIndexCompleted(context.BlobsWritten, context.BytesWritten, context.Duration);
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/indexation.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/indexation.cpp
@@ -36,9 +36,9 @@ void TInsertColumnEngineChanges::DoWriteIndexOnComplete(NColumnShard::TColumnSha
         if (!DataToIndex.empty()) {
             self->UpdateInsertTableCounters();
         }
-        self->IncCounter(NColumnShard::COUNTER_INDEXING_BLOBS_WRITTEN, context.BlobsWritten);
-        self->IncCounter(NColumnShard::COUNTER_INDEXING_BYTES_WRITTEN, context.BytesWritten);
-        self->IncCounter(NColumnShard::COUNTER_INDEXING_TIME, context.Duration.MilliSeconds());
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BLOBS_WRITTEN, context.BlobsWritten);
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_BYTES_WRITTEN, context.BytesWritten);
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_TIME, context.Duration.MilliSeconds());
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
@@ -42,13 +42,13 @@ void TChangesWithAppend::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self
                 case NOlap::TPortionMeta::EProduced::UNSPECIFIED:
                     Y_ABORT_UNLESS(false);   // unexpected
                 case NOlap::TPortionMeta::EProduced::INSERTED:
-                    self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_PORTIONS_WRITTEN);
+                    self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_INDEXING_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::COMPACTED:
-                    self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_PORTIONS_WRITTEN);
+                    self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_COMPACTION_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::SPLIT_COMPACTED:
-                    self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_PORTIONS_WRITTEN);
+                    self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::EVICTED:
                     Y_ABORT("Unexpected evicted case");
@@ -58,19 +58,19 @@ void TChangesWithAppend::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self
                     break;
             }
         }
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_DEACTIVATED, PortionsToRemove.size());
+        self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_PORTIONS_DEACTIVATED, PortionsToRemove.size());
 
         THashSet<TUnifiedBlobId> blobsDeactivated;
         for (auto& [_, portionInfo] : PortionsToRemove) {
             for (auto& rec : portionInfo.Records) {
                 blobsDeactivated.emplace(portionInfo.GetBlobId(rec.BlobRange.GetBlobIdxVerified()));
             }
-            self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_DEACTIVATED, portionInfo.GetTotalRawBytes());
+            self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_RAW_BYTES_DEACTIVATED, portionInfo.GetTotalRawBytes());
         }
 
-        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BLOBS_DEACTIVATED, blobsDeactivated.size());
+        self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_BLOBS_DEACTIVATED, blobsDeactivated.size());
         for (auto& blobId : blobsDeactivated) {
-            self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BYTES_DEACTIVATED, blobId.BlobSize());
+            self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_BYTES_DEACTIVATED, blobId.BlobSize());
         }
     }
     {

--- a/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
@@ -42,13 +42,13 @@ void TChangesWithAppend::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self
                 case NOlap::TPortionMeta::EProduced::UNSPECIFIED:
                     Y_ABORT_UNLESS(false);   // unexpected
                 case NOlap::TPortionMeta::EProduced::INSERTED:
-                    self->IncCounter(NColumnShard::COUNTER_INDEXING_PORTIONS_WRITTEN);
+                    self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::COMPACTED:
-                    self->IncCounter(NColumnShard::COUNTER_COMPACTION_PORTIONS_WRITTEN);
+                    self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::SPLIT_COMPACTED:
-                    self->IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_PORTIONS_WRITTEN);
+                    self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::EVICTED:
                     Y_ABORT("Unexpected evicted case");
@@ -58,19 +58,19 @@ void TChangesWithAppend::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self
                     break;
             }
         }
-        self->IncCounter(NColumnShard::COUNTER_PORTIONS_DEACTIVATED, PortionsToRemove.size());
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_DEACTIVATED, PortionsToRemove.size());
 
         THashSet<TUnifiedBlobId> blobsDeactivated;
         for (auto& [_, portionInfo] : PortionsToRemove) {
             for (auto& rec : portionInfo.Records) {
                 blobsDeactivated.emplace(portionInfo.GetBlobId(rec.BlobRange.GetBlobIdxVerified()));
             }
-            self->IncCounter(NColumnShard::COUNTER_RAW_BYTES_DEACTIVATED, portionInfo.GetTotalRawBytes());
+            self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_DEACTIVATED, portionInfo.GetTotalRawBytes());
         }
 
-        self->IncCounter(NColumnShard::COUNTER_BLOBS_DEACTIVATED, blobsDeactivated.size());
+        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BLOBS_DEACTIVATED, blobsDeactivated.size());
         for (auto& blobId : blobsDeactivated) {
-            self->IncCounter(NColumnShard::COUNTER_BYTES_DEACTIVATED, blobId.BlobSize());
+            self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BYTES_DEACTIVATED, blobId.BlobSize());
         }
     }
     {

--- a/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
@@ -42,13 +42,13 @@ void TChangesWithAppend::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self
                 case NOlap::TPortionMeta::EProduced::UNSPECIFIED:
                     Y_ABORT_UNLESS(false);   // unexpected
                 case NOlap::TPortionMeta::EProduced::INSERTED:
-                    self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_PORTIONS_WRITTEN);
+                    self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_INDEXING_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::COMPACTED:
-                    self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_PORTIONS_WRITTEN);
+                    self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_COMPACTION_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::SPLIT_COMPACTED:
-                    self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_PORTIONS_WRITTEN);
+                    self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SPLIT_COMPACTION_PORTIONS_WRITTEN);
                     break;
                 case NOlap::TPortionMeta::EProduced::EVICTED:
                     Y_ABORT("Unexpected evicted case");
@@ -58,19 +58,19 @@ void TChangesWithAppend::DoWriteIndexOnComplete(NColumnShard::TColumnShard* self
                     break;
             }
         }
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_DEACTIVATED, PortionsToRemove.size());
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_PORTIONS_DEACTIVATED, PortionsToRemove.size());
 
         THashSet<TUnifiedBlobId> blobsDeactivated;
         for (auto& [_, portionInfo] : PortionsToRemove) {
             for (auto& rec : portionInfo.Records) {
                 blobsDeactivated.emplace(portionInfo.GetBlobId(rec.BlobRange.GetBlobIdxVerified()));
             }
-            self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_DEACTIVATED, portionInfo.GetTotalRawBytes());
+            self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_RAW_BYTES_DEACTIVATED, portionInfo.GetTotalRawBytes());
         }
 
-        self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BLOBS_DEACTIVATED, blobsDeactivated.size());
+        self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BLOBS_DEACTIVATED, blobsDeactivated.size());
         for (auto& blobId : blobsDeactivated) {
-            self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BYTES_DEACTIVATED, blobId.BlobSize());
+            self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_BYTES_DEACTIVATED, blobId.BlobSize());
         }
     }
     {

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -400,10 +400,9 @@ void TColumnShardScan::Finish(const NColumnShard::TScanCounters::EStatusFinish s
     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_COLUMNSHARD_SCAN,
         "Scan " << ScanActorId << " finished for tablet " << TabletId);
 
-    bool success = (status == NColumnShard::TScanCounters::EStatusFinish::Success);
-    Send(ColumnShardActorId, new NColumnShard::TEvPrivate::TEvReadFinished(RequestCookie, TxId, success));
+    Send(ColumnShardActorId, new NColumnShard::TEvPrivate::TEvReadFinished(RequestCookie, TxId));
     AFL_VERIFY(StartInstant);
-    ScanCountersPool.OnScanDuration(status, TMonotonic::Now() - *StartInstant);
+    ScanCountersPool.OnScanFinished(status, TMonotonic::Now() - *StartInstant);
     ReportStats();
     PassAway();
 }

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -400,7 +400,8 @@ void TColumnShardScan::Finish(const NColumnShard::TScanCounters::EStatusFinish s
     LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_COLUMNSHARD_SCAN,
         "Scan " << ScanActorId << " finished for tablet " << TabletId);
 
-    Send(ColumnShardActorId, new NColumnShard::TEvPrivate::TEvReadFinished(RequestCookie, TxId));
+    bool success = (status == NColumnShard::TScanCounters::EStatusFinish::Success);
+    Send(ColumnShardActorId, new NColumnShard::TEvPrivate::TEvReadFinished(RequestCookie, TxId, success));
     AFL_VERIFY(StartInstant);
     ScanCountersPool.OnScanDuration(status, TMonotonic::Now() - *StartInstant);
     ReportStats();

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
@@ -80,13 +80,13 @@ void TTxInternalScan::Complete(const TActorContext& ctx) {
         auto issue = NYql::YqlIssue({}, NYql::TIssuesIds::KIKIMR_TEMPORARILY_UNAVAILABLE, TStringBuilder()
             << "Table " << request.GetPathId() << " (shard " << Self->TabletID() << ") scan failed, reason: " << requestCookie.GetErrorMessage());
         NYql::IssueToMessage(issue, ev->Record.MutableIssues()->Add());
-        Self->ScanCounters.OnScanDuration(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
+        Self->Stats.GetScanCounters().OnScanDuration(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
         ctx.Send(scanComputeActor, ev.Release());
         return;
     }
     auto scanActor = ctx.Register(new TColumnShardScan(Self->SelfId(), scanComputeActor, Self->GetStoragesManager(),
         TComputeShardingPolicy(), ScanId, TxId, ScanGen, *requestCookie, Self->TabletID(), TDuration::Max(), ReadMetadataRange,
-        NKikimrDataEvents::FORMAT_ARROW, Self->ScanCounters));
+        NKikimrDataEvents::FORMAT_ARROW, Self->Stats.GetScanCounters()));
 
     AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_SCAN)("event", "TTxInternalScan started")("actor_id", scanActor)("trace_detailed", detailedInfo);
 }

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
@@ -80,7 +80,7 @@ void TTxInternalScan::Complete(const TActorContext& ctx) {
         auto issue = NYql::YqlIssue({}, NYql::TIssuesIds::KIKIMR_TEMPORARILY_UNAVAILABLE, TStringBuilder()
             << "Table " << request.GetPathId() << " (shard " << Self->TabletID() << ") scan failed, reason: " << requestCookie.GetErrorMessage());
         NYql::IssueToMessage(issue, ev->Record.MutableIssues()->Add());
-        Self->Stats.GetScanCounters().OnScanFinished(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
+        Self->Counters.GetScanCounters().OnScanFinished(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
         ctx.Send(scanComputeActor, ev.Release());
         return;
     }

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
@@ -86,7 +86,7 @@ void TTxInternalScan::Complete(const TActorContext& ctx) {
     }
     auto scanActor = ctx.Register(new TColumnShardScan(Self->SelfId(), scanComputeActor, Self->GetStoragesManager(),
         TComputeShardingPolicy(), ScanId, TxId, ScanGen, *requestCookie, Self->TabletID(), TDuration::Max(), ReadMetadataRange,
-        NKikimrDataEvents::FORMAT_ARROW, Self->Stats.GetScanCounters()));
+        NKikimrDataEvents::FORMAT_ARROW, Self->Counters.GetScanCounters()));
 
     AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_SCAN)("event", "TTxInternalScan started")("actor_id", scanActor)("trace_detailed", detailedInfo);
 }

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
@@ -80,7 +80,7 @@ void TTxInternalScan::Complete(const TActorContext& ctx) {
         auto issue = NYql::YqlIssue({}, NYql::TIssuesIds::KIKIMR_TEMPORARILY_UNAVAILABLE, TStringBuilder()
             << "Table " << request.GetPathId() << " (shard " << Self->TabletID() << ") scan failed, reason: " << requestCookie.GetErrorMessage());
         NYql::IssueToMessage(issue, ev->Record.MutableIssues()->Add());
-        Self->Stats.GetScanCounters().OnScanDuration(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
+        Self->Stats.GetScanCounters().OnScanFinished(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
         ctx.Send(scanComputeActor, ev.Release());
         return;
     }

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
@@ -191,7 +191,7 @@ void TTxScan::Complete(const TActorContext& ctx) {
     auto dataFormat = request.GetDataFormat();
     const TDuration timeout = TDuration::MilliSeconds(request.GetTimeoutMs());
     if (scanGen > 1) {
-        Self->IncCounter(NColumnShard::COUNTER_SCAN_RESTARTED);
+        Self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SCAN_RESTARTED);
     }
     const NActors::TLogContextGuard gLogging = NActors::TLogContextBuilder::Build()
         ("tx_id", txId)("scan_id", scanId)("gen", scanGen)("table", table)("snapshot", snapshot)("tablet", Self->TabletID())("timeout", timeout);
@@ -226,22 +226,22 @@ void TTxScan::Complete(const TActorContext& ctx) {
         auto issue = NYql::YqlIssue({}, NYql::TIssuesIds::KIKIMR_TEMPORARILY_UNAVAILABLE, TStringBuilder()
             << "Table " << table << " (shard " << Self->TabletID() << ") scan failed, reason: " << requestCookie.GetErrorMessage());
         NYql::IssueToMessage(issue, ev->Record.MutableIssues()->Add());
-        Self->ScanCounters.OnScanDuration(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
+        Self->Stats.GetScanCounters().OnScanDuration(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
         ctx.Send(scanComputeActor, ev.Release());
         return;
     }
     auto statsDelta = Self->InFlightReadsTracker.GetSelectStatsDelta();
 
-    Self->IncCounter(NColumnShard::COUNTER_READ_INDEX_PORTIONS, statsDelta.Portions);
-    Self->IncCounter(NColumnShard::COUNTER_READ_INDEX_BLOBS, statsDelta.Blobs);
-    Self->IncCounter(NColumnShard::COUNTER_READ_INDEX_ROWS, statsDelta.Rows);
-    Self->IncCounter(NColumnShard::COUNTER_READ_INDEX_BYTES, statsDelta.Bytes);
+    Self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_READ_INDEX_PORTIONS, statsDelta.Portions);
+    Self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_READ_INDEX_BLOBS, statsDelta.Blobs);
+    Self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_READ_INDEX_ROWS, statsDelta.Rows);
+    Self->Stats.GetTabletCounters().IncCounter(NColumnShard::COUNTER_READ_INDEX_BYTES, statsDelta.Bytes);
 
     TComputeShardingPolicy shardingPolicy;
     AFL_VERIFY(shardingPolicy.DeserializeFromProto(request.GetComputeShardingPolicy()));
 
     auto scanActor = ctx.Register(new TColumnShardScan(Self->SelfId(), scanComputeActor, Self->GetStoragesManager(),
-        shardingPolicy, scanId, txId, scanGen, *requestCookie, Self->TabletID(), timeout, ReadMetadataRange, dataFormat, Self->ScanCounters));
+        shardingPolicy, scanId, txId, scanGen, *requestCookie, Self->TabletID(), timeout, ReadMetadataRange, dataFormat, Self->Stats.GetScanCounters()));
 
     AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_SCAN)("event", "TTxScan started")("actor_id", scanActor)("trace_detailed", detailedInfo);
 }

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
@@ -226,7 +226,7 @@ void TTxScan::Complete(const TActorContext& ctx) {
         auto issue = NYql::YqlIssue({}, NYql::TIssuesIds::KIKIMR_TEMPORARILY_UNAVAILABLE, TStringBuilder()
             << "Table " << table << " (shard " << Self->TabletID() << ") scan failed, reason: " << requestCookie.GetErrorMessage());
         NYql::IssueToMessage(issue, ev->Record.MutableIssues()->Add());
-        Self->Stats.GetScanCounters().OnScanDuration(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
+        Self->Stats.GetScanCounters().OnScanFinished(NColumnShard::TScanCounters::EStatusFinish::CannotAddInFlight, TDuration::Zero());
         ctx.Send(scanComputeActor, ev.Release());
         return;
     }

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
@@ -191,7 +191,7 @@ void TTxScan::Complete(const TActorContext& ctx) {
     auto dataFormat = request.GetDataFormat();
     const TDuration timeout = TDuration::MilliSeconds(request.GetTimeoutMs());
     if (scanGen > 1) {
-        Self->Counters.GetTabletCounters().IncCounter(NColumnShard::COUNTER_SCAN_RESTARTED);
+        Self->Counters.GetTabletCounters()->IncCounter(NColumnShard::COUNTER_SCAN_RESTARTED);
     }
     const NActors::TLogContextGuard gLogging = NActors::TLogContextBuilder::Build()
         ("tx_id", txId)("scan_id", scanId)("gen", scanGen)("table", table)("snapshot", snapshot)("tablet", Self->TabletID())("timeout", timeout);
@@ -231,7 +231,7 @@ void TTxScan::Complete(const TActorContext& ctx) {
         return;
     }
 
-    Self->Counters.GetTabletCounters().OnScanStarted(Self->InFlightReadsTracker.GetSelectStatsDelta());
+    Self->Counters.GetTabletCounters()->OnScanStarted(Self->InFlightReadsTracker.GetSelectStatsDelta());
 
     TComputeShardingPolicy shardingPolicy;
     AFL_VERIFY(shardingPolicy.DeserializeFromProto(request.GetComputeShardingPolicy()));

--- a/ydb/core/tx/columnshard/hooks/testing/ro_controller.h
+++ b/ydb/core/tx/columnshard/hooks/testing/ro_controller.h
@@ -82,10 +82,10 @@ public:
 
     void WaitIndexation(const TDuration d) const {
         TInstant start = TInstant::Now();
-        ui32 indexationStart = GetInsertStartedCounter().Val();
+        ui32 insertsStart = GetInsertStartedCounter().Val();
         while (Now() - start < d) {
-            if (indexationStart != GetInsertStartedCounter().Val()) {
-                indexationStart = GetInsertStartedCounter().Val();
+            if (insertsStart != GetInsertStartedCounter().Val()) {
+                insertsStart = GetInsertStartedCounter().Val();
                 start = TInstant::Now();
             }
             Cerr << "WAIT_INDEXATION: " << GetInsertStartedCounter().Val() << Endl;

--- a/ydb/core/tx/columnshard/hooks/testing/ro_controller.h
+++ b/ydb/core/tx/columnshard/hooks/testing/ro_controller.h
@@ -82,10 +82,10 @@ public:
 
     void WaitIndexation(const TDuration d) const {
         TInstant start = TInstant::Now();
-        ui32 compactionsStart = GetInsertStartedCounter().Val();
+        ui32 indexationStart = GetInsertStartedCounter().Val();
         while (Now() - start < d) {
-            if (compactionsStart != GetInsertStartedCounter().Val()) {
-                compactionsStart = GetInsertStartedCounter().Val();
+            if (indexationStart != GetInsertStartedCounter().Val()) {
+                indexationStart = GetInsertStartedCounter().Val();
                 start = TInstant::Now();
             }
             Cerr << "WAIT_INDEXATION: " << GetInsertStartedCounter().Val() << Endl;

--- a/ydb/core/tx/columnshard/operations/write.cpp
+++ b/ydb/core/tx/columnshard/operations/write.cpp
@@ -51,7 +51,7 @@ namespace NKikimr::NColumnShard {
 
             const auto counters = owner.InsertTable->Commit(dbTable, snapshot.GetPlanStep(), snapshot.GetTxId(), { gWriteId },
                                                       pathExists);
-            owner.Counters.GetTabletCounters().OnWriteCommitted(counters);
+            owner.Counters.GetTabletCounters()->OnWriteCommitted(counters);
         }
         owner.UpdateInsertTableCounters();
     }

--- a/ydb/core/tx/columnshard/operations/write.cpp
+++ b/ydb/core/tx/columnshard/operations/write.cpp
@@ -52,9 +52,9 @@ namespace NKikimr::NColumnShard {
             auto counters = owner.InsertTable->Commit(dbTable, snapshot.GetPlanStep(), snapshot.GetTxId(), { gWriteId },
                                                       pathExists);
 
-            owner.IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
-            owner.IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
-            owner.IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
+            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
+            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
+            owner.Stats.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
         }
         owner.UpdateInsertTableCounters();
     }

--- a/ydb/core/tx/columnshard/operations/write.cpp
+++ b/ydb/core/tx/columnshard/operations/write.cpp
@@ -52,9 +52,9 @@ namespace NKikimr::NColumnShard {
             auto counters = owner.InsertTable->Commit(dbTable, snapshot.GetPlanStep(), snapshot.GetTxId(), { gWriteId },
                                                       pathExists);
 
-            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
-            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
-            owner.Stats.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
+            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
+            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
+            owner.Counters.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
         }
         owner.UpdateInsertTableCounters();
     }

--- a/ydb/core/tx/columnshard/operations/write.cpp
+++ b/ydb/core/tx/columnshard/operations/write.cpp
@@ -49,12 +49,9 @@ namespace NKikimr::NColumnShard {
                 return owner.TablesManager.HasTable(pathId);
             };
 
-            auto counters = owner.InsertTable->Commit(dbTable, snapshot.GetPlanStep(), snapshot.GetTxId(), { gWriteId },
+            const auto counters = owner.InsertTable->Commit(dbTable, snapshot.GetPlanStep(), snapshot.GetTxId(), { gWriteId },
                                                       pathExists);
-
-            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
-            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
-            owner.Counters.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
+            owner.Counters.GetTabletCounters().OnWriteCommitted(counters);
         }
         owner.UpdateInsertTableCounters();
     }

--- a/ydb/core/tx/columnshard/resource_subscriber/counters.cpp
+++ b/ydb/core/tx/columnshard/resource_subscriber/counters.cpp
@@ -1,9 +1,12 @@
 #include "counters.h"
 
+#include <util/system/guard.h>
+
 namespace NKikimr::NOlap::NResourceBroker::NSubscribe {
 
 
 std::shared_ptr<TSubscriberTypeCounters> TSubscriberCounters::GetTypeCounters(const TString& resourceType) {
+    TGuard lock(Mutex);
     auto it = ResourceTypeCounters.find(resourceType);
     if (it == ResourceTypeCounters.end()) {
         it = ResourceTypeCounters.emplace(resourceType, std::make_shared<TSubscriberTypeCounters>(*this, resourceType)).first;

--- a/ydb/core/tx/columnshard/tables_manager.h
+++ b/ydb/core/tx/columnshard/tables_manager.h
@@ -88,9 +88,6 @@ public:
     std::optional<NOlap::TSnapshot> DropVersion;
     YDB_READONLY_DEF(TSet<NOlap::TSnapshot>, Versions);
 
-    YDB_READONLY(TInstant, LastAccessTime, TInstant::Zero());
-    YDB_READONLY(TInstant, LastUpdateTime, TInstant::Zero());
-
 public:
     const TString& GetTieringUsage() const {
         return TieringUsage;
@@ -119,18 +116,6 @@ public:
 
     bool IsDropped() const {
         return DropVersion.has_value();
-    }
-
-    void UpdateLastAccessTime(TInstant value) {
-        if (LastAccessTime < value) {
-            LastAccessTime = value;
-        }
-    }
-
-    void UpdateLastUpdateTime(TInstant value) {
-        if (LastUpdateTime < value) {
-            LastUpdateTime = value;
-        }
     }
 
     TTableInfo() = default;
@@ -257,14 +242,6 @@ public:
     void AddSchemaVersion(const ui32 presetId, const NOlap::TSnapshot& version, const NKikimrSchemeOp::TColumnTableSchema& schema, NIceDb::TNiceDb& db, std::shared_ptr<TTiersManager>& manager);
     void AddTableVersion(const ui64 pathId, const NOlap::TSnapshot& version, const NKikimrTxColumnShard::TTableVersionInfo& versionInfo, NIceDb::TNiceDb& db, std::shared_ptr<TTiersManager>& manager);
     bool FillMonitoringReport(NTabletFlatExecutor::TTransactionContext& txc, NJson::TJsonValue& json);
-
-    void RegisterAccess(ui64 pathId, TInstant time = TAppData::TimeProvider->Now()) {
-        Tables[pathId].UpdateLastAccessTime(time);
-    }
-
-    void RegisterUpdate(ui64 pathId, TInstant time = TAppData::TimeProvider->Now()) {
-        Tables[pathId].UpdateLastUpdateTime(time);
-    }
 
     [[nodiscard]] std::unique_ptr<NTabletFlatExecutor::ITransaction> CreateAddShardingInfoTx(TColumnShard& owner, const ui64 pathId, const ui64 versionId, const NSharding::TGranuleShardingLogicContainer& tabletShardingLogic) const;
 };

--- a/ydb/core/tx/columnshard/tables_manager.h
+++ b/ydb/core/tx/columnshard/tables_manager.h
@@ -88,6 +88,9 @@ public:
     std::optional<NOlap::TSnapshot> DropVersion;
     YDB_READONLY_DEF(TSet<NOlap::TSnapshot>, Versions);
 
+    YDB_READONLY(TInstant, LastAccessTime, TInstant::Zero());
+    YDB_READONLY(TInstant, LastUpdateTime, TInstant::Zero());
+
 public:
     const TString& GetTieringUsage() const {
         return TieringUsage;
@@ -116,6 +119,18 @@ public:
 
     bool IsDropped() const {
         return DropVersion.has_value();
+    }
+
+    void UpdateLastAccessTime(TInstant value) {
+        if (LastAccessTime < value) {
+            LastAccessTime = value;
+        }
+    }
+
+    void UpdateLastUpdateTime(TInstant value) {
+        if (LastUpdateTime < value) {
+            LastUpdateTime = value;
+        }
     }
 
     TTableInfo() = default;
@@ -242,6 +257,14 @@ public:
     void AddSchemaVersion(const ui32 presetId, const NOlap::TSnapshot& version, const NKikimrSchemeOp::TColumnTableSchema& schema, NIceDb::TNiceDb& db, std::shared_ptr<TTiersManager>& manager);
     void AddTableVersion(const ui64 pathId, const NOlap::TSnapshot& version, const NKikimrTxColumnShard::TTableVersionInfo& versionInfo, NIceDb::TNiceDb& db, std::shared_ptr<TTiersManager>& manager);
     bool FillMonitoringReport(NTabletFlatExecutor::TTransactionContext& txc, NJson::TJsonValue& json);
+
+    void RegisterAccess(ui64 pathId, TInstant time = TAppData::TimeProvider->Now()) {
+        Tables[pathId].UpdateLastAccessTime(time);
+    }
+
+    void RegisterUpdate(ui64 pathId, TInstant time = TAppData::TimeProvider->Now()) {
+        Tables[pathId].UpdateLastUpdateTime(time);
+    }
 
     [[nodiscard]] std::unique_ptr<NTabletFlatExecutor::ITransaction> CreateAddShardingInfoTx(TColumnShard& owner, const ui64 pathId, const ui64 versionId, const NSharding::TGranuleShardingLogicContainer& tabletShardingLogic) const;
 };

--- a/ydb/core/tx/columnshard/transactions/operators/long_tx_write.h
+++ b/ydb/core/tx/columnshard/transactions/operators/long_tx_write.h
@@ -54,9 +54,9 @@ namespace NKikimr::NColumnShard {
 
             auto counters = owner.InsertTable->Commit(dbTable, version.GetPlanStep(), version.GetTxId(), WriteIds, pathExists);
 
-            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
-            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
-            owner.Counters.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
+            owner.Counters.GetTabletCounters()->IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
+            owner.Counters.GetTabletCounters()->IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
+            owner.Counters.GetTabletCounters()->IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
 
             NIceDb::TNiceDb db(txc.DB);
             for (TWriteId writeId : WriteIds) {

--- a/ydb/core/tx/columnshard/transactions/operators/long_tx_write.h
+++ b/ydb/core/tx/columnshard/transactions/operators/long_tx_write.h
@@ -54,9 +54,9 @@ namespace NKikimr::NColumnShard {
 
             auto counters = owner.InsertTable->Commit(dbTable, version.GetPlanStep(), version.GetTxId(), WriteIds, pathExists);
 
-            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
-            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
-            owner.Stats.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
+            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
+            owner.Counters.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
+            owner.Counters.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
 
             NIceDb::TNiceDb db(txc.DB);
             for (TWriteId writeId : WriteIds) {

--- a/ydb/core/tx/columnshard/transactions/operators/long_tx_write.h
+++ b/ydb/core/tx/columnshard/transactions/operators/long_tx_write.h
@@ -54,9 +54,9 @@ namespace NKikimr::NColumnShard {
 
             auto counters = owner.InsertTable->Commit(dbTable, version.GetPlanStep(), version.GetTxId(), WriteIds, pathExists);
 
-            owner.IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
-            owner.IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
-            owner.IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
+            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BLOBS_COMMITTED, counters.Rows);
+            owner.Stats.GetTabletCounters().IncCounter(COUNTER_BYTES_COMMITTED, counters.Bytes);
+            owner.Stats.GetTabletCounters().IncCounter(COUNTER_RAW_BYTES_COMMITTED, counters.RawBytes);
 
             NIceDb::TNiceDb db(txc.DB);
             for (TWriteId writeId : WriteIds) {

--- a/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
+++ b/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
@@ -7,7 +7,7 @@ void IProposeTxOperator::DoSendReply(TColumnShard& owner, const TActorContext& c
     std::unique_ptr<TEvColumnShard::TEvProposeTransactionResult> evResult = std::make_unique<TEvColumnShard::TEvProposeTransactionResult>(
         owner.TabletID(), txInfo.TxKind, txInfo.TxId, GetProposeStartInfoVerified().GetStatus(), GetProposeStartInfoVerified().GetStatusMessage());
     if (IsFail()) {
-        owner.Stats.GetTabletCounters().IncCounter(COUNTER_PREPARE_ERROR);
+        owner.Counters.GetTabletCounters().IncCounter(COUNTER_PREPARE_ERROR);
         AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("message", GetProposeStartInfoVerified().GetStatusMessage())("tablet_id", owner.TabletID())("tx_id", txInfo.TxId);
     } else {
         evResult->Record.SetMinStep(txInfo.MinStep);
@@ -15,7 +15,7 @@ void IProposeTxOperator::DoSendReply(TColumnShard& owner, const TActorContext& c
         if (owner.ProcessingParams) {
             evResult->Record.MutableDomainCoordinators()->CopyFrom(owner.ProcessingParams->GetCoordinators());
         }
-        owner.Stats.GetTabletCounters().IncCounter(COUNTER_PREPARE_SUCCESS);
+        owner.Counters.GetTabletCounters().IncCounter(COUNTER_PREPARE_SUCCESS);
     }
     ctx.Send(txInfo.Source, evResult.release());
 }

--- a/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
+++ b/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
@@ -7,7 +7,7 @@ void IProposeTxOperator::DoSendReply(TColumnShard& owner, const TActorContext& c
     std::unique_ptr<TEvColumnShard::TEvProposeTransactionResult> evResult = std::make_unique<TEvColumnShard::TEvProposeTransactionResult>(
         owner.TabletID(), txInfo.TxKind, txInfo.TxId, GetProposeStartInfoVerified().GetStatus(), GetProposeStartInfoVerified().GetStatusMessage());
     if (IsFail()) {
-        owner.IncCounter(COUNTER_PREPARE_ERROR);
+        owner.Stats.GetTabletCounters().IncCounter(COUNTER_PREPARE_ERROR);
         AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("message", GetProposeStartInfoVerified().GetStatusMessage())("tablet_id", owner.TabletID())("tx_id", txInfo.TxId);
     } else {
         evResult->Record.SetMinStep(txInfo.MinStep);
@@ -15,7 +15,7 @@ void IProposeTxOperator::DoSendReply(TColumnShard& owner, const TActorContext& c
         if (owner.ProcessingParams) {
             evResult->Record.MutableDomainCoordinators()->CopyFrom(owner.ProcessingParams->GetCoordinators());
         }
-        owner.IncCounter(COUNTER_PREPARE_SUCCESS);
+        owner.Stats.GetTabletCounters().IncCounter(COUNTER_PREPARE_SUCCESS);
     }
     ctx.Send(txInfo.Source, evResult.release());
 }

--- a/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
+++ b/ydb/core/tx/columnshard/transactions/operators/propose_tx.cpp
@@ -7,7 +7,7 @@ void IProposeTxOperator::DoSendReply(TColumnShard& owner, const TActorContext& c
     std::unique_ptr<TEvColumnShard::TEvProposeTransactionResult> evResult = std::make_unique<TEvColumnShard::TEvProposeTransactionResult>(
         owner.TabletID(), txInfo.TxKind, txInfo.TxId, GetProposeStartInfoVerified().GetStatus(), GetProposeStartInfoVerified().GetStatusMessage());
     if (IsFail()) {
-        owner.Counters.GetTabletCounters().IncCounter(COUNTER_PREPARE_ERROR);
+        owner.Counters.GetTabletCounters()->IncCounter(COUNTER_PREPARE_ERROR);
         AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("message", GetProposeStartInfoVerified().GetStatusMessage())("tablet_id", owner.TabletID())("tx_id", txInfo.TxId);
     } else {
         evResult->Record.SetMinStep(txInfo.MinStep);
@@ -15,7 +15,7 @@ void IProposeTxOperator::DoSendReply(TColumnShard& owner, const TActorContext& c
         if (owner.ProcessingParams) {
             evResult->Record.MutableDomainCoordinators()->CopyFrom(owner.ProcessingParams->GetCoordinators());
         }
-        owner.Counters.GetTabletCounters().IncCounter(COUNTER_PREPARE_SUCCESS);
+        owner.Counters.GetTabletCounters()->IncCounter(COUNTER_PREPARE_SUCCESS);
     }
     ctx.Send(txInfo.Source, evResult.release());
 }

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -736,6 +736,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
             UNIT_ASSERT_GT(tabletStats.GetRowCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetDataSize(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetPartCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetRowUpdates(), 0);
             UNIT_ASSERT_GT(tabletStats.GetImmediateTxCompleted(), 0);
             UNIT_ASSERT_GT(tabletStats.GetPlannedTxCompleted(), 0);
@@ -748,6 +749,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
             UNIT_ASSERT_GT(tabletStats.GetRowCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetDataSize(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetPartCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetRowUpdates(), 0);
             UNIT_ASSERT_GT(tabletStats.GetImmediateTxCompleted(), 0);
             UNIT_ASSERT_GT(tabletStats.GetPlannedTxCompleted(), 0);

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -736,6 +736,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
             UNIT_ASSERT_GT(tabletStats.GetRowCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetDataSize(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetRowUpdates(), 0);
             UNIT_ASSERT_GT(tabletStats.GetImmediateTxCompleted(), 0);
             UNIT_ASSERT_GT(tabletStats.GetPlannedTxCompleted(), 0);
         }
@@ -747,6 +748,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
             UNIT_ASSERT_GT(tabletStats.GetRowCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetDataSize(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetRowUpdates(), 0);
             UNIT_ASSERT_GT(tabletStats.GetImmediateTxCompleted(), 0);
             UNIT_ASSERT_GT(tabletStats.GetPlannedTxCompleted(), 0);
         }

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -736,6 +736,8 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
             UNIT_ASSERT_GT(tabletStats.GetRowCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetDataSize(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetImmediateTxCompleted(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetPlannedTxCompleted(), 0);
         }
 
         {
@@ -745,6 +747,8 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
             UNIT_ASSERT_GT(tabletStats.GetRowCount(), 0);
             UNIT_ASSERT_GT(tabletStats.GetDataSize(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetImmediateTxCompleted(), 0);
+            UNIT_ASSERT_GT(tabletStats.GetPlannedTxCompleted(), 0);
         }
 
 #if 0


### PR DESCRIPTION
Track missing table stats in column shard similarly to data shard. New stats are available in DescribeTable.
