### PR TITLE
Introduce computation node for BlockMapJoinCore (LeftOnly and LeftSemi)

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -1,12 +1,295 @@
 #include "mkql_map_join.h"
 
-#include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
+#include <ydb/library/yql/minikql/computation/mkql_block_builder.h>
+#include <ydb/library/yql/minikql/computation/mkql_block_impl.h>
+#include <ydb/library/yql/minikql/computation/mkql_block_reader.h>
+#include <ydb/library/yql/minikql/computation/mkql_computation_node_holders_codegen.h>
+#include <ydb/library/yql/minikql/invoke_builtins/mkql_builtins.h>
 #include <ydb/library/yql/minikql/mkql_node_cast.h>
 #include <ydb/library/yql/minikql/mkql_program_builder.h>
 
 namespace NKikimr {
 namespace NMiniKQL {
 
+namespace {
+
+size_t CalcMaxBlockLength(const TVector<TType*>& items) {
+    return CalcBlockLen(std::accumulate(items.cbegin(), items.cend(), 0ULL,
+        [](size_t max, const TType* type) {
+            const TType* itemType = AS_TYPE(TBlockType, type)->GetItemType();
+            return std::max(max, CalcMaxBlockItemSize(itemType));
+        }));
+}
+
+
+class TBlockWideMapJoinWrapper : public TStatefulWideFlowComputationNode<TBlockWideMapJoinWrapper>
+{
+using TBaseComputation = TStatefulWideFlowComputationNode<TBlockWideMapJoinWrapper>;
+public:
+    TBlockWideMapJoinWrapper(TComputationMutables& mutables,
+        const TVector<TType*>&& resultJoinItems, const TVector<TType*>&& leftFlowItems,
+        TVector<ui32>&& leftKeyColumns,
+        IComputationWideFlowNode* flow, IComputationNode* dict)
+        : TBaseComputation(mutables, flow, EValueRepresentation::Boxed)
+        , ResultJoinItems_(std::move(resultJoinItems))
+        , LeftFlowItems_(std::move(leftFlowItems))
+        , LeftKeyColumns_(std::move(leftKeyColumns))
+        , Flow_(flow)
+        , Dict_(dict)
+        , WideFieldsIndex_(mutables.IncrementWideFieldsIndex(ResultJoinItems_.size()))
+    {}
+
+    EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
+        auto& s = GetState(state, ctx);
+        auto** fields = ctx.WideFields.data() + WideFieldsIndex_;
+        const auto dict = Dict_->GetValue(ctx);
+
+        do {
+            while (s.IsNotFull() && s.NextRow()) {
+                const auto key = MakeKeysTuple(ctx, s, LeftKeyColumns_);
+                if (key && dict.Contains(key) == true) {
+                    s.CopyRow();
+                }
+            }
+            if (!s.IsFinished()) {
+                switch (Flow_->FetchValues(ctx, fields)) {
+                case EFetchResult::Yield:
+                    return EFetchResult::Yield;
+                case EFetchResult::One:
+                    s.Reset();
+                    continue;
+                case EFetchResult::Finish:
+                    s.Finish();
+                    break;
+                }
+            }
+            // Leave the outer loop, if no values left in the flow.
+            Y_DEBUG_ABORT_UNLESS(s.IsFinished());
+            break;
+        } while (true);
+
+        if (s.IsEmpty()) {
+            return EFetchResult::Finish;
+        }
+        s.MakeBlocks();
+        const auto sliceSize = s.Slice();
+
+        for (size_t i = 0; i < ResultJoinItems_.size(); i++) {
+            if (const auto out = output[i]) {
+                *out = s.Get(sliceSize, ctx.HolderFactory, i);
+            }
+        }
+
+        return EFetchResult::One;
+    }
+
+private:
+    void RegisterDependencies() const final {
+        if (const auto flow = this->FlowDependsOn(Flow_)) {
+            this->DependsOn(flow, Dict_);
+        }
+    }
+
+    class TState : public TComputationValue<TState> {
+        using TBase = TComputationValue<TState>;
+        size_t Current_ = 0;
+        size_t Next_ = 0;
+        bool IsFinished_ = false;
+        size_t MaxLength_;
+        size_t BuilderAllocatedSize_ = 0;
+        size_t MaxBuilderAllocatedSize_ = 0;
+        static const size_t MaxAllocatedFactor_ = 4;
+        size_t InputRows_ = 0;
+        size_t OutputRows_ = 0;
+        size_t InputWidth_;
+        size_t OutputWidth_;
+        TUnboxedValueVector Inputs_;
+        const std::vector<arrow::ValueDescr> InputsDescr_;
+        TVector<std::deque<std::shared_ptr<arrow::ArrayData>>> Deques;
+        TVector<std::shared_ptr<arrow::ArrayData>> Arrays;
+        TVector<std::unique_ptr<IBlockReader>> Readers_;
+        TVector<std::unique_ptr<IBlockItemConverter>> Converters_;
+        TVector<std::unique_ptr<IArrayBuilder>> Builders_;
+
+    public:
+        TState(TMemoryUsageInfo* memInfo, TComputationContext& ctx,
+            const TVector<TType*>& inputItems, const TVector<TType*> outputItems,
+            NUdf::TUnboxedValue**const fields)
+            : TBase(memInfo)
+            , InputWidth_(inputItems.size() - 1)
+            , OutputWidth_(outputItems.size() - 1)
+            , Inputs_(inputItems.size())
+            , InputsDescr_(ToValueDescr(inputItems))
+            , Deques(OutputWidth_)
+            , Arrays(OutputWidth_)
+        {
+            const auto& pgBuilder = ctx.Builder->GetPgBuilder();
+            MaxLength_ = CalcMaxBlockLength(outputItems);
+            for (size_t i = 0; i < inputItems.size(); i++) {
+                fields[i] = &Inputs_[i];
+                const TType* blockItemType = AS_TYPE(TBlockType, inputItems[i])->GetItemType();
+                Readers_.push_back(MakeBlockReader(TTypeInfoHelper(), blockItemType));
+                Converters_.push_back(MakeBlockItemConverter(TTypeInfoHelper(), blockItemType, pgBuilder));
+            }
+            // The last output column (i.e. block length) doesn't require a block builder.
+            for (size_t i = 0; i < OutputWidth_; i++) {
+                const TType* blockItemType = AS_TYPE(TBlockType, outputItems[i])->GetItemType();
+                Builders_.push_back(MakeArrayBuilder(TTypeInfoHelper(), blockItemType, ctx.ArrowMemoryPool, MaxLength_, &pgBuilder, &BuilderAllocatedSize_));
+            }
+            MaxBuilderAllocatedSize_ = MaxAllocatedFactor_ * BuilderAllocatedSize_;
+        }
+
+        void Reset() {
+            Next_ = 0;
+            InputRows_ = GetBlockCount(Inputs_.back());
+        }
+
+        void Finish() {
+            IsFinished_ = true;
+        }
+
+        bool NextRow() {
+            if (Next_ >= InputRows_) {
+                return false;
+            }
+            Current_ = Next_++;
+            return true;
+        }
+
+        bool IsNotFull() {
+            return OutputRows_ < MaxLength_
+                && BuilderAllocatedSize_ <= MaxBuilderAllocatedSize_;
+        }
+
+        bool IsEmpty() {
+            return OutputRows_ == 0;
+        }
+
+        bool IsFinished() {
+            return IsFinished_;
+        }
+
+        TBlockItem GetItem(size_t idx) const {
+            const auto& datum = TArrowBlock::From(Inputs_[idx]).GetDatum();
+            ARROW_DEBUG_CHECK_DATUM_TYPES(InputsDescr_[idx], datum.descr());
+            if (datum.is_scalar()) {
+                return Readers_[idx]->GetScalarItem(*datum.scalar());
+            }
+            MKQL_ENSURE(datum.is_array(), "Expecting array");
+            return Readers_[idx]->GetItem(*datum.array(), Current_);
+        }
+
+        NUdf::TUnboxedValuePod GetValue(const THolderFactory& holderFactory, size_t idx) const {
+            return Converters_[idx]->MakeValue(GetItem(idx), holderFactory);
+        }
+
+        void AddValue(const NUdf::TUnboxedValuePod& value, size_t idx) {
+            Builders_[idx]->Add(value);
+        }
+
+        void AddItem(const TBlockItem& item, size_t idx) {
+            Builders_[idx]->Add(item);
+        }
+
+        void CopyRow() {
+            // Copy items from the "left" flow.
+            for (size_t i = 0; i < InputWidth_; i++) {
+                AddItem(GetItem(i), i);
+            }
+            OutputRows_++;
+        }
+
+        void CopyArray(size_t idx, size_t popCount, const ui8* sparseBitmap, size_t bitmapSize) {
+            const auto& datum = TArrowBlock::From(Inputs_[idx]).GetDatum();
+            Y_ENSURE(datum.is_array());
+            Builders_[idx]->AddMany(*datum.array(), popCount, sparseBitmap, bitmapSize);
+        }
+
+        void MakeBlocks() {
+            if (OutputRows_ == 0) {
+                return;
+            }
+            BuilderAllocatedSize_ = 0;
+
+            for (size_t i = 0; i < Builders_.size(); i++) {
+                const auto& datum = Builders_[i]->Build(IsFinished_);
+                Deques[i].clear();
+                MKQL_ENSURE(datum.is_arraylike(), "Unexpected block type (expecting array or chunked array)");
+                ForEachArrayData(datum, [this, i](const auto& arrayData) {
+                    Deques[i].push_back(arrayData);
+                });
+            }
+        }
+
+        ui64 Slice() {
+            auto sliceSize = OutputRows_;
+            for (size_t i = 0; i < Deques.size(); i++) {
+                const auto& arrays = Deques[i];
+                if (arrays.empty()) {
+                    continue;
+                }
+                Y_ABORT_UNLESS(ui64(arrays.front()->length) <= OutputRows_);
+                sliceSize = std::min<ui64>(sliceSize, arrays.front()->length);
+            }
+
+            for (size_t i = 0; i < Arrays.size(); i++) {
+                auto& arrays = Deques[i];
+                if (arrays.empty()) {
+                    continue;
+                }
+                if (auto& head = arrays.front(); ui64(head->length) == sliceSize) {
+                    Arrays[i] = std::move(head);
+                    arrays.pop_front();
+                } else {
+                    Arrays[i] = Chop(head, sliceSize);
+                }
+            }
+
+            OutputRows_ -= sliceSize;
+            return sliceSize;
+        }
+
+        NUdf::TUnboxedValuePod Get(const ui64 sliceSize, const THolderFactory& holderFactory, const size_t idx) const {
+            MKQL_ENSURE(idx <= OutputWidth_, "Deques index overflow");
+            // Return the slice length as the last column value (i.e. block length).
+            if (idx == OutputWidth_) {
+                return holderFactory.CreateArrowBlock(arrow::Datum(std::make_shared<arrow::UInt64Scalar>(sliceSize)));
+            }
+            if (auto array = Arrays[idx]) {
+                return holderFactory.CreateArrowBlock(std::move(array));
+            } else {
+                return NUdf::TUnboxedValuePod();
+            }
+        }
+
+    };
+
+    void MakeState(TComputationContext& ctx, NUdf::TUnboxedValue& state) const {
+        state = ctx.HolderFactory.Create<TState>(ctx, LeftFlowItems_, ResultJoinItems_, ctx.WideFields.data() + WideFieldsIndex_);
+    }
+
+    TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
+        if (!state.HasValue()) {
+            MakeState(ctx, state);
+        }
+        return *static_cast<TState*>(state.AsBoxed().Get());
+    }
+
+    NUdf::TUnboxedValue MakeKeysTuple(const TComputationContext& ctx, const TState& state, const TVector<ui32>& keyColumns) const {
+        // TODO: Handle complex key.
+        // TODO: Handle converters.
+        return state.GetValue(ctx.HolderFactory, keyColumns.front());
+    }
+
+    const TVector<TType*> ResultJoinItems_;
+    const TVector<TType*> LeftFlowItems_;
+    const TVector<ui32> LeftKeyColumns_;
+    IComputationWideFlowNode* const Flow_;
+    IComputationNode* const Dict_;
+    ui32 WideFieldsIndex_;
+};
+
+} // namespace
 
 IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
     MKQL_ENSURE(callable.GetInputsCount() == 4, "Expected 4 args");
