### PR TITLE
Do rm -rf ./.ya instead of ya gc cache

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -295,6 +295,7 @@ runs:
             RERUN_FAILED_OPT="-X"
           fi
 
+          s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
           echo $CURRENT_MESSAGE | GITHUB_TOKEN="${{ github.token }}" .github/scripts/tests/comment-pr.py
 
           CURRENT_PUBLIC_DIR_RELATIVE=try_$RETRY
@@ -346,8 +347,6 @@ runs:
           if [ $TESTS_RESULT = 0 ] || [ $RETRY = $TEST_RETRY_COUNT ]; then
             IS_LAST_RETRY=1
           fi
-
-          s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
 
           if [ $FAILED_TESTS_COUNT -gt 500 ]; then 
             IS_LAST_RETRY=1

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -295,7 +295,6 @@ runs:
             RERUN_FAILED_OPT="-X"
           fi
 
-          s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
           echo $CURRENT_MESSAGE | GITHUB_TOKEN="${{ github.token }}" .github/scripts/tests/comment-pr.py
 
           CURRENT_PUBLIC_DIR_RELATIVE=try_$RETRY
@@ -347,6 +346,8 @@ runs:
           if [ $TESTS_RESULT = 0 ] || [ $RETRY = $TEST_RETRY_COUNT ]; then
             IS_LAST_RETRY=1
           fi
+
+          s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
 
           if [ $FAILED_TESTS_COUNT -gt 500 ]; then 
             IS_LAST_RETRY=1

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -214,7 +214,7 @@ jobs:
         fetch-depth: 2
     - name: Clean ya cache
       shell: bash
-      run: ./ya gc cache
+      run: rm -rf ./.ya
     - name: Setup ydb access
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

There are some problems with ya gc cache which lead to failed check on PRs
e.g.
https://github.com/ydb-platform/ydb/actions/runs/10163060050/job/28105111243?pr=7225


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information