### PR TITLE
Mark SystemPython udfs for remote execution

### DIFF
--- a/ydb/library/yql/providers/yt/gateway/native/yql_yt_transform.cpp
+++ b/ydb/library/yql/providers/yt/gateway/native/yql_yt_transform.cpp
@@ -321,6 +321,10 @@ TCallableVisitFunc TGatewayTransformer::operator()(TInternName name) {
                     !ExecCtx_.FunctionRegistry_->IsLoadedUdfModule(moduleName) ||
                     moduleName == TStringBuf("Geo");
 
+                if (moduleName.StartsWith("SystemPython")) {
+                    *RemoteExecutionFlag_ = true;
+                }
+
                 const auto udfPath = FindUdfPath(moduleName);
                 if (!udfPath.StartsWith(NMiniKQL::StaticModulePrefix)) {
                     const auto fileInfo = ExecCtx_.UserFiles_->GetFile(udfPath);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

SystemPython udfs should not be executed locally since they depend on environment which is adjusted via `pragma yt.DockerImage`

With `execute_udf_locally_if_possible = true` flag they try to execute in DQ or locally and fail because of unexpected environment

Tested on internal cluster, it works