@@ -18,6 +301,7 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
                 "Expected Multi as a resulting item type");
     const auto joinComponents = GetWideComponents(joinFlowType);
     MKQL_ENSURE(joinComponents.size() > 0, "Expected at least one column");
+    const TVector<TType*> joinItems(joinComponents.cbegin(), joinComponents.cend());
 
     const auto leftFlowNode = callable.GetInput(0);
     MKQL_ENSURE(leftFlowNode.GetStaticType()->IsFlow(),
@@ -27,15 +311,13 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
                 "Expected Multi as a left stream item type");
     const auto leftFlowComponents = GetWideComponents(leftFlowType);
     MKQL_ENSURE(leftFlowComponents.size() > 0, "Expected at least one column");
-
-    const auto rightDictNode = callable.GetInput(1);
-    const auto rightDictType = AS_TYPE(TDictType, rightDictNode);
+    const TVector<TType*> leftFlowItems(leftFlowComponents.cbegin(), leftFlowComponents.cend());
 
     const auto joinKindNode = callable.GetInput(2);
     const auto rawKind = AS_VALUE(TDataLiteral, joinKindNode)->AsValue().Get<ui32>();
-    const auto kind = GetJoinKind(rawKind);
+    const auto joinKind = GetJoinKind(rawKind);
     // TODO: Handle other join types.
-    Y_ENSURE(kind == EJoinKind::LeftSemi);
+    Y_ENSURE(joinKind == EJoinKind::LeftSemi);
 
     const auto tupleLiteral = AS_VALUE(TTupleLiteral, callable.GetInput(3));
     TVector<ui32> leftKeyColumns;
@@ -49,11 +331,10 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
 
     const auto flow = LocateNode(ctx.NodeLocator, callable, 0);
     const auto dict = LocateNode(ctx.NodeLocator, callable, 1);
