### PR TITLE
Fix pr_labels in case of empty description

### DIFF
--- a/.github/workflows/pr_labels.yaml
+++ b/.github/workflows/pr_labels.yaml
@@ -47,6 +47,7 @@ jobs:
               }
             }
             // add first encountered label
+            if (!description) return;
             for (let pair of mapping) {
               if (!description.includes(pair[0])) continue;
               // add label


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The bug was introduced in https://github.com/ydb-platform/ydb/pull/7043/files 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
