### PR TITLE
tablets with disabled metrics ignore metric-related balancers (#4052)

### DIFF
--- a/ydb/core/mind/hive/balancer.cpp
+++ b/ydb/core/mind/hive/balancer.cpp
@@ -243,7 +243,9 @@ protected:
             std::vector<TTabletInfo*> tablets;
             tablets.reserve(nodeTablets.size());
             for (TTabletInfo* tablet : nodeTablets) {
-                if (tablet->IsGoodForBalancer(now) && (!Settings.FilterObjectId || tablet->GetObjectId() == *Settings.FilterObjectId)) {
+                if (tablet->IsGoodForBalancer(now) && 
+                    (!Settings.FilterObjectId || tablet->GetObjectId() == *Settings.FilterObjectId) &&
+                    tablet->HasAllowedMetric(Settings.ResourceToBalance)) {
                     tablet->UpdateWeight();
                     tablets.emplace_back(tablet);
                 }

--- a/ydb/core/mind/hive/hive.h
+++ b/ydb/core/mind/hive/hive.h
@@ -98,7 +98,7 @@ constexpr std::size_t EBalancerTypeSize = static_cast<std::size_t>(EBalancerType
 TString EBalancerTypeName(EBalancerType value);
 
 enum class EResourceToBalance {
-    Dominant,
+    ComputeResources,
     Counter,
     CPU,
     Memory,
@@ -288,7 +288,7 @@ struct TBalancerSettings {
     bool RecheckOnFinish = false;
     ui64 MaxInFlight = 1;
     const std::vector<TNodeId> FilterNodeIds = {};
-    EResourceToBalance ResourceToBalance = EResourceToBalance::Dominant;
+    EResourceToBalance ResourceToBalance = EResourceToBalance::ComputeResources;
     std::optional<TFullObjectId> FilterObjectId;
 };
 

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2352,7 +2352,7 @@ void THive::Handle(TEvPrivate::TEvProcessTabletBalancer::TPtr&) {
             case EResourceToBalance::Network:
                 balancerType = EBalancerType::ScatterNetwork;
                 break;
-            case EResourceToBalance::Dominant:
+            case EResourceToBalance::ComputeResources:
                 balancerType = EBalancerType::Scatter;
                 break;
         }

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -207,7 +207,7 @@ i32 TNodeInfo::GetPriorityForTablet(const TTabletInfo& tablet) const {
 
 bool TNodeInfo::IsAbleToRunTablet(const TTabletInfo& tablet, TTabletDebugState* debugState) const {
     if (tablet.IsAliveOnLocal(Local)) {
-        return !IsOverloaded();
+        return !(IsOverloaded() && tablet.HasAllowedMetric(EResourceToBalance::ComputeResources));
     }
     if (tablet.IsLeader()) {
         const TLeaderTabletInfo& leader = tablet.AsLeader();
@@ -283,7 +283,7 @@ bool TNodeInfo::IsAbleToRunTablet(const TTabletInfo& tablet, TTabletDebugState* 
         }
     }
 
-    if (tablet.IsAlive() && IsOverloaded()) {
+    if (tablet.IsAlive() && IsOverloaded() && tablet.HasAllowedMetric(EResourceToBalance::ComputeResources)) {
         // we don't move already running tablet to another overloaded node
         if (debugState) {
             debugState->NodesWithoutResources++;
@@ -400,7 +400,7 @@ double TNodeInfo::GetNodeUsageForTablet(const TTabletInfo& tablet) const {
 
 double TNodeInfo::GetNodeUsage(const TResourceNormalizedValues& normValues, EResourceToBalance resource) const {
     double usage = TTabletInfo::ExtractResourceUsage(normValues, resource);
-    if (resource == EResourceToBalance::Dominant && AveragedNodeTotalUsage.IsValueStable()) {
+    if (resource == EResourceToBalance::ComputeResources && AveragedNodeTotalUsage.IsValueStable()) {
         usage = std::max(usage, AveragedNodeTotalUsage.GetValue());
     }
     return usage;

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -213,9 +213,9 @@ public:
     }
 
     double GetNodeUsageForTablet(const TTabletInfo& tablet) const;
-    double GetNodeUsage(EResourceToBalance resource = EResourceToBalance::Dominant) const;
+    double GetNodeUsage(EResourceToBalance resource = EResourceToBalance::ComputeResources) const;
     double GetNodeUsage(const TResourceNormalizedValues& normValues,
-                        EResourceToBalance resource = EResourceToBalance::Dominant) const;
+                        EResourceToBalance resource = EResourceToBalance::ComputeResources) const;
 
     ui64 GetTabletsRunningByType(TTabletTypes::EType tabletType) const;
 

--- a/ydb/core/mind/hive/tablet_info.h
+++ b/ydb/core/mind/hive/tablet_info.h
@@ -226,6 +226,8 @@ public:
     void BecomeUnknown(TNodeInfo* node);
     bool Kick();
     const TVector<i64>& GetTabletAllowedMetricIds() const;
+    static bool HasAllowedMetric(const TVector<i64>& allowedMetricIds, EResourceToBalance resource);
+    bool HasAllowedMetric(EResourceToBalance resource) const;
 
     void UpdateResourceUsage(const NKikimrTabletBase::TMetrics& metrics);
     TResourceRawValues GetResourceCurrentValues() const;
@@ -236,18 +238,18 @@ public:
     void ActualizeCounter();
 
     template <typename ResourcesType>
-    static double GetUsage(const ResourcesType& current, const ResourcesType& maximum, EResourceToBalance resource = EResourceToBalance::Dominant) {
+    static double GetUsage(const ResourcesType& current, const ResourcesType& maximum, EResourceToBalance resource = EResourceToBalance::ComputeResources) {
         auto normValues = NormalizeRawValues(current, maximum);
         return ExtractResourceUsage(normValues, resource);
     }
 
-    static double ExtractResourceUsage(const TResourceNormalizedValues& normValues, EResourceToBalance resource = EResourceToBalance::Dominant) {
+    static double ExtractResourceUsage(const TResourceNormalizedValues& normValues, EResourceToBalance resource = EResourceToBalance::ComputeResources) {
         switch (resource) {
         case EResourceToBalance::CPU: return std::get<NMetrics::EResource::CPU>(normValues);
         case EResourceToBalance::Memory: return std::get<NMetrics::EResource::Memory>(normValues);
         case EResourceToBalance::Network: return std::get<NMetrics::EResource::Network>(normValues);
         case EResourceToBalance::Counter: return std::get<NMetrics::EResource::Counter>(normValues);
-        case EResourceToBalance::Dominant: return max(normValues);
+        case EResourceToBalance::ComputeResources: return max(normValues);
         }
     }
 


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

ignore resource overloads when balancing columnshards

### Changelog category <!-- remove all except one -->


* Improvement

### Additional information

backport of https://github.com/ydb-platform/ydb/pull/4052
