### PR TITLE
Add opt-in option for dumping ACL in ydb tools dump

### DIFF
--- a/ydb/library/backup/backup.h
+++ b/ydb/library/backup/backup.h
@@ -27,7 +27,7 @@ public:
 void BackupFolder(TDriver driver, const TString& database, const TString& relDbPath, TFsPath folderPath,
         const TVector<TRegExMatch>& exclusionPatterns,
         bool schemaOnly, bool useConsistentCopyTable, bool avoidCopy = false, bool savePartialResult = false,
-        bool preservePoolKinds = false, bool ordered = false);
+        bool preservePoolKinds = false, bool ordered = false, bool preserveACL = false);
 
 struct TRestoreFolderParams {
     bool OnlyCheck = false;

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -76,6 +76,11 @@ void TCommandDump::Config(TConfig& config) {
         .DefaultValue("database").StoreResult(&ConsistencyLevel);
     config.Opts->AddLongOption("ordered", "Preserve order by primary key in backup files.")
             .StoreTrue(&Ordered);
+    config.Opts->AddLongOption("preserve-acl", "Preserve ACL including owner."
+            " If this option is enabled, ACL and owner will be saved to dump."
+            " In this case, the dump may not be restored if it is restored with an older version of the CLI."
+            " By default this option is disabled.")
+        .StoreTrue(&PreserveACL);
 }
 
 void TCommandDump::Parse(TConfig& config) {
@@ -99,7 +104,7 @@ int TCommandDump::Run(TConfig& config) {
     try {
         TString relPath = NYdb::RelPathFromAbsolute(config.Database, Path);
         NYdb::NBackup::BackupFolder(CreateDriver(config), config.Database, relPath, FilePath, ExclusionPatterns,
-            IsSchemeOnly, useConsistentCopyTable, AvoidCopy, SavePartialResult, PreservePoolKinds, Ordered);
+            IsSchemeOnly, useConsistentCopyTable, AvoidCopy, SavePartialResult, PreservePoolKinds, Ordered, PreserveACL);
     } catch (const NYdb::NBackup::TYdbErrorException& e) {
         e.LogToStderr();
         return EXIT_FAILURE;

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -80,7 +80,7 @@ void TCommandDump::Config(TConfig& config) {
             " If this option is enabled, ACL and owner will be saved to dump."
             " In this case, the dump may not be restored if it is restored with an older version of the CLI."
             " By default this option is disabled and the user who will perform the restore will be used"
-            " as the owner of the restored objects")
+            " as the owner of the restored objects.")
         .StoreTrue(&PreserveACL);
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -79,7 +79,8 @@ void TCommandDump::Config(TConfig& config) {
     config.Opts->AddLongOption("preserve-acl", "Preserve ACL including owner."
             " If this option is enabled, ACL and owner will be saved to dump."
             " In this case, the dump may not be restored if it is restored with an older version of the CLI."
-            " By default this option is disabled.")
+            " By default this option is disabled and the user who will perform the restore will be used"
+            " as the owner of the restored objects")
         .StoreTrue(&PreserveACL);
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -78,7 +78,7 @@ void TCommandDump::Config(TConfig& config) {
             .StoreTrue(&Ordered);
     config.Opts->AddLongOption("preserve-acl", "Preserve ACL including owner."
             " If this option is enabled, ACL and owner will be saved to dump."
-            " In this case, the dump may not be restored if it is restored with an older version of the CLI."
+            " In this case, the dump may not be restored if it is restored with an old version of the CLI."
             " By default this option is disabled and the user who will perform the restore will be used"
             " as the owner of the restored objects.")
         .StoreTrue(&PreserveACL);

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.h
@@ -44,6 +44,7 @@ private:
     TString ConsistencyLevel;
     bool PreservePoolKinds = false;
     bool Ordered = false;
+    bool PreserveACL = false;
 };
 
 class TCommandRestore : public TToolsCommand, public TCommandWithPath {

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -174,7 +174,8 @@ class BaseTestBackupInFiles(object):
                 "--database", "/Root",
                 "tools", "dump",
                 "--path", os.path.join('/Root', path),
-                "--output", backup_files_dir
+                "--output", backup_files_dir,
+                "--preserve-acl",
             ] +
             additional_args
         )


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
```
$ ydb tools dump --help

  --preserve-acl          Preserve ACL including owner. If this option is enabled, ACL and owner will be saved to dump. In this
                          case, the dump may not be restored if it is restored with an old version of the CLI. By default this
                          option is disabled and the user who will perform the restore will be used as the owner of the restored
                          objects. (default: 0)

```

