### PR TITLE
dq_input_transform_lookup: fix indexes for left-side lookup key

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -385,10 +385,8 @@ THashMap<TStringBuf, size_t> GetNameToIndex(const ::google::protobuf::RepeatedPt
 
 THashMap<TStringBuf, size_t> GetNameToIndex(const NMiniKQL::TStructType* type) {
     THashMap<TStringBuf, size_t> result;
-    for (ui32 i = 0; i != type->GetMembersCount()//names.size()
-                         ; ++i) {
-        auto name = type->GetMemberName(i);
-        result[name] = i;
+    for (ui32 i = 0; i != type->GetMembersCount(); ++i) {
+        result[type->GetMemberName(i)] = i;
     }
     return result;
 }
@@ -431,12 +429,12 @@ std::pair<IDqComputeActorAsyncInput*, NActors::IActor*> CreateInputTransformStre
 
     const auto rightRowType = DeserializeStructType(settings.GetRightSource().GetSerializedRowType(), args.TypeEnv);
 
-    auto leftJoinColumns = GetNameToIndex(narrowInputRowType);
+    auto inputColumns = GetNameToIndex(narrowInputRowType);
     auto rightJoinColumns = GetNameToIndex(settings.GetRightJoinKeyNames());
 
     auto leftJoinColumnIndexes = GetJoinColumnIndexes(
             settings.GetLeftJoinKeyNames(),
-            leftJoinColumns);
+            inputColumns);
     auto rightJoinColumnIndexes  = GetJoinColumnIndexes(rightRowType, rightJoinColumns);
     Y_ABORT_UNLESS(rightJoinColumnIndexes.size() == rightJoinColumns.size());
     Y_ABORT_UNLESS(leftJoinColumnIndexes.size() == rightJoinColumnIndexes.size());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

`leftJoinColumnIndexes` should've been indexes into input row, not into left-side key fields
