### PR TITLE
Use granular updates for mediator timecast when available

### DIFF
--- a/ydb/core/base/domain.cpp
+++ b/ydb/core/base/domain.cpp
@@ -5,7 +5,8 @@ namespace NKikimr {
 
     TDomainsInfo::TDomain::TDomain(const TString &name, ui32 domainUid, ui64 schemeRootId,
             TVectorUi64 coordinators, TVectorUi64 mediators, TVectorUi64 allocators,
-            ui64 domainPlanResolution, const TStoragePoolKinds *poolTypes)
+            ui64 domainPlanResolution, ui32 timecastBucketsPerMediator,
+            const TStoragePoolKinds *poolTypes)
         : DomainUid(domainUid)
         , SchemeRoot(schemeRootId)
         , Name(name)
@@ -13,6 +14,7 @@ namespace NKikimr {
         , Mediators(std::move(mediators))
         , TxAllocators(std::move(allocators))
         , DomainPlanResolution(domainPlanResolution)
+        , TimecastBucketsPerMediator(timecastBucketsPerMediator)
         , StoragePoolTypes(poolTypes ? *poolTypes : TStoragePoolKinds())
     {}
 

--- a/ydb/core/base/tx_processing.cpp
+++ b/ydb/core/base/tx_processing.cpp
@@ -69,7 +69,7 @@ NKikimrSubDomains::TProcessingParams NKikimr::ExtractProcessingParams(const NKik
 }
 
 NKikimr::TTimeCastBuckets::TTimeCastBuckets()
-    : TimecastBucketsPerMediator(TDomainsInfo::TDomain::TimecastBucketsPerMediator)
+    : TimecastBucketsPerMediator(TDomainsInfo::TDomain::DefaultTimecastBucketsPerMediator)
 {}
 
 NKikimr::TTimeCastBuckets::TTimeCastBuckets(ui32 timecastBuckets)

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -424,7 +424,7 @@ private:
     void MediatorTimeCastUnregisterTablet(const TActorContext& ctx);
     void Handle(TEvMediatorTimecast::TEvRegisterTabletResult::TPtr& ev, const TActorContext& ctx);
 
-    TIntrusivePtr<TMediatorTimecastEntry> MediatorTimeCastEntry;
+    TMediatorTimecastEntry::TCPtr MediatorTimeCastEntry;
 
     void DeleteExpiredTransactions(const TActorContext& ctx);
     void Handle(TEvPersQueue::TEvCancelTransactionProposal::TPtr& ev, const TActorContext& ctx);

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -153,4 +153,5 @@ message TFeatureFlags {
     optional bool EnableChangefeedsOnIndexTables = 134 [default = false];
     optional bool EnableResourcePoolsCounters = 135 [default = false];
     optional bool EnableOptionalColumnsInColumnShard = 136 [default = false];
+    optional bool EnableGranularTimecast = 137 [default = true];
 }

--- a/ydb/core/protos/tx_mediator_timecast.proto
+++ b/ydb/core/protos/tx_mediator_timecast.proto
@@ -29,6 +29,10 @@ message TEvGranularWatch {
 
     // The list of tablets the client is currently tracking
     repeated fixed64 Tablets = 3 [packed = true];
+
+    // The maximum LatestStep observed in the past
+    // Mediator may avoid sending updates with LatestStep less than MinStep
+    optional uint64 MinStep = 4;
 }
 
 // sent from local timecast to mediator to change the list of tablets

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -63,6 +63,7 @@ public:
     FEATURE_FLAG_SETTER(EnableResourcePools)
     FEATURE_FLAG_SETTER(EnableChangefeedsOnIndexTables)
     FEATURE_FLAG_SETTER(EnableBackupService)
+    FEATURE_FLAG_SETTER(EnableGranularTimecast)
 
     #undef FEATURE_FLAG_SETTER
 };

--- a/ydb/core/testlib/tablet_helpers.cpp
+++ b/ydb/core/testlib/tablet_helpers.cpp
@@ -88,14 +88,14 @@ namespace NKikimr {
             const ui64 tabletId = ev->Get()->TabletId;
             auto& entry = Entries[tabletId];
             if (!entry) {
-                entry = new TMediatorTimecastEntry();
+                entry = new TMediatorTimecastSharedEntry();
             }
 
-            ctx.Send(ev->Sender, new TEvMediatorTimecast::TEvRegisterTabletResult(tabletId, entry));
+            ctx.Send(ev->Sender, new TEvMediatorTimecast::TEvRegisterTabletResult(tabletId, new TMediatorTimecastEntry(entry, entry)));
         }
 
     private:
