### PR TITLE
futher fixing type inferring

### DIFF
--- a/ydb/core/external_sources/object_storage/inference/arrow_inferencinator.cpp
+++ b/ydb/core/external_sources/object_storage/inference/arrow_inferencinator.cpp
@@ -14,64 +14,84 @@ namespace NKikimr::NExternalSource::NObjectStorage::NInference {
 
 namespace {
 
-bool ArrowToYdbType(Ydb::Type& optionalType, const arrow::DataType& type) {
-    auto& resType = *optionalType.mutable_optional_type()->mutable_item();
+bool ShouldBeOptional(const arrow::DataType& type) {
     switch (type.id()) {
     case arrow::Type::NA:
-        resType.set_type_id(Ydb::Type::UTF8);
+    case arrow::Type::STRING:
+    case arrow::Type::BINARY:
+    case arrow::Type::LARGE_BINARY:
+    case arrow::Type::FIXED_SIZE_BINARY:
+        return false;
+    default:
+        return true;
+    }
+}
+
+bool ArrowToYdbType(Ydb::Type& resType, const arrow::DataType& type) {
+    Ydb::Type* maybeOptionalType;
+    if (ShouldBeOptional(type)) {
+        maybeOptionalType = resType.mutable_optional_type()->mutable_item();
+    }
+    else {
+        maybeOptionalType = &resType;
+    }
+
+    switch (type.id()) {
+    case arrow::Type::NA:
+        maybeOptionalType->set_type_id(Ydb::Type::UTF8);
         return true;
     case arrow::Type::BOOL:
-        resType.set_type_id(Ydb::Type::BOOL);
+        maybeOptionalType->set_type_id(Ydb::Type::BOOL);
         return true;
     case arrow::Type::UINT8:
-        resType.set_type_id(Ydb::Type::UINT8);
+        maybeOptionalType->set_type_id(Ydb::Type::UINT8);
         return true;
     case arrow::Type::INT8:
-        resType.set_type_id(Ydb::Type::INT8);
+        maybeOptionalType->set_type_id(Ydb::Type::INT8);
         return true;
     case arrow::Type::UINT16:
-        resType.set_type_id(Ydb::Type::UINT16);
+        maybeOptionalType->set_type_id(Ydb::Type::UINT16);
         return true;
     case arrow::Type::INT16:
-        resType.set_type_id(Ydb::Type::INT16);
+        maybeOptionalType->set_type_id(Ydb::Type::INT16);
         return true;
     case arrow::Type::UINT32:
-        resType.set_type_id(Ydb::Type::UINT32);
+        maybeOptionalType->set_type_id(Ydb::Type::UINT32);
         return true;
     case arrow::Type::INT32:
-        resType.set_type_id(Ydb::Type::INT32);
+        maybeOptionalType->set_type_id(Ydb::Type::INT32);
         return true;
     case arrow::Type::UINT64:
-        resType.set_type_id(Ydb::Type::UINT64);
+        maybeOptionalType->set_type_id(Ydb::Type::UINT64);
         return true;
     case arrow::Type::INT64:
-        resType.set_type_id(Ydb::Type::INT64);
+        maybeOptionalType->set_type_id(Ydb::Type::INT64);
         return true;
     case arrow::Type::HALF_FLOAT: // TODO: is there anything?
         return false;
     case arrow::Type::FLOAT:
-        resType.set_type_id(Ydb::Type::FLOAT);
+        maybeOptionalType->set_type_id(Ydb::Type::FLOAT);
         return true;
     case arrow::Type::DOUBLE:
-        resType.set_type_id(Ydb::Type::DOUBLE);
+        maybeOptionalType->set_type_id(Ydb::Type::DOUBLE);
         return true;
     case arrow::Type::STRING: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::UTF8);
+        maybeOptionalType->set_type_id(Ydb::Type::UTF8);
         return true;
     case arrow::Type::BINARY: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::STRING);
+        maybeOptionalType->set_type_id(Ydb::Type::STRING);
         return true;
     case arrow::Type::FIXED_SIZE_BINARY: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::STRING);
+        maybeOptionalType->set_type_id(Ydb::Type::STRING);
         return true;
     case arrow::Type::DATE32:
-        resType.set_type_id(Ydb::Type::DATE);
+        maybeOptionalType->set_type_id(Ydb::Type::DATE);
         return true;
     case arrow::Type::DATE64: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::DATETIME64);
+        maybeOptionalType->set_type_id(Ydb::Type::DATETIME64);
         return true;
     case arrow::Type::TIMESTAMP:
-        resType.set_type_id(Ydb::Type::TIMESTAMP);
+        maybeOptionalType->set_type_id(Ydb::Type::TIMESTAMP);
         return true;
     case arrow::Type::TIME32: // TODO: is there anything?
         return false;
@@ -80,10 +100,10 @@ bool ArrowToYdbType(Ydb::Type& optionalType, const arrow::DataType& type) {
     case arrow::Type::INTERVAL_MONTHS: // TODO: is it true?
         return false;
     case arrow::Type::INTERVAL_DAY_TIME: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::INTERVAL64);
+        maybeOptionalType->set_type_id(Ydb::Type::INTERVAL64);
         return true;
     case arrow::Type::DECIMAL128: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::DOUBLE);
