### PR TITLE
tpc ds q72: manually optimize join order

### DIFF
--- a/ydb/library/benchmarks/queries/tpcds/yql/q72.sql
+++ b/ydb/library/benchmarks/queries/tpcds/yql/q72.sql
@@ -9,13 +9,13 @@ select  item.i_item_desc
       ,sum(case when p_promo_sk is not null then 1 else 0 end) promo
       ,count(*) total_cnt
 from {{catalog_sales}} as catalog_sales
-join {{inventory}} as inventory on (catalog_sales.cs_item_sk = inventory.inv_item_sk)
-join {{warehouse}} as warehouse on (warehouse.w_warehouse_sk=inventory.inv_warehouse_sk)
-join {{item}} as item on (item.i_item_sk = catalog_sales.cs_item_sk)
 join {{customer_demographics}} as customer_demographics on (catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
 join {{household_demographics}} as household_demographics on (catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
 join {{date_dim}} d1 on (catalog_sales.cs_sold_date_sk = d1.d_date_sk)
+join {{inventory}} as inventory on (catalog_sales.cs_item_sk = inventory.inv_item_sk)
 join {{date_dim}} d2 on (inventory.inv_date_sk = d2.d_date_sk)
+join {{warehouse}} as warehouse on (warehouse.w_warehouse_sk=inventory.inv_warehouse_sk)
+join {{item}} as item on (item.i_item_sk = catalog_sales.cs_item_sk)
 join {{date_dim}} d3 on (catalog_sales.cs_ship_date_sk = d3.d_date_sk)
 left join {{promotion}} as promotion on (catalog_sales.cs_promo_sk=promotion.p_promo_sk)
 left join {{catalog_returns}} as catalog_returns on (catalog_returns.cr_item_sk = catalog_sales.cs_item_sk and catalog_returns.cr_order_number = catalog_sales.cs_order_number)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Really fixes #6473
It is not quite clear if this patch is a good thing (the point of this query/test is to verify quality of optimizer; if we just rewrite query manually, what is the point of this? but at least, it should make clear what JOIN order should be after CBO/RBO/... applied, and about expected performance of this query)