### PR TITLE
HLL in YT statistics

### DIFF
--- a/ydb/library/yql/providers/yt/common/yql_configuration.h
+++ b/ydb/library/yql/providers/yt/common/yql_configuration.h
@@ -89,4 +89,6 @@ constexpr ui16 DEFAULT_MAX_COLUMN_GROUPS = 64;
 
 constexpr bool DEFAULT_DISABLE_FUSE_OPERATIONS = false;
 
+constexpr bool DEFAULT_FETCH_COLUMNAR_STATS_FROM_NODES = false;
+
 } // NYql

--- a/ydb/library/yql/providers/yt/common/yql_yt_settings.cpp
+++ b/ydb/library/yql/providers/yt/common/yql_yt_settings.cpp
@@ -500,6 +500,7 @@ TYtConfiguration::TYtConfiguration()
         });
     REGISTER_SETTING(*this, MinColumnGroupSize).Lower(2);
     REGISTER_SETTING(*this, MaxColumnGroups);
+    REGISTER_SETTING(*this, FetchColumnarStatsFromNodes);
 }
 
 EReleaseTempDataMode GetReleaseTempDataMode(const TYtSettings& settings) {

--- a/ydb/library/yql/providers/yt/common/yql_yt_settings.h
+++ b/ydb/library/yql/providers/yt/common/yql_yt_settings.h
@@ -280,6 +280,7 @@ struct TYtSettings {
     NCommon::TConfSetting<EColumnGroupMode, false> ColumnGroupMode;
     NCommon::TConfSetting<ui16, false> MinColumnGroupSize;
     NCommon::TConfSetting<ui16, false> MaxColumnGroups;
+    NCommon::TConfSetting<bool, false> FetchColumnarStatsFromNodes;
 };
 
 EReleaseTempDataMode GetReleaseTempDataMode(const TYtSettings& settings);

--- a/ydb/library/yql/providers/yt/gateway/native/yql_yt_native.cpp
+++ b/ydb/library/yql/providers/yt/gateway/native/yql_yt_native.cpp
@@ -2515,7 +2515,6 @@ private:
                 result.Data[idx.first].Stat = statInfo;
 
                 statInfo->ColumnarStats = std::move(statsMap[idx.first]);
-
                 auto type = GetTypeFromAttributes(attrs, false);
                 ui16 viewSyntaxVersion = 1;
                 if (type == "document") {

--- a/ydb/library/yql/providers/yt/provider/yql_yt_datasink_exec.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_datasink_exec.cpp
@@ -145,9 +145,9 @@ private:
             TExprNode::TListType children = outTable.Raw()->ChildrenList();
             if (auto& name = children[TYtOutTable::idx_Name]; name->IsAtom("") && !res.OutTableStats[i].first.empty())
                 name = ctx.NewAtom(name->Pos(), res.OutTableStats[i].first);
-            if (const auto stat = res.OutTableStats[i].second) {
+            if (const auto stat = res.OutTableStats[i].second)
                 children[TYtOutTable::idx_Stat] = stat->ToExprNode(ctx, outTable.Pos()).Ptr();
-            }
+
             newOutTables.push_back(ctx.ChangeChildren(outTable.Ref(), std::move(children)));
         }
         output = ctx.ChangeChild(*input, TYtOutputOpBase::idx_Output, ctx.NewList(outSection.Pos(), std::move(newOutTables)));

--- a/ydb/library/yql/providers/yt/provider/yql_yt_datasink_exec.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_datasink_exec.cpp
@@ -145,9 +145,9 @@ private:
             TExprNode::TListType children = outTable.Raw()->ChildrenList();
             if (auto& name = children[TYtOutTable::idx_Name]; name->IsAtom("") && !res.OutTableStats[i].first.empty())
                 name = ctx.NewAtom(name->Pos(), res.OutTableStats[i].first);
-            if (const auto stat = res.OutTableStats[i].second)
+            if (const auto stat = res.OutTableStats[i].second) {
                 children[TYtOutTable::idx_Stat] = stat->ToExprNode(ctx, outTable.Pos()).Ptr();
-
+            }
             newOutTables.push_back(ctx.ChangeChildren(outTable.Ref(), std::move(children)));
         }
         output = ctx.ChangeChild(*input, TYtOutputOpBase::idx_Output, ctx.NewList(outSection.Pos(), std::move(newOutTables)));

