### PR TITLE
The `WriteId` is deleted along with the transaction

### DIFF
--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -206,7 +206,7 @@ private:
         bool Deleting = false;
     };
 
-    THashMap<TWriteId, TTxWriteInfo> TxWrites;
+    THashMap<TWriteId, TTxWriteInfo> TxWrites, NewTxWrites;
     bool TxWritesChanged = false;
     ui32 NextSupportivePartitionId = 100'000;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The `WriteId` was deleted when the tablet received all the `TEvDeletePartitionDone'. If the tablet restarted at that moment, then the transaction was restored to the CALCULATING state and it needed the value `WriteId`

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
