### PR TITLE
Remove fq/generic from asan precommit checks (too long, and not profitable)

### DIFF
--- a/ydb/tests/fq/generic/ya.make
+++ b/ydb/tests/fq/generic/ya.make
@@ -33,10 +33,15 @@ ENDIF()
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
-    # Including of docker_compose/recipe.inc automatically converts these tests into LARGE, 
-    # which makes it impossible to run them during precommit checks on Github CI. 
-    # Next several lines forces these tests to be MEDIUM. To see discussion, visit YDBOPS-8928.
-    SIZE(MEDIUM)
+    IF (SANITIZER_TYPE)
+        # Too huge for precommit check with sanitizers
+        SIZE(LARGE)
+    ELSE()
+        # Including of docker_compose/recipe.inc automatically converts these tests into LARGE, 
+        # which makes it impossible to run them during precommit checks on Github CI. 
+        # Next several lines forces these tests to be MEDIUM. To see discussion, visit YDBOPS-8928.
+        SIZE(MEDIUM)
+    ENDIF()
     SET(TEST_TAGS_VALUE)
     SET(TEST_REQUIREMENTS_VALUE)
     # This requirement forces tests to be launched consequently,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It takes 30min+ in asan checks

Profits are unclear


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

