### PR TITLE
Added another cost based optimization level

### DIFF
--- a/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
+++ b/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
@@ -79,7 +79,8 @@ void InferStatisticsForReadTable(const TExprNode::TPtr& input, TTypeAnnotationCo
         byteSize, 
         0.0, 
         keyColumns,
-        inputStats->ColumnStatistics);
+        inputStats->ColumnStatistics,
+        inputStats->StorageType);
 
     YQL_CLOG(TRACE, CoreDq) << "Infer statistics for read table" << stats->ToString();
 
@@ -119,6 +120,19 @@ void InferStatisticsForKqpTable(const TExprNode::TPtr& input, TTypeAnnotationCon
         }
     }
 
+    EStorageType storageType = EStorageType::NA;
+    switch (tableData.Metadata->Kind) {
+        case EKikimrTableKind::Datashard:
+            storageType = EStorageType::RowStorage;
+            break;
+        case EKikimrTableKind::Olap:
+            storageType = EStorageType::ColumnStorage;
+            break;
+        default:
+            break;
+    }
+    stats->StorageType = storageType;
+
     YQL_CLOG(TRACE, CoreDq) << "Infer statistics for table: " << path.Value() << ": " << stats->ToString();
 
     typeCtx->SetStats(input.Get(), stats);
@@ -151,7 +165,8 @@ void InferStatisticsForSteamLookup(const TExprNode::TPtr& input, TTypeAnnotation
         byteSize, 
         0, 
         inputStats->KeyColumns,
-        inputStats->ColumnStatistics);
+        inputStats->ColumnStatistics,
+        inputStats->StorageType);
 
     typeCtx->SetStats(input.Get(), res); 
 
