### PR TITLE
Fix distconf IC session subscription state machine

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,6 +1,5 @@
 ydb/core/blobstorage/dsproxy/ut TBlobStorageProxySequenceTest.TestBlock42PutWithChangingSlowDisk
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
-ydb/core/blobstorage/ut_blobstorage BlobPatching.PatchBlock42
 ydb/core/client/ut TClientTest.PromoteFollower
 ydb/core/client/ut TClientTest.ReadFromFollower
 ydb/core/client/ut TFlatTest.AutoSplitMergeQueue

--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -145,30 +145,44 @@ namespace NKikimr::NStorage {
             }
         }
 
-        for (const auto& [nodeId, sessionId] : SubscribedSessions) {
+        for (const auto& [nodeId, subs] : SubscribedSessions) {
             bool okay = false;
             if (Binding && Binding->NodeId == nodeId) {
-                Y_ABORT_UNLESS(sessionId == Binding->SessionId);
+                Y_VERIFY_S(subs.SessionId == Binding->SessionId || !Binding->SessionId,
+                    "Binding# " << Binding->ToString() << " Subscription# " << subs.ToString());
                 okay = true;
             }
             if (const auto it = DirectBoundNodes.find(nodeId); it != DirectBoundNodes.end()) {
-                Y_ABORT_UNLESS(!sessionId || sessionId == it->second.SessionId);
+                Y_VERIFY_S(!subs.SessionId || subs.SessionId == it->second.SessionId, "sessionId# " << subs.SessionId
+                    << " node.SessionId# " << it->second.SessionId);
                 okay = true;
             }
-            if (!sessionId) {
+            if (!subs.SessionId) {
                 okay = true; // may be just obsolete subscription request
             }
             if (ConnectedDynamicNodes.contains(nodeId)) {
                 okay = true;
             }
             Y_ABORT_UNLESS(okay);
+            if (subs.SubscriptionCookie) {
+                const auto it = SubscriptionCookieMap.find(subs.SubscriptionCookie);
+                Y_ABORT_UNLESS(it != SubscriptionCookieMap.end());
+                Y_ABORT_UNLESS(it->second == nodeId);
+            }
+        }
+        for (const auto& [cookie, nodeId] : SubscriptionCookieMap) {
+            const auto it = SubscribedSessions.find(nodeId);
+            Y_ABORT_UNLESS(it != SubscribedSessions.end());
+            const TSessionSubscription& subs = it->second;
+            Y_VERIFY_S(subs.SubscriptionCookie == cookie, "SubscriptionCookie# " << subs.SubscriptionCookie
+                << " cookie# " << cookie);
         }
 
         if (Binding) {
             Y_ABORT_UNLESS(SubscribedSessions.contains(Binding->NodeId));
         }
         for (const auto& [nodeId, info] : DirectBoundNodes) {
-            Y_ABORT_UNLESS(SubscribedSessions.contains(nodeId));
+            Y_VERIFY_S(SubscribedSessions.contains(nodeId), "NodeId# " << nodeId);
         }
 
         Y_ABORT_UNLESS(!StorageConfig || CheckFingerprint(*StorageConfig));
@@ -229,6 +243,13 @@ namespace NKikimr::NStorage {
     }
 
     STFUNC(TDistributedConfigKeeper::StateFunc) {
+        STLOG(PRI_DEBUG, BS_NODE, NWDC15, "StateFunc", (Type, ev->GetTypeRewrite()), (Sender, ev->Sender),
+            (SessionId, ev->InterconnectSession), (Cookie, ev->Cookie));
+        const ui32 senderNodeId = ev->Sender.NodeId();
+        if (ev->InterconnectSession && SubscribedSessions.contains(senderNodeId)) {
+            // keep session actors intact
+            SubscribeToPeerNode(senderNodeId, ev->InterconnectSession);
+        }
         STRICT_STFUNC_BODY(
             hFunc(TEvNodeConfigPush, Handle);
             hFunc(TEvNodeConfigReversePush, Handle);
@@ -239,7 +260,6 @@ namespace NKikimr::NStorage {
             hFunc(TEvInterconnect::TEvNodesInfo, Handle);
             hFunc(TEvInterconnect::TEvNodeConnected, Handle);
             hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
-            hFunc(TEvents::TEvUndelivered, Handle);
             cFunc(TEvPrivate::EvErrorTimeout, HandleErrorTimeout);
             hFunc(TEvPrivate::TEvStorageConfigLoaded, Handle);
             hFunc(TEvPrivate::TEvStorageConfigStored, Handle);
@@ -252,6 +272,12 @@ namespace NKikimr::NStorage {
             cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
             cFunc(TEvents::TSystem::Poison, PassAway);
         )
+        for (ui32 nodeId : std::exchange(UnsubscribeQueue, {})) {
+            UnsubscribeInterconnect(nodeId);
+        }
+        if (IsSelfStatic && StorageConfig && NodeListObtained) {
+            IssueNextBindRequest();
+        }
         ConsistencyCheck();
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -240,7 +240,20 @@ namespace NKikimr::NStorage {
         TString ErrorReason;
 
         // subscribed IC sessions
-        THashMap<ui32, TActorId> SubscribedSessions;
+        struct TSessionSubscription {
+            TActorId SessionId;
+            ui64 SubscriptionCookie = 0; // when nonzero, we didn't have TEvNodeConnected yet
+
+            TSessionSubscription(TActorId sessionId) : SessionId(sessionId) {}
+
+            TString ToString() const {
+                return TStringBuilder() << "{SessionId# " << SessionId << " SubscriptionCookie# " << SubscriptionCookie << "}";
+            }
+        };
+        THashMap<ui32, TSessionSubscription> SubscribedSessions;
+        ui64 NextSubscribeCookie = 1;
+        THashMap<ui64, ui32> SubscriptionCookieMap;
+        THashSet<ui32> UnsubscribeQueue;
 
         // child actors
         THashSet<TActorId> ChildActors;
@@ -287,8 +300,9 @@ namespace NKikimr::NStorage {
         void BindToSession(TActorId sessionId);
         void Handle(TEvInterconnect::TEvNodeConnected::TPtr ev);
         void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr ev);
-        void Handle(TEvents::TEvUndelivered::TPtr ev);
+        void HandleDisconnect(ui32 nodeId, TActorId sessionId);
         void UnsubscribeInterconnect(ui32 nodeId);
+        TActorId SubscribeToPeerNode(ui32 nodeId, TActorId sessionId);
         void AbortBinding(const char *reason, bool sendUnbindMessage = true);
         void HandleWakeup();
         void Handle(TEvNodeConfigReversePush::TPtr ev);

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -58,9 +58,6 @@ namespace NKikimr::NStorage {
         // issue updates
         NodeIds = std::move(nodeIds);
         BindQueue.Update(NodeIds);
-        if (NodeListObtained && StorageConfigLoaded) {
-            IssueNextBindRequest();
-        }
     }
 
     void TDistributedConfigKeeper::IssueNextBindRequest() {
@@ -73,15 +70,13 @@ namespace NKikimr::NStorage {
                 Y_ABORT_UNLESS(*nodeId != SelfId().NodeId());
                 Binding.emplace(*nodeId, ++BindingCookie);
 
-                if (const auto [it, inserted] = SubscribedSessions.try_emplace(Binding->NodeId); it->second) {
-                    BindToSession(it->second);
-                } else if (inserted) {
-                    TActivationContext::Send(new IEventHandle(TEvInterconnect::EvConnectNode, 0,
-                        TActivationContext::InterconnectProxy(Binding->NodeId), SelfId(), nullptr,
-                        it->first));
+                const TActorId sessionId = SubscribeToPeerNode(Binding->NodeId, TActorId());
+                if (sessionId) {
+                    BindToSession(sessionId);
                 }
 
-                STLOG(PRI_DEBUG, BS_NODE, NWDC29, "Initiated bind", (Binding, Binding));
+                STLOG(PRI_DEBUG, BS_NODE, NWDC29, "Initiated bind", (NodeId, nodeId), (Binding, Binding),
+                    (SessionId, sessionId));
             } else if (closest != TMonotonic::Max() && !Scheduled) {
                 STLOG(PRI_DEBUG, BS_NODE, NWDC30, "Delaying bind");
                 TActivationContext::Schedule(closest, new IEventHandle(TEvents::TSystem::Wakeup, 0, SelfId(), {}, nullptr, 0));
@@ -113,59 +108,94 @@ namespace NKikimr::NStorage {
     void TDistributedConfigKeeper::Handle(TEvInterconnect::TEvNodeConnected::TPtr ev) {
         const ui32 nodeId = ev->Get()->NodeId;
         const TActorId sessionId = ev->Sender;
+        const ui64 cookie = ev->Cookie;
 
-        STLOG(PRI_DEBUG, BS_NODE, NWDC14, "TEvNodeConnected", (NodeId, nodeId));
+        STLOG(PRI_DEBUG, BS_NODE, NWDC14, "TEvNodeConnected", (NodeId, nodeId), (SessionId, sessionId), (Cookie, cookie),
+            (CookieInFlight, SubscriptionCookieMap.contains(cookie)),
+            (SubscriptionExists, SubscribedSessions.contains(nodeId)));
 
         if (!IsSelfStatic) {
             return OnStaticNodeConnected(nodeId, sessionId);
         }
 
+        // check subscription map, do we really have this subscription in flight
+        const auto cookieIt = SubscriptionCookieMap.find(cookie);
+        if (cookieIt == SubscriptionCookieMap.end()) {
+            // we are not going to subscribe with this subscription; check if we have any other pending subscriptions
+            // for this node, and unsubscribe if not
+            if (!SubscribedSessions.contains(nodeId)) {
+                TActivationContext::Send(new IEventHandle(TEvents::TSystem::Unsubscribe, 0, ev->Sender, SelfId(), nullptr, 0));
+            }
+            return;
+        }
+        Y_ABORT_UNLESS(nodeId == cookieIt->second);
+        SubscriptionCookieMap.erase(cookieIt);
+
         // update subscription information
-        const auto [it, inserted] = SubscribedSessions.try_emplace(nodeId, sessionId);
-        Y_ABORT_UNLESS(!inserted);
-        Y_ABORT_UNLESS(!it->second);
-        it->second = sessionId;
+        const auto it = SubscribedSessions.find(nodeId);
+        Y_ABORT_UNLESS(it != SubscribedSessions.end());
+        TSessionSubscription& subs = it->second;
+
+        // check the cookie
+        Y_ABORT_UNLESS(subs.SubscriptionCookie == cookie);
+        subs.SubscriptionCookie = 0;
+
+        // check if the session actor has changed; if so, we have to simulate disconnection first, because this means
+        // a race -- we started subscribing when knowing other session actor, and now it got changed
+        if (subs.SessionId && sessionId != subs.SessionId) {
+            HandleDisconnect(nodeId, subs.SessionId);
+        }
+        subs.SessionId = sessionId;
 
         if (Binding && Binding->NodeId == nodeId) {
             STLOG(PRI_DEBUG, BS_NODE, NWDC09, "Continuing bind", (Binding, Binding));
-            BindToSession(ev->Sender);
+            BindToSession(sessionId);
         }
-
-        // in case of obsolete subscriptions
-        UnsubscribeInterconnect(nodeId);
     }
 
     void TDistributedConfigKeeper::Handle(TEvInterconnect::TEvNodeDisconnected::TPtr ev) {
         const ui32 nodeId = ev->Get()->NodeId;
+        const TActorId sessionId = ev->Sender;
+        const ui64 cookie = ev->Cookie;
 
-        STLOG(PRI_DEBUG, BS_NODE, NWDC07, "TEvNodeDisconnected", (NodeId, nodeId));
+        STLOG(PRI_DEBUG, BS_NODE, NWDC07, "TEvNodeDisconnected", (NodeId, nodeId), (SessionId, sessionId), (Cookie, cookie));
 
         if (!IsSelfStatic) {
-            return OnStaticNodeDisconnected(nodeId, ev->Sender);
+            return OnStaticNodeDisconnected(nodeId, sessionId);
         }
 
         const auto it = SubscribedSessions.find(nodeId);
         if (it == SubscribedSessions.end()) {
-            return; // this may be a race with unsubscription
+            return; // some kind of a race with unsubscription, we don't need this notification anymore
         }
-        Y_ABORT_UNLESS(!it->second || it->second == ev->Sender);
+        TSessionSubscription& subs = it->second;
+
+        if (subs.SubscriptionCookie && cookie != subs.SubscriptionCookie) {
+            return; // a race with other TEvNodeDisconnected, don't care, ignore
+        }
+
+        if (subs.SubscriptionCookie) {
+            const auto cookieIt = SubscriptionCookieMap.find(subs.SubscriptionCookie);
+            Y_ABORT_UNLESS(cookieIt != SubscriptionCookieMap.end());
+            Y_ABORT_UNLESS(cookieIt->second == nodeId);
+            SubscriptionCookieMap.erase(cookieIt);
+        }
+
+        const TActorId subsSessionId = subs.SessionId;
         SubscribedSessions.erase(it);
 
-        OnDynamicNodeDisconnected(nodeId, ev->Sender);
+        HandleDisconnect(nodeId, subsSessionId);
+    }
+
+    void TDistributedConfigKeeper::HandleDisconnect(ui32 nodeId, TActorId sessionId) {
+        STLOG(PRI_DEBUG, BS_NODE, NWDC56, "HandleDisconnect", (NodeId, nodeId), (SessionId, sessionId));
+
+        OnDynamicNodeDisconnected(nodeId, sessionId);
 
         UnbindNode(nodeId, "disconnection");
 
         if (Binding && Binding->NodeId == nodeId) {
             AbortBinding("disconnection", false);
-        }
-    }
-
-    void TDistributedConfigKeeper::Handle(TEvents::TEvUndelivered::TPtr ev) {
-        auto& msg = *ev->Get();
-        if (msg.SourceType == TEvents::TSystem::Subscribe) {
-            const ui32 nodeId = ev->Cookie;
-            STLOG(PRI_DEBUG, BS_NODE, NWDC15, "TEvUndelivered for subscription", (NodeId, nodeId));
-            UnbindNode(nodeId, "disconnection");
         }
     }
 
@@ -179,10 +209,56 @@ namespace NKikimr::NStorage {
         if (ConnectedDynamicNodes.contains(nodeId)) {
             return;
         }
-        if (const auto it = SubscribedSessions.find(nodeId); it != SubscribedSessions.end() && it->second) {
-            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Unsubscribe, 0, it->second, SelfId(), nullptr, 0));
+        if (const auto it = SubscribedSessions.find(nodeId); it != SubscribedSessions.end()) {
+            TSessionSubscription& subs = it->second;
+            STLOG(PRI_DEBUG, BS_NODE, NWDC55, "UnsubscribeInterconnect", (NodeId, nodeId), (Subscription, subs));
+            if (subs.SubscriptionCookie) {
+                // we are waiting for TEvNodeConnected, so just drop it; we will generate unsubscribe when we get that
+                // TEvNodeConnected
+                const auto jt = SubscriptionCookieMap.find(subs.SubscriptionCookie);
+                Y_ABORT_UNLESS(jt != SubscriptionCookieMap.end());
+                Y_ABORT_UNLESS(jt->second == nodeId);
+                SubscriptionCookieMap.erase(jt);
+            } else {
+                // we already had TEvNodeConnected, so we have to unsubscribe
+                Y_ABORT_UNLESS(subs.SessionId);
+                TActivationContext::Send(new IEventHandle(TEvents::TSystem::Unsubscribe, 0, subs.SessionId, SelfId(),
+                    nullptr, 0));
+            }
             SubscribedSessions.erase(it);
         }
+    }
+
+    TActorId TDistributedConfigKeeper::SubscribeToPeerNode(ui32 nodeId, TActorId sessionId) {
+        const auto [it, inserted] = SubscribedSessions.try_emplace(nodeId, sessionId);
+        TSessionSubscription& subs = it->second;
+        STLOG(PRI_DEBUG, BS_NODE, NWDC54, "SubscribeToPeerNode", (NodeId, nodeId), (SessionId, sessionId),
+            (Inserted, inserted), (Subscription, subs), (NextSubscribeCookie, NextSubscribeCookie));
+        if (inserted) {
+            // start subscription; always subscribe to the proxy to get the latest working session actor
+            subs.SubscriptionCookie = NextSubscribeCookie++;
+            SubscriptionCookieMap.emplace(subs.SubscriptionCookie, nodeId);
+            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Subscribe, 0,
+                TActivationContext::InterconnectProxy(nodeId), SelfId(), nullptr, subs.SubscriptionCookie));
+        } else if (!sessionId) {
+            // we don't have the actual session and and only want to establish new connection; however, we have already
+            // sent the subscription message, because this entry is not the new one, so just relax here and do nothing
+        } else if (!subs.SessionId) {
+            // we don't have confirmed session id and never received message from the peer node, but now we got one;
+            // however, this may be a phantom session, which is dead already, and we can't use this actor identifier for
+            // anything, but we may want to store it in order to compare with future messages to detect sudden session
+            // change (this will mean reconnection)
+            Y_ABORT_UNLESS(subs.SubscriptionCookie); // ensure we are expecting TEvNodeConnected
+            subs.SessionId = sessionId;
+        } else if (sessionId != subs.SessionId) {
+            // we have session id actor changed; if this happens after we receive TEvNodeConnected, this is protocol
+            // violation, some bug in message handling logic (it can't happen, because messages from further sessions
+            // can be received only after TEvNodeDisconnected, which drops this record); if this happens before that,
+            // we just have to simulate disconnection hoping that subscription brings us to this new session actor
+            Y_ABORT_UNLESS(subs.SubscriptionCookie);
+            HandleDisconnect(nodeId, std::exchange(subs.SessionId, sessionId));
+        }
+        return subs.SessionId;
     }
 
     void TDistributedConfigKeeper::AbortBinding(const char *reason, bool sendUnbindMessage) {
@@ -199,18 +275,15 @@ namespace NKikimr::NStorage {
 
             ApplyConfigUpdateToDynamicNodes(true);
 
-            IssueNextBindRequest();
-
             FanOutReversePush(nullptr);
 
-            UnsubscribeInterconnect(binding.NodeId);
+            UnsubscribeQueue.insert(binding.NodeId);
         }
     }
 
     void TDistributedConfigKeeper::HandleWakeup() {
         Y_ABORT_UNLESS(Scheduled);
         Scheduled = false;
-        IssueNextBindRequest();
     }
 
     void TDistributedConfigKeeper::Handle(TEvNodeConfigReversePush::TPtr ev) {
@@ -323,16 +396,11 @@ namespace NKikimr::NStorage {
 
         // abort current outgoing binding if there is a race
         if (Binding && senderNodeId == Binding->NodeId && senderNodeId < SelfId().NodeId()) {
-            AbortBinding("mutual binding");
+            AbortBinding("mutual binding", true);
         }
 
-        // subscribe for interconnect session
-        if (const auto [it, inserted] = SubscribedSessions.try_emplace(senderNodeId); inserted) {
-            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Subscribe, IEventHandle::FlagTrackDelivery,
-                ev->InterconnectSession, SelfId(), nullptr, senderNodeId));
-        } else {
-            Y_ABORT_UNLESS(!it->second || it->second == ev->InterconnectSession);
-        }
+        // ensure we have subscription to this node
+        SubscribeToPeerNode(senderNodeId, ev->InterconnectSession);
 
         std::unique_ptr<TEvNodeConfigPush> pushEv;
         auto getPushEv = [&] {
@@ -355,10 +423,11 @@ namespace NKikimr::NStorage {
             STLOG(PRI_CRIT, BS_NODE, NWDC12, "distributed configuration protocol violation: cookie/session mismatch",
                 (Sender, ev->Sender),
                 (Cookie, ev->Cookie),
+                (SelfId, SelfId()),
                 (SessionId, ev->InterconnectSession),
                 (ExpectedCookie, info.Cookie),
                 (ExpectedSessionId, info.SessionId));
-            Y_DEBUG_ABORT_UNLESS(false);
+            Y_DEBUG_ABORT();
             return;
         }
 
@@ -381,7 +450,7 @@ namespace NKikimr::NStorage {
                     (SessionId, ev->InterconnectSession),
                     (Record, record),
                     (NodeId, nodeId));
-                Y_DEBUG_ABORT_UNLESS(false);
+                Y_DEBUG_ABORT();
             }
         }
 
@@ -433,9 +502,7 @@ namespace NKikimr::NStorage {
 
             DirectBoundNodes.erase(it);
 
-            IssueNextBindRequest();
-
-            UnsubscribeInterconnect(nodeId);
+            UnsubscribeQueue.insert(nodeId);
         }
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -54,7 +54,6 @@ namespace NKikimr::NStorage {
         Y_ABORT_UNLESS(!Scepter);
         RootState = ERootState::INITIAL;
         ErrorReason = {};
-        IssueNextBindRequest();
     }
 
     void TDistributedConfigKeeper::ProcessGather(TEvGather *res) {

--- a/ydb/core/util/testactorsys.h
+++ b/ydb/core/util/testactorsys.h
@@ -300,11 +300,13 @@ public:
         TPerNodeInfo& info = PerNodeInfo.at(nodeId);
         info.ActorSystem->Stop();
 
-        for (;;) {
+        bool found;
+        do {
+            found = false;
+
             // delete all mailboxes from this node (expecting that new one can be created during deletion)
             const TMailboxId from(nodeId, 0, 0);
             const TMailboxId to(nodeId + 1, 0, 0);
-            bool found = false;
             for (auto it = Mailboxes.begin(); it != Mailboxes.end(); ) {
                 if (from <= it->first && it->first < to) {
                     TMailboxInfo& mbox = it->second;
@@ -316,36 +318,34 @@ public:
                     ++it;
                 }
             }
-            if (found) {
-                continue;
-            }
 
-            std::deque<TScheduleItem> deleteQueue;
             auto it = ScheduleQ.begin();
             while (it != ScheduleQ.end()) {
                 auto& queue = it->second;
-                bool found = false;
+                bool foundItem = false;
                 for (auto& item : queue) {
                     if (item.NodeId == nodeId) {
-                        found = true;
+                        foundItem = true;
                         break;
                     }
                 }
-                if (found) {
+                if (foundItem) {
                     std::deque<TScheduleItem> newQueue;
                     for (auto& item : queue) {
-                        (item.NodeId == nodeId ? deleteQueue : newQueue).push_back(std::move(item));
+                        if (item.NodeId != nodeId) {
+                            newQueue.push_back(std::move(item));
+                        }
                     }
                     queue.swap(newQueue);
-                    it = queue.empty() ? ScheduleQ.erase(it) : std::next(it);
+                    if (queue.empty()) {
+                        it = ScheduleQ.erase(it);
+                    }
+                    found = true;
                 } else {
                     ++it;
                 }
             }
-            if (deleteQueue.empty()) {
-                break;
-            }
-        }
+        } while (found);
 
         PerNodeInfo.erase(nodeId);
         SetupNode(nodeId, PerNodeInfo[nodeId]);
@@ -562,7 +562,7 @@ public:
             if (FilterFunction && !FilterFunction(item->NodeId, event)) { // event is dropped by the filter function
                 continue;
             }
-            WrapInActorContext(TransformEvent(event.get(), item->NodeId), [&](IActor *actor) {
+            const bool success = WrapInActorContext(TransformEvent(event.get(), item->NodeId), [&](IActor *actor) {
                 TAutoPtr<IEventHandle> ev(event.release());
 
                 const ui32 type = ev->GetTypeRewrite();
@@ -580,14 +580,18 @@ public:
 
                 ++EventsProcessed;
             });
+            if (!success) { // can't find the actor
+                event = IEventHandle::ForwardOnNondelivery(std::move(event), TEvents::TEvUndelivered::ReasonActorUnknown);
+                Send(event.release(), item->NodeId);
+            }
         }
     }
 
     template<typename TCallback>
-    void WrapInActorContext(TActorId actorId, TCallback&& callback) {
+    bool WrapInActorContext(TActorId actorId, TCallback&& callback) {
         const auto mboxIt = Mailboxes.find(actorId);
         if (mboxIt == Mailboxes.end()) {
-            return;
+            return false;
         }
         TMailboxInfo& mbox = mboxIt->second;
         if (IActor *actor = mbox.Header.FindActor(actorId.LocalId())) {
@@ -639,7 +643,9 @@ public:
             if (mbox.Header.IsEmpty()) {
                 Mailboxes.erase(mboxIt);
             }
+            return true;
         }
+        return false;
     }
 
     TActorId AllocateEdgeActor(ui32 nodeId, const char *file = "", int line = 0) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix distconf IC session subscription state machine

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fixed distconf state machine to support arbitrary session actor changes correctly. Also the test actor system was fixed
to generate undelivered messages when actor vanishes after Send(), but before message processing.

#7116