-    Y_UNUSED(dictType);
-    Y_UNUSED(leftKeyColumns);
-    Y_UNUSED(flow);
-    Y_UNUSED(dict);
-    return nullptr;
+
+    return new TBlockWideMapJoinWrapper(ctx.Mutables, std::move(joinItems),
+        std::move(leftFlowItems), std::move(leftKeyColumns),
+        static_cast<IComputationWideFlowNode*>(flow), dict);
 }
 
 } // namespace NMiniKQL

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -1,0 +1,60 @@
+#include "mkql_map_join.h"
+
+#include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
+#include <ydb/library/yql/minikql/mkql_node_cast.h>
+#include <ydb/library/yql/minikql/mkql_program_builder.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+
+IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    MKQL_ENSURE(callable.GetInputsCount() == 4, "Expected 4 args");
+
+    const auto joinType = callable.GetType()->GetReturnType();
+    MKQL_ENSURE(joinType->IsFlow(), "Expected WideFlow as a resulting stream");
+    const auto joinFlowType = AS_TYPE(TFlowType, joinType);
+    MKQL_ENSURE(joinFlowType->GetItemType()->IsMulti(),
+                "Expected Multi as a resulting item type");
+    const auto joinComponents = GetWideComponents(joinFlowType);
+    MKQL_ENSURE(joinComponents.size() > 0, "Expected at least one column");
+
+    const auto leftFlowNode = callable.GetInput(0);
+    MKQL_ENSURE(leftFlowNode.GetStaticType()->IsFlow(),
+                "Expected WideFlow as a left stream");
+    const auto leftFlowType = AS_TYPE(TFlowType, leftFlowNode);
+    MKQL_ENSURE(leftFlowType->GetItemType()->IsMulti(),
+                "Expected Multi as a left stream item type");
+    const auto leftFlowComponents = GetWideComponents(leftFlowType);
+    MKQL_ENSURE(leftFlowComponents.size() > 0, "Expected at least one column");
+
+    const auto rightDictNode = callable.GetInput(1);
+    const auto rightDictType = AS_TYPE(TDictType, rightDictNode);
+
+    const auto joinKindNode = callable.GetInput(2);
+    const auto rawKind = AS_VALUE(TDataLiteral, joinKindNode)->AsValue().Get<ui32>();
+    const auto kind = GetJoinKind(rawKind);
+    // TODO: Handle other join types.
+    Y_ENSURE(kind == EJoinKind::LeftSemi);
+
+    const auto tupleLiteral = AS_VALUE(TTupleLiteral, callable.GetInput(3));
+    TVector<ui32> leftKeyColumns;
+    leftKeyColumns.reserve(tupleLiteral->GetValuesCount());
+    for (ui32 i = 0; i < tupleLiteral->GetValuesCount(); i++) {
+        const auto item = AS_VALUE(TDataLiteral, tupleLiteral->GetValue(i));
+        leftKeyColumns.emplace_back(item->AsValue().Get<ui32>());
+    }
+    // TODO: Handle multi keys.
+    Y_ENSURE(leftKeyColumns.size() == 1);
+
+    const auto flow = LocateNode(ctx.NodeLocator, callable, 0);
+    const auto dict = LocateNode(ctx.NodeLocator, callable, 1);
+    Y_UNUSED(dictType);
+    Y_UNUSED(leftKeyColumns);
+    Y_UNUSED(flow);
+    Y_UNUSED(dict);
+    return nullptr;
+}
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <ydb/library/yql/minikql/computation/mkql_computation_node.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+} // NKikimr
+} // NMiniKQL

--- a/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_factory.cpp
@@ -14,6 +14,7 @@
 #include "mkql_block_if.h"
 #include "mkql_block_just.h"
 #include "mkql_block_logical.h"
+#include "mkql_block_map_join.h"
 #include "mkql_block_compress.h"
 #include "mkql_block_skiptake.h"
 #include "mkql_block_top.h"
@@ -309,6 +310,7 @@ struct TCallableComputationNodeBuilderFuncMapFiller {
         {"BlockMergeFinalizeHashed", &WrapBlockMergeFinalizeHashed},
         {"BlockMergeManyFinalizeHashed", &WrapBlockMergeManyFinalizeHashed},
         {"ScalarApply", &WrapScalarApply},
+        {"BlockMapJoinCore", &WrapBlockMapJoinCore},
         {"MakeHeap", &WrapMakeHeap},
         {"PushHeap", &WrapPushHeap},
         {"PopHeap", &WrapPopHeap},

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -73,7 +73,7 @@ namespace {
             });
 
         const auto keyList = pgmBuilder.NewList(keyType, keyListItems);
