### PR TITLE
Fix PEERDIR

### DIFF
--- a/ydb/tools/cfg/ya.make
+++ b/ydb/tools/cfg/ya.make
@@ -30,6 +30,7 @@ PEERDIR(
     contrib/python/six
     ydb/tools/cfg/walle
     library/cpp/resource
+    library/python/resource
     ydb/core/protos
 )
 


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

Now it arrives via jsonschema -> setuptools -> library/python/resource chain, I register it explicitly, since the latest jsonschema do not depend on setuptools
