### PR TITLE
Move unacknowledged messages back to OriginalMessagesToPassDown queue

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_federated_topic/impl/federated_write_session.cpp
@@ -175,6 +175,14 @@ std::shared_ptr<NTopic::IWriteSession> TFederatedWriteSessionImpl::OpenSubsessio
             }
         });
 
+    {
+        // Unacknowledged messages should be resent.
+        for (auto& msg : OriginalMessagesToPassDown) {
+            OriginalMessagesToGetAck.emplace_back(std::move(msg));
+        }
+        OriginalMessagesToPassDown = std::move(OriginalMessagesToGetAck);
+    }
+
     NTopic::TWriteSessionSettings wsSettings = Settings;
     wsSettings
         // .MaxMemoryUsage(Settings.MaxMemoryUsage_)  // to fix if split not by half on creation


### PR DESCRIPTION
When a new subsession is created, move messages from OriginalMessagesToGetAck queue to OriginalMessagesToPassDown queue.