@@ -195,7 +210,8 @@ void InferStatisticsForLookupTable(const TExprNode::TPtr& input, TTypeAnnotation
         byteSize, 
         0, 
         inputStats->KeyColumns,
-        inputStats->ColumnStatistics));
+        inputStats->ColumnStatistics,
+        inputStats->StorageType));
 }
 
 /**
@@ -250,7 +266,8 @@ void InferStatisticsForRowsSourceSettings(const TExprNode::TPtr& input, TTypeAnn
         byteSize, 
         cost, 
         keyColumns, 
-        inputStats->ColumnStatistics));
+        inputStats->ColumnStatistics,
+        inputStats->StorageType));
 }
 
 /**
@@ -282,7 +299,8 @@ void InferStatisticsForReadTableIndexRanges(const TExprNode::TPtr& input, TTypeA
         inputStats->ByteSize, 
         inputStats->Cost, 
         indexColumnsPtr,
-        inputStats->ColumnStatistics);
+        inputStats->ColumnStatistics,
+        inputStats->StorageType);
 
     typeCtx->SetStats(input.Get(), stats);
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
@@ -148,7 +148,7 @@ bool TKqpProviderContext::IsJoinApplicable(const std::shared_ptr<IBaseOptimizerN
 
     switch( joinAlgo ) {
         case EJoinAlgoType::LookupJoin:
-            if ((OptLevel >= 2) && (left->Stats->Nrows > 1000)) {
+            if ((OptLevel != 3) && (left->Stats->Nrows > 1000)) {
                 return false;
             }
             return IsLookupJoinApplicable(left, right, joinConditions, leftJoinKeys, rightJoinKeys, *this);
@@ -157,7 +157,7 @@ bool TKqpProviderContext::IsJoinApplicable(const std::shared_ptr<IBaseOptimizerN
             if (joinKind != EJoinKind::LeftSemi) {
                 return false;
             }
-            if ((OptLevel >= 2) && (right->Stats->Nrows > 1000)) {
+            if ((OptLevel != 3) && (right->Stats->Nrows > 1000)) {
                 return false;
             }
             return IsLookupJoinApplicable(right, left, joinConditions, rightJoinKeys, leftJoinKeys, *this);
@@ -176,13 +176,13 @@ double TKqpProviderContext::ComputeJoinCost(const TOptimizerStatistics& leftStat
     
     switch(joinAlgo) {
         case EJoinAlgoType::LookupJoin:
-            if (OptLevel == 2) {
+            if (OptLevel == 3) {
                 return -1;
             }
             return leftStats.Nrows + outputRows;
 
         case EJoinAlgoType::LookupJoinReverse:
-            if (OptLevel == 2) {
+            if (OptLevel == 3) {
                 return -1;
             }
             return rightStats.Nrows + outputRows;

--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -166,14 +166,14 @@ protected:
     }
 
     TMaybeNode<TExprBase> RewriteEquiJoin(TExprBase node, TExprContext& ctx) {
-        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) >= 3;
+        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) >= 2;
         TExprBase output = DqRewriteEquiJoin(node, KqpCtx.Config->GetHashJoinMode(), useCBO, ctx, TypesCtx, KqpCtx.JoinsCount);
         DumpAppliedRule("RewriteEquiJoin", node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 
     TMaybeNode<TExprBase> JoinToIndexLookup(TExprBase node, TExprContext& ctx) {
-        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) >= 3;
+        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) >= 2;
         TExprBase output = KqpJoinToIndexLookup(node, ctx, KqpCtx, useCBO);
         DumpAppliedRule("JoinToIndexLookup", node.Ptr(), output.Ptr(), ctx);
         return output;

--- a/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log.cpp
@@ -166,14 +166,14 @@ protected:
     }
 
     TMaybeNode<TExprBase> RewriteEquiJoin(TExprBase node, TExprContext& ctx) {
-        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) == 3;
+        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) >= 3;
         TExprBase output = DqRewriteEquiJoin(node, KqpCtx.Config->GetHashJoinMode(), useCBO, ctx, TypesCtx, KqpCtx.JoinsCount);
         DumpAppliedRule("RewriteEquiJoin", node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 
     TMaybeNode<TExprBase> JoinToIndexLookup(TExprBase node, TExprContext& ctx) {
-        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) == 3;
+        bool useCBO = Config->CostBasedOptimizationLevel.Get().GetOrElse(Config->DefaultCostBasedOptimizationLevel) >= 3;
         TExprBase output = KqpJoinToIndexLookup(node, ctx, KqpCtx, useCBO);
         DumpAppliedRule("JoinToIndexLookup", node.Ptr(), output.Ptr(), ctx);
         return output;

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -169,7 +169,7 @@ struct TKikimrConfiguration : public TKikimrSettings, public NCommon::TSettingDi
     bool EnableOltpSink = false;
     NKikimrConfig::TTableServiceConfig_EBlockChannelsMode BlockChannelsMode;
     bool EnableSpillingGenericQuery = false;
-    ui32 DefaultCostBasedOptimizationLevel = 3;
+    ui32 DefaultCostBasedOptimizationLevel = 4;
     bool EnableConstantFolding = true;
     ui64 DefaultEnableSpillingNodes = 0;
 

--- a/ydb/core/kqp/ut/join/data/join_order/tpcds64_1000s.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpcds64_1000s.json
@@ -3,23 +3,9 @@
   "args":
     [
       {
-        "op_name":"InnerJoin (MapJoin)",
+        "op_name":"InnerJoin (Grace)",
         "args":
           [
-            {
-              "op_name":"InnerJoin (Grace)",
-              "args":
-                [
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_sales"
-                  },
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_returns"
-                  }
-                ]
-            },
             {
               "op_name":"InnerJoin (MapJoin)",
               "args":
@@ -41,102 +27,62 @@
                                       "args":
                                         [
                                           {
-                                            "op_name":"InnerJoin (MapJoin)",
+                                            "op_name":"InnerJoin (Grace)",
                                             "args":
                                               [
                                                 {
-                                                  "op_name":"TableFullScan",
-                                                  "table":"test\/ds\/customer_address"
-                                                },
-                                                {
-                                                  "op_name":"InnerJoin (MapJoin)",
+                                                  "op_name":"InnerJoin (Grace)",
                                                   "args":
                                                     [
-                                                      {
-                                                        "op_name":"TableFullScan",
-                                                        "table":"test\/ds\/customer_demographics"
-                                                      },
                                                       {
                                                         "op_name":"InnerJoin (MapJoin)",
                                                         "args":
                                                           [
                                                             {
-                                                              "op_name":"InnerJoin (MapJoin)",
+                                                              "op_name":"InnerJoin (Grace)",
                                                               "args":
                                                                 [
                                                                   {
-                                                                    "op_name":"InnerJoin (MapJoin)",
+                                                                    "op_name":"TableFullScan",
+                                                                    "table":"test\/ds\/store_sales"
+                                                                  },
+                                                                  {
+                                                                    "op_name":"InnerJoin (Grace)",
                                                                     "args":
                                                                       [
                                                                         {
                                                                           "op_name":"TableFullScan",
-                                                                          "table":"test\/ds\/customer"
+                                                                          "table":"test\/ds\/catalog_sales"
                                                                         },
                                                                         {
-                                                                          "op_name":"InnerJoin (MapJoin)",
-                                                                          "args":
-                                                                            [
-                                                                              {
-                                                                                "op_name":"TableFullScan",
-                                                                                "table":"test\/ds\/customer_demographics"
-                                                                              },
-                                                                              {
-                                                                                "op_name":"InnerJoin (MapJoin)",
-                                                                                "args":
-                                                                                  [
-                                                                                    {
-                                                                                      "op_name":"TableFullScan",
-                                                                                      "table":"test\/ds\/customer_address"
-                                                                                    },
-                                                                                    {
-                                                                                      "op_name":"InnerJoin (Grace)",
-                                                                                      "args":
-                                                                                        [
-                                                                                          {
-                                                                                            "op_name":"TableFullScan",
-                                                                                            "table":"test\/ds\/store_returns"
-                                                                                          },
-                                                                                          {
-                                                                                            "op_name":"InnerJoin (MapJoin)",
-                                                                                            "args":
-                                                                                              [
-                                                                                                {
-                                                                                                  "op_name":"TableLookup",
-                                                                                                  "table":"test\/ds\/store_sales"
-                                                                                                },
-                                                                                                {
-                                                                                                  "op_name":"TableFullScan",
-                                                                                                  "table":"test\/ds\/item"
-                                                                                                }
-                                                                                              ]
-                                                                                          }
-                                                                                        ]
-                                                                                    }
-                                                                                  ]
-                                                                              }
-                                                                            ]
+                                                                          "op_name":"TableFullScan",
+                                                                          "table":"test\/ds\/catalog_returns"
                                                                         }
                                                                       ]
-                                                                  },
-                                                                  {
-                                                                    "op_name":"TableFullScan",
-                                                                    "table":"test\/ds\/date_dim"
                                                                   }
                                                                 ]
                                                             },
                                                             {
                                                               "op_name":"TableFullScan",
-                                                              "table":"test\/ds\/store"
+                                                              "table":"test\/ds\/item"
                                                             }
                                                           ]
+                                                      },
+                                                      {
+                                                        "op_name":"TableFullScan",
+                                                        "table":"test\/ds\/store_returns"
                                                       }
                                                     ]
+                                                },
+                                                {
+                                                  "op_name":"TableFullScan",
+                                                  "table":"test\/ds\/customer_address"
                                                 }
                                               ]
                                           },
                                           {
                                             "op_name":"TableFullScan",
-                                            "table":"test\/ds\/date_dim"
+                                            "table":"test\/ds\/customer_demographics"
                                           }
                                         ]
                                     },
@@ -148,23 +94,77 @@
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/promotion"
+                                "table":"test\/ds\/store"
                               }
                             ]
                         },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/promotion"
+                        }
+                      ]
+                  },
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/household_demographics"
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/income_band"
+                        }
+                      ]
+                  }
+                ]
+            },
+            {
+              "op_name":"InnerJoin (MapJoin)",
+              "args":
+                [
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
                         {
                           "op_name":"InnerJoin (MapJoin)",
                           "args":
                             [
                               {
-                                "op_name":"TableFullScan",
-                                "table":"test\/ds\/household_demographics"
+                                "op_name":"InnerJoin (Grace)",
+                                "args":
+                                  [
+                                    {
+                                      "op_name":"InnerJoin (MapJoin)",
+                                      "args":
+                                        [
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer"
+                                          },
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer_demographics"
+                                          }
+                                        ]
+                                    },
+                                    {
+                                      "op_name":"TableFullScan",
+                                      "table":"test\/ds\/customer_address"
+                                    }
+                                  ]
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/income_band"
+                                "table":"test\/ds\/date_dim"
                               }
                             ]
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/date_dim"
                         }
                       ]
                   },
@@ -187,23 +187,9 @@
           ]
       },
       {
-        "op_name":"InnerJoin (MapJoin)",
+        "op_name":"InnerJoin (Grace)",
         "args":
           [
-            {
-              "op_name":"InnerJoin (Grace)",
-              "args":
-                [
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_sales"
-                  },
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_returns"
-                  }
-                ]
-            },
             {
               "op_name":"InnerJoin (MapJoin)",
               "args":
@@ -225,102 +211,62 @@
                                       "args":
                                         [
                                           {
-                                            "op_name":"InnerJoin (MapJoin)",
+                                            "op_name":"InnerJoin (Grace)",
                                             "args":
                                               [
                                                 {
-                                                  "op_name":"TableFullScan",
-                                                  "table":"test\/ds\/customer_address"
-                                                },
-                                                {
-                                                  "op_name":"InnerJoin (MapJoin)",
+                                                  "op_name":"InnerJoin (Grace)",
                                                   "args":
                                                     [
-                                                      {
-                                                        "op_name":"TableFullScan",
-                                                        "table":"test\/ds\/customer_demographics"
-                                                      },
                                                       {
                                                         "op_name":"InnerJoin (MapJoin)",
                                                         "args":
                                                           [
                                                             {
-                                                              "op_name":"InnerJoin (MapJoin)",
+                                                              "op_name":"InnerJoin (Grace)",
                                                               "args":
                                                                 [
                                                                   {
-                                                                    "op_name":"InnerJoin (MapJoin)",
+                                                                    "op_name":"TableFullScan",
+                                                                    "table":"test\/ds\/store_sales"
+                                                                  },
+                                                                  {
+                                                                    "op_name":"InnerJoin (Grace)",
                                                                     "args":
                                                                       [
                                                                         {
                                                                           "op_name":"TableFullScan",
-                                                                          "table":"test\/ds\/customer"
+                                                                          "table":"test\/ds\/catalog_sales"
                                                                         },
                                                                         {
-                                                                          "op_name":"InnerJoin (MapJoin)",
-                                                                          "args":
-                                                                            [
-                                                                              {
-                                                                                "op_name":"TableFullScan",
-                                                                                "table":"test\/ds\/customer_demographics"
-                                                                              },
-                                                                              {
-                                                                                "op_name":"InnerJoin (MapJoin)",
-                                                                                "args":
-                                                                                  [
-                                                                                    {
-                                                                                      "op_name":"TableFullScan",
-                                                                                      "table":"test\/ds\/customer_address"
-                                                                                    },
-                                                                                    {
-                                                                                      "op_name":"InnerJoin (Grace)",
-                                                                                      "args":
-                                                                                        [
-                                                                                          {
-                                                                                            "op_name":"TableFullScan",
-                                                                                            "table":"test\/ds\/store_returns"
-                                                                                          },
-                                                                                          {
-                                                                                            "op_name":"InnerJoin (MapJoin)",
-                                                                                            "args":
-                                                                                              [
-                                                                                                {
-                                                                                                  "op_name":"TableLookup",
-                                                                                                  "table":"test\/ds\/store_sales"
-                                                                                                },
-                                                                                                {
-                                                                                                  "op_name":"TableFullScan",
-                                                                                                  "table":"test\/ds\/item"
-                                                                                                }
-                                                                                              ]
-                                                                                          }
-                                                                                        ]
-                                                                                    }
-                                                                                  ]
-                                                                              }
-                                                                            ]
+                                                                          "op_name":"TableFullScan",
+                                                                          "table":"test\/ds\/catalog_returns"
                                                                         }
                                                                       ]
-                                                                  },
-                                                                  {
-                                                                    "op_name":"TableFullScan",
-                                                                    "table":"test\/ds\/date_dim"
                                                                   }
                                                                 ]
                                                             },
                                                             {
                                                               "op_name":"TableFullScan",
-                                                              "table":"test\/ds\/store"
+                                                              "table":"test\/ds\/item"
                                                             }
                                                           ]
+                                                      },
+                                                      {
+                                                        "op_name":"TableFullScan",
+                                                        "table":"test\/ds\/store_returns"
                                                       }
                                                     ]
+                                                },
+                                                {
+                                                  "op_name":"TableFullScan",
+                                                  "table":"test\/ds\/customer_address"
                                                 }
                                               ]
                                           },
                                           {
                                             "op_name":"TableFullScan",
-                                            "table":"test\/ds\/date_dim"
+                                            "table":"test\/ds\/customer_demographics"
                                           }
                                         ]
                                     },
@@ -332,23 +278,77 @@
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/promotion"
+                                "table":"test\/ds\/store"
                               }
                             ]
                         },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/promotion"
+                        }
+                      ]
+                  },
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/household_demographics"
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/income_band"
+                        }
+                      ]
+                  }
+                ]
+            },
+            {
+              "op_name":"InnerJoin (MapJoin)",
+              "args":
+                [
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
                         {
                           "op_name":"InnerJoin (MapJoin)",
                           "args":
                             [
                               {
-                                "op_name":"TableFullScan",
-                                "table":"test\/ds\/household_demographics"
+                                "op_name":"InnerJoin (Grace)",
+                                "args":
+                                  [
+                                    {
+                                      "op_name":"InnerJoin (MapJoin)",
+                                      "args":
+                                        [
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer"
+                                          },
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer_demographics"
+                                          }
+                                        ]
+                                    },
+                                    {
+                                      "op_name":"TableFullScan",
+                                      "table":"test\/ds\/customer_address"
+                                    }
+                                  ]
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/income_band"
+                                "table":"test\/ds\/date_dim"
                               }
                             ]
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/date_dim"
                         }
                       ]
                   },

--- a/ydb/core/kqp/ut/join/data/join_order/tpcds64_1000s_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpcds64_1000s_column_store.json
@@ -3,23 +3,9 @@
   "args":
     [
       {
-        "op_name":"InnerJoin (MapJoin)",
+        "op_name":"InnerJoin (Grace)",
         "args":
           [
-            {
-              "op_name":"InnerJoin (Grace)",
-              "args":
-                [
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_sales"
-                  },
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_returns"
-                  }
-                ]
-            },
             {
               "op_name":"InnerJoin (MapJoin)",
               "args":
@@ -41,102 +27,62 @@
                                       "args":
                                         [
                                           {
-                                            "op_name":"InnerJoin (MapJoin)",
+                                            "op_name":"InnerJoin (Grace)",
                                             "args":
                                               [
                                                 {
-                                                  "op_name":"TableFullScan",
-                                                  "table":"test\/ds\/customer_address"
-                                                },
-                                                {
-                                                  "op_name":"InnerJoin (MapJoin)",
+                                                  "op_name":"InnerJoin (Grace)",
                                                   "args":
                                                     [
-                                                      {
-                                                        "op_name":"TableFullScan",
-                                                        "table":"test\/ds\/customer_demographics"
-                                                      },
                                                       {
                                                         "op_name":"InnerJoin (MapJoin)",
                                                         "args":
                                                           [
                                                             {
-                                                              "op_name":"InnerJoin (MapJoin)",
+                                                              "op_name":"InnerJoin (Grace)",
                                                               "args":
                                                                 [
                                                                   {
-                                                                    "op_name":"InnerJoin (MapJoin)",
+                                                                    "op_name":"TableFullScan",
+                                                                    "table":"test\/ds\/store_sales"
+                                                                  },
+                                                                  {
+                                                                    "op_name":"InnerJoin (Grace)",
                                                                     "args":
                                                                       [
                                                                         {
                                                                           "op_name":"TableFullScan",
-                                                                          "table":"test\/ds\/customer"
+                                                                          "table":"test\/ds\/catalog_sales"
                                                                         },
                                                                         {
-                                                                          "op_name":"InnerJoin (MapJoin)",
-                                                                          "args":
-                                                                            [
-                                                                              {
-                                                                                "op_name":"TableFullScan",
-                                                                                "table":"test\/ds\/customer_demographics"
-                                                                              },
-                                                                              {
-                                                                                "op_name":"InnerJoin (MapJoin)",
-                                                                                "args":
-                                                                                  [
-                                                                                    {
-                                                                                      "op_name":"TableFullScan",
-                                                                                      "table":"test\/ds\/customer_address"
-                                                                                    },
-                                                                                    {
-                                                                                      "op_name":"InnerJoin (Grace)",
-                                                                                      "args":
-                                                                                        [
-                                                                                          {
-                                                                                            "op_name":"TableFullScan",
-                                                                                            "table":"test\/ds\/store_returns"
-                                                                                          },
-                                                                                          {
-                                                                                            "op_name":"InnerJoin (MapJoin)",
-                                                                                            "args":
-                                                                                              [
-                                                                                                {
-                                                                                                  "op_name":"TableFullScan",
-                                                                                                  "table":"test\/ds\/item"
-                                                                                                },
-                                                                                                {
-                                                                                                  "op_name":"TableFullScan",
-                                                                                                  "table":"test\/ds\/store_sales"
-                                                                                                }
-                                                                                              ]
-                                                                                          }
-                                                                                        ]
-                                                                                    }
-                                                                                  ]
-                                                                              }
-                                                                            ]
+                                                                          "op_name":"TableFullScan",
+                                                                          "table":"test\/ds\/catalog_returns"
                                                                         }
                                                                       ]
-                                                                  },
-                                                                  {
-                                                                    "op_name":"TableFullScan",
-                                                                    "table":"test\/ds\/date_dim"
                                                                   }
                                                                 ]
                                                             },
                                                             {
                                                               "op_name":"TableFullScan",
-                                                              "table":"test\/ds\/store"
+                                                              "table":"test\/ds\/item"
                                                             }
                                                           ]
+                                                      },
+                                                      {
+                                                        "op_name":"TableFullScan",
+                                                        "table":"test\/ds\/store_returns"
                                                       }
                                                     ]
+                                                },
+                                                {
+                                                  "op_name":"TableFullScan",
+                                                  "table":"test\/ds\/customer_address"
                                                 }
                                               ]
                                           },
                                           {
                                             "op_name":"TableFullScan",
-                                            "table":"test\/ds\/date_dim"
+                                            "table":"test\/ds\/customer_demographics"
                                           }
                                         ]
                                     },
@@ -148,23 +94,77 @@
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/promotion"
+                                "table":"test\/ds\/store"
                               }
                             ]
                         },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/promotion"
+                        }
+                      ]
+                  },
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/household_demographics"
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/income_band"
+                        }
+                      ]
+                  }
+                ]
+            },
+            {
+              "op_name":"InnerJoin (MapJoin)",
+              "args":
+                [
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
                         {
                           "op_name":"InnerJoin (MapJoin)",
                           "args":
                             [
                               {
-                                "op_name":"TableFullScan",
-                                "table":"test\/ds\/household_demographics"
+                                "op_name":"InnerJoin (Grace)",
+                                "args":
+                                  [
+                                    {
+                                      "op_name":"InnerJoin (MapJoin)",
+                                      "args":
+                                        [
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer"
+                                          },
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer_demographics"
+                                          }
+                                        ]
+                                    },
+                                    {
+                                      "op_name":"TableFullScan",
+                                      "table":"test\/ds\/customer_address"
+                                    }
+                                  ]
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/income_band"
+                                "table":"test\/ds\/date_dim"
                               }
                             ]
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/date_dim"
                         }
                       ]
                   },
@@ -187,23 +187,9 @@
           ]
       },
       {
-        "op_name":"InnerJoin (MapJoin)",
+        "op_name":"InnerJoin (Grace)",
         "args":
           [
-            {
-              "op_name":"InnerJoin (Grace)",
-              "args":
-                [
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_sales"
-                  },
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"test\/ds\/catalog_returns"
-                  }
-                ]
-            },
             {
               "op_name":"InnerJoin (MapJoin)",
               "args":
@@ -225,102 +211,62 @@
                                       "args":
                                         [
                                           {
-                                            "op_name":"InnerJoin (MapJoin)",
+                                            "op_name":"InnerJoin (Grace)",
                                             "args":
                                               [
                                                 {
-                                                  "op_name":"TableFullScan",
-                                                  "table":"test\/ds\/customer_address"
-                                                },
-                                                {
-                                                  "op_name":"InnerJoin (MapJoin)",
+                                                  "op_name":"InnerJoin (Grace)",
                                                   "args":
                                                     [
-                                                      {
-                                                        "op_name":"TableFullScan",
-                                                        "table":"test\/ds\/customer_demographics"
-                                                      },
                                                       {
                                                         "op_name":"InnerJoin (MapJoin)",
                                                         "args":
                                                           [
                                                             {
-                                                              "op_name":"InnerJoin (MapJoin)",
+                                                              "op_name":"InnerJoin (Grace)",
                                                               "args":
                                                                 [
                                                                   {
-                                                                    "op_name":"InnerJoin (MapJoin)",
+                                                                    "op_name":"TableFullScan",
+                                                                    "table":"test\/ds\/store_sales"
+                                                                  },
+                                                                  {
+                                                                    "op_name":"InnerJoin (Grace)",
                                                                     "args":
                                                                       [
                                                                         {
                                                                           "op_name":"TableFullScan",
-                                                                          "table":"test\/ds\/customer"
+                                                                          "table":"test\/ds\/catalog_sales"
                                                                         },
                                                                         {
-                                                                          "op_name":"InnerJoin (MapJoin)",
-                                                                          "args":
-                                                                            [
-                                                                              {
-                                                                                "op_name":"TableFullScan",
-                                                                                "table":"test\/ds\/customer_demographics"
-                                                                              },
-                                                                              {
-                                                                                "op_name":"InnerJoin (MapJoin)",
-                                                                                "args":
-                                                                                  [
-                                                                                    {
-                                                                                      "op_name":"TableFullScan",
-                                                                                      "table":"test\/ds\/customer_address"
-                                                                                    },
-                                                                                    {
-                                                                                      "op_name":"InnerJoin (Grace)",
-                                                                                      "args":
-                                                                                        [
-                                                                                          {
-                                                                                            "op_name":"TableFullScan",
-                                                                                            "table":"test\/ds\/store_returns"
-                                                                                          },
-                                                                                          {
-                                                                                            "op_name":"InnerJoin (MapJoin)",
-                                                                                            "args":
-                                                                                              [
-                                                                                                {
-                                                                                                  "op_name":"TableFullScan",
-                                                                                                  "table":"test\/ds\/item"
-                                                                                                },
-                                                                                                {
-                                                                                                  "op_name":"TableFullScan",
-                                                                                                  "table":"test\/ds\/store_sales"
-                                                                                                }
-                                                                                              ]
-                                                                                          }
-                                                                                        ]
-                                                                                    }
-                                                                                  ]
-                                                                              }
-                                                                            ]
+                                                                          "op_name":"TableFullScan",
+                                                                          "table":"test\/ds\/catalog_returns"
                                                                         }
                                                                       ]
-                                                                  },
-                                                                  {
-                                                                    "op_name":"TableFullScan",
-                                                                    "table":"test\/ds\/date_dim"
                                                                   }
                                                                 ]
                                                             },
                                                             {
                                                               "op_name":"TableFullScan",
-                                                              "table":"test\/ds\/store"
+                                                              "table":"test\/ds\/item"
                                                             }
                                                           ]
+                                                      },
+                                                      {
+                                                        "op_name":"TableFullScan",
+                                                        "table":"test\/ds\/store_returns"
                                                       }
                                                     ]
+                                                },
+                                                {
+                                                  "op_name":"TableFullScan",
+                                                  "table":"test\/ds\/customer_address"
                                                 }
                                               ]
                                           },
                                           {
                                             "op_name":"TableFullScan",
-                                            "table":"test\/ds\/date_dim"
+                                            "table":"test\/ds\/customer_demographics"
                                           }
                                         ]
                                     },
@@ -332,23 +278,77 @@
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/promotion"
+                                "table":"test\/ds\/store"
                               }
                             ]
                         },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/promotion"
+                        }
+                      ]
+                  },
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/household_demographics"
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/income_band"
+                        }
+                      ]
+                  }
+                ]
+            },
+            {
+              "op_name":"InnerJoin (MapJoin)",
+              "args":
+                [
+                  {
+                    "op_name":"InnerJoin (MapJoin)",
+                    "args":
+                      [
                         {
                           "op_name":"InnerJoin (MapJoin)",
                           "args":
                             [
                               {
-                                "op_name":"TableFullScan",
-                                "table":"test\/ds\/household_demographics"
+                                "op_name":"InnerJoin (Grace)",
+                                "args":
+                                  [
+                                    {
+                                      "op_name":"InnerJoin (MapJoin)",
+                                      "args":
+                                        [
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer"
+                                          },
+                                          {
+                                            "op_name":"TableFullScan",
+                                            "table":"test\/ds\/customer_demographics"
+                                          }
+                                        ]
+                                    },
+                                    {
+                                      "op_name":"TableFullScan",
+                                      "table":"test\/ds\/customer_address"
+                                    }
+                                  ]
                               },
                               {
                                 "op_name":"TableFullScan",
-                                "table":"test\/ds\/income_band"
+                                "table":"test\/ds\/date_dim"
                               }
                             ]
+                        },
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"test\/ds\/date_dim"
                         }
                       ]
                   },

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -298,7 +298,7 @@ message TTableServiceConfig {
 
     optional bool EnableQueryServiceSpilling = 63 [ default = true ];
 
-    optional uint32 DefaultCostBasedOptimizationLevel = 64 [default = 3];
+    optional uint32 DefaultCostBasedOptimizationLevel = 64 [default = 4];
 
     optional bool EnableConstantFolding = 65 [ default = true ];
 

--- a/ydb/library/yql/core/yql_statistics.cpp
+++ b/ydb/library/yql/core/yql_statistics.cpp
@@ -51,6 +51,7 @@ TOptimizerStatistics::TOptimizerStatistics(
     double cost,
     TIntrusivePtr<TKeyColumns> keyColumns,
     TIntrusivePtr<TColumnStatMap> columnMap,
+    EStorageType storageType,
     std::unique_ptr<IProviderStatistics> specific)
     : Type(type)
     , Nrows(nrows)
@@ -59,6 +60,7 @@ TOptimizerStatistics::TOptimizerStatistics(
     , Cost(cost)
     , KeyColumns(keyColumns)
     , ColumnStatistics(columnMap)
+    , StorageType(storageType)
     , Specific(std::move(specific))
 {
 }

--- a/ydb/library/yql/core/yql_statistics.cpp
+++ b/ydb/library/yql/core/yql_statistics.cpp
@@ -22,6 +22,20 @@ static TString ConvertToStatisticsTypeString(EStatisticsType type) {
     return "";
 }
 
+static TString ConvertToStatisticsTypeString(EStorageType storageType) {
+    switch (storageType) {
+        case EStorageType::NA:
+            return "NA";
+        case EStorageType::RowStorage:
+            return "RowStorage";
+        case EStorageType::ColumnStorage:
+            return "ColumnStorage";
+        default:
+            Y_ENSURE(false,"Unknown Storage type");
+    }
+    return "";
+}
+
 TString TOptimizerStatistics::ToString() const {
     std::stringstream ss;
     ss << *this;
@@ -36,6 +50,7 @@ std::ostream& NYql::operator<<(std::ostream& os, const TOptimizerStatistics& s) 
             os << ", " << c;
         }
     }
+    os << ", Storage: " << ConvertToStatisticsTypeString(s.StorageType);
     return os;
 }
 

--- a/ydb/library/yql/core/yql_statistics.h
+++ b/ydb/library/yql/core/yql_statistics.h
@@ -19,6 +19,12 @@ enum EStatisticsType : ui32 {
     ManyManyJoin
 };
 
+enum EStorageType : ui32 {
+    NA,
+    RowStorage,
+    ColumnStorage
+};
+
 // Providers may subclass this struct to associate specific statistics, useful to
 // derive stats for higher-level operators in the plan.
 struct IProviderStatistics {
@@ -61,6 +67,7 @@ struct TOptimizerStatistics {
     double Selectivity = 1.0;
     TIntrusivePtr<TKeyColumns> KeyColumns;
     TIntrusivePtr<TColumnStatMap> ColumnStatistics;
+    EStorageType StorageType = EStorageType::NA;
     std::unique_ptr<const IProviderStatistics> Specific;
     std::shared_ptr<TVector<TString>> Labels = {};
 
@@ -75,6 +82,7 @@ struct TOptimizerStatistics {
         double cost = 0.0,
         TIntrusivePtr<TKeyColumns> keyColumns = {},
         TIntrusivePtr<TColumnStatMap> columnMap = {},
+        EStorageType storageType = EStorageType::NA,
         std::unique_ptr<IProviderStatistics> specific = nullptr);
 
     TOptimizerStatistics& operator+=(const TOptimizerStatistics& other);

--- a/ydb/library/yql/dq/opt/dq_cbo_ut.cpp
+++ b/ydb/library/yql/dq/opt/dq_cbo_ut.cpp
@@ -62,11 +62,11 @@ Y_UNIT_TEST(JoinSearch2Rels) {
     std::stringstream ss;
     res->Print(ss);
     TString expected = R"__(Join: (InnerJoin,MapJoin) b.1=a.1,
-Type: ManyManyJoin, Nrows: 2e+10, Ncols: 2, ByteSize: 0, Cost: 2.00112e+10
+Type: ManyManyJoin, Nrows: 2e+10, Ncols: 2, ByteSize: 0, Cost: 2.00112e+10, Storage: NA
     Rel: b
-    Type: BaseTable, Nrows: 1e+06, Ncols: 1, ByteSize: 0, Cost: 9.00001e+06
+    Type: BaseTable, Nrows: 1e+06, Ncols: 1, ByteSize: 0, Cost: 9.00001e+06, Storage: NA
     Rel: a
-    Type: BaseTable, Nrows: 100000, Ncols: 1, ByteSize: 0, Cost: 1e+06
+    Type: BaseTable, Nrows: 100000, Ncols: 1, ByteSize: 0, Cost: 1e+06, Storage: NA
 )__";
 
     UNIT_ASSERT_STRINGS_EQUAL(expected, ss.str());
@@ -114,15 +114,15 @@ Y_UNIT_TEST(JoinSearch3Rels) {
     res->Print(ss);
 
     TString expected = R"__(Join: (InnerJoin,MapJoin) a.1=b.1,a.1=c.1,
-Type: ManyManyJoin, Nrows: 4e+13, Ncols: 3, ByteSize: 0, Cost: 4.004e+13
+Type: ManyManyJoin, Nrows: 4e+13, Ncols: 3, ByteSize: 0, Cost: 4.004e+13, Storage: NA
     Join: (InnerJoin,MapJoin) b.1=a.1,
-    Type: ManyManyJoin, Nrows: 2e+10, Ncols: 2, ByteSize: 0, Cost: 2.00112e+10
+    Type: ManyManyJoin, Nrows: 2e+10, Ncols: 2, ByteSize: 0, Cost: 2.00112e+10, Storage: NA
         Rel: b
-        Type: BaseTable, Nrows: 1e+06, Ncols: 1, ByteSize: 0, Cost: 9.00001e+06
+        Type: BaseTable, Nrows: 1e+06, Ncols: 1, ByteSize: 0, Cost: 9.00001e+06, Storage: NA
         Rel: a
-        Type: BaseTable, Nrows: 100000, Ncols: 1, ByteSize: 0, Cost: 1e+06
+        Type: BaseTable, Nrows: 100000, Ncols: 1, ByteSize: 0, Cost: 1e+06, Storage: NA
     Rel: c
-    Type: BaseTable, Nrows: 10000, Ncols: 1, ByteSize: 0, Cost: 9009
+    Type: BaseTable, Nrows: 10000, Ncols: 1, ByteSize: 0, Cost: 9009, Storage: NA
 )__";
 
     UNIT_ASSERT_STRINGS_EQUAL(expected, ss.str());

--- a/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
@@ -319,10 +319,9 @@ TExprBase DqOptimizeEquiJoinWithCosts(
         rels.end(), 
         [](std::shared_ptr<TRelOptimizerNode>& r) {return r->Stats->StorageType==EStorageType::RowStorage; });
 
-    Y_UNUSED(allRowStorage);
-    //if (optLevel == 3 && allRowStorage) {
-    //    return node;
-    //}
+    if (optLevel == 3 && allRowStorage) {
+        return node;
+    }
 
     equiJoinCounter++;
 

--- a/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
@@ -314,6 +314,16 @@ TExprBase DqOptimizeEquiJoinWithCosts(
 
     YQL_CLOG(TRACE, CoreDq) << "All statistics for join in place";
 
+    bool allRowStorage = std::all_of(
+        rels.begin(), 
+        rels.end(), 
+        [](std::shared_ptr<TRelOptimizerNode>& r) {return r->Stats->StorageType==EStorageType::RowStorage; });
+
+    Y_UNUSED(allRowStorage);
+    //if (optLevel == 3 && allRowStorage) {
+    //    return node;
+    //}
+
     equiJoinCounter++;
 
     auto joinTuple = equiJoin.Arg(equiJoin.ArgCount() - 2).Cast<TCoEquiJoinTuple>();

--- a/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
@@ -319,7 +319,7 @@ TExprBase DqOptimizeEquiJoinWithCosts(
         rels.end(), 
         [](std::shared_ptr<TRelOptimizerNode>& r) {return r->Stats->StorageType==EStorageType::RowStorage; });
 
-    if (optLevel == 3 && allRowStorage) {
+    if (optLevel == 2 && allRowStorage) {
         return node;
     }
 

--- a/ydb/library/yql/dq/opt/dq_opt_stat.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_stat.cpp
@@ -71,7 +71,9 @@ namespace {
                         inputStats->Ncols, 
                         inputStats->ByteSize, 
                         inputStats->Cost, 
-                        inputStats->KeyColumns);
+                        inputStats->KeyColumns,
+                        inputStats->ColumnStatistics,
+                        inputStats->StorageType);
                     outputStats->Labels = inputStats->Labels;
                     return outputStats;
                 }
@@ -380,7 +382,16 @@ void InferStatisticsForFlatMap(const TExprNode::TPtr& input, TTypeAnnotationCont
 
         double selectivity = TPredicateSelectivityComputer(inputStats).Compute(flatmap.Lambda().Body());
 
-        auto outputStats = TOptimizerStatistics(inputStats->Type, inputStats->Nrows * selectivity, inputStats->Ncols, inputStats->ByteSize * selectivity, inputStats->Cost, inputStats->KeyColumns );
+        auto outputStats = TOptimizerStatistics(
+            inputStats->Type, 
+            inputStats->Nrows * selectivity, 
+            inputStats->Ncols, 
+            inputStats->ByteSize * selectivity, 
+            inputStats->Cost, 
+            inputStats->KeyColumns,
+            inputStats->ColumnStatistics,
+            inputStats->StorageType);
+
         outputStats.Labels = inputStats->Labels;
         outputStats.Selectivity *= selectivity;
 
@@ -424,7 +435,16 @@ void InferStatisticsForFilter(const TExprNode::TPtr& input, TTypeAnnotationConte
     auto filterBody = filter.Lambda().Body();
     double selectivity = TPredicateSelectivityComputer(inputStats).Compute(filterBody);
 
-    auto outputStats = TOptimizerStatistics(inputStats->Type, inputStats->Nrows * selectivity, inputStats->Ncols, inputStats->ByteSize * selectivity, inputStats->Cost, inputStats->KeyColumns);
+    auto outputStats = TOptimizerStatistics(
+        inputStats->Type, 
+        inputStats->Nrows * selectivity, 
+        inputStats->Ncols, 
+        inputStats->ByteSize * selectivity, 
+        inputStats->Cost, 
+        inputStats->KeyColumns,
+        inputStats->ColumnStatistics,
+        inputStats->StorageType);
+
     outputStats.Selectivity *= selectivity;
     outputStats.Labels = inputStats->Labels;
 

--- a/ydb/library/yql/providers/dq/common/yql_dq_settings.h
+++ b/ydb/library/yql/providers/dq/common/yql_dq_settings.h
@@ -56,7 +56,7 @@ struct TDqSettings {
         static constexpr bool ExportStats = false;
         static constexpr ETaskRunnerStats TaskRunnerStats = ETaskRunnerStats::Basic;
         static constexpr ESpillingEngine SpillingEngine = ESpillingEngine::Disable;
-        static constexpr ui32 CostBasedOptimizationLevel = 3;
+        static constexpr ui32 CostBasedOptimizationLevel = 4;
         static constexpr ui32 MaxDPccpDPTableSize = 40000U;
         static constexpr ui64 MaxAttachmentsSize = 2_GB;
         static constexpr bool SplitStageOnDqReplicate = true;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Новая логика уровней оптимизаций:

0 - CBO выключен
1 - CBO не включается, но считаются предсказания оптимизатора
2 - CBO включается в полном виде только для запросов, где есть OLAP таблицы
3 - CBO включается для всех запросов, но для даташардов предпочитает lookup join.
4 - CBO включен в полном виде всегда

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
