### PR TITLE
Use -DDEBUGINFO_LINES_ONLY for all build types

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -115,6 +115,7 @@ runs:
           --stat
           --test-threads "${{ inputs.test_threads }}" --link-threads "${{ inputs.link_threads }}"
           -DUSE_EAT_MY_DATA
+          -DDEBUGINFO_LINES_ONLY
         )
 
         TEST_RETRY_COUNT=${{ inputs.test_retry_count }}
@@ -138,7 +139,6 @@ runs:
           release-asan)
             params+=(
               --build "release" --sanitize="address"
-              -DDEBUGINFO_LINES_ONLY
             )
             if [ $TEST_RETRY_COUNT -z ]; then
               TEST_RETRY_COUNT=1
@@ -147,7 +147,6 @@ runs:
           release-tsan)
             params+=(
               --build "release" --sanitize="thread"
-              -DDEBUGINFO_LINES_ONLY
             )
             if [ $TEST_RETRY_COUNT -z ]; then
               TEST_RETRY_COUNT=1
@@ -156,7 +155,6 @@ runs:
           release-msan)
             params+=(
               --build "release" --sanitize="memory"
-              -DDEBUGINFO_LINES_ONLY
             )
             if [ $TEST_RETRY_COUNT -z ]; then
               TEST_RETRY_COUNT=1


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

In CI we don't need any other types of symbols except of line info

Huge binaries are problem because massive io and disk free space problems in github agents

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Check is here: https://github.com/ydb-platform/ydb/pull/7506