### PR TITLE
The value of the `WriteInflightSize` in the main partition

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2229,6 +2229,7 @@ void TPartition::CommitWriteOperations(TTransaction& t)
             }, std::nullopt};
             msg.Internal = true;
 
+            WriteInflightSize += msg.Msg.Data.size();
             ExecRequest(msg, *Parameters, PersistRequest.Get());
 
             auto& info = TxSourceIdForPostPersist[blob.SourceId];

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -745,7 +745,6 @@ void TPartition::HandleOnWrite(TEvPQ::TEvWrite::TPtr& ev, const TActorContext& c
     if (WaitingForPreviousBlobQuota() || WaitingForSubDomainQuota(ctx)) {
         SetDeadlinesForWrites(ctx);
     }
-    PQ_LOG_D("WriteInflightSize: add " << WriteInflightSize << ", " << size);
     WriteInflightSize += size;
 
     // TODO: remove decReservedSize == 0
@@ -1121,7 +1120,6 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
     auto& sourceIdBatch = parameters.SourceIdBatch;
     auto sourceId = sourceIdBatch.GetSource(p.Msg.SourceId);
 
-    PQ_LOG_D("WriteInflightSize: sub " << WriteInflightSize << ", " << p.Msg.Data.size());
     Y_ABORT_UNLESS(WriteInflightSize >= p.Msg.Data.size(),
                    "PQ %" PRIu64 ", Partition {%" PRIu32 ", %" PRIu32 "}, WriteInflightSize=%" PRIu64 ", p.Msg.Data.size=%" PRISZT,
                    TabletID, Partition.OriginalPartitionId, Partition.InternalPartitionId,
@@ -1544,7 +1542,6 @@ void TPartition::FilterDeadlinedWrites(const TActorContext& ctx, TMessageQueue& 
 
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_ERROR].Increment(1);
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_BYTES_ERROR].Increment(msg.Data.size() + msg.SourceId.size());
-            PQ_LOG_D("WriteInflightSize: sub " << WriteInflightSize << ", " << msg.Data.size());
             Y_ABORT_UNLESS(WriteInflightSize >= msg.Data.size(),
                            "WriteInflightSize=%" PRIu64 ", msg.Data.size=%" PRISZT,
                            WriteInflightSize, msg.Data.size());
@@ -1744,7 +1741,6 @@ void TPartition::EndAppendHeadWithNewWrites(TEvKeyValue::TEvRequest* request, co
                 .HeartbeatVersion = std::nullopt,
             }, std::nullopt};
 
-            PQ_LOG_D("WriteInflightSize: add " << WriteInflightSize << ", " << heartbeat->Data.size());
             WriteInflightSize += heartbeat->Data.size();
             ExecRequest(hbMsg, *Parameters, request);
 

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -745,6 +745,7 @@ void TPartition::HandleOnWrite(TEvPQ::TEvWrite::TPtr& ev, const TActorContext& c
     if (WaitingForPreviousBlobQuota() || WaitingForSubDomainQuota(ctx)) {
         SetDeadlinesForWrites(ctx);
     }
+    PQ_LOG_D("WriteInflightSize: add " << WriteInflightSize << ", " << size);
     WriteInflightSize += size;
 
     // TODO: remove decReservedSize == 0
@@ -1120,6 +1121,11 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
     auto& sourceIdBatch = parameters.SourceIdBatch;
     auto sourceId = sourceIdBatch.GetSource(p.Msg.SourceId);
 
+    PQ_LOG_D("WriteInflightSize: sub " << WriteInflightSize << ", " << p.Msg.Data.size());
+    Y_ABORT_UNLESS(WriteInflightSize >= p.Msg.Data.size(),
+                   "PQ %" PRIu64 ", Partition {%" PRIu32 ", %" PRIu32 "}, WriteInflightSize=%" PRIu64 ", p.Msg.Data.size=%" PRISZT,
+                   TabletID, Partition.OriginalPartitionId, Partition.InternalPartitionId,
+                   WriteInflightSize, p.Msg.Data.size());
     WriteInflightSize -= p.Msg.Data.size();
 
     TabletCounters.Percentile()[COUNTER_LATENCY_PQ_RECEIVE_QUEUE].IncrementFor(ctx.Now().MilliSeconds() - p.Msg.ReceiveTimestamp);
@@ -1538,6 +1544,10 @@ void TPartition::FilterDeadlinedWrites(const TActorContext& ctx, TMessageQueue& 
 
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_ERROR].Increment(1);
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_BYTES_ERROR].Increment(msg.Data.size() + msg.SourceId.size());
+            PQ_LOG_D("WriteInflightSize: sub " << WriteInflightSize << ", " << msg.Data.size());
+            Y_ABORT_UNLESS(WriteInflightSize >= msg.Data.size(),
+                           "WriteInflightSize=%" PRIu64 ", msg.Data.size=%" PRISZT,
+                           WriteInflightSize, msg.Data.size());
             WriteInflightSize -= msg.Data.size();
         }
 
