### PR TITLE
Double free when accessing .AsBoxed() on Pod with 0 refcount (#7659)

### DIFF
--- a/ydb/library/yql/parser/pg_wrapper/utils.h
+++ b/ydb/library/yql/parser/pg_wrapper/utils.h
@@ -65,7 +65,7 @@ inline NKikimr::NUdf::TUnboxedValuePod AnyDatumToPod(Datum datum, bool passByVal
 }
 
 inline Datum PointerDatumFromPod(const NKikimr::NUdf::TUnboxedValuePod& value) {
-    return (Datum)(((const NKikimr::NMiniKQL::TMkqlPAllocHeader*)value.AsBoxed().Get()) + 1);
+    return (Datum)(((const NKikimr::NMiniKQL::TMkqlPAllocHeader*)value.AsRawBoxed()) + 1);
 }
 
 inline Datum PointerDatumFromItem(const NKikimr::NUdf::TBlockItem& value) {

--- a/ydb/library/yql/public/udf/udf_value.h
+++ b/ydb/library/yql/public/udf/udf_value.h
@@ -827,6 +827,8 @@ public:
 
     inline TStringValue AsStringValue() const;
     inline IBoxedValuePtr AsBoxed() const;
+    inline TStringValue::TData* AsRawStringValue() const;
+    inline IBoxedValue* AsRawBoxed() const;
     inline bool UniqueBoxed() const;
 
     // special values

--- a/ydb/library/yql/public/udf/udf_value_inl.h
+++ b/ydb/library/yql/public/udf/udf_value_inl.h
@@ -390,6 +390,18 @@ inline IBoxedValuePtr TUnboxedValuePod::AsBoxed() const
     return IBoxedValuePtr(Raw.Boxed.Value);
 }
 
+inline TStringValue::TData* TUnboxedValuePod::AsRawStringValue() const
+{
+    UDF_VERIFY(IsString(), "Value is not a string");
+    return Raw.String.Value;
+}
+
+inline IBoxedValue* TUnboxedValuePod::AsRawBoxed() const
+{
+    UDF_VERIFY(IsBoxed(), "Value is not boxed");
+    return Raw.Boxed.Value;
+}
+
 inline bool TUnboxedValuePod::UniqueBoxed() const
 {
     UDF_VERIFY(IsBoxed(), "Value is not boxed");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Additional information

...
