### PR TITLE
Memory leaks

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -493,8 +493,8 @@ void TPartition::DestroyActor(const TActorContext& ctx)
         UsersInfoStorage->Clear(ctx);
     }
 
+    Send(ReadQuotaTrackerActor, new TEvents::TEvPoisonPill());
     if (!IsSupportive()) {
-        Send(ReadQuotaTrackerActor, new TEvents::TEvPoisonPill());
         Send(WriteQuotaTrackerActor, new TEvents::TEvPoisonPill());
     }
 

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -505,6 +505,7 @@ private:
     bool CheckTxWriteOperations(const NKikimrPQ::TDataTransaction& txBody) const;
 
     void MoveTopTxToCalculating(TDistributedTransaction& tx, const TActorContext& ctx);
+    void DeletePartition(const TPartitionId& partitionId, const TActorContext& ctx);
 };
 
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed bugs:
1. In the `TEvDeletePartitionDone` message handler of the PQ tablet, the `TEvPoison` message was not sent to the partition actor.
2. In the `TEvPoison` handler of the actor of the service partition, the `TEvPoison` message was not sent to the actor of the read quoter.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
