### PR TITLE
Add concurrent tiering updates to OLAP scenario test

### DIFF
--- a/ydb/tests/olap/scenario/helpers/data_generators.py
+++ b/ydb/tests/olap/scenario/helpers/data_generators.py
@@ -68,6 +68,32 @@ class ColumnValueGeneratorConst(IColumnValueGenerator):
         return self._value
 
 
+class ColumnValueGeneratorLambda(IColumnValueGenerator):
+    """Arbitrary value generator.
+    
+    Uses arbitrary function to generate values."""
+
+    def __init__(self, func) -> None:
+        """Constructor.
+
+         Args:
+            func: Function used to generate values.
+        Example:
+            DataGeneratorPerColumn(
+                self.schema2, 10,
+                ColumnValueGeneratorDefault(init_value=10))
+                    .with_column('not_level', ColumnValueGeneratorLambda(lambda: time.now())
+            )
+        """
+
+        super().__init__()
+        self._func = func
+
+    @override
+    def generate_value(self, column: ScenarioTestHelper.Column) -> Any:
+        return self._func()
+
+
 class ColumnValueGeneratorRandom(IColumnValueGenerator):
     """Random column value generator.
 

--- a/ydb/tests/olap/scenario/helpers/data_generators.py
+++ b/ydb/tests/olap/scenario/helpers/data_generators.py
@@ -70,7 +70,7 @@ class ColumnValueGeneratorConst(IColumnValueGenerator):
 
 class ColumnValueGeneratorLambda(IColumnValueGenerator):
     """Arbitrary value generator.
-    
+
     Uses arbitrary function to generate values."""
 
     def __init__(self, func) -> None:

--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -8,6 +8,7 @@ import json
 from ydb.tests.olap.lib.ydb_cluster import YdbCluster
 from abc import abstractmethod, ABC
 from typing import Set, List, Dict, Any, Callable
+from time import sleep
 
 
 class TestContext:
@@ -247,21 +248,37 @@ class ScenarioTestHelper:
         return result
 
     @staticmethod
-    def _run_with_expected_status(operation: callable, expected_status: ydb.StatusCode | Set[ydb.StatusCode]):
+    def _run_with_expected_status(
+            operation: callable,
+            expected_status: ydb.StatusCode | Set[ydb.StatusCode],
+            retriable_status: ydb.StatusCode | Set[ydb.StatusCode] = {},
+            n_retries = 0,
+        ):
         if isinstance(expected_status, ydb.StatusCode):
             expected_status = {expected_status}
-        try:
-            result = operation()
-            if ydb.StatusCode.SUCCESS not in expected_status:
-                pytest.fail(
-                    f'Unexpected status: must be in {repr(expected_status)}, but get {repr(ydb.StatusCode.SUCCESS)}'
-                )
-            return result
-        except ydb.issues.Error as e:
-            allure.attach(f'{repr(e.status)}: {e}', 'request status', allure.attachment_type.TEXT)
-            if e.status not in expected_status:
-                pytest.fail(f'Unexpected status: must be in {repr(expected_status)}, but get {repr(e)}')
-            return None
+        if isinstance(retriable_status, ydb.StatusCode):
+            retriable_status = {retriable_status}
+
+        result = None
+        error = None
+        status = None
+        for _ in range(n_retries + 1):
+            try:
+                result = operation()
+                error = None
+                status = ydb.StatusCode.SUCCESS
+            except ydb.issues.Error as e:
+                result = None
+                error = e
+                status = error.status
+                allure.attach(f'{repr(status)}: {error}', 'request status', allure.attachment_type.TEXT)
+
+            if status in expected_status:
+                return result
+            if status not in retriable_status:
+                pytest.fail(f'Unexpected status: must be in {repr(expected_status)}, but get {repr(error or status)}')
+            sleep(1)
+        pytest.fail(f'Retries exceeded with unexpected status: must be in {repr(expected_status)}, but get {repr(error or status)}')
 
     def _bulk_upsert_impl(
         self, tablename: str, data_generator: ScenarioTestHelper.IDataGenerator, expected_status: ydb.StatusCode | Set[ydb.StatusCode]
@@ -302,6 +319,8 @@ class ScenarioTestHelper:
         self,
         yqlble: ScenarioTestHelper.IYqlble,
         expected_status: ydb.StatusCode | Set[ydb.StatusCode] = ydb.StatusCode.SUCCESS,
+        retries = 0,
+        retriable_status: ydb.StatusCode | Set[ydb.StatusCode] = {ydb.StatusCode.OVERLOADED, ydb.StatusCode.BAD_SESSION},
         comment: str = '',
     ) -> None:
         """Run a schema query on the database under test.
