### PR TITLE
24-3 Rescue asan tests (remove NO_EXPORT_DYNAMIC_SYMBOLS for them)

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -1,6 +1,8 @@
 PROGRAM(ydbd)
 
-NO_EXPORT_DYNAMIC_SYMBOLS()
+IF (NOT SANITIZER_TYPE)  # for some reasons some tests with asan are failed, see comment in CPPCOM-32
+    NO_EXPORT_DYNAMIC_SYMBOLS()
+ENDIF()
 
 IF (OS_LINUX)
     ALLOCATOR(TCMALLOC_256K)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Needed to fix some asan tests 

PR in main: #7290

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
