### PR TITLE
YQ WM move resource pools into metadata folder

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
@@ -241,7 +241,7 @@ void TResourcePoolManager::PrepareCreateResourcePool(NKqpProto::TKqpSchemeOperat
     }
 
     auto& schemeTx = *schemeOperation.MutableCreateResourcePool();
-    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".resource_pools/"}));
+    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".metadata/workload_manager/pools/"}));
     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateResourcePool);
 
     FillResourcePoolDescription(*schemeTx.MutableCreateResourcePool(), settings);
@@ -249,7 +249,7 @@ void TResourcePoolManager::PrepareCreateResourcePool(NKqpProto::TKqpSchemeOperat
 
 void TResourcePoolManager::PrepareAlterResourcePool(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TDropObjectSettings& settings, TInternalModificationContext& context) const {
     auto& schemeTx = *schemeOperation.MutableAlterResourcePool();
-    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".resource_pools/"}));
+    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".metadata/workload_manager/pools/"}));
     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpAlterResourcePool);
 
     FillResourcePoolDescription(*schemeTx.MutableCreateResourcePool(), settings);
@@ -257,7 +257,7 @@ void TResourcePoolManager::PrepareAlterResourcePool(NKqpProto::TKqpSchemeOperati
 
 void TResourcePoolManager::PrepareDropResourcePool(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TDropObjectSettings& settings, TInternalModificationContext& context) const {
     auto& schemeTx = *schemeOperation.MutableDropResourcePool();
-    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".resource_pools/"}));
+    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".metadata/workload_manager/pools/"}));
     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpDropResourcePool);
 
     schemeTx.MutableDrop()->SetName(settings.GetObjectId());

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
@@ -16,7 +16,7 @@ NMetadata::NModifications::IOperationsManager::TPtr TResourcePoolClassifierBehav
 }
 
 TString TResourcePoolClassifierBehaviour::GetInternalStorageTablePath() const {
-    return "workload_manager/classifiers";
+    return "workload_manager/classifiers/resource_pool_classifiers";
 }
 
 TString TResourcePoolClassifierBehaviour::GetTypeId() const {

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
@@ -16,7 +16,7 @@ NMetadata::NModifications::IOperationsManager::TPtr TResourcePoolClassifierBehav
 }
 
 TString TResourcePoolClassifierBehaviour::GetInternalStorageTablePath() const {
-    return "resource_pools/resource_pools_classifiers";
+    return "workload_manager/classifiers";
 }
 
 TString TResourcePoolClassifierBehaviour::GetTypeId() const {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
@@ -232,7 +232,7 @@ void TestCreateResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGat
         {"concurrent_query_limit", "10"},
         {"queue_size", "100"}
     });
-    const auto& resourcePool = TestCreateObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.resource_pools/" << poolId);
+    const auto& resourcePool = TestCreateObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.metadata/workload_manager/pools/" << poolId);
 
     UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
     UNIT_ASSERT(resourcePool.ResourcePoolInfo);
@@ -249,7 +249,7 @@ void TestAlterResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGate
     }, {
         "queue_size"
     });
-    const auto& resourcePool = TestAlterObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.resource_pools/" << poolId);
+    const auto& resourcePool = TestAlterObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.metadata/workload_manager/pools/" << poolId);
 
     UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
     UNIT_ASSERT(resourcePool.ResourcePoolInfo);
@@ -262,7 +262,7 @@ void TestAlterResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGate
 
 void TestDropResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGateway> gateway, const TString& poolId) {
     TDropObjectSettings settings("RESOURCE_POOL", poolId, {});
-    TestDropObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.resource_pools/" << poolId);
+    TestDropObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.metadata/workload_manager/pools/" << poolId);
 }
 
 TKikimrRunner GetKikimrRunnerWithResourcePools() {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -6593,7 +6593,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         auto& runtime = *kikimr.GetTestServer().GetRuntime();
-        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
         const auto& resourcePool = resourcePoolDesc->ResultSet.at(0);
         UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
         UNIT_ASSERT(resourcePool.ResourcePoolInfo);
@@ -6625,7 +6625,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
             auto& runtime = *kikimr.GetTestServer().GetRuntime();
-            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
             UNIT_ASSERT_VALUES_EQUAL(resourcePoolDesc->ResultSet.at(0).Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
         }
 
@@ -6636,7 +6636,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                 );)";
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Check failed: path: '/Root/.resource_pools/MyResourcePool', error: path exist");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Check failed: path: '/Root/.metadata/workload_manager/pools/MyResourcePool', error: path exist");
         }
     }
 
