### PR TITLE
add http-handle returning configs

### DIFF
--- a/ydb/core/viewer/json_handlers_viewer.cpp
+++ b/ydb/core/viewer/json_handlers_viewer.cpp
@@ -11,6 +11,7 @@
 #include "viewer_describe_consumer.h"
 #include "viewer_describe.h"
 #include "viewer_describe_topic.h"
+#include "viewer_feature_flags.h"
 #include "viewer_graph.h"
 #include "viewer_healthcheck.h"
 #include "viewer_hiveinfo.h"
@@ -265,6 +266,10 @@ void InitViewerCheckAccessJsonHandler(TJsonHandlers& jsonHandlers) {
     jsonHandlers.AddHandler("/viewer/check_access", new TJsonHandler<TCheckAccess>(TCheckAccess::GetSwagger()));
 }
 
+void InitViewerFeatureFlagsJsonHandler(TJsonHandlers& handlers) {
+    handlers.AddHandler("/viewer/feature_flags", new TJsonHandler<TJsonFeatureFlags>(TJsonFeatureFlags::GetSwagger()));
+}
+
 void InitViewerJsonHandlers(TJsonHandlers& jsonHandlers) {
     InitViewerCapabilitiesJsonHandler(jsonHandlers);
     InitViewerNodelistJsonHandler(jsonHandlers);
@@ -303,6 +308,7 @@ void InitViewerJsonHandlers(TJsonHandlers& jsonHandlers) {
     InitViewerRenderJsonHandler(jsonHandlers);
     InitViewerAutocompleteJsonHandler(jsonHandlers);
     InitViewerCheckAccessJsonHandler(jsonHandlers);
+    InitViewerFeatureFlagsJsonHandler(jsonHandlers);
 }
 
 }

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -193,6 +193,14 @@ void TViewerPipeClient::RequestConsoleListTenants() {
     SendRequestToPipe(pipeClient, request.Release());
 }
 
