### PR TITLE
[Http] Reply with structured issues when client accepts json data

### DIFF
--- a/ydb/core/mon/async_http_mon.cpp
+++ b/ydb/core/mon/async_http_mon.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/base/ticket_parser.h>
 
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/lwtrace/all.h>
 #include <library/cpp/lwtrace/mon/mon_lwtrace.h>
 #include <ydb/library/actors/core/probes.h>
@@ -145,6 +146,11 @@ public:
         return {};
     }
 
+    bool AcceptsJsonResponse() {
+        TStringBuf acceptHeader = GetHeader("Accept");
+        return acceptHeader.find(TStringBuf("application/json")) != TStringBuf::npos;
+    }
+
     virtual TStringBuf GetCookie(TStringBuf name) const override {
         NHttp::TCookies cookies(GetHeader("Cookie"));
         return cookies.Get(name);
@@ -247,10 +253,15 @@ public:
         PassAway();
     }
 
+    bool CredentialsProvided() {
+        return Container.GetCookie("ydb_session_id") || Container.GetHeader("Authorization");
+    }
+
     TString YdbToHttpError(Ydb::StatusIds::StatusCode status) {
         switch (status) {
         case Ydb::StatusIds::UNAUTHORIZED:
-            return "401 Unauthorized";
+            // YDB status UNAUTHORIZED is used for both access denied case and if no credentials were provided.
+            return CredentialsProvided() ? "403 Forbidden" : "401 Unauthorized";
         case Ydb::StatusIds::INTERNAL_ERROR:
             return "500 Internal Server Error";
         case Ydb::StatusIds::UNAVAILABLE:
@@ -267,26 +278,45 @@ public:
     }
 
     void ReplyErrorAndPassAway(const NKikimr::NGRpcService::TEvRequestAuthAndCheckResult& result) {
+        ReplyErrorAndPassAway(result.Status, result.Issues, true);
+    }
+
+    void ReplyErrorAndPassAway(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues, bool addAccessControlHeaders) {
         NHttp::THttpIncomingRequestPtr request = Event->Get()->Request;
-        NHttp::THeaders headers(request->Headers);
         TStringBuilder response;
         TStringBuilder body;
-        const TString httpError = YdbToHttpError(result.Status);
-        body << "<html><body><h1>" << httpError << "</h1>";
-        if (result.Issues) {
-            body << "<p>" << result.Issues.ToString() << "</p>";
+        TStringBuf contentType;
+        const TString httpError = YdbToHttpError(status);
+
+        if (Container.AcceptsJsonResponse()) {
+            contentType = "application/json";
+            NJson::TJsonValue json;
+            TString message;
+            MakeJsonErrorReply(json, message, issues, NYdb::EStatus(status));
+            NJson::WriteJson(&body.Out, &json);
+        } else {
+            contentType = "text/html";
+            body << "<html><body><h1>" << httpError << "</h1>";
+            if (issues) {
+                body << "<p>" << issues.ToString() << "</p>";
+            }
+            body << "</body></html>";
         }
-        body << "</body></html>";
-        TString origin = TString(headers["Origin"]);
-        if (origin.empty()) {
-            origin = "*";
-        }
+
         response << "HTTP/1.1 " << httpError << "\r\n";
-        response << "Access-Control-Allow-Origin: " << origin << "\r\n";
-        response << "Access-Control-Allow-Credentials: true\r\n";
-        response << "Access-Control-Allow-Headers: Content-Type,Authorization,Origin,Accept\r\n";
-        response << "Access-Control-Allow-Methods: OPTIONS, GET, POST, PUT, DELETE\r\n";
-        response << "Content-Type: text/html\r\n";
+        if (addAccessControlHeaders) {
+            NHttp::THeaders headers(request->Headers);
+            TString origin = TString(headers["Origin"]);
+            if (origin.empty()) {
+                origin = "*";
+            }
+            response << "Access-Control-Allow-Origin: " << origin << "\r\n";
+            response << "Access-Control-Allow-Credentials: true\r\n";
+            response << "Access-Control-Allow-Headers: Content-Type,Authorization,Origin,Accept\r\n";
+            response << "Access-Control-Allow-Methods: OPTIONS, GET, POST, PUT, DELETE\r\n";
+        }
+
+        response << "Content-Type: " << contentType << "\r\n";
         response << "Content-Length: " << body.Size() << "\r\n";
         response << "\r\n";
         response << body;
@@ -295,21 +325,9 @@ public:
     }
 
     void ReplyForbiddenAndPassAway(const TString& error = {}) {
-        NHttp::THttpIncomingRequestPtr request = Event->Get()->Request;
-        TStringBuilder response;
-        TStringBuilder body;
-        body << "<html><body><h1>403 Forbidden</h1>";
-        if (!error.empty()) {
-            body << "<p>" << error << "</p>";
-        }
-        body << "</body></html>";
-        response << "HTTP/1.1 403 Forbidden\r\n";
-        response << "Content-Type: text/html\r\n";
-        response << "Content-Length: " << body.Size() << "\r\n";
-        response << "\r\n";
-        response << body;
-        ReplyWith(request->CreateResponseString(response));
-        PassAway();
+        NYql::TIssues issues;
+        issues.AddIssue(error);
+        ReplyErrorAndPassAway(Ydb::StatusIds::UNAUTHORIZED, issues, false);
     }
 
     void SendRequest(const NKikimr::NGRpcService::TEvRequestAuthAndCheckResult* result = nullptr) {

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -8,6 +8,7 @@
 
 #include <library/cpp/json/json_value.h>
 #include <library/cpp/json/json_reader.h>
+#include <library/cpp/protobuf/json/proto2json.h>
 
 #include <util/string/ascii.h>
 
@@ -85,6 +86,48 @@ NActors::IEventHandle* GetAuthorizeTicketResult(const NActors::TActorId& owner) 
         );
     } else {
         return nullptr;
+    }
+}
+
+void MakeJsonErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const NYdb::TStatus& status) {
+    MakeJsonErrorReply(jsonResponse, message, status.GetIssues(), status.GetStatus());
+}
+
+void MakeJsonErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const NYql::TIssues& issues, NYdb::EStatus status) {
+    google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage> protoIssues;
+    NYql::IssuesToMessage(issues, &protoIssues);
+
+    message.clear();
+
+    NJson::TJsonValue& jsonIssues = jsonResponse["issues"];
+    for (const auto& queryIssue : protoIssues) {
+        NJson::TJsonValue& issue = jsonIssues.AppendValue({});
+        NProtobufJson::Proto2Json(queryIssue, issue);
+    }
+
+    TString textStatus = TStringBuilder() << status;
+    jsonResponse["status"] = textStatus;
+
+    // find first deepest error
+    std::stable_sort(protoIssues.begin(), protoIssues.end(), [](const Ydb::Issue::IssueMessage& a, const Ydb::Issue::IssueMessage& b) -> bool {
+        return a.severity() < b.severity();
+    });
+
+    const google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage>* protoIssuesPtr = &protoIssues;
+    while (protoIssuesPtr->size() > 0 && protoIssuesPtr->at(0).issuesSize() > 0) {
+        protoIssuesPtr = &protoIssuesPtr->at(0).issues();
+    }
+
+    if (protoIssuesPtr->size() > 0) {
+        const Ydb::Issue::IssueMessage& issue = protoIssuesPtr->at(0);
+        NProtobufJson::Proto2Json(issue, jsonResponse["error"]);
+        message = issue.message();
+    } else {
+        jsonResponse["error"]["message"] = textStatus;
+    }
+
+    if (message.empty()) {
+        message = textStatus;
     }
 }
 

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <library/cpp/json/writer/json_value.h>
 #include <library/cpp/monlib/service/monservice.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/monlib/service/pages/resources/css_mon_page.h>
