### PR TITLE
grace join: fix switching to spilling mode with LEFT* JOIN

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -808,6 +808,8 @@ private:
             }
 
             auto isYield = FetchAndPackData(ctx, output);
+            if (isYield == EFetchResult::One)
+                return isYield;
             if (IsSpillingAllowed && ctx.SpillerFactory && IsSwitchToSpillingModeCondition()) {
                 const auto used = TlsAllocState->GetUsed();
                 const auto limit = TlsAllocState->GetLimit();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Not for changelog (changelog entry is not required)

### Additional information

Fixes YQL-18856 (result mismatch in TPC DS 100 q87 with spilling enabled); triaged with help of #7347 (thanks!)