-        return pgmBuilder.ToSortedDict(keyList, false,
+        return pgmBuilder.ToHashedDict(keyList, false,
             [&](TRuntimeNode item) {
                 return item;
             }, [&](TRuntimeNode) {

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -1,0 +1,201 @@
+#include "mkql_computation_node_ut.h"
+
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/compute/kernel.h>
+#include <ydb/library/yql/minikql/computation/mkql_block_builder.h>
+#include <ydb/library/yql/minikql/computation/mkql_block_impl.h>
+#include <ydb/library/yql/minikql/computation/mkql_computation_node_holders.h>
+#include <ydb/library/yql/minikql/mkql_node_cast.h>
+#include <ydb/library/yql/public/udf/arrow/udf_arrow_helpers.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+namespace {
+    TMap<const TString, ui64> NameToIndex(const TStructType* structType) {
+        TMap<const TString, ui64> map;
+        for (size_t i = 0; i < structType->GetMembersCount(); i++) {
+            const TString name(structType->GetMemberName(i));
+            map[name] = i;
+        }
+        return map;
+    }
+
+    TVector<TString> GeneratePayload(size_t level) {
+        constexpr size_t alphaSize = 'Z' - 'A' + 1;
+        if (level == 1) {
+            TVector<TString> alphabet(alphaSize);
+            std::iota(alphabet.begin(), alphabet.end(), 'A');
+            return alphabet;
+        }
+        const auto subPayload = GeneratePayload(level - 1);
+        TVector<TString> payload;
+        payload.reserve(alphaSize * subPayload.size());
+        for (char ch = 'A'; ch <= 'Z'; ch++) {
+            for (const auto& tail : subPayload) {
+                payload.emplace_back(ch + tail);
+            }
+        }
+        return payload;
+    }
+
+    constexpr size_t payloadSize = 2;
+    static const TVector<TString> twoLetterPayloads = GeneratePayload(payloadSize);
+
+    template <typename T, bool isOptional = false>
+    const TRuntimeNode MakeSimpleKey(
+        TProgramBuilder& pgmBuilder,
+        T value,
+        bool isEmpty = false
+    ) {
+        if constexpr (!isOptional) {
+            return pgmBuilder.NewDataLiteral<T>(value);
+        }
+        const auto keyType = pgmBuilder.NewDataType(NUdf::TDataType<T>::Id, true);
+        if (isEmpty) {
+            return pgmBuilder.NewEmptyOptional(keyType);
+        }
+        return pgmBuilder.NewOptional(pgmBuilder.NewDataLiteral<T>(value));
+    }
+
+    template <typename TKey>
+    const TRuntimeNode MakeSet(
+        TProgramBuilder& pgmBuilder,
+        const TVector<TKey>& keyValues
+    ) {
+        const auto keyType = pgmBuilder.NewDataType(NUdf::TDataType<TKey>::Id);
+
+        TRuntimeNode::TList keyListItems;
+        std::transform(keyValues.cbegin(), keyValues.cend(),
+            std::back_inserter(keyListItems), [&pgmBuilder](const auto key) {
+                return pgmBuilder.NewDataLiteral<TKey>(key);
+            });
+
+        const auto keyList = pgmBuilder.NewList(keyType, keyListItems);
+        return pgmBuilder.ToSortedDict(keyList, false,
+            [&](TRuntimeNode item) {
+                return item;
+            }, [&](TRuntimeNode) {
+                return pgmBuilder.NewVoid();
+            });
+    }
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinTest) {
+    Y_UNIT_TEST(TestLeftSemiOnUint64) {
+        TSetup<false> setup;
+        TProgramBuilder& pb = *setup.PgmBuilder;
+
+        const TVector<ui64> dictKeys = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144};
+        const auto dict = MakeSet(pb, dictKeys);
+
+        const auto ui64Type = pb.NewDataType(NUdf::TDataType<ui64>::Id);
+        const auto strType = pb.NewDataType(NUdf::TDataType<char*>::Id);
+        const auto ui64BlockType = pb.NewBlockType(ui64Type, TBlockType::EShape::Many);
+        const auto strBlockType = pb.NewBlockType(strType, TBlockType::EShape::Many);
+        const auto blockLenType = pb.NewBlockType(ui64Type, TBlockType::EShape::Scalar);
+        const auto structType = pb.NewStructType({
+            {"key", ui64BlockType},
+            {"subkey", ui64BlockType},
+            {"payload", strBlockType},
+            {"_yql_block_length", blockLenType}
+        });
+        const auto fields = NameToIndex(AS_TYPE(TStructType, structType));
+        const auto listStructType = pb.NewListType(structType);
+
+        const auto leftArg = pb.Arg(listStructType);
+
+        const auto leftWideFlow = pb.ExpandMap(pb.ToFlow(leftArg),
+            [&](TRuntimeNode item) -> TRuntimeNode::TList {
+                return {
+                    pb.Member(item, "key"),
+                    pb.Member(item, "subkey"),
+                    pb.Member(item, "payload"),
+                    pb.Member(item, "_yql_block_length")
+                };
+            });
+
+        const auto joinNode = pb.BlockMapJoinCore(leftWideFlow, dict,
+            EJoinKind::LeftSemi, {0});
+
+        const auto rootNode = pb.Collect(pb.NarrowMap(joinNode,
+            [&](TRuntimeNode::TList items) -> TRuntimeNode {
+                return pb.NewStruct(structType, {
+                    {"key", items[0]},
+                    {"subkey", items[1]},
+                    {"payload", items[2]},
+                    {"_yql_block_length", items[3]}
+                });
+            }));
+
+        const auto graph = setup.BuildGraph(rootNode, {leftArg.GetNode()});
+        const auto& leftBlocks = graph->GetEntryPoint(0, true);
+        const auto& holderFactory = graph->GetHolderFactory();
+        auto& ctx = graph->GetContext();
+
+        constexpr size_t testSize = 256;
+        TVector<ui64> keys(testSize);
+        TVector<ui64> subkeys;
+        std::iota(keys.begin(), keys.end(), 1);
+        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(subkeys),
+            [](const auto& value) { return value * 1001; });
+
+        TVector<const char*> payloads;
+        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(payloads),
+            [](const auto& value) { return twoLetterPayloads[value].c_str(); });
+
+        const size_t blockSize = 64;
+        size_t current = 0;
+        TDefaultListRepresentation leftListValues;
+        while (current < testSize) {
+            arrow::UInt64Builder keysBuilder(&ctx.ArrowMemoryPool);
+            arrow::UInt64Builder subkeysBuilder(&ctx.ArrowMemoryPool);
+            arrow::BinaryBuilder payloadsBuilder(&ctx.ArrowMemoryPool);
+            ARROW_OK(keysBuilder.Reserve(blockSize));
+            ARROW_OK(subkeysBuilder.Reserve(blockSize));
+            ARROW_OK(payloadsBuilder.Reserve(blockSize));
+            for (size_t i = 0; i < blockSize; i++, current++) {
+                keysBuilder.UnsafeAppend(keys[current]);
+                subkeysBuilder.UnsafeAppend(subkeys[current]);
+                ARROW_OK(payloadsBuilder.Append(payloads[current], payloadSize));
+            }
+            std::shared_ptr<arrow::ArrayData> keysData;
+            ARROW_OK(keysBuilder.FinishInternal(&keysData));
+            std::shared_ptr<arrow::ArrayData> subkeysData;
+            ARROW_OK(subkeysBuilder.FinishInternal(&subkeysData));
+            std::shared_ptr<arrow::ArrayData> payloadsData;
+            ARROW_OK(payloadsBuilder.FinishInternal(&payloadsData));
+
+            NUdf::TUnboxedValue* items = nullptr;
+            const auto structObj = holderFactory.CreateDirectArrayHolder(fields.size(), items);
+            items[fields.at("key")] = holderFactory.CreateArrowBlock(keysData);
+            items[fields.at("subkey")] = holderFactory.CreateArrowBlock(subkeysData);
+            items[fields.at("payload")] = holderFactory.CreateArrowBlock(payloadsData);
+            items[fields.at("_yql_block_length")] = MakeBlockCount(holderFactory, blockSize);
+            leftListValues = leftListValues.Append(std::move(structObj));
+        }
+        leftBlocks->SetValue(ctx, holderFactory.CreateDirectListHolder(std::move(leftListValues)));
+        const auto joinIterator = graph->GetValue().GetListIterator();
+
+        NUdf::TUnboxedValue item;
+        TVector<NUdf::TUnboxedValue> joinResult;
+        while (joinIterator.Next(item)) {
+            joinResult.push_back(item);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(joinResult.size(), 1);
+        const auto blocks = joinResult.front();
+        const auto blockLengthValue = blocks.GetElement(fields.at("_yql_block_length"));
+        const auto blockLengthDatum = TArrowBlock::From(blockLengthValue).GetDatum();
+        UNIT_ASSERT(blockLengthDatum.is_scalar());
+        const auto blockLength = blockLengthDatum.scalar_as<arrow::UInt64Scalar>().value;
+        const auto dictSize = std::count_if(dictKeys.cbegin(), dictKeys.cend(),
+            [](ui64 key) { return key < testSize; });
+        UNIT_ASSERT_VALUES_EQUAL(dictSize, blockLength);
+    }
+} // Y_UNIT_TEST_SUITE
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -195,6 +195,118 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinTest) {
             [](ui64 key) { return key < testSize; });
         UNIT_ASSERT_VALUES_EQUAL(dictSize, blockLength);
     }