--- a/ydb/library/yql/providers/yt/provider/yql_yt_join_reorder.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_join_reorder.cpp
@@ -235,7 +235,6 @@ private:
         auto stat = std::make_shared<TOptimizerStatistics>();
         stat->ColumnStatistics = TIntrusivePtr<TOptimizerStatistics::TColumnStatMap>(
             new TOptimizerStatistics::TColumnStatMap());
-
         auto providerStats = std::make_unique<TYtProviderStatistic>();
 
         if (Y_UNLIKELY(!section.Settings().Empty()) && Y_UNLIKELY(section.Settings().Item(0).Name() == "Test")) {

--- a/ydb/library/yql/providers/yt/provider/yql_yt_provider_context.h
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_provider_context.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ydb/library/yql/core/yql_statistics.h>
+
+namespace NYql {
+
+struct TYtColumnStatistic {
+    int64_t DataWeight;
+};
+
+class TYtProviderStatistic : public IProviderStatistics {
+public:
+    std::unordered_map<TString, TYtColumnStatistic> ColumnStatistics;
+    TVector<TString> SortColumns;
+};
+
+}  // namespace NYql

--- a/ydb/library/yql/providers/yt/provider/yql_yt_table.h
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_table.h
@@ -27,6 +27,11 @@ namespace NYql {
 
 class TYtKey;
 
+struct TYtTableColumnarStats {
+    THashMap<TString, i64> DataWeight;
+    THashMap<TString, ui64> EstimatedUniqueCounts;
+};
+
 struct TYtTableStatInfo: public TThrRefBase {
     using TPtr = TIntrusivePtr<TYtTableStatInfo>;
 
@@ -57,6 +62,7 @@ struct TYtTableStatInfo: public TThrRefBase {
     ui64 ModifyTime = 0;
     ui64 Revision = 0;
     ui64 TableRevision = 0; // Not serializable
+    TYtTableColumnarStats ColumnarStats;
 };
 
 struct TYtTableMetaInfo: public TThrRefBase {

--- a/yt/cpp/mapreduce/interface/common.h
+++ b/yt/cpp/mapreduce/interface/common.h
@@ -1193,6 +1193,9 @@ struct TTableColumnarStatistics
     /// Total data weight for all chunks for each of requested columns.
     THashMap<TString, i64> ColumnDataWeight;
 
+    /// Estimated number of unique elements for each column.
+    THashMap<TString, ui64> ColumnEstimatedUniqueCounts;
+
     /// Total weight of all old chunks that don't keep columnar statistics.
     i64 LegacyChunksDataWeight = 0;
 

--- a/yt/cpp/mapreduce/interface/serialize.cpp
+++ b/yt/cpp/mapreduce/interface/serialize.cpp
@@ -509,6 +509,7 @@ void Deserialize(TTableColumnarStatistics& statistics, const TNode& node)
 {
     const auto& nodeMap = node.AsMap();
     DESERIALIZE_ITEM("column_data_weights", statistics.ColumnDataWeight);
+    DESERIALIZE_ITEM("column_estimated_unique_counts", statistics.ColumnEstimatedUniqueCounts);
     DESERIALIZE_ITEM("legacy_chunks_data_weight", statistics.LegacyChunksDataWeight);
     DESERIALIZE_ITEM("timestamp_total_weight", statistics.TimestampTotalWeight);
 }


### PR DESCRIPTION
Fetch HLL and data weight from YT data nodes (protected by pragma)
Use existing field in optimizer statistics for HLL.

Put data weight and sort keys in provider-specific statistics, to be used later by the YT provider (which is not yet implemented).

Changes in yt/cpp/mapreduce are included in this PR temporarily, until repository sync. These changes will go away before merging.