### PR TITLE
24-3: Add basic dynconfig audit

### DIFF
--- a/ydb/core/cms/console/console_audit.cpp
+++ b/ydb/core/cms/console/console_audit.cpp
@@ -1,0 +1,34 @@
+#include "console_audit.h"
+
+#include <ydb/core/audit/audit_log.h>
+#include <ydb/core/util/address_classifier.h>
+
+namespace NKikimr::NConsole {
+
+void AuditLogReplaceConfigTransaction(
+    const TString& peer,
+    const TString& userSID,
+    const TString& oldConfig,
+    const TString& newConfig,
+    const TString& reason,
+    bool success)
+{
+    static const TString COMPONENT_NAME = "console";
+
+    static const TString EMPTY_VALUE = "{none}";
+
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("status", TString(success ? "SUCCESS" : "ERROR"))
+        AUDIT_PART("reason", reason, !reason.empty())
+        AUDIT_PART("operation", TString("REPLACE DYNCONFIG"))
+        AUDIT_PART("old_config", oldConfig)
+        AUDIT_PART("new_config", newConfig)
+    );
+}
+
+} // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_audit.h
+++ b/ydb/core/cms/console/console_audit.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace NKikimr::NConsole {
+
+void AuditLogReplaceConfigTransaction(
+    const TString& peer,
+    const TString& userSID,
+    const TString& oldConfig,
+    const TString& newConfig,
+    const TString& reason,
+    bool success);
+
+} // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_configs_manager.cpp
+++ b/ydb/core/cms/console/console_configs_manager.cpp
@@ -1,6 +1,7 @@
 #include "console_configs_manager.h"
 
 #include "configs_dispatcher.h"
+#include "console_audit.h"
 #include "console_configs_provider.h"
 #include "console_impl.h"
 #include "http.h"
@@ -972,6 +973,26 @@ void TConfigsManager::ScheduleLogCleanup(const TActorContext &ctx)
                     new IEventHandle(SelfId(), SelfId(), new TEvPrivate::TEvCleanupLog),
                     AppData(ctx)->SystemPoolId,
                     LogCleanupTimerCookieHolder.Get());
+}
+
+void TConfigsManager::HandleUnauthorized(TEvConsole::TEvReplaceYamlConfigRequest::TPtr &ev, const TActorContext &) {
+    AuditLogReplaceConfigTransaction(
+        /* peer = */ ev->Get()->Record.GetPeerName(),
+        /* userSID = */ ev->Get()->Record.GetUserToken(),
+        /* oldConfig = */ YamlConfig,
+        /* newConfig = */ ev->Get()->Record.GetRequest().config(),
+        /* reason = */ "Unauthorized.",
+        /* success = */ false);
+}
+
+void TConfigsManager::HandleUnauthorized(TEvConsole::TEvSetYamlConfigRequest::TPtr &ev, const TActorContext &) {
+    AuditLogReplaceConfigTransaction(
+        /* peer = */ ev->Get()->Record.GetPeerName(),
+        /* userSID = */ ev->Get()->Record.GetUserToken(),
+        /* oldConfig = */ YamlConfig,
+        /* newConfig = */ ev->Get()->Record.GetRequest().config(),
+        /* reason = */ "Unauthorized.",
+        /* success = */ false);
 }
 
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/ya.make
+++ b/ydb/core/cms/console/ya.make
@@ -11,6 +11,8 @@ SRCS(
     configs_dispatcher.h
     console.cpp
     console.h
+    console_audit.cpp
+    console_audit.h
     console_configs_manager.cpp
     console_configs_manager.h
     console_configs_provider.cpp

--- a/ydb/core/protos/console_config.proto
+++ b/ydb/core/protos/console_config.proto
@@ -258,6 +258,7 @@ message TConfigureResponse {
 message TSetYamlConfigRequest {
     optional Ydb.DynamicConfig.SetConfigRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TSetYamlConfigResponse {
@@ -267,6 +268,7 @@ message TSetYamlConfigResponse {
 message TReplaceYamlConfigRequest {
     optional Ydb.DynamicConfig.ReplaceConfigRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TReplaceYamlConfigResponse {


### PR DESCRIPTION
Add audit log events for all dynconfig changes

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
