### PR TITLE
Set no-omit-frame-pointer by default (#5688)

### DIFF
--- a/build/internal/ya.conf
+++ b/build/internal/ya.conf
@@ -11,6 +11,7 @@ USE_AIO = "static"
 USE_ICONV = "static"
 USE_IDN = "static"
 APPLE_SDK_LOCAL = "yes"
+CFLAGS = "-fno-omit-frame-pointer"
 
 [flags]
 OPENSOURCE = "yes"
@@ -19,3 +20,4 @@ USE_AIO = "static"
 USE_ICONV = "static"
 USE_IDN = "static"
 APPLE_SDK_LOCAL = "yes"
+CFLAGS = "-fno-omit-frame-pointer"


### PR DESCRIPTION
The current way of development require to rebuild binary to get flame graph for performance analysis, it make performance analysis difficult. So set no-omit-frame-pointer allows to get flame graph easily.

