### PR TITLE
Forbid creating empty tiering rules in column shards

### DIFF
--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -92,6 +92,36 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
                                  << " after=" << GetUint64(rows[0].at("RawBytes")));
         }
     }
+
+    Y_UNIT_TEST(EmptyTieringRule) {
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NOlap::TWaitCompactionController>();
+
+        TKikimrSettings runnerSettings;
+        runnerSettings.WithSampleTables = false;
+        TTestHelper testHelper(runnerSettings);
+        TLocalHelper localHelper(testHelper.GetKikimr());
+        NYdb::NTable::TTableClient tableClient = testHelper.GetKikimr().GetTableClient();
+        Tests::NCommon::TLoggerInit(testHelper.GetKikimr()).Initialize();
+        Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->SetSecretKey("fakeSecret");
+
+        localHelper.CreateTestOlapTable();
+
+        {
+            const TString query = R"(
+            CREATE OBJECT IF NOT EXISTS empty_tiering_rule (TYPE TIERING_RULE)
+                WITH (defaultColumn = timestamp, description = `{"rules": []}`))";
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        }
+
+        testHelper.CreateTier("tier1");
+        const TString correctTieringRule = testHelper.CreateTieringRule("tier1", "timestamp");
+        {
+            const TString query = "ALTER OBJECT " + correctTieringRule + R"( (TYPE TIERING_RULE) SET description `{"rules": []}`)";
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        }
+    }
 }
 
 }   // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -111,7 +111,7 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
             CREATE OBJECT IF NOT EXISTS empty_tiering_rule (TYPE TIERING_RULE)
                 WITH (defaultColumn = timestamp, description = `{"rules": []}`))";
             auto result = testHelper.GetSession().ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
         }
 
         testHelper.CreateTier("tier1");
@@ -119,7 +119,7 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
         {
             const TString query = "ALTER OBJECT " + correctTieringRule + R"( (TYPE TIERING_RULE) SET description `{"rules": []}`)";
             auto result = testHelper.GetSession().ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
         }
     }
 }

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
@@ -175,8 +175,8 @@ public:
         AFL_VERIFY(tier);
         if (!TTLColumnName) {
             TTLColumnName = tier->GetEvictColumnName();
-        } else if (TTLColumnName.value() != tier->GetEvictColumnName()) {
-            AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("problem", "incorrect_tiering_metadata")("column_before", TTLColumnName.value())
+        } else if (*TTLColumnName != tier->GetEvictColumnName()) {
+            AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("problem", "incorrect_tiering_metadata")("column_before", *TTLColumnName)
                 ("column_new", tier->GetEvictColumnName());
             return false;
         }
