### PR TITLE
add partitioning policy to column table description

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -777,7 +777,7 @@ message TColumnTableSharding {
 }
 
 message TColumnPartitioningPolicy {
-    reserved = 1; // SizeToSplit 
+    reserved 1; // SizeToSplit 
 
     optional uint32 MinPartitionsCount = 2;
     optional uint32 MaxPartitionsCount = 3;

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -805,6 +805,8 @@ message TColumnTableDescription {
 
     // Channels for standalone column table
     optional TColumnStorageConfig StorageConfig = 13;
+
+    optional TPartitioningPolicy PartitioningPolicy = 14;
 }
 
 message TAlterColumnTable {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -776,6 +776,13 @@ message TColumnTableSharding {
     repeated TGranuleShardInfo ShardsInfo = 7;
 }
 
+message TColumnPartitioningPolicy {
+    reserved = 1; // SizeToSplit 
+
+    optional uint32 MinPartitionsCount = 2;
+    optional uint32 MaxPartitionsCount = 3;
+}
+
 message TColumnTableDescription {
     optional string Name = 1;
 
@@ -806,7 +813,7 @@ message TColumnTableDescription {
     // Channels for standalone column table
     optional TColumnStorageConfig StorageConfig = 13;
 
-    optional TPartitioningPolicy PartitioningPolicy = 14;
+    optional TColumnPartitioningPolicy PartitioningPolicy = 14;
 }
 
 message TAlterColumnTable {

--- a/ydb/core/tx/schemeshard/olap/operations/create_table.cpp
+++ b/ydb/core/tx/schemeshard/olap/operations/create_table.cpp
@@ -78,6 +78,7 @@ public:
             tableInfo->Description.MutableTtlSettings()->CopyFrom(*TtlSettings);
             tableInfo->Description.MutableTtlSettings()->SetVersion(1);
         }
+        FillDefaultPartitioningPolicy(*tableInfo->Description.MutablePartitioningPolicy());
 
         return tableInfo;
     }
@@ -86,6 +87,11 @@ private:
     virtual TConclusionStatus BuildDescription(const TOperationContext& context, TColumnTableInfo::TPtr& table) const = 0;
     virtual bool DoDeserialize(const NKikimrSchemeOp::TColumnTableDescription& description, IErrorCollector& errors) = 0;
     virtual const TOlapSchema& GetSchema() const = 0;
+
+    void FillDefaultPartitioningPolicy(NKikimrSchemeOp::TPartitioningPolicy& policy) const {
+        policy.SetMinPartitionsCount(ShardsCount);
+        policy.SetMaxPartitionsCount(ShardsCount);
+    }
 
     static void FillDefaultSharding(NKikimrSchemeOp::TColumnTableSharding& info) {
         if (info.HasRandomSharding()) {

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -477,6 +477,7 @@ void TPathDescriber::DescribeColumnTable(TPathId pathId, TPathElement::TPtr path
     auto description = pathDescription->MutableColumnTableDescription();
     description->CopyFrom(tableInfo->Description);
     description->MutableSharding()->CopyFrom(tableInfo->Description.GetSharding());
+    description->MutablePartitioningPolicy()->CopyFrom(tableInfo->Description.GetPartitioningPolicy());
 
     if (tableInfo->IsStandalone()) {
         FillAggregatedStats(*pathDescription, tableInfo->GetStats());


### PR DESCRIPTION
Add partitioning policy to ColumnTableDescription for use in embedded UI. Partitioning policy info is available via DescribeTable.