+void TViewerPipeClient::RequestConsoleNodeConfigByTenant(TString tenant, ui64 cookie) {
+    TActorId pipeClient = ConnectTabletPipe(GetConsoleId());
+    auto request = MakeHolder<NConsole::TEvConsole::TEvGetNodeConfigRequest>();
+    request->Record.MutableNode()->SetTenant(tenant);
+    request->Record.AddItemKinds(static_cast<ui32>(NKikimrConsole::TConfigItem::FeatureFlagsItem));
+    SendRequestToPipe(pipeClient, request.Release(), cookie);
+}
+
 TViewerPipeClient::TRequestResponse<NConsole::TEvConsole::TEvListTenantsResponse> TViewerPipeClient::MakeRequestConsoleListTenants() {
     TActorId pipeClient = ConnectTabletPipe(GetConsoleId());
     THolder<NConsole::TEvConsole::TEvListTenantsRequest> request = MakeHolder<NConsole::TEvConsole::TEvListTenantsRequest>();

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -193,18 +193,18 @@ void TViewerPipeClient::RequestConsoleListTenants() {
     SendRequestToPipe(pipeClient, request.Release());
 }
 
-void TViewerPipeClient::RequestConsoleNodeConfigByTenant(TString tenant, ui64 cookie) {
-    TActorId pipeClient = ConnectTabletPipe(GetConsoleId());
-    auto request = MakeHolder<NConsole::TEvConsole::TEvGetNodeConfigRequest>();
-    request->Record.MutableNode()->SetTenant(tenant);
-    request->Record.AddItemKinds(static_cast<ui32>(NKikimrConsole::TConfigItem::FeatureFlagsItem));
-    SendRequestToPipe(pipeClient, request.Release(), cookie);
-}
-
 TViewerPipeClient::TRequestResponse<NConsole::TEvConsole::TEvListTenantsResponse> TViewerPipeClient::MakeRequestConsoleListTenants() {
     TActorId pipeClient = ConnectTabletPipe(GetConsoleId());
     THolder<NConsole::TEvConsole::TEvListTenantsRequest> request = MakeHolder<NConsole::TEvConsole::TEvListTenantsRequest>();
     return MakeRequestToPipe<NConsole::TEvConsole::TEvListTenantsResponse>(pipeClient, request.Release());
+}
+
+TViewerPipeClient::TRequestResponse<NConsole::TEvConsole::TEvGetNodeConfigResponse> TViewerPipeClient::MakeRequestConsoleNodeConfigByTenant(TString tenant, ui64 cookie) {
+    TActorId pipeClient = ConnectTabletPipe(GetConsoleId());
+    auto request = MakeHolder<NConsole::TEvConsole::TEvGetNodeConfigRequest>();
+    request->Record.MutableNode()->SetTenant(tenant);
+    request->Record.AddItemKinds(static_cast<ui32>(NKikimrConsole::TConfigItem::FeatureFlagsItem));
+    return MakeRequestToPipe<NConsole::TEvConsole::TEvGetNodeConfigResponse>(pipeClient, request.Release(), cookie);
 }
 
 void TViewerPipeClient::RequestConsoleGetTenantStatus(const TString& path) {

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -189,8 +189,8 @@ protected:
     TRequestResponse<TEvHive::TEvResponseHiveDomainStats> MakeRequestHiveDomainStats(TTabletId hiveId);
     TRequestResponse<TEvHive::TEvResponseHiveStorageStats> MakeRequestHiveStorageStats(TTabletId hiveId);
     void RequestConsoleListTenants();
-    void RequestConsoleNodeConfigByTenant(TString tenant, ui64 cookie = 0);
     TRequestResponse<NConsole::TEvConsole::TEvListTenantsResponse> MakeRequestConsoleListTenants();
+    TRequestResponse<NConsole::TEvConsole::TEvGetNodeConfigResponse> MakeRequestConsoleNodeConfigByTenant(TString tenant, ui64 cookie = 0);
     void RequestConsoleGetTenantStatus(const TString& path);
     TRequestResponse<NConsole::TEvConsole::TEvGetTenantStatusResponse> MakeRequestConsoleGetTenantStatus(const TString& path);
     void RequestBSControllerConfig();

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -189,6 +189,7 @@ protected:
     TRequestResponse<TEvHive::TEvResponseHiveDomainStats> MakeRequestHiveDomainStats(TTabletId hiveId);
     TRequestResponse<TEvHive::TEvResponseHiveStorageStats> MakeRequestHiveStorageStats(TTabletId hiveId);
     void RequestConsoleListTenants();
+    void RequestConsoleNodeConfigByTenant(TString tenant, ui64 cookie = 0);
     TRequestResponse<NConsole::TEvConsole::TEvListTenantsResponse> MakeRequestConsoleListTenants();
     void RequestConsoleGetTenantStatus(const TString& path);
     TRequestResponse<NConsole::TEvConsole::TEvGetTenantStatusResponse> MakeRequestConsoleGetTenantStatus(const TString& path);

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -724,12 +724,14 @@ message TFeatureFlagsConfig {
     message TFeatureFlag {
         string Name = 1;
         bool Enabled = 2;
+        bool IsDefault = 3;
     }
 
-    message TTenant {
+    message TDatabase {
         string Name = 1;
         repeated TFeatureFlag FeatureFlags = 2;
     }
 
-    repeated TTenant Tenants = 1;
+    uint32 Version = 1;
+    repeated TDatabase Databases = 2;
 }

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -719,3 +719,17 @@ message TPDiskInfo {
     TPDiskInfoWhiteboard Whiteboard = 1;
     TPDiskInfoBSC BSC = 2;
 }
+
+message TFeatureFlagsConfig {
+    message TFeatureFlag {
+        string Name = 1;
+        bool Enabled = 2;
+    }
+
+    message TTenant {
+        string Name = 1;
+        repeated TFeatureFlag FeatureFlags = 2;
+    }
+
+    repeated TTenant Tenants = 1;
+}

--- a/ydb/core/viewer/viewer_feature_flags.h
+++ b/ydb/core/viewer/viewer_feature_flags.h
@@ -1,0 +1,174 @@
+#pragma once
+
+namespace NKikimr::NViewer {
+
+using namespace NActors;
+
+class TJsonFeatureFlags : public TViewerPipeClient {
+    using TThis = TJsonFeatureFlags;
+    using TBase = TViewerPipeClient;
+    IViewer* Viewer;
+    NMon::TEvHttpInfo::TPtr Event;
+    TJsonSettings JsonSettings;
+    ui32 Timeout = 0;
+
+    TString Database;
+    NKikimrViewer::TFeatureFlagsConfig Result;
+    THashMap<ui64, TString> TenantsByCookie;
+    ui64 Cookie = 0;
+    TString DomainPath;
+    THashMap<TString, THashMap<TString, bool>> FeatureFlagsByTenant;
+
+public:
+    TJsonFeatureFlags(IViewer* viewer, NMon::TEvHttpInfo::TPtr &ev)
+        : Viewer(viewer)
+        , Event(ev)
+    {}
+
+    void MakeNodeConfigRequest(const TString& tenant) {
+        RequestConsoleNodeConfigByTenant(tenant, Cookie);
+        TenantsByCookie[Cookie++] = tenant;
+    }
+
+    void Bootstrap() override {
+        const auto& params(Event->Get()->Request.GetParams());
+
+        JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), true);
+        JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);
+        Database = params.Get("database");
+        Timeout = FromStringWithDefault<ui32>(params.Get("timeout"), 10000);
+
+        TIntrusivePtr<TDomainsInfo> domains = AppData()->DomainsInfo;
+        auto* domain = domains->GetDomain();
+        DomainPath = "/" + domain->Name;
+
+        MakeNodeConfigRequest(DomainPath);
+        if (!Database) {
+            RequestConsoleListTenants();
+        } else {
+            MakeNodeConfigRequest(Database);
+        }
+
+        Become(&TThis::StateWork, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
+    }
+
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NConsole::TEvConsole::TEvListTenantsResponse, Handle);
+            hFunc(NConsole::TEvConsole::TEvGetNodeConfigResponse, Handle);
+            cFunc(TEvents::TSystem::Wakeup, HandleTimeout);
+        }
+    }
+
+    void Handle(NConsole::TEvConsole::TEvListTenantsResponse::TPtr& ev) {
+        auto rec = ev->Release()->Record;
+
+        Ydb::Cms::ListDatabasesResult listTenantsResult;
+        rec.GetResponse().operation().result().UnpackTo(&listTenantsResult);
+        for (const TString& path : listTenantsResult.paths()) {
+            MakeNodeConfigRequest(path);
+        }
+
+        RequestDone();
+    }
+
+    void Handle(NConsole::TEvConsole::TEvGetNodeConfigResponse::TPtr& ev) {
+        TString tenant = TenantsByCookie[ev.Get()->Cookie];
+        NKikimrConsole::TGetNodeConfigResponse rec = ev->Release()->Record;
+        FeatureFlagsByTenant[tenant] = ParseFeatureFlags(rec.GetConfig().GetFeatureFlags());
+
+        RequestDone();
+    }
+
+    THashMap<TString, bool> ParseFeatureFlags(const NKikimrConfig::TFeatureFlags& featureFlags) {
+        THashMap<TString, bool> features;
+        const google::protobuf::Reflection* reflection = featureFlags.GetReflection();
+        const google::protobuf::Descriptor* descriptor = featureFlags.GetDescriptor();
+
+        for (int i = 0; i < descriptor->field_count(); ++i) {
+            const google::protobuf::FieldDescriptor* field = descriptor->field(i);
+            if (reflection->HasField(featureFlags, field) && field->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_BOOL) {
+                bool isEnabled = reflection->GetBool(featureFlags, field);
+                features[field->name()] = isEnabled;
+            }
+        }
+        return features;
+    }
+
+    void ReplyAndPassAway() override {
+        auto domainFeaturesIt = FeatureFlagsByTenant.find(DomainPath);
+        if (domainFeaturesIt == FeatureFlagsByTenant.end()) {
+            Send(Event->Sender, new NMon::TEvHttpInfoRes(Viewer->GetHTTPINTERNALERROR(Event->Get(), "text/plain", "No domain info from Console"), 0, NMon::IEvHttpInfoRes::EContentType::Custom));
+            PassAway();
+            return;
+        }
+
+        // remove features that are the same as in the domain
+        for (auto& [tenant, features] : FeatureFlagsByTenant) {
+            if (tenant != DomainPath) {
+                for (const auto& [name, enabled] : domainFeaturesIt->second) {
+                    auto featureIt = features.find(name);
+                    if (featureIt != features.end() && featureIt->second == enabled) {
+                        features.erase(name);
+                    }
+                }
+            }
+        }
+
+        // prepare response
+        for (const auto& [tenant, features] : FeatureFlagsByTenant) {
+            if (!Database || Database == tenant) {
+                auto tenantProto = Result.AddTenants();
+                tenantProto->SetName(tenant);
+                for (const auto& [name, enabled] : features) {
+                    auto flag = tenantProto->AddFeatureFlags();
+                    flag->SetName(name);
+                    flag->SetEnabled(enabled);
+                }
+            }
+        }
+
+        TStringStream json;
+        TProtoToJson::ProtoToJson(json, Result, JsonSettings);
+        Send(Event->Sender, new NMon::TEvHttpInfoRes(Viewer->GetHTTPOKJSON(Event->Get(), json.Str()), 0, NMon::IEvHttpInfoRes::EContentType::Custom));
+        PassAway();
+    }
+
+    void HandleTimeout() {
+        Send(Event->Sender, new NMon::TEvHttpInfoRes(Viewer->GetHTTPGATEWAYTIMEOUT(Event->Get()), 0, NMon::IEvHttpInfoRes::EContentType::Custom));
+        PassAway();
+    }
+
+    static YAML::Node GetSwagger() {
+        TSimpleYamlBuilder yaml({
+            .Method = "get",
+            .Tag = "viewer",
+            .Summary = "Feature flags",
+            .Description = "Returns feature flags of each database"
+        });
+        yaml.AddParameter({
+            .Name = "database",
+            .Description = "database name",
+            .Type = "string",
+        });
+        yaml.AddParameter({
+            .Name = "timeout",
+            .Description = "timeout in ms",
+            .Type = "integer",
+        });
+        yaml.AddParameter({
+            .Name = "enums",
+            .Description = "convert enums to strings",
+            .Type = "boolean",
+        });
+        yaml.AddParameter({
+            .Name = "ui64",
+            .Description = "return ui64 as number",
+            .Type = "boolean",
+        });
+        yaml.SetResponseSchema(TProtoToYaml::ProtoToYamlSchema<NKikimrViewer::TFeatureFlagsConfig>());
+        return yaml;
+    }
+};
+
+}

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1720,7 +1720,6 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
-        headers["X-Want-Trace"] = "1";
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoGet("/viewer/feature_flags?timeout=600000&base64=false", &responseStream, headers);
         const TString response = responseStream.ReadAll();
         UNIT_ASSERT_EQUAL_C(statusCode, HTTP_OK, statusCode << ": " << response);

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1706,9 +1706,6 @@ Y_UNIT_TEST_SUITE(Viewer) {
         ui16 monPort = tp.GetPort(8765);
         auto settings = TServerSettings(port);
 
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableVectorIndex(true);
-
         settings.InitKikimrRunConfig()
                 .SetNodeCount(1)
                 .SetUseRealThreads(true)
@@ -1723,13 +1720,14 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
+        headers["X-Want-Trace"] = "1";
         const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoGet("/viewer/feature_flags?timeout=600000&base64=false", &responseStream, headers);
         const TString response = responseStream.ReadAll();
         UNIT_ASSERT_EQUAL_C(statusCode, HTTP_OK, statusCode << ": " << response);
         NJson::TJsonReaderConfig jsonCfg;
         NJson::TJsonValue json;
         NJson::ReadJsonTree(response, &jsonCfg, &json, /* throwOnError = */ true);
-        auto resultSets = json["Tenants"].GetArray();
+        auto resultSets = json["Databases"].GetArray();
         UNIT_ASSERT_EQUAL_C(1, resultSets.size(), response);
     }
 }

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1698,4 +1698,38 @@ Y_UNIT_TEST_SUITE(Viewer) {
         UNIT_ASSERT_VALUES_EQUAL_C(ticketParser->AuthorizeTicketRequests, 1, response);
         UNIT_ASSERT_VALUES_EQUAL_C(ticketParser->AuthorizeTicketSuccesses, 1, response);
     }
