### PR TITLE
ci: remove use ubuntu-2204 without oslogin for gh runner image

### DIFF
--- a/ydb/ci/gh-runner-image/image.pkr.hcl
+++ b/ydb/ci/gh-runner-image/image.pkr.hcl
@@ -11,7 +11,7 @@ source "yandex" "this" {
   image_description = "ydb github actions runner image"
   image_pooled      = false
 
-  source_image_family = "ubuntu-2204-lts-oslogin"
+  source_image_family = "ubuntu-2204-lts"
   instance_cores      = 4
   instance_mem_gb     = 16
 
@@ -32,13 +32,14 @@ build {
     content     = <<EOF
 set -x
 apt-get update
-apt-get -y --no-install-recommends dist-upgrade
+# wait for unattended-upgrade is finished
+apt-get -o DPkg::Lock::Timeout=600 -y --no-install-recommends dist-upgrade
 apt-get -y install --no-install-recommends \
   antlr3 clang-12 clang-14 cmake docker.io git jq libaio-dev libaio1 libicu70 libidn11-dev libkrb5-3 \
   liblttng-ust1 lld-14 llvm-14 m4 make ninja-build parallel postgresql-client postgresql-client \
   python-is-python3 python3-pip s3cmd s3cmd zlib1g
 
-apt-get -y purge lxd-agent-loader snapd
+apt-get -y purge lxd-agent-loader snapd modemanager
 apt-get -y autoremove
 
 pip3 install conan==1.59 pytest==7.1.3 pytest-timeout pytest-xdist==3.3.1 setproctitle==1.3.2 \


### PR DESCRIPTION
also remove modemmanager, add dist-upgrade lock timeout

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
