### PR TITLE
Update translation settings in purecalc

### DIFF
--- a/ydb/library/yql/public/purecalc/common/worker_factory.cpp
+++ b/ydb/library/yql/public/purecalc/common/worker_factory.cpp
@@ -183,8 +183,16 @@ TExprNode::TPtr TWorkerFactory<TBase>::Compile(
         settings.ModuleMapping = modules;
         settings.EnableGenericUdfs = true;
         settings.File = "generated.sql";
+        settings.Flags = {
+            "AnsiOrderByLimitInUnionAll",
+            "AnsiRankForNullableKeys",
+            "DisableAnsiOptionalAs",
+            "DisableCoalesceJoinKeysOnQualifiedAll",
+            "DisableUnorderedSubqueries",
+            "FlexibleTypes"
+        };
         if (BlockEngineMode_ != EBlockEngineMode::Disable) {
-            settings.Flags = {"EmitAggApply"};
+            settings.Flags.insert("EmitAggApply");
         }
         for (const auto& [key, block] : UserData_) {
             TStringBuf alias(key.Alias());

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/ut/test_spec.cpp
@@ -241,8 +241,8 @@ Y_UNIT_TEST_SUITE(TestMorePullListArrowIO) {
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
                 R"(SELECT
-                    `uint64` + 1 as `uint64`,
-                    `int64`  - 2  as `int64`,
+                    uint64 + 1 as uint64,
+                    int64  - 2  as int64,
                 FROM Input)",
                 ETranslationMode::SQL
             );
@@ -318,8 +318,8 @@ Y_UNIT_TEST_SUITE(TestMorePullStreamArrowIO) {
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
                 R"(SELECT
-                    `uint64` + 1 as `uint64`,
-                    `int64`  - 2  as `int64`,
+                    uint64 + 1 as uint64,
+                    int64  - 2  as int64,
                 FROM Input)",
                 ETranslationMode::SQL
             );
@@ -393,8 +393,8 @@ Y_UNIT_TEST_SUITE(TestMorePushStreamArrowIO) {
                 TArrowInputSpec({schema}),
                 TArrowOutputSpec(schema),
                 R"(SELECT
-                    `uint64` + 1 as `uint64`,
-                    `int64`  - 2  as `int64`,
+                    uint64 + 1 as uint64,
+                    int64  - 2  as int64,
                 FROM Input)",
                 ETranslationMode::SQL
             );

--- a/ydb/library/yql/public/purecalc/io_specs/mkql/ut/test.inl
+++ b/ydb/library/yql/public/purecalc/io_specs/mkql/ut/test.inl
@@ -67,7 +67,7 @@ Y_UNIT_TEST_SUITE(TEST_SUITE_NAME) {
             auto program = CREATE_PROGRAM(
                 inputSpec,
                 outputSpec,
-                "SELECT `int64`, `bool`, `string` FROM Input",
+                "SELECT int64, bool, string FROM Input",
                 ETranslationMode::SQL, 1
             );
 
@@ -134,9 +134,9 @@ Y_UNIT_TEST_SUITE(TEST_SUITE_NAME) {
                 inputSpec,
                 outputSpec,
                 R"(
-SELECT `int64`, `uint64` FROM Input0
+SELECT int64, uint64 FROM Input0
 UNION ALL
-SELECT `bool`, `yson` FROM Input1
+SELECT bool, yson FROM Input1
                 )",
                 ETranslationMode::SQL, 1
             );
@@ -182,7 +182,7 @@ SELECT `bool`, `yson` FROM Input1
             auto program = CREATE_PROGRAM(
                 INPUT_SPEC {schema},
             OUTPUT_SPEC {someOptionalSchema},
-            "SELECT `int64`, `bool`, Nothing(String?) as `string` FROM Input",
+            "SELECT int64, bool, Nothing(String?) as string FROM Input",
             ETranslationMode::SQL, 1
             );
 
@@ -208,7 +208,7 @@ SELECT `bool`, `yson` FROM Input1
             CREATE_PROGRAM(
                 INPUT_SPEC {schema},
             OUTPUT_SPEC {someSchema},
-            "SELECT `int64`, `bool`, Nothing(String?) as `string` FROM Input",
+            "SELECT int64, bool, Nothing(String?) as string FROM Input",
             ETranslationMode::SQL, 1
             );
         }(), TCompileError, "Failed to optimize");
@@ -234,7 +234,7 @@ SELECT `bool`, `yson` FROM Input1
             auto program = CREATE_PROGRAM(
                 inputSpec,
                 outputSpec,
-                "SELECT `int64`, `bool`, `string` FROM Input",
+                "SELECT int64, bool, string FROM Input",
                 ETranslationMode::SQL, 1
             );
 
@@ -286,17 +286,17 @@ SELECT `bool`, `yson` FROM Input1
                 outputSpec,
                 R"(
 SELECT
-    t0.`int64` AS `int64`,
-    t0.`uint64` AS `uint64`,
-    t0.`double` AS `double`,
-    t1.`bool` AS `bool`,
-    t1.`string` AS `string`
+    t0.int64 AS int64,
+    t0.uint64 AS uint64,
+    t0.double AS double,
+    t1.bool AS bool,
+    t1.string AS string
 FROM
     Input0 AS t0
 INNER JOIN
     Input1 AS t1
-ON t0.`int64` == t1.`int64`
-ORDER BY `int64`
+ON t0.int64 == t1.int64
+ORDER BY int64
                 )",
                 ETranslationMode::SQL, 1
             );
@@ -660,7 +660,7 @@ ORDER BY `int64`
             auto program = CREATE_PROGRAM(
                 INPUT_SPEC(inputSchema),
                 OUTPUT_SPEC(NYT::TNode::CreateEntity()),
-                "SELECT `int64`, TableName() AS `tname` FROM Input",
+                "SELECT int64, TableName() AS tname FROM Input",
                 ETranslationMode::SQL
             );
             
@@ -688,7 +688,7 @@ ORDER BY `int64`
             auto program = CREATE_PROGRAM(
                 INPUT_SPEC(inputSchema).SetTableNames(tableNames),
                 OUTPUT_SPEC(NYT::TNode::CreateEntity()),
-                "SELECT `int64`, TableName() AS `tname` FROM TABLES()",
+                "SELECT int64, TableName() AS tname FROM TABLES()",
                 ETranslationMode::SQL
             );
             
@@ -724,7 +724,7 @@ $union = (
     UNION ALL
     SELECT * FROM Input1
 );
-SELECT TableName() AS `tname`, `int64` FROM $union
+SELECT TableName() AS tname, int64 FROM $union
                 )"
             );
             
@@ -762,7 +762,7 @@ $union = (
     UNION ALL
     SELECT * FROM $input1
 );
-SELECT TableName() AS `tname`, `int64` FROM $union
+SELECT TableName() AS tname, int64 FROM $union
                 )"
             );
             


### PR DESCRIPTION
Translation settings in purecalc are updated to match the actual defaults in gateways.conf. Since `"FlexibleTypes"` translation setting is set as a default for purecalc worker, all fields with type-like names being escaped can be used as is now.

### Changelog category 

* Improvement