### PR TITLE
Dsproxy put lwtrack

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -74,6 +74,8 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
 
     bool Done = false;
 
+    NLWTrace::TOrbit Orbit;
+
     struct TIncarnationRecord {
         ui64 IncarnationGuid = 0;
         TMonotonic ExpirationTimestamp = TMonotonic::Max();
@@ -134,6 +136,22 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
 
         // Send to VDisks.
         for (auto& ev : events) {
+            if (LWPROBE_ENABLED(DSProxyVPutSent) || Orbit.HasShuttles()) {
+                auto vDiskId = std::visit([](const auto& item) { return VDiskIDFromVDiskID(item->Record.GetVDiskID()); }, ev);
+                auto itemsCount = std::visit(overloaded{
+                    [](const std::unique_ptr<TEvBlobStorage::TEvVPut>&) { return 1; },
+                    [](const std::unique_ptr<TEvBlobStorage::TEvVMultiPut>& item) { return item->Record.GetItems().size(); }
+                }, ev);
+                LWTRACK(
+                    DSProxyVPutSent, Orbit,
+                    std::visit([](const auto& item) { return item->Type(); }, ev),
+                    vDiskId.ToStringWOGeneration(),
+                    Info->GetFailDomainOrderNumber(vDiskId),
+                    itemsCount,
+                    std::visit([](const auto& item) { return item->GetBufferBytes(); }, ev),
+                    accelerate
+                );
+            }
             std::visit([&](auto& ev) { SendToQueue(std::move(ev), 0, TimeStatsEnabled); }, ev);
             ++RequestsSent;
             if (AccelerateRequestsSent == 0) {
@@ -269,7 +287,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
             HandleIncarnation(TActivationContext::Monotonic(), Info->GetOrderNumber(shortId), record.GetIncarnationGuid());
         }
 
-        LWPROBE(DSProxyVDiskRequestDuration, TEvBlobStorage::EvVPut, blobId.BlobSize(), blobId.TabletID(),
+        LWTRACK(DSProxyVDiskRequestDuration, Orbit, TEvBlobStorage::EvVPut, blobId.BlobSize(), blobId.TabletID(),
                 Info->GroupID.GetRawId(), blobId.Channel(), Info->GetFailDomainOrderNumber(shortId),
                 GetStartTime(record.GetTimestamps()),
                 GetTotalTimeMs(record.GetTimestamps()),
@@ -343,11 +361,12 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         WaitingVDiskResponseCount[vdisk]--;
 
         // Trace put request duration
-        if (LWPROBE_ENABLED(DSProxyVDiskRequestDuration)) {
+        if (LWPROBE_ENABLED(DSProxyVDiskRequestDuration) || Orbit.HasShuttles()) {
             for (auto &item : record.GetItems()) {
                 TLogoBlobID blobId = LogoBlobIDFromLogoBlobID(item.GetBlobID());
                 NKikimrProto::EReplyStatus itemStatus = item.GetStatus();
-                LWPROBE(DSProxyVDiskRequestDuration, TEvBlobStorage::EvVMultiPut, blobId.BlobSize(), blobId.TabletID(),
+                LWTRACK(DSProxyVDiskRequestDuration, Orbit,
+                        TEvBlobStorage::EvVMultiPut, blobId.BlobSize(), blobId.TabletID(),
                         Info->GroupID.GetRawId(), blobId.Channel(), Info->GetFailDomainOrderNumber(shortId),
                         GetStartTime(record.GetTimestamps()),
                         GetTotalTimeMs(record.GetTimestamps()),
@@ -402,6 +421,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
                 TDuration timeToAccelerate = TDuration::MicroSeconds(timeToAccelerateUs);
                 TMonotonic now = TActivationContext::Monotonic();
                 TMonotonic nextAcceleration = StartTime + timeToAccelerate;
+                LWTRACK(DSProxyScheduleAccelerate, Orbit, nextAcceleration > now ? (nextAcceleration - now).MicroSeconds() / 1000.0 : 0.0);
                 if (nextAcceleration > now) {
                     ui64 causeIdx = RootCauseTrack.RegisterAccelerate();
                     Schedule(nextAcceleration - now, new TEvAccelerate(causeIdx));
@@ -456,7 +476,10 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         ResponsesSent++;
         Y_ABORT_UNLESS(ResponsesSent <= PutImpl.Blobs.size());
         RootCauseTrack.RenderTrack(PutImpl.Blobs[blobIdx].Orbit);
-        LWTRACK(DSProxyPutReply, PutImpl.Blobs[blobIdx].Orbit);
+        if (PutImpl.Blobs[blobIdx].Orbit.HasShuttles()) {
+            LWTRACK(DSProxyPutReply, PutImpl.Blobs[blobIdx].Orbit, blobId.ToString(), NKikimrProto::EReplyStatus_Name(status), putResult->ErrorReason);
+        }
+        LWTRACK(DSProxyPutReply, Orbit, blobId.ToString(), NKikimrProto::EReplyStatus_Name(status), putResult->ErrorReason);
         putResult->Orbit = std::move(PutImpl.Blobs[blobIdx].Orbit);
         putResult->WrittenBeyondBarrier = PutImpl.WrittenBeyondBarrier[blobIdx];
         putResult->ExecutionRelay = std::move(PutImpl.Blobs[blobIdx].ExecutionRelay);
@@ -599,6 +622,22 @@ public:
         for (size_t blobIdx = 0; blobIdx < PutImpl.Blobs.size(); ++blobIdx) {
             LWTRACK(DSProxyPutBootstrapStart, PutImpl.Blobs[blobIdx].Orbit);
         }
+
+        auto getTotalSize = [&]() {
+            ui64 totalSize = 0;
+            for (auto& blob : PutImpl.Blobs) {
+                totalSize += blob.BufferSize;
+            }
+            return totalSize;
+        };
+        LWTRACK(
+            DSProxyPutRequest, Orbit,
+            Info->GroupID.GetRawId(),
+            NKikimrBlobStorage::EPutHandleClass_Name(HandleClass),
+            TEvBlobStorage::TEvPut::TacticName(Tactic),
+            PutImpl.Blobs.size(),
+            getTotalSize()
+        );
 
         Become(&TBlobStorageGroupPutRequest::StateWait, TDuration::MilliSeconds(DsPutWakeupMs), new TKikimrEvents::TEvWakeup);
 

--- a/ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h
+++ b/ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h
@@ -267,13 +267,15 @@ struct TEventTypeField {
     PROBE(DSProxyPutBootstrapDone, GROUPS("DSProxy","Durations"), \
       TYPES(ui64, double, double, double, double, ui64, ui64), \
       NAMES("size", "wilsonMs", "allocateMs", "waitTotalMs", "splitTotalMs", "splitTotalCount", "blobIdx")) \
-    PROBE(DSProxyPutReply, GROUPS("DSProxy"), TYPES(), NAMES()) \
+    PROBE(DSProxyPutReply, GROUPS("DSProxy"), TYPES(TString, TString, TString), NAMES("blobId", "status", "errorReason")) \
     PROBE(DSProxyPutResumeBootstrap, GROUPS("DSProxy"), TYPES(), NAMES()) \
     PROBE(DSProxyPutPauseBootstrap, GROUPS("DSProxy"), TYPES(), NAMES()) \
-    PROBE(DSProxyScheduleAccelerate, GROUPS("DSProxy"), TYPES(), NAMES()) \
+    PROBE(DSProxyScheduleAccelerate, GROUPS("DSProxy"), TYPES(double), NAMES("timeBeforeAccelerationMs")) \
     PROBE(DSProxyStartTransfer, GROUPS("DSProxy"), TYPES(), NAMES()) \
     PROBE(VDiskStartProcessing, GROUPS("DSProxy"), TYPES(), NAMES()) \
     PROBE(VDiskReply, GROUPS("DSProxy"), TYPES(), NAMES()) \
+    PROBE(DSProxyPutRequest, GROUPS("DSProxy", "LWTrackStart"), TYPES(ui32, TString, TString, ui64, ui64), NAMES("groupId", "handleClass", "tactic", "count", "totalSize")) \
+    PROBE(DSProxyVPutSent, GROUPS("DSProxy"), TYPES(NKikimr::TEventTypeField, TString, ui32, ui32, ui64, bool), NAMES("type", "vDiskId", "vdiskOrderNum", "count", "totalSize", "accelerate")) \
 /**/
 LWTRACE_DECLARE_PROVIDER(BLOBSTORAGE_PROVIDER)
 


### PR DESCRIPTION
* Not for changelog (changelog entry is not required)


New track example:
```
     0.000     +0.000 ms [45949048134482826] BLOBSTORAGE_PROVIDER.DSProxyPutRequest(groupId='2181038080', handleClass='UserData', tactic='Default', count='1', totalSize='2000000')
     0.384     +0.384 ms [45949048135287394] BLOBSTORAGE_PROVIDER.DSProxyVPutSent(type='EvVPut(268633088)', vDiskId='[82000000:_:1:2:0]', vdiskOrderNum='5', count='1', totalSize='2000000', accelerate='0')
     0.425     +0.041 ms [45949048135374100] BLOBSTORAGE_PROVIDER.DSProxyVPutSent(type='EvVPut(268633088)', vDiskId='[82000000:_:2:2:0]', vdiskOrderNum='8', count='1', totalSize='2000000', accelerate='0')
     0.454     +0.029 ms [45949048135434818] BLOBSTORAGE_PROVIDER.DSProxyVPutSent(type='EvVPut(268633088)', vDiskId='[82000000:_:0:2:0]', vdiskOrderNum='2', count='1', totalSize='2000000', accelerate='0')
    55.625    +55.170 ms [45949048251028710] BLOBSTORAGE_PROVIDER.DSProxyVDiskRequestDuration(type='EvVPut(268633088)', size='2000000', tabletId='72058588398405462', groupId='2181038080', channel='0', vdiskOrderNum='2', startTime='21932719.873719', totalDurationMs='55.152000', vdiskDurationMs='18.350000', transferDurationMs='36.802000', handleClass='UserData', status='OK')
    55.713     +0.088 ms [45949048251212820] BLOBSTORAGE_PROVIDER.DSProxyScheduleAccelerate(timeBeforeAccelerationMs='4.921000')
    57.896     +2.183 ms [45949048255786814] BLOBSTORAGE_PROVIDER.DSProxyVDiskRequestDuration(type='EvVPut(268633088)', size='2000000', tabletId='72058588398405462', groupId='2181038080', channel='0', vdiskOrderNum='8', startTime='21932719.873690', totalDurationMs='57.459000', vdiskDurationMs='22.820000', transferDurationMs='34.639000', handleClass='UserData', status='OK')
    60.782     +2.886 ms [45949048261834180] BLOBSTORAGE_PROVIDER.DSProxyVPutSent(type='EvVPut(268633088)', vDiskId='[82000000:_:1:0:0]', vdiskOrderNum='3', count='1', totalSize='2000000', accelerate='1')
    60.837     +0.055 ms [45949048261948962] BLOBSTORAGE_PROVIDER.DSProxyScheduleAccelerate(timeBeforeAccelerationMs='60.395000')
    61.004     +0.167 ms [45949048262298616] BLOBSTORAGE_PROVIDER.DSProxyVDiskRequestDuration(type='EvVPut(268633088)', size='2000000', tabletId='72058588398405462', groupId='2181038080', channel='0', vdiskOrderNum='5', startTime='21932719.873652', totalDurationMs='60.606000', vdiskDurationMs='26.454000', transferDurationMs='34.152000', handleClass='UserData', status='OK')
    61.102     +0.098 ms [45949048262504630] BLOBSTORAGE_PROVIDER.DSProxyPutReply(blobId='[72058588398405462:2:4:0:4679:2000000:0]', status='OK', errorReason='')
```