### PR TITLE
Fix columns in ticket parser mon page

### DIFF
--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -1452,7 +1452,6 @@ private:
             html << "<table class='table simple-table1 table-hover table-condensed'>";
             html << "<thead><tr>";
             html << "<th>Ticket</th>";
-            html << "<th>UID</th>";
             html << "<th>Database</th>";
             html << "<th>Subject</th>";
             html << "<th>Error</th>";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix columns in ticket parser mon page. It is already fixed in main.
There is one extra column declaration in tickets table. Rows values are without it.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
