### PR TITLE
Transactions are loaded in chunks

### DIFF
--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -804,7 +804,7 @@ void TPersQueue::SendTransactionsReadRequest(const TString& fromKey, bool includ
                                              const TActorContext& ctx)
 {
     THolder<TEvKeyValue::TEvRequest> request(new TEvKeyValue::TEvRequest);
-    request->Record.SetCookie(READ_CONFIG_STAGE_2_COOKIE);
+    request->Record.SetCookie(READ_TXS_COOKIE);
 
     AddCmdReadTransactionRange(*request, fromKey, includeFrom);
 
@@ -1329,11 +1329,11 @@ void TPersQueue::Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext&
     case WRITE_CONFIG_COOKIE:
         EndWriteConfig(resp, ctx);
         break;
-    case READ_CONFIG_STAGE_1_COOKIE:
+    case READ_CONFIG_COOKIE:
         // read is only for config - is signal to create interal actors
         HandleConfigReadResponse(std::move(resp), ctx);
         break;
-    case READ_CONFIG_STAGE_2_COOKIE:
+    case READ_TXS_COOKIE:
         HandleTransactionsReadResponse(std::move(resp), ctx);
         break;
     case WRITE_STATE_COOKIE:
@@ -3172,7 +3172,7 @@ void TPersQueue::Handle(TEvInterconnect::TEvNodeInfo::TPtr& ev, const TActorCont
     ResourceMetrics = Executor()->GetResourceMetrics();
 
     THolder<TEvKeyValue::TEvRequest> request(new TEvKeyValue::TEvRequest);
-    request->Record.SetCookie(READ_CONFIG_STAGE_1_COOKIE);
+    request->Record.SetCookie(READ_CONFIG_COOKIE);
 
     request->Record.AddCmdRead()->SetKey(KeyConfig());
     request->Record.AddCmdRead()->SetKey(KeyState());

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -1018,10 +1018,11 @@ void TPersQueue::ReadConfig(const NKikimrClient::TKeyValueResponse::TReadResult&
     }
 
     Y_ABORT_UNLESS(readRange.HasStatus());
-    if (readRange.GetStatus() != NKikimrProto::OK && readRange.GetStatus() != NKikimrProto::NODATA) {
-        LOG_ERROR_S(ctx, NKikimrServices::PERSQUEUE,
-            "Tablet " << TabletID() << " Transactions read error " << ctx.SelfID <<
-            " Error status code " << readRange.GetStatus());
+    if (readRange.GetStatus() != NKikimrProto::OK &&
+        //readRange.GetStatus() != NKikimrProto::OVERRUN &&
+        readRange.GetStatus() != NKikimrProto::NODATA) {
+        PQ_LOG_ERROR("Transactions read error " << ctx.SelfID <<
+                     " Error status code " << readRange.GetStatus());
         ctx.Send(ctx.SelfID, new TEvents::TEvPoisonPill());
         return;
     }

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -3237,6 +3237,10 @@ void TPersQueue::AddCmdReadTransactionRange(TEvKeyValue::TEvRequest& request,
     cmd->MutableRange()->SetTo(GetTxKey(Max<ui64>()));
     cmd->MutableRange()->SetIncludeTo(true);
     cmd->SetIncludeData(true);
+
+    PQ_LOG_D("Transactions request." <<
+             " From " << cmd->MutableRange()->GetFrom() <<
+             ", To " << cmd->MutableRange()->GetTo());
 }
 
 void TPersQueue::HandleWakeup(const TActorContext& ctx) {

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -514,12 +514,10 @@ private:
     std::deque<std::pair<ui64, ui64>> PlannedTxs;
 
     void BeginInitTransactions();
-    //TString ContinueInitTransactions(const NKikimrClient::TKeyValueResponse::TReadRangeResult& readRange);
     void EndInitTransactions();
 
     void EndReadConfig(const TActorContext& ctx);
 
-    void RequestTransactionRange(const TString& fromKey, const TActorContext& ctx);
     void AddCmdReadTransactionRange(TEvKeyValue::TEvRequest& request,
                                     const TString& fromKey, bool includeFrom);
 

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -32,12 +32,10 @@ struct TTransaction;
 class TPersQueue : public NKeyValue::TKeyValueFlat {
     enum ECookie : ui64 {
         WRITE_CONFIG_COOKIE = 2,
-        //READ_CONFIG_COOKIE  = 3,
+        READ_CONFIG_COOKIE  = 3,
         WRITE_STATE_COOKIE  = 4,
         WRITE_TX_COOKIE = 5,
-        READ_CONFIG_STAGE_1_COOKIE = 6,
-        READ_CONFIG_STAGE_2_COOKIE = 7,
-        READ_TXS_COOKIE = 8,
+        READ_TXS_COOKIE = 6,
     };
 
     void CreatedHook(const TActorContext& ctx) override;

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -506,6 +506,14 @@ private:
 
     void MoveTopTxToCalculating(TDistributedTransaction& tx, const TActorContext& ctx);
     void DeletePartition(const TPartitionId& partitionId, const TActorContext& ctx);
+
+    std::deque<std::pair<ui64, ui64>> PlannedTxs;
+
+    void BeginInitTransactions();
+    void ContinueInitTransactions(const NKikimrClient::TKeyValueResponse::TReadRangeResult& readRange);
+    void EndInitTransactions(THashMap<ui32, TVector<TTransaction>>& partitionTxs);
+
+    void EndReadConfig(const TActorContext& ctx);
 };
 
 

--- a/ydb/core/persqueue/ut/make_config.cpp
+++ b/ydb/core/persqueue/ut/make_config.cpp
@@ -1,6 +1,7 @@
 #include "make_config.h"
 
 #include <util/datetime/base.h>
+#include <util/string/printf.h>
 
 #include <ydb/core/persqueue/utils.h>
 
@@ -49,6 +50,15 @@ NKikimrPQ::TPQTabletConfig MakeConfig(const TMakeConfigParams& params)
     config.SetMeteringMode(params.MeteringMode);
     config.MutablePartitionConfig()->SetLifetimeSeconds(TDuration::Hours(24).Seconds());
     config.MutablePartitionConfig()->SetWriteSpeedInBytesPerSecond(10 << 20);
+
+    if (params.HugeConfig) {
+        for (size_t i = 0; i < 2'500; ++i) {
+            TString name = Sprintf("fake-consumer-%s-%" PRISZT,
+                                   TString(3'000, 'a').data(), i);
+            config.AddReadRules(name);
+            config.AddReadRuleGenerations(1);
+        }
+    }
 
     Migrate(config);
 

--- a/ydb/core/persqueue/ut/make_config.h
+++ b/ydb/core/persqueue/ut/make_config.h
@@ -32,6 +32,7 @@ struct TMakeConfigParams {
     TVector<TPartitionParams> AllPartitions;
     ui32 PartitionsCount = 1;
     NKikimrPQ::TPQTabletConfig::EMeteringMode MeteringMode = NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS;
+    bool HugeConfig = false;
 };
 
 NKikimrPQ::TPQTabletConfig MakeConfig(const TMakeConfigParams& params);

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -1588,7 +1588,6 @@ Y_UNIT_TEST_F(Huge_ProposeTransacton, TPQTabletFixture)
                                              .Consumers={
                                              {.Consumer="client-1", .Generation=0},
                                              {.Consumer="client-3", .Generation=7},
-                                             {.Consumer=TString(7'000'000, 'a'), .Generation=7}
                                              },
                                              .Partitions={
                                              {.Id=0},
@@ -1598,7 +1597,8 @@ Y_UNIT_TEST_F(Huge_ProposeTransacton, TPQTabletFixture)
                                              {.Id=0, .TabletId=Ctx->TabletId, .Children={}, .Parents={2}},
                                              {.Id=1, .TabletId=Ctx->TabletId, .Children={}, .Parents={2}},
                                              {.Id=2, .TabletId=mockTabletId,  .Children={0, 1}, .Parents={}}
-                                             }});
+                                             },
+                                             .HugeConfig = true});
 
     const ui64 txId_1 = 67890;
     SendProposeTransactionRequest({.TxId=txId_1,
@@ -1621,10 +1621,9 @@ Y_UNIT_TEST_F(Huge_ProposeTransacton, TPQTabletFixture)
     PQTabletRestart(*Ctx);
     ResetPipe();
 
-    WaitForProposePartitionConfigResult(2);
-//    SendPlanStep({.Step=100, .TxIds={txId_1, txId_2}});
-//    WaitPlanStepAck({.Step=100, .TxIds={txId_1, txId_2}});
-//    WaitPlanStepAccepted({.Step=100});
+    SendPlanStep({.Step=100, .TxIds={txId_1, txId_2}});
+    WaitPlanStepAck({.Step=100, .TxIds={txId_1, txId_2}});
+    WaitPlanStepAccepted({.Step=100});
 }
 
 }

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -177,6 +177,7 @@ protected:
     void SetUp(NUnitTest::TTestContext&) override;
     void TearDown(NUnitTest::TTestContext&) override;
 
+    void ResetPipe();
     void EnsurePipeExist();
     void SendToPipe(const TActorId& sender,
                     IEventBase* event,
@@ -256,8 +257,14 @@ void TPQTabletFixture::SetUp(NUnitTest::TTestContext&)
 
 void TPQTabletFixture::TearDown(NUnitTest::TTestContext&)
 {
+    ResetPipe();
+}
+
+void TPQTabletFixture::ResetPipe()
+{
     if (Pipe != TActorId()) {
         Ctx->Runtime->ClosePipe(Pipe, Ctx->Edge, 0);
+        Pipe = TActorId();
     }
 }
 
@@ -1612,10 +1619,12 @@ Y_UNIT_TEST_F(Huge_ProposeTransacton, TPQTabletFixture)
                                    .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
 
     PQTabletRestart(*Ctx);
-
-    SendPlanStep({.Step=100, .TxIds={txId_1}});
+    ResetPipe();
 
     WaitForProposePartitionConfigResult(2);
+//    SendPlanStep({.Step=100, .TxIds={txId_1, txId_2}});
+//    WaitPlanStepAck({.Step=100, .TxIds={txId_1, txId_2}});
+//    WaitPlanStepAccepted({.Step=100});
 }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The `KV` tablet can respond to the `ReadRange` request with `OVERRUN`. In this case, the `PQ` tablet makes a repeat request. Requests the range from the last received key.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
