### PR TITLE
Fix FilterPushdownEnableMultiusage on dependent predicates

### DIFF
--- a/ydb/library/yql/core/common_opt/yql_co_finalizers.cpp
+++ b/ydb/library/yql/core/common_opt/yql_co_finalizers.cpp
@@ -94,6 +94,9 @@ void FilterPushdownWithMultiusage(const TExprNode::TPtr& node, TNodeOnNodeOwnedM
 
         TCoFlatMapBase parentFlatMap(parent);
         if (auto cond = parentFlatMap.Lambda().Body().Maybe<TCoConditionalValueBase>()) {
+            if (IsDepended(parentFlatMap.Lambda().Ref(), *node)) {
+                return;
+            }
             likelyCount += bool(cond.Cast().Predicate().Maybe<TCoLikely>());
             auto pos = cond.Cast().Predicate().Pos();
             parentFilterLambdas.push_back(ctx.NewLambda(pos,

--- a/ydb/library/yql/tests/sql/dq_file/part2/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part2/canondata/result.json
@@ -1978,6 +1978,28 @@
         }
     ],
     "test.test[optimizers-test_fuse_map_take-default.txt-Results]": [],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Analyze]": [
+        {
+            "checksum": "ffabf5d4f7f9ae1818a52a55257cba6b",
+            "size": 6017,
+            "uri": "https://{canondata_backend}/1942671/c9c83131b391b0a13b103155f61dd4f9a78f6ce6/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Analyze_/plan.txt"
+        }
+    ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Debug]": [
+        {
+            "checksum": "1ab625c1f050d16d1e0cf2dfab9aabd8",
+            "size": 2631,
+            "uri": "https://{canondata_backend}/1942671/c9c83131b391b0a13b103155f61dd4f9a78f6ce6/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Plan]": [
+        {
+            "checksum": "ffabf5d4f7f9ae1818a52a55257cba6b",
+            "size": 6017,
+            "uri": "https://{canondata_backend}/1942671/c9c83131b391b0a13b103155f61dd4f9a78f6ce6/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Plan_/plan.txt"
+        }
+    ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Results]": [],
     "test.test[order_by-native_desc_sort-over_sorted-Analyze]": [
         {
             "checksum": "a4984e0c0c8309cb787d8d24c6759ea9",

--- a/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
@@ -1581,6 +1581,20 @@
             "uri": "https://{canondata_backend}/1781765/028f42f897160b53900546b39900217bb2eb9fb1/resource.tar.gz#test.test_optimizers-yql-16134-default.txt-Plan_/plan.txt"
         }
     ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Debug]": [
+        {
+            "checksum": "7f983c2bd71aacbf8c05a09d8a6ccfec",
+            "size": 4181,
+            "uri": "https://{canondata_backend}/1777230/e81b9e2c64fe4b93a822d7b1454621e0e1f09374/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Plan]": [
+        {
+            "checksum": "22f22312b28ba379827f031e01ab68d7",
+            "size": 8940,
+            "uri": "https://{canondata_backend}/1777230/e81b9e2c64fe4b93a822d7b1454621e0e1f09374/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Plan_/plan.txt"
+        }
+    ],
     "test.test[optimizers-yql_5830_fuse_outer_with_extra_deps--Debug]": [
         {
             "checksum": "b38b9309220b31121d36d282c7020cc0",

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -11199,6 +11199,13 @@
             "uri": "https://{canondata_backend}/1936273/49c67b7d7a39200caa18261ed9d1bc5db8f0665a/resource.tar.gz#test_sql2yql.test_optimizers-yql-18408_filter_multiusage_pushdown_/sql.yql"
         }
     ],
+    "test_sql2yql.test[optimizers-yql-18733_no_filter_multiusage_pushdown]": [
+        {
+            "checksum": "b2f87a348272c18d0ae93bf3f421b79c",
+            "size": 2300,
+            "uri": "https://{canondata_backend}/1942671/a0a38df298ba29d07b694136c15631b91a455b2b/resource.tar.gz#test_sql2yql.test_optimizers-yql-18733_no_filter_multiusage_pushdown_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[optimizers-yql-2171_aggregate_desc_sort_and_extract]": [
         {
             "checksum": "e46724f353c724da2d05f34ac86ebc12",
@@ -30671,6 +30678,13 @@
             "checksum": "3abed13d03b0bf6565b54d2982f6a070",
             "size": 3526,
             "uri": "https://{canondata_backend}/1936273/49c67b7d7a39200caa18261ed9d1bc5db8f0665a/resource.tar.gz#test_sql_format.test_optimizers-yql-18408_filter_multiusage_pushdown_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[optimizers-yql-18733_no_filter_multiusage_pushdown]": [
+        {
+            "checksum": "a776d7acfad71c3c81e59cbd969fd103",
+            "size": 207,
+            "uri": "https://{canondata_backend}/1942671/a0a38df298ba29d07b694136c15631b91a455b2b/resource.tar.gz#test_sql_format.test_optimizers-yql-18733_no_filter_multiusage_pushdown_/formatted.sql"
         }
     ],
     "test_sql_format.test[optimizers-yql-2171_aggregate_desc_sort_and_extract]": [

--- a/ydb/library/yql/tests/sql/suites/optimizers/yql-18733_no_filter_multiusage_pushdown.cfg
+++ b/ydb/library/yql/tests/sql/suites/optimizers/yql-18733_no_filter_multiusage_pushdown.cfg
@@ -1,0 +1,2 @@
+in Input input3.txt
+res result.txt

--- a/ydb/library/yql/tests/sql/suites/optimizers/yql-18733_no_filter_multiusage_pushdown.sql
+++ b/ydb/library/yql/tests/sql/suites/optimizers/yql-18733_no_filter_multiusage_pushdown.sql
@@ -1,0 +1,6 @@
+pragma config.flags("OptimizerFlags", "FilterPushdownEnableMultiusage");
+USE plato;
+
+$src = select distinct key from Input where value = 'ddd';
+
+select * from Input where key = $src;

--- a/ydb/library/yql/tests/sql/yt_native_file/part2/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part2/canondata/result.json
@@ -1758,6 +1758,27 @@
             "uri": "https://{canondata_backend}/1946324/7d1d6b1f697cbe9fb62c81047eb61d3fa72baf62/resource.tar.gz#test.test_optimizers-test_fuse_map_take-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Debug]": [
+        {
+            "checksum": "f050ac74230eb7dbc822b133663d3df9",
+            "size": 3057,
+            "uri": "https://{canondata_backend}/1942173/e2eaa722feec576f4e13850918acdacbd580f3f6/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Debug_/opt.yql"
+        }
+    ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Plan]": [
+        {
+            "checksum": "7efd4097d90d06075f422fa174e52d50",
+            "size": 8448,
+            "uri": "https://{canondata_backend}/1942173/e2eaa722feec576f4e13850918acdacbd580f3f6/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Plan_/plan.txt"
+        }
+    ],
+    "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Results]": [
+        {
+            "checksum": "42f0d61ed39ab67ff4bb545f73263c66",
+            "size": 1281,
+            "uri": "https://{canondata_backend}/1942173/e2eaa722feec576f4e13850918acdacbd580f3f6/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Results_/results.txt"
+        }
+    ],
     "test.test[order_by-native_desc_sort-over_sorted-Debug]": [
         {
             "checksum": "77e61c150cfecb02799d4731b020ba6d",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* Fix FilterPushdownEnableMultiusage on dependent predicates

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
