### PR TITLE
ydb_topic: Unmute BasicUsage.ConflictingWrites test

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -59,7 +59,6 @@ ydb/public/sdk/cpp/client/ydb_persqueue_public/ut RetryPolicy.TWriteSession_Test
 ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/with_offset_ranges_mode_ut [*/*]*
 ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/with_offset_ranges_mode_ut RetryPolicy.TWriteSession_TestBrokenPolicy
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*]*
-ydb/public/sdk/cpp/client/ydb_topic/ut BasicUsage.ConflictingWrites
 ydb/public/sdk/cpp/client/ydb_topic/ut BasicUsage.ReadSessionCorrectClose
 ydb/public/sdk/cpp/client/ydb_topic/ut BasicUsage.WriteRead
 ydb/public/sdk/cpp/client/ydb_topic/ut TSettingsValidation.TestDifferentDedupParams


### PR DESCRIPTION
The test works after https://github.com/ydb-platform/ydb/pull/5256.

It was temporarily broken by https://github.com/ydb-platform/ydb/pull/7682, that was reverted by https://github.com/ydb-platform/ydb/pull/7837.