@@ -330,7 +349,7 @@ class ScenarioTestHelper:
             yql = yqlble.to_yql(self.test_context)
             allure.attach(yql, 'request', allure.attachment_type.TEXT)
             self._run_with_expected_status(
-                lambda: YdbCluster.get_ydb_driver().table_client.session().create().execute_scheme(yql), expected_status
+                lambda: YdbCluster.get_ydb_driver().table_client.session().create().execute_scheme(yql), expected_status, retriable_status, retries
             )
 
     @classmethod

--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -256,11 +256,11 @@ class ScenarioTestHelper:
 
     @staticmethod
     def _run_with_expected_status(
-            operation: callable,
-            expected_status: ydb.StatusCode | Set[ydb.StatusCode],
-            retriable_status: ydb.StatusCode | Set[ydb.StatusCode] = {},
-            n_retries = 0,
-        ):
+        operation: callable,
+        expected_status: ydb.StatusCode | Set[ydb.StatusCode],
+        retriable_status: ydb.StatusCode | Set[ydb.StatusCode] = {},
+        n_retries=0,
+    ):
         if isinstance(expected_status, ydb.StatusCode):
             expected_status = {expected_status}
         if isinstance(retriable_status, ydb.StatusCode):
@@ -326,7 +326,7 @@ class ScenarioTestHelper:
         self,
         yqlble: ScenarioTestHelper.IYqlble,
         expected_status: ydb.StatusCode | Set[ydb.StatusCode] = ydb.StatusCode.SUCCESS,
-        retries = 0,
+        retries=0,
         retriable_status: ydb.StatusCode | Set[ydb.StatusCode] = DEFAULT_RETRIABLE_ERRORS,
         comment: str = '',
     ) -> None:

--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -551,7 +551,7 @@ class ScenarioTestHelper:
             return result_set.result_set.rows[0][0]
 
     @allure.step('Describe table {path}')
-    def describe_table(self, path: str, settings: ydb.DescribeTableSettings = None) -> List[ydb.SchemeEntry]:
+    def describe_table(self, path: str, settings: ydb.DescribeTableSettings = None) -> ydb.TableSchemeEntry:
         """Get table description.
 
         Args:

--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -60,6 +60,13 @@ class ScenarioTestHelper:
         sth.execute_scheme_query(DropTable(table_name))
     """
 
+    DEFAULT_RETRIABLE_ERRORS = {
+        ydb.StatusCode.OVERLOADED,
+        ydb.StatusCode.BAD_SESSION,
+        ydb.StatusCode.CONNECTION_LOST,
+        ydb.StatusCode.UNAVAILABLE,
+    }
+
     class Column:
         """A class that describes a table column."""
 
@@ -277,7 +284,7 @@ class ScenarioTestHelper:
                 return result
             if status not in retriable_status:
                 pytest.fail(f'Unexpected status: must be in {repr(expected_status)}, but get {repr(error or status)}')
-            sleep(1)
+            sleep(3)
         pytest.fail(f'Retries exceeded with unexpected status: must be in {repr(expected_status)}, but get {repr(error or status)}')
 
     def _bulk_upsert_impl(
@@ -320,7 +327,7 @@ class ScenarioTestHelper:
         yqlble: ScenarioTestHelper.IYqlble,
         expected_status: ydb.StatusCode | Set[ydb.StatusCode] = ydb.StatusCode.SUCCESS,
         retries = 0,
-        retriable_status: ydb.StatusCode | Set[ydb.StatusCode] = {ydb.StatusCode.OVERLOADED, ydb.StatusCode.BAD_SESSION},
+        retriable_status: ydb.StatusCode | Set[ydb.StatusCode] = DEFAULT_RETRIABLE_ERRORS,
         comment: str = '',
     ) -> None:
         """Run a schema query on the database under test.

--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -523,6 +523,22 @@ class ScenarioTestHelper:
         ):
             result_set = self.execute_scan_query(f'SELECT count(*) FROM `{self.get_full_path(tablename)}`')
             return result_set.result_set.rows[0][0]
+    
+    @allure.step('Describe table {path}')
+    def describe_table(self, path: str, settings: ydb.DescribeTableSettings = None) -> List[ydb.SchemeEntry]:
+        """Get table description.
+
+        Args:
+            path: Relative path to a table.
+            settings: DescribeTableSettings.
+
+        Returns:
+            TableSchemeEntry object.
+        """
+
+        return self._run_with_expected_status(
+            lambda: YdbCluster.get_ydb_driver().table_client.session().create().describe_table(self.get_full_path(path), settings), ydb.StatusCode.SUCCESS
+        )
 
     @allure.step('List path {path}')
     def list_path(self, path: str) -> List[ydb.SchemeEntry]:

--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -523,7 +523,7 @@ class ScenarioTestHelper:
         ):
             result_set = self.execute_scan_query(f'SELECT count(*) FROM `{self.get_full_path(tablename)}`')
             return result_set.result_set.rows[0][0]
-    
+
     @allure.step('Describe table {path}')
     def describe_table(self, path: str, settings: ydb.DescribeTableSettings = None) -> List[ydb.SchemeEntry]:
         """Get table description.

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -96,10 +96,7 @@ class TestAlterTiering(BaseTestSet):
                     sth.execute_scheme_query(AlterTable(table).set_tiering(tiering_rule), retries=10)
                 else:
                     sth.execute_scheme_query(AlterTable(table).reset_tiering(), retries=10)
