### PR TITLE
ci: upgrade actions/checkout@v4, actions/github-script@v7, test_retry_count input variable

### DIFF
--- a/.github/actions/build_and_test_ya/action.yml
+++ b/.github/actions/build_and_test_ya/action.yml
@@ -42,6 +42,9 @@ inputs:
   additional_ya_make_args:
     type: string
     default: ""
+  test_retry_count:
+    default: ""
+    description: "how many times to retry failed tests"
   secs:
     type: string
     default: ""
@@ -124,6 +127,7 @@ runs:
         bazel_remote_username: ${{ fromJSON( inputs.secs ).REMOTE_CACHE_USERNAME || '' }}
         bazel_remote_password: ${{ fromJSON( inputs.secs ).REMOTE_CACHE_PASSWORD || '' }}
         put_build_results_to_cache: ${{ inputs.put_build_results_to_cache }}
+        test_retry_count: ${{ inputs.test_retry_count }}
         
     - name: build_stats
       shell: bash

--- a/.github/workflows/acceptance_run.yml
+++ b/.github/workflows/acceptance_run.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: [ self-hosted, "${{ inputs.runner_label || 'auto-provisioned' }}", "${{ format('build-preset-{0}', inputs.build_preset || 'relwithdebinfo') }}" ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
 
@@ -50,7 +50,6 @@ jobs:
         build_target: "ydb/tests/acceptance"
         increment: false
         run_tests: true
-        test_retry_count: 1
         test_size: small,medium,large
         test_type: unittest,py3test,py2test,pytest
         test_threads: 1

--- a/.github/workflows/acceptance_run.yml
+++ b/.github/workflows/acceptance_run.yml
@@ -50,6 +50,7 @@ jobs:
         build_target: "ydb/tests/acceptance"
         increment: false
         run_tests: true
+        test_retry_count: 1
         test_size: small,medium,large
         test_type: unittest,py3test,py2test,pytest
         test_threads: 1

--- a/.github/workflows/allowed_dirs.yml
+++ b/.github/workflows/allowed_dirs.yml
@@ -11,7 +11,7 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check dirs
       run: ${{github.workspace}}/.github/check_dirs.sh  ${{github.workspace}}

--- a/.github/workflows/build_analytics.yml
+++ b/.github/workflows/build_analytics.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: [ self-hosted, "${{ inputs.runner_label || 'auto-provisioned' }}", "${{ format('build-preset-{0}', inputs.build_preset || 'relwithdebinfo') }}" ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
 
@@ -49,7 +49,6 @@ jobs:
         build_target: ${{ inputs.build_target || 'ydb/apps/ydbd'}}
         increment: false
         run_tests: false
-        test_retry_count: 1
         put_build_results_to_cache: false
         additional_ya_make_args: "-DDUMP_LINKER_MAP -DCOMPILER_TIME_TRACE --add-result .json"
         secs: ${{ format('{{"TESTMO_TOKEN2":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}',

--- a/.github/workflows/build_and_test_provisioned.yml
+++ b/.github/workflows/build_and_test_provisioned.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: [ self-hosted, "${{ inputs.runner_label }}" ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.checkout_ref }}
     - name: Build

--- a/.github/workflows/build_and_test_ya.yml
+++ b/.github/workflows/build_and_test_ya.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: [ self-hosted, "${{ inputs.runner_label }}", "${{ inputs.runner_additional_label || inputs.runner_label }}"]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
 

--- a/.github/workflows/collect_analytics.yml
+++ b/.github/workflows/collect_analytics.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [ self-hosted ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.commit_sha }}
     - name: Setup ydb access

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build

--- a/.github/workflows/docs_release.yaml
+++ b/.github/workflows/docs_release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Extract version
         shell: bash
         run: echo "version=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed -e 's|stable-|v|g' -e 's|-|.|g' >> $GITHUB_OUTPUT

--- a/.github/workflows/postcommit_asan.yml
+++ b/.github/workflows/postcommit_asan.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and test release-asan
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Setup ydb access

--- a/.github/workflows/postcommit_relwithdebinfo.yml
+++ b/.github/workflows/postcommit_relwithdebinfo.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and test relwithdebinfo
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Setup ydb access

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Check if running tests is allowed
         id: check-ownership-membership
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           script: |
@@ -81,7 +81,7 @@ jobs:
       - name: comment-if-waiting-on-ok
         if: steps.check-ownership-membership.outputs.result == 'false' &&
             github.event.action == 'opened'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let externalContributorLabel = 'external';
@@ -100,7 +100,7 @@ jobs:
             });
 
       - name: cleanup-test-label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let labelsToRemove = ['ok-to-test', 'rebase-and-check'];
@@ -126,7 +126,7 @@ jobs:
       - name: check is mergeable
         id: check-is-mergeable
         if: steps.check-ownership-membership.outputs.result == 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -210,7 +210,7 @@ jobs:
     name: Build and test ${{ matrix.build_preset }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ needs.check-running-allowed.outputs.commit_sha }}
         fetch-depth: 2
@@ -227,7 +227,6 @@ jobs:
         run_tests: ${{ contains(fromJSON('["relwithdebinfo", "release-asan"]'), matrix.build_preset) }}
         test_size: "small,medium"
         test_threads: 52
-        test_retry_count: 1
         put_build_results_to_cache: true
         secs: ${{ format('{{"TESTMO_TOKEN2":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}',
           secrets.TESTMO_TOKEN2, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}

--- a/.github/workflows/pr_labels.yaml
+++ b/.github/workflows/pr_labels.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Update PR labels
         id: update-pr-labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/prewarm-ccache.yml
+++ b/.github/workflows/prewarm-ccache.yml
@@ -13,7 +13,7 @@ jobs:
         version: ["ubuntu-2204", "ubuntu-2004", "ubuntu-1804"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: build
         shell: bash
         run: |


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Upgrade `actions/checkout@v4`, `actions/github-script@v7` for removing warning about deprecated Node.js version.
Add missed `test_retry_count` input for build_and_test_ya action. Use default `test_retry_count` for all existing workflows.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
