### PR TITLE
Wait for all CAs inside Executer before shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ __pycache__/
 *.pb.h
 *.pb.cc
 
+# Other generated
+*.fbs.h
+
 # MacOS specific
 .DS_Store
 

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2641,23 +2641,15 @@ private:
     }
 
     void HandleShutdown(TEvDqCompute::TEvState::TPtr& ev) {
-        if (ev->Get()->Record.GetState() == NDqProto::COMPUTE_STATE_FINISHED) {
-            YQL_ENSURE(Planner);
+        YQL_ENSURE(Planner);
 
-            if (ev->Get()->Record.GetStatusCode() != NDqProto::StatusIds::ABORTED) {
-                return;
-            }
+        TActorId actor = ev->Sender;
+        ui64 taskId = ev->Get()->Record.GetTaskId();
 
-            TActorId actor = ev->Sender;
-            ui64 taskId = ev->Get()->Record.GetTaskId();
+        Planner->CompletedCA(taskId, actor);
 
-            Planner->CompletedCA(taskId, actor);
-
-            if (Planner->GetPendingComputeTasks().empty() && Planner->GetPendingComputeActors().empty()) {
-                PassAway();
-            }
-        } else {
-            // TODO: handle other states.
+        if (Planner->GetPendingComputeTasks().empty() && Planner->GetPendingComputeActors().empty()) {
+            PassAway();
         }
     }
 

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2605,6 +2605,8 @@ private:
                 DoShutdown();
             } else {
                 this->Become(&TThis::WaitShutdownState);
+                LOG_I("Waiting for shutdown of " << Planner->GetPendingComputeTasks().size() << " tasks and "
+                    << Planner->GetPendingComputeActors().size() << " compute actors");
                 TActivationContext::Schedule(TDuration::Seconds(10), new IEventHandle(SelfId(), SelfId(), new TEvents::TEvPoison));
             }
         } else {

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2627,6 +2627,10 @@ private:
         if (ev->Get()->Record.GetState() == NDqProto::COMPUTE_STATE_FINISHED) {
             YQL_ENSURE(Planner);
 
+            if (ev->Get()->Record.GetStatusCode() != NDqProto::StatusIds::ABORTED) {
+                return;
+            }
+
             TActorId actor = ev->Sender;
             ui64 taskId = ev->Get()->Record.GetTaskId();
 
@@ -2636,7 +2640,7 @@ private:
                 DoShutdown();
             }
         } else {
-            // TODO: handle another states.
+            // TODO: handle other states.
         }
     }
 

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -214,8 +214,6 @@ public:
                 YqlIssue({}, TIssuesIds::KIKIMR_LOCKS_INVALIDATED, message));
         }
 
-        AlreadyReplied = true;
-
         auto& response = *ResponseEv->Record.MutableResponse();
 
         FillResponseStats(Ydb::StatusIds::SUCCESS);
@@ -282,6 +280,7 @@ public:
         ExecuterSpan.EndOk();
 
         Request.Transactions.crop(0);
+        AlreadyReplied = true;
         PassAway();
     }
 
@@ -2620,7 +2619,7 @@ private:
             hFunc(TEvInterconnect::TEvNodeDisconnected, HandleShutdown);
             hFunc(TEvents::TEvPoison, HandleShutdown);
             default:
-                ; // ignore all other events
+                LOG_E("Unexpected event: " << ev->GetTypeName()); // ignore all other events
         }
     }
 

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1713,7 +1713,7 @@ protected:
         LOG_E("Sending timeout response to: " << Target);
 
         Request.Transactions.crop(0);
-        this->PassAway();
+        this->Shutdown();
     }
 
     void FillResponseStats(Ydb::StatusIds::StatusCode status) {
@@ -1778,7 +1778,7 @@ protected:
         ExecuterStateSpan.EndError(response.DebugString());
 
         Request.Transactions.crop(0);
-        this->PassAway();
+        this->Shutdown();
     }
 
 protected:
@@ -1846,6 +1846,12 @@ protected:
     }
 
 protected:
