### PR TITLE
Remove migration flag FIX_UNUSED_PARAMETR_PLS (devtools request)

### DIFF
--- a/build/internal/ya.conf
+++ b/build/internal/ya.conf
@@ -23,4 +23,4 @@ USE_IDN = "static"
 APPLE_SDK_LOCAL = "yes"
 CFLAGS = "-fno-omit-frame-pointer"
 # TODO: uncomment after warnings fix
-FIX_UNUSED_PARAMETR_PLS = "1"  # 2 aug 2024. Transitional flag for protobuf fix, DTCC-2275
+# FIX_UNUSED_PARAMETR_PLS = "1"  # 31 jul 2024. Transitional flag for protobuf fix, DTCC-2275

--- a/build/internal/ya.conf
+++ b/build/internal/ya.conf
@@ -22,5 +22,3 @@ USE_ICONV = "static"
 USE_IDN = "static"
 APPLE_SDK_LOCAL = "yes"
 CFLAGS = "-fno-omit-frame-pointer"
-# TODO: uncomment after warnings fix
-# FIX_UNUSED_PARAMETR_PLS = "1"  # 31 jul 2024. Transitional flag for protobuf fix, DTCC-2275

--- a/ydb/core/cms/console/console_configs_provider.cpp
+++ b/ydb/core/cms/console/console_configs_provider.cpp
@@ -100,7 +100,7 @@ public:
         Die(ctx);
     }
 
-    void Handle(TEvents::TEvPoisonPill::TPtr &ev, const TActorContext &ctx)
+    void Handle(TEvents::TEvPoisonPill::TPtr &/*ev*/, const TActorContext &ctx)
     {
         LOG_DEBUG_S(ctx, NKikimrServices::CMS_CONFIGS,
                     "TTabletConfigSender(" << Subscription->Id << ") die to poison pill");

--- a/ydb/core/cms/console/console_configs_provider.cpp
+++ b/ydb/core/cms/console/console_configs_provider.cpp
@@ -100,7 +100,7 @@ public:
         Die(ctx);
     }
 
-    void Handle(TEvents::TEvPoisonPill::TPtr &/*ev*/, const TActorContext &ctx)
+    void Handle(TEvents::TEvPoisonPill::TPtr &ev, const TActorContext &ctx)
     {
         LOG_DEBUG_S(ctx, NKikimrServices::CMS_CONFIGS,
                     "TTabletConfigSender(" << Subscription->Id << ") die to poison pill");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It was added in 
https://github.com/ydb-platform/ydb/pull/7330
https://github.com/ydb-platform/ydb/pull/7396

Now it is useless because that behaviour is default

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Checked in same PR