@@ -6661,7 +6661,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
             auto& runtime = *kikimr.GetTestServer().GetRuntime();
-            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
             const auto& properties = resourcePoolDesc->ResultSet.at(0).ResourcePoolInfo->Description.GetProperties().GetProperties();
             UNIT_ASSERT_VALUES_EQUAL(properties.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(properties.at("concurrent_query_limit"), "20");
@@ -6678,7 +6678,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
             auto& runtime = *kikimr.GetTestServer().GetRuntime();
-            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
             const auto& properties = resourcePoolDesc->ResultSet.at(0).ResourcePoolInfo->Description.GetProperties().GetProperties();
             UNIT_ASSERT_VALUES_EQUAL(properties.size(), 3);
             UNIT_ASSERT_VALUES_EQUAL(properties.at("concurrent_query_limit"), "30");
@@ -6734,7 +6734,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         }
 
         auto& runtime = *kikimr.GetTestServer().GetRuntime();
-        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
         const auto& resourcePool = resourcePoolDesc->ResultSet.at(0);
         UNIT_ASSERT_VALUES_EQUAL(resourcePoolDesc->ErrorCount, 1);
         UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown);

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -179,7 +179,7 @@ protected:
     void StartRequest() override {
         LOG_D("Start pool fetching");
         auto event = NTableCreator::BuildSchemeCacheNavigateRequest(
-            {{".resource_pools", PoolId}},
+            {{".metadata/workload_manager/pools", PoolId}},
             Database,
             UserToken
         );
@@ -326,7 +326,7 @@ protected:
         auto event = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
 
         auto& schemeTx = *event->Record.MutableTransaction()->MutableModifyScheme();
-        schemeTx.SetWorkingDir(JoinPath({Database, ".resource_pools"}));
+        schemeTx.SetWorkingDir(JoinPath({Database, ".metadata/workload_manager/pools"}));
         schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateResourcePool);
         schemeTx.SetInternal(true);
 

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -354,7 +354,7 @@ public:
         auto token = NACLib::TUserToken(userSID, {});
 
         WaitFor(FUTURE_WAIT_TIMEOUT, "pool acl", [this, token, access, poolId](TString& errorString) {
-            auto response = Navigate(TStringBuilder() << ".resource_pools/" << (poolId ? poolId : Settings_.PoolId_));
+            auto response = Navigate(TStringBuilder() << ".metadata/workload_manager/pools/" << (poolId ? poolId : Settings_.PoolId_));
             if (!response) {
                 errorString = "empty response";
                 return false;

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
@@ -58,7 +58,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
 
         const TString& userSID = "user@test";
         TSampleQueries::CheckSuccess(ydb->ExecuteQuery(TStringBuilder() << R"(
-            GRANT DESCRIBE SCHEMA ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
+            GRANT DESCRIBE SCHEMA ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
         ));
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::DescribeSchema);
 
@@ -67,7 +67,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
         UNIT_ASSERT_STRING_CONTAINS(failedResponse->Get()->Issues.ToString(), TStringBuilder() << "You don't have access permissions for resource pool " << ydb->GetSettings().PoolId_);
 
         TSampleQueries::CheckSuccess(ydb->ExecuteQuery(TStringBuilder() << R"(
-            GRANT SELECT ROW ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
+            GRANT SELECT ROW ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
         ));
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::SelectRow);
 
@@ -86,7 +86,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
     Y_UNIT_TEST(TestCreateDefaultPool) {
         auto ydb = TYdbSetupSettings().Create();
 
-        const TString path = TStringBuilder() << ".resource_pools/" << NResourcePool::DEFAULT_POOL_ID;
+        const TString path = TStringBuilder() << ".metadata/workload_manager/pools/" << NResourcePool::DEFAULT_POOL_ID;
         auto response = ydb->Navigate(path, NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
         UNIT_ASSERT_VALUES_EQUAL(response->ErrorCount, 1);
         UNIT_ASSERT_VALUES_EQUAL(response->ResultSet.at(0).Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown);
@@ -224,7 +224,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceSubscriptions) {
 
         const TString& userSID = "test@user";
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
-            GRANT ALL ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << R"(` TO `)" << userSID << R"(`;
+            GRANT ALL ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << R"(` TO `)" << userSID << R"(`;
         )");
 
         const auto& response = ydb->GetRuntime()->GrabEdgeEvent<TEvUpdatePoolInfo>(subscriber, FUTURE_WAIT_TIMEOUT);

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
@@ -70,7 +70,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceTables) {
             CanonizePath({ydb->GetSettings().DomainName_, ".metadata/workload_manager"})
         ).GetValue(FUTURE_WAIT_TIMEOUT);
         UNIT_ASSERT_VALUES_EQUAL_C(listResult.GetStatus(), NYdb::EStatus::SUCCESS, listResult.GetIssues().ToString());
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 3);
     }
 
     Y_UNIT_TEST(TestTablesIsNotCreatingForUnlimitedPool) {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
@@ -83,12 +83,11 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceTables) {
 
         // Check that there is no .metadata folder
         auto listResult = ydb->GetSchemeClient().ListDirectory(
-            CanonizePath(ydb->GetSettings().DomainName_)
+            CanonizePath({ydb->GetSettings().DomainName_, ".metadata", "workload_manager"})
         ).GetValue(FUTURE_WAIT_TIMEOUT);
         UNIT_ASSERT_VALUES_EQUAL_C(listResult.GetStatus(), NYdb::EStatus::SUCCESS, listResult.GetIssues().ToString());
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[0].Name, ".metadata");
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[1].Name, ".sys");
+        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[0].Name, "pools");
     }
 
     Y_UNIT_TEST(TestPoolStateFetcherActor) {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
@@ -87,7 +87,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceTables) {
         ).GetValue(FUTURE_WAIT_TIMEOUT);
         UNIT_ASSERT_VALUES_EQUAL_C(listResult.GetStatus(), NYdb::EStatus::SUCCESS, listResult.GetIssues().ToString());
         UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[0].Name, ".resource_pools");