@@ -197,7 +197,7 @@ public:
 
     const TString& GetEvictColumnName() const {
         AFL_VERIFY(TTLColumnName);
-        return TTLColumnName.value();
+        return *TTLColumnName;
     }
 
     TString GetDebugString() const {

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
@@ -174,6 +174,10 @@ public:
     [[nodiscard]] bool Add(const std::shared_ptr<TTierInfo>& tier) {
         AFL_VERIFY(tier);
         if (!TTLColumnName) {
+            if (tier->GetEvictColumnName().Empty()) {
+                AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("problem", "empty_evict_column_name");
+                return false;
+            }
             TTLColumnName = tier->GetEvictColumnName();
         } else if (*TTLColumnName != tier->GetEvictColumnName()) {
             AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("problem", "incorrect_tiering_metadata")("column_before", *TTLColumnName)

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
@@ -110,9 +110,6 @@ class TTiering {
     TTiersMap TierByName;
     TSet<TTierRef> OrderedTiers;
     std::optional<TString> TTLColumnName;
-
-    friend class TTieringBuilder;
-
 public:
 
     class TTieringContext {

--- a/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
@@ -174,7 +174,7 @@ void TTieringActualizer::DoExtractTasks(TTieringProcessContext& tasksContext, co
 void TTieringActualizer::Refresh(const std::optional<TTiering>& info, const TAddExternalContext& externalContext) {
     Tiering = info;
     if (Tiering) {
-        TieringColumnId = VersionedIndex.GetLastSchema()->GetColumnId(Tiering->GetTtlColumn());
+        TieringColumnId = VersionedIndex.GetLastSchema()->GetColumnId(Tiering->GetEvictColumnName());
     } else {
         TieringColumnId = {};
     }

--- a/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
@@ -173,7 +173,7 @@ void TTieringActualizer::DoExtractTasks(TTieringProcessContext& tasksContext, co
 
 void TTieringActualizer::Refresh(const std::optional<TTiering>& info, const TAddExternalContext& externalContext) {
     Tiering = info;
-    if (Tiering) {
+    if (Tiering && Tiering->HasTiers()) {
         TieringColumnId = VersionedIndex.GetLastSchema()->GetColumnId(Tiering->GetEvictColumnName());
     } else {
         TieringColumnId = {};

--- a/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
@@ -173,7 +173,7 @@ void TTieringActualizer::DoExtractTasks(TTieringProcessContext& tasksContext, co
 
 void TTieringActualizer::Refresh(const std::optional<TTiering>& info, const TAddExternalContext& externalContext) {
     Tiering = info;
-    if (Tiering && Tiering->HasTiers()) {
+    if (Tiering) {
         TieringColumnId = VersionedIndex.GetLastSchema()->GetColumnId(Tiering->GetEvictColumnName());
     } else {
         TieringColumnId = {};

--- a/ydb/core/tx/tiering/manager.cpp
+++ b/ydb/core/tx/tiering/manager.cpp
@@ -199,19 +199,19 @@ THashMap<ui64, NKikimr::NOlap::TTiering> TTiersManager::GetTiering() const {
     Y_ABORT_UNLESS(snapshotPtr);
     auto& tierConfigs = snapshotPtr->GetTierConfigs();
     for (auto&& i : PathIdTiering) {
-        auto* tiering = snapshotPtr->GetTieringById(i.second);
-        if (tiering) {
+        auto* tiering_rule = snapshotPtr->GetTieringById(i.second);
+        if (tiering_rule) {
             AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("path_id", i.first)("tiering_name", i.second)("event", "activation");
-            result.emplace(i.first, tiering->BuildOlapTiers());
-            for (auto& [pathId, pathTiering] : result) {
-                for (auto& [name, tier] : pathTiering.GetTierByName()) {
-                    AFL_VERIFY(name != NOlap::NTiering::NCommon::DeleteTierName);
-                    auto it = tierConfigs.find(name);
-                    if (it != tierConfigs.end()) {
-                        tier->SetSerializer(NTiers::ConvertCompression(it->second.GetCompression()));
-                    }
+            NOlap::TTiering tiering = tiering_rule->BuildOlapTiers();
+            AFL_VERIFY(tiering.HasTiers());
+            for (auto& [name, tier] : tiering.GetTierByName()) {
+                AFL_VERIFY(name != NOlap::NTiering::NCommon::DeleteTierName);
+                auto it = tierConfigs.find(name);
+                if (it != tierConfigs.end()) {
+                    tier->SetSerializer(NTiers::ConvertCompression(it->second.GetCompression()));
                 }
             }
+            result.emplace(i.first, std::move(tiering));
         } else {
             AFL_ERROR(NKikimrServices::TX_COLUMNSHARD)("path_id", i.first)("tiering_name", i.second)("event", "not_found");
         }

--- a/ydb/core/tx/tiering/manager.cpp
+++ b/ydb/core/tx/tiering/manager.cpp
@@ -199,11 +199,10 @@ THashMap<ui64, NKikimr::NOlap::TTiering> TTiersManager::GetTiering() const {
     Y_ABORT_UNLESS(snapshotPtr);
     auto& tierConfigs = snapshotPtr->GetTierConfigs();
     for (auto&& i : PathIdTiering) {
-        auto* tiering_rule = snapshotPtr->GetTieringById(i.second);
-        if (tiering_rule) {
+        auto* tieringRule = snapshotPtr->GetTieringById(i.second);
+        if (tieringRule) {
             AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("path_id", i.first)("tiering_name", i.second)("event", "activation");
-            NOlap::TTiering tiering = tiering_rule->BuildOlapTiers();
-            AFL_VERIFY(tiering.HasTiers());
+            NOlap::TTiering tiering = tieringRule->BuildOlapTiers();
             for (auto& [name, tier] : tiering.GetTierByName()) {
                 AFL_VERIFY(name != NOlap::NTiering::NCommon::DeleteTierName);
                 auto it = tierConfigs.find(name);

--- a/ydb/core/tx/tiering/rule/manager.cpp
+++ b/ydb/core/tx/tiering/rule/manager.cpp
@@ -21,6 +21,9 @@ NMetadata::NModifications::TOperationParsingResult TTieringRulesManager::DoBuild
     {
         auto fValue = settings.GetFeaturesExtractor().Extract(TTieringRule::TDecoder::DefaultColumn);
         if (fValue) {
+            if (fValue->Empty()) {
+                return TConclusionStatus::Fail("defaultColumn cannot be empty");
+            }
             result.SetColumn(TTieringRule::TDecoder::DefaultColumn, NMetadata::NInternal::TYDBValue::Utf8(*fValue));
         }
     }

--- a/ydb/core/tx/tiering/rule/object.cpp
+++ b/ydb/core/tx/tiering/rule/object.cpp
@@ -65,6 +65,9 @@ bool TTieringRule::DeserializeFromRecord(const TDecoder& decoder, const Ydb::Val
     if (!decoder.Read(decoder.GetDefaultColumnIdx(), DefaultColumn, r)) {
         return false;
     }
+    if (DefaultColumn.Empty()) {
+        return false;
+    }
     NJson::TJsonValue jsonDescription;
     if (!decoder.ReadJson(decoder.GetDescriptionIdx(), jsonDescription, r)) {
         return false;

--- a/ydb/core/tx/tiering/rule/object.cpp
+++ b/ydb/core/tx/tiering/rule/object.cpp
@@ -30,6 +30,10 @@ bool TTieringRule::DeserializeDescriptionFromJson(const NJson::TJsonValue& jsonI
     if (!jsonInfo["rules"].GetArrayPointer(&rules)) {
         return false;
     }
+    if (rules->empty()) {
+        AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("event", "tiering_rule_deserialization_failed")("reason", "empty_rules");
+        return false;
+    }
     for (auto&& i : *rules) {
         TTieringInterval interval;
         if (!interval.DeserializeFromJson(i)) {

--- a/ydb/core/tx/tiering/rule/object.cpp
+++ b/ydb/core/tx/tiering/rule/object.cpp
@@ -76,6 +76,7 @@ bool TTieringRule::DeserializeFromRecord(const TDecoder& decoder, const Ydb::Val
 }
 
 NKikimr::NOlap::TTiering TTieringRule::BuildOlapTiers() const {
+    AFL_VERIFY(!Intervals.empty());
     NOlap::TTiering result;
     for (auto&& r : Intervals) {
         AFL_VERIFY(result.Add(std::make_shared<NOlap::TTierInfo>(r.GetTierName(), r.GetDurationForEvict(), GetDefaultColumn())));


### PR DESCRIPTION
- refactor TTiering
- don't crash when tiering rules are empty
- fail when parsing empty tiering rules