+    // Introduced separate method from `PassAway()` - to not get confused with expectations from other actors,
+    // that `PassAway()` should kill actor immediately.
+    virtual void Shutdown() {
+        PassAway();
+    }
+
     void PassAway() override {
         YQL_ENSURE(AlreadyReplied && ResponseEv);
         this->Send(Target, ResponseEv.release());

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1847,7 +1847,7 @@ protected:
 
 protected:
     void PassAway() override {
-        YQL_ENSURE(ResponseEv);
+        YQL_ENSURE(AlreadyReplied && ResponseEv);
         this->Send(Target, ResponseEv.release());
 
         for (auto channelPair: ResultChannelProxies) {

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1686,6 +1686,7 @@ protected:
 
     void TimeoutError(TActorId abortSender) {
         if (AlreadyReplied) {
+            LOG_E("Timeout when we already replied - not good" << Endl << TBackTrace().PrintToString() << Endl);
             return;
         }
 
@@ -1747,6 +1748,7 @@ protected:
         google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage>* issues)
     {
         if (AlreadyReplied) {
+            LOG_E("Error when we already replied - not good" << Endl << TBackTrace().PrintToString() << Endl);
             return;
         }
 

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -557,6 +557,17 @@ void TKqpPlanner::CompletedCA(ui64 taskId, TActorId computeActor) {
     return;
 }
 
+void TKqpPlanner::TaskNotStarted(ui64 taskId) {
+    // NOTE: should be invoked only while shutting down - when node is disconnected.
+
+    auto& task = TasksGraph.GetTask(taskId);
+
+    YQL_ENSURE(!task.ComputeActorId);
+    YQL_ENSURE(!task.Meta.Completed);
+
+    PendingComputeTasks.erase(taskId);
+}
+
 TProgressStat::TEntry TKqpPlanner::CalculateConsumptionUpdate() {
     TProgressStat::TEntry consumption;
 

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -554,7 +554,8 @@ void TKqpPlanner::CompletedCA(ui64 taskId, TActorId computeActor) {
     YQL_ENSURE(it != PendingComputeActors.end());
     LastStats.emplace_back(std::move(it->second));
     PendingComputeActors.erase(it);
-    return;
+
+    LOG_I("Compute actor has finished execution: " << computeActor.ToString());
 }
 
 void TKqpPlanner::TaskNotStarted(ui64 taskId) {

--- a/ydb/core/kqp/executer_actor/kqp_planner.h
+++ b/ydb/core/kqp/executer_actor/kqp_planner.h
@@ -74,6 +74,7 @@ public:
     std::unique_ptr<IEventHandle> AssignTasksToNodes();
     bool AcknowledgeCA(ui64 taskId, TActorId computeActor, const NYql::NDqProto::TEvComputeActorState* state);
     void CompletedCA(ui64 taskId, TActorId computeActor);
+    void TaskNotStarted(ui64 taskId);
     TProgressStat::TEntry CalculateConsumptionUpdate();
     void ShiftConsumption();
     void Submit();

--- a/ydb/core/kqp/executer_actor/kqp_scan_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scan_executer.cpp
@@ -273,6 +273,9 @@ private:
 public:
 
     void Finalize() {
+        YQL_ENSURE(!AlreadyReplied);
+        AlreadyReplied = true;
+
         FillResponseStats(Ydb::StatusIds::SUCCESS);
 
         LWTRACK(KqpScanExecuterFinalize, ResponseEv->Orbit, TxId, LastTaskId, LastComputeActorId, ResponseEv->ResultsSize());
@@ -281,8 +284,6 @@ public:
             ExecuterSpan.EndOk();
         }
 
-        LOG_D("Sending response to: " << Target);
-        Send(Target, ResponseEv.release());
         PassAway();
     }
 

--- a/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_limits_ut.cpp
@@ -923,10 +923,11 @@ Y_UNIT_TEST_SUITE(KqpLimits) {
                 if (totalEvState == actorCount*2) {
                     return TTestActorRuntime::EEventAction::DROP;
                 }
+            } else if (ev->GetTypeRewrite() == TEvents::TEvPoison::EventType && totalEvState == actorCount*2 &&
+                ev->Sender == executerId && ev->Recipient == executerId)
+            {
+                timeoutPoison = true;
             }
-
-            timeoutPoison = ev->GetTypeRewrite() == TEvents::TEvPoison::EventType && totalEvState == actorCount*2
-                && ev->Sender == executerId && ev->Recipient == executerId;
 
             return TTestActorRuntime::EEventAction::PROCESS;
         });

--- a/ydb/core/kqp/ut/query/ya.make
+++ b/ydb/core/kqp/ut/query/ya.make
@@ -12,7 +12,7 @@ IF (WITH_VALGRIND)
     SIZE(LARGE)
     TAG(ya:fat)
 ELSE()
-    TIMEOUT(600)
+    TIMEOUT(60)
     SIZE(MEDIUM)
 ENDIF()
 

--- a/ydb/core/kqp/ut/query/ya.make
+++ b/ydb/core/kqp/ut/query/ya.make
@@ -12,7 +12,7 @@ IF (WITH_VALGRIND)
     SIZE(LARGE)
     TAG(ya:fat)
 ELSE()
-    TIMEOUT(60)
+    TIMEOUT(600)
     SIZE(MEDIUM)
 ENDIF()
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -520,6 +520,10 @@ protected:
             auto ev = MakeHolder<TEvDqCompute::TEvState>();
             auto& record = ev->Record;
 
+            if (RuntimeSettings.StatsMode >= NDqProto::DQ_STATS_MODE_BASIC) {
+                FillStats(record.MutableStats(), /* last */ true);
+            }
+
             record.SetState(NDqProto::COMPUTE_STATE_FINISHED);
             record.SetStatusCode(NDqProto::StatusIds::ABORTED);
             record.SetTaskId(Task.GetId());

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -515,6 +515,18 @@ protected:
             RuntimeSettings.TerminateHandler(success, issues);
         }
 
+        // Send final state to executer to inform about termination.
+        {
+            auto ev = MakeHolder<TEvDqCompute::TEvState>();
+            auto& record = ev->Record;
+
+            record.SetState(NDqProto::COMPUTE_STATE_FINISHED);
+            record.SetStatusCode(NDqProto::StatusIds::ABORTED);
+            record.SetTaskId(Task.GetId());
+
+            this->Send(ExecuterId, ev.Release());
+        }
+
         this->PassAway();
         Terminated = true;
     }

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -516,7 +516,7 @@ protected:
         }
 
         // Send final state to executer to inform about termination.
-        {
+        if (!success) {
             auto ev = MakeHolder<TEvDqCompute::TEvState>();
             auto& record = ev->Record;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Implement additional state for TKqpDataExecuter in which it will wait for all children Compute Actors for graceful shutdown.

Also Executer will respect node disconnects and timeouts - to not hang on waiting forever.

### Changelog category <!-- remove all except one -->

* New feature