### PR TITLE
allow to configure min alloc size (#7951)

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -89,6 +89,8 @@ class TKqpCaFactory : public IKqpNodeComputeActorFactory {
     std::atomic<ui64> MkqlHeavyProgramMemoryLimit = 0;
     std::atomic<ui64> MinChannelBufferSize = 0;
     std::atomic<ui64> ReasonableSpillingTreshold = 0;
+    std::atomic<ui64> MinMemAllocSize = 8_MB;
+    std::atomic<ui64> MinMemFreeSize = 32_MB;
 
 public:
     TKqpCaFactory(const NKikimrConfig::TTableServiceConfig::TResourceManager& config,
@@ -108,6 +110,8 @@ public:
         MkqlHeavyProgramMemoryLimit.store(config.GetMkqlHeavyProgramMemoryLimit());
         MinChannelBufferSize.store(config.GetMinChannelBufferSize());
         ReasonableSpillingTreshold.store(config.GetReasonableSpillingTreshold());
+        MinMemAllocSize.store(config.GetMinMemAllocSize());
+        MinMemFreeSize.store(config.GetMinMemFreeSize());
     }
 
     TActorStartResult CreateKqpComputeActor(TCreateArgs&& args) {
@@ -115,6 +119,8 @@ public:
         memoryLimits.ChannelBufferSize = 0;
         memoryLimits.MkqlLightProgramMemoryLimit = MkqlLightProgramMemoryLimit.load();
         memoryLimits.MkqlHeavyProgramMemoryLimit = MkqlHeavyProgramMemoryLimit.load();
+        memoryLimits.MinMemAllocSize = MinMemAllocSize.load();
+        memoryLimits.MinMemFreeSize = MinMemFreeSize.load();
 
         auto estimation = ResourceManager_->EstimateTaskResources(*args.Task, args.NumberOfTasks);
         NRm::TKqpResourcesRequest resourcesRequest;

--- a/ydb/core/kqp/node_service/kqp_node_service.cpp
+++ b/ydb/core/kqp/node_service/kqp_node_service.cpp
@@ -329,6 +329,8 @@ private:
             FORCE_VALUE(EnableInstantMkqlMemoryAlloc);
             FORCE_VALUE(MaxTotalChannelBuffersSize);
             FORCE_VALUE(MinChannelBufferSize);
+            FORCE_VALUE(MinMemAllocSize);
+            FORCE_VALUE(MinMemFreeSize);
 #undef FORCE_VALUE
 
             LOG_I("Updated table service config: " << Config.DebugString());

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -23,7 +23,7 @@ message TTableServiceConfig {
         optional uint32 ComputeActorsCount = 1 [default = 10000];
         optional uint64 ChannelBufferSize = 2 [default = 8388608];              //  8 MB
         reserved 3;
-        optional uint64 MkqlLightProgramMemoryLimit = 4 [default = 524288];   // 512 KB
+        optional uint64 MkqlLightProgramMemoryLimit = 4 [default = 1048576];   // 1 MiB
         optional uint64 MkqlHeavyProgramMemoryLimit = 5 [default = 31457280];   // 30 MB
         optional uint64 QueryMemoryLimit = 6 [default = 32212254720];           // 30 GB
         optional uint32 PublishStatisticsIntervalSec = 7 [default = 2];
@@ -43,6 +43,9 @@ message TTableServiceConfig {
         optional uint64 KqpPatternCachePatternAccessTimesBeforeTryToCompile = 20 [default = 5];
         optional uint64 KqpPatternCacheCompiledCapacityBytes = 21 [default = 104857600]; // 100 MiB
         optional uint64 ReasonableSpillingTreshold = 22 [default = 104857600]; // 100 MiB
+
+        optional uint64 MinMemAllocSize = 23 [default = 8388608]; // 8 MiB
+        optional uint64 MinMemFreeSize = 24  [default = 33554432]; // 32 MiB
     }
 
     message TSpillingServiceConfig {


### PR DESCRIPTION
### Changelog entry 

currently mkql allocator makes requests by chunks of 30MiB minimum, so making that configurable and changing that limit to 8MiB.

also minimal 'free' quota is 1MiB because of alignment rules (mkql aligns in 1MiB)

### Changelog category 

* Improvement

### Additional information

...