+        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[0].Name, ".metadata");
         UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[1].Name, ".sys");
     }
 

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -480,7 +480,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolsDdl) {
         );
 
         IYdbSetup::WaitFor(FUTURE_WAIT_TIMEOUT, "pool drop", [ydb, poolId](TString& errorString) {
-            auto kind = ydb->Navigate(TStringBuilder() << ".resource_pools/" << poolId)->ResultSet.at(0).Kind;
+            auto kind = ydb->Navigate(TStringBuilder() << ".metadata/workload_manager/pools/" << poolId)->ResultSet.at(0).Kind;
 
             errorString = TStringBuilder() << "kind = " << kind;
             return kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown;
@@ -500,7 +500,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolsDdl) {
             CREATE RESOURCE POOL )" << poolId << R"( WITH (
                 CONCURRENT_QUERY_LIMIT=1
             );
-            GRANT DESCRIBE SCHEMA ON `/Root/.resource_pools/)" << poolId << "` TO `" << userSID << "`;"
+            GRANT DESCRIBE SCHEMA ON `/Root/.metadata/workload_manager/pools/)" << poolId << "` TO `" << userSID << "`;"
         );
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::DescribeSchema, poolId);
 
@@ -510,7 +510,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolsDdl) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), TStringBuilder() << "You don't have access permissions for resource pool " << poolId);
 
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
-            GRANT SELECT ROW ON `/Root/.resource_pools/)" << poolId << "` TO `" << userSID << "`;"
+            GRANT SELECT ROW ON `/Root/.metadata/workload_manager/pools/)" << poolId << "` TO `" << userSID << "`;"
         );
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::SelectRow, poolId);
         TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings));