-        THashMap<ui64, TIntrusivePtr<TMediatorTimecastEntry>> Entries;
+        THashMap<ui64, TIntrusivePtr<TMediatorTimecastSharedEntry>> Entries;
     };
 
     void SetupMediatorTimecastProxy(TTestActorRuntime& runtime, ui32 nodeIndex, bool useFake = false)

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -503,8 +503,12 @@ namespace Tests {
         if (!planResolution) {
             planResolution = Settings->UseRealThreads ? 7 : 500;
         }
+        ui32 timecastBuckets = Settings->DomainTimecastBuckets;
+        if (!timecastBuckets) {
+            timecastBuckets = TDomainsInfo::TDomain::DefaultTimecastBucketsPerMediator;
+        }
         auto domain = TDomainsInfo::TDomain::ConstructDomainWithExplicitTabletIds(Settings->DomainName, domainId, ChangeStateStorage(SchemeRoot, domainId),
-                                                                                  planResolution,
+                                                                                  planResolution, timecastBuckets,
                                                                                   TVector<ui64>{TDomainsInfo::MakeTxCoordinatorIDFixed(1)},
                                                                                   TVector<ui64>{TDomainsInfo::MakeTxMediatorIDFixed(1)},
                                                                                   TVector<ui64>{TDomainsInfo::MakeTxAllocatorIDFixed(1)},

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -145,6 +145,7 @@ namespace Tests {
         NKikimrConfig::TCompactionConfig CompactionConfig;
         TMap<ui32, TString> NodeKeys;
         ui64 DomainPlanResolution = 0;
+        ui32 DomainTimecastBuckets = 0;
         std::shared_ptr<NKikimr::NMsgBusProxy::IPersQueueGetReadSessionsInfoWorkerFactory> PersQueueGetReadSessionsInfoWorkerFactory;
         std::shared_ptr<NKikimr::NHttpProxy::IAuthFactory> DataStreamsAuthFactory;
         std::shared_ptr<NKikimr::NPQ::TPersQueueMirrorReaderFactory> PersQueueMirrorReaderFactory = std::make_shared<NKikimr::NPQ::TPersQueueMirrorReaderFactory>();
@@ -193,6 +194,7 @@ namespace Tests {
         TServerSettings& SetEnableKqpSpilling(bool value) { EnableKqpSpilling = value; return *this; }
         TServerSettings& SetEnableForceFollowers(bool value) { EnableForceFollowers = value; return *this; }
         TServerSettings& SetDomainPlanResolution(ui64 resolution) { DomainPlanResolution = resolution; return *this; }
+        TServerSettings& SetDomainTimecastBuckets(ui32 buckets) { DomainTimecastBuckets = buckets; return *this; }
         TServerSettings& SetFeatureFlags(const NKikimrConfig::TFeatureFlags& value) { FeatureFlags = value; return *this; }
         TServerSettings& SetCompactionConfig(const NKikimrConfig::TCompactionConfig& value) { CompactionConfig = value; return *this; }
         TServerSettings& SetEnableDbCounters(bool value) { FeatureFlags.SetEnableDbCounters(value); return *this; }

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -436,7 +436,7 @@ private:
     ui64 StatsReportRound = 0;
     TString OwnerPath;
 
-    TIntrusivePtr<TMediatorTimecastEntry> MediatorTimeCastEntry;
+    TMediatorTimecastEntry::TCPtr MediatorTimeCastEntry;
     bool MediatorTimeCastRegistered = false;
     TSet<ui64> MediatorTimeCastWaitingSteps;
     const TDuration PeriodicWakeupActivationPeriod;

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -2698,7 +2698,7 @@ private:
         { }
     };
 
-    TIntrusivePtr<TMediatorTimecastEntry> MediatorTimeCastEntry;
+    TMediatorTimecastEntry::TCPtr MediatorTimeCastEntry;
     TSet<ui64> MediatorTimeCastWaitingSteps;
     TMultiMap<TRowVersion, TMediatorDelayedReply> MediatorDelayedReplies;
 

--- a/ydb/core/tx/datashard/datashard_ut_order.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_order.cpp
@@ -13,6 +13,7 @@
 #include <ydb/core/tx/tx_processing.h>
 #include <ydb/public/lib/deprecated/kicli/kicli.h>
 #include <ydb/core/testlib/tenant_runtime.h>
+#include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/library/actors/util/memory_tracker.h>
 #include <util/system/valgrind.h>
 
@@ -3876,6 +3877,9 @@ Y_UNIT_TEST(TestUnprotectedReadsThenWriteVisibility) {
         ui64 AllowedStep = 0;
     };
     THashMap<ui32, TNodeState> mediatorState;
+
+    // Don't allow granular timecast side-stepping mediator time hacks in this test
+    TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(runtime);
 
     bool mustWaitForSteps[2] = { false, false };
 

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -2887,6 +2887,9 @@ Y_UNIT_TEST_SUITE(DataShardReadIterator) {
 
         TTestHelper helper(serverSettings);
 
+        // Don't allow granular timecast side-stepping mediator time hacks in this test
+        TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(*helper.Server->GetRuntime());
+
         auto waitFor = [&](const auto& condition, const TString& description) {
             if (!condition()) {
                 Cerr << "... waiting for " << description << Endl;
@@ -3017,6 +3020,9 @@ Y_UNIT_TEST_SUITE(DataShardReadIterator) {
             .SetUseRealThreads(false);
 
         TTestHelper helper(serverSettings);
+
+        // Don't allow granular timecast side-stepping mediator time hacks in this test
+        TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(*helper.Server->GetRuntime());
 
         auto waitFor = [&](const auto& condition, const TString& description) {
             if (!condition()) {

--- a/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/tx/long_tx_service/public/lock_handle.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/tx/tx_proxy/upload_rows.h>
+#include <ydb/core/testlib/actors/block_events.h>
 
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h> // Y_UNIT_TEST_(TWIN|QUAD)
 #include <ydb/core/mind/local.h>
@@ -806,6 +807,9 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         Tests::TServer::TPtr server = new TServer(serverSettings);
         auto &runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
+
+        // Don't allow granular timecast side-stepping mediator time hacks in this test
+        TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(runtime);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
@@ -3732,6 +3736,9 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         auto &runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
 
+        // Don't allow granular timecast side-stepping mediator time hacks in this test
+        TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(runtime);
+
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
 
@@ -4150,6 +4157,9 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         auto &runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
 
+        // Don't allow granular timecast side-stepping mediator time hacks in this test
+        TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(runtime);
+
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
         runtime.SetLogPriority(NKikimrServices::KQP_EXECUTER, NLog::PRI_TRACE);
@@ -4264,6 +4274,9 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         Tests::TServer::TPtr server = new TServer(serverSettings);
         auto &runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
+
+        // Don't allow granular timecast side-stepping mediator time hacks in this test
+        TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(runtime);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
@@ -4401,6 +4414,9 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         Tests::TServer::TPtr server = new TServer(serverSettings);
         auto &runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
+
+        // Don't allow granular timecast side-stepping mediator time hacks in this test
+        TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockGranularUpdate(runtime);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_COORDINATOR, NLog::PRI_TRACE);

--- a/ydb/core/tx/mediator/mediator_impl.h
+++ b/ydb/core/tx/mediator/mediator_impl.h
@@ -388,7 +388,7 @@ public:
         struct DomainConfiguration : Table<2> {
             struct Version : Column<1, NScheme::NTypeIds::Uint64> {};
             struct Coordinators : Column<2, NScheme::NTypeIds::String> { using Type = TVector<TCoordinatorId>; };
-            struct TimeCastBuckets : Column<3, NScheme::NTypeIds::Uint32> { static constexpr ui32 Default = TDomainsInfo::TDomain::TimecastBucketsPerMediator; };
+            struct TimeCastBuckets : Column<3, NScheme::NTypeIds::Uint32> { static constexpr ui32 Default = TDomainsInfo::TDomain::DefaultTimecastBucketsPerMediator; };
 
             using TKey = TableKey<Version>;
             using TColumns = TableColumns<Version, Coordinators, TimeCastBuckets>;

--- a/ydb/core/tx/time_cast/time_cast.cpp
+++ b/ydb/core/tx/time_cast/time_cast.cpp
@@ -20,20 +20,43 @@ namespace NKikimr {
 // We will unsubscribe from idle coordinators after 5 minutes
 static constexpr TDuration MaxIdleCoordinatorSubscriptionTime = TDuration::Minutes(5);
 
-ui64 TMediatorTimecastEntry::Get(ui64 tabletId) const {
-    Y_UNUSED(tabletId);
-    return AtomicGet(Step);
+ui64 TMediatorTimecastSharedEntry::Get() const noexcept {
+    return Step.load(std::memory_order_acquire);
 }
 
-void TMediatorTimecastEntry::Update(ui64 step, ui64 *exemption, ui64 exsz) {
-    Y_ABORT_UNLESS(exsz == 0, "exemption lists not supported yet");
-    Y_UNUSED(exemption);
-    Y_UNUSED(exsz);
+void TMediatorTimecastSharedEntry::Set(ui64 step) noexcept {
+    ui64 current = Step.load(std::memory_order_relaxed);
+    Step.store(Max(current, step), std::memory_order_release);
+}
 
-    // Mediator time shouldn't go back while shards are running
-    if (Get(0) < step) {
-        AtomicSet(Step, step);
-    }
+TMediatorTimecastEntry::TMediatorTimecastEntry(
+        const TMediatorTimecastSharedEntry::TPtr& safeStep,
+        const TMediatorTimecastSharedEntry::TPtr& latestStep) noexcept
+    : SafeStep(safeStep)
+    , LatestStep(latestStep)
+{
+    Y_ABORT_UNLESS(SafeStep);
+    Y_ABORT_UNLESS(LatestStep);
+}
+
+TMediatorTimecastEntry::~TMediatorTimecastEntry() noexcept {
+    // nothing
+}
+
+ui64 TMediatorTimecastEntry::Get(ui64 tabletId) const noexcept {
+    Y_UNUSED(tabletId);
+    ui64 latest = LatestStep->Get();
+    ui64 frozen = FrozenStep.load(std::memory_order_relaxed);
+    ui64 safe = SafeStep->Get();
+    return Max(Min(latest, frozen), safe);
+}
+
+ui64 TMediatorTimecastEntry::GetFrozenStep() const noexcept {
+    return FrozenStep.load(std::memory_order_relaxed);
+}
+
+void TMediatorTimecastEntry::SetFrozenStep(ui64 step) noexcept {
+    FrozenStep.store(step, std::memory_order_relaxed);
 }
 
 class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
@@ -64,27 +87,88 @@ class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
             , PlanStep(planStep)
         { }
 
-        // An inverse based on (PlanStep, TabletId) tuple
-        inline bool operator<(const TWaiter& rhs) const {
-            return rhs.PlanStep < PlanStep ||
-                (rhs.PlanStep == PlanStep && rhs.TabletId < TabletId);
+        struct TCompare {
+            constexpr bool operator()(const TWaiter& a, const TWaiter& b) const noexcept {
+                return a.PlanStep < b.PlanStep;
+            }
+        };
+
+        struct TInverseCompare {
+            constexpr bool operator()(const TWaiter& a, const TWaiter& b) const noexcept {
+                return b.PlanStep < a.PlanStep;
+            }
+        };
+    };
+
+    using TWaiterSet = std::multiset<TWaiter, TWaiter::TCompare>;
+    using TWaiterQueue = std::priority_queue<TWaiter, std::vector<TWaiter>, TWaiter::TInverseCompare>;
+
+    struct TTabletWaiter {
+        ui64 PlanStep;
+        ui64 TabletId;
+
+        TTabletWaiter() = default;
+        TTabletWaiter(ui64 planStep, ui64 tabletId)
+            : PlanStep(planStep)
+            , TabletId(tabletId)
+        {}
+
+        inline bool operator<(const TTabletWaiter& rhs) const noexcept {
+            return PlanStep < rhs.PlanStep ||
+                (PlanStep == rhs.PlanStep && TabletId < rhs.TabletId);
         }
     };
 
+    using TTabletWaiterSet = std::set<TTabletWaiter>;
+
+    struct TMediator;
+    struct TMediatorBucket;
+
+    struct TTabletInfo : public TIntrusiveListItem<TTabletInfo> {
+        const ui64 TabletId;
+        TMediator* Mediator = nullptr;
+        ui32 BucketId = 0;
+        ui32 RefCount = 0;
+        TMediatorTimecastEntry::TPtr Entry;
+        TWaiterSet Waiters;
+        ui64 SubscriptionId = 0;
+        ui64 FrozenStep = Max<ui64>();
+        ui64 MinStep = 0;
+        bool Synced = false;
+
+        explicit TTabletInfo(ui64 tabletId)
+            : TabletId(tabletId)
+        {}
+    };
+
     struct TMediatorBucket {
-        TIntrusivePtr<TMediatorTimecastEntry> Entry;
-        std::priority_queue<TWaiter> Waiters;
+        const TMediatorTimecastSharedEntry::TPtr SafeStep = new TMediatorTimecastSharedEntry;
+        const TMediatorTimecastSharedEntry::TPtr LatestStep = new TMediatorTimecastSharedEntry;
+        THashSet<ui64> Tablets;
+        TIntrusiveList<TTabletInfo> PendingSubscribe;
+        TIntrusiveList<TTabletInfo> PendingUpdate;
+        TWaiterQueue Waiters;
+        TTabletWaiterSet TabletWaiters;
+        ui64 SubscriptionId = 0;
+        bool WatchSent = false;
+        bool WatchSynced = false;
+
+        bool AddNewTablet(ui64 tabletId) {
+            return Tablets.insert(tabletId).second;
+        }
     };
 
     struct TMediator {
+        const ui64 TabletId;
         const ui32 BucketsSz;
         TArrayHolder<TMediatorBucket> Buckets;
         std::vector<ui64> Coordinators;
 
         TActorId PipeClient;
 
-        TMediator(ui32 bucketsSz)
-            : BucketsSz(bucketsSz)
+        TMediator(ui64 tabletId, ui32 bucketsSz)
+            : TabletId(tabletId)
+            , BucketsSz(bucketsSz)
             , Buckets(new TMediatorBucket[bucketsSz])
         {}
     };
@@ -93,13 +177,6 @@ class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
         std::set<ui64> WaitingSteps;
         bool RetryPending = false;
         bool Subscribed = false;
-    };
-
-    struct TTabletInfo {
-        ui64 MediatorTabletId;
-        TMediator* Mediator;
-        ui32 BucketId;
-        ui32 RefCount = 0;
     };
 
     struct TCoordinatorSubscriber {
@@ -125,55 +202,176 @@ class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
     ui64 LastSeqNo = 0;
     THashMap<ui64, TCoordinator> Coordinators;
     THashMap<TActorId, TCoordinatorSubscriber> CoordinatorSubscribers;
+    ui64 NextWatchSubscriptionId = 1;
 
-    TMediator& MediatorInfo(ui64 mediator, const NKikimrSubDomains::TProcessingParams &processing) {
-        auto pr = Mediators.try_emplace(mediator, processing.GetTimeCastBucketsPerMediator());
-        if (!pr.second) {
-            Y_ABORT_UNLESS(pr.first->second.BucketsSz == processing.GetTimeCastBucketsPerMediator());
+    TMediator& MediatorInfo(ui64 mediator, const NKikimrSubDomains::TProcessingParams& processing) {
+        auto it = Mediators.find(mediator);
+        if (it == Mediators.end()) {
+            auto res = Mediators.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(mediator),
+                std::forward_as_tuple(mediator, processing.GetTimeCastBucketsPerMediator()));
+            it = res.first;
+        } else {
+            Y_ABORT_UNLESS(it->second.BucketsSz == processing.GetTimeCastBucketsPerMediator());
         }
-        if (pr.first->second.Coordinators.empty()) {
-            pr.first->second.Coordinators.assign(
+
+        // Note: some older tablets may have an empty list of coordinators
+        // We fill the list of coordinators the first time we observe a non-empty list
+        if (it->second.Coordinators.empty()) {
+            it->second.Coordinators.assign(
                 processing.GetCoordinators().begin(),
                 processing.GetCoordinators().end());
         }
-        return pr.first->second;
+
+        return it->second;
     }
 
-    void RegisterMediator(ui64 mediatorTabletId, TMediator &mediator, const TActorContext &ctx) {
-        TAutoPtr<TEvMediatorTimecast::TEvWatch> ev(new TEvMediatorTimecast::TEvWatch());
+    const TActorId& MediatorPipe(TMediator& mediator, const TActorContext& ctx) {
+        if (!mediator.PipeClient) {
+            mediator.PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, mediator.TabletId));
+        }
+        return mediator.PipeClient;
+    }
+
+    void SendGranularWatch(TMediator& mediator, ui32 bucketId, const TActorContext& ctx) {
+        auto& bucket = mediator.Buckets[bucketId];
+
+        while (!bucket.PendingSubscribe.Empty()) {
+            bucket.PendingSubscribe.PopFront();
+        }
+        while (!bucket.PendingUpdate.Empty()) {
+            bucket.PendingUpdate.PopFront();
+        }
+
+        if (!AppData(ctx)->FeatureFlags.GetEnableGranularTimecast()) {
+            bucket.SubscriptionId = Max<ui64>();
+            return;
+        }
+
+        bucket.SubscriptionId = NextWatchSubscriptionId++;
+        auto req = std::make_unique<TEvMediatorTimecast::TEvGranularWatch>(bucketId, bucket.SubscriptionId);
+        req->Record.SetMinStep(bucket.LatestStep->Get());
+
+        for (ui64 tabletId : bucket.Tablets) {
+            auto& tabletInfo = Tablets.at(tabletId);
+            Y_ABORT_UNLESS(tabletInfo.Mediator == &mediator);
+            Y_ABORT_UNLESS(tabletInfo.BucketId == bucketId);
+            tabletInfo.SubscriptionId = bucket.SubscriptionId;
+            bucket.PendingSubscribe.PushBack(&tabletInfo);
+            tabletInfo.FrozenStep = Max<ui64>(); // will be unfrozen unless reported as frozen
+            tabletInfo.MinStep = tabletInfo.Entry->Get(); // will not freeze below this step
+            tabletInfo.Synced = false;
+            req->Record.AddTablets(tabletId);
+        }
+
+        const auto& client = MediatorPipe(mediator, ctx);
+        LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+            << " SEND to Mediator# " << mediator.TabletId << " " << req->ToString());
+        NTabletPipe::SendData(ctx, client, req.release());
+    }
+
+    void SendGranularWatchAdd(TMediator& mediator, ui32 bucketId, ui64 tabletId, const TActorContext& ctx) {
+        auto& bucket = mediator.Buckets[bucketId];
+
+        Y_ABORT_UNLESS(bucket.Tablets.contains(tabletId));
+        auto& tabletInfo = Tablets.at(tabletId);
+        Y_ABORT_UNLESS(tabletInfo.Mediator == &mediator);
+        Y_ABORT_UNLESS(tabletInfo.BucketId == bucketId);
+
+        if (bucket.SubscriptionId == Max<ui64>()) {
+            tabletInfo.SubscriptionId = Max<ui64>();
+            return;
+        }
+
+        tabletInfo.SubscriptionId = NextWatchSubscriptionId++;
+        bucket.PendingSubscribe.PushBack(&tabletInfo);
+        tabletInfo.FrozenStep = Max<ui64>(); // will be unfrozen unless reported as frozen
+        tabletInfo.MinStep = tabletInfo.Entry->Get(); // will not freeze below this step
+        tabletInfo.Synced = false;
+
+        auto req = std::make_unique<TEvMediatorTimecast::TEvGranularWatchModify>(bucketId, tabletInfo.SubscriptionId);
+        req->Record.AddAddTablets(tabletId);
+
+        const auto& client = MediatorPipe(mediator, ctx);
+        LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+            << " SEND to Mediator# " << mediator.TabletId << " " << req->ToString());
+        NTabletPipe::SendData(ctx, client, req.release());
+    }
+
+    void SendGranularWatchRemove(TMediator& mediator, ui32 bucketId, ui64 tabletId, const TActorContext& ctx) {
+        auto& bucket = mediator.Buckets[bucketId];
+
+        Y_ABORT_UNLESS(bucket.Tablets.contains(tabletId));
+        auto& tabletInfo = Tablets.at(tabletId);
+        Y_ABORT_UNLESS(tabletInfo.Mediator == &mediator);
+        Y_ABORT_UNLESS(tabletInfo.BucketId == bucketId);
+        tabletInfo.SubscriptionId = Max<ui64>();
+        tabletInfo.Synced = false;
+        bucket.PendingSubscribe.Remove(&tabletInfo);
+        bucket.PendingUpdate.Remove(&tabletInfo);
+        bucket.Tablets.erase(tabletId);
+
+        if (bucket.SubscriptionId == Max<ui64>()) {
+            return;
+        }
+
+        auto req = std::make_unique<TEvMediatorTimecast::TEvGranularWatchModify>(bucketId, NextWatchSubscriptionId++);
+        req->Record.AddRemoveTablets(tabletId);
+
+        const auto& client = MediatorPipe(mediator, ctx);
+        LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+            << " SEND to Mediator# " << mediator.TabletId << " " << req->ToString());
+        NTabletPipe::SendData(ctx, client, req.release());
+    }
+
+    void RegisterMediator(TMediator& mediator, const TActorContext& ctx) {
+        auto req = std::make_unique<TEvMediatorTimecast::TEvWatch>();
+
         for (ui32 bucketId = 0, e = mediator.BucketsSz; bucketId != e; ++bucketId) {
-            auto &x = mediator.Buckets[bucketId];
-            if (!x.Entry)
-                continue;
-            if (x.Entry.RefCount() == 1) {
-                x.Entry.Drop();
-                x.Waiters = { };
+            auto& bucket = mediator.Buckets[bucketId];
+            if (bucket.Tablets.empty()) {
+                // There are no tablets interested in this bucket, avoid unnecessary watches
+                bucket.WatchSent = false;
+                bucket.Waiters = { };
                 continue;
             }
 
-            ev->Record.AddBucket(bucketId);
+            SendGranularWatch(mediator, bucketId, ctx);
+
+            req->Record.AddBucket(bucketId);
+            bucket.WatchSent = true;
+            bucket.WatchSynced = false;
         }
 
-        if (ev->Record.BucketSize()) {
-            mediator.PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, mediatorTabletId));
-            LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
-                << " SEND to# " << mediatorTabletId << " Mediator " << ev->ToString());
-            NTabletPipe::SendData(ctx, mediator.PipeClient, ev.Release());
+        if (req->Record.BucketSize()) {
+            const auto& client = MediatorPipe(mediator, ctx);
+            LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+                << " SEND to Mediator# " << mediator.TabletId << " " << req->ToString());
+            NTabletPipe::SendData(ctx, client, req.release());
         }
     }
 
-    void SubscribeBucket(ui64 mediatorTabletId, TMediator &mediator, ui32 bucketId, const TActorContext &ctx) {
-        if (mediator.PipeClient) {
-            TAutoPtr<TEvMediatorTimecast::TEvWatch> ev(new TEvMediatorTimecast::TEvWatch(bucketId));
-            LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
-                << " SEND to# " << mediatorTabletId << " Mediator " << ev->ToString());
-            NTabletPipe::SendData(ctx, mediator.PipeClient, ev.Release());
+    void SubscribeBucket(TMediator& mediator, ui32 bucketId, ui64 tabletId, const TActorContext& ctx) {
+        auto& bucket = mediator.Buckets[bucketId];
+        Y_ABORT_UNLESS(bucket.Tablets.contains(tabletId));
+        if (bucket.WatchSent) {
+            SendGranularWatchAdd(mediator, bucketId, tabletId, ctx);
         } else {
-            RegisterMediator(mediatorTabletId, mediator, ctx);
+            SendGranularWatch(mediator, bucketId, ctx);
+
+            auto req = std::make_unique<TEvMediatorTimecast::TEvWatch>(bucketId);
+
+            const auto& client = MediatorPipe(mediator, ctx);
+            LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+                << " SEND to Mediator# " << mediator.TabletId << " " << req->ToString());
+            NTabletPipe::SendData(ctx, client, req.release());
+
+            bucket.WatchSent = true;
         }
     }
 
-    void TryResync(const TActorId &pipeClient, ui64 tabletId, const TActorContext &ctx) {
+    void TryResync(const TActorId& pipeClient, ui64 tabletId, const TActorContext& ctx) {
         ResyncCoordinator(tabletId, pipeClient, ctx);
 
         auto it = Mediators.find(tabletId);
@@ -181,34 +379,35 @@ class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
             return;
         }
 
-        TMediator &mediator = it->second;
+        TMediator& mediator = it->second;
         if (mediator.PipeClient == pipeClient) {
             mediator.PipeClient = TActorId();
-            RegisterMediator(tabletId, mediator, ctx);
+            RegisterMediator(mediator, ctx);
         }
     }
 
-    void SyncCoordinator(ui64 coordinatorId, TCoordinator &coordinator, const TActorContext &ctx);
-    void ResyncCoordinator(ui64 coordinatorId, const TActorId &pipeClient, const TActorContext &ctx);
-    void NotifyCoordinatorWaiters(ui64 coordinatorId, TCoordinator &coordinator, const TActorContext &ctx);
+    void SyncCoordinator(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx);
+    void ResyncCoordinator(ui64 coordinatorId, const TActorId& pipeClient, const TActorContext& ctx);
+    void NotifyCoordinatorWaiters(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx);
 
-    void Handle(TEvMediatorTimecast::TEvRegisterTablet::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvMediatorTimecast::TEvUnregisterTablet::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvMediatorTimecast::TEvWaitPlanStep::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvMediatorTimecast::TEvUpdate::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvTabletPipe::TEvClientConnected::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvPrivate::TEvRetryCoordinator::TPtr &ev, const TActorContext &ctx);
+    void Handle(TEvMediatorTimecast::TEvRegisterTablet::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvMediatorTimecast::TEvUnregisterTablet::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvMediatorTimecast::TEvWaitPlanStep::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvMediatorTimecast::TEvUpdate::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvMediatorTimecast::TEvGranularUpdate::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvRetryCoordinator::TPtr& ev, const TActorContext& ctx);
 
     // Client requests for readstep subscriptions
-    void Handle(TEvMediatorTimecast::TEvSubscribeReadStep::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvMediatorTimecast::TEvWaitReadStep::TPtr &ev, const TActorContext &ctx);
+    void Handle(TEvMediatorTimecast::TEvSubscribeReadStep::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvMediatorTimecast::TEvWaitReadStep::TPtr& ev, const TActorContext& ctx);
 
     // Coordinator replies for readstep subscriptions
-    void Handle(TEvTxProxy::TEvSubscribeReadStepResult::TPtr &ev, const TActorContext &ctx);
-    void Handle(TEvTxProxy::TEvSubscribeReadStepUpdate::TPtr &ev, const TActorContext &ctx);
+    void Handle(TEvTxProxy::TEvSubscribeReadStepResult::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvTxProxy::TEvSubscribeReadStepUpdate::TPtr& ev, const TActorContext& ctx);
 
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -225,6 +424,7 @@ public:
             HFunc(TEvMediatorTimecast::TEvUnregisterTablet, Handle);
             HFunc(TEvMediatorTimecast::TEvWaitPlanStep, Handle);
             HFunc(TEvMediatorTimecast::TEvUpdate, Handle);
+            HFunc(TEvMediatorTimecast::TEvGranularUpdate, Handle);
 
             HFunc(TEvMediatorTimecast::TEvSubscribeReadStep, Handle);
             HFunc(TEvMediatorTimecast::TEvUnsubscribeReadStep, Handle);
@@ -241,90 +441,123 @@ public:
     }
 };
 
-void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvRegisterTablet::TPtr &ev, const TActorContext &ctx) {
-    const TEvMediatorTimecast::TEvRegisterTablet *msg = ev->Get();
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvRegisterTablet::TPtr& ev, const TActorContext& ctx) {
+    const TEvMediatorTimecast::TEvRegisterTablet* msg = ev->Get();
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE " << msg->ToString());
     const ui64 tabletId = msg->TabletId;
-    const NKikimrSubDomains::TProcessingParams &processingParams = msg->ProcessingParams;
+    const NKikimrSubDomains::TProcessingParams& processingParams = msg->ProcessingParams;
 
-    auto& tabletInfo = Tablets[tabletId];
+    auto it = Tablets.find(tabletId);
+    if (it == Tablets.end()) {
+        auto res = Tablets.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(tabletId),
+            std::forward_as_tuple(tabletId));
+        it = res.first;
+    }
+    auto& tabletInfo = it->second;
 
     TMediators mediators(processingParams);
     Y_ABORT_UNLESS(mediators.List().size());
     const ui64 mediatorTabletId = mediators.Select(tabletId);
-    tabletInfo.MediatorTabletId = mediatorTabletId;
 
     TTimeCastBuckets buckets(processingParams);
     const ui32 bucketId = buckets.Select(tabletId);
-    tabletInfo.BucketId = bucketId;
 
-    TMediator &mediator = MediatorInfo(mediatorTabletId, processingParams);
-    tabletInfo.Mediator = &mediator;
+    TMediator& mediator = MediatorInfo(mediatorTabletId, processingParams);
 
     Y_ABORT_UNLESS(bucketId < mediator.BucketsSz);
-    auto &bucket = mediator.Buckets[bucketId];
-    if (!bucket.Entry)
-        bucket.Entry = new TMediatorTimecastEntry();
+    auto& bucket = mediator.Buckets[bucketId];
+
+    if (tabletInfo.Mediator && (tabletInfo.Mediator != &mediator || tabletInfo.BucketId != bucketId)) {
+        // Tablet unexpectedly changed their mediator/bucket
+        SendGranularWatchRemove(*tabletInfo.Mediator, tabletInfo.BucketId, tabletId, ctx);
+        tabletInfo.Mediator = nullptr;
+        tabletInfo.Entry.Reset();
+    }
+
+    tabletInfo.Mediator = &mediator;
+    tabletInfo.BucketId = bucketId;
+    if (!tabletInfo.Entry) {
+        tabletInfo.Entry = new TMediatorTimecastEntry(bucket.SafeStep, bucket.LatestStep);
+    }
 
     ++tabletInfo.RefCount;
+    if (bucket.AddNewTablet(tabletId)) {
+        // New tablet for this bucket, make sure we subscribe
+        SubscribeBucket(mediator, bucketId, tabletId, ctx);
+    }
 
     TAutoPtr<TEvMediatorTimecast::TEvRegisterTabletResult> result(
-        new TEvMediatorTimecast::TEvRegisterTabletResult(tabletId, bucket.Entry));
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
-        << " SEND to# " << ev->Sender.ToString() << " Sender " << result->ToString());
+        new TEvMediatorTimecast::TEvRegisterTabletResult(tabletId, tabletInfo.Entry));
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+        << " SEND to Sender# " << ev->Sender << " " << result->ToString());
     ctx.Send(ev->Sender, result.Release());
-
-    SubscribeBucket(mediatorTabletId, mediator, bucketId, ctx);
 }
 
-void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnregisterTablet::TPtr &ev, const TActorContext &ctx) {
-    const auto *msg = ev->Get();
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnregisterTablet::TPtr& ev, const TActorContext& ctx) {
+    const auto* msg = ev->Get();
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE " << msg->ToString());
     const ui64 tabletId = msg->TabletId;
 
     auto it = Tablets.find(tabletId);
-    if (it != Tablets.end()) {
-        Y_ABORT_UNLESS(it->second.RefCount > 0);
-        if (0 == --it->second.RefCount) {
-            // Note: buckets are unsubscribed lazily when entry refcount reaches zero on reconnect
-            Tablets.erase(it);
+    if (it == Tablets.end()) {
+        return;
+    }
+
+    auto& tabletInfo = it->second;
+
+    Y_ABORT_UNLESS(tabletInfo.RefCount > 0);
+    if (0 == --tabletInfo.RefCount) {
+        if (tabletInfo.Mediator) {
+            SendGranularWatchRemove(*tabletInfo.Mediator, tabletInfo.BucketId, tabletId, ctx);
         }
+        // Note: buckets are unsubscribed lazily when entry refcount reaches zero on reconnect
+        Tablets.erase(it);
     }
 }
 
-void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvWaitPlanStep::TPtr &ev, const TActorContext &ctx) {
-    const auto *msg = ev->Get();
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvWaitPlanStep::TPtr& ev, const TActorContext& ctx) {
+    const auto* msg = ev->Get();
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE " << msg->ToString());
     const ui64 tabletId = msg->TabletId;
     const ui64 planStep = msg->PlanStep;
 
     auto it = Tablets.find(tabletId);
     Y_ABORT_UNLESS(it != Tablets.end(), "TEvWaitPlanStep TabletId# %" PRIu64 " is not subscribed", tabletId);
+    auto& tabletInfo = it->second;
 
-    TMediator &mediator = *it->second.Mediator;
-    const ui32 bucketId = it->second.BucketId;
-    auto &bucket = mediator.Buckets[bucketId];
-    Y_DEBUG_ABORT_UNLESS(bucket.Entry, "TEvWaitPlanStep TabletId# %" PRIu64 " has no timecast entry, possible race", tabletId);
-    if (!bucket.Entry) {
+    Y_DEBUG_ABORT_UNLESS(tabletInfo.Entry, "TEvWaitPlanStep TabletId# %" PRIu64 " has no timecast entry, possible race", tabletId);
+    if (!tabletInfo.Entry) {
         return;
     }
 
-    const ui64 currentStep = bucket.Entry->Get(tabletId);
+    Y_ABORT_UNLESS(tabletInfo.Mediator);
+    TMediator& mediator = *tabletInfo.Mediator;
+    auto& bucket = mediator.Buckets[tabletInfo.BucketId];
+
+    const ui64 currentStep = tabletInfo.Entry->Get(tabletId);
     if (currentStep < planStep) {
-        bucket.Waiters.emplace(ev->Sender, tabletId, planStep);
-        for (ui64 coordinatorId : mediator.Coordinators) {
-            TMediatorCoordinator &coordinator = MediatorCoordinators[coordinatorId];
-            if (coordinator.WaitingSteps.insert(planStep).second && !coordinator.RetryPending) {
-                Send(MakePipePerNodeCacheID(false),
-                    new TEvPipeCache::TEvForward(
-                        new TEvTxProxy::TEvRequirePlanSteps(coordinatorId, planStep),
-                        coordinatorId,
-                        !coordinator.Subscribed));
-                coordinator.Subscribed = true;
+        if (bucket.LatestStep->Get() < planStep) {
+            bucket.Waiters.emplace(ev->Sender, tabletId, planStep);
+            for (ui64 coordinatorId : mediator.Coordinators) {
+                TMediatorCoordinator& coordinator = MediatorCoordinators[coordinatorId];
+                if (coordinator.WaitingSteps.insert(planStep).second && !coordinator.RetryPending) {
+                    Send(MakePipePerNodeCacheID(false),
+                        new TEvPipeCache::TEvForward(
+                            new TEvTxProxy::TEvRequirePlanSteps(coordinatorId, planStep),
+                            coordinatorId,
+                            !coordinator.Subscribed));
+                    coordinator.Subscribed = true;
+                }
             }
+        } else {
+            // Either frozen or not synchronized yet
+            tabletInfo.Waiters.emplace(ev->Sender, tabletId, planStep);
+            bucket.TabletWaiters.insert(TTabletWaiter(planStep, tabletId));
         }
         return;
     }
@@ -333,25 +566,25 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvWaitPlanStep::TPtr &
     ctx.Send(ev->Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(tabletId, currentStep));
 }
 
-void TMediatorTimecastProxy::Handle(TEvTabletPipe::TEvClientConnected::TPtr &ev, const TActorContext &ctx) {
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
+void TMediatorTimecastProxy::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActorContext& ctx) {
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE EvClientConnected");
-    TEvTabletPipe::TEvClientConnected *msg = ev->Get();
+    TEvTabletPipe::TEvClientConnected* msg = ev->Get();
     if (msg->Status != NKikimrProto::OK) {
         TryResync(msg->ClientId, msg->TabletId, ctx);
     }
 }
 
-void TMediatorTimecastProxy::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr &ev, const TActorContext &ctx) {
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
+void TMediatorTimecastProxy::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActorContext& ctx) {
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE EvClientDestroyed");
-    TEvTabletPipe::TEvClientDestroyed *msg = ev->Get();
+    TEvTabletPipe::TEvClientDestroyed* msg = ev->Get();
     TryResync(msg->ClientId, msg->TabletId, ctx);
 }
 
-void TMediatorTimecastProxy::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr &ev, const TActorContext &ctx) {
-    auto *msg = ev->Get();
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
+void TMediatorTimecastProxy::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev, const TActorContext& ctx) {
+    auto* msg = ev->Get();
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE EvDeliveryProblem " << msg->TabletId);
     auto it = MediatorCoordinators.find(msg->TabletId);
     if (it != MediatorCoordinators.end()) {
@@ -362,9 +595,9 @@ void TMediatorTimecastProxy::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr &ev, 
     }
 }
 
-void TMediatorTimecastProxy::Handle(TEvPrivate::TEvRetryCoordinator::TPtr &ev, const TActorContext &ctx) {
-    auto *msg = ev->Get();
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
+void TMediatorTimecastProxy::Handle(TEvPrivate::TEvRetryCoordinator::TPtr& ev, const TActorContext& ctx) {
+    auto* msg = ev->Get();
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE EvRetryCoordinator " << msg->Coordinator);
     auto it = MediatorCoordinators.find(msg->Coordinator);
     if (it != MediatorCoordinators.end() && it->second.RetryPending) {
@@ -380,28 +613,28 @@ void TMediatorTimecastProxy::Handle(TEvPrivate::TEvRetryCoordinator::TPtr &ev, c
     }
 }
 
-void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUpdate::TPtr &ev, const TActorContext &ctx) {
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID.ToString()
-        << " HANDLE "<< ev->Get()->ToString());
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUpdate::TPtr& ev, const TActorContext& ctx) {
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+        << " HANDLE " << ev->Get()->ToString());
 
-    const NKikimrTxMediatorTimecast::TEvUpdate &record = ev->Get()->Record;
+    const NKikimrTxMediatorTimecast::TEvUpdate& record = ev->Get()->Record;
 
     const ui64 mediatorTabletId = record.GetMediator();
     auto it = Mediators.find(mediatorTabletId);
     if (it != Mediators.end()) {
-        auto &mediator = it->second;
+        auto& mediator = it->second;
         Y_ABORT_UNLESS(record.GetBucket() < mediator.BucketsSz);
-        auto &bucket = mediator.Buckets[record.GetBucket()];
+        auto& bucket = mediator.Buckets[record.GetBucket()];
         const ui64 step = record.GetTimeBarrier();
-        switch (bucket.Entry.RefCount()) {
+        switch (bucket.SafeStep.RefCount()) {
             case 0:
                 break;
             case 1:
-                bucket.Entry.Drop();
                 bucket.Waiters = { };
-                break;
+                bucket.TabletWaiters = { };
+                [[fallthrough]];
             default: {
-                bucket.Entry->Update(step, nullptr, 0);
+                bucket.SafeStep->Set(step);
                 THashSet<std::pair<TActorId, ui64>> processed; // a set of processed tablets
                 while (!bucket.Waiters.empty()) {
                     const auto& top = bucket.Waiters.top();
@@ -412,6 +645,27 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUpdate::TPtr &ev, co
                         ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, step));
                     }
                     bucket.Waiters.pop();
+                }
+                while (!bucket.TabletWaiters.empty()) {
+                    const auto& candidate = *bucket.TabletWaiters.begin();
+                    if (step < candidate.PlanStep) {
+                        break;
+                    }
+                    auto it = Tablets.find(candidate.TabletId);
+                    if (it != Tablets.end()) {
+                        auto& tabletInfo = it->second;
+                        while (!tabletInfo.Waiters.empty()) {
+                            const auto& top = *tabletInfo.Waiters.begin();
+                            if (step < top.PlanStep) {
+                                break;
+                            }
+                            if (processed.insert(std::make_pair(top.Sender, top.TabletId)).second) {
+                                ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, step));
+                            }
+                            tabletInfo.Waiters.erase(tabletInfo.Waiters.begin());
+                        }
+                    }
+                    bucket.TabletWaiters.erase(bucket.TabletWaiters.begin());
                 }
                 break;
             }
@@ -427,7 +681,179 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUpdate::TPtr &ev, co
     }
 }
 
