### PR TITLE
Fix: Python udf not working when the function has name 'func'

### DIFF
--- a/ydb/library/yql/mount/lib/yql/core.yql
+++ b/ydb/library/yql/mount/lib/yql/core.yql
@@ -85,8 +85,9 @@ def signature(script, name):
         name = name.decode("utf-8")
 
     try:
-        exec(script)
-        func = locals()[name]
+        local_variables = {}
+        exec(script, None, local_variables)
+        func = local_variables[name]
         if typing is not None and hasattr(func, "__annotations__"):
             ann = func.__annotations__
             if ann:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