+        maybeOptionalType->set_type_id(Ydb::Type::DOUBLE);
         return true;
     case arrow::Type::DECIMAL256: // TODO: is there anything?
         return false;
@@ -93,7 +113,7 @@ bool ArrowToYdbType(Ydb::Type& optionalType, const arrow::DataType& type) {
         return false;
     }
     case arrow::Type::STRUCT: { // TODO: is ok?
-        auto& structType = *resType.mutable_struct_type();
+        auto& structType = *maybeOptionalType->mutable_struct_type();
         for (const auto& field : type.fields()) {
             auto& member = *structType.add_members();
             auto& memberType = *member.mutable_type();
@@ -106,7 +126,7 @@ bool ArrowToYdbType(Ydb::Type& optionalType, const arrow::DataType& type) {
     }
     case arrow::Type::SPARSE_UNION:
     case arrow::Type::DENSE_UNION: { // TODO: is ok?
-        auto& variant = *resType.mutable_variant_type()->mutable_struct_items();
+        auto& variant = *maybeOptionalType->mutable_variant_type()->mutable_struct_items();
         for (const auto& field : type.fields()) {
             auto& member = *variant.add_members();
             if (!ArrowToYdbType(*member.mutable_type(), *field->type())) {
@@ -127,13 +147,13 @@ bool ArrowToYdbType(Ydb::Type& optionalType, const arrow::DataType& type) {
     case arrow::Type::EXTENSION: // TODO: is representable?
         return false;
     case arrow::Type::DURATION: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::INTERVAL64);
+        maybeOptionalType->set_type_id(Ydb::Type::INTERVAL64);
         return true;
     case arrow::Type::LARGE_STRING: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::UTF8);
+        maybeOptionalType->set_type_id(Ydb::Type::UTF8);
         return true;
     case arrow::Type::LARGE_BINARY: // TODO: is it true?
-        resType.set_type_id(Ydb::Type::STRING);
+        maybeOptionalType->set_type_id(Ydb::Type::STRING);
         return true;
     case arrow::Type::MAX_ID:
         return false;

--- a/ydb/core/external_sources/object_storage/inference/ut/arrow_inference_ut.cpp
+++ b/ydb/core/external_sources/object_storage/inference/ut/arrow_inference_ut.cpp
@@ -97,8 +97,8 @@ TEST_F(ArrowInferenceTest, csv_simple) {
     ASSERT_EQ(fields[0].type().optional_type().item().type_id(), Ydb::Type::INT64);
     ASSERT_EQ(fields[0].name(), "A");
 
-    ASSERT_TRUE(fields[1].type().optional_type().item().has_type_id());
-    ASSERT_EQ(fields[1].type().optional_type().item().type_id(), Ydb::Type::UTF8);
+    ASSERT_TRUE(fields[1].type().has_type_id());
+    ASSERT_EQ(fields[1].type().type_id(), Ydb::Type::UTF8);
     ASSERT_EQ(fields[1].name(), "B");
 
     ASSERT_TRUE(fields[2].type().optional_type().item().has_type_id());
@@ -133,8 +133,8 @@ TEST_F(ArrowInferenceTest, tsv_simple) {
     ASSERT_EQ(fields[0].type().optional_type().item().type_id(), Ydb::Type::INT64);
     ASSERT_EQ(fields[0].name(), "A");
 
-    ASSERT_TRUE(fields[1].type().optional_type().item().has_type_id());
-    ASSERT_EQ(fields[1].type().optional_type().item().type_id(), Ydb::Type::UTF8);
+    ASSERT_TRUE(fields[1].type().has_type_id());
+    ASSERT_EQ(fields[1].type().type_id(), Ydb::Type::UTF8);
     ASSERT_EQ(fields[1].name(), "B");
 
     ASSERT_TRUE(fields[2].type().optional_type().item().has_type_id());

--- a/ydb/tests/fq/s3/test_s3_0.py
+++ b/ydb/tests/fq/s3/test_s3_0.py
@@ -118,7 +118,7 @@ Pear,15,33,2024-05-06'''
         assert result_set.columns[0].name == "Date"
         assert result_set.columns[0].type.optional_type.item.type_id == ydb.Type.DATE
         assert result_set.columns[1].name == "Fruit"
-        assert result_set.columns[1].type.optional_type.item.type_id == ydb.Type.UTF8
+        assert result_set.columns[1].type.type_id == ydb.Type.UTF8
         assert result_set.columns[2].name == "Price"
         assert result_set.columns[2].type.optional_type.item.type_id == ydb.Type.INT64
         assert result_set.columns[3].name == "Weight"
@@ -176,9 +176,9 @@ Pear,15,'''
         logging.debug(str(result_set))
         assert len(result_set.columns) == 3
         assert result_set.columns[0].name == "Fruit"
-        assert result_set.columns[0].type.optional_type.item.type_id == ydb.Type.UTF8
+        assert result_set.columns[0].type.type_id == ydb.Type.UTF8
         assert result_set.columns[1].name == "Missing column"
-        assert result_set.columns[1].type.optional_type.item.type_id == ydb.Type.UTF8
+        assert result_set.columns[1].type.type_id == ydb.Type.UTF8
         assert result_set.columns[2].name == "Price"
         assert result_set.columns[2].type.optional_type.item.type_id == ydb.Type.INT64
         assert len(result_set.rows) == 3
@@ -233,7 +233,7 @@ Apple,2,22,
         assert result_set.columns[0].name == "Date"
         assert result_set.columns[0].type.optional_type.item.type_id == ydb.Type.DATE
         assert result_set.columns[1].name == "Fruit"
-        assert result_set.columns[1].type.optional_type.item.type_id == ydb.Type.UTF8
+        assert result_set.columns[1].type.type_id == ydb.Type.UTF8
         assert result_set.columns[2].name == "Price"
         assert result_set.columns[2].type.optional_type.item.type_id == ydb.Type.INT64
         assert result_set.columns[3].name == "Weight"
@@ -248,7 +248,7 @@ Apple,2,22,
         assert result_set.rows[1].items[2].int64_value == 2
         assert result_set.rows[1].items[3].int64_value == 22
         assert result_set.rows[2].items[0].uint32_value == 19849
-        assert result_set.rows[2].items[1].null_flag_value == NullValue.NULL_VALUE
+        assert result_set.rows[2].items[1].text_value == ""
         assert result_set.rows[2].items[2].int64_value == 15
         assert result_set.rows[2].items[3].int64_value == 33
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

`arrow::Type::STRING`, `arrow::Type::BINARY`, etc types are now not optional with type inferring

### Changelog category <!-- remove all except one -->

* Improvement