### PR TITLE
Add TotalNodeCpuUsage to local's metrics

### DIFF
--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -490,6 +490,9 @@ void TNodeInfo::UpdateResourceTotalUsage(const NKikimrHive::TEvTabletMetrics& me
         AveragedNodeTotalUsage.Push(metrics.GetTotalNodeUsage());
         NodeTotalUsage = AveragedNodeTotalUsage.GetValue();
     }
+    if (metrics.HasTotalNodeCpuUsage()) {
+        AveragedNodeTotalCpuUsage.Push(metrics.GetTotalNodeCpuUsage());
+    }
 }
 
 TResourceRawValues TNodeInfo::GetResourceCurrentValues() const {

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -76,6 +76,7 @@ public:
     NMetrics::TAverageValue<TResourceRawValues, 20> AveragedResourceTotalValues;
     double NodeTotalUsage = 0;
     NMetrics::TFastRiseAverageValue<double, 20> AveragedNodeTotalUsage;
+    NMetrics::TAverageValue<double, 20> AveragedNodeTotalCpuUsage;
     TResourceRawValues ResourceMaximumValues;
     TInstant StartTime;
     TNodeLocation Location;

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -652,12 +652,11 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
             const NKikimrWhiteboard::TSystemStateInfo& info = record.GetSystemStateInfo(0);
 
             if (info.HasNumberOfCpus()) {
-                ui64 cpuUsageSum = 0;
+                double cpuUsageSum = 0;
                 for (const auto& poolInfo : info.poolstats()) {
                     cpuUsageSum += poolInfo.usage() * poolInfo.threads();
                 }
-
-                CpuUsage = static_cast<double>(cpuUsageSum) / info.GetNumberOfCpus();
+                CpuUsage = cpuUsageSum / info.GetNumberOfCpus();
             }
 
             if (static_cast<ui32>(info.PoolStatsSize()) > AppData()->UserPoolId) {

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -106,10 +106,11 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
     constexpr static TDuration UPDATE_SYSTEM_USAGE_INTERVAL = TDuration::MilliSeconds(1000);
     constexpr static TDuration DRAIN_NODE_TIMEOUT = TDuration::MilliSeconds(15000);
     ui64 UserPoolUsage = 0; // (usage uS x threads) / sec
+    ui64 UserPoolLimit = 0; // PotentialMaxThreadCount of UserPool
     ui64 MemUsage = 0;
     ui64 MemLimit = 0;
-    ui64 CpuLimit = 0; // PotentialMaxThreadCount of UserPool
     double NodeUsage = 0;
+    double CpuUsage = 0; // Sum of CPU usage in all pools / Number of CPUs
 
     bool SentDrainNode = false;
     bool DrainResultReceived = false;
@@ -275,8 +276,8 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
     void FillResourceMaximum(NKikimrTabletBase::TMetrics* record) {
         record->CopyFrom(ResourceLimit);
         if (!record->HasCPU()) {
-            if (CpuLimit != 0) {
-                record->SetCPU(CpuLimit);
+            if (UserPoolLimit != 0) {
+                record->SetCPU(UserPoolLimit);
             }
         }
         if (!record->HasMemory()) {
@@ -587,6 +588,7 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
                 record.MutableTotalResourceUsage()->SetMemory(MemUsage);
             }
             record.SetTotalNodeUsage(NodeUsage);
+            record.SetTotalNodeCpuUsage(CpuUsage);
             FillResourceMaximum(record.MutableResourceMaximum());
             NTabletPipe::SendData(ctx, HivePipeClient, event.Release());
             SendTabletMetricsTime = ctx.Now();
@@ -648,10 +650,20 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
         const NKikimrWhiteboard::TEvSystemStateResponse& record = ev->Get()->Record;
         if (!record.GetSystemStateInfo().empty()) {
             const NKikimrWhiteboard::TSystemStateInfo& info = record.GetSystemStateInfo(0);
+
+            if (info.HasNumberOfCpus()) {
+                ui64 cpuUsageSum = 0;
+                for (const auto& poolInfo : info.poolstats()) {
+                    cpuUsageSum += poolInfo.usage() * poolInfo.threads();
+                }
+
+                CpuUsage = static_cast<double>(cpuUsageSum) / info.GetNumberOfCpus();
+            }
+
             if (static_cast<ui32>(info.PoolStatsSize()) > AppData()->UserPoolId) {
                 const auto& poolStats(info.GetPoolStats(AppData()->UserPoolId));
-                CpuLimit = poolStats.limit() * 1'000'000; // microseconds
-                UserPoolUsage = poolStats.usage() * CpuLimit; // microseconds
+                UserPoolLimit = poolStats.limit() * 1'000'000; // microseconds
+                UserPoolUsage = poolStats.usage() * UserPoolLimit; // microseconds
             }
 
             // Note: we use allocated memory because MemoryUsed(AnonRSS) has lag

--- a/ydb/core/protos/hive.proto
+++ b/ydb/core/protos/hive.proto
@@ -245,8 +245,9 @@ message TTabletMetrics {
 message TEvTabletMetrics {
     repeated TTabletMetrics TabletMetrics = 1;
     optional NKikimrTabletBase.TMetrics TotalResourceUsage = 2;
-    optional double TotalNodeUsage = 3;
     optional NKikimrTabletBase.TMetrics ResourceMaximum = 4;
+    optional double TotalNodeUsage = 3;
+    optional double TotalNodeCpuUsage = 5;
 }
 
 message TEvReassignTablet {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add new metric `TotalNodeCpuUsage` to local that tracks overall node's cpu usage

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)


