### PR TITLE
stable-24-3: Enable COUNT in view queries (#6820)

### DIFF
--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1774,7 +1774,7 @@ private:
 
         auto queryExecutor = MakeIntrusive<TKqpQueryExecutor>(Gateway, Cluster, SessionCtx, KqpRunner);
         auto kikimrDataSource = CreateKikimrDataSource(*FuncRegistry, *TypesCtx, gatewayProxy, SessionCtx,
-            ExternalSourceFactory, IsInternalCall);
+            ExternalSourceFactory, IsInternalCall, GUCSettings);
         auto kikimrDataSink = CreateKikimrDataSink(*FuncRegistry, *TypesCtx, gatewayProxy, SessionCtx, ExternalSourceFactory, queryExecutor);
 
         FillSettings.AllResultsBytesLimit = Nothing();

--- a/ydb/core/kqp/host/kqp_translate.cpp
+++ b/ydb/core/kqp/host/kqp_translate.cpp
@@ -1,6 +1,8 @@
 #include "kqp_translate.h"
 
+#include <ydb/core/kqp/provider/yql_kikimr_results.h>
 #include <ydb/library/yql/sql/sql.h>
+#include <ydb/public/api/protos/ydb_query.pb.h>
 
 
 namespace NKikimr {

--- a/ydb/core/kqp/host/kqp_translate.h
+++ b/ydb/core/kqp/host/kqp_translate.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <ydb/core/kqp/provider/yql_kikimr_results.h>
-#include <ydb/core/kqp/common/kqp.h>
+#include <ydb/core/kqp/common/simple/query_ast.h>
+#include <ydb/core/kqp/provider/yql_kikimr_provider.h>
+#include <ydb/core/protos/table_service_config.pb.h>
 #include <ydb/library/yql/core/pg_settings/guc_settings.h>
 
 namespace NKikimr {

--- a/ydb/core/kqp/provider/rewrite_io_utils.h
+++ b/ydb/core/kqp/provider/rewrite_io_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/kqp/host/kqp_translate.h>
 #include <ydb/library/yql/ast/yql_expr.h>
 
 namespace NYql {
@@ -10,7 +11,8 @@ TExprNode::TPtr RewriteReadFromView(
     const TExprNode::TPtr& node,
     TExprContext& ctx,
     const TString& query,
-    const TString& cluster
+    NKikimr::NKqp::TKqpTranslationSettingsBuilder& settingsBuilder,
+    IModuleResolver::TPtr moduleResolver
 );
 
 }

--- a/ydb/core/kqp/provider/yql_kikimr_provider.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.h
@@ -567,7 +567,8 @@ TIntrusivePtr<IDataProvider> CreateKikimrDataSource(
     TIntrusivePtr<IKikimrGateway> gateway,
     TIntrusivePtr<TKikimrSessionContext> sessionCtx,
     const NKikimr::NExternalSource::IExternalSourceFactory::TPtr& sourceFactory,
-    bool isInternalCall);
+    bool isInternalCall,
+    TGUCSettings::TPtr gucSettings);
 
 TIntrusivePtr<IDataProvider> CreateKikimrDataSink(
     const NKikimr::NMiniKQL::IFunctionRegistry& functionRegistry,

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/create_view.sql
@@ -1,0 +1,43 @@
+CREATE VIEW `/Root/aggregates_and_window` WITH (security_invoker = TRUE) AS
+    SELECT
+        series.title AS series,
+        series_stats.seasons_with_episode_count_greater_than_average AS seasons_with_episode_count_greater_than_average
+    FROM (
+        SELECT
+            series_id,
+            SUM(
+                CASE
+                    WHEN episode_count > average_episodes_in_season
+                        THEN 1
+                    ELSE 0
+                END
+            ) AS seasons_with_episode_count_greater_than_average
+        FROM (
+            SELECT
+                series_id,
+                season_id,
+                episode_count,
+                AVG(episode_count) OVER average_episodes_in_season_window AS average_episodes_in_season
+            FROM (
+                SELECT
+                    series_id,
+                    season_id,
+                    COUNT(*) AS episode_count
+                FROM `/Root/episodes`
+                GROUP BY
+                    series_id,
+                    season_id
+            )
+            WINDOW
+                average_episodes_in_season_window AS (
+                    PARTITION BY
+                        series_id
+                )
+        )
+        GROUP BY
+            series_id
+    )
+        AS series_stats
+    JOIN `/Root/series`
+        AS series
+    USING (series_id);

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/aggregates_and_window`;

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/etalon_query.sql
@@ -1,0 +1,46 @@
+SELECT
+    *
+FROM (
+    SELECT
+        series.title AS series,
+        series_stats.seasons_with_episode_count_greater_than_average AS seasons_with_episode_count_greater_than_average
+    FROM (
+        SELECT
+            series_id,
+            SUM(
+                CASE
+                    WHEN episode_count > average_episodes_in_season
+                        THEN 1
+                    ELSE 0
+                END
+            ) AS seasons_with_episode_count_greater_than_average
+        FROM (
+            SELECT
+                series_id,
+                season_id,
+                episode_count,
+                AVG(episode_count) OVER average_episodes_in_season_window AS average_episodes_in_season
+            FROM (
+                SELECT
+                    series_id,
+                    season_id,
+                    COUNT(*) AS episode_count
+                FROM `/Root/episodes`
+                GROUP BY
+                    series_id,
+                    season_id
+            )
+            WINDOW
+                average_episodes_in_season_window AS (
+                    PARTITION BY
+                        series_id
+                )
+        )
+        GROUP BY
+            series_id
+    )
+        AS series_stats
+    JOIN `/Root/series`
+        AS series
+    USING (series_id)
+);

--- a/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/aggregates_and_window/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/aggregates_and_window`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/create_view.sql
@@ -1,0 +1,9 @@
+CREATE VIEW `/Root/count_episodes` WITH (security_invoker = TRUE) AS
+    SELECT
+        series_id,
+        season_id,
+        COUNT(*)
+    FROM `/Root/episodes`
+    GROUP BY
+        series_id,
+        season_id;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/count_episodes`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/etalon_query.sql
@@ -1,0 +1,12 @@
+SELECT
+    *
+FROM (
+    SELECT
+        series_id,
+        season_id,
+        COUNT(*)
+    FROM `/Root/episodes`
+    GROUP BY
+        series_id,
+        season_id
+);

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/count_episodes`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/create_view.sql
@@ -1,0 +1,22 @@
+CREATE VIEW `/Root/count_episodes_with_titles` WITH (security_invoker = TRUE) AS
+    SELECT
+        series.title AS series,
+        seasons.title AS season,
+        episodes.episode_count AS episode_count
+    FROM (
+        SELECT
+            series_id,
+            season_id,
+            COUNT(*) AS episode_count
+        FROM `/Root/episodes`
+        GROUP BY
+            series_id,
+            season_id
+    )
+        AS episodes
+    JOIN `/Root/series`
+        AS series
+    ON episodes.series_id == series.series_id
+    JOIN `/Root/seasons`
+        AS seasons
+    ON episodes.series_id == seasons.series_id AND episodes.season_id == seasons.season_id;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/count_episodes_with_titles`;

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/etalon_query.sql
@@ -1,0 +1,25 @@
+SELECT
+    *
+FROM (
+    SELECT
+        series.title AS series,
+        seasons.title AS season,
+        episodes.episode_count AS episode_count
+    FROM (
+        SELECT
+            series_id,
+            season_id,
+            COUNT(*) AS episode_count
+        FROM `/Root/episodes`
+        GROUP BY
+            series_id,
+            season_id
+    )
+        AS episodes
+    JOIN `/Root/series`
+        AS series
+    ON episodes.series_id == series.series_id
+    JOIN `/Root/seasons`
+        AS seasons
+    ON episodes.series_id == seasons.series_id AND episodes.season_id == seasons.season_id
+);

--- a/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_episodes_with_titles/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/count_episodes_with_titles`;

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/create_view.sql
@@ -1,0 +1,4 @@
+CREATE VIEW `/Root/count_rows` WITH (security_invoker = TRUE) AS
+    SELECT
+        COUNT(*)
+    FROM `/Root/episodes`;

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW `/Root/count_rows`;

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/etalon_query.sql
@@ -1,0 +1,7 @@
+SELECT
+    *
+FROM (
+    SELECT
+        COUNT(*)
+    FROM `/Root/episodes`
+);

--- a/ydb/core/kqp/ut/view/input/cases/count_rows/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/count_rows/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM `/Root/count_rows`;


### PR DESCRIPTION
Enables aggregate functions inside views by:
- providing ModuleResolver from KQP host to CompileExpr function
- repeating ExpandApplyForLambdas transformation step when rewriting a read from a view

Same as https://github.com/ydb-platform/ydb/pull/6820.

See also similar [PR](https://github.com/ydb-platform/ydb/pull/7501) to stable-24-2.