### PR TITLE
Upload html summary before updating status

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -334,8 +334,6 @@ runs:
             IS_LAST_RETRY=1
           fi
 
-          s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
-
           if [ $FAILED_TESTS_COUNT -gt 500 ]; then 
             IS_LAST_RETRY=1
             TOO_MANY_FAILED="Too many tests failed, NOT going to retry"
@@ -351,9 +349,17 @@ runs:
               --status_report_file statusrep.txt \
               --is_retry $IS_RETRY \
               --is_last_retry $IS_LAST_RETRY \
+              --comment_color_file summary_color.txt \
+              --comment_text_file summary_text.txt \
               "Tests" $CURRENT_PUBLIC_DIR/ya-test.html "$CURRENT_JUNIT_XML_PATH"
           fi
-            
+
+          s3cmd sync --follow-symlinks --acl-public --no-progress --stats --no-check-md5 "$PUBLIC_DIR/" "$S3_BUCKET_PATH/"
+
+          if [ "${{ inputs.run_tests }}" = "true" ]; then
+            cat summary_text.txt | GITHUB_TOKEN="${{ github.token }}" .github/scripts/tests/comment-pr.py --color `cat summary_color.txt`
+          fi
+          
           # upload tests results to YDB
           ydb_upload_run_name="${TESTMO_RUN_NAME// /"_"}"
           result=`.github/scripts/upload_tests_results.py --test-results-file ${CURRENT_JUNIT_XML_PATH} --run-timestamp $(date +%s) --commit $(git rev-parse HEAD) --build-type ${BUILD_PRESET} --pull $ydb_upload_run_name --job-name "${{ github.workflow }}" --job-id "${{ github.run_id }}" --branch ${GITHUB_REF_NAME}`

--- a/.github/scripts/tests/comment-pr.py
+++ b/.github/scripts/tests/comment-pr.py
@@ -32,7 +32,7 @@ def main():
         event = json.load(fp)
 
     pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
-    update_pr_comment_text(pr, build_preset, run_number, color, args.text.read().rstrip(), args.rewrite)
+    update_pr_comment_text(pr, build_preset, run_number, color, args.text.read(), args.rewrite)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/comment-pr.py
+++ b/.github/scripts/tests/comment-pr.py
@@ -32,7 +32,13 @@ def main():
         event = json.load(fp)
 
     pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
-    update_pr_comment_text(pr, build_preset, run_number, color, args.text.read(), args.rewrite)
+    text = args.text.read()
+    if text.endswith("\n"):
+        # dirty hack because echo adds a new line 
+        # and 'echo | comment-pr.py' leads to an extra newline  
+        text = text[:-1]
+
+    update_pr_comment_text(pr, build_preset, run_number, color, text, args.rewrite)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -400,6 +400,7 @@ def main():
 
     with open(args.comment_text_file, "w") as f:
         f.write('\n'.join(text))
+        f.write('\n')
 
     with open(args.status_report_file, "w") as f:
         f.write(overall_status)

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 import argparse
 import dataclasses
-import datetime
-import json
 import os
-import re
 import sys
 import traceback
-from github import Github, Auth as GithubAuth
-from github.PullRequest import PullRequest
 from enum import Enum
 from operator import attrgetter
-from typing import List, Optional, Dict
+from typing import List, Dict
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from junit_utils import get_property_value, iter_xml_files
-from gh_status import update_pr_comment_text
 from get_test_history import get_test_history
 
 
@@ -328,7 +322,7 @@ def gen_summary(public_dir, public_dir_url, paths, is_retry: bool, build_preset)
     return summary
 
 
-def get_comment_text(pr: PullRequest, summary: TestSummary, summary_links: str, is_last_retry: bool)->tuple[str, list[str]]:
+def get_comment_text(summary: TestSummary, summary_links: str, is_last_retry: bool)->tuple[str, list[str]]:
     color = "red"
     if summary.is_failed:
         color = "red" if is_last_retry else "yellow"
@@ -379,6 +373,8 @@ def main():
     parser.add_argument('--status_report_file', required=False)
     parser.add_argument('--is_retry', required=True, type=int)
     parser.add_argument('--is_last_retry', required=True, type=int)
+    parser.add_argument('--comment_color_file', required=True)
+    parser.add_argument('--comment_text_file', required=True)
     parser.add_argument("args", nargs="+", metavar="TITLE html_out path")
     args = parser.parse_args()
 
@@ -397,21 +393,16 @@ def main():
     else:
         overall_status = "success"
 
-    if os.environ.get("GITHUB_EVENT_NAME") in ("pull_request", "pull_request_target"):
-        gh = Github(auth=GithubAuth.Token(os.environ["GITHUB_TOKEN"]))
-        run_number = int(os.environ.get("GITHUB_RUN_NUMBER"))
+    color, text = get_comment_text(summary, args.summary_links, is_last_retry=bool(args.is_last_retry))
 
-        with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
-            event = json.load(fp)
+    with open(args.comment_color_file, "w") as f:
+        f.write(color)
 
-        pr = gh.create_from_raw_data(PullRequest, event["pull_request"])
-        color, text = get_comment_text(pr, summary, args.summary_links, is_last_retry=bool(args.is_last_retry))
+    with open(args.comment_text_file, "w") as f:
+        f.write('\n'.join(text))
 
-        update_pr_comment_text(pr, args.build_preset, run_number, color, text='\n'.join(text), rewrite=False)
-
-    if args.status_report_file:
-        with open(args.status_report_file, 'w') as fo:
-            fo.write(overall_status)
+    with open(args.status_report_file, "w") as f:
+        f.write(overall_status)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Remove commenting logic from `generate-summary.py`:
Before the change logic was "generate html and comment PR"
After the change "generate html, create text for status, upload html, show comment"

It needed because after 1st test try and before 2nd try links were not working 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Check: https://github.com/ydb-platform/ydb/pull/8225