+
+    Y_UNIT_TEST(TestLeftOnlyOnUint64) {
+        TSetup<false> setup;
+        TProgramBuilder& pb = *setup.PgmBuilder;
+
+        const TVector<ui64> dictKeys = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144};
+        const auto dict = MakeSet(pb, dictKeys);
+
+        const auto ui64Type = pb.NewDataType(NUdf::TDataType<ui64>::Id);
+        const auto strType = pb.NewDataType(NUdf::TDataType<char*>::Id);
+        const auto ui64BlockType = pb.NewBlockType(ui64Type, TBlockType::EShape::Many);
+        const auto strBlockType = pb.NewBlockType(strType, TBlockType::EShape::Many);
+        const auto blockLenType = pb.NewBlockType(ui64Type, TBlockType::EShape::Scalar);
+        const auto structType = pb.NewStructType({
+            {"key", ui64BlockType},
+            {"subkey", ui64BlockType},
+            {"payload", strBlockType},
+            {"_yql_block_length", blockLenType}
+        });
+        const auto fields = NameToIndex(AS_TYPE(TStructType, structType));
+        const auto listStructType = pb.NewListType(structType);
+
+        const auto leftArg = pb.Arg(listStructType);
+
+        const auto leftWideFlow = pb.ExpandMap(pb.ToFlow(leftArg),
+            [&](TRuntimeNode item) -> TRuntimeNode::TList {
+                return {
+                    pb.Member(item, "key"),
+                    pb.Member(item, "subkey"),
+                    pb.Member(item, "payload"),
+                    pb.Member(item, "_yql_block_length")
+                };
+            });
+
+        const auto joinNode = pb.BlockMapJoinCore(leftWideFlow, dict,
+            EJoinKind::LeftOnly, {0});
+
+        const auto rootNode = pb.Collect(pb.NarrowMap(joinNode,
+            [&](TRuntimeNode::TList items) -> TRuntimeNode {
+                return pb.NewStruct(structType, {
+                    {"key", items[0]},
+                    {"subkey", items[1]},
+                    {"payload", items[2]},
+                    {"_yql_block_length", items[3]}
+                });
+            }));
+
+        const auto graph = setup.BuildGraph(rootNode, {leftArg.GetNode()});
+        const auto& leftBlocks = graph->GetEntryPoint(0, true);
+        const auto& holderFactory = graph->GetHolderFactory();
+        auto& ctx = graph->GetContext();
+
+        constexpr size_t testSize = 256;
+        TVector<ui64> keys(testSize);
+        TVector<ui64> subkeys;
+        std::iota(keys.begin(), keys.end(), 1);
+        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(subkeys),
+            [](const auto& value) { return value * 1001; });
+
+        TVector<const char*> payloads;
+        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(payloads),
+            [](const auto& value) { return twoLetterPayloads[value].c_str(); });
+
+        const size_t blockSize = 64;
+        size_t current = 0;
+        TDefaultListRepresentation leftListValues;
+        while (current < testSize) {
+            arrow::UInt64Builder keysBuilder(&ctx.ArrowMemoryPool);
+            arrow::UInt64Builder subkeysBuilder(&ctx.ArrowMemoryPool);
+            arrow::BinaryBuilder payloadsBuilder(&ctx.ArrowMemoryPool);
+            ARROW_OK(keysBuilder.Reserve(blockSize));
+            ARROW_OK(subkeysBuilder.Reserve(blockSize));
+            ARROW_OK(payloadsBuilder.Reserve(blockSize));
+            for (size_t i = 0; i < blockSize; i++, current++) {
+                keysBuilder.UnsafeAppend(keys[current]);
+                subkeysBuilder.UnsafeAppend(subkeys[current]);
+                ARROW_OK(payloadsBuilder.Append(payloads[current], payloadSize));
+            }
+            std::shared_ptr<arrow::ArrayData> keysData;
+            ARROW_OK(keysBuilder.FinishInternal(&keysData));
+            std::shared_ptr<arrow::ArrayData> subkeysData;
+            ARROW_OK(subkeysBuilder.FinishInternal(&subkeysData));
+            std::shared_ptr<arrow::ArrayData> payloadsData;
+            ARROW_OK(payloadsBuilder.FinishInternal(&payloadsData));
+
+            NUdf::TUnboxedValue* items = nullptr;
+            const auto structObj = holderFactory.CreateDirectArrayHolder(fields.size(), items);
+            items[fields.at("key")] = holderFactory.CreateArrowBlock(keysData);
+            items[fields.at("subkey")] = holderFactory.CreateArrowBlock(subkeysData);
+            items[fields.at("payload")] = holderFactory.CreateArrowBlock(payloadsData);
+            items[fields.at("_yql_block_length")] = MakeBlockCount(holderFactory, blockSize);
+            leftListValues = leftListValues.Append(std::move(structObj));
+        }
+        leftBlocks->SetValue(ctx, holderFactory.CreateDirectListHolder(std::move(leftListValues)));
+        const auto joinIterator = graph->GetValue().GetListIterator();
+
+        NUdf::TUnboxedValue item;
+        TVector<NUdf::TUnboxedValue> joinResult;
+        while (joinIterator.Next(item)) {
+            joinResult.push_back(item);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(joinResult.size(), 1);
+        const auto blocks = joinResult.front();
+        const auto blockLengthValue = blocks.GetElement(fields.at("_yql_block_length"));
+        const auto blockLengthDatum = TArrowBlock::From(blockLengthValue).GetDatum();
+        UNIT_ASSERT(blockLengthDatum.is_scalar());
+        const auto blockLength = blockLengthDatum.scalar_as<arrow::UInt64Scalar>().value;
+        const auto dictSize = std::count_if(dictKeys.cbegin(), dictKeys.cend(),
+            [](ui64 key) { return key < testSize; });
+        UNIT_ASSERT_VALUES_EQUAL(testSize - dictSize, blockLength);
+    }
 } // Y_UNIT_TEST_SUITE
 
 } // namespace NMiniKQL

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -81,231 +81,128 @@ namespace {
             });
     }
 