@@ -524,7 +524,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
         const TString& userSID = "user@test";
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             GRANT DESCRIBE SCHEMA ON `/Root` TO `)" << userSID << R"(`;
-            GRANT DESCRIBE SCHEMA, SELECT ROW ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
+            GRANT DESCRIBE SCHEMA, SELECT ROW ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
         );
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::DescribeSchema | NACLib::EAccessRights::SelectRow);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
@@ -34,7 +34,7 @@ TPath::TChecker IsParentPathValid(const TPath& parentPath) {
 }
 
 bool IsParentPathValid(const THolder<TProposeResponse>& result, const TPath& parentPath) {
-    const TString& resourcePoolsDir = JoinPath({parentPath.GetDomainPathString(), ".resource_pools"});
+    const TString& resourcePoolsDir = JoinPath({parentPath.GetDomainPathString(), ".metadata/workload_manager/pools"});
     if (parentPath.PathString() != resourcePoolsDir) {
         result->SetError(NKikimrScheme::EStatus::StatusSchemeError, TStringBuilder() << "Resource pools shoud be placed in " << resourcePoolsDir);
         return false;

--- a/ydb/core/tx/schemeshard/ut_resource_pool/ut_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/ut_resource_pool/ut_resource_pool.cpp
@@ -9,16 +9,16 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
             )", {NKikimrScheme::StatusAccepted});
 
         env.TestWaitNotification(runtime, txId);
 
-        TestLs(runtime, "/MyRoot/.resource_pools/MyResourcePool", false, NLs::PathExist);
+        TestLs(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool", false, NLs::PathExist);
     }
 
     Y_UNIT_TEST(CreateResourcePoolWithProperties) {
@@ -26,10 +26,10 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {
@@ -49,7 +49,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         properties.MutableProperties()->insert({"concurrent_query_limit", "10"});
         properties.MutableProperties()->insert({"query_cancel_after_seconds", "60"});
 
-        auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+        auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
         TestDescribeResult(describeResult, {NLs::PathExist});
         UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
         const auto& resourcePoolDescription = describeResult.GetPathDescription().GetResourcePoolDescription();
@@ -63,21 +63,21 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
             )", {NKikimrScheme::StatusAccepted});
 
         env.TestWaitNotification(runtime, txId);
 
-        TestLs(runtime, "/MyRoot/.resource_pools/MyResourcePool", false, NLs::PathExist);
+        TestLs(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool", false, NLs::PathExist);
 
-        TestDropResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", "MyResourcePool");
+        TestDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "MyResourcePool");
         env.TestWaitNotification(runtime, txId);
 
-        TestLs(runtime, "/MyRoot/.resource_pools/MyResourcePool", false, NLs::PathNotExist);
+        TestLs(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool", false, NLs::PathNotExist);
     }
 
     Y_UNIT_TEST(DropResourcePoolTwice) {
@@ -85,16 +85,16 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
             Name: "MyResourcePool"
         )");
         env.TestWaitNotification(runtime, txId);
 
-        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", "MyResourcePool");
-        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", "MyResourcePool");
+        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "MyResourcePool");
+        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "MyResourcePool");
         TestModificationResult(runtime, txId - 1);
 
         auto ev = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>();
@@ -106,7 +106,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         UNIT_ASSERT_VALUES_EQUAL(record.GetPathDropTxId(), txId - 1);
 
         env.TestWaitNotification(runtime, txId - 1);
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool"), {
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool"), {
             NLs::PathNotExist
         });
     }
@@ -116,11 +116,11 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 123;
 
-        AsyncMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        AsyncMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool1"
             )");
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool2"
             )");
         TestModificationResult(runtime, txId-2, NKikimrScheme::StatusAccepted);
@@ -129,14 +129,14 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
 
         env.TestWaitNotification(runtime, {txId, txId-1, txId-2});
 
-        TestDescribe(runtime, "/MyRoot/.resource_pools/MyResourcePool1");
-        TestDescribe(runtime, "/MyRoot/.resource_pools/MyResourcePool2");
+        TestDescribe(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool1");
+        TestDescribe(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool2");
 
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools"),
                            {NLs::PathVersionEqual(7)});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool1"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool1"),
                            {NLs::PathVersionEqual(2)});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool2"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool2"),
                            {NLs::PathVersionEqual(2)});
     }
 
@@ -151,12 +151,12 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
                 Name: "NilNoviSubLuna"
             )";
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig);
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig);
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig);
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig);
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig);
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig);
 
         ui64 sts[3];
         sts[0] = TestModificationResults(runtime, txId-2, {ESts::StatusAccepted, ESts::StatusMultipleModifications, ESts::StatusAlreadyExists});
