### PR TITLE
Speedup Restore_block42

### DIFF
--- a/ydb/core/blobstorage/dsproxy/ut_strategy/strategy_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut_strategy/strategy_ut.cpp
@@ -100,12 +100,12 @@ void RunStrategyTest(TBlobStorageGroupType type) {
     TString data(1000, 'x');
     TLogoBlobID id(1'000'000'000, 1, 1, 0, data.size(), 0);
     std::vector<TRope> parts(type.TotalPartCount());
+    ErasureSplit(TBlobStorageGroupType::CrcModeNone, type, TRope(data), parts);
 
     for (ui32 iter = 0; iter < 100'000; ++iter) {
         Ctest << "iteration# " << iter << Endl;
 
         TBlackboard blackboard(&info, &groupQueues, NKikimrBlobStorage::UserData, NKikimrBlobStorage::FastRead);
-        ErasureSplit(TBlobStorageGroupType::CrcModeNone, type, TRope(data), parts);
         blackboard.RegisterBlobForPut(id, 0);
         for (ui32 i = 0; i < parts.size(); ++i) {
             blackboard.AddPartToPut(id, i, TRope(parts[i]));

--- a/ydb/core/blobstorage/dsproxy/ut_strategy/strategy_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut_strategy/strategy_ut.cpp
@@ -97,13 +97,14 @@ void RunStrategyTest(TBlobStorageGroupType type) {
 
     std::unordered_map<TString, std::tuple<EStrategyOutcome, TString>> transitions;
 
-    for (ui32 iter = 0; iter < 1'000'000; ++iter) {
+    TString data(1000, 'x');
+    TLogoBlobID id(1'000'000'000, 1, 1, 0, data.size(), 0);
+    std::vector<TRope> parts(type.TotalPartCount());
+
+    for (ui32 iter = 0; iter < 100'000; ++iter) {
         Ctest << "iteration# " << iter << Endl;
 
         TBlackboard blackboard(&info, &groupQueues, NKikimrBlobStorage::UserData, NKikimrBlobStorage::FastRead);
-        TString data(1000, 'x');
-        TLogoBlobID id(1'000'000'000, 1, 1, 0, data.size(), 0);
-        std::vector<TRope> parts(type.TotalPartCount());
         ErasureSplit(TBlobStorageGroupType::CrcModeNone, type, TRope(data), parts);
         blackboard.RegisterBlobForPut(id, 0);
         for (ui32 i = 0; i < parts.size(); ++i) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Do less iterations
Do common stuff outside of the loop

This test is too long for asan (timeout in 10min)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Without asan
```
maxim-yurchuk@yurchuk-github:~/ydb/ydb/core/blobstorage/dsproxy/ut_strategy$ time ya make --build=relwithdebinfo -tA -F="*Restore_block42*"

<...>

Number of suites by filter *Restore_block42*

Total 1 suite:
        1 - GOOD
Total 1 test:
        1 - GOOD
Ok

real    0m18.331s
user    0m28.140s
sys     0m1.895s
```

With asan 
```
maxim-yurchuk@yurchuk-github:~/ydb/ydb/core/blobstorage/dsproxy/ut_strategy$ time ya make --build=release -tA --sanitize=address -DDEBUGINFO_LINES_ONLY -F="*Restore_block42*"

<...>

Total 1 suite:
        1 - GOOD
Total 1 test:
        1 - GOOD
Ok

real    1m41.205s
user    1m52.320s
sys     0m2.923s
```
-- still x5 longer (build was not executed, all binaries were built before ya make invokation)