### PR TITLE
fix query id for recompilation

### DIFF
--- a/ydb/core/kqp/compile_service/kqp_compile_service.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_service.cpp
@@ -774,7 +774,11 @@ private:
                     : (TableServiceConfig.GetEnableAstCache() && !request.QueryAst)
                         ? ECompileActorAction::PARSE
                         : ECompileActorAction::COMPILE);
-            TKqpCompileRequest compileRequest(ev->Sender, request.Uid, request.Query ? *request.Query : *compileResult->Query,
+            auto query = request.Query ? *request.Query : *compileResult->Query;
+            if (compileResult) {
+                query.UserSid = compileResult->Query->UserSid;
+            }
+            TKqpCompileRequest compileRequest(ev->Sender, request.Uid, query,
                 compileSettings, request.UserToken, dbCounters, request.GUCSettings, request.ApplicationName,
                 ev->Cookie, std::move(ev->Get()->IntrestedInResult),
                 ev->Get()->UserRequestContext,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Get queryIt.second' in kqp_compile_service.cpp:44 error if:

make request with user sid (it will be saved in queryId)
change table scheme
make the same request (it will be with recompilation, queryId with sid will be removed from cache and make new queryId without sid)
make the same request (it will be with sid and it doesn't find it in cache, then in cache will be 2 query Id with and without sid)
change table scheme
make the same request (it will be with recompilation, queryId with sid will be removed from cache and make new queryId without sid, then it will be compiled and try to put it in cache, but this queryId without sid is already in cache)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information


