### PR TITLE
ci: upgrade runner version and PyGitHub

### DIFF
--- a/ydb/ci/gh-runner-image/image.pkr.hcl
+++ b/ydb/ci/gh-runner-image/image.pkr.hcl
@@ -43,7 +43,7 @@ apt-get -y purge lxd-agent-loader snapd modemanager
 apt-get -y autoremove
 
 pip3 install conan==1.59 pytest==7.1.3 pytest-timeout pytest-xdist==3.3.1 setproctitle==1.3.2 \
-  grpcio grpcio-tools PyHamcrest tornado xmltodict pyarrow boto3 moto[server] psutil pygithub==1.59.1
+  grpcio grpcio-tools PyHamcrest tornado xmltodict pyarrow boto3 moto[server] psutil pygithub==2.3.0
 
 (CCACHE_VERSION=4.8.1 OS_ARCH=$(uname -m);
   curl -s -L https://github.com/ccache/ccache/releases/download/v$CCACHE_VERSION/ccache-$CCACHE_VERSION-linux-$OS_ARCH.tar.xz \

--- a/ydb/ci/gh-runner-image/ydbtech.pkr.hcl
+++ b/ydb/ci/gh-runner-image/ydbtech.pkr.hcl
@@ -15,5 +15,5 @@ variable "subnet_id" {
 
 variable "github_runner_version" {
   type = string
-  default = "2.318.0"
+  default = "2.319.1"
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Upgrade PyGithub to 2.3.0 (with default retrying enabled), and also upgrade github agent to the latest 2.319.1

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
