### PR TITLE
Change threshhold for postcommit open gate

### DIFF
--- a/.github/workflows/gate_postcommits.yml
+++ b/.github/workflows/gate_postcommits.yml
@@ -15,9 +15,8 @@ jobs:
         queue_size=$(curl -Ls -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/${{github.repository}}/actions/runs?per_page=1000\&page=1\&status=queued\&event=pull_request_target | \
           jq '[.workflow_runs[] | {name,status,id,updated_at,"waiting_seconds":(now - (.updated_at | fromdate)), html_url}]' | \
-          jq '[.[] | select(.waiting_seconds > 600)] | length')
+          jq '[.[] | select(.waiting_seconds > 60)] | length')
         echo "Queue size: $queue_size"
-        # temporary solution for https://www.githubstatus.com/incidents/m70hk23gx3nx (some workflows are uncancellable stuck)
         if (( queue_size > 0 ));then
           echo "Close gate for postcommits"
           query='.runners[] | select(.labels[].name=="ghrun") | select( any([.labels[].name][]; .=="postcommit")) | .id'
@@ -41,7 +40,6 @@ jobs:
         
         echo "$j1" | sed '$d' | jq "$query" | while read x;do
           echo "Runner: $x"
-          # temporary solution for https://www.githubstatus.com/incidents/m70hk23gx3nx (some workflows are uncancellable stuck)
           if (( queue_size > 0 ));then
             curl -Ls -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{secrets.GH_PERSONAL_ACCESS_TOKEN}}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

I saw problems with pr checks (they were in queue state, but postcommit gate was opened), and I think we have to reduce "waiting in queue" threshold  

also remove obsolete comments

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
