### PR TITLE
added processing of the maximum waiting for a response from the tablet

### DIFF
--- a/ydb/core/statistics/service/service.cpp
+++ b/ydb/core/statistics/service/service.cpp
@@ -28,6 +28,7 @@ namespace NStat {
 static constexpr TDuration DefaultAggregateKeepAlivePeriod = TDuration::MilliSeconds(500);
 static constexpr TDuration DefaultAggregateKeepAliveTimeout = TDuration::Seconds(3);
 static constexpr TDuration DefaultAggregateKeepAliveAckTimeout = TDuration::Seconds(3);
+static constexpr TDuration DefaultStatisticsResponseTimeout = TDuration::Seconds(3);
 static constexpr size_t DefaultMaxInFlightTabletRequests = 5;
 static constexpr size_t DefaultFanOutFactor = 5;
 
@@ -37,6 +38,7 @@ TStatServiceSettings::TStatServiceSettings()
     : AggregateKeepAlivePeriod(DefaultAggregateKeepAlivePeriod)
     , AggregateKeepAliveTimeout(DefaultAggregateKeepAliveTimeout)
     , AggregateKeepAliveAckTimeout(DefaultAggregateKeepAliveAckTimeout)
+    , StatisticsResponseTimeout(DefaultStatisticsResponseTimeout)
     , MaxInFlightTabletRequests(DefaultMaxInFlightTabletRequests)
     , FanOutFactor(DefaultFanOutFactor)
 {}

--- a/ydb/core/statistics/service/service.h
+++ b/ydb/core/statistics/service/service.h
@@ -9,6 +9,7 @@ struct TStatServiceSettings {
     TDuration AggregateKeepAlivePeriod;
     TDuration AggregateKeepAliveTimeout;
     TDuration AggregateKeepAliveAckTimeout;
+    TDuration StatisticsResponseTimeout;
     size_t MaxInFlightTabletRequests;
     size_t FanOutFactor;
 
@@ -26,6 +27,11 @@ struct TStatServiceSettings {
 
     TStatServiceSettings& SetAggregateKeepAliveAckTimeout(const TDuration& val) {
         AggregateKeepAliveAckTimeout = val;
+        return *this;
+    }
+
+    TStatServiceSettings& SetStatisticsResponseTimeout(const TDuration& val) {
+        StatisticsResponseTimeout = val;
         return *this;
     }
 


### PR DESCRIPTION
### Changelog entry

* skip TEvStatisticsResponse if the node IDs do not match
* add the maximum waiting period for TEvStatisticsResponse from a tablet

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

