### PR TITLE
Introduce computation node for BlockMapJoinCore (Left and Inner)

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -313,6 +313,14 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
     MKQL_ENSURE(leftFlowComponents.size() > 0, "Expected at least one column");
     const TVector<TType*> leftFlowItems(leftFlowComponents.cbegin(), leftFlowComponents.cend());
 
+    const auto rightDictNode = callable.GetInput(1);
+    MKQL_ENSURE(rightDictNode.GetStaticType()->IsDict(),
+                "Expected Dict as a right join part");
+    const auto rightDictType = AS_TYPE(TDictType, rightDictNode);
+    MKQL_ENSURE(rightDictType->GetPayloadType()->IsVoid() ||
+                rightDictType->GetPayloadType()->IsTuple(),
+                "Expected Void or Tuple as a right dict item type");
+
     const auto joinKindNode = callable.GetInput(2);
     const auto rawKind = AS_VALUE(TDataLiteral, joinKindNode)->AsValue().Get<ui32>();
     const auto joinKind = GetJoinKind(rawKind);

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -170,12 +170,14 @@ const TRuntimeNode BuildBlockJoin(TProgramBuilder& pgmBuilder, EJoinKind joinKin
         });
 
     const auto joinNode = pgmBuilder.BlockMapJoinCore(leftWideFlow, dictNode, joinKind, keyColumns);
+    const auto joinItems = GetWideComponents(AS_TYPE(TFlowType, joinNode.GetStaticType()));
+    const auto resultType = AS_TYPE(TTupleType, pgmBuilder.NewTupleType(joinItems));
 
     const auto rootNode = pgmBuilder.Collect(pgmBuilder.NarrowMap(joinNode,
         [&](TRuntimeNode::TList items) -> TRuntimeNode {
             TVector<TRuntimeNode> tupleElements;
-            tupleElements.reserve(tupleType->GetElementsCount());
-            for (size_t i = 0; i < tupleType->GetElementsCount(); i++) {
+            tupleElements.reserve(resultType->GetElementsCount());
+            for (size_t i = 0; i < resultType->GetElementsCount(); i++) {
                 tupleElements.emplace_back(items[i]);
             }
             return pgmBuilder.NewTuple(tupleElements);

--- a/ydb/library/yql/minikql/mkql_program_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_program_builder.cpp
@@ -5860,7 +5860,8 @@ TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode d
     if constexpr (RuntimeVersion < 51U) {
         THROW yexception() << "Runtime version (" << RuntimeVersion << ") too old for " << __func__;
     }
-    MKQL_ENSURE(joinKind == EJoinKind::LeftSemi || joinKind == EJoinKind::LeftOnly,
+    MKQL_ENSURE(joinKind == EJoinKind::Inner ||
+                joinKind == EJoinKind::LeftSemi || joinKind == EJoinKind::LeftOnly,
                 "Unsupported join kind");
     MKQL_ENSURE(!leftKeyColumns.empty(), "At least one key column must be specified");
 
@@ -5873,9 +5874,27 @@ TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode d
 
     auto returnJoinItems = ValidateBlockFlowType(flow.GetStaticType(), false);
     const auto payloadType = AS_TYPE(TDictType, dict.GetStaticType())->GetPayloadType();
-    // XXX: This is the contract ensured by the expression compiler and
-    // optimizers for join types that don't require the right (i.e. dict) part.
-    MKQL_ENSURE(payloadType->IsVoid(), "Dict payload has to be Void");
+    if (joinKind == EJoinKind::Inner) {
+        // XXX: This is the contract ensured by the expression compiler and
+        // optimizers to ease the processing of the dict payload in wide context.
+        MKQL_ENSURE(payloadType->IsTuple(), "Dict payload has to be a Tuple");
+        const auto payloadItems = AS_TYPE(TTupleType, payloadType)->GetElements();
+        TVector<TType*> dictBlockItems;
+        dictBlockItems.reserve(payloadItems.size());
+        for (const auto& payloadItem : payloadItems) {
+            MKQL_ENSURE(!payloadItem->IsBlock(), "Dict payload item has to be non-block");
+            dictBlockItems.emplace_back(NewBlockType(payloadItem, TBlockType::EShape::Many));
+        }
+        // Block length column has to be the last column in wide block flow item,
+        // so all contents of the dict payload should be appended to the resulting
+        // wide type before the block size column.
+        const auto blockLenPos = std::prev(returnJoinItems.end());
+        returnJoinItems.insert(blockLenPos, dictBlockItems.cbegin(), dictBlockItems.cend());
+    } else {
+        // XXX: This is the contract ensured by the expression compiler and
+        // optimizers for join types that don't require the right (i.e. dict) part.
+        MKQL_ENSURE(payloadType->IsVoid(), "Dict payload has to be Void");
+    }
     TType* returnJoinType = NewFlowType(NewMultiType(returnJoinItems));
 
     TCallableBuilder callableBuilder(Env, __func__, returnJoinType);


### PR DESCRIPTION
This patchset is the second part of the series implementing `BlockMapJoinCore` MKQL callable. This part implements `BlockMapJoinCore` computation node for the join types, that require "dict" payload (i.e. `Inner` and `Left`). Implemented class handles only joins that doesn't require cartesian product (i.e. with no duplicates in the "dict" payload). The support for cartesian product is implemented in scope of the next PRs.

### Changelog category

* New feature
