### PR TITLE
environment variable `YDB_TOKEN` in `ydb-cli` tests

### DIFF
--- a/ydb/apps/ydb/ut/run_ydb.cpp
+++ b/ydb/apps/ydb/ut/run_ydb.cpp
@@ -23,6 +23,8 @@ TString GetYdbDatabase()
 
 TString RunYdb(const TList<TString>& args1, const TList<TString>& args2, bool checkExitCode)
 {
+    SetEnv("YDB_TOKEN", "root@builin");
+
     TShellCommand command(BinaryPath(GetEnv("YDB_CLI_BINARY")));
 
     command << "-e" << ("grpc://" + GetYdbEndpoint());

--- a/ydb/apps/ydb/ut/workload-transfer-topic-to-table.cpp
+++ b/ydb/apps/ydb/ut/workload-transfer-topic-to-table.cpp
@@ -81,7 +81,7 @@ TString ExecYdb(const TList<TString>& args, bool checkExitCode = true)
     //
     // ydb -e grpc://${YDB_ENDPOINT} -d /${YDB_DATABASE} workload transfer topic-to-table ${args}
     //
-    return RunYdb({"--user", "root", "--no-password", "workload", "transfer", "topic-to-table"}, args,
+    return RunYdb({"workload", "transfer", "topic-to-table"}, args,
                   checkExitCode);
 }
 
@@ -96,8 +96,6 @@ void RunYdb(const TList<TString>& args,
 
 Y_UNIT_TEST(Default_Run)
 {
-    RunYdb({"-v", "yql", "-s", R"(ALTER USER root PASSWORD "")"}, TList<TString>());
-
     ExecYdb({"init"});
     auto output = ExecYdb({"run", "-s", "10"});
     ExecYdb({"clean"});
@@ -110,8 +108,6 @@ Y_UNIT_TEST(Default_Run)
 
 Y_UNIT_TEST(Default_Init_Clean)
 {
-    RunYdb({"-v", "yql", "-s", R"(ALTER USER root PASSWORD "")"}, TList<TString>());
-
     const TString topic = "transfer-topic";
     const TString table = "transfer-table";
 
@@ -121,8 +117,6 @@ Y_UNIT_TEST(Default_Init_Clean)
 
 Y_UNIT_TEST(Specific_Init_Clean)
 {
-    RunYdb({"-v", "yql", "-s", R"(ALTER USER root PASSWORD "")"}, TList<TString>());
-
     const TString topic = "my-topic";
     const TString table = "my-table";
 
@@ -140,15 +134,11 @@ Y_UNIT_TEST(Specific_Init_Clean)
 
 Y_UNIT_TEST(Clean_Without_Init)
 {
-    RunYdb({"-v", "yql", "-s", R"(ALTER USER root PASSWORD "")"}, TList<TString>());
-
     UNIT_ASSERT_EXCEPTION(ExecYdb({"clean"}), yexception);
 }
 
 Y_UNIT_TEST(Double_Init)
 {
-    RunYdb({"-v", "yql", "-s", R"(ALTER USER root PASSWORD "")"}, TList<TString>());
-
     ExecYdb({"init"});
     UNIT_ASSERT_EXCEPTION(ExecYdb({"init"}), yexception);
     ExecYdb({"clean"});
@@ -172,8 +162,6 @@ void EnsureStatisticsColumns(const TList<TString>& args,
 
 Y_UNIT_TEST(Statistics)
 {
-    RunYdb({"-v", "yql", "-s", R"(ALTER USER root PASSWORD "")"}, TList<TString>());
-
     EnsureStatisticsColumns({"run", "-s", "1", "--warmup", "0"},
                             {"Window", "Write speed", "Write time", "Inflight", "Read speed", "Topic time", "Select time", "Upsert time", "Commit time"},
                             {"#", "msg/s", "MB/s", "percentile,ms", "percentile,msg", "msg/s", "MB/s", "percentile,ms", "percentile,ms", "percentile,ms", "percentile,ms"});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Refactoring tests for `ydb-cli`. The tests use a recipe. It creates a database `/local` with the user `root`.

Previously, `ydb-cli` was called in tests and the `--user root --no-password` options were added to the command.

Now, before calling the command, the value for the environment variable `YDB_TOKEN` is set.

### Changelog category <!-- remove all except one -->

* Improvement
* Not for changelog (changelog entry is not required)

### Additional information

...
