### PR TITLE
Fix env var name in CI

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -274,7 +274,7 @@ runs:
           CURRENT_MESSAGE="**{platform_name}-${BUILD_PRESET}** is running..." 
           if [ $IS_RETRY = 0 ]; then
             CURRENT_MESSAGE="Check $CURRENT_MESSAGE"
-            RERUN_FAILED_TESTS=""
+            RERUN_FAILED_OPT=""
           else
             CURRENT_MESSAGE="Failed tests rerun (try $RETRY) $CURRENT_MESSAGE"
             RERUN_FAILED_OPT="-X"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It was a typo 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