@@ -1734,6 +1744,7 @@ void TPartition::EndAppendHeadWithNewWrites(TEvKeyValue::TEvRequest* request, co
                 .HeartbeatVersion = std::nullopt,
             }, std::nullopt};
 
+            PQ_LOG_D("WriteInflightSize: add " << WriteInflightSize << ", " << heartbeat->Data.size());
             WriteInflightSize += heartbeat->Data.size();
             ExecRequest(hbMsg, *Parameters, request);
 

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -1120,10 +1120,10 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
     auto& sourceIdBatch = parameters.SourceIdBatch;
     auto sourceId = sourceIdBatch.GetSource(p.Msg.SourceId);
 
-    Y_ABORT_UNLESS(WriteInflightSize >= p.Msg.Data.size(),
-                   "PQ %" PRIu64 ", Partition {%" PRIu32 ", %" PRIu32 "}, WriteInflightSize=%" PRIu64 ", p.Msg.Data.size=%" PRISZT,
-                   TabletID, Partition.OriginalPartitionId, Partition.InternalPartitionId,
-                   WriteInflightSize, p.Msg.Data.size());
+    Y_DEBUG_ABORT_UNLESS(WriteInflightSize >= p.Msg.Data.size(),
+                         "PQ %" PRIu64 ", Partition {%" PRIu32 ", %" PRIu32 "}, WriteInflightSize=%" PRIu64 ", p.Msg.Data.size=%" PRISZT,
+                         TabletID, Partition.OriginalPartitionId, Partition.InternalPartitionId,
+                         WriteInflightSize, p.Msg.Data.size());
     WriteInflightSize -= p.Msg.Data.size();
 
     TabletCounters.Percentile()[COUNTER_LATENCY_PQ_RECEIVE_QUEUE].IncrementFor(ctx.Now().MilliSeconds() - p.Msg.ReceiveTimestamp);
@@ -1542,9 +1542,10 @@ void TPartition::FilterDeadlinedWrites(const TActorContext& ctx, TMessageQueue& 
 
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_ERROR].Increment(1);
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_BYTES_ERROR].Increment(msg.Data.size() + msg.SourceId.size());
-            Y_ABORT_UNLESS(WriteInflightSize >= msg.Data.size(),
-                           "WriteInflightSize=%" PRIu64 ", msg.Data.size=%" PRISZT,
-                           WriteInflightSize, msg.Data.size());
+            Y_DEBUG_ABORT_UNLESS(WriteInflightSize >= msg.Data.size(),
+                                 "PQ %" PRIu64 ", Partition {%" PRIu32 ", %" PRIu32 "}, WriteInflightSize=%" PRIu64 ", msg.Data.size=%" PRISZT,
+                                 TabletID, Partition.OriginalPartitionId, Partition.InternalPartitionId,
+                                 WriteInflightSize, msg.Data.size());
             WriteInflightSize -= msg.Data.size();
         }
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -1880,6 +1880,29 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_27, TFixture)
     }
 }
 
+Y_UNIT_TEST_F(WriteToTopic_Demo_28, TFixture)
+{
+    // The test verifies that the `WriteInflightSize` is correctly considered for the main partition.
+    // Writing to the service partition does not change the `WriteInflightSize` of the main one.
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    TString message(16'000, 'a');
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, TString(16'000, 'a'), &tx, 0);
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID_1);
+
+    CommitTx(tx, EStatus::SUCCESS);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, TString(20'000, 'b'), nullptr, 0);
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID_2);
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2), nullptr, 0);
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
+}
+
 }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

During the commit of the transaction in the main partition, the `WriteInflightSize` did not take into account the size of the head of the recorded data. If you write to the partition without a transaction after the commit, the value of `WriteInflightSize` overflowed and the session of writing to the partition ended with the error `Write inflight limit reached`

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
