### PR TITLE
ci: download the latest github runner on a VM start

### DIFF
--- a/ydb/ci/gh-runner-controller/src/scaler/cloud_config.py
+++ b/ydb/ci/gh-runner-controller/src/scaler/cloud_config.py
@@ -3,7 +3,7 @@ import pkgutil
 import yaml
 
 
-def create_userdata(repo_url, gh_token, runner_name, runner_labels, ssh_keys):
+def create_userdata(repo_url, gh_token, runner_name, runner_labels, ssh_keys, agent_mirror_url_prefix):
     runner_username = "runner"
 
     install_script = pkgutil.get_data(__name__, "scripts/install_runner.sh")
@@ -16,6 +16,7 @@ REPO_URL="{repo_url}"
 GITHUB_TOKEN="{gh_token}"
 RUNNER_NAME="{runner_name}"
 RUNNER_LABELS="{runner_labels}"
+AGENT_MIRROR_URL_PREFIX="{agent_mirror_url_prefix}"
 """.strip().encode(
         "utf8"
     )

--- a/ydb/ci/gh-runner-controller/src/scaler/controller.py
+++ b/ydb/ci/gh-runner-controller/src/scaler/controller.py
@@ -189,7 +189,8 @@ class ScaleController:
             labels.extend(preset['additional_labels'])
 
         vm_labels = {self.prefix: runner_name}
-        user_data = create_userdata(self.gh.html_url, new_runner_token, runner_name, labels, self.cfg.ssh_keys)
+        user_data = create_userdata(self.gh.html_url, new_runner_token, runner_name, labels, self.cfg.ssh_keys,
+                                    self.cfg.agent_mirror_url_prefix)
 
         placement = random.choice(self.cfg.yc_zones)
         zone_id = placement['zone_id']
@@ -198,7 +199,7 @@ class ScaleController:
         self.logger.info("start runner %s in %s (%s)", runner_name, zone_id, labels)
 
         try:
-            instance = self.yc.start_vm(zone_id, subnet_id, runner_name, preset_name, user_data, vm_labels)
+            response = self.yc.start_vm(zone_id, subnet_id, runner_name, preset_name, user_data, vm_labels)
         except grpc.RpcError as rpc_error:
             # noinspection PyUnresolvedReferences
             if rpc_error.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
@@ -206,7 +207,7 @@ class ScaleController:
             else:
                 raise
 
-        self.logger.info("instance %s started", instance.id)
+        self.logger.info("starting, operation_id=%s", response.id)
         return runner_name
 
     def delete_runner(self, runner):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

This PR changes the way how a VM gets an agent. 
Old behavior: use bundled version with enabled auto-upgrade
New behavior: download the latest agent version from our S3 mirror, and fall back to bundled version if download fails. Auto-upgrade is disabled.

Should help with auto-upgrade pause during builds..

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