@@ -165,13 +165,13 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
 
         for (ui32 i=0; i<3; ++i) {
             if (sts[i] == ESts::StatusAlreadyExists) {
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/NilNoviSubLuna"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/NilNoviSubLuna"),
                                    {NLs::Finished,
                                     NLs::IsResourcePool});
             }
 
             if (sts[i] == ESts::StatusMultipleModifications) {
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/NilNoviSubLuna"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/NilNoviSubLuna"),
                                    {NLs::Finished,
                                     NLs::IsResourcePool});
             }
@@ -179,12 +179,12 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
 
         env.TestWaitNotification(runtime, {txId-2, txId-1, txId});
 
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/NilNoviSubLuna"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/NilNoviSubLuna"),
                            {NLs::Finished,
                             NLs::IsResourcePool,
                             NLs::PathVersionEqual(2)});
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig, {ESts::StatusAlreadyExists});
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig, {ESts::StatusAlreadyExists});
     }
 
     Y_UNIT_TEST(ReadOnlyMode) {
@@ -192,11 +192,11 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 123;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
         AsyncMkDir(runtime, ++txId, "/MyRoot", "SubDirA");
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
             )");
 
@@ -211,13 +211,13 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         // Check that describe works
         TestDescribeResult(DescribePath(runtime, "/MyRoot/SubDirA"),
                            {NLs::Finished});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool"),
                            {NLs::Finished,
                             NLs::IsResourcePool});
 
         // Check that new modifications fail
         TestMkDir(runtime, ++txId, "/MyRoot", "SubDirBBBB", {NKikimrScheme::StatusReadOnly});
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool2"
             )", {NKikimrScheme::StatusReadOnly});
 
@@ -235,18 +235,18 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 123;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
         TestCreateResourcePool(runtime, ++txId, "/MyRoot", R"(
                 Name: "AnotherDir/MyResourcePool"
-            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.resource_pools"}});
+            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.metadata/workload_manager/pools"}});
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "AnotherDir/MyResourcePool"
-            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.resource_pools"}});
+            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.metadata/workload_manager/pools"}});
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: ""
             )", {{NKikimrScheme::StatusSchemeError, "error: path part shouldn't be empty"}});
     }
@@ -256,10 +256,10 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {
@@ -280,7 +280,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         properties.MutableProperties()->insert({"query_count_limit", "50"});
 
         {
-            auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+            auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
             TestDescribeResult(describeResult, {NLs::PathExist});
             UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
             const auto& resourcePoolDescription = describeResult.GetPathDescription().GetResourcePoolDescription();
@@ -289,7 +289,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
             UNIT_ASSERT_VALUES_EQUAL(resourcePoolDescription.GetProperties().DebugString(), properties.DebugString());
         }
 
-        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {
@@ -309,7 +309,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         properties.MutableProperties()->insert({"query_cancel_after_seconds", "60"});
 
         {
-            auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+            auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
             TestDescribeResult(describeResult, {NLs::PathExist});
             UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
             const auto& resourcePoolDescription = describeResult.GetPathDescription().GetResourcePoolDescription();
@@ -324,10 +324,10 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {

--- a/ydb/core/tx/schemeshard/ut_resource_pool_reboots/ut_resource_pool_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_resource_pool_reboots/ut_resource_pool_reboots.cpp
@@ -7,9 +7,9 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
     Y_UNIT_TEST(CreateResourcePoolWithReboots) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
-            AsyncMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+            AsyncMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
 
-            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                     Name: "MyResourcePool"
                     Properties {
                         Properties {
@@ -31,7 +31,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
 
             {
                 TInactiveZone inactive(activeZone);
-                auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+                auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
                 TestDescribeResult(describeResult, {NLs::Finished});
 
                 UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
@@ -46,22 +46,22 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
     Y_UNIT_TEST(ParallelCreateDrop) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
-            TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+            TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                     Name: "DropMe"
                 )");
-            AsyncDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "DropMe");
+            AsyncDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "DropMe");
             t.TestEnv->TestWaitNotification(runtime, t.TxId-1);
 
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "DropMe");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "DropMe");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/DropMe"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/DropMe"),
                                    {NLs::PathNotExist});
             }
         });
@@ -71,22 +71,22 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
                 TInactiveZone inactive(activeZone);
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });
@@ -98,21 +98,21 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });
@@ -124,32 +124,32 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });
@@ -161,19 +161,19 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+            TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                     Name: "ResourcePool"
                 )");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
@@ -181,7 +181,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
         });
@@ -193,29 +193,29 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Moved resource pools into `.metadata` folder

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information