-void TMediatorTimecastProxy::SyncCoordinator(ui64 coordinatorId, TCoordinator &coordinator, const TActorContext &ctx) {
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvGranularUpdate::TPtr& ev, const TActorContext& ctx) {
+    auto* msg = ev->Get();
+    LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+        << " HANDLE " << msg->ToString());
+
+    const ui64 mediatorTabletId = msg->Record.GetMediator();
+    auto it = Mediators.find(mediatorTabletId);
+    if (it == Mediators.end()) {
+        // Ignore messages from unknown mediators
+        // Note: we don't clean up mediators, so this shouldn't happen
+        return;
+    }
+
+    auto& mediator = it->second;
+    const ui32 bucketId = msg->Record.GetBucket();
+    if (bucketId >= mediator.BucketsSz) {
+        LOG_CRIT_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+            << " got update from Mediator# " << mediatorTabletId << " Bucket# " << bucketId
+            << " expecting only " << mediator.BucketsSz << " buckets");
+        return;
+    }
+
+    auto& bucket = mediator.Buckets[bucketId];
+    if (msg->Record.GetSubscriptionId() < bucket.SubscriptionId) {
+        // Ignore messages from old subscriptions
+        return;
+    }
+
+    if (msg->Record.FrozenTabletsSize() != msg->Record.FrozenStepsSize()) {
+        LOG_CRIT_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+            << " got update from Mediator# " << mediatorTabletId << " Bucket# " << bucketId
+            << " with mismatched frozen records");
+        return;
+    }
+
+    size_t frozenSize = msg->Record.FrozenTabletsSize();
+    size_t unfrozenSize = msg->Record.UnfrozenTabletsSize();
+
+    for (size_t i = 0; i < frozenSize; ++i) {
+        ui64 tabletId = msg->Record.GetFrozenTablets(i);
+        ui64 step = msg->Record.GetFrozenSteps(i);
+        if (!bucket.Tablets.contains(tabletId)) {
+            // We are not interested in this tablet
+            continue;
+        }
+        auto& tabletInfo = Tablets.at(tabletId);
+        if (msg->Record.GetSubscriptionId() < tabletInfo.SubscriptionId) {
+            // We have resubscribed to this tablet and this update must be ignored
+            continue;
+        }
+        // This tablet is now frozen at this step
+        tabletInfo.FrozenStep = step;
+        // Update frozen steps for synchronized tablets
+        if (tabletInfo.Synced && bucket.WatchSynced) {
+            bucket.PendingUpdate.PushBack(&tabletInfo);
+        }
+    }
+
+    for (size_t i = 0; i < unfrozenSize; ++i) {
+        ui64 tabletId = msg->Record.GetUnfrozenTablets(i);
+        if (!bucket.Tablets.contains(tabletId)) {
+            // We are not interested in this tablet
+            continue;
+        }
+        auto& tabletInfo = Tablets.at(tabletId);
+        if (msg->Record.GetSubscriptionId() < tabletInfo.SubscriptionId) {
+            // We have resubscribed to this tablet and this update must be ignored
+            continue;
+        }
+        // This tablet is no longer frozen
+        tabletInfo.FrozenStep = Max<ui64>();
+        // Update frozen steps for synchronized tablets
+        if (tabletInfo.Synced && bucket.WatchSynced) {
+            bucket.PendingUpdate.PushBack(&tabletInfo);
+        }
+    }
+
+    while (!bucket.PendingSubscribe.Empty()) {
+        auto* tabletInfo = bucket.PendingSubscribe.Front();
+        if (msg->Record.GetSubscriptionId() < tabletInfo->SubscriptionId) {
+            // This tablet (and all others) is not subscribed yet
+            break;
+        }
+        // This tablet is now subscribed and needs to be updated
+        bucket.PendingUpdate.PushBack(tabletInfo);
+        tabletInfo->Synced = true;
+    }
+
+    bucket.SubscriptionId = msg->Record.GetSubscriptionId();
+
+    const ui64 latestStep = msg->Record.GetLatestStep();
+
+    if (!bucket.WatchSynced) {
+        // We may have connected to a lagging mediator, make sure we don't sync too early
+        if (latestStep < bucket.LatestStep->Get()) {
+            return;
+        }
+
+        // We have reached an expected state, now this bucket is synchronized
+        bucket.WatchSynced = true;
+    } else if (latestStep < bucket.LatestStep->Get()) {
+        // This should never happen, but since we need to protect against
+        // mediator time jumping backwards for running instances we will ignore
+        // this update. Note that the current state is already updated, it's
+        // just not published yet, and will be published later.
+        LOG_CRIT_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
+            << " got update from Mediator# " << mediatorTabletId
+            << " with LatestStep# " << latestStep
+            << " previous LatestStep# " << bucket.LatestStep->Get());
+        return;
+    }
+
+    TIntrusiveList<TTabletInfo> checkWaiters;
+
+    // Process frozen step updates
+    while (!bucket.PendingUpdate.Empty()) {
+        auto* tabletInfo = bucket.PendingUpdate.PopFront();
+        ui64 frozenStep = Max(tabletInfo->FrozenStep, tabletInfo->MinStep);
+        tabletInfo->Entry->SetFrozenStep(frozenStep);
+        // Note: all waiters in tabletInfo are always below LatestStep
+        if (!tabletInfo->Waiters.empty() && tabletInfo->Waiters.begin()->PlanStep <= frozenStep) {
+            checkWaiters.PushBack(tabletInfo);
+        }
+    }
+
+    // Publish the new latest step
+    bucket.LatestStep->Set(latestStep);
+
+    THashSet<std::pair<TActorId, ui64>> processed; // a set of processed tablets
+    while (!bucket.Waiters.empty()) {
+        const auto& top = bucket.Waiters.top();
+        if (latestStep < top.PlanStep) {
+            break;
+        }
+        auto it = Tablets.find(top.TabletId);
+        if (it != Tablets.end() && bucket.Tablets.contains(top.TabletId)) {
+            auto& tabletInfo = it->second;
+            ui64 frozenStep = Max(tabletInfo.FrozenStep, tabletInfo.MinStep);
+            if (tabletInfo.Synced && top.PlanStep <= frozenStep) {
+                // Send update immediately
+                if (processed.insert(std::make_pair(top.Sender, top.TabletId)).second) {
+                    ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, Min(latestStep, frozenStep)));
+                }
+            } else {
+                // Move this waiter to the per-tablet waiter
+                tabletInfo.Waiters.insert(top);
+                bucket.TabletWaiters.insert(TTabletWaiter(top.PlanStep, top.TabletId));
+            }
+        }
+        bucket.Waiters.pop();
+    }
+
+    while (!checkWaiters.Empty()) {
+        auto* tabletInfo = checkWaiters.PopFront();
+        ui64 frozenStep = Max(tabletInfo->FrozenStep, tabletInfo->MinStep);
+        ui64 step = Min(latestStep, frozenStep);
+        while (!tabletInfo->Waiters.empty()) {
+            const auto& top = *tabletInfo->Waiters.begin();
+            if (step < top.PlanStep) {
+                break;
+            }
+            if (processed.insert(std::make_pair(top.Sender, top.TabletId)).second) {
+                ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, step));
+            }
+            // Current queue may have more waiters for the same plan step, but
+            // all of them will be processed and erased in this loop.
+            bucket.TabletWaiters.erase(TTabletWaiter(top.PlanStep, top.TabletId));
+            tabletInfo->Waiters.erase(tabletInfo->Waiters.begin());
+        }
+    }
+}
+
+void TMediatorTimecastProxy::SyncCoordinator(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx) {
     const ui64 seqNo = LastSeqNo;
 
     if (!coordinator.PipeClient) {
@@ -445,13 +871,13 @@ void TMediatorTimecastProxy::SyncCoordinator(ui64 coordinatorId, TCoordinator &c
     NTabletPipe::SendData(ctx, coordinator.PipeClient, new TEvTxProxy::TEvSubscribeReadStep(coordinatorId, seqNo));
 }
 
-void TMediatorTimecastProxy::ResyncCoordinator(ui64 coordinatorId, const TActorId &pipeClient, const TActorContext &ctx) {
+void TMediatorTimecastProxy::ResyncCoordinator(ui64 coordinatorId, const TActorId& pipeClient, const TActorContext& ctx) {
     auto itCoordinator = Coordinators.find(coordinatorId);
     if (itCoordinator == Coordinators.end()) {
         return;
     }
 
-    auto &coordinator = itCoordinator->second;
+    auto& coordinator = itCoordinator->second;
     if (coordinator.PipeClient != pipeClient) {
         return;
     }
@@ -467,14 +893,14 @@ void TMediatorTimecastProxy::ResyncCoordinator(ui64 coordinatorId, const TActorI
     SyncCoordinator(coordinatorId, coordinator, ctx);
 }
 
-void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvSubscribeReadStep::TPtr &ev, const TActorContext &ctx) {
-    const auto *msg = ev->Get();
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvSubscribeReadStep::TPtr& ev, const TActorContext& ctx) {
+    const auto* msg = ev->Get();
     LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE " << msg->ToString());
 
     const ui64 coordinatorId = msg->CoordinatorId;
-    auto &subscriber = CoordinatorSubscribers[ev->Sender];
-    auto &coordinator = Coordinators[coordinatorId];
+    auto& subscriber = CoordinatorSubscribers[ev->Sender];
+    auto& coordinator = Coordinators[coordinatorId];
     subscriber.Coordinators.insert(coordinatorId);
     coordinator.Subscribers.insert(ev->Sender);
     ui64 seqNo = ++LastSeqNo;
@@ -483,16 +909,16 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvSubscribeReadStep::T
     SyncCoordinator(coordinatorId, coordinator, ctx);
 }
 
-void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep::TPtr &ev, const TActorContext &ctx) {
-    const auto *msg = ev->Get();
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep::TPtr& ev, const TActorContext& ctx) {
+    const auto* msg = ev->Get();
     LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE " << msg->ToString());
 
-    auto &subscriber = CoordinatorSubscribers[ev->Sender];
+    auto& subscriber = CoordinatorSubscribers[ev->Sender];
     if (msg->CoordinatorId == 0) {
         // Unsubscribe from all coordinators
         for (ui64 coordinatorId : subscriber.Coordinators) {
-            auto &coordinator = Coordinators[coordinatorId];
+            auto& coordinator = Coordinators[coordinatorId];
             coordinator.Subscribers.erase(ev->Sender);
             if (coordinator.Subscribers.empty()) {
                 coordinator.IdleStart = ctx.Monotonic();
@@ -501,7 +927,7 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep:
         subscriber.Coordinators.clear();
     } else if (subscriber.Coordinators.contains(msg->CoordinatorId)) {
         // Unsubscribe from specific coordinator
-        auto &coordinator = Coordinators[msg->CoordinatorId];
+        auto& coordinator = Coordinators[msg->CoordinatorId];
         coordinator.Subscribers.erase(ev->Sender);
         if (coordinator.Subscribers.empty()) {
             coordinator.IdleStart = ctx.Monotonic();
@@ -515,8 +941,8 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep:
     }
 }
 
-void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvWaitReadStep::TPtr &ev, const TActorContext &ctx) {
-    const auto *msg = ev->Get();
+void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvWaitReadStep::TPtr& ev, const TActorContext& ctx) {
+    const auto* msg = ev->Get();
     LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE " << msg->ToString());
 
@@ -525,7 +951,7 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvWaitReadStep::TPtr &
     if (itCoordinator == Coordinators.end()) {
         return;
     }
-    auto &coordinator = itCoordinator->second;
+    auto& coordinator = itCoordinator->second;
 
     if (!coordinator.Subscribers.contains(ev->Sender)) {
         return;
@@ -544,8 +970,8 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvWaitReadStep::TPtr &
     coordinator.WaitRequests[key] = ev->Cookie;
 }
 
-void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepResult::TPtr &ev, const TActorContext &ctx) {
-    const auto &record = ev->Get()->Record;
+void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepResult::TPtr& ev, const TActorContext& ctx) {
+    const auto& record = ev->Get()->Record;
     LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE TEvSubscribeReadStepResult " << record.ShortDebugString());
 
@@ -554,7 +980,7 @@ void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepResult::TPtr
     if (itCoordinator == Coordinators.end()) {
         return;
     }
-    auto &coordinator = itCoordinator->second;
+    auto& coordinator = itCoordinator->second;
 
     bool updated = false;
     const ui64 nextReadStep = record.GetNextAcquireStep();
@@ -594,8 +1020,8 @@ void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepResult::TPtr
     }
 }
 
-void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepUpdate::TPtr &ev, const TActorContext &ctx) {
-    const auto &record = ev->Get()->Record;
+void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepUpdate::TPtr& ev, const TActorContext& ctx) {
+    const auto& record = ev->Get()->Record;
     LOG_DEBUG_S(ctx, NKikimrServices::TX_MEDIATOR_TIMECAST, "Actor# " << ctx.SelfID
         << " HANDLE TEvSubscribeReadStepUpdate " << record.ShortDebugString());
 
@@ -604,7 +1030,7 @@ void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepUpdate::TPtr
     if (itCoordinator == Coordinators.end()) {
         return;
     }
-    auto &coordinator = itCoordinator->second;
+    auto& coordinator = itCoordinator->second;
 
     const ui64 nextReadStep = record.GetNextAcquireStep();
     if (coordinator.LastObservedReadStep < nextReadStep) {
@@ -625,7 +1051,7 @@ void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepUpdate::TPtr
     }
 }
 
-void TMediatorTimecastProxy::NotifyCoordinatorWaiters(ui64 coordinatorId, TCoordinator &coordinator, const TActorContext &ctx) {
+void TMediatorTimecastProxy::NotifyCoordinatorWaiters(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx) {
     const ui64 step = coordinator.LastObservedReadStep;
     for (auto it = coordinator.WaitRequests.begin(); it != coordinator.WaitRequests.end();) {
         const ui64 waitStep = it->first.first;

--- a/ydb/core/tx/time_cast/time_cast_ut.cpp
+++ b/ydb/core/tx/time_cast/time_cast_ut.cpp
@@ -1,4 +1,8 @@
 #include "time_cast.h"
+#include <ydb/core/tx/tx.h>
+#include <ydb/core/tx/tx_processing.h>
+#include <ydb/core/base/tx_processing.h>
+#include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/testlib/test_client.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -41,7 +45,7 @@ namespace NKikimr::NMediatorTimeCastTest {
 
             Tests::TServer::TPtr server = new TServer(serverSettings);
 
-            auto &runtime = *server->GetRuntime();
+            auto& runtime = *server->GetRuntime();
             runtime.SetLogPriority(NKikimrServices::TX_MEDIATOR_TIMECAST, NActors::NLog::PRI_DEBUG);
 
             auto sender = runtime.AllocateEdgeActor();
@@ -77,6 +81,344 @@ namespace NKikimr::NMediatorTimeCastTest {
                 UNIT_ASSERT_GE(notify->Get()->ReadStep, waitStep2);
                 UNIT_ASSERT_GE(notify->Get()->ReadStep, stepPtr->Get());
             }
+        }
+
+        class TTargetTablet
+            : public TActor<TTargetTablet>
+            , public NTabletFlatExecutor::TTabletExecutedFlat
+        {
+        public:
+            TTargetTablet(const TActorId& tablet, TTabletStorageInfo* info)
+                : TActor(&TThis::StateInit)
+                , TTabletExecutedFlat(info, tablet, nullptr)
+            {}
+
+        private:
+            STFUNC(StateInit) {
+                StateInitImpl(ev, SelfId());
+            }
+
+            STFUNC(StateWork) {
+                switch (ev->GetTypeRewrite()) {
+                    hFunc(TEvTxProcessing::TEvPlanStep, Handle);
+                default:
+                    HandleDefaultEvents(ev, SelfId());
+                }
+            }
+
+            void Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev) {
+                ui64 step = ev->Get()->Record.GetStep();
+                THashMap<TActorId, TVector<ui64>> acks;
+                for (const auto& tx : ev->Get()->Record.GetTransactions()) {
+                    ui64 txId = tx.GetTxId();
+                    TActorId owner = ActorIdFromProto(tx.GetAckTo());
+                    acks[owner].push_back(txId);
+                }
+                for (auto& pr : acks) {
+                    auto owner = pr.first;
+                    Send(owner, new TEvTxProcessing::TEvPlanStepAck(TabletID(), step, pr.second.begin(), pr.second.end()));
+                }
+                Send(ev->Sender, new TEvTxProcessing::TEvPlanStepAccepted(TabletID(), step));
+            }
+
+        private:
+            void DefaultSignalTabletActive(const TActorContext&) override {
+                // must be empty
+            }
+
+            void OnActivateExecutor(const TActorContext& ctx) override {
+                Become(&TThis::StateWork);
+                SignalTabletActive(ctx);
+            }
+
+            void OnDetach(const TActorContext&) override {
+                PassAway();
+            }
+
+            void OnTabletDead(TEvTablet::TEvTabletDead::TPtr&, const TActorContext&) override {
+                PassAway();
+            }
+        };
+
+        TActorId BootTarget(TTestActorRuntime& runtime, ui64 tabletId) {
+            auto boot = CreateTestBootstrapper(runtime,
+                CreateTestTabletInfo(tabletId, TTabletTypes::Dummy),
+                [](const TActorId& tablet, TTabletStorageInfo* info) {
+                    return new TTargetTablet(tablet, info);
+                });
+
+            {
+                TDispatchOptions options;
+                options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot, 1));
+                runtime.DispatchEvents(options);
+            }
+
+            return boot;
+        }
+
+        ui64 PlanTx(const TServer::TPtr& server, ui64 txId, std::vector<ui64> tablets) {
+            auto& runtime = *server->GetRuntime();
+            ui64 coordinatorId = ChangeStateStorage(TTestTxConfig::Coordinator, server->GetSettings().Domain);
+            auto req = std::make_unique<TEvTxProxy::TEvProposeTransaction>(
+                coordinatorId, txId, 0, Min<ui64>(), Max<ui64>());
+            auto* affectedSet = req->Record.MutableTransaction()->MutableAffectedSet();
+            for (ui64 tabletId : tablets) {
+                auto* x = affectedSet->Add();
+                x->SetTabletId(tabletId);
+                x->SetFlags(TEvTxProxy::TEvProposeTransaction::AffectedWrite);
+            }
+            auto sender = runtime.AllocateEdgeActor();
+            ForwardToTablet(runtime, coordinatorId, sender, req.release());
+            for (;;) {
+                auto ev = runtime.GrabEdgeEventRethrow<TEvTxProxy::TEvProposeTransactionStatus>(sender);
+                auto* msg = ev->Get();
+                switch (msg->GetStatus()) {
+                    case TEvTxProxy::TEvProposeTransactionStatus::EStatus::StatusAccepted:
+                        break;
+                    case TEvTxProxy::TEvProposeTransactionStatus::EStatus::StatusPlanned:
+                        return msg->Record.GetStepId();
+                    default:
+                        UNIT_ASSERT_C(false, "Unexpected status " << int(msg->GetStatus()));
+                }
+            }
+        }
+
+        TMediatorTimecastEntry::TCPtr RegisterTablet(const TServer::TPtr& server, ui64 tabletId) {
+            auto& runtime = *server->GetRuntime();
+            auto sender = runtime.AllocateEdgeActor();
+            auto params = ExtractProcessingParams(*runtime.GetAppData().DomainsInfo->GetDomain());
+            auto req = std::make_unique<TEvMediatorTimecast::TEvRegisterTablet>(tabletId, params);
+            runtime.Send(new IEventHandle(MakeMediatorTimecastProxyID(), sender, req.release()), 0, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvMediatorTimecast::TEvRegisterTabletResult>(sender);
+            return ev->Get()->Entry;
+        }
+
+        Y_UNIT_TEST(GranularTimecast) {
+            TPortManager pm;
+            TServerSettings serverSettings(pm.GetPort(2134));
+            serverSettings.SetDomainName("Root")
+                .SetDomainPlanResolution(500)
+                .SetDomainTimecastBuckets(1)
+                .SetEnableGranularTimecast(true)
+                .SetUseRealThreads(false);
+
+            TServer::TPtr server = new TServer(serverSettings);
+
+            auto& runtime = *server->GetRuntime();
+            runtime.SetLogPriority(NKikimrServices::TX_MEDIATOR_TIMECAST, NActors::NLog::PRI_DEBUG);
+
+            auto sender = runtime.AllocateEdgeActor();
+
+            ui64 tablet1 = ChangeStateStorage(TTestTxConfig::TxTablet0, server->GetSettings().Domain);
+            BootTarget(runtime, tablet1);
+            ui64 tablet2 = ChangeStateStorage(TTestTxConfig::TxTablet1, server->GetSettings().Domain);
+            BootTarget(runtime, tablet2);
+            ui64 tablet3 = ChangeStateStorage(TTestTxConfig::TxTablet3, server->GetSettings().Domain);
+            BootTarget(runtime, tablet3);
+
+            auto entry1 = RegisterTablet(server, tablet1);
+            auto entry2 = RegisterTablet(server, tablet2);
+            auto entry3 = RegisterTablet(server, tablet3);
+
+            ui64 testStep1 = entry1->Get();
+            runtime.SimulateSleep(TDuration::Seconds(2));
+            ui64 testStep2 = entry1->Get();
+            Cerr << "... have step " << testStep1 << " and " << testStep2 << " after sleep" << Endl;
+            UNIT_ASSERT_C(testStep1 < testStep2, "Have step " << testStep1 << " and " << testStep2 << " after sleep");
+
+            TBlockEvents<TEvTxProcessing::TEvPlanStepAck> blockAcks(runtime);
+            TBlockEvents<TEvTxProcessing::TEvPlanStep> blockPlan1(runtime,
+                [&](auto& ev) { return ev->Get()->Record.GetTabletID() == tablet1; });
+            TBlockEvents<TEvTxProcessing::TEvPlanStep> blockPlan2(runtime,
+                [&](auto& ev) { return ev->Get()->Record.GetTabletID() == tablet2; });
+
+            ui64 stepTx1 = PlanTx(server, 1, { tablet1, tablet2 });
+            Cerr << "... tx1 planned at step " << stepTx1 << Endl;
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan1.size(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan2.size(), 1u);
+
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+
+            UNIT_ASSERT_C(entry1->Get() == stepTx1-1, "tablet1 step " << entry1->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry2->Get() == stepTx1-1, "tablet2 step " << entry2->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry3->Get() == stepTx1, "tablet3 step " << entry3->Get() << " not at " << stepTx1);
+
+            ui64 stepTx2 = PlanTx(server, 2, { tablet1, tablet2 });
+            Cerr << "... tx2 planned at step " << stepTx2 << Endl;
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan1.size(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan2.size(), 2u);
+
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+
+            UNIT_ASSERT_C(entry1->Get() == stepTx1-1, "tablet1 step " << entry1->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry2->Get() == stepTx1-1, "tablet2 step " << entry2->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry3->Get() == stepTx2, "tablet3 step " << entry3->Get() << " not at " << stepTx2);
+
+            Cerr << "... unblocking tx1 at tablet2" << Endl;
+            blockPlan2.Unblock(1);
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+
+            UNIT_ASSERT_C(entry1->Get() == stepTx1-1, "tablet1 step " << entry1->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry2->Get() == stepTx2-1, "tablet2 step " << entry2->Get() << " not at " << (stepTx2-1));
+            UNIT_ASSERT_C(entry3->Get() == stepTx2, "tablet3 step " << entry3->Get() << " not at " << stepTx2);
+
+            Cerr << "... unblocking tx2 at tablet2" << Endl;
+            blockPlan2.Unblock(1);
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+
+            UNIT_ASSERT_C(entry1->Get() == stepTx1-1, "tablet1 step " << entry1->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry2->Get() == stepTx2, "tablet2 step " << entry2->Get() << " not at " << stepTx2);
+            UNIT_ASSERT_C(entry3->Get() == stepTx2, "tablet3 step " << entry3->Get() << " not at " << stepTx2);
+
+            TBlockEvents<TEvMediatorTimecast::TEvNotifyPlanStep> blockNotify(runtime);
+
+            // This tests notify when latest step is updated for a non-frozen tablet
+            runtime.Send(new IEventHandle(MakeMediatorTimecastProxyID(), sender, new TEvMediatorTimecast::TEvWaitPlanStep(tablet2, stepTx2+1)));
+            runtime.WaitFor("step notify", [&]{ return blockNotify.size() > 0; });
+            UNIT_ASSERT_VALUES_EQUAL(blockNotify.size(), 1u);
+            ui64 notifiedStep = blockNotify[0]->Get()->PlanStep;
+            blockNotify.clear();
+            Cerr << "... notified at step " << notifiedStep << Endl;
+            UNIT_ASSERT_C(notifiedStep >= stepTx2+1, "notified at " << notifiedStep << " expected at least " << (stepTx2+1));
+
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+            UNIT_ASSERT_C(entry1->Get() == stepTx1-1, "tablet1 step " << entry1->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry2->Get() == notifiedStep, "tablet2 step " << entry2->Get() << " not at " << notifiedStep);
+            UNIT_ASSERT_C(entry3->Get() == notifiedStep, "tablet3 step " << entry3->Get() << " not at " << notifiedStep);
+
+            TBlockEvents<TEvMediatorTimecast::TEvGranularUpdate> blockUpdate(runtime);
+
+            // Plan a new tx and double check nothing has changed yet
+            ui64 stepTx3 = PlanTx(server, 3, { tablet2 });
+            Cerr << "... tx3 planned at step " << stepTx3 << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(entry1->Get(), stepTx1-1);
+            UNIT_ASSERT_VALUES_EQUAL(entry2->Get(), notifiedStep);
+            UNIT_ASSERT_VALUES_EQUAL(entry3->Get(), notifiedStep);
+
+            // This tests notify after latest step is updated and then tablet's frozen step changes
+            runtime.Send(new IEventHandle(MakeMediatorTimecastProxyID(), sender, new TEvMediatorTimecast::TEvWaitPlanStep(tablet2, stepTx3)));
+            runtime.WaitFor("granular update", [&]{ return blockUpdate.size() > 0 && blockUpdate.back()->Get()->Record.GetLatestStep() >= stepTx3; });
+            UNIT_ASSERT_VALUES_EQUAL(blockUpdate.size(), 1u); // new step + freeze
+            blockUpdate.Unblock();
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+            UNIT_ASSERT_C(entry1->Get() == stepTx1-1, "tablet1 step " << entry1->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry2->Get() == stepTx3-1, "tablet2 step " << entry2->Get() << " not at " << (stepTx3-1));
+            UNIT_ASSERT_C(entry3->Get() == stepTx3, "tablet3 step " << entry3->Get() << " not at " << stepTx3);
+            UNIT_ASSERT_VALUES_EQUAL(blockNotify.size(), 0u); // not notified yet!
+
+            blockPlan2.Unblock();
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(blockUpdate.size(), 1u); // unfreeze
+            blockUpdate.Unblock();
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+            UNIT_ASSERT_C(entry1->Get() == stepTx1-1, "tablet1 step " << entry1->Get() << " not at " << (stepTx1-1));
+            UNIT_ASSERT_C(entry2->Get() == stepTx3, "tablet2 step " << entry2->Get() << " not at " << stepTx3);
+            UNIT_ASSERT_C(entry3->Get() == stepTx3, "tablet3 step " << entry3->Get() << " not at " << stepTx3);
+
+            UNIT_ASSERT_VALUES_EQUAL(blockNotify.size(), 1u); // notified!
+            Cerr << "... notified at step " << blockNotify[0]->Get()->PlanStep << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(blockNotify[0]->Get()->PlanStep, stepTx3);
+            blockNotify.clear();
+
+            blockAcks.clear();
+            blockPlan1.clear();
+            blockPlan2.clear();
+            blockUpdate.clear();
+
+            // Test that attaching to a lagging mediator doesn't cause time to go backwards
+            Cerr << "... restarting mediator" << Endl;
+            ui64 mediatorId = ChangeStateStorage(TTestTxConfig::Mediator, server->GetSettings().Domain);
+            RebootTablet(runtime, mediatorId, sender);
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan1.size(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan2.size(), 3u);
+            for (;;) {
+                while (blockUpdate.size() > 0) {
+                    Cerr << "... unblocking update: " << blockUpdate[0]->Get()->Record.ShortDebugString() << Endl;
+                    blockUpdate.Unblock(1);
+                    runtime.SimulateSleep(TDuration::MilliSeconds(1));
+                    UNIT_ASSERT_VALUES_EQUAL(entry1->Get(), stepTx1-1);
+                    UNIT_ASSERT_VALUES_EQUAL(entry2->Get(), stepTx3);
+                    UNIT_ASSERT_VALUES_EQUAL(entry3->Get(), stepTx3);
+                }
+                if (blockPlan2.empty()) {
+                    break;
+                }
+                Cerr << "... unblocking plan for tablet2" << Endl;
+                blockPlan2.Unblock(1);
+                runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            }
+
+            blockAcks.clear();
+            blockPlan1.clear();
+            blockPlan2.clear();
+            blockUpdate.clear();
+
+            // Test that attaching to a mediator without granular support allows time to go forward
+            Cerr << "... restarting mediator" << Endl;
+            RebootTablet(runtime, mediatorId, sender);
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan1.size(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(blockPlan2.size(), 3u);
+            UNIT_ASSERT_VALUES_EQUAL(entry1->Get(), stepTx1-1);
+            UNIT_ASSERT_VALUES_EQUAL(entry2->Get(), stepTx3);
+            UNIT_ASSERT_VALUES_EQUAL(entry3->Get(), stepTx3);
+
+            Cerr << "... fully unblocking tx1" << Endl;
+            blockPlan1.Unblock(1);
+            blockPlan2.Unblock(1);
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(entry1->Get(), stepTx1);
+            UNIT_ASSERT_VALUES_EQUAL(entry2->Get(), stepTx3);
+            UNIT_ASSERT_VALUES_EQUAL(entry3->Get(), stepTx3);
+
+            Cerr << "... fully unblocking tx2" << Endl;
+            blockPlan1.Unblock(1);
+            blockPlan2.Unblock(1);
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(entry1->Get(), stepTx2);
+            UNIT_ASSERT_VALUES_EQUAL(entry2->Get(), stepTx3);
+            UNIT_ASSERT_VALUES_EQUAL(entry3->Get(), stepTx3);
+
+            Cerr << "... fully unblocking tx3" << Endl;
+            blockPlan2.Unblock(1);
+            runtime.SimulateSleep(TDuration::MilliSeconds(1));
+            Cerr << "... tablet1 at " << entry1->Get() << Endl;
+            Cerr << "... tablet2 at " << entry2->Get() << Endl;
+            Cerr << "... tablet3 at " << entry3->Get() << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(entry1->Get(), stepTx3);
+            UNIT_ASSERT_VALUES_EQUAL(entry2->Get(), stepTx3);
+            UNIT_ASSERT_VALUES_EQUAL(entry3->Get(), stepTx3);
         }
 
     } // Y_UNIT_TEST_SUITE(MediatorTimeCast)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Use granular mediator time that is not blocked by other tablets.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Additional information

Part of #6512.