+    void TestBlockJoinOnUint64(EJoinKind joinKind) {
+        TSetup<false> setup;
+        TProgramBuilder& pb = *setup.PgmBuilder;
+
+        const TVector<ui64> dictKeys = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144};
+        const auto dict = MakeSet(pb, dictKeys);
+
+        const auto ui64Type = pb.NewDataType(NUdf::TDataType<ui64>::Id);
+        const auto strType = pb.NewDataType(NUdf::TDataType<char*>::Id);
+        const auto ui64BlockType = pb.NewBlockType(ui64Type, TBlockType::EShape::Many);
+        const auto strBlockType = pb.NewBlockType(strType, TBlockType::EShape::Many);
+        const auto blockLenType = pb.NewBlockType(ui64Type, TBlockType::EShape::Scalar);
+        const auto structType = pb.NewStructType({
+            {"key", ui64BlockType},
+            {"subkey", ui64BlockType},
+            {"payload", strBlockType},
+            {"_yql_block_length", blockLenType}
+        });
+        const auto fields = NameToIndex(AS_TYPE(TStructType, structType));
+        const auto listStructType = pb.NewListType(structType);
+
+        const auto leftArg = pb.Arg(listStructType);
+
+        const auto leftWideFlow = pb.ExpandMap(pb.ToFlow(leftArg),
+            [&](TRuntimeNode item) -> TRuntimeNode::TList {
+                return {
+                    pb.Member(item, "key"),
+                    pb.Member(item, "subkey"),
+                    pb.Member(item, "payload"),
+                    pb.Member(item, "_yql_block_length")
+                };
+            });
+
+        const auto joinNode = pb.BlockMapJoinCore(leftWideFlow, dict, joinKind, {0});
+
+        const auto rootNode = pb.Collect(pb.NarrowMap(joinNode,
+            [&](TRuntimeNode::TList items) -> TRuntimeNode {
+                return pb.NewStruct(structType, {
+                    {"key", items[0]},
+                    {"subkey", items[1]},
+                    {"payload", items[2]},
+                    {"_yql_block_length", items[3]}
+                });
+            }));
+
+        const auto graph = setup.BuildGraph(rootNode, {leftArg.GetNode()});
+        const auto& leftBlocks = graph->GetEntryPoint(0, true);
+        const auto& holderFactory = graph->GetHolderFactory();
+        auto& ctx = graph->GetContext();
+
+        constexpr size_t testSize = 256;
+        TVector<ui64> keys(testSize);
+        TVector<ui64> subkeys;
+        std::iota(keys.begin(), keys.end(), 1);
+        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(subkeys),
+            [](const auto& value) { return value * 1001; });
+
+        TVector<const char*> payloads;
+        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(payloads),
+            [](const auto& value) { return twoLetterPayloads[value].c_str(); });
+
+        const size_t blockSize = 64;
+        size_t current = 0;
+        TDefaultListRepresentation leftListValues;
+        while (current < testSize) {
+            arrow::UInt64Builder keysBuilder(&ctx.ArrowMemoryPool);
+            arrow::UInt64Builder subkeysBuilder(&ctx.ArrowMemoryPool);
+            arrow::BinaryBuilder payloadsBuilder(&ctx.ArrowMemoryPool);
+            ARROW_OK(keysBuilder.Reserve(blockSize));
+            ARROW_OK(subkeysBuilder.Reserve(blockSize));
+            ARROW_OK(payloadsBuilder.Reserve(blockSize));
+            for (size_t i = 0; i < blockSize; i++, current++) {
+                keysBuilder.UnsafeAppend(keys[current]);
+                subkeysBuilder.UnsafeAppend(subkeys[current]);
+                ARROW_OK(payloadsBuilder.Append(payloads[current], payloadSize));
+            }
+            std::shared_ptr<arrow::ArrayData> keysData;
+            ARROW_OK(keysBuilder.FinishInternal(&keysData));
+            std::shared_ptr<arrow::ArrayData> subkeysData;
+            ARROW_OK(subkeysBuilder.FinishInternal(&subkeysData));
+            std::shared_ptr<arrow::ArrayData> payloadsData;
+            ARROW_OK(payloadsBuilder.FinishInternal(&payloadsData));
+
+            NUdf::TUnboxedValue* items = nullptr;
+            const auto structObj = holderFactory.CreateDirectArrayHolder(fields.size(), items);
+            items[fields.at("key")] = holderFactory.CreateArrowBlock(keysData);
+            items[fields.at("subkey")] = holderFactory.CreateArrowBlock(subkeysData);
+            items[fields.at("payload")] = holderFactory.CreateArrowBlock(payloadsData);
+            items[fields.at("_yql_block_length")] = MakeBlockCount(holderFactory, blockSize);
+            leftListValues = leftListValues.Append(std::move(structObj));
+        }
+        leftBlocks->SetValue(ctx, holderFactory.CreateDirectListHolder(std::move(leftListValues)));
+        const auto joinIterator = graph->GetValue().GetListIterator();
+
+        NUdf::TUnboxedValue item;
+        TVector<NUdf::TUnboxedValue> joinResult;
+        while (joinIterator.Next(item)) {
+            joinResult.push_back(item);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(joinResult.size(), 1);
+        const auto blocks = joinResult.front();
+        const auto blockLengthValue = blocks.GetElement(fields.at("_yql_block_length"));
+        const auto blockLengthDatum = TArrowBlock::From(blockLengthValue).GetDatum();
+        UNIT_ASSERT(blockLengthDatum.is_scalar());
+        const auto blockLength = blockLengthDatum.scalar_as<arrow::UInt64Scalar>().value;
+        const auto dictSize = std::count_if(dictKeys.cbegin(), dictKeys.cend(),
+            [](ui64 key) { return key < testSize; });
+        const auto expectedLength = joinKind == EJoinKind::LeftSemi ? dictSize
+                                  : joinKind == EJoinKind::LeftOnly ? testSize - dictSize
+                                  : -1;
+        UNIT_ASSERT_VALUES_EQUAL(expectedLength, blockLength);
+    }
 } // namespace
 
 Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinTest) {
     Y_UNIT_TEST(TestLeftSemiOnUint64) {
-        TSetup<false> setup;
-        TProgramBuilder& pb = *setup.PgmBuilder;
-
-        const TVector<ui64> dictKeys = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144};
-        const auto dict = MakeSet(pb, dictKeys);
-
-        const auto ui64Type = pb.NewDataType(NUdf::TDataType<ui64>::Id);
-        const auto strType = pb.NewDataType(NUdf::TDataType<char*>::Id);
-        const auto ui64BlockType = pb.NewBlockType(ui64Type, TBlockType::EShape::Many);
-        const auto strBlockType = pb.NewBlockType(strType, TBlockType::EShape::Many);
-        const auto blockLenType = pb.NewBlockType(ui64Type, TBlockType::EShape::Scalar);
-        const auto structType = pb.NewStructType({
-            {"key", ui64BlockType},
-            {"subkey", ui64BlockType},
-            {"payload", strBlockType},
-            {"_yql_block_length", blockLenType}
-        });
-        const auto fields = NameToIndex(AS_TYPE(TStructType, structType));
-        const auto listStructType = pb.NewListType(structType);
-
-        const auto leftArg = pb.Arg(listStructType);
-
-        const auto leftWideFlow = pb.ExpandMap(pb.ToFlow(leftArg),
-            [&](TRuntimeNode item) -> TRuntimeNode::TList {
-                return {
-                    pb.Member(item, "key"),
-                    pb.Member(item, "subkey"),
-                    pb.Member(item, "payload"),
-                    pb.Member(item, "_yql_block_length")
-                };
-            });
-
-        const auto joinNode = pb.BlockMapJoinCore(leftWideFlow, dict,
-            EJoinKind::LeftSemi, {0});
-
-        const auto rootNode = pb.Collect(pb.NarrowMap(joinNode,
-            [&](TRuntimeNode::TList items) -> TRuntimeNode {
-                return pb.NewStruct(structType, {
-                    {"key", items[0]},
-                    {"subkey", items[1]},
-                    {"payload", items[2]},
-                    {"_yql_block_length", items[3]}
-                });
-            }));
-
-        const auto graph = setup.BuildGraph(rootNode, {leftArg.GetNode()});
-        const auto& leftBlocks = graph->GetEntryPoint(0, true);
-        const auto& holderFactory = graph->GetHolderFactory();
-        auto& ctx = graph->GetContext();
-
-        constexpr size_t testSize = 256;
-        TVector<ui64> keys(testSize);
-        TVector<ui64> subkeys;
-        std::iota(keys.begin(), keys.end(), 1);
-        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(subkeys),
-            [](const auto& value) { return value * 1001; });
-
-        TVector<const char*> payloads;
-        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(payloads),
-            [](const auto& value) { return twoLetterPayloads[value].c_str(); });
-
-        const size_t blockSize = 64;
-        size_t current = 0;
-        TDefaultListRepresentation leftListValues;
-        while (current < testSize) {
-            arrow::UInt64Builder keysBuilder(&ctx.ArrowMemoryPool);
-            arrow::UInt64Builder subkeysBuilder(&ctx.ArrowMemoryPool);
-            arrow::BinaryBuilder payloadsBuilder(&ctx.ArrowMemoryPool);
-            ARROW_OK(keysBuilder.Reserve(blockSize));
-            ARROW_OK(subkeysBuilder.Reserve(blockSize));
-            ARROW_OK(payloadsBuilder.Reserve(blockSize));
-            for (size_t i = 0; i < blockSize; i++, current++) {
-                keysBuilder.UnsafeAppend(keys[current]);
-                subkeysBuilder.UnsafeAppend(subkeys[current]);
-                ARROW_OK(payloadsBuilder.Append(payloads[current], payloadSize));
-            }
-            std::shared_ptr<arrow::ArrayData> keysData;
-            ARROW_OK(keysBuilder.FinishInternal(&keysData));
-            std::shared_ptr<arrow::ArrayData> subkeysData;
-            ARROW_OK(subkeysBuilder.FinishInternal(&subkeysData));
-            std::shared_ptr<arrow::ArrayData> payloadsData;
-            ARROW_OK(payloadsBuilder.FinishInternal(&payloadsData));
-
-            NUdf::TUnboxedValue* items = nullptr;
-            const auto structObj = holderFactory.CreateDirectArrayHolder(fields.size(), items);
-            items[fields.at("key")] = holderFactory.CreateArrowBlock(keysData);
-            items[fields.at("subkey")] = holderFactory.CreateArrowBlock(subkeysData);
-            items[fields.at("payload")] = holderFactory.CreateArrowBlock(payloadsData);
-            items[fields.at("_yql_block_length")] = MakeBlockCount(holderFactory, blockSize);
-            leftListValues = leftListValues.Append(std::move(structObj));
-        }
-        leftBlocks->SetValue(ctx, holderFactory.CreateDirectListHolder(std::move(leftListValues)));
-        const auto joinIterator = graph->GetValue().GetListIterator();
-
-        NUdf::TUnboxedValue item;
-        TVector<NUdf::TUnboxedValue> joinResult;
-        while (joinIterator.Next(item)) {
-            joinResult.push_back(item);
-        }
-
-        UNIT_ASSERT_VALUES_EQUAL(joinResult.size(), 1);
-        const auto blocks = joinResult.front();
-        const auto blockLengthValue = blocks.GetElement(fields.at("_yql_block_length"));
-        const auto blockLengthDatum = TArrowBlock::From(blockLengthValue).GetDatum();
-        UNIT_ASSERT(blockLengthDatum.is_scalar());
-        const auto blockLength = blockLengthDatum.scalar_as<arrow::UInt64Scalar>().value;
-        const auto dictSize = std::count_if(dictKeys.cbegin(), dictKeys.cend(),
-            [](ui64 key) { return key < testSize; });
-        UNIT_ASSERT_VALUES_EQUAL(dictSize, blockLength);
+        TestBlockJoinOnUint64(EJoinKind::LeftSemi);
     }
 
     Y_UNIT_TEST(TestLeftOnlyOnUint64) {
-        TSetup<false> setup;
-        TProgramBuilder& pb = *setup.PgmBuilder;
-
-        const TVector<ui64> dictKeys = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144};
-        const auto dict = MakeSet(pb, dictKeys);
-
-        const auto ui64Type = pb.NewDataType(NUdf::TDataType<ui64>::Id);
-        const auto strType = pb.NewDataType(NUdf::TDataType<char*>::Id);
-        const auto ui64BlockType = pb.NewBlockType(ui64Type, TBlockType::EShape::Many);
-        const auto strBlockType = pb.NewBlockType(strType, TBlockType::EShape::Many);
-        const auto blockLenType = pb.NewBlockType(ui64Type, TBlockType::EShape::Scalar);
-        const auto structType = pb.NewStructType({
-            {"key", ui64BlockType},
-            {"subkey", ui64BlockType},
-            {"payload", strBlockType},
-            {"_yql_block_length", blockLenType}
-        });
-        const auto fields = NameToIndex(AS_TYPE(TStructType, structType));
-        const auto listStructType = pb.NewListType(structType);
-
-        const auto leftArg = pb.Arg(listStructType);
-
-        const auto leftWideFlow = pb.ExpandMap(pb.ToFlow(leftArg),
-            [&](TRuntimeNode item) -> TRuntimeNode::TList {
-                return {
-                    pb.Member(item, "key"),
-                    pb.Member(item, "subkey"),
-                    pb.Member(item, "payload"),
-                    pb.Member(item, "_yql_block_length")
-                };
-            });
-
-        const auto joinNode = pb.BlockMapJoinCore(leftWideFlow, dict,
-            EJoinKind::LeftOnly, {0});
-
-        const auto rootNode = pb.Collect(pb.NarrowMap(joinNode,
-            [&](TRuntimeNode::TList items) -> TRuntimeNode {
-                return pb.NewStruct(structType, {
-                    {"key", items[0]},
-                    {"subkey", items[1]},
-                    {"payload", items[2]},
-                    {"_yql_block_length", items[3]}
-                });
-            }));
-
-        const auto graph = setup.BuildGraph(rootNode, {leftArg.GetNode()});
-        const auto& leftBlocks = graph->GetEntryPoint(0, true);
-        const auto& holderFactory = graph->GetHolderFactory();
-        auto& ctx = graph->GetContext();
-
-        constexpr size_t testSize = 256;
-        TVector<ui64> keys(testSize);
-        TVector<ui64> subkeys;
-        std::iota(keys.begin(), keys.end(), 1);
-        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(subkeys),
-            [](const auto& value) { return value * 1001; });
-
-        TVector<const char*> payloads;
-        std::transform(keys.cbegin(), keys.cend(), std::back_inserter(payloads),
-            [](const auto& value) { return twoLetterPayloads[value].c_str(); });
-
-        const size_t blockSize = 64;
-        size_t current = 0;
-        TDefaultListRepresentation leftListValues;
-        while (current < testSize) {
-            arrow::UInt64Builder keysBuilder(&ctx.ArrowMemoryPool);
-            arrow::UInt64Builder subkeysBuilder(&ctx.ArrowMemoryPool);
-            arrow::BinaryBuilder payloadsBuilder(&ctx.ArrowMemoryPool);
-            ARROW_OK(keysBuilder.Reserve(blockSize));
-            ARROW_OK(subkeysBuilder.Reserve(blockSize));
-            ARROW_OK(payloadsBuilder.Reserve(blockSize));
-            for (size_t i = 0; i < blockSize; i++, current++) {
-                keysBuilder.UnsafeAppend(keys[current]);
-                subkeysBuilder.UnsafeAppend(subkeys[current]);
-                ARROW_OK(payloadsBuilder.Append(payloads[current], payloadSize));
-            }
-            std::shared_ptr<arrow::ArrayData> keysData;
-            ARROW_OK(keysBuilder.FinishInternal(&keysData));
-            std::shared_ptr<arrow::ArrayData> subkeysData;
-            ARROW_OK(subkeysBuilder.FinishInternal(&subkeysData));
-            std::shared_ptr<arrow::ArrayData> payloadsData;
-            ARROW_OK(payloadsBuilder.FinishInternal(&payloadsData));
-
-            NUdf::TUnboxedValue* items = nullptr;
-            const auto structObj = holderFactory.CreateDirectArrayHolder(fields.size(), items);
-            items[fields.at("key")] = holderFactory.CreateArrowBlock(keysData);
-            items[fields.at("subkey")] = holderFactory.CreateArrowBlock(subkeysData);
-            items[fields.at("payload")] = holderFactory.CreateArrowBlock(payloadsData);
-            items[fields.at("_yql_block_length")] = MakeBlockCount(holderFactory, blockSize);
-            leftListValues = leftListValues.Append(std::move(structObj));
-        }
-        leftBlocks->SetValue(ctx, holderFactory.CreateDirectListHolder(std::move(leftListValues)));
-        const auto joinIterator = graph->GetValue().GetListIterator();
-
-        NUdf::TUnboxedValue item;
-        TVector<NUdf::TUnboxedValue> joinResult;
-        while (joinIterator.Next(item)) {
-            joinResult.push_back(item);
-        }
-
-        UNIT_ASSERT_VALUES_EQUAL(joinResult.size(), 1);
-        const auto blocks = joinResult.front();
-        const auto blockLengthValue = blocks.GetElement(fields.at("_yql_block_length"));
-        const auto blockLengthDatum = TArrowBlock::From(blockLengthValue).GetDatum();
-        UNIT_ASSERT(blockLengthDatum.is_scalar());
-        const auto blockLength = blockLengthDatum.scalar_as<arrow::UInt64Scalar>().value;
-        const auto dictSize = std::count_if(dictKeys.cbegin(), dictKeys.cend(),
-            [](ui64 key) { return key < testSize; });
-        UNIT_ASSERT_VALUES_EQUAL(testSize - dictSize, blockLength);
+        TestBlockJoinOnUint64(EJoinKind::LeftOnly);
     }
 } // Y_UNIT_TEST_SUITE
 