-                # Not implemented in SDK
-                # assert sth.describe_table(table).tiering == tiering_rule
             sth.execute_scheme_query(AlterTable(table).reset_tiering(), retries=10)
-            # assert sth.describe_table(table).tiering == None
 
     def _loop_alter_tiering_rule(self, ctx: TestContext, tiering_rule: str, default_column_values: Iterable[str], config_values: Iterable[TieringPolicy], duration: datetime.timedelta):
         deadline = datetime.datetime.now() + duration

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -116,8 +116,8 @@ class TestAlterTiering(BaseTestSet):
         deadline = datetime.datetime.now() + duration
         sth = ScenarioTestHelper(ctx)
         while datetime.datetime.now() < deadline:
-            sth.execute_scheme_query(AlterTableStore(store).add_column(sth.Column(column_name, random.choice(data_types))), expected_status={StatusCode.SUCCESS, StatusCode.OVERLOADED})
-            sth.execute_scheme_query(AlterTableStore(store).drop_column(column_name), expected_status={StatusCode.SUCCESS, StatusCode.OVERLOADED})
+            sth.execute_scheme_query(AlterTableStore(store).add_column(sth.Column(column_name, random.choice(data_types))), retries=3)
+            sth.execute_scheme_query(AlterTableStore(store).drop_column(column_name), retries=3)
 
     def _override_tier(self, sth, name, config):
         sth.execute_scheme_query(CreateTierIfNotExists(name, config))

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -93,12 +93,12 @@ class TestAlterTiering(BaseTestSet):
         while datetime.datetime.now() < deadline:
             for tiering_rule in tiering_rules:
                 if tiering_rule is not None:
-                    sth.execute_scheme_query(AlterTable(table).set_tiering(tiering_rule))
+                    sth.execute_scheme_query(AlterTable(table).set_tiering(tiering_rule), retries=10)
                 else:
-                    sth.execute_scheme_query(AlterTable(table).reset_tiering())
+                    sth.execute_scheme_query(AlterTable(table).reset_tiering(), retries=10)
                 # Not implemented in SDK
                 # assert sth.describe_table(table).tiering == tiering_rule
-            sth.execute_scheme_query(AlterTable(table).reset_tiering())
+            sth.execute_scheme_query(AlterTable(table).reset_tiering(), retries=10)
             # assert sth.describe_table(table).tiering == None
 
     def _loop_alter_tiering_rule(self, ctx: TestContext, tiering_rule: str, default_column_values: Iterable[str], config_values: Iterable[TieringPolicy], duration: datetime.timedelta):
@@ -107,7 +107,7 @@ class TestAlterTiering(BaseTestSet):
         for default_column, config in zip(itertools.cycle(default_column_values), itertools.cycle(config_values)):
             if datetime.datetime.now() >= deadline:
                 break
-            sth.execute_scheme_query(AlterTieringRule(tiering_rule, default_column, config))
+            sth.execute_scheme_query(AlterTieringRule(tiering_rule, default_column, config), retries=10)
 
     def _loop_alter_column(self, ctx: TestContext, store: str, duration: datetime.timedelta):
         column_name = 'tmp_column_' + ''.join(random.choice(ascii_lowercase) for _ in range(8))
@@ -116,8 +116,8 @@ class TestAlterTiering(BaseTestSet):
         deadline = datetime.datetime.now() + duration
         sth = ScenarioTestHelper(ctx)
         while datetime.datetime.now() < deadline:
-            sth.execute_scheme_query(AlterTableStore(store).add_column(sth.Column(column_name, random.choice(data_types))), retries=3)
-            sth.execute_scheme_query(AlterTableStore(store).drop_column(column_name), retries=3)
+            sth.execute_scheme_query(AlterTableStore(store).add_column(sth.Column(column_name, random.choice(data_types))), retries=10)
+            sth.execute_scheme_query(AlterTableStore(store).drop_column(column_name), retries=10)
 
     def _override_tier(self, sth, name, config):
         sth.execute_scheme_query(CreateTierIfNotExists(name, config))

--- a/ydb/tests/olap/scenario/ya.make
+++ b/ydb/tests/olap/scenario/ya.make
@@ -17,6 +17,7 @@ PY3TEST()
     PEERDIR(
         contrib/python/allure-pytest
         contrib/python/allure-python-commons
+        contrib/python/boto3
         contrib/python/pandas
         contrib/python/requests
         ydb/public/sdk/python


### PR DESCRIPTION
- add retries in the test to handle failures on nemesis cluster
- update many tables on the same store in parallel
- add ADD COLUMN, DROP COLUMN workload
- validate that eviction occur