@@ -10,11 +11,16 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/mon.h>
+#include <ydb/library/yql/public/issue/yql_issue.h>
+#include <ydb/public/sdk/cpp/client/ydb_types/status/status.h>
 
 namespace NActors {
 
 IEventHandle* SelectAuthorizationScheme(const NActors::TActorId& owner, NMonitoring::IMonHttpRequest& request);
 IEventHandle* GetAuthorizeTicketResult(const NActors::TActorId& owner);
+
+void MakeJsonErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const NYql::TIssues& issues, NYdb::EStatus status);
+void MakeJsonErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const NYdb::TStatus& status);
 
 class TActorSystem;
 struct TActorId;

--- a/ydb/core/mon/ya.make
+++ b/ydb/core/mon/ya.make
@@ -14,6 +14,7 @@ SRCS(
 PEERDIR(
     library/cpp/json
     library/cpp/lwtrace/mon
+    library/cpp/protobuf/json
     library/cpp/string_utils/url
     ydb/core/base
     ydb/core/grpc_services/base
@@ -21,6 +22,8 @@ PEERDIR(
     ydb/library/aclib
     ydb/library/actors/core
     ydb/library/actors/http
+    ydb/library/yql/public/issue
+    ydb/public/sdk/cpp/client/ydb_types/status
 )
 
 END()

--- a/ydb/core/viewer/json_local_rpc.h
+++ b/ydb/core/viewer/json_local_rpc.h
@@ -209,7 +209,7 @@ public:
             if (!Result->Status->IsSuccess()) {
                 NJson::TJsonValue json;
                 TString message;
-                MakeErrorReply(json, message, Result->Status.value());
+                MakeJsonErrorReply(json, message, Result->Status.value());
                 TStringStream stream;
                 NJson::WriteJson(&stream, &json);
                 if (Result->Status->GetStatus() == NYdb::EStatus::UNAUTHORIZED) {

--- a/ydb/core/viewer/json_query.h
+++ b/ydb/core/viewer/json_query.h
@@ -478,7 +478,7 @@ private:
     void MakeErrorReply(NJson::TJsonValue& jsonResponse, const NYdb::TStatus& status) {
         TString message;
 
-        NViewer::MakeErrorReply(jsonResponse, message, status);
+        MakeJsonErrorReply(jsonResponse, message, status);
 
         if (Span) {
             Span.EndError(message);
@@ -738,7 +738,5 @@ YAML::Node TJsonRequestSwagger<TJsonQuery>::GetSwagger() {
         )___");
     return node;
 }
-
-
 }
 }

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -774,44 +774,6 @@ TString TViewer::GetHTTPFORWARD(const TRequestState& request, const TString& loc
     return res;
 }
 
-void MakeErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const NYdb::TStatus& status) {
-    google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage> protoIssues;
-    NYql::IssuesToMessage(status.GetIssues(), &protoIssues);
-
-    message.clear();
-
-    NJson::TJsonValue& jsonIssues = jsonResponse["issues"];
-    for (const auto& queryIssue : protoIssues) {
-        NJson::TJsonValue& issue = jsonIssues.AppendValue({});
-        NProtobufJson::Proto2Json(queryIssue, issue);
-    }
-
-    TString textStatus = TStringBuilder() << status.GetStatus();
-    jsonResponse["status"] = textStatus;
-
-    // find first deepest error
-    std::stable_sort(protoIssues.begin(), protoIssues.end(), [](const Ydb::Issue::IssueMessage& a, const Ydb::Issue::IssueMessage& b) -> bool {
-        return a.severity() < b.severity();
-    });
-
-    const google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage>* protoIssuesPtr = &protoIssues;
-    while (protoIssuesPtr->size() > 0 && protoIssuesPtr->at(0).issuesSize() > 0) {
-        protoIssuesPtr = &protoIssuesPtr->at(0).issues();
-    }
-
-    if (protoIssuesPtr->size() > 0) {
-        const Ydb::Issue::IssueMessage& issue = protoIssuesPtr->at(0);
-        NProtobufJson::Proto2Json(issue, jsonResponse["error"]);
-        message = issue.message();
-    } else {
-        jsonResponse["error"]["message"] = textStatus;
-    }
-
-    if (message.empty()) {
-        message = textStatus;
-    }
-}
-
 NKikimrViewer::EFlag GetFlagFromTabletState(NKikimrWhiteboard::TTabletStateInfo::ETabletState state) {
     NKikimrViewer::EFlag flag = NKikimrViewer::EFlag::Grey;
     switch (state) {

--- a/ydb/core/viewer/viewer.h
+++ b/ydb/core/viewer/viewer.h
@@ -261,8 +261,6 @@ void SplitIds(TStringBuf source, char delim, std::unordered_set<ValueType>& valu
     GenericSplitIds<ValueType>(source, delim, std::inserter(values, values.end()));
 }
 
-void MakeErrorReply(NJson::TJsonValue& jsonResponse, TString& message, const NYdb::TStatus& status);
-
 TString GetHTTPOKJSON();
 TString GetHTTPGATEWAYTIMEOUT();
 NKikimrViewer::EFlag GetFlagFromTabletState(NKikimrWhiteboard::TTabletStateInfo::ETabletState state);

--- a/ydb/core/viewer/ya.make
+++ b/ydb/core/viewer/ya.make
@@ -530,6 +530,7 @@ PEERDIR(
     ydb/core/grpc_services
     ydb/core/grpc_services/local_rpc
     ydb/core/health_check
+    ydb/core/mon
     ydb/core/node_whiteboard
     ydb/core/protos
     ydb/core/scheme


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

When client says that it expects data in json format, send issues in json format instead of html.
It improves issues display in YDB UI

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
