### PR TITLE
Do docker-compose tests in parallel

### DIFF
--- a/ydb/core/external_sources/hive_metastore/ut/ya.make
+++ b/ydb/core/external_sources/hive_metastore/ut/ya.make
@@ -29,6 +29,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)

--- a/ydb/core/external_sources/s3/ut/ya.make
+++ b/ydb/core/external_sources/s3/ut/ya.make
@@ -28,6 +28,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/clickhouse/ya.make
@@ -34,6 +34,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -52,7 +53,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server/ya.make
@@ -34,6 +34,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -52,7 +53,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/mysql/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/mysql/ya.make
@@ -34,6 +34,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -52,7 +53,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/oracle/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/oracle/ya.make
@@ -34,6 +34,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -52,7 +53,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/postgresql/ya.make
@@ -34,6 +34,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -52,7 +53,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ya.make
@@ -34,6 +34,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -52,7 +53,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/library/yql/providers/generic/connector/tests/join/ya.make
+++ b/ydb/library/yql/providers/generic/connector/tests/join/ya.make
@@ -34,6 +34,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -52,7 +53,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 TEST_SRCS(

--- a/ydb/tests/fq/generic/ya.make
+++ b/ydb/tests/fq/generic/ya.make
@@ -30,6 +30,7 @@ IF (AUTOCHECK)
     )
 ENDIF()
 
+ENV(COMPOSE_HTTP_TIMEOUT=1200)  # during parallel tests execution there could be huge disk io, which triggers timeouts in docker-compose 
 INCLUDE(${ARCADIA_ROOT}/library/recipes/docker_compose/recipe.inc)
 
 IF (OPENSOURCE)
@@ -48,7 +49,6 @@ IF (OPENSOURCE)
     # otherwise CI system would be overloaded due to simultaneous launch of many Docker containers.
     # See DEVTOOLSSUPPORT-44103, YA-1759 for details.
     TAG(ya:not_autocheck)
-    REQUIREMENTS(cpu:all)
 ENDIF()
 
 DEPENDS(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Then huge disk io consumption happens the tests are failing with the following error:

```
RecipeStartUpError: docker_compose-1 failed
Stderr tail:-tests-join-postgresql UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)\nFailed: &lt;Service: postgresql&gt;\nPending: set()\nFailed: ServiceName(project='join', service='fq-connector-go', number=1)\nPending: set()\n\nERROR: for fq-tests-join-fq-connector-go UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)\nFailed: &lt;Service: fq-connector-go&gt;\nPending: set()\n\nERROR: for clickhouse UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)\n\nERROR: for postgresql UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)\n\nERROR: for fq-connector-go UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)\nAn HTTP request took too long to complete. Retry with --verbose to obtain debug information.\nIf you encounter this issue regularly because of slow network conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher value (current value: 60).\n"
```

The problem can be reproduced with `stress --hdd 100` in separate process

Timeout was increased significally 

Cpu requirement was removed

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information