### PR TITLE
do not look at active/inactive pdisk status in healthcheck

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -1700,12 +1700,9 @@ public:
                                  ETags::PDiskState);
         }
         switch (status->number()) {
-            case NKikimrBlobStorage::ACTIVE: {
-                context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
-                break;
-            }
+            case NKikimrBlobStorage::ACTIVE:
             case NKikimrBlobStorage::INACTIVE: {
-                context.ReportStatus(Ydb::Monitoring::StatusFlag::YELLOW, "PDisk is inactive", ETags::PDiskState);
+                context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
                 break;
             }
             case NKikimrBlobStorage::FAULTY:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

treat inactive pdisks as alive in healthcheck

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