+
+    Y_UNIT_TEST(SimpleFeatureFlags) {
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        ui16 monPort = tp.GetPort(8765);
+        auto settings = TServerSettings(port);
+
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+
+        settings.InitKikimrRunConfig()
+                .SetNodeCount(1)
+                .SetUseRealThreads(true)
+                .SetDomainName("Root")
+                .SetMonitoringPortOffset(monPort, true);
+
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+        TClient client(settings);
+
+        TKeepAliveHttpClient httpClient("localhost", monPort);
+        TStringStream responseStream;
+        TKeepAliveHttpClient::THeaders headers;
+        headers["Content-Type"] = "application/json";
+        const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoGet("/viewer/feature_flags?timeout=600000&base64=false", &responseStream, headers);
+        const TString response = responseStream.ReadAll();
+        UNIT_ASSERT_EQUAL_C(statusCode, HTTP_OK, statusCode << ": " << response);
+        NJson::TJsonReaderConfig jsonCfg;
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(response, &jsonCfg, &json, /* throwOnError = */ true);
+        auto resultSets = json["Tenants"].GetArray();
+        UNIT_ASSERT_EQUAL_C(1, resultSets.size(), response);
+    }
 }

--- a/ydb/core/viewer/ya.make
+++ b/ydb/core/viewer/ya.make
@@ -62,6 +62,7 @@ SRCS(
     viewer_describe_consumer.h
     viewer_describe.h
     viewer_describe_topic.h
+    viewer_feature_flags.h
     viewer_graph.h
     viewer_healthcheck.h
     viewer_helper.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

https://github.com/ydb-platform/ydb/issues/6822
add http-handle returning configs

filters: `database` and `features` parameters limit response

example Response  `/viewer/feature_flags?features=EnableTempTables,EnableStatistics`
```
{
  "Version": 1,
  "Databases": [
    {
      "Name": "/slice",
      "FeatureFlags": [
        {
          "Name": "EnableStatistics",
          "Enabled": true,
          "IsDefault": true
        },
        {
          "Name": "EnableTempTables"
        }
      ]
    },
    {
      "Name": "/slice/db",
      "FeatureFlags": [
        {
          "Name": "EnableStatistics",
          "Enabled": true,
          "IsDefault": true
        },
        {
          "Name": "EnableTempTables",
          "Enabled": true
        }
      ]
    }
  ]
}
```

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
