### PR TITLE
speed up tables manager in schemeshard

### DIFF
--- a/ydb/core/tx/schemeshard/olap/manager/manager.cpp
+++ b/ydb/core/tx/schemeshard/olap/manager/manager.cpp
@@ -29,12 +29,12 @@ void TTablesStorage::OnRemoveObject(const TPathId& pathId, TColumnTableInfo::TPt
     }
 }
 
-const std::set<NKikimr::TPathId>& TTablesStorage::GetTablesWithTiering(const TString& tieringId) const {
+const THashSet<TPathId>& TTablesStorage::GetTablesWithTiering(const TString& tieringId) const {
     auto it = PathsByTieringId.find(tieringId);
     if (it != PathsByTieringId.end()) {
         return it->second;
     } else {
-        return Default<std::set<TPathId>>();
+        return Default<THashSet<TPathId>>();
     }
 }
 

--- a/ydb/core/tx/schemeshard/olap/manager/manager.h
+++ b/ydb/core/tx/schemeshard/olap/manager/manager.h
@@ -9,7 +9,7 @@ namespace NKikimr::NSchemeShard {
 class TTablesStorage {
 private:
     THashMap<TPathId, TColumnTableInfo::TPtr> Tables;
-    THashMap<TString, std::set<TPathId>> PathsByTieringId;
+    THashMap<TString, THashSet<TPathId>> PathsByTieringId;
     THashMap<ui64, TColumnTablesLayout::TTableIdsGroup> TablesByShard;
 
     void OnAddObject(const TPathId& pathId, TColumnTableInfo::TPtr object);
@@ -20,7 +20,7 @@ public:
 
     TColumnTablesLayout GetTablesLayout(const std::vector<ui64>& tabletIds) const;
 
-    const std::set<TPathId>& GetTablesWithTiering(const TString& tieringId) const;
+    const THashSet<TPathId>& GetTablesWithTiering(const TString& tieringId) const;
 
     class TTableReadGuard {
     protected:

--- a/ydb/core/tx/tiering/rule/ss_fetcher.cpp
+++ b/ydb/core/tx/tiering/rule/ss_fetcher.cpp
@@ -17,7 +17,7 @@ void TFetcherCheckUserTieringPermissions::DoProcess(NSchemeShard::TSchemeShard& 
     } else {
         bool denied = false;
         for (auto&& i : TieringRuleIds) {
-            const std::set<TPathId>& pathIds = schemeShard.ColumnTables.GetTablesWithTiering(i);
+            const auto& pathIds = schemeShard.ColumnTables.GetTablesWithTiering(i);
             for (auto&& pathId : pathIds) {
                 auto path = NSchemeShard::TPath::Init(pathId, &schemeShard);
                 if (!path.IsResolved() || path.IsUnderDeleting() || path.IsDeleted()) {


### PR DESCRIPTION
use hash instead of set to prevent TPathId slow comparision
* Performance improvement
