### PR TITLE
Remove unnecessary message

### DIFF
--- a/ydb/core/protos/index_builder.proto
+++ b/ydb/core/protos/index_builder.proto
@@ -109,7 +109,7 @@ message TEvListResponse {
 
 enum EBuildStatus {
     INVALID = 0;
-    ACCEPTED = 1;
+    ACCEPTED = 1; // DEPRECATED don't use it, it does nothing, we cannot remove it for now, because old nodes can send it
     IN_PROGRESS = 2;
     DONE = 3;
 

--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -664,15 +664,14 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
         return;
     }
 
-    auto response = MakeHolder<TEvDataShard::TEvBuildIndexProgressResponse>();
-    response->Record.SetBuildIndexId(record.GetBuildIndexId());
-    response->Record.SetTabletId(TabletID());
-    response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ACCEPTED);
 
     TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
-    response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
-    response->Record.SetRequestSeqNoRound(seqNo.Round);
     auto badRequest = [&](const TString& error) {
+        auto response = MakeHolder<TEvDataShard::TEvBuildIndexProgressResponse>();
+        response->Record.SetBuildIndexId(record.GetBuildIndexId());
+        response->Record.SetTabletId(TabletID());
+        response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
+        response->Record.SetRequestSeqNoRound(seqNo.Round);
         response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
         auto issue = response->Record.AddIssues();
         issue->set_severity(NYql::TSeverityIds::S_ERROR);
@@ -699,7 +698,6 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
     if (const auto* recCard = ScanManager.Get(buildIndexId)) {
         if (recCard->SeqNo == seqNo) {
             // do no start one more scan
-            ctx.Send(ev->Sender, std::move(response));
             return;
         }
 
@@ -774,8 +772,6 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
     TScanRecord recCard = {scanId, seqNo};
 
     ScanManager.Set(buildIndexId, recCard);
-
-    ctx.Send(ev->Sender, std::move(response));
 }
 
 }


### PR DESCRIPTION
ACCEPTED is unnecessary, because 
1. if schemeshard doesn't restart, it doesn't change anything from schemeshard/datashard point of view
2. if schemeshard restart, it's same because we anyway restart scan for this shard from scratch, so there won't be any difference