--- a/ydb/library/yql/minikql/comp_nodes/ut/ya.make.inc
+++ b/ydb/library/yql/minikql/comp_nodes/ut/ya.make.inc
@@ -26,6 +26,7 @@ SET(ORIG_SOURCES
     mkql_block_compress_ut.cpp
     mkql_block_exists_ut.cpp
     mkql_block_skiptake_ut.cpp
+    mkql_block_map_join_ut.cpp
     mkql_block_top_sort_ut.cpp
     mkql_blocks_ut.cpp
     mkql_combine_ut.cpp

--- a/ydb/library/yql/minikql/comp_nodes/ya.make.inc
+++ b/ydb/library/yql/minikql/comp_nodes/ya.make.inc
@@ -21,6 +21,7 @@ SET(ORIG_SOURCES
     mkql_block_if.cpp
     mkql_block_just.cpp
     mkql_block_logical.cpp
+    mkql_block_map_join.cpp
     mkql_block_compress.cpp
     mkql_block_func.cpp
     mkql_block_skiptake.cpp

--- a/ydb/library/yql/minikql/mkql_program_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_program_builder.cpp
@@ -5857,7 +5857,8 @@ TRuntimeNode TProgramBuilder::ScalarApply(const TArrayRef<const TRuntimeNode>& a
 TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode dict,
     EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns
 ) {
-    MKQL_ENSURE(joinKind == EJoinKind::LeftSemi, "Unsupported join kind");
+    MKQL_ENSURE(joinKind == EJoinKind::LeftSemi || joinKind == EJoinKind::LeftOnly,
+                "Unsupported join kind");
     MKQL_ENSURE(!leftKeyColumns.empty(), "At least one key column must be specified");
 
     TRuntimeNode::TList leftKeyColumnsNodes;

--- a/ydb/library/yql/minikql/mkql_program_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_program_builder.cpp
@@ -5857,6 +5857,9 @@ TRuntimeNode TProgramBuilder::ScalarApply(const TArrayRef<const TRuntimeNode>& a
 TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode dict,
     EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns
 ) {
+    if constexpr (RuntimeVersion < 51U) {
+        THROW yexception() << "Runtime version (" << RuntimeVersion << ") too old for " << __func__;
+    }
     MKQL_ENSURE(joinKind == EJoinKind::LeftSemi || joinKind == EJoinKind::LeftOnly,
                 "Unsupported join kind");
     MKQL_ENSURE(!leftKeyColumns.empty(), "At least one key column must be specified");

--- a/ydb/library/yql/minikql/mkql_program_builder.h
+++ b/ydb/library/yql/minikql/mkql_program_builder.h
@@ -255,6 +255,8 @@ public:
     TRuntimeNode BlockFromPg(TRuntimeNode input, TType* returnType);
     TRuntimeNode BlockPgResolvedCall(const std::string_view& name, ui32 id,
         const TArrayRef<const TRuntimeNode>& args, TType* returnType);
+    TRuntimeNode BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode dict,
+        EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns);
 
     //-- logical functions
     TRuntimeNode BlockNot(TRuntimeNode data);

--- a/ydb/library/yql/minikql/mkql_runtime_version.h
+++ b/ydb/library/yql/minikql/mkql_runtime_version.h
@@ -24,7 +24,7 @@ namespace NMiniKQL {
 // 1. Bump this version every time incompatible runtime nodes are introduced.
 // 2. Make sure you provide runtime node generation for previous runtime versions.
 #ifndef MKQL_RUNTIME_VERSION
-#define MKQL_RUNTIME_VERSION 50U
+#define MKQL_RUNTIME_VERSION 51U
 #endif
 
 // History:


### PR DESCRIPTION
This patchset is the first part of the series implementing `BlockMapJoinCore` MKQL callable. This part implements `BlockMapJoinCore` computation node for the join types, that don't require "dict" payload (i.e. `LeftSeim` and `LeftOnly`), so MKQL version is bumped either. The support for other `MapJoinCore` types are implemented in scope of the next PRs.

By the way the new flag is added to `ValidateBlock*Type` helpers to control whether the resulting item types are block or "raw" (i.e. unwrapped).

### Changelog category

* New feature
