### PR TITLE
Fix segfault when UserToken == nullptr

### DIFF
--- a/ydb/core/mon/async_http_mon.cpp
+++ b/ydb/core/mon/async_http_mon.cpp
@@ -374,13 +374,15 @@ public:
             return ReplyErrorAndPassAway(result);
         }
         bool found = false;
-        for (const TString& sid : ActorMonPage->AllowedSIDs) {
-            if (result.UserToken->IsExist(sid)) {
-                found = true;
-                break;
+        if (result.UserToken) {
+            for (const TString& sid : ActorMonPage->AllowedSIDs) {
+                if (result.UserToken->IsExist(sid)) {
+                    found = true;
+                    break;
+                }
             }
         }
-        if (found || ActorMonPage->AllowedSIDs.empty()) {
+        if (found || ActorMonPage->AllowedSIDs.empty() || !result.UserToken) {
             SendRequest(&result);
         } else {
             return ReplyForbiddenAndPassAway("SID is not allowed");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix segfault that appeared after https://github.com/ydb-platform/ydb/commit/6576464d6b8dca046c27847c1ff60fc6748f329d (https://github.com/ydb-platform/ydb/pull/5982)

In code that was before the bug there was no case when execution reaches the point Handle(TEvAuthorizeTicketResult) with Token == nullptr

https://github.com/ydb-platform/ydb/blob/e791eb9a768ec51b5ca478c2aff5236a22ed67b8/ydb/core/mon/mon.cpp - DefaultAuthorizer

https://github.com/ydb-platform/ydb/blob/e791eb9a768ec51b5ca478c2aff5236a22ed67b8/ydb/core/mon/async_http_mon.cpp - we get nullptr in Authorizer and execute SendRequest() without check

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
