### PR TITLE
Properly optimize unordered YtOutput over YtDqProcessWrite

### DIFF
--- a/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt_write.cpp
+++ b/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt_write.cpp
@@ -669,30 +669,7 @@ TMaybeNode<TExprBase> TYtPhysicalOptProposalTransformer::YtDqWrite(TExprBase nod
             .Build().Done();
     }
 
-    const auto& items = GetSeqItemType(write.Input().Ref().GetTypeAnn())->Cast<TStructExprType>()->GetItems();
-    auto expand = ctx.Builder(write.Pos())
-        .Callable("ExpandMap")
-            .Add(0, write.Input().Ptr())
-            .Lambda(1)
-                .Param("item")
-                .Do([&](TExprNodeBuilder& lambda) -> TExprNodeBuilder& {
-                    ui32 i = 0U;
-                    for (const auto& item : items) {
-                        lambda.Callable(i++, "Member")
-                            .Arg(0, "item")
-                            .Atom(1, item->GetName())
-                        .Seal();
-                    }
-                    return lambda;
-                })
-            .Seal()
-        .Seal().Build();
-
-    return Build<TCoDiscard>(ctx, write.Pos())
-        .Input<TYtDqWideWrite>()
-            .Input(std::move(expand))
-            .Settings(write.Settings())
-        .Build().Done();
+    return node;
 }
 
 TMaybeNode<TExprBase> TYtPhysicalOptProposalTransformer::Fill(TExprBase node, TExprContext& ctx) const {

--- a/ydb/library/yql/tests/sql/dq_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part0/canondata/result.json
@@ -45,23 +45,23 @@
     "test.test[action-eval_asatom-default.txt-Results]": [],
     "test.test[action-eval_input_output_table--Analyze]": [
         {
-            "checksum": "a40d48ebab13dfcac8342e19462f2faa",
-            "size": 6474,
-            "uri": "https://{canondata_backend}/1781765/dc6851b092ce1eab8c455f2f5947ff5e5fb41411/resource.tar.gz#test.test_action-eval_input_output_table--Analyze_/plan.txt"
+            "checksum": "302b334624dce8fdd832200067248ff7",
+            "size": 6164,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_action-eval_input_output_table--Analyze_/plan.txt"
         }
     ],
     "test.test[action-eval_input_output_table--Debug]": [
         {
-            "checksum": "6406cdf11c45417488596389f239650d",
-            "size": 2776,
-            "uri": "https://{canondata_backend}/1942173/bf351a1a8ee8d6c0b6502a57775b3dee11ed5877/resource.tar.gz#test.test_action-eval_input_output_table--Debug_/opt.yql_patched"
+            "checksum": "915428f4858a139e2b68e3b511b96fc0",
+            "size": 2559,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_action-eval_input_output_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_input_output_table--Plan]": [
         {
-            "checksum": "a40d48ebab13dfcac8342e19462f2faa",
-            "size": 6474,
-            "uri": "https://{canondata_backend}/1781765/dc6851b092ce1eab8c455f2f5947ff5e5fb41411/resource.tar.gz#test.test_action-eval_input_output_table--Plan_/plan.txt"
+            "checksum": "302b334624dce8fdd832200067248ff7",
+            "size": 6164,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_action-eval_input_output_table--Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_input_output_table--Results]": [],
@@ -401,16 +401,16 @@
     ],
     "test.test[aggregate-group_compact_sorted_with_diff_order--Debug]": [
         {
-            "checksum": "0561a652a16bcd9bbfc0dc2ac970b896",
-            "size": 11149,
-            "uri": "https://{canondata_backend}/1942173/bf351a1a8ee8d6c0b6502a57775b3dee11ed5877/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Debug_/opt.yql_patched"
+            "checksum": "ac7ef0633f599a5b8ce5f70eab5dca9a",
+            "size": 10330,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_compact_sorted_with_diff_order--Plan]": [
         {
-            "checksum": "7be116a56f20dfa9fe217283dd709375",
-            "size": 36684,
-            "uri": "https://{canondata_backend}/1936997/0369012b4079b3fe371b0e69a32dd2ddf31664b0/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Plan_/plan.txt"
+            "checksum": "0e6141ebf4ef95e3eb1d118c383050b1",
+            "size": 36066,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_compact_sorted_with_diff_order--Results]": [],
@@ -1037,16 +1037,16 @@
     ],
     "test.test[insert-append_after_replace-default.txt-Debug]": [
         {
-            "checksum": "346e9980be178e50040b1bc905424347",
-            "size": 2855,
-            "uri": "https://{canondata_backend}/212715/70085563c7b6ff5dacc6f9b036630913d5a5a13d/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d9ecfd489dfcaeaa24ad8c01434e1e3a",
+            "size": 2704,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_after_replace-default.txt-Plan]": [
         {
-            "checksum": "c9441c2fcedae63174120f514223729f",
-            "size": 9237,
-            "uri": "https://{canondata_backend}/1942173/c999536ef513eb5b4dd68e63db12a69de93764c9/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Plan_/plan.txt"
+            "checksum": "55d72c0e34d7e8ac45fac30c4b671334",
+            "size": 8825,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_after_replace-default.txt-Results]": [],
@@ -1074,45 +1074,45 @@
     "test.test[insert-insert_null-default.txt-Results]": [],
     "test.test[insert-insert_relabeled-default.txt-Analyze]": [
         {
-            "checksum": "67f0f828b72d6db96a3edec325914256",
-            "size": 4912,
-            "uri": "https://{canondata_backend}/1936997/a36e4ac0da388a8e1ac773455c73c5a459846a00/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Analyze_/plan.txt"
+            "checksum": "0ac4ec57a83ffbf43198e5b64dea16e2",
+            "size": 4706,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-insert_relabeled-default.txt-Debug]": [
         {
-            "checksum": "776f429f9af2036706ae3598ca7524ec",
-            "size": 2345,
-            "uri": "https://{canondata_backend}/212715/70085563c7b6ff5dacc6f9b036630913d5a5a13d/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3e796984fa26ad82659fbe39d1149f5a",
+            "size": 2187,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-insert_relabeled-default.txt-Plan]": [
         {
-            "checksum": "67f0f828b72d6db96a3edec325914256",
-            "size": 4912,
-            "uri": "https://{canondata_backend}/1937150/af1149e4ecbbaf59deead854c81e1ca2a679d76d/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Plan_/plan.txt"
+            "checksum": "0ac4ec57a83ffbf43198e5b64dea16e2",
+            "size": 4706,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-insert_relabeled-default.txt-Results]": [],
     "test.test[insert-keepmeta--Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1942100/d68f1b9ece8066295ccc2383f178f0352ea78cc9/resource.tar.gz#test.test_insert-keepmeta--Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-keepmeta--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-keepmeta--Debug]": [
         {
-            "checksum": "f963ea0cd181e78eb4ecb1150d8185e8",
-            "size": 1876,
-            "uri": "https://{canondata_backend}/1942173/bf351a1a8ee8d6c0b6502a57775b3dee11ed5877/resource.tar.gz#test.test_insert-keepmeta--Debug_/opt.yql_patched"
+            "checksum": "98856c88e6f51888c981d758a6602e55",
+            "size": 1753,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-keepmeta--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-keepmeta--Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1942100/d68f1b9ece8066295ccc2383f178f0352ea78cc9/resource.tar.gz#test.test_insert-keepmeta--Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-keepmeta--Plan_/plan.txt"
         }
     ],
     "test.test[insert-keepmeta--Results]": [],
@@ -1140,23 +1140,23 @@
     "test.test[insert-literals_to_string-default.txt-Results]": [],
     "test.test[insert-override--Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/937458/ca874ae4a90e1527826d17c1da5f3d3dad325887/resource.tar.gz#test.test_insert-override--Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-override--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-override--Debug]": [
         {
-            "checksum": "f963ea0cd181e78eb4ecb1150d8185e8",
-            "size": 1876,
-            "uri": "https://{canondata_backend}/212715/70085563c7b6ff5dacc6f9b036630913d5a5a13d/resource.tar.gz#test.test_insert-override--Debug_/opt.yql_patched"
+            "checksum": "98856c88e6f51888c981d758a6602e55",
+            "size": 1753,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-override--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override--Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1936947/d3ad1f71376242a4fc97e61cf881b89ec47382a6/resource.tar.gz#test.test_insert-override--Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-override--Plan_/plan.txt"
         }
     ],
     "test.test[insert-override--Results]": [],
@@ -1172,16 +1172,16 @@
     ],
     "test.test[insert-select_after_replace-default.txt-Debug]": [
         {
-            "checksum": "dd9bf1931c9bdda94eb456b3606fc4b9",
-            "size": 2608,
-            "uri": "https://{canondata_backend}/1689644/bb7a5ebb839768b3371fdb6466d95c49c7caa5bc/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cbf8931f03e90c04543f35ce06864af2",
+            "size": 2485,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_after_replace-default.txt-Plan]": [
         {
-            "checksum": "207738aa021ef473a4c79761115499f4",
-            "size": 8085,
-            "uri": "https://{canondata_backend}/1936273/0d86ad2b4c27fcc90610fc18283a8b444dba82f9/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Plan_/plan.txt"
+            "checksum": "c5dcdf3f3664f53b865400208368e2bd",
+            "size": 7879,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_after_replace-default.txt-Results]": [],
@@ -1869,23 +1869,23 @@
     "test.test[library-library_alias--Results]": [],
     "test.test[limit-insert_with_limit--Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1923547/1858de51f4bbf46999ba5d6867a7ba86040642ee/resource.tar.gz#test.test_limit-insert_with_limit--Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_limit-insert_with_limit--Analyze_/plan.txt"
         }
     ],
     "test.test[limit-insert_with_limit--Debug]": [
         {
-            "checksum": "3ae0ee09ce70615650dd25ae7b4e63bb",
-            "size": 1907,
-            "uri": "https://{canondata_backend}/212715/70085563c7b6ff5dacc6f9b036630913d5a5a13d/resource.tar.gz#test.test_limit-insert_with_limit--Debug_/opt.yql_patched"
+            "checksum": "9d14e69f1f0136ff9531bd56e06ac554",
+            "size": 1784,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_limit-insert_with_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-insert_with_limit--Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1923547/1858de51f4bbf46999ba5d6867a7ba86040642ee/resource.tar.gz#test.test_limit-insert_with_limit--Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_limit-insert_with_limit--Plan_/plan.txt"
         }
     ],
     "test.test[limit-insert_with_limit--Results]": [],
@@ -2011,23 +2011,23 @@
     "test.test[optimizers-yql-7767_key_filter_with_view--Results]": [],
     "test.test[order_by-assume_cut_prefix--Analyze]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1781765/dc6851b092ce1eab8c455f2f5947ff5e5fb41411/resource.tar.gz#test.test_order_by-assume_cut_prefix--Analyze_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_order_by-assume_cut_prefix--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-assume_cut_prefix--Debug]": [
         {
-            "checksum": "8a345d017a71743019c4291f3cb3a8d8",
-            "size": 2704,
-            "uri": "https://{canondata_backend}/1942173/bf351a1a8ee8d6c0b6502a57775b3dee11ed5877/resource.tar.gz#test.test_order_by-assume_cut_prefix--Debug_/opt.yql_patched"
+            "checksum": "95dbe7043ea33f0dffc932b9a0d98627",
+            "size": 2509,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_order_by-assume_cut_prefix--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_cut_prefix--Plan]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1781765/dc6851b092ce1eab8c455f2f5947ff5e5fb41411/resource.tar.gz#test.test_order_by-assume_cut_prefix--Plan_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_order_by-assume_cut_prefix--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-assume_cut_prefix--Results]": [],
@@ -2886,9 +2886,9 @@
     "test.test[sampling-zero_percentage--Results]": [],
     "test.test[schema-append_to_desc--Analyze]": [
         {
-            "checksum": "bf13d78280fb7b7cd157af05d5134d34",
-            "size": 5434,
-            "uri": "https://{canondata_backend}/1689644/b4e0fff7bd6d755d64cb96382df5ee2d81572655/resource.tar.gz#test.test_schema-append_to_desc--Analyze_/plan.txt"
+            "checksum": "847db4b112ac0bc912305d78e2301449",
+            "size": 5131,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_schema-append_to_desc--Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_schema-append_to_desc--Analyze_/extracted"
@@ -2896,16 +2896,16 @@
     ],
     "test.test[schema-append_to_desc--Debug]": [
         {
-            "checksum": "1b72fae90cb1c65c93ce0a2755aacc0c",
-            "size": 2146,
-            "uri": "https://{canondata_backend}/1942173/bf351a1a8ee8d6c0b6502a57775b3dee11ed5877/resource.tar.gz#test.test_schema-append_to_desc--Debug_/opt.yql_patched"
+            "checksum": "de9ebb42656806d6f67545cf571121ca",
+            "size": 1889,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_schema-append_to_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-append_to_desc--Plan]": [
         {
-            "checksum": "bf13d78280fb7b7cd157af05d5134d34",
-            "size": 5434,
-            "uri": "https://{canondata_backend}/1903885/1f5c633d9ef5c6b22274dcefd1b823de60aa2a36/resource.tar.gz#test.test_schema-append_to_desc--Plan_/plan.txt"
+            "checksum": "847db4b112ac0bc912305d78e2301449",
+            "size": 5131,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_schema-append_to_desc--Plan_/plan.txt"
         }
     ],
     "test.test[schema-append_to_desc--Results]": [
@@ -2915,23 +2915,23 @@
     ],
     "test.test[schema-copy-schema-Analyze]": [
         {
-            "checksum": "617e5fef213a8ad0a505a28ae28ac974",
-            "size": 4876,
-            "uri": "https://{canondata_backend}/1923547/1858de51f4bbf46999ba5d6867a7ba86040642ee/resource.tar.gz#test.test_schema-copy-schema-Analyze_/plan.txt"
+            "checksum": "1ae0ffebc6fe8af516e03f46e9e791f7",
+            "size": 4670,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_schema-copy-schema-Analyze_/plan.txt"
         }
     ],
     "test.test[schema-copy-schema-Debug]": [
         {
-            "checksum": "a2c6da077efdd3157408e6c8b0e8191c",
-            "size": 2160,
-            "uri": "https://{canondata_backend}/1942173/bf351a1a8ee8d6c0b6502a57775b3dee11ed5877/resource.tar.gz#test.test_schema-copy-schema-Debug_/opt.yql_patched"
+            "checksum": "c12af0939a3a124f25f9bbab86e260aa",
+            "size": 1994,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_schema-copy-schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-copy-schema-Plan]": [
         {
-            "checksum": "617e5fef213a8ad0a505a28ae28ac974",
-            "size": 4876,
-            "uri": "https://{canondata_backend}/1923547/1858de51f4bbf46999ba5d6867a7ba86040642ee/resource.tar.gz#test.test_schema-copy-schema-Plan_/plan.txt"
+            "checksum": "1ae0ffebc6fe8af516e03f46e9e791f7",
+            "size": 4670,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_schema-copy-schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-schema-Results]": [],
@@ -3197,9 +3197,9 @@
     ],
     "test.test[type_v3-replace_diff_layout--Analyze]": [
         {
-            "checksum": "67651793bc8dc2180de345b99d08a6c3",
-            "size": 11582,
-            "uri": "https://{canondata_backend}/1599023/0bd57d257eeb1652a68140e9608a6813bf473a94/resource.tar.gz#test.test_type_v3-replace_diff_layout--Analyze_/plan.txt"
+            "checksum": "f97d727782f46aba5f9fc852ca9e9094",
+            "size": 10964,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_type_v3-replace_diff_layout--Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_type_v3-replace_diff_layout--Analyze_/extracted"
@@ -3207,16 +3207,16 @@
     ],
     "test.test[type_v3-replace_diff_layout--Debug]": [
         {
-            "checksum": "0e306be871fca10f1755dbcf3cb2b17c",
-            "size": 4504,
-            "uri": "https://{canondata_backend}/1599023/0bd57d257eeb1652a68140e9608a6813bf473a94/resource.tar.gz#test.test_type_v3-replace_diff_layout--Debug_/opt.yql_patched"
+            "checksum": "7782b2dce5970814f0b6f155a2926a9b",
+            "size": 4379,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_type_v3-replace_diff_layout--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-replace_diff_layout--Plan]": [
         {
-            "checksum": "67651793bc8dc2180de345b99d08a6c3",
-            "size": 11582,
-            "uri": "https://{canondata_backend}/1599023/0bd57d257eeb1652a68140e9608a6813bf473a94/resource.tar.gz#test.test_type_v3-replace_diff_layout--Plan_/plan.txt"
+            "checksum": "f97d727782f46aba5f9fc852ca9e9094",
+            "size": 10964,
+            "uri": "https://{canondata_backend}/1937429/44565291a008d35ab2663966004d6717f2618b42/resource.tar.gz#test.test_type_v3-replace_diff_layout--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-replace_diff_layout--Results]": [

--- a/ydb/library/yql/tests/sql/dq_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part1/canondata/result.json
@@ -804,23 +804,23 @@
     "test.test[case-case_val_then_else-default.txt-Results]": [],
     "test.test[column_order-insert_reorder_without_columnorder--Analyze]": [
         {
-            "checksum": "20c574f29d0ccaed7d6268b9615d99fa",
-            "size": 5810,
-            "uri": "https://{canondata_backend}/1599023/53262e114e5fb21cb58c259e812c31e2f63afae0/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Analyze_/plan.txt"
+            "checksum": "e63effc478ce3e370bbea5f1dad7eea5",
+            "size": 5604,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Analyze_/plan.txt"
         }
     ],
     "test.test[column_order-insert_reorder_without_columnorder--Debug]": [
         {
-            "checksum": "7ab0c279f788e690d78fbaca1d2ff81f",
-            "size": 2494,
-            "uri": "https://{canondata_backend}/1599023/53262e114e5fb21cb58c259e812c31e2f63afae0/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Debug_/opt.yql_patched"
+            "checksum": "e82009ca7eb87d29aad9f68ce5fd3d90",
+            "size": 2369,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_reorder_without_columnorder--Plan]": [
         {
-            "checksum": "20c574f29d0ccaed7d6268b9615d99fa",
-            "size": 5810,
-            "uri": "https://{canondata_backend}/1599023/53262e114e5fb21cb58c259e812c31e2f63afae0/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Plan_/plan.txt"
+            "checksum": "e63effc478ce3e370bbea5f1dad7eea5",
+            "size": 5604,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_reorder_without_columnorder--Results]": [],
@@ -930,16 +930,16 @@
     ],
     "test.test[epochs-reset_sortness_on_append--Debug]": [
         {
-            "checksum": "2a81a3db41ac00a0a86099a99ac36b42",
-            "size": 3513,
-            "uri": "https://{canondata_backend}/1917492/1ed6d08398686e90568735860251083949d84e4e/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Debug_/opt.yql_patched"
+            "checksum": "25bc4083b0a325042f4cccbe6d02d1ea",
+            "size": 3340,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Debug_/opt.yql_patched"
         }
     ],
     "test.test[epochs-reset_sortness_on_append--Plan]": [
         {
-            "checksum": "899f5f9803d76c85e2e582c214c91b5d",
-            "size": 12486,
-            "uri": "https://{canondata_backend}/1903280/cfc00695f60d304a5b897d2cf0fdcda9f6f0bc03/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Plan_/plan.txt"
+            "checksum": "8f546de2592d81aeea1979d61eec6bac",
+            "size": 12183,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Plan_/plan.txt"
         }
     ],
     "test.test[epochs-reset_sortness_on_append--Results]": [
@@ -1236,16 +1236,16 @@
     ],
     "test.test[insert-select_after_replace_unwrap-default.txt-Debug]": [
         {
-            "checksum": "c24f45e3825c2d6512c92ac49f0fefd0",
-            "size": 2805,
-            "uri": "https://{canondata_backend}/1917492/1ed6d08398686e90568735860251083949d84e4e/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5f337b73ddf0d9e32d786d6b156df507",
+            "size": 2682,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_after_replace_unwrap-default.txt-Plan]": [
         {
-            "checksum": "a497799456a2cfa028e698fa1108a509",
-            "size": 8185,
-            "uri": "https://{canondata_backend}/1903280/cfc00695f60d304a5b897d2cf0fdcda9f6f0bc03/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Plan_/plan.txt"
+            "checksum": "e74c5ba2db4dc08ddc34341969abc5ba",
+            "size": 7979,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_after_replace_unwrap-default.txt-Results]": [],
@@ -1258,9 +1258,9 @@
     ],
     "test.test[insert-yql-13083-existig-Analyze]": [
         {
-            "checksum": "5d900cea67bfe08c9e55fd9ca4dcff1c",
-            "size": 15204,
-            "uri": "https://{canondata_backend}/1937027/591a1ceca790d81eaf524a7a3e730722b0d7bdb7/resource.tar.gz#test.test_insert-yql-13083-existig-Analyze_/plan.txt"
+            "checksum": "fe9f1ebe1c0e5cad414231e5cae505d1",
+            "size": 14380,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert-yql-13083-existig-Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_insert-yql-13083-existig-Analyze_/extracted"
@@ -1268,16 +1268,16 @@
     ],
     "test.test[insert-yql-13083-existig-Debug]": [
         {
-            "checksum": "08f5738088f619aef836cacfbeff00ad",
-            "size": 6120,
-            "uri": "https://{canondata_backend}/1871102/093ef1237a5eb90e2e1f6670f45824dd7aa652e1/resource.tar.gz#test.test_insert-yql-13083-existig-Debug_/opt.yql_patched"
+            "checksum": "c9438f236d28b69f765af59395fef285",
+            "size": 5717,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert-yql-13083-existig-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-yql-13083-existig-Plan]": [
         {
-            "checksum": "52daec5a09b912ba2fdbc0184e9d9b72",
-            "size": 15941,
-            "uri": "https://{canondata_backend}/1937027/591a1ceca790d81eaf524a7a3e730722b0d7bdb7/resource.tar.gz#test.test_insert-yql-13083-existig-Plan_/plan.txt"
+            "checksum": "5c4d1fffaa67aff4961c2251e8696ab4",
+            "size": 15117,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert-yql-13083-existig-Plan_/plan.txt"
         }
     ],
     "test.test[insert-yql-13083-existig-Results]": [
@@ -1287,23 +1287,23 @@
     ],
     "test.test[insert_monotonic-from_empty--Analyze]": [
         {
-            "checksum": "fb5aff9f64e2b548e3dfb01a4100ef22",
-            "size": 6407,
-            "uri": "https://{canondata_backend}/1599023/485071e5baca6869dc8f230eb457bd5709090ce7/resource.tar.gz#test.test_insert_monotonic-from_empty--Analyze_/plan.txt"
+            "checksum": "ebc4ef2c95c2b8eda90a0cf059fe0dbc",
+            "size": 6104,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert_monotonic-from_empty--Analyze_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-from_empty--Debug]": [
         {
-            "checksum": "de5f80bf64423e3015fc1b83c9403a15",
-            "size": 2655,
-            "uri": "https://{canondata_backend}/212715/aab8e82a2c99c314ec161e2391e4cf12a1c26fd8/resource.tar.gz#test.test_insert_monotonic-from_empty--Debug_/opt.yql_patched"
+            "checksum": "6c880bc7588e23f9f8d969684f8e1b64",
+            "size": 2399,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert_monotonic-from_empty--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-from_empty--Plan]": [
         {
-            "checksum": "fb5aff9f64e2b548e3dfb01a4100ef22",
-            "size": 6407,
-            "uri": "https://{canondata_backend}/1599023/485071e5baca6869dc8f230eb457bd5709090ce7/resource.tar.gz#test.test_insert_monotonic-from_empty--Plan_/plan.txt"
+            "checksum": "ebc4ef2c95c2b8eda90a0cf059fe0dbc",
+            "size": 6104,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_insert_monotonic-from_empty--Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-from_empty--Results]": [],
@@ -1912,23 +1912,23 @@
     "test.test[order_by-order_by_list_of_strings--Results]": [],
     "test.test[pg-insert--Analyze]": [
         {
-            "checksum": "9615717d31e2b991e962bca0bc3af300",
-            "size": 4817,
-            "uri": "https://{canondata_backend}/1937027/123d9506c8b6c83cb2d0ef07a81699fbbe66ec3e/resource.tar.gz#test.test_pg-insert--Analyze_/plan.txt"
+            "checksum": "f79a066bf2590f27059800d774caf90b",
+            "size": 4611,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_pg-insert--Analyze_/plan.txt"
         }
     ],
     "test.test[pg-insert--Debug]": [
         {
-            "checksum": "3a9b6baa97c72b4ef351b97da423710e",
-            "size": 1905,
-            "uri": "https://{canondata_backend}/212715/aab8e82a2c99c314ec161e2391e4cf12a1c26fd8/resource.tar.gz#test.test_pg-insert--Debug_/opt.yql_patched"
+            "checksum": "e917fe873749866a66d3576bd80f89e0",
+            "size": 1782,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_pg-insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-insert--Plan]": [
         {
-            "checksum": "9615717d31e2b991e962bca0bc3af300",
-            "size": 4817,
-            "uri": "https://{canondata_backend}/1937027/123d9506c8b6c83cb2d0ef07a81699fbbe66ec3e/resource.tar.gz#test.test_pg-insert--Plan_/plan.txt"
+            "checksum": "f79a066bf2590f27059800d774caf90b",
+            "size": 4611,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_pg-insert--Plan_/plan.txt"
         }
     ],
     "test.test[pg-insert--Results]": [],
@@ -1956,23 +1956,23 @@
     "test.test[pg-join_using3-default.txt-Results]": [],
     "test.test[pg-name--Analyze]": [
         {
-            "checksum": "74c11442c60e73460c5f6f697b963794",
-            "size": 7540,
-            "uri": "https://{canondata_backend}/1599023/53262e114e5fb21cb58c259e812c31e2f63afae0/resource.tar.gz#test.test_pg-name--Analyze_/plan.txt"
+            "checksum": "fb4a18cccbcf6f82ed20283fbb336805",
+            "size": 7334,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_pg-name--Analyze_/plan.txt"
         }
     ],
     "test.test[pg-name--Debug]": [
         {
-            "checksum": "44a348fa18e1d109f6b473cba301089c",
-            "size": 3546,
-            "uri": "https://{canondata_backend}/1599023/53262e114e5fb21cb58c259e812c31e2f63afae0/resource.tar.gz#test.test_pg-name--Debug_/opt.yql_patched"
+            "checksum": "9d73d58f88c89558a74cff7053c924b4",
+            "size": 3422,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_pg-name--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-name--Plan]": [
         {
-            "checksum": "74c11442c60e73460c5f6f697b963794",
-            "size": 7540,
-            "uri": "https://{canondata_backend}/1599023/53262e114e5fb21cb58c259e812c31e2f63afae0/resource.tar.gz#test.test_pg-name--Plan_/plan.txt"
+            "checksum": "fb4a18cccbcf6f82ed20283fbb336805",
+            "size": 7334,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_pg-name--Plan_/plan.txt"
         }
     ],
     "test.test[pg-name--Results]": [],
@@ -2565,16 +2565,16 @@
     ],
     "test.test[sampling-bind_multiple_sample-default.txt-Debug]": [
         {
-            "checksum": "05ad14cc2b4bea99af8d60425d5532cd",
-            "size": 3996,
-            "uri": "https://{canondata_backend}/1917492/1ed6d08398686e90568735860251083949d84e4e/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e49bfba6b9a97820256df68f9749f08f",
+            "size": 3847,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_multiple_sample-default.txt-Plan]": [
         {
-            "checksum": "8ff4e818721c1d73de33e1892e9293e9",
-            "size": 10370,
-            "uri": "https://{canondata_backend}/1814674/522ed289227f8ca49d5b5d2d75ab25980e8e24b7/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Plan_/plan.txt"
+            "checksum": "cd53350802c1cac934fc66b3fd922d9f",
+            "size": 9958,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-join_right_sample-default.txt-Analyze]": [
@@ -2890,23 +2890,23 @@
     ],
     "test.test[table_range-concat_sorted_max_tables--Analyze]": [
         {
-            "checksum": "6386e4bc0c90ae4e4db92f752e433e0e",
-            "size": 5375,
-            "uri": "https://{canondata_backend}/1777230/9dfd3c4035bfb7213a3b629ffb6082e868823c0f/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Analyze_/plan.txt"
+            "checksum": "e9c23a443fdaa9f1325a1dee4c3d5e61",
+            "size": 5169,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Analyze_/plan.txt"
         }
     ],
     "test.test[table_range-concat_sorted_max_tables--Debug]": [
         {
-            "checksum": "36e27839cbbefde77013e7acbcb60c5f",
-            "size": 2402,
-            "uri": "https://{canondata_backend}/1942100/72a92167d580e34a66a471ffefa0527d367c0a13/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Debug_/opt.yql_patched"
+            "checksum": "c35156e2b54c8dd288753d127d9e1949",
+            "size": 2302,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-concat_sorted_max_tables--Plan]": [
         {
-            "checksum": "6386e4bc0c90ae4e4db92f752e433e0e",
-            "size": 5375,
-            "uri": "https://{canondata_backend}/1809005/07f25687be3b33f8c1b18410a8bca7559e7b59bc/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Plan_/plan.txt"
+            "checksum": "e9c23a443fdaa9f1325a1dee4c3d5e61",
+            "size": 5169,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Plan_/plan.txt"
         }
     ],
     "test.test[table_range-concat_sorted_max_tables--Results]": [],
@@ -3233,16 +3233,16 @@
     ],
     "test.test[window-win_fuse_window-default.txt-Debug]": [
         {
-            "checksum": "572be4dae655bd3ab1cdae56258bc90e",
-            "size": 7397,
-            "uri": "https://{canondata_backend}/1942100/72a92167d580e34a66a471ffefa0527d367c0a13/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d4cd8ba168ba4a193dd2cbbee941fb62",
+            "size": 7247,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_fuse_window-default.txt-Plan]": [
         {
-            "checksum": "f39ec7052cb3d45a5ff2da38590f88cd",
-            "size": 10141,
-            "uri": "https://{canondata_backend}/1942671/d6da076374b1124e492566e9f81d7f26078203f0/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Plan_/plan.txt"
+            "checksum": "6034127b0084d66ec6b5939ece29bc40",
+            "size": 9935,
+            "uri": "https://{canondata_backend}/1937429/73a35abfefcb4c30cf44393e3335cf2af34209e7/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_fuse_window-default.txt-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part10/canondata/result.json
@@ -743,23 +743,23 @@
     "test.test[csee-same_l1-default.txt-Results]": [],
     "test.test[dq-precompute_parallel_indep--Analyze]": [
         {
-            "checksum": "4f6978cd58bf614cf032ab65c9ccd92e",
-            "size": 16119,
-            "uri": "https://{canondata_backend}/1942525/68adc93267fab0086b1faf825d05122058d5f469/resource.tar.gz#test.test_dq-precompute_parallel_indep--Analyze_/plan.txt"
+            "checksum": "90de64d4ec4bcd77bb0e5a838cd12856",
+            "size": 15501,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_dq-precompute_parallel_indep--Analyze_/plan.txt"
         }
     ],
     "test.test[dq-precompute_parallel_indep--Debug]": [
         {
-            "checksum": "60e05e19e13cece105b65405a56027f7",
-            "size": 5127,
-            "uri": "https://{canondata_backend}/1942525/68adc93267fab0086b1faf825d05122058d5f469/resource.tar.gz#test.test_dq-precompute_parallel_indep--Debug_/opt.yql_patched"
+            "checksum": "ee4ec74a6826550c37ba1fe5ae1a89d4",
+            "size": 5061,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_dq-precompute_parallel_indep--Debug_/opt.yql_patched"
         }
     ],
     "test.test[dq-precompute_parallel_indep--Plan]": [
         {
-            "checksum": "f0c8afc03280179f72fde524e4bbeaf1",
-            "size": 16363,
-            "uri": "https://{canondata_backend}/1942525/68adc93267fab0086b1faf825d05122058d5f469/resource.tar.gz#test.test_dq-precompute_parallel_indep--Plan_/plan.txt"
+            "checksum": "585739314064396afccf3edf8a5364c1",
+            "size": 15745,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_dq-precompute_parallel_indep--Plan_/plan.txt"
         }
     ],
     "test.test[dq-precompute_parallel_indep--Results]": [
@@ -1188,23 +1188,23 @@
     "test.test[insert-double_append_to_anonymous--Results]": [],
     "test.test[insert-replace_inferred--Analyze]": [
         {
-            "checksum": "fd76338a47a06eda45544a2a9dc7a642",
-            "size": 4919,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_insert-replace_inferred--Analyze_/plan.txt"
+            "checksum": "ceccf2acfc9240b3cbe02176e41fc221",
+            "size": 4713,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_insert-replace_inferred--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-replace_inferred--Debug]": [
         {
-            "checksum": "a150123bc33eb7942a50c79446859b06",
-            "size": 2819,
-            "uri": "https://{canondata_backend}/1942415/ad5ade59004e97b62f357b05c8baba968f696aa5/resource.tar.gz#test.test_insert-replace_inferred--Debug_/opt.yql_patched"
+            "checksum": "f5aa6e11122e392080061a7476aa13dd",
+            "size": 2630,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_insert-replace_inferred--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_inferred--Plan]": [
         {
-            "checksum": "fd76338a47a06eda45544a2a9dc7a642",
-            "size": 4919,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_insert-replace_inferred--Plan_/plan.txt"
+            "checksum": "ceccf2acfc9240b3cbe02176e41fc221",
+            "size": 4713,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_insert-replace_inferred--Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_inferred--Results]": [],
@@ -2390,23 +2390,23 @@
     "test.test[produce-reduce_with_flat_lambda-default.txt-Results]": [],
     "test.test[schema-copy-read_schema-Analyze]": [
         {
-            "checksum": "617e5fef213a8ad0a505a28ae28ac974",
-            "size": 4876,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_schema-copy-read_schema-Analyze_/plan.txt"
+            "checksum": "1ae0ffebc6fe8af516e03f46e9e791f7",
+            "size": 4670,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-copy-read_schema-Analyze_/plan.txt"
         }
     ],
     "test.test[schema-copy-read_schema-Debug]": [
         {
-            "checksum": "225eb8f18ffd3b4069a15f26a9c63f07",
-            "size": 2160,
-            "uri": "https://{canondata_backend}/1600758/355a697506f4007ca3fcd5fef0049412eb61f38b/resource.tar.gz#test.test_schema-copy-read_schema-Debug_/opt.yql_patched"
+            "checksum": "61a885fca8cdd1de857feb9ec3120f1d",
+            "size": 1994,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-copy-read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-copy-read_schema-Plan]": [
         {
-            "checksum": "617e5fef213a8ad0a505a28ae28ac974",
-            "size": 4876,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_schema-copy-read_schema-Plan_/plan.txt"
+            "checksum": "1ae0ffebc6fe8af516e03f46e9e791f7",
+            "size": 4670,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-copy-read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-read_schema-Results]": [],
@@ -2422,16 +2422,16 @@
     ],
     "test.test[schema-insert-schema-Debug]": [
         {
-            "checksum": "91a70e8586615fd9c3035eb06472dac1",
-            "size": 2980,
-            "uri": "https://{canondata_backend}/1031349/6c70521322fc43f752ef6b89f8667fefd006af8b/resource.tar.gz#test.test_schema-insert-schema-Debug_/opt.yql_patched"
+            "checksum": "7cb1a4b34470541e945d0103f66fa4f2",
+            "size": 2814,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-insert-schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert-schema-Plan]": [
         {
-            "checksum": "6d2666bfe7a154a87a5f88de868962b3",
-            "size": 8313,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_schema-insert-schema-Plan_/plan.txt"
+            "checksum": "191d447641f8d810de80b5d56e4a5271",
+            "size": 8107,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-insert-schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert-schema-Results]": [],
@@ -2459,23 +2459,23 @@
     "test.test[schema-read_schema_other--Results]": [],
     "test.test[schema-user_schema_override--Analyze]": [
         {
-            "checksum": "26acea70db93ead62217c14a786426ff",
-            "size": 4780,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_schema-user_schema_override--Analyze_/plan.txt"
+            "checksum": "a35c2f77b166a6e718d96e111fa58cb1",
+            "size": 4574,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-user_schema_override--Analyze_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_override--Debug]": [
         {
-            "checksum": "44d95db421757ed80956bb09e3d8e155",
-            "size": 1949,
-            "uri": "https://{canondata_backend}/1600758/355a697506f4007ca3fcd5fef0049412eb61f38b/resource.tar.gz#test.test_schema-user_schema_override--Debug_/opt.yql_patched"
+            "checksum": "e653083eebe272024a4ac21ca7db86c4",
+            "size": 1849,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-user_schema_override--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-user_schema_override--Plan]": [
         {
-            "checksum": "26acea70db93ead62217c14a786426ff",
-            "size": 4780,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_schema-user_schema_override--Plan_/plan.txt"
+            "checksum": "a35c2f77b166a6e718d96e111fa58cb1",
+            "size": 4574,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_schema-user_schema_override--Plan_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_override--Results]": [],
@@ -2613,23 +2613,23 @@
     "test.test[type_v3-ignore_v3_hint-opt-Results]": [],
     "test.test[type_v3-insert_struct_v3_with_native--Analyze]": [
         {
-            "checksum": "0a7731361601cd656dc4bf0586ad5c29",
-            "size": 16860,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Analyze_/plan.txt"
+            "checksum": "07290f3c3edbbeb62c2b97066a7ce37f",
+            "size": 16036,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Analyze_/plan.txt"
         }
     ],
     "test.test[type_v3-insert_struct_v3_with_native--Debug]": [
         {
-            "checksum": "5b5b0c6d2c56717088eba7d76789e934",
-            "size": 5291,
-            "uri": "https://{canondata_backend}/1937424/d5d9e5b42a440866dd2b2f9da0c4923a86da8bea/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Debug_/opt.yql_patched"
+            "checksum": "84974b3d47389558948b4fb21be81477",
+            "size": 5132,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-insert_struct_v3_with_native--Plan]": [
         {
-            "checksum": "ffb2eb74663705eaf1f7a5c404df5691",
-            "size": 17228,
-            "uri": "https://{canondata_backend}/1600758/32cfdeb8c6377a2e7e62c6c4adbb95f25af7669b/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Plan_/plan.txt"
+            "checksum": "91f257bbc65dea98ba8adaffa99a54c6",
+            "size": 16404,
+            "uri": "https://{canondata_backend}/1871102/cedf8264a1905131c6de15c01a397082d1677da3/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-insert_struct_v3_with_native--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part11/canondata/result.json
@@ -1,23 +1,23 @@
 {
     "test.test[action-action_eval_cluster_table_for--Analyze]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Analyze_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Analyze_/plan.txt"
         }
     ],
     "test.test[action-action_eval_cluster_table_for--Debug]": [
         {
-            "checksum": "d6111c7c93c258e0e77f5c5e30170108",
-            "size": 2650,
-            "uri": "https://{canondata_backend}/1773845/a812a6b27edfab9c887a13050ef92c0208b89025/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Debug_/opt.yql_patched"
+            "checksum": "9fe2a3d01ad53c9d0396e90a6ad8fa9d",
+            "size": 2433,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-action_eval_cluster_table_for--Plan]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Plan_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Plan_/plan.txt"
         }
     ],
     "test.test[action-action_eval_cluster_table_for--Results]": [],
@@ -45,23 +45,23 @@
     "test.test[action-action_nested_query-default.txt-Results]": [],
     "test.test[action-insert_each_from_folder--Analyze]": [
         {
-            "checksum": "a2826ccf09ac27be05034998a205455d",
-            "size": 6665,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_action-insert_each_from_folder--Analyze_/plan.txt"
+            "checksum": "e8cdc2c1074beaca4fc6deb4aea0baf0",
+            "size": 6459,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_action-insert_each_from_folder--Analyze_/plan.txt"
         }
     ],
     "test.test[action-insert_each_from_folder--Debug]": [
         {
-            "checksum": "ab8854182d215af7a344a489c14a1118",
-            "size": 2900,
-            "uri": "https://{canondata_backend}/1937429/7495c8355df97f85fa824cc601aaf3eb891c07d7/resource.tar.gz#test.test_action-insert_each_from_folder--Debug_/opt.yql_patched"
+            "checksum": "1cda8005e41081746cee4da9d4c10abe",
+            "size": 2834,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_action-insert_each_from_folder--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-insert_each_from_folder--Plan]": [
         {
-            "checksum": "a2826ccf09ac27be05034998a205455d",
-            "size": 6665,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_action-insert_each_from_folder--Plan_/plan.txt"
+            "checksum": "e8cdc2c1074beaca4fc6deb4aea0baf0",
+            "size": 6459,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_action-insert_each_from_folder--Plan_/plan.txt"
         }
     ],
     "test.test[action-insert_each_from_folder--Results]": [],
@@ -831,16 +831,16 @@
     ],
     "test.test[dq-blacklisted_pragmas1--Debug]": [
         {
-            "checksum": "18623f8bb234dd4177de2df458952f95",
-            "size": 1940,
-            "uri": "https://{canondata_backend}/1773845/a812a6b27edfab9c887a13050ef92c0208b89025/resource.tar.gz#test.test_dq-blacklisted_pragmas1--Debug_/opt.yql_patched"
+            "checksum": "6ed0122d87aaf752faa7bd7826fb31a9",
+            "size": 1817,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_dq-blacklisted_pragmas1--Debug_/opt.yql_patched"
         }
     ],
     "test.test[dq-blacklisted_pragmas1--Plan]": [
         {
-            "checksum": "14d974e2a4612975604c2c1f36f2bf3e",
-            "size": 4821,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_dq-blacklisted_pragmas1--Plan_/plan.txt"
+            "checksum": "fbf704ba8d857d149b8fd8404a7347ae",
+            "size": 4615,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_dq-blacklisted_pragmas1--Plan_/plan.txt"
         }
     ],
     "test.test[dq-blacklisted_pragmas1--Results]": [],
@@ -1035,16 +1035,16 @@
     ],
     "test.test[insert-select_after_insert_relabeled-default.txt-Debug]": [
         {
-            "checksum": "edf0a32576b11dde6b03b0a1aae3ba8d",
-            "size": 3315,
-            "uri": "https://{canondata_backend}/1942173/5dda369a5c566435d55e882d65f0212fa3dfb906/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Debug_/opt.yql_patched"
+            "checksum": "be80e44c87fcac59092cfcf4072e44b3",
+            "size": 3157,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_after_insert_relabeled-default.txt-Plan]": [
         {
-            "checksum": "1d2a3b1f5517149a740ebd384236b711",
-            "size": 8227,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Plan_/plan.txt"
+            "checksum": "b1a4ca7357b84f4d1b6ceb117b127060",
+            "size": 8021,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_after_insert_relabeled-default.txt-Results]": [],
@@ -1072,45 +1072,45 @@
     "test.test[insert-trivial_literals_multirow-default.txt-Results]": [],
     "test.test[insert-yql-13083--Analyze]": [
         {
-            "checksum": "5d900cea67bfe08c9e55fd9ca4dcff1c",
-            "size": 15204,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_insert-yql-13083--Analyze_/plan.txt"
+            "checksum": "fe9f1ebe1c0e5cad414231e5cae505d1",
+            "size": 14380,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert-yql-13083--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-yql-13083--Debug]": [
         {
-            "checksum": "0e7b584533df5425b8cf1ec55896a4e8",
-            "size": 5858,
-            "uri": "https://{canondata_backend}/1903280/419b5c18140d44a17c33d80899398c8647846b33/resource.tar.gz#test.test_insert-yql-13083--Debug_/opt.yql_patched"
+            "checksum": "be885288c5833b076598e956413ff502",
+            "size": 5466,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert-yql-13083--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-yql-13083--Plan]": [
         {
-            "checksum": "52daec5a09b912ba2fdbc0184e9d9b72",
-            "size": 15941,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_insert-yql-13083--Plan_/plan.txt"
+            "checksum": "5c4d1fffaa67aff4961c2251e8696ab4",
+            "size": 15117,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert-yql-13083--Plan_/plan.txt"
         }
     ],
     "test.test[insert-yql-13083--Results]": [],
     "test.test[insert_monotonic-keep_meta-default.txt-Analyze]": [
         {
-            "checksum": "dd6113dc5c4ddce8983668e3d0e8e55e",
-            "size": 6399,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Analyze_/plan.txt"
+            "checksum": "6966860acb7b91de54f12a0d26837063",
+            "size": 6096,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-keep_meta-default.txt-Debug]": [
         {
-            "checksum": "2b280e874c36d5bc4c55df8e71e24eb9",
-            "size": 2651,
-            "uri": "https://{canondata_backend}/1942173/0b677ef0f2a213c297f159290ba893840fb81eda/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ceb09709211a76aeda822c9c5150e0b1",
+            "size": 2395,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-keep_meta-default.txt-Plan]": [
         {
-            "checksum": "dd6113dc5c4ddce8983668e3d0e8e55e",
-            "size": 6399,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Plan_/plan.txt"
+            "checksum": "6966860acb7b91de54f12a0d26837063",
+            "size": 6096,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-keep_meta-default.txt-Results]": [],
@@ -1745,23 +1745,23 @@
     "test.test[optimizers-yql-7532_wrong_field_subset_for_calcoverwindow-default.txt-Results]": [],
     "test.test[order_by-assume_over_input_desc--Analyze]": [
         {
-            "checksum": "16849280a28a6f1488e5d5940175186d",
-            "size": 7957,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_order_by-assume_over_input_desc--Analyze_/plan.txt"
+            "checksum": "05b0fb8063ed0adbafac22280fc31ec3",
+            "size": 7654,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_order_by-assume_over_input_desc--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-assume_over_input_desc--Debug]": [
         {
-            "checksum": "99b8bb7245193b7c025123d2295aad05",
-            "size": 3517,
-            "uri": "https://{canondata_backend}/1773845/a812a6b27edfab9c887a13050ef92c0208b89025/resource.tar.gz#test.test_order_by-assume_over_input_desc--Debug_/opt.yql_patched"
+            "checksum": "bbd75796d7052ae70519c659dff735e2",
+            "size": 3306,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_order_by-assume_over_input_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_over_input_desc--Plan]": [
         {
-            "checksum": "16849280a28a6f1488e5d5940175186d",
-            "size": 7957,
-            "uri": "https://{canondata_backend}/1936947/a99026e839b7e22714c2a9a81971a3b5e3ed1eb4/resource.tar.gz#test.test_order_by-assume_over_input_desc--Plan_/plan.txt"
+            "checksum": "05b0fb8063ed0adbafac22280fc31ec3",
+            "size": 7654,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_order_by-assume_over_input_desc--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-assume_over_input_desc--Results]": [],
@@ -2369,16 +2369,16 @@
     ],
     "test.test[sampling-yql-14664_deps-default.txt-Debug]": [
         {
-            "checksum": "9bb083f292ae4e04b1ddba733806437b",
-            "size": 2914,
-            "uri": "https://{canondata_backend}/1871182/c64792309300c8a3ee5259c1e1f4dd46543501ee/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Debug_/opt.yql_patched"
+            "checksum": "85c96c5ce8dc09e8e47ac194c292f931",
+            "size": 2791,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-yql-14664_deps-default.txt-Plan]": [
         {
-            "checksum": "6c48e5e83ef9ceafee268314702bd17d",
-            "size": 8981,
-            "uri": "https://{canondata_backend}/1937424/567d7f4e2a03fd773183d9e7015f2f468ea57566/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Plan_/plan.txt"
+            "checksum": "edac0f9ce7979a8141e460ce243eb4c5",
+            "size": 8775,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-fake_column-default.txt-Analyze]": [
@@ -2691,23 +2691,23 @@
     "test.test[tpch-q4-default.txt-Results]": [],
     "test.test[type_v3-append_diff_layout1--Analyze]": [
         {
-            "checksum": "8def2ce8f2ca909b478b4b8871d53398",
-            "size": 14217,
-            "uri": "https://{canondata_backend}/1937424/567d7f4e2a03fd773183d9e7015f2f468ea57566/resource.tar.gz#test.test_type_v3-append_diff_layout1--Analyze_/plan.txt"
+            "checksum": "90bfb019471b8cef544005ab44215984",
+            "size": 13482,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_type_v3-append_diff_layout1--Analyze_/plan.txt"
         }
     ],
     "test.test[type_v3-append_diff_layout1--Debug]": [
         {
-            "checksum": "60daed94fac3cbe89e2f20877843d4cd",
-            "size": 5352,
-            "uri": "https://{canondata_backend}/1937424/567d7f4e2a03fd773183d9e7015f2f468ea57566/resource.tar.gz#test.test_type_v3-append_diff_layout1--Debug_/opt.yql_patched"
+            "checksum": "d1fa9869b80039fe140a387ce8af6dd3",
+            "size": 5014,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_type_v3-append_diff_layout1--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-append_diff_layout1--Plan]": [
         {
-            "checksum": "8def2ce8f2ca909b478b4b8871d53398",
-            "size": 14217,
-            "uri": "https://{canondata_backend}/1937424/567d7f4e2a03fd773183d9e7015f2f468ea57566/resource.tar.gz#test.test_type_v3-append_diff_layout1--Plan_/plan.txt"
+            "checksum": "90bfb019471b8cef544005ab44215984",
+            "size": 13482,
+            "uri": "https://{canondata_backend}/1871102/fc62e492471256a62165f341a79346abd3d08986/resource.tar.gz#test.test_type_v3-append_diff_layout1--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-append_diff_layout1--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part12/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part12/canondata/result.json
@@ -947,23 +947,23 @@
     "test.test[distinct-distinct_star_inmem-default.txt-Results]": [],
     "test.test[dq-pool_trees_whitelist--Analyze]": [
         {
-            "checksum": "14d974e2a4612975604c2c1f36f2bf3e",
-            "size": 4821,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_dq-pool_trees_whitelist--Analyze_/plan.txt"
+            "checksum": "fbf704ba8d857d149b8fd8404a7347ae",
+            "size": 4615,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_dq-pool_trees_whitelist--Analyze_/plan.txt"
         }
     ],
     "test.test[dq-pool_trees_whitelist--Debug]": [
         {
-            "checksum": "7280b75b72333358da0f4fc9b97df640",
-            "size": 1950,
-            "uri": "https://{canondata_backend}/1942671/ba6b48915abb43891f21c0cc2e363567908ff398/resource.tar.gz#test.test_dq-pool_trees_whitelist--Debug_/opt.yql_patched"
+            "checksum": "5de7c1e5460141ce7ea31b6fe7b8f2db",
+            "size": 1827,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_dq-pool_trees_whitelist--Debug_/opt.yql_patched"
         }
     ],
     "test.test[dq-pool_trees_whitelist--Plan]": [
         {
-            "checksum": "14d974e2a4612975604c2c1f36f2bf3e",
-            "size": 4821,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_dq-pool_trees_whitelist--Plan_/plan.txt"
+            "checksum": "fbf704ba8d857d149b8fd8404a7347ae",
+            "size": 4615,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_dq-pool_trees_whitelist--Plan_/plan.txt"
         }
     ],
     "test.test[dq-pool_trees_whitelist--Results]": [],
@@ -979,16 +979,16 @@
     ],
     "test.test[epochs-read_modified--Debug]": [
         {
-            "checksum": "12f93156d0fc7e52fbaa1b9615729b6e",
-            "size": 6297,
-            "uri": "https://{canondata_backend}/1031349/596c297595e75709124ce2ef96947a7ecc9a2056/resource.tar.gz#test.test_epochs-read_modified--Debug_/opt.yql_patched"
+            "checksum": "aca9c34728e38b3a2f2d4cf45da662de",
+            "size": 6147,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_epochs-read_modified--Debug_/opt.yql_patched"
         }
     ],
     "test.test[epochs-read_modified--Plan]": [
         {
-            "checksum": "6306d8f335823e853e432824dd156da4",
-            "size": 21736,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_epochs-read_modified--Plan_/plan.txt"
+            "checksum": "55b0745c3685bc49ed2fffe74afbbacf",
+            "size": 20912,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_epochs-read_modified--Plan_/plan.txt"
         }
     ],
     "test.test[epochs-read_modified--Results]": [],
@@ -1345,60 +1345,60 @@
     ],
     "test.test[insert-from_two_sorted_by_calc-default.txt-Debug]": [
         {
-            "checksum": "7186d0c541557f27055c3452bec9282d",
-            "size": 5734,
-            "uri": "https://{canondata_backend}/1031349/596c297595e75709124ce2ef96947a7ecc9a2056/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "969d1c8c74f4cd0d173230bc1546e667",
+            "size": 5595,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-from_two_sorted_by_calc-default.txt-Plan]": [
         {
-            "checksum": "b4320920b1f249bd69bb22cdafc1ad5c",
-            "size": 17268,
-            "uri": "https://{canondata_backend}/1031349/596c297595e75709124ce2ef96947a7ecc9a2056/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Plan_/plan.txt"
+            "checksum": "b1cd3fa75280f69a0ade519830b79028",
+            "size": 16650,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-from_two_sorted_by_calc-default.txt-Results]": [],
     "test.test[insert-insert_from_other--Analyze]": [
         {
-            "checksum": "d05d06be9f327fe64fd879ccb79843eb",
-            "size": 4783,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_insert-insert_from_other--Analyze_/plan.txt"
+            "checksum": "7354ecdd9461c296fb6d771350203cb6",
+            "size": 4577,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-insert_from_other--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-insert_from_other--Debug]": [
         {
-            "checksum": "7c8826663f563a0fd3a4a056771a991a",
-            "size": 2138,
-            "uri": "https://{canondata_backend}/212715/36e8f174710e3d7655961f1eb097cfd95efa9f56/resource.tar.gz#test.test_insert-insert_from_other--Debug_/opt.yql_patched"
+            "checksum": "c9a0edab09cff110b1d110b875db1088",
+            "size": 2037,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-insert_from_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-insert_from_other--Plan]": [
         {
-            "checksum": "d05d06be9f327fe64fd879ccb79843eb",
-            "size": 4783,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_insert-insert_from_other--Plan_/plan.txt"
+            "checksum": "7354ecdd9461c296fb6d771350203cb6",
+            "size": 4577,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-insert_from_other--Plan_/plan.txt"
         }
     ],
     "test.test[insert-insert_from_other--Results]": [],
     "test.test[insert-override-with_read_udf-Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_insert-override-with_read_udf-Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-override-with_read_udf-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-override-with_read_udf-Debug]": [
         {
-            "checksum": "dad82bf44a54cdd838ef5d745eb93274",
-            "size": 2021,
-            "uri": "https://{canondata_backend}/212715/36e8f174710e3d7655961f1eb097cfd95efa9f56/resource.tar.gz#test.test_insert-override-with_read_udf-Debug_/opt.yql_patched"
+            "checksum": "92e6de06cbd23a7475a64ae4ece06fb3",
+            "size": 1898,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-override-with_read_udf-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-with_read_udf-Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_insert-override-with_read_udf-Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_insert-override-with_read_udf-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-with_read_udf-Results]": [],
@@ -1708,16 +1708,16 @@
     ],
     "test.test[join-lookupjoin_with_cache--Debug]": [
         {
-            "checksum": "27088d7344c11c9686ba654480576b1d",
-            "size": 4816,
-            "uri": "https://{canondata_backend}/1942415/b6b41eb77627490bfce387dccb1eea7766e2bb71/resource.tar.gz#test.test_join-lookupjoin_with_cache--Debug_/opt.yql_patched"
+            "checksum": "b4ad14d33a77490e7f4c27247266c649",
+            "size": 4812,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_join-lookupjoin_with_cache--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_with_cache--Plan]": [
         {
-            "checksum": "8783e1360c6023a489f4d9a49905d095",
-            "size": 11223,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_join-lookupjoin_with_cache--Plan_/plan.txt"
+            "checksum": "13b1ffb4795c6d7ae35fe3600f25aa94",
+            "size": 11955,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_join-lookupjoin_with_cache--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_with_cache--Results]": [],
@@ -3051,23 +3051,23 @@
     "test.test[produce-reduce_multi_in-sorted-Results]": [],
     "test.test[produce-reduce_multi_in_difftype_assume--Analyze]": [
         {
-            "checksum": "cc566d37600fd6f7a1119c426458709f",
-            "size": 7227,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume--Analyze_/plan.txt"
+            "checksum": "619c0870fa64891c52031b754552adc3",
+            "size": 6924,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume--Analyze_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume--Debug]": [
         {
-            "checksum": "d27dbd85651d43a0579830d0063f31cc",
-            "size": 4638,
-            "uri": "https://{canondata_backend}/1942671/ba6b48915abb43891f21c0cc2e363567908ff398/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume--Debug_/opt.yql_patched"
+            "checksum": "270e10e7070c3d58b9b3dd1bb5034fc2",
+            "size": 4434,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume--Plan]": [
         {
-            "checksum": "cc566d37600fd6f7a1119c426458709f",
-            "size": 7227,
-            "uri": "https://{canondata_backend}/1880306/234eadcde1cd54bffae64f4516628981e02b093d/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume--Plan_/plan.txt"
+            "checksum": "619c0870fa64891c52031b754552adc3",
+            "size": 6924,
+            "uri": "https://{canondata_backend}/1871102/62570278011b2c51fb3ba23cde15a7bb184e27c4/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part13/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part13/canondata/result.json
@@ -77,16 +77,16 @@
     ],
     "test.test[action-runtime_if_select-default.txt-Debug]": [
         {
-            "checksum": "84d381f9922463d000ebbebf6d7a9a2c",
-            "size": 4734,
-            "uri": "https://{canondata_backend}/1936842/0049c952a1bcb0ee8c00f8d262e8ccbc9a964444/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1c6139ae932d6b806710e09259fb55d2",
+            "size": 4670,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-runtime_if_select-default.txt-Plan]": [
         {
-            "checksum": "9af8b026add87026d9ae5c6d8ac7a688",
-            "size": 12293,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Plan_/plan.txt"
+            "checksum": "775b478e526933a3e633890420034069",
+            "size": 12087,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-runtime_if_select-default.txt-Results]": [],
@@ -1019,9 +1019,9 @@
     "test.test[in-in_with_nulls_and_optionals_extra-default.txt-Results]": [],
     "test.test[insert-append_sorted-to_sorted-Analyze]": [
         {
-            "checksum": "f0809492bcad2d6518438e4b6bc80503",
-            "size": 26578,
-            "uri": "https://{canondata_backend}/1937492/280f310029e9135c17fc7143ea31b16e51fad84f/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Analyze_/plan.txt"
+            "checksum": "c81430c2e09d6c34d9891ba4daf09f31",
+            "size": 24930,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_insert-append_sorted-to_sorted-Analyze_/extracted"
@@ -1029,16 +1029,16 @@
     ],
     "test.test[insert-append_sorted-to_sorted-Debug]": [
         {
-            "checksum": "d7e29f82ff1f30dcc2198b1b083bbff8",
-            "size": 9523,
-            "uri": "https://{canondata_backend}/1937492/280f310029e9135c17fc7143ea31b16e51fad84f/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Debug_/opt.yql_patched"
+            "checksum": "b2bbf00263469cf3c506fe6de85632d1",
+            "size": 7702,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted-to_sorted-Plan]": [
         {
-            "checksum": "1f1a8ffb65efdf21766d5f6f3b77ad4c",
-            "size": 27446,
-            "uri": "https://{canondata_backend}/1937492/280f310029e9135c17fc7143ea31b16e51fad84f/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Plan_/plan.txt"
+            "checksum": "a6244ecf809aad90a000a08afc849f39",
+            "size": 25798,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_sorted-to_sorted-Results]": [
@@ -1053,45 +1053,45 @@
     ],
     "test.test[insert-override-from_sorted-Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_insert-override-from_sorted-Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-override-from_sorted-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted-Debug]": [
         {
-            "checksum": "592400857e253535eb612d96e0990e3d",
-            "size": 2158,
-            "uri": "https://{canondata_backend}/212715/21331f4fe45d1287dd8384e49ee3fa8810d7cb37/resource.tar.gz#test.test_insert-override-from_sorted-Debug_/opt.yql_patched"
+            "checksum": "97a79b908cbd90799b4194a0addc1c49",
+            "size": 2035,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-override-from_sorted-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-from_sorted-Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_insert-override-from_sorted-Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-override-from_sorted-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted-Results]": [],
     "test.test[insert-override-proto-Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_insert-override-proto-Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-override-proto-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-override-proto-Debug]": [
         {
-            "checksum": "41b383375042157d26e3eb61ba9d97e6",
-            "size": 2347,
-            "uri": "https://{canondata_backend}/212715/21331f4fe45d1287dd8384e49ee3fa8810d7cb37/resource.tar.gz#test.test_insert-override-proto-Debug_/opt.yql_patched"
+            "checksum": "125db5091fe5cc3e88d04054b07e0946",
+            "size": 2224,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-override-proto-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-proto-Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_insert-override-proto-Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-override-proto-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-proto-Results]": [],
@@ -1102,23 +1102,23 @@
     ],
     "test.test[insert-yql-14538--Analyze]": [
         {
-            "checksum": "0892c8b1f6ccc71c63754805dbfd467e",
-            "size": 8966,
-            "uri": "https://{canondata_backend}/1881367/a6f45cfdcb35e48fac5aa7035f92a24199221a45/resource.tar.gz#test.test_insert-yql-14538--Analyze_/plan.txt"
+            "checksum": "be7dc2c52116a42ffc490498b326ac89",
+            "size": 8758,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-yql-14538--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-yql-14538--Debug]": [
         {
-            "checksum": "425a6d507d112e57f88bdc311aa013e3",
-            "size": 3746,
-            "uri": "https://{canondata_backend}/1881367/a6f45cfdcb35e48fac5aa7035f92a24199221a45/resource.tar.gz#test.test_insert-yql-14538--Debug_/opt.yql_patched"
+            "checksum": "e08166d08f357e82560ffe793eb9d8af",
+            "size": 3619,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-yql-14538--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-yql-14538--Plan]": [
         {
-            "checksum": "12a9f1c527909d9c1036c8de9141b012",
-            "size": 9210,
-            "uri": "https://{canondata_backend}/1881367/a6f45cfdcb35e48fac5aa7035f92a24199221a45/resource.tar.gz#test.test_insert-yql-14538--Plan_/plan.txt"
+            "checksum": "7d6a51ebd6ee4ebf44ab9807298e9364",
+            "size": 9002,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_insert-yql-14538--Plan_/plan.txt"
         }
     ],
     "test.test[insert-yql-14538--Results]": [],
@@ -1585,16 +1585,16 @@
     ],
     "test.test[limit-yql-8611_calc_peephole--Debug]": [
         {
-            "checksum": "de2c45de84ecdfa2e03538b258df21b9",
-            "size": 6169,
-            "uri": "https://{canondata_backend}/1871002/b2080f1ec9f69fd0b008bc4523f011038ec40f55/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Debug_/opt.yql_patched"
+            "checksum": "acea9e1814f3255c4c4413be9f32a9eb",
+            "size": 5942,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-yql-8611_calc_peephole--Plan]": [
         {
-            "checksum": "a85bd58c9f208a50c14806b31a65d4a4",
-            "size": 15036,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Plan_/plan.txt"
+            "checksum": "4bdc5ae42fceff8f85422cbdd9e80fe6",
+            "size": 14212,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Plan_/plan.txt"
         }
     ],
     "test.test[limit-yql-8611_calc_peephole--Results]": [
@@ -1670,23 +1670,23 @@
     "test.test[optimizers-yson_dup_serialize--Results]": [],
     "test.test[order_by-assume_with_transform_desc--Analyze]": [
         {
-            "checksum": "0043ba85c7f7e37eae65789bb486fdbc",
-            "size": 7674,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_order_by-assume_with_transform_desc--Analyze_/plan.txt"
+            "checksum": "7c89d623563db5204a6298619af1b453",
+            "size": 7364,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_order_by-assume_with_transform_desc--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-assume_with_transform_desc--Debug]": [
         {
-            "checksum": "fe7010f923139a9dcaa8097f11b4794f",
-            "size": 3708,
-            "uri": "https://{canondata_backend}/1871002/b2080f1ec9f69fd0b008bc4523f011038ec40f55/resource.tar.gz#test.test_order_by-assume_with_transform_desc--Debug_/opt.yql_patched"
+            "checksum": "2730b60a18d691574d285dd4eb77a495",
+            "size": 3490,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_order_by-assume_with_transform_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_with_transform_desc--Plan]": [
         {
-            "checksum": "0043ba85c7f7e37eae65789bb486fdbc",
-            "size": 7674,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_order_by-assume_with_transform_desc--Plan_/plan.txt"
+            "checksum": "7c89d623563db5204a6298619af1b453",
+            "size": 7364,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_order_by-assume_with_transform_desc--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-assume_with_transform_desc--Results]": [],
@@ -2520,16 +2520,16 @@
     ],
     "test.test[schema-insert_sorted-read_schema-Debug]": [
         {
-            "checksum": "d9afb91e54752e2e339b947d418a1850",
-            "size": 4227,
-            "uri": "https://{canondata_backend}/1925821/301359f830853bb29d8dc6bedf12ccc575fd3fd8/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Debug_/opt.yql_patched"
+            "checksum": "536046bdb7e7741701aeed5b2610605a",
+            "size": 3875,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert_sorted-read_schema-Plan]": [
         {
-            "checksum": "2df2156cc869bc0408d20293b3490029",
-            "size": 9801,
-            "uri": "https://{canondata_backend}/1936997/93899b3de50fae3f9677baacc98094a7a629590a/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Plan_/plan.txt"
+            "checksum": "b6714d88ced45bc87049b7ed4564f702",
+            "size": 9498,
+            "uri": "https://{canondata_backend}/1937429/b2e019e5c80a384dae2cb46b81e53ad9800ec6e1/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert_sorted-read_schema-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part14/canondata/result.json
@@ -786,23 +786,23 @@
     "test.test[blocks-struct_type--Results]": [],
     "test.test[column_order-insert_with_reorder_cols--Analyze]": [
         {
-            "checksum": "60b979d2ae5fec69190a4ea74c2fdef4",
-            "size": 5726,
-            "uri": "https://{canondata_backend}/1936997/ad7538cf8edf8e81865f7eee42c2de851daf1211/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Analyze_/plan.txt"
+            "checksum": "e462df23755dc060535e8da0978d851a",
+            "size": 5520,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Analyze_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_reorder_cols--Debug]": [
         {
-            "checksum": "d5a6686b99fa0aef5f896f40e124b53f",
-            "size": 3208,
-            "uri": "https://{canondata_backend}/212715/fb7de84cfa831b168de43ed871dba2c5ad6e54b7/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Debug_/opt.yql_patched"
+            "checksum": "79026e117f7281bf6a79878a25358ffc",
+            "size": 3089,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_with_reorder_cols--Plan]": [
         {
-            "checksum": "60b979d2ae5fec69190a4ea74c2fdef4",
-            "size": 5726,
-            "uri": "https://{canondata_backend}/1936997/ad7538cf8edf8e81865f7eee42c2de851daf1211/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Plan_/plan.txt"
+            "checksum": "e462df23755dc060535e8da0978d851a",
+            "size": 5520,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_reorder_cols--Results]": [],
@@ -1255,9 +1255,9 @@
     "test.test[in-in_ansi_join--Results]": [],
     "test.test[insert-append_sorted-to_sorted_calc-Analyze]": [
         {
-            "checksum": "ca582490362ca72c20607af2a6d3dad8",
-            "size": 23723,
-            "uri": "https://{canondata_backend}/1781765/e6ccfc9e44a62c32a107d9b796d30e78c8539094/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Analyze_/plan.txt"
+            "checksum": "e12fa04f924c294bc572650d7d43cda9",
+            "size": 22075,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_insert-append_sorted-to_sorted_calc-Analyze_/extracted"
@@ -1265,16 +1265,16 @@
     ],
     "test.test[insert-append_sorted-to_sorted_calc-Debug]": [
         {
-            "checksum": "f104d860b466caf8398c6c9940756dca",
-            "size": 8467,
-            "uri": "https://{canondata_backend}/1781765/e6ccfc9e44a62c32a107d9b796d30e78c8539094/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Debug_/opt.yql_patched"
+            "checksum": "35d543c509e048a013df1ae2444c7c37",
+            "size": 6578,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_calc-Plan]": [
         {
-            "checksum": "8a4f1676b994803673b3927dbe5934e3",
-            "size": 24591,
-            "uri": "https://{canondata_backend}/1781765/e6ccfc9e44a62c32a107d9b796d30e78c8539094/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Plan_/plan.txt"
+            "checksum": "4881f9148218371bbd663773ed6229a1",
+            "size": 22943,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_calc-Results]": [
@@ -1289,23 +1289,23 @@
     ],
     "test.test[insert-select_relabel-default.txt-Analyze]": [
         {
-            "checksum": "26f0e9d3c9dd9f7cbb6bf3b730f70ae7",
-            "size": 4883,
-            "uri": "https://{canondata_backend}/1936997/ad7538cf8edf8e81865f7eee42c2de851daf1211/resource.tar.gz#test.test_insert-select_relabel-default.txt-Analyze_/plan.txt"
+            "checksum": "743cd5e1ebfd3e66ac5961101c74572e",
+            "size": 4677,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_insert-select_relabel-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-select_relabel-default.txt-Debug]": [
         {
-            "checksum": "2d1923047321eb53cbc74d0a29d93010",
-            "size": 1967,
-            "uri": "https://{canondata_backend}/212715/fb7de84cfa831b168de43ed871dba2c5ad6e54b7/resource.tar.gz#test.test_insert-select_relabel-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1663154328ab71dd05b0a584d2eed95e",
+            "size": 1844,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_insert-select_relabel-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_relabel-default.txt-Plan]": [
         {
-            "checksum": "26f0e9d3c9dd9f7cbb6bf3b730f70ae7",
-            "size": 4883,
-            "uri": "https://{canondata_backend}/1936997/ad7538cf8edf8e81865f7eee42c2de851daf1211/resource.tar.gz#test.test_insert-select_relabel-default.txt-Plan_/plan.txt"
+            "checksum": "743cd5e1ebfd3e66ac5961101c74572e",
+            "size": 4677,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_insert-select_relabel-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_relabel-default.txt-Results]": [],
@@ -1537,16 +1537,16 @@
     ],
     "test.test[join-mapjoin_with_anonymous--Debug]": [
         {
-            "checksum": "e6909ffd9787dd2707ebcc614d28fa09",
-            "size": 3561,
-            "uri": "https://{canondata_backend}/1781765/e6ccfc9e44a62c32a107d9b796d30e78c8539094/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Debug_/opt.yql_patched"
+            "checksum": "6b717d178b2582513b318601e7068e43",
+            "size": 3533,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_with_anonymous--Plan]": [
         {
-            "checksum": "9f12bab7315d1cef7d80add54b25f4fb",
-            "size": 9651,
-            "uri": "https://{canondata_backend}/1936997/ad7538cf8edf8e81865f7eee42c2de851daf1211/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Plan_/plan.txt"
+            "checksum": "5aa7c552591975e8949e1fdf069e92bf",
+            "size": 9445,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_with_anonymous--Results]": [],
@@ -1947,16 +1947,16 @@
     ],
     "test.test[key_filter-calc_dependent_with_tmp-default.txt-Debug]": [
         {
-            "checksum": "4a5bb81eb6c37c7bacab963b4df1a26f",
-            "size": 4997,
-            "uri": "https://{canondata_backend}/1781765/e6ccfc9e44a62c32a107d9b796d30e78c8539094/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f14fcc44c42602d47a0a234deb0e4f62",
+            "size": 4862,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-calc_dependent_with_tmp-default.txt-Plan]": [
         {
-            "checksum": "d9be40e8930273faf5bc8f74f7f76603",
-            "size": 11708,
-            "uri": "https://{canondata_backend}/1781765/e6ccfc9e44a62c32a107d9b796d30e78c8539094/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Plan_/plan.txt"
+            "checksum": "adea997ab7590e042e1f2fb5b89e07a5",
+            "size": 11604,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-calc_dependent_with_tmp-default.txt-Results]": [],
@@ -2097,16 +2097,16 @@
     ],
     "test.test[optimizers-sort_over_sorted_same_keys-default.txt-Debug]": [
         {
-            "checksum": "e5be509632d26da427a99a94a1334a6d",
-            "size": 3490,
-            "uri": "https://{canondata_backend}/1942173/f4ab26b3187e68e4bbc4f6f3da1d885be2999e83/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2da1b424757345c3f42b66d15fea290d",
+            "size": 3314,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-sort_over_sorted_same_keys-default.txt-Plan]": [
         {
-            "checksum": "01431e0fb6dea1b24d91519affa27c91",
-            "size": 10252,
-            "uri": "https://{canondata_backend}/1936997/ad7538cf8edf8e81865f7eee42c2de851daf1211/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Plan_/plan.txt"
+            "checksum": "5c4cd1ae47ab91f5913e87d0ec11ba05",
+            "size": 9949,
+            "uri": "https://{canondata_backend}/1937429/5c4bfbf1589eb61d7300d31dac8b0581c1292c14/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-sort_over_sorted_same_keys-default.txt-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part15/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part15/canondata/result.json
@@ -717,23 +717,23 @@
     "test.test[blocks-top_sort_two_desc--Results]": [],
     "test.test[column_order-insert_with_desc_sort_and_native_types-default.txt-Analyze]": [
         {
-            "checksum": "93d42d1ae010753f0b26877fb816a8af",
-            "size": 8818,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_column_order-insert_with_desc_sort_and_native_types-default.txt-Analyze_/plan.txt"
+            "checksum": "46423ced50c64c2d120bfbb9c89aae01",
+            "size": 8508,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_column_order-insert_with_desc_sort_and_native_types-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_desc_sort_and_native_types-default.txt-Debug]": [
         {
-            "checksum": "1a4a2a05031e1484d1aa7adcd0864dfd",
-            "size": 4763,
-            "uri": "https://{canondata_backend}/212715/7f23eb7613e022b32c2a34a6e06cb7c849d68d04/resource.tar.gz#test.test_column_order-insert_with_desc_sort_and_native_types-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d8ca4db352aea640db5c48e66a842dec",
+            "size": 4540,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_column_order-insert_with_desc_sort_and_native_types-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_with_desc_sort_and_native_types-default.txt-Plan]": [
         {
-            "checksum": "93d42d1ae010753f0b26877fb816a8af",
-            "size": 8818,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_column_order-insert_with_desc_sort_and_native_types-default.txt-Plan_/plan.txt"
+            "checksum": "46423ced50c64c2d120bfbb9c89aae01",
+            "size": 8508,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_column_order-insert_with_desc_sort_and_native_types-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_desc_sort_and_native_types-default.txt-Results]": [],
@@ -971,31 +971,31 @@
     ],
     "test.test[insert-part_sortness-desc-Analyze]": [
         {
-            "checksum": "0fc9318664a7913559431ddc43820252",
-            "size": 4782,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_insert-part_sortness-desc-Analyze_/plan.txt"
+            "checksum": "d9e097cbe8916dfc11138dd87d38eb66",
+            "size": 4576,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_insert-part_sortness-desc-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-part_sortness-desc-Debug]": [
         {
-            "checksum": "bedf2187db4120b52ea9c3290939c87c",
-            "size": 2116,
-            "uri": "https://{canondata_backend}/212715/7f23eb7613e022b32c2a34a6e06cb7c849d68d04/resource.tar.gz#test.test_insert-part_sortness-desc-Debug_/opt.yql_patched"
+            "checksum": "d9b96bc2c6c9c03c80e5c26646091bf1",
+            "size": 2016,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_insert-part_sortness-desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-part_sortness-desc-Plan]": [
         {
-            "checksum": "0fc9318664a7913559431ddc43820252",
-            "size": 4782,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_insert-part_sortness-desc-Plan_/plan.txt"
+            "checksum": "d9e097cbe8916dfc11138dd87d38eb66",
+            "size": 4576,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_insert-part_sortness-desc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-part_sortness-desc-Results]": [],
     "test.test[insert-select_operate_with_columns--Analyze]": [
         {
-            "checksum": "60727d04e6f062e98b2983fb9ba5ca23",
-            "size": 4976,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_insert-select_operate_with_columns--Analyze_/plan.txt"
+            "checksum": "297e72f6cfad38cb86c73deb30ea441a",
+            "size": 4770,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_insert-select_operate_with_columns--Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_insert-select_operate_with_columns--Analyze_/extracted"
@@ -1003,16 +1003,16 @@
     ],
     "test.test[insert-select_operate_with_columns--Debug]": [
         {
-            "checksum": "1b6a9f29774791512538a486dd7819e8",
-            "size": 2621,
-            "uri": "https://{canondata_backend}/212715/7f23eb7613e022b32c2a34a6e06cb7c849d68d04/resource.tar.gz#test.test_insert-select_operate_with_columns--Debug_/opt.yql_patched"
+            "checksum": "b62cd36680a95944ab44c6848d91a482",
+            "size": 2491,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_insert-select_operate_with_columns--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_operate_with_columns--Plan]": [
         {
-            "checksum": "60727d04e6f062e98b2983fb9ba5ca23",
-            "size": 4976,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_insert-select_operate_with_columns--Plan_/plan.txt"
+            "checksum": "297e72f6cfad38cb86c73deb30ea441a",
+            "size": 4770,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_insert-select_operate_with_columns--Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_operate_with_columns--Results]": [
@@ -1395,16 +1395,16 @@
     ],
     "test.test[join-premap_merge_with_remap-off-Debug]": [
         {
-            "checksum": "bfc0715690074eb53a329d0bf85da659",
-            "size": 7149,
-            "uri": "https://{canondata_backend}/1942100/21245e81d28b28ef09d03385075d39472fbb3dba/resource.tar.gz#test.test_join-premap_merge_with_remap-off-Debug_/opt.yql_patched"
+            "checksum": "6a972ce94983ef17b7458da6545a55e9",
+            "size": 6862,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_join-premap_merge_with_remap-off-Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_merge_with_remap-off-Plan]": [
         {
-            "checksum": "11b39fa847cde739c4b1d230b5b61972",
-            "size": 14712,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_join-premap_merge_with_remap-off-Plan_/plan.txt"
+            "checksum": "f323b0ac1af4ae2ce4148fb2b56fb934",
+            "size": 14409,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_join-premap_merge_with_remap-off-Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_merge_with_remap-off-Results]": [
@@ -1683,23 +1683,23 @@
     ],
     "test.test[order_by-assume_with_filter--Analyze]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_order_by-assume_with_filter--Analyze_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_order_by-assume_with_filter--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-assume_with_filter--Debug]": [
         {
-            "checksum": "73b72beff2730d4498d2065fed618389",
-            "size": 2900,
-            "uri": "https://{canondata_backend}/1781765/97c29e53add37e5e221fbc6e22055fd1d8762911/resource.tar.gz#test.test_order_by-assume_with_filter--Debug_/opt.yql_patched"
+            "checksum": "7eb09cad7dc831bff5a7a2da9ac203ba",
+            "size": 2637,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_order_by-assume_with_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_with_filter--Plan]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_order_by-assume_with_filter--Plan_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_order_by-assume_with_filter--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-assume_with_filter--Results]": [],
@@ -2626,16 +2626,16 @@
     ],
     "test.test[select-table_content_from_double_opt-default.txt-Debug]": [
         {
-            "checksum": "448eed14d48481bab5aa455f362f1d79",
-            "size": 3567,
-            "uri": "https://{canondata_backend}/1599023/e9f8d240b4483477bcadcd3788795f2462724043/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Debug_/opt.yql_patched"
+            "checksum": "11e472a00b21639bc2e9b2550d9b08ad",
+            "size": 3505,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-table_content_from_double_opt-default.txt-Plan]": [
         {
-            "checksum": "8aa9ba318ba819f8e0624214ff406655",
-            "size": 9574,
-            "uri": "https://{canondata_backend}/1600758/aad142702907f13e911494c1a7b312bad34f692a/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Plan_/plan.txt"
+            "checksum": "0d4b3446f369ea4500f2f242aa70ed7b",
+            "size": 9368,
+            "uri": "https://{canondata_backend}/1925821/4ae9bde3c1ecde0f833266f025b433a41c077ebf/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-table_content_from_double_opt-default.txt-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part16/canondata/result.json
@@ -1,23 +1,23 @@
 {
     "test.test[action-action_eval_cluster_use--Analyze]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_action-action_eval_cluster_use--Analyze_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_action-action_eval_cluster_use--Analyze_/plan.txt"
         }
     ],
     "test.test[action-action_eval_cluster_use--Debug]": [
         {
-            "checksum": "d6111c7c93c258e0e77f5c5e30170108",
-            "size": 2650,
-            "uri": "https://{canondata_backend}/1599023/0d561bfbc99b4f6e2f0bd1ed4d23df64344df344/resource.tar.gz#test.test_action-action_eval_cluster_use--Debug_/opt.yql_patched"
+            "checksum": "9fe2a3d01ad53c9d0396e90a6ad8fa9d",
+            "size": 2433,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_action-action_eval_cluster_use--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-action_eval_cluster_use--Plan]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_action-action_eval_cluster_use--Plan_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_action-action_eval_cluster_use--Plan_/plan.txt"
         }
     ],
     "test.test[action-action_eval_cluster_use--Results]": [],
@@ -941,23 +941,23 @@
     "test.test[insert-trivial_literals-default.txt-Results]": [],
     "test.test[insert_monotonic-to_empty--Analyze]": [
         {
-            "checksum": "6bd87f2c2d91461758ddad703ffa013f",
-            "size": 6407,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_insert_monotonic-to_empty--Analyze_/plan.txt"
+            "checksum": "fc894515691f3b360e7f37e7b848fe1f",
+            "size": 6104,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_insert_monotonic-to_empty--Analyze_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-to_empty--Debug]": [
         {
-            "checksum": "22595a5d9eab13863fdca3c0b77f57ae",
-            "size": 2654,
-            "uri": "https://{canondata_backend}/1775319/1964a58b726ec8cbf6829b28927d8edd78ceddd1/resource.tar.gz#test.test_insert_monotonic-to_empty--Debug_/opt.yql_patched"
+            "checksum": "943a1513ac0ac87cb5df6cff4dc45e2a",
+            "size": 2398,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_insert_monotonic-to_empty--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-to_empty--Plan]": [
         {
-            "checksum": "6bd87f2c2d91461758ddad703ffa013f",
-            "size": 6407,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_insert_monotonic-to_empty--Plan_/plan.txt"
+            "checksum": "fc894515691f3b360e7f37e7b848fe1f",
+            "size": 6104,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_insert_monotonic-to_empty--Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-to_empty--Results]": [],
@@ -1797,23 +1797,23 @@
     "test.test[lambda-lambda_brief-default.txt-Results]": [],
     "test.test[limit-insert_with_limit-dynamic-Analyze]": [
         {
-            "checksum": "143bf7d2d0887f476fc4c8b1b30274dd",
-            "size": 5633,
-            "uri": "https://{canondata_backend}/1599023/1a5ae6170a572008429f35f362ba7a5e8f15d2db/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Analyze_/plan.txt"
+            "checksum": "b56cfc7eca4fb556e1b459625c696991",
+            "size": 5427,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Analyze_/plan.txt"
         }
     ],
     "test.test[limit-insert_with_limit-dynamic-Debug]": [
         {
-            "checksum": "e66f9bc622341ac3b7d717aa1c7fb2b6",
-            "size": 2409,
-            "uri": "https://{canondata_backend}/1599023/1a5ae6170a572008429f35f362ba7a5e8f15d2db/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Debug_/opt.yql_patched"
+            "checksum": "1a22ef4fc6186f958e1e165c7dc4095a",
+            "size": 2262,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-insert_with_limit-dynamic-Plan]": [
         {
-            "checksum": "143bf7d2d0887f476fc4c8b1b30274dd",
-            "size": 5633,
-            "uri": "https://{canondata_backend}/1599023/1a5ae6170a572008429f35f362ba7a5e8f15d2db/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Plan_/plan.txt"
+            "checksum": "b56cfc7eca4fb556e1b459625c696991",
+            "size": 5427,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Plan_/plan.txt"
         }
     ],
     "test.test[limit-insert_with_limit-dynamic-Results]": [],
@@ -1841,23 +1841,23 @@
     "test.test[limit-many_top_sorts-default.txt-Results]": [],
     "test.test[limit-sort_calc_limit--Analyze]": [
         {
-            "checksum": "112ea50a23acb5b530a8ecb8d00c2d4e",
-            "size": 8603,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_limit-sort_calc_limit--Analyze_/plan.txt"
+            "checksum": "1c5ff91cddef437a54bfd77d8820f57c",
+            "size": 8499,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_limit-sort_calc_limit--Analyze_/plan.txt"
         }
     ],
     "test.test[limit-sort_calc_limit--Debug]": [
         {
-            "checksum": "1ec44e40d68b2605e4d8f684c8984048",
-            "size": 3508,
-            "uri": "https://{canondata_backend}/1599023/0d561bfbc99b4f6e2f0bd1ed4d23df64344df344/resource.tar.gz#test.test_limit-sort_calc_limit--Debug_/opt.yql_patched"
+            "checksum": "c0f46bf1226702dd8021c3043dc3df7c",
+            "size": 3357,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_limit-sort_calc_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-sort_calc_limit--Plan]": [
         {
-            "checksum": "fd1f28b7c2e585b748b4fcc108d36e5c",
-            "size": 7758,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_limit-sort_calc_limit--Plan_/plan.txt"
+            "checksum": "d1c16f9b09afd9383bf91d0f9e0bf100",
+            "size": 7654,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_limit-sort_calc_limit--Plan_/plan.txt"
         }
     ],
     "test.test[limit-sort_calc_limit--Results]": [],
@@ -1973,45 +1973,45 @@
     "test.test[order_by-SortByTwoFields--Results]": [],
     "test.test[order_by-assume_over_input--Analyze]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_order_by-assume_over_input--Analyze_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_order_by-assume_over_input--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-assume_over_input--Debug]": [
         {
-            "checksum": "9e813bd76e7c5509d10019752d4bb507",
-            "size": 2663,
-            "uri": "https://{canondata_backend}/1599023/0d561bfbc99b4f6e2f0bd1ed4d23df64344df344/resource.tar.gz#test.test_order_by-assume_over_input--Debug_/opt.yql_patched"
+            "checksum": "09c9c92e58598792598759cb360dec27",
+            "size": 2366,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_order_by-assume_over_input--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_over_input--Plan]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_order_by-assume_over_input--Plan_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_order_by-assume_over_input--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-assume_over_input--Results]": [],
     "test.test[order_by-extract_members_over_sort_desc--Analyze]": [
         {
-            "checksum": "44954206f1b658f4347a347c79bfaa86",
-            "size": 9357,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Analyze_/plan.txt"
+            "checksum": "9b708e80f0cfc9e4d7b8e53953eaf850",
+            "size": 9151,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-extract_members_over_sort_desc--Debug]": [
         {
-            "checksum": "8f8d776de71c521b730318f74dc39ffc",
-            "size": 3969,
-            "uri": "https://{canondata_backend}/1599023/1a5ae6170a572008429f35f362ba7a5e8f15d2db/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Debug_/opt.yql_patched"
+            "checksum": "8316f9f3353c706928e2ee1dfe66bb17",
+            "size": 3785,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-extract_members_over_sort_desc--Plan]": [
         {
-            "checksum": "44954206f1b658f4347a347c79bfaa86",
-            "size": 9357,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Plan_/plan.txt"
+            "checksum": "9b708e80f0cfc9e4d7b8e53953eaf850",
+            "size": 9151,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-extract_members_over_sort_desc--Results]": [],
@@ -2347,23 +2347,23 @@
     "test.test[pg_catalog-columns-default.txt-Results]": [],
     "test.test[pragma-config_exec--Analyze]": [
         {
-            "checksum": "49226c5ed1226aacf447e83f0de3f342",
-            "size": 8435,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_pragma-config_exec--Analyze_/plan.txt"
+            "checksum": "2ae5d9751ebfb832322fa58a75a8859d",
+            "size": 8229,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_pragma-config_exec--Analyze_/plan.txt"
         }
     ],
     "test.test[pragma-config_exec--Debug]": [
         {
-            "checksum": "a1423f933f63dccc7d1a3225f55f8488",
-            "size": 2478,
-            "uri": "https://{canondata_backend}/1599023/0d561bfbc99b4f6e2f0bd1ed4d23df64344df344/resource.tar.gz#test.test_pragma-config_exec--Debug_/opt.yql_patched"
+            "checksum": "1e9f80759c515e65c09aa8e7142ff957",
+            "size": 2353,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_pragma-config_exec--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pragma-config_exec--Plan]": [
         {
-            "checksum": "1c597c7ae684487a714bae6a927364e6",
-            "size": 8557,
-            "uri": "https://{canondata_backend}/1599023/6ea95a71ae6e3995d639ef495d263a106e521882/resource.tar.gz#test.test_pragma-config_exec--Plan_/plan.txt"
+            "checksum": "ff46c3a752416f9cc583fe0a539016e0",
+            "size": 8351,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_pragma-config_exec--Plan_/plan.txt"
         }
     ],
     "test.test[pragma-config_exec--Results]": [],
@@ -2910,16 +2910,16 @@
     ],
     "test.test[window-row_number_no_part_multi_input-default.txt-Debug]": [
         {
-            "checksum": "2128066dceb8474f32d1ca68171fd9c3",
-            "size": 6581,
-            "uri": "https://{canondata_backend}/1599023/1a5ae6170a572008429f35f362ba7a5e8f15d2db/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Debug_/opt.yql_patched"
+            "checksum": "43fafd35e7c69c812c43a56647b6c8b0",
+            "size": 6426,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-row_number_no_part_multi_input-default.txt-Plan]": [
         {
-            "checksum": "5290778ee60c96f8d11e5e507134ac2e",
-            "size": 11930,
-            "uri": "https://{canondata_backend}/1814674/739b009a486b0e8db90456b565caa1bb207293b1/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Plan_/plan.txt"
+            "checksum": "d1caaf3b4a7ea1e9cfea6a213908a56a",
+            "size": 11724,
+            "uri": "https://{canondata_backend}/1871102/bf551d97ceb3ef56f786a233cb690503836fb993/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-row_number_no_part_multi_input-default.txt-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part17/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part17/canondata/result.json
@@ -511,16 +511,16 @@
     ],
     "test.test[bigdate-table_io-default.txt-Debug]": [
         {
-            "checksum": "f5ce9db7630709861cf6ef24b03e06a1",
-            "size": 5441,
-            "uri": "https://{canondata_backend}/1600758/25298d1c532d0c67aa8f12ec2205b095eb24cdb4/resource.tar.gz#test.test_bigdate-table_io-default.txt-Debug_/opt.yql_patched"
+            "checksum": "167b90bb9961a905db042a1989b45d5c",
+            "size": 5246,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_bigdate-table_io-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_io-default.txt-Plan]": [
         {
-            "checksum": "8a5bd5be69231d893ed984ff4eb25966",
-            "size": 13442,
-            "uri": "https://{canondata_backend}/1600758/25298d1c532d0c67aa8f12ec2205b095eb24cdb4/resource.tar.gz#test.test_bigdate-table_io-default.txt-Plan_/plan.txt"
+            "checksum": "9ec71937a00c7ada160c32515642b5a0",
+            "size": 13236,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_bigdate-table_io-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-table_io-default.txt-Results]": [],
@@ -649,16 +649,16 @@
     ],
     "test.test[column_order-align_publish_native--Debug]": [
         {
-            "checksum": "2a2cc6fd097392f77c3c25bb62cf0d6e",
-            "size": 4027,
-            "uri": "https://{canondata_backend}/1942671/0f9b7a385d3b24e66ca2f542c2406826dcead5f4/resource.tar.gz#test.test_column_order-align_publish_native--Debug_/opt.yql_patched"
+            "checksum": "a3f0735bff5bb5904cf21e88c46b12b5",
+            "size": 3825,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_column_order-align_publish_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-align_publish_native--Plan]": [
         {
-            "checksum": "0edfcb7240687f48a4c63a4c2cb328d9",
-            "size": 11974,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_column_order-align_publish_native--Plan_/plan.txt"
+            "checksum": "8477e8fe87e07179f271fa7ee9e97b59",
+            "size": 11664,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_column_order-align_publish_native--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-align_publish_native--Results]": [],
@@ -733,23 +733,23 @@
     "test.test[csee-yql-7237--Results]": [],
     "test.test[dq-blacklisted_pragmas--Analyze]": [
         {
-            "checksum": "14d974e2a4612975604c2c1f36f2bf3e",
-            "size": 4821,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_dq-blacklisted_pragmas--Analyze_/plan.txt"
+            "checksum": "fbf704ba8d857d149b8fd8404a7347ae",
+            "size": 4615,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_dq-blacklisted_pragmas--Analyze_/plan.txt"
         }
     ],
     "test.test[dq-blacklisted_pragmas--Debug]": [
         {
-            "checksum": "de9ead1de3defcecb53bef71a6803d7a",
-            "size": 1942,
-            "uri": "https://{canondata_backend}/1942671/0f9b7a385d3b24e66ca2f542c2406826dcead5f4/resource.tar.gz#test.test_dq-blacklisted_pragmas--Debug_/opt.yql_patched"
+            "checksum": "fb1357a4b6ef480958cc8166de683362",
+            "size": 1819,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_dq-blacklisted_pragmas--Debug_/opt.yql_patched"
         }
     ],
     "test.test[dq-blacklisted_pragmas--Plan]": [
         {
-            "checksum": "14d974e2a4612975604c2c1f36f2bf3e",
-            "size": 4821,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_dq-blacklisted_pragmas--Plan_/plan.txt"
+            "checksum": "fbf704ba8d857d149b8fd8404a7347ae",
+            "size": 4615,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_dq-blacklisted_pragmas--Plan_/plan.txt"
         }
     ],
     "test.test[dq-blacklisted_pragmas--Results]": [],
@@ -783,23 +783,23 @@
     ],
     "test.test[dq-precompute_parallel--Analyze]": [
         {
-            "checksum": "f9c47ba3674c25cf16b42e2db9a0bf83",
-            "size": 9205,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_dq-precompute_parallel--Analyze_/plan.txt"
+            "checksum": "395db2c94ee146dbcc85d42c614f2af3",
+            "size": 8793,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_dq-precompute_parallel--Analyze_/plan.txt"
         }
     ],
     "test.test[dq-precompute_parallel--Debug]": [
         {
-            "checksum": "3d0aed3b228d77756bf6259513db3ace",
-            "size": 3393,
-            "uri": "https://{canondata_backend}/1937492/9ba008b22e29bc0b3fc3b0b722d6d7c245775122/resource.tar.gz#test.test_dq-precompute_parallel--Debug_/opt.yql_patched"
+            "checksum": "b8a393ab6ed00708c815b658d87b6c3e",
+            "size": 3242,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_dq-precompute_parallel--Debug_/opt.yql_patched"
         }
     ],
     "test.test[dq-precompute_parallel--Plan]": [
         {
-            "checksum": "27ff52267c84ddf4e3a9554ef54d7b17",
-            "size": 9327,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_dq-precompute_parallel--Plan_/plan.txt"
+            "checksum": "c9a392b667cb2f44123d39167f388186",
+            "size": 8915,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_dq-precompute_parallel--Plan_/plan.txt"
         }
     ],
     "test.test[dq-precompute_parallel--Results]": [
@@ -1141,23 +1141,23 @@
     "test.test[in-yql-14677-default.txt-Results]": [],
     "test.test[insert-multiappend_sorted-default.txt-Analyze]": [
         {
-            "checksum": "eb4fd5291d7acfd0b3f3b07921ca39aa",
-            "size": 42872,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Analyze_/plan.txt"
+            "checksum": "48ff67f012e7d63c01fdc6c4f6e5c7de",
+            "size": 39988,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-multiappend_sorted-default.txt-Debug]": [
         {
-            "checksum": "bc7690dfc148218b65bf6931f5f2f473",
-            "size": 12360,
-            "uri": "https://{canondata_backend}/1937492/9ba008b22e29bc0b3fc3b0b722d6d7c245775122/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a5beb47c55935341062b46a7f81ef579",
+            "size": 12325,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-multiappend_sorted-default.txt-Plan]": [
         {
-            "checksum": "23d9b9cd988218bf179530259bd172f3",
-            "size": 44858,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Plan_/plan.txt"
+            "checksum": "e93e1822b64869cb95a02cc4f91b2ee1",
+            "size": 41974,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-multiappend_sorted-default.txt-Results]": [],
@@ -1962,16 +1962,16 @@
     ],
     "test.test[pg-nulls-default.txt-Debug]": [
         {
-            "checksum": "9bca871fff70318fe74b82570b6dcd6b",
-            "size": 4724,
-            "uri": "https://{canondata_backend}/1920236/ea9b79a4af23814e47242a86125bfc9db48e103e/resource.tar.gz#test.test_pg-nulls-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7384ec37f6d17f7da891631a58d78267",
+            "size": 4536,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_pg-nulls-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-nulls-default.txt-Plan]": [
         {
-            "checksum": "bbe8e3dd33e6d56611d92d6ebfa998b7",
-            "size": 17514,
-            "uri": "https://{canondata_backend}/1920236/ea9b79a4af23814e47242a86125bfc9db48e103e/resource.tar.gz#test.test_pg-nulls-default.txt-Plan_/plan.txt"
+            "checksum": "6285a15aa40793c76e982ffb7386d770",
+            "size": 17308,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_pg-nulls-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-nulls-default.txt-Results]": [],
@@ -2701,23 +2701,23 @@
     "test.test[tpch-q2-default.txt-Results]": [],
     "test.test[type_v3-non_strict--Analyze]": [
         {
-            "checksum": "69e7478f99fd383aa684e61cde3f93e9",
-            "size": 6517,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_type_v3-non_strict--Analyze_/plan.txt"
+            "checksum": "b83f39f0d16dfbf74941c8ade1811367",
+            "size": 6207,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_type_v3-non_strict--Analyze_/plan.txt"
         }
     ],
     "test.test[type_v3-non_strict--Debug]": [
         {
-            "checksum": "ee0aad9eeb2b12e16bbe8e78ec1a21f4",
-            "size": 3361,
-            "uri": "https://{canondata_backend}/1942671/0f9b7a385d3b24e66ca2f542c2406826dcead5f4/resource.tar.gz#test.test_type_v3-non_strict--Debug_/opt.yql_patched"
+            "checksum": "f03d60389dcaca93b6713b1f3ce093d4",
+            "size": 3103,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_type_v3-non_strict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-non_strict--Plan]": [
         {
-            "checksum": "69e7478f99fd383aa684e61cde3f93e9",
-            "size": 6517,
-            "uri": "https://{canondata_backend}/1936273/7c78e1e45ae282daee686c006624daa21a7c6ca6/resource.tar.gz#test.test_type_v3-non_strict--Plan_/plan.txt"
+            "checksum": "b83f39f0d16dfbf74941c8ade1811367",
+            "size": 6207,
+            "uri": "https://{canondata_backend}/1031349/fade0e1ab4ddcf96add4ba75388b76b0ae6970f8/resource.tar.gz#test.test_type_v3-non_strict--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-non_strict--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part18/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part18/canondata/result.json
@@ -1,23 +1,23 @@
 {
     "test.test[action-eval_input_output_table_subquery--Analyze]": [
         {
-            "checksum": "a40d48ebab13dfcac8342e19462f2faa",
-            "size": 6474,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Analyze_/plan.txt"
+            "checksum": "302b334624dce8fdd832200067248ff7",
+            "size": 6164,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Analyze_/plan.txt"
         }
     ],
     "test.test[action-eval_input_output_table_subquery--Debug]": [
         {
-            "checksum": "6406cdf11c45417488596389f239650d",
-            "size": 2776,
-            "uri": "https://{canondata_backend}/212715/b10a3a963ab6644683db33c830058d65ff99d14f/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Debug_/opt.yql_patched"
+            "checksum": "915428f4858a139e2b68e3b511b96fc0",
+            "size": 2559,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_input_output_table_subquery--Plan]": [
         {
-            "checksum": "a40d48ebab13dfcac8342e19462f2faa",
-            "size": 6474,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Plan_/plan.txt"
+            "checksum": "302b334624dce8fdd832200067248ff7",
+            "size": 6164,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_input_output_table_subquery--Results]": [],
@@ -1122,9 +1122,9 @@
     "test.test[insert-append_missing_null-default.txt-Results]": [],
     "test.test[insert-append_sorted-to_sorted_desc-Analyze]": [
         {
-            "checksum": "1159183b3d52537e8b51438df418646a",
-            "size": 27826,
-            "uri": "https://{canondata_backend}/1775059/17f0d56cbd3b1817a494481bb24fbafc1bd7be1b/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Analyze_/plan.txt"
+            "checksum": "914dcb19332433fc7c2f35286cc8ce9f",
+            "size": 26178,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_insert-append_sorted-to_sorted_desc-Analyze_/extracted"
@@ -1132,16 +1132,16 @@
     ],
     "test.test[insert-append_sorted-to_sorted_desc-Debug]": [
         {
-            "checksum": "49da501b0037a47d15ee44188db08fea",
-            "size": 10509,
-            "uri": "https://{canondata_backend}/1775059/17f0d56cbd3b1817a494481bb24fbafc1bd7be1b/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Debug_/opt.yql_patched"
+            "checksum": "22de73756297da471b7d444335349bd2",
+            "size": 8580,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_desc-Plan]": [
         {
-            "checksum": "0626b4824feb226ba569f61ed686325e",
-            "size": 28821,
-            "uri": "https://{canondata_backend}/1775059/17f0d56cbd3b1817a494481bb24fbafc1bd7be1b/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Plan_/plan.txt"
+            "checksum": "9ef5c1bbdc4e9fb95fd644faeb8c8a6a",
+            "size": 27173,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_desc-Results]": [
@@ -1151,45 +1151,45 @@
     ],
     "test.test[insert-drop_sortness--Analyze]": [
         {
-            "checksum": "e5cf2bf4ba28552757409e4cdcdffe3f",
-            "size": 4755,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_insert-drop_sortness--Analyze_/plan.txt"
+            "checksum": "b1353c270797db22c5efc7ceef1d6a90",
+            "size": 4549,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert-drop_sortness--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness--Debug]": [
         {
-            "checksum": "5472162b0ebbf04f7e578379fab6deec",
-            "size": 2071,
-            "uri": "https://{canondata_backend}/1775319/1bcaed71cff9ecfa94f385155cd972c6f6a29a5a/resource.tar.gz#test.test_insert-drop_sortness--Debug_/opt.yql_patched"
+            "checksum": "41ab5e903efbdc3d43950f9bc968030e",
+            "size": 2007,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert-drop_sortness--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-drop_sortness--Plan]": [
         {
-            "checksum": "e5cf2bf4ba28552757409e4cdcdffe3f",
-            "size": 4755,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_insert-drop_sortness--Plan_/plan.txt"
+            "checksum": "b1353c270797db22c5efc7ceef1d6a90",
+            "size": 4549,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert-drop_sortness--Plan_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness--Results]": [],
     "test.test[insert_monotonic-several1-default.txt-Analyze]": [
         {
-            "checksum": "82630037f95ff838cc57d8cfeb1346e2",
-            "size": 6880,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Analyze_/plan.txt"
+            "checksum": "048afcf0d226a3dd69e97cb7ff4349eb",
+            "size": 6577,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-several1-default.txt-Debug]": [
         {
-            "checksum": "8992ad4c005ee1ed256648fe7300fae8",
-            "size": 2877,
-            "uri": "https://{canondata_backend}/1775319/1bcaed71cff9ecfa94f385155cd972c6f6a29a5a/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "54531581275991a6ef7d3e78cfd7c800",
+            "size": 2626,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-several1-default.txt-Plan]": [
         {
-            "checksum": "82630037f95ff838cc57d8cfeb1346e2",
-            "size": 6880,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Plan_/plan.txt"
+            "checksum": "048afcf0d226a3dd69e97cb7ff4349eb",
+            "size": 6577,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-several1-default.txt-Results]": [],
@@ -1936,23 +1936,23 @@
     "test.test[optimizers-sort_constraint_in_left--Results]": [],
     "test.test[optimizers-yql-5978_fill_multi_usage--Analyze]": [
         {
-            "checksum": "1a476eda5a72674ce99240b75d75b3f4",
-            "size": 9402,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_optimizers-yql-5978_fill_multi_usage--Analyze_/plan.txt"
+            "checksum": "7e3f782da6b5e3243244ebf64facd8b0",
+            "size": 9196,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_optimizers-yql-5978_fill_multi_usage--Analyze_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-5978_fill_multi_usage--Debug]": [
         {
-            "checksum": "875bafb8e1ea65c9dc9d8781133bd031",
-            "size": 4743,
-            "uri": "https://{canondata_backend}/1773845/57222273edb3e600187ff62653acf03a13f24744/resource.tar.gz#test.test_optimizers-yql-5978_fill_multi_usage--Debug_/opt.yql_patched"
+            "checksum": "e3eee06a6ed6995554353edcc4b72ec6",
+            "size": 4715,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_optimizers-yql-5978_fill_multi_usage--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-5978_fill_multi_usage--Plan]": [
         {
-            "checksum": "1a476eda5a72674ce99240b75d75b3f4",
-            "size": 9402,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_optimizers-yql-5978_fill_multi_usage--Plan_/plan.txt"
+            "checksum": "7e3f782da6b5e3243244ebf64facd8b0",
+            "size": 9196,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_optimizers-yql-5978_fill_multi_usage--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-5978_fill_multi_usage--Results]": [],
@@ -2122,16 +2122,16 @@
     ],
     "test.test[pg-nulls_native-default.txt-Debug]": [
         {
-            "checksum": "2edbf9d3e4d56c2945a331005a496fe4",
-            "size": 4865,
-            "uri": "https://{canondata_backend}/1871182/1e53ee2b92848bee51fb8b73b6906845db1d0bd7/resource.tar.gz#test.test_pg-nulls_native-default.txt-Debug_/opt.yql_patched"
+            "checksum": "41ac692cc4d8cb9253a8b888d067f912",
+            "size": 4677,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_pg-nulls_native-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-nulls_native-default.txt-Plan]": [
         {
-            "checksum": "a28dba86feb2383b39fb7b0969c2ff7a",
-            "size": 17524,
-            "uri": "https://{canondata_backend}/1871182/1e53ee2b92848bee51fb8b73b6906845db1d0bd7/resource.tar.gz#test.test_pg-nulls_native-default.txt-Plan_/plan.txt"
+            "checksum": "1d9c53f6858fb7604b7eff494f71bbc5",
+            "size": 17318,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_pg-nulls_native-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-nulls_native-default.txt-Results]": [],
@@ -2587,16 +2587,16 @@
     ],
     "test.test[produce-reduce_with_presort_diff_order--Debug]": [
         {
-            "checksum": "9e37218026c65d862d6e4e0447f208a5",
-            "size": 11129,
-            "uri": "https://{canondata_backend}/1775059/17f0d56cbd3b1817a494481bb24fbafc1bd7be1b/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Debug_/opt.yql_patched"
+            "checksum": "54e0bdf17c8feb1f46b228598ef50be2",
+            "size": 9959,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_with_presort_diff_order--Plan]": [
         {
-            "checksum": "b90be399c731921d76bb49c7ad3f2059",
-            "size": 31713,
-            "uri": "https://{canondata_backend}/1775059/17f0d56cbd3b1817a494481bb24fbafc1bd7be1b/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Plan_/plan.txt"
+            "checksum": "9182aa9d4f1206623c5978cd7ec19836",
+            "size": 31095,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_with_presort_diff_order--Results]": [],
@@ -2929,23 +2929,23 @@
     "test.test[type_v3-decimal_yt_llvm--Results]": [],
     "test.test[type_v3-insert_struct_v3_wo_native--Analyze]": [
         {
-            "checksum": "a3b7d2241ab11a816affc45e91b5c0eb",
-            "size": 16900,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Analyze_/plan.txt"
+            "checksum": "a20af9453335939bdcc4a8dc0616c95f",
+            "size": 16076,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Analyze_/plan.txt"
         }
     ],
     "test.test[type_v3-insert_struct_v3_wo_native--Debug]": [
         {
-            "checksum": "ea6f4b50b67e4f7d5653978d82a00c83",
-            "size": 5275,
-            "uri": "https://{canondata_backend}/1775059/17f0d56cbd3b1817a494481bb24fbafc1bd7be1b/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Debug_/opt.yql_patched"
+            "checksum": "77aab5f3efb8439e3af02ee144796740",
+            "size": 5116,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-insert_struct_v3_wo_native--Plan]": [
         {
-            "checksum": "e8dc7504646876cb7c7c3b9b7fec6bc3",
-            "size": 17268,
-            "uri": "https://{canondata_backend}/1880306/e4ccac619cc79d4b07e7e803e386d47da238c793/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Plan_/plan.txt"
+            "checksum": "d4a6fc1b1825354a877c3418b9257740",
+            "size": 16444,
+            "uri": "https://{canondata_backend}/1937429/e5eaf8d78c61231eab5dfa6a18215af9f922a482/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-insert_struct_v3_wo_native--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part19/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part19/canondata/result.json
@@ -718,16 +718,16 @@
     ],
     "test.test[blocks-tuple_nth--Debug]": [
         {
-            "checksum": "4665d8468ecd3a66a73ed9dd2ad79706",
-            "size": 4593,
-            "uri": "https://{canondata_backend}/937458/818e067fe83fe9b2daba4296b6b1e552d869fd55/resource.tar.gz#test.test_blocks-tuple_nth--Debug_/opt.yql_patched"
+            "checksum": "c24d993bc8948a1df3ebf3295c0f17af",
+            "size": 4407,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_blocks-tuple_nth--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-tuple_nth--Plan]": [
         {
-            "checksum": "b14fd28b65b813465b0c746f430d5b9c",
-            "size": 8308,
-            "uri": "https://{canondata_backend}/937458/818e067fe83fe9b2daba4296b6b1e552d869fd55/resource.tar.gz#test.test_blocks-tuple_nth--Plan_/plan.txt"
+            "checksum": "465a73d4fc886bfd65a0ff146d093c8e",
+            "size": 8102,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_blocks-tuple_nth--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-tuple_nth--Results]": [],
@@ -1089,23 +1089,23 @@
     "test.test[in-in_compact_distinct--Results]": [],
     "test.test[insert-replace_ordered_by_key_desc-default.txt-Analyze]": [
         {
-            "checksum": "d3b2c2ab51a5d8c46498b814614c9f06",
-            "size": 7567,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Analyze_/plan.txt"
+            "checksum": "233e9cd3e6ae641af206885d7703aed5",
+            "size": 7264,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-replace_ordered_by_key_desc-default.txt-Debug]": [
         {
-            "checksum": "855c151f0b730e82a7e87e8c89bce53b",
-            "size": 3325,
-            "uri": "https://{canondata_backend}/1937001/c532d39f625a9d91399ea4cd2915137da80494ed/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "28bfba361c7f546a922274a814ee68c5",
+            "size": 3114,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_ordered_by_key_desc-default.txt-Plan]": [
         {
-            "checksum": "d3b2c2ab51a5d8c46498b814614c9f06",
-            "size": 7567,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Plan_/plan.txt"
+            "checksum": "233e9cd3e6ae641af206885d7703aed5",
+            "size": 7264,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_ordered_by_key_desc-default.txt-Results]": [],
@@ -1116,23 +1116,23 @@
     ],
     "test.test[insert_monotonic-truncate_and_append-default.txt-Analyze]": [
         {
-            "checksum": "15cacf72e723df425ee60c462c81514b",
-            "size": 11424,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Analyze_/plan.txt"
+            "checksum": "a455ded4ae4b002da62e0850f225c14b",
+            "size": 10818,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-truncate_and_append-default.txt-Debug]": [
         {
-            "checksum": "36f1cf2bd46e77c4988ddcb70cceba2a",
-            "size": 3775,
-            "uri": "https://{canondata_backend}/1937001/c532d39f625a9d91399ea4cd2915137da80494ed/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Debug_/opt.yql_patched"
+            "checksum": "90c52412b8091737f392337006903c02",
+            "size": 3485,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-truncate_and_append-default.txt-Plan]": [
         {
-            "checksum": "7cc44339e0b9d45f1f6465c5ccaf8670",
-            "size": 11668,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Plan_/plan.txt"
+            "checksum": "503315fdbe5c4908ded36416059a24f8",
+            "size": 11062,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-truncate_and_append-default.txt-Results]": [],
@@ -1862,16 +1862,16 @@
     ],
     "test.test[optimizers-yql-9297_publish_ytcopy--Debug]": [
         {
-            "checksum": "7f61d8b62f9add33bc47efcff8c470d9",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/1889210/2fbf7f68942208b15ab6eb23b14b78640f078541/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Debug_/opt.yql_patched"
+            "checksum": "c85d4f93284cb2e74273a3f812a7763a",
+            "size": 5475,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-9297_publish_ytcopy--Plan]": [
         {
-            "checksum": "e2c127d65f046cc2b3e7b8ec6ed66359",
-            "size": 18164,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Plan_/plan.txt"
+            "checksum": "0554c494d18b7e7eca2df8a20a06216a",
+            "size": 17551,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-9297_publish_ytcopy--Results]": [],
@@ -2613,16 +2613,16 @@
     ],
     "test.test[sampling-insert--Debug]": [
         {
-            "checksum": "9b34e1b93b372a28319f772930920b67",
-            "size": 2717,
-            "uri": "https://{canondata_backend}/1889210/2fbf7f68942208b15ab6eb23b14b78640f078541/resource.tar.gz#test.test_sampling-insert--Debug_/opt.yql_patched"
+            "checksum": "c4703bb1e763fd945712bfc776bfa231",
+            "size": 2594,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_sampling-insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-insert--Plan]": [
         {
-            "checksum": "b756cd4ec40fc72f0fe39d6a5d7ad45d",
-            "size": 8073,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_sampling-insert--Plan_/plan.txt"
+            "checksum": "9dd074024dcfb465bba9965425588759",
+            "size": 7867,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_sampling-insert--Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert_sorted-schema-Analyze]": [
@@ -2637,16 +2637,16 @@
     ],
     "test.test[schema-insert_sorted-schema-Debug]": [
         {
-            "checksum": "66811940e669c50cf7511d7fbbed603f",
-            "size": 4227,
-            "uri": "https://{canondata_backend}/1889210/2fbf7f68942208b15ab6eb23b14b78640f078541/resource.tar.gz#test.test_schema-insert_sorted-schema-Debug_/opt.yql_patched"
+            "checksum": "717a960ab3125c5a3d6104e292dfd6a3",
+            "size": 3875,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_schema-insert_sorted-schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert_sorted-schema-Plan]": [
         {
-            "checksum": "2df2156cc869bc0408d20293b3490029",
-            "size": 9801,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_schema-insert_sorted-schema-Plan_/plan.txt"
+            "checksum": "b6714d88ced45bc87049b7ed4564f702",
+            "size": 9498,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_schema-insert_sorted-schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert_sorted-schema-Results]": [],
@@ -2757,16 +2757,16 @@
     ],
     "test.test[select-table_content_from_sort_desc-default.txt-Debug]": [
         {
-            "checksum": "f0fa26ea3f686f2f48c122a29a9497f5",
-            "size": 4517,
-            "uri": "https://{canondata_backend}/1599023/b080029bbb6c170d431b28986bae182148dfda4a/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e3dd6611927b0aa85b7de4441324a357",
+            "size": 4402,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-table_content_from_sort_desc-default.txt-Plan]": [
         {
-            "checksum": "d182dedae42f59bff3e2a5282f86853e",
-            "size": 11708,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Plan_/plan.txt"
+            "checksum": "e1dd38d477cbf39690e8819b23b40f0f",
+            "size": 11502,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-table_content_from_sort_desc-default.txt-Results]": [],
@@ -2870,16 +2870,16 @@
     ],
     "test.test[type_v3-append_struct-default.txt-Debug]": [
         {
-            "checksum": "62c8aaaa648cae9143c87902a7b67c37",
-            "size": 4351,
-            "uri": "https://{canondata_backend}/1925821/68e7a27709136850ff3e2dbf29d04ceac681d1a8/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Debug_/opt.yql_patched"
+            "checksum": "31f404cf22add3199eb5cb2f28457787",
+            "size": 4226,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-append_struct-default.txt-Plan]": [
         {
-            "checksum": "4d2b8b82af8573951ce8d4c93b6a2da8",
-            "size": 21849,
-            "uri": "https://{canondata_backend}/1599023/9fb10775fd57dc9adafaafe2a658f6533a20dc46/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Plan_/plan.txt"
+            "checksum": "c27c6428a768b93c64e46bf65558322f",
+            "size": 21437,
+            "uri": "https://{canondata_backend}/1881367/3848e32ce807b5f10bb012e51d0ebe5ff6708554/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[union-union_positional-default.txt-Analyze]": [

--- a/ydb/library/yql/tests/sql/dq_file/part2/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part2/canondata/result.json
@@ -862,23 +862,23 @@
     "test.test[distinct-distinct_count_and_full_count-default.txt-Results]": [],
     "test.test[dq-precompute_parallel_mix--Analyze]": [
         {
-            "checksum": "191f1cfae918330a0d2b2b7c5880565e",
-            "size": 10762,
-            "uri": "https://{canondata_backend}/1937027/06ef7ef6dee3ee697013fd133a8e8a843e5f5de9/resource.tar.gz#test.test_dq-precompute_parallel_mix--Analyze_/plan.txt"
+            "checksum": "602b5761ba226dd1649435fd6c34f37d",
+            "size": 10350,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_dq-precompute_parallel_mix--Analyze_/plan.txt"
         }
     ],
     "test.test[dq-precompute_parallel_mix--Debug]": [
         {
-            "checksum": "1194dd203292ab84e7c874dbc9aa6fce",
-            "size": 3928,
-            "uri": "https://{canondata_backend}/1775059/f8f056a0190a716df840d5350581b5176f1620e0/resource.tar.gz#test.test_dq-precompute_parallel_mix--Debug_/opt.yql_patched"
+            "checksum": "e37846f33885712421a18708df55fb55",
+            "size": 3777,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_dq-precompute_parallel_mix--Debug_/opt.yql_patched"
         }
     ],
     "test.test[dq-precompute_parallel_mix--Plan]": [
         {
-            "checksum": "1e3854603cf82672f83af3c5bf63caf8",
-            "size": 10884,
-            "uri": "https://{canondata_backend}/1937027/06ef7ef6dee3ee697013fd133a8e8a843e5f5de9/resource.tar.gz#test.test_dq-precompute_parallel_mix--Plan_/plan.txt"
+            "checksum": "7a19dfc256e3a77d46755854080fb2e0",
+            "size": 10472,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_dq-precompute_parallel_mix--Plan_/plan.txt"
         }
     ],
     "test.test[dq-precompute_parallel_mix--Results]": [
@@ -1113,16 +1113,16 @@
     ],
     "test.test[hor_join-runtime_dep-default.txt-Debug]": [
         {
-            "checksum": "84da955306d65b93fda687444c18f348",
-            "size": 3823,
-            "uri": "https://{canondata_backend}/1937429/8c62189ab5d8963fa2bc00211d90a8db6a318dd6/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c94f11b06154c1aefa07b74cb257cc01",
+            "size": 3700,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-runtime_dep-default.txt-Plan]": [
         {
-            "checksum": "1ad2935a662f33ba63d1a74b9997b3b6",
-            "size": 9608,
-            "uri": "https://{canondata_backend}/1936947/2bc3e51a8b9883f1a1d8b98124fe921cba1fca45/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Plan_/plan.txt"
+            "checksum": "36c64485264dada33753dec86dbb5a4c",
+            "size": 9402,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-runtime_dep-default.txt-Results]": [],
@@ -1244,23 +1244,23 @@
     ],
     "test.test[insert-append--Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1920236/e3a40a0f1b28089f5bcc00a85b3176919dc509ac/resource.tar.gz#test.test_insert-append--Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_insert-append--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-append--Debug]": [
         {
-            "checksum": "f963ea0cd181e78eb4ecb1150d8185e8",
-            "size": 1876,
-            "uri": "https://{canondata_backend}/1775319/5a2e4244925f618671b7e7801de8c86ee95936fd/resource.tar.gz#test.test_insert-append--Debug_/opt.yql_patched"
+            "checksum": "98856c88e6f51888c981d758a6602e55",
+            "size": 1753,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_insert-append--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append--Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1880306/d5d62ef14be34ac15a1ed62998afe353287d5bd5/resource.tar.gz#test.test_insert-append--Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_insert-append--Plan_/plan.txt"
         }
     ],
     "test.test[insert-append--Results]": [],
@@ -1773,16 +1773,16 @@
     ],
     "test.test[join-yql-8125--Debug]": [
         {
-            "checksum": "fcaceb7f1e238367caa7d0ae15144079",
-            "size": 6009,
-            "uri": "https://{canondata_backend}/1775059/f8f056a0190a716df840d5350581b5176f1620e0/resource.tar.gz#test.test_join-yql-8125--Debug_/opt.yql_patched"
+            "checksum": "d4f707e1dfc4dfafc1981f7bbee886ef",
+            "size": 5951,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_join-yql-8125--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-8125--Plan]": [
         {
-            "checksum": "29fc3f5d02503976cdd58e970c217744",
-            "size": 20706,
-            "uri": "https://{canondata_backend}/1775059/f8f056a0190a716df840d5350581b5176f1620e0/resource.tar.gz#test.test_join-yql-8125--Plan_/plan.txt"
+            "checksum": "31e19bb810398b936f1fb038c1b63c6e",
+            "size": 20088,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_join-yql-8125--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-8125--Results]": [],
@@ -1871,16 +1871,16 @@
     ],
     "test.test[key_filter-string_with_ff-default.txt-Debug]": [
         {
-            "checksum": "3603bdce6b7f534ea2456c3b0b1dd7b4",
-            "size": 4855,
-            "uri": "https://{canondata_backend}/1871002/74160783fcdc3a479258b5a4bea49b3bd257f296/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8988ea9f4c26b364ef66f5d072556848",
+            "size": 4740,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-string_with_ff-default.txt-Plan]": [
         {
-            "checksum": "444773fde4b8543d3a17c99c13c3b73a",
-            "size": 11607,
-            "uri": "https://{canondata_backend}/1937001/441781d594b64769bedacb579efb911f22209130/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Plan_/plan.txt"
+            "checksum": "71f4bad052c657ad551bd5049ed0f7a5",
+            "size": 11297,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-string_with_ff-default.txt-Results]": [],
@@ -1943,16 +1943,16 @@
     ],
     "test.test[optimizers-sort_over_sorted_prefix_keys-default.txt-Debug]": [
         {
-            "checksum": "141e1d4a012d1f15668e2b44384e7885",
-            "size": 3510,
-            "uri": "https://{canondata_backend}/1937429/8c62189ab5d8963fa2bc00211d90a8db6a318dd6/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9a39541578d4b8a4ccd476e4729501eb",
+            "size": 3253,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-sort_over_sorted_prefix_keys-default.txt-Plan]": [
         {
-            "checksum": "01431e0fb6dea1b24d91519affa27c91",
-            "size": 10252,
-            "uri": "https://{canondata_backend}/1942671/157db22ce38fb6cce530ef150bd605411e8ebf46/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Plan_/plan.txt"
+            "checksum": "5c4cd1ae47ab91f5913e87d0ec11ba05",
+            "size": 9949,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-sort_over_sorted_prefix_keys-default.txt-Results]": [],
@@ -2398,23 +2398,23 @@
     "test.test[produce-process_streaming_inline_bash-default.txt-Results]": [],
     "test.test[produce-reduce_with_assume--Analyze]": [
         {
-            "checksum": "27fdfb7a96b5936702fca907f7fc8009",
-            "size": 7027,
-            "uri": "https://{canondata_backend}/1900335/2fc18e157d21b28ad4015e983afc5e1e854e557f/resource.tar.gz#test.test_produce-reduce_with_assume--Analyze_/plan.txt"
+            "checksum": "654ea37b6065e5415bee3eaca606d3c3",
+            "size": 6724,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_produce-reduce_with_assume--Analyze_/plan.txt"
         }
     ],
     "test.test[produce-reduce_with_assume--Debug]": [
         {
-            "checksum": "4e4d23822d16762e7772dc0b8cacb755",
-            "size": 3435,
-            "uri": "https://{canondata_backend}/1937429/8c62189ab5d8963fa2bc00211d90a8db6a318dd6/resource.tar.gz#test.test_produce-reduce_with_assume--Debug_/opt.yql_patched"
+            "checksum": "615fc0ed9ba341cf515ee35ada799446",
+            "size": 3242,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_produce-reduce_with_assume--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_with_assume--Plan]": [
         {
-            "checksum": "27fdfb7a96b5936702fca907f7fc8009",
-            "size": 7027,
-            "uri": "https://{canondata_backend}/1781765/f3b4483a271a53c7042af53dd89e7eaa7933954c/resource.tar.gz#test.test_produce-reduce_with_assume--Plan_/plan.txt"
+            "checksum": "654ea37b6065e5415bee3eaca606d3c3",
+            "size": 6724,
+            "uri": "https://{canondata_backend}/1881367/550f3b79ddf2520d4c20e67e83a71edceeb0c664/resource.tar.gz#test.test_produce-reduce_with_assume--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_with_assume--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part3/canondata/result.json
@@ -555,16 +555,16 @@
     ],
     "test.test[column_order-insert_tmp-default.txt-Debug]": [
         {
-            "checksum": "5176d233f1cc64844b2635b734e53a02",
-            "size": 6191,
-            "uri": "https://{canondata_backend}/1942415/42f023aa89a69415cadca29b0048d54ece1df54a/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2ee8c939c5391be22c55f22fe459a0fc",
+            "size": 6134,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_tmp-default.txt-Plan]": [
         {
-            "checksum": "8d44824faf600056af9c92348472b3f4",
-            "size": 19774,
-            "uri": "https://{canondata_backend}/1871102/0f954067db9c14aae8830105a157009ce2550f6c/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Plan_/plan.txt"
+            "checksum": "ddb129d41fb5a40f45ef6c643ac76bce",
+            "size": 19362,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_tmp-default.txt-Results]": [],
@@ -861,45 +861,45 @@
     ],
     "test.test[insert-drop_sortness-calc-Analyze]": [
         {
-            "checksum": "e5cf2bf4ba28552757409e4cdcdffe3f",
-            "size": 4755,
-            "uri": "https://{canondata_backend}/1899731/5f48750839c300c592c921895adce61b6bdd10c7/resource.tar.gz#test.test_insert-drop_sortness-calc-Analyze_/plan.txt"
+            "checksum": "b1353c270797db22c5efc7ceef1d6a90",
+            "size": 4549,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_insert-drop_sortness-calc-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness-calc-Debug]": [
         {
-            "checksum": "35ef5394fa8652f01559055b7c5f9d2b",
-            "size": 1995,
-            "uri": "https://{canondata_backend}/1942415/42f023aa89a69415cadca29b0048d54ece1df54a/resource.tar.gz#test.test_insert-drop_sortness-calc-Debug_/opt.yql_patched"
+            "checksum": "f837f8c27ee2cd3c3f3923bbf3822d11",
+            "size": 1931,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_insert-drop_sortness-calc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-drop_sortness-calc-Plan]": [
         {
-            "checksum": "e5cf2bf4ba28552757409e4cdcdffe3f",
-            "size": 4755,
-            "uri": "https://{canondata_backend}/1689644/3fdfb429a8dcc4548c5c2c7b4633524c2cc4180d/resource.tar.gz#test.test_insert-drop_sortness-calc-Plan_/plan.txt"
+            "checksum": "b1353c270797db22c5efc7ceef1d6a90",
+            "size": 4549,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_insert-drop_sortness-calc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness-calc-Results]": [],
     "test.test[insert-replace_inferred_op--Analyze]": [
         {
-            "checksum": "fd76338a47a06eda45544a2a9dc7a642",
-            "size": 4919,
-            "uri": "https://{canondata_backend}/1889210/da393fb38fcaca393cf8430a37949f2b175d2215/resource.tar.gz#test.test_insert-replace_inferred_op--Analyze_/plan.txt"
+            "checksum": "ceccf2acfc9240b3cbe02176e41fc221",
+            "size": 4713,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_insert-replace_inferred_op--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-replace_inferred_op--Debug]": [
         {
-            "checksum": "842adbedb022d0227cb7c92c0214d135",
-            "size": 2812,
-            "uri": "https://{canondata_backend}/1942415/42f023aa89a69415cadca29b0048d54ece1df54a/resource.tar.gz#test.test_insert-replace_inferred_op--Debug_/opt.yql_patched"
+            "checksum": "ec1e609c9129f752b635a8a5ae7436eb",
+            "size": 2623,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_insert-replace_inferred_op--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_inferred_op--Plan]": [
         {
-            "checksum": "fd76338a47a06eda45544a2a9dc7a642",
-            "size": 4919,
-            "uri": "https://{canondata_backend}/1889210/da393fb38fcaca393cf8430a37949f2b175d2215/resource.tar.gz#test.test_insert-replace_inferred_op--Plan_/plan.txt"
+            "checksum": "ceccf2acfc9240b3cbe02176e41fc221",
+            "size": 4713,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_insert-replace_inferred_op--Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_inferred_op--Results]": [],
@@ -2145,23 +2145,23 @@
     "test.test[produce-reduce_lambda_list_mem-default.txt-Results]": [],
     "test.test[produce-reduce_multi_in_difftype_assume_keytuple--Analyze]": [
         {
-            "checksum": "cc566d37600fd6f7a1119c426458709f",
-            "size": 7227,
-            "uri": "https://{canondata_backend}/1937027/7e92a59557f254d8b58c96118ce2e626b197c0b1/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume_keytuple--Analyze_/plan.txt"
+            "checksum": "619c0870fa64891c52031b754552adc3",
+            "size": 6924,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume_keytuple--Analyze_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume_keytuple--Debug]": [
         {
-            "checksum": "3481ea72c4b2154511a8585342b6c593",
-            "size": 4907,
-            "uri": "https://{canondata_backend}/1777230/84194ad8ae2188df41a496fbc52fcf70c26dfad4/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume_keytuple--Debug_/opt.yql_patched"
+            "checksum": "b0ace2d8f64f3fb368d40652d9ad6710",
+            "size": 4642,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume_keytuple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume_keytuple--Plan]": [
         {
-            "checksum": "cc566d37600fd6f7a1119c426458709f",
-            "size": 7227,
-            "uri": "https://{canondata_backend}/1937027/7e92a59557f254d8b58c96118ce2e626b197c0b1/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume_keytuple--Plan_/plan.txt"
+            "checksum": "619c0870fa64891c52031b754552adc3",
+            "size": 6924,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_produce-reduce_multi_in_difftype_assume_keytuple--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume_keytuple--Results]": [],
@@ -2558,23 +2558,23 @@
     "test.test[tpch-q10-default.txt-Results]": [],
     "test.test[type_v3-append_diff_flags--Analyze]": [
         {
-            "checksum": "fc8fc8ee754dd4cb3ef7f8154e6c07b3",
-            "size": 6487,
-            "uri": "https://{canondata_backend}/1889210/da393fb38fcaca393cf8430a37949f2b175d2215/resource.tar.gz#test.test_type_v3-append_diff_flags--Analyze_/plan.txt"
+            "checksum": "55c1cc549ff3a7370ee69b1f0dec55ca",
+            "size": 6177,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_type_v3-append_diff_flags--Analyze_/plan.txt"
         }
     ],
     "test.test[type_v3-append_diff_flags--Debug]": [
         {
-            "checksum": "00034c7dd5b6b9f10bdc423fd71fc3de",
-            "size": 2522,
-            "uri": "https://{canondata_backend}/1777230/84194ad8ae2188df41a496fbc52fcf70c26dfad4/resource.tar.gz#test.test_type_v3-append_diff_flags--Debug_/opt.yql_patched"
+            "checksum": "49fc142c2366d41df837c9d462d0fe13",
+            "size": 2327,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_type_v3-append_diff_flags--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-append_diff_flags--Plan]": [
         {
-            "checksum": "fc8fc8ee754dd4cb3ef7f8154e6c07b3",
-            "size": 6487,
-            "uri": "https://{canondata_backend}/1889210/da393fb38fcaca393cf8430a37949f2b175d2215/resource.tar.gz#test.test_type_v3-append_diff_flags--Plan_/plan.txt"
+            "checksum": "55c1cc549ff3a7370ee69b1f0dec55ca",
+            "size": 6177,
+            "uri": "https://{canondata_backend}/1871102/487289822b55151d5bfd88d1dcd849a7a02d10b3/resource.tar.gz#test.test_type_v3-append_diff_flags--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-append_diff_flags--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part4/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part4/canondata/result.json
@@ -746,16 +746,16 @@
     ],
     "test.test[datetime-date_tz_table_sort_desc--Debug]": [
         {
-            "checksum": "28ef040a3b2974e6fb7315bc76744a98",
-            "size": 3969,
-            "uri": "https://{canondata_backend}/1599023/99c2356674b1e20f456cfa1987af5df85eb4bfa3/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Debug_/opt.yql_patched"
+            "checksum": "184d302f149eb61d398475e96052770d",
+            "size": 3909,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[datetime-date_tz_table_sort_desc--Plan]": [
         {
-            "checksum": "1310c95c4af0e1a51fea7c1cef3842dc",
-            "size": 10722,
-            "uri": "https://{canondata_backend}/1599023/99c2356674b1e20f456cfa1987af5df85eb4bfa3/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Plan_/plan.txt"
+            "checksum": "02843afa60539941a7d437fbd5ae8c03",
+            "size": 10516,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Plan_/plan.txt"
         }
     ],
     "test.test[datetime-date_tz_table_sort_desc--Results]": [],
@@ -1347,16 +1347,16 @@
     ],
     "test.test[join-lookupjoin_with_cache-off-Debug]": [
         {
-            "checksum": "afadd5daad41e51bcf433f1b22288c86",
-            "size": 4629,
-            "uri": "https://{canondata_backend}/1031349/f562047a0458cc3f13d0bd9bc809240f0048d755/resource.tar.gz#test.test_join-lookupjoin_with_cache-off-Debug_/opt.yql_patched"
+            "checksum": "9d12327ca026923caf514219d4103042",
+            "size": 4611,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_join-lookupjoin_with_cache-off-Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_with_cache-off-Plan]": [
         {
-            "checksum": "d559d5782522a86db7d1fb530578c392",
-            "size": 11518,
-            "uri": "https://{canondata_backend}/1936947/c075b3a6b857003250f6fcdaddd6e5508fb9d58f/resource.tar.gz#test.test_join-lookupjoin_with_cache-off-Plan_/plan.txt"
+            "checksum": "34b18fc456d4103d8df577408728bb51",
+            "size": 12250,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_join-lookupjoin_with_cache-off-Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_with_cache-off-Results]": [
@@ -1857,9 +1857,9 @@
     "test.test[optimizers-yql-18408_filter_multiusage_pushdown-default.txt-Results]": [],
     "test.test[optimizers-yql-6008_limit_after_map--Analyze]": [
         {
-            "checksum": "60c17d9463ea6506e9cb6dc419a16f9b",
-            "size": 8569,
-            "uri": "https://{canondata_backend}/1599023/99c2356674b1e20f456cfa1987af5df85eb4bfa3/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Analyze_/plan.txt"
+            "checksum": "41e8113956134cebcb30241fb1d507a0",
+            "size": 8157,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_optimizers-yql-6008_limit_after_map--Analyze_/extracted"
@@ -1867,16 +1867,16 @@
     ],
     "test.test[optimizers-yql-6008_limit_after_map--Debug]": [
         {
-            "checksum": "f39aa0c06cb0f8adcc09f844f4a685a2",
-            "size": 3640,
-            "uri": "https://{canondata_backend}/1599023/99c2356674b1e20f456cfa1987af5df85eb4bfa3/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Debug_/opt.yql_patched"
+            "checksum": "fd49ec74c78f0bad0ddabed523023a70",
+            "size": 3292,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-6008_limit_after_map--Plan]": [
         {
-            "checksum": "732c36b0f406e18d7e4db88c3b233119",
-            "size": 8691,
-            "uri": "https://{canondata_backend}/1599023/99c2356674b1e20f456cfa1987af5df85eb4bfa3/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Plan_/plan.txt"
+            "checksum": "c395eeb28c457500f10b0e607b061f73",
+            "size": 8279,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-6008_limit_after_map--Results]": [
@@ -1981,23 +1981,23 @@
     ],
     "test.test[order_by-sort_with_take_limit--Analyze]": [
         {
-            "checksum": "e167d1c263e22409b5504e5ead86f0dc",
-            "size": 6497,
-            "uri": "https://{canondata_backend}/1784826/661585ebf866b4e8570c8873f6d379794d41fd45/resource.tar.gz#test.test_order_by-sort_with_take_limit--Analyze_/plan.txt"
+            "checksum": "d1f4d181e740cae66eb558f79823398c",
+            "size": 6393,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_order_by-sort_with_take_limit--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-sort_with_take_limit--Debug]": [
         {
-            "checksum": "f082acb60369c369224772eb1d3b96d7",
-            "size": 2626,
-            "uri": "https://{canondata_backend}/1784826/661585ebf866b4e8570c8873f6d379794d41fd45/resource.tar.gz#test.test_order_by-sort_with_take_limit--Debug_/opt.yql_patched"
+            "checksum": "427a1011825fbf0c63011bde2ec73355",
+            "size": 2491,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_order_by-sort_with_take_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-sort_with_take_limit--Plan]": [
         {
-            "checksum": "e167d1c263e22409b5504e5ead86f0dc",
-            "size": 6497,
-            "uri": "https://{canondata_backend}/1784826/661585ebf866b4e8570c8873f6d379794d41fd45/resource.tar.gz#test.test_order_by-sort_with_take_limit--Plan_/plan.txt"
+            "checksum": "d1f4d181e740cae66eb558f79823398c",
+            "size": 6393,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_order_by-sort_with_take_limit--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-sort_with_take_limit--Results]": [],
@@ -2679,23 +2679,23 @@
     ],
     "test.test[schema-copy-other-Analyze]": [
         {
-            "checksum": "088a4c504382098b21c58ac9e596fd93",
-            "size": 4906,
-            "uri": "https://{canondata_backend}/1923547/408f17dd7de3f1f4f32904831b08b3c57e38a7c7/resource.tar.gz#test.test_schema-copy-other-Analyze_/plan.txt"
+            "checksum": "c88a24c7fccafbe196d8ad195d0baa0b",
+            "size": 4700,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_schema-copy-other-Analyze_/plan.txt"
         }
     ],
     "test.test[schema-copy-other-Debug]": [
         {
-            "checksum": "7003696578309cf4112346ff562b121e",
-            "size": 2630,
-            "uri": "https://{canondata_backend}/1781765/e2adc29b0cfedd2d07b9052970265a4b4f24285c/resource.tar.gz#test.test_schema-copy-other-Debug_/opt.yql_patched"
+            "checksum": "e1f1882241613697c725c079da8d8daa",
+            "size": 2441,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_schema-copy-other-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-copy-other-Plan]": [
         {
-            "checksum": "088a4c504382098b21c58ac9e596fd93",
-            "size": 4906,
-            "uri": "https://{canondata_backend}/1923547/408f17dd7de3f1f4f32904831b08b3c57e38a7c7/resource.tar.gz#test.test_schema-copy-other-Plan_/plan.txt"
+            "checksum": "c88a24c7fccafbe196d8ad195d0baa0b",
+            "size": 4700,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_schema-copy-other-Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-other-Results]": [],
@@ -2711,16 +2711,16 @@
     ],
     "test.test[schema-copy-yamred_dsv_raw-Debug]": [
         {
-            "checksum": "741d8fdb22b6618500c43b7e730169c2",
-            "size": 1917,
-            "uri": "https://{canondata_backend}/1781765/e2adc29b0cfedd2d07b9052970265a4b4f24285c/resource.tar.gz#test.test_schema-copy-yamred_dsv_raw-Debug_/opt.yql_patched"
+            "checksum": "0200eba63ff1fb58588a02e4d8c44dea",
+            "size": 1794,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_schema-copy-yamred_dsv_raw-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-copy-yamred_dsv_raw-Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1923547/408f17dd7de3f1f4f32904831b08b3c57e38a7c7/resource.tar.gz#test.test_schema-copy-yamred_dsv_raw-Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_schema-copy-yamred_dsv_raw-Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-yamred_dsv_raw-Results]": [],
@@ -2736,16 +2736,16 @@
     ],
     "test.test[schema-insert_sorted-row_spec-Debug]": [
         {
-            "checksum": "66811940e669c50cf7511d7fbbed603f",
-            "size": 4227,
-            "uri": "https://{canondata_backend}/1925821/76f31386bb8c24a8c6deb4852e43a6b3c032e597/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Debug_/opt.yql_patched"
+            "checksum": "717a960ab3125c5a3d6104e292dfd6a3",
+            "size": 3875,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert_sorted-row_spec-Plan]": [
         {
-            "checksum": "2df2156cc869bc0408d20293b3490029",
-            "size": 9801,
-            "uri": "https://{canondata_backend}/1781765/8e6436592f8b9b13cf17fdef98d9ba42d0973071/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Plan_/plan.txt"
+            "checksum": "b6714d88ced45bc87049b7ed4564f702",
+            "size": 9498,
+            "uri": "https://{canondata_backend}/1881367/207835e4d274fcf7987814492f265b341fdcd02b/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert_sorted-row_spec-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part5/canondata/result.json
@@ -1306,9 +1306,9 @@
     "test.test[in-in_noansi_empty-default.txt-Results]": [],
     "test.test[insert-append_sorted--Analyze]": [
         {
-            "checksum": "ca582490362ca72c20607af2a6d3dad8",
-            "size": 23723,
-            "uri": "https://{canondata_backend}/1942525/b841c1f7e178a6bdcbcc7188f97e9d64098db934/resource.tar.gz#test.test_insert-append_sorted--Analyze_/plan.txt"
+            "checksum": "e12fa04f924c294bc572650d7d43cda9",
+            "size": 22075,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_insert-append_sorted--Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_insert-append_sorted--Analyze_/extracted"
@@ -1316,16 +1316,16 @@
     ],
     "test.test[insert-append_sorted--Debug]": [
         {
-            "checksum": "fa97668f011ef0b2ab77fe2aac9460f7",
-            "size": 8164,
-            "uri": "https://{canondata_backend}/1599023/1b6e8347ca7cf43e4ffb87f89e02cf72c8adfa32/resource.tar.gz#test.test_insert-append_sorted--Debug_/opt.yql_patched"
+            "checksum": "9dc610c4f9e4c2b32484f58c038bd961",
+            "size": 6260,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_insert-append_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted--Plan]": [
         {
-            "checksum": "8a4f1676b994803673b3927dbe5934e3",
-            "size": 24591,
-            "uri": "https://{canondata_backend}/1942525/b841c1f7e178a6bdcbcc7188f97e9d64098db934/resource.tar.gz#test.test_insert-append_sorted--Plan_/plan.txt"
+            "checksum": "4881f9148218371bbd663773ed6229a1",
+            "size": 22943,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_insert-append_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_sorted--Results]": [
@@ -1979,23 +1979,23 @@
     "test.test[join-yql-8980--Results]": [],
     "test.test[json-jsondocument/insert--Analyze]": [
         {
-            "checksum": "30a5b743eebd0ba91ff69ae5896c5b92",
-            "size": 4783,
-            "uri": "https://{canondata_backend}/1942415/b35d2514a5150e9f12a175bf916b9aef176e9b54/resource.tar.gz#test.test_json-jsondocument_insert--Analyze_/plan.txt"
+            "checksum": "cbc87b82878cf7766d0776544d98493e",
+            "size": 4577,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_json-jsondocument_insert--Analyze_/plan.txt"
         }
     ],
     "test.test[json-jsondocument/insert--Debug]": [
         {
-            "checksum": "dd0981e73710a5b64d60c662eef7dc38",
-            "size": 1772,
-            "uri": "https://{canondata_backend}/1937001/e9568c600a7ff09a1216f02e1671f22c6f5aa0fe/resource.tar.gz#test.test_json-jsondocument_insert--Debug_/opt.yql_patched"
+            "checksum": "65b76e31edda40092e94f88875b84a0f",
+            "size": 1673,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_json-jsondocument_insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[json-jsondocument/insert--Plan]": [
         {
-            "checksum": "30a5b743eebd0ba91ff69ae5896c5b92",
-            "size": 4783,
-            "uri": "https://{canondata_backend}/1942415/b35d2514a5150e9f12a175bf916b9aef176e9b54/resource.tar.gz#test.test_json-jsondocument_insert--Plan_/plan.txt"
+            "checksum": "cbc87b82878cf7766d0776544d98493e",
+            "size": 4577,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_json-jsondocument_insert--Plan_/plan.txt"
         }
     ],
     "test.test[json-jsondocument/insert--Results]": [],
@@ -2750,16 +2750,16 @@
     ],
     "test.test[schema-insert-row_spec-Debug]": [
         {
-            "checksum": "91a70e8586615fd9c3035eb06472dac1",
-            "size": 2980,
-            "uri": "https://{canondata_backend}/1775319/581989ddfd844cd7fb811fb9f47c5b23d36a9346/resource.tar.gz#test.test_schema-insert-row_spec-Debug_/opt.yql_patched"
+            "checksum": "7cb1a4b34470541e945d0103f66fa4f2",
+            "size": 2814,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_schema-insert-row_spec-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert-row_spec-Plan]": [
         {
-            "checksum": "6d2666bfe7a154a87a5f88de868962b3",
-            "size": 8313,
-            "uri": "https://{canondata_backend}/1130705/a877e9a38d4cdcd3a3048f1fe39ff52ef1e78652/resource.tar.gz#test.test_schema-insert-row_spec-Plan_/plan.txt"
+            "checksum": "191d447641f8d810de80b5d56e4a5271",
+            "size": 8107,
+            "uri": "https://{canondata_backend}/1925821/5c7988bca7ff7631d849ea3fc0177b71ea70a9e8/resource.tar.gz#test.test_schema-insert-row_spec-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert-row_spec-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part6/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part6/canondata/result.json
@@ -796,16 +796,16 @@
     ],
     "test.test[epochs-use_sorted_by_complex_type--Debug]": [
         {
-            "checksum": "78187283c49e12bf06738a455e0376b5",
-            "size": 5249,
-            "uri": "https://{canondata_backend}/1937424/c9a4c8efbcba2c1a1772ede4bf146f439970ae1a/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Debug_/opt.yql_patched"
+            "checksum": "b32a28d949f12d237ce8d5a062c342b6",
+            "size": 5127,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Debug_/opt.yql_patched"
         }
     ],
     "test.test[epochs-use_sorted_by_complex_type--Plan]": [
         {
-            "checksum": "55aec94437eb80ef9df86401cc95bfdc",
-            "size": 11712,
-            "uri": "https://{canondata_backend}/1937424/c9a4c8efbcba2c1a1772ede4bf146f439970ae1a/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Plan_/plan.txt"
+            "checksum": "70dc6928df95ef78641fed29327719f9",
+            "size": 11506,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Plan_/plan.txt"
         }
     ],
     "test.test[epochs-use_sorted_by_complex_type--Results]": [],
@@ -1222,126 +1222,126 @@
     ],
     "test.test[insert-after_group_by-default.txt-Debug]": [
         {
-            "checksum": "0e4329cc58160ce1896d355377ac62d8",
-            "size": 3360,
-            "uri": "https://{canondata_backend}/212715/f378560b982f85f8f3e84ad2e95e4205b1a7b465/resource.tar.gz#test.test_insert-after_group_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8e0268af1c228d4755a4f00d9ec976bd",
+            "size": 3213,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-after_group_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-after_group_by-default.txt-Plan]": [
         {
-            "checksum": "9d42fa888ee2f1786f511d300e7f26d3",
-            "size": 6473,
-            "uri": "https://{canondata_backend}/1775059/0320e0a444559c89851159b0ca77b3fb930f0227/resource.tar.gz#test.test_insert-after_group_by-default.txt-Plan_/plan.txt"
+            "checksum": "0fb6c0d4c458148495bce678c718db54",
+            "size": 6267,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-after_group_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-after_group_by-default.txt-Results]": [],
     "test.test[insert-part_sortness--Analyze]": [
         {
-            "checksum": "0fc9318664a7913559431ddc43820252",
-            "size": 4782,
-            "uri": "https://{canondata_backend}/1871182/02c4e8ba45dea18da2d4af195dc4a2de592050d0/resource.tar.gz#test.test_insert-part_sortness--Analyze_/plan.txt"
+            "checksum": "d9e097cbe8916dfc11138dd87d38eb66",
+            "size": 4576,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-part_sortness--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-part_sortness--Debug]": [
         {
-            "checksum": "5a6f1dbad83c8a0e505aae684952e2bb",
-            "size": 2163,
-            "uri": "https://{canondata_backend}/212715/f378560b982f85f8f3e84ad2e95e4205b1a7b465/resource.tar.gz#test.test_insert-part_sortness--Debug_/opt.yql_patched"
+            "checksum": "b7eae12d01174b1471a27d3c26419146",
+            "size": 2063,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-part_sortness--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-part_sortness--Plan]": [
         {
-            "checksum": "0fc9318664a7913559431ddc43820252",
-            "size": 4782,
-            "uri": "https://{canondata_backend}/1871182/02c4e8ba45dea18da2d4af195dc4a2de592050d0/resource.tar.gz#test.test_insert-part_sortness--Plan_/plan.txt"
+            "checksum": "d9e097cbe8916dfc11138dd87d38eb66",
+            "size": 4576,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-part_sortness--Plan_/plan.txt"
         }
     ],
     "test.test[insert-part_sortness--Results]": [],
     "test.test[insert-replace_ordered_by_key-default.txt-Analyze]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1871182/02c4e8ba45dea18da2d4af195dc4a2de592050d0/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Analyze_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-replace_ordered_by_key-default.txt-Debug]": [
         {
-            "checksum": "f8ffbce9dd66cf902829729aedb4389d",
-            "size": 2527,
-            "uri": "https://{canondata_backend}/212715/f378560b982f85f8f3e84ad2e95e4205b1a7b465/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Debug_/opt.yql_patched"
+            "checksum": "af663e1df02fdd8309c3a43572152c46",
+            "size": 2317,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_ordered_by_key-default.txt-Plan]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1871182/02c4e8ba45dea18da2d4af195dc4a2de592050d0/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Plan_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_ordered_by_key-default.txt-Results]": [],
     "test.test[insert-select_subquery--Analyze]": [
         {
-            "checksum": "89fdebcc2d395e4b9f930070d246546c",
-            "size": 6496,
-            "uri": "https://{canondata_backend}/1597364/1c16bdfe873e066d73d8cd1f3a20ffa0db6a804d/resource.tar.gz#test.test_insert-select_subquery--Analyze_/plan.txt"
+            "checksum": "87fea21e85848c635de7d9028a1b52ba",
+            "size": 6290,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-select_subquery--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-select_subquery--Debug]": [
         {
-            "checksum": "35f7fb76c47294c45f339376c3556af4",
-            "size": 2424,
-            "uri": "https://{canondata_backend}/212715/f378560b982f85f8f3e84ad2e95e4205b1a7b465/resource.tar.gz#test.test_insert-select_subquery--Debug_/opt.yql_patched"
+            "checksum": "f8247782f1c2ba1556562fdd905b164d",
+            "size": 2362,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-select_subquery--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_subquery--Plan]": [
         {
-            "checksum": "89fdebcc2d395e4b9f930070d246546c",
-            "size": 6496,
-            "uri": "https://{canondata_backend}/1597364/1c16bdfe873e066d73d8cd1f3a20ffa0db6a804d/resource.tar.gz#test.test_insert-select_subquery--Plan_/plan.txt"
+            "checksum": "87fea21e85848c635de7d9028a1b52ba",
+            "size": 6290,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-select_subquery--Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_subquery--Results]": [],
     "test.test[insert-select_with_sort_limit-default.txt-Analyze]": [
         {
-            "checksum": "e167d1c263e22409b5504e5ead86f0dc",
-            "size": 6497,
-            "uri": "https://{canondata_backend}/1942278/d9a3667b4b47eaef4ecbf7f8215efdd87df9db8b/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Analyze_/plan.txt"
+            "checksum": "d1f4d181e740cae66eb558f79823398c",
+            "size": 6393,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-select_with_sort_limit-default.txt-Debug]": [
         {
-            "checksum": "e66e7b967b2f90682a9d652d23dd6bd1",
-            "size": 2598,
-            "uri": "https://{canondata_backend}/1942278/d9a3667b4b47eaef4ecbf7f8215efdd87df9db8b/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7ac3edd0533ee406b504c4c76406942b",
+            "size": 2463,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_with_sort_limit-default.txt-Plan]": [
         {
-            "checksum": "e167d1c263e22409b5504e5ead86f0dc",
-            "size": 6497,
-            "uri": "https://{canondata_backend}/1942278/d9a3667b4b47eaef4ecbf7f8215efdd87df9db8b/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Plan_/plan.txt"
+            "checksum": "d1f4d181e740cae66eb558f79823398c",
+            "size": 6393,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_with_sort_limit-default.txt-Results]": [],
     "test.test[insert-trivial_select-default.txt-Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1871182/02c4e8ba45dea18da2d4af195dc4a2de592050d0/resource.tar.gz#test.test_insert-trivial_select-default.txt-Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-trivial_select-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-trivial_select-default.txt-Debug]": [
         {
-            "checksum": "f963ea0cd181e78eb4ecb1150d8185e8",
-            "size": 1876,
-            "uri": "https://{canondata_backend}/212715/f378560b982f85f8f3e84ad2e95e4205b1a7b465/resource.tar.gz#test.test_insert-trivial_select-default.txt-Debug_/opt.yql_patched"
+            "checksum": "98856c88e6f51888c981d758a6602e55",
+            "size": 1753,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-trivial_select-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-trivial_select-default.txt-Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1871182/02c4e8ba45dea18da2d4af195dc4a2de592050d0/resource.tar.gz#test.test_insert-trivial_select-default.txt-Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_insert-trivial_select-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-trivial_select-default.txt-Results]": [],
@@ -1651,16 +1651,16 @@
     ],
     "test.test[join-mapjoin_with_anonymous-off-Debug]": [
         {
-            "checksum": "fe97e2d5d227ea66efb4befd4ce7ebdf",
-            "size": 3432,
-            "uri": "https://{canondata_backend}/1937424/c9a4c8efbcba2c1a1772ede4bf146f439970ae1a/resource.tar.gz#test.test_join-mapjoin_with_anonymous-off-Debug_/opt.yql_patched"
+            "checksum": "22b79b7aab7d5db569f30ffa9ca90ca2",
+            "size": 3285,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_join-mapjoin_with_anonymous-off-Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_with_anonymous-off-Plan]": [
         {
-            "checksum": "608115b8725a890ca971f5922a76ee8c",
-            "size": 9946,
-            "uri": "https://{canondata_backend}/1936947/2fc43e3b7bf2ac6312b395248938656a7fa50fcc/resource.tar.gz#test.test_join-mapjoin_with_anonymous-off-Plan_/plan.txt"
+            "checksum": "b8f15ccd0df521c46f0f5b67bfb93336",
+            "size": 9740,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_join-mapjoin_with_anonymous-off-Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_with_anonymous-off-Results]": [
@@ -1760,16 +1760,16 @@
     ],
     "test.test[join-yql-8125-off-Debug]": [
         {
-            "checksum": "1d7f1b84f350e45e41da8996db34451e",
-            "size": 6079,
-            "uri": "https://{canondata_backend}/1937424/c9a4c8efbcba2c1a1772ede4bf146f439970ae1a/resource.tar.gz#test.test_join-yql-8125-off-Debug_/opt.yql_patched"
+            "checksum": "636a9f84f1e276f59838ae5f6970adeb",
+            "size": 5924,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_join-yql-8125-off-Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-8125-off-Plan]": [
         {
-            "checksum": "c0c2eb63d25d7de72301d07e1b2e7152",
-            "size": 21296,
-            "uri": "https://{canondata_backend}/1937424/c9a4c8efbcba2c1a1772ede4bf146f439970ae1a/resource.tar.gz#test.test_join-yql-8125-off-Plan_/plan.txt"
+            "checksum": "1c0337cc5e12150057be523f94b85828",
+            "size": 20678,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_join-yql-8125-off-Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-8125-off-Results]": [
@@ -2014,23 +2014,23 @@
     "test.test[order_by-order_by_missing_project_column-default.txt-Results]": [],
     "test.test[order_by-sort_with_take--Analyze]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1814674/64f652d95448e5a2fcab7cb3e9de5012799360ee/resource.tar.gz#test.test_order_by-sort_with_take--Analyze_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_order_by-sort_with_take--Analyze_/plan.txt"
         }
     ],
     "test.test[order_by-sort_with_take--Debug]": [
         {
-            "checksum": "36d890d40c7c4980a0d85120e317667d",
-            "size": 2587,
-            "uri": "https://{canondata_backend}/1871002/f2b11283e242599ec077764e30c7c497103c2c47/resource.tar.gz#test.test_order_by-sort_with_take--Debug_/opt.yql_patched"
+            "checksum": "1e84326d1d2b9caa4a8053454cdb544b",
+            "size": 2377,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_order_by-sort_with_take--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-sort_with_take--Plan]": [
         {
-            "checksum": "c78b6f43c8394d398e0c63aa70d6458c",
-            "size": 6397,
-            "uri": "https://{canondata_backend}/1814674/64f652d95448e5a2fcab7cb3e9de5012799360ee/resource.tar.gz#test.test_order_by-sort_with_take--Plan_/plan.txt"
+            "checksum": "c28166b7d529fba3482658ac42d89ddd",
+            "size": 6094,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_order_by-sort_with_take--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-sort_with_take--Results]": [],
@@ -2503,23 +2503,23 @@
     ],
     "test.test[produce-process_with_assume--Analyze]": [
         {
-            "checksum": "3f29bef99abe4b5924e963f404f353a9",
-            "size": 6497,
-            "uri": "https://{canondata_backend}/1871002/59223ec2dccf492ad5e53d9cbcba19f9bfd55043/resource.tar.gz#test.test_produce-process_with_assume--Analyze_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_produce-process_with_assume--Analyze_/plan.txt"
         }
     ],
     "test.test[produce-process_with_assume--Debug]": [
         {
-            "checksum": "9404612eda18dd0929b372f7e0c19f3e",
-            "size": 2871,
-            "uri": "https://{canondata_backend}/1871002/f2b11283e242599ec077764e30c7c497103c2c47/resource.tar.gz#test.test_produce-process_with_assume--Debug_/opt.yql_patched"
+            "checksum": "4ba969e839aefc5a7dd99fbded8d8db8",
+            "size": 2671,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_produce-process_with_assume--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_with_assume--Plan]": [
         {
-            "checksum": "3f29bef99abe4b5924e963f404f353a9",
-            "size": 6497,
-            "uri": "https://{canondata_backend}/1871002/59223ec2dccf492ad5e53d9cbcba19f9bfd55043/resource.tar.gz#test.test_produce-process_with_assume--Plan_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_produce-process_with_assume--Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_with_assume--Results]": [],
@@ -2569,9 +2569,9 @@
     "test.test[produce-reduce_multi_in_difftype--Results]": [],
     "test.test[schema-append_to_desc_with_remap--Analyze]": [
         {
-            "checksum": "00bdcfe49df1d501af25b49a732444f9",
-            "size": 5541,
-            "uri": "https://{canondata_backend}/1946324/47e94ddd58ca9cb41da885e7cdfd25697c2cad44/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Analyze_/plan.txt"
+            "checksum": "4a3615e810a64653f5fe509ef89d2443",
+            "size": 5231,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Analyze_/plan.txt"
         },
         {
             "uri": "file://test.test_schema-append_to_desc_with_remap--Analyze_/extracted"
@@ -2579,16 +2579,16 @@
     ],
     "test.test[schema-append_to_desc_with_remap--Debug]": [
         {
-            "checksum": "f6e082b1570fbd6e7f715529f944d344",
-            "size": 2251,
-            "uri": "https://{canondata_backend}/1871002/f2b11283e242599ec077764e30c7c497103c2c47/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Debug_/opt.yql_patched"
+            "checksum": "b64233ada9e4e6f92e0e0d9a747a3241",
+            "size": 1977,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-append_to_desc_with_remap--Plan]": [
         {
-            "checksum": "00bdcfe49df1d501af25b49a732444f9",
-            "size": 5541,
-            "uri": "https://{canondata_backend}/1847551/90d311c790166a6d9e917addc40539f7bb113779/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Plan_/plan.txt"
+            "checksum": "4a3615e810a64653f5fe509ef89d2443",
+            "size": 5231,
+            "uri": "https://{canondata_backend}/1936273/921006dac2a4100d3f0822b61dc56296f0c6ef83/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Plan_/plan.txt"
         }
     ],
     "test.test[schema-append_to_desc_with_remap--Results]": [

--- a/ydb/library/yql/tests/sql/dq_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part7/canondata/result.json
@@ -1,23 +1,23 @@
 {
     "test.test[action-action_eval_cluster_table--Analyze]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1936947/900ed4b07b3e497bdca6ea0063b227dc2b03c52d/resource.tar.gz#test.test_action-action_eval_cluster_table--Analyze_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_action-action_eval_cluster_table--Analyze_/plan.txt"
         }
     ],
     "test.test[action-action_eval_cluster_table--Debug]": [
         {
-            "checksum": "d6111c7c93c258e0e77f5c5e30170108",
-            "size": 2650,
-            "uri": "https://{canondata_backend}/1942100/681b12141420eba184a0557376121d518d52c23b/resource.tar.gz#test.test_action-action_eval_cluster_table--Debug_/opt.yql_patched"
+            "checksum": "9fe2a3d01ad53c9d0396e90a6ad8fa9d",
+            "size": 2433,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_action-action_eval_cluster_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-action_eval_cluster_table--Plan]": [
         {
-            "checksum": "2b9bcfc32f1f6673d10295f6fe17f12d",
-            "size": 6504,
-            "uri": "https://{canondata_backend}/1936947/900ed4b07b3e497bdca6ea0063b227dc2b03c52d/resource.tar.gz#test.test_action-action_eval_cluster_table--Plan_/plan.txt"
+            "checksum": "4f1be07e94fcf0a8c67e043e37e0b610",
+            "size": 6194,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_action-action_eval_cluster_table--Plan_/plan.txt"
         }
     ],
     "test.test[action-action_eval_cluster_table--Results]": [],
@@ -612,38 +612,38 @@
     ],
     "test.test[column_order-insert--Debug]": [
         {
-            "checksum": "bd9be303c1c6b227ac287770c56fc6cc",
-            "size": 7372,
-            "uri": "https://{canondata_backend}/212715/7330261df3fff15f3668f75005d797e388f41e2f/resource.tar.gz#test.test_column_order-insert--Debug_/opt.yql_patched"
+            "checksum": "edda1b9928d438d37a5703aa657bfd89",
+            "size": 7460,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_column_order-insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert--Plan]": [
         {
-            "checksum": "a2437b27f8ac92558dd9c27ec28fd493",
-            "size": 25492,
-            "uri": "https://{canondata_backend}/1937367/24a3ed09a524cab36402a50f39546eeec677142d/resource.tar.gz#test.test_column_order-insert--Plan_/plan.txt"
+            "checksum": "ae65acc5151643704f3410a78205f803",
+            "size": 25602,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_column_order-insert--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert--Results]": [],
     "test.test[column_order-insert_with_new_cols--Analyze]": [
         {
-            "checksum": "18651caec05683a84c42e574fbed8c80",
-            "size": 5446,
-            "uri": "https://{canondata_backend}/1936273/8b81b6cb59f6a92df19d5bd6d41b3d3cbc71f8b5/resource.tar.gz#test.test_column_order-insert_with_new_cols--Analyze_/plan.txt"
+            "checksum": "55718bbd272a7587511ba76808cbdd7d",
+            "size": 5240,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_column_order-insert_with_new_cols--Analyze_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_new_cols--Debug]": [
         {
-            "checksum": "b20139b87feff3346e0fb7af2e42b620",
-            "size": 3842,
-            "uri": "https://{canondata_backend}/1936273/8b81b6cb59f6a92df19d5bd6d41b3d3cbc71f8b5/resource.tar.gz#test.test_column_order-insert_with_new_cols--Debug_/opt.yql_patched"
+            "checksum": "560e4e81501c0ff133b7c6d8c0e98c37",
+            "size": 3699,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_column_order-insert_with_new_cols--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_with_new_cols--Plan]": [
         {
-            "checksum": "18651caec05683a84c42e574fbed8c80",
-            "size": 5446,
-            "uri": "https://{canondata_backend}/1936273/8b81b6cb59f6a92df19d5bd6d41b3d3cbc71f8b5/resource.tar.gz#test.test_column_order-insert_with_new_cols--Plan_/plan.txt"
+            "checksum": "55718bbd272a7587511ba76808cbdd7d",
+            "size": 5240,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_column_order-insert_with_new_cols--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_new_cols--Results]": [],
@@ -1134,38 +1134,38 @@
     ],
     "test.test[insert-anonymous_tables-default.txt-Debug]": [
         {
-            "checksum": "45bf1b5d249bf78ca88a05825c255f45",
-            "size": 5377,
-            "uri": "https://{canondata_backend}/1600758/8cab8973f2ea39497a139c994f146f17f194bc88/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1938378586a16126f401f0bb1abf9ada",
+            "size": 5251,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-anonymous_tables-default.txt-Plan]": [
         {
-            "checksum": "6d497bde1abf903f32789c0e9340367d",
-            "size": 17137,
-            "uri": "https://{canondata_backend}/1936997/7795d91e16dc8934afb9cac9de729a7e77d64422/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Plan_/plan.txt"
+            "checksum": "24247b28e1082ca5930d994c7bdca4e3",
+            "size": 16931,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-anonymous_tables-default.txt-Results]": [],
     "test.test[insert-drop_sortness-desc-Analyze]": [
         {
-            "checksum": "e5cf2bf4ba28552757409e4cdcdffe3f",
-            "size": 4755,
-            "uri": "https://{canondata_backend}/1936947/900ed4b07b3e497bdca6ea0063b227dc2b03c52d/resource.tar.gz#test.test_insert-drop_sortness-desc-Analyze_/plan.txt"
+            "checksum": "b1353c270797db22c5efc7ceef1d6a90",
+            "size": 4549,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_insert-drop_sortness-desc-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness-desc-Debug]": [
         {
-            "checksum": "fd1c33c26c75c7b1ba2cd5e24634c8b9",
-            "size": 2025,
-            "uri": "https://{canondata_backend}/212715/7330261df3fff15f3668f75005d797e388f41e2f/resource.tar.gz#test.test_insert-drop_sortness-desc-Debug_/opt.yql_patched"
+            "checksum": "70418c6d513ee3ae084fdb3a2172c97d",
+            "size": 1961,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_insert-drop_sortness-desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-drop_sortness-desc-Plan]": [
         {
-            "checksum": "e5cf2bf4ba28552757409e4cdcdffe3f",
-            "size": 4755,
-            "uri": "https://{canondata_backend}/1936947/900ed4b07b3e497bdca6ea0063b227dc2b03c52d/resource.tar.gz#test.test_insert-drop_sortness-desc-Plan_/plan.txt"
+            "checksum": "b1353c270797db22c5efc7ceef1d6a90",
+            "size": 4549,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_insert-drop_sortness-desc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness-desc-Results]": [],
@@ -1577,16 +1577,16 @@
     ],
     "test.test[join-premap_merge_with_remap--Debug]": [
         {
-            "checksum": "db3f90a29627a475fd9957c3a55944cc",
-            "size": 7180,
-            "uri": "https://{canondata_backend}/1936273/b293975a7642b91c5614f8db12d1bd08a0069400/resource.tar.gz#test.test_join-premap_merge_with_remap--Debug_/opt.yql_patched"
+            "checksum": "9be7ad58af469769cd7b0b9a947a25a9",
+            "size": 6891,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_join-premap_merge_with_remap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_merge_with_remap--Plan]": [
         {
-            "checksum": "d21966f7bee5e5ae1f4707351818e350",
-            "size": 14310,
-            "uri": "https://{canondata_backend}/1900335/6da4e798745eb2a68f5231cd7d5c7f35ec91c905/resource.tar.gz#test.test_join-premap_merge_with_remap--Plan_/plan.txt"
+            "checksum": "6711cd74dbdeb696f5780786f53441e5",
+            "size": 14007,
+            "uri": "https://{canondata_backend}/1881367/ee39bf74f87a4d157fac936390f8e3e30882b7ef/resource.tar.gz#test.test_join-premap_merge_with_remap--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_merge_with_remap--Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part8/canondata/result.json
@@ -55,16 +55,16 @@
     ],
     "test.test[action-parallel_for-default.txt-Debug]": [
         {
-            "checksum": "f5d7262171affa62948c210a0f3d26d2",
-            "size": 3380,
-            "uri": "https://{canondata_backend}/1889210/290b4f93cd73f51c3c423aad96ed153cfafde858/resource.tar.gz#test.test_action-parallel_for-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7142e5c133b3bb9bd688f42569254796",
+            "size": 3251,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_action-parallel_for-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-parallel_for-default.txt-Plan]": [
         {
-            "checksum": "176505fecb28d925e064bf4600e43af0",
-            "size": 14153,
-            "uri": "https://{canondata_backend}/1889210/290b4f93cd73f51c3c423aad96ed153cfafde858/resource.tar.gz#test.test_action-parallel_for-default.txt-Plan_/plan.txt"
+            "checksum": "340f009aabba53bdd5bd4339347afccd",
+            "size": 13850,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_action-parallel_for-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-parallel_for-default.txt-Results]": [],
@@ -568,45 +568,45 @@
     "test.test[bigdate-int_literals-default.txt-Results]": [],
     "test.test[bigdate-tz_table_rw--Analyze]": [
         {
-            "checksum": "d5aa7a172af52da596dbcd52e2e9265b",
-            "size": 4907,
-            "uri": "https://{canondata_backend}/1847551/64ea763599113186da9b7cad1e7ab323b87b6968/resource.tar.gz#test.test_bigdate-tz_table_rw--Analyze_/plan.txt"
+            "checksum": "16b91e1c9fcda6d880a02448dad1dcf9",
+            "size": 4701,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_bigdate-tz_table_rw--Analyze_/plan.txt"
         }
     ],
     "test.test[bigdate-tz_table_rw--Debug]": [
         {
-            "checksum": "743dab3c96aa6797c6867eaf34c282d6",
-            "size": 2481,
-            "uri": "https://{canondata_backend}/1847551/64ea763599113186da9b7cad1e7ab323b87b6968/resource.tar.gz#test.test_bigdate-tz_table_rw--Debug_/opt.yql_patched"
+            "checksum": "edc205134f5c91181a189c2ba025c6e4",
+            "size": 2339,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_bigdate-tz_table_rw--Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-tz_table_rw--Plan]": [
         {
-            "checksum": "d5aa7a172af52da596dbcd52e2e9265b",
-            "size": 4907,
-            "uri": "https://{canondata_backend}/1847551/64ea763599113186da9b7cad1e7ab323b87b6968/resource.tar.gz#test.test_bigdate-tz_table_rw--Plan_/plan.txt"
+            "checksum": "16b91e1c9fcda6d880a02448dad1dcf9",
+            "size": 4701,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_bigdate-tz_table_rw--Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-tz_table_rw--Results]": [],
     "test.test[binding-insert_binding--Analyze]": [
         {
-            "checksum": "a2826ccf09ac27be05034998a205455d",
-            "size": 6665,
-            "uri": "https://{canondata_backend}/212715/05112758aa31c86216a47b30fa10eee1e52db258/resource.tar.gz#test.test_binding-insert_binding--Analyze_/plan.txt"
+            "checksum": "e8cdc2c1074beaca4fc6deb4aea0baf0",
+            "size": 6459,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_binding-insert_binding--Analyze_/plan.txt"
         }
     ],
     "test.test[binding-insert_binding--Debug]": [
         {
-            "checksum": "ab8854182d215af7a344a489c14a1118",
-            "size": 2900,
-            "uri": "https://{canondata_backend}/937458/8cf48c219a2939bf3e0b54c55a5f53cb19e8be63/resource.tar.gz#test.test_binding-insert_binding--Debug_/opt.yql_patched"
+            "checksum": "1cda8005e41081746cee4da9d4c10abe",
+            "size": 2834,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_binding-insert_binding--Debug_/opt.yql_patched"
         }
     ],
     "test.test[binding-insert_binding--Plan]": [
         {
-            "checksum": "a2826ccf09ac27be05034998a205455d",
-            "size": 6665,
-            "uri": "https://{canondata_backend}/1937429/21da85bae1b4363f9d35ac14bdb3122767615cb5/resource.tar.gz#test.test_binding-insert_binding--Plan_/plan.txt"
+            "checksum": "e8cdc2c1074beaca4fc6deb4aea0baf0",
+            "size": 6459,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_binding-insert_binding--Plan_/plan.txt"
         }
     ],
     "test.test[binding-insert_binding--Results]": [],
@@ -871,16 +871,16 @@
     ],
     "test.test[column_order-align_publish--Debug]": [
         {
-            "checksum": "62547fa2acb1e97497fed6722c7f8a57",
-            "size": 3472,
-            "uri": "https://{canondata_backend}/1599023/ec28b7e0cb376a1e45f470b7991522c343aa2f7e/resource.tar.gz#test.test_column_order-align_publish--Debug_/opt.yql_patched"
+            "checksum": "6af2f9ea1559d1680cdca92cfe24028d",
+            "size": 3270,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_column_order-align_publish--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-align_publish--Plan]": [
         {
-            "checksum": "144bb0d56f4dbf00a669b5cb7133716d",
-            "size": 10915,
-            "uri": "https://{canondata_backend}/1937001/96df220872bbb62db85fbbf2896ad6c42e1ea831/resource.tar.gz#test.test_column_order-align_publish--Plan_/plan.txt"
+            "checksum": "d92fd994e03bdd3810d07f08d8682188",
+            "size": 10605,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_column_order-align_publish--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-align_publish--Results]": [],
@@ -1455,45 +1455,45 @@
     ],
     "test.test[insert-override-from_sorted_calc-Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1946324/c7905148ccc6742256ee4a209186276ffdcd07ac/resource.tar.gz#test.test_insert-override-from_sorted_calc-Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_insert-override-from_sorted_calc-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted_calc-Debug]": [
         {
-            "checksum": "28052cfe558e5c380049374cb9ce23a0",
-            "size": 2084,
-            "uri": "https://{canondata_backend}/212715/35bf2a37bee330f63cec410540910308a006c774/resource.tar.gz#test.test_insert-override-from_sorted_calc-Debug_/opt.yql_patched"
+            "checksum": "d780a0f27970d6e3016331395b93a695",
+            "size": 1961,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_insert-override-from_sorted_calc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-from_sorted_calc-Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1946324/c7905148ccc6742256ee4a209186276ffdcd07ac/resource.tar.gz#test.test_insert-override-from_sorted_calc-Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_insert-override-from_sorted_calc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted_calc-Results]": [],
     "test.test[insert-override-from_sorted_desc-Analyze]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1946324/c7905148ccc6742256ee4a209186276ffdcd07ac/resource.tar.gz#test.test_insert-override-from_sorted_desc-Analyze_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_insert-override-from_sorted_desc-Analyze_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted_desc-Debug]": [
         {
-            "checksum": "3036de3c7f8ac90817c5031dc11d01a7",
-            "size": 2113,
-            "uri": "https://{canondata_backend}/212715/35bf2a37bee330f63cec410540910308a006c774/resource.tar.gz#test.test_insert-override-from_sorted_desc-Debug_/opt.yql_patched"
+            "checksum": "07c4e7b5168251a37fd5cf543ec78a27",
+            "size": 1990,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_insert-override-from_sorted_desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-from_sorted_desc-Plan]": [
         {
-            "checksum": "ccd242cd805d76e67cc1a8e59179ec61",
-            "size": 4812,
-            "uri": "https://{canondata_backend}/1946324/c7905148ccc6742256ee4a209186276ffdcd07ac/resource.tar.gz#test.test_insert-override-from_sorted_desc-Plan_/plan.txt"
+            "checksum": "7c15476df0f24d9e76fea49d51a91954",
+            "size": 4606,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_insert-override-from_sorted_desc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted_desc-Results]": [],
@@ -2120,16 +2120,16 @@
     ],
     "test.test[optimizers-passthrough_sortness_over_map-default.txt-Debug]": [
         {
-            "checksum": "8a63419e3ac30ad5a0b8cb3ffc506cd2",
-            "size": 7094,
-            "uri": "https://{canondata_backend}/1777230/65685e9d54d416f54450defb84f83fe3b04456b0/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3c31a9a19e1d2f1df1f32595e10e9e31",
+            "size": 6614,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-passthrough_sortness_over_map-default.txt-Plan]": [
         {
-            "checksum": "2d849cfcecebc879171301f23762bca9",
-            "size": 23728,
-            "uri": "https://{canondata_backend}/1871102/fc5ed8103fd812712bf2a97977898a961a27156e/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Plan_/plan.txt"
+            "checksum": "4e478e83115716c4318f26d92c2b3053",
+            "size": 23013,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-passthrough_sortness_over_map-default.txt-Results]": [],
@@ -2744,16 +2744,16 @@
     ],
     "test.test[schema-insert-read_schema-Debug]": [
         {
-            "checksum": "2b177fb7b9f7696004ed6abe3e87fba3",
-            "size": 2980,
-            "uri": "https://{canondata_backend}/1777230/65685e9d54d416f54450defb84f83fe3b04456b0/resource.tar.gz#test.test_schema-insert-read_schema-Debug_/opt.yql_patched"
+            "checksum": "068ca707104a7f60afc8740d16bd2569",
+            "size": 2814,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_schema-insert-read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert-read_schema-Plan]": [
         {
-            "checksum": "6d2666bfe7a154a87a5f88de868962b3",
-            "size": 8313,
-            "uri": "https://{canondata_backend}/1942278/fa8d61d23d54178691359d36c79c3aeb38e8d3a9/resource.tar.gz#test.test_schema-insert-read_schema-Plan_/plan.txt"
+            "checksum": "191d447641f8d810de80b5d56e4a5271",
+            "size": 8107,
+            "uri": "https://{canondata_backend}/1881367/e42a6d3bf5f7cfd5174c33ae18a047e043b3972e/resource.tar.gz#test.test_schema-insert-read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert-read_schema-Results]": [],

--- a/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part9/canondata/result.json
@@ -601,23 +601,23 @@
     "test.test[case-case_then_else-default.txt-Results]": [],
     "test.test[column_order-ordered_plus_native--Analyze]": [
         {
-            "checksum": "60b979d2ae5fec69190a4ea74c2fdef4",
-            "size": 5726,
-            "uri": "https://{canondata_backend}/1899731/f13813265d02f2bab07ec1fa74995b07aef66427/resource.tar.gz#test.test_column_order-ordered_plus_native--Analyze_/plan.txt"
+            "checksum": "e462df23755dc060535e8da0978d851a",
+            "size": 5520,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_column_order-ordered_plus_native--Analyze_/plan.txt"
         }
     ],
     "test.test[column_order-ordered_plus_native--Debug]": [
         {
-            "checksum": "c57799d560dea4a91a4dd4b851beef63",
-            "size": 3116,
-            "uri": "https://{canondata_backend}/1937367/6f10cbbe8f7236353e26f98539fa9e27ba019196/resource.tar.gz#test.test_column_order-ordered_plus_native--Debug_/opt.yql_patched"
+            "checksum": "7fcac2728a0248036405696772c0ae73",
+            "size": 3017,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_column_order-ordered_plus_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-ordered_plus_native--Plan]": [
         {
-            "checksum": "60b979d2ae5fec69190a4ea74c2fdef4",
-            "size": 5726,
-            "uri": "https://{canondata_backend}/1899731/f13813265d02f2bab07ec1fa74995b07aef66427/resource.tar.gz#test.test_column_order-ordered_plus_native--Plan_/plan.txt"
+            "checksum": "e462df23755dc060535e8da0978d851a",
+            "size": 5520,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_column_order-ordered_plus_native--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-ordered_plus_native--Results]": [],
@@ -743,16 +743,16 @@
     ],
     "test.test[datetime-date_tz_table_sort_asc--Debug]": [
         {
-            "checksum": "8d71d282c7fc123508e7426747148a24",
-            "size": 3292,
-            "uri": "https://{canondata_backend}/1031349/076467d819158b21cec57980925415e6cf3dc8e6/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Debug_/opt.yql_patched"
+            "checksum": "431b75bfd8c7d01e088ef3549a636c0c",
+            "size": 3232,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[datetime-date_tz_table_sort_asc--Plan]": [
         {
-            "checksum": "e2942820480d1b2bd77f99ea46771701",
-            "size": 9558,
-            "uri": "https://{canondata_backend}/1031349/076467d819158b21cec57980925415e6cf3dc8e6/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Plan_/plan.txt"
+            "checksum": "25746c36c0c5a76ab499bb7451dc04f3",
+            "size": 9352,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Plan_/plan.txt"
         }
     ],
     "test.test[datetime-date_tz_table_sort_asc--Results]": [],
@@ -1064,67 +1064,67 @@
     ],
     "test.test[insert-merge_publish--Analyze]": [
         {
-            "checksum": "3c30d96b5141294cdf574c6e35e4997a",
-            "size": 19698,
-            "uri": "https://{canondata_backend}/1936947/4e75efdf8bb6c4502b7bcfedc52bbdf182bdb39c/resource.tar.gz#test.test_insert-merge_publish--Analyze_/plan.txt"
+            "checksum": "ed28bb578fdab3bb4f882441dbe898a9",
+            "size": 18462,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert-merge_publish--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-merge_publish--Debug]": [
         {
-            "checksum": "9beccf35b68ed7460c8134982b6edbb9",
-            "size": 6173,
-            "uri": "https://{canondata_backend}/1775319/51c3a56c67678c3d2a0dc1fc0b8bad4d612addb3/resource.tar.gz#test.test_insert-merge_publish--Debug_/opt.yql_patched"
+            "checksum": "7a875d4b10d595549dddea7cc4902f70",
+            "size": 6006,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert-merge_publish--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-merge_publish--Plan]": [
         {
-            "checksum": "29fe5e9964010c7b19cdcd7edbf76870",
-            "size": 20308,
-            "uri": "https://{canondata_backend}/1936947/4e75efdf8bb6c4502b7bcfedc52bbdf182bdb39c/resource.tar.gz#test.test_insert-merge_publish--Plan_/plan.txt"
+            "checksum": "2a07f8a381f344b4bd93016b6d316cbb",
+            "size": 19072,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert-merge_publish--Plan_/plan.txt"
         }
     ],
     "test.test[insert-merge_publish--Results]": [],
     "test.test[insert-two_input_tables--Analyze]": [
         {
-            "checksum": "7a87722e11c808cfe30fe1dea97fb7ca",
-            "size": 7628,
-            "uri": "https://{canondata_backend}/1847551/3a392ffe35b72cb523557617b3ab1c0abb94bee4/resource.tar.gz#test.test_insert-two_input_tables--Analyze_/plan.txt"
+            "checksum": "ff706697442a4da2373fdbe6734dde63",
+            "size": 7216,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert-two_input_tables--Analyze_/plan.txt"
         }
     ],
     "test.test[insert-two_input_tables--Debug]": [
         {
-            "checksum": "4363fdb925c19f92d7f0b9a525ce1575",
-            "size": 2685,
-            "uri": "https://{canondata_backend}/1775319/51c3a56c67678c3d2a0dc1fc0b8bad4d612addb3/resource.tar.gz#test.test_insert-two_input_tables--Debug_/opt.yql_patched"
+            "checksum": "ff5f03131a3340a017a422fa80b32367",
+            "size": 2534,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert-two_input_tables--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-two_input_tables--Plan]": [
         {
-            "checksum": "f669624284c812480545eea1411891e3",
-            "size": 7750,
-            "uri": "https://{canondata_backend}/1847551/3a392ffe35b72cb523557617b3ab1c0abb94bee4/resource.tar.gz#test.test_insert-two_input_tables--Plan_/plan.txt"
+            "checksum": "9d14f57da0e2c5a7be8cb2d439479fa5",
+            "size": 7338,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert-two_input_tables--Plan_/plan.txt"
         }
     ],
     "test.test[insert-two_input_tables--Results]": [],
     "test.test[insert_monotonic-several2-default.txt-Analyze]": [
         {
-            "checksum": "15cacf72e723df425ee60c462c81514b",
-            "size": 11424,
-            "uri": "https://{canondata_backend}/1925821/8b9754f3dd9865c249cc027cdcc425fcff470d9c/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Analyze_/plan.txt"
+            "checksum": "a455ded4ae4b002da62e0850f225c14b",
+            "size": 10818,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Analyze_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-several2-default.txt-Debug]": [
         {
-            "checksum": "4748af8801d497e8eeab069121f01ccf",
-            "size": 3825,
-            "uri": "https://{canondata_backend}/1775319/51c3a56c67678c3d2a0dc1fc0b8bad4d612addb3/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Debug_/opt.yql_patched"
+            "checksum": "db72b3fd7b1b357efb2258467137403d",
+            "size": 3535,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-several2-default.txt-Plan]": [
         {
-            "checksum": "7cc44339e0b9d45f1f6465c5ccaf8670",
-            "size": 11668,
-            "uri": "https://{canondata_backend}/1925821/8b9754f3dd9865c249cc027cdcc425fcff470d9c/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Plan_/plan.txt"
+            "checksum": "503315fdbe5c4908ded36416059a24f8",
+            "size": 11062,
+            "uri": "https://{canondata_backend}/1925821/e6400c81a69303c23d02b835c07822136f1644aa/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-several2-default.txt-Results]": [],

--- a/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part0/canondata/result.json
@@ -43,30 +43,30 @@
     ],
     "test.test[action-eval_sample--Debug]": [
         {
-            "checksum": "53df25c6b35748481a12324ad6841bb9",
-            "size": 1774,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_action-eval_sample--Debug_/opt.yql_patched"
+            "checksum": "df6e10bf7f65292e47b7b23012a7337d",
+            "size": 1651,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_action-eval_sample--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_sample--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_action-eval_sample--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_action-eval_sample--Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_values_output_table_subquery--Debug]": [
         {
-            "checksum": "5539f6e9e41730947cad445324fdc4bc",
-            "size": 1444,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_action-eval_values_output_table_subquery--Debug_/opt.yql_patched"
+            "checksum": "4ae900763f78c2474095f79afd0867da",
+            "size": 1297,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_action-eval_values_output_table_subquery--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_values_output_table_subquery--Plan]": [
         {
-            "checksum": "cfd299a8d7555c1c3002c9d22008a032",
-            "size": 4189,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_action-eval_values_output_table_subquery--Plan_/plan.txt"
+            "checksum": "3f6bda8da975cd0d0a51b642b8a14894",
+            "size": 3983,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_action-eval_values_output_table_subquery--Plan_/plan.txt"
         }
     ],
     "test.test[action-runtime_repr_code-default.txt-Debug]": [
@@ -169,86 +169,86 @@
     ],
     "test.test[aggr_factory-hll-default.txt-Debug]": [
         {
-            "checksum": "419c40519a1fcdac01dfa93aa653ee65",
-            "size": 8912,
-            "uri": "https://{canondata_backend}/1817427/0f9f31d9f1b7cb672f07dbd4f2c3505d34646c46/resource.tar.gz#test.test_aggr_factory-hll-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e8e017f85a93d40342acb104190c6481",
+            "size": 8813,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggr_factory-hll-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-hll-default.txt-Plan]": [
         {
-            "checksum": "d879d3b8a1ff3e323428ea3c933de406",
-            "size": 13735,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggr_factory-hll-default.txt-Plan_/plan.txt"
+            "checksum": "47fa3f0bf52d23bc83926ebbf299bc5c",
+            "size": 13323,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggr_factory-hll-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-sum_if-default.txt-Debug]": [
         {
-            "checksum": "8ae84a334c3e189f1ce1f74b1ed50395",
-            "size": 4911,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_aggr_factory-sum_if-default.txt-Debug_/opt.yql_patched"
+            "checksum": "22af57a5d0b634bbb6a09604b1b92d16",
+            "size": 4783,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggr_factory-sum_if-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-sum_if-default.txt-Plan]": [
         {
-            "checksum": "5a5b036ed1b8a4abcc5d40732d503252",
-            "size": 9932,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggr_factory-sum_if-default.txt-Plan_/plan.txt"
+            "checksum": "68a84361029bbf9051fcd80d023b673c",
+            "size": 9520,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggr_factory-sum_if-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-agg_filter_pushdown--Debug]": [
         {
-            "checksum": "f98a27694c89d3313494be92b0881394",
-            "size": 6076,
-            "uri": "https://{canondata_backend}/1784826/b75bc7a39416a98d42669626d9908406d40f5689/resource.tar.gz#test.test_aggregate-agg_filter_pushdown--Debug_/opt.yql_patched"
+            "checksum": "880393a1f02de6e97b93e2bca1f356e2",
+            "size": 5675,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-agg_filter_pushdown--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-agg_filter_pushdown--Plan]": [
         {
-            "checksum": "df39d69d33f20580187528cd1c945725",
-            "size": 8584,
-            "uri": "https://{canondata_backend}/1916746/c3497ca6eb01621704698070e992d6ec57dccaaf/resource.tar.gz#test.test_aggregate-agg_filter_pushdown--Plan_/plan.txt"
+            "checksum": "32e816388db081ec42e7f951c42b4c18",
+            "size": 7966,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-agg_filter_pushdown--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-agg_phases_table2-default.txt-Debug]": [
         {
-            "checksum": "08d06ff1731d274f5848c4765ca33de7",
-            "size": 6327,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_aggregate-agg_phases_table2-default.txt-Debug_/opt.yql_patched"
+            "checksum": "03b1899eca31c361b32d51f9afbbb9ff",
+            "size": 5901,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-agg_phases_table2-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-agg_phases_table2-default.txt-Plan]": [
         {
-            "checksum": "901405efb0d754ec35f3666078665a66",
-            "size": 10822,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-agg_phases_table2-default.txt-Plan_/plan.txt"
+            "checksum": "03fbd156c8916aaf07fd6094429c7a6d",
+            "size": 9998,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-agg_phases_table2-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_by_column_lookup_in_const_dict-default.txt-Debug]": [
         {
-            "checksum": "a7f537133072dc678d2d7076afc0e69c",
-            "size": 4546,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_aggregate-aggregate_by_column_lookup_in_const_dict-default.txt-Debug_/opt.yql_patched"
+            "checksum": "14ed6fd65d77ea208477a4f1062cb145",
+            "size": 4362,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-aggregate_by_column_lookup_in_const_dict-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_by_column_lookup_in_const_dict-default.txt-Plan]": [
         {
-            "checksum": "5b34466f9dea236e8ef55862f24fbbe9",
-            "size": 8525,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-aggregate_by_column_lookup_in_const_dict-default.txt-Plan_/plan.txt"
+            "checksum": "56e5fa0b7e6c6bee32c075c3d9156004",
+            "size": 7907,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-aggregate_by_column_lookup_in_const_dict-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_distinct_expr-default.txt-Debug]": [
         {
-            "checksum": "eaa262371479fa7cf657b575a7015653",
-            "size": 11032,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "263f53bc75e9c965f3cb1edfef047602",
+            "size": 10836,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_distinct_expr-default.txt-Plan]": [
         {
-            "checksum": "0e47f62d3f38ccac89be36773ebf4bdd",
-            "size": 13272,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr-default.txt-Plan_/plan.txt"
+            "checksum": "d1fd249d76f1712885a42aa311203b76",
+            "size": 12654,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-compare_by_nulls-default.txt-Debug]": [
@@ -267,128 +267,128 @@
     ],
     "test.test[aggregate-group_by_expr_alias_on_subexp--Debug]": [
         {
-            "checksum": "337e3cc3a6ba79fdf39f7b690a88aa59",
-            "size": 5590,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_aggregate-group_by_expr_alias_on_subexp--Debug_/opt.yql_patched"
+            "checksum": "63e7a0e56b5087c1b8deb715ce480d73",
+            "size": 5234,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_expr_alias_on_subexp--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_alias_on_subexp--Plan]": [
         {
-            "checksum": "df39d69d33f20580187528cd1c945725",
-            "size": 8584,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-group_by_expr_alias_on_subexp--Plan_/plan.txt"
+            "checksum": "32e816388db081ec42e7f951c42b4c18",
+            "size": 7966,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_expr_alias_on_subexp--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_and_having--Debug]": [
         {
-            "checksum": "d956bf7f394c5d2cf061fc34cc02401e",
-            "size": 4378,
-            "uri": "https://{canondata_backend}/1871102/bc396b8b31a3dc31af3e0918ca66137d03d31eff/resource.tar.gz#test.test_aggregate-group_by_expr_and_having--Debug_/opt.yql_patched"
+            "checksum": "815a4bafb309dfe0d98a8d8ac79a191e",
+            "size": 4153,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_expr_and_having--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_and_having--Plan]": [
         {
-            "checksum": "001bec05c7a3849ee94d95855bf1c58b",
-            "size": 6317,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-group_by_expr_and_having--Plan_/plan.txt"
+            "checksum": "c3e8bc192cad51479d696aa073fcf05f",
+            "size": 5905,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_expr_and_having--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_with_join--Debug]": [
         {
-            "checksum": "2fb4d8cc1f1efcf361adaf2955505b58",
-            "size": 6246,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_aggregate-group_by_expr_with_join--Debug_/opt.yql_patched"
+            "checksum": "b611595966c2704177e60e018418b229",
+            "size": 6039,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_expr_with_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_with_join--Plan]": [
         {
-            "checksum": "9b11ef3740e3fde53ee91771db75c1c2",
-            "size": 10102,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-group_by_expr_with_join--Plan_/plan.txt"
+            "checksum": "2935bebc09572862c2edf65604678173",
+            "size": 9690,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_expr_with_join--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_full_path-default.txt-Debug]": [
         {
-            "checksum": "73740cdcc07180a62c8b8580793639ba",
-            "size": 4221,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_aggregate-group_by_full_path-default.txt-Debug_/opt.yql_patched"
+            "checksum": "fe26bad2be3064952238d475c54649c6",
+            "size": 4049,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_full_path-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_full_path-default.txt-Plan]": [
         {
-            "checksum": "9f8c71906761e989364e99ab2dae0fd3",
-            "size": 8427,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-group_by_full_path-default.txt-Plan_/plan.txt"
+            "checksum": "2410a08c170367afac13d98218da0473",
+            "size": 7809,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_full_path-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_mul_gs_expr_and_column--Debug]": [
         {
-            "checksum": "09b225541346979269ecad738602049b",
-            "size": 8296,
-            "uri": "https://{canondata_backend}/1689644/18aea5c3a0447215049c64a3fe8baabe8432318a/resource.tar.gz#test.test_aggregate-group_by_mul_gs_expr_and_column--Debug_/opt.yql_patched"
+            "checksum": "4ecf7e1fcf1a36f4bcf062f03070fd89",
+            "size": 7727,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_mul_gs_expr_and_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_mul_gs_expr_and_column--Plan]": [
         {
-            "checksum": "238488f45198e02104d3782f4d5cea4c",
-            "size": 11311,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-group_by_mul_gs_expr_and_column--Plan_/plan.txt"
+            "checksum": "ed7cc280281a78c191c4638167f32a0e",
+            "size": 10693,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_mul_gs_expr_and_column--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_mul_ru_ru--Debug]": [
         {
-            "checksum": "bd47e70529abc0ffa3e183fb35724d91",
-            "size": 25752,
-            "uri": "https://{canondata_backend}/1784826/005fe8649f704b944d36818e25abae394c77449c/resource.tar.gz#test.test_aggregate-group_by_mul_ru_ru--Debug_/opt.yql_patched"
+            "checksum": "9d57d7dd0d29c7a1ef4dff0ead2824ca",
+            "size": 23745,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_mul_ru_ru--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_mul_ru_ru--Plan]": [
         {
-            "checksum": "fdafa6be523d56e8707e27d131a7781d",
-            "size": 32204,
-            "uri": "https://{canondata_backend}/1784826/005fe8649f704b944d36818e25abae394c77449c/resource.tar.gz#test.test_aggregate-group_by_mul_ru_ru--Plan_/plan.txt"
+            "checksum": "2947130d6ef3de1c3cae994bfe408790",
+            "size": 29938,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_mul_ru_ru--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_column_ref--Debug]": [
         {
-            "checksum": "07164faa8b951b79f758ea8d5e92b809",
-            "size": 9272,
-            "uri": "https://{canondata_backend}/1871102/bc396b8b31a3dc31af3e0918ca66137d03d31eff/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref--Debug_/opt.yql_patched"
+            "checksum": "a22bd41198d271f342632c80ebd1d00e",
+            "size": 8628,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_column_ref--Plan]": [
         {
-            "checksum": "871a11c56cbd17553e0ce6567b87fb96",
-            "size": 14650,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref--Plan_/plan.txt"
+            "checksum": "6266271dc8c3771ab9ab4cb9f307e435",
+            "size": 13620,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_with_select_distinct--Debug]": [
         {
-            "checksum": "fad237150eb75750a8594c8efe0fe27a",
-            "size": 8476,
-            "uri": "https://{canondata_backend}/1925842/84e93710d3cca32fd387e92f5cdc278b7b0c2248/resource.tar.gz#test.test_aggregate-group_by_ru_with_select_distinct--Debug_/opt.yql_patched"
+            "checksum": "2650e34ae22c12ce5dee0f23f224ed03",
+            "size": 8212,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_ru_with_select_distinct--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_with_select_distinct--Plan]": [
         {
-            "checksum": "26ad50c6e5207bd4817a0a7836b6743e",
-            "size": 18301,
-            "uri": "https://{canondata_backend}/1925842/84e93710d3cca32fd387e92f5cdc278b7b0c2248/resource.tar.gz#test.test_aggregate-group_by_ru_with_select_distinct--Plan_/plan.txt"
+            "checksum": "09ac0dae6d00d77385a9e9af5917bfa2",
+            "size": 17065,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_ru_with_select_distinct--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_tablerow_column--Debug]": [
         {
-            "checksum": "6694c742c3514cfe8d10be1a86fe5abe",
-            "size": 4214,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_aggregate-group_by_tablerow_column--Debug_/opt.yql_patched"
+            "checksum": "f5dda8b14d581663131a06311ab3e413",
+            "size": 4054,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_tablerow_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_tablerow_column--Plan]": [
         {
-            "checksum": "5b34466f9dea236e8ef55862f24fbbe9",
-            "size": 8525,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_aggregate-group_by_tablerow_column--Plan_/plan.txt"
+            "checksum": "56e5fa0b7e6c6bee32c075c3d9156004",
+            "size": 7907,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_aggregate-group_by_tablerow_column--Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-bitcast_interval64-default.txt-Debug]": [
@@ -421,16 +421,16 @@
     ],
     "test.test[bigdate-tz_table_fill--Debug]": [
         {
-            "checksum": "cac9a3b70ea348bcc8bc4442f0944b2a",
-            "size": 1728,
-            "uri": "https://{canondata_backend}/1781765/b01c2f55734719b317a72d0cf115a1f45a1cd60a/resource.tar.gz#test.test_bigdate-tz_table_fill--Debug_/opt.yql_patched"
+            "checksum": "cebdfe37ec22e94e4d513234bf1cae83",
+            "size": 1590,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_bigdate-tz_table_fill--Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-tz_table_fill--Plan]": [
         {
-            "checksum": "c02eec4057ce149596021b60ef2b3243",
-            "size": 5166,
-            "uri": "https://{canondata_backend}/1781765/b01c2f55734719b317a72d0cf115a1f45a1cd60a/resource.tar.gz#test.test_bigdate-tz_table_fill--Plan_/plan.txt"
+            "checksum": "6a8580653fb158ef4e951b9a4c26cc4c",
+            "size": 4960,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_bigdate-tz_table_fill--Plan_/plan.txt"
         }
     ],
     "test.test[binding-named_callable-default.txt-Debug]": [
@@ -477,86 +477,86 @@
     ],
     "test.test[blocks-combine_all_avg_filter_opt--Debug]": [
         {
-            "checksum": "bc080cc163092e680387ff8a085d138d",
-            "size": 3695,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-combine_all_avg_filter_opt--Debug_/opt.yql_patched"
+            "checksum": "f619f59258f825401fc868f601a464cb",
+            "size": 3628,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-combine_all_avg_filter_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_avg_filter_opt--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-combine_all_avg_filter_opt--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-combine_all_avg_filter_opt--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_count--Debug]": [
         {
-            "checksum": "5fdf22d12bccc57eaf717b8dc5591ecd",
-            "size": 4875,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-combine_all_count--Debug_/opt.yql_patched"
+            "checksum": "0a5cc3adcd7f76b55ea223a9204df4e9",
+            "size": 4692,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-combine_all_count--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_count--Plan]": [
         {
-            "checksum": "16c8e05f1b7597af07188b30158e0406",
-            "size": 5489,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-combine_all_count--Plan_/plan.txt"
+            "checksum": "f7a478d08cf8e151091461b03050e010",
+            "size": 5283,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-combine_all_count--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_greater_or_equal--Debug]": [
         {
-            "checksum": "e5b293e3d942a80dc5a6facd0c6110bd",
-            "size": 28171,
-            "uri": "https://{canondata_backend}/1942100/e7574592fb0a25d803789da2e47df9cee0be4808/resource.tar.gz#test.test_blocks-date_greater_or_equal--Debug_/opt.yql_patched"
+            "checksum": "f92fb423ba704f3e2f6f8f33e3e62f64",
+            "size": 24221,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-date_greater_or_equal--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_greater_or_equal--Plan]": [
         {
-            "checksum": "fe66d03c15b37a053205c1b23150a020",
-            "size": 15887,
-            "uri": "https://{canondata_backend}/1942100/e7574592fb0a25d803789da2e47df9cee0be4808/resource.tar.gz#test.test_blocks-date_greater_or_equal--Plan_/plan.txt"
+            "checksum": "e0b70c711bba0b9a8af7293607a6483c",
+            "size": 15475,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-date_greater_or_equal--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_not_equals_scalar--Debug]": [
         {
-            "checksum": "0040e09046bb0a1c43356154405fc19e",
-            "size": 20617,
-            "uri": "https://{canondata_backend}/1942100/e7574592fb0a25d803789da2e47df9cee0be4808/resource.tar.gz#test.test_blocks-date_not_equals_scalar--Debug_/opt.yql_patched"
+            "checksum": "9b03751714363beccf31f3f86df860d4",
+            "size": 16714,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-date_not_equals_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_not_equals_scalar--Plan]": [
         {
-            "checksum": "c2c59fe5fff4e9bf9c6c6a1c9640b948",
-            "size": 8788,
-            "uri": "https://{canondata_backend}/1942100/e7574592fb0a25d803789da2e47df9cee0be4808/resource.tar.gz#test.test_blocks-date_not_equals_scalar--Plan_/plan.txt"
+            "checksum": "222ba369728bb74934ed71281f423a9c",
+            "size": 8376,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-date_not_equals_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-div_uint64_opt2--Debug]": [
         {
-            "checksum": "1ecc3b5e6444ee9852168aaed8b2d856",
-            "size": 2295,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-div_uint64_opt2--Debug_/opt.yql_patched"
+            "checksum": "802d5e1b2a2259104fff4d949a5b2c94",
+            "size": 2165,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-div_uint64_opt2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-div_uint64_opt2--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-div_uint64_opt2--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-div_uint64_opt2--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-filter_direct_col--Debug]": [
         {
-            "checksum": "50de2216792375224468f808fbb2f906",
-            "size": 2846,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-filter_direct_col--Debug_/opt.yql_patched"
+            "checksum": "839f1b1f8bef2db764eeafffe36fdec8",
+            "size": 2600,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-filter_direct_col--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-filter_direct_col--Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-filter_direct_col--Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-filter_direct_col--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_div_scalar--Debug]": [
@@ -589,86 +589,86 @@
     ],
     "test.test[blocks-mul_uint64_opt2--Debug]": [
         {
-            "checksum": "2edc87987d3c68b10ee126d4c613f0b4",
-            "size": 2296,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-mul_uint64_opt2--Debug_/opt.yql_patched"
+            "checksum": "51dd3f8013311015b8b8bf7e2a0856e0",
+            "size": 2166,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-mul_uint64_opt2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-mul_uint64_opt2--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-mul_uint64_opt2--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-mul_uint64_opt2--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-string_with--Debug]": [
         {
-            "checksum": "c1e081e2588f1434488f4d51a220a92b",
-            "size": 5040,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-string_with--Debug_/opt.yql_patched"
+            "checksum": "b5fdd92b742519540f867b2e322107d0",
+            "size": 4402,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-string_with--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-string_with--Plan]": [
         {
-            "checksum": "441473944c28a9fdbd7ce1af70eb021b",
-            "size": 6233,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-string_with--Plan_/plan.txt"
+            "checksum": "abb862fdcf4a685b46c0f44e5ed5874d",
+            "size": 5821,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-string_with--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-top_sort_one_desc--Debug]": [
         {
-            "checksum": "7c29e08d034fc86af4db70656c839df5",
-            "size": 3260,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-top_sort_one_desc--Debug_/opt.yql_patched"
+            "checksum": "3c9545e49cd5c136f68ad9732364300b",
+            "size": 3052,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-top_sort_one_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-top_sort_one_desc--Plan]": [
         {
-            "checksum": "159ab47c102e7d87cc5fb3d9620dcbc2",
-            "size": 6299,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-top_sort_one_desc--Plan_/plan.txt"
+            "checksum": "8617cf1ef0981ed83d7dde0cfb8f22f7",
+            "size": 5887,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-top_sort_one_desc--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-tuple_type--Debug]": [
         {
-            "checksum": "fad1dbf1810a46ef2e0e19d2ff0f8daf",
-            "size": 2278,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-tuple_type--Debug_/opt.yql_patched"
+            "checksum": "f48c00cc11c4e75d626157bef0facf2b",
+            "size": 2150,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-tuple_type--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-tuple_type--Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1937367/ffca086af5b9f4abfc40059b4d4cd9f14a69a4c3/resource.tar.gz#test.test_blocks-tuple_type--Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_blocks-tuple_type--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_tmp-default.txt-Debug]": [
         {
-            "checksum": "699ff9845709ed1558837f2f4b103305",
-            "size": 4817,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6de94146778bf2da45d91c05b91ec9d0",
+            "size": 4636,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_tmp-default.txt-Plan]": [
         {
-            "checksum": "699c4ee9db3c0f770cd005043bc56e9e",
-            "size": 12939,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Plan_/plan.txt"
+            "checksum": "2379b8a9d4267ee567a59ba3df9793d3",
+            "size": 12321,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_column_order-insert_tmp-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_reorder_cols--Debug]": [
         {
-            "checksum": "8f5b2c501888be2302660c32562ec925",
-            "size": 4209,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Debug_/opt.yql_patched"
+            "checksum": "916232a2d675069f5a12c904aa5eb8f1",
+            "size": 3987,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_with_reorder_cols--Plan]": [
         {
-            "checksum": "f7c74f54b4e0649f5a0ae17a9daf4538",
-            "size": 7036,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Plan_/plan.txt"
+            "checksum": "e0d352a00f9146973590a2a33f435fdf",
+            "size": 6624,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_column_order-insert_with_reorder_cols--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-union_all-default.txt-Debug]": [
@@ -701,16 +701,16 @@
     ],
     "test.test[csee-yql-7237--Debug]": [
         {
-            "checksum": "fcdfc38a9cf4ad16cdfe7d2924127747",
-            "size": 10781,
-            "uri": "https://{canondata_backend}/1871102/bc396b8b31a3dc31af3e0918ca66137d03d31eff/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql_patched"
+            "checksum": "fbdc3bf631af94cb7087c2e8938b3685",
+            "size": 10579,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_csee-yql-7237--Debug_/opt.yql_patched"
         }
     ],
     "test.test[csee-yql-7237--Plan]": [
         {
-            "checksum": "7adbfc42f3290ebd3b1b03a4b70109a8",
-            "size": 15537,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_csee-yql-7237--Plan_/plan.txt"
+            "checksum": "c11d461d90e83438e8cabe76203f68a7",
+            "size": 14919,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_csee-yql-7237--Plan_/plan.txt"
         }
     ],
     "test.test[datetime-date_cast-default.txt-Debug]": [
@@ -729,16 +729,16 @@
     ],
     "test.test[distinct-distinct_window-default.txt-Debug]": [
         {
-            "checksum": "8c35feb73d6b8636da6bcb7e11b701ba",
-            "size": 7422,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_distinct-distinct_window-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5fb535a9e6114ef548f2d440cf23fe1b",
+            "size": 7205,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_distinct-distinct_window-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_window-default.txt-Plan]": [
         {
-            "checksum": "692b3e9c0b526bb3f125d344ec6a0b92",
-            "size": 10377,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_distinct-distinct_window-default.txt-Plan_/plan.txt"
+            "checksum": "9d22ae1a4617218972c4c02e62a2af39",
+            "size": 9965,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_distinct-distinct_window-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[expr-as_dict_list_key-default.txt-Debug]": [
@@ -897,16 +897,16 @@
     ],
     "test.test[expr-tagged_runtime-default.txt-Debug]": [
         {
-            "checksum": "1a51c6e432736f37e913499e4fc5b8ec",
-            "size": 3814,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_expr-tagged_runtime-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4f8a645d2fdbc5df7f8a0316908b065f",
+            "size": 3576,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_expr-tagged_runtime-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-tagged_runtime-default.txt-Plan]": [
         {
-            "checksum": "00818d61eb8baf3d988e79d805934af8",
-            "size": 10321,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_expr-tagged_runtime-default.txt-Plan_/plan.txt"
+            "checksum": "9f55d680601bd7e3121fd697eaea918d",
+            "size": 9909,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_expr-tagged_runtime-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[expr-unicode_literals-default.txt-Debug]": [
@@ -925,16 +925,16 @@
     ],
     "test.test[file-file_constness--Debug]": [
         {
-            "checksum": "7942fcd3fbe23fa63127bf7377f35ae6",
-            "size": 5118,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_file-file_constness--Debug_/opt.yql_patched"
+            "checksum": "e4c2928b239ee631961199facdb20495",
+            "size": 4794,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_file-file_constness--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-file_constness--Plan]": [
         {
-            "checksum": "fcb3fac66758bdf710add4888459ac6b",
-            "size": 8425,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_file-file_constness--Plan_/plan.txt"
+            "checksum": "f1f5f9687ade29f7d83e3e95a7f11fd8",
+            "size": 7807,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_file-file_constness--Plan_/plan.txt"
         }
     ],
     "test.test[file-file_skip_take--Debug]": [
@@ -953,30 +953,30 @@
     ],
     "test.test[flatten_by-flatten_and_where--Debug]": [
         {
-            "checksum": "7ad47f6ef38d62977cdbe6ad7323ebf3",
-            "size": 5058,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_flatten_by-flatten_and_where--Debug_/opt.yql_patched"
+            "checksum": "5f5cbe8cf2a5cdecb7a837ee647b6eae",
+            "size": 4771,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_and_where--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_and_where--Plan]": [
         {
-            "checksum": "b03d6fcad67631132f0cd58cabadba0a",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_flatten_by-flatten_and_where--Plan_/plan.txt"
+            "checksum": "261b45fcb0c591cd4d8b93883414dec3",
+            "size": 7936,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_and_where--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_by_typed_table--Debug]": [
         {
-            "checksum": "2d65f9fa0991465734bbe83998f61731",
-            "size": 2138,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_flatten_by-flatten_by_typed_table--Debug_/opt.yql_patched"
+            "checksum": "afd838447074c21caa69112196e222c1",
+            "size": 2079,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_by_typed_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_by_typed_table--Plan]": [
         {
-            "checksum": "d5391ec6249c774e7d060cc96a2207e1",
-            "size": 4002,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_flatten_by-flatten_by_typed_table--Plan_/plan.txt"
+            "checksum": "50f47bc73b32e5132fce6e25f7a3685f",
+            "size": 3796,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_by_typed_table--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_columns_with_opt_struct-default.txt-Debug]": [
@@ -995,58 +995,58 @@
     ],
     "test.test[flatten_by-flatten_dict_by_opt--Debug]": [
         {
-            "checksum": "e9924436b757b612d7403e7670ae3761",
-            "size": 5891,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_flatten_by-flatten_dict_by_opt--Debug_/opt.yql_patched"
+            "checksum": "6d8659ecbd7e22c2959af3b38f12dc19",
+            "size": 5511,
+            "uri": "https://{canondata_backend}/1937429/af1c6e6e04642438d43d596ae49e1f47c2f9a8bf/resource.tar.gz#test.test_flatten_by-flatten_dict_by_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_dict_by_opt--Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_flatten_by-flatten_dict_by_opt--Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_dict_by_opt--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_one_field_another--Debug]": [
         {
-            "checksum": "0ee5dd19bb57198649868822c5edfb95",
-            "size": 4886,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_flatten_by-flatten_one_field_another--Debug_/opt.yql_patched"
+            "checksum": "fae8709ab53eaefb495a9911461e8dc1",
+            "size": 4599,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_one_field_another--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_one_field_another--Plan]": [
         {
-            "checksum": "b03d6fcad67631132f0cd58cabadba0a",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_flatten_by-flatten_one_field_another--Plan_/plan.txt"
+            "checksum": "261b45fcb0c591cd4d8b93883414dec3",
+            "size": 7936,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_one_field_another--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_with_group_by--Debug]": [
         {
-            "checksum": "ba8fc04a0a8f2e252acf6cf4f3c6a38e",
-            "size": 8381,
-            "uri": "https://{canondata_backend}/1871102/bc396b8b31a3dc31af3e0918ca66137d03d31eff/resource.tar.gz#test.test_flatten_by-flatten_with_group_by--Debug_/opt.yql_patched"
+            "checksum": "396036d4d3ad71d4b18ac5d5182cc3e7",
+            "size": 7891,
+            "uri": "https://{canondata_backend}/1937429/af1c6e6e04642438d43d596ae49e1f47c2f9a8bf/resource.tar.gz#test.test_flatten_by-flatten_with_group_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_with_group_by--Plan]": [
         {
-            "checksum": "4309689f41cbcd9b784ad1b380a1f920",
-            "size": 10923,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_flatten_by-flatten_with_group_by--Plan_/plan.txt"
+            "checksum": "e02dc818c0ae2002044505b0851c0f66",
+            "size": 10099,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_flatten_by-flatten_with_group_by--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-out_hor_join-default.txt-Debug]": [
         {
-            "checksum": "2f3fc4eb870aa279db40bc2626619a2b",
-            "size": 9343,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_hor_join-out_hor_join-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5b04489c28ea0f9d481b5ebf838dbe36",
+            "size": 8882,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_hor_join-out_hor_join-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-out_hor_join-default.txt-Plan]": [
         {
-            "checksum": "f9d39ba80918737e35759fe10c38966d",
-            "size": 19506,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_hor_join-out_hor_join-default.txt-Plan_/plan.txt"
+            "checksum": "f97b13fe8fde008b198aeb7ea3bab204",
+            "size": 18270,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_hor_join-out_hor_join-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-skip_yamr--Debug]": [
@@ -1065,16 +1065,16 @@
     ],
     "test.test[hor_join-table_record--Debug]": [
         {
-            "checksum": "64b56235c9cd9297a8884203fd08c5cc",
-            "size": 3166,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_hor_join-table_record--Debug_/opt.yql_patched"
+            "checksum": "5ff4663afdca37f7872f88434016d891",
+            "size": 3044,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_hor_join-table_record--Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-table_record--Plan]": [
         {
-            "checksum": "fbfa307ae9f34b69a59709d85fa01066",
-            "size": 6532,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_hor_join-table_record--Plan_/plan.txt"
+            "checksum": "72c40da2c11b08944ee3966679418332",
+            "size": 6326,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_hor_join-table_record--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_ansi_variant-default.txt-Debug]": [
@@ -1093,184 +1093,184 @@
     ],
     "test.test[in-in_enum_single0-default.txt-Debug]": [
         {
-            "checksum": "3befbbaba66488fc30a076d9d34e3be2",
-            "size": 1918,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_in-in_enum_single0-default.txt-Debug_/opt.yql_patched"
+            "checksum": "148d9f87508515e8f4bfd7fc7fbf781c",
+            "size": 1795,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_in-in_enum_single0-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_enum_single0-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_in-in_enum_single0-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_in-in_enum_single0-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-after_group_by-default.txt-Debug]": [
         {
-            "checksum": "8c8a708af95497f327fe982096bdba55",
-            "size": 6335,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert-after_group_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f3d24e6fed8fb4e685ed0ce2856b7fa1",
+            "size": 5816,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-after_group_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-after_group_by-default.txt-Plan]": [
         {
-            "checksum": "f8dce41a98855a27fb2956f7c475825d",
-            "size": 11670,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert-after_group_by-default.txt-Plan_/plan.txt"
+            "checksum": "2fa0460eb39e8da8b3810a3060dbbf2b",
+            "size": 10846,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-after_group_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-append--Debug]": [
         {
-            "checksum": "a43badace5e81c3a047722d285199578",
-            "size": 1837,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert-append--Debug_/opt.yql_patched"
+            "checksum": "e54fc9ec38a4294496f70a3a5f25e522",
+            "size": 1714,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-append--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append--Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert-append--Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-append--Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_calc-Debug]": [
         {
-            "checksum": "86c0aa095f6d6e6d7ce0fc0f70dcb6f6",
-            "size": 3582,
-            "uri": "https://{canondata_backend}/1942173/2aaf63bbc78a9bfa7f1e976bed8f31dcd209800f/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Debug_/opt.yql_patched"
+            "checksum": "f4c03862ee08d5267a7dd35525cf8824",
+            "size": 3459,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_calc-Plan]": [
         {
-            "checksum": "ea2b880a50308a3c86548aaac7e2dfc0",
-            "size": 13283,
-            "uri": "https://{canondata_backend}/1942173/2aaf63bbc78a9bfa7f1e976bed8f31dcd209800f/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Plan_/plan.txt"
+            "checksum": "c8b7da59f4c9716c37f6bb2361e2448f",
+            "size": 13077,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-append_sorted-to_sorted_calc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-from_two_sorted_by_calc-default.txt-Debug]": [
         {
-            "checksum": "fe9db58d0e32b89a75cba27ac95cf0f2",
-            "size": 4609,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b85cfb9aaff51b8f9675b6427f5bcd5b",
+            "size": 4484,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-from_two_sorted_by_calc-default.txt-Plan]": [
         {
-            "checksum": "9c6641ae3074304a301933b583060036",
-            "size": 15674,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Plan_/plan.txt"
+            "checksum": "d0b5a3ab72a782d3deac82376ff92bec",
+            "size": 15468,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-from_two_sorted_by_calc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-with_read_udf-Debug]": [
         {
-            "checksum": "a6e9f3a26532dc5139c2b5f0cd359f9d",
-            "size": 1982,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert-override-with_read_udf-Debug_/opt.yql_patched"
+            "checksum": "62c7ddcc63f45cb5416d8b3848cad2b5",
+            "size": 1859,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-override-with_read_udf-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-with_read_udf-Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert-override-with_read_udf-Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-override-with_read_udf-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_after_insert_relabeled-default.txt-Debug]": [
         {
-            "checksum": "ac3445d05b8e7d2354f6f5eaba8eb112",
-            "size": 2953,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2117776b46df15e75cee7de9d9d7f44e",
+            "size": 2795,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_after_insert_relabeled-default.txt-Plan]": [
         {
-            "checksum": "a24b090fe603f73b99f7cea87cd976c3",
-            "size": 7109,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Plan_/plan.txt"
+            "checksum": "3f77c29d63f1c436ee50f0bd30820322",
+            "size": 6903,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-select_after_insert_relabeled-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_subquery--Debug]": [
         {
-            "checksum": "eb1d8ae05f683724fbaba5dd8d4a4ef4",
-            "size": 2635,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert-select_subquery--Debug_/opt.yql_patched"
+            "checksum": "cc32fda7d5cf99a2fd3adb10fda46656",
+            "size": 2573,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-select_subquery--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_subquery--Plan]": [
         {
-            "checksum": "d1018ea06a95c7ccb2920fc3eeeeba28",
-            "size": 5858,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert-select_subquery--Plan_/plan.txt"
+            "checksum": "03b62b8fb58486f40986a7b8effd807e",
+            "size": 5652,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-select_subquery--Plan_/plan.txt"
         }
     ],
     "test.test[insert-yql-13083-existig-Debug]": [
         {
-            "checksum": "6f84515618c94a53e83f5f375e61969e",
-            "size": 4790,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert-yql-13083-existig-Debug_/opt.yql_patched"
+            "checksum": "aab62777e8a02d0ad40c0df1767771ec",
+            "size": 4603,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-yql-13083-existig-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-yql-13083-existig-Plan]": [
         {
-            "checksum": "0dfc71f535d6ad38f91ea8e659c702df",
-            "size": 15902,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert-yql-13083-existig-Plan_/plan.txt"
+            "checksum": "2aa9f27b1dead7adb133004fad4cd6e4",
+            "size": 15284,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert-yql-13083-existig-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-from_empty--Debug]": [
         {
-            "checksum": "5ee9b89709e0f451f7dafc3643a3e88c",
-            "size": 2161,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert_monotonic-from_empty--Debug_/opt.yql_patched"
+            "checksum": "919bf8807dec4909e60f7de8a3473c18",
+            "size": 2038,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert_monotonic-from_empty--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-from_empty--Plan]": [
         {
-            "checksum": "c7dbe6c7a720181de154425c4b936d8c",
-            "size": 4429,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert_monotonic-from_empty--Plan_/plan.txt"
+            "checksum": "db1eb96f1e6a40e698ee10515adbde38",
+            "size": 4223,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert_monotonic-from_empty--Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-truncate_and_append-default.txt-Debug]": [
         {
-            "checksum": "425dd587776602858f48950157b81493",
-            "size": 2947,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e1c54fa79c952f1f98ed6bb7aa783314",
+            "size": 2792,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-truncate_and_append-default.txt-Plan]": [
         {
-            "checksum": "bdf376271ea872d8cba4ee0c4595a5ae",
-            "size": 7734,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Plan_/plan.txt"
+            "checksum": "2c2c8b8153b35886999d1c77e1b80fcd",
+            "size": 7322,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_insert_monotonic-truncate_and_append-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-bush_in--Debug]": [
         {
-            "checksum": "f7584f82e42aaf0a3d1e655b8f0a5124",
-            "size": 7379,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-bush_in--Debug_/opt.yql_patched"
+            "checksum": "0b889b8bedbc56fa6ee277bbfe9dc878",
+            "size": 7252,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-bush_in--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-bush_in--Plan]": [
         {
-            "checksum": "18291d084a9fc97ecbe4e5cf3770435b",
-            "size": 14568,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-bush_in--Plan_/plan.txt"
+            "checksum": "3d6e05a60acbe6ff81964c7991ff65c6",
+            "size": 14362,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-bush_in--Plan_/plan.txt"
         }
     ],
     "test.test[join-flatten_columns2--Debug]": [
         {
-            "checksum": "74b73336bc897c70fdfee43060e63681",
-            "size": 5452,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-flatten_columns2--Debug_/opt.yql_patched"
+            "checksum": "8a197abd7b3a139589594669f6f1e924",
+            "size": 5252,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-flatten_columns2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-flatten_columns2--Plan]": [
         {
-            "checksum": "1a3e1221d8c4908d2d7ed5eba76cf003",
-            "size": 8690,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-flatten_columns2--Plan_/plan.txt"
+            "checksum": "f9e599b9522940fe72882fad8ab70d5c",
+            "size": 8484,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-flatten_columns2--Plan_/plan.txt"
         }
     ],
     "test.test[join-inmem_with_null_key--Debug]": [
@@ -1317,254 +1317,254 @@
     ],
     "test.test[join-join_right_cbo--Debug]": [
         {
-            "checksum": "0d929b623fab198a0aa3cdb5f2e3e0a2",
-            "size": 4389,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-join_right_cbo--Debug_/opt.yql_patched"
+            "checksum": "4c0a00e992b28da0fa4d155cb04d9fde",
+            "size": 4281,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-join_right_cbo--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_right_cbo--Plan]": [
         {
-            "checksum": "d6671209b032ecda51583005660c84a4",
-            "size": 7931,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-join_right_cbo--Plan_/plan.txt"
+            "checksum": "099d20c752b20fc9ca849cb057aaaee4",
+            "size": 7725,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-join_right_cbo--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_without_correlation_and_struct_access--Debug]": [
         {
-            "checksum": "d3bc042b368e1df9c0691ec96675d0d9",
-            "size": 6656,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-join_without_correlation_and_struct_access--Debug_/opt.yql_patched"
+            "checksum": "5ef89af3502f2e1158fe3a1a6bca71fd",
+            "size": 6512,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-join_without_correlation_and_struct_access--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_without_correlation_and_struct_access--Plan]": [
         {
-            "checksum": "2683b47f1ed2aad22115679b43608f4b",
-            "size": 8531,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-join_without_correlation_and_struct_access--Plan_/plan.txt"
+            "checksum": "9348eecf038ad21bf4cf2f415df82bc6",
+            "size": 8325,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-join_without_correlation_and_struct_access--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_join_right_pushdown_nested_right--Debug]": [
         {
-            "checksum": "98434a360ca44cdece78c2cca98c39c9",
-            "size": 8603,
-            "uri": "https://{canondata_backend}/1775319/3b44e895c72b145fbb42791c71ac67e92b04da1e/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_right--Debug_/opt.yql_patched"
+            "checksum": "2d25a1cbe76579a99aac24c4b98c17ad",
+            "size": 8497,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_right--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_join_right_pushdown_nested_right--Plan]": [
         {
-            "checksum": "4aa32511da03157eac326961da592a0c",
-            "size": 13134,
-            "uri": "https://{canondata_backend}/1775319/3b44e895c72b145fbb42791c71ac67e92b04da1e/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_right--Plan_/plan.txt"
+            "checksum": "4cf21ccdacb0efad6d8cd85908397bee",
+            "size": 12928,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_right--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_bug7646_subst--Debug]": [
         {
-            "checksum": "e7f906db4072c338f514ae3be9f23e80",
-            "size": 6517,
-            "uri": "https://{canondata_backend}/1942278/2e8d4d4aa30a29a3de8192b786bec2b9953d0111/resource.tar.gz#test.test_join-lookupjoin_bug7646_subst--Debug_/opt.yql_patched"
+            "checksum": "0e54586a09f294991aed9d13dd25c91e",
+            "size": 6127,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_bug7646_subst--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_bug7646_subst--Plan]": [
         {
-            "checksum": "96049c3522211c36d5590da7e9c86657",
-            "size": 17761,
-            "uri": "https://{canondata_backend}/1916746/dc625f1c361a810930a4fb5321d1d922f40c2078/resource.tar.gz#test.test_join-lookupjoin_bug7646_subst--Plan_/plan.txt"
+            "checksum": "fb3acf9290fbbc40b3828b41b8293b17",
+            "size": 16937,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_bug7646_subst--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_inner_1o--Debug]": [
         {
-            "checksum": "505989fa073e143af8f3ae2af752d783",
-            "size": 4026,
-            "uri": "https://{canondata_backend}/1689644/2ee3b6d5bfb54197d98505d1816ea7ef61d5d5be/resource.tar.gz#test.test_join-lookupjoin_inner_1o--Debug_/opt.yql_patched"
+            "checksum": "f63ebccd1378448f8c07eb60c4aa968f",
+            "size": 3842,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_inner_1o--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_inner_1o--Plan]": [
         {
-            "checksum": "05b8f5650c9798713f58911fb8beb6fa",
-            "size": 4998,
-            "uri": "https://{canondata_backend}/995452/68866583e27aabd907b1703b70f496c159c7fdce/resource.tar.gz#test.test_join-lookupjoin_inner_1o--Plan_/plan.txt"
+            "checksum": "6363951f040c47733f52556c30277ac0",
+            "size": 4792,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_inner_1o--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_inner_2o--Debug]": [
         {
-            "checksum": "f94c6492acfa487787e8e835a1f3468b",
-            "size": 3856,
-            "uri": "https://{canondata_backend}/1773845/44882e951f54e61a828db7e02bf6d48db259a20d/resource.tar.gz#test.test_join-lookupjoin_inner_2o--Debug_/opt.yql_patched"
+            "checksum": "52658c9a398bb8d87744a8f0841fa7e2",
+            "size": 3672,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_inner_2o--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_inner_2o--Plan]": [
         {
-            "checksum": "7da94ce26b3b7e6c7f591b3a2b16d088",
-            "size": 5172,
-            "uri": "https://{canondata_backend}/1889210/aa6d695470458a7dea5a2179eeb3d8e09e6ceb7c/resource.tar.gz#test.test_join-lookupjoin_inner_2o--Plan_/plan.txt"
+            "checksum": "60518359dfa4e7b59d62bd83a7be31e9",
+            "size": 4966,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_inner_2o--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_semi_1o--Debug]": [
         {
-            "checksum": "cc543c64a70070542ce462dbb9ccaaf0",
-            "size": 4177,
-            "uri": "https://{canondata_backend}/1936997/ad2f6b1cda61f25852892d6f19c313c449abd577/resource.tar.gz#test.test_join-lookupjoin_semi_1o--Debug_/opt.yql_patched"
+            "checksum": "e1b89a21bfcefc624609100022f7c1c2",
+            "size": 3935,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_semi_1o--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_semi_1o--Plan]": [
         {
-            "checksum": "f1f0d21152976a123ada398982ecee57",
-            "size": 7118,
-            "uri": "https://{canondata_backend}/1847551/5444fe7857d94ceb83255ccb2b58c332c7dcb415/resource.tar.gz#test.test_join-lookupjoin_semi_1o--Plan_/plan.txt"
+            "checksum": "3656366ed0b6509f30086b81d0f85b5a",
+            "size": 6706,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-lookupjoin_semi_1o--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_on_very_complex_type--Debug]": [
         {
-            "checksum": "cf657befed5c37fd4f5b08f7575a6b62",
-            "size": 9022,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-mapjoin_on_very_complex_type--Debug_/opt.yql_patched"
+            "checksum": "6d71cf1c91dd864e2b4e1351ec0307bf",
+            "size": 8594,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-mapjoin_on_very_complex_type--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_on_very_complex_type--Plan]": [
         {
-            "checksum": "25d3748076e133727434631982d87a48",
-            "size": 10011,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-mapjoin_on_very_complex_type--Plan_/plan.txt"
+            "checksum": "5efb144065890d631c4ee7bf0e4a1f42",
+            "size": 9393,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-mapjoin_on_very_complex_type--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_any_no_join_reduce--Debug]": [
         {
-            "checksum": "18794567ff80cecdacb4f6613e532cf5",
-            "size": 4573,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_join-mergejoin_any_no_join_reduce--Debug_/opt.yql_patched"
+            "checksum": "8428db6cbea21686e695f45399de16d9",
+            "size": 4449,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-mergejoin_any_no_join_reduce--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_any_no_join_reduce--Plan]": [
         {
-            "checksum": "90b4f48b58f544e8a9f4b935849c6097",
-            "size": 7199,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-mergejoin_any_no_join_reduce--Plan_/plan.txt"
+            "checksum": "2863476d10acbc663e2c24ae25969204",
+            "size": 6787,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-mergejoin_any_no_join_reduce--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_with_different_key_names--Debug]": [
         {
-            "checksum": "870cdf7ff72f1384f4b6a84e8384d39e",
-            "size": 9508,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-mergejoin_with_different_key_names--Debug_/opt.yql_patched"
+            "checksum": "24b06d4e209d902c3c11c494a08492e9",
+            "size": 9189,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-mergejoin_with_different_key_names--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_with_different_key_names--Plan]": [
         {
-            "checksum": "34ccfcbab7e3c9f2f0afbcdfc011deea",
-            "size": 17364,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-mergejoin_with_different_key_names--Plan_/plan.txt"
+            "checksum": "cbebd7087f6cbf798cbb3d5df5d182ae",
+            "size": 16952,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-mergejoin_with_different_key_names--Plan_/plan.txt"
         }
     ],
     "test.test[join-opt_on_opt_side--Debug]": [
         {
-            "checksum": "0d8aaf5bb4823b41552856702f4b37b1",
-            "size": 4594,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-opt_on_opt_side--Debug_/opt.yql_patched"
+            "checksum": "50f2f4a30f2a5354044fba4c88d2d6c7",
+            "size": 4489,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-opt_on_opt_side--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-opt_on_opt_side--Plan]": [
         {
-            "checksum": "c59f7ebe64b7294539fdbe292efe9d1e",
-            "size": 7390,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-opt_on_opt_side--Plan_/plan.txt"
+            "checksum": "3375460bda2d21ee3e4669fccea5df1d",
+            "size": 7184,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-opt_on_opt_side--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_inner--Debug]": [
         {
-            "checksum": "5efd1bb403b9b3a32bd7eb00741bfac4",
-            "size": 4946,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-premap_common_inner--Debug_/opt.yql_patched"
+            "checksum": "1aba91badeb213f776d9843880ae2ceb",
+            "size": 4793,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-premap_common_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_inner--Plan]": [
         {
-            "checksum": "ce166513642ef8f98118abe6506d6ebe",
-            "size": 7933,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-premap_common_inner--Plan_/plan.txt"
+            "checksum": "fd506d2b6f8ff49ec956548e68a8458b",
+            "size": 7727,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-premap_common_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_merge_extrasort2--Debug]": [
         {
-            "checksum": "b03e8882f5164eef66ec2fb2efba09bc",
-            "size": 5555,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-premap_merge_extrasort2--Debug_/opt.yql_patched"
+            "checksum": "0b306a940743afdc5d2f5a7e07b6af40",
+            "size": 5339,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-premap_merge_extrasort2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_merge_extrasort2--Plan]": [
         {
-            "checksum": "54f464587f4a901b0221259535ff6f1c",
-            "size": 8326,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-premap_merge_extrasort2--Plan_/plan.txt"
+            "checksum": "5778acb16bcea48e00ebaa4cfd349e29",
+            "size": 7914,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-premap_merge_extrasort2--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_random--Debug]": [
         {
-            "checksum": "dda0932c847dd27182a354ddf6734081",
-            "size": 6140,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-pullup_random--Debug_/opt.yql_patched"
+            "checksum": "7665400df3af67485312221274ab49e6",
+            "size": 5870,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-pullup_random--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_random--Plan]": [
         {
-            "checksum": "3a038d71235939a2032a2fcb3ae3bc68",
-            "size": 8969,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-pullup_random--Plan_/plan.txt"
+            "checksum": "7eec04553777a0bcb10360aa0488b958",
+            "size": 8557,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-pullup_random--Plan_/plan.txt"
         }
     ],
     "test.test[join-pushdown_filter_over_left--Debug]": [
         {
-            "checksum": "0dd83012748c7efd7ae7d3b9f64b305f",
-            "size": 6073,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-pushdown_filter_over_left--Debug_/opt.yql_patched"
+            "checksum": "eaea02a9c3e06b37ccad056a55eba726",
+            "size": 5750,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-pushdown_filter_over_left--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pushdown_filter_over_left--Plan]": [
         {
-            "checksum": "78c178b96e9cdb6bf6344bc935827871",
-            "size": 9003,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-pushdown_filter_over_left--Plan_/plan.txt"
+            "checksum": "71ba47753307965fd3028c2ac759dbf4",
+            "size": 8591,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-pushdown_filter_over_left--Plan_/plan.txt"
         }
     ],
     "test.test[join-star_join--Debug]": [
         {
-            "checksum": "0b0bd413d0588090a05a5a0177f0fad7",
-            "size": 10127,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_join-star_join--Debug_/opt.yql_patched"
+            "checksum": "d47f2e999d65b45958d08771874d966f",
+            "size": 9886,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-star_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join--Plan]": [
         {
-            "checksum": "0c0a30ca024f296dda646f035c529b51",
-            "size": 14469,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-star_join--Plan_/plan.txt"
+            "checksum": "2863a9c632a1cd8950afc3c017f08af9",
+            "size": 14263,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-star_join--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-14829_left--Debug]": [
         {
-            "checksum": "dbc76a4c2699d23b5b0d4d37c25204ea",
-            "size": 11874,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_join-yql-14829_left--Debug_/opt.yql_patched"
+            "checksum": "b3f39aaa72677869315cf9e084e0da73",
+            "size": 11664,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-yql-14829_left--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-14829_left--Plan]": [
         {
-            "checksum": "2188a34957bfb8b02f6fa8689096896a",
-            "size": 23398,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-yql-14829_left--Plan_/plan.txt"
+            "checksum": "c8a4532f0627f30163078cf3cef44c79",
+            "size": 22574,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-yql-14829_left--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-4275--Debug]": [
         {
-            "checksum": "ffecf3b1091b711b066501457e0dd481",
-            "size": 4879,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_join-yql-4275--Debug_/opt.yql_patched"
+            "checksum": "98daa5101348f43c105d7e5431e5b610",
+            "size": 4817,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-yql-4275--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-4275--Plan]": [
         {
-            "checksum": "0829ed771d380be500728adf76bab03e",
-            "size": 6934,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_join-yql-4275--Plan_/plan.txt"
+            "checksum": "ef1b5e9b063cf608c8fabd0603953634",
+            "size": 6728,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_join-yql-4275--Plan_/plan.txt"
         }
     ],
     "test.test[json-json_value/passing-default.txt-Debug]": [
@@ -1597,30 +1597,30 @@
     ],
     "test.test[key_filter-datetime-default.txt-Debug]": [
         {
-            "checksum": "f61f4508d46baeb457a18a1ac02c5f5f",
-            "size": 20133,
-            "uri": "https://{canondata_backend}/1880306/b37d868cbc1b4f3a33d791be30c3d0edb8aafd82/resource.tar.gz#test.test_key_filter-datetime-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b2efebf6849691d9ae18b3070919f3a6",
+            "size": 19047,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_key_filter-datetime-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-datetime-default.txt-Plan]": [
         {
-            "checksum": "975c7f7b6044bdc55168421292f18b90",
-            "size": 78401,
-            "uri": "https://{canondata_backend}/1942415/86ac18e01a32d8b6649614e5361f3acd4c2c5d31/resource.tar.gz#test.test_key_filter-datetime-default.txt-Plan_/plan.txt"
+            "checksum": "d2dbed99a30e3d0a9a62deb97109bee1",
+            "size": 72839,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_key_filter-datetime-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-yql-14157--Debug]": [
         {
-            "checksum": "f8f925e70836fe6b46d2196076015647",
-            "size": 5709,
-            "uri": "https://{canondata_backend}/1871102/7e4f0f70c801fe41694c38bb443c06892d88b82a/resource.tar.gz#test.test_key_filter-yql-14157--Debug_/opt.yql_patched"
+            "checksum": "5da3ae5315213b3af90cad44d9dda77b",
+            "size": 5330,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_key_filter-yql-14157--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-yql-14157--Plan]": [
         {
-            "checksum": "d207579ec53f9e02e6fd24bbee53a838",
-            "size": 10940,
-            "uri": "https://{canondata_backend}/1871102/7e4f0f70c801fe41694c38bb443c06892d88b82a/resource.tar.gz#test.test_key_filter-yql-14157--Plan_/plan.txt"
+            "checksum": "376cbab3b521cd9f51f0f3029f0ff103",
+            "size": 10116,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_key_filter-yql-14157--Plan_/plan.txt"
         }
     ],
     "test.test[lambda-list_aggregate-default.txt-Debug]": [
@@ -1639,16 +1639,16 @@
     ],
     "test.test[limit-empty_read_after_limit-default.txt-Debug]": [
         {
-            "checksum": "76a5d1c2883861d4a0efbca22de808b8",
-            "size": 2454,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_limit-empty_read_after_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "10896905e035b58ecef02955e813dd2e",
+            "size": 2331,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_limit-empty_read_after_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-empty_read_after_limit-default.txt-Plan]": [
         {
-            "checksum": "0bd0d33e1cb43827629f3a9e3db50843",
-            "size": 5259,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_limit-empty_read_after_limit-default.txt-Plan_/plan.txt"
+            "checksum": "2f31a92d71259c19c40879adc06b4616",
+            "size": 5053,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_limit-empty_read_after_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[match_recognize-alerts-default.txt-Debug]": [
@@ -1681,30 +1681,30 @@
     ],
     "test.test[optimizers-unused_columns_group_one_of_multi--Debug]": [
         {
-            "checksum": "5791634deeb165daa403fd3e692af881",
-            "size": 5829,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_optimizers-unused_columns_group_one_of_multi--Debug_/opt.yql_patched"
+            "checksum": "0d49f92fd889bad75cbbbe25f758681b",
+            "size": 5632,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_optimizers-unused_columns_group_one_of_multi--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-unused_columns_group_one_of_multi--Plan]": [
         {
-            "checksum": "2a45f5a4cf4c29e44502de669ccb7091",
-            "size": 6310,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_optimizers-unused_columns_group_one_of_multi--Plan_/plan.txt"
+            "checksum": "65cb237e979671c05857f244e599d4bf",
+            "size": 5898,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_optimizers-unused_columns_group_one_of_multi--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-12620_stage_multiuse--Debug]": [
         {
-            "checksum": "4cdd134ed37a0218c0cccfa2266553c7",
-            "size": 2277,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_optimizers-yql-12620_stage_multiuse--Debug_/opt.yql_patched"
+            "checksum": "afe144e975bcbf6ca30d6a7fa86732c2",
+            "size": 2154,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_optimizers-yql-12620_stage_multiuse--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-12620_stage_multiuse--Plan]": [
         {
-            "checksum": "7500bae390d51b4b2e3be5255f77063f",
-            "size": 5756,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_optimizers-yql-12620_stage_multiuse--Plan_/plan.txt"
+            "checksum": "0fdea848435894515fe2d119747cc11e",
+            "size": 5550,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_optimizers-yql-12620_stage_multiuse--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-5978_fill_multi_usage--Debug]": [
@@ -1723,30 +1723,30 @@
     ],
     "test.test[order_by-assume_with_filter--Debug]": [
         {
-            "checksum": "ff82f4509feed3aa5b3a67fa484fa0e6",
-            "size": 2377,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_order_by-assume_with_filter--Debug_/opt.yql_patched"
+            "checksum": "9931817db4774e3472540d5d4f204e9d",
+            "size": 2254,
+            "uri": "https://{canondata_backend}/1937429/af1c6e6e04642438d43d596ae49e1f47c2f9a8bf/resource.tar.gz#test.test_order_by-assume_with_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_with_filter--Plan]": [
         {
-            "checksum": "e19fa7d5fb8ea0203e7552d58d5d186b",
-            "size": 4421,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_order_by-assume_with_filter--Plan_/plan.txt"
+            "checksum": "6d76f5fe611ba44f5251fb5c3ecc00d4",
+            "size": 4215,
+            "uri": "https://{canondata_backend}/1937429/af1c6e6e04642438d43d596ae49e1f47c2f9a8bf/resource.tar.gz#test.test_order_by-assume_with_filter--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_tablerecord_column--Debug]": [
         {
-            "checksum": "eb3de2366d8fc262ba5e3e817776b5b7",
-            "size": 3865,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_order_by-order_by_tablerecord_column--Debug_/opt.yql_patched"
+            "checksum": "ac2e450a663d525b9c2152c2032b8c8b",
+            "size": 3462,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_order_by-order_by_tablerecord_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_tablerecord_column--Plan]": [
         {
-            "checksum": "72f57fa087947360ce510729a29435cd",
-            "size": 8517,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_order_by-order_by_tablerecord_column--Plan_/plan.txt"
+            "checksum": "79f01eb862c3d6da7e782b9a480e1f69",
+            "size": 7899,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_order_by-order_by_tablerecord_column--Plan_/plan.txt"
         }
     ],
     "test.test[params-tuple--Debug]": [
@@ -1765,16 +1765,16 @@
     ],
     "test.test[pg-aggregate_minus_zero--Debug]": [
         {
-            "checksum": "ad33a8db38cec4428cd69a7547aa4c4e",
-            "size": 4258,
-            "uri": "https://{canondata_backend}/1903280/e408d73e432cdcbd076f8502cb4502ad1d54ab5a/resource.tar.gz#test.test_pg-aggregate_minus_zero--Debug_/opt.yql_patched"
+            "checksum": "b0e31fdb0afc4cf30ea65a924eb0da99",
+            "size": 4148,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-aggregate_minus_zero--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-aggregate_minus_zero--Plan]": [
         {
-            "checksum": "dd83fce4e59774da7b2c8dbe6a4f0a8d",
-            "size": 5926,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_pg-aggregate_minus_zero--Plan_/plan.txt"
+            "checksum": "29afbdcb032f0084d8a9d64ec69df686",
+            "size": 5720,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-aggregate_minus_zero--Plan_/plan.txt"
         }
     ],
     "test.test[pg-join_using5-default.txt-Debug]": [
@@ -1793,16 +1793,16 @@
     ],
     "test.test[pg-join_using_tables3-default.txt-Debug]": [
         {
-            "checksum": "2a0eca1520fbe0859e25ac0e763ad088",
-            "size": 10173,
-            "uri": "https://{canondata_backend}/1871102/7e4f0f70c801fe41694c38bb443c06892d88b82a/resource.tar.gz#test.test_pg-join_using_tables3-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e67d0167f514f82d65c6531d56d9d032",
+            "size": 10013,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-join_using_tables3-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-join_using_tables3-default.txt-Plan]": [
         {
-            "checksum": "376f941f4cb31eb70650dba4f7de3d7f",
-            "size": 9494,
-            "uri": "https://{canondata_backend}/1936273/06ec9981cd0dff814bd34ee2b9e387dc50662ef2/resource.tar.gz#test.test_pg-join_using_tables3-default.txt-Plan_/plan.txt"
+            "checksum": "f92c6ff541822dc6cb834662a44bc3cc",
+            "size": 9288,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-join_using_tables3-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-multi_usage_cross_join-default.txt-Debug]": [
@@ -1961,16 +1961,16 @@
     ],
     "test.test[pg-select_subquery-default.txt-Debug]": [
         {
-            "checksum": "00afc72a5b7627a9a506173321958097",
-            "size": 1893,
-            "uri": "https://{canondata_backend}/1903280/e408d73e432cdcbd076f8502cb4502ad1d54ab5a/resource.tar.gz#test.test_pg-select_subquery-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5275089eaee87a8bb81c818b6f444cd8",
+            "size": 1793,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-select_subquery-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_subquery-default.txt-Plan]": [
         {
-            "checksum": "ba8d30257dc710101add4d98ea788a8f",
-            "size": 3474,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_pg-select_subquery-default.txt-Plan_/plan.txt"
+            "checksum": "8be0a0c6357c5f15033a0c092d757680",
+            "size": 3268,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-select_subquery-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_subquery2-default.txt-Debug]": [
@@ -2227,16 +2227,16 @@
     ],
     "test.test[pg-tpch-q01-default.txt-Debug]": [
         {
-            "checksum": "f19e3b7d2091b8a960afec1f2cee32ca",
-            "size": 14175,
-            "uri": "https://{canondata_backend}/1871102/bc9c6bf8429fbf6f3c50296c2d5689b53f467982/resource.tar.gz#test.test_pg-tpch-q01-default.txt-Debug_/opt.yql_patched"
+            "checksum": "24f1392352b2617c5e0193c449491bd2",
+            "size": 13922,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-tpch-q01-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q01-default.txt-Plan]": [
         {
-            "checksum": "b651118ad2c889a7943deb9660e24d60",
-            "size": 7198,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_pg-tpch-q01-default.txt-Plan_/plan.txt"
+            "checksum": "48e1a81befabedce4fb6bac307fb2a03",
+            "size": 6992,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_pg-tpch-q01-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg_catalog-pg_auth_members-default.txt-Debug]": [
@@ -2339,170 +2339,170 @@
     ],
     "test.test[produce-discard_process_with_lambda-default.txt-Debug]": [
         {
-            "checksum": "36783f1f1d93a5a06ec02b0be4c9af41",
-            "size": 1827,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_produce-discard_process_with_lambda-default.txt-Debug_/opt.yql_patched"
+            "checksum": "13e1688c64041da74bf6191ddde63e15",
+            "size": 1704,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-discard_process_with_lambda-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-discard_process_with_lambda-default.txt-Plan]": [
         {
-            "checksum": "e1e0113c319bbab950930b916438faeb",
-            "size": 4106,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_produce-discard_process_with_lambda-default.txt-Plan_/plan.txt"
+            "checksum": "c03842f59c6d08585e0fb309dfcf700c",
+            "size": 3900,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-discard_process_with_lambda-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_and_filter-default.txt-Debug]": [
         {
-            "checksum": "ca57e298cd730e7b0e23b38185f263dd",
-            "size": 2147,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_produce-process_and_filter-default.txt-Debug_/opt.yql_patched"
+            "checksum": "da521ca136590e78aa0f2433b5331345",
+            "size": 2085,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-process_and_filter-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_and_filter-default.txt-Plan]": [
         {
-            "checksum": "f8d571877f7dc9485437273ffb98bf80",
-            "size": 4049,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_produce-process_and_filter-default.txt-Plan_/plan.txt"
+            "checksum": "6e75c1259c6d74d8fe96f40e2bd1c5f0",
+            "size": 3843,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-process_and_filter-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_streaming_count-default.txt-Debug]": [
         {
-            "checksum": "f5a06f6620ba5ab1934b75215c9188e3",
-            "size": 2966,
-            "uri": "https://{canondata_backend}/1942415/5b26f4b648a9df1479bbbc97e8ae2c11afb1c858/resource.tar.gz#test.test_produce-process_streaming_count-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f9a9f4ae701c52d4d0ea4640284fd152",
+            "size": 2903,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-process_streaming_count-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_streaming_count-default.txt-Plan]": [
         {
-            "checksum": "d2c37acca7bd1a9fd9785e2708fa0809",
-            "size": 4964,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_produce-process_streaming_count-default.txt-Plan_/plan.txt"
+            "checksum": "927354b505a77d69dba17dbbe3819d55",
+            "size": 4758,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-process_streaming_count-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_with_udf-default.txt-Debug]": [
         {
-            "checksum": "052e51b871b7c9527dfbf1b498180a5a",
-            "size": 2458,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_produce-process_with_udf-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f833618b967c293591c4b44c337a3c7e",
+            "size": 2329,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-process_with_udf-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_with_udf-default.txt-Plan]": [
         {
-            "checksum": "e1e0113c319bbab950930b916438faeb",
-            "size": 4106,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_produce-process_with_udf-default.txt-Plan_/plan.txt"
+            "checksum": "c03842f59c6d08585e0fb309dfcf700c",
+            "size": 3900,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-process_with_udf-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_by_struct-default.txt-Debug]": [
         {
-            "checksum": "4a319290fe3f954957d9cd13d7099a07",
-            "size": 2704,
-            "uri": "https://{canondata_backend}/1847551/2bfab2820a88a860dc79c68c8576526e1b77d98c/resource.tar.gz#test.test_produce-reduce_by_struct-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d6d772f6e131feffa12f89b0b08a6f6b",
+            "size": 2604,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-reduce_by_struct-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_by_struct-default.txt-Plan]": [
         {
-            "checksum": "1adf166d2beedd46dfd61e61b1f7e52c",
-            "size": 9299,
-            "uri": "https://{canondata_backend}/1847551/2bfab2820a88a860dc79c68c8576526e1b77d98c/resource.tar.gz#test.test_produce-reduce_by_struct-default.txt-Plan_/plan.txt"
+            "checksum": "20282175ae7d821651604cb855b68f5a",
+            "size": 9093,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-reduce_by_struct-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in-sorted-Debug]": [
         {
-            "checksum": "53861b17441527591a4576c48603a566",
-            "size": 3674,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_produce-reduce_multi_in-sorted-Debug_/opt.yql_patched"
+            "checksum": "08dfc22c6142da04b5e95cb99aa9cc41",
+            "size": 3562,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-reduce_multi_in-sorted-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in-sorted-Plan]": [
         {
-            "checksum": "907c219319a36e99c18dde918c412369",
-            "size": 6942,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_produce-reduce_multi_in-sorted-Plan_/plan.txt"
+            "checksum": "bb136ae430c60c797eab9a06c0aa22ee",
+            "size": 6736,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-reduce_multi_in-sorted-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_with_presort_diff_order--Debug]": [
         {
-            "checksum": "89309ef77869d93f26dbbaa19b4a894c",
-            "size": 13421,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Debug_/opt.yql_patched"
+            "checksum": "da27aeb0ba0c3fd1e1f60e32c362a8ef",
+            "size": 12557,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_with_presort_diff_order--Plan]": [
         {
-            "checksum": "0f207a05d114be3eef0b523a1cfcf844",
-            "size": 29339,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Plan_/plan.txt"
+            "checksum": "0852c525a9199520a1f379a910312eb5",
+            "size": 27691,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_produce-reduce_with_presort_diff_order--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-bind_expr_udf--Debug]": [
         {
-            "checksum": "37a4382f66894d3f88d5185c1837d3e6",
-            "size": 2715,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_sampling-bind_expr_udf--Debug_/opt.yql_patched"
+            "checksum": "30c878b7596d82d63fcd13aa5b99f495",
+            "size": 2469,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-bind_expr_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_expr_udf--Plan]": [
         {
-            "checksum": "db6039bdce5c6b215f17bdd9f92c85dd",
-            "size": 5630,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_sampling-bind_expr_udf--Plan_/plan.txt"
+            "checksum": "b3c08e41d7c4e952f476ef8e9f7afc47",
+            "size": 5218,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-bind_expr_udf--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-bind_small_rate-default.txt-Debug]": [
         {
-            "checksum": "33bb55ccd89c5d560a880f094822e15a",
-            "size": 2115,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_sampling-bind_small_rate-default.txt-Debug_/opt.yql_patched"
+            "checksum": "74fd460d141c386b51bc7e7d505aafd4",
+            "size": 1992,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-bind_small_rate-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_small_rate-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_sampling-bind_small_rate-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-bind_small_rate-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-map--Debug]": [
         {
-            "checksum": "6ce3214f0e4c2708bf7954aa4f6ca5cd",
-            "size": 1902,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_sampling-map--Debug_/opt.yql_patched"
+            "checksum": "087d14a8788dc2bbdab73d5c4ecc26ac",
+            "size": 1779,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-map--Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-map--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_sampling-map--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-map--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-sample-default.txt-Debug]": [
         {
-            "checksum": "a7cc57f6e3157991d943d9735f66c688",
-            "size": 3124,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_sampling-sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "34118b93b09611a44270a89db8c62b62",
+            "size": 2878,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-sample-default.txt-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_sampling-sample-default.txt-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-subquery_filter-default.txt-Debug]": [
         {
-            "checksum": "33b03c2bd3bbc4909cc1c64545543491",
-            "size": 2321,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_sampling-subquery_filter-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e27a58da218c718318795bd9d4f64865",
+            "size": 2259,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-subquery_filter-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-subquery_filter-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_sampling-subquery_filter-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_sampling-subquery_filter-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-limit_directread--Debug]": [
@@ -2563,44 +2563,44 @@
     ],
     "test.test[schema-select_all_inferschema-extra_field-Debug]": [
         {
-            "checksum": "7d0c83fb95dace85fbcb60bc839d1445",
-            "size": 2597,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_schema-select_all_inferschema-extra_field-Debug_/opt.yql_patched"
+            "checksum": "4e9a4edc2bcf4f1aeb81133e614a5fa7",
+            "size": 2408,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-select_all_inferschema-extra_field-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_all_inferschema-extra_field-Plan]": [
         {
-            "checksum": "271a7659178cf38f1a94409b5140f41d",
-            "size": 3593,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_schema-select_all_inferschema-extra_field-Plan_/plan.txt"
+            "checksum": "f3fcfbf6cfbb0739880500c7ff9a956d",
+            "size": 3387,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-select_all_inferschema-extra_field-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_all_inferschema_limit--Debug]": [
         {
-            "checksum": "6ed66b1bbfe55d2025353b0afcd17d2b",
-            "size": 2627,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_schema-select_all_inferschema_limit--Debug_/opt.yql_patched"
+            "checksum": "2ffdc57a8ea9c22f55445ec114cdf0a8",
+            "size": 2438,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-select_all_inferschema_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_all_inferschema_limit--Plan]": [
         {
-            "checksum": "271a7659178cf38f1a94409b5140f41d",
-            "size": 3593,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_schema-select_all_inferschema_limit--Plan_/plan.txt"
+            "checksum": "f3fcfbf6cfbb0739880500c7ff9a956d",
+            "size": 3387,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-select_all_inferschema_limit--Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_operate_with_columns_simple-default.txt-Debug]": [
         {
-            "checksum": "a785dcbe0d8fca4a0f84fb9d07ffc299",
-            "size": 2162,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_schema-select_operate_with_columns_simple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "28e6397f35ca901f8d24517839a876ab",
+            "size": 2096,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-select_operate_with_columns_simple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_operate_with_columns_simple-default.txt-Plan]": [
         {
-            "checksum": "5792be9b0216936e0a308387d67a7c2d",
-            "size": 4093,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_schema-select_operate_with_columns_simple-default.txt-Plan_/plan.txt"
+            "checksum": "c278bc688048d218f4d30f969b6b3213",
+            "size": 3887,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-select_operate_with_columns_simple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_no_infer--Debug]": [
@@ -2619,86 +2619,86 @@
     ],
     "test.test[schema-user_schema_patch_columns--Debug]": [
         {
-            "checksum": "721f422745821c99f94a858c6a6fc119",
-            "size": 2606,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_schema-user_schema_patch_columns--Debug_/opt.yql_patched"
+            "checksum": "110a32d73a6fdd6660ebd4cce941fa00",
+            "size": 2482,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-user_schema_patch_columns--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-user_schema_patch_columns--Plan]": [
         {
-            "checksum": "d2293bdffa4e745eaa50e86994995559",
-            "size": 4111,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_schema-user_schema_patch_columns--Plan_/plan.txt"
+            "checksum": "c900dd61bd1e072c8dc67c78fee0ebec",
+            "size": 3905,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_schema-user_schema_patch_columns--Plan_/plan.txt"
         }
     ],
     "test.test[select-substring-default.txt-Debug]": [
         {
-            "checksum": "69e0baa31ae3a62394a578d781cc6273",
-            "size": 2176,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_select-substring-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9e8992c77fae72419de4faf6dac1c2d4",
+            "size": 2076,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_select-substring-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-substring-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_select-substring-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_select-substring-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-tablepathprefix-default.txt-Debug]": [
         {
-            "checksum": "2dca224010340925c29c24fc829e4c15",
-            "size": 2075,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_select-tablepathprefix-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f8b54d110807544ce9f91a49fa692b10",
+            "size": 1952,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_select-tablepathprefix-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-tablepathprefix-default.txt-Plan]": [
         {
-            "checksum": "d3d12b50351a0b60b57956afa973efa6",
-            "size": 4187,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_select-tablepathprefix-default.txt-Plan_/plan.txt"
+            "checksum": "3d78eb0add5f98e8ea3384a94f5c165c",
+            "size": 3981,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_select-tablepathprefix-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_all_key_without-default.txt-Debug]": [
         {
-            "checksum": "423fdbca8142d037c61745d4cb7d4448",
-            "size": 6583,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_all_key_without-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1a2f36405ac6c3d93589281d3d0fd7ca",
+            "size": 6287,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_all_key_without-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_all_key_without-default.txt-Plan]": [
         {
-            "checksum": "de57a0adf0ee10083b19d62926d4671f",
-            "size": 9103,
-            "uri": "https://{canondata_backend}/1889210/ec3b6b1de6d778148ba06365bbe2c2fb53c07e80/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_all_key_without-default.txt-Plan_/plan.txt"
+            "checksum": "5c82c7c3687d27008c20b4fdbc252621",
+            "size": 8691,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_all_key_without-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_same_key-default.txt-Debug]": [
         {
-            "checksum": "d7cecfaef87c466d41edb14d2f25575d",
-            "size": 6258,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key-default.txt-Debug_/opt.yql_patched"
+            "checksum": "272b75002d9c5d04c06be6f6a024e699",
+            "size": 5997,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_same_key-default.txt-Plan]": [
         {
-            "checksum": "84d8628991680f471c5fe5d2dd3086b6",
-            "size": 9136,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key-default.txt-Plan_/plan.txt"
+            "checksum": "df2567a82663dc61534169e9aa734411",
+            "size": 8724,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_qualified_all_and_group_by-default.txt-Debug]": [
         {
-            "checksum": "34690cb93897c2e02cf6f35300293610",
-            "size": 5368,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_simple_columns-simple_columns_qualified_all_and_group_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6e24b400eef6fba488de52890984949d",
+            "size": 5040,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_simple_columns-simple_columns_qualified_all_and_group_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_qualified_all_and_group_by-default.txt-Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_simple_columns-simple_columns_qualified_all_and_group_by-default.txt-Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_simple_columns-simple_columns_qualified_all_and_group_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[table_range-concat_empty_sorted_with_key_diff--Debug]": [
@@ -2759,44 +2759,44 @@
     ],
     "test.test[table_range-tablepath_with_non_existing--Debug]": [
         {
-            "checksum": "ba5f6ff359cbd5e5e58c833f8ef8cf74",
-            "size": 2488,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_table_range-tablepath_with_non_existing--Debug_/opt.yql_patched"
+            "checksum": "341353025fc021b1722947de5083ef09",
+            "size": 2366,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_table_range-tablepath_with_non_existing--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-tablepath_with_non_existing--Plan]": [
         {
-            "checksum": "b9d0df1b282c0c5d29fbef28201e6c36",
-            "size": 4077,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_table_range-tablepath_with_non_existing--Plan_/plan.txt"
+            "checksum": "521c71c7fad70299a490d692deb1c0a1",
+            "size": 3871,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_table_range-tablepath_with_non_existing--Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q4-default.txt-Debug]": [
         {
-            "checksum": "7292362d355a15380a74d5b99ab38a2d",
-            "size": 8936,
-            "uri": "https://{canondata_backend}/1942100/19f57226e1981b417dcd7e8effae6c4c1fbb32d6/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f03190da4d70eda691f9b495c202c5e5",
+            "size": 8570,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_tpch-q4-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q4-default.txt-Plan]": [
         {
-            "checksum": "175db821e1c9a7d0ee266641845a4fed",
-            "size": 14458,
-            "uri": "https://{canondata_backend}/1924537/c7ea2c3fd8e76be397eb059191897d8d01921d1b/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
+            "checksum": "cb13cc86619b1662db0ccd674a9a6815",
+            "size": 13840,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_tpch-q4-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q7-default.txt-Debug]": [
         {
-            "checksum": "63a087536ce3cf1bc72dc226f7dde9a1",
-            "size": 11240,
-            "uri": "https://{canondata_backend}/212715/21559565f64527becae9026391f72c061d482bd8/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d395e651c71257439b189998c02b1709",
+            "size": 10735,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_tpch-q7-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q7-default.txt-Plan]": [
         {
-            "checksum": "97336c16c78602ab770d7a5069aa0788",
-            "size": 16787,
-            "uri": "https://{canondata_backend}/1871182/5749e15e2645ff9220b338130cfe265260d2cd07/resource.tar.gz#test.test_tpch-q7-default.txt-Plan_/plan.txt"
+            "checksum": "3b8335c31675b91e64be7b1825b760fd",
+            "size": 16169,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_tpch-q7-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-hor_join_with_mix_weak_access--Debug]": [
@@ -2815,44 +2815,44 @@
     ],
     "test.test[window-generic/aggregations_include_current--Debug]": [
         {
-            "checksum": "5a8cc6011960be64103039bd861d120b",
-            "size": 9806,
-            "uri": "https://{canondata_backend}/1784826/4c0fb703e2bf3d3d6d2977ee2244bf93048cb406/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql_patched"
+            "checksum": "15ba2c329043218b83819508371e06fd",
+            "size": 9285,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-generic_aggregations_include_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_include_current--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-generic_aggregations_include_current--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-generic_aggregations_include_current--Plan_/plan.txt"
         }
     ],
     "test.test[window-generic/session_aliases--Debug]": [
         {
-            "checksum": "488c7a2f148bdd203ff109f486d76324",
-            "size": 7247,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-generic_session_aliases--Debug_/opt.yql_patched"
+            "checksum": "69a0ab7e3463025f7395c268298bf288",
+            "size": 6845,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-generic_session_aliases--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/session_aliases--Plan]": [
         {
-            "checksum": "702a395959580a7a64c91724ba286b84",
-            "size": 5707,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-generic_session_aliases--Plan_/plan.txt"
+            "checksum": "6c885e91238b3116892cb25e704c7328",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-generic_session_aliases--Plan_/plan.txt"
         }
     ],
     "test.test[window-presort_window_partition_by_table-default.txt-Debug]": [
         {
-            "checksum": "4e869ee84e1b1eea087b81eab110aa22",
-            "size": 4547,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-presort_window_partition_by_table-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8d8d2db294427126c93c1954dc1a1282",
+            "size": 4447,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-presort_window_partition_by_table-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-presort_window_partition_by_table-default.txt-Plan]": [
         {
-            "checksum": "d6d88cd3e26b243c8ab0fd67b010a4f6",
-            "size": 7014,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-presort_window_partition_by_table-default.txt-Plan_/plan.txt"
+            "checksum": "9995b5c6cf61b6fb168d17bee004b2aa",
+            "size": 6808,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-presort_window_partition_by_table-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-udaf_no_merge-default.txt-Debug]": [
@@ -2871,86 +2871,86 @@
     ],
     "test.test[window-win_func_aggr_4func_no_part--Debug]": [
         {
-            "checksum": "b77f4379f82249a77974291bf6addfd7",
-            "size": 4094,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part--Debug_/opt.yql_patched"
+            "checksum": "7e13e9e892c17da6648b94a274f30cbb",
+            "size": 3952,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_4func_no_part--Plan]": [
         {
-            "checksum": "e73e482ef8e1fd5e2f1fb173e85002a7",
-            "size": 5560,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part--Plan_/plan.txt"
+            "checksum": "79359b10317c94ad618b5563fe45b4e4",
+            "size": 5354,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_aggr_4func_sort_desc--Debug]": [
         {
-            "checksum": "af0eaff077d2a0a3a2311027bc4dcdea",
-            "size": 4754,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-win_func_aggr_4func_sort_desc--Debug_/opt.yql_patched"
+            "checksum": "89171de06b1b2f5a8b493970b0101dcb",
+            "size": 4595,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_aggr_4func_sort_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_4func_sort_desc--Plan]": [
         {
-            "checksum": "9f92eb6e9e798ebb30ffde05d9e40eef",
-            "size": 6302,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_func_aggr_4func_sort_desc--Plan_/plan.txt"
+            "checksum": "6ffc1cb7a0dc0b6bc10daaa492be7d94",
+            "size": 6096,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_aggr_4func_sort_desc--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_lead_lag_worm_with_part_other--Debug]": [
         {
-            "checksum": "2cc2247174982c327723638904d0e7b0",
-            "size": 9131,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part_other--Debug_/opt.yql_patched"
+            "checksum": "cd5d4d7d9687914dd9135fa0298279b2",
+            "size": 8373,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_lead_lag_worm_with_part_other--Plan]": [
         {
-            "checksum": "cdd8c059068b99ecd28979c162f5d698",
-            "size": 8450,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part_other--Plan_/plan.txt"
+            "checksum": "d3731dd27ea3b42b6511c7e8d0432c79",
+            "size": 7832,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part_other--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Debug]": [
         {
-            "checksum": "64a3b7027319e8dcc7a09ed4dcc533a0",
-            "size": 4400,
-            "uri": "https://{canondata_backend}/1777230/216d4e6d62fea8f58776a41a12ef7ca23fab393c/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql_patched"
+            "checksum": "cb31c3afc21619cb53f9b4274cbc46a2",
+            "size": 4253,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_order_by_udf_empty_rank--Plan]": [
         {
-            "checksum": "9f92eb6e9e798ebb30ffde05d9e40eef",
-            "size": 6302,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Plan_/plan.txt"
+            "checksum": "6ffc1cb7a0dc0b6bc10daaa492be7d94",
+            "size": 6096,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_order_by_udf_empty_rank--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_rank_by_all--Debug]": [
         {
-            "checksum": "9a391c1096a1612821106038fdfaea7d",
-            "size": 3798,
-            "uri": "https://{canondata_backend}/1880306/5d2fb97b23cd70975bc5d744391981f9d5595c04/resource.tar.gz#test.test_window-win_func_rank_by_all--Debug_/opt.yql_patched"
+            "checksum": "3e94f4d53260dcb0951f7e033fa7cefb",
+            "size": 3736,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_rank_by_all--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_rank_by_all--Plan]": [
         {
-            "checksum": "bd67f838edb07ed44512867f64dda80a",
-            "size": 5601,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_func_rank_by_all--Plan_/plan.txt"
+            "checksum": "135aee0995e6816890255244b97c9e88",
+            "size": 5395,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_func_rank_by_all--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_fuse_window-default.txt-Debug]": [
         {
-            "checksum": "e243f568f1d1b0b2017bb798436f1208",
-            "size": 9851,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Debug_/opt.yql_patched"
+            "checksum": "405c6dd63075bc81e81c34404ada9a3c",
+            "size": 9232,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_fuse_window-default.txt-Plan]": [
         {
-            "checksum": "ee5a9701f3b47cb2492bae395a05c77e",
-            "size": 12015,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Plan_/plan.txt"
+            "checksum": "f0825abdd1eb20897c07215327c8f899",
+            "size": 11397,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_fuse_window-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_lead_in_mem-default.txt-Debug]": [
@@ -2983,30 +2983,30 @@
     ],
     "test.test[window-win_over_few_partitions--Debug]": [
         {
-            "checksum": "bb205f2838323537ec6fc42453f611c1",
-            "size": 8582,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-win_over_few_partitions--Debug_/opt.yql_patched"
+            "checksum": "bf9d2ca65c762487b18fcd68ed10db03",
+            "size": 7913,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_over_few_partitions--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_over_few_partitions--Plan]": [
         {
-            "checksum": "ba7f83a488cab086fe5a5bea57d58224",
-            "size": 10848,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_over_few_partitions--Plan_/plan.txt"
+            "checksum": "a53887aa5e2ce020e5106b924c5e4c86",
+            "size": 10024,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_over_few_partitions--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_over_few_partitions_other--Debug]": [
         {
-            "checksum": "612dc5bc804dfae823941eb6b1f7ea60",
-            "size": 8563,
-            "uri": "https://{canondata_backend}/1773845/06318af62e5da72747e6343c15ed6d2ac79bfaf0/resource.tar.gz#test.test_window-win_over_few_partitions_other--Debug_/opt.yql_patched"
+            "checksum": "2cc6549978048164c8c2faacdc2c8fcd",
+            "size": 8074,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_over_few_partitions_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_over_few_partitions_other--Plan]": [
         {
-            "checksum": "99657bffc263717a838893b3e5b504cd",
-            "size": 10216,
-            "uri": "https://{canondata_backend}/1937367/7890620b546312cfd9cbc4ee46166efc1a36450c/resource.tar.gz#test.test_window-win_over_few_partitions_other--Plan_/plan.txt"
+            "checksum": "995ff953564d08fd16175b763d1c9880",
+            "size": 9598,
+            "uri": "https://{canondata_backend}/1924537/7199a3a7eba1a101a7ecd6552b3df25cb9a6ef2b/resource.tar.gz#test.test_window-win_over_few_partitions_other--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_peephole-default.txt-Debug]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part1/canondata/result.json
@@ -1,16 +1,16 @@
 {
     "test.test[action-action_eval_cluster_use--Debug]": [
         {
-            "checksum": "e197d0a388e7caabf3c957ae62140024",
-            "size": 3009,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_action-action_eval_cluster_use--Debug_/opt.yql_patched"
+            "checksum": "f6d496a1d49e365118fd95d6791ec400",
+            "size": 2763,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-action_eval_cluster_use--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-action_eval_cluster_use--Plan]": [
         {
-            "checksum": "c22d75728ebf1dc427e2aae2591ae6c9",
-            "size": 7041,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_action-action_eval_cluster_use--Plan_/plan.txt"
+            "checksum": "fe11af3091c1a4f332793f79f2bd536a",
+            "size": 6629,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-action_eval_cluster_use--Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_range--Debug]": [
@@ -29,16 +29,16 @@
     ],
     "test.test[action-eval_skip_take--Debug]": [
         {
-            "checksum": "cc3805d8e9415588923eed19f2b88778",
-            "size": 3041,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_action-eval_skip_take--Debug_/opt.yql_patched"
+            "checksum": "7b2e5477e63ab390f68eedda161c3005",
+            "size": 2890,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-eval_skip_take--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_skip_take--Plan]": [
         {
-            "checksum": "64d6ea3abebbff1e09ad295798dfdb4e",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_action-eval_skip_take--Plan_/plan.txt"
+            "checksum": "60f75e83f930ef46872b182deb42c77e",
+            "size": 5326,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-eval_skip_take--Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_variant-default.txt-Debug]": [
@@ -57,30 +57,30 @@
     ],
     "test.test[action-insert_after_eval--Debug]": [
         {
-            "checksum": "ed241ee5ac5c32e540fc175fb427680b",
-            "size": 1619,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_action-insert_after_eval--Debug_/opt.yql_patched"
+            "checksum": "bad24e56f8d77be54b854337db7035aa",
+            "size": 1501,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-insert_after_eval--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-insert_after_eval--Plan]": [
         {
-            "checksum": "69ffe06cf88dd21ae82f8646a5c3eda3",
-            "size": 4190,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_action-insert_after_eval--Plan_/plan.txt"
+            "checksum": "afc21adffbeb9bfd7ee943e64f1d18a7",
+            "size": 3984,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-insert_after_eval--Plan_/plan.txt"
         }
     ],
     "test.test[action-parallel_for-default.txt-Debug]": [
         {
-            "checksum": "6ec0e4da069c34048582f21d86d31f0f",
-            "size": 3391,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_action-parallel_for-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cea172ec73d548d4b781ed6d2ef6ecde",
+            "size": 3217,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-parallel_for-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-parallel_for-default.txt-Plan]": [
         {
-            "checksum": "ef111b5c3fb788d00da42033d9764ebe",
-            "size": 13093,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_action-parallel_for-default.txt-Plan_/plan.txt"
+            "checksum": "9f303d1c49baf9627150e29c69dffe85",
+            "size": 12475,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_action-parallel_for-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-subquery_orderby2-default.txt-Debug]": [
@@ -211,16 +211,16 @@
     ],
     "test.test[aggr_factory-count-default.txt-Debug]": [
         {
-            "checksum": "ebf120e0dc9cb94431a2d5351e82b055",
-            "size": 4848,
-            "uri": "https://{canondata_backend}/1942415/2281e913fb2696f40033d948971841a683a66e27/resource.tar.gz#test.test_aggr_factory-count-default.txt-Debug_/opt.yql_patched"
+            "checksum": "18fe6cde3a4e42f4baee1b23ac7f06ec",
+            "size": 4702,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggr_factory-count-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-count-default.txt-Plan]": [
         {
-            "checksum": "870bc69e51ee0c002f970b8353ce4387",
-            "size": 11155,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggr_factory-count-default.txt-Plan_/plan.txt"
+            "checksum": "eb9079a5085e466142b2e7b0a2890b39",
+            "size": 10537,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggr_factory-count-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-multi_list_nulls-default.txt-Debug]": [
@@ -239,156 +239,156 @@
     ],
     "test.test[aggr_factory-variance-default.txt-Debug]": [
         {
-            "checksum": "70f9ee87455b3dfdce29e6869646f3a3",
-            "size": 8229,
-            "uri": "https://{canondata_backend}/1775059/2e1d9d5a92aa3d5860f533a731915fa7e5798df4/resource.tar.gz#test.test_aggr_factory-variance-default.txt-Debug_/opt.yql_patched"
+            "checksum": "fbd693d6951cd5533e3d1a079729341c",
+            "size": 8130,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggr_factory-variance-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-variance-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggr_factory-variance-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggr_factory-variance-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_column_alias_reuse-default.txt-Debug]": [
         {
-            "checksum": "e3c56524b1d5b950aee86d38ce14c90d",
-            "size": 4936,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e51ca2776042ac541f1d1fb51fa5a961",
+            "size": 4638,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_column_alias_reuse-default.txt-Plan]": [
         {
-            "checksum": "d6d6b7f544242bdb1708d72d222cddec",
-            "size": 8557,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse-default.txt-Plan_/plan.txt"
+            "checksum": "2986d7ccd8bd9d212566d0be158f9eaa",
+            "size": 7939,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_alt_duo--Debug]": [
         {
-            "checksum": "58327678b83636600cdeb74c26def8ec",
-            "size": 5458,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_aggregate-group_by_gs_alt_duo--Debug_/opt.yql_patched"
+            "checksum": "e6547ae57fa13a4422b204d5008ba06f",
+            "size": 5082,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_gs_alt_duo--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_alt_duo--Plan]": [
         {
-            "checksum": "28c2ab3b456e34dadfd529005a3e689e",
-            "size": 8484,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-group_by_gs_alt_duo--Plan_/plan.txt"
+            "checksum": "3ceffa5883fca835378d5359d3859d5f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_gs_alt_duo--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_subselect-default.txt-Debug]": [
         {
-            "checksum": "a9a017f224a00ff7afed26df9ca1c2a2",
-            "size": 7427,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_aggregate-group_by_gs_subselect-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b25e83df764133ab5a2f9fbc2820be4b",
+            "size": 6963,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_gs_subselect-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_subselect-default.txt-Plan]": [
         {
-            "checksum": "cd5f2c7d9faec30cb837e1041e61bc3a",
-            "size": 11432,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-group_by_gs_subselect-default.txt-Plan_/plan.txt"
+            "checksum": "d138d6c4123ed6ed5751e2022ed3b0b8",
+            "size": 10814,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_gs_subselect-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_mul_gs_ru--Debug]": [
         {
-            "checksum": "b4ebb211e63e020556dfc1456878a9b8",
-            "size": 11546,
-            "uri": "https://{canondata_backend}/1689644/02b7f024485c8d2d2cbc698ac544ecb552066815/resource.tar.gz#test.test_aggregate-group_by_mul_gs_ru--Debug_/opt.yql_patched"
+            "checksum": "929cc80169414062fcb38e330b47f812",
+            "size": 10826,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_mul_gs_ru--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_mul_gs_ru--Plan]": [
         {
-            "checksum": "c859e7066594842a69625580c95ce050",
-            "size": 14090,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-group_by_mul_gs_ru--Plan_/plan.txt"
+            "checksum": "0b04937a290fc1a7c737b757352d1654",
+            "size": 13266,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_mul_gs_ru--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_join_star-default.txt-Debug]": [
         {
-            "checksum": "931e582876265ec94d8e5a4abcb44b62",
-            "size": 8715,
-            "uri": "https://{canondata_backend}/1871102/7b4f38a71959b2a4d7977fc0b5d14d82c519d35e/resource.tar.gz#test.test_aggregate-group_by_ru_join_star-default.txt-Debug_/opt.yql_patched"
+            "checksum": "844a9a948433b0e393a521c089539db8",
+            "size": 8378,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_ru_join_star-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_join_star-default.txt-Plan]": [
         {
-            "checksum": "c67a122bf3f1410067d9353f6d898210",
-            "size": 14728,
-            "uri": "https://{canondata_backend}/1871102/7b4f38a71959b2a4d7977fc0b5d14d82c519d35e/resource.tar.gz#test.test_aggregate-group_by_ru_join_star-default.txt-Plan_/plan.txt"
+            "checksum": "0c15fe44b7e95f0d85bb65aea9bde2c7",
+            "size": 13904,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_ru_join_star-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_with_window_func--Debug]": [
         {
-            "checksum": "30142821625d52a8d86806bef725b1b7",
-            "size": 7804,
-            "uri": "https://{canondata_backend}/1942525/ec97a3e319902cc36fb85651547b6e4cac4c1a70/resource.tar.gz#test.test_aggregate-group_by_ru_with_window_func--Debug_/opt.yql_patched"
+            "checksum": "133eaa08c371a4c87c7e097ec6dae2a5",
+            "size": 7562,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_ru_with_window_func--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_with_window_func--Plan]": [
         {
-            "checksum": "453199fe70d7e91552c3760b7a54faf8",
-            "size": 13571,
-            "uri": "https://{canondata_backend}/1942525/ec97a3e319902cc36fb85651547b6e4cac4c1a70/resource.tar.gz#test.test_aggregate-group_by_ru_with_window_func--Plan_/plan.txt"
+            "checksum": "fa398de09aa069b68f495dd8bf1ed7d1",
+            "size": 12747,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_ru_with_window_func--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_compact--Debug]": [
         {
-            "checksum": "a75bd8349ce7f4bf7889c1fcbf05ad45",
-            "size": 5299,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_aggregate-group_by_session_compact--Debug_/opt.yql_patched"
+            "checksum": "ee71f4a9f4a3d4741159a33c892aa93e",
+            "size": 4981,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_session_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_compact--Plan]": [
         {
-            "checksum": "702a395959580a7a64c91724ba286b84",
-            "size": 5707,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-group_by_session_compact--Plan_/plan.txt"
+            "checksum": "6c885e91238b3116892cb25e704c7328",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_session_compact--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_extended--Debug]": [
         {
-            "checksum": "9c918885710145932f76285ac6094e2e",
-            "size": 5243,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_aggregate-group_by_session_extended--Debug_/opt.yql_patched"
+            "checksum": "ce7dff6bd170100e5d048287203b31da",
+            "size": 4925,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_session_extended--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_extended--Plan]": [
         {
-            "checksum": "702a395959580a7a64c91724ba286b84",
-            "size": 5707,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-group_by_session_extended--Plan_/plan.txt"
+            "checksum": "6c885e91238b3116892cb25e704c7328",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-group_by_session_extended--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-percentile_and_variance--Debug]": [
         {
-            "checksum": "dc91cf5081379f49a6deddc7929e79ae",
-            "size": 7129,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_aggregate-percentile_and_variance--Debug_/opt.yql_patched"
+            "checksum": "813902013485da33eb5110c505a00558",
+            "size": 7014,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-percentile_and_variance--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-percentile_and_variance--Plan]": [
         {
-            "checksum": "1fc289f1cde313e443c94649b94e540a",
-            "size": 5661,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-percentile_and_variance--Plan_/plan.txt"
+            "checksum": "334ac35a87e1dcf3b243634e1e872716",
+            "size": 5455,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-percentile_and_variance--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-subquery_aggregation--Debug]": [
         {
-            "checksum": "304515c098e86226cb123d7d25c62cec",
-            "size": 5270,
-            "uri": "https://{canondata_backend}/1946324/e1f7c67cafa20200008de81571567844ef07755d/resource.tar.gz#test.test_aggregate-subquery_aggregation--Debug_/opt.yql_patched"
+            "checksum": "d7acb9fbb9ae67ca50fb31d6142a58f2",
+            "size": 4898,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-subquery_aggregation--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-subquery_aggregation--Plan]": [
         {
-            "checksum": "3d2785000d4a0f2db300d7c2dafcf37d",
-            "size": 8528,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_aggregate-subquery_aggregation--Plan_/plan.txt"
+            "checksum": "388dbcb74a997197b1616e8649f97051",
+            "size": 7910,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_aggregate-subquery_aggregation--Plan_/plan.txt"
         }
     ],
     "test.test[ansi_idents-escaping-default.txt-Debug]": [
@@ -421,16 +421,16 @@
     ],
     "test.test[ansi_idents-order_by-default.txt-Debug]": [
         {
-            "checksum": "bf791d348fb81f44e17df8c5dab8469e",
-            "size": 2052,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_ansi_idents-order_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "122e16cfd800c6ed2ebf4246fa20da15",
+            "size": 1929,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_ansi_idents-order_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ansi_idents-order_by-default.txt-Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_ansi_idents-order_by-default.txt-Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_ansi_idents-order_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[ansi_idents-string_escaping-default.txt-Debug]": [
@@ -463,16 +463,16 @@
     ],
     "test.test[bigdate-table_arithmetic_sub-default.txt-Debug]": [
         {
-            "checksum": "a559e9825371febda30fb84696c1692e",
-            "size": 8333,
-            "uri": "https://{canondata_backend}/1130705/860bc32122e91b708962eed99b803801035ed515/resource.tar.gz#test.test_bigdate-table_arithmetic_sub-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7c5edd134ed6dcacffcedb93aa93cff5",
+            "size": 7778,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_bigdate-table_arithmetic_sub-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_arithmetic_sub-default.txt-Plan]": [
         {
-            "checksum": "19bf27644f711504f344c14e4e2aaed2",
-            "size": 8641,
-            "uri": "https://{canondata_backend}/1130705/860bc32122e91b708962eed99b803801035ed515/resource.tar.gz#test.test_bigdate-table_arithmetic_sub-default.txt-Plan_/plan.txt"
+            "checksum": "8bd1b60392f86b2c25d8b2c2aa460ccf",
+            "size": 8229,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_bigdate-table_arithmetic_sub-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[binding-bind_select-default.txt-Debug]": [
@@ -505,142 +505,142 @@
     ],
     "test.test[blocks-add_uint64_opt2--Debug]": [
         {
-            "checksum": "e22e052500123bc5ddce22a487a40ae5",
-            "size": 2293,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-add_uint64_opt2--Debug_/opt.yql_patched"
+            "checksum": "749f9270e8711736b3669e5d9905a292",
+            "size": 2163,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-add_uint64_opt2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_uint64_opt2--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-add_uint64_opt2--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-add_uint64_opt2--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-coalesce_ints--Debug]": [
         {
-            "checksum": "f1c18281ce0553dd5091cd664189aa2d",
-            "size": 4300,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-coalesce_ints--Debug_/opt.yql_patched"
+            "checksum": "99df9f4c143e3eb1ee4da6ee68c364f0",
+            "size": 3762,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-coalesce_ints--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-coalesce_ints--Plan]": [
         {
-            "checksum": "97de1980fa8bc3521a8e43346ae0d485",
-            "size": 6196,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-coalesce_ints--Plan_/plan.txt"
+            "checksum": "98f25705c9e738a47faba381f7773bbc",
+            "size": 5784,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-coalesce_ints--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_decimal--Debug]": [
         {
-            "checksum": "6a14942091e192a9cfc41b1f8bd222f0",
-            "size": 9047,
-            "uri": "https://{canondata_backend}/1871182/aba145d12e60259474a4d54a3c0451194ac1617f/resource.tar.gz#test.test_blocks-combine_all_decimal--Debug_/opt.yql_patched"
+            "checksum": "f866bf40490583dfc4bced6c91505c11",
+            "size": 8739,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_all_decimal--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_decimal--Plan]": [
         {
-            "checksum": "c6efb578089e649666b0f254bce73693",
-            "size": 5645,
-            "uri": "https://{canondata_backend}/1809005/7142336c5d0d72d24df8de2731d5f39f0b6e741c/resource.tar.gz#test.test_blocks-combine_all_decimal--Plan_/plan.txt"
+            "checksum": "d06f465be5c8b137a35e2ddc6f9e974f",
+            "size": 5439,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_all_decimal--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_min_filter--Debug]": [
         {
-            "checksum": "29a4530555819599901f599a116aa9f0",
-            "size": 3157,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-combine_all_min_filter--Debug_/opt.yql_patched"
+            "checksum": "32a3563e8d0c393c9f3138b4ce6c6026",
+            "size": 3090,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_all_min_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_min_filter--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-combine_all_min_filter--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_all_min_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_min_filter_opt--Debug]": [
         {
-            "checksum": "04aac68d063fcd0444f827d332631be4",
-            "size": 3209,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-combine_all_min_filter_opt--Debug_/opt.yql_patched"
+            "checksum": "740dd21190a72873d6f57a39807d744b",
+            "size": 3142,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_all_min_filter_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_min_filter_opt--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-combine_all_min_filter_opt--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_all_min_filter_opt--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_max--Debug]": [
         {
-            "checksum": "815f014c81f612549334d28ff5542baa",
-            "size": 6419,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-combine_hashed_max--Debug_/opt.yql_patched"
+            "checksum": "af86eb81791a8865cc87bb3dfa14b30f",
+            "size": 5893,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_hashed_max--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_max--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-combine_hashed_max--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-combine_hashed_max--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_less_or_equal--Debug]": [
         {
-            "checksum": "4e5eebc017464616b078a40bc3121a53",
-            "size": 28171,
-            "uri": "https://{canondata_backend}/1942525/c5f89e47e168e72c1372db8b5d6d6ab7387f91cf/resource.tar.gz#test.test_blocks-date_less_or_equal--Debug_/opt.yql_patched"
+            "checksum": "4dd63f22f81dea3662383fea6646d256",
+            "size": 24221,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-date_less_or_equal--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_less_or_equal--Plan]": [
         {
-            "checksum": "fe66d03c15b37a053205c1b23150a020",
-            "size": 15887,
-            "uri": "https://{canondata_backend}/1942525/c5f89e47e168e72c1372db8b5d6d6ab7387f91cf/resource.tar.gz#test.test_blocks-date_less_or_equal--Plan_/plan.txt"
+            "checksum": "e0b70c711bba0b9a8af7293607a6483c",
+            "size": 15475,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-date_less_or_equal--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-decimal_unary--Debug]": [
         {
-            "checksum": "c6286d593f3ce2581337dee33cd574ff",
-            "size": 2241,
-            "uri": "https://{canondata_backend}/1775319/b7d43990cdf7ceef10e2a27dcd97d11ed7c5fde7/resource.tar.gz#test.test_blocks-decimal_unary--Debug_/opt.yql_patched"
+            "checksum": "91d5eaa9920fe9015067ab6eca6c9a1e",
+            "size": 2135,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-decimal_unary--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-decimal_unary--Plan]": [
         {
-            "checksum": "e65c86ba6e55033fe5f47711b65bba6d",
-            "size": 4093,
-            "uri": "https://{canondata_backend}/1775319/b7d43990cdf7ceef10e2a27dcd97d11ed7c5fde7/resource.tar.gz#test.test_blocks-decimal_unary--Plan_/plan.txt"
+            "checksum": "73e50c3285312f865e29210e7f952098",
+            "size": 3887,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-decimal_unary--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-distinct_mixed_keys--Debug]": [
         {
-            "checksum": "8a1c4eaf681e49661dbe802d96a52122",
-            "size": 12963,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-distinct_mixed_keys--Debug_/opt.yql_patched"
+            "checksum": "6f38d2adf7c7e6928ec8a6c8aada24ec",
+            "size": 12280,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-distinct_mixed_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-distinct_mixed_keys--Plan]": [
         {
-            "checksum": "98ea8ccc6db2afaa50a8a42bca33d1d6",
-            "size": 17509,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-distinct_mixed_keys--Plan_/plan.txt"
+            "checksum": "fb44e5df78e3f2f3e02c41d60a622b24",
+            "size": 16479,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-distinct_mixed_keys--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-distinct_opt_state_all--Debug]": [
         {
-            "checksum": "2b6f3aeb9749443bc4a4bf39b01606a2",
-            "size": 13702,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-distinct_opt_state_all--Debug_/opt.yql_patched"
+            "checksum": "339fc494450a3e78b430fcdccfb3837e",
+            "size": 13426,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-distinct_opt_state_all--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-distinct_opt_state_all--Plan]": [
         {
-            "checksum": "dec608820e749ec64885ad0efcc7a75c",
-            "size": 13898,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-distinct_opt_state_all--Plan_/plan.txt"
+            "checksum": "ae589d80c91ec67366bc06e3b143d208",
+            "size": 13280,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-distinct_opt_state_all--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_add_interval_scalar--Debug]": [
@@ -659,128 +659,128 @@
     ],
     "test.test[blocks-lazy_nonstrict_nested--Debug]": [
         {
-            "checksum": "1819d620a4724d624ba8baa8ec069222",
-            "size": 2544,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Debug_/opt.yql_patched"
+            "checksum": "357eb5534af2b54f9275a9442017b2f2",
+            "size": 2417,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-lazy_nonstrict_nested--Plan]": [
         {
-            "checksum": "268f40d4cd05bdaf1da7d54f3cb20944",
-            "size": 4077,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Plan_/plan.txt"
+            "checksum": "bea2bf2feac939761164aa8b2b8b5923",
+            "size": 3871,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-lazy_nonstrict_nested--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-partial_blocks1--Debug]": [
         {
-            "checksum": "c17ca64c105e8ffce3fcacc4feee453a",
-            "size": 2311,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-partial_blocks1--Debug_/opt.yql_patched"
+            "checksum": "fd8a0f07461eb8d30fb67e67c08198eb",
+            "size": 2161,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-partial_blocks1--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-partial_blocks1--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-partial_blocks1--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-partial_blocks1--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_to_strings--Debug]": [
         {
-            "checksum": "6b7d784a7800aa30f7bf0eea7fa21d30",
-            "size": 4251,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-pg_to_strings--Debug_/opt.yql_patched"
+            "checksum": "b02ca04b74f5b36de263f6631f98976b",
+            "size": 3919,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-pg_to_strings--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_to_strings--Plan]": [
         {
-            "checksum": "d21a51c34f9162c6bd4660e841f7b3fa",
-            "size": 7164,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-pg_to_strings--Plan_/plan.txt"
+            "checksum": "593dd0ccfe433305850bf799a7794ef8",
+            "size": 6752,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-pg_to_strings--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-sub_uint64_opt2--Debug]": [
         {
-            "checksum": "382ff71d051ac28cf21da617fbfbcd04",
-            "size": 2296,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-sub_uint64_opt2--Debug_/opt.yql_patched"
+            "checksum": "ad1e47756a7a8490df22fa176887bfc8",
+            "size": 2166,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-sub_uint64_opt2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-sub_uint64_opt2--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-sub_uint64_opt2--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-sub_uint64_opt2--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-tuple_nth--Debug]": [
         {
-            "checksum": "b7828b942e381d5fa263ac7773793f55",
-            "size": 5794,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-tuple_nth--Debug_/opt.yql_patched"
+            "checksum": "0d7318be27b3dc875919033bd07150f9",
+            "size": 5260,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-tuple_nth--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-tuple_nth--Plan]": [
         {
-            "checksum": "20ec3cb89e06b32241805034fb9a406f",
-            "size": 8671,
-            "uri": "https://{canondata_backend}/1889210/b0118a685beb1cfba4436799d514f392b983c379/resource.tar.gz#test.test_blocks-tuple_nth--Plan_/plan.txt"
+            "checksum": "bab5929414b541ac6b186069e489d79c",
+            "size": 8259,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_blocks-tuple_nth--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_limit_offset-default.txt-Debug]": [
         {
-            "checksum": "dcacf08838fd389fdb29eafc837be6ea",
-            "size": 3355,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_column_order-select_limit_offset-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b43e80b74ebbc97b0bd145250b7e848c",
+            "size": 3204,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_limit_offset-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_limit_offset-default.txt-Plan]": [
         {
-            "checksum": "161e598bf7865e241e895a6b78cb5bf0",
-            "size": 6582,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_column_order-select_limit_offset-default.txt-Plan_/plan.txt"
+            "checksum": "ce46cdeacf429011ac62b4d4dc38ec1c",
+            "size": 6170,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_limit_offset-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_orderby-default.txt-Debug]": [
         {
-            "checksum": "9d14b1a00ca7d4a76596a27cbc5bca9b",
-            "size": 2240,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_column_order-select_orderby-default.txt-Debug_/opt.yql_patched"
+            "checksum": "60603aadf970df01e403763bb0112442",
+            "size": 2117,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_orderby-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_orderby-default.txt-Plan]": [
         {
-            "checksum": "54d04f82562aa7035e2dccb4389e5163",
-            "size": 3601,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_column_order-select_orderby-default.txt-Plan_/plan.txt"
+            "checksum": "bebba0c9098fb05950cba5ad705ff1ad",
+            "size": 3395,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_orderby-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_plain_nosimple-default.txt-Debug]": [
         {
-            "checksum": "3ad96bbf621b45ad18f5e2016dde411d",
-            "size": 5602,
-            "uri": "https://{canondata_backend}/1937424/be6de2a45c0e092d8da0f5c04670601e603a4d75/resource.tar.gz#test.test_column_order-select_plain_nosimple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a42059ada25a38a0aac11491aaf7abe1",
+            "size": 5495,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_plain_nosimple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_plain_nosimple-default.txt-Plan]": [
         {
-            "checksum": "b41e485a7b3e85be951c89ed0e441fb0",
-            "size": 9506,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_column_order-select_plain_nosimple-default.txt-Plan_/plan.txt"
+            "checksum": "458ea711019c63295d15d2de9fea5fca",
+            "size": 9300,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_plain_nosimple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_subquery-default.txt-Debug]": [
         {
-            "checksum": "fe2011adfd8cc24c6cd7501f0604ca2a",
-            "size": 1921,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_column_order-select_subquery-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c8d099b2c46d53848046eed7d01a6174",
+            "size": 1821,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_subquery-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_subquery-default.txt-Plan]": [
         {
-            "checksum": "ba8d30257dc710101add4d98ea788a8f",
-            "size": 3474,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_column_order-select_subquery-default.txt-Plan_/plan.txt"
+            "checksum": "8be0a0c6357c5f15033a0c092d757680",
+            "size": 3268,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_column_order-select_subquery-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[csee-l2_dup_l1_many-default.txt-Debug]": [
@@ -911,16 +911,16 @@
     ],
     "test.test[expr-empty_iterator2--Debug]": [
         {
-            "checksum": "66282ad0973985a1208ab14a7476b68c",
-            "size": 3359,
-            "uri": "https://{canondata_backend}/1937027/3f938aec3ab110638fd95877815c7fb4362a4261/resource.tar.gz#test.test_expr-empty_iterator2--Debug_/opt.yql_patched"
+            "checksum": "7e06e67fe4977398a1e271bb96012733",
+            "size": 3231,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_expr-empty_iterator2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-empty_iterator2--Plan]": [
         {
-            "checksum": "924ba396f0060e96a17b081f6106bf12",
-            "size": 6316,
-            "uri": "https://{canondata_backend}/1937027/3f938aec3ab110638fd95877815c7fb4362a4261/resource.tar.gz#test.test_expr-empty_iterator2--Plan_/plan.txt"
+            "checksum": "5e088a524803d85fd21ea943211278e2",
+            "size": 5904,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_expr-empty_iterator2--Plan_/plan.txt"
         }
     ],
     "test.test[expr-expr_add_literal_nulls-default.txt-Debug]": [
@@ -1093,58 +1093,58 @@
     ],
     "test.test[file-parse_file_in_select_as_uint64--Debug]": [
         {
-            "checksum": "0591f880520e5cdf8e0c39add9ca362a",
-            "size": 2532,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_file-parse_file_in_select_as_uint64--Debug_/opt.yql_patched"
+            "checksum": "c8ad0d3e134949de5fdb810115d97108",
+            "size": 2406,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_file-parse_file_in_select_as_uint64--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-parse_file_in_select_as_uint64--Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_file-parse_file_in_select_as_uint64--Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_file-parse_file_in_select_as_uint64--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-out_mem_limit-default.txt-Debug]": [
         {
-            "checksum": "60cda73222095c4fc4bae6fadafa15ec",
-            "size": 10408,
-            "uri": "https://{canondata_backend}/1937429/280843cc8d8c85d96284e8fe059b340a3a45c757/resource.tar.gz#test.test_hor_join-out_mem_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "fac9d8d428964a2e8493cf651b16c64f",
+            "size": 9839,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_hor_join-out_mem_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-out_mem_limit-default.txt-Plan]": [
         {
-            "checksum": "a8280f86c88685688891cc00595867dc",
-            "size": 22131,
-            "uri": "https://{canondata_backend}/1937429/280843cc8d8c85d96284e8fe059b340a3a45c757/resource.tar.gz#test.test_hor_join-out_mem_limit-default.txt-Plan_/plan.txt"
+            "checksum": "38624e3245959f9082bcc0e476e513de",
+            "size": 20689,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_hor_join-out_mem_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_compact_distinct--Debug]": [
         {
-            "checksum": "690c84f147d30010e76d34e1c15acc3d",
-            "size": 4956,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_in-in_compact_distinct--Debug_/opt.yql_patched"
+            "checksum": "7bfdc9c67dfb18f42c85a95282724cea",
+            "size": 4727,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_compact_distinct--Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_compact_distinct--Plan]": [
         {
-            "checksum": "f5533a8d5e85db992695fda4e9804a39",
-            "size": 9823,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_in-in_compact_distinct--Plan_/plan.txt"
+            "checksum": "13d7dad996376058c00af25fe5ed42f8",
+            "size": 9205,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_compact_distinct--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_compact_distinct-empty-Debug]": [
         {
-            "checksum": "3e78e8ac4145ea6bd1f1ce81ce58c016",
-            "size": 3055,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_in-in_compact_distinct-empty-Debug_/opt.yql_patched"
+            "checksum": "3afd9592b858b7198ff825c7255f33e6",
+            "size": 2809,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_compact_distinct-empty-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_compact_distinct-empty-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_in-in_compact_distinct-empty-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_compact_distinct-empty-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_noansi_empty-default.txt-Debug]": [
@@ -1163,16 +1163,16 @@
     ],
     "test.test[in-in_noansi_join--Debug]": [
         {
-            "checksum": "d26f6a1029c797658b8679e29b1cc8f3",
-            "size": 24597,
-            "uri": "https://{canondata_backend}/1871102/7b4f38a71959b2a4d7977fc0b5d14d82c519d35e/resource.tar.gz#test.test_in-in_noansi_join--Debug_/opt.yql_patched"
+            "checksum": "5e2ed79e8ca9e0650379db9a5ebbf4fd",
+            "size": 23979,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_noansi_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_noansi_join--Plan]": [
         {
-            "checksum": "9318b32fb2d525ef191a8e791ab11183",
-            "size": 78692,
-            "uri": "https://{canondata_backend}/1871102/7b4f38a71959b2a4d7977fc0b5d14d82c519d35e/resource.tar.gz#test.test_in-in_noansi_join--Plan_/plan.txt"
+            "checksum": "49e7d6b9b5d3dd4e9014c166a73c8489",
+            "size": 75602,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_noansi_join--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_nonliteral_tuple-default.txt-Debug]": [
@@ -1191,16 +1191,16 @@
     ],
     "test.test[in-in_scalar_vector_subquery-default.txt-Debug]": [
         {
-            "checksum": "f1ba7b5edfdf71cad417632b214f8c83",
-            "size": 13288,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_in-in_scalar_vector_subquery-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c7b76be46c63898dfd59d686da6d73a4",
+            "size": 12868,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_scalar_vector_subquery-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_scalar_vector_subquery-default.txt-Plan]": [
         {
-            "checksum": "855d8ce8c3358c3dbce6492214c11dad",
-            "size": 34650,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_in-in_scalar_vector_subquery-default.txt-Plan_/plan.txt"
+            "checksum": "7b5fc84f09887e5f921b8fef6a1463f4",
+            "size": 33208,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_in-in_scalar_vector_subquery-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_with_cast-default.txt-Debug]": [
@@ -1233,58 +1233,58 @@
     ],
     "test.test[insert-insert_null-default.txt-Debug]": [
         {
-            "checksum": "4f36db6143ad26d146ee836d112c3ab2",
-            "size": 1220,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_insert-insert_null-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8292e09cfb389ef452158fdef92f7ef3",
+            "size": 1160,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert-insert_null-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-insert_null-default.txt-Plan]": [
         {
-            "checksum": "3cf567e0ee80834ae556a49558719b57",
-            "size": 3557,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_insert-insert_null-default.txt-Plan_/plan.txt"
+            "checksum": "ea0187bfaf6b869fa837eac4f7b606a9",
+            "size": 3351,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert-insert_null-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-keepmeta--Debug]": [
         {
-            "checksum": "a43badace5e81c3a047722d285199578",
-            "size": 1837,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_insert-keepmeta--Debug_/opt.yql_patched"
+            "checksum": "e54fc9ec38a4294496f70a3a5f25e522",
+            "size": 1714,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert-keepmeta--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-keepmeta--Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_insert-keepmeta--Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert-keepmeta--Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted-Debug]": [
         {
-            "checksum": "a60d1e90384c4e9458a7e27d4ed56e59",
-            "size": 2119,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_insert-override-from_sorted-Debug_/opt.yql_patched"
+            "checksum": "28933eeadb303c9df68b036d97cfa3ea",
+            "size": 1996,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert-override-from_sorted-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-from_sorted-Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_insert-override-from_sorted-Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert-override-from_sorted-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-several2-default.txt-Debug]": [
         {
-            "checksum": "7e2e88de64755664cd67fa6562bca766",
-            "size": 2997,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1d0a2d6fed07f885dd2e41906c0b1113",
+            "size": 2842,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-several2-default.txt-Plan]": [
         {
-            "checksum": "bdf376271ea872d8cba4ee0c4595a5ae",
-            "size": 7734,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Plan_/plan.txt"
+            "checksum": "2c2c8b8153b35886999d1c77e1b80fcd",
+            "size": 7322,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_insert_monotonic-several2-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-cross_join_with_lazy_list--Debug]": [
@@ -1303,16 +1303,16 @@
     ],
     "test.test[join-full_equal_null--Debug]": [
         {
-            "checksum": "c06624d3c9773b15569f571e7a06457b",
-            "size": 5434,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_join-full_equal_null--Debug_/opt.yql_patched"
+            "checksum": "2025174bb16a803db331f7b9452b9b17",
+            "size": 5392,
+            "uri": "https://{canondata_backend}/1600758/a3c9dd835d113e6cdf30d9e35d9cc95c3a203da3/resource.tar.gz#test.test_join-full_equal_null--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-full_equal_null--Plan]": [
         {
-            "checksum": "f5de556396fa150ec5e2b969357acecd",
-            "size": 8305,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-full_equal_null--Plan_/plan.txt"
+            "checksum": "44be539abdc385266daf573dce0eb67e",
+            "size": 8099,
+            "uri": "https://{canondata_backend}/1600758/a3c9dd835d113e6cdf30d9e35d9cc95c3a203da3/resource.tar.gz#test.test_join-full_equal_null--Plan_/plan.txt"
         }
     ],
     "test.test[join-inner_all--Debug]": [
@@ -1331,30 +1331,30 @@
     ],
     "test.test[join-join_and_distinct_key--Debug]": [
         {
-            "checksum": "5c149b46442796313b44c049e7c7a460",
-            "size": 8464,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_join-join_and_distinct_key--Debug_/opt.yql_patched"
+            "checksum": "6251d717e259d483a858ca3bb3e84e13",
+            "size": 8347,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-join_and_distinct_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_and_distinct_key--Plan]": [
         {
-            "checksum": "ffe6fc4b79e8488a5062508047648a62",
-            "size": 10653,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-join_and_distinct_key--Plan_/plan.txt"
+            "checksum": "2ec1a8039f9a51ea68b3831d7b632c9a",
+            "size": 10447,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-join_and_distinct_key--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_semi_correlation_in_order_by--Debug]": [
         {
-            "checksum": "89e77c6b1f2ed4fc9e72fecc15d918cb",
-            "size": 4013,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_join-join_semi_correlation_in_order_by--Debug_/opt.yql_patched"
+            "checksum": "6b87c1143b437d2a8b4e41f6188a1471",
+            "size": 3692,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-join_semi_correlation_in_order_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_semi_correlation_in_order_by--Plan]": [
         {
-            "checksum": "39f043d649c6875ddbf4e2ca184a984d",
-            "size": 6851,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-join_semi_correlation_in_order_by--Plan_/plan.txt"
+            "checksum": "5af72cb569f258f327686086438fda48",
+            "size": 6439,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-join_semi_correlation_in_order_by--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_all--Debug]": [
@@ -1373,86 +1373,86 @@
     ],
     "test.test[join-mergejoin_with_different_key_names_nested--Debug]": [
         {
-            "checksum": "1ef7f7725569fac7a6d36422fa9cf140",
-            "size": 6717,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nested--Debug_/opt.yql_patched"
+            "checksum": "61542f7b23937fc98830630d39e7a8a5",
+            "size": 6589,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nested--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_with_different_key_names_nested--Plan]": [
         {
-            "checksum": "b5df63bc7e567481caa8c6b9c6f23391",
-            "size": 11458,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nested--Plan_/plan.txt"
+            "checksum": "15b6c0cdde040305b8fd822e3a36c676",
+            "size": 11252,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nested--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_with_different_key_names_nonsorted--Debug]": [
         {
-            "checksum": "c1345b8eac25d4036c5a1db14221fe02",
-            "size": 7370,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nonsorted--Debug_/opt.yql_patched"
+            "checksum": "86e71db2d102f6638aca0b622c4c336c",
+            "size": 6925,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nonsorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_with_different_key_names_nonsorted--Plan]": [
         {
-            "checksum": "3f29ff15db507ab4c40a14373d80f637",
-            "size": 11198,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nonsorted--Plan_/plan.txt"
+            "checksum": "268954aee97bd0adf34412b2224d0017",
+            "size": 10580,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_nonsorted--Plan_/plan.txt"
         }
     ],
     "test.test[join-nopushdown_filter_over_inner--Debug]": [
         {
-            "checksum": "7669e28bea9f309542cdb468d1b40d35",
-            "size": 5293,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_join-nopushdown_filter_over_inner--Debug_/opt.yql_patched"
+            "checksum": "888fd8cfa4f998fac3b1f398812614a0",
+            "size": 5093,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-nopushdown_filter_over_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-nopushdown_filter_over_inner--Plan]": [
         {
-            "checksum": "1a3e1221d8c4908d2d7ed5eba76cf003",
-            "size": 8690,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-nopushdown_filter_over_inner--Plan_/plan.txt"
+            "checksum": "f9e599b9522940fe72882fad8ab70d5c",
+            "size": 8484,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-nopushdown_filter_over_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-star_join_inners_premap--Debug]": [
         {
-            "checksum": "6ba64d59f8db2debe9b0e760eef44c76",
-            "size": 8022,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_join-star_join_inners_premap--Debug_/opt.yql_patched"
+            "checksum": "709cef812eced6e6aa7f798f1dd4270f",
+            "size": 7741,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-star_join_inners_premap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join_inners_premap--Plan]": [
         {
-            "checksum": "3e4e5ef46f6cf4dc8aa5deb68ed3a92d",
-            "size": 11021,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-star_join_inners_premap--Plan_/plan.txt"
+            "checksum": "07d27888d364ab23ffd0799a84741dbd",
+            "size": 10815,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-star_join_inners_premap--Plan_/plan.txt"
         }
     ],
     "test.test[join-star_join_mirror--Debug]": [
         {
-            "checksum": "0b0bd413d0588090a05a5a0177f0fad7",
-            "size": 10127,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_join-star_join_mirror--Debug_/opt.yql_patched"
+            "checksum": "d47f2e999d65b45958d08771874d966f",
+            "size": 9886,
+            "uri": "https://{canondata_backend}/1600758/a3c9dd835d113e6cdf30d9e35d9cc95c3a203da3/resource.tar.gz#test.test_join-star_join_mirror--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join_mirror--Plan]": [
         {
-            "checksum": "0c0a30ca024f296dda646f035c529b51",
-            "size": 14469,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-star_join_mirror--Plan_/plan.txt"
+            "checksum": "2863a9c632a1cd8950afc3c017f08af9",
+            "size": 14263,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-star_join_mirror--Plan_/plan.txt"
         }
     ],
     "test.test[join-star_join_semionly_premap--Debug]": [
         {
-            "checksum": "6e2e79d102fba0516ff1144ec0265c27",
-            "size": 6186,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_join-star_join_semionly_premap--Debug_/opt.yql_patched"
+            "checksum": "a9f3e790c43b9dd449c0d4456239c453",
+            "size": 6045,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-star_join_semionly_premap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join_semionly_premap--Plan]": [
         {
-            "checksum": "511ea81d650ec24e428e1fcbf3eeba22",
-            "size": 9470,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_join-star_join_semionly_premap--Plan_/plan.txt"
+            "checksum": "896749a2643013ff69cd93455bd40cb1",
+            "size": 9264,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_join-star_join_semionly_premap--Plan_/plan.txt"
         }
     ],
     "test.test[json-json_exists/example--Debug]": [
@@ -1499,86 +1499,86 @@
     ],
     "test.test[key_filter-calc_dependent_with_tmp-default.txt-Debug]": [
         {
-            "checksum": "bc63695c7e8bcfce67cc84615bd4dc19",
-            "size": 4262,
-            "uri": "https://{canondata_backend}/1599023/eb05d714fcbcafa4262343caabd2d434680b871d/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Debug_/opt.yql_patched"
+            "checksum": "158960719255cf374d4e0f592759a73f",
+            "size": 3986,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-calc_dependent_with_tmp-default.txt-Plan]": [
         {
-            "checksum": "365e26190e13f9615d88215aa0e955de",
-            "size": 8962,
-            "uri": "https://{canondata_backend}/937458/723b54967ebf37cfd185a6ec15f32ee0ef9e0000/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Plan_/plan.txt"
+            "checksum": "81b4179b50da0ec2df5f58d66a06c471",
+            "size": 8550,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_key_filter-calc_dependent_with_tmp-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-is_null--Debug]": [
         {
-            "checksum": "e5fbf932119e3397fb9179785016d262",
-            "size": 2088,
-            "uri": "https://{canondata_backend}/1777230/7a8ff3ba7b5adcc59a41a277e242e5bc1cb1fd71/resource.tar.gz#test.test_key_filter-is_null--Debug_/opt.yql_patched"
+            "checksum": "f70a1faf25b5414999fbdc91fa5fa2fa",
+            "size": 1965,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_key_filter-is_null--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-is_null--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1942671/f468a04ad00942cea778cc9820b86cfe206e01c1/resource.tar.gz#test.test_key_filter-is_null--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_key_filter-is_null--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-mixed_sort--Debug]": [
         {
-            "checksum": "adbbb4c809d95dfe5d9e106b194c184f",
-            "size": 4315,
-            "uri": "https://{canondata_backend}/1937492/25ba4af5668f7538d9f023e197d18accc3c301dd/resource.tar.gz#test.test_key_filter-mixed_sort--Debug_/opt.yql_patched"
+            "checksum": "8ef756a347e745034fe6553ef85d7624",
+            "size": 4164,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_key_filter-mixed_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-mixed_sort--Plan]": [
         {
-            "checksum": "b025478f7d13be1af38e79bcbbf6c03f",
-            "size": 9114,
-            "uri": "https://{canondata_backend}/1781765/ea1992429fe52bc22525ecde142148e8363bc270/resource.tar.gz#test.test_key_filter-mixed_sort--Plan_/plan.txt"
+            "checksum": "4fde2110a2a24dee757394dd83342b34",
+            "size": 8702,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_key_filter-mixed_sort--Plan_/plan.txt"
         }
     ],
     "test.test[limit-empty_sort_desc_after_limit-default.txt-Debug]": [
         {
-            "checksum": "fbb5109221b0c609ba0cb7105a309197",
-            "size": 3484,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_limit-empty_sort_desc_after_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "74526d859cb87461c81a2269af2bf016",
+            "size": 3331,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_limit-empty_sort_desc_after_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-empty_sort_desc_after_limit-default.txt-Plan]": [
         {
-            "checksum": "a8c803da0b9e869edc6d438c5b4fc2c1",
-            "size": 7081,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_limit-empty_sort_desc_after_limit-default.txt-Plan_/plan.txt"
+            "checksum": "f37dcede66118b5d792b93c1a93a7480",
+            "size": 6875,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_limit-empty_sort_desc_after_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[limit-limit-dynamic-Debug]": [
         {
-            "checksum": "45678a5116e43ca19ad39ab0a4b64611",
-            "size": 2116,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_limit-limit-dynamic-Debug_/opt.yql_patched"
+            "checksum": "6695cfa63e92e469a01e57ffacfc5887",
+            "size": 2005,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_limit-limit-dynamic-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-limit-dynamic-Plan]": [
         {
-            "checksum": "418086b69ac4a67baa9ed1983d4ecd49",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_limit-limit-dynamic-Plan_/plan.txt"
+            "checksum": "fb002ebdc33b29d4424586db2a9ffd02",
+            "size": 3492,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_limit-limit-dynamic-Plan_/plan.txt"
         }
     ],
     "test.test[limit-yql-7900_empty_sorted_without_keys-default.txt-Debug]": [
         {
-            "checksum": "cc774b497a9d1c8fc016cbd9eeea6a79",
-            "size": 3951,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_limit-yql-7900_empty_sorted_without_keys-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b22211e2c70ece59285ff96a51874134",
+            "size": 3655,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_limit-yql-7900_empty_sorted_without_keys-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-yql-7900_empty_sorted_without_keys-default.txt-Plan]": [
         {
-            "checksum": "a538975609ecfccec92f48753af123d6",
-            "size": 7619,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_limit-yql-7900_empty_sorted_without_keys-default.txt-Plan_/plan.txt"
+            "checksum": "ab6f2eab8c50357a476431d31e534de4",
+            "size": 7207,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_limit-yql-7900_empty_sorted_without_keys-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[match_recognize-alerts-streaming-default.txt-Debug]": [
@@ -1611,30 +1611,30 @@
     ],
     "test.test[optimizers-sort_over_sorted_prefix_keys-default.txt-Debug]": [
         {
-            "checksum": "aca0ce5781b95d9f9be5f82ab51b12cf",
-            "size": 3450,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5fd944a3e8c332d5f531f16865678f49",
+            "size": 3204,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-sort_over_sorted_prefix_keys-default.txt-Plan]": [
         {
-            "checksum": "0468ed0e3a091726280ae82d1e80d2e0",
-            "size": 7632,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Plan_/plan.txt"
+            "checksum": "0e784fede018681dcb1771e1aa0a64d7",
+            "size": 7220,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-sort_over_sorted_prefix_keys-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-sort_over_sorted_same_keys-default.txt-Debug]": [
         {
-            "checksum": "af95460ce7d2b71f4e0224f53a17f997",
-            "size": 3196,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8af0b02d730f2dc08602f6267daa67ba",
+            "size": 3045,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-sort_over_sorted_same_keys-default.txt-Plan]": [
         {
-            "checksum": "0468ed0e3a091726280ae82d1e80d2e0",
-            "size": 7632,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Plan_/plan.txt"
+            "checksum": "0e784fede018681dcb1771e1aa0a64d7",
+            "size": 7220,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-sort_over_sorted_same_keys-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-total_order-default.txt-Debug]": [
@@ -1653,86 +1653,86 @@
     ],
     "test.test[optimizers-unused_columns_group--Debug]": [
         {
-            "checksum": "a3d400bc0880b6ef5e5c7925ff0471c5",
-            "size": 6107,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_optimizers-unused_columns_group--Debug_/opt.yql_patched"
+            "checksum": "cff936f58ac00bf3bbf95269859676b3",
+            "size": 5703,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-unused_columns_group--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-unused_columns_group--Plan]": [
         {
-            "checksum": "e4333107b58b983ca7239ca088be2942",
-            "size": 10816,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_optimizers-unused_columns_group--Plan_/plan.txt"
+            "checksum": "b84f7f737ca6b2d863640a2255cc3663",
+            "size": 9992,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-unused_columns_group--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-18300-flatmap-over-extend-default.txt-Debug]": [
         {
-            "checksum": "da2568442cc2748c1feded2bbad512fc",
-            "size": 3663,
-            "uri": "https://{canondata_backend}/1847551/835c782382c7e31538089525681c9ce680e6df7b/resource.tar.gz#test.test_optimizers-yql-18300-flatmap-over-extend-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f1e67f943dddbe1c1c2cebd47bea65cb",
+            "size": 3455,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-yql-18300-flatmap-over-extend-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-18300-flatmap-over-extend-default.txt-Plan]": [
         {
-            "checksum": "8225566dd6a38075253a0319ea7f1495",
-            "size": 8173,
-            "uri": "https://{canondata_backend}/1847551/835c782382c7e31538089525681c9ce680e6df7b/resource.tar.gz#test.test_optimizers-yql-18300-flatmap-over-extend-default.txt-Plan_/plan.txt"
+            "checksum": "8b14c1a8f4658320d4ed51ac46f6bcdf",
+            "size": 7761,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_optimizers-yql-18300-flatmap-over-extend-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-literal--Debug]": [
         {
-            "checksum": "ac6969c115a3e3ac121d436673a6a562",
-            "size": 1532,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_order_by-literal--Debug_/opt.yql_patched"
+            "checksum": "9071cd273060f58fac0c965d286649c3",
+            "size": 1474,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-literal--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-literal--Plan]": [
         {
-            "checksum": "de5175726ff344e85a1d1bb61be2b087",
-            "size": 3814,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_order_by-literal--Plan_/plan.txt"
+            "checksum": "1c0a60fc93f8d409f34e567be923529f",
+            "size": 3608,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-literal--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_expr_with_deps-default.txt-Debug]": [
         {
-            "checksum": "7ae11e6279f041ad5cfe72f0a7a37fbd",
-            "size": 4432,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_order_by-order_by_expr_with_deps-default.txt-Debug_/opt.yql_patched"
+            "checksum": "db16008bc8bbbff73d2b87b441c0dd73",
+            "size": 4365,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-order_by_expr_with_deps-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_expr_with_deps-default.txt-Plan]": [
         {
-            "checksum": "b7c4906f81d8734438d0a6aa72cba6cb",
-            "size": 8441,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_order_by-order_by_expr_with_deps-default.txt-Plan_/plan.txt"
+            "checksum": "45df3dd17b01e55b9b64ca60bb98478f",
+            "size": 8235,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-order_by_expr_with_deps-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_num_key_and_subkey--Debug]": [
         {
-            "checksum": "7d1f084c1865c76a4055b3114c1ffa54",
-            "size": 3293,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey--Debug_/opt.yql_patched"
+            "checksum": "372191d0642e714f1bc68fce00b8c2c3",
+            "size": 3047,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_num_key_and_subkey--Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey--Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_num_key_and_subkey_desc--Debug]": [
         {
-            "checksum": "7b07c1b01602df5f00efc24ac0ae0690",
-            "size": 3023,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey_desc--Debug_/opt.yql_patched"
+            "checksum": "f5f9c3afc9942e9a718dfdd6d0137e27",
+            "size": 2870,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_num_key_and_subkey_desc--Plan]": [
         {
-            "checksum": "654acd0e6b0b3e64caa66bbbf583d612",
-            "size": 5179,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey_desc--Plan_/plan.txt"
+            "checksum": "1803bcd1073585a5ad284a4d29e54336",
+            "size": 4973,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_order_by-order_by_num_key_and_subkey_desc--Plan_/plan.txt"
         }
     ],
     "test.test[params-struct--Debug]": [
@@ -1863,30 +1863,30 @@
     ],
     "test.test[pg-select_columnref1-default.txt-Debug]": [
         {
-            "checksum": "259d06acf4354b50a7b6175fa65ec59b",
-            "size": 2277,
-            "uri": "https://{canondata_backend}/1903280/b3ad5a45d76b516f66899551cc71277d7e559aab/resource.tar.gz#test.test_pg-select_columnref1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3c619a31aa229bd38b400f7a2ef40768",
+            "size": 2157,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-select_columnref1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_columnref1-default.txt-Plan]": [
         {
-            "checksum": "2c9d7953bda3e79ed62a5c81dce4022a",
-            "size": 3581,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_pg-select_columnref1-default.txt-Plan_/plan.txt"
+            "checksum": "db83a37e448bcab50000e7d07029d853",
+            "size": 3375,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-select_columnref1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_common_type_unionall--Debug]": [
         {
-            "checksum": "682063789279f950994c25892f959cec",
-            "size": 10081,
-            "uri": "https://{canondata_backend}/1920236/181899389bad039416c7d70e3b0869cbbc3b469a/resource.tar.gz#test.test_pg-select_common_type_unionall--Debug_/opt.yql_patched"
+            "checksum": "42b3bbcafc12bd1018a5fa3a7da206ac",
+            "size": 9860,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-select_common_type_unionall--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_common_type_unionall--Plan]": [
         {
-            "checksum": "1cdf9955e8367246a4668ba3075ff0cf",
-            "size": 18268,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_pg-select_common_type_unionall--Plan_/plan.txt"
+            "checksum": "ce057de2c636477ebdc0a1ab5d511ce4",
+            "size": 18062,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-select_common_type_unionall--Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_join_inner-default.txt-Debug]": [
@@ -2143,44 +2143,44 @@
     ],
     "test.test[pg-tpch-q06-default.txt-Debug]": [
         {
-            "checksum": "5ae48930e867387895f046342cb838da",
-            "size": 5328,
-            "uri": "https://{canondata_backend}/1903280/b3ad5a45d76b516f66899551cc71277d7e559aab/resource.tar.gz#test.test_pg-tpch-q06-default.txt-Debug_/opt.yql_patched"
+            "checksum": "db055cf848b20e446be1e4b186391ec6",
+            "size": 5261,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-tpch-q06-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q06-default.txt-Plan]": [
         {
-            "checksum": "d45977fb9da677e174469adfd3cc54b8",
-            "size": 6195,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_pg-tpch-q06-default.txt-Plan_/plan.txt"
+            "checksum": "85df5d8e3006c76bdf6c301fd21ce0ef",
+            "size": 5989,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-tpch-q06-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q11-default.txt-Debug]": [
         {
-            "checksum": "acc1b0c39fa7f963be78d826e56363f6",
-            "size": 15559,
-            "uri": "https://{canondata_backend}/1871102/7b4f38a71959b2a4d7977fc0b5d14d82c519d35e/resource.tar.gz#test.test_pg-tpch-q11-default.txt-Debug_/opt.yql_patched"
+            "checksum": "75f4e64d0b086fd7527704ae8d9553e8",
+            "size": 15384,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-tpch-q11-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q11-default.txt-Plan]": [
         {
-            "checksum": "a0b2bef1a0fbbf28ba25049bd94ac901",
-            "size": 25015,
-            "uri": "https://{canondata_backend}/1871102/7b4f38a71959b2a4d7977fc0b5d14d82c519d35e/resource.tar.gz#test.test_pg-tpch-q11-default.txt-Plan_/plan.txt"
+            "checksum": "64ec5f5bbbf554d73e2f91265bfe36d0",
+            "size": 24603,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-tpch-q11-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q16-default.txt-Debug]": [
         {
-            "checksum": "1a2cbe3d1e0d10d46b3d5be7c42bd1e2",
-            "size": 14610,
-            "uri": "https://{canondata_backend}/1925821/dac6f3daadae295a25f47fbbf7c202e6dc5c6db3/resource.tar.gz#test.test_pg-tpch-q16-default.txt-Debug_/opt.yql_patched"
+            "checksum": "02db3b0bf9361d0e34a5a2f0cfcc4704",
+            "size": 14346,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-tpch-q16-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q16-default.txt-Plan]": [
         {
-            "checksum": "87d2ba26a66fc53491b9161ce790d890",
-            "size": 16029,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_pg-tpch-q16-default.txt-Plan_/plan.txt"
+            "checksum": "1b27ef3cdae449cb7c972d6d3bbf85a6",
+            "size": 15411,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_pg-tpch-q16-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-unknown-default.txt-Debug]": [
@@ -2255,86 +2255,86 @@
     ],
     "test.test[produce-reduce_multi_in--Debug]": [
         {
-            "checksum": "d18940efe84cac33c5960e8a0f72c7ea",
-            "size": 3945,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_produce-reduce_multi_in--Debug_/opt.yql_patched"
+            "checksum": "0d6a8a2b5712d2545a68b7c3c52f61d6",
+            "size": 3833,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in--Plan]": [
         {
-            "checksum": "2fe4807d71c1ff84e2507cff784b2cd0",
-            "size": 8257,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_produce-reduce_multi_in--Plan_/plan.txt"
+            "checksum": "e6aedf118d0ef1ecae20fdaa7e72e7d2",
+            "size": 8051,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_keytuple--Debug]": [
         {
-            "checksum": "4af7698bbe9368d9561d2f7359040fbc",
-            "size": 4139,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple--Debug_/opt.yql_patched"
+            "checksum": "139d96278412ef21849a261811b27341",
+            "size": 4027,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_keytuple--Plan]": [
         {
-            "checksum": "2fe4807d71c1ff84e2507cff784b2cd0",
-            "size": 8257,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple--Plan_/plan.txt"
+            "checksum": "e6aedf118d0ef1ecae20fdaa7e72e7d2",
+            "size": 8051,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_presort--Debug]": [
         {
-            "checksum": "f818d9deeac32250ba6b2e80095e8927",
-            "size": 4224,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_produce-reduce_multi_in_presort--Debug_/opt.yql_patched"
+            "checksum": "b75c36170cbd9bc1599afebab3c663a2",
+            "size": 4112,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in_presort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_presort--Plan]": [
         {
-            "checksum": "2fe4807d71c1ff84e2507cff784b2cd0",
-            "size": 8257,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_produce-reduce_multi_in_presort--Plan_/plan.txt"
+            "checksum": "e6aedf118d0ef1ecae20fdaa7e72e7d2",
+            "size": 8051,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in_presort--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_sampling-sorted-Debug]": [
         {
-            "checksum": "e1ace66265979e6030c6078702c298ff",
-            "size": 3719,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_produce-reduce_multi_in_sampling-sorted-Debug_/opt.yql_patched"
+            "checksum": "a56b759c8fb97a49fc3c76d299aa77db",
+            "size": 3607,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in_sampling-sorted-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_sampling-sorted-Plan]": [
         {
-            "checksum": "907c219319a36e99c18dde918c412369",
-            "size": 6942,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_produce-reduce_multi_in_sampling-sorted-Plan_/plan.txt"
+            "checksum": "bb136ae430c60c797eab9a06c0aa22ee",
+            "size": 6736,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_multi_in_sampling-sorted-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_with_assume_in_subquery--Debug]": [
         {
-            "checksum": "07df306725b385ac7be0c9db0e54968a",
-            "size": 4636,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_produce-reduce_with_assume_in_subquery--Debug_/opt.yql_patched"
+            "checksum": "dc42243e29f87ad5ea2de986922be656",
+            "size": 4325,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_with_assume_in_subquery--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_with_assume_in_subquery--Plan]": [
         {
-            "checksum": "acd22d78538816551e5240676d633b12",
-            "size": 7879,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_produce-reduce_with_assume_in_subquery--Plan_/plan.txt"
+            "checksum": "13161e13f9e2710d3c0aa3312fb76610",
+            "size": 7261,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_with_assume_in_subquery--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_with_flat_lambda-default.txt-Debug]": [
         {
-            "checksum": "85cae956ff7e152256a139ab4aab3092",
-            "size": 2779,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_produce-reduce_with_flat_lambda-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9b9f2f29d05f9876818382d96c9128d1",
+            "size": 2533,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_with_flat_lambda-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_with_flat_lambda-default.txt-Plan]": [
         {
-            "checksum": "c5e4a27217c895cb04fa77ac1aeafb04",
-            "size": 5741,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_produce-reduce_with_flat_lambda-default.txt-Plan_/plan.txt"
+            "checksum": "3e278c1dc31e39b0e31637e2c3774735",
+            "size": 5329,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_produce-reduce_with_flat_lambda-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-direct_read--Debug]": [
@@ -2353,58 +2353,58 @@
     ],
     "test.test[sampling-join_right_sample-default.txt-Debug]": [
         {
-            "checksum": "f23ed5803ec8b75173748398022a418e",
-            "size": 4605,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_sampling-join_right_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6a95a4db00f9b525dd885eaeae52d16d",
+            "size": 4482,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_sampling-join_right_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-join_right_sample-default.txt-Plan]": [
         {
-            "checksum": "c7e01500e2ec1c0b3aa453089973fcbf",
-            "size": 6393,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_sampling-join_right_sample-default.txt-Plan_/plan.txt"
+            "checksum": "645dd6379c553af93b2633c5fbd50000",
+            "size": 6187,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_sampling-join_right_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-map-dynamic-Debug]": [
         {
-            "checksum": "670448932a3adf46028bb4322a121fc6",
-            "size": 2311,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_sampling-map-dynamic-Debug_/opt.yql_patched"
+            "checksum": "83a39c86237634dc2947461e614763ea",
+            "size": 2188,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_sampling-map-dynamic-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-map-dynamic-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_sampling-map-dynamic-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_sampling-map-dynamic-Plan_/plan.txt"
         }
     ],
     "test.test[schema-fake_column-default.txt-Debug]": [
         {
-            "checksum": "74dd6c9e74bb32463ae2f1903fdf0950",
-            "size": 2556,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_schema-fake_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cc786092f7903e8b5ef7c6eabc3f4376",
+            "size": 2454,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-fake_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-fake_column-default.txt-Plan]": [
         {
-            "checksum": "3a71b24fc8ac999e06c75a7eab9778eb",
-            "size": 6938,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_schema-fake_column-default.txt-Plan_/plan.txt"
+            "checksum": "bac27784e3ac6718ca4b279908da3d86",
+            "size": 6526,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-fake_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-read_schema_other--Debug]": [
         {
-            "checksum": "82809deaa739db4b127d7b8be7b8cf17",
-            "size": 2948,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_schema-read_schema_other--Debug_/opt.yql_patched"
+            "checksum": "d971e9d49b0797c4b0c5c9276b4819a7",
+            "size": 2838,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-read_schema_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-read_schema_other--Plan]": [
         {
-            "checksum": "248b9f8bd926155be2ff131c4a1c6362",
-            "size": 5123,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_schema-read_schema_other--Plan_/plan.txt"
+            "checksum": "3c18f3529c08aa5aecf92acd7df42acc",
+            "size": 4917,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-read_schema_other--Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_all-read_schema-Debug]": [
@@ -2423,58 +2423,58 @@
     ],
     "test.test[schema-select_all_inferschema_range--Debug]": [
         {
-            "checksum": "1edd0ae8f0938294fca7b52faedf717f",
-            "size": 3149,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_schema-select_all_inferschema_range--Debug_/opt.yql_patched"
+            "checksum": "bb3ba51060d6bb05147ebae43c16b414",
+            "size": 2960,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-select_all_inferschema_range--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_all_inferschema_range--Plan]": [
         {
-            "checksum": "5b128a68a8e98be83deb12e0fd8ac7b9",
-            "size": 4562,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_schema-select_all_inferschema_range--Plan_/plan.txt"
+            "checksum": "7e2e70a1d9bc06de60cbe7bb6d7568cb",
+            "size": 4356,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-select_all_inferschema_range--Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_fields_inferschema--Debug]": [
         {
-            "checksum": "ba2c75f2ae96d588f60b758cdf17af11",
-            "size": 2243,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_schema-select_fields_inferschema--Debug_/opt.yql_patched"
+            "checksum": "e80aec7c779d1f4f6fa7206f35561f9b",
+            "size": 2131,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-select_fields_inferschema--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_fields_inferschema--Plan]": [
         {
-            "checksum": "6c24c1fcf8ab55d9aea54ca6c63208d2",
-            "size": 3488,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_schema-select_fields_inferschema--Plan_/plan.txt"
+            "checksum": "e4a8b404013b5c8faf7f38e2439417fc",
+            "size": 3282,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-select_fields_inferschema--Plan_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_directread-default.txt-Debug]": [
         {
-            "checksum": "95f921addf657ea5b28ab4b2e22c860a",
-            "size": 2156,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_schema-user_schema_directread-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6159fd28219dd27c646e18521a033409",
+            "size": 1990,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-user_schema_directread-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-user_schema_directread-default.txt-Plan]": [
         {
-            "checksum": "f3a5b257af7349c56a14befff28bcb27",
-            "size": 4168,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_schema-user_schema_directread-default.txt-Plan_/plan.txt"
+            "checksum": "796056c97ecf7cb4b13a72ebdc4d3777",
+            "size": 3962,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-user_schema_directread-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_with_sort--Debug]": [
         {
-            "checksum": "c6bf3f9f9888019b35e1deb7e908dce4",
-            "size": 4234,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_schema-user_schema_with_sort--Debug_/opt.yql_patched"
+            "checksum": "9fcbc3d67e94eb002d0695218bbac8c6",
+            "size": 4033,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-user_schema_with_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-user_schema_with_sort--Plan]": [
         {
-            "checksum": "1eb0bdd021a64c2eed41914b7e8e931e",
-            "size": 8187,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_schema-user_schema_with_sort--Plan_/plan.txt"
+            "checksum": "301161ee07fda231abeddbd9899c1d59",
+            "size": 7775,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_schema-user_schema_with_sort--Plan_/plan.txt"
         }
     ],
     "test.test[select-autogen_columns_conflict-default.txt-Debug]": [
@@ -2493,16 +2493,16 @@
     ],
     "test.test[select-backtick_with_escapes-default.txt-Debug]": [
         {
-            "checksum": "7f13a75d279609cee644330d3bf14b22",
-            "size": 2205,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_select-backtick_with_escapes-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e1df2def32b77dfbfc687b1c8f8a7de4",
+            "size": 2073,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-backtick_with_escapes-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-backtick_with_escapes-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-backtick_with_escapes-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-backtick_with_escapes-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-bin_ops_long_concat-default.txt-Debug]": [
@@ -2521,30 +2521,30 @@
     ],
     "test.test[select-complex_filter_with_order-default.txt-Debug]": [
         {
-            "checksum": "6f6742b915b57f4de254ffbbc9c7a8b3",
-            "size": 3174,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_select-complex_filter_with_order-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c3927fbc5770c950d082715d1049559f",
+            "size": 2928,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-complex_filter_with_order-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-complex_filter_with_order-default.txt-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-complex_filter_with_order-default.txt-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-complex_filter_with_order-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-dot_name_subrequest-default.txt-Debug]": [
         {
-            "checksum": "9b8e429f95ab7d5654136dd76e88584f",
-            "size": 2975,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_select-dot_name_subrequest-default.txt-Debug_/opt.yql_patched"
+            "checksum": "be9463f5e66eb1c0e8fb3c1b711d053c",
+            "size": 2781,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-dot_name_subrequest-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-dot_name_subrequest-default.txt-Plan]": [
         {
-            "checksum": "96a1aaa1c90375e854e9749dfded727b",
-            "size": 6203,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-dot_name_subrequest-default.txt-Plan_/plan.txt"
+            "checksum": "f1f3d94de29dba1e33c50e9679a2a6c0",
+            "size": 5791,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-dot_name_subrequest-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-extend_and_take--Debug]": [
@@ -2563,58 +2563,58 @@
     ],
     "test.test[select-if-default.txt-Debug]": [
         {
-            "checksum": "d1b5b4a06a820e77227e6d6218ab09a3",
-            "size": 2133,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_select-if-default.txt-Debug_/opt.yql_patched"
+            "checksum": "15e7af967d5e460307a492c84ed4729f",
+            "size": 2032,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-if-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-if-default.txt-Plan]": [
         {
-            "checksum": "d118decf89a5561dd4a8172d27e13b62",
-            "size": 4047,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-if-default.txt-Plan_/plan.txt"
+            "checksum": "280a65d38bb94cf48f6d81ef128b0b2f",
+            "size": 3841,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-if-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-one_labeled_column-default.txt-Debug]": [
         {
-            "checksum": "65ce640315a25a3b62ea0cb09b5e6301",
-            "size": 1863,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_select-one_labeled_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "830a2e7072280292913c941bdf2d1f84",
+            "size": 1801,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-one_labeled_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-one_labeled_column-default.txt-Plan]": [
         {
-            "checksum": "5c41b58f8a68c081f47cebbfa8a13331",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-one_labeled_column-default.txt-Plan_/plan.txt"
+            "checksum": "c6ed3026b5067eb08a3ae9247dec4859",
+            "size": 3839,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-one_labeled_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-table_content_from_double_opt-default.txt-Debug]": [
         {
-            "checksum": "2ad20407a596ac7634ade9d86dc32b82",
-            "size": 3047,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e7e07bdd46222a9970feaec826808322",
+            "size": 2985,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-table_content_from_double_opt-default.txt-Plan]": [
         {
-            "checksum": "87ba2fb27466bd1ba6747c678a7e5cda",
-            "size": 8523,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Plan_/plan.txt"
+            "checksum": "1d45a4421a9a7f70b8c770bca8e87ccf",
+            "size": 8317,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-table_content_from_double_opt-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-two_selects_with_diff_fields-default.txt-Debug]": [
         {
-            "checksum": "cd1ac58d850857ebafd01a0748644f5c",
-            "size": 2011,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_select-two_selects_with_diff_fields-default.txt-Debug_/opt.yql_patched"
+            "checksum": "085bd35de10c907862188395dc754226",
+            "size": 1949,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-two_selects_with_diff_fields-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-two_selects_with_diff_fields-default.txt-Plan]": [
         {
-            "checksum": "0421e7991d45385234cfc3d1d62a0066",
-            "size": 4695,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-two_selects_with_diff_fields-default.txt-Plan_/plan.txt"
+            "checksum": "270207d0d4b0cea4f496a91e16395698",
+            "size": 4489,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-two_selects_with_diff_fields-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-values-default.txt-Debug]": [
@@ -2633,30 +2633,30 @@
     ],
     "test.test[select-where_not_null--Debug]": [
         {
-            "checksum": "d573d335c49a77624b07b8d03f6afa58",
-            "size": 2124,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_select-where_not_null--Debug_/opt.yql_patched"
+            "checksum": "5b704bb3815f84afd6daa1a6eeb9d828",
+            "size": 1958,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-where_not_null--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-where_not_null--Plan]": [
         {
-            "checksum": "f3a5b257af7349c56a14befff28bcb27",
-            "size": 4168,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_select-where_not_null--Plan_/plan.txt"
+            "checksum": "796056c97ecf7cb4b13a72ebdc4d3777",
+            "size": 3962,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_select-where_not_null--Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_base-default.txt-Debug]": [
         {
-            "checksum": "885d6df62df5de6445e15201318c32e7",
-            "size": 2197,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_simple_columns-simple_columns_base-default.txt-Debug_/opt.yql_patched"
+            "checksum": "28b773995e6137cbb1dbd347db26be67",
+            "size": 2052,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_simple_columns-simple_columns_base-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_base-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_simple_columns-simple_columns_base-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_simple_columns-simple_columns_base-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-append_diff_layout1--Debug]": [
@@ -2675,114 +2675,114 @@
     ],
     "test.test[type_v3-ignore_v3_hint-protofield-Debug]": [
         {
-            "checksum": "bc9e69e5859599428e3c47a8de55b2c7",
-            "size": 4268,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_type_v3-ignore_v3_hint-protofield-Debug_/opt.yql_patched"
+            "checksum": "0bf33a76425d1578c83f585c83367f60",
+            "size": 4172,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_type_v3-ignore_v3_hint-protofield-Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-ignore_v3_hint-protofield-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_type_v3-ignore_v3_hint-protofield-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_type_v3-ignore_v3_hint-protofield-Plan_/plan.txt"
         }
     ],
     "test.test[union-union_multiin--Debug]": [
         {
-            "checksum": "5e9e151f051c9353e8b44f148462cff7",
-            "size": 4526,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_union-union_multiin--Debug_/opt.yql_patched"
+            "checksum": "c49a5037380bec058fdb23e0d2166ab9",
+            "size": 4157,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union-union_multiin--Debug_/opt.yql_patched"
         }
     ],
     "test.test[union-union_multiin--Plan]": [
         {
-            "checksum": "6c4ae2cfafdf336b245ed08d0612c9a8",
-            "size": 8965,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_union-union_multiin--Plan_/plan.txt"
+            "checksum": "72b65e5bcbfe114175e526700c42e516",
+            "size": 8347,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union-union_multiin--Plan_/plan.txt"
         }
     ],
     "test.test[union-union_trivial-default.txt-Debug]": [
         {
-            "checksum": "19975fd4573bf91ed57c4230e82954b1",
-            "size": 4267,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_union-union_trivial-default.txt-Debug_/opt.yql_patched"
+            "checksum": "54b449ba2cbfeb4d9276b54d9677f90d",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union-union_trivial-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union-union_trivial-default.txt-Plan]": [
         {
-            "checksum": "557bc89a85905abb0ed11c3a582e7ca7",
-            "size": 8682,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_union-union_trivial-default.txt-Plan_/plan.txt"
+            "checksum": "54088b3737324fad73e00ec915cb733d",
+            "size": 8064,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union-union_trivial-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[union_all-path_and_record-default.txt-Debug]": [
         {
-            "checksum": "6f442cbd87fbae7fcc48f42a74acd604",
-            "size": 3137,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_union_all-path_and_record-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6a77131c25a1a110ffc4be9f1e27a818",
+            "size": 2993,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union_all-path_and_record-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-path_and_record-default.txt-Plan]": [
         {
-            "checksum": "49580339a4bfcb03c0c332df6f80f0c5",
-            "size": 6152,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_union_all-path_and_record-default.txt-Plan_/plan.txt"
+            "checksum": "f885296c744bd2465b26063643c41cd2",
+            "size": 5946,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union_all-path_and_record-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_multiin--Debug]": [
         {
-            "checksum": "ebcc833cede8270f3d92f74cb476201a",
-            "size": 3242,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_union_all-union_all_multiin--Debug_/opt.yql_patched"
+            "checksum": "f4c7c4ed66be16296c35ef51b3d29a97",
+            "size": 3042,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union_all-union_all_multiin--Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-union_all_multiin--Plan]": [
         {
-            "checksum": "744b492921865f872fba04b7f6961e76",
-            "size": 6755,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_union_all-union_all_multiin--Plan_/plan.txt"
+            "checksum": "88789000ad7167d7f1cbb5dd4c621274",
+            "size": 6343,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union_all-union_all_multiin--Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_subexpr-default.txt-Debug]": [
         {
-            "checksum": "9dd39424f1f93c54d3538a41f23ec95d",
-            "size": 3516,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_union_all-union_all_subexpr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a067cf38c94c5198ae9c39d95ffc4e71",
+            "size": 3270,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union_all-union_all_subexpr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-union_all_subexpr-default.txt-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_union_all-union_all_subexpr-default.txt-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_union_all-union_all_subexpr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[view-trivial_view--Debug]": [
         {
-            "checksum": "e6cefb3b382e5cee84889b1e9293f14c",
-            "size": 2329,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_view-trivial_view--Debug_/opt.yql_patched"
+            "checksum": "f37dcec1b4d7d4762de2b346149863c2",
+            "size": 2217,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_view-trivial_view--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-trivial_view--Plan]": [
         {
-            "checksum": "0bdc229ba4a65aa8bbf04fac7811ed84",
-            "size": 4003,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_view-trivial_view--Plan_/plan.txt"
+            "checksum": "82ba93631a802a81398418118a30491b",
+            "size": 3797,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_view-trivial_view--Plan_/plan.txt"
         }
     ],
     "test.test[view-view_with_lambda_process--Debug]": [
         {
-            "checksum": "a77e7aa76cee0130408c1a97dae5bb4f",
-            "size": 2603,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_view-view_with_lambda_process--Debug_/opt.yql_patched"
+            "checksum": "5799ef8250e18226def696efd805bdd4",
+            "size": 2454,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_view-view_with_lambda_process--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-view_with_lambda_process--Plan]": [
         {
-            "checksum": "0bdc229ba4a65aa8bbf04fac7811ed84",
-            "size": 4003,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_view-view_with_lambda_process--Plan_/plan.txt"
+            "checksum": "82ba93631a802a81398418118a30491b",
+            "size": 3797,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_view-view_with_lambda_process--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field--Debug]": [
@@ -2801,16 +2801,16 @@
     ],
     "test.test[window-all_columns_hide_window_special_ones-default.txt-Debug]": [
         {
-            "checksum": "adf40f04dafb36df151baa9be145b762",
-            "size": 5061,
-            "uri": "https://{canondata_backend}/1599023/b20a85d970ee9487ed1d9f65d26dc4494b43f0c8/resource.tar.gz#test.test_window-all_columns_hide_window_special_ones-default.txt-Debug_/opt.yql_patched"
+            "checksum": "373868114b38eeebfc147e7cdac748ff",
+            "size": 4867,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-all_columns_hide_window_special_ones-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-all_columns_hide_window_special_ones-default.txt-Plan]": [
         {
-            "checksum": "79d9fe9041a1ad943eb7b93baa6aff7d",
-            "size": 6509,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-all_columns_hide_window_special_ones-default.txt-Plan_/plan.txt"
+            "checksum": "41e761bd62749f37d8663fc9e320c60e",
+            "size": 6303,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-all_columns_hide_window_special_ones-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-rank/nulls-default.txt-Debug]": [
@@ -2829,100 +2829,100 @@
     ],
     "test.test[window-rank/unordered--Debug]": [
         {
-            "checksum": "53b9681065b5d17ee470470d7776da44",
-            "size": 6631,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_window-rank_unordered--Debug_/opt.yql_patched"
+            "checksum": "e9dbc67e6e5ba4f06799688c040d15b8",
+            "size": 6284,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-rank_unordered--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-rank/unordered--Plan]": [
         {
-            "checksum": "89fbc756648f0a5e4611496fc99dc9c8",
-            "size": 7161,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-rank_unordered--Plan_/plan.txt"
+            "checksum": "458330ba22a6f1a5ad1062d740910594",
+            "size": 6749,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-rank_unordered--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_aggr_4func--Debug]": [
         {
-            "checksum": "dd88b06e3f5b135e384396149c64ee35",
-            "size": 5152,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_window-win_func_aggr_4func--Debug_/opt.yql_patched"
+            "checksum": "caae8e878d05dd9d93fdc1ecf0cd97bd",
+            "size": 4822,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_aggr_4func--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_4func--Plan]": [
         {
-            "checksum": "d9c35fc4249d68f9158b0e130fd31be4",
-            "size": 5710,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-win_func_aggr_4func--Plan_/plan.txt"
+            "checksum": "53c83b2c69df913e90dd4fd8c1947c28",
+            "size": 5298,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_aggr_4func--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_aggr_4func_no_part_sorted--Debug]": [
         {
-            "checksum": "f14f5f63e8c2a6f345d5f1a1b2dd5a0a",
-            "size": 4007,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part_sorted--Debug_/opt.yql_patched"
+            "checksum": "0ebcdf918aa9d598dcfa8ad03c54232d",
+            "size": 3865,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_4func_no_part_sorted--Plan]": [
         {
-            "checksum": "e73e482ef8e1fd5e2f1fb173e85002a7",
-            "size": 5560,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part_sorted--Plan_/plan.txt"
+            "checksum": "79359b10317c94ad618b5563fe45b4e4",
+            "size": 5354,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_aggr_4func_no_part_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_aggr_hist--Debug]": [
         {
-            "checksum": "1a2bb37dbe4b16d14e12091db01fc124",
-            "size": 7045,
-            "uri": "https://{canondata_backend}/1942100/9e10c600658243ef9def34925559150fea4464d5/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql_patched"
+            "checksum": "d006b640ae96be8a214c9dd5ed00bdf2",
+            "size": 6705,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_aggr_hist--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_hist--Plan]": [
         {
-            "checksum": "d9c35fc4249d68f9158b0e130fd31be4",
-            "size": 5710,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-win_func_aggr_hist--Plan_/plan.txt"
+            "checksum": "53c83b2c69df913e90dd4fd8c1947c28",
+            "size": 5298,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_aggr_hist--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_lead_lag_opt--Debug]": [
         {
-            "checksum": "d17ac1a71ef0aa12ca924f496ff1cbf1",
-            "size": 9063,
-            "uri": "https://{canondata_backend}/1942671/e4607b99ae7f4e7b30412ee7a9c84a28608e2619/resource.tar.gz#test.test_window-win_func_lead_lag_opt--Debug_/opt.yql_patched"
+            "checksum": "3d8269564c262be8728c55ca5f0eedbf",
+            "size": 8704,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_lead_lag_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_lead_lag_opt--Plan]": [
         {
-            "checksum": "2b05035552bf5c71ee97d09a3093c64b",
-            "size": 11795,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-win_func_lead_lag_opt--Plan_/plan.txt"
+            "checksum": "249e8a0e938757220c71b6d62093b1ab",
+            "size": 11383,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_lead_lag_opt--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_part_by_expr--Debug]": [
         {
-            "checksum": "dfde2638f6529f6990a8121fb0b73823",
-            "size": 6180,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_window-win_func_part_by_expr--Debug_/opt.yql_patched"
+            "checksum": "fe253564efafdb8d45d61355b5979f71",
+            "size": 5749,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_part_by_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_part_by_expr--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-win_func_part_by_expr--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_part_by_expr--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_rank_by_opt_all--Debug]": [
         {
-            "checksum": "fbb89203238cda7dafd9ccda57b0e789",
-            "size": 4328,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_window-win_func_rank_by_opt_all--Debug_/opt.yql_patched"
+            "checksum": "b2d52fe5ec9f2e4129761d63b484b053",
+            "size": 4266,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_rank_by_opt_all--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_rank_by_opt_all--Plan]": [
         {
-            "checksum": "bd67f838edb07ed44512867f64dda80a",
-            "size": 5601,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-win_func_rank_by_opt_all--Plan_/plan.txt"
+            "checksum": "135aee0995e6816890255244b97c9e88",
+            "size": 5395,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-win_func_rank_by_opt_all--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_over_joined--Debug]": [
@@ -2941,44 +2941,44 @@
     ],
     "test.test[window-yql-14479-default.txt-Debug]": [
         {
-            "checksum": "f2fed334052e29c9cb8845ea78c84afa",
-            "size": 4656,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_window-yql-14479-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4527ed61d16f4fb6b1739abffc3f0c5c",
+            "size": 4339,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-yql-14479-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-yql-14479-default.txt-Plan]": [
         {
-            "checksum": "b00abd1fa62645b4c409338be8cbbd2a",
-            "size": 6142,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-yql-14479-default.txt-Plan_/plan.txt"
+            "checksum": "78e8bc597a8e406155f9e0ab5311979f",
+            "size": 5730,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-yql-14479-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-yql-14738-default.txt-Debug]": [
         {
-            "checksum": "f0d97ec78eca24033121c223d7ec3253",
-            "size": 18704,
-            "uri": "https://{canondata_backend}/1871182/cf13957d635dc8c77a65ef70797b7c6b8d4646c5/resource.tar.gz#test.test_window-yql-14738-default.txt-Debug_/opt.yql_patched"
+            "checksum": "368e8d7ec83c6b7f4e93fb4523d01b64",
+            "size": 17903,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-yql-14738-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-yql-14738-default.txt-Plan]": [
         {
-            "checksum": "5cc3d41204efdcfc73bafc247d61b8ad",
-            "size": 21261,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_window-yql-14738-default.txt-Plan_/plan.txt"
+            "checksum": "f7470c36df2025d600581fd798fb7a33",
+            "size": 20231,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_window-yql-14738-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[ypath-limit_with_range-default.txt-Debug]": [
         {
-            "checksum": "f57a256e9b0d9c46c53fc6539e5bb356",
-            "size": 2040,
-            "uri": "https://{canondata_backend}/1871102/597d6ee930787f14a7fd3507c37be2e17e206201/resource.tar.gz#test.test_ypath-limit_with_range-default.txt-Debug_/opt.yql_patched"
+            "checksum": "47320a4a274925c2df9badcbd1c02e44",
+            "size": 1929,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_ypath-limit_with_range-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ypath-limit_with_range-default.txt-Plan]": [
         {
-            "checksum": "418086b69ac4a67baa9ed1983d4ecd49",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1925842/70942689b7ce63cefca5f7da5343fab5153230a8/resource.tar.gz#test.test_ypath-limit_with_range-default.txt-Plan_/plan.txt"
+            "checksum": "fb002ebdc33b29d4424586db2a9ffd02",
+            "size": 3492,
+            "uri": "https://{canondata_backend}/1130705/20da23c279246100d1cf6675c98b016c27d78ebb/resource.tar.gz#test.test_ypath-limit_with_range-default.txt-Plan_/plan.txt"
         }
     ]
 }

--- a/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part10/canondata/result.json
@@ -15,16 +15,16 @@
     ],
     "test.test[action-discard-default.txt-Debug]": [
         {
-            "checksum": "a084bdd31ac6f96c86e5f37c48dbc03b",
-            "size": 5217,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_action-discard-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e47a9ce4668402c4a721e40f1ffd0288",
+            "size": 4973,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-discard-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-discard-default.txt-Plan]": [
         {
-            "checksum": "354f7522ad017e176ab34f0c9bbdb935",
-            "size": 11631,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_action-discard-default.txt-Plan_/plan.txt"
+            "checksum": "1e501352e1506f04ee1e9631364b435f",
+            "size": 10807,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-discard-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_astagged-default.txt-Debug]": [
@@ -43,30 +43,30 @@
     ],
     "test.test[action-eval_input_output_table--Debug]": [
         {
-            "checksum": "e9253808e3d07578ab01b98a5cc33c37",
-            "size": 3199,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_action-eval_input_output_table--Debug_/opt.yql_patched"
+            "checksum": "af0fabeb9e9de1f83802b692ed03b5e1",
+            "size": 2953,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-eval_input_output_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_input_output_table--Plan]": [
         {
-            "checksum": "760256deffb030b1d2456d4f27ab342f",
-            "size": 7011,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_action-eval_input_output_table--Plan_/plan.txt"
+            "checksum": "905ef7e67f39874c7c7e646334dd061f",
+            "size": 6599,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-eval_input_output_table--Plan_/plan.txt"
         }
     ],
     "test.test[action-insert_each_from_folder--Debug]": [
         {
-            "checksum": "a9d47f02c596301bd0e10a333e25437e",
-            "size": 1801,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_action-insert_each_from_folder--Debug_/opt.yql_patched"
+            "checksum": "e005bcac66f3a646c48b21720d029b07",
+            "size": 1735,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-insert_each_from_folder--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-insert_each_from_folder--Plan]": [
         {
-            "checksum": "c8724b228ad4389dbb1bf8fee5c64d16",
-            "size": 3613,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_action-insert_each_from_folder--Plan_/plan.txt"
+            "checksum": "d0001d3bd2c2eda97c42230016627a5e",
+            "size": 3407,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-insert_each_from_folder--Plan_/plan.txt"
         }
     ],
     "test.test[action-pass_action_as_param-default.txt-Debug]": [
@@ -113,16 +113,16 @@
     ],
     "test.test[action-subquery-default.txt-Debug]": [
         {
-            "checksum": "e3735ab4dc1de953882ac6e1df4ce07f",
-            "size": 3911,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_action-subquery-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9cdcaab010b81afacd33bb16a060f169",
+            "size": 3743,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-subquery-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-subquery-default.txt-Plan]": [
         {
-            "checksum": "06e9adf2e1da5c9a32c93755f4882697",
-            "size": 9854,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_action-subquery-default.txt-Plan_/plan.txt"
+            "checksum": "69c36c6c8b8041268b6803c33e87e537",
+            "size": 9236,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_action-subquery-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[agg_apply-opt_len_count_all-default.txt-Debug]": [
@@ -197,30 +197,30 @@
     ],
     "test.test[aggr_factory-booland-default.txt-Debug]": [
         {
-            "checksum": "d9e5d5e7cf0e98eccd6641ea29da2663",
-            "size": 6603,
-            "uri": "https://{canondata_backend}/1775059/dc8990562e130c6e73af5ecb4e53b5601afceb01/resource.tar.gz#test.test_aggr_factory-booland-default.txt-Debug_/opt.yql_patched"
+            "checksum": "61e02edc8763bf4e8e6c423370e39dc2",
+            "size": 6505,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggr_factory-booland-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-booland-default.txt-Plan]": [
         {
-            "checksum": "b04a7b524988f38190d4f7d6f057bd1a",
-            "size": 13318,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggr_factory-booland-default.txt-Plan_/plan.txt"
+            "checksum": "d77130b7c4f1b83c7ecedee655385188",
+            "size": 12906,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggr_factory-booland-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-histogram-default.txt-Debug]": [
         {
-            "checksum": "10d4d96b47b482db1c8eef3a19238e90",
-            "size": 7094,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_aggr_factory-histogram-default.txt-Debug_/opt.yql_patched"
+            "checksum": "867cb7ff730ec35ea2a337a091773a1e",
+            "size": 6962,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggr_factory-histogram-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-histogram-default.txt-Plan]": [
         {
-            "checksum": "fccab27fc32f2ce1893577cb2b715619",
-            "size": 10347,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggr_factory-histogram-default.txt-Plan_/plan.txt"
+            "checksum": "28710e9b64679ddb78df5852c2e8b85b",
+            "size": 9935,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggr_factory-histogram-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-transform_output-default.txt-Debug]": [
@@ -239,170 +239,170 @@
     ],
     "test.test[aggregate-GroupByTwoFields--Debug]": [
         {
-            "checksum": "889bb6089cf536c5a2bc79b554229053",
-            "size": 5518,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-GroupByTwoFields--Debug_/opt.yql_patched"
+            "checksum": "fa043b90cff594519e86095276c63b3a",
+            "size": 5170,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-GroupByTwoFields--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-GroupByTwoFields--Plan]": [
         {
-            "checksum": "b2bfbb7a8ce3d9439240bbb150704641",
-            "size": 8498,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-GroupByTwoFields--Plan_/plan.txt"
+            "checksum": "743a67af3ae90ca9a75922f8c3f28884",
+            "size": 7880,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-GroupByTwoFields--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_distinct_list-default.txt-Debug]": [
         {
-            "checksum": "078ebcb9c946633edba7070e9e1e52ab",
-            "size": 13081,
-            "uri": "https://{canondata_backend}/1775319/03adc08e0094e5a177cb3345876b4674592b389c/resource.tar.gz#test.test_aggregate-aggregate_distinct_list-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f57ca86ee36915839aa6144865564870",
+            "size": 12750,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-aggregate_distinct_list-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_distinct_list-default.txt-Plan]": [
         {
-            "checksum": "ad1e803c7d3d3412cdf987f031fa66ac",
-            "size": 25500,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-aggregate_distinct_list-default.txt-Plan_/plan.txt"
+            "checksum": "9c206a51e9c226ac371a9870a40208b5",
+            "size": 24470,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-aggregate_distinct_list-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_with_deep_aggregated_column--Debug]": [
         {
-            "checksum": "533bee28f66b47449d1af04b18a4ec7e",
-            "size": 5626,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-aggregate_with_deep_aggregated_column--Debug_/opt.yql_patched"
+            "checksum": "f9fb589578e20e5cdc3913005d4c4b4b",
+            "size": 5324,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-aggregate_with_deep_aggregated_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_with_deep_aggregated_column--Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-aggregate_with_deep_aggregated_column--Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-aggregate_with_deep_aggregated_column--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_with_lambda--Debug]": [
         {
-            "checksum": "9afe6eebb0c538616ab1e634cee581bc",
-            "size": 3468,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_aggregate-aggregate_with_lambda--Debug_/opt.yql_patched"
+            "checksum": "0813e328f82ad5c00643fb48a5139088",
+            "size": 3338,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-aggregate_with_lambda--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_with_lambda--Plan]": [
         {
-            "checksum": "fb430f6d3c0374fef02c4d774347644d",
-            "size": 6189,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-aggregate_with_lambda--Plan_/plan.txt"
+            "checksum": "8428baf11b9fe650c7f5a9a4f65aeade",
+            "size": 5777,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-aggregate_with_lambda--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-compare_by_tuple--Debug]": [
         {
-            "checksum": "bc0cfe95afbe436692e24d7aeb59b763",
-            "size": 5698,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_aggregate-compare_by_tuple--Debug_/opt.yql_patched"
+            "checksum": "96722786fd4ae7887962f3c84d8e15d0",
+            "size": 5452,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-compare_by_tuple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-compare_by_tuple--Plan]": [
         {
-            "checksum": "b83ec87b51bba8b868ad6c8710a36dc7",
-            "size": 6346,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-compare_by_tuple--Plan_/plan.txt"
+            "checksum": "8f91c92ee6acb1c8f6da4b3ed822787d",
+            "size": 5934,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-compare_by_tuple--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-dedup_state_keys--Debug]": [
         {
-            "checksum": "409c1929dec6cfc2d7cbd089b8f3fd0c",
-            "size": 5492,
-            "uri": "https://{canondata_backend}/1924537/ed5c3cfadad0d4915690e6595935fd0ac4b575d5/resource.tar.gz#test.test_aggregate-dedup_state_keys--Debug_/opt.yql_patched"
+            "checksum": "6910da6a20ce91cb5290f65510b92cad",
+            "size": 5131,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-dedup_state_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-dedup_state_keys--Plan]": [
         {
-            "checksum": "d4475b4ce49986967e40aeacc55b9d97",
-            "size": 8454,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-dedup_state_keys--Plan_/plan.txt"
+            "checksum": "2b8caaa263fad6a40e505e78b6d874b6",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-dedup_state_keys--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_cube_grouping_and_expr-default.txt-Debug]": [
         {
-            "checksum": "65177e632844e7742f51f106e2f95943",
-            "size": 11436,
-            "uri": "https://{canondata_backend}/1916746/0a46213528e6fcf563f737604a75716fd35df71d/resource.tar.gz#test.test_aggregate-group_by_cube_grouping_and_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "fb6ee929b54913480f986df37f11ab30",
+            "size": 10691,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_cube_grouping_and_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_cube_grouping_and_expr-default.txt-Plan]": [
         {
-            "checksum": "ed74f9e52952dc5def20473518c36c4e",
-            "size": 17334,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-group_by_cube_grouping_and_expr-default.txt-Plan_/plan.txt"
+            "checksum": "fbec7c714f3163e077129d328b75af73",
+            "size": 16304,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_cube_grouping_and_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_semi_join--Debug]": [
         {
-            "checksum": "f966dba16ede4f6512a397b36c09eda0",
-            "size": 7728,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-group_by_expr_semi_join--Debug_/opt.yql_patched"
+            "checksum": "96c45a97eedaea35eda358aef956fcb3",
+            "size": 7468,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_expr_semi_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_semi_join--Plan]": [
         {
-            "checksum": "29044c0d8c68cc5c2841596b8eb5e8e3",
-            "size": 10612,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-group_by_expr_semi_join--Plan_/plan.txt"
+            "checksum": "6b1beb42d5d9dbad75fb92d5d7534a8b",
+            "size": 10200,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_expr_semi_join--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_few_empty--Debug]": [
         {
-            "checksum": "f771ec2ee829ab7ff3fcf218099aaaef",
-            "size": 10886,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-group_by_gs_few_empty--Debug_/opt.yql_patched"
+            "checksum": "fcdfda91572821eef9a5c81a0199f358",
+            "size": 9964,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_gs_few_empty--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_few_empty--Plan]": [
         {
-            "checksum": "5915f68a32b3e7ab1e562ec9ce8fb45c",
-            "size": 15769,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-group_by_gs_few_empty--Plan_/plan.txt"
+            "checksum": "9a3a76a2990c67ea79b67b9187badd44",
+            "size": 14739,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_gs_few_empty--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_flatten_expr-default.txt-Debug]": [
         {
-            "checksum": "dbf2790dd7df315749f4f36317f44d01",
-            "size": 7331,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "738d86bad37cdae0af3a9d76e5e3ba18",
+            "size": 6934,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_flatten_expr-default.txt-Plan]": [
         {
-            "checksum": "04760a14c021e2d326ac5bb6860b30ae",
-            "size": 11170,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_expr-default.txt-Plan_/plan.txt"
+            "checksum": "5b896fa1c3d86875af19754f7246e2b1",
+            "size": 10552,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_mul_gb_ru--Debug]": [
         {
-            "checksum": "552f5b03f5fc538a5ea47a3810a5fa7c",
-            "size": 13405,
-            "uri": "https://{canondata_backend}/1916746/0a46213528e6fcf563f737604a75716fd35df71d/resource.tar.gz#test.test_aggregate-group_by_mul_gb_ru--Debug_/opt.yql_patched"
+            "checksum": "90687e60b50ae394ffb1953b9861c9ed",
+            "size": 12591,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_mul_gb_ru--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_mul_gb_ru--Plan]": [
         {
-            "checksum": "872aa9539809ae1ad709998bcccccf5f",
-            "size": 17012,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-group_by_mul_gb_ru--Plan_/plan.txt"
+            "checksum": "66632a768134c20580943cd6336adf55",
+            "size": 15982,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_mul_gb_ru--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_aggr_expr--Debug]": [
         {
-            "checksum": "c19eb91e09b0d22b4f5d7bc3d806c04c",
-            "size": 11902,
-            "uri": "https://{canondata_backend}/1924537/ed5c3cfadad0d4915690e6595935fd0ac4b575d5/resource.tar.gz#test.test_aggregate-group_by_rollup_aggr_expr--Debug_/opt.yql_patched"
+            "checksum": "c399465c516e48ccdc441eb431c20f6d",
+            "size": 11341,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_rollup_aggr_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_aggr_expr--Plan]": [
         {
-            "checksum": "f2ab773bc71e1584193fea8b604d6f47",
-            "size": 14485,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-group_by_rollup_aggr_expr--Plan_/plan.txt"
+            "checksum": "62c31ba95f97cd10c9634a6891951d20",
+            "size": 13867,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_by_rollup_aggr_expr--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_rename-default.txt-Debug]": [
@@ -421,58 +421,58 @@
     ],
     "test.test[aggregate-group_compact_sorted_distinct--Debug]": [
         {
-            "checksum": "016b5622962c7962452c383306be7e00",
-            "size": 5607,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct--Debug_/opt.yql_patched"
+            "checksum": "0fc75b60cf2340eb94873283b96cd88e",
+            "size": 5279,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_compact_sorted_distinct--Plan]": [
         {
-            "checksum": "7d771113cb26892c63b73deae909e3f2",
-            "size": 5709,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct--Plan_/plan.txt"
+            "checksum": "669ae8d9a42798f0257e720f10d7e885",
+            "size": 5297,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-percentiles_containers--Debug]": [
         {
-            "checksum": "55bd9aec516496eda20a212d1a880e36",
-            "size": 10362,
-            "uri": "https://{canondata_backend}/1775059/dc8990562e130c6e73af5ecb4e53b5601afceb01/resource.tar.gz#test.test_aggregate-percentiles_containers--Debug_/opt.yql_patched"
+            "checksum": "aef8d576e4dff2ef07280f72a8223e1a",
+            "size": 10012,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-percentiles_containers--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-percentiles_containers--Plan]": [
         {
-            "checksum": "ed7458b40771133ca9407b00f3428124",
-            "size": 10945,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-percentiles_containers--Plan_/plan.txt"
+            "checksum": "72cf26be37d6b4655f127ae8eed365b3",
+            "size": 10533,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-percentiles_containers--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-percentiles_grouped--Debug]": [
         {
-            "checksum": "049f917ce8c896d4b0e9a97167b1701d",
-            "size": 9559,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-percentiles_grouped--Debug_/opt.yql_patched"
+            "checksum": "74348e95b5953009480ff395cfa10cd2",
+            "size": 9159,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-percentiles_grouped--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-percentiles_grouped--Plan]": [
         {
-            "checksum": "c0056428ddbd26973496bc6589a3ac24",
-            "size": 11143,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-percentiles_grouped--Plan_/plan.txt"
+            "checksum": "41d28baa19e2f4955533380fa0915249",
+            "size": 10525,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-percentiles_grouped--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-percentiles_grouped_expr--Debug]": [
         {
-            "checksum": "ef6ba9c47693ca33ca4d7f9e92e3b587",
-            "size": 9827,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_aggregate-percentiles_grouped_expr--Debug_/opt.yql_patched"
+            "checksum": "a1b6265ca74f364e25aecd8564e45d64",
+            "size": 9385,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-percentiles_grouped_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-percentiles_grouped_expr--Plan]": [
         {
-            "checksum": "cc16e91710e96c568ad233d7f4f95b43",
-            "size": 11429,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_aggregate-percentiles_grouped_expr--Plan_/plan.txt"
+            "checksum": "550df6b2ba64f7d4bce919ff6997ebb1",
+            "size": 10811,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_aggregate-percentiles_grouped_expr--Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-bitcast_date32-default.txt-Debug]": [
@@ -505,30 +505,30 @@
     ],
     "test.test[bigdate-table_explicit_cast-default.txt-Debug]": [
         {
-            "checksum": "7d1ddeebbc081685dea5cbc0a5a62c81",
-            "size": 17282,
-            "uri": "https://{canondata_backend}/1937429/c619076ae9ed63153f2bbb2b2ac56cc6f7585a31/resource.tar.gz#test.test_bigdate-table_explicit_cast-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4ddd7a38043cb708c6ae30bd2fa8d8ca",
+            "size": 15554,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_bigdate-table_explicit_cast-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_explicit_cast-default.txt-Plan]": [
         {
-            "checksum": "14b6d9e033eb14c0658b903b514c51d4",
-            "size": 19723,
-            "uri": "https://{canondata_backend}/1937429/c619076ae9ed63153f2bbb2b2ac56cc6f7585a31/resource.tar.gz#test.test_bigdate-table_explicit_cast-default.txt-Plan_/plan.txt"
+            "checksum": "5a318f97307a45c6fbb3eda548785bad",
+            "size": 18487,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_bigdate-table_explicit_cast-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[binding-anon_table_binding-default.txt-Debug]": [
         {
-            "checksum": "ebc57e7673a8943a9e269c4de199891a",
-            "size": 1802,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_binding-anon_table_binding-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4ae0afb88d94b3520c1d1edcb80dbfa6",
+            "size": 1742,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_binding-anon_table_binding-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[binding-anon_table_binding-default.txt-Plan]": [
         {
-            "checksum": "a58dceb4be42964b6181d7689b87bcf6",
-            "size": 5715,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_binding-anon_table_binding-default.txt-Plan_/plan.txt"
+            "checksum": "8e753662e5bb28012ce67f4c1a4c111b",
+            "size": 5509,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_binding-anon_table_binding-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[binding-tie-default.txt-Debug]": [
@@ -561,170 +561,170 @@
     ],
     "test.test[blocks-add_decimal--Debug]": [
         {
-            "checksum": "3b41a09ad32d2e3ab74db02fd98fd386",
-            "size": 2539,
-            "uri": "https://{canondata_backend}/1925821/b3b1e9eed0dbfb05c9eb91f8523c914ef2b33985/resource.tar.gz#test.test_blocks-add_decimal--Debug_/opt.yql_patched"
+            "checksum": "5358828ba734f6a646bcc3f8f1798f2e",
+            "size": 2409,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-add_decimal--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_decimal--Plan]": [
         {
-            "checksum": "f6ee0c504755fc4e53aea49fe66277b6",
-            "size": 4097,
-            "uri": "https://{canondata_backend}/1925821/b3b1e9eed0dbfb05c9eb91f8523c914ef2b33985/resource.tar.gz#test.test_blocks-add_decimal--Plan_/plan.txt"
+            "checksum": "eb05966c5d2fbf9140e4f10947a8ed19",
+            "size": 3891,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-add_decimal--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-coalesce_bools--Debug]": [
         {
-            "checksum": "7ca8710ba5c6493da83b6bc790cd1e24",
-            "size": 4553,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-coalesce_bools--Debug_/opt.yql_patched"
+            "checksum": "1388757a1317c8563766401d68f99a4b",
+            "size": 4013,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-coalesce_bools--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-coalesce_bools--Plan]": [
         {
-            "checksum": "1e73eee7e5f09a5e19f452f3eb32ed3e",
-            "size": 6224,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-coalesce_bools--Plan_/plan.txt"
+            "checksum": "cb79de29418a8362a6ef9b7ea5927963",
+            "size": 5812,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-coalesce_bools--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-coalesce_complex-default.txt-Debug]": [
         {
-            "checksum": "9d1018624bc4a42f4c3787dd5ea192a8",
-            "size": 8950,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-coalesce_complex-default.txt-Debug_/opt.yql_patched"
+            "checksum": "55768050629885156e5e9ad9e360de37",
+            "size": 8150,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-coalesce_complex-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-coalesce_complex-default.txt-Plan]": [
         {
-            "checksum": "e24225df342c85aade818d773b358b88",
-            "size": 21144,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-coalesce_complex-default.txt-Plan_/plan.txt"
+            "checksum": "ba7db22a8e631ab14e8acebd48728352",
+            "size": 19908,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-coalesce_complex-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_count_filter_opt--Debug]": [
         {
-            "checksum": "ff710bca28a37039ad0ca60b734fe5e7",
-            "size": 3652,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_all_count_filter_opt--Debug_/opt.yql_patched"
+            "checksum": "c1929b628fa4566d327988c8d51fbb0a",
+            "size": 3544,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_all_count_filter_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_count_filter_opt--Plan]": [
         {
-            "checksum": "292233847881b866a7f0f6376dd4bc43",
-            "size": 5589,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_all_count_filter_opt--Plan_/plan.txt"
+            "checksum": "37b39cc33c58de23e77643081a9b7ebe",
+            "size": 5383,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_all_count_filter_opt--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_max_filter--Debug]": [
         {
-            "checksum": "6a6fa1d9f903758f5128f08471cb692d",
-            "size": 3157,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_all_max_filter--Debug_/opt.yql_patched"
+            "checksum": "4fcd6dd204bc590272c5bd67c42de5a2",
+            "size": 3090,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_all_max_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_max_filter--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_all_max_filter--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_all_max_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_some--Debug]": [
         {
-            "checksum": "3c6c2a5384dcaa40a6dbb07f00a38f9d",
-            "size": 9321,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_all_some--Debug_/opt.yql_patched"
+            "checksum": "55dd9afefd892eaee894bc02488878bf",
+            "size": 8883,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_all_some--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_some--Plan]": [
         {
-            "checksum": "a1361799631618b84ec6b61887b259c0",
-            "size": 5459,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_all_some--Plan_/plan.txt"
+            "checksum": "16a0de7e33ba5f70a4588de69a651389",
+            "size": 5253,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_all_some--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_min--Debug]": [
         {
-            "checksum": "6202a02ef0da58c79465f169f5d95238",
-            "size": 6419,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_hashed_min--Debug_/opt.yql_patched"
+            "checksum": "32af7d8bb3a67871a37c95b0606ce198",
+            "size": 5893,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_hashed_min--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_min--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_hashed_min--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_hashed_min--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_sum_many_keys--Debug]": [
         {
-            "checksum": "13d3233308af0920f66628bda1b65e38",
-            "size": 22393,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_hashed_sum_many_keys--Debug_/opt.yql_patched"
+            "checksum": "301595602d8f7113fdd4ee4eefc82fce",
+            "size": 20993,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_hashed_sum_many_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_sum_many_keys--Plan]": [
         {
-            "checksum": "d1cced30681ea4330f6655714a134dfa",
-            "size": 29794,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-combine_hashed_sum_many_keys--Plan_/plan.txt"
+            "checksum": "c5ba537891a3c91bbdd852878c3a4301",
+            "size": 27734,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-combine_hashed_sum_many_keys--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_greater_scalar--Debug]": [
         {
-            "checksum": "110c01130f33f237131a375e38398a49",
-            "size": 26413,
-            "uri": "https://{canondata_backend}/1773845/6e12a9ad8ca1393c67d99ce6c0f78660e657fae0/resource.tar.gz#test.test_blocks-date_greater_scalar--Debug_/opt.yql_patched"
+            "checksum": "d0955f2fe45588ee86430304d10b154e",
+            "size": 22397,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-date_greater_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_greater_scalar--Plan]": [
         {
-            "checksum": "1ac2afa98f4d958a9cca1e31d65a570d",
-            "size": 12272,
-            "uri": "https://{canondata_backend}/1773845/6e12a9ad8ca1393c67d99ce6c0f78660e657fae0/resource.tar.gz#test.test_blocks-date_greater_scalar--Plan_/plan.txt"
+            "checksum": "e81ad78037d8967dd443aa92a9b04411",
+            "size": 11448,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-date_greater_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_group_by--Debug]": [
         {
-            "checksum": "b124bdc5db3fdd533c29cdefb0b9fe9d",
-            "size": 8219,
-            "uri": "https://{canondata_backend}/1773845/6e12a9ad8ca1393c67d99ce6c0f78660e657fae0/resource.tar.gz#test.test_blocks-date_group_by--Debug_/opt.yql_patched"
+            "checksum": "6486edca868e00495e4e211814f5d9f8",
+            "size": 7733,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-date_group_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_group_by--Plan]": [
         {
-            "checksum": "3b367b2bb8940dec203844172d00e110",
-            "size": 6754,
-            "uri": "https://{canondata_backend}/1773845/6e12a9ad8ca1393c67d99ce6c0f78660e657fae0/resource.tar.gz#test.test_blocks-date_group_by--Plan_/plan.txt"
+            "checksum": "b71bd52ffe95d097af0b9c01fc4b7ac2",
+            "size": 6342,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-date_group_by--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_sub_scalar--Debug]": [
         {
-            "checksum": "eb79b95cc8ab6ece8cda0d373ffc3cb7",
-            "size": 24887,
-            "uri": "https://{canondata_backend}/1814674/9488849b466e427dfdcf2f4a65bd7c6352ffabd6/resource.tar.gz#test.test_blocks-date_sub_scalar--Debug_/opt.yql_patched"
+            "checksum": "32944a79393de8d0ee5db111888c3a5b",
+            "size": 21041,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-date_sub_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_sub_scalar--Plan]": [
         {
-            "checksum": "12018a00b8a92db5880e226557881949",
-            "size": 11319,
-            "uri": "https://{canondata_backend}/1814674/9488849b466e427dfdcf2f4a65bd7c6352ffabd6/resource.tar.gz#test.test_blocks-date_sub_scalar--Plan_/plan.txt"
+            "checksum": "615d7d9c113bc4c8587aa608ff7f7783",
+            "size": 10495,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-date_sub_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-finalize_hashed_keys--Debug]": [
         {
-            "checksum": "3f54d7f0a158f67593e5ef2b48900240",
-            "size": 7691,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-finalize_hashed_keys--Debug_/opt.yql_patched"
+            "checksum": "d6dec61f4b2bad487f568823255aa767",
+            "size": 7007,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-finalize_hashed_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-finalize_hashed_keys--Plan]": [
         {
-            "checksum": "ee4e40b52a0d274490852a3d77b97020",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-finalize_hashed_keys--Plan_/plan.txt"
+            "checksum": "e905d9662310a564a8c1b21d19846433",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-finalize_hashed_keys--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_mul--Debug]": [
@@ -743,226 +743,226 @@
     ],
     "test.test[blocks-member--Debug]": [
         {
-            "checksum": "2a86014aed3c8985762199014213079e",
-            "size": 2698,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
+            "checksum": "95943ca9cafad1a967c72cb960bcb263",
+            "size": 2564,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-member--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-member--Plan]": [
         {
-            "checksum": "c9f210385f21f66be2c3865dbae5a078",
-            "size": 4072,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
+            "checksum": "c4dfdfe4214db2bf3b808ac033303fbd",
+            "size": 3866,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-member--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-minmax_strings--Debug]": [
         {
-            "checksum": "7dbb9ede721854f7f4d1ff52d175d962",
-            "size": 13576,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-minmax_strings--Debug_/opt.yql_patched"
+            "checksum": "3d5e78c75e53010f65c98b2915309966",
+            "size": 12699,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-minmax_strings--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-minmax_strings--Plan]": [
         {
-            "checksum": "9046bdf02634ec5e27c22fc4d74acad9",
-            "size": 15167,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-minmax_strings--Plan_/plan.txt"
+            "checksum": "45c683179395054940f242659cfedd35",
+            "size": 14343,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-minmax_strings--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-minmax_tuple--Debug]": [
         {
-            "checksum": "8195b3ed8838ca1a29398ea09d2181a5",
-            "size": 7573,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-minmax_tuple--Debug_/opt.yql_patched"
+            "checksum": "802665397660434f4bc0f7dfda5badef",
+            "size": 7331,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-minmax_tuple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-minmax_tuple--Plan]": [
         {
-            "checksum": "2dfce13d3e832a817b0a3b5fe1c1fa72",
-            "size": 10830,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-minmax_tuple--Plan_/plan.txt"
+            "checksum": "33926934bbcec8f74922e0571a650a60",
+            "size": 10418,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-minmax_tuple--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-not--Debug]": [
         {
-            "checksum": "9a8c689c10c9f8df59523408e853c888",
-            "size": 2124,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-not--Debug_/opt.yql_patched"
+            "checksum": "df2326b2c37a716fd63b4f4ab7b44e2f",
+            "size": 1999,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-not--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-not--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-not--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-not--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_to_numbers--Debug]": [
         {
-            "checksum": "6c961ba21a62fe19fdab76b1371a4d32",
-            "size": 3313,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-pg_to_numbers--Debug_/opt.yql_patched"
+            "checksum": "a6b169b0ba5f69732853caa4c6521dcf",
+            "size": 3015,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-pg_to_numbers--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_to_numbers--Plan]": [
         {
-            "checksum": "6deaaf08320d9faff9f19d79e784b9b5",
-            "size": 4288,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-pg_to_numbers--Plan_/plan.txt"
+            "checksum": "6868870583c99460f60f4b6f0bc47576",
+            "size": 4082,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-pg_to_numbers--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_top_sort--Debug]": [
         {
-            "checksum": "41856be26da64bdbdfa63c271eab54f5",
-            "size": 3330,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-pg_top_sort--Debug_/opt.yql_patched"
+            "checksum": "8c088c0ed5efb5afbb88b4c7ce376c65",
+            "size": 3128,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-pg_top_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_top_sort--Plan]": [
         {
-            "checksum": "9b4d9293743b40df36f3d405592b87be",
-            "size": 5465,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-pg_top_sort--Plan_/plan.txt"
+            "checksum": "d99a75813aac95593c6a83f52a847aaf",
+            "size": 5259,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-pg_top_sort--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-sort_two_asc--Debug]": [
         {
-            "checksum": "198956f77fb854dfb621f721a610acb3",
-            "size": 3420,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-sort_two_asc--Debug_/opt.yql_patched"
+            "checksum": "6bf066985efac6fd09410fae3b45c3ae",
+            "size": 3172,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-sort_two_asc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-sort_two_asc--Plan]": [
         {
-            "checksum": "280c2f9dd2d67499ddb3297b26a6ef99",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-sort_two_asc--Plan_/plan.txt"
+            "checksum": "606023bfbee343b9efa9e8f1f3aa1577",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-sort_two_asc--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-string_len_and_cmp--Debug]": [
         {
-            "checksum": "c4498199bd5f817150a6ff13dbbe0be7",
-            "size": 7782,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-string_len_and_cmp--Debug_/opt.yql_patched"
+            "checksum": "8c12cdfdc522622f9d9747e155fc17d3",
+            "size": 6144,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-string_len_and_cmp--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-string_len_and_cmp--Plan]": [
         {
-            "checksum": "5b0950239c1f99a5a19ef4a54d057f17",
-            "size": 6233,
-            "uri": "https://{canondata_backend}/1920236/31599412903e3e1d26b432101f243bc49a0140e6/resource.tar.gz#test.test_blocks-string_len_and_cmp--Plan_/plan.txt"
+            "checksum": "73a59abde8949382e67ae40e3d1d962b",
+            "size": 5821,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_blocks-string_len_and_cmp--Plan_/plan.txt"
         }
     ],
     "test.test[case-case_multi_val-default.txt-Debug]": [
         {
-            "checksum": "7d1c81a3dede5101419871652bceea96",
-            "size": 2123,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_case-case_multi_val-default.txt-Debug_/opt.yql_patched"
+            "checksum": "34e82ef3959486e1b8c7e91fec3580fa",
+            "size": 2000,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_case-case_multi_val-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[case-case_multi_val-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_case-case_multi_val-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_case-case_multi_val-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[case-case_val_then_else-default.txt-Debug]": [
         {
-            "checksum": "3373e7bb18ebe53f707fad9e93da8b78",
-            "size": 2078,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_case-case_val_then_else-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8f2d4689c7259b02613a407bd53d1a1b",
+            "size": 2012,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_case-case_val_then_else-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[case-case_val_then_else-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_case-case_val_then_else-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_case-case_val_then_else-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[case-case_when_then-default.txt-Debug]": [
         {
-            "checksum": "864d017c14aa977bec9f8a607f5780a2",
-            "size": 2040,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_case-case_when_then-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f84be0c619ac960b6c5952d71e449f51",
+            "size": 1917,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_case-case_when_then-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[case-case_when_then-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_case-case_when_then-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_case-case_when_then-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-align_publish--Debug]": [
         {
-            "checksum": "95131b755923668f5f227ebd6a0c5f4c",
-            "size": 4164,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_column_order-align_publish--Debug_/opt.yql_patched"
+            "checksum": "2157be1ffc64bdc950523819182978a7",
+            "size": 3804,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-align_publish--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-align_publish--Plan]": [
         {
-            "checksum": "1e9e9453f29c925d6cd40781ff1ee144",
-            "size": 11950,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_column_order-align_publish--Plan_/plan.txt"
+            "checksum": "de77eb9452a429979bff62eb654bd72c",
+            "size": 11332,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-align_publish--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-ordered_plus_native--Debug]": [
         {
-            "checksum": "2ccc09d3f81c7e7e85358a40582c4a39",
-            "size": 4109,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_column_order-ordered_plus_native--Debug_/opt.yql_patched"
+            "checksum": "3718446ef749777843943014a83546e8",
+            "size": 3909,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-ordered_plus_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-ordered_plus_native--Plan]": [
         {
-            "checksum": "f7c74f54b4e0649f5a0ae17a9daf4538",
-            "size": 7036,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_column_order-ordered_plus_native--Plan_/plan.txt"
+            "checksum": "e0d352a00f9146973590a2a33f435fdf",
+            "size": 6624,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-ordered_plus_native--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_limit_offset_reorder-default.txt-Debug]": [
         {
-            "checksum": "0f65ac733fb439f56aca077c7db5926b",
-            "size": 3054,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_column_order-select_limit_offset_reorder-default.txt-Debug_/opt.yql_patched"
+            "checksum": "32e1a8fe120769155f011c51f6855ab8",
+            "size": 2903,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-select_limit_offset_reorder-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_limit_offset_reorder-default.txt-Plan]": [
         {
-            "checksum": "0bd848986144b54078ddb2d875387af6",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_column_order-select_limit_offset_reorder-default.txt-Plan_/plan.txt"
+            "checksum": "98a95ac3c76cad45e4395284047c256f",
+            "size": 5326,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-select_limit_offset_reorder-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_plain-default.txt-Debug]": [
         {
-            "checksum": "cd003a6452f3c2c7f4a2b0c33c584cdf",
-            "size": 7509,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_column_order-select_plain-default.txt-Debug_/opt.yql_patched"
+            "checksum": "04ca71ab94a6379e6ab98b5fd681d2bc",
+            "size": 6965,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-select_plain-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_plain-default.txt-Plan]": [
         {
-            "checksum": "4bb8310faa118b6ed0c640c1191f0272",
-            "size": 14444,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_column_order-select_plain-default.txt-Plan_/plan.txt"
+            "checksum": "9e53ca36a98a94a859b4c99b644d9986",
+            "size": 13620,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_column_order-select_plain-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[count-count_distinct_from_view_concat--Debug]": [
         {
-            "checksum": "04f10d1e03d14d9d9f848f5e0692cdc0",
-            "size": 3751,
-            "uri": "https://{canondata_backend}/1775319/b97ff5ed3a4d5d578648b4f46958e240bd92efaf/resource.tar.gz#test.test_count-count_distinct_from_view_concat--Debug_/opt.yql_patched"
+            "checksum": "b29e1050b3c6629cb650791f7b2a113f",
+            "size": 3665,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_count-count_distinct_from_view_concat--Debug_/opt.yql_patched"
         }
     ],
     "test.test[count-count_distinct_from_view_concat--Plan]": [
         {
-            "checksum": "374b61a8685ec66ac6e828a2da71fd0d",
-            "size": 6430,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_count-count_distinct_from_view_concat--Plan_/plan.txt"
+            "checksum": "c5ae12a6b69ea019fe9e5a65aa944323",
+            "size": 6018,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_count-count_distinct_from_view_concat--Plan_/plan.txt"
         }
     ],
     "test.test[csee-closure_in_l2_and_l1-default.txt-Debug]": [
@@ -1009,16 +1009,16 @@
     ],
     "test.test[datetime-date_types-default.txt-Debug]": [
         {
-            "checksum": "bec9d5a6e890675268be716d9375d79d",
-            "size": 2264,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_datetime-date_types-default.txt-Debug_/opt.yql_patched"
+            "checksum": "198b61fc389d9be12ad4b2a901666faa",
+            "size": 2110,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_datetime-date_types-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[datetime-date_types-default.txt-Plan]": [
         {
-            "checksum": "7c4e243b7c3c13b3fe2f684321d763f7",
-            "size": 4446,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_datetime-date_types-default.txt-Plan_/plan.txt"
+            "checksum": "95aa21e48905bc4b859e8bdb0f915bc2",
+            "size": 4240,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_datetime-date_types-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[expr-as_set-default.txt-Debug]": [
@@ -1079,16 +1079,16 @@
     ],
     "test.test[expr-empty_iterator--Debug]": [
         {
-            "checksum": "0bb16ff0a44a71e9626b223528b6430b",
-            "size": 3075,
-            "uri": "https://{canondata_backend}/1900335/f1fffeb1ddc0f2e9c7365a9f5248bd3f6ab6b2ea/resource.tar.gz#test.test_expr-empty_iterator--Debug_/opt.yql_patched"
+            "checksum": "b884fb46fd65f0b91b633746541091bc",
+            "size": 3015,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_expr-empty_iterator--Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-empty_iterator--Plan]": [
         {
-            "checksum": "924ba396f0060e96a17b081f6106bf12",
-            "size": 6316,
-            "uri": "https://{canondata_backend}/1936997/87e515739da8be66e10c9c8a996573ee89a061df/resource.tar.gz#test.test_expr-empty_iterator--Plan_/plan.txt"
+            "checksum": "5e088a524803d85fd21ea943211278e2",
+            "size": 5904,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_expr-empty_iterator--Plan_/plan.txt"
         }
     ],
     "test.test[expr-expr_yql_function-default.txt-Debug]": [
@@ -1191,30 +1191,30 @@
     ],
     "test.test[flatten_by-flatten_list--Debug]": [
         {
-            "checksum": "094600810d7fbe878adeca652f9947a8",
-            "size": 4955,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_flatten_by-flatten_list--Debug_/opt.yql_patched"
+            "checksum": "65b921160bdc7557abd586c8f5920af3",
+            "size": 4668,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_flatten_by-flatten_list--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_list--Plan]": [
         {
-            "checksum": "b03d6fcad67631132f0cd58cabadba0a",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_flatten_by-flatten_list--Plan_/plan.txt"
+            "checksum": "261b45fcb0c591cd4d8b93883414dec3",
+            "size": 7936,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_flatten_by-flatten_list--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-out_range-default.txt-Debug]": [
         {
-            "checksum": "fb5f5268fb59d4310a0bab17e8d543f7",
-            "size": 9847,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_hor_join-out_range-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8acb414dea27e33740b0b9476588a8cc",
+            "size": 9279,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_hor_join-out_range-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-out_range-default.txt-Plan]": [
         {
-            "checksum": "bb82eec54c5961bf79260e413b29ed07",
-            "size": 20373,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_hor_join-out_range-default.txt-Plan_/plan.txt"
+            "checksum": "30d6ef5fcf00f59168f5faaebf54e8ba",
+            "size": 18931,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_hor_join-out_range-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-row_num_per_sect--Debug]": [
@@ -1233,114 +1233,114 @@
     ],
     "test.test[in-in_with_list_dict-default.txt-Debug]": [
         {
-            "checksum": "bea52068827ba426948aa99c739fbc55",
-            "size": 2513,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_in-in_with_list_dict-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a1ec19cb26d60aa4a5e699ca98c589bd",
+            "size": 2387,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_in-in_with_list_dict-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_with_list_dict-default.txt-Plan]": [
         {
-            "checksum": "5c41b58f8a68c081f47cebbfa8a13331",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_in-in_with_list_dict-default.txt-Plan_/plan.txt"
+            "checksum": "c6ed3026b5067eb08a3ae9247dec4859",
+            "size": 3839,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_in-in_with_list_dict-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-merge_publish--Debug]": [
         {
-            "checksum": "62855e29920159f13a826c2d628fa158",
-            "size": 3800,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_insert-merge_publish--Debug_/opt.yql_patched"
+            "checksum": "64ebc7e15210475430faab9682fa1c41",
+            "size": 3661,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-merge_publish--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-merge_publish--Plan]": [
         {
-            "checksum": "db6b2a3f4caff49d6a94c015d0d2dda3",
-            "size": 12703,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_insert-merge_publish--Plan_/plan.txt"
+            "checksum": "7a56cb028b7e1beb44f36a221fa80c58",
+            "size": 12497,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-merge_publish--Plan_/plan.txt"
         }
     ],
     "test.test[insert-override--Debug]": [
         {
-            "checksum": "a43badace5e81c3a047722d285199578",
-            "size": 1837,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_insert-override--Debug_/opt.yql_patched"
+            "checksum": "e54fc9ec38a4294496f70a3a5f25e522",
+            "size": 1714,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-override--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override--Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_insert-override--Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-override--Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted_calc-Debug]": [
         {
-            "checksum": "97c6afb0b5f48e83e544c2e3e75441d6",
-            "size": 2045,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_insert-override-from_sorted_calc-Debug_/opt.yql_patched"
+            "checksum": "aae0f7073441c3457ba6374bc225ff8e",
+            "size": 1922,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-override-from_sorted_calc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-from_sorted_calc-Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_insert-override-from_sorted_calc-Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-override-from_sorted_calc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-from_sorted_desc-Debug]": [
         {
-            "checksum": "bc3c22616beaff007cc4def6cad032e2",
-            "size": 2074,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_insert-override-from_sorted_desc-Debug_/opt.yql_patched"
+            "checksum": "75fbe621b9c0b539ade566d26bda35e7",
+            "size": 1951,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-override-from_sorted_desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-from_sorted_desc-Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_insert-override-from_sorted_desc-Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-override-from_sorted_desc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_ordered_by_key-default.txt-Debug]": [
         {
-            "checksum": "0da53c07d42a29c0aa7f2801de00bbab",
-            "size": 2142,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2bd7e0ee0d117461d0477b1dd83b1cc6",
+            "size": 2019,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_ordered_by_key-default.txt-Plan]": [
         {
-            "checksum": "70a4984063ce12ddafbbb6833c2f6202",
-            "size": 4411,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Plan_/plan.txt"
+            "checksum": "c7e835bcb19930f389dcf9a0a3b932cd",
+            "size": 4205,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_insert-replace_ordered_by_key-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-bush_dis_in_in_in--Debug]": [
         {
-            "checksum": "85c01cef3cd564dc10a4a76a88f751af",
-            "size": 13574,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-bush_dis_in_in_in--Debug_/opt.yql_patched"
+            "checksum": "80b95ab914b912d415eb94a6d4277623",
+            "size": 13214,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-bush_dis_in_in_in--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-bush_dis_in_in_in--Plan]": [
         {
-            "checksum": "d7777df9ec16f128bb710c9667c8108e",
-            "size": 18461,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-bush_dis_in_in_in--Plan_/plan.txt"
+            "checksum": "3606e28cd2d2aa5c331b5004fb6e24e5",
+            "size": 18049,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-bush_dis_in_in_in--Plan_/plan.txt"
         }
     ],
     "test.test[join-bush_in_in--Debug]": [
         {
-            "checksum": "653d8b24746b952c672a9bac017dd0e0",
-            "size": 8463,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-bush_in_in--Debug_/opt.yql_patched"
+            "checksum": "eee5b0f0bac5fe17cf5dcf46a8dd546a",
+            "size": 8312,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-bush_in_in--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-bush_in_in--Plan]": [
         {
-            "checksum": "5d3c4809594a0c296789cdbe4f221f91",
-            "size": 13050,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-bush_in_in--Plan_/plan.txt"
+            "checksum": "bf4fd559ce20158672ae596e5afda94b",
+            "size": 12844,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-bush_in_in--Plan_/plan.txt"
         }
     ],
     "test.test[join-convert_check_key_mem2--Debug]": [
@@ -1359,58 +1359,58 @@
     ],
     "test.test[join-convert_key--Debug]": [
         {
-            "checksum": "34c511790b5411542e9f87e72c7a6ea5",
-            "size": 4776,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_join-convert_key--Debug_/opt.yql_patched"
+            "checksum": "cac347fa7a734bd4e52af50549362f8f",
+            "size": 4438,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-convert_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-convert_key--Plan]": [
         {
-            "checksum": "5ac22822a3e9cda8218257c57dd2bb9b",
-            "size": 7890,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-convert_key--Plan_/plan.txt"
+            "checksum": "8ca09e513afd87c545d76f66d90ab163",
+            "size": 7478,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-convert_key--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_with_duplicate_keys_on_sorted--Debug]": [
         {
-            "checksum": "39e938fa3245b39a4861ed2533939e29",
-            "size": 5699,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-join_with_duplicate_keys_on_sorted--Debug_/opt.yql_patched"
+            "checksum": "9794fe6ec1db6c2bc0cbce1ea4999bf0",
+            "size": 5524,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-join_with_duplicate_keys_on_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_with_duplicate_keys_on_sorted--Plan]": [
         {
-            "checksum": "5d78e808e3f6ea1848eb048dd63d2f25",
-            "size": 8297,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-join_with_duplicate_keys_on_sorted--Plan_/plan.txt"
+            "checksum": "da0f5c948c79450c04b05507d5f90aa0",
+            "size": 8091,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-join_with_duplicate_keys_on_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_cast_to_string--Debug]": [
         {
-            "checksum": "27f3b7c5be71db4cd8f03f64b5183024",
-            "size": 4745,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-left_cast_to_string--Debug_/opt.yql_patched"
+            "checksum": "2472aacec4c48bf73515136d9ce01f8a",
+            "size": 4615,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-left_cast_to_string--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_cast_to_string--Plan]": [
         {
-            "checksum": "8f6bec0e5268f0cacaef99581ca3b3ec",
-            "size": 8069,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-left_cast_to_string--Plan_/plan.txt"
+            "checksum": "e4caadd70a721d36691057255070fee2",
+            "size": 7863,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-left_cast_to_string--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_join_right_pushdown_null--Debug]": [
         {
-            "checksum": "11489a58abcbb9409c145e4213713010",
-            "size": 9174,
-            "uri": "https://{canondata_backend}/1937367/3ef9cc8a4e0d288b6b9042eaffa1d05a694c9890/resource.tar.gz#test.test_join-left_join_right_pushdown_null--Debug_/opt.yql_patched"
+            "checksum": "dc200fb714ac74022a564b3a701e118e",
+            "size": 8850,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-left_join_right_pushdown_null--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_join_right_pushdown_null--Plan]": [
         {
-            "checksum": "5c98282623024c748419934471adcc64",
-            "size": 12301,
-            "uri": "https://{canondata_backend}/1937367/3ef9cc8a4e0d288b6b9042eaffa1d05a694c9890/resource.tar.gz#test.test_join-left_join_right_pushdown_null--Plan_/plan.txt"
+            "checksum": "5833f0ad8501edeb8c72a6b647baa2a5",
+            "size": 11889,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-left_join_right_pushdown_null--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_only_with_other--Debug]": [
@@ -1443,44 +1443,44 @@
     ],
     "test.test[join-lookupjoin_with_cache--Debug]": [
         {
-            "checksum": "7ccfe54683c0d8c4864268381aaf938e",
-            "size": 5879,
-            "uri": "https://{canondata_backend}/1942278/b724a85f61a1b5e50837de1f8065e63d7914acf7/resource.tar.gz#test.test_join-lookupjoin_with_cache--Debug_/opt.yql_patched"
+            "checksum": "bb20c3df32cf80cb1e011d086f2f465e",
+            "size": 5356,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-lookupjoin_with_cache--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_with_cache--Plan]": [
         {
-            "checksum": "8b25285d40681aedd1342b0209544572",
-            "size": 10905,
-            "uri": "https://{canondata_backend}/1031349/1625cfaeeef2a2283ba558f905015944d2907a0f/resource.tar.gz#test.test_join-lookupjoin_with_cache--Plan_/plan.txt"
+            "checksum": "bfa0820e6ccf5472d3068ba91fe06d77",
+            "size": 10287,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-lookupjoin_with_cache--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_sharded-default.txt-Debug]": [
         {
-            "checksum": "ddfdfc26f2443654a745b1924aed882d",
-            "size": 4892,
-            "uri": "https://{canondata_backend}/1817427/4ff49d850f6bd5eb12475dc9b7f9a85cf8b3ea28/resource.tar.gz#test.test_join-mapjoin_sharded-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b961bcc57e9fc11765069208c29488a9",
+            "size": 4634,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-mapjoin_sharded-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_sharded-default.txt-Plan]": [
         {
-            "checksum": "50b07f14354a4d699697171df554a0b1",
-            "size": 11811,
-            "uri": "https://{canondata_backend}/1817427/4ff49d850f6bd5eb12475dc9b7f9a85cf8b3ea28/resource.tar.gz#test.test_join-mapjoin_sharded-default.txt-Plan_/plan.txt"
+            "checksum": "8a6e5e8bf24b0dcd0061888dc6532bc7",
+            "size": 11193,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-mapjoin_sharded-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_choose_primary--Debug]": [
         {
-            "checksum": "7e286504266a9e0692f327e1e3f9fc74",
-            "size": 4914,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-mergejoin_choose_primary--Debug_/opt.yql_patched"
+            "checksum": "e8d62668b2d2f35c6195a7e044d121da",
+            "size": 4730,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-mergejoin_choose_primary--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_choose_primary--Plan]": [
         {
-            "checksum": "1666f93e7e500cc71de863ea3afbeb56",
-            "size": 8633,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-mergejoin_choose_primary--Plan_/plan.txt"
+            "checksum": "56ac792c0ecdb981c7ab14a96fd4452f",
+            "size": 8427,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-mergejoin_choose_primary--Plan_/plan.txt"
         }
     ],
     "test.test[join-nopushdown_filter_with_depends_on--Debug]": [
@@ -1499,72 +1499,72 @@
     ],
     "test.test[join-premap_common_semi--Debug]": [
         {
-            "checksum": "086a8e0c09f30687f048c2fa1af89a82",
-            "size": 4419,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-premap_common_semi--Debug_/opt.yql_patched"
+            "checksum": "a65fbd298a3dd312f55a9048b261a950",
+            "size": 4313,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-premap_common_semi--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_semi--Plan]": [
         {
-            "checksum": "696df1beabaee62eb11b28eab28639a5",
-            "size": 7609,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-premap_common_semi--Plan_/plan.txt"
+            "checksum": "c968996874126aadfb3bc3e2aca7bac9",
+            "size": 7403,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-premap_common_semi--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_no_premap--Debug]": [
         {
-            "checksum": "5939c21b3d338ff24ad9942c1eaf3eb0",
-            "size": 13283,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-premap_no_premap--Debug_/opt.yql_patched"
+            "checksum": "26928a6b1801b6e64deae67e59f07e7a",
+            "size": 12850,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-premap_no_premap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_no_premap--Plan]": [
         {
-            "checksum": "9dc0fdeee8bfceb93b79cd872e7c60a7",
-            "size": 24798,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-premap_no_premap--Plan_/plan.txt"
+            "checksum": "72f9dccb7e0fab91804ede3047d9b968",
+            "size": 23974,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-premap_no_premap--Plan_/plan.txt"
         }
     ],
     "test.test[join-star_join_multi--Debug]": [
         {
-            "checksum": "a9d46a25642acfc3e175fdcfa252ed45",
-            "size": 13331,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_join-star_join_multi--Debug_/opt.yql_patched"
+            "checksum": "951680b91f574c3835f42577ac94e924",
+            "size": 13230,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-star_join_multi--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join_multi--Plan]": [
         {
-            "checksum": "10d67595848c568f1084aa3a6df10fec",
-            "size": 20213,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-star_join_multi--Plan_/plan.txt"
+            "checksum": "8b719f1fc66130f2c3f83c922aa2aca9",
+            "size": 20007,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-star_join_multi--Plan_/plan.txt"
         }
     ],
     "test.test[join-two_aggrs-default.txt-Debug]": [
         {
-            "checksum": "7538189872d105b9f704dfeb930ff12a",
-            "size": 7032,
-            "uri": "https://{canondata_backend}/1924537/ed5c3cfadad0d4915690e6595935fd0ac4b575d5/resource.tar.gz#test.test_join-two_aggrs-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6095611d59d20a8bb86da5454c69921c",
+            "size": 6791,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-two_aggrs-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-two_aggrs-default.txt-Plan]": [
         {
-            "checksum": "849984ae22247646f215ea39072133a3",
-            "size": 10097,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-two_aggrs-default.txt-Plan_/plan.txt"
+            "checksum": "b64d868c6ee584be635563af81fc80aa",
+            "size": 9685,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-two_aggrs-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-12022--Debug]": [
         {
-            "checksum": "f9b78cf64fa32093bfe84f555af6010d",
-            "size": 3891,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_join-yql-12022--Debug_/opt.yql_patched"
+            "checksum": "398be1c4afc6b2fd88e6916a5e768059",
+            "size": 3829,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-yql-12022--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-12022--Plan]": [
         {
-            "checksum": "245df2e81ba9cd09ea456a0958ab80be",
-            "size": 6897,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_join-yql-12022--Plan_/plan.txt"
+            "checksum": "3d0377a6d380ac8506586f91f164fb72",
+            "size": 6691,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_join-yql-12022--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-14847--Debug]": [
@@ -1639,16 +1639,16 @@
     ],
     "test.test[key_filter-calc_dependent-default.txt-Debug]": [
         {
-            "checksum": "50f4d6ea5ff98b8f2d6faefd5048d1e8",
-            "size": 2066,
-            "uri": "https://{canondata_backend}/1871002/9019728020210534a127e3c174bdaee350b24eb0/resource.tar.gz#test.test_key_filter-calc_dependent-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1a2fc472d5dbc8da417ec8b1dd7557cd",
+            "size": 2004,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_key_filter-calc_dependent-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-calc_dependent-default.txt-Plan]": [
         {
-            "checksum": "31d406ffbf435de871b9f93ad9cd55ec",
-            "size": 3440,
-            "uri": "https://{canondata_backend}/1924537/280c373d33b3fa7358932c3c5a3ba8cafe8e864d/resource.tar.gz#test.test_key_filter-calc_dependent-default.txt-Plan_/plan.txt"
+            "checksum": "4a9722a51fa8c8416dacb8151a8e59d3",
+            "size": 3234,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_key_filter-calc_dependent-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-contains_tuples_no_keyfilter-default.txt-Debug]": [
@@ -1667,16 +1667,16 @@
     ],
     "test.test[key_filter-is_null_multi_key--Debug]": [
         {
-            "checksum": "46ef1456784aa7ce4809b96518878760",
-            "size": 2106,
-            "uri": "https://{canondata_backend}/1937492/9c0c9edddcc1f430ff1d1fef895c2a7e9551e706/resource.tar.gz#test.test_key_filter-is_null_multi_key--Debug_/opt.yql_patched"
+            "checksum": "8ce62e675f3584f3972fbcdae4a2fa75",
+            "size": 1983,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_key_filter-is_null_multi_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-is_null_multi_key--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1937150/76094074c3e8abf3d874b96212509e8911a2d64d/resource.tar.gz#test.test_key_filter-is_null_multi_key--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_key_filter-is_null_multi_key--Plan_/plan.txt"
         }
     ],
     "test.test[lambda-lambda_brief-default.txt-Debug]": [
@@ -1695,16 +1695,16 @@
     ],
     "test.test[lambda-lambda_with_tie-default.txt-Debug]": [
         {
-            "checksum": "c2df0ca5a91ef2e41a3a5f8e29c99f67",
-            "size": 1953,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_lambda-lambda_with_tie-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cb296e082e6179154a8598e9a8908589",
+            "size": 1890,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_lambda-lambda_with_tie-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[lambda-lambda_with_tie-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_lambda-lambda_with_tie-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_lambda-lambda_with_tie-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[library-library_via_http--Debug]": [
@@ -1723,44 +1723,44 @@
     ],
     "test.test[limit-limit_skip_take-default.txt-Debug]": [
         {
-            "checksum": "7cb288038b08029dfdf4ed67d5692f04",
-            "size": 2848,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_limit-limit_skip_take-default.txt-Debug_/opt.yql_patched"
+            "checksum": "21343c10663bf1f5eb297439008ba4a3",
+            "size": 2697,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_limit-limit_skip_take-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-limit_skip_take-default.txt-Plan]": [
         {
-            "checksum": "64d6ea3abebbff1e09ad295798dfdb4e",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_limit-limit_skip_take-default.txt-Plan_/plan.txt"
+            "checksum": "60f75e83f930ef46872b182deb42c77e",
+            "size": 5326,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_limit-limit_skip_take-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[limit-many_top_sorts-default.txt-Debug]": [
         {
-            "checksum": "4b371309c3a6ec9154b4d74ba4fd3e21",
-            "size": 3710,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_limit-many_top_sorts-default.txt-Debug_/opt.yql_patched"
+            "checksum": "54922fc8cdde8774156a2e1963c97d4e",
+            "size": 3341,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_limit-many_top_sorts-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-many_top_sorts-default.txt-Plan]": [
         {
-            "checksum": "88b94e02301014ed520e68e5193ff66f",
-            "size": 8168,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_limit-many_top_sorts-default.txt-Plan_/plan.txt"
+            "checksum": "e3d55fe661b5bccd71446636742d18ba",
+            "size": 7550,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_limit-many_top_sorts-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[limit-yql-9617_empty_lambda-default.txt-Debug]": [
         {
-            "checksum": "f3586c8aad0ea777515ced9ca6109bf0",
-            "size": 4373,
-            "uri": "https://{canondata_backend}/1773845/2a7af4d2ef6c4edbdf207315a461ad93975f1939/resource.tar.gz#test.test_limit-yql-9617_empty_lambda-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f06e5ffbc5cf7ece344909affee942cf",
+            "size": 4070,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_limit-yql-9617_empty_lambda-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-yql-9617_empty_lambda-default.txt-Plan]": [
         {
-            "checksum": "b03d6fcad67631132f0cd58cabadba0a",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/1784826/60c1f1c4d6e1901a467234ec3ea5f29fc871e44f/resource.tar.gz#test.test_limit-yql-9617_empty_lambda-default.txt-Plan_/plan.txt"
+            "checksum": "261b45fcb0c591cd4d8b93883414dec3",
+            "size": 7936,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_limit-yql-9617_empty_lambda-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[match_recognize-test_type-streaming-default.txt-Debug]": [
@@ -1779,16 +1779,16 @@
     ],
     "test.test[optimizers-aggregate_over_aggregate--Debug]": [
         {
-            "checksum": "069a0ccc8e3b014a59c0521947adba85",
-            "size": 4253,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_optimizers-aggregate_over_aggregate--Debug_/opt.yql_patched"
+            "checksum": "67a054d4bcc4dd156b8136ace4cbac86",
+            "size": 3884,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_optimizers-aggregate_over_aggregate--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-aggregate_over_aggregate--Plan]": [
         {
-            "checksum": "28c2ab3b456e34dadfd529005a3e689e",
-            "size": 8484,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_optimizers-aggregate_over_aggregate--Plan_/plan.txt"
+            "checksum": "3ceffa5883fca835378d5359d3859d5f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_optimizers-aggregate_over_aggregate--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-instant_contains_lookup-default.txt-Debug]": [
@@ -1821,86 +1821,86 @@
     ],
     "test.test[order_by-assume_over_input--Debug]": [
         {
-            "checksum": "ae8405e27cfb1e3b75a228573d9bdab0",
-            "size": 2113,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-assume_over_input--Debug_/opt.yql_patched"
+            "checksum": "96d6dd816939da88c8a5338f2373e69c",
+            "size": 1990,
+            "uri": "https://{canondata_backend}/995452/f3edc5905f3fec9aade63210a7de845a74964f60/resource.tar.gz#test.test_order_by-assume_over_input--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_over_input--Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-assume_over_input--Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-assume_over_input--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-literal_take_zero_sort--Debug]": [
         {
-            "checksum": "8368f253900a6db6f0470e6a74f8d787",
-            "size": 1577,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-literal_take_zero_sort--Debug_/opt.yql_patched"
+            "checksum": "ccd8c237c4f1e68cf96a6fc9241b36d6",
+            "size": 1477,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-literal_take_zero_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-literal_take_zero_sort--Plan]": [
         {
-            "checksum": "cc7b9d0ba163633b64529667a35a9ca2",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-literal_take_zero_sort--Plan_/plan.txt"
+            "checksum": "ad32fd6f97f690b53607a251ff509ad5",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-literal_take_zero_sort--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_expr_over_sorted_table--Debug]": [
         {
-            "checksum": "4f47bc2720be79cbf30c01df81fb7851",
-            "size": 3312,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-order_by_expr_over_sorted_table--Debug_/opt.yql_patched"
+            "checksum": "c0e90592a47c63f5cd53afb51b819cc2",
+            "size": 3182,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_expr_over_sorted_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_expr_over_sorted_table--Plan]": [
         {
-            "checksum": "3e32b1fc7461d0969ffb41902609a489",
-            "size": 5257,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-order_by_expr_over_sorted_table--Plan_/plan.txt"
+            "checksum": "4c8f7eff95e53893bea0ad7746d7b162",
+            "size": 5051,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_expr_over_sorted_table--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_list_of_strings--Debug]": [
         {
-            "checksum": "e6998fa6383fe2c47a58397245c17952",
-            "size": 2962,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-order_by_list_of_strings--Debug_/opt.yql_patched"
+            "checksum": "d6a291a980a20759f27205fc3de4d9df",
+            "size": 2832,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_list_of_strings--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_list_of_strings--Plan]": [
         {
-            "checksum": "c4f3470fbdf3ef5a66fd6948f639c11e",
-            "size": 5353,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-order_by_list_of_strings--Plan_/plan.txt"
+            "checksum": "1f54c8956e9fb4ff7a5939356fa5caef",
+            "size": 5147,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_list_of_strings--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_tablerow_column--Debug]": [
         {
-            "checksum": "d607002fa602e8ca44eb6eeb0a66f390",
-            "size": 1909,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-order_by_tablerow_column--Debug_/opt.yql_patched"
+            "checksum": "b4bbe998dfe956e5176c31fdcbdf52e8",
+            "size": 1847,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_tablerow_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_tablerow_column--Plan]": [
         {
-            "checksum": "284bf9266edff51fe82cbeb5be038a08",
-            "size": 3537,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-order_by_tablerow_column--Plan_/plan.txt"
+            "checksum": "ba5b09a1389f79cc68674182c1065b9d",
+            "size": 3331,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_tablerow_column--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_tuple_expr-default.txt-Debug]": [
         {
-            "checksum": "59bfb3f49bab62abc289ddc2780936c9",
-            "size": 1984,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-order_by_tuple_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "47ad6c753e56d452c4cfe649f3c54fe5",
+            "size": 1861,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_tuple_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_tuple_expr-default.txt-Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-order_by_tuple_expr-default.txt-Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-order_by_tuple_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-sort_decimals--Debug]": [
@@ -1919,30 +1919,30 @@
     ],
     "test.test[order_by-sort_with_take--Debug]": [
         {
-            "checksum": "9e2af672d586401f23f2c0713b7f527f",
-            "size": 2174,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-sort_with_take--Debug_/opt.yql_patched"
+            "checksum": "64f17606d8c08a45ddba3122eccce203",
+            "size": 2051,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-sort_with_take--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-sort_with_take--Plan]": [
         {
-            "checksum": "70a4984063ce12ddafbbb6833c2f6202",
-            "size": 4411,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-sort_with_take--Plan_/plan.txt"
+            "checksum": "c7e835bcb19930f389dcf9a0a3b932cd",
+            "size": 4205,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-sort_with_take--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-sort_with_take_limit--Debug]": [
         {
-            "checksum": "1d7323e005d4e85c98d820ac8e3019e4",
-            "size": 2187,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_order_by-sort_with_take_limit--Debug_/opt.yql_patched"
+            "checksum": "ca5d0a3b53f28c3de28dd14ddda3fcf1",
+            "size": 2064,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-sort_with_take_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-sort_with_take_limit--Plan]": [
         {
-            "checksum": "c749b0a5683a2ceb1fc4a0cf883c07df",
-            "size": 4414,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_order_by-sort_with_take_limit--Plan_/plan.txt"
+            "checksum": "06af560a42a6aa12a72690b00ccb1b3f",
+            "size": 4208,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_order_by-sort_with_take_limit--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-tuple01-default.txt-Debug]": [
@@ -1975,16 +1975,16 @@
     ],
     "test.test[pg-all_data--Debug]": [
         {
-            "checksum": "1c15f4bd28d21ad286abc9b8665e41ac",
-            "size": 7521,
-            "uri": "https://{canondata_backend}/1925821/992a34e888ed32c76f5523b3b17ddf6d688f8400/resource.tar.gz#test.test_pg-all_data--Debug_/opt.yql_patched"
+            "checksum": "f520dec77b5d697f67012825f0d0a42e",
+            "size": 6754,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-all_data--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-all_data--Plan]": [
         {
-            "checksum": "e8cff5023a8569b62f156d4d22eb64b0",
-            "size": 4444,
-            "uri": "https://{canondata_backend}/1923547/40200d31a1ad0c37ac00180085c8cefe8ebbd21a/resource.tar.gz#test.test_pg-all_data--Plan_/plan.txt"
+            "checksum": "20ab1b06d3165ede69d46f7c23d7f061",
+            "size": 4238,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-all_data--Plan_/plan.txt"
         }
     ],
     "test.test[pg-coalesce-default.txt-Debug]": [
@@ -2045,16 +2045,16 @@
     ],
     "test.test[pg-pg_column_case--Debug]": [
         {
-            "checksum": "007d43a7a5601a085b3930c5af4f6034",
-            "size": 2520,
-            "uri": "https://{canondata_backend}/1031349/45aada6c316544e03166fc51527848ab05146f50/resource.tar.gz#test.test_pg-pg_column_case--Debug_/opt.yql_patched"
+            "checksum": "4f2a580d19b5a319370f685b21d4caa7",
+            "size": 2315,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-pg_column_case--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-pg_column_case--Plan]": [
         {
-            "checksum": "8de1d9e52f191d3dcf00bfd6fcaf3586",
-            "size": 3593,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_pg-pg_column_case--Plan_/plan.txt"
+            "checksum": "1f441b68b4dde712215bb324e3cec82e",
+            "size": 3387,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-pg_column_case--Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_agg_group-default.txt-Debug]": [
@@ -2171,16 +2171,16 @@
     ],
     "test.test[pg-select_qstarref1-default.txt-Debug]": [
         {
-            "checksum": "e9651d486f8a2aeb13ee38c55c7d02e2",
-            "size": 2385,
-            "uri": "https://{canondata_backend}/1031349/45aada6c316544e03166fc51527848ab05146f50/resource.tar.gz#test.test_pg-select_qstarref1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0fe3e69dff1781686796e97b856f4600",
+            "size": 2218,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-select_qstarref1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_qstarref1-default.txt-Plan]": [
         {
-            "checksum": "7bb0824d6fbd0b74944e3b1ce4821dc2",
-            "size": 3611,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_pg-select_qstarref1-default.txt-Plan_/plan.txt"
+            "checksum": "d5981c0125365db3224dcbe690b62ac9",
+            "size": 3405,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-select_qstarref1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_sort_project_same_desc-default.txt-Debug]": [
@@ -2395,58 +2395,58 @@
     ],
     "test.test[pg-tpch-q04-default.txt-Debug]": [
         {
-            "checksum": "e220e7e22783530d275ef9ba11ecd4f4",
-            "size": 12616,
-            "uri": "https://{canondata_backend}/1942525/b4d44e1b8a193a5dc50da6f951aa3ca91cef4a94/resource.tar.gz#test.test_pg-tpch-q04-default.txt-Debug_/opt.yql_patched"
+            "checksum": "16ba681038c9fd4189bd10c62ce954e6",
+            "size": 12335,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q04-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q04-default.txt-Plan]": [
         {
-            "checksum": "da2af15e41275bea72bd46665c2217f9",
-            "size": 24016,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_pg-tpch-q04-default.txt-Plan_/plan.txt"
+            "checksum": "87ffca3c03beee7fd0179a53d62d1914",
+            "size": 23398,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q04-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q15-default.txt-Debug]": [
         {
-            "checksum": "73cf8a327458bf96a63593d2809bd77d",
-            "size": 8182,
-            "uri": "https://{canondata_backend}/1600758/f9d9ee3d5b97fd56bd7322b776b036fa6cdaa418/resource.tar.gz#test.test_pg-tpch-q15-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9c2640661e98a7ad63cc03ef729acf8c",
+            "size": 8077,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q15-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q15-default.txt-Plan]": [
         {
-            "checksum": "9a0712effe804fae389ffcacd7bdc114",
-            "size": 10658,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_pg-tpch-q15-default.txt-Plan_/plan.txt"
+            "checksum": "d1bac18aaf93c9d4a4c7f9fa40c928f0",
+            "size": 10452,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q15-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q17-default.txt-Debug]": [
         {
-            "checksum": "a84d500b0e8323270068a6baad55978f",
-            "size": 13723,
-            "uri": "https://{canondata_backend}/1031349/45aada6c316544e03166fc51527848ab05146f50/resource.tar.gz#test.test_pg-tpch-q17-default.txt-Debug_/opt.yql_patched"
+            "checksum": "caf0a2ab5cb4d07a617e34f6bade429f",
+            "size": 13654,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q17-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q17-default.txt-Plan]": [
         {
-            "checksum": "85dd518d3bc76deab80222310fd54e0c",
-            "size": 18916,
-            "uri": "https://{canondata_backend}/1923547/fd9cad60c6b50eab6cb9e18561d636e0cc6acbe7/resource.tar.gz#test.test_pg-tpch-q17-default.txt-Plan_/plan.txt"
+            "checksum": "8771c0d9505f27032cc46d3faffedda1",
+            "size": 18710,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q17-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q22-default.txt-Debug]": [
         {
-            "checksum": "a1ab090ab6928252c93a53175d83775b",
-            "size": 15422,
-            "uri": "https://{canondata_backend}/1936947/e0ab61c2931d523d0b56e7e367e5b739f4083c29/resource.tar.gz#test.test_pg-tpch-q22-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7f22d28bd6b104586f1bb15bd3de97b3",
+            "size": 15290,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q22-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q22-default.txt-Plan]": [
         {
-            "checksum": "d98b8a6f9d6de12f6757db19469de88f",
-            "size": 19827,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_pg-tpch-q22-default.txt-Plan_/plan.txt"
+            "checksum": "3a13a8e3d0617f2fd8e116bd9bb45b38",
+            "size": 19621,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_pg-tpch-q22-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-variadic-default.txt-Debug]": [
@@ -2521,44 +2521,44 @@
     ],
     "test.test[sampling-bind_expr-default.txt-Debug]": [
         {
-            "checksum": "a5b3ef535c5e362c44d880db9dfdb408",
-            "size": 2310,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_sampling-bind_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "decee561f83ed265d1c82001dec65404",
+            "size": 2187,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_sampling-bind_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_expr-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_sampling-bind_expr-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_sampling-bind_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-join_left_sample-default.txt-Debug]": [
         {
-            "checksum": "48868b9befb28effe9abe57c08754aa4",
-            "size": 4604,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_sampling-join_left_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2749618933ee43dd3d3d094f23c4750d",
+            "size": 4481,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_sampling-join_left_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-join_left_sample-default.txt-Plan]": [
         {
-            "checksum": "2718ebb23a9f804f7594b47edbcc763e",
-            "size": 6393,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_sampling-join_left_sample-default.txt-Plan_/plan.txt"
+            "checksum": "56f54877474b3b325b1ed0b3ddca13bf",
+            "size": 6187,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_sampling-join_left_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-yql-14664_deps-default.txt-Debug]": [
         {
-            "checksum": "9bfce3afbd4fd7944c39813c96d9b157",
-            "size": 3297,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f7ded79321e3885ee5c3d8d1a4eeb566",
+            "size": 3146,
+            "uri": "https://{canondata_backend}/995452/f3edc5905f3fec9aade63210a7de845a74964f60/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-yql-14664_deps-default.txt-Plan]": [
         {
-            "checksum": "cce66161e998ebe82195bf392341ec5c",
-            "size": 9321,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Plan_/plan.txt"
+            "checksum": "b09499a2da0276d6790ab30c1024b338",
+            "size": 8909,
+            "uri": "https://{canondata_backend}/995452/f3edc5905f3fec9aade63210a7de845a74964f60/resource.tar.gz#test.test_sampling-yql-14664_deps-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-zero_percentage--Debug]": [
@@ -2577,30 +2577,30 @@
     ],
     "test.test[schema-concat--Debug]": [
         {
-            "checksum": "f5b66c7b66b8c4d099f91dca6204c80e",
-            "size": 2196,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_schema-concat--Debug_/opt.yql_patched"
+            "checksum": "b92975bf8289ab7504a382c5fecc6bef",
+            "size": 2134,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_schema-concat--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-concat--Plan]": [
         {
-            "checksum": "38f1f606a1050621442ce58fa0c78ec3",
-            "size": 3932,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_schema-concat--Plan_/plan.txt"
+            "checksum": "3299e08a2eed725e9a8749e560133923",
+            "size": 3726,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_schema-concat--Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-schema-Debug]": [
         {
-            "checksum": "83caabaa3626d87b6b6c7ecf89d9a0ea",
-            "size": 2121,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_schema-copy-schema-Debug_/opt.yql_patched"
+            "checksum": "da2c3fa43c4b4f2e16afd4fae67c4f80",
+            "size": 1955,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_schema-copy-schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-copy-schema-Plan]": [
         {
-            "checksum": "7500992aa021c7bca6f99ec65aaa1114",
-            "size": 4378,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_schema-copy-schema-Plan_/plan.txt"
+            "checksum": "1cc21051f46906d9746b86f8cbc65b12",
+            "size": 4172,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_schema-copy-schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_all-row_spec_part-Debug]": [
@@ -2619,16 +2619,16 @@
     ],
     "test.test[schema-select_with_map-partial_read_schema-Debug]": [
         {
-            "checksum": "3e693270e3d73c028ecbc2326e42e056",
-            "size": 1806,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_schema-select_with_map-partial_read_schema-Debug_/opt.yql_patched"
+            "checksum": "08018879dc73475c5ba258f197558e78",
+            "size": 1706,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_schema-select_with_map-partial_read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_with_map-partial_read_schema-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_schema-select_with_map-partial_read_schema-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_schema-select_with_map-partial_read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-skip_complex_type2--Debug]": [
@@ -2675,44 +2675,44 @@
     ],
     "test.test[select-create_tuples-default.txt-Debug]": [
         {
-            "checksum": "38a1d624b0c895270ee49524c4bcced3",
-            "size": 2160,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_select-create_tuples-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f803a89c5b4369b8d43d746d6a8f60d2",
+            "size": 2054,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-create_tuples-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-create_tuples-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_select-create_tuples-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-create_tuples-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-discard-default.txt-Debug]": [
         {
-            "checksum": "7efef43b1f46bdf149ddff8527117522",
-            "size": 15939,
-            "uri": "https://{canondata_backend}/1773845/568497964ed4eafb4677a8bff4c82793d24c1d33/resource.tar.gz#test.test_select-discard-default.txt-Debug_/opt.yql_patched"
+            "checksum": "98b9a3e4b77d04d9c5db315c22cd2884",
+            "size": 15546,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-discard-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-discard-default.txt-Plan]": [
         {
-            "checksum": "45a29149302ec203aae2d74d55bef1b7",
-            "size": 24230,
-            "uri": "https://{canondata_backend}/1773845/568497964ed4eafb4677a8bff4c82793d24c1d33/resource.tar.gz#test.test_select-discard-default.txt-Plan_/plan.txt"
+            "checksum": "04f56a1a6f5d00ac1d3ded8f7acc1d79",
+            "size": 23612,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-discard-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-dot_in_alias-default.txt-Debug]": [
         {
-            "checksum": "f96cbaffce5edc2b2ff89a13edd01e06",
-            "size": 3294,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_select-dot_in_alias-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d0f01684657ccc1ca2032c7ce1c35495",
+            "size": 3042,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-dot_in_alias-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-dot_in_alias-default.txt-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_select-dot_in_alias-default.txt-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-dot_in_alias-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-double_at_ids-default.txt-Debug]": [
@@ -2731,30 +2731,30 @@
     ],
     "test.test[select-from_in_front-default.txt-Debug]": [
         {
-            "checksum": "5e7d66e7fbc4e77b9593504bae154852",
-            "size": 2069,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_select-from_in_front-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0a3da334d7b33f2a78ae781838a799b8",
+            "size": 1946,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-from_in_front-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-from_in_front-default.txt-Plan]": [
         {
-            "checksum": "79ec6dc46dcee369564c2fd62b0d9f33",
-            "size": 3599,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_select-from_in_front-default.txt-Plan_/plan.txt"
+            "checksum": "269e0e2d6d87b9bd36b788560366ffe7",
+            "size": 3393,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-from_in_front-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-qualified_all_and_group_by-default.txt-Debug]": [
         {
-            "checksum": "f11c5b7b64416f2fa9eff47da9b065b7",
-            "size": 5383,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_select-qualified_all_and_group_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "306eb5faee0c897a0fdebcc02e273265",
+            "size": 5055,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-qualified_all_and_group_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-qualified_all_and_group_by-default.txt-Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_select-qualified_all_and_group_by-default.txt-Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-qualified_all_and_group_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-simple_struct_field_access--Debug]": [
@@ -2773,100 +2773,100 @@
     ],
     "test.test[select-trivial_order_by-default.txt-Debug]": [
         {
-            "checksum": "ca2f28f229bbf04606959585c12ac84c",
-            "size": 2008,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_select-trivial_order_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "85cfb3b28ff3a3f0bfa8e8bfb4708b7e",
+            "size": 1885,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-trivial_order_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-trivial_order_by-default.txt-Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_select-trivial_order_by-default.txt-Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-trivial_order_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-type_assert-default.txt-Debug]": [
         {
-            "checksum": "e83497b2665a0eeb3f6b2e5e1ddbb449",
-            "size": 2333,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_select-type_assert-default.txt-Debug_/opt.yql_patched"
+            "checksum": "594a08ba011caacbeb6a83f58b23a144",
+            "size": 2267,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-type_assert-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-type_assert-default.txt-Plan]": [
         {
-            "checksum": "7cc22d84c27acd6631be63c021fb8002",
-            "size": 6308,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_select-type_assert-default.txt-Plan_/plan.txt"
+            "checksum": "d74dfdb3451c76f483da6498b54e0514",
+            "size": 6102,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-type_assert-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-where_cast-default.txt-Debug]": [
         {
-            "checksum": "bc9eee3d1f902562ccf7cb8cdd95be7a",
-            "size": 2020,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_select-where_cast-default.txt-Debug_/opt.yql_patched"
+            "checksum": "fb232d62c07ab5c32dabc12c318697ca",
+            "size": 1956,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-where_cast-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-where_cast-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_select-where_cast-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_select-where_cast-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_all-default.txt-Debug]": [
         {
-            "checksum": "c3e00b44e94b971deefcb01570dbe98a",
-            "size": 6810,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_simple_columns-simple_columns_join_all-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f1626db5179563442f13146ac3d904ba",
+            "size": 6496,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_simple_columns-simple_columns_join_all-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_all-default.txt-Plan]": [
         {
-            "checksum": "84d8628991680f471c5fe5d2dd3086b6",
-            "size": 9136,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_simple_columns-simple_columns_join_all-default.txt-Plan_/plan.txt"
+            "checksum": "df2567a82663dc61534169e9aa734411",
+            "size": 8724,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_simple_columns-simple_columns_join_all-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_same_key_without-default.txt-Debug]": [
         {
-            "checksum": "f2b40d4d298aba9abe8be5ae16cf5475",
-            "size": 5924,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_without-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e56c68dac6e7ec98f52fc8d093cfbb71",
+            "size": 5707,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_without-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_same_key_without-default.txt-Plan]": [
         {
-            "checksum": "5893f325ec90c6a4f705a5d84eaddc04",
-            "size": 9106,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_without-default.txt-Plan_/plan.txt"
+            "checksum": "4d0079405537dabba1aef47cdb6d7b89",
+            "size": 8694,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_without-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_without_resolve_dublicates-default.txt-Debug]": [
         {
-            "checksum": "662243137c89f992b8c01feda760615b",
-            "size": 6921,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates-default.txt-Debug_/opt.yql_patched"
+            "checksum": "007ad3373bb41383f1ea14ea3427ef4c",
+            "size": 6587,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_without_resolve_dublicates-default.txt-Plan]": [
         {
-            "checksum": "84d8628991680f471c5fe5d2dd3086b6",
-            "size": 9136,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates-default.txt-Plan_/plan.txt"
+            "checksum": "df2567a82663dc61534169e9aa734411",
+            "size": 8724,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[table_range-range_over_desc--Debug]": [
         {
-            "checksum": "11b07ed380f6281b0de6625f12b60ffa",
-            "size": 3994,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_table_range-range_over_desc--Debug_/opt.yql_patched"
+            "checksum": "d7d93079fc0d5532bdcd4497cb579258",
+            "size": 3706,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_table_range-range_over_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-range_over_desc--Plan]": [
         {
-            "checksum": "f51d57d752d9ca26b560338dae5e6ccf",
-            "size": 6713,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_table_range-range_over_desc--Plan_/plan.txt"
+            "checksum": "28efd198db96dc0ab5e711930fe95781",
+            "size": 6301,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_table_range-range_over_desc--Plan_/plan.txt"
         }
     ],
     "test.test[table_range-range_over_like--Debug]": [
@@ -2885,30 +2885,30 @@
     ],
     "test.test[type_v3-ignore_v3_hint--Debug]": [
         {
-            "checksum": "4c4393339244229d3508a5a70d35bd42",
-            "size": 3139,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_type_v3-ignore_v3_hint--Debug_/opt.yql_patched"
+            "checksum": "00dbc2ce16bfd4e089d706e0f522b816",
+            "size": 3043,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_type_v3-ignore_v3_hint--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-ignore_v3_hint--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_type_v3-ignore_v3_hint--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_type_v3-ignore_v3_hint--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-ignore_v3_hint-tag_opt-Debug]": [
         {
-            "checksum": "407df038d90c1f6059af256675ecd143",
-            "size": 3206,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_type_v3-ignore_v3_hint-tag_opt-Debug_/opt.yql_patched"
+            "checksum": "304cdcc27e654e4728d174fce7f4f666",
+            "size": 3110,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_type_v3-ignore_v3_hint-tag_opt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-ignore_v3_hint-tag_opt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_type_v3-ignore_v3_hint-tag_opt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_type_v3-ignore_v3_hint-tag_opt-Plan_/plan.txt"
         }
     ],
     "test.test[view-file_inner_library--Debug]": [
@@ -2927,100 +2927,100 @@
     ],
     "test.test[view-view_with_library--Debug]": [
         {
-            "checksum": "6378c903d86aa9132e3df78c92f3a35b",
-            "size": 2816,
-            "uri": "https://{canondata_backend}/1937027/b9d8bf5296438b5378e7a452d0f1d00c40561e66/resource.tar.gz#test.test_view-view_with_library--Debug_/opt.yql_patched"
+            "checksum": "f6f01ef9e231f3ca45202bf266bbb30f",
+            "size": 2667,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_view-view_with_library--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-view_with_library--Plan]": [
         {
-            "checksum": "0bdc229ba4a65aa8bbf04fac7811ed84",
-            "size": 4003,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_view-view_with_library--Plan_/plan.txt"
+            "checksum": "82ba93631a802a81398418118a30491b",
+            "size": 3797,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_view-view_with_library--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_num_access--Debug]": [
         {
-            "checksum": "930b7e898e78064540d495c0a6fef51d",
-            "size": 2899,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_weak_field-weak_field_num_access--Debug_/opt.yql_patched"
+            "checksum": "38418ad38f781c77ba135b48676e2c72",
+            "size": 2773,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_weak_field-weak_field_num_access--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_num_access--Plan]": [
         {
-            "checksum": "8f2045b33dbbbda42749d89d7e400b08",
-            "size": 6373,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_weak_field-weak_field_num_access--Plan_/plan.txt"
+            "checksum": "d0beb142ed653e35380d817f9e2b5e6b",
+            "size": 6167,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_weak_field-weak_field_num_access--Plan_/plan.txt"
         }
     ],
     "test.test[window-current/session_aliases--Debug]": [
         {
-            "checksum": "bd1f888ad3773298d39ac8d3c09b50c8",
-            "size": 6422,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_window-current_session_aliases--Debug_/opt.yql_patched"
+            "checksum": "6d970d00de5d9b72e1428cb3d615c740",
+            "size": 6027,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-current_session_aliases--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/session_aliases--Plan]": [
         {
-            "checksum": "702a395959580a7a64c91724ba286b84",
-            "size": 5707,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_window-current_session_aliases--Plan_/plan.txt"
+            "checksum": "6c885e91238b3116892cb25e704c7328",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-current_session_aliases--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/aggregations_compact--Debug]": [
         {
-            "checksum": "779612835337dad0916cba82790a7b3f",
-            "size": 10285,
-            "uri": "https://{canondata_backend}/1781765/58e0b22add7a393132eabc727108a73e69b35616/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql_patched"
+            "checksum": "432a4542ab2f3eaf2707752e442c04e1",
+            "size": 9962,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-full_aggregations_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations_compact--Plan]": [
         {
-            "checksum": "d300746695bb94d7b2b1aaa99301bd12",
-            "size": 10230,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_window-full_aggregations_compact--Plan_/plan.txt"
+            "checksum": "341b60ca11b887ff0d1063c9e540054d",
+            "size": 9818,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-full_aggregations_compact--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/session_aliases_compact--Debug]": [
         {
-            "checksum": "e08e17292bf8c3be11121393fe4a21c9",
-            "size": 6917,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_window-full_session_aliases_compact--Debug_/opt.yql_patched"
+            "checksum": "aeda262d5989ffbd1d80817de2c5d1fe",
+            "size": 6515,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-full_session_aliases_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/session_aliases_compact--Plan]": [
         {
-            "checksum": "702a395959580a7a64c91724ba286b84",
-            "size": 5707,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_window-full_session_aliases_compact--Plan_/plan.txt"
+            "checksum": "6c885e91238b3116892cb25e704c7328",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-full_session_aliases_compact--Plan_/plan.txt"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Debug]": [
         {
-            "checksum": "0955cf75a6fd4616d77f89f4557d9e77",
-            "size": 10130,
-            "uri": "https://{canondata_backend}/1942100/36e8856aeb3dbe102564ba7b01b14e3652fde5e6/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
+            "checksum": "ae3c5282a2b1067c47f3e2624f7c6fe0",
+            "size": 9614,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-generic_aggregations_before_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_before_current--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_window-generic_aggregations_before_current--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-generic_aggregations_before_current--Plan_/plan.txt"
         }
     ],
     "test.test[window-leading/aggregations_leadlag--Debug]": [
         {
-            "checksum": "e451926a3e89d698eb243ae6fc3f5018",
-            "size": 8009,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_window-leading_aggregations_leadlag--Debug_/opt.yql_patched"
+            "checksum": "c73f425fe25189c6bc8d5b90b0af7bb8",
+            "size": 7510,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-leading_aggregations_leadlag--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-leading/aggregations_leadlag--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_window-leading_aggregations_leadlag--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-leading_aggregations_leadlag--Plan_/plan.txt"
         }
     ],
     "test.test[window-rank/nulls_legacy-default.txt-Debug]": [
@@ -3067,30 +3067,30 @@
     ],
     "test.test[window-win_func_rank_by_part--Debug]": [
         {
-            "checksum": "ee6124496286b1a0000e5d805fef8017",
-            "size": 6059,
-            "uri": "https://{canondata_backend}/1924537/bc0aa6d2dc96c8e2d21b35c367a15ca1ca298c7c/resource.tar.gz#test.test_window-win_func_rank_by_part--Debug_/opt.yql_patched"
+            "checksum": "b7f2ee710e17a2e25a689be667486b85",
+            "size": 5638,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-win_func_rank_by_part--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_rank_by_part--Plan]": [
         {
-            "checksum": "d66e2764aff8124e98c47f54f4f91075",
-            "size": 8421,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_window-win_func_rank_by_part--Plan_/plan.txt"
+            "checksum": "30ca8165df10779cb274e78f25373baa",
+            "size": 7803,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-win_func_rank_by_part--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_spec_with_part--Debug]": [
         {
-            "checksum": "3ab280c6940797a84810915b8c0a1e94",
-            "size": 7482,
-            "uri": "https://{canondata_backend}/1937492/2bb2455c1ebb5ccab2ce4acc1aa8fb7defa3f4b8/resource.tar.gz#test.test_window-win_func_spec_with_part--Debug_/opt.yql_patched"
+            "checksum": "f16f1aa6320b78a74c7136a989c5299f",
+            "size": 6906,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-win_func_spec_with_part--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_spec_with_part--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1923547/14c0d60ad63ffaedb974b51b52039901f095b5c5/resource.tar.gz#test.test_window-win_func_spec_with_part--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1130705/2dbc543e7e2156e1086b7eff9aaab72ade9022c4/resource.tar.gz#test.test_window-win_func_spec_with_part--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_group_peephole-default.txt-Debug]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part2/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part2/canondata/result.json
@@ -113,16 +113,16 @@
     ],
     "test.test[aggr_factory-avg_if-default.txt-Debug]": [
         {
-            "checksum": "0dcc5b2112a2cc0481e48f299ca5f874",
-            "size": 5562,
-            "uri": "https://{canondata_backend}/1903280/2b1b058e22a4e5579f7fc777d49c2545641d2de5/resource.tar.gz#test.test_aggr_factory-avg_if-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7d6d2bbcd80392e18af8bb84ef5e4ab6",
+            "size": 5434,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggr_factory-avg_if-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-avg_if-default.txt-Plan]": [
         {
-            "checksum": "5a5b036ed1b8a4abcc5d40732d503252",
-            "size": 9932,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggr_factory-avg_if-default.txt-Plan_/plan.txt"
+            "checksum": "68a84361029bbf9051fcd80d023b673c",
+            "size": 9520,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggr_factory-avg_if-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-flatten--Debug]": [
@@ -141,30 +141,30 @@
     ],
     "test.test[aggr_factory-multi--Debug]": [
         {
-            "checksum": "96114a043c8aa06ab5a1bd4a03f37743",
-            "size": 32974,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_aggr_factory-multi--Debug_/opt.yql_patched"
+            "checksum": "aa364d2d822c0f338c35cc17f8ef4e72",
+            "size": 32625,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggr_factory-multi--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-multi--Plan]": [
         {
-            "checksum": "4368f0a27eb8298520c78bca6f730e81",
-            "size": 5718,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggr_factory-multi--Plan_/plan.txt"
+            "checksum": "0d51005f3fc3a8b56daa5ab863a3b564",
+            "size": 5512,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggr_factory-multi--Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-top-default.txt-Debug]": [
         {
-            "checksum": "208ace7c21f7049767b3747525f0f608",
-            "size": 8885,
-            "uri": "https://{canondata_backend}/1931696/aa01322068982c9db282565ddc2dd49ccf46c624/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql_patched"
+            "checksum": "147066213d81c9f4c99fc5accd0a8963",
+            "size": 8786,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggr_factory-top-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-top-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggr_factory-top-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggr_factory-top-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-udaf_in_udaf-default.txt-Debug]": [
@@ -183,212 +183,212 @@
     ],
     "test.test[aggregate-aggregate_udf_nested--Debug]": [
         {
-            "checksum": "913db9e961c1b4dc513e43b50f4a2ce5",
-            "size": 4342,
-            "uri": "https://{canondata_backend}/1936842/18141a621093276a79f47460b44d37b4b9a67a7c/resource.tar.gz#test.test_aggregate-aggregate_udf_nested--Debug_/opt.yql_patched"
+            "checksum": "291f7a95729e7985edcf8741220d84b6",
+            "size": 4170,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-aggregate_udf_nested--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_udf_nested--Plan]": [
         {
-            "checksum": "43d46c5de3526cb1eb127824e35b957c",
-            "size": 8429,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-aggregate_udf_nested--Plan_/plan.txt"
+            "checksum": "5bc78cf16099430b91776e14ce25c837",
+            "size": 7811,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-aggregate_udf_nested--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_with_default_yson_options-default.txt-Debug]": [
         {
-            "checksum": "e465adadbc21abb0c0ff2d58fef67e8f",
-            "size": 5900,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-aggregate_with_default_yson_options-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d11dbee886810f858fbe58b44529062f",
+            "size": 5597,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-aggregate_with_default_yson_options-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_with_default_yson_options-default.txt-Plan]": [
         {
-            "checksum": "d4475b4ce49986967e40aeacc55b9d97",
-            "size": 8454,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-aggregate_with_default_yson_options-default.txt-Plan_/plan.txt"
+            "checksum": "2b8caaa263fad6a40e505e78b6d874b6",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-aggregate_with_default_yson_options-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_column_alias_reuse_for_join--Debug]": [
         {
-            "checksum": "f802793c6261c0fe605eec02044813ed",
-            "size": 6358,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse_for_join--Debug_/opt.yql_patched"
+            "checksum": "10d2c0109f5c2be5756749c300112035",
+            "size": 6151,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse_for_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_column_alias_reuse_for_join--Plan]": [
         {
-            "checksum": "92596d0ab6ea44da8f078c8e7b4655be",
-            "size": 10430,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse_for_join--Plan_/plan.txt"
+            "checksum": "1559731f550edbdfe84505e541532e82",
+            "size": 10018,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_column_alias_reuse_for_join--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_cube_expr_trio--Debug]": [
         {
-            "checksum": "9a36447ca03c4c8249e4f6d1e7be9f0b",
-            "size": 12573,
-            "uri": "https://{canondata_backend}/1597364/f3c4bf4e09a28f4077a38c32370e775272290057/resource.tar.gz#test.test_aggregate-group_by_cube_expr_trio--Debug_/opt.yql_patched"
+            "checksum": "767a41a9806d0cc40b917fe786c1038d",
+            "size": 12037,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_cube_expr_trio--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_cube_expr_trio--Plan]": [
         {
-            "checksum": "a8142abe70a341dcb7801418d6390639",
-            "size": 17323,
-            "uri": "https://{canondata_backend}/1597364/f3c4bf4e09a28f4077a38c32370e775272290057/resource.tar.gz#test.test_aggregate-group_by_cube_expr_trio--Plan_/plan.txt"
+            "checksum": "e807ad2745747e89ec5ea4d83c47e877",
+            "size": 16499,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_cube_expr_trio--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_columns_reuse-default.txt-Debug]": [
         {
-            "checksum": "4b80cedddfe8cd6c314faefc578851df",
-            "size": 4934,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-group_by_expr_columns_reuse-default.txt-Debug_/opt.yql_patched"
+            "checksum": "361be33d0d9605e06b25667ab0460390",
+            "size": 4629,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_expr_columns_reuse-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_columns_reuse-default.txt-Plan]": [
         {
-            "checksum": "5b34466f9dea236e8ef55862f24fbbe9",
-            "size": 8525,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_by_expr_columns_reuse-default.txt-Plan_/plan.txt"
+            "checksum": "56e5fa0b7e6c6bee32c075c3d9156004",
+            "size": 7907,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_expr_columns_reuse-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_mul_col--Debug]": [
         {
-            "checksum": "8abc07d9c04742bf7a23947d8e824908",
-            "size": 5353,
-            "uri": "https://{canondata_backend}/1689644/76bd2942df187ba04bb9771a46cdadf0d1dbe01c/resource.tar.gz#test.test_aggregate-group_by_expr_mul_col--Debug_/opt.yql_patched"
+            "checksum": "2562208d70a4f83a54bf217f89d8232b",
+            "size": 5021,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_expr_mul_col--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_mul_col--Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_by_expr_mul_col--Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_expr_mul_col--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_flatten_columns-default.txt-Debug]": [
         {
-            "checksum": "e13e591b4e05b3554cf0fa6d47b870cf",
-            "size": 7447,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a0c846f72ee54d48b5b3d7466c394beb",
+            "size": 7012,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_flatten_columns-default.txt-Plan]": [
         {
-            "checksum": "04760a14c021e2d326ac5bb6860b30ae",
-            "size": 11170,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_columns-default.txt-Plan_/plan.txt"
+            "checksum": "5b896fa1c3d86875af19754f7246e2b1",
+            "size": 10552,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_gs_flatten_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_mul_gs_gs--Debug]": [
         {
-            "checksum": "2ced4354fbf7661ae50cebd535984b98",
-            "size": 13338,
-            "uri": "https://{canondata_backend}/1597364/f3c4bf4e09a28f4077a38c32370e775272290057/resource.tar.gz#test.test_aggregate-group_by_mul_gs_gs--Debug_/opt.yql_patched"
+            "checksum": "642013051618dfe386aedde09af320d4",
+            "size": 12413,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_mul_gs_gs--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_mul_gs_gs--Plan]": [
         {
-            "checksum": "33c8be2b357b76dc075afd33bb78294e",
-            "size": 17155,
-            "uri": "https://{canondata_backend}/1597364/f3c4bf4e09a28f4077a38c32370e775272290057/resource.tar.gz#test.test_aggregate-group_by_mul_gs_gs--Plan_/plan.txt"
+            "checksum": "1065e34483ae25651dd5bf80a23029d3",
+            "size": 16125,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_mul_gs_gs--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_duo--Debug]": [
         {
-            "checksum": "24c293a59a1d9b0dde92f904e6974786",
-            "size": 9544,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-group_by_rollup_duo--Debug_/opt.yql_patched"
+            "checksum": "bc60d896404c5da07e33c74e6f543dde",
+            "size": 9151,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_rollup_duo--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_duo--Plan]": [
         {
-            "checksum": "6525193d909602276aa1676799185182",
-            "size": 14520,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_by_rollup_duo--Plan_/plan.txt"
+            "checksum": "9405f21d88f90b8cfb5af6bdbc155042",
+            "size": 13902,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_rollup_duo--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_join--Debug]": [
         {
-            "checksum": "99f7b6d7fd19e46ab662c87790a2667e",
-            "size": 8614,
-            "uri": "https://{canondata_backend}/1031349/0b9bcb16a38e69c55142d62ab5b476d514cf83bf/resource.tar.gz#test.test_aggregate-group_by_ru_join--Debug_/opt.yql_patched"
+            "checksum": "a173c169212ed88f062e1df7f9c39d1b",
+            "size": 8296,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_ru_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_join--Plan]": [
         {
-            "checksum": "c67a122bf3f1410067d9353f6d898210",
-            "size": 14728,
-            "uri": "https://{canondata_backend}/1031349/0b9bcb16a38e69c55142d62ab5b476d514cf83bf/resource.tar.gz#test.test_aggregate-group_by_ru_join--Plan_/plan.txt"
+            "checksum": "0c15fe44b7e95f0d85bb65aea9bde2c7",
+            "size": 13904,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_by_ru_join--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_compact_sorted--Debug]": [
         {
-            "checksum": "4c9eefc9792b45b1025a0116de5c143b",
-            "size": 4216,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-group_compact_sorted--Debug_/opt.yql_patched"
+            "checksum": "68aed4da9107f201824021c806090eb1",
+            "size": 3928,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_compact_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_compact_sorted--Plan]": [
         {
-            "checksum": "7d771113cb26892c63b73deae909e3f2",
-            "size": 5709,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_compact_sorted--Plan_/plan.txt"
+            "checksum": "669ae8d9a42798f0257e720f10d7e885",
+            "size": 5297,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_compact_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_compact_sorted_distinct_complex--Debug]": [
         {
-            "checksum": "4e549e7c1aff79b803e522ae1c72d816",
-            "size": 6423,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct_complex--Debug_/opt.yql_patched"
+            "checksum": "27eeab6ffc5a70290ea468986faf42bd",
+            "size": 6073,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct_complex--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_compact_sorted_distinct_complex--Plan]": [
         {
-            "checksum": "d7131e7b2848e9a901826b35243429a5",
-            "size": 7956,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct_complex--Plan_/plan.txt"
+            "checksum": "1f03afdf59f79949a7f1b8d8e2ebead2",
+            "size": 7338,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_compact_sorted_distinct_complex--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_compact_sorted_with_diff_order--Debug]": [
         {
-            "checksum": "cf5d8d0c6f07ec3b96e8df1c51bca1dc",
-            "size": 15121,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Debug_/opt.yql_patched"
+            "checksum": "b30661bbf4710766154ffec7fb7861a8",
+            "size": 13976,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_compact_sorted_with_diff_order--Plan]": [
         {
-            "checksum": "4e2e7568c1e7081e7b422ad4f1206a78",
-            "size": 39088,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Plan_/plan.txt"
+            "checksum": "db8f9c7be77fe0f917853c90acea7330",
+            "size": 35998,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-group_compact_sorted_with_diff_order--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-list_after_group-default.txt-Debug]": [
         {
-            "checksum": "7d59f52b97957b3f6a397e09c90adaf8",
-            "size": 5243,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_aggregate-list_after_group-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0b28feabd7a1c01b9403c3fcf91d2ac6",
+            "size": 4866,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-list_after_group-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-list_after_group-default.txt-Plan]": [
         {
-            "checksum": "33a068ca7ae9789bd69b719e54979722",
-            "size": 8456,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-list_after_group-default.txt-Plan_/plan.txt"
+            "checksum": "71f5140aaefb3772a9c7873c069584b8",
+            "size": 7838,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-list_after_group-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-list_with_fold_map--Debug]": [
         {
-            "checksum": "83468977a64b66aa0f8c7399e990ab5b",
-            "size": 4200,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_aggregate-list_with_fold_map--Debug_/opt.yql_patched"
+            "checksum": "11e653022f6d6df4539a8567b00692f3",
+            "size": 3996,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-list_with_fold_map--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-list_with_fold_map--Plan]": [
         {
-            "checksum": "9b089d95b8283871699aa32d0f59b68a",
-            "size": 6347,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_aggregate-list_with_fold_map--Plan_/plan.txt"
+            "checksum": "a4deae64e62ad6ec2479fede0c754040",
+            "size": 5935,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_aggregate-list_with_fold_map--Plan_/plan.txt"
         }
     ],
     "test.test[ansi_idents-struct_access-default.txt-Debug]": [
@@ -435,128 +435,128 @@
     ],
     "test.test[bigdate-table_int_cast-default.txt-Debug]": [
         {
-            "checksum": "177fc2fac903bdde7623c6ad50195b2e",
-            "size": 22146,
-            "uri": "https://{canondata_backend}/1784826/45c8e56b489fcd70fc011cedb88a592ff2ca27ed/resource.tar.gz#test.test_bigdate-table_int_cast-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1041a100c9cdb8f46d004a635dfdc1c1",
+            "size": 18588,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_bigdate-table_int_cast-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_int_cast-default.txt-Plan]": [
         {
-            "checksum": "6d78c2d08feedc71f9d5a8a97c784b84",
-            "size": 18494,
-            "uri": "https://{canondata_backend}/1784826/45c8e56b489fcd70fc011cedb88a592ff2ca27ed/resource.tar.gz#test.test_bigdate-table_int_cast-default.txt-Plan_/plan.txt"
+            "checksum": "0bc45a6f8754fa84ea10647f0ddf88c7",
+            "size": 17258,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_bigdate-table_int_cast-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[blocks-add_int64--Debug]": [
         {
-            "checksum": "8d9c917ef0bec3e69a24575113db1401",
-            "size": 2199,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-add_int64--Debug_/opt.yql_patched"
+            "checksum": "8963b46ec19040f8bcb910dabf900600",
+            "size": 2069,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-add_int64--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_int64--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-add_int64--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-add_int64--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-add_uint64--Debug]": [
         {
-            "checksum": "c39d04d36aee8de13d07e6340de6e06b",
-            "size": 2206,
-            "uri": "https://{canondata_backend}/1937492/54848250dae40c5771348f82812131e229eff17d/resource.tar.gz#test.test_blocks-add_uint64--Debug_/opt.yql_patched"
+            "checksum": "33759d4d3f7517a1c266d4a7ded76eb0",
+            "size": 2076,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-add_uint64--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_uint64--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-add_uint64--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-add_uint64--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_max--Debug]": [
         {
-            "checksum": "e9ee35972ec178ea9c07b62d81851e95",
-            "size": 9584,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_all_max--Debug_/opt.yql_patched"
+            "checksum": "4bb9d4e5d1fd01560e6ba0977578aae9",
+            "size": 9146,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-combine_all_max--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_max--Plan]": [
         {
-            "checksum": "a1361799631618b84ec6b61887b259c0",
-            "size": 5459,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_all_max--Plan_/plan.txt"
+            "checksum": "16a0de7e33ba5f70a4588de69a651389",
+            "size": 5253,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-combine_all_max--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_minmax_double--Debug]": [
         {
-            "checksum": "c1f36bfc616bc9b0f3debde176032eb8",
-            "size": 3467,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_all_minmax_double--Debug_/opt.yql_patched"
+            "checksum": "8131d4a3e70d2e80b91bb9c597d3824b",
+            "size": 3359,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-combine_all_minmax_double--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_minmax_double--Plan]": [
         {
-            "checksum": "c3d72fbe12613c4c43eab7e8b8c5d99d",
-            "size": 5462,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_all_minmax_double--Plan_/plan.txt"
+            "checksum": "fd55267dea9475830b9b7027c37f96b3",
+            "size": 5256,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-combine_all_minmax_double--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_set--Debug]": [
         {
-            "checksum": "f43c48be8a72ab32bf1778cac551f14d",
-            "size": 4128,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_hashed_set--Debug_/opt.yql_patched"
+            "checksum": "59e777f3d1e5360a57b9823dcf6d76cf",
+            "size": 4006,
+            "uri": "https://{canondata_backend}/1937150/c1acae706dd71ce088fc48a032c252e2fac078b9/resource.tar.gz#test.test_blocks-combine_hashed_set--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_set--Plan]": [
         {
-            "checksum": "fcb3fac66758bdf710add4888459ac6b",
-            "size": 8425,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_hashed_set--Plan_/plan.txt"
+            "checksum": "f1f5f9687ade29f7d83e3e95a7f11fd8",
+            "size": 7807,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-combine_hashed_set--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_some--Debug]": [
         {
-            "checksum": "3f193b96324165f1ab61335b15964741",
-            "size": 6295,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_hashed_some--Debug_/opt.yql_patched"
+            "checksum": "d5c150964cee050121d2ecc68143cf72",
+            "size": 5769,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-combine_hashed_some--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_some--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-combine_hashed_some--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-combine_hashed_some--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_greater--Debug]": [
         {
-            "checksum": "b39852f36efceeefb6b311a9692ec16a",
-            "size": 28023,
-            "uri": "https://{canondata_backend}/1031349/3daaddd1248215e45b8dc38843e4765e3f4672da/resource.tar.gz#test.test_blocks-date_greater--Debug_/opt.yql_patched"
+            "checksum": "520a2c61456e7d083e998e61232ad903",
+            "size": 24073,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-date_greater--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_greater--Plan]": [
         {
-            "checksum": "fe66d03c15b37a053205c1b23150a020",
-            "size": 15887,
-            "uri": "https://{canondata_backend}/1031349/3daaddd1248215e45b8dc38843e4765e3f4672da/resource.tar.gz#test.test_blocks-date_greater--Plan_/plan.txt"
+            "checksum": "e0b70c711bba0b9a8af7293607a6483c",
+            "size": 15475,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-date_greater--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_not_equals--Debug]": [
         {
-            "checksum": "18f9302685ee3883600e1cfc89e3a30b",
-            "size": 28171,
-            "uri": "https://{canondata_backend}/1031349/3daaddd1248215e45b8dc38843e4765e3f4672da/resource.tar.gz#test.test_blocks-date_not_equals--Debug_/opt.yql_patched"
+            "checksum": "9ddcbaa5b24572bd3a88181931a5104f",
+            "size": 24221,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-date_not_equals--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_not_equals--Plan]": [
         {
-            "checksum": "fe66d03c15b37a053205c1b23150a020",
-            "size": 15887,
-            "uri": "https://{canondata_backend}/1031349/3daaddd1248215e45b8dc38843e4765e3f4672da/resource.tar.gz#test.test_blocks-date_not_equals--Plan_/plan.txt"
+            "checksum": "e0b70c711bba0b9a8af7293607a6483c",
+            "size": 15475,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-date_not_equals--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_div--Debug]": [
@@ -589,30 +589,30 @@
     ],
     "test.test[blocks-pg_to_dates--Debug]": [
         {
-            "checksum": "717f0d82b2f04b20f16dd4809099d8f5",
-            "size": 2653,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-pg_to_dates--Debug_/opt.yql_patched"
+            "checksum": "15322ee3a6664d4cac0a6d46e68fe933",
+            "size": 2451,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-pg_to_dates--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_to_dates--Plan]": [
         {
-            "checksum": "f3a5b257af7349c56a14befff28bcb27",
-            "size": 4168,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-pg_to_dates--Plan_/plan.txt"
+            "checksum": "796056c97ecf7cb4b13a72ebdc4d3777",
+            "size": 3962,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-pg_to_dates--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-sort_two_desc--Debug]": [
         {
-            "checksum": "73de871769ae144fa838e062b18a21e9",
-            "size": 3430,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-sort_two_desc--Debug_/opt.yql_patched"
+            "checksum": "2eba4a5bc3b99c7c5073ec1a79de634f",
+            "size": 3182,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-sort_two_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-sort_two_desc--Plan]": [
         {
-            "checksum": "280c2f9dd2d67499ddb3297b26a6ef99",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1600758/44b793dc4f9aa9048cbf1897771845ad02299cd0/resource.tar.gz#test.test_blocks-sort_two_desc--Plan_/plan.txt"
+            "checksum": "606023bfbee343b9efa9e8f1f3aa1577",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_blocks-sort_two_desc--Plan_/plan.txt"
         }
     ],
     "test.test[case-case_opt_then-default.txt-Debug]": [
@@ -631,16 +631,16 @@
     ],
     "test.test[case-case_val_when_then-default.txt-Debug]": [
         {
-            "checksum": "11a3607bbdbe89a243fd40ba515c9ea8",
-            "size": 2038,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_case-case_val_when_then-default.txt-Debug_/opt.yql_patched"
+            "checksum": "72913d1850cc2106ed8d2984463fc9dc",
+            "size": 1915,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_case-case_val_when_then-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[case-case_val_when_then-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_case-case_val_when_then-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_case-case_val_when_then-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_action-default.txt-Debug]": [
@@ -687,16 +687,16 @@
     ],
     "test.test[count-count_nullable--Debug]": [
         {
-            "checksum": "50c1494d31adabb92673dfebf0920b33",
-            "size": 4956,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_count-count_nullable--Debug_/opt.yql_patched"
+            "checksum": "c088129ad6461b6c4000a16dcd0e1bf1",
+            "size": 4643,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_count-count_nullable--Debug_/opt.yql_patched"
         }
     ],
     "test.test[count-count_nullable--Plan]": [
         {
-            "checksum": "d4475b4ce49986967e40aeacc55b9d97",
-            "size": 8454,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_count-count_nullable--Plan_/plan.txt"
+            "checksum": "2b8caaa263fad6a40e505e78b6d874b6",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_count-count_nullable--Plan_/plan.txt"
         }
     ],
     "test.test[csee-expr-default.txt-Debug]": [
@@ -799,16 +799,16 @@
     ],
     "test.test[epochs-reset_sortness_on_append--Debug]": [
         {
-            "checksum": "c564614084f61f1fe052964d6047a9a3",
-            "size": 3763,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Debug_/opt.yql_patched"
+            "checksum": "1711351e25ba5e07a3cbdf44b739b9b0",
+            "size": 3611,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Debug_/opt.yql_patched"
         }
     ],
     "test.test[epochs-reset_sortness_on_append--Plan]": [
         {
-            "checksum": "2c34f864cbe7f59ce3ab8ef3171c4585",
-            "size": 12237,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Plan_/plan.txt"
+            "checksum": "ce24913752ad72148b4d289fce0be3b1",
+            "size": 11619,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_epochs-reset_sortness_on_append--Plan_/plan.txt"
         }
     ],
     "test.test[expr-as_tuple_syntax-default.txt-Debug]": [
@@ -1023,58 +1023,58 @@
     ],
     "test.test[file-file_list_simple--Debug]": [
         {
-            "checksum": "07e92fe00515cb6b245fc154ba7b7790",
-            "size": 2361,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_file-file_list_simple--Debug_/opt.yql_patched"
+            "checksum": "cbc08f4cb5d8be4ce4499ecdaa06f938",
+            "size": 2238,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_file-file_list_simple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-file_list_simple--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_file-file_list_simple--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_file-file_list_simple--Plan_/plan.txt"
         }
     ],
     "test.test[file-where_key_in_get_file_content--Debug]": [
         {
-            "checksum": "07e92fe00515cb6b245fc154ba7b7790",
-            "size": 2361,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_file-where_key_in_get_file_content--Debug_/opt.yql_patched"
+            "checksum": "cbc08f4cb5d8be4ce4499ecdaa06f938",
+            "size": 2238,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_file-where_key_in_get_file_content--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-where_key_in_get_file_content--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_file-where_key_in_get_file_content--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_file-where_key_in_get_file_content--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_by_aster_opt-default.txt-Debug]": [
         {
-            "checksum": "594addb2ce7a6d6bd246aace90b93f54",
-            "size": 2215,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_flatten_by-flatten_by_aster_opt-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e977ef44c65c14eed5b4271ccabd5dc2",
+            "size": 2075,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_flatten_by-flatten_by_aster_opt-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_by_aster_opt-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_flatten_by-flatten_by_aster_opt-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_flatten_by-flatten_by_aster_opt-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_columns_by_aggregate-default.txt-Debug]": [
         {
-            "checksum": "42289e1948d6a7537e4e2b33bbda88d6",
-            "size": 3174,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_flatten_by-flatten_columns_by_aggregate-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2e8895dd74432ccf764c996f9978a283",
+            "size": 3107,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_flatten_by-flatten_columns_by_aggregate-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_columns_by_aggregate-default.txt-Plan]": [
         {
-            "checksum": "4368f0a27eb8298520c78bca6f730e81",
-            "size": 5718,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_flatten_by-flatten_columns_by_aggregate-default.txt-Plan_/plan.txt"
+            "checksum": "0d51005f3fc3a8b56daa5ab863a3b564",
+            "size": 5512,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_flatten_by-flatten_columns_by_aggregate-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_corr_name_column-default.txt-Debug]": [
@@ -1107,128 +1107,128 @@
     ],
     "test.test[hor_join-double_input-default.txt-Debug]": [
         {
-            "checksum": "d64e1c12436439c5da4c7984dee37dcd",
-            "size": 3145,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_hor_join-double_input-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b08e5952f4b81de937468097e22b4f77",
+            "size": 3045,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-double_input-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-double_input-default.txt-Plan]": [
         {
-            "checksum": "3ea24c56b8702662565ca8d6e0c7bfb3",
-            "size": 6032,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_hor_join-double_input-default.txt-Plan_/plan.txt"
+            "checksum": "dea14c7d898a1d72f2af8f94431d0f57",
+            "size": 5826,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-double_input-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-empty_out_hor_join-default.txt-Debug]": [
         {
-            "checksum": "54d077b0e38d9dba1371f077d506375b",
-            "size": 6000,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_hor_join-empty_out_hor_join-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4de1b2efdaafd114d7add60fd5c39581",
+            "size": 5611,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-empty_out_hor_join-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-empty_out_hor_join-default.txt-Plan]": [
         {
-            "checksum": "08301a0882f4571ba4ef33854b2a5d54",
-            "size": 13223,
-            "uri": "https://{canondata_backend}/1777230/d2b110ab2b7d773dfd02514ef84c146d73d2ed75/resource.tar.gz#test.test_hor_join-empty_out_hor_join-default.txt-Plan_/plan.txt"
+            "checksum": "912dfe85518bf4b3cc9720d7838f810d",
+            "size": 12399,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-empty_out_hor_join-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-out_table_record-default.txt-Debug]": [
         {
-            "checksum": "e91952b6d0de3986d1299667a702733c",
-            "size": 3611,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_hor_join-out_table_record-default.txt-Debug_/opt.yql_patched"
+            "checksum": "91743bc45ee48c10deeb8e8047d2018c",
+            "size": 3367,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-out_table_record-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-out_table_record-default.txt-Plan]": [
         {
-            "checksum": "aca95afe256069a6e02d9edbe9476b8b",
-            "size": 6171,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_hor_join-out_table_record-default.txt-Plan_/plan.txt"
+            "checksum": "50be3cd593accde264fa5b4d47bda4bb",
+            "size": 5759,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-out_table_record-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-runtime_dep-default.txt-Debug]": [
         {
-            "checksum": "488cb82227e9ed8c01d0f817a27774af",
-            "size": 4799,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Debug_/opt.yql_patched"
+            "checksum": "dbd0ab6eff5140cfa1610777ceb5d0cd",
+            "size": 4476,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-runtime_dep-default.txt-Plan]": [
         {
-            "checksum": "35e7990a580b06751b1977d37e64e38b",
-            "size": 10843,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Plan_/plan.txt"
+            "checksum": "2d9ff5e05d610f2f83563a2a40bea446",
+            "size": 10225,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-runtime_dep-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-skip_sampling--Debug]": [
         {
-            "checksum": "c10b769eebf317bbd615789cd8a81d38",
-            "size": 4320,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_hor_join-skip_sampling--Debug_/opt.yql_patched"
+            "checksum": "d8bd62af3983f03f0eb4e41c028c1b40",
+            "size": 4074,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-skip_sampling--Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-skip_sampling--Plan]": [
         {
-            "checksum": "6f2959fe72f83b7519d87a3f2bf3abd1",
-            "size": 8735,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_hor_join-skip_sampling--Plan_/plan.txt"
+            "checksum": "7e5c3cb5a16a33fa13f998e9c9a53897",
+            "size": 8323,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_hor_join-skip_sampling--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_with_table_of_tuples-default.txt-Debug]": [
         {
-            "checksum": "e2b135f24464f4a92a213a9a9efd1f19",
-            "size": 7665,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_in-in_with_table_of_tuples-default.txt-Debug_/opt.yql_patched"
+            "checksum": "28c14eea31578023485d4110814dddc7",
+            "size": 7311,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_in-in_with_table_of_tuples-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_with_table_of_tuples-default.txt-Plan]": [
         {
-            "checksum": "4c643b0b38b0c43075516ef92850b824",
-            "size": 14236,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_in-in_with_table_of_tuples-default.txt-Plan_/plan.txt"
+            "checksum": "9e35c789e0a76f17ff99a2764d592afd",
+            "size": 13618,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_in-in_with_table_of_tuples-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_ordered_by_key_desc-default.txt-Debug]": [
         {
-            "checksum": "d1ae607e79993e84591e39b8a5884117",
-            "size": 2952,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "02c8e832808dbd9c8a9c71df3e6be34e",
+            "size": 2799,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_ordered_by_key_desc-default.txt-Plan]": [
         {
-            "checksum": "bfdc62132a802bf800a864f3fb3ed0e4",
-            "size": 6018,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Plan_/plan.txt"
+            "checksum": "d21e1b27fe4fc54bc8661e99fafa43a7",
+            "size": 5812,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_insert-replace_ordered_by_key_desc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_operate_with_columns--Debug]": [
         {
-            "checksum": "4261b6d6f1775031c1a5d0f65d149869",
-            "size": 2643,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_insert-select_operate_with_columns--Debug_/opt.yql_patched"
+            "checksum": "fca9a0e85d32bc81840cb3aa9a793d0f",
+            "size": 2513,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_insert-select_operate_with_columns--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_operate_with_columns--Plan]": [
         {
-            "checksum": "60727d04e6f062e98b2983fb9ba5ca23",
-            "size": 4976,
-            "uri": "https://{canondata_backend}/1936842/51593b2a750dbb036388d012a30fa937edaab5f0/resource.tar.gz#test.test_insert-select_operate_with_columns--Plan_/plan.txt"
+            "checksum": "297e72f6cfad38cb86c73deb30ea441a",
+            "size": 4770,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_insert-select_operate_with_columns--Plan_/plan.txt"
         }
     ],
     "test.test[insert-trivial_select-default.txt-Debug]": [
         {
-            "checksum": "a43badace5e81c3a047722d285199578",
-            "size": 1837,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_insert-trivial_select-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e54fc9ec38a4294496f70a3a5f25e522",
+            "size": 1714,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_insert-trivial_select-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-trivial_select-default.txt-Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_insert-trivial_select-default.txt-Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_insert-trivial_select-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-equi_join_by_expr--Debug]": [
@@ -1247,16 +1247,16 @@
     ],
     "test.test[join-filter_joined--Debug]": [
         {
-            "checksum": "aa9910794ee794322149e182b5465f8b",
-            "size": 4217,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-filter_joined--Debug_/opt.yql_patched"
+            "checksum": "b0cdce03d5d3d006fccf8873258cf218",
+            "size": 4153,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-filter_joined--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-filter_joined--Plan]": [
         {
-            "checksum": "c59f7ebe64b7294539fdbe292efe9d1e",
-            "size": 7390,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-filter_joined--Plan_/plan.txt"
+            "checksum": "3375460bda2d21ee3e4669fccea5df1d",
+            "size": 7184,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-filter_joined--Plan_/plan.txt"
         }
     ],
     "test.test[join-from_in_front_join--Debug]": [
@@ -1275,16 +1275,16 @@
     ],
     "test.test[join-group_compact_by--Debug]": [
         {
-            "checksum": "fdff46a4a6570c4f7e54bbec0477c3c0",
-            "size": 5262,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_join-group_compact_by--Debug_/opt.yql_patched"
+            "checksum": "95e3c3adf20f633d3fae131e33f64298",
+            "size": 5159,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-group_compact_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-group_compact_by--Plan]": [
         {
-            "checksum": "74b9065417488a1c815728f00b259ec2",
-            "size": 8148,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-group_compact_by--Plan_/plan.txt"
+            "checksum": "61ae2c1caff6280901a46e69af5f708f",
+            "size": 7942,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-group_compact_by--Plan_/plan.txt"
         }
     ],
     "test.test[join-inner_with_order--Debug]": [
@@ -1303,198 +1303,198 @@
     ],
     "test.test[join-join_without_correlation_names--Debug]": [
         {
-            "checksum": "ecce04ff112aaa631b608e913ef1dbaa",
-            "size": 6167,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-join_without_correlation_names--Debug_/opt.yql_patched"
+            "checksum": "ad50c55958f4dbe853e8c3f84bc45436",
+            "size": 5912,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-join_without_correlation_names--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_without_correlation_names--Plan]": [
         {
-            "checksum": "84d8628991680f471c5fe5d2dd3086b6",
-            "size": 9136,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-join_without_correlation_names--Plan_/plan.txt"
+            "checksum": "df2567a82663dc61534169e9aa734411",
+            "size": 8724,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-join_without_correlation_names--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_join_null_column--Debug]": [
         {
-            "checksum": "325bad29e9b3489f5f9020364fea96ae",
-            "size": 6063,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-left_join_null_column--Debug_/opt.yql_patched"
+            "checksum": "d04ce75210137b9504d2c53d10d6b537",
+            "size": 5774,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-left_join_null_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_join_null_column--Plan]": [
         {
-            "checksum": "c9983ba54e458da1119b1a897f5313be",
-            "size": 8441,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-left_join_null_column--Plan_/plan.txt"
+            "checksum": "80b7f864a9641a9839d6d57e0561a4ce",
+            "size": 8029,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-left_join_null_column--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_null_literal--Debug]": [
         {
-            "checksum": "1576a329a424b453ca5b19c1de5c8f8a",
-            "size": 1598,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-left_null_literal--Debug_/opt.yql_patched"
+            "checksum": "9544b8faf53a0fd6e38a881f90777b36",
+            "size": 1504,
+            "uri": "https://{canondata_backend}/1937150/c1acae706dd71ce088fc48a032c252e2fac078b9/resource.tar.gz#test.test_join-left_null_literal--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_null_literal--Plan]": [
         {
-            "checksum": "a64daf19d801a52f5888f5997e784a39",
-            "size": 3744,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-left_null_literal--Plan_/plan.txt"
+            "checksum": "0f7468663fc95ebbf5021015b21dfc43",
+            "size": 3538,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-left_null_literal--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_semi--Debug]": [
         {
-            "checksum": "65e9d3ab3f890fe27d12f7578b8a08e8",
-            "size": 3956,
-            "uri": "https://{canondata_backend}/1937424/9ed743c2cd08afd61c490370ea9258f4884062df/resource.tar.gz#test.test_join-lookupjoin_semi--Debug_/opt.yql_patched"
+            "checksum": "b464227c76d44e1f45cb2f120c617c9d",
+            "size": 3714,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-lookupjoin_semi--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_semi--Plan]": [
         {
-            "checksum": "b02ced194f7e29073c7d1f442a0d90cf",
-            "size": 7018,
-            "uri": "https://{canondata_backend}/1773845/8306172c11c2ee937e16acb37e9787f892b4c8d0/resource.tar.gz#test.test_join-lookupjoin_semi--Plan_/plan.txt"
+            "checksum": "917187038300b96108959eb3fb0b8c5f",
+            "size": 6606,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-lookupjoin_semi--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_with_anonymous--Debug]": [
         {
-            "checksum": "f07409caeb721b5e433423733efb80e5",
-            "size": 4212,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Debug_/opt.yql_patched"
+            "checksum": "7a562da916760a4895547b4630f4fb35",
+            "size": 3865,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_with_anonymous--Plan]": [
         {
-            "checksum": "c89a9e50ff693729bc8c80a5945909f2",
-            "size": 9568,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Plan_/plan.txt"
+            "checksum": "4522857a1b6cfcb9d99881fbfc683bc7",
+            "size": 9156,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-mapjoin_with_anonymous--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_cross--Debug]": [
         {
-            "checksum": "c9881b5a2fbe5f94971c28dda7c26205",
-            "size": 4933,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-premap_common_cross--Debug_/opt.yql_patched"
+            "checksum": "b7c84c02fc728dfb4dc8bb8af82cc9c3",
+            "size": 4778,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_common_cross--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_cross--Plan]": [
         {
-            "checksum": "9f0ef4aa3f71f7dc2ba98d7ca96b16fc",
-            "size": 7939,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-premap_common_cross--Plan_/plan.txt"
+            "checksum": "039a24eacd0a38065c0861209abd92a9",
+            "size": 7733,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_common_cross--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_inner_filter--Debug]": [
         {
-            "checksum": "93973f604c4197bdeb983a2535e54d8c",
-            "size": 5771,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-premap_common_inner_filter--Debug_/opt.yql_patched"
+            "checksum": "ca962c90cbb2f9399f4eb0978845ac08",
+            "size": 5541,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_common_inner_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_inner_filter--Plan]": [
         {
-            "checksum": "9332136733b5782027ee6912ab4bd1c1",
-            "size": 8969,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-premap_common_inner_filter--Plan_/plan.txt"
+            "checksum": "acd5cc4cb8ccb26c41c6a51db3567a9a",
+            "size": 8557,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_common_inner_filter--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_multiparents--Debug]": [
         {
-            "checksum": "96790c2daafe9c8ad5eefd5c4b7b4cfd",
-            "size": 8396,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-premap_common_multiparents--Debug_/opt.yql_patched"
+            "checksum": "fc9f890c6f02baba1895d4ee93912aee",
+            "size": 8102,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_common_multiparents--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_multiparents--Plan]": [
         {
-            "checksum": "c866da82dfc7c38d0b121ffdd92cdf50",
-            "size": 14685,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-premap_common_multiparents--Plan_/plan.txt"
+            "checksum": "c0f094a3d41712bb604637b440040055",
+            "size": 14273,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_common_multiparents--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_nonseq_flatmap--Debug]": [
         {
-            "checksum": "63fb364536ee7f39c0204571f15d51aa",
-            "size": 5406,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-premap_nonseq_flatmap--Debug_/opt.yql_patched"
+            "checksum": "d4fb0760af731901297d174795b4e0b7",
+            "size": 5191,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_nonseq_flatmap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_nonseq_flatmap--Plan]": [
         {
-            "checksum": "b1e1327967d39c561a6814ac1e92b6db",
-            "size": 8416,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-premap_nonseq_flatmap--Plan_/plan.txt"
+            "checksum": "47efd89a4580d6f8a1e5602a3eecd520",
+            "size": 8004,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-premap_nonseq_flatmap--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_context_dep--Debug]": [
         {
-            "checksum": "8d5e27791a1b8a0aead11d555c89fdce",
-            "size": 5996,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-pullup_context_dep--Debug_/opt.yql_patched"
+            "checksum": "9915e2435a50f2202d23b7fe6b9c9fe5",
+            "size": 5726,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-pullup_context_dep--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_context_dep--Plan]": [
         {
-            "checksum": "b7edb651cbd27c387a2acac2906de62b",
-            "size": 8940,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-pullup_context_dep--Plan_/plan.txt"
+            "checksum": "482ac1f286ca7524ff41dcbf34e06a24",
+            "size": 8528,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-pullup_context_dep--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_left_semi--Debug]": [
         {
-            "checksum": "5999b8cfc020f928c7d89014a041caa5",
-            "size": 4492,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-pullup_left_semi--Debug_/opt.yql_patched"
+            "checksum": "9205f9df06cdf4c6b8df3066d6f4a658",
+            "size": 4388,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-pullup_left_semi--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_left_semi--Plan]": [
         {
-            "checksum": "a7920fab0d5c8499753243881520d758",
-            "size": 7716,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-pullup_left_semi--Plan_/plan.txt"
+            "checksum": "859a33673542d1abf56a9c66a871f573",
+            "size": 7510,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-pullup_left_semi--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_null_column--Debug]": [
         {
-            "checksum": "1178953e0c02bbdd3bab2a524ac87434",
-            "size": 5170,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-pullup_null_column--Debug_/opt.yql_patched"
+            "checksum": "c54b62791e184c43d457300abc100293",
+            "size": 4996,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-pullup_null_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_null_column--Plan]": [
         {
-            "checksum": "a7920fab0d5c8499753243881520d758",
-            "size": 7716,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-pullup_null_column--Plan_/plan.txt"
+            "checksum": "859a33673542d1abf56a9c66a871f573",
+            "size": 7510,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-pullup_null_column--Plan_/plan.txt"
         }
     ],
     "test.test[join-split_to_list_as_key--Debug]": [
         {
-            "checksum": "c8036033f77827b003fb728ff3067f07",
-            "size": 7025,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-split_to_list_as_key--Debug_/opt.yql_patched"
+            "checksum": "164cbddadf7fe94f781d39497d00591b",
+            "size": 6672,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-split_to_list_as_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-split_to_list_as_key--Plan]": [
         {
-            "checksum": "9eeb60ac0c0377643e505c8bb79fe381",
-            "size": 9003,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-split_to_list_as_key--Plan_/plan.txt"
+            "checksum": "76dc03f6e0d6e9dfac9a0e2f583986cd",
+            "size": 8591,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-split_to_list_as_key--Plan_/plan.txt"
         }
     ],
     "test.test[join-star_join_inners--Debug]": [
         {
-            "checksum": "2a75450e5e7c6517bd0b4603d622b082",
-            "size": 7532,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_join-star_join_inners--Debug_/opt.yql_patched"
+            "checksum": "c091446a67141c8717fd7ddf69014fee",
+            "size": 7291,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-star_join_inners--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join_inners--Plan]": [
         {
-            "checksum": "776baeee6fb24ed51089a6309dd223d4",
-            "size": 11021,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_join-star_join_inners--Plan_/plan.txt"
+            "checksum": "8f9c5667bee0a6db9c11894f99d44018",
+            "size": 10815,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_join-star_join_inners--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-6199--Debug]": [
@@ -1527,72 +1527,72 @@
     ],
     "test.test[key_filter-contains_tuples-default.txt-Debug]": [
         {
-            "checksum": "f4bc0af17c43318f6ccea36d77d88fd7",
-            "size": 4474,
-            "uri": "https://{canondata_backend}/1871182/a8f0dda19ece2eb39da3b275b4504de52525ed97/resource.tar.gz#test.test_key_filter-contains_tuples-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0ba239a3109721ff0467b05cc428b8e1",
+            "size": 4323,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-contains_tuples-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-contains_tuples-default.txt-Plan]": [
         {
-            "checksum": "594c1cc942190ea19e10ad53ce0bcaa3",
-            "size": 8859,
-            "uri": "https://{canondata_backend}/1881367/3feb1db5b60d51b9a3d47ed357ac65c22486b85b/resource.tar.gz#test.test_key_filter-contains_tuples-default.txt-Plan_/plan.txt"
+            "checksum": "2d16f43bfb39b9dbb0b7f5010f2458b2",
+            "size": 8447,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-contains_tuples-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-empty_range--Debug]": [
         {
-            "checksum": "62e7d3f3a5389609671407d7beffa640",
-            "size": 13309,
-            "uri": "https://{canondata_backend}/1903280/2343eee3524c6c664bac08d52d0f809e48cea584/resource.tar.gz#test.test_key_filter-empty_range--Debug_/opt.yql_patched"
+            "checksum": "d546ecb85992b5ee502d2f60de98234e",
+            "size": 12517,
+            "uri": "https://{canondata_backend}/1937150/c1acae706dd71ce088fc48a032c252e2fac078b9/resource.tar.gz#test.test_key_filter-empty_range--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-empty_range--Plan]": [
         {
-            "checksum": "bf0c698ab412356596b6643f743bb0ab",
-            "size": 33019,
-            "uri": "https://{canondata_backend}/1899731/bba6112c4b516a09fee27f75e3322c427b4816be/resource.tar.gz#test.test_key_filter-empty_range--Plan_/plan.txt"
+            "checksum": "2ebb6af33aa08194fcb254d57e3cd45c",
+            "size": 30547,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-empty_range--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-lambda_with_null_filter--Debug]": [
         {
-            "checksum": "e08f365736e7058c3238f603a2590433",
-            "size": 5147,
-            "uri": "https://{canondata_backend}/212715/0124304932490e8522ccaa9f64a12a6581f01f80/resource.tar.gz#test.test_key_filter-lambda_with_null_filter--Debug_/opt.yql_patched"
+            "checksum": "8cd403e2726a1352a9ef3bd3362f4f42",
+            "size": 5024,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-lambda_with_null_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-lambda_with_null_filter--Plan]": [
         {
-            "checksum": "b3e74a56f3537a0f85e717e17fe58fb9",
-            "size": 6993,
-            "uri": "https://{canondata_backend}/1942671/68e31366cf1a6133bff50bb00ba3e9914c574e89/resource.tar.gz#test.test_key_filter-lambda_with_null_filter--Plan_/plan.txt"
+            "checksum": "c6a02feeab8d084ed9930a284067e552",
+            "size": 6787,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-lambda_with_null_filter--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-pushdown_keyextract_type_adjust-default.txt-Debug]": [
         {
-            "checksum": "820facfcec2707756795cedf4a9b48d6",
-            "size": 3535,
-            "uri": "https://{canondata_backend}/937458/f57709bc8e1c04ed657f3b4d90660c39f2576d10/resource.tar.gz#test.test_key_filter-pushdown_keyextract_type_adjust-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3f9c0f367d77f6012e9f7aa273f78ddc",
+            "size": 3289,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-pushdown_keyextract_type_adjust-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-pushdown_keyextract_type_adjust-default.txt-Plan]": [
         {
-            "checksum": "24cfcf778d4c85a2778659410030cd13",
-            "size": 5745,
-            "uri": "https://{canondata_backend}/1871102/f0a9b9c880579562763596ec0b76238e2fc7d147/resource.tar.gz#test.test_key_filter-pushdown_keyextract_type_adjust-default.txt-Plan_/plan.txt"
+            "checksum": "b692061fab4a7d672208b27e644f0c83",
+            "size": 5333,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-pushdown_keyextract_type_adjust-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-yql_5895_or-default.txt-Debug]": [
         {
-            "checksum": "39fb29482c16b3e52ceae4241cf6fac9",
-            "size": 2012,
-            "uri": "https://{canondata_backend}/1599023/f5139673af87593900b015cd3cadd13aa63e4ece/resource.tar.gz#test.test_key_filter-yql_5895_or-default.txt-Debug_/opt.yql_patched"
+            "checksum": "72801300bfe41b0111c2312a40a458be",
+            "size": 1889,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-yql_5895_or-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-yql_5895_or-default.txt-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1916746/5651e28bd35f79ee890a4ad5c11a29c834dbc75e/resource.tar.gz#test.test_key_filter-yql_5895_or-default.txt-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_key_filter-yql_5895_or-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[lambda-list_aggregate_flatmap-default.txt-Debug]": [
@@ -1611,30 +1611,30 @@
     ],
     "test.test[like-like_clause-default.txt-Debug]": [
         {
-            "checksum": "43a74e639b99046ef61a8015e4e36caf",
-            "size": 3387,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_like-like_clause-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2e72df47b676d988226aa7e236165d0d",
+            "size": 3264,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_like-like_clause-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[like-like_clause-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_like-like_clause-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_like-like_clause-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[like-like_clause_no_pattern-default.txt-Debug]": [
         {
-            "checksum": "faa7ee84d450d82d1934867bf65941bf",
-            "size": 2856,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_like-like_clause_no_pattern-default.txt-Debug_/opt.yql_patched"
+            "checksum": "346031f2f6df63475745f6a565524719",
+            "size": 2723,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_like-like_clause_no_pattern-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[like-like_clause_no_pattern-default.txt-Plan]": [
         {
-            "checksum": "453e6bdef311d50c899c4f802154107a",
-            "size": 5122,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_like-like_clause_no_pattern-default.txt-Plan_/plan.txt"
+            "checksum": "6b0d5b7d305eaabdaf06c30fc5739536",
+            "size": 4916,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_like-like_clause_no_pattern-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[like-like_escape-default.txt-Debug]": [
@@ -1667,30 +1667,30 @@
     ],
     "test.test[limit-empty_sort_after_limit-default.txt-Debug]": [
         {
-            "checksum": "76a5d1c2883861d4a0efbca22de808b8",
-            "size": 2454,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_limit-empty_sort_after_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "10896905e035b58ecef02955e813dd2e",
+            "size": 2331,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_limit-empty_sort_after_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-empty_sort_after_limit-default.txt-Plan]": [
         {
-            "checksum": "0bd0d33e1cb43827629f3a9e3db50843",
-            "size": 5259,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_limit-empty_sort_after_limit-default.txt-Plan_/plan.txt"
+            "checksum": "2f31a92d71259c19c40879adc06b4616",
+            "size": 5053,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_limit-empty_sort_after_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[limit-insert_with_limit--Debug]": [
         {
-            "checksum": "d19e4dcc80153c4c6aeebe1611a8c523",
-            "size": 1868,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_limit-insert_with_limit--Debug_/opt.yql_patched"
+            "checksum": "3ea0694b0fb8ed56a6c8829bbe906570",
+            "size": 1745,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_limit-insert_with_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-insert_with_limit--Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_limit-insert_with_limit--Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_limit-insert_with_limit--Plan_/plan.txt"
         }
     ],
     "test.test[limit-limit--Debug]": [
@@ -1709,72 +1709,72 @@
     ],
     "test.test[optimizers-group_visit_lambdas--Debug]": [
         {
-            "checksum": "6300c118617cb594bbb9ef7bad6ceae0",
-            "size": 4426,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_optimizers-group_visit_lambdas--Debug_/opt.yql_patched"
+            "checksum": "b33aa27f74f61b7ee3cb4e7b7ab52841",
+            "size": 4282,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-group_visit_lambdas--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-group_visit_lambdas--Plan]": [
         {
-            "checksum": "8e658d1c149d5e44c415514823f7f3e1",
-            "size": 12739,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_optimizers-group_visit_lambdas--Plan_/plan.txt"
+            "checksum": "7e42c784037f019dcd2892d6212fde24",
+            "size": 12533,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-group_visit_lambdas--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-test_fuse_map_take-default.txt-Debug]": [
         {
-            "checksum": "b5e9e9e0f5ffc7b2212f49f2697bbd1f",
-            "size": 6313,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_optimizers-test_fuse_map_take-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1b1fc6644d4e9b18eef2234ad5ac883f",
+            "size": 5903,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-test_fuse_map_take-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-test_fuse_map_take-default.txt-Plan]": [
         {
-            "checksum": "9250bc0f5ff71805205c707e83c48d8d",
-            "size": 11413,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_optimizers-test_fuse_map_take-default.txt-Plan_/plan.txt"
+            "checksum": "e2724a29efb72685c67e1b5c17843174",
+            "size": 10589,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-test_fuse_map_take-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-4240-aggregate_whole_struct-default.txt-Debug]": [
         {
-            "checksum": "b8ce70b4c97d1a402865c9183e05e029",
-            "size": 8174,
-            "uri": "https://{canondata_backend}/1689644/76bd2942df187ba04bb9771a46cdadf0d1dbe01c/resource.tar.gz#test.test_optimizers-yql-4240-aggregate_whole_struct-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c5b4d714d850669cd92efbd0eb72b5fe",
+            "size": 7640,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-yql-4240-aggregate_whole_struct-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-4240-aggregate_whole_struct-default.txt-Plan]": [
         {
-            "checksum": "58851647608de5b60a8f09585d64bafb",
-            "size": 10924,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_optimizers-yql-4240-aggregate_whole_struct-default.txt-Plan_/plan.txt"
+            "checksum": "a293dc24e0bd92c7a5d5478b9954376b",
+            "size": 10100,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-yql-4240-aggregate_whole_struct-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-8953_logical_fuse_with_table_props--Debug]": [
         {
-            "checksum": "5762d1a94038e4a92c1fb9a03cc37ee6",
-            "size": 6032,
-            "uri": "https://{canondata_backend}/1689644/76bd2942df187ba04bb9771a46cdadf0d1dbe01c/resource.tar.gz#test.test_optimizers-yql-8953_logical_fuse_with_table_props--Debug_/opt.yql_patched"
+            "checksum": "eae1a8e2063461f2618c74dcb3cfc240",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-yql-8953_logical_fuse_with_table_props--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-8953_logical_fuse_with_table_props--Plan]": [
         {
-            "checksum": "ae5a920c9511d430d614dfd09cba3b4c",
-            "size": 9701,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_optimizers-yql-8953_logical_fuse_with_table_props--Plan_/plan.txt"
+            "checksum": "b4ae3a1d2236856690c48b56703e628f",
+            "size": 9289,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_optimizers-yql-8953_logical_fuse_with_table_props--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-SortByOneFieldDesc--Debug]": [
         {
-            "checksum": "8d984d8d0d67bb54b23f94a2231fcf40",
-            "size": 2697,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_order_by-SortByOneFieldDesc--Debug_/opt.yql_patched"
+            "checksum": "e19fc2c59a84b87ca40895686dc5f44a",
+            "size": 2591,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_order_by-SortByOneFieldDesc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-SortByOneFieldDesc--Plan]": [
         {
-            "checksum": "d4a91f7f72d0cbf3213366df21dc86a5",
-            "size": 5195,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_order_by-SortByOneFieldDesc--Plan_/plan.txt"
+            "checksum": "64bcb92bf83bfa909f915358d77f0ae4",
+            "size": 4989,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_order_by-SortByOneFieldDesc--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-assume_over_input_desc--Debug]": [
@@ -1793,30 +1793,30 @@
     ],
     "test.test[order_by-limit--Debug]": [
         {
-            "checksum": "4e464037b99ea7f9c3c1e90c5766c887",
-            "size": 3395,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_order_by-limit--Debug_/opt.yql_patched"
+            "checksum": "b72f803b2bf95708ebc7f239bb4eb660",
+            "size": 3199,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_order_by-limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-limit--Plan]": [
         {
-            "checksum": "11074c5b7f5be1c9c85c27d437c5fa87",
-            "size": 5541,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_order_by-limit--Plan_/plan.txt"
+            "checksum": "d5c9c8440b21826be0c44227c3594259",
+            "size": 5335,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_order_by-limit--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-sort_simple--Debug]": [
         {
-            "checksum": "e3840d8f8e2861ab2084653767995b76",
-            "size": 6048,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_order_by-sort_simple--Debug_/opt.yql_patched"
+            "checksum": "eaa0bf3ca294d96acc8da7ac23f8564e",
+            "size": 5748,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_order_by-sort_simple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-sort_simple--Plan]": [
         {
-            "checksum": "ac9665680ed08306a19bad39534d04bb",
-            "size": 13259,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_order_by-sort_simple--Plan_/plan.txt"
+            "checksum": "36956b0b4f3c63fa4bcae10ba6be5990",
+            "size": 12229,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_order_by-sort_simple--Plan_/plan.txt"
         }
     ],
     "test.test[params-complex_yson--Debug]": [
@@ -1891,16 +1891,16 @@
     ],
     "test.test[pg-insert--Debug]": [
         {
-            "checksum": "b58a9ddeff77e94f9829a9fe87501bb7",
-            "size": 1881,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_pg-insert--Debug_/opt.yql_patched"
+            "checksum": "ee5b1305d910fcc8960d8f669b761f6a",
+            "size": 1758,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-insert--Plan]": [
         {
-            "checksum": "29af4840ab79acd2922ddc3bcf44aada",
-            "size": 4316,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_pg-insert--Plan_/plan.txt"
+            "checksum": "1b93e97e4e79ded337c792c524b78965",
+            "size": 4110,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-insert--Plan_/plan.txt"
         }
     ],
     "test.test[pg-join_using6-default.txt-Debug]": [
@@ -1933,16 +1933,16 @@
     ],
     "test.test[pg-nulls-default.txt-Debug]": [
         {
-            "checksum": "e5f7bb119c409006cc7618d903aa30c0",
-            "size": 6091,
-            "uri": "https://{canondata_backend}/212715/a080bda5fe51f325c67cbb486688a784425d33eb/resource.tar.gz#test.test_pg-nulls-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0122905f5febdb5bad90b57072a16327",
+            "size": 5567,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-nulls-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-nulls-default.txt-Plan]": [
         {
-            "checksum": "e56dc64f63349cf53da40157b0c83c3b",
-            "size": 18383,
-            "uri": "https://{canondata_backend}/212715/a080bda5fe51f325c67cbb486688a784425d33eb/resource.tar.gz#test.test_pg-nulls-default.txt-Plan_/plan.txt"
+            "checksum": "289a49ae1dfc7114638b8783722b15cf",
+            "size": 17765,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-nulls-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-numbers_to_pg-default.txt-Debug]": [
@@ -2003,16 +2003,16 @@
     ],
     "test.test[pg-select_from_columns-default.txt-Debug]": [
         {
-            "checksum": "f00a4d1b839776335ae6263fb7d8a62e",
-            "size": 1859,
-            "uri": "https://{canondata_backend}/1923547/67f6df540c55c53542953e1bf74b7234a7231c48/resource.tar.gz#test.test_pg-select_from_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "fde9ecd1e5c124c0ff10c95e904a1f9e",
+            "size": 1799,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-select_from_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_from_columns-default.txt-Plan]": [
         {
-            "checksum": "f1b109b624a2933a9e9671fee3b8f8a0",
-            "size": 3552,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_pg-select_from_columns-default.txt-Plan_/plan.txt"
+            "checksum": "c65ca1febc1e260b98beac75485bc366",
+            "size": 3346,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-select_from_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_join_full_equi_and_one-default.txt-Debug]": [
@@ -2185,58 +2185,58 @@
     ],
     "test.test[pg-tpch-q09-default.txt-Debug]": [
         {
-            "checksum": "a71e7d72b8b2e6d9a62256a92f3c2503",
-            "size": 13198,
-            "uri": "https://{canondata_backend}/1889210/e1bf5e6526d1b15d6473a14bffa39f90b43ef0a9/resource.tar.gz#test.test_pg-tpch-q09-default.txt-Debug_/opt.yql_patched"
+            "checksum": "51ca2e51ee7afaba547fe4964e5f4724",
+            "size": 13005,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q09-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q09-default.txt-Plan]": [
         {
-            "checksum": "beb9ac61c2d7fd81cd807d8dcb3e7b39",
-            "size": 14867,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_pg-tpch-q09-default.txt-Plan_/plan.txt"
+            "checksum": "e1414b497b649206508f83789aa09b96",
+            "size": 14455,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q09-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q12-default.txt-Debug]": [
         {
-            "checksum": "44243287698b03105fbd215678a3b237",
-            "size": 8802,
-            "uri": "https://{canondata_backend}/1925821/51271a4c1e68c9a6fac1bcd92a6e2fc045e94c85/resource.tar.gz#test.test_pg-tpch-q12-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e32b0744961447f5cb61bb042156c1ea",
+            "size": 8555,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q12-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q12-default.txt-Plan]": [
         {
-            "checksum": "952ef894521a5857020505fba64817dc",
-            "size": 10189,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_pg-tpch-q12-default.txt-Plan_/plan.txt"
+            "checksum": "5278cb95f636424edc97056e4a424e26",
+            "size": 9777,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q12-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q14-default.txt-Debug]": [
         {
-            "checksum": "a272986a3e3f7cae30f3bd43f8ce3c17",
-            "size": 6145,
-            "uri": "https://{canondata_backend}/1923547/67f6df540c55c53542953e1bf74b7234a7231c48/resource.tar.gz#test.test_pg-tpch-q14-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ab594133107599b5e15b23cf0662f81f",
+            "size": 5894,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q14-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q14-default.txt-Plan]": [
         {
-            "checksum": "479e96da6ae3bdae1588a9d4ce36d468",
-            "size": 9141,
-            "uri": "https://{canondata_backend}/1942671/5a661456ce25dbd5f847fbc6f7766f270fa2d5a1/resource.tar.gz#test.test_pg-tpch-q14-default.txt-Plan_/plan.txt"
+            "checksum": "75c0ca5300b2a4c19c8bcfafe8606ee2",
+            "size": 8729,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q14-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q18-default.txt-Debug]": [
         {
-            "checksum": "31fe697a421862519f21ae130d75a495",
-            "size": 16137,
-            "uri": "https://{canondata_backend}/1871102/be067cf2e456db3441ab42f48d84a7a3399220b0/resource.tar.gz#test.test_pg-tpch-q18-default.txt-Debug_/opt.yql_patched"
+            "checksum": "955875337e044d6350d2c3a57034c657",
+            "size": 15955,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q18-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q18-default.txt-Plan]": [
         {
-            "checksum": "55eafaa150b182dc16180d602340025e",
-            "size": 18309,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_pg-tpch-q18-default.txt-Plan_/plan.txt"
+            "checksum": "bc9829277aaa4029e5538c0f897d7ce2",
+            "size": 18103,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_pg-tpch-q18-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-variadic_array_arg-default.txt-Debug]": [
@@ -2297,86 +2297,86 @@
     ],
     "test.test[produce-process_with_assume--Debug]": [
         {
-            "checksum": "4e440b521be3be08ff8a513173f16934",
-            "size": 2439,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_produce-process_with_assume--Debug_/opt.yql_patched"
+            "checksum": "2fc3db7c72f2481259dd50f4c324fdc9",
+            "size": 2322,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-process_with_assume--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_with_assume--Plan]": [
         {
-            "checksum": "67f0f828b72d6db96a3edec325914256",
-            "size": 4912,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_produce-process_with_assume--Plan_/plan.txt"
+            "checksum": "0ac4ec57a83ffbf43198e5b64dea16e2",
+            "size": 4706,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-process_with_assume--Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_with_lambda-default.txt-Debug]": [
         {
-            "checksum": "09d6a60120d25a5707ac3940adb5b695",
-            "size": 1815,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_produce-process_with_lambda-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9b07fcccfcf6c423bb36b5bff1217af6",
+            "size": 1692,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-process_with_lambda-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_with_lambda-default.txt-Plan]": [
         {
-            "checksum": "e1e0113c319bbab950930b916438faeb",
-            "size": 4106,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_produce-process_with_lambda-default.txt-Plan_/plan.txt"
+            "checksum": "c03842f59c6d08585e0fb309dfcf700c",
+            "size": 3900,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-process_with_lambda-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_with_udf_validate_ignore_broken-default.txt-Debug]": [
         {
-            "checksum": "ea64a6b97d0f4c1bfceed8db05c7b08e",
-            "size": 2537,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_produce-process_with_udf_validate_ignore_broken-default.txt-Debug_/opt.yql_patched"
+            "checksum": "eaf69382d3c596176518ba347c9a1a13",
+            "size": 2408,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-process_with_udf_validate_ignore_broken-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_with_udf_validate_ignore_broken-default.txt-Plan]": [
         {
-            "checksum": "f43917493f5566405971a49a5355698e",
-            "size": 4077,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_produce-process_with_udf_validate_ignore_broken-default.txt-Plan_/plan.txt"
+            "checksum": "19ca2a4a4ad8f0260301e0d00e46dca3",
+            "size": 3871,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-process_with_udf_validate_ignore_broken-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_lambda_presort_twin-default.txt-Debug]": [
         {
-            "checksum": "7cf4df797456e294745865b1e78626f5",
-            "size": 3122,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8115c6c6eb3c94c15259ab1a567f8ff5",
+            "size": 3020,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_lambda_presort_twin-default.txt-Plan]": [
         {
-            "checksum": "d7ca27c3140db29d7ce8d1f7c41e6deb",
-            "size": 6641,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin-default.txt-Plan_/plan.txt"
+            "checksum": "1e6ec9e208c5bed2cd1de42bf0f34bec",
+            "size": 6435,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_lambda_presort_twin_list-default.txt-Debug]": [
         {
-            "checksum": "34873366c57c87bdd41e1e2c818037a6",
-            "size": 3190,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin_list-default.txt-Debug_/opt.yql_patched"
+            "checksum": "52b3f842e73ceb641004316e9970accb",
+            "size": 3088,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin_list-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_lambda_presort_twin_list-default.txt-Plan]": [
         {
-            "checksum": "d7ca27c3140db29d7ce8d1f7c41e6deb",
-            "size": 6641,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin_list-default.txt-Plan_/plan.txt"
+            "checksum": "1e6ec9e208c5bed2cd1de42bf0f34bec",
+            "size": 6435,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin_list-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_stage_and_flatmap--Debug]": [
         {
-            "checksum": "f63582853c2c8fdec3895c46a0fe9a8c",
-            "size": 4749,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_produce-reduce_multi_in_stage_and_flatmap--Debug_/opt.yql_patched"
+            "checksum": "be2d12f31f33c317aaf374f583ba7d66",
+            "size": 4486,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-reduce_multi_in_stage_and_flatmap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_stage_and_flatmap--Plan]": [
         {
-            "checksum": "4df1ed7c5e9ac68a1937d5d1c3dd35e3",
-            "size": 9408,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_produce-reduce_multi_in_stage_and_flatmap--Plan_/plan.txt"
+            "checksum": "7ac9cfca0e3f184ff99f2ca3e5f22ce9",
+            "size": 8996,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_produce-reduce_multi_in_stage_and_flatmap--Plan_/plan.txt"
         }
     ],
     "test.test[produce-yql-10297-default.txt-Debug]": [
@@ -2395,114 +2395,114 @@
     ],
     "test.test[sampling-reduce_with_presort-default.txt-Debug]": [
         {
-            "checksum": "c29ab9f7a789133f2b269562d2524340",
-            "size": 4268,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_sampling-reduce_with_presort-default.txt-Debug_/opt.yql_patched"
+            "checksum": "69d19718ff81d5c883716395d0d38f2e",
+            "size": 4022,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_sampling-reduce_with_presort-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-reduce_with_presort-default.txt-Plan]": [
         {
-            "checksum": "a3f7de17df68e6f9abb4d87460382fc1",
-            "size": 7956,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_sampling-reduce_with_presort-default.txt-Plan_/plan.txt"
+            "checksum": "07ab91ac1f6c05d1adaad9a4f77c35cf",
+            "size": 7544,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_sampling-reduce_with_presort-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-subquery_limit-default.txt-Debug]": [
         {
-            "checksum": "c76833ec204550ad1c10155b61894e24",
-            "size": 2166,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_sampling-subquery_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "aa780ecc5445299836d8f95603ffe171",
+            "size": 2055,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_sampling-subquery_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-subquery_limit-default.txt-Plan]": [
         {
-            "checksum": "1d9419510c94a714c94a6d33da010cb7",
-            "size": 4201,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_sampling-subquery_limit-default.txt-Plan_/plan.txt"
+            "checksum": "a49bb06d855f20a234b2247378903cb0",
+            "size": 4097,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_sampling-subquery_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-take_with_sampling-default.txt-Debug]": [
         {
-            "checksum": "982c0dcc6d73ec0bea733c1fc90fb404",
-            "size": 1777,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_sampling-take_with_sampling-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d591a262d394e9408c0e2ca9049e8b40",
+            "size": 1666,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_sampling-take_with_sampling-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-take_with_sampling-default.txt-Plan]": [
         {
-            "checksum": "418086b69ac4a67baa9ed1983d4ecd49",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_sampling-take_with_sampling-default.txt-Plan_/plan.txt"
+            "checksum": "fb002ebdc33b29d4424586db2a9ffd02",
+            "size": 3492,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_sampling-take_with_sampling-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-def_values_job--Debug]": [
         {
-            "checksum": "55843f1c54e808e0d94d797c16fc3763",
-            "size": 2072,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_schema-def_values_job--Debug_/opt.yql_patched"
+            "checksum": "e2fe17fbec02933ca00de12a38c59901",
+            "size": 1949,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-def_values_job--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-def_values_job--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_schema-def_values_job--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-def_values_job--Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert_sorted-read_schema-Debug]": [
         {
-            "checksum": "dbe875e0ca0dd715ff20e10ac17bf578",
-            "size": 3495,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Debug_/opt.yql_patched"
+            "checksum": "e9e820a9d3ce0f1f06b0529c3bf4ade4",
+            "size": 3329,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert_sorted-read_schema-Plan]": [
         {
-            "checksum": "36a657eee9ded15c5098aa8917a739d1",
-            "size": 6691,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Plan_/plan.txt"
+            "checksum": "d0450f877aa43e90188f113b7b2b2aff",
+            "size": 6485,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-insert_sorted-read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_field-read_schema-Debug]": [
         {
-            "checksum": "aab67552a624b3c3e4d810ed3856a246",
-            "size": 1914,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_schema-select_field-read_schema-Debug_/opt.yql_patched"
+            "checksum": "f430a6e7e856e4cf87361ea1210901a7",
+            "size": 1854,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-select_field-read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_field-read_schema-Plan]": [
         {
-            "checksum": "62c7f54f40958665bdef492623ca2302",
-            "size": 3438,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_schema-select_field-read_schema-Plan_/plan.txt"
+            "checksum": "cbc56016bd36c156942af6e90ab684a2",
+            "size": 3232,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-select_field-read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_simple-default.txt-Debug]": [
         {
-            "checksum": "5468fbb030f554f18dfea1e3b1665927",
-            "size": 2677,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_schema-select_simple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "96de06c114a80fc51419d06bb0a62006",
+            "size": 2505,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-select_simple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_simple-default.txt-Plan]": [
         {
-            "checksum": "f3a5b257af7349c56a14befff28bcb27",
-            "size": 4168,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_schema-select_simple-default.txt-Plan_/plan.txt"
+            "checksum": "796056c97ecf7cb4b13a72ebdc4d3777",
+            "size": 3962,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-select_simple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_with_map-sorted_desc-Debug]": [
         {
-            "checksum": "caee0100bf2be9319de8275b7cedf847",
-            "size": 2101,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_schema-select_with_map-sorted_desc-Debug_/opt.yql_patched"
+            "checksum": "d81aa67e118c09efb7c11324f4481066",
+            "size": 1978,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-select_with_map-sorted_desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_with_map-sorted_desc-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_schema-select_with_map-sorted_desc-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_schema-select_with_map-sorted_desc-Plan_/plan.txt"
         }
     ],
     "test.test[schema-skip_complex_type--Debug]": [
@@ -2535,44 +2535,44 @@
     ],
     "test.test[select-autoextract_source_value-default.txt-Debug]": [
         {
-            "checksum": "e56735e8c1044a9e4c285ff23835809d",
-            "size": 2496,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-autoextract_source_value-default.txt-Debug_/opt.yql_patched"
+            "checksum": "38f217d2a0c51724cf10f124c3f3d828",
+            "size": 2435,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-autoextract_source_value-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-autoextract_source_value-default.txt-Plan]": [
         {
-            "checksum": "7206fba1c32216d7f01d33f4bb8843b4",
-            "size": 6191,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-autoextract_source_value-default.txt-Plan_/plan.txt"
+            "checksum": "3c2e874106a8bf85878caaa018a21c8a",
+            "size": 5985,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-autoextract_source_value-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-bit_ops-default.txt-Debug]": [
         {
-            "checksum": "40ff6b686c2ebfc603d783763d691dbe",
-            "size": 2808,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-bit_ops-default.txt-Debug_/opt.yql_patched"
+            "checksum": "af821b0adea577963e4bf771a5cce355",
+            "size": 2557,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-bit_ops-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-bit_ops-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-bit_ops-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-bit_ops-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-calculated_values-default.txt-Debug]": [
         {
-            "checksum": "cb48179f6eb3218c9d2f1fef358421d3",
-            "size": 3372,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_select-calculated_values-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4cba8bd44fdc1a4f4f50a3ca93f6d7a5",
+            "size": 3076,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-calculated_values-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-calculated_values-default.txt-Plan]": [
         {
-            "checksum": "ee7d6807c455d83cf4348ef470c6a45e",
-            "size": 6200,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-calculated_values-default.txt-Plan_/plan.txt"
+            "checksum": "cfc091e969921c506341adea3cecb504",
+            "size": 5788,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-calculated_values-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-core_func_test_bit-default.txt-Debug]": [
@@ -2591,114 +2591,114 @@
     ],
     "test.test[select-dict_lookup_by_key-default.txt-Debug]": [
         {
-            "checksum": "33c7a6756873876c284841633de191e5",
-            "size": 2326,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-dict_lookup_by_key-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c9ea8f48f2e98c5b779aee731b261cb6",
+            "size": 2221,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-dict_lookup_by_key-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-dict_lookup_by_key-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-dict_lookup_by_key-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-dict_lookup_by_key-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-exists_false-default.txt-Debug]": [
         {
-            "checksum": "38e7a9248f77b4ef288e4d26717dab31",
-            "size": 2757,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-exists_false-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ed6f569ae85fb2778223893d81514d9d",
+            "size": 2649,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-exists_false-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-exists_false-default.txt-Plan]": [
         {
-            "checksum": "13ae41801c0ae1748297e160d786640e",
-            "size": 6593,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-exists_false-default.txt-Plan_/plan.txt"
+            "checksum": "2382005837714fa38f565cec0dd016f5",
+            "size": 6181,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-exists_false-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-exists_true-default.txt-Debug]": [
         {
-            "checksum": "cf2ad3ed239b30f985997288eb321e53",
-            "size": 1847,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-exists_true-default.txt-Debug_/opt.yql_patched"
+            "checksum": "659c89868bc077d24fd33f5a5706f0b3",
+            "size": 1781,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-exists_true-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-exists_true-default.txt-Plan]": [
         {
-            "checksum": "d5391ec6249c774e7d060cc96a2207e1",
-            "size": 4002,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-exists_true-default.txt-Plan_/plan.txt"
+            "checksum": "50f47bc73b32e5132fce6e25f7a3685f",
+            "size": 3796,
+            "uri": "https://{canondata_backend}/1937150/c1acae706dd71ce088fc48a032c252e2fac078b9/resource.tar.gz#test.test_select-exists_true-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-sampleselect-1000-Debug]": [
         {
-            "checksum": "56b6bb0f194085ba58e8b4da15e225fb",
-            "size": 2205,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-sampleselect-1000-Debug_/opt.yql_patched"
+            "checksum": "b38e00868f2af599066ff68a7c9ba90d",
+            "size": 2078,
+            "uri": "https://{canondata_backend}/1937150/c1acae706dd71ce088fc48a032c252e2fac078b9/resource.tar.gz#test.test_select-sampleselect-1000-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-sampleselect-1000-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-sampleselect-1000-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-sampleselect-1000-Plan_/plan.txt"
         }
     ],
     "test.test[select-select_all_filtered-default.txt-Debug]": [
         {
-            "checksum": "5259778a99b5f620ffceb026249ae355",
-            "size": 1853,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-select_all_filtered-default.txt-Debug_/opt.yql_patched"
+            "checksum": "19bcdffdb846664f67e3d3b405afa333",
+            "size": 1730,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-select_all_filtered-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-select_all_filtered-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-select_all_filtered-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-select_all_filtered-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-select_concrete_detailed_columns-default.txt-Debug]": [
         {
-            "checksum": "cca8fc3f18774c23a93d1af9373787da",
-            "size": 1840,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-select_concrete_detailed_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a189d6d7dc382beb9862fbcf43d58167",
+            "size": 1739,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-select_concrete_detailed_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-select_concrete_detailed_columns-default.txt-Plan]": [
         {
-            "checksum": "f9c32cfa292cb0b6a1d359f137ba179f",
-            "size": 3470,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-select_concrete_detailed_columns-default.txt-Plan_/plan.txt"
+            "checksum": "251b12b7f171104a94790f620a758274",
+            "size": 3264,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-select_concrete_detailed_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-shift_columns-default.txt-Debug]": [
         {
-            "checksum": "664b69d2dbad8d6b7a324273845abec5",
-            "size": 1963,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-shift_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a88786ba5d0009e127abed5d2ec66302",
+            "size": 1840,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-shift_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-shift_columns-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-shift_columns-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-shift_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-table_funcs_spec-default.txt-Debug]": [
         {
-            "checksum": "7f34fec62032955d3bc3fb06427c7729",
-            "size": 2914,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-table_funcs_spec-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3742083879ff1df74ba0224c62b1ecd3",
+            "size": 2719,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-table_funcs_spec-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-table_funcs_spec-default.txt-Plan]": [
         {
-            "checksum": "5c41b58f8a68c081f47cebbfa8a13331",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-table_funcs_spec-default.txt-Plan_/plan.txt"
+            "checksum": "c6ed3026b5067eb08a3ae9247dec4859",
+            "size": 3839,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-table_funcs_spec-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-unlabeled--Debug]": [
@@ -2717,86 +2717,86 @@
     ],
     "test.test[select-use_cluster-default.txt-Debug]": [
         {
-            "checksum": "e281bdd12e51301a050afe0ad552cf8e",
-            "size": 1736,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-use_cluster-default.txt-Debug_/opt.yql_patched"
+            "checksum": "87f097698527f000fd1967c71b64a12b",
+            "size": 1674,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-use_cluster-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-use_cluster-default.txt-Plan]": [
         {
-            "checksum": "31d406ffbf435de871b9f93ad9cd55ec",
-            "size": 3440,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-use_cluster-default.txt-Plan_/plan.txt"
+            "checksum": "4a9722a51fa8c8416dacb8151a8e59d3",
+            "size": 3234,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-use_cluster-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-where_in-default.txt-Debug]": [
         {
-            "checksum": "3859098c44e65743221803249fd298bd",
-            "size": 2047,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_select-where_in-default.txt-Debug_/opt.yql_patched"
+            "checksum": "dde34d23da393fd551a1bef9b155a5a6",
+            "size": 1924,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-where_in-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-where_in-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_select-where_in-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_select-where_in-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q16-default.txt-Debug]": [
         {
-            "checksum": "105cdc7859a4658e0754538acc377fa0",
-            "size": 14411,
-            "uri": "https://{canondata_backend}/1784826/0a671f0041536dd8b645b7d6371020286ad6d20f/resource.tar.gz#test.test_tpch-q16-default.txt-Debug_/opt.yql_patched"
+            "checksum": "93900688156a21e1328e6fce931da9e1",
+            "size": 13719,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_tpch-q16-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q16-default.txt-Plan]": [
         {
-            "checksum": "2a697900f0ef9e45cb14c5fe35bc6082",
-            "size": 21011,
-            "uri": "https://{canondata_backend}/1600758/c8284240363ef5bf0b7386b33e442bf5c0edbb00/resource.tar.gz#test.test_tpch-q16-default.txt-Plan_/plan.txt"
+            "checksum": "51c4dffa82eb2d8a099c8e4bf10ce1d3",
+            "size": 20187,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_tpch-q16-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q19-default.txt-Debug]": [
         {
-            "checksum": "001ba8d41fe6c1fa4e558cf48ca0f142",
-            "size": 6849,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_tpch-q19-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3ee85184b294bcd923d97a50bd428a20",
+            "size": 6782,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_tpch-q19-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q19-default.txt-Plan]": [
         {
-            "checksum": "a26aaca08e60aef12aa69df01603f7c1",
-            "size": 12231,
-            "uri": "https://{canondata_backend}/1936273/1e8f0ef8205e43a3653a661c8e5709ef5f1a8ff7/resource.tar.gz#test.test_tpch-q19-default.txt-Plan_/plan.txt"
+            "checksum": "43f13502a031d87ecb7d900c10eaeeff",
+            "size": 12025,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_tpch-q19-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-insert_struct_v3_with_native--Debug]": [
         {
-            "checksum": "487dcdf5509e3b603b84e00c448a0c22",
-            "size": 4559,
-            "uri": "https://{canondata_backend}/1880306/8651aacb2cc2414eb4ec79c3aac4ee5403cabfc7/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Debug_/opt.yql_patched"
+            "checksum": "67afd7ddbfc2f611f8656aa1ca5340a0",
+            "size": 4400,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-insert_struct_v3_with_native--Plan]": [
         {
-            "checksum": "0acad097fc68942e20a30acc65d6df6c",
-            "size": 14651,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Plan_/plan.txt"
+            "checksum": "7f2ec5d06da7d256e1a9296dc27c2d45",
+            "size": 14033,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_type_v3-insert_struct_v3_with_native--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-insert_struct_v3_wo_native--Debug]": [
         {
-            "checksum": "3a7785071553399ebf05af92d710b076",
-            "size": 4759,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Debug_/opt.yql_patched"
+            "checksum": "90fa384b09077a3630496a7cb409bb49",
+            "size": 4600,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-insert_struct_v3_wo_native--Plan]": [
         {
-            "checksum": "83dd5f83c0e0749996f4b209ae7db8d9",
-            "size": 15191,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Plan_/plan.txt"
+            "checksum": "2840acb578ee24fa5b1ed53a1270eca2",
+            "size": 14573,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_type_v3-insert_struct_v3_wo_native--Plan_/plan.txt"
         }
     ],
     "test.test[udf-sqlproject_grounds-default.txt-Debug]": [
@@ -2815,72 +2815,72 @@
     ],
     "test.test[udf-two_regexps--Debug]": [
         {
-            "checksum": "a4c60a3e31683964bc252624ca38b154",
-            "size": 2090,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_udf-two_regexps--Debug_/opt.yql_patched"
+            "checksum": "aea76bd31188f113989d39a821e28ea4",
+            "size": 1979,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_udf-two_regexps--Debug_/opt.yql_patched"
         }
     ],
     "test.test[udf-two_regexps--Plan]": [
         {
-            "checksum": "1d9419510c94a714c94a6d33da010cb7",
-            "size": 4201,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_udf-two_regexps--Plan_/plan.txt"
+            "checksum": "a49bb06d855f20a234b2247378903cb0",
+            "size": 4097,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_udf-two_regexps--Plan_/plan.txt"
         }
     ],
     "test.test[view-system_udf--Debug]": [
         {
-            "checksum": "fc911c9eed921d7cb6ed0d47c1323486",
-            "size": 2674,
-            "uri": "https://{canondata_backend}/1900335/1c84908d492197ead2c896624a2389b6dc3780ab/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql_patched"
+            "checksum": "0a349c251431c29829e29d2f48e8239c",
+            "size": 2562,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_view-system_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-system_udf--Plan]": [
         {
-            "checksum": "d91cfa222265c675ee95346eaa89e40a",
-            "size": 4009,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_view-system_udf--Plan_/plan.txt"
+            "checksum": "0dfaf577392f418680bc5a045d5257e7",
+            "size": 3803,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_view-system_udf--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_aggregation--Debug]": [
         {
-            "checksum": "fe5c2b8bb8b9f66d1c6e0ad2c1e47041",
-            "size": 4995,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_weak_field-weak_field_aggregation--Debug_/opt.yql_patched"
+            "checksum": "f2311c0bf875325b1155ee865eb4721e",
+            "size": 4799,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_weak_field-weak_field_aggregation--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_aggregation--Plan]": [
         {
-            "checksum": "98a6cf93b070a89836f470e459b10e64",
-            "size": 8733,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_weak_field-weak_field_aggregation--Plan_/plan.txt"
+            "checksum": "c0f005f3336f0d210739926d2d560fc1",
+            "size": 8321,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_weak_field-weak_field_aggregation--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_esc_yson--Debug]": [
         {
-            "checksum": "ba8ff4c358c37e8dbbe303fbb564d206",
-            "size": 2940,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_weak_field-weak_field_esc_yson--Debug_/opt.yql_patched"
+            "checksum": "fb67ff3d3dce3cb5d31ea9e4542f7b4e",
+            "size": 2807,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_weak_field-weak_field_esc_yson--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_esc_yson--Plan]": [
         {
-            "checksum": "0718812342a8362ca06bc79c8a4e030a",
-            "size": 5897,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_weak_field-weak_field_esc_yson--Plan_/plan.txt"
+            "checksum": "9a760701878af98b806b7ea05a9893fb",
+            "size": 5691,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_weak_field-weak_field_esc_yson--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_rest--Debug]": [
         {
-            "checksum": "1c1925fc50fbeec4de4cde25be6f67ed",
-            "size": 4618,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_weak_field-weak_field_rest--Debug_/opt.yql_patched"
+            "checksum": "538640b900a150d1c1da504e98ba953e",
+            "size": 4174,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_weak_field-weak_field_rest--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_rest--Plan]": [
         {
-            "checksum": "5b2739ddf96a13adc610a8d61aa60173",
-            "size": 6173,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_weak_field-weak_field_rest--Plan_/plan.txt"
+            "checksum": "d5bca6b4a11640c3806c8266ad283b7a",
+            "size": 5761,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_weak_field-weak_field_rest--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_to_yson--Debug]": [
@@ -2899,72 +2899,72 @@
     ],
     "test.test[window-full/session--Debug]": [
         {
-            "checksum": "333f05b30f4566a815ef4c596c6fd1f6",
-            "size": 13899,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_window-full_session--Debug_/opt.yql_patched"
+            "checksum": "3686ec3be8fa6640e428268fc0c16598",
+            "size": 13069,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-full_session--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/session--Plan]": [
         {
-            "checksum": "fcf7aff83e2380daa27800dcb2f077e1",
-            "size": 12950,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_window-full_session--Plan_/plan.txt"
+            "checksum": "7f7139800c8adb504e160b3038ba7e5b",
+            "size": 12126,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-full_session--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/session_aliases--Debug]": [
         {
-            "checksum": "d5414bac5bc6a9e87cfabc5266971d85",
-            "size": 14757,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_window-full_session_aliases--Debug_/opt.yql_patched"
+            "checksum": "47d22b82d599d4f9d30a2fdcda4406d8",
+            "size": 13912,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-full_session_aliases--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/session_aliases--Plan]": [
         {
-            "checksum": "6d4c1cc30f0e1b7f030e29c0dfd88eee",
-            "size": 15105,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_window-full_session_aliases--Plan_/plan.txt"
+            "checksum": "7b43052c4c1210ce94cfbc197c835bbb",
+            "size": 14075,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-full_session_aliases--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_expr_bounds--Debug]": [
         {
-            "checksum": "ad834ee371a6072eccd1f19a4d83295c",
-            "size": 4093,
-            "uri": "https://{canondata_backend}/1937492/ee063a1785481b59e1e3de2e39ff9cdf4b142e4b/resource.tar.gz#test.test_window-win_expr_bounds--Debug_/opt.yql_patched"
+            "checksum": "937db8387f614b32a422329d3740687b",
+            "size": 3972,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-win_expr_bounds--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_expr_bounds--Plan]": [
         {
-            "checksum": "8fdc30ef736185a7715811a38de3a74f",
-            "size": 6191,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_window-win_expr_bounds--Plan_/plan.txt"
+            "checksum": "f2ee1921117b42774cac74ab0a6c2c2c",
+            "size": 5985,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-win_expr_bounds--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_aggr_4func_sort--Debug]": [
         {
-            "checksum": "cd52eb6438c76604fe9f6fad8de2275d",
-            "size": 5099,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_window-win_func_aggr_4func_sort--Debug_/opt.yql_patched"
+            "checksum": "5758c5bcd6a296a2d0c60b5372376bb7",
+            "size": 4781,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-win_func_aggr_4func_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_4func_sort--Plan]": [
         {
-            "checksum": "d9c35fc4249d68f9158b0e130fd31be4",
-            "size": 5710,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_window-win_func_aggr_4func_sort--Plan_/plan.txt"
+            "checksum": "53c83b2c69df913e90dd4fd8c1947c28",
+            "size": 5298,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-win_func_aggr_4func_sort--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_over_group_by--Debug]": [
         {
-            "checksum": "f7f57cad04a639cd4aff71f2e0fc3022",
-            "size": 9194,
-            "uri": "https://{canondata_backend}/212715/b9f267b2022a251b638e7a1f1ebeb788c308ed2f/resource.tar.gz#test.test_window-win_func_over_group_by--Debug_/opt.yql_patched"
+            "checksum": "2b2a5c278a178c6e51b4a26c7b27b2ff",
+            "size": 8571,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-win_func_over_group_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_over_group_by--Plan]": [
         {
-            "checksum": "f4c04c57048b6181aa0eca23404c5a89",
-            "size": 10952,
-            "uri": "https://{canondata_backend}/1936842/5461a7f0f4d722c81cba2eff5dd1d41bf3a77f80/resource.tar.gz#test.test_window-win_func_over_group_by--Plan_/plan.txt"
+            "checksum": "ec216e603ba333ec6bebb18ae4e424d1",
+            "size": 10128,
+            "uri": "https://{canondata_backend}/1809005/ad7c074711ee8d1675aebabbf8025a2c8bd317d8/resource.tar.gz#test.test_window-win_func_over_group_by--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_multiaggr-default.txt-Debug]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part3/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part3/canondata/result.json
@@ -1,16 +1,16 @@
 {
     "test.test[action-action_eval_cluster_table_for--Debug]": [
         {
-            "checksum": "e197d0a388e7caabf3c957ae62140024",
-            "size": 3009,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Debug_/opt.yql_patched"
+            "checksum": "f6d496a1d49e365118fd95d6791ec400",
+            "size": 2763,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-action_eval_cluster_table_for--Plan]": [
         {
-            "checksum": "c22d75728ebf1dc427e2aae2591ae6c9",
-            "size": 7041,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Plan_/plan.txt"
+            "checksum": "fe11af3091c1a4f332793f79f2bd536a",
+            "size": 6629,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-action_eval_cluster_table_for--Plan_/plan.txt"
         }
     ],
     "test.test[action-action_opt_args-default.txt-Debug]": [
@@ -113,16 +113,16 @@
     ],
     "test.test[action-eval_table_with_view-default.txt-Debug]": [
         {
-            "checksum": "f155ab39bd6378a6f5169b527fb996b6",
-            "size": 1734,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_action-eval_table_with_view-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f4f8af54f95cb213a85648c088230d1b",
+            "size": 1611,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-eval_table_with_view-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_table_with_view-default.txt-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_action-eval_table_with_view-default.txt-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-eval_table_with_view-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-inline_action-default.txt-Debug]": [
@@ -169,30 +169,30 @@
     ],
     "test.test[action-runtime_if_select-default.txt-Debug]": [
         {
-            "checksum": "2a807d3fc906e014cbb666cd2c28e4aa",
-            "size": 3322,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Debug_/opt.yql_patched"
+            "checksum": "75ec2d3cb80cccd3838bd61a9619e27c",
+            "size": 3258,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-runtime_if_select-default.txt-Plan]": [
         {
-            "checksum": "efaa45fb7cc963058cd01d24bcdd3665",
-            "size": 9228,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Plan_/plan.txt"
+            "checksum": "7e9cd7092e86839244ebbeeccbc76d36",
+            "size": 9022,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-runtime_if_select-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-select_from_subquery_with_orderby-default.txt-Debug]": [
         {
-            "checksum": "e6d0fadb16dcec08dd34e1c9778daa51",
-            "size": 2249,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_action-select_from_subquery_with_orderby-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b4a33e851de440138d20f8f4e58df51e",
+            "size": 2126,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-select_from_subquery_with_orderby-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-select_from_subquery_with_orderby-default.txt-Plan]": [
         {
-            "checksum": "1492bb4858b9ea50a1cf2ee9fa121154",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_action-select_from_subquery_with_orderby-default.txt-Plan_/plan.txt"
+            "checksum": "688c81b1f7ca8128832f5c147aab3ac2",
+            "size": 3839,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_action-select_from_subquery_with_orderby-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-subquery_accessnode-default.txt-Debug]": [
@@ -281,16 +281,16 @@
     ],
     "test.test[agg_apply-table--Debug]": [
         {
-            "checksum": "1a96043b7b0fa33322abe79bd5f6078f",
-            "size": 3381,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_agg_apply-table--Debug_/opt.yql_patched"
+            "checksum": "9a7e4015a7f2f4fcbc321d759655a46a",
+            "size": 3314,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_agg_apply-table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[agg_apply-table--Plan]": [
         {
-            "checksum": "4eb5ebdb8cbf6d6f121ebd0de25bf65e",
-            "size": 5659,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_agg_apply-table--Plan_/plan.txt"
+            "checksum": "1a312a7aa25bfbba679141010ab783ef",
+            "size": 5453,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_agg_apply-table--Plan_/plan.txt"
         }
     ],
     "test.test[agg_phases-count-default.txt-Debug]": [
@@ -351,16 +351,16 @@
     ],
     "test.test[aggr_factory-bitxor-default.txt-Debug]": [
         {
-            "checksum": "1f7058898a9050a65766e7394a5d7c8a",
-            "size": 6632,
-            "uri": "https://{canondata_backend}/1942671/bd60b99dd88b56e4393d96a9767150c5edda50e8/resource.tar.gz#test.test_aggr_factory-bitxor-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b98d8acb6a469fbf7f4c50147990782e",
+            "size": 6534,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggr_factory-bitxor-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-bitxor-default.txt-Plan]": [
         {
-            "checksum": "bc48acda1e477c8daa387d3a1c3e9ef4",
-            "size": 13322,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggr_factory-bitxor-default.txt-Plan_/plan.txt"
+            "checksum": "dcd250bb62eed7eae08239d31389e128",
+            "size": 12910,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggr_factory-bitxor-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-def_value_full_table-default.txt-Debug]": [
@@ -379,16 +379,16 @@
     ],
     "test.test[aggr_factory-min_by-default.txt-Debug]": [
         {
-            "checksum": "3af40a82a2d282041a5c43943745fa5a",
-            "size": 6199,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_aggr_factory-min_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "dd2e17b6058ed16996c122b31433a341",
+            "size": 6067,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggr_factory-min_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-min_by-default.txt-Plan]": [
         {
-            "checksum": "b02669d2d38597cc186352f1a7f0a55c",
-            "size": 10346,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggr_factory-min_by-default.txt-Plan_/plan.txt"
+            "checksum": "68eae5a44fe96a6eeabf0fc50b05482e",
+            "size": 9934,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggr_factory-min_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-transform_input-default.txt-Debug]": [
@@ -407,16 +407,16 @@
     ],
     "test.test[aggregate-aggregate_distinct_expr_with_groupby_expr-default.txt-Debug]": [
         {
-            "checksum": "393ada046278c53f7429ecc00b5cd475",
-            "size": 12210,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_groupby_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ee572f1aff6bf7e6fea256f1903b5b73",
+            "size": 11753,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_groupby_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_distinct_expr_with_groupby_expr-default.txt-Plan]": [
         {
-            "checksum": "a0c9d7e04f107dc14ca8051849f81f62",
-            "size": 16838,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_groupby_expr-default.txt-Plan_/plan.txt"
+            "checksum": "686f3a503ed7a4a923be1722a3de8fd4",
+            "size": 15808,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_groupby_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_distinct_in_access_node_exprs-default.txt-Debug]": [
@@ -435,198 +435,198 @@
     ],
     "test.test[aggregate-aggregation_with_named_node--Debug]": [
         {
-            "checksum": "a6edca6c7045824fe5a79089e7988021",
-            "size": 5352,
-            "uri": "https://{canondata_backend}/212715/281225c593b89b14398e3d64718321920556da62/resource.tar.gz#test.test_aggregate-aggregation_with_named_node--Debug_/opt.yql_patched"
+            "checksum": "8f79a8462f188fc94e41efd121a31a12",
+            "size": 5244,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-aggregation_with_named_node--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregation_with_named_node--Plan]": [
         {
-            "checksum": "4eb5ebdb8cbf6d6f121ebd0de25bf65e",
-            "size": 5659,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-aggregation_with_named_node--Plan_/plan.txt"
+            "checksum": "1a312a7aa25bfbba679141010ab783ef",
+            "size": 5453,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-aggregation_with_named_node--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-avg_interval-default.txt-Debug]": [
         {
-            "checksum": "9bb2d42937ffb7167207d21876e050b5",
-            "size": 3820,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_aggregate-avg_interval-default.txt-Debug_/opt.yql_patched"
+            "checksum": "953fecc02e613072fa9996aecd5b551f",
+            "size": 3753,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-avg_interval-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-avg_interval-default.txt-Plan]": [
         {
-            "checksum": "4eb5ebdb8cbf6d6f121ebd0de25bf65e",
-            "size": 5659,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-avg_interval-default.txt-Plan_/plan.txt"
+            "checksum": "1a312a7aa25bfbba679141010ab783ef",
+            "size": 5453,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-avg_interval-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-avg_with_having-default.txt-Debug]": [
         {
-            "checksum": "66ff2be65cdeee3d309f285f24dc8398",
-            "size": 5601,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_aggregate-avg_with_having-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0790778bc954338873985c144c005aab",
+            "size": 5296,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-avg_with_having-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-avg_with_having-default.txt-Plan]": [
         {
-            "checksum": "b03d6fcad67631132f0cd58cabadba0a",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-avg_with_having-default.txt-Plan_/plan.txt"
+            "checksum": "261b45fcb0c591cd4d8b93883414dec3",
+            "size": 7936,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-avg_with_having-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_cube_grouping--Debug]": [
         {
-            "checksum": "7a4d75674e371f921e847c5819e8dcdb",
-            "size": 22928,
-            "uri": "https://{canondata_backend}/1809005/449266ceea96f804e1d66117274a19488add46b9/resource.tar.gz#test.test_aggregate-group_by_cube_grouping--Debug_/opt.yql_patched"
+            "checksum": "9d1583c9fadcdbaeab44e02899570c71",
+            "size": 21680,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_cube_grouping--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_cube_grouping--Plan]": [
         {
-            "checksum": "1814ee9b675b83130b3aea4429fc9cb9",
-            "size": 29028,
-            "uri": "https://{canondata_backend}/1809005/449266ceea96f804e1d66117274a19488add46b9/resource.tar.gz#test.test_aggregate-group_by_cube_grouping--Plan_/plan.txt"
+            "checksum": "b784e073169995518b5a3b7a601323a6",
+            "size": 27380,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_cube_grouping--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_column_reuse--Debug]": [
         {
-            "checksum": "b57beccf64fdf7b7a41ff38d7fc18be8",
-            "size": 9460,
-            "uri": "https://{canondata_backend}/212715/281225c593b89b14398e3d64718321920556da62/resource.tar.gz#test.test_aggregate-group_by_rollup_column_reuse--Debug_/opt.yql_patched"
+            "checksum": "b83350496ccb944b0f9220a136b46a1d",
+            "size": 8791,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_rollup_column_reuse--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_column_reuse--Plan]": [
         {
-            "checksum": "871a11c56cbd17553e0ce6567b87fb96",
-            "size": 14650,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-group_by_rollup_column_reuse--Plan_/plan.txt"
+            "checksum": "6266271dc8c3771ab9ab4cb9f307e435",
+            "size": 13620,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_rollup_column_reuse--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_join_agg--Debug]": [
         {
-            "checksum": "18aa9b914f2af10d251ba089b5b27fb7",
-            "size": 11494,
-            "uri": "https://{canondata_backend}/1881367/fd6fe303f95983c7923be22740c4aa07b052e199/resource.tar.gz#test.test_aggregate-group_by_ru_join_agg--Debug_/opt.yql_patched"
+            "checksum": "45ba7179c1055215d327d4b56ed0dea7",
+            "size": 11128,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_ru_join_agg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_join_agg--Plan]": [
         {
-            "checksum": "f284da35d48a30f75b068c1c025a365c",
-            "size": 15812,
-            "uri": "https://{canondata_backend}/1881367/fd6fe303f95983c7923be22740c4aa07b052e199/resource.tar.gz#test.test_aggregate-group_by_ru_join_agg--Plan_/plan.txt"
+            "checksum": "34e1e49a0922277278ad5672a31c374b",
+            "size": 15194,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_ru_join_agg--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_join_grouping-default.txt-Debug]": [
         {
-            "checksum": "cfeccce470edd31442d45c508fa47135",
-            "size": 13201,
-            "uri": "https://{canondata_backend}/1881367/fd6fe303f95983c7923be22740c4aa07b052e199/resource.tar.gz#test.test_aggregate-group_by_ru_join_grouping-default.txt-Debug_/opt.yql_patched"
+            "checksum": "57191fabcda692903d55387b19a017a6",
+            "size": 12707,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_ru_join_grouping-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_join_grouping-default.txt-Plan]": [
         {
-            "checksum": "7183fd1c44e2cdac250936680a59ad71",
-            "size": 18126,
-            "uri": "https://{canondata_backend}/1881367/fd6fe303f95983c7923be22740c4aa07b052e199/resource.tar.gz#test.test_aggregate-group_by_ru_join_grouping-default.txt-Plan_/plan.txt"
+            "checksum": "ffd578b908c5e03ca26955953a4c8f8c",
+            "size": 17302,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_ru_join_grouping-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_aliases--Debug]": [
         {
-            "checksum": "c82e11207402f4c17a6af0781f699588",
-            "size": 5719,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_aggregate-group_by_session_aliases--Debug_/opt.yql_patched"
+            "checksum": "a68754d2ccee4f1fc3bbe94276d3375e",
+            "size": 5281,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_session_aliases--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_aliases--Plan]": [
         {
-            "checksum": "702a395959580a7a64c91724ba286b84",
-            "size": 5707,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-group_by_session_aliases--Plan_/plan.txt"
+            "checksum": "6c885e91238b3116892cb25e704c7328",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_session_aliases--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_distinct--Debug]": [
         {
-            "checksum": "7c974707768286e79db969f3a8ac55f6",
-            "size": 11252,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_aggregate-group_by_session_distinct--Debug_/opt.yql_patched"
+            "checksum": "3bc8a5aac6f99657917edfff23c9877a",
+            "size": 10679,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_session_distinct--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_distinct--Plan]": [
         {
-            "checksum": "7f0ced887f2d45f95087edec21d9fa5e",
-            "size": 12171,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-group_by_session_distinct--Plan_/plan.txt"
+            "checksum": "6bb8d55fda493d6595106fed7646fd78",
+            "size": 11553,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_session_distinct--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_only--Debug]": [
         {
-            "checksum": "ace3176824a6e7754e576f8e3aea52ff",
-            "size": 3556,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_aggregate-group_by_session_only--Debug_/opt.yql_patched"
+            "checksum": "f28d9eb2305d17ceae04fa4f2484f29a",
+            "size": 3484,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_session_only--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_only--Plan]": [
         {
-            "checksum": "cce2cd9e36caf665afa11e4d25eebbc7",
-            "size": 5907,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-group_by_session_only--Plan_/plan.txt"
+            "checksum": "de7011fb6df13e704e0e3d6b5da8a785",
+            "size": 5701,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-group_by_session_only--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-having_distinct_expr--Debug]": [
         {
-            "checksum": "be375580a8fc8dac1b036f11cc09283b",
-            "size": 5491,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_aggregate-having_distinct_expr--Debug_/opt.yql_patched"
+            "checksum": "ba67839547f3ffa5fd00c1b91527103f",
+            "size": 5215,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-having_distinct_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-having_distinct_expr--Plan]": [
         {
-            "checksum": "4a30610d47390fe12e96306726b8d56f",
-            "size": 8569,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-having_distinct_expr--Plan_/plan.txt"
+            "checksum": "7de037d72806aeebcc7a8158d729b0aa",
+            "size": 7951,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-having_distinct_expr--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-native_desc_group_compact_by--Debug]": [
         {
-            "checksum": "0fbf0acf6d2549ea7ef9f4d5bbcad89c",
-            "size": 12019,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_aggregate-native_desc_group_compact_by--Debug_/opt.yql_patched"
+            "checksum": "71b50eef580ee502ef16772ec65eece0",
+            "size": 11275,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-native_desc_group_compact_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-native_desc_group_compact_by--Plan]": [
         {
-            "checksum": "8a0e541a3edad51f5ad12ee6d3e36c07",
-            "size": 24679,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-native_desc_group_compact_by--Plan_/plan.txt"
+            "checksum": "fb014308699b7b7b4130c2bfe02f0a38",
+            "size": 22619,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-native_desc_group_compact_by--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-table_row_aggregation-default.txt-Debug]": [
         {
-            "checksum": "70a11d832638e75b3b62d1eaef3bbc29",
-            "size": 4376,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_aggregate-table_row_aggregation-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1f99164d178ca091a0fc248262f71a5c",
+            "size": 4027,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-table_row_aggregation-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-table_row_aggregation-default.txt-Plan]": [
         {
-            "checksum": "70989f02c05ccc458f1236ecc745b302",
-            "size": 8486,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_aggregate-table_row_aggregation-default.txt-Plan_/plan.txt"
+            "checksum": "b94038a37235430ef0d37c495e4458ca",
+            "size": 7868,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_aggregate-table_row_aggregation-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[ansi_idents-basic_columns-default.txt-Debug]": [
         {
-            "checksum": "af90c8c1127fcc6bae81a7114b632749",
-            "size": 2830,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_ansi_idents-basic_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5f6e07fb12d7258d6c5479ccc9aa6305",
+            "size": 2704,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_ansi_idents-basic_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ansi_idents-basic_columns-default.txt-Plan]": [
         {
-            "checksum": "df04111c024790a6acc9bdbe03f27531",
-            "size": 6201,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_ansi_idents-basic_columns-default.txt-Plan_/plan.txt"
+            "checksum": "5a5857020d5dd64a30be59b49a6d5c5f",
+            "size": 5789,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_ansi_idents-basic_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-bitcast_datetime64-default.txt-Debug]": [
@@ -729,142 +729,142 @@
     ],
     "test.test[blocks-add_uint64_opt--Debug]": [
         {
-            "checksum": "355c856366ac26d0b7c47b5a648345b3",
-            "size": 2258,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-add_uint64_opt--Debug_/opt.yql_patched"
+            "checksum": "55aaec0f9cb637198fb87d0e0eec7cbd",
+            "size": 2128,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-add_uint64_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_uint64_opt--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-add_uint64_opt--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-add_uint64_opt--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_pg_filter--Debug]": [
         {
-            "checksum": "f82f5187bf7ae8e78a1bd5ba09d9c0bc",
-            "size": 9634,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-combine_all_pg_filter--Debug_/opt.yql_patched"
+            "checksum": "d79eb80f389c31c4fb6c003d9bb3c167",
+            "size": 9366,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-combine_all_pg_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_pg_filter--Plan]": [
         {
-            "checksum": "4bfc5ea7a30331a2bd6d709f890dc4a4",
-            "size": 5915,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-combine_all_pg_filter--Plan_/plan.txt"
+            "checksum": "6e38987cecdf2cc0fa343cf22c1487cf",
+            "size": 5709,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-combine_all_pg_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_top_sort--Debug]": [
         {
-            "checksum": "81b8f150d5f3c618aeb40706da1b5aa5",
-            "size": 7539,
-            "uri": "https://{canondata_backend}/1937027/1fa3c45f23533a1bb342d776d47ad0cab615b010/resource.tar.gz#test.test_blocks-date_top_sort--Debug_/opt.yql_patched"
+            "checksum": "2f5c3b32783632176bfc1f82f7879059",
+            "size": 6515,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-date_top_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_top_sort--Plan]": [
         {
-            "checksum": "d3e735ed81932f570200d742ea9f0238",
-            "size": 7022,
-            "uri": "https://{canondata_backend}/1937027/1fa3c45f23533a1bb342d776d47ad0cab615b010/resource.tar.gz#test.test_blocks-date_top_sort--Plan_/plan.txt"
+            "checksum": "75f02535ff78ef8e0953ab1f6361450d",
+            "size": 6610,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-date_top_sort--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-distinct_opt_state_keys--Debug]": [
         {
-            "checksum": "4998e3766ac76db347f0ccf92d80c985",
-            "size": 15189,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-distinct_opt_state_keys--Debug_/opt.yql_patched"
+            "checksum": "d87f51a8354da1ff5dea45e6540f707c",
+            "size": 14428,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-distinct_opt_state_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-distinct_opt_state_keys--Plan]": [
         {
-            "checksum": "4e52ed2fd4bcbbee96a3a3c0ce716981",
-            "size": 17657,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-distinct_opt_state_keys--Plan_/plan.txt"
+            "checksum": "a908a4549f60918b7fdb2b2cb47ed74a",
+            "size": 16627,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-distinct_opt_state_keys--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-filter_partial_expr--Debug]": [
         {
-            "checksum": "159b5dd882dcd532da7ac2f843e2b8d0",
-            "size": 3203,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-filter_partial_expr--Debug_/opt.yql_patched"
+            "checksum": "93ddf5341eb4a9c901a1ee18fa64481b",
+            "size": 3001,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-filter_partial_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-filter_partial_expr--Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-filter_partial_expr--Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-filter_partial_expr--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg--Debug]": [
         {
-            "checksum": "9489c5b679218e323c560432f4b8d343",
-            "size": 2328,
-            "uri": "https://{canondata_backend}/1773845/d457410f55fa78719c90f46313eb092f85285ffa/resource.tar.gz#test.test_blocks-pg--Debug_/opt.yql_patched"
+            "checksum": "e891e3f7f92795c17300fce9c0ee4e2b",
+            "size": 2174,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-pg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg--Plan]": [
         {
-            "checksum": "747f7599200e86260d0c8ff9b2ead06d",
-            "size": 4118,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-pg--Plan_/plan.txt"
+            "checksum": "14df822299904b674b4bfae568eda16e",
+            "size": 3912,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-pg--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-struct_type--Debug]": [
         {
-            "checksum": "954bcba6d37b0005f57c0c0b1bbcc8d9",
-            "size": 4866,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-struct_type--Debug_/opt.yql_patched"
+            "checksum": "8f803cd1a3c15b61c53c12644687c41a",
+            "size": 4559,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-struct_type--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-struct_type--Plan]": [
         {
-            "checksum": "e315348f49a454626706371533572797",
-            "size": 8452,
-            "uri": "https://{canondata_backend}/1775059/8319243eaa5a66d81373b6b1e006032ac64053b8/resource.tar.gz#test.test_blocks-struct_type--Plan_/plan.txt"
+            "checksum": "0dc665eda2d78c8b6fa71575614d6530",
+            "size": 7834,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_blocks-struct_type--Plan_/plan.txt"
         }
     ],
     "test.test[case-case_then_else-default.txt-Debug]": [
         {
-            "checksum": "3a7296b84e359596dbb10e9a84454532",
-            "size": 2078,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_case-case_then_else-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9bb095980e6f41eed34599f0fe074ae0",
+            "size": 2012,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_case-case_then_else-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[case-case_then_else-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_case-case_then_else-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_case-case_then_else-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[coalesce-coalesce_few_real-default.txt-Debug]": [
         {
-            "checksum": "ba75985223e6d18d2a578ada695904cc",
-            "size": 2893,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_coalesce-coalesce_few_real-default.txt-Debug_/opt.yql_patched"
+            "checksum": "da444b0957a19682ee82bb29b229f4f5",
+            "size": 2619,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_coalesce-coalesce_few_real-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[coalesce-coalesce_few_real-default.txt-Plan]": [
         {
-            "checksum": "d5391ec6249c774e7d060cc96a2207e1",
-            "size": 4002,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_coalesce-coalesce_few_real-default.txt-Plan_/plan.txt"
+            "checksum": "50f47bc73b32e5132fce6e25f7a3685f",
+            "size": 3796,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_coalesce-coalesce_few_real-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-winfunc-default.txt-Debug]": [
         {
-            "checksum": "6b4566594674675c6d225ddde782d60b",
-            "size": 4594,
-            "uri": "https://{canondata_backend}/1880306/5a95521c84a4cb8286aaf87c7cc708a550521ebf/resource.tar.gz#test.test_column_order-winfunc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "72326d5c42ae4386e67c4a03e9902790",
+            "size": 4426,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_column_order-winfunc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-winfunc-default.txt-Plan]": [
         {
-            "checksum": "f87059d0f1e4cc5e71b5f56a733d6c0c",
-            "size": 6509,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_column_order-winfunc-default.txt-Plan_/plan.txt"
+            "checksum": "2aa050ed209ac58061e60d36ecefeba7",
+            "size": 6303,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_column_order-winfunc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[csee-closure_l2-default.txt-Debug]": [
@@ -939,44 +939,44 @@
     ],
     "test.test[datetime-date_tz_table_sort_asc--Debug]": [
         {
-            "checksum": "fd9d61251ad1bda343701794e5477bab",
-            "size": 3391,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Debug_/opt.yql_patched"
+            "checksum": "1ad4a9199631b7a583222178c0ee8973",
+            "size": 3271,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[datetime-date_tz_table_sort_asc--Plan]": [
         {
-            "checksum": "2bdfa16386e34667dc34780d2cffa028",
-            "size": 9077,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Plan_/plan.txt"
+            "checksum": "1e7fd67d32a3bd1c21a4b14d4c12dd3f",
+            "size": 8665,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_datetime-date_tz_table_sort_asc--Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_count_and_full_count-default.txt-Debug]": [
         {
-            "checksum": "072b7c005881dad277f22f47b24651ef",
-            "size": 7070,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_distinct-distinct_count_and_full_count-default.txt-Debug_/opt.yql_patched"
+            "checksum": "20472e5080758a0dadeed32b04a139d8",
+            "size": 6678,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_distinct-distinct_count_and_full_count-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_count_and_full_count-default.txt-Plan]": [
         {
-            "checksum": "63538acc29487601705223e0ed675331",
-            "size": 11188,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_distinct-distinct_count_and_full_count-default.txt-Plan_/plan.txt"
+            "checksum": "46697bb6cae1ff80332cf521d473b8bc",
+            "size": 10570,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_distinct-distinct_count_and_full_count-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[epochs-use_sorted_by_complex_type--Debug]": [
         {
-            "checksum": "c95fd72969011ab90715004ab8543a66",
-            "size": 6021,
-            "uri": "https://{canondata_backend}/1600758/a15f9cf5339b0e207418f7b4835a133a635b8325/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Debug_/opt.yql_patched"
+            "checksum": "04d125abcc8088f727e25e0189237e82",
+            "size": 5692,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Debug_/opt.yql_patched"
         }
     ],
     "test.test[epochs-use_sorted_by_complex_type--Plan]": [
         {
-            "checksum": "85235a79d9d132ef74ba223b08866c01",
-            "size": 11095,
-            "uri": "https://{canondata_backend}/1899731/f0dfb945aff4e1cc5b65f5d742bdd47d25cd9237/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Plan_/plan.txt"
+            "checksum": "385578d54ffbe10c2386e8225bc408a2",
+            "size": 10477,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_epochs-use_sorted_by_complex_type--Plan_/plan.txt"
         }
     ],
     "test.test[expr-as_dict_dict_key-default.txt-Debug]": [
@@ -1219,30 +1219,30 @@
     ],
     "test.test[hor_join-filters--Debug]": [
         {
-            "checksum": "c1edbbe00b6ff5ed065bb94c25765a55",
-            "size": 2792,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_hor_join-filters--Debug_/opt.yql_patched"
+            "checksum": "89bb15cad1bac1f0afe3cb60fc5ff1ff",
+            "size": 2692,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_hor_join-filters--Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-filters--Plan]": [
         {
-            "checksum": "3314b17f44a997e11a01158be2969d15",
-            "size": 7180,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_hor_join-filters--Plan_/plan.txt"
+            "checksum": "63fa95d2bf707e873d5c766f500742fe",
+            "size": 6974,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_hor_join-filters--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-out_sampling--Debug]": [
         {
-            "checksum": "6a44b6bbc23949fe5bd2867528743ab6",
-            "size": 9152,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_hor_join-out_sampling--Debug_/opt.yql_patched"
+            "checksum": "e8affbf36cd278c1b054775b897887a0",
+            "size": 8803,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_hor_join-out_sampling--Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-out_sampling--Plan]": [
         {
-            "checksum": "c211c7876e1058f34b4339b561ff5d58",
-            "size": 16983,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_hor_join-out_sampling--Plan_/plan.txt"
+            "checksum": "db1a5b4b4aef1b57b5e6ffc2c7e7c263",
+            "size": 16159,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_hor_join-out_sampling--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_ansi_dict-default.txt-Debug]": [
@@ -1261,16 +1261,16 @@
     ],
     "test.test[in-in_immediate_subquery-default.txt-Debug]": [
         {
-            "checksum": "38e7d6432d2888746e0ca200a1cf96de",
-            "size": 6475,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_in-in_immediate_subquery-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a8344667e07ce2e5b6b6ee85b0195ec0",
+            "size": 6249,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_in-in_immediate_subquery-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_immediate_subquery-default.txt-Plan]": [
         {
-            "checksum": "726ee59190ae98b87edf1c5206bc95f6",
-            "size": 12534,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_in-in_immediate_subquery-default.txt-Plan_/plan.txt"
+            "checksum": "ad34039926e09d5bfe233dd60c3e9540",
+            "size": 11916,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_in-in_immediate_subquery-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_noansi_list_dict-default.txt-Debug]": [
@@ -1303,30 +1303,30 @@
     ],
     "test.test[in-in_sorted_by_tuple--Debug]": [
         {
-            "checksum": "c48e68dd8b3ea04a57d9eff75bb2620c",
-            "size": 10261,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_in-in_sorted_by_tuple--Debug_/opt.yql_patched"
+            "checksum": "1eda37e178aad53db35715c6b992ca78",
+            "size": 10041,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_in-in_sorted_by_tuple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_sorted_by_tuple--Plan]": [
         {
-            "checksum": "72f8416190088cbeba0a92205c7cef5e",
-            "size": 11303,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_in-in_sorted_by_tuple--Plan_/plan.txt"
+            "checksum": "61c18a7edff188560c16eb54e55f74ed",
+            "size": 10685,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_in-in_sorted_by_tuple--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_types_cast-default.txt-Debug]": [
         {
-            "checksum": "8f481c7c664ac3c76171779a9a32ccd0",
-            "size": 2093,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_in-in_types_cast-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8b9e7952dc6bcb42bd7e526afdc87031",
+            "size": 1970,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_in-in_types_cast-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_types_cast-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_in-in_types_cast-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_in-in_types_cast-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_with_literal_list_of_structs-default.txt-Debug]": [
@@ -1359,58 +1359,58 @@
     ],
     "test.test[insert-append_sorted-to_sorted-Debug]": [
         {
-            "checksum": "c792adfeec49f3fef30691f961a17a3f",
-            "size": 5825,
-            "uri": "https://{canondata_backend}/1773845/0521791101aaba753d6a90b7233dad60ef28eed1/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Debug_/opt.yql_patched"
+            "checksum": "49dd720165ef70c2300c513725ccddda",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted-to_sorted-Plan]": [
         {
-            "checksum": "86ce876ed3f180a2a6d1c5d08930621f",
-            "size": 17380,
-            "uri": "https://{canondata_backend}/1773845/0521791101aaba753d6a90b7233dad60ef28eed1/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Plan_/plan.txt"
+            "checksum": "4b8c78e542bcd8a2703e4646a4774608",
+            "size": 16556,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-append_sorted-to_sorted-Plan_/plan.txt"
         }
     ],
     "test.test[insert-insert_from_other--Debug]": [
         {
-            "checksum": "82c7f34ab239f1c0b5ae2d57b8cf3e51",
-            "size": 2160,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_insert-insert_from_other--Debug_/opt.yql_patched"
+            "checksum": "aa48ce9de2050152fbe84d53a4d85499",
+            "size": 2059,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-insert_from_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-insert_from_other--Plan]": [
         {
-            "checksum": "d05d06be9f327fe64fd879ccb79843eb",
-            "size": 4783,
-            "uri": "https://{canondata_backend}/1936842/11d23d4a39031af80d6dc470ce99f9427771e7d4/resource.tar.gz#test.test_insert-insert_from_other--Plan_/plan.txt"
+            "checksum": "7354ecdd9461c296fb6d771350203cb6",
+            "size": 4577,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-insert_from_other--Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_inferred--Debug]": [
         {
-            "checksum": "d1381b34869e5f18a52564054ba91411",
-            "size": 2841,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_insert-replace_inferred--Debug_/opt.yql_patched"
+            "checksum": "82beb0eb17407da641be91345badc278",
+            "size": 2652,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-replace_inferred--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_inferred--Plan]": [
         {
-            "checksum": "fd76338a47a06eda45544a2a9dc7a642",
-            "size": 4919,
-            "uri": "https://{canondata_backend}/1936842/11d23d4a39031af80d6dc470ce99f9427771e7d4/resource.tar.gz#test.test_insert-replace_inferred--Plan_/plan.txt"
+            "checksum": "ceccf2acfc9240b3cbe02176e41fc221",
+            "size": 4713,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-replace_inferred--Plan_/plan.txt"
         }
     ],
     "test.test[insert-trivial_literals-default.txt-Debug]": [
         {
-            "checksum": "e99432893dc96ade8f4d78788df85784",
-            "size": 1444,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_insert-trivial_literals-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7e821e449e15d4a84cf0b6869783a6ef",
+            "size": 1297,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-trivial_literals-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-trivial_literals-default.txt-Plan]": [
         {
-            "checksum": "f196d46e9ba50bb2c5ce48cff5da851c",
-            "size": 4192,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_insert-trivial_literals-default.txt-Plan_/plan.txt"
+            "checksum": "af9eca9e80748994375492c0a5c9a705",
+            "size": 3986,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_insert-trivial_literals-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-inmem_by_uncomparable_tuples--Debug]": [
@@ -1457,156 +1457,156 @@
     ],
     "test.test[join-join_cbo_3_tables--Debug]": [
         {
-            "checksum": "080410cff9e3de0045c18a4c6777ec16",
-            "size": 9118,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-join_cbo_3_tables--Debug_/opt.yql_patched"
+            "checksum": "2eae7f76c4472e2fb591ee0a7902ecff",
+            "size": 8953,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-join_cbo_3_tables--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_cbo_3_tables--Plan]": [
         {
-            "checksum": "b4e47cbb9ed490e7ce5eaf23fd834eb5",
-            "size": 15079,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-join_cbo_3_tables--Plan_/plan.txt"
+            "checksum": "5c912f3ac18b1fba952a3637c96103e7",
+            "size": 14873,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-join_cbo_3_tables--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_comp_common_table--Debug]": [
         {
-            "checksum": "13b94e78de17f9792ea46d8ac8c06727",
-            "size": 19337,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-join_comp_common_table--Debug_/opt.yql_patched"
+            "checksum": "54d912c8bc170ccaeafde1cbc4a07cb5",
+            "size": 19112,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-join_comp_common_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_comp_common_table--Plan]": [
         {
-            "checksum": "e2633f3d8109090baa044f1a7fb7a247",
-            "size": 46641,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-join_comp_common_table--Plan_/plan.txt"
+            "checksum": "72938f2022c69e7cc32bbb02d48548f2",
+            "size": 46023,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-join_comp_common_table--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_only_semi_and_other--Debug]": [
         {
-            "checksum": "6f6e54803b8cd0e6bfdd3997a8ea36f4",
-            "size": 9985,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-left_only_semi_and_other--Debug_/opt.yql_patched"
+            "checksum": "8c44856c6f3a441aa32e6e354c2de226",
+            "size": 9847,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-left_only_semi_and_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_only_semi_and_other--Plan]": [
         {
-            "checksum": "cb4e34f1cc3d5ff3f1090e25d9c84c5a",
-            "size": 14872,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-left_only_semi_and_other--Plan_/plan.txt"
+            "checksum": "5b2c38fb3223159f2bd837aa942f7a21",
+            "size": 14666,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-left_only_semi_and_other--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_bug8533--Debug]": [
         {
-            "checksum": "b0f8faeb8c000834023fb55fb384e721",
-            "size": 3508,
-            "uri": "https://{canondata_backend}/1946324/2d0e82b79c2a0410ba7aa17082291afdb358a973/resource.tar.gz#test.test_join-lookupjoin_bug8533--Debug_/opt.yql_patched"
+            "checksum": "d818d5223c8ab03b60a17d9428a73b39",
+            "size": 3324,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-lookupjoin_bug8533--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_bug8533--Plan]": [
         {
-            "checksum": "f47bf8454a77824c0cdbb58413470d0d",
-            "size": 4898,
-            "uri": "https://{canondata_backend}/1817427/1a35e0d0ff8325d8afe371360e9bd6591698bdb9/resource.tar.gz#test.test_join-lookupjoin_bug8533--Plan_/plan.txt"
+            "checksum": "3c5c3becfec3a7893fadeb2c0bbb6b0d",
+            "size": 4692,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-lookupjoin_bug8533--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_semi_2o--Debug]": [
         {
-            "checksum": "80ddae8d7edd84e18ba91f445086018f",
-            "size": 4182,
-            "uri": "https://{canondata_backend}/1936997/70cfe451d58d423a2f6c2d5b61cb4b957ad492bc/resource.tar.gz#test.test_join-lookupjoin_semi_2o--Debug_/opt.yql_patched"
+            "checksum": "c0193bc3d4331988a82dfdbb6af5f786",
+            "size": 3940,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-lookupjoin_semi_2o--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_semi_2o--Plan]": [
         {
-            "checksum": "e3b00a3cfe3221ef73a9585ce4a9f1a7",
-            "size": 7292,
-            "uri": "https://{canondata_backend}/1946324/ea4b7cbd354feb40188d7ffd92eebdc7d6656eeb/resource.tar.gz#test.test_join-lookupjoin_semi_2o--Plan_/plan.txt"
+            "checksum": "e472c22ce69ff5ba18988ce6107730bf",
+            "size": 6880,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-lookupjoin_semi_2o--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_early_rewrite_star--Debug]": [
         {
-            "checksum": "7b0d5c7e44d4c6c5f79d998f3e1a8e9c",
-            "size": 4688,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-mapjoin_early_rewrite_star--Debug_/opt.yql_patched"
+            "checksum": "0c8d876696778022e52cb33af1fcc299",
+            "size": 4396,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-mapjoin_early_rewrite_star--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_early_rewrite_star--Plan]": [
         {
-            "checksum": "b156d6d8d65204e62aef4edb72759321",
-            "size": 8005,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-mapjoin_early_rewrite_star--Plan_/plan.txt"
+            "checksum": "6fba1d142070d852581bf38c29c0a167",
+            "size": 7593,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-mapjoin_early_rewrite_star--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_inner_both_sides--Debug]": [
         {
-            "checksum": "1d1e1150c8a70042adc7028094eb15b1",
-            "size": 5557,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-premap_common_inner_both_sides--Debug_/opt.yql_patched"
+            "checksum": "0c532cf23d5659d182019e56cbe92abb",
+            "size": 5381,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_common_inner_both_sides--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_inner_both_sides--Plan]": [
         {
-            "checksum": "1d42f0e4d2225f6a35e7a448402c4572",
-            "size": 8071,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-premap_common_inner_both_sides--Plan_/plan.txt"
+            "checksum": "283eacb9254f1e853378dc1d64a91bd8",
+            "size": 7865,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_common_inner_both_sides--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_multiparents_no_premap--Debug]": [
         {
-            "checksum": "01a98d2c98a9f97c9cbae835c57e6af5",
-            "size": 6935,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-premap_common_multiparents_no_premap--Debug_/opt.yql_patched"
+            "checksum": "6938feffde12fd89faf9d2d2dd99995b",
+            "size": 6545,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_common_multiparents_no_premap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_multiparents_no_premap--Plan]": [
         {
-            "checksum": "792fc9cfd2e8c75e1f68330c5cd92a95",
-            "size": 11610,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-premap_common_multiparents_no_premap--Plan_/plan.txt"
+            "checksum": "b3e33cb840539b2b115a40703908ec4f",
+            "size": 10992,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_common_multiparents_no_premap--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_right_tablecontent--Debug]": [
         {
-            "checksum": "cd6899fe7aed7eb11bfd63c15cd3d0ae",
-            "size": 5486,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-premap_common_right_tablecontent--Debug_/opt.yql_patched"
+            "checksum": "e9b17528768973590f480d1184d06709",
+            "size": 5336,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_common_right_tablecontent--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_right_tablecontent--Plan]": [
         {
-            "checksum": "5ed16c7c36fc775edf84f98ede79ad2c",
-            "size": 7469,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-premap_common_right_tablecontent--Plan_/plan.txt"
+            "checksum": "669e00ec7831721ba28d7a378aa68961",
+            "size": 7263,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_common_right_tablecontent--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_merge_inner--Debug]": [
         {
-            "checksum": "596ff6405969816fba2fbe30f577d12b",
-            "size": 4447,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-premap_merge_inner--Debug_/opt.yql_patched"
+            "checksum": "5ab56d0c3b4645bd294a16cb391abc27",
+            "size": 4326,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_merge_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_merge_inner--Plan]": [
         {
-            "checksum": "47bb6d1fd3f37fc2cc49c9774ea6b9c4",
-            "size": 7997,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-premap_merge_inner--Plan_/plan.txt"
+            "checksum": "159d9ad8760ea51e41f42c99b912f494",
+            "size": 7791,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-premap_merge_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-right_trivial--Debug]": [
         {
-            "checksum": "666325746b9ff7e34ff198b4589bcd4c",
-            "size": 4835,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_join-right_trivial--Debug_/opt.yql_patched"
+            "checksum": "1e40bd1d17bf770d70e57081de8fe125",
+            "size": 4723,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-right_trivial--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-right_trivial--Plan]": [
         {
-            "checksum": "13800fd8890f811509a6a562241b5f67",
-            "size": 8040,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_join-right_trivial--Plan_/plan.txt"
+            "checksum": "a461d574c9327b58de46f3963746637c",
+            "size": 7834,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_join-right_trivial--Plan_/plan.txt"
         }
     ],
     "test.test[json-json_exists/common_syntax-default.txt-Debug]": [
@@ -1653,44 +1653,44 @@
     ],
     "test.test[json-jsondocument/insert--Debug]": [
         {
-            "checksum": "41d5984bd2a0172c276f302ca03d1210",
-            "size": 1733,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_json-jsondocument_insert--Debug_/opt.yql_patched"
+            "checksum": "5cc0675967bd64f58081cdf0de5d95f7",
+            "size": 1634,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_json-jsondocument_insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[json-jsondocument/insert--Plan]": [
         {
-            "checksum": "10b1c3d1399d823fce19de33462f94f5",
-            "size": 4285,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_json-jsondocument_insert--Plan_/plan.txt"
+            "checksum": "36e6b715eb44dbaf8b31ed4b34be2f6a",
+            "size": 4079,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_json-jsondocument_insert--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-complex-default.txt-Debug]": [
         {
-            "checksum": "210f96d5694ccaf85aea6a749d7e11f6",
-            "size": 3037,
-            "uri": "https://{canondata_backend}/1936273/767c1a5676b10be17339412ae8874ce4ab61dd21/resource.tar.gz#test.test_key_filter-complex-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1e6a0d4167b35762e0581d2cf8e69aeb",
+            "size": 2914,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_key_filter-complex-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-complex-default.txt-Plan]": [
         {
-            "checksum": "5f87fb14946b9b4ac407b20b08e82490",
-            "size": 3604,
-            "uri": "https://{canondata_backend}/1937367/bb50542bb2f38841a604cf6a95ab5946af46a767/resource.tar.gz#test.test_key_filter-complex-default.txt-Plan_/plan.txt"
+            "checksum": "97c7f373a9ae004b0dd3ae378ecfe558",
+            "size": 3398,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_key_filter-complex-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-dependent_value-default.txt-Debug]": [
         {
-            "checksum": "adea05070dce0c9e460d136bc2f50615",
-            "size": 2161,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_key_filter-dependent_value-default.txt-Debug_/opt.yql_patched"
+            "checksum": "79377e6e3ed1827711d0fc390a4fb2e2",
+            "size": 2038,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_key_filter-dependent_value-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-dependent_value-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_key_filter-dependent_value-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_key_filter-dependent_value-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[library-forward_import--Debug]": [
@@ -1723,16 +1723,16 @@
     ],
     "test.test[limit-sort_calc_limit--Debug]": [
         {
-            "checksum": "abe0d3a2aa60fd4b3859566ff27cad5e",
-            "size": 3006,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_limit-sort_calc_limit--Debug_/opt.yql_patched"
+            "checksum": "8b1c4e7625300c8e86ad203ae5d8173f",
+            "size": 2853,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_limit-sort_calc_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-sort_calc_limit--Plan]": [
         {
-            "checksum": "23cff0f0ece4b3f8d53c5e61a981d416",
-            "size": 6114,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_limit-sort_calc_limit--Plan_/plan.txt"
+            "checksum": "5c632a0356b2905cbdce472e0c9654aa",
+            "size": 5908,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_limit-sort_calc_limit--Plan_/plan.txt"
         }
     ],
     "test.test[match_recognize-test_type-default.txt-Debug]": [
@@ -1765,44 +1765,44 @@
     ],
     "test.test[optimizers-combinebykey_fields_subset_range--Debug]": [
         {
-            "checksum": "dd0ead56a308f766f0df5754cc053c06",
-            "size": 4025,
-            "uri": "https://{canondata_backend}/1880306/5a95521c84a4cb8286aaf87c7cc708a550521ebf/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset_range--Debug_/opt.yql_patched"
+            "checksum": "21c652c9848d70e5bfc29347947eb950",
+            "size": 3939,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset_range--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-combinebykey_fields_subset_range--Plan]": [
         {
-            "checksum": "cf42ae23958ffa124f6cc68d6d802b86",
-            "size": 6718,
-            "uri": "https://{canondata_backend}/1937001/77f00e9133036a8e1753bdab20eb00e2c561af33/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset_range--Plan_/plan.txt"
+            "checksum": "b072bff659236d33e004306c69823da2",
+            "size": 6306,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset_range--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-length_over_merge_fs_multiusage--Debug]": [
         {
-            "checksum": "3c9caacc231635782de8fb2c9443d9ec",
-            "size": 2250,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_optimizers-length_over_merge_fs_multiusage--Debug_/opt.yql_patched"
+            "checksum": "7f8fcf1b9b52727683a96aadd31fc609",
+            "size": 2208,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-length_over_merge_fs_multiusage--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-length_over_merge_fs_multiusage--Plan]": [
         {
-            "checksum": "2308b05e900191a7a70238ec133cdd4b",
-            "size": 4679,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_optimizers-length_over_merge_fs_multiusage--Plan_/plan.txt"
+            "checksum": "b05d661dfe1a46379decd3fc48231524",
+            "size": 4473,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-length_over_merge_fs_multiusage--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-unused_columns_window_no_payloads--Debug]": [
         {
-            "checksum": "216004ec1007edd32709ad7b1e6aa9de",
-            "size": 1745,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_optimizers-unused_columns_window_no_payloads--Debug_/opt.yql_patched"
+            "checksum": "719bbd49bc0f6e0caa32d0d193d28837",
+            "size": 1685,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-unused_columns_window_no_payloads--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-unused_columns_window_no_payloads--Plan]": [
         {
-            "checksum": "9d12e0506eef7f4bb64b94597206736c",
-            "size": 3438,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_optimizers-unused_columns_window_no_payloads--Plan_/plan.txt"
+            "checksum": "8f2ae9504aba07995cb8a60e0d9e5a57",
+            "size": 3232,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-unused_columns_window_no_payloads--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-10042_disable_fuse_depends_on-default.txt-Debug]": [
@@ -1821,114 +1821,114 @@
     ],
     "test.test[optimizers-yql-10070_extract_members_over_calcoverwindow-default.txt-Debug]": [
         {
-            "checksum": "2b047a249084baee70777af8f4f6a8bb",
-            "size": 5285,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_optimizers-yql-10070_extract_members_over_calcoverwindow-default.txt-Debug_/opt.yql_patched"
+            "checksum": "620c90922a15c0b761196b42eb5fee71",
+            "size": 5011,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-10070_extract_members_over_calcoverwindow-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-10070_extract_members_over_calcoverwindow-default.txt-Plan]": [
         {
-            "checksum": "1bf32e22e7594f051d259bc08b7d2f3f",
-            "size": 8420,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_optimizers-yql-10070_extract_members_over_calcoverwindow-default.txt-Plan_/plan.txt"
+            "checksum": "b5b5f2e3cb746253e379f0b4ffc0cf30",
+            "size": 8008,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-10070_extract_members_over_calcoverwindow-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-2582_limit_for_join_input--Debug]": [
         {
-            "checksum": "90d6c53cbe9d95ea10c10b17a8894d21",
-            "size": 5474,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input--Debug_/opt.yql_patched"
+            "checksum": "62177406dd740d1f3a87a099c20a55cb",
+            "size": 5228,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-2582_limit_for_join_input--Plan]": [
         {
-            "checksum": "48d44ccbe939d81fcd4a8a736e760634",
-            "size": 9874,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input--Plan_/plan.txt"
+            "checksum": "934cad6293fd3faec89c52e0d5f7913c",
+            "size": 9462,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-6038_direct_row--Debug]": [
         {
-            "checksum": "df9b8e3d3cf4c2719d0a81af166a5106",
-            "size": 8914,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_optimizers-yql-6038_direct_row--Debug_/opt.yql_patched"
+            "checksum": "303f2ea92987e773641115563552a5f2",
+            "size": 8520,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-6038_direct_row--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-6038_direct_row--Plan]": [
         {
-            "checksum": "3b1895888f35a64da6aba39ded90a005",
-            "size": 13554,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_optimizers-yql-6038_direct_row--Plan_/plan.txt"
+            "checksum": "5e194409d7bfd33252f39f9f6d645480",
+            "size": 12730,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-6038_direct_row--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-9297_publish_ytcopy--Debug]": [
         {
-            "checksum": "4059df1d8a37974e0ab4efc9a841d299",
-            "size": 4089,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Debug_/opt.yql_patched"
+            "checksum": "da82b21c0bc0780dfc7d62e3a2f96d38",
+            "size": 3936,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-9297_publish_ytcopy--Plan]": [
         {
-            "checksum": "5dadca53ec4604862c7685e6a903c414",
-            "size": 11203,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Plan_/plan.txt"
+            "checksum": "12b229a3ddd8e9c386d1bb3bdb8a6348",
+            "size": 10997,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_optimizers-yql-9297_publish_ytcopy--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-extract_members_over_sort_desc--Debug]": [
         {
-            "checksum": "e8be69a1cb4df7541692d7a39e96de34",
-            "size": 4491,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Debug_/opt.yql_patched"
+            "checksum": "d2c6f94fbe51aa2018f9a4e447900a47",
+            "size": 4215,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-extract_members_over_sort_desc--Plan]": [
         {
-            "checksum": "9eb68f96b14b1e7968ab40d170f0e403",
-            "size": 9814,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Plan_/plan.txt"
+            "checksum": "7eac4d29f6d76f1ff5062dfa41d9340c",
+            "size": 9402,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_order_by-extract_members_over_sort_desc--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_expr--Debug]": [
         {
-            "checksum": "8650b7100ab1f367caf7abf8b289956a",
-            "size": 2916,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_order_by-order_by_expr--Debug_/opt.yql_patched"
+            "checksum": "85f29b18e308d483bde708ef3e362a04",
+            "size": 2763,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_order_by-order_by_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_expr--Plan]": [
         {
-            "checksum": "62fb5350846de9426f98cb4db01cd38b",
-            "size": 5413,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_order_by-order_by_expr--Plan_/plan.txt"
+            "checksum": "ef8508bc656de36ceb6d5d2ffb0afc38",
+            "size": 5207,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_order_by-order_by_expr--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_missing_project_column-default.txt-Debug]": [
         {
-            "checksum": "585d48f50f6deaa0e3c881b0d5cf86c8",
-            "size": 10348,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_order_by-order_by_missing_project_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cd55cf2f76e1c8b791760c713d62844d",
+            "size": 9565,
+            "uri": "https://{canondata_backend}/1600758/1260842a548b9eeb101aabd689cd26a911953004/resource.tar.gz#test.test_order_by-order_by_missing_project_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_missing_project_column-default.txt-Plan]": [
         {
-            "checksum": "ac1dff5b06a965318c8a07621e01a6e7",
-            "size": 27608,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_order_by-order_by_missing_project_column-default.txt-Plan_/plan.txt"
+            "checksum": "d525ac8fb71eceae37195d394af67006",
+            "size": 25548,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_order_by-order_by_missing_project_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_udf_duo--Debug]": [
         {
-            "checksum": "8441032fbab174bc8bf28cdd07b0c355",
-            "size": 3270,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_order_by-order_by_udf_duo--Debug_/opt.yql_patched"
+            "checksum": "7610770d0fcf66c2053af4e66f22e8e5",
+            "size": 3087,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_order_by-order_by_udf_duo--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_udf_duo--Plan]": [
         {
-            "checksum": "6a1a49241df06b517ddd23745b216b26",
-            "size": 5354,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_order_by-order_by_udf_duo--Plan_/plan.txt"
+            "checksum": "c047b8570ecc5072cba4dbbe57eb4400",
+            "size": 5148,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_order_by-order_by_udf_duo--Plan_/plan.txt"
         }
     ],
     "test.test[pg-dates_to_pg-default.txt-Debug]": [
@@ -1961,16 +1961,16 @@
     ],
     "test.test[pg-drop_table--Debug]": [
         {
-            "checksum": "4cf6eabbaf166c1ee01e420a13bfb759",
-            "size": 2712,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_pg-drop_table--Debug_/opt.yql_patched"
+            "checksum": "a9d09ae3225e338d0265b081c7a4bfe9",
+            "size": 2580,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_pg-drop_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-drop_table--Plan]": [
         {
-            "checksum": "bebf7ece91422127f53270e38b03a42d",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_pg-drop_table--Plan_/plan.txt"
+            "checksum": "bdb6de66e7228d0ab5862992111e0af8",
+            "size": 8142,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_pg-drop_table--Plan_/plan.txt"
         }
     ],
     "test.test[pg-join_using4-default.txt-Debug]": [
@@ -2465,30 +2465,30 @@
     ],
     "test.test[pg-tpch-q07-default.txt-Debug]": [
         {
-            "checksum": "f255a4ebb3554d56413f8cc8c27b8817",
-            "size": 13500,
-            "uri": "https://{canondata_backend}/1936273/c028e933e71cf21a9a9c47b54a1423aa1ec616fc/resource.tar.gz#test.test_pg-tpch-q07-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1278a9ee13ef1720c2e755ee516ae7fa",
+            "size": 13154,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_pg-tpch-q07-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q07-default.txt-Plan]": [
         {
-            "checksum": "1a314212de7439b5e9c557176a0a343a",
-            "size": 14534,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_pg-tpch-q07-default.txt-Plan_/plan.txt"
+            "checksum": "7b15c0c0fb603d801257e390ce0d3837",
+            "size": 14122,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_pg-tpch-q07-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q10-default.txt-Debug]": [
         {
-            "checksum": "073de0d1b11275c9d6e02bbe1af61e3b",
-            "size": 12230,
-            "uri": "https://{canondata_backend}/1936997/309411518e7a4273fae079dcfe6302a5ff52dd6c/resource.tar.gz#test.test_pg-tpch-q10-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4eacd9806b8f43d3f7da0c3769efa9bd",
+            "size": 12017,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_pg-tpch-q10-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q10-default.txt-Plan]": [
         {
-            "checksum": "e8cc493ee07d76fbbecef45b1ccb7172",
-            "size": 14010,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_pg-tpch-q10-default.txt-Plan_/plan.txt"
+            "checksum": "56a5772f464ceb6a621b82581826898c",
+            "size": 13804,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_pg-tpch-q10-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-type_aliases-default.txt-Debug]": [
@@ -2605,170 +2605,170 @@
     ],
     "test.test[produce-process_lambda_opt_args-default.txt-Debug]": [
         {
-            "checksum": "e2259aa77ae943bcfe8fc9caedb98d00",
-            "size": 2669,
-            "uri": "https://{canondata_backend}/1814674/0e62762049861bcf9f9d67d9b14ebdbaab665fa3/resource.tar.gz#test.test_produce-process_lambda_opt_args-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2eb2936d3cfa2b930043416307e85808",
+            "size": 2546,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_produce-process_lambda_opt_args-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_lambda_opt_args-default.txt-Plan]": [
         {
-            "checksum": "a501aca13d0cdb216b2b1e3875ab929e",
-            "size": 8249,
-            "uri": "https://{canondata_backend}/1814674/0e62762049861bcf9f9d67d9b14ebdbaab665fa3/resource.tar.gz#test.test_produce-process_lambda_opt_args-default.txt-Plan_/plan.txt"
+            "checksum": "4e45a924292e4ce19ac7ba2cd8e696fb",
+            "size": 8043,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_produce-process_lambda_opt_args-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_with_udf_validate-default.txt-Debug]": [
         {
-            "checksum": "d38c739bd48daee1bc9164fd494c78df",
-            "size": 2525,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_produce-process_with_udf_validate-default.txt-Debug_/opt.yql_patched"
+            "checksum": "651883404e76f4500371765bd16439b9",
+            "size": 2396,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_produce-process_with_udf_validate-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_with_udf_validate-default.txt-Plan]": [
         {
-            "checksum": "e97777422acf4a769794fb2f03b24c7f",
-            "size": 4106,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_produce-process_with_udf_validate-default.txt-Plan_/plan.txt"
+            "checksum": "345d3307a6ab70d5cd71c17d87940e76",
+            "size": 3900,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_produce-process_with_udf_validate-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-bind_default-default.txt-Debug]": [
         {
-            "checksum": "340d5c43440eb7af53cbf5ace34a5764",
-            "size": 2149,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_sampling-bind_default-default.txt-Debug_/opt.yql_patched"
+            "checksum": "396f0036a602324fc7184076f26f4abe",
+            "size": 2026,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_sampling-bind_default-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_default-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_sampling-bind_default-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_sampling-bind_default-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-bind_multiple_sample-default.txt-Debug]": [
         {
-            "checksum": "045b412bf8e610a5592bbb658decd67f",
-            "size": 3052,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f66a38e93b4dc835dcd9788516c7b3b1",
+            "size": 2927,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_multiple_sample-default.txt-Plan]": [
         {
-            "checksum": "ff3c47c4afb61385ab6b807412403364",
-            "size": 7055,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Plan_/plan.txt"
+            "checksum": "1f477365deb35a7c3fb0c7cf9a1be345",
+            "size": 6849,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_sampling-bind_multiple_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-read_schema-Debug]": [
         {
-            "checksum": "111ccb12b8b27db0cfd9ef6af213df33",
-            "size": 2121,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_schema-copy-read_schema-Debug_/opt.yql_patched"
+            "checksum": "544149162d1d154c8fab6ae01a24a093",
+            "size": 1955,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-copy-read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-copy-read_schema-Plan]": [
         {
-            "checksum": "7500992aa021c7bca6f99ec65aaa1114",
-            "size": 4378,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_schema-copy-read_schema-Plan_/plan.txt"
+            "checksum": "1cc21051f46906d9746b86f8cbc65b12",
+            "size": 4172,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-copy-read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert_sorted-row_spec-Debug]": [
         {
-            "checksum": "e86f130206e983c4589a2290fa2d6c71",
-            "size": 3495,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Debug_/opt.yql_patched"
+            "checksum": "c67265ca0eb4943f387283ba4bbff3c6",
+            "size": 3329,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert_sorted-row_spec-Plan]": [
         {
-            "checksum": "36a657eee9ded15c5098aa8917a739d1",
-            "size": 6691,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Plan_/plan.txt"
+            "checksum": "d0450f877aa43e90188f113b7b2b2aff",
+            "size": 6485,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-insert_sorted-row_spec-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_field-row_spec-Debug]": [
         {
-            "checksum": "c9b3660b4575398eb487239bcdd0eb60",
-            "size": 1914,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_schema-select_field-row_spec-Debug_/opt.yql_patched"
+            "checksum": "951ef7872ba4088306769a53d7322c65",
+            "size": 1854,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-select_field-row_spec-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_field-row_spec-Plan]": [
         {
-            "checksum": "62c7f54f40958665bdef492623ca2302",
-            "size": 3438,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_schema-select_field-row_spec-Plan_/plan.txt"
+            "checksum": "cbc56016bd36c156942af6e90ab684a2",
+            "size": 3232,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-select_field-row_spec-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_field-schema-Debug]": [
         {
-            "checksum": "c9b3660b4575398eb487239bcdd0eb60",
-            "size": 1914,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_schema-select_field-schema-Debug_/opt.yql_patched"
+            "checksum": "951ef7872ba4088306769a53d7322c65",
+            "size": 1854,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-select_field-schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_field-schema-Plan]": [
         {
-            "checksum": "62c7f54f40958665bdef492623ca2302",
-            "size": 3438,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_schema-select_field-schema-Plan_/plan.txt"
+            "checksum": "cbc56016bd36c156942af6e90ab684a2",
+            "size": 3232,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_schema-select_field-schema-Plan_/plan.txt"
         }
     ],
     "test.test[select-column_labels-default.txt-Debug]": [
         {
-            "checksum": "5d61094415d5c939316d9a8a87fb122a",
-            "size": 2093,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_select-column_labels-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1e82f21dbad98237e284dc1d09f9b567",
+            "size": 1991,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-column_labels-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-column_labels-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_select-column_labels-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-column_labels-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-from_in_front_sub-default.txt-Debug]": [
         {
-            "checksum": "cd22af50bbcdf82cd3a3baa401de1261",
-            "size": 6316,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_select-from_in_front_sub-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e2cc2e9a9ccd73205c52f4d48495f32c",
+            "size": 5931,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-from_in_front_sub-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-from_in_front_sub-default.txt-Plan]": [
         {
-            "checksum": "9fcc1ab58bf8a90cb2e5cd1040498881",
-            "size": 8586,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_select-from_in_front_sub-default.txt-Plan_/plan.txt"
+            "checksum": "78e9f57f7b3718332213c08887f94713",
+            "size": 7968,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-from_in_front_sub-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-hits_count--Debug]": [
         {
-            "checksum": "58f80337a8ca5d0bf9412224281ea7fd",
-            "size": 5779,
-            "uri": "https://{canondata_backend}/212715/281225c593b89b14398e3d64718321920556da62/resource.tar.gz#test.test_select-hits_count--Debug_/opt.yql_patched"
+            "checksum": "d15288193fe4d3d674a3b4ea71fe64f9",
+            "size": 5539,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-hits_count--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-hits_count--Plan]": [
         {
-            "checksum": "ed85fc7f11d8e1a15165688cd73fb408",
-            "size": 7847,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_select-hits_count--Plan_/plan.txt"
+            "checksum": "031c7a14506a7c435e2d113bdc923dec",
+            "size": 7435,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-hits_count--Plan_/plan.txt"
         }
     ],
     "test.test[select-literal_bool-default.txt-Debug]": [
         {
-            "checksum": "a9cb46128da759c656d8296fbc34d7b4",
-            "size": 1943,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_select-literal_bool-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8271874b0189fce25aac1dc5851c0908",
+            "size": 1820,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-literal_bool-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-literal_bool-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_select-literal_bool-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-literal_bool-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-result_label-default.txt-Debug]": [
@@ -2787,16 +2787,16 @@
     ],
     "test.test[select-trivial_group_by-default.txt-Debug]": [
         {
-            "checksum": "63bafb8d1477591b2aaceaf9b185103a",
-            "size": 5044,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_select-trivial_group_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2568ccb47f00a88028df47488e3e7a02",
+            "size": 4670,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-trivial_group_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-trivial_group_by-default.txt-Plan]": [
         {
-            "checksum": "28c2ab3b456e34dadfd529005a3e689e",
-            "size": 8484,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_select-trivial_group_by-default.txt-Plan_/plan.txt"
+            "checksum": "3ceffa5883fca835378d5359d3859d5f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_select-trivial_group_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[table_range-each_with_non_existing--Debug]": [
@@ -2815,16 +2815,16 @@
     ],
     "test.test[table_range-range_with_view--Debug]": [
         {
-            "checksum": "14a4a58f5818fbe28d5dca2c3c505be6",
-            "size": 5292,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_table_range-range_with_view--Debug_/opt.yql_patched"
+            "checksum": "0447461dd33669ca31b1a8c3619d66ce",
+            "size": 5006,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_table_range-range_with_view--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-range_with_view--Plan]": [
         {
-            "checksum": "d19f9fa41a19417ba1a39e8397fbea43",
-            "size": 9044,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_table_range-range_with_view--Plan_/plan.txt"
+            "checksum": "c1c96a9d1e51b731413dce89f99abf25",
+            "size": 8632,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_table_range-range_with_view--Plan_/plan.txt"
         }
     ],
     "test.test[table_range-table_funcs_expr--Debug]": [
@@ -2843,86 +2843,86 @@
     ],
     "test.test[tpch-q1-default.txt-Debug]": [
         {
-            "checksum": "74d287e089cb54372e8d0d1a69fa1d32",
-            "size": 11930,
-            "uri": "https://{canondata_backend}/212715/281225c593b89b14398e3d64718321920556da62/resource.tar.gz#test.test_tpch-q1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f63c4c77f3a59b3bf8a34bd721bbe277",
+            "size": 10919,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q1-default.txt-Plan]": [
         {
-            "checksum": "2c221be4f870e44e98bb25243282c824",
-            "size": 8746,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_tpch-q1-default.txt-Plan_/plan.txt"
+            "checksum": "9d6e9af40c081c6f6c114af6c120e940",
+            "size": 8128,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q13-default.txt-Debug]": [
         {
-            "checksum": "3ef2d54b0dedd393a86070338557d923",
-            "size": 11633,
-            "uri": "https://{canondata_backend}/212715/281225c593b89b14398e3d64718321920556da62/resource.tar.gz#test.test_tpch-q13-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f14b9e936a4106a9d9dac81b72152cd4",
+            "size": 11232,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q13-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q13-default.txt-Plan]": [
         {
-            "checksum": "6923bda3df2e45519bedee520877affe",
-            "size": 12409,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_tpch-q13-default.txt-Plan_/plan.txt"
+            "checksum": "77810d2ed3fca8388a327a0cec0c4b07",
+            "size": 11791,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q13-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q20-default.txt-Debug]": [
         {
-            "checksum": "87b624483ebc5e5c16da1329b3807588",
-            "size": 12824,
-            "uri": "https://{canondata_backend}/1781765/b6c58f1d0b751ec5aa47270960497d937fb99d83/resource.tar.gz#test.test_tpch-q20-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6ecb71f4d0114ec5babf5f68e01f144e",
+            "size": 12177,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q20-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q20-default.txt-Plan]": [
         {
-            "checksum": "85a99e51b694ab4b05a55a49b8ebcc13",
-            "size": 20926,
-            "uri": "https://{canondata_backend}/1916746/a90748a6b22ac58085134b48a89244e8cf4ff460/resource.tar.gz#test.test_tpch-q20-default.txt-Plan_/plan.txt"
+            "checksum": "8d8d12ad7a62d25cffd6ce88e1fc3a46",
+            "size": 19484,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q20-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q21-default.txt-Debug]": [
         {
-            "checksum": "4862b4f0d64d8cce37a9331bad54009c",
-            "size": 12619,
-            "uri": "https://{canondata_backend}/212715/281225c593b89b14398e3d64718321920556da62/resource.tar.gz#test.test_tpch-q21-default.txt-Debug_/opt.yql_patched"
+            "checksum": "13a2427097251d0e8e67a9219adf6cd1",
+            "size": 12037,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q21-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q21-default.txt-Plan]": [
         {
-            "checksum": "13af283ecfc21d18c56b790e6dda2e15",
-            "size": 24208,
-            "uri": "https://{canondata_backend}/1936273/7f2b5ac89f370ae1b9fb4cf1aea4ff095e5ad6af/resource.tar.gz#test.test_tpch-q21-default.txt-Plan_/plan.txt"
+            "checksum": "c2750a3c92a04bb96bda835be1ad650b",
+            "size": 22766,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q21-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q6-default.txt-Debug]": [
         {
-            "checksum": "c417bc5eee4422a0c5731da044ec929b",
-            "size": 4463,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_tpch-q6-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c58af1e9d32ac72fbcb8f27a66180f36",
+            "size": 4396,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q6-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q6-default.txt-Plan]": [
         {
-            "checksum": "ea81bed2a55030e001c80bd55f61697d",
-            "size": 5987,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_tpch-q6-default.txt-Plan_/plan.txt"
+            "checksum": "237c233c2cd1453e6f91eac71432647a",
+            "size": 5781,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_tpch-q6-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-mergejoin_with_sort--Debug]": [
         {
-            "checksum": "755a4badf60cda92c61e5ed8bd6ece49",
-            "size": 5555,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_type_v3-mergejoin_with_sort--Debug_/opt.yql_patched"
+            "checksum": "774db36a45d72de3e649b9d3db8d181c",
+            "size": 5353,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_type_v3-mergejoin_with_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-mergejoin_with_sort--Plan]": [
         {
-            "checksum": "dec6602a3921849ac78437ae0c2c0a7f",
-            "size": 8963,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_type_v3-mergejoin_with_sort--Plan_/plan.txt"
+            "checksum": "6d6f9ac218e4f021fadb05993f94d594",
+            "size": 8551,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_type_v3-mergejoin_with_sort--Plan_/plan.txt"
         }
     ],
     "test.test[udf-udaf_default-default.txt-Debug]": [
@@ -2969,184 +2969,184 @@
     ],
     "test.test[union_all-mix_map_and_project-trivial_map-Debug]": [
         {
-            "checksum": "92a0ef5fb262196006a9807628c86b79",
-            "size": 3885,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_union_all-mix_map_and_project-trivial_map-Debug_/opt.yql_patched"
+            "checksum": "520b5e06b34faa1f24fd6eaf7ae5d9fa",
+            "size": 3685,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_union_all-mix_map_and_project-trivial_map-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-mix_map_and_project-trivial_map-Plan]": [
         {
-            "checksum": "0436650285730a52c94c4b9a42b07959",
-            "size": 6752,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_union_all-mix_map_and_project-trivial_map-Plan_/plan.txt"
+            "checksum": "2e2d43d58a7a12cd51a6eef5ff3e35f4",
+            "size": 6340,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_union_all-mix_map_and_project-trivial_map-Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_with_limits-default.txt-Debug]": [
         {
-            "checksum": "2ae2c21259e6f73298d6e18a93b93970",
-            "size": 2635,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_union_all-union_all_with_limits-default.txt-Debug_/opt.yql_patched"
+            "checksum": "705534b23320bbbdb58185df71c0dd61",
+            "size": 2484,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_union_all-union_all_with_limits-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-union_all_with_limits-default.txt-Plan]": [
         {
-            "checksum": "51e75f1384662801092a360d9199b57e",
-            "size": 7139,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_union_all-union_all_with_limits-default.txt-Plan_/plan.txt"
+            "checksum": "6f992f04b502fcb120bf75631dcd2852",
+            "size": 6727,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_union_all-union_all_with_limits-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[view-trivial_view_concat--Debug]": [
         {
-            "checksum": "a9e3b2ca24e789f918df73147fb4dd5f",
-            "size": 2353,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_view-trivial_view_concat--Debug_/opt.yql_patched"
+            "checksum": "8af7cbc493da46286b903cf2ecffc5e7",
+            "size": 2241,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_view-trivial_view_concat--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-trivial_view_concat--Plan]": [
         {
-            "checksum": "f46097f8a6216d77c93042cc6f90d100",
-            "size": 4201,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_view-trivial_view_concat--Plan_/plan.txt"
+            "checksum": "653d20dfc8769943ae1bad9a0dcd2ae9",
+            "size": 3995,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_view-trivial_view_concat--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_esc_string--Debug]": [
         {
-            "checksum": "363917c9cff1def2ab9370f91650167b",
-            "size": 2717,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_weak_field-weak_field_esc_string--Debug_/opt.yql_patched"
+            "checksum": "db4225043883e8bda146eb0bfe03595b",
+            "size": 2614,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_weak_field-weak_field_esc_string--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_esc_string--Plan]": [
         {
-            "checksum": "0718812342a8362ca06bc79c8a4e030a",
-            "size": 5897,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_weak_field-weak_field_esc_string--Plan_/plan.txt"
+            "checksum": "9a760701878af98b806b7ea05a9893fb",
+            "size": 5691,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_weak_field-weak_field_esc_string--Plan_/plan.txt"
         }
     ],
     "test.test[window-current/aggregations--Debug]": [
         {
-            "checksum": "6e189705e1167aa1b365aadbb19a2569",
-            "size": 8238,
-            "uri": "https://{canondata_backend}/1937492/e4d5d6d9d9cf16ad53e6ec723a0d4a250eae8aba/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql_patched"
+            "checksum": "c07c153a4fd149137f254152bbe0d08e",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-current_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/aggregations--Plan]": [
         {
-            "checksum": "99bd43632e9f29e73bb279eb8b96ce84",
-            "size": 7361,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-current_aggregations--Plan_/plan.txt"
+            "checksum": "0d3d18bc7d34188daac23682f3eaae20",
+            "size": 6949,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-current_aggregations--Plan_/plan.txt"
         }
     ],
     "test.test[window-current/ansi_current_with_win--Debug]": [
         {
-            "checksum": "0b2e989f91b2c3b8a1227f5b75b3f788",
-            "size": 6970,
-            "uri": "https://{canondata_backend}/1881367/fd6fe303f95983c7923be22740c4aa07b052e199/resource.tar.gz#test.test_window-current_ansi_current_with_win--Debug_/opt.yql_patched"
+            "checksum": "de04e38359b645ab5a0420771c3f7a01",
+            "size": 6588,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-current_ansi_current_with_win--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/ansi_current_with_win--Plan]": [
         {
-            "checksum": "a69f6f99fb946191b14b9c371e5d9fbe",
-            "size": 5739,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-current_ansi_current_with_win--Plan_/plan.txt"
+            "checksum": "be8c89bfbe10454d24401995ea09e3be",
+            "size": 5327,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-current_ansi_current_with_win--Plan_/plan.txt"
         }
     ],
     "test.test[window-current/session_incompat_sort--Debug]": [
         {
-            "checksum": "0c450f728fa91ca7e43030b7688299c7",
-            "size": 7934,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_window-current_session_incompat_sort--Debug_/opt.yql_patched"
+            "checksum": "4097e2e3755669c8a6b61d8882d3586b",
+            "size": 7340,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-current_session_incompat_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/session_incompat_sort--Plan]": [
         {
-            "checksum": "379af19b2ae21b4089f8f78d72b8ddd2",
-            "size": 7987,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-current_session_incompat_sort--Plan_/plan.txt"
+            "checksum": "b85a5064798ae2bc0b3165324facc37c",
+            "size": 7369,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-current_session_incompat_sort--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/aggregations--Debug]": [
         {
-            "checksum": "16f6034109a60c1941399c887a9098db",
-            "size": 14814,
-            "uri": "https://{canondata_backend}/1937492/e4d5d6d9d9cf16ad53e6ec723a0d4a250eae8aba/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql_patched"
+            "checksum": "185997f5844b2f285b9c5173726510b5",
+            "size": 14489,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-full_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations--Plan]": [
         {
-            "checksum": "d92791b7ed68c8f3e237304c8622586a",
-            "size": 14917,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-full_aggregations--Plan_/plan.txt"
+            "checksum": "9ebe6daa4cd1558831b2e15bdc3a546f",
+            "size": 14505,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-full_aggregations--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/aggregations_leadlag_compact--Debug]": [
         {
-            "checksum": "d91b7fc2721c1e548cdd8c640aed5d7d",
-            "size": 8999,
-            "uri": "https://{canondata_backend}/1817427/d7d3f1e61738ea87fcd3efca1630aefe5b70739d/resource.tar.gz#test.test_window-full_aggregations_leadlag_compact--Debug_/opt.yql_patched"
+            "checksum": "57bf6050f460454ce8510413effb7bf6",
+            "size": 8686,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-full_aggregations_leadlag_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations_leadlag_compact--Plan]": [
         {
-            "checksum": "d300746695bb94d7b2b1aaa99301bd12",
-            "size": 10230,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-full_aggregations_leadlag_compact--Plan_/plan.txt"
+            "checksum": "341b60ca11b887ff0d1063c9e540054d",
+            "size": 9818,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-full_aggregations_leadlag_compact--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/session_incompat_sort--Debug]": [
         {
-            "checksum": "e2d4614f2c7a2c4d107859be2cc36213",
-            "size": 13821,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_window-full_session_incompat_sort--Debug_/opt.yql_patched"
+            "checksum": "365894bd3447114b651d43e261e8c227",
+            "size": 13222,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-full_session_incompat_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/session_incompat_sort--Plan]": [
         {
-            "checksum": "863458abc25e41bb1638533ddb634f48",
-            "size": 13113,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-full_session_incompat_sort--Plan_/plan.txt"
+            "checksum": "fba7477f6b55c1c394b961e1c2e584fa",
+            "size": 12495,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-full_session_incompat_sort--Plan_/plan.txt"
         }
     ],
     "test.test[window-lagging/aggregations--Debug]": [
         {
-            "checksum": "ef86ff6a2b4cc7c4657473f768fc3592",
-            "size": 9988,
-            "uri": "https://{canondata_backend}/1881367/fd6fe303f95983c7923be22740c4aa07b052e199/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
+            "checksum": "24f70001c79e72d4f3e54cc4a4fcff82",
+            "size": 9467,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-lagging_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-lagging/aggregations--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-lagging_aggregations--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-lagging_aggregations--Plan_/plan.txt"
         }
     ],
     "test.test[window-row_number_no_part_from_subq-default.txt-Debug]": [
         {
-            "checksum": "6f8bf5c644975c0147ca09272f005fd5",
-            "size": 2970,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_window-row_number_no_part_from_subq-default.txt-Debug_/opt.yql_patched"
+            "checksum": "599f154d0468dc9ef78aac64d082b747",
+            "size": 2806,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-row_number_no_part_from_subq-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-row_number_no_part_from_subq-default.txt-Plan]": [
         {
-            "checksum": "abb95f1bc702594d02a0471ab296c0b6",
-            "size": 6674,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-row_number_no_part_from_subq-default.txt-Plan_/plan.txt"
+            "checksum": "997af573f4ab496a18a03df3033ad729",
+            "size": 6262,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-row_number_no_part_from_subq-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_by_all_avg_interval-default.txt-Debug]": [
         {
-            "checksum": "d7cefde84c4d12153e30b5c8754f874b",
-            "size": 4651,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_window-win_by_all_avg_interval-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f390118db394844a8c9d0d7d2b85a4ac",
+            "size": 4529,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-win_by_all_avg_interval-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_by_all_avg_interval-default.txt-Plan]": [
         {
-            "checksum": "e03207d50afa0ec72bdb20a82af58aa0",
-            "size": 6080,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-win_by_all_avg_interval-default.txt-Plan_/plan.txt"
+            "checksum": "602f862487ddc6577a33ec45851c580c",
+            "size": 5874,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-win_by_all_avg_interval-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_nth_value-default.txt-Debug]": [
@@ -3165,30 +3165,30 @@
     ],
     "test.test[window-win_func_part_by_expr_new-default.txt-Debug]": [
         {
-            "checksum": "becf651c29528cc27e981d140da15cb3",
-            "size": 5766,
-            "uri": "https://{canondata_backend}/1889210/9f0ba7bc92451aa4a498112bc8c2e703011101c2/resource.tar.gz#test.test_window-win_func_part_by_expr_new-default.txt-Debug_/opt.yql_patched"
+            "checksum": "991565dd24fa0ac621bff96ddd539d92",
+            "size": 5483,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-win_func_part_by_expr_new-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_part_by_expr_new-default.txt-Plan]": [
         {
-            "checksum": "2f227593a3d29deed5f339977aa76202",
-            "size": 7317,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-win_func_part_by_expr_new-default.txt-Plan_/plan.txt"
+            "checksum": "c9d22fd08472e88fa944b9054d566167",
+            "size": 6905,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-win_func_part_by_expr_new-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-yql-15636-default.txt-Debug]": [
         {
-            "checksum": "758df7c6363445605ac8c8ad6248a457",
-            "size": 8587,
-            "uri": "https://{canondata_backend}/1937492/7ae37c32b42bb57d4df171a62ced7ab76867a8ea/resource.tar.gz#test.test_window-yql-15636-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5fa00d6d0935b94c22b5ec8561370018",
+            "size": 7980,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-yql-15636-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-yql-15636-default.txt-Plan]": [
         {
-            "checksum": "911382af4662993e9ea3038b5b21dec0",
-            "size": 10242,
-            "uri": "https://{canondata_backend}/1942671/a6ef6234ecec8bdd9b5f7ec30206378c9f7268ef/resource.tar.gz#test.test_window-yql-15636-default.txt-Plan_/plan.txt"
+            "checksum": "51b6cbedb04aa664c9865a630519d7ce",
+            "size": 9624,
+            "uri": "https://{canondata_backend}/1130705/98bfcb23db43674b07f163a5d89bc355761ccf70/resource.tar.gz#test.test_window-yql-15636-default.txt-Plan_/plan.txt"
         }
     ]
 }

--- a/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
@@ -1,16 +1,16 @@
 {
     "test.test[action-dep_world_quote_code-default.txt-Debug]": [
         {
-            "checksum": "64e8af0c07567b8c0a0cbffb894050f5",
-            "size": 2430,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_action-dep_world_quote_code-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f0e42e4fbda8073706bbc6183453fa15",
+            "size": 2364,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_action-dep_world_quote_code-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-dep_world_quote_code-default.txt-Plan]": [
         {
-            "checksum": "676fa6e33adf2988e1791c0b96ccad35",
-            "size": 4843,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_action-dep_world_quote_code-default.txt-Plan_/plan.txt"
+            "checksum": "6350e95e45f1efd417c449984eb3d59a",
+            "size": 4637,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_action-dep_world_quote_code-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_each_input_table-default.txt-Debug]": [
@@ -225,44 +225,44 @@
     ],
     "test.test[aggr_factory-every-default.txt-Debug]": [
         {
-            "checksum": "d9e5d5e7cf0e98eccd6641ea29da2663",
-            "size": 6603,
-            "uri": "https://{canondata_backend}/1899731/562cca064d940bb64b83976ec2ca6a7764fd98d8/resource.tar.gz#test.test_aggr_factory-every-default.txt-Debug_/opt.yql_patched"
+            "checksum": "61e02edc8763bf4e8e6c423370e39dc2",
+            "size": 6505,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggr_factory-every-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-every-default.txt-Plan]": [
         {
-            "checksum": "b04a7b524988f38190d4f7d6f057bd1a",
-            "size": 13318,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_aggr_factory-every-default.txt-Plan_/plan.txt"
+            "checksum": "d77130b7c4f1b83c7ecedee655385188",
+            "size": 12906,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggr_factory-every-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-median-default.txt-Debug]": [
         {
-            "checksum": "c9ebc6a68f44007b370d6a2e16a5073f",
-            "size": 8786,
-            "uri": "https://{canondata_backend}/1899731/562cca064d940bb64b83976ec2ca6a7764fd98d8/resource.tar.gz#test.test_aggr_factory-median-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6c26aefb306fbf7a99590db3905d060d",
+            "size": 8687,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggr_factory-median-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-median-default.txt-Plan]": [
         {
-            "checksum": "d879d3b8a1ff3e323428ea3c933de406",
-            "size": 13735,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_aggr_factory-median-default.txt-Plan_/plan.txt"
+            "checksum": "47fa3f0bf52d23bc83926ebbf299bc5c",
+            "size": 13323,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggr_factory-median-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-mode-default.txt-Debug]": [
         {
-            "checksum": "b8dbf7a8e8764b15d71351ae03e8b4d7",
-            "size": 9975,
-            "uri": "https://{canondata_backend}/1937001/0b1b1b11d81f8bfda202cd476f81472ffab64f3e/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4991328f704d7ed2a31fb70e0010f93b",
+            "size": 9876,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-mode-default.txt-Plan]": [
         {
-            "checksum": "d879d3b8a1ff3e323428ea3c933de406",
-            "size": 13735,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Plan_/plan.txt"
+            "checksum": "47fa3f0bf52d23bc83926ebbf299bc5c",
+            "size": 13323,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggr_factory-mode-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-multi_minmaxby-default.txt-Debug]": [
@@ -281,72 +281,72 @@
     ],
     "test.test[aggregate-avg_and_sum_float--Debug]": [
         {
-            "checksum": "40ef1e4d306c2a747250e4190eb1cc95",
-            "size": 5975,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_aggregate-avg_and_sum_float--Debug_/opt.yql_patched"
+            "checksum": "28637c5d5f129fb5f898d7498ac48589",
+            "size": 5599,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-avg_and_sum_float--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-avg_and_sum_float--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_aggregate-avg_and_sum_float--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-avg_and_sum_float--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-count_distinct_with_filter--Debug]": [
         {
-            "checksum": "f6f4af6475eb36f0502ced3f3ce357a6",
-            "size": 3759,
-            "uri": "https://{canondata_backend}/1903885/57c8c16e8d59ca015d6fb4db0868914a8581ab15/resource.tar.gz#test.test_aggregate-count_distinct_with_filter--Debug_/opt.yql_patched"
+            "checksum": "1be0bdac10c0faffc196a15523e58e6c",
+            "size": 3673,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-count_distinct_with_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-count_distinct_with_filter--Plan]": [
         {
-            "checksum": "8e96180afdbb01f6d58b42da1e3fb4f7",
-            "size": 6236,
-            "uri": "https://{canondata_backend}/1917492/5102ff9886383ecee950ea3115c186532b973f8e/resource.tar.gz#test.test_aggregate-count_distinct_with_filter--Plan_/plan.txt"
+            "checksum": "1e64cfdec402b57af45128ed904e5f2a",
+            "size": 5824,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-count_distinct_with_filter--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_duo--Debug]": [
         {
-            "checksum": "19400056f73e7cce2233b12512190609",
-            "size": 7116,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_aggregate-group_by_gs_duo--Debug_/opt.yql_patched"
+            "checksum": "1201435b89d08a5755702196782e871b",
+            "size": 6725,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-group_by_gs_duo--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_duo--Plan]": [
         {
-            "checksum": "cd5f2c7d9faec30cb837e1041e61bc3a",
-            "size": 11432,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_aggregate-group_by_gs_duo--Plan_/plan.txt"
+            "checksum": "d138d6c4123ed6ed5751e2022ed3b0b8",
+            "size": 10814,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-group_by_gs_duo--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_tz_date--Debug]": [
         {
-            "checksum": "a93d3f57c9a80b8aa69af9774c362483",
-            "size": 4232,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_aggregate-group_by_tz_date--Debug_/opt.yql_patched"
+            "checksum": "fee971a3583cf7bba737babc06def3a2",
+            "size": 4062,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-group_by_tz_date--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_tz_date--Plan]": [
         {
-            "checksum": "fdb27cacbc35fa1d6245113fe4c875ad",
-            "size": 6319,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_aggregate-group_by_tz_date--Plan_/plan.txt"
+            "checksum": "1d74c988f49a4db28be4e0a318fc7dcd",
+            "size": 5907,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-group_by_tz_date--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_with_where-default.txt-Debug]": [
         {
-            "checksum": "097462f47ad58fd44d060e4a0caf1db7",
-            "size": 4895,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_aggregate-group_by_with_where-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ec02ac859ee5d7abc6edb2660a610025",
+            "size": 4597,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-group_by_with_where-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_with_where-default.txt-Plan]": [
         {
-            "checksum": "5b34466f9dea236e8ef55862f24fbbe9",
-            "size": 8525,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_aggregate-group_by_with_where-default.txt-Plan_/plan.txt"
+            "checksum": "56e5fa0b7e6c6bee32c075c3d9156004",
+            "size": 7907,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_aggregate-group_by_with_where-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-percentile_interval-default.txt-Debug]": [
@@ -393,58 +393,58 @@
     ],
     "test.test[blocks-bitcast_block--Debug]": [
         {
-            "checksum": "ea652935da32f3245dd9ce540ef792db",
-            "size": 1858,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-bitcast_block--Debug_/opt.yql_patched"
+            "checksum": "d446b0502ddb92be2ac8ff2ca97bddd5",
+            "size": 1792,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-bitcast_block--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-bitcast_block--Plan]": [
         {
-            "checksum": "5c41b58f8a68c081f47cebbfa8a13331",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-bitcast_block--Plan_/plan.txt"
+            "checksum": "c6ed3026b5067eb08a3ae9247dec4859",
+            "size": 3839,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-bitcast_block--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_avg--Debug]": [
         {
-            "checksum": "c53d0eb85c9a7a3467c48719ac7dbb71",
-            "size": 10329,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-combine_all_avg--Debug_/opt.yql_patched"
+            "checksum": "59f829672cc3eb2f462569a33a8eb03f",
+            "size": 10034,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-combine_all_avg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_avg--Plan]": [
         {
-            "checksum": "12778df40791b604dc27b3100881428a",
-            "size": 5559,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-combine_all_avg--Plan_/plan.txt"
+            "checksum": "d7e96a43cac0274336b5928cdef15c54",
+            "size": 5353,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-combine_all_avg--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_avg--Debug]": [
         {
-            "checksum": "9acd5942f2c32ada7371db31064dc23b",
-            "size": 7973,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-combine_hashed_avg--Debug_/opt.yql_patched"
+            "checksum": "ce723532ff9d9b8e323fb96ae9b4f0ea",
+            "size": 7424,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-combine_hashed_avg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_avg--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-combine_hashed_avg--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-combine_hashed_avg--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_count--Debug]": [
         {
-            "checksum": "bfacde35ed24a7b91c0ffa82be0dca8f",
-            "size": 6800,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-combine_hashed_count--Debug_/opt.yql_patched"
+            "checksum": "596facc8825283dd79581eec720aaab4",
+            "size": 6201,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-combine_hashed_count--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_count--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-combine_hashed_count--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-combine_hashed_count--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_add_interval--Debug]": [
@@ -463,198 +463,198 @@
     ],
     "test.test[blocks-date_less_scalar--Debug]": [
         {
-            "checksum": "7f8161ff9314cccd88c64f3dc43efa26",
-            "size": 26413,
-            "uri": "https://{canondata_backend}/1942100/1e9a5e72f569c854fa2389b79a6e91ed71db2f5b/resource.tar.gz#test.test_blocks-date_less_scalar--Debug_/opt.yql_patched"
+            "checksum": "a0777c55a41e314426b7403f0316ce82",
+            "size": 22397,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-date_less_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_less_scalar--Plan]": [
         {
-            "checksum": "1ac2afa98f4d958a9cca1e31d65a570d",
-            "size": 12272,
-            "uri": "https://{canondata_backend}/1942100/1e9a5e72f569c854fa2389b79a6e91ed71db2f5b/resource.tar.gz#test.test_blocks-date_less_scalar--Plan_/plan.txt"
+            "checksum": "e81ad78037d8967dd443aa92a9b04411",
+            "size": 11448,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-date_less_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_sub_interval_scalar--Debug]": [
         {
-            "checksum": "0a77cd778737887789483148115ad8ae",
-            "size": 8296,
-            "uri": "https://{canondata_backend}/1920236/24fc177ad15ffb34261b5dbf2e1c5c96c4ad7faf/resource.tar.gz#test.test_blocks-date_sub_interval_scalar--Debug_/opt.yql_patched"
+            "checksum": "c7f1c7c4bd669ad48c42402c06412278",
+            "size": 7620,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-date_sub_interval_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_sub_interval_scalar--Plan]": [
         {
-            "checksum": "d7dc5671b9ef733316dfc1d26ae18c1f",
-            "size": 7299,
-            "uri": "https://{canondata_backend}/1920236/24fc177ad15ffb34261b5dbf2e1c5c96c4ad7faf/resource.tar.gz#test.test_blocks-date_sub_interval_scalar--Plan_/plan.txt"
+            "checksum": "b309ec00eeb6f3f5fa044efec428cf5a",
+            "size": 6887,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-date_sub_interval_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-decimal_comparison--Debug]": [
         {
-            "checksum": "2d5a263433c13ff6f5d31cefd40bcc96",
-            "size": 4161,
-            "uri": "https://{canondata_backend}/1130705/7b1ee13c4da21e2ddff70372802eda23a04da498/resource.tar.gz#test.test_blocks-decimal_comparison--Debug_/opt.yql_patched"
+            "checksum": "9cba36c6f77e9000da51242793bd3c92",
+            "size": 3663,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-decimal_comparison--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-decimal_comparison--Plan]": [
         {
-            "checksum": "e65c86ba6e55033fe5f47711b65bba6d",
-            "size": 4093,
-            "uri": "https://{canondata_backend}/1784826/2b2e157f3cee0db3cfdb7f3fc538c5f30f0b593e/resource.tar.gz#test.test_blocks-decimal_comparison--Plan_/plan.txt"
+            "checksum": "73e50c3285312f865e29210e7f952098",
+            "size": 3887,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-decimal_comparison--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-distinct_pure_all--Debug]": [
         {
-            "checksum": "a368ba0efe31dc0503d90694682eb845",
-            "size": 5498,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-distinct_pure_all--Debug_/opt.yql_patched"
+            "checksum": "0b75c00dbe3e29ad0dff7338ca2e343e",
+            "size": 5360,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-distinct_pure_all--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-distinct_pure_all--Plan]": [
         {
-            "checksum": "8b04f3a5cc82343ff91f4ffebe882f2c",
-            "size": 7693,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-distinct_pure_all--Plan_/plan.txt"
+            "checksum": "cc1f441cba86e3a4c5e09b8c14df7ccc",
+            "size": 7281,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-distinct_pure_all--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-distinct_pure_keys--Debug]": [
         {
-            "checksum": "8f868f4ec5aad0873d6005e26a512c3d",
-            "size": 11936,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-distinct_pure_keys--Debug_/opt.yql_patched"
+            "checksum": "80799d587855b4ee5469c0790bcaa69e",
+            "size": 11328,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-distinct_pure_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-distinct_pure_keys--Plan]": [
         {
-            "checksum": "0edd86cfb9d99904e937b3ca89aebd8f",
-            "size": 16836,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-distinct_pure_keys--Plan_/plan.txt"
+            "checksum": "ceb885ec5bcedef377210a33d4c40e49",
+            "size": 15806,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-distinct_pure_keys--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-group_by_complex_key--Debug]": [
         {
-            "checksum": "1943cb2e2b3689330b02e910a6ad35fc",
-            "size": 5398,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-group_by_complex_key--Debug_/opt.yql_patched"
+            "checksum": "62a8904738305448371db41e3e4a287f",
+            "size": 5272,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-group_by_complex_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-group_by_complex_key--Plan]": [
         {
-            "checksum": "d4aed3777ec94be7f7fba6c81981c953",
-            "size": 6728,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-group_by_complex_key--Plan_/plan.txt"
+            "checksum": "57e9712705bc3a17375950b8442e07e2",
+            "size": 6522,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-group_by_complex_key--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-if--Debug]": [
         {
-            "checksum": "60850ca6965ba485f807944040162fad",
-            "size": 4741,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-if--Debug_/opt.yql_patched"
+            "checksum": "70868bc8b431a52606de0a5748a1a492",
+            "size": 4187,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-if--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-if--Plan]": [
         {
-            "checksum": "df04111c024790a6acc9bdbe03f27531",
-            "size": 6201,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-if--Plan_/plan.txt"
+            "checksum": "5a5857020d5dd64a30be59b49a6d5c5f",
+            "size": 5789,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-if--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-json_document_type--Debug]": [
         {
-            "checksum": "ae4976c95cf8ab2817bcde8f5534d869",
-            "size": 4587,
-            "uri": "https://{canondata_backend}/1777230/d5e3d98cf6995b96a3c4251d868e977b824b9934/resource.tar.gz#test.test_blocks-json_document_type--Debug_/opt.yql_patched"
+            "checksum": "a2110e768022ae932b65f028a2df4bd5",
+            "size": 4280,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-json_document_type--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-json_document_type--Plan]": [
         {
-            "checksum": "e315348f49a454626706371533572797",
-            "size": 8452,
-            "uri": "https://{canondata_backend}/1777230/d5e3d98cf6995b96a3c4251d868e977b824b9934/resource.tar.gz#test.test_blocks-json_document_type--Plan_/plan.txt"
+            "checksum": "0dc665eda2d78c8b6fa71575614d6530",
+            "size": 7834,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-json_document_type--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_tofrom--Debug]": [
         {
-            "checksum": "cac652c4ad550593dc391006c8dc44f0",
-            "size": 2857,
-            "uri": "https://{canondata_backend}/1871182/7b2e6a8eef11913e44a68128db2ffa8d3a7bc41e/resource.tar.gz#test.test_blocks-pg_tofrom--Debug_/opt.yql_patched"
+            "checksum": "770cfb27fc09b1c22376d7b295b51d92",
+            "size": 2631,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-pg_tofrom--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_tofrom--Plan]": [
         {
-            "checksum": "68af463565d7d156cdb9c2b51156b775",
-            "size": 4193,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-pg_tofrom--Plan_/plan.txt"
+            "checksum": "5a46fbb1b4735c814f1f745dba105b38",
+            "size": 3987,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-pg_tofrom--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-sort_two_mix--Debug]": [
         {
-            "checksum": "0d86b11340e60326f0a1499379ef56ed",
-            "size": 3430,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-sort_two_mix--Debug_/opt.yql_patched"
+            "checksum": "d6debab5efba48c51fb3fae11453a48f",
+            "size": 3182,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-sort_two_mix--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-sort_two_mix--Plan]": [
         {
-            "checksum": "280c2f9dd2d67499ddb3297b26a6ef99",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-sort_two_mix--Plan_/plan.txt"
+            "checksum": "606023bfbee343b9efa9e8f1f3aa1577",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-sort_two_mix--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-top_sort_two_asc--Debug]": [
         {
-            "checksum": "0eb25f35e5c2951cf3d87b7d01c29dd8",
-            "size": 3491,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-top_sort_two_asc--Debug_/opt.yql_patched"
+            "checksum": "ea832e3c832b29e98a0d1119470694fd",
+            "size": 3243,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-top_sort_two_asc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-top_sort_two_asc--Plan]": [
         {
-            "checksum": "7ec9fd674afb45088683be4f80b63673",
-            "size": 6326,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-top_sort_two_asc--Plan_/plan.txt"
+            "checksum": "fca964732d0b2d808bdb66bb8ba035cb",
+            "size": 5914,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-top_sort_two_asc--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-top_sort_two_mix--Debug]": [
         {
-            "checksum": "60cceb4bd41f5e938930be6c58288912",
-            "size": 3501,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-top_sort_two_mix--Debug_/opt.yql_patched"
+            "checksum": "93260010e15349ea7ab94af9933905c1",
+            "size": 3253,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-top_sort_two_mix--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-top_sort_two_mix--Plan]": [
         {
-            "checksum": "7ec9fd674afb45088683be4f80b63673",
-            "size": 6326,
-            "uri": "https://{canondata_backend}/1937429/55b1826e8916057871ed62c50bfb88b54489cc6e/resource.tar.gz#test.test_blocks-top_sort_two_mix--Plan_/plan.txt"
+            "checksum": "fca964732d0b2d808bdb66bb8ba035cb",
+            "size": 5914,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_blocks-top_sort_two_mix--Plan_/plan.txt"
         }
     ],
     "test.test[coalesce-coalesce_few_opt--Debug]": [
         {
-            "checksum": "69497b6a17e9c690ad3892acb52febc1",
-            "size": 5726,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_coalesce-coalesce_few_opt--Debug_/opt.yql_patched"
+            "checksum": "f310584d56b341d8025bb1bc1c034bab",
+            "size": 5128,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_coalesce-coalesce_few_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[coalesce-coalesce_few_opt--Plan]": [
         {
-            "checksum": "fe6c788aadefb6525f34f5c8f603a083",
-            "size": 4221,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_coalesce-coalesce_few_opt--Plan_/plan.txt"
+            "checksum": "3b9ae3c5869373bd8981acf74c9f1cda",
+            "size": 4015,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_coalesce-coalesce_few_opt--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert--Debug]": [
         {
-            "checksum": "86b70bbffe85108c052450ae2a0400ea",
-            "size": 5937,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_column_order-insert--Debug_/opt.yql_patched"
+            "checksum": "ab0a69761f1ee7425ec5ab15dab04d21",
+            "size": 5623,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_column_order-insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert--Plan]": [
         {
-            "checksum": "a3f3eb167f54ba2b7f1568f76895e04d",
-            "size": 17708,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_column_order-insert--Plan_/plan.txt"
+            "checksum": "d187c32c8d6426baf80bd13fa6bc7765",
+            "size": 16884,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_column_order-insert--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-values-default.txt-Debug]": [
@@ -673,30 +673,30 @@
     ],
     "test.test[count-boolean_count--Debug]": [
         {
-            "checksum": "1cf056ded198bba2cb8113f75e6450f0",
-            "size": 5224,
-            "uri": "https://{canondata_backend}/1031349/649e9fb0066dcf65927023413b5303c88dd88938/resource.tar.gz#test.test_count-boolean_count--Debug_/opt.yql_patched"
+            "checksum": "7d52ddd00e24d2816d39a2fa70aca5c0",
+            "size": 5182,
+            "uri": "https://{canondata_backend}/1937429/3ec353865b88f20c966196a0ce16243c37e12190/resource.tar.gz#test.test_count-boolean_count--Debug_/opt.yql_patched"
         }
     ],
     "test.test[count-boolean_count--Plan]": [
         {
-            "checksum": "ad312cfcb106e7c3edeefec6f3f9888e",
-            "size": 9116,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_count-boolean_count--Plan_/plan.txt"
+            "checksum": "d8d373d019a18dee942a82298d8fa49b",
+            "size": 8910,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_count-boolean_count--Plan_/plan.txt"
         }
     ],
     "test.test[count-count_by_nulls--Debug]": [
         {
-            "checksum": "ae32cecedd6f28e80b2ea37142da8cf6",
-            "size": 3197,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_count-count_by_nulls--Debug_/opt.yql_patched"
+            "checksum": "5e38994e79f8798c2968bc31dbdf2bd2",
+            "size": 3130,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_count-count_by_nulls--Debug_/opt.yql_patched"
         }
     ],
     "test.test[count-count_by_nulls--Plan]": [
         {
-            "checksum": "3c8d4a29697eba1b528fd7bb05476b18",
-            "size": 5662,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_count-count_by_nulls--Plan_/plan.txt"
+            "checksum": "0f9af9860c3fd20b0aaaabca2383a4a7",
+            "size": 5456,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_count-count_by_nulls--Plan_/plan.txt"
         }
     ],
     "test.test[count-count_no_grouping-default.txt-Debug]": [
@@ -715,16 +715,16 @@
     ],
     "test.test[count-count_nullable_sub-default.txt-Debug]": [
         {
-            "checksum": "6656fcc1b9a60de83cf49d6cc6c9de3a",
-            "size": 6306,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_count-count_nullable_sub-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1a65a9c10f5023711eb4be87311c3b48",
+            "size": 5922,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_count-count_nullable_sub-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[count-count_nullable_sub-default.txt-Plan]": [
         {
-            "checksum": "9fcc1ab58bf8a90cb2e5cd1040498881",
-            "size": 8586,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_count-count_nullable_sub-default.txt-Plan_/plan.txt"
+            "checksum": "78e9f57f7b3718332213c08887f94713",
+            "size": 7968,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_count-count_nullable_sub-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[csee-complete_l2-default.txt-Debug]": [
@@ -799,30 +799,30 @@
     ],
     "test.test[distinct-distinct_count_and_avg-default.txt-Debug]": [
         {
-            "checksum": "2e6f60443cd65dc14c66040f9d8fdd58",
-            "size": 7787,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_distinct-distinct_count_and_avg-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ae50a8fd8bc07c6dfa910eaadb310ac1",
+            "size": 7426,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_distinct-distinct_count_and_avg-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_count_and_avg-default.txt-Plan]": [
         {
-            "checksum": "f4cd242ccbafd06ce3c68cbc03776fd8",
-            "size": 11431,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_distinct-distinct_count_and_avg-default.txt-Plan_/plan.txt"
+            "checksum": "7460180d7243885a209eb30940213d98",
+            "size": 10813,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_distinct-distinct_count_and_avg-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_star1--Debug]": [
         {
-            "checksum": "e977fd678c72e43c9d27766eb05c6bda",
-            "size": 4353,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_distinct-distinct_star1--Debug_/opt.yql_patched"
+            "checksum": "12f0f8a80de250d7c2551d0e3810fed2",
+            "size": 3984,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_distinct-distinct_star1--Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_star1--Plan]": [
         {
-            "checksum": "28c2ab3b456e34dadfd529005a3e689e",
-            "size": 8484,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_distinct-distinct_star1--Plan_/plan.txt"
+            "checksum": "3ceffa5883fca835378d5359d3859d5f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_distinct-distinct_star1--Plan_/plan.txt"
         }
     ],
     "test.test[expr-as_dict_implicit_cast-default.txt-Debug]": [
@@ -925,16 +925,16 @@
     ],
     "test.test[expr-len--Debug]": [
         {
-            "checksum": "32295c00f97f6d31d25987422792fbe4",
-            "size": 2005,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_expr-len--Debug_/opt.yql_patched"
+            "checksum": "d73ed1422020478c2c044616bd0f54cb",
+            "size": 1939,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_expr-len--Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-len--Plan]": [
         {
-            "checksum": "156312d25bbd5c2a397753914620ade3",
-            "size": 4439,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_expr-len--Plan_/plan.txt"
+            "checksum": "fedfd74e9c95204e508f3b3dc228c862",
+            "size": 4233,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_expr-len--Plan_/plan.txt"
         }
     ],
     "test.test[expr-list_replicate-default.txt-Debug]": [
@@ -1023,16 +1023,16 @@
     ],
     "test.test[flatten_by-flatten_by_opt_dict--Debug]": [
         {
-            "checksum": "b6f40179a2f917fac6ce0028c72b9c7a",
-            "size": 5813,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_flatten_by-flatten_by_opt_dict--Debug_/opt.yql_patched"
+            "checksum": "a15a1432ef4bae7e41b64d05aa881254",
+            "size": 5463,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_flatten_by-flatten_by_opt_dict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_by_opt_dict--Plan]": [
         {
-            "checksum": "df39d69d33f20580187528cd1c945725",
-            "size": 8584,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_flatten_by-flatten_by_opt_dict--Plan_/plan.txt"
+            "checksum": "32e816388db081ec42e7f951c42b4c18",
+            "size": 7966,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_flatten_by-flatten_by_opt_dict--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_expr_groupby--Debug]": [
@@ -1051,30 +1051,30 @@
     ],
     "test.test[flatten_by-flatten_member_is_struct--Debug]": [
         {
-            "checksum": "b25fb56a7e3cefcef97097fab8ad2164",
-            "size": 4670,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_flatten_by-flatten_member_is_struct--Debug_/opt.yql_patched"
+            "checksum": "9844b537ff10155b2a2911b549955aa2",
+            "size": 4537,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_flatten_by-flatten_member_is_struct--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_member_is_struct--Plan]": [
         {
-            "checksum": "5905ada80a16e712439a00d629e7dc64",
-            "size": 5559,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_flatten_by-flatten_member_is_struct--Plan_/plan.txt"
+            "checksum": "614c5d83412e8ae2eacc36b0e971b3ec",
+            "size": 5353,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_flatten_by-flatten_member_is_struct--Plan_/plan.txt"
         }
     ],
     "test.test[in-basic_in-default.txt-Debug]": [
         {
-            "checksum": "05c618568a24e8292fe32829a69a913a",
-            "size": 3759,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_in-basic_in-default.txt-Debug_/opt.yql_patched"
+            "checksum": "41467a7e65b975b04df391568e3b7353",
+            "size": 3464,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_in-basic_in-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-basic_in-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_in-basic_in-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_in-basic_in-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_ansi_empty-default.txt-Debug]": [
@@ -1107,142 +1107,142 @@
     ],
     "test.test[in-in_tuple_table-default.txt-Debug]": [
         {
-            "checksum": "2d1b388a160986349410fed768d8191a",
-            "size": 1967,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_in-in_tuple_table-default.txt-Debug_/opt.yql_patched"
+            "checksum": "65597c7ce3128154e54baf8984fd52c7",
+            "size": 1901,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_in-in_tuple_table-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_tuple_table-default.txt-Plan]": [
         {
-            "checksum": "188a8ad973e88fd0702196e90c0bbdc8",
-            "size": 4063,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_in-in_tuple_table-default.txt-Plan_/plan.txt"
+            "checksum": "099434ebd48ccb81724a92532dff13e6",
+            "size": 3857,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_in-in_tuple_table-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_with_opt_tuple-default.txt-Debug]": [
         {
-            "checksum": "3b78d073e364980cf8149fd535d807da",
-            "size": 2127,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_in-in_with_opt_tuple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2a15366e4b0492419899f994369bdfe7",
+            "size": 2004,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_in-in_with_opt_tuple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_with_opt_tuple-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_in-in_with_opt_tuple-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_in-in_with_opt_tuple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-double_append_to_anonymous--Debug]": [
         {
-            "checksum": "1451361b7e5f895220dc5251c0de23a6",
-            "size": 2668,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_insert-double_append_to_anonymous--Debug_/opt.yql_patched"
+            "checksum": "3c15165fa2b86fce925b77312edc3a0d",
+            "size": 2543,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-double_append_to_anonymous--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-double_append_to_anonymous--Plan]": [
         {
-            "checksum": "112cc425df1620f6ab575c4a4a598614",
-            "size": 9544,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_insert-double_append_to_anonymous--Plan_/plan.txt"
+            "checksum": "760c51d07c18066ce01de080630e09f0",
+            "size": 9132,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-double_append_to_anonymous--Plan_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness-desc-Debug]": [
         {
-            "checksum": "d79cc02ba9dc72faa4fe526df01f3586",
-            "size": 1986,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_insert-drop_sortness-desc-Debug_/opt.yql_patched"
+            "checksum": "5019b02d9671cbfa8e40d77bda65ecf3",
+            "size": 1922,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-drop_sortness-desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-drop_sortness-desc-Plan]": [
         {
-            "checksum": "413e79be6c07fac2542dc5026c5796b1",
-            "size": 4257,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_insert-drop_sortness-desc-Plan_/plan.txt"
+            "checksum": "86f38fe8fde6ac5658e36849f3d29a4a",
+            "size": 4051,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-drop_sortness-desc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_relabel-default.txt-Debug]": [
         {
-            "checksum": "fc0070bb9544acf1e89711fb68de9de9",
-            "size": 1989,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_insert-select_relabel-default.txt-Debug_/opt.yql_patched"
+            "checksum": "84235ffb651e53e0accc4df09e691daa",
+            "size": 1866,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-select_relabel-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_relabel-default.txt-Plan]": [
         {
-            "checksum": "26f0e9d3c9dd9f7cbb6bf3b730f70ae7",
-            "size": 4883,
-            "uri": "https://{canondata_backend}/1889210/431569691fa60b20bf9ef4cc94610d8f1b1518e2/resource.tar.gz#test.test_insert-select_relabel-default.txt-Plan_/plan.txt"
+            "checksum": "743cd5e1ebfd3e66ac5961101c74572e",
+            "size": 4677,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-select_relabel-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_with_sort_limit-default.txt-Debug]": [
         {
-            "checksum": "26444261bb41c3527af750e0db8ac074",
-            "size": 2159,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bc881ba3fcd8f35480c3dff54c5b615e",
+            "size": 2036,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_with_sort_limit-default.txt-Plan]": [
         {
-            "checksum": "c749b0a5683a2ceb1fc4a0cf883c07df",
-            "size": 4414,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Plan_/plan.txt"
+            "checksum": "06af560a42a6aa12a72690b00ccb1b3f",
+            "size": 4208,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-select_with_sort_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-two_input_tables--Debug]": [
         {
-            "checksum": "b061aa9d315c5943c5801c8c33e66ef4",
-            "size": 2583,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_insert-two_input_tables--Debug_/opt.yql_patched"
+            "checksum": "ccd700975ccf7cb1a9da9897a58312bb",
+            "size": 2432,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-two_input_tables--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-two_input_tables--Plan]": [
         {
-            "checksum": "f84637f4954217d9bfe36a350b02943d",
-            "size": 6756,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_insert-two_input_tables--Plan_/plan.txt"
+            "checksum": "f25c41b25525e452736f50c089947fb1",
+            "size": 6344,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-two_input_tables--Plan_/plan.txt"
         }
     ],
     "test.test[insert-udf_empty--Debug]": [
         {
-            "checksum": "44c043d14b699d628b4d56ed5926454c",
-            "size": 1950,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_insert-udf_empty--Debug_/opt.yql_patched"
+            "checksum": "417ca5e5ee25ce1170e89df835dc29ff",
+            "size": 1827,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-udf_empty--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-udf_empty--Plan]": [
         {
-            "checksum": "cf41c3ee4ccc3bbb0ec4380f64f4b100",
-            "size": 4142,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_insert-udf_empty--Plan_/plan.txt"
+            "checksum": "c6602c5ff8ff1bb12601f14ae4ca4cb7",
+            "size": 3936,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-udf_empty--Plan_/plan.txt"
         }
     ],
     "test.test[insert-yql-14538--Debug]": [
         {
-            "checksum": "bb17678e2a16686b51afe0d0ece89c0c",
-            "size": 3899,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_insert-yql-14538--Debug_/opt.yql_patched"
+            "checksum": "fc0b9221a6758f99aac54a1a6efafd79",
+            "size": 3625,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-yql-14538--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-yql-14538--Plan]": [
         {
-            "checksum": "71d93ed012e517d12f93fa82b41e62a3",
-            "size": 9359,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_insert-yql-14538--Plan_/plan.txt"
+            "checksum": "87cf6d0f5138fa56558772b69d548c07",
+            "size": 8741,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_insert-yql-14538--Plan_/plan.txt"
         }
     ],
     "test.test[join-anyjoin_merge_nodup--Debug]": [
         {
-            "checksum": "532887ba5c676ec0ec027c3da955d599",
-            "size": 8083,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-anyjoin_merge_nodup--Debug_/opt.yql_patched"
+            "checksum": "44cf0822d6acc773ac32734ed1a2ba00",
+            "size": 7803,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-anyjoin_merge_nodup--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-anyjoin_merge_nodup--Plan]": [
         {
-            "checksum": "2c995ef06064c0645a96fa6f1a89fbc9",
-            "size": 23747,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-anyjoin_merge_nodup--Plan_/plan.txt"
+            "checksum": "61265aab60269b24d13deb3d3d03c8c9",
+            "size": 22923,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-anyjoin_merge_nodup--Plan_/plan.txt"
         }
     ],
     "test.test[join-convert_check_key_mem--Debug]": [
@@ -1275,114 +1275,114 @@
     ],
     "test.test[join-left_join_right_pushdown_nested_left--Debug]": [
         {
-            "checksum": "7c5dd95456fe1aa5cdb13d2e2a329456",
-            "size": 9466,
-            "uri": "https://{canondata_backend}/1889210/b9d99810b5aa874f24a7724b667bc80ecaf06a9b/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_left--Debug_/opt.yql_patched"
+            "checksum": "84ca4bb8146513e75dfc0047778d5e21",
+            "size": 9362,
+            "uri": "https://{canondata_backend}/1937429/3ec353865b88f20c966196a0ce16243c37e12190/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_left--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_join_right_pushdown_nested_left--Plan]": [
         {
-            "checksum": "0ec78f38bf44afc858cb5909b97ad0bd",
-            "size": 9944,
-            "uri": "https://{canondata_backend}/1889210/b9d99810b5aa874f24a7724b667bc80ecaf06a9b/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_left--Plan_/plan.txt"
+            "checksum": "0cb75d9a78c6bf81c5946429dd3e4643",
+            "size": 9738,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-left_join_right_pushdown_nested_left--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_semi_with_other--Debug]": [
         {
-            "checksum": "16229a3e5a3002c44ac4f38996ee8743",
-            "size": 9072,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-left_semi_with_other--Debug_/opt.yql_patched"
+            "checksum": "dc4e391bb7a5979e533c4b6bb17894c1",
+            "size": 8934,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-left_semi_with_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_semi_with_other--Plan]": [
         {
-            "checksum": "a9c66041ed226051e4fd6a786ab68376",
-            "size": 12451,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-left_semi_with_other--Plan_/plan.txt"
+            "checksum": "e1586b8f10f5255b4f834cac78ccdd8e",
+            "size": 12245,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-left_semi_with_other--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_inner--Debug]": [
         {
-            "checksum": "feb24b7535136bcea737d89e743cac95",
-            "size": 3510,
-            "uri": "https://{canondata_backend}/1936947/6095fab1db6e0377f921b1eba9729a210c851732/resource.tar.gz#test.test_join-lookupjoin_inner--Debug_/opt.yql_patched"
+            "checksum": "75f6493798154347c5fcfae028469293",
+            "size": 3326,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-lookupjoin_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_inner--Plan]": [
         {
-            "checksum": "9c49b07c760217e5999b8ffbf8515831",
-            "size": 4898,
-            "uri": "https://{canondata_backend}/1689644/d9f7f300a7765b4357ace844e283ab2252edc3ae/resource.tar.gz#test.test_join-lookupjoin_inner--Plan_/plan.txt"
+            "checksum": "ca60d96d2027a0b4a5ed84feef1498a8",
+            "size": 4692,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-lookupjoin_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_dup_key--Debug]": [
         {
-            "checksum": "96792d4ebec40f7899a4793e314e0aaf",
-            "size": 3186,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_join-mapjoin_dup_key--Debug_/opt.yql_patched"
+            "checksum": "039f41c21974797721997997555adbc2",
+            "size": 2986,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mapjoin_dup_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_dup_key--Plan]": [
         {
-            "checksum": "5bc5c70985446240ec4d2e43d505b5a9",
-            "size": 5990,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-mapjoin_dup_key--Plan_/plan.txt"
+            "checksum": "647ea18f7a635fed2d8c55a0dc1512ca",
+            "size": 5784,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mapjoin_dup_key--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_opt_vs_2xopt--Debug]": [
         {
-            "checksum": "0cc67d59670107a8c65dc8ea43111c8f",
-            "size": 5239,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_join-mapjoin_opt_vs_2xopt--Debug_/opt.yql_patched"
+            "checksum": "2caac2eb5ba225a2a7d4455ef765ae3c",
+            "size": 5063,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mapjoin_opt_vs_2xopt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_opt_vs_2xopt--Plan]": [
         {
-            "checksum": "654925edf685ed94392baa6a9574af05",
-            "size": 12818,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-mapjoin_opt_vs_2xopt--Plan_/plan.txt"
+            "checksum": "37615311b4854a53e02debcad6e0ef2e",
+            "size": 12200,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mapjoin_opt_vs_2xopt--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_with_empty_struct--Debug]": [
         {
-            "checksum": "1aad44aa36780c7e6c5291f800f84d5e",
-            "size": 2682,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-mapjoin_with_empty_struct--Debug_/opt.yql_patched"
+            "checksum": "4b7823b65a04a154fed12680af7eb56b",
+            "size": 2618,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mapjoin_with_empty_struct--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_with_empty_struct--Plan]": [
         {
-            "checksum": "b68539d8d78c00286d1b1ed9bcef2261",
-            "size": 6679,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-mapjoin_with_empty_struct--Plan_/plan.txt"
+            "checksum": "9c65490827eb1e11f05906ae8baa3e03",
+            "size": 6473,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mapjoin_with_empty_struct--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_force_no_sorted--Debug]": [
         {
-            "checksum": "8300978f906feb7978acb18005e9c35b",
-            "size": 4101,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-mergejoin_force_no_sorted--Debug_/opt.yql_patched"
+            "checksum": "914e53ba232dcee8aa5deefee8cece3d",
+            "size": 3995,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mergejoin_force_no_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_force_no_sorted--Plan]": [
         {
-            "checksum": "2cf0c2d7ea11c268640e4ae3ec7c4ceb",
-            "size": 8323,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-mergejoin_force_no_sorted--Plan_/plan.txt"
+            "checksum": "ee785de5b23362c4f4851104c2e9b0da",
+            "size": 7911,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mergejoin_force_no_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_narrows_output_sort--Debug]": [
         {
-            "checksum": "02ce1334c1b687f4fb50b6835e8f16eb",
-            "size": 8212,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-mergejoin_narrows_output_sort--Debug_/opt.yql_patched"
+            "checksum": "b87627a469367bda89ad0e1c8e4b21c3",
+            "size": 7920,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mergejoin_narrows_output_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_narrows_output_sort--Plan]": [
         {
-            "checksum": "e953ff5fc7be3d8061ceddb0777280d4",
-            "size": 14887,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-mergejoin_narrows_output_sort--Plan_/plan.txt"
+            "checksum": "4a620d810a19329c1c722674bb28817e",
+            "size": 14475,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-mergejoin_narrows_output_sort--Plan_/plan.txt"
         }
     ],
     "test.test[join-nested_semi_join--Debug]": [
@@ -1401,100 +1401,100 @@
     ],
     "test.test[join-premap_context_dep--Debug]": [
         {
-            "checksum": "90a2898d2d2b9bcc8a5c6da5507cd17e",
-            "size": 6133,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-premap_context_dep--Debug_/opt.yql_patched"
+            "checksum": "4a1c41da46cb2f2b7c127fc39bb9c6f9",
+            "size": 5863,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-premap_context_dep--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_context_dep--Plan]": [
         {
-            "checksum": "18dee5f4923b18400093be14c52eba45",
-            "size": 8940,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-premap_context_dep--Plan_/plan.txt"
+            "checksum": "25b69faa23fcf008010e2a1b57f7aa8c",
+            "size": 8528,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-premap_context_dep--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_cross--Debug]": [
         {
-            "checksum": "36d1b68ce2e17979a0bbe927c3d0386b",
-            "size": 5896,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-pullup_cross--Debug_/opt.yql_patched"
+            "checksum": "95fa1dc98563982a6574d8822738e20a",
+            "size": 5641,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-pullup_cross--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_cross--Plan]": [
         {
-            "checksum": "c290ab13a877d7d6f200213b402f7dd1",
-            "size": 8943,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-pullup_cross--Plan_/plan.txt"
+            "checksum": "f9e1cbbba3b2bb41ee16220af95c8fea",
+            "size": 8531,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-pullup_cross--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_left--Debug]": [
         {
-            "checksum": "276558034af31e4485b7048b35c6c6d0",
-            "size": 5447,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-pullup_left--Debug_/opt.yql_patched"
+            "checksum": "97d4123892eda84e9b6069ec326857fe",
+            "size": 5273,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-pullup_left--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_left--Plan]": [
         {
-            "checksum": "988d794bda1a2643b81e371363cec386",
-            "size": 8042,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-pullup_left--Plan_/plan.txt"
+            "checksum": "22a229f3c90f90e9f6972bc7235cdd36",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-pullup_left--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_renaming--Debug]": [
         {
-            "checksum": "b6e2fc8f37a2007e497d78b55e366e3b",
-            "size": 5779,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-pullup_renaming--Debug_/opt.yql_patched"
+            "checksum": "8c0a0df80d0b27ff7a484d51fb1e61c7",
+            "size": 5603,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-pullup_renaming--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_renaming--Plan]": [
         {
-            "checksum": "988d794bda1a2643b81e371363cec386",
-            "size": 8042,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-pullup_renaming--Plan_/plan.txt"
+            "checksum": "22a229f3c90f90e9f6972bc7235cdd36",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1937429/3ec353865b88f20c966196a0ce16243c37e12190/resource.tar.gz#test.test_join-pullup_renaming--Plan_/plan.txt"
         }
     ],
     "test.test[join-pushdown_filter_over_inner_with_strict_udf--Debug]": [
         {
-            "checksum": "e94ae897704b79e9b55785fb88535615",
-            "size": 6322,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_strict_udf--Debug_/opt.yql_patched"
+            "checksum": "727931b7b07ee7cf60e9a0a8177de481",
+            "size": 6113,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_strict_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pushdown_filter_over_inner_with_strict_udf--Plan]": [
         {
-            "checksum": "5de7a13c6697b1815543ca9167c5a119",
-            "size": 10344,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_strict_udf--Plan_/plan.txt"
+            "checksum": "aa7146be2ccbe125c1dfe0c4bf8f31a4",
+            "size": 10138,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_strict_udf--Plan_/plan.txt"
         }
     ],
     "test.test[join-selfjoin_on_sorted--Debug]": [
         {
-            "checksum": "4c8283748c36ba668acb5a3f27f39c30",
-            "size": 2718,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_join-selfjoin_on_sorted--Debug_/opt.yql_patched"
+            "checksum": "82962ba5e22e320d43bf1bdeff922586",
+            "size": 2518,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-selfjoin_on_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-selfjoin_on_sorted--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-selfjoin_on_sorted--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-selfjoin_on_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[join-selfjoin_on_sorted_with_filter--Debug]": [
         {
-            "checksum": "87b0a71e7f6b693ab128ec426472e66c",
-            "size": 2805,
-            "uri": "https://{canondata_backend}/1946324/02914522fe745acca38b55e2fe9d3870e7990c88/resource.tar.gz#test.test_join-selfjoin_on_sorted_with_filter--Debug_/opt.yql_patched"
+            "checksum": "039fa9c2a6c2ab9e5cc71a17dec87173",
+            "size": 2605,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-selfjoin_on_sorted_with_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-selfjoin_on_sorted_with_filter--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1937027/1bacb5a7368b18003f80b761d72bba2ffb941db4/resource.tar.gz#test.test_join-selfjoin_on_sorted_with_filter--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-selfjoin_on_sorted_with_filter--Plan_/plan.txt"
         }
     ],
     "test.test[join-simple_columns_partial--Debug]": [
@@ -1513,30 +1513,30 @@
     ],
     "test.test[join-star_join_semionly--Debug]": [
         {
-            "checksum": "d066080384992c1fae340d9a9e61edbd",
-            "size": 5891,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_join-star_join_semionly--Debug_/opt.yql_patched"
+            "checksum": "56d0e9fccf4b17b1c572def79d6f706c",
+            "size": 5776,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-star_join_semionly--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join_semionly--Plan]": [
         {
-            "checksum": "7b4ab1aa0c257756163c3fd7f5ebd191",
-            "size": 9470,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-star_join_semionly--Plan_/plan.txt"
+            "checksum": "cec7a9c391dc62adf1cc1603d8a409e1",
+            "size": 9264,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-star_join_semionly--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-14829_leftonly--Debug]": [
         {
-            "checksum": "ddf27032c0fd7ecfb867961181961296",
-            "size": 7303,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_join-yql-14829_leftonly--Debug_/opt.yql_patched"
+            "checksum": "b8d616934f384b29b66bd9988571a3b7",
+            "size": 7159,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-yql-14829_leftonly--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-14829_leftonly--Plan]": [
         {
-            "checksum": "c141629e0c4131b88634b15bc8af5163",
-            "size": 18839,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_join-yql-14829_leftonly--Plan_/plan.txt"
+            "checksum": "abb27507ba0be7260eea2f593294249f",
+            "size": 18221,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_join-yql-14829_leftonly--Plan_/plan.txt"
         }
     ],
     "test.test[json-combination/nested-default.txt-Debug]": [
@@ -1583,128 +1583,128 @@
     ],
     "test.test[key_filter-contains-default.txt-Debug]": [
         {
-            "checksum": "abbf9ff48f285fd22d47b2d044048595",
-            "size": 2273,
-            "uri": "https://{canondata_backend}/1942671/02d92cf0c0511f91b97bd2224cd03d9e3aefd466/resource.tar.gz#test.test_key_filter-contains-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8d41fab09bb1829a39b3d76d11cfb3b2",
+            "size": 2150,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-contains-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-contains-default.txt-Plan]": [
         {
-            "checksum": "5f87fb14946b9b4ac407b20b08e82490",
-            "size": 3604,
-            "uri": "https://{canondata_backend}/1942415/82f39468e8f3a5a2c1a857e8a7b93fca015e5f50/resource.tar.gz#test.test_key_filter-contains-default.txt-Plan_/plan.txt"
+            "checksum": "97c7f373a9ae004b0dd3ae378ecfe558",
+            "size": 3398,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-contains-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-is_null_or_data--Debug]": [
         {
-            "checksum": "413c35c05a1d54c2c50fe114a969f6f1",
-            "size": 2128,
-            "uri": "https://{canondata_backend}/1917492/1c586496574adc79f6979d2bd0b899751c55c96d/resource.tar.gz#test.test_key_filter-is_null_or_data--Debug_/opt.yql_patched"
+            "checksum": "3e3a48db863792fc29f222888768553a",
+            "size": 2005,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-is_null_or_data--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-is_null_or_data--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/995452/5703745614275ced6550a5b45b1332aece4e0264/resource.tar.gz#test.test_key_filter-is_null_or_data--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-is_null_or_data--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-part_key_over_dynamic--Debug]": [
         {
-            "checksum": "da065197a470212881ab743955616946",
-            "size": 2101,
-            "uri": "https://{canondata_backend}/1946324/0ef792f4c8727a446387a75b6353548ce40c8808/resource.tar.gz#test.test_key_filter-part_key_over_dynamic--Debug_/opt.yql_patched"
+            "checksum": "f01b854735ca8bec0100519559463e18",
+            "size": 2039,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-part_key_over_dynamic--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-part_key_over_dynamic--Plan]": [
         {
-            "checksum": "31d406ffbf435de871b9f93ad9cd55ec",
-            "size": 3440,
-            "uri": "https://{canondata_backend}/1937027/2414691e45095ddadb0f9b93443850019c262f0e/resource.tar.gz#test.test_key_filter-part_key_over_dynamic--Plan_/plan.txt"
+            "checksum": "4a9722a51fa8c8416dacb8151a8e59d3",
+            "size": 3234,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-part_key_over_dynamic--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-ranges--Debug]": [
         {
-            "checksum": "e2e4dfce860f6f8317788643b9e678ff",
-            "size": 2263,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_key_filter-ranges--Debug_/opt.yql_patched"
+            "checksum": "c387d560aae4c16cc86464a95e605240",
+            "size": 2140,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-ranges--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-ranges--Plan]": [
         {
-            "checksum": "f4eb9b1740f82a75909d8884f1e80cc3",
-            "size": 3984,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_key_filter-ranges--Plan_/plan.txt"
+            "checksum": "f31047fbae53b2a1a2957367fb373954",
+            "size": 3778,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-ranges--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-string_with_ff-default.txt-Debug]": [
         {
-            "checksum": "31dd193c41b822096ff282541c15089e",
-            "size": 4443,
-            "uri": "https://{canondata_backend}/1784826/1efa8dd3b1200aa50410f28c1d2b5de157cb2228/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ba392768e2beb3c94461ddf8648ab156",
+            "size": 4277,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-string_with_ff-default.txt-Plan]": [
         {
-            "checksum": "ce89c2cef88c409ece04d5f1ff3e0e32",
-            "size": 10591,
-            "uri": "https://{canondata_backend}/1925842/4b2954699cef315188bd79d9ac1f433ed1155890/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Plan_/plan.txt"
+            "checksum": "0092245f47a36430ff1f999d07a8474c",
+            "size": 9973,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_key_filter-string_with_ff-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[lambda-lambda_udf--Debug]": [
         {
-            "checksum": "1de47c3d2a484038b97e0af8855445b5",
-            "size": 2807,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_lambda-lambda_udf--Debug_/opt.yql_patched"
+            "checksum": "7dbf814a7d7c6a6863436978867126d2",
+            "size": 2661,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_lambda-lambda_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[lambda-lambda_udf--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_lambda-lambda_udf--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_lambda-lambda_udf--Plan_/plan.txt"
         }
     ],
     "test.test[like-like_clause_escape-default.txt-Debug]": [
         {
-            "checksum": "8d14f6e24940610dae763076524940ef",
-            "size": 3338,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_like-like_clause_escape-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f3242bc17b624bc27b035d63f8234e80",
+            "size": 3215,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_like-like_clause_escape-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[like-like_clause_escape-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_like-like_clause_escape-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_like-like_clause_escape-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[limit-empty_sort_calc_after_limit-default.txt-Debug]": [
         {
-            "checksum": "f0e676a4581697d6c61d9b675786c520",
-            "size": 3306,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_limit-empty_sort_calc_after_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "33f790e6a94bbe98e569cc2b2131c4ed",
+            "size": 3153,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_limit-empty_sort_calc_after_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-empty_sort_calc_after_limit-default.txt-Plan]": [
         {
-            "checksum": "a8c803da0b9e869edc6d438c5b4fc2c1",
-            "size": 7081,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_limit-empty_sort_calc_after_limit-default.txt-Plan_/plan.txt"
+            "checksum": "f37dcede66118b5d792b93c1a93a7480",
+            "size": 6875,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_limit-empty_sort_calc_after_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-nonselected_direct_row--Debug]": [
         {
-            "checksum": "8b5d70cb31c105309d443a31d1188534",
-            "size": 2372,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_optimizers-nonselected_direct_row--Debug_/opt.yql_patched"
+            "checksum": "a508c130bc5c1ccfe64ed08be50ee04b",
+            "size": 2249,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-nonselected_direct_row--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-nonselected_direct_row--Plan]": [
         {
-            "checksum": "3bfc86d61215ce0ae33d5660fff817c0",
-            "size": 4587,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_optimizers-nonselected_direct_row--Plan_/plan.txt"
+            "checksum": "7cfa93ad87692f0effa8d60c42376544",
+            "size": 4381,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-nonselected_direct_row--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-wide_if_present_over_double_just-default.txt-Debug]": [
@@ -1723,142 +1723,142 @@
     ],
     "test.test[optimizers-yql-2582_limit_for_join_input_other--Debug]": [
         {
-            "checksum": "829c17cd1444f749675c7c5b3d86a612",
-            "size": 6252,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input_other--Debug_/opt.yql_patched"
+            "checksum": "b1c249fc8cab73ebe0cdb28d9b178bca",
+            "size": 6004,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input_other--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-2582_limit_for_join_input_other--Plan]": [
         {
-            "checksum": "95b4826ab9fe05e419ed7d845a8eafce",
-            "size": 9863,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input_other--Plan_/plan.txt"
+            "checksum": "d8e7a12fc1f785691b7abe30768493d6",
+            "size": 9451,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-yql-2582_limit_for_join_input_other--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-6008_limit_after_map--Debug]": [
         {
-            "checksum": "bca643a0431dacbc74ac94c6d3baff05",
-            "size": 3309,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Debug_/opt.yql_patched"
+            "checksum": "d0e6c6a23d1a21414e962da03622db8d",
+            "size": 3063,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-6008_limit_after_map--Plan]": [
         {
-            "checksum": "42b73ad797be5b8ab6ecd852ce41d95c",
-            "size": 8648,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Plan_/plan.txt"
+            "checksum": "4c7f2f49cd7da892f168ffdde9bdb92d",
+            "size": 8236,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-yql-6008_limit_after_map--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql_6179_merge_chunks_of_outputs--Debug]": [
         {
-            "checksum": "9f9f7d659261e7bbcb40c39fd05ba305",
-            "size": 4508,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_optimizers-yql_6179_merge_chunks_of_outputs--Debug_/opt.yql_patched"
+            "checksum": "f3a61f16a29fcfc8d997fc068b5f2a7e",
+            "size": 4404,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-yql_6179_merge_chunks_of_outputs--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql_6179_merge_chunks_of_outputs--Plan]": [
         {
-            "checksum": "dac0d4e5b2a7df6d884df2f063a7d018",
-            "size": 11395,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_optimizers-yql_6179_merge_chunks_of_outputs--Plan_/plan.txt"
+            "checksum": "9f771acfba5596bad48f0acef3c74369",
+            "size": 10983,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_optimizers-yql_6179_merge_chunks_of_outputs--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-SortByTwoFields--Debug]": [
         {
-            "checksum": "925b65cb6877aa91b617af45ac6684ae",
-            "size": 2188,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_order_by-SortByTwoFields--Debug_/opt.yql_patched"
+            "checksum": "6878585700ecbcc77508905e031c80bb",
+            "size": 2094,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-SortByTwoFields--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-SortByTwoFields--Plan]": [
         {
-            "checksum": "b0d2ecb103a6a956f56523c590bf4e00",
-            "size": 3560,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_order_by-SortByTwoFields--Plan_/plan.txt"
+            "checksum": "60c1b1db48ad363b978c9a92d5d93465",
+            "size": 3354,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-SortByTwoFields--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-SortByTwoFieldsDesc--Debug]": [
         {
-            "checksum": "08b92172e83002ed4b5112da922a8b8c",
-            "size": 3082,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_order_by-SortByTwoFieldsDesc--Debug_/opt.yql_patched"
+            "checksum": "ffc00ca284b2dc08d8e17f71d5d0a2da",
+            "size": 2928,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-SortByTwoFieldsDesc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-SortByTwoFieldsDesc--Plan]": [
         {
-            "checksum": "2e4bbd1d87409b7b30349eb480dbfa92",
-            "size": 5282,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_order_by-SortByTwoFieldsDesc--Plan_/plan.txt"
+            "checksum": "5b1d06dfa2af907ab866a4623b77398b",
+            "size": 5076,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-SortByTwoFieldsDesc--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_expr_mul_cols--Debug]": [
         {
-            "checksum": "2c9b9a9090225e273f9e729b611d5dff",
-            "size": 3444,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_order_by-order_by_expr_mul_cols--Debug_/opt.yql_patched"
+            "checksum": "06394ea9f780b04e81df80764b073a6f",
+            "size": 3283,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-order_by_expr_mul_cols--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_expr_mul_cols--Plan]": [
         {
-            "checksum": "f185f0d83099b823dc2fafffebc9f302",
-            "size": 6365,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_order_by-order_by_expr_mul_cols--Plan_/plan.txt"
+            "checksum": "db250e767dec6db3052a5ec01d1d70ad",
+            "size": 6159,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-order_by_expr_mul_cols--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_expr_simple--Debug]": [
         {
-            "checksum": "e7bc1f52295d57d4938ee5c011cfb5d4",
-            "size": 2829,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_order_by-order_by_expr_simple--Debug_/opt.yql_patched"
+            "checksum": "823442c069b6e4a3eb3a51a1d5ac473c",
+            "size": 2676,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-order_by_expr_simple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_expr_simple--Plan]": [
         {
-            "checksum": "6ddbfeb496edb95f716290d3314cb455",
-            "size": 5317,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_order_by-order_by_expr_simple--Plan_/plan.txt"
+            "checksum": "1b4ff335639e427966a02f51ff426c2f",
+            "size": 5111,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-order_by_expr_simple--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_tablepath_column--Debug]": [
         {
-            "checksum": "c8c7aec9ba784ac1fee3a18961334be5",
-            "size": 3925,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_order_by-order_by_tablepath_column--Debug_/opt.yql_patched"
+            "checksum": "97cc99556fd4ba39a23adbc30eb07d84",
+            "size": 3522,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-order_by_tablepath_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_tablepath_column--Plan]": [
         {
-            "checksum": "76c8d18428c2edf2832886371860be0a",
-            "size": 8515,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_order_by-order_by_tablepath_column--Plan_/plan.txt"
+            "checksum": "dc40ec1e8839ac2093a329652df15f2f",
+            "size": 7897,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-order_by_tablepath_column--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-ordered_fill--Debug]": [
         {
-            "checksum": "c27e3f81986f58969ba531a07fa1ecb7",
-            "size": 2721,
-            "uri": "https://{canondata_backend}/1784826/39983ce26d6fd1f3d9079ef38b8b1b03e2957453/resource.tar.gz#test.test_order_by-ordered_fill--Debug_/opt.yql_patched"
+            "checksum": "8820e080a411617e7d891feb36b6c7b9",
+            "size": 2605,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-ordered_fill--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-ordered_fill--Plan]": [
         {
-            "checksum": "9b534749c3919ce24699457686390c36",
-            "size": 6913,
-            "uri": "https://{canondata_backend}/1936842/6f6327c460b7c4ef46ca640f1509fdae0c0b5366/resource.tar.gz#test.test_order_by-ordered_fill--Plan_/plan.txt"
+            "checksum": "e0c76b022cc0b639dc38fe7fba2ac530",
+            "size": 6501,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-ordered_fill--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-presort_order_by_table-default.txt-Debug]": [
         {
-            "checksum": "1676a06e1f2bbcefa97b6af50c9e4389",
-            "size": 3413,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_order_by-presort_order_by_table-default.txt-Debug_/opt.yql_patched"
+            "checksum": "da04a9833aea21cab6beaff149fdc34f",
+            "size": 3251,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-presort_order_by_table-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-presort_order_by_table-default.txt-Plan]": [
         {
-            "checksum": "fd9ee1c4af19152424d4945e0e642f71",
-            "size": 8828,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_order_by-presort_order_by_table-default.txt-Plan_/plan.txt"
+            "checksum": "e35afb1301ba4d65e02fa78192d6c5e2",
+            "size": 8416,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_order_by-presort_order_by_table-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[params-no_optional_param-default.txt-Debug]": [
@@ -1905,16 +1905,16 @@
     ],
     "test.test[pg-aggregate_combine_all--Debug]": [
         {
-            "checksum": "a7a60072d730dd993a26034c95a247e0",
-            "size": 3944,
-            "uri": "https://{canondata_backend}/1936947/4bbe3286f93307fe5336387a3303b9f689a6d3e1/resource.tar.gz#test.test_pg-aggregate_combine_all--Debug_/opt.yql_patched"
+            "checksum": "b4d8afb52634313b7a7472343e4674e2",
+            "size": 3877,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_pg-aggregate_combine_all--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-aggregate_combine_all--Plan]": [
         {
-            "checksum": "c13909d84fe5e6c741b338984a2324ae",
-            "size": 5869,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_pg-aggregate_combine_all--Plan_/plan.txt"
+            "checksum": "00cdd95b1a4b21c2ee5c28990c158d73",
+            "size": 5663,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_pg-aggregate_combine_all--Plan_/plan.txt"
         }
     ],
     "test.test[pg-aggregate_emit_agg_apply-default.txt-Debug]": [
@@ -2381,30 +2381,30 @@
     ],
     "test.test[pg-tpch-q02-default.txt-Debug]": [
         {
-            "checksum": "385e4851f671f9fb68ccc9ccf13aa8da",
-            "size": 20475,
-            "uri": "https://{canondata_backend}/1936273/758a5f9b9f5606d8945867b24c986af6c6230554/resource.tar.gz#test.test_pg-tpch-q02-default.txt-Debug_/opt.yql_patched"
+            "checksum": "85a42de880d18e1032df92c058b5f875",
+            "size": 19956,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_pg-tpch-q02-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q02-default.txt-Plan]": [
         {
-            "checksum": "4640017946da886094b099197fdda3ae",
-            "size": 28169,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_pg-tpch-q02-default.txt-Plan_/plan.txt"
+            "checksum": "5252c98b80e169e8dd715346442ff11f",
+            "size": 27757,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_pg-tpch-q02-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q13-default.txt-Debug]": [
         {
-            "checksum": "c1dc3c1f9efeab7221533bf1f5701dd3",
-            "size": 14805,
-            "uri": "https://{canondata_backend}/1871182/7b2e6a8eef11913e44a68128db2ffa8d3a7bc41e/resource.tar.gz#test.test_pg-tpch-q13-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b5c8cc1474a77dfa17926ba58389c68b",
+            "size": 14602,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_pg-tpch-q13-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q13-default.txt-Plan]": [
         {
-            "checksum": "a50d07604b9d5be95090d919dc758a20",
-            "size": 14469,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_pg-tpch-q13-default.txt-Plan_/plan.txt"
+            "checksum": "16319359f0c6455cd5707b5f369ce75a",
+            "size": 14057,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_pg-tpch-q13-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-uuid_from_pg-default.txt-Debug]": [
@@ -2465,156 +2465,156 @@
     ],
     "test.test[produce-discard_reduce_lambda-default.txt-Debug]": [
         {
-            "checksum": "c1fa3a57310f467ed7af72a8bd4fb826",
-            "size": 2882,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_produce-discard_reduce_lambda-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1ebd54942fe6ac8f9591133b15836c2d",
+            "size": 2787,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-discard_reduce_lambda-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-discard_reduce_lambda-default.txt-Plan]": [
         {
-            "checksum": "7b47a07269e5fd7506eafaa11e4cfdd7",
-            "size": 3610,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_produce-discard_reduce_lambda-default.txt-Plan_/plan.txt"
+            "checksum": "274da28f43a671f1f0b712f8f977b63a",
+            "size": 3404,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-discard_reduce_lambda-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-native_desc_reduce_with_presort--Debug]": [
         {
-            "checksum": "9ccd0924647566a04dd85ec9a29825ac",
-            "size": 8846,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_produce-native_desc_reduce_with_presort--Debug_/opt.yql_patched"
+            "checksum": "9a8e9dd0116133e8696b412b9457acf9",
+            "size": 8495,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-native_desc_reduce_with_presort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-native_desc_reduce_with_presort--Plan]": [
         {
-            "checksum": "04e24f4daae7c81ee1a0371b35f6a3f7",
-            "size": 14513,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_produce-native_desc_reduce_with_presort--Plan_/plan.txt"
+            "checksum": "a32ea36b81ea5c3c2f63ba131b462423",
+            "size": 13689,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-native_desc_reduce_with_presort--Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_streaming-default.txt-Debug]": [
         {
-            "checksum": "d0816a830d583a4031009d99c6f32a87",
-            "size": 3513,
-            "uri": "https://{canondata_backend}/1775319/79b5cc0dd052f278f7543f1b8e92f8c6ea53fbd6/resource.tar.gz#test.test_produce-process_streaming-default.txt-Debug_/opt.yql_patched"
+            "checksum": "383f893ee667694dd1f246a3a2ccafb9",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-process_streaming-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_streaming-default.txt-Plan]": [
         {
-            "checksum": "0a53779f7cba8bf9905cdc08418f6a98",
-            "size": 4504,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_produce-process_streaming-default.txt-Plan_/plan.txt"
+            "checksum": "e2a41062346dd23c9c1623e954cddc82",
+            "size": 4298,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-process_streaming-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_lambda-default.txt-Debug]": [
         {
-            "checksum": "5a4a2c6c4d78d7a9ce5d82336219b7a7",
-            "size": 3833,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_produce-reduce_lambda-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ecaa7f535ca50e623e09184d4ddeb2c6",
+            "size": 3643,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-reduce_lambda-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_lambda-default.txt-Plan]": [
         {
-            "checksum": "69ba4607733f7366c494efb9923bdc79",
-            "size": 5741,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_produce-reduce_lambda-default.txt-Plan_/plan.txt"
+            "checksum": "967a7d635dd1fdaf099da1db6696b704",
+            "size": 5329,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-reduce_lambda-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_sampling--Debug]": [
         {
-            "checksum": "8da54359e2fa28f1fb2b213bfd87eafa",
-            "size": 3990,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_produce-reduce_multi_in_sampling--Debug_/opt.yql_patched"
+            "checksum": "6bdbfe3d776ee5a778da5e6c1d80827a",
+            "size": 3878,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-reduce_multi_in_sampling--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_sampling--Plan]": [
         {
-            "checksum": "2fe4807d71c1ff84e2507cff784b2cd0",
-            "size": 8257,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_produce-reduce_multi_in_sampling--Plan_/plan.txt"
+            "checksum": "e6aedf118d0ef1ecae20fdaa7e72e7d2",
+            "size": 8051,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-reduce_multi_in_sampling--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-map-keyfilter-Debug]": [
         {
-            "checksum": "d3fcab6eb8210ab2d0fc89125425be57",
-            "size": 2072,
-            "uri": "https://{canondata_backend}/1031349/f44368e534fed647ff8661c989fd96716fabe7a3/resource.tar.gz#test.test_sampling-map-keyfilter-Debug_/opt.yql_patched"
+            "checksum": "bc351978912b108012864e58f45e2d82",
+            "size": 1949,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-map-keyfilter-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-map-keyfilter-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1936842/9bb151f52e4d7f91706c6b5d9ff144cc8872a6b7/resource.tar.gz#test.test_sampling-map-keyfilter-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-map-keyfilter-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-read--Debug]": [
         {
-            "checksum": "d2aba87a276b8d581c57351ff873cbcf",
-            "size": 1759,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_sampling-read--Debug_/opt.yql_patched"
+            "checksum": "0c50aef2ce9bddf2ee0504cf40eed3a9",
+            "size": 1636,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-read--Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-read--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_sampling-read--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-read--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-reduce-with_premap-Debug]": [
         {
-            "checksum": "f5efbd7457c95890f8dafae1e2223f34",
-            "size": 4695,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_sampling-reduce-with_premap-Debug_/opt.yql_patched"
+            "checksum": "657affdc3c68ec8dc4f056ec821bd546",
+            "size": 4384,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-reduce-with_premap-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-reduce-with_premap-Plan]": [
         {
-            "checksum": "acd22d78538816551e5240676d633b12",
-            "size": 7879,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_sampling-reduce-with_premap-Plan_/plan.txt"
+            "checksum": "13161e13f9e2710d3c0aa3312fb76610",
+            "size": 7261,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-reduce-with_premap-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-subquery_default-default.txt-Debug]": [
         {
-            "checksum": "340d5c43440eb7af53cbf5ace34a5764",
-            "size": 2149,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_sampling-subquery_default-default.txt-Debug_/opt.yql_patched"
+            "checksum": "396f0036a602324fc7184076f26f4abe",
+            "size": 2026,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-subquery_default-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-subquery_default-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_sampling-subquery_default-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-subquery_default-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-subquery_expr-default.txt-Debug]": [
         {
-            "checksum": "a5b3ef535c5e362c44d880db9dfdb408",
-            "size": 2310,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_sampling-subquery_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "decee561f83ed265d1c82001dec65404",
+            "size": 2187,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-subquery_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-subquery_expr-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_sampling-subquery_expr-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_sampling-subquery_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-limit_simple--Debug]": [
         {
-            "checksum": "aa9935be174142a7bbaf24bea6dca41c",
-            "size": 1901,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_schema-limit_simple--Debug_/opt.yql_patched"
+            "checksum": "755a0f746b09a60daaf8e190f1f9bd00",
+            "size": 1841,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_schema-limit_simple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-limit_simple--Plan]": [
         {
-            "checksum": "62c7f54f40958665bdef492623ca2302",
-            "size": 3438,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_schema-limit_simple--Plan_/plan.txt"
+            "checksum": "cbc56016bd36c156942af6e90ab684a2",
+            "size": 3232,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_schema-limit_simple--Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_all-row_spec_diff_sort2-Debug]": [
@@ -2647,16 +2647,16 @@
     ],
     "test.test[schema-select_all_inferschema_op_custom_tmp--Debug]": [
         {
-            "checksum": "d1fbf36936346481669ff010ce16c9e4",
-            "size": 2787,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_schema-select_all_inferschema_op_custom_tmp--Debug_/opt.yql_patched"
+            "checksum": "b82759f9b59ce7e3e06a45d43f600c84",
+            "size": 2598,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_schema-select_all_inferschema_op_custom_tmp--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_all_inferschema_op_custom_tmp--Plan]": [
         {
-            "checksum": "a04ec8dda3feaef394eb05fcb2f1492e",
-            "size": 3604,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_schema-select_all_inferschema_op_custom_tmp--Plan_/plan.txt"
+            "checksum": "45906ae2ceda28ce1789d52e115dc341",
+            "size": 3398,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_schema-select_all_inferschema_op_custom_tmp--Plan_/plan.txt"
         }
     ],
     "test.test[schema-yamred_dsv_select_from_dict--Debug]": [
@@ -2675,30 +2675,30 @@
     ],
     "test.test[select-corr_name_in_select-default.txt-Debug]": [
         {
-            "checksum": "5247a587aad5ec584306eaa06eeef51d",
-            "size": 2608,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_select-corr_name_in_select-default.txt-Debug_/opt.yql_patched"
+            "checksum": "66dfd6c78de43eae27651c2daff0beaf",
+            "size": 2496,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-corr_name_in_select-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-corr_name_in_select-default.txt-Plan]": [
         {
-            "checksum": "d7e7959dac78faa3fc130a529934e55d",
-            "size": 5120,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_select-corr_name_in_select-default.txt-Plan_/plan.txt"
+            "checksum": "cb211d29e0cafbf23da639618b98f144",
+            "size": 4914,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-corr_name_in_select-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-dict_with_few_keys-default.txt-Debug]": [
         {
-            "checksum": "233fd16b88145783c2c18dc361f6009a",
-            "size": 3224,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_select-dict_with_few_keys-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e75c80eeba70d75871315fa6531759f3",
+            "size": 3030,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-dict_with_few_keys-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-dict_with_few_keys-default.txt-Plan]": [
         {
-            "checksum": "ee7d6807c455d83cf4348ef470c6a45e",
-            "size": 6200,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_select-dict_with_few_keys-default.txt-Plan_/plan.txt"
+            "checksum": "cfc091e969921c506341adea3cecb504",
+            "size": 5788,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-dict_with_few_keys-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-digits--Debug]": [
@@ -2717,44 +2717,44 @@
     ],
     "test.test[select-multi_source_issue-default.txt-Debug]": [
         {
-            "checksum": "7d5136f87fabd31fab59276ba898a095",
-            "size": 2570,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_select-multi_source_issue-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5907fbf0130329786d36c987e9e6d485",
+            "size": 2528,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-multi_source_issue-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-multi_source_issue-default.txt-Plan]": [
         {
-            "checksum": "46879c9353ce03e1385e9a7718e6a849",
-            "size": 6174,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_select-multi_source_issue-default.txt-Plan_/plan.txt"
+            "checksum": "5252943d44a88662c1ef56729d43e60e",
+            "size": 5968,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-multi_source_issue-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-optional_as_warn-default.txt-Debug]": [
         {
-            "checksum": "fe6b3bf5c972c0374c312b1e4b4552f9",
-            "size": 3062,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_select-optional_as_warn-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7f66b0b7fefa2311c18d6c312d48aa2f",
+            "size": 2864,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-optional_as_warn-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-optional_as_warn-default.txt-Plan]": [
         {
-            "checksum": "381f217e3d3d77799c5a68e72c92749a",
-            "size": 6896,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_select-optional_as_warn-default.txt-Plan_/plan.txt"
+            "checksum": "81e6a1af6c235aa4089778a73729400e",
+            "size": 6484,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-optional_as_warn-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-scalar_subquery-default.txt-Debug]": [
         {
-            "checksum": "4d98d80cc00bb2222239cb4d08b59f39",
-            "size": 3430,
-            "uri": "https://{canondata_backend}/1817427/6b9d6900149bd623684788c18b56b70ca178d680/resource.tar.gz#test.test_select-scalar_subquery-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ff51d43ea353299a6fcdcab2ac267afe",
+            "size": 3322,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-scalar_subquery-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-scalar_subquery-default.txt-Plan]": [
         {
-            "checksum": "ad940930fc7f566294786e577b67f2d8",
-            "size": 5461,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_select-scalar_subquery-default.txt-Plan_/plan.txt"
+            "checksum": "5a26023580863452ea2d8815cfc8d006",
+            "size": 5255,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-scalar_subquery-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-select_all-default.txt-Debug]": [
@@ -2773,58 +2773,58 @@
     ],
     "test.test[select-select_all_ordered-default.txt-Debug]": [
         {
-            "checksum": "59bfb3f49bab62abc289ddc2780936c9",
-            "size": 1984,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_select-select_all_ordered-default.txt-Debug_/opt.yql_patched"
+            "checksum": "47ad6c753e56d452c4cfe649f3c54fe5",
+            "size": 1861,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-select_all_ordered-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-select_all_ordered-default.txt-Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_select-select_all_ordered-default.txt-Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-select_all_ordered-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-tablename_with_table_row-default.txt-Debug]": [
         {
-            "checksum": "25da176340e78f4d0d1ee94940338edf",
-            "size": 4260,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_select-tablename_with_table_row-default.txt-Debug_/opt.yql_patched"
+            "checksum": "56ab523e786ccee8a1aba69d5bdda19e",
+            "size": 3987,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-tablename_with_table_row-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-tablename_with_table_row-default.txt-Plan]": [
         {
-            "checksum": "00a6a2610c569830afcbb1888e527f2f",
-            "size": 8913,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_select-tablename_with_table_row-default.txt-Plan_/plan.txt"
+            "checksum": "d6387932d0af7caec022fed2aad42856",
+            "size": 8295,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_select-tablename_with_table_row-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_coalesce_without_left_semi_1-default.txt-Debug]": [
         {
-            "checksum": "52330f7ed1975a2742429b5d5336b01e",
-            "size": 3988,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "aeed44636069c6307f95b341c69a0fcb",
+            "size": 3923,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_coalesce_without_left_semi_1-default.txt-Plan]": [
         {
-            "checksum": "c2c26858a60a83ad2dfda8c7d07627b5",
-            "size": 8445,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_1-default.txt-Plan_/plan.txt"
+            "checksum": "9a166272ef60d3787078b4530c591967",
+            "size": 8239,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_without_resolve_dublicates_mult-default.txt-Debug]": [
         {
-            "checksum": "8e68b1b2cbecaa846e02bbf365421d3d",
-            "size": 7093,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates_mult-default.txt-Debug_/opt.yql_patched"
+            "checksum": "014b4cb5659ebc3d387ae11ea7ee667d",
+            "size": 6738,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates_mult-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_without_resolve_dublicates_mult-default.txt-Plan]": [
         {
-            "checksum": "84d8628991680f471c5fe5d2dd3086b6",
-            "size": 9136,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates_mult-default.txt-Plan_/plan.txt"
+            "checksum": "df2567a82663dc61534169e9aa734411",
+            "size": 8724,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_simple_columns-simple_columns_join_without_resolve_dublicates_mult-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_tablerow-default.txt-Debug]": [
@@ -2843,72 +2843,72 @@
     ],
     "test.test[table_range-concat_with_view--Debug]": [
         {
-            "checksum": "14a4a58f5818fbe28d5dca2c3c505be6",
-            "size": 5292,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_table_range-concat_with_view--Debug_/opt.yql_patched"
+            "checksum": "0447461dd33669ca31b1a8c3619d66ce",
+            "size": 5006,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_table_range-concat_with_view--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-concat_with_view--Plan]": [
         {
-            "checksum": "d19f9fa41a19417ba1a39e8397fbea43",
-            "size": 9044,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_table_range-concat_with_view--Plan_/plan.txt"
+            "checksum": "c1c96a9d1e51b731413dce89f99abf25",
+            "size": 8632,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_table_range-concat_with_view--Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q14-default.txt-Debug]": [
         {
-            "checksum": "efe0edb2265f0e0e961789b69ecd7881",
-            "size": 6608,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_tpch-q14-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2d86dac7182610b4b8c189ec20097c62",
+            "size": 6357,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_tpch-q14-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q14-default.txt-Plan]": [
         {
-            "checksum": "3decaa57cd36473254b8b45d1119bcf8",
-            "size": 8831,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_tpch-q14-default.txt-Plan_/plan.txt"
+            "checksum": "74f6b5ac6d199317d4de72f2c74ed869",
+            "size": 8419,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_tpch-q14-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q2-default.txt-Debug]": [
         {
-            "checksum": "a87e0b8a382e9f0b5b475f08a302f536",
-            "size": 12701,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_tpch-q2-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2b314900b22ccc94c9c0a354a5308af1",
+            "size": 11972,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_tpch-q2-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q2-default.txt-Plan]": [
         {
-            "checksum": "a3417dd81ce3ad9fe482477fe5310931",
-            "size": 18290,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_tpch-q2-default.txt-Plan_/plan.txt"
+            "checksum": "9ac5b3262eaa6039d1dea388cc0d1ac0",
+            "size": 17260,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_tpch-q2-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-json--Debug]": [
         {
-            "checksum": "35deb6f015d56144274b2351d0cec15e",
-            "size": 2607,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_type_v3-json--Debug_/opt.yql_patched"
+            "checksum": "9a3e451a859ba85133c260ca4e66773f",
+            "size": 2503,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_type_v3-json--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-json--Plan]": [
         {
-            "checksum": "088ab842a3e6c4018e118dbaa8ea3f46",
-            "size": 7309,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_type_v3-json--Plan_/plan.txt"
+            "checksum": "76036d0208499b237e9b662a456dfb70",
+            "size": 6897,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_type_v3-json--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-non_strict--Debug]": [
         {
-            "checksum": "68716e724979b784d52001407badb6c7",
-            "size": 3865,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_type_v3-non_strict--Debug_/opt.yql_patched"
+            "checksum": "0d6bf4b9ff9c921295f9b13af608c95c",
+            "size": 3563,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_type_v3-non_strict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-non_strict--Plan]": [
         {
-            "checksum": "3fb033aca202f4958b557c99e604c4f7",
-            "size": 7050,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_type_v3-non_strict--Plan_/plan.txt"
+            "checksum": "f5f02451ebeeed7e8aef68f263117aa4",
+            "size": 6638,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_type_v3-non_strict--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-replace_diff_layout--Debug]": [
@@ -2969,30 +2969,30 @@
     ],
     "test.test[union_all-mix_map_and_read-default.txt-Debug]": [
         {
-            "checksum": "3736512c97e98745bb746eb2366d5fff",
-            "size": 3183,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_union_all-mix_map_and_read-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f27a15198c9f2b53664e0d9a88a15a22",
+            "size": 2937,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_union_all-mix_map_and_read-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-mix_map_and_read-default.txt-Plan]": [
         {
-            "checksum": "8de13ba54b4b55e945f6d7e4958df2ce",
-            "size": 6529,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_union_all-mix_map_and_read-default.txt-Plan_/plan.txt"
+            "checksum": "bc213dd4cc11e9632c29ab5d7c253433",
+            "size": 6117,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_union_all-mix_map_and_read-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_fields-default.txt-Debug]": [
         {
-            "checksum": "c9024dfb182a4fb9c3dca198bccf1121",
-            "size": 3143,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_union_all-union_all_fields-default.txt-Debug_/opt.yql_patched"
+            "checksum": "74da5a8e79d1182b8dff97a859960fcf",
+            "size": 2943,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_union_all-union_all_fields-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-union_all_fields-default.txt-Plan]": [
         {
-            "checksum": "ee7d6807c455d83cf4348ef470c6a45e",
-            "size": 6200,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_union_all-union_all_fields-default.txt-Plan_/plan.txt"
+            "checksum": "cfc091e969921c506341adea3cecb504",
+            "size": 5788,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_union_all-union_all_fields-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_trivial-default.txt-Debug]": [
@@ -3011,16 +3011,16 @@
     ],
     "test.test[view-all_from_view--Debug]": [
         {
-            "checksum": "b25e777a6173292f64adc72c4973a9c6",
-            "size": 1948,
-            "uri": "https://{canondata_backend}/1880306/b7c0983a1c6c9c608654f7a228532df5441ad227/resource.tar.gz#test.test_view-all_from_view--Debug_/opt.yql_patched"
+            "checksum": "e21c097b806a4cf0a791ad44cd1e759a",
+            "size": 1886,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_view-all_from_view--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-all_from_view--Plan]": [
         {
-            "checksum": "31d406ffbf435de871b9f93ad9cd55ec",
-            "size": 3440,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_view-all_from_view--Plan_/plan.txt"
+            "checksum": "4a9722a51fa8c8416dacb8151a8e59d3",
+            "size": 3234,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_view-all_from_view--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-optimize_weak_fields_map--Debug]": [
@@ -3039,128 +3039,128 @@
     ],
     "test.test[weak_field-weak_field_join_condition--Debug]": [
         {
-            "checksum": "e35369dbcf3e1a45c27c331baa5ad60b",
-            "size": 7257,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_weak_field-weak_field_join_condition--Debug_/opt.yql_patched"
+            "checksum": "f974cc846a1e6ae682a21f06d3ce9f68",
+            "size": 7088,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_weak_field-weak_field_join_condition--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_join_condition--Plan]": [
         {
-            "checksum": "3c6f5d72da5ac69002b3380ee6111a90",
-            "size": 10306,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_weak_field-weak_field_join_condition--Plan_/plan.txt"
+            "checksum": "030d224ff7c73017884a3fcc750431e0",
+            "size": 10100,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_weak_field-weak_field_join_condition--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_join_where--Debug]": [
         {
-            "checksum": "00eae78feece9c56a0cd71e9470c71d7",
-            "size": 8121,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_weak_field-weak_field_join_where--Debug_/opt.yql_patched"
+            "checksum": "dc6776f3b472a154a2287f05bee3afd8",
+            "size": 7952,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_weak_field-weak_field_join_where--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_join_where--Plan]": [
         {
-            "checksum": "b2f4ebd7268390551e60958ec7885e95",
-            "size": 11242,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_weak_field-weak_field_join_where--Plan_/plan.txt"
+            "checksum": "1e6339e307349d1c70614ea8f71b43df",
+            "size": 11036,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_weak_field-weak_field_join_where--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_real_col-default.txt-Debug]": [
         {
-            "checksum": "9b5e796fe9b10a956bb687f48a47bfc2",
-            "size": 3340,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_weak_field-weak_field_real_col-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2bf0b926b76b1a74806ffdbf5107563c",
+            "size": 3098,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_weak_field-weak_field_real_col-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_real_col-default.txt-Plan]": [
         {
-            "checksum": "ee7d6807c455d83cf4348ef470c6a45e",
-            "size": 6200,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_weak_field-weak_field_real_col-default.txt-Plan_/plan.txt"
+            "checksum": "cfc091e969921c506341adea3cecb504",
+            "size": 5788,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_weak_field-weak_field_real_col-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-current/session--Debug]": [
         {
-            "checksum": "38dba6f9fac61a46e5929c97bce2f4fe",
-            "size": 6297,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_window-current_session--Debug_/opt.yql_patched"
+            "checksum": "0bc4e01894b35497f8953c02a9c13cde",
+            "size": 5937,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-current_session--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/session--Plan]": [
         {
-            "checksum": "e7efb3f7edde9656bf810dc99f196601",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-current_session--Plan_/plan.txt"
+            "checksum": "c2811c6ab32fd90a6aa5cdabc95cf483",
+            "size": 5326,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-current_session--Plan_/plan.txt"
         }
     ],
     "test.test[window-empty/aggregations--Debug]": [
         {
-            "checksum": "2358957fa3599b75393c34bd105b26c3",
-            "size": 6752,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_window-empty_aggregations--Debug_/opt.yql_patched"
+            "checksum": "26b1c14d78630c729fb0ef7a51aca640",
+            "size": 6354,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-empty_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-empty/aggregations--Plan]": [
         {
-            "checksum": "84f8ff05d9110a914ec463797b424a76",
-            "size": 7361,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-empty_aggregations--Plan_/plan.txt"
+            "checksum": "a848d413a8dde7d63f1d7a9d6fe37026",
+            "size": 6949,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-empty_aggregations--Plan_/plan.txt"
         }
     ],
     "test.test[window-empty/aggregations_leadlag--Debug]": [
         {
-            "checksum": "bb816b6e09882db43e1eb785e4fccc7b",
-            "size": 7420,
-            "uri": "https://{canondata_backend}/1880306/0f9ac3129b286de769b44c8e97758dc928cf7c9a/resource.tar.gz#test.test_window-empty_aggregations_leadlag--Debug_/opt.yql_patched"
+            "checksum": "08a1b8605c23b23996fefa53c38f240a",
+            "size": 7059,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-empty_aggregations_leadlag--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-empty/aggregations_leadlag--Plan]": [
         {
-            "checksum": "64aff5f434dd97b1bcfea686bc5c60a1",
-            "size": 7626,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-empty_aggregations_leadlag--Plan_/plan.txt"
+            "checksum": "ddfd5ddaf91dbfe73b3d2e1ac2398e96",
+            "size": 7214,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-empty_aggregations_leadlag--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/session_compact--Debug]": [
         {
-            "checksum": "b422594f86885958538de544aa42a129",
-            "size": 6851,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_window-full_session_compact--Debug_/opt.yql_patched"
+            "checksum": "b263815a4060d2fd59589bd6a783d1a5",
+            "size": 6477,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-full_session_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/session_compact--Plan]": [
         {
-            "checksum": "e7efb3f7edde9656bf810dc99f196601",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-full_session_compact--Plan_/plan.txt"
+            "checksum": "c2811c6ab32fd90a6aa5cdabc95cf483",
+            "size": 5326,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-full_session_compact--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_by_all_aggregate--Debug]": [
         {
-            "checksum": "2c4c5ff9dad34caf6978fb4ccb350351",
-            "size": 19198,
-            "uri": "https://{canondata_backend}/1809005/161342601473b76623944595105e92912ad1b3f6/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql_patched"
+            "checksum": "fb63c6c30ee35986f7f1a2e414a7c874",
+            "size": 19069,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_by_all_aggregate--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_by_all_aggregate--Plan]": [
         {
-            "checksum": "326fc9b4b19cb3d6b942a6fbce67cb32",
-            "size": 7044,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-win_by_all_aggregate--Plan_/plan.txt"
+            "checksum": "a916cdbf1353c86e1f20a379bc44b167",
+            "size": 6838,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_by_all_aggregate--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_aggr_with_qualified_all--Debug]": [
         {
-            "checksum": "61f5eb3cc2cffca8d99e2598f3e6826c",
-            "size": 5987,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all--Debug_/opt.yql_patched"
+            "checksum": "5191159288887f9b884ab21546b82197",
+            "size": 5516,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_with_qualified_all--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_percent_rank-default.txt-Debug]": [
@@ -3179,30 +3179,30 @@
     ],
     "test.test[window-win_func_with_struct_access-default.txt-Debug]": [
         {
-            "checksum": "5fd0123a68e009dbb4abfb0b0e6203a3",
-            "size": 6087,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_window-win_func_with_struct_access-default.txt-Debug_/opt.yql_patched"
+            "checksum": "538d1e1f19efc60ce413fedf1f44bfc0",
+            "size": 5829,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_func_with_struct_access-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_with_struct_access-default.txt-Plan]": [
         {
-            "checksum": "6dc53254124b493a0f70e66612837574",
-            "size": 8509,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-win_func_with_struct_access-default.txt-Plan_/plan.txt"
+            "checksum": "0445e433cb29c2c02fed56bd65c913c7",
+            "size": 8097,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_func_with_struct_access-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_multiaggr_library--Debug]": [
         {
-            "checksum": "676a09f31d7935e5e5081bd7b0030046",
-            "size": 3518,
-            "uri": "https://{canondata_backend}/212715/3045678bab9ba65eca350a0c5b4618902a97028e/resource.tar.gz#test.test_window-win_multiaggr_library--Debug_/opt.yql_patched"
+            "checksum": "40176e4bef2ca6b9637c70d3c57232e7",
+            "size": 3422,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_multiaggr_library--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_multiaggr_library--Plan]": [
         {
-            "checksum": "e73e482ef8e1fd5e2f1fb173e85002a7",
-            "size": 5560,
-            "uri": "https://{canondata_backend}/1931696/8382830b676a61af36d1344910d51cd1bf39f3ef/resource.tar.gz#test.test_window-win_multiaggr_library--Plan_/plan.txt"
+            "checksum": "79359b10317c94ad618b5563fe45b4e4",
+            "size": 5354,
+            "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_window-win_multiaggr_library--Plan_/plan.txt"
         }
     ]
 }

--- a/ydb/library/yql/tests/sql/hybrid_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part5/canondata/result.json
@@ -1,16 +1,16 @@
 {
     "test.test[action-action_nested_query-default.txt-Debug]": [
         {
-            "checksum": "358af6654b98e449737593922c8a9c00",
-            "size": 1980,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_action-action_nested_query-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8567793b6c76ea486a18416b3878812d",
+            "size": 1857,
+            "uri": "https://{canondata_backend}/1937150/8a03b22cb41a5d45a74b6bace2f08e86727532d3/resource.tar.gz#test.test_action-action_nested_query-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-action_nested_query-default.txt-Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_action-action_nested_query-default.txt-Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_action-action_nested_query-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-action_udf_args--Debug]": [
@@ -183,16 +183,16 @@
     ],
     "test.test[aggr_factory-avg-default.txt-Debug]": [
         {
-            "checksum": "294e7d1800060dd734935af3e5d45220",
-            "size": 7304,
-            "uri": "https://{canondata_backend}/1925821/388676377b8029f361a2f44783f99dd3d81d73e6/resource.tar.gz#test.test_aggr_factory-avg-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cc2ec2459665190ae9133f08b63d8f36",
+            "size": 7205,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggr_factory-avg-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-avg-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggr_factory-avg-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggr_factory-avg-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-container_empty-default.txt-Debug]": [
@@ -267,156 +267,156 @@
     ],
     "test.test[aggregate-GroupByOneField--Debug]": [
         {
-            "checksum": "4dafc39311460657ad9cf403e8eaa781",
-            "size": 5237,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_aggregate-GroupByOneField--Debug_/opt.yql_patched"
+            "checksum": "82f49afe1a020a003f82708fca299082",
+            "size": 4911,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-GroupByOneField--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-GroupByOneField--Plan]": [
         {
-            "checksum": "4df1af4900628d40008ffbf2301ec1b2",
-            "size": 8473,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-GroupByOneField--Plan_/plan.txt"
+            "checksum": "a02c243480f107a17c822d7c3fe9a19e",
+            "size": 7855,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-GroupByOneField--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-agg_phases_table3-default.txt-Debug]": [
         {
-            "checksum": "eaec2daf4790397d6c22640c8adcab3a",
-            "size": 7122,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_aggregate-agg_phases_table3-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c7582882a492723915e704edac7fc28c",
+            "size": 6724,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-agg_phases_table3-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-agg_phases_table3-default.txt-Plan]": [
         {
-            "checksum": "27d8e036331fe82e20a603d93e3b2ece",
-            "size": 11186,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-agg_phases_table3-default.txt-Plan_/plan.txt"
+            "checksum": "d4ceee7abef56d8ec398fd3cb8dfb389",
+            "size": 10568,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-agg_phases_table3-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_with_lambda_inside_avg--Debug]": [
         {
-            "checksum": "73a541242a3d02317429f857c7212805",
-            "size": 3478,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_aggregate-aggregate_with_lambda_inside_avg--Debug_/opt.yql_patched"
+            "checksum": "543f4ea551aa0cf7b50d7d0fff0d727a",
+            "size": 3411,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-aggregate_with_lambda_inside_avg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_with_lambda_inside_avg--Plan]": [
         {
-            "checksum": "0e56f2addf2b393236b33f1567613332",
-            "size": 5616,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-aggregate_with_lambda_inside_avg--Plan_/plan.txt"
+            "checksum": "769127c4504c755518199b95d4a783c6",
+            "size": 5410,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-aggregate_with_lambda_inside_avg--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregation_and_order-default.txt-Debug]": [
         {
-            "checksum": "63bafb8d1477591b2aaceaf9b185103a",
-            "size": 5044,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_aggregate-aggregation_and_order-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2568ccb47f00a88028df47488e3e7a02",
+            "size": 4670,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-aggregation_and_order-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregation_and_order-default.txt-Plan]": [
         {
-            "checksum": "28c2ab3b456e34dadfd529005a3e689e",
-            "size": 8484,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-aggregation_and_order-default.txt-Plan_/plan.txt"
+            "checksum": "3ceffa5883fca835378d5359d3859d5f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-aggregation_and_order-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggrs_no_grouping_via_map_compact-default.txt-Debug]": [
         {
-            "checksum": "0cd53d146a3e8512d0a82e3a7ed87721",
-            "size": 18147,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map_compact-default.txt-Debug_/opt.yql_patched"
+            "checksum": "40ec779cb1654b9eb6c03127bb34f168",
+            "size": 17015,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map_compact-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggrs_no_grouping_via_map_compact-default.txt-Plan]": [
         {
-            "checksum": "b282765515d796a5b695551e2d697a13",
-            "size": 6280,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map_compact-default.txt-Plan_/plan.txt"
+            "checksum": "0ec750e8e4884ae4a7ae510ef3214e59",
+            "size": 5868,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map_compact-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_cube_duo--Debug]": [
         {
-            "checksum": "b450777f0abf789e808b42e13ad38eeb",
-            "size": 11871,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_aggregate-group_by_cube_duo--Debug_/opt.yql_patched"
+            "checksum": "5ecd58db8abbebc23827399c57f083dd",
+            "size": 11347,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_cube_duo--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_cube_duo--Plan]": [
         {
-            "checksum": "c4cb82543f8837f95f4cee25834b3312",
-            "size": 17444,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-group_by_cube_duo--Plan_/plan.txt"
+            "checksum": "ee3c9788e32ee99edb501249b2c5829b",
+            "size": 16620,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_cube_duo--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_order_by_expr--Debug]": [
         {
-            "checksum": "304eeb54e6458831e77723891b1eba2c",
-            "size": 4813,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_aggregate-group_by_expr_order_by_expr--Debug_/opt.yql_patched"
+            "checksum": "15f0336291830223896d2e9757791f64",
+            "size": 4598,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_expr_order_by_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_order_by_expr--Plan]": [
         {
-            "checksum": "bab5f99a95fe34f992cb6ec2868d4874",
-            "size": 7392,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-group_by_expr_order_by_expr--Plan_/plan.txt"
+            "checksum": "b82caf0827e77fd29807796338643bb7",
+            "size": 6980,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_expr_order_by_expr--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_grouping--Debug]": [
         {
-            "checksum": "e0e1396e6acae89855cfd8fa7a85e3c3",
-            "size": 7605,
-            "uri": "https://{canondata_backend}/1903885/30b9584e8f05b41130d55065740d7b6ac71681c4/resource.tar.gz#test.test_aggregate-group_by_gs_grouping--Debug_/opt.yql_patched"
+            "checksum": "adcb64c32fbb830546b6758108c61bd2",
+            "size": 7125,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_gs_grouping--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_grouping--Plan]": [
         {
-            "checksum": "238488f45198e02104d3782f4d5cea4c",
-            "size": 11311,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-group_by_gs_grouping--Plan_/plan.txt"
+            "checksum": "ed7cc280281a78c191c4638167f32a0e",
+            "size": 10693,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_gs_grouping--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_grouping_hum--Debug]": [
         {
-            "checksum": "644c58ae1fa6c2d445799331b38a3074",
-            "size": 13420,
-            "uri": "https://{canondata_backend}/1924537/14e797d0b8163c5715f39d1cd8d7cca217a146e0/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum--Debug_/opt.yql_patched"
+            "checksum": "aadcd4a45e5472f3517aec7f1246c2a1",
+            "size": 12499,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_grouping_hum--Plan]": [
         {
-            "checksum": "c36b55d1a5faee071d3bf6f4de678eff",
-            "size": 17571,
-            "uri": "https://{canondata_backend}/1924537/14e797d0b8163c5715f39d1cd8d7cca217a146e0/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum--Plan_/plan.txt"
+            "checksum": "4538513645af0d7c1ab6c414669e3fbc",
+            "size": 16335,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session--Debug]": [
         {
-            "checksum": "a75bd8349ce7f4bf7889c1fcbf05ad45",
-            "size": 5299,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_aggregate-group_by_session--Debug_/opt.yql_patched"
+            "checksum": "ee71f4a9f4a3d4741159a33c892aa93e",
+            "size": 4981,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_session--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session--Plan]": [
         {
-            "checksum": "702a395959580a7a64c91724ba286b84",
-            "size": 5707,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-group_by_session--Plan_/plan.txt"
+            "checksum": "6c885e91238b3116892cb25e704c7328",
+            "size": 5295,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_session--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_distinct_compact--Debug]": [
         {
-            "checksum": "5ff04f4e62ab80abe65ef824b23d7d10",
-            "size": 8118,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_aggregate-group_by_session_distinct_compact--Debug_/opt.yql_patched"
+            "checksum": "ed703fad33d3231f0edac03214000ebe",
+            "size": 7600,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_session_distinct_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_distinct_compact--Plan]": [
         {
-            "checksum": "379af19b2ae21b4089f8f78d72b8ddd2",
-            "size": 7987,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_aggregate-group_by_session_distinct_compact--Plan_/plan.txt"
+            "checksum": "b85a5064798ae2bc0b3165324facc37c",
+            "size": 7369,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_aggregate-group_by_session_distinct_compact--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-null_type-default.txt-Debug]": [
@@ -519,30 +519,30 @@
     ],
     "test.test[bigdate-table_io-default.txt-Debug]": [
         {
-            "checksum": "9bff9374f3a79f3c593af10c677c154c",
-            "size": 7220,
-            "uri": "https://{canondata_backend}/1916746/20a437a5fb75db1d155b2c7ac7c1c29c2c434035/resource.tar.gz#test.test_bigdate-table_io-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c2a6e3b72a9ce80d041384349f846a50",
+            "size": 6816,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_bigdate-table_io-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_io-default.txt-Plan]": [
         {
-            "checksum": "64627d2234f6844fe7f03b0950ce108d",
-            "size": 14527,
-            "uri": "https://{canondata_backend}/1916746/20a437a5fb75db1d155b2c7ac7c1c29c2c434035/resource.tar.gz#test.test_bigdate-table_io-default.txt-Plan_/plan.txt"
+            "checksum": "1cf1a56994bc3c59b4c568932be9737f",
+            "size": 13703,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_bigdate-table_io-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-tz_table_rw--Debug]": [
         {
-            "checksum": "9e22b67a67062b92602fbab77b8f2905",
-            "size": 2503,
-            "uri": "https://{canondata_backend}/1809005/00d7f85b5e63ac9e1c2d00a2ed95e0bff9eb30cc/resource.tar.gz#test.test_bigdate-tz_table_rw--Debug_/opt.yql_patched"
+            "checksum": "79bd4f7085856cd2e180ca3f85419826",
+            "size": 2361,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_bigdate-tz_table_rw--Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-tz_table_rw--Plan]": [
         {
-            "checksum": "d5aa7a172af52da596dbcd52e2e9265b",
-            "size": 4907,
-            "uri": "https://{canondata_backend}/1809005/00d7f85b5e63ac9e1c2d00a2ed95e0bff9eb30cc/resource.tar.gz#test.test_bigdate-tz_table_rw--Plan_/plan.txt"
+            "checksum": "16b91e1c9fcda6d880a02448dad1dcf9",
+            "size": 4701,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_bigdate-tz_table_rw--Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-tznumliterals-default.txt-Debug]": [
@@ -603,142 +603,142 @@
     ],
     "test.test[blocks-combine_all_min--Debug]": [
         {
-            "checksum": "df31890632b832b243e1e708a65a095c",
-            "size": 9584,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-combine_all_min--Debug_/opt.yql_patched"
+            "checksum": "78dc9a78c7307df77136042eca936ef4",
+            "size": 9146,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_all_min--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_min--Plan]": [
         {
-            "checksum": "a1361799631618b84ec6b61887b259c0",
-            "size": 5459,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-combine_all_min--Plan_/plan.txt"
+            "checksum": "16a0de7e33ba5f70a4588de69a651389",
+            "size": 5253,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_all_min--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_sum_filter--Debug]": [
         {
-            "checksum": "b73125781d233f9a9c5134a7615fbcba",
-            "size": 3157,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-combine_all_sum_filter--Debug_/opt.yql_patched"
+            "checksum": "f249de9f0c7618b1fe09db7b64515985",
+            "size": 3090,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_all_sum_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_sum_filter--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-combine_all_sum_filter--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_all_sum_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_pg--Debug]": [
         {
-            "checksum": "97dd9272e7f17080401295fadec8142e",
-            "size": 14746,
-            "uri": "https://{canondata_backend}/1936947/b2a18b57448ea3af13fca68af5ba965519208b69/resource.tar.gz#test.test_blocks-combine_hashed_pg--Debug_/opt.yql_patched"
+            "checksum": "b625b03d2cef662b6c50e89affd3a8d6",
+            "size": 13986,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_hashed_pg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_pg--Plan]": [
         {
-            "checksum": "c6196221384fd5e24dcc7c1f9afb0789",
-            "size": 6439,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-combine_hashed_pg--Plan_/plan.txt"
+            "checksum": "19fe2319057e53cfe33a6d306548da66",
+            "size": 6027,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_hashed_pg--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_sum--Debug]": [
         {
-            "checksum": "bd3d029402e16e3dfd89285fe893a17f",
-            "size": 6587,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-combine_hashed_sum--Debug_/opt.yql_patched"
+            "checksum": "01320bc2c3df8f879fe2556b6c8d88a3",
+            "size": 6061,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_hashed_sum--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_sum--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-combine_hashed_sum--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-combine_hashed_sum--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-complex_scalars--Debug]": [
         {
-            "checksum": "1cf837efbb1d8a8b5af3afbd70342081",
-            "size": 4342,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-complex_scalars--Debug_/opt.yql_patched"
+            "checksum": "78b8496846f95e15b48c1aa7ffcb8b32",
+            "size": 3890,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-complex_scalars--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-complex_scalars--Plan]": [
         {
-            "checksum": "df04111c024790a6acc9bdbe03f27531",
-            "size": 6201,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-complex_scalars--Plan_/plan.txt"
+            "checksum": "5a5857020d5dd64a30be59b49a6d5c5f",
+            "size": 5789,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-complex_scalars--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_sub--Debug]": [
         {
-            "checksum": "8192eec0dab2a5cf273775616b1d9c1c",
-            "size": 26399,
-            "uri": "https://{canondata_backend}/1937429/45c0ed022ecb2172e5287c350269fdad6a7b0868/resource.tar.gz#test.test_blocks-date_sub--Debug_/opt.yql_patched"
+            "checksum": "ef3424af39ed3f049f703a7cd386b918",
+            "size": 22553,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-date_sub--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_sub--Plan]": [
         {
-            "checksum": "8e2ffde4b139fbcf23538af8042d8ce4",
-            "size": 15073,
-            "uri": "https://{canondata_backend}/1937429/45c0ed022ecb2172e5287c350269fdad6a7b0868/resource.tar.gz#test.test_blocks-date_sub--Plan_/plan.txt"
+            "checksum": "b34d03bdf2dc028ce4694a62c3df6411",
+            "size": 14661,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-date_sub--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-div_uint64--Debug]": [
         {
-            "checksum": "5bcfde3b22243618cf49111a7f611851",
-            "size": 2260,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-div_uint64--Debug_/opt.yql_patched"
+            "checksum": "6430c139aa5c77ecddeb565459c030f3",
+            "size": 2130,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-div_uint64--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-div_uint64--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-div_uint64--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-div_uint64--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-exists--Debug]": [
         {
-            "checksum": "a6f62d11f146277f67a093053be5da5f",
-            "size": 3694,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-exists--Debug_/opt.yql_patched"
+            "checksum": "406e32130bd00524faff0d854419805c",
+            "size": 3356,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-exists--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-exists--Plan]": [
         {
-            "checksum": "2014a39ca1d809e305636d251e5ca9fe",
-            "size": 6274,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-exists--Plan_/plan.txt"
+            "checksum": "3689b5079e471178ed59bc4520be69a2",
+            "size": 5862,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-exists--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-filter_by_column_with_drop--Debug]": [
         {
-            "checksum": "145a39064bcce7f0edee2a8a85e0aa62",
-            "size": 2884,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-filter_by_column_with_drop--Debug_/opt.yql_patched"
+            "checksum": "16aaaf31219f5033d4406bf08c114c6c",
+            "size": 2778,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-filter_by_column_with_drop--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-filter_by_column_with_drop--Plan]": [
         {
-            "checksum": "df483b7602e4a7e0c52d32c020937033",
-            "size": 6197,
-            "uri": "https://{canondata_backend}/1942173/93f715b822feb505dc8e1414f77e95370014ff2e/resource.tar.gz#test.test_blocks-filter_by_column_with_drop--Plan_/plan.txt"
+            "checksum": "92594f42cba57cb23a313a86366db84e",
+            "size": 5785,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-filter_by_column_with_drop--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_add_date_scalar--Debug]": [
         {
-            "checksum": "69ebf9438577c4b3374e894aa0e2dbb5",
-            "size": 8296,
-            "uri": "https://{canondata_backend}/1817427/6546f8246a5429deab454c88f00768467941c774/resource.tar.gz#test.test_blocks-interval_add_date_scalar--Debug_/opt.yql_patched"
+            "checksum": "5cc987bf2131704ab045f87d87ea3543",
+            "size": 7620,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-interval_add_date_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-interval_add_date_scalar--Plan]": [
         {
-            "checksum": "d7dc5671b9ef733316dfc1d26ae18c1f",
-            "size": 7299,
-            "uri": "https://{canondata_backend}/1817427/6546f8246a5429deab454c88f00768467941c774/resource.tar.gz#test.test_blocks-interval_add_date_scalar--Plan_/plan.txt"
+            "checksum": "b309ec00eeb6f3f5fa044efec428cf5a",
+            "size": 6887,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_blocks-interval_add_date_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_mul_scalar--Debug]": [
@@ -841,30 +841,30 @@
     ],
     "test.test[distinct-distinct_having_no_agg-default.txt-Debug]": [
         {
-            "checksum": "8f2a675d74319c5eee6632b78e608a43",
-            "size": 3541,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_distinct-distinct_having_no_agg-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4b3193bb0c208e299a81c16be1997a04",
+            "size": 3435,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_distinct-distinct_having_no_agg-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_having_no_agg-default.txt-Plan]": [
         {
-            "checksum": "f8106e46383fe8e2792188af7d3842fa",
-            "size": 6289,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_distinct-distinct_having_no_agg-default.txt-Plan_/plan.txt"
+            "checksum": "64807f0a6d1a2ff39401a494cd770899",
+            "size": 5877,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_distinct-distinct_having_no_agg-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_star-default.txt-Debug]": [
         {
-            "checksum": "537e720353b21fd26d6ce9e14824fd78",
-            "size": 9992,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_distinct-distinct_star-default.txt-Debug_/opt.yql_patched"
+            "checksum": "324095a72e2c783afbaf85e710b74b97",
+            "size": 9278,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_distinct-distinct_star-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_star-default.txt-Plan]": [
         {
-            "checksum": "8753ec544606e6ac8d6f70e0af45f847",
-            "size": 19443,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_distinct-distinct_star-default.txt-Plan_/plan.txt"
+            "checksum": "391b82d44ff8a47f46507da055029865",
+            "size": 18207,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_distinct-distinct_star-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_star_inmem-default.txt-Debug]": [
@@ -1149,16 +1149,16 @@
     ],
     "test.test[file-where_key_in_file_content_typed--Debug]": [
         {
-            "checksum": "7e528c96c4ad3aeb0d8ed0fb4b2ea5ac",
-            "size": 2228,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_file-where_key_in_file_content_typed--Debug_/opt.yql_patched"
+            "checksum": "7c893440acb39d66301f2172fe79caaf",
+            "size": 2105,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_file-where_key_in_file_content_typed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-where_key_in_file_content_typed--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_file-where_key_in_file_content_typed--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_file-where_key_in_file_content_typed--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_by_group_by_alias_collision-default.txt-Debug]": [
@@ -1177,16 +1177,16 @@
     ],
     "test.test[flatten_by-flatten_dict--Debug]": [
         {
-            "checksum": "2bc52aae708703e14f5317b3ec876024",
-            "size": 6924,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_flatten_by-flatten_dict--Debug_/opt.yql_patched"
+            "checksum": "3b104ea19d1d00d9931148f319d0f05a",
+            "size": 6469,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_flatten_by-flatten_dict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_dict--Plan]": [
         {
-            "checksum": "df39d69d33f20580187528cd1c945725",
-            "size": 8584,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_flatten_by-flatten_dict--Plan_/plan.txt"
+            "checksum": "32e816388db081ec42e7f951c42b4c18",
+            "size": 7966,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_flatten_by-flatten_dict--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_expr--Debug]": [
@@ -1219,30 +1219,30 @@
     ],
     "test.test[flatten_by-struct_without_correlation-default.txt-Debug]": [
         {
-            "checksum": "c596d5403144cbdd62f0a7de2cc928c4",
-            "size": 5338,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_flatten_by-struct_without_correlation-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ed92cf78204e7bd5bbdd86542e342831",
+            "size": 5037,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_flatten_by-struct_without_correlation-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-struct_without_correlation-default.txt-Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_flatten_by-struct_without_correlation-default.txt-Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_flatten_by-struct_without_correlation-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-group_ranges--Debug]": [
         {
-            "checksum": "8adfd000dff64d1a770c51a8a2fc89ee",
-            "size": 3993,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_hor_join-group_ranges--Debug_/opt.yql_patched"
+            "checksum": "1c633398aa3a6ed934f14234f9485621",
+            "size": 3747,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_hor_join-group_ranges--Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-group_ranges--Plan]": [
         {
-            "checksum": "381dde9c5b8050e003c339ed9cc706c3",
-            "size": 7636,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_hor_join-group_ranges--Plan_/plan.txt"
+            "checksum": "60197086970a8ad2979f81414c0a8eb2",
+            "size": 7224,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_hor_join-group_ranges--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_ansi-default.txt-Debug]": [
@@ -1261,30 +1261,30 @@
     ],
     "test.test[in-in_ansi_join--Debug]": [
         {
-            "checksum": "4004ebdf381c73efe0a7be100b079dba",
-            "size": 30807,
-            "uri": "https://{canondata_backend}/1937027/6d0939288c9b56900c5658b406dce84069849150/resource.tar.gz#test.test_in-in_ansi_join--Debug_/opt.yql_patched"
+            "checksum": "a05ccc64e2145946519ab5844ae8340d",
+            "size": 29883,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_in-in_ansi_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_ansi_join--Plan]": [
         {
-            "checksum": "5c05e08eebf2df65246c6860f2727159",
-            "size": 92624,
-            "uri": "https://{canondata_backend}/1937027/6d0939288c9b56900c5658b406dce84069849150/resource.tar.gz#test.test_in-in_ansi_join--Plan_/plan.txt"
+            "checksum": "81f4e63c119fe48d18a6e0caf4c4f69e",
+            "size": 87886,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_in-in_ansi_join--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_enum_single1-default.txt-Debug]": [
         {
-            "checksum": "de4839103adb0d841638d880dae8a58c",
-            "size": 1984,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_in-in_enum_single1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e8991bbe6bb3620d4e2864d89d9e6971",
+            "size": 1861,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_in-in_enum_single1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_enum_single1-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_in-in_enum_single1-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_in-in_enum_single1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_with_literal_list_of_structs_ansi-default.txt-Debug]": [
@@ -1317,72 +1317,72 @@
     ],
     "test.test[insert-drop_sortness-calc-Debug]": [
         {
-            "checksum": "1ae6bb5ccb5ace9cc021f22241a317da",
-            "size": 1956,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_insert-drop_sortness-calc-Debug_/opt.yql_patched"
+            "checksum": "8548b57d6c1093801babe3a225bf168a",
+            "size": 1892,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_insert-drop_sortness-calc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-drop_sortness-calc-Plan]": [
         {
-            "checksum": "413e79be6c07fac2542dc5026c5796b1",
-            "size": 4257,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_insert-drop_sortness-calc-Plan_/plan.txt"
+            "checksum": "86f38fe8fde6ac5658e36849f3d29a4a",
+            "size": 4051,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_insert-drop_sortness-calc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-part_sortness-desc-Debug]": [
         {
-            "checksum": "25df73a610bdda8ddb94b2f84a35adaf",
-            "size": 2077,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_insert-part_sortness-desc-Debug_/opt.yql_patched"
+            "checksum": "f06e551fedd5a7b79da9beef7c0ba565",
+            "size": 1977,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_insert-part_sortness-desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-part_sortness-desc-Plan]": [
         {
-            "checksum": "02e04cabe6fe6ddce08d1cfa5ef5c88e",
-            "size": 4284,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_insert-part_sortness-desc-Plan_/plan.txt"
+            "checksum": "8b45085710875be445d0bb960360b8d0",
+            "size": 4078,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_insert-part_sortness-desc-Plan_/plan.txt"
         }
     ],
     "test.test[join-anyjoin_common_nodup--Debug]": [
         {
-            "checksum": "b990d8d3ea65e647ba56b83732a5f850",
-            "size": 9354,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_join-anyjoin_common_nodup--Debug_/opt.yql_patched"
+            "checksum": "6c7200ca65646be2ffc8053ec536095b",
+            "size": 9072,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-anyjoin_common_nodup--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-anyjoin_common_nodup--Plan]": [
         {
-            "checksum": "c96c6e1ecf084b168805e5c0dab2b334",
-            "size": 25183,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_join-anyjoin_common_nodup--Plan_/plan.txt"
+            "checksum": "58f7f895df77fc396a4683354181fedf",
+            "size": 24359,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-anyjoin_common_nodup--Plan_/plan.txt"
         }
     ],
     "test.test[join-count_bans--Debug]": [
         {
-            "checksum": "3a5df3eefd8869e217fd64a535c1018b",
-            "size": 9787,
-            "uri": "https://{canondata_backend}/1847551/2505f7fa026ee9e2d5013e7854c2b1b29ddac476/resource.tar.gz#test.test_join-count_bans--Debug_/opt.yql_patched"
+            "checksum": "07c7669636bca7b0c835807b6a85987c",
+            "size": 9633,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-count_bans--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-count_bans--Plan]": [
         {
-            "checksum": "f026c042b26fe5ff0335b14dc4e9de9d",
-            "size": 12564,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_join-count_bans--Plan_/plan.txt"
+            "checksum": "4d68641371d032b505d2af63b8b75e5b",
+            "size": 12152,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-count_bans--Plan_/plan.txt"
         }
     ],
     "test.test[join-full_trivial_udf_call--Debug]": [
         {
-            "checksum": "8b9874cc238097b80519832b35869b5d",
-            "size": 5466,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_join-full_trivial_udf_call--Debug_/opt.yql_patched"
+            "checksum": "b3c8a719f6c9efeac099e11291caf618",
+            "size": 5329,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-full_trivial_udf_call--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-full_trivial_udf_call--Plan]": [
         {
-            "checksum": "a5282bd5339f8e2d58b8b29a785d36de",
-            "size": 8364,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_join-full_trivial_udf_call--Plan_/plan.txt"
+            "checksum": "85486e5a325c36b3062f3708f879ae94",
+            "size": 8158,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-full_trivial_udf_call--Plan_/plan.txt"
         }
     ],
     "test.test[join-inner_trivial--Debug]": [
@@ -1401,72 +1401,72 @@
     ],
     "test.test[join-lookupjoin_inner_1o2o--Debug]": [
         {
-            "checksum": "b1325461742e4b50478bc8e5138596b4",
-            "size": 3585,
-            "uri": "https://{canondata_backend}/1916746/8274cf63dcf67115e58ea3bbe527ddd5351280b1/resource.tar.gz#test.test_join-lookupjoin_inner_1o2o--Debug_/opt.yql_patched"
+            "checksum": "a5cf0d65430566f93e79a74a9fe95d40",
+            "size": 3401,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-lookupjoin_inner_1o2o--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_inner_1o2o--Plan]": [
         {
-            "checksum": "9c49b07c760217e5999b8ffbf8515831",
-            "size": 4898,
-            "uri": "https://{canondata_backend}/1781765/ea68b1b8bd28a879a641208edf107febf840efbe/resource.tar.gz#test.test_join-lookupjoin_inner_1o2o--Plan_/plan.txt"
+            "checksum": "ca60d96d2027a0b4a5ed84feef1498a8",
+            "size": 4692,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-lookupjoin_inner_1o2o--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_early_rewrite_sequence--Debug]": [
         {
-            "checksum": "2aeffd51bda3a5881c0ecc58ea17782b",
-            "size": 6464,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_join-mapjoin_early_rewrite_sequence--Debug_/opt.yql_patched"
+            "checksum": "36d30ed43f80c63e6a192f11f5fa028b",
+            "size": 5974,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-mapjoin_early_rewrite_sequence--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_early_rewrite_sequence--Plan]": [
         {
-            "checksum": "762b27e13a7c85563f54d92d211d3862",
-            "size": 10625,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_join-mapjoin_early_rewrite_sequence--Plan_/plan.txt"
+            "checksum": "1fa05e7a40a78a09c26ff98606c1fbc1",
+            "size": 10213,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-mapjoin_early_rewrite_sequence--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_map_cross--Debug]": [
         {
-            "checksum": "85a4c7e9a1317243818f81f2ff916954",
-            "size": 4150,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_join-premap_map_cross--Debug_/opt.yql_patched"
+            "checksum": "0143c3c9a360da3c8ebfbfee8677c1d1",
+            "size": 3966,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-premap_map_cross--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_map_cross--Plan]": [
         {
-            "checksum": "cfccc71a019d335adc3cd110cb743a02",
-            "size": 6911,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_join-premap_map_cross--Plan_/plan.txt"
+            "checksum": "582caa09b7420c942feaabca70d69fff",
+            "size": 6705,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-premap_map_cross--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_map_inner--Debug]": [
         {
-            "checksum": "d78db8ce19db84389c564f512d799c74",
-            "size": 4501,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_join-premap_map_inner--Debug_/opt.yql_patched"
+            "checksum": "26bcea968a29e2afbe808b4575cd3f64",
+            "size": 4259,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-premap_map_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_map_inner--Plan]": [
         {
-            "checksum": "f4475807cbd9e8b4ae7583f9f9c95f89",
-            "size": 8278,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_join-premap_map_inner--Plan_/plan.txt"
+            "checksum": "d370340d41ed9d0d8391306100f4214f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-premap_map_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-star_join_inners_vk_sorted--Debug]": [
         {
-            "checksum": "90e9b8a90ca03ae13a9822bdc753f330",
-            "size": 7532,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_join-star_join_inners_vk_sorted--Debug_/opt.yql_patched"
+            "checksum": "8a1c1955c2b78e87b3fa1dafee5da9ad",
+            "size": 7291,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-star_join_inners_vk_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-star_join_inners_vk_sorted--Plan]": [
         {
-            "checksum": "2b1f4ebe8241cc3ab899aa0dbdf406d4",
-            "size": 11021,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_join-star_join_inners_vk_sorted--Plan_/plan.txt"
+            "checksum": "895c2554e26a94d613b0eb0ba7636029",
+            "size": 10815,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_join-star_join_inners_vk_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[json-combination/unwrapped-default.txt-Debug]": [
@@ -1499,30 +1499,30 @@
     ],
     "test.test[key_filter-empty_range_over_dynamic--Debug]": [
         {
-            "checksum": "3729c3fb7efcd3001479dee7f98d4033",
-            "size": 2111,
-            "uri": "https://{canondata_backend}/1130705/3f60bcfcce10585f0600a1f740aac67736af80eb/resource.tar.gz#test.test_key_filter-empty_range_over_dynamic--Debug_/opt.yql_patched"
+            "checksum": "ea492fd5ff0893b14c7fc4e86ee4edf7",
+            "size": 1988,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_key_filter-empty_range_over_dynamic--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-empty_range_over_dynamic--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1900335/daba17ec7c325f37db22e33b644617159d9d4c1e/resource.tar.gz#test.test_key_filter-empty_range_over_dynamic--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_key_filter-empty_range_over_dynamic--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-range_union_lower_excluded-default.txt-Debug]": [
         {
-            "checksum": "7e87c25cd9e91a4b99cedcd81e4a672d",
-            "size": 2141,
-            "uri": "https://{canondata_backend}/1899731/0b34c816ed2e69b5515f65c093b8c6fb72fa0b5b/resource.tar.gz#test.test_key_filter-range_union_lower_excluded-default.txt-Debug_/opt.yql_patched"
+            "checksum": "57ed1934838660028ddd1cd54b288bf2",
+            "size": 2018,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_key_filter-range_union_lower_excluded-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-range_union_lower_excluded-default.txt-Plan]": [
         {
-            "checksum": "5f87fb14946b9b4ac407b20b08e82490",
-            "size": 3604,
-            "uri": "https://{canondata_backend}/1942173/15df976e3f9470e21cf0d87e972e6ba69514af08/resource.tar.gz#test.test_key_filter-range_union_lower_excluded-default.txt-Plan_/plan.txt"
+            "checksum": "97c7f373a9ae004b0dd3ae378ecfe558",
+            "size": 3398,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_key_filter-range_union_lower_excluded-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-string_with_legacy--Debug]": [
@@ -1541,114 +1541,114 @@
     ],
     "test.test[like-ilike_clause-default.txt-Debug]": [
         {
-            "checksum": "1d6400cc510ff8fc85352d9353d54a70",
-            "size": 3333,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_like-ilike_clause-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f120e6eaf35f22dff138f3f6814e70d7",
+            "size": 3210,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_like-ilike_clause-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[like-ilike_clause-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_like-ilike_clause-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_like-ilike_clause-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[limit-zero_limit-default.txt-Debug]": [
         {
-            "checksum": "835d578fb98e95c33dee82ac98d50999",
-            "size": 3364,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_limit-zero_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f587ff91986e87bd0bd28d0095540155",
+            "size": 3118,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_limit-zero_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-zero_limit-default.txt-Plan]": [
         {
-            "checksum": "17ac5b4afa0242da6a75f95bc0429a54",
-            "size": 7882,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_limit-zero_limit-default.txt-Plan_/plan.txt"
+            "checksum": "a25f7db0f11abe3b33ecc30b824c11ce",
+            "size": 7470,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_limit-zero_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-sort_constraint_in_left--Debug]": [
         {
-            "checksum": "8fbc07ca980c63c444a3a71e18069b13",
-            "size": 6388,
-            "uri": "https://{canondata_backend}/1942671/61eb06c863ce88ccafd51a635d2c410b81696481/resource.tar.gz#test.test_optimizers-sort_constraint_in_left--Debug_/opt.yql_patched"
+            "checksum": "7138155c80e799e87a73767fb4fd5e46",
+            "size": 5909,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_optimizers-sort_constraint_in_left--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-sort_constraint_in_left--Plan]": [
         {
-            "checksum": "08e7402ad4397da95dd48abda760200e",
-            "size": 11955,
-            "uri": "https://{canondata_backend}/1775319/2dcfad1c25628fb0e78faa957f3057561e2762a1/resource.tar.gz#test.test_optimizers-sort_constraint_in_left--Plan_/plan.txt"
+            "checksum": "d4fa425d9b53520e9e61a372a32b8637",
+            "size": 10925,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_optimizers-sort_constraint_in_left--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-test_fuse_map_predicate_limit-default.txt-Debug]": [
         {
-            "checksum": "c6739bca67874dc770c6b4f5359173f8",
-            "size": 5971,
-            "uri": "https://{canondata_backend}/1847551/2505f7fa026ee9e2d5013e7854c2b1b29ddac476/resource.tar.gz#test.test_optimizers-test_fuse_map_predicate_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b7c53af14a4e5a6106ac4ec5d5eae230",
+            "size": 5582,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_optimizers-test_fuse_map_predicate_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-test_fuse_map_predicate_limit-default.txt-Plan]": [
         {
-            "checksum": "d9f98b1bf6aade355c6d431ee26ea485",
-            "size": 11384,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_optimizers-test_fuse_map_predicate_limit-default.txt-Plan_/plan.txt"
+            "checksum": "40890656c709d0ab808266895df4fbb6",
+            "size": 10560,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_optimizers-test_fuse_map_predicate_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-10737_lost_passthrough-default.txt-Debug]": [
         {
-            "checksum": "76bd322698f9684f87e26390007e8faa",
-            "size": 2952,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_optimizers-yql-10737_lost_passthrough-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c540942957720531fe58c5254724655c",
+            "size": 2722,
+            "uri": "https://{canondata_backend}/1937150/8a03b22cb41a5d45a74b6bace2f08e86727532d3/resource.tar.gz#test.test_optimizers-yql-10737_lost_passthrough-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-10737_lost_passthrough-default.txt-Plan]": [
         {
-            "checksum": "a8971b56708ea6160cafd7271a37dd11",
-            "size": 7689,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_optimizers-yql-10737_lost_passthrough-default.txt-Plan_/plan.txt"
+            "checksum": "9b46a569550b1dab20764c89d4e85e13",
+            "size": 7277,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_optimizers-yql-10737_lost_passthrough-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-SortByOneField--Debug]": [
         {
-            "checksum": "dc8dd956aff616f86561d3c21b2c1b13",
-            "size": 2014,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_order_by-SortByOneField--Debug_/opt.yql_patched"
+            "checksum": "da76e84eb582b0ef7215eeec0af300dc",
+            "size": 1954,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_order_by-SortByOneField--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-SortByOneField--Plan]": [
         {
-            "checksum": "0367b8a4291a38c1d88a762c23697ebc",
-            "size": 3535,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_order_by-SortByOneField--Plan_/plan.txt"
+            "checksum": "bb0901fd2c09bbd06fce1fad64375146",
+            "size": 3329,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_order_by-SortByOneField--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_dot_column-default.txt-Debug]": [
         {
-            "checksum": "d457bd5fb26d9c343bdd997745ede9ad",
-            "size": 3093,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_order_by-order_by_dot_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "62959f6611e98a2d5a0b36f3f49276f2",
+            "size": 2912,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_order_by-order_by_dot_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_dot_column-default.txt-Plan]": [
         {
-            "checksum": "654acd0e6b0b3e64caa66bbbf583d612",
-            "size": 5179,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_order_by-order_by_dot_column-default.txt-Plan_/plan.txt"
+            "checksum": "1803bcd1073585a5ad284a4d29e54336",
+            "size": 4973,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_order_by-order_by_dot_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_tuple-default.txt-Debug]": [
         {
-            "checksum": "8a1d7ebf6f7caf422321dc23d79af3fc",
-            "size": 2782,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_order_by-order_by_tuple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5b48c31218ff25b098807a6a9c713cad",
+            "size": 2654,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_order_by-order_by_tuple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_tuple-default.txt-Plan]": [
         {
-            "checksum": "b740c0dff136ac74f26874552a13e039",
-            "size": 5150,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_order_by-order_by_tuple-default.txt-Plan_/plan.txt"
+            "checksum": "70a49bd65ea8bc6eda627ee61e000b52",
+            "size": 4944,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_order_by-order_by_tuple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-presort_mem-default.txt-Debug]": [
@@ -1751,16 +1751,16 @@
     ],
     "test.test[pg-doubles_search_path-default.txt-Debug]": [
         {
-            "checksum": "267cfcd0191e2c56259d686998d9b9bd",
-            "size": 3402,
-            "uri": "https://{canondata_backend}/1925842/3bbdcdb1d64d89357b8a4a5a80903c46df42d63e/resource.tar.gz#test.test_pg-doubles_search_path-default.txt-Debug_/opt.yql_patched"
+            "checksum": "14abd70106fb5576e1f178dbfb2b2826",
+            "size": 3335,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-doubles_search_path-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-doubles_search_path-default.txt-Plan]": [
         {
-            "checksum": "78f0e1e757a64d6371b7201489602b7a",
-            "size": 5824,
-            "uri": "https://{canondata_backend}/1936842/06c9068023d4aba6d1f84ef3d63cea3dfcf5c68c/resource.tar.gz#test.test_pg-doubles_search_path-default.txt-Plan_/plan.txt"
+            "checksum": "88eff2add21b06125a79f49bc5929fc6",
+            "size": 5618,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-doubles_search_path-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-join_using1-default.txt-Debug]": [
@@ -1933,16 +1933,16 @@
     ],
     "test.test[pg-select_limit-default.txt-Debug]": [
         {
-            "checksum": "11d332f44ad33b56802aceedf9d65b0f",
-            "size": 1821,
-            "uri": "https://{canondata_backend}/1925842/3bbdcdb1d64d89357b8a4a5a80903c46df42d63e/resource.tar.gz#test.test_pg-select_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0c3033f2170713d6455f81ce73317c01",
+            "size": 1698,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-select_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_limit-default.txt-Plan]": [
         {
-            "checksum": "ebbd7546cb76695b3c858bfe2d8f0a21",
-            "size": 3504,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_pg-select_limit-default.txt-Plan_/plan.txt"
+            "checksum": "e9014acf3993c726885a94be423217ee",
+            "size": 3298,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-select_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_table2-default.txt-Debug]": [
@@ -2241,30 +2241,30 @@
     ],
     "test.test[pg-tpch-q05-default.txt-Debug]": [
         {
-            "checksum": "67364ebd4788f57f13acfaec73ae5ad2",
-            "size": 9268,
-            "uri": "https://{canondata_backend}/1031349/3c8f732aa45769ab10250cc800e87f450743f81d/resource.tar.gz#test.test_pg-tpch-q05-default.txt-Debug_/opt.yql_patched"
+            "checksum": "42807b024d76ae0a1643ac1b8afe0b5c",
+            "size": 9163,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-tpch-q05-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q05-default.txt-Plan]": [
         {
-            "checksum": "58f919d766a591be041d4d16837911c8",
-            "size": 14769,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_pg-tpch-q05-default.txt-Plan_/plan.txt"
+            "checksum": "706053c152b906739414fdcd814b0a98",
+            "size": 14563,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-tpch-q05-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q19-default.txt-Debug]": [
         {
-            "checksum": "ee18d9ccfd4ae28ea8229bad096b89e2",
-            "size": 6685,
-            "uri": "https://{canondata_backend}/1781765/3edb558c746de3e3eb76dd191620ecd84e716aec/resource.tar.gz#test.test_pg-tpch-q19-default.txt-Debug_/opt.yql_patched"
+            "checksum": "170c9f6f5e2aa38c2ff4869931e52a89",
+            "size": 6618,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-tpch-q19-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q19-default.txt-Plan]": [
         {
-            "checksum": "68df541990c573718e2c3f017cebe1a8",
-            "size": 12411,
-            "uri": "https://{canondata_backend}/1936947/84340d96ab4fb1192229debacaf1bfa19eeb156f/resource.tar.gz#test.test_pg-tpch-q19-default.txt-Plan_/plan.txt"
+            "checksum": "8506c8d089f3979e5e19cfd72a02febd",
+            "size": 12205,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_pg-tpch-q19-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg_catalog-pg_set_config-default.txt-Debug]": [
@@ -2325,184 +2325,184 @@
     ],
     "test.test[produce-process_trivial_as_struct-default.txt-Debug]": [
         {
-            "checksum": "46d493c581b0afc4765edae2dde55c4a",
-            "size": 2096,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_produce-process_trivial_as_struct-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b42d0c871bf99b23369a32a7d168cdfe",
+            "size": 2034,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-process_trivial_as_struct-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_trivial_as_struct-default.txt-Plan]": [
         {
-            "checksum": "f8d571877f7dc9485437273ffb98bf80",
-            "size": 4049,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_produce-process_trivial_as_struct-default.txt-Plan_/plan.txt"
+            "checksum": "6e75c1259c6d74d8fe96f40e2bd1c5f0",
+            "size": 3843,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-process_trivial_as_struct-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-process_with_lambda_outstream-default.txt-Debug]": [
         {
-            "checksum": "8ee4e572b1dd25027dcdd9ce7760644e",
-            "size": 2118,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_produce-process_with_lambda_outstream-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8b6ca2b9561ff8946af549503dc715b8",
+            "size": 1995,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-process_with_lambda_outstream-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_with_lambda_outstream-default.txt-Plan]": [
         {
-            "checksum": "f05b563617e5e7acc5efd38e375cabef",
-            "size": 6511,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_produce-process_with_lambda_outstream-default.txt-Plan_/plan.txt"
+            "checksum": "050fc0c84cb0198e1c41318648b760ca",
+            "size": 6305,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-process_with_lambda_outstream-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_lambda_list_table-default.txt-Debug]": [
         {
-            "checksum": "9950226c62ecb65422c156e0b87bb786",
-            "size": 4041,
-            "uri": "https://{canondata_backend}/1942100/b201d568b193640b6566b849a56d9528b0cb0d2d/resource.tar.gz#test.test_produce-reduce_lambda_list_table-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cf25f6ea70525b00a08ed6631bbfdbed",
+            "size": 3943,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-reduce_lambda_list_table-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_lambda_list_table-default.txt-Plan]": [
         {
-            "checksum": "f6366693bed8eb2420ebef76a647a6d1",
-            "size": 7140,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_produce-reduce_lambda_list_table-default.txt-Plan_/plan.txt"
+            "checksum": "1be7f1daf1c6111d3fe5c5af65db8d1f",
+            "size": 6934,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-reduce_lambda_list_table-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_keytuple_difftype--Debug]": [
         {
-            "checksum": "f9f557394be90ed34cdc6810514d934f",
-            "size": 4298,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple_difftype--Debug_/opt.yql_patched"
+            "checksum": "3b58b4dccd364e7b208b45beb076707e",
+            "size": 4102,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple_difftype--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_keytuple_difftype--Plan]": [
         {
-            "checksum": "2174bad6e946f621c2a3ec5de8409f45",
-            "size": 9249,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple_difftype--Plan_/plan.txt"
+            "checksum": "9e5816bf97f2e974c2a19fd92302d35e",
+            "size": 9043,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_produce-reduce_multi_in_keytuple_difftype--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-sort-default.txt-Debug]": [
         {
-            "checksum": "54f6b0ccc32fbe76077421d47197f8f7",
-            "size": 2748,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_sampling-sort-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b388fa28e3234c6e94257b52024fbeb4",
+            "size": 2502,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_sampling-sort-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-sort-default.txt-Plan]": [
         {
-            "checksum": "db6039bdce5c6b215f17bdd9f92c85dd",
-            "size": 5630,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_sampling-sort-default.txt-Plan_/plan.txt"
+            "checksum": "b3c08e41d7c4e952f476ef8e9f7afc47",
+            "size": 5218,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_sampling-sort-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-topsort-default.txt-Debug]": [
         {
-            "checksum": "2862458ebc8d00b393a3d58e34beb7b2",
-            "size": 2746,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_sampling-topsort-default.txt-Debug_/opt.yql_patched"
+            "checksum": "42211a01912107a281896c1f677d7aa4",
+            "size": 2500,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_sampling-topsort-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-topsort-default.txt-Plan]": [
         {
-            "checksum": "db6039bdce5c6b215f17bdd9f92c85dd",
-            "size": 5630,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_sampling-topsort-default.txt-Plan_/plan.txt"
+            "checksum": "b3c08e41d7c4e952f476ef8e9f7afc47",
+            "size": 5218,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_sampling-topsort-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-append_to_desc_with_remap--Debug]": [
         {
-            "checksum": "20303b6a0eb9d124b783ff67e8d843a9",
-            "size": 2021,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Debug_/opt.yql_patched"
+            "checksum": "c6d1ddf22365bdcd14031babc8ba193f",
+            "size": 1898,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-append_to_desc_with_remap--Plan]": [
         {
-            "checksum": "67f0f828b72d6db96a3edec325914256",
-            "size": 4912,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Plan_/plan.txt"
+            "checksum": "0ac4ec57a83ffbf43198e5b64dea16e2",
+            "size": 4706,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_schema-append_to_desc_with_remap--Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert-schema-Debug]": [
         {
-            "checksum": "61994ec249f1de092c92f62eba8641bb",
-            "size": 2717,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_schema-insert-schema-Debug_/opt.yql_patched"
+            "checksum": "7910e0504bd81d70446b02cd6fc31aef",
+            "size": 2551,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_schema-insert-schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert-schema-Plan]": [
         {
-            "checksum": "4679ad300705e8756401b84e82e41708",
-            "size": 7195,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_schema-insert-schema-Plan_/plan.txt"
+            "checksum": "1863ed9cf7592491284072211b0f5960",
+            "size": 6989,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_schema-insert-schema-Plan_/plan.txt"
         }
     ],
     "test.test[select-braces-default.txt-Debug]": [
         {
-            "checksum": "9c641229659d6a3e8a85b072522f7d0b",
-            "size": 1939,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_select-braces-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3afcad2867e292ea695243b779c09f72",
+            "size": 1816,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-braces-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-braces-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_select-braces-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-braces-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-cast_double_to_uint32-default.txt-Debug]": [
         {
-            "checksum": "07dfc80dae5681bfa31c896a3a1f51d0",
-            "size": 2227,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_select-cast_double_to_uint32-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d720dc09ea437a307ed29ba2928daecc",
+            "size": 2104,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-cast_double_to_uint32-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-cast_double_to_uint32-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_select-cast_double_to_uint32-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-cast_double_to_uint32-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-literal_negative-default.txt-Debug]": [
         {
-            "checksum": "a08c2f829aacb1938a2a0906fc7fb842",
-            "size": 1942,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_select-literal_negative-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c1b84dd090c27a427a03917b1f3ebd0a",
+            "size": 1819,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-literal_negative-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-literal_negative-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_select-literal_negative-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-literal_negative-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-sampleselect--Debug]": [
         {
-            "checksum": "c9ea7e303ab2d1667a8d091f09cfce4a",
-            "size": 2198,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_select-sampleselect--Debug_/opt.yql_patched"
+            "checksum": "f7423041aafe6fdd81acd8313749fefa",
+            "size": 2071,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-sampleselect--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-sampleselect--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_select-sampleselect--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-sampleselect--Plan_/plan.txt"
         }
     ],
     "test.test[select-trivial_having-default.txt-Debug]": [
         {
-            "checksum": "2a495a47aa3aedfc836594003518475b",
-            "size": 3890,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_select-trivial_having-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e755ad86d5572108509e907d646693f3",
+            "size": 3664,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-trivial_having-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-trivial_having-default.txt-Plan]": [
         {
-            "checksum": "312da030ef72a791e56273e0beb05401",
-            "size": 6216,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_select-trivial_having-default.txt-Plan_/plan.txt"
+            "checksum": "efa6faa9e73cf14af51433fc2b2d69f8",
+            "size": 5804,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_select-trivial_having-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-no_simple_columns_tablerow-default.txt-Debug]": [
@@ -2535,114 +2535,114 @@
     ],
     "test.test[simple_columns-simple_columns_join_coalesce_without_left_semi_2-default.txt-Debug]": [
         {
-            "checksum": "52330f7ed1975a2742429b5d5336b01e",
-            "size": 3988,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_2-default.txt-Debug_/opt.yql_patched"
+            "checksum": "aeed44636069c6307f95b341c69a0fcb",
+            "size": 3923,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_2-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_coalesce_without_left_semi_2-default.txt-Plan]": [
         {
-            "checksum": "c2c26858a60a83ad2dfda8c7d07627b5",
-            "size": 8445,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_2-default.txt-Plan_/plan.txt"
+            "checksum": "9a166272ef60d3787078b4530c591967",
+            "size": 8239,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_simple_columns-simple_columns_join_coalesce_without_left_semi_2-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[table_range-concat_sorted_max_tables--Debug]": [
         {
-            "checksum": "d972c55eb063686fac815202aa0e57a3",
-            "size": 2990,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Debug_/opt.yql_patched"
+            "checksum": "e2d9ea4b489ffc56f6c6f981da39dfb2",
+            "size": 2862,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-concat_sorted_max_tables--Plan]": [
         {
-            "checksum": "8115c900e0769d0411f60ba206afc6ec",
-            "size": 6910,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Plan_/plan.txt"
+            "checksum": "ab841c43b0e2eb126099fc20c447a434",
+            "size": 6498,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_table_range-concat_sorted_max_tables--Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q12-default.txt-Debug]": [
         {
-            "checksum": "82447d37a4cb1a9cf69fd5eaae000b17",
-            "size": 8387,
-            "uri": "https://{canondata_backend}/1600758/c2444e0028e549a597015e04214fcddd5c0457e4/resource.tar.gz#test.test_tpch-q12-default.txt-Debug_/opt.yql_patched"
+            "checksum": "eecf96751e05abfd51411684fabcf88d",
+            "size": 7819,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_tpch-q12-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q12-default.txt-Plan]": [
         {
-            "checksum": "00ff67af215fde54361afb2f6ba1f422",
-            "size": 12068,
-            "uri": "https://{canondata_backend}/1936947/6f000951d71e982eacc37b8740fd7f8c55f332c8/resource.tar.gz#test.test_tpch-q12-default.txt-Plan_/plan.txt"
+            "checksum": "f159bb84b9e92e4af8001f1f9ab1c8ed",
+            "size": 11244,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_tpch-q12-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q22-default.txt-Debug]": [
         {
-            "checksum": "a3be5b90656c6034d6f8303aacfff67c",
-            "size": 11800,
-            "uri": "https://{canondata_backend}/1937027/6d0939288c9b56900c5658b406dce84069849150/resource.tar.gz#test.test_tpch-q22-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6b96d374e23b0a2671124cb5c1d09677",
+            "size": 11378,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_tpch-q22-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q22-default.txt-Plan]": [
         {
-            "checksum": "f9bb8bc59e1efff1591be853eac85cc3",
-            "size": 17540,
-            "uri": "https://{canondata_backend}/1937027/6d0939288c9b56900c5658b406dce84069849150/resource.tar.gz#test.test_tpch-q22-default.txt-Plan_/plan.txt"
+            "checksum": "d6ca5efd717fbd8af4056c786fa52479",
+            "size": 16922,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_tpch-q22-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q3-default.txt-Debug]": [
         {
-            "checksum": "3bf5a5852b1115962e1015af6bf62a4e",
-            "size": 10989,
-            "uri": "https://{canondata_backend}/1900335/f1c180bd59d254359d6ab8c3c15823c798570993/resource.tar.gz#test.test_tpch-q3-default.txt-Debug_/opt.yql_patched"
+            "checksum": "137fe5c80075e154bbe9916efd7c8b99",
+            "size": 10607,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_tpch-q3-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q3-default.txt-Plan]": [
         {
-            "checksum": "9c1dd21a9b4d6115600afac08a16272d",
-            "size": 16186,
-            "uri": "https://{canondata_backend}/1936947/9bc2c8c93fa559744ab957e743285e3b6973f7c5/resource.tar.gz#test.test_tpch-q3-default.txt-Plan_/plan.txt"
+            "checksum": "be385968e074b6b76762bcb354c50534",
+            "size": 15774,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_tpch-q3-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-append_struct-default.txt-Debug]": [
         {
-            "checksum": "1712650051d0d8209e227681ae5f53c3",
-            "size": 3549,
-            "uri": "https://{canondata_backend}/995452/4ffaebb4e13206f09e4cf732b182f6789fcd79a1/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Debug_/opt.yql_patched"
+            "checksum": "29bb50c73f327ed00a6b5cd61881b48e",
+            "size": 3420,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-append_struct-default.txt-Plan]": [
         {
-            "checksum": "80d5fda141f6bd242bc5d6cf178a5bd8",
-            "size": 18098,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Plan_/plan.txt"
+            "checksum": "bd01cf865d759005db9111a3d0bdfc2f",
+            "size": 17686,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_type_v3-append_struct-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-decimal_yt_llvm--Debug]": [
         {
-            "checksum": "03a816037859cb7c47388a6699f5b451",
-            "size": 3540,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_type_v3-decimal_yt_llvm--Debug_/opt.yql_patched"
+            "checksum": "9d64e322843169e315246a7fe1413180",
+            "size": 3399,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_type_v3-decimal_yt_llvm--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-decimal_yt_llvm--Plan]": [
         {
-            "checksum": "9fd766f0b618e57b6aa384411c48a22a",
-            "size": 11781,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_type_v3-decimal_yt_llvm--Plan_/plan.txt"
+            "checksum": "c2c0ee6f0eee8d3edc261ef2562edf2c",
+            "size": 11575,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_type_v3-decimal_yt_llvm--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-decimal_yt_nollvm--Debug]": [
         {
-            "checksum": "44010b4931a87037530df041665aa7db",
-            "size": 3543,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_type_v3-decimal_yt_nollvm--Debug_/opt.yql_patched"
+            "checksum": "51285758e47861ff1b2a6c3a0750eed5",
+            "size": 3402,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_type_v3-decimal_yt_nollvm--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-decimal_yt_nollvm--Plan]": [
         {
-            "checksum": "9fd766f0b618e57b6aa384411c48a22a",
-            "size": 11781,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_type_v3-decimal_yt_nollvm--Plan_/plan.txt"
+            "checksum": "c2c0ee6f0eee8d3edc261ef2562edf2c",
+            "size": 11575,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_type_v3-decimal_yt_nollvm--Plan_/plan.txt"
         }
     ],
     "test.test[union-union_positional-default.txt-Debug]": [
@@ -2675,58 +2675,58 @@
     ],
     "test.test[view-file_inner--Debug]": [
         {
-            "checksum": "b63d057a6dc7a207c4f15f6e20fd5302",
-            "size": 2917,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_view-file_inner--Debug_/opt.yql_patched"
+            "checksum": "c72da2f4bbff01585c1791020b99186a",
+            "size": 2805,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_view-file_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-file_inner--Plan]": [
         {
-            "checksum": "58716d223e36cef2306244a69797fb89",
-            "size": 4083,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_view-file_inner--Plan_/plan.txt"
+            "checksum": "eaf191dcf5b273e7f396f83ec654fa29",
+            "size": 3877,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_view-file_inner--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-yql-7888_mapfieldsubset--Debug]": [
         {
-            "checksum": "ba8ff2b14a19c6f8a6a806e980be8805",
-            "size": 4784,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_weak_field-yql-7888_mapfieldsubset--Debug_/opt.yql_patched"
+            "checksum": "e6a0231eac5d3603c0b104dc4f69e2f8",
+            "size": 4698,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_weak_field-yql-7888_mapfieldsubset--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-yql-7888_mapfieldsubset--Plan]": [
         {
-            "checksum": "0f16d19f388c3b959de7aa35f1fce2ee",
-            "size": 10304,
-            "uri": "https://{canondata_backend}/1942173/0acc2a3f8cbb79cf0ba7d20a184ad86f2e3d87ba/resource.tar.gz#test.test_weak_field-yql-7888_mapfieldsubset--Plan_/plan.txt"
+            "checksum": "d304d507155c7465d480ff759a249c79",
+            "size": 9892,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_weak_field-yql-7888_mapfieldsubset--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/syscolumns--Debug]": [
         {
-            "checksum": "05fd5359fab9c30a60ae06df241f533f",
-            "size": 12207,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_window-full_syscolumns--Debug_/opt.yql_patched"
+            "checksum": "068d45a7fd395ab3473c121c14ef683d",
+            "size": 11809,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-full_syscolumns--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/syscolumns--Plan]": [
         {
-            "checksum": "cfbfff9df10b44eb3d7f85051cdefd59",
-            "size": 18342,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_window-full_syscolumns--Plan_/plan.txt"
+            "checksum": "a481f6a3d0f226233f0dd86dc9c956e0",
+            "size": 17518,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-full_syscolumns--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_auto_arg_two_sort-default.txt-Debug]": [
         {
-            "checksum": "6109945e4b52ccfbceac7af06a96f20c",
-            "size": 5991,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_window-win_func_auto_arg_two_sort-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2fd488d3e73724da505da9bd71f2876f",
+            "size": 5529,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_auto_arg_two_sort-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_auto_arg_two_sort-default.txt-Plan]": [
         {
-            "checksum": "9fe5d04ca51106415daf206f8316baec",
-            "size": 5741,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_window-win_func_auto_arg_two_sort-default.txt-Plan_/plan.txt"
+            "checksum": "dac32f27040f48861eaa42e4a228bb5e",
+            "size": 5329,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_auto_arg_two_sort-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_cume_dist_ansi-default.txt-Debug]": [
@@ -2759,58 +2759,58 @@
     ],
     "test.test[window-win_func_over_group_by_list_names--Debug]": [
         {
-            "checksum": "4a18a2e6f486cf3252ab01461e27d640",
-            "size": 13067,
-            "uri": "https://{canondata_backend}/1937027/6d0939288c9b56900c5658b406dce84069849150/resource.tar.gz#test.test_window-win_func_over_group_by_list_names--Debug_/opt.yql_patched"
+            "checksum": "838e1ffadf158fb476e04dbc05c1b79d",
+            "size": 12664,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_over_group_by_list_names--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_over_group_by_list_names--Plan]": [
         {
-            "checksum": "95023442bc0660e48038a147297073f4",
-            "size": 9696,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_window-win_func_over_group_by_list_names--Plan_/plan.txt"
+            "checksum": "13e93b2369df19578e01865f5da22186",
+            "size": 9284,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_over_group_by_list_names--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_over_group_by_list_names_order_prefix--Debug]": [
         {
-            "checksum": "c492b8d241eccbc2fc690ef2af054280",
-            "size": 12902,
-            "uri": "https://{canondata_backend}/1937027/6d0939288c9b56900c5658b406dce84069849150/resource.tar.gz#test.test_window-win_func_over_group_by_list_names_order_prefix--Debug_/opt.yql_patched"
+            "checksum": "4927c6db7e307cb20f1b3d1e78bd82c5",
+            "size": 12518,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_over_group_by_list_names_order_prefix--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_over_group_by_list_names_order_prefix--Plan]": [
         {
-            "checksum": "95023442bc0660e48038a147297073f4",
-            "size": 9696,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_window-win_func_over_group_by_list_names_order_prefix--Plan_/plan.txt"
+            "checksum": "13e93b2369df19578e01865f5da22186",
+            "size": 9284,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_over_group_by_list_names_order_prefix--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_rank_with_order_by_aggr_key--Debug]": [
         {
-            "checksum": "996279a3cae6fe0b80b62e5fd91f672c",
-            "size": 5852,
-            "uri": "https://{canondata_backend}/1936997/335b572434427c91a0ca005e493230d435e15e97/resource.tar.gz#test.test_window-win_func_rank_with_order_by_aggr_key--Debug_/opt.yql_patched"
+            "checksum": "0568711f4447c4903857eff98c743aa5",
+            "size": 5635,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_rank_with_order_by_aggr_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_rank_with_order_by_aggr_key--Plan]": [
         {
-            "checksum": "02ef9d1f70aa51db91a8c86c95b58b7b",
-            "size": 9746,
-            "uri": "https://{canondata_backend}/1936997/335b572434427c91a0ca005e493230d435e15e97/resource.tar.gz#test.test_window-win_func_rank_with_order_by_aggr_key--Plan_/plan.txt"
+            "checksum": "a54dcdc5b59d957b82eda3f7b8c4d37d",
+            "size": 9128,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_rank_with_order_by_aggr_key--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_with_struct_access_full_access-default.txt-Debug]": [
         {
-            "checksum": "5fd0123a68e009dbb4abfb0b0e6203a3",
-            "size": 6087,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_window-win_func_with_struct_access_full_access-default.txt-Debug_/opt.yql_patched"
+            "checksum": "538d1e1f19efc60ce413fedf1f44bfc0",
+            "size": 5829,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_with_struct_access_full_access-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_with_struct_access_full_access-default.txt-Plan]": [
         {
-            "checksum": "6dc53254124b493a0f70e66612837574",
-            "size": 8509,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_window-win_func_with_struct_access_full_access-default.txt-Plan_/plan.txt"
+            "checksum": "0445e433cb29c2c02fed56bd65c913c7",
+            "size": 8097,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_func_with_struct_access_full_access-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_peephole_double_usage-default.txt-Debug]": [
@@ -2829,30 +2829,30 @@
     ],
     "test.test[window-win_with_cur_row--Debug]": [
         {
-            "checksum": "ac8a39920a09d9c038bc20fe1bd25583",
-            "size": 5695,
-            "uri": "https://{canondata_backend}/1784826/cbf6ad4c227ab017bb5ebc2f4ab5719247fa9785/resource.tar.gz#test.test_window-win_with_cur_row--Debug_/opt.yql_patched"
+            "checksum": "47bd524b256654af99ed4812ce2c3a9d",
+            "size": 5327,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_with_cur_row--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_with_cur_row--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_window-win_with_cur_row--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_window-win_with_cur_row--Plan_/plan.txt"
         }
     ],
     "test.test[ypath-direct_read_from_dynamic--Debug]": [
         {
-            "checksum": "36f7167a1d8f9ccae289a10911e21435",
-            "size": 2125,
-            "uri": "https://{canondata_backend}/1871102/c16b260c9474b6209b41c05f68145ad16f292a86/resource.tar.gz#test.test_ypath-direct_read_from_dynamic--Debug_/opt.yql_patched"
+            "checksum": "42cd9e623c8c150766e9c548381b5123",
+            "size": 2002,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_ypath-direct_read_from_dynamic--Debug_/opt.yql_patched"
         }
     ],
     "test.test[ypath-direct_read_from_dynamic--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1931696/cc756dc950b218e9f3589a791267d21773207f44/resource.tar.gz#test.test_ypath-direct_read_from_dynamic--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/e8a59d866b0d94fc2277cc98140dae6c5e6c1510/resource.tar.gz#test.test_ypath-direct_read_from_dynamic--Plan_/plan.txt"
         }
     ]
 }

--- a/ydb/library/yql/tests/sql/hybrid_file/part6/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part6/canondata/result.json
@@ -1,16 +1,16 @@
 {
     "test.test[action-eval_anon_table--Debug]": [
         {
-            "checksum": "9870eed47417c21ce599217eab1b5f6e",
-            "size": 1804,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_action-eval_anon_table--Debug_/opt.yql_patched"
+            "checksum": "dae0b62f779b93539cb93d44a2e804cd",
+            "size": 1744,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_action-eval_anon_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_anon_table--Plan]": [
         {
-            "checksum": "ddafe1e5e57cc150a3beeef44995f7d3",
-            "size": 5719,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_action-eval_anon_table--Plan_/plan.txt"
+            "checksum": "142416dfe8f215574743502829d3bb25",
+            "size": 5513,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_action-eval_anon_table--Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_folder_via_file--Debug]": [
@@ -99,16 +99,16 @@
     ],
     "test.test[action-table_content_before_from_folder--Debug]": [
         {
-            "checksum": "c2874243446fd02ab24c55f2d42134c4",
-            "size": 2135,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_action-table_content_before_from_folder--Debug_/opt.yql_patched"
+            "checksum": "ce3d2cee7a29064b15930c0066d515aa",
+            "size": 2012,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_action-table_content_before_from_folder--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-table_content_before_from_folder--Plan]": [
         {
-            "checksum": "3c7c7548a48c074fc90a8258d3f284c6",
-            "size": 4631,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_action-table_content_before_from_folder--Plan_/plan.txt"
+            "checksum": "3baa7778fbe622539893693257a430e5",
+            "size": 4425,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_action-table_content_before_from_folder--Plan_/plan.txt"
         }
     ],
     "test.test[agg_apply-avg_state_type-default.txt-Debug]": [
@@ -211,72 +211,72 @@
     ],
     "test.test[aggr_factory-boolor-default.txt-Debug]": [
         {
-            "checksum": "266dacc69a162378566526f8cfd9716a",
-            "size": 6600,
-            "uri": "https://{canondata_backend}/1775059/911ce87dfd191215448f6561296c2a8e49efdd36/resource.tar.gz#test.test_aggr_factory-boolor-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a213a2349dda1fc209478d5b37a041eb",
+            "size": 6502,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-boolor-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-boolor-default.txt-Plan]": [
         {
-            "checksum": "b04a7b524988f38190d4f7d6f057bd1a",
-            "size": 13318,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggr_factory-boolor-default.txt-Plan_/plan.txt"
+            "checksum": "d77130b7c4f1b83c7ecedee655385188",
+            "size": 12906,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-boolor-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-max_by-default.txt-Debug]": [
         {
-            "checksum": "02142f36a7193b08a1de49ae53d33432",
-            "size": 6199,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_aggr_factory-max_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5750b95b3cb97729517b592548c0d1a8",
+            "size": 6067,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-max_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-max_by-default.txt-Plan]": [
         {
-            "checksum": "b02669d2d38597cc186352f1a7f0a55c",
-            "size": 10346,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggr_factory-max_by-default.txt-Plan_/plan.txt"
+            "checksum": "68eae5a44fe96a6eeabf0fc50b05482e",
+            "size": 9934,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-max_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-min-default.txt-Debug]": [
         {
-            "checksum": "cf7816b18e8ddb81c3be722e64c7d45c",
-            "size": 6597,
-            "uri": "https://{canondata_backend}/1775059/911ce87dfd191215448f6561296c2a8e49efdd36/resource.tar.gz#test.test_aggr_factory-min-default.txt-Debug_/opt.yql_patched"
+            "checksum": "73315945fb0c0f8258e8ae0ae6ba510d",
+            "size": 6499,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-min-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-min-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggr_factory-min-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-min-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-some-default.txt-Debug]": [
         {
-            "checksum": "2da7963fa3dcc29f0ba95ec3e4ccd1b5",
-            "size": 6520,
-            "uri": "https://{canondata_backend}/1775059/911ce87dfd191215448f6561296c2a8e49efdd36/resource.tar.gz#test.test_aggr_factory-some-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3236a6bfeeb4fa88b02825c79bb34789",
+            "size": 6422,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-some-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-some-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggr_factory-some-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-some-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-stddev-default.txt-Debug]": [
         {
-            "checksum": "781b22e8d0fa5a00ddeb95229dc55cf4",
-            "size": 8448,
-            "uri": "https://{canondata_backend}/1775059/911ce87dfd191215448f6561296c2a8e49efdd36/resource.tar.gz#test.test_aggr_factory-stddev-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ac3e583c69f42358276e9501aef567cb",
+            "size": 8349,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-stddev-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-stddev-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggr_factory-stddev-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggr_factory-stddev-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-agg_full_table_list-default.txt-Debug]": [
@@ -309,114 +309,114 @@
     ],
     "test.test[aggregate-aggregate_list_in_key-default.txt-Debug]": [
         {
-            "checksum": "c3069c831ada840c3db8db7bb5077fc1",
-            "size": 26493,
-            "uri": "https://{canondata_backend}/1847551/d84e968fa8a66e33f0268ab656a20e2b84ad109c/resource.tar.gz#test.test_aggregate-aggregate_list_in_key-default.txt-Debug_/opt.yql_patched"
+            "checksum": "983f7e3b67ee47b121888601fcb9f420",
+            "size": 25763,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-aggregate_list_in_key-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_list_in_key-default.txt-Plan]": [
         {
-            "checksum": "4c4286249ee9e9419f969ed537ff74a4",
-            "size": 44291,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggregate-aggregate_list_in_key-default.txt-Plan_/plan.txt"
+            "checksum": "9965d1d7928e121fc718a1c5b9ad0630",
+            "size": 42849,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-aggregate_list_in_key-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_with_const_yson_options-default.txt-Debug]": [
         {
-            "checksum": "e465adadbc21abb0c0ff2d58fef67e8f",
-            "size": 5900,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_aggregate-aggregate_with_const_yson_options-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d11dbee886810f858fbe58b44529062f",
+            "size": 5597,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-aggregate_with_const_yson_options-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_with_const_yson_options-default.txt-Plan]": [
         {
-            "checksum": "d4475b4ce49986967e40aeacc55b9d97",
-            "size": 8454,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggregate-aggregate_with_const_yson_options-default.txt-Plan_/plan.txt"
+            "checksum": "2b8caaa263fad6a40e505e78b6d874b6",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-aggregate_with_const_yson_options-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregation_by_udf--Debug]": [
         {
-            "checksum": "bc8aa0e69f40c10cccdf3f999ed45513",
-            "size": 3477,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_aggregate-aggregation_by_udf--Debug_/opt.yql_patched"
+            "checksum": "ba8a6221c4ea11fa42f473169cf18136",
+            "size": 3410,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-aggregation_by_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregation_by_udf--Plan]": [
         {
-            "checksum": "a17bf07539465596b593ec8be1058b6c",
-            "size": 5664,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggregate-aggregation_by_udf--Plan_/plan.txt"
+            "checksum": "3b75cd314a813afd6e1c9c43167edba6",
+            "size": 5458,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-aggregation_by_udf--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-avg_and_sum_by_value--Debug]": [
         {
-            "checksum": "70ce7b432c89df719288802a37bd8acf",
-            "size": 6196,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_aggregate-avg_and_sum_by_value--Debug_/opt.yql_patched"
+            "checksum": "0b7f0f235fcf93ce670d8370aed54e39",
+            "size": 5820,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-avg_and_sum_by_value--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-avg_and_sum_by_value--Plan]": [
         {
-            "checksum": "28c2ab3b456e34dadfd529005a3e689e",
-            "size": 8484,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggregate-avg_and_sum_by_value--Plan_/plan.txt"
+            "checksum": "3ceffa5883fca835378d5359d3859d5f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-avg_and_sum_by_value--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr--Debug]": [
         {
-            "checksum": "76b0b69b3305bd68d191a1657f8ecd6d",
-            "size": 4821,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_aggregate-group_by_expr--Debug_/opt.yql_patched"
+            "checksum": "e996ba0fe4353b879ac677d07aeb3e84",
+            "size": 4597,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr--Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggregate-group_by_expr--Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_expr--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_only_join--Debug]": [
         {
-            "checksum": "49e4701c4f6db04edb903ca5eb075f5f",
-            "size": 6395,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_aggregate-group_by_expr_only_join--Debug_/opt.yql_patched"
+            "checksum": "90c1ad3e300e3ad38afd811992a06b24",
+            "size": 6289,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_expr_only_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_only_join--Plan]": [
         {
-            "checksum": "b8fa4db0ca1d52a81fd64ea1fc464c1f",
-            "size": 8683,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggregate-group_by_expr_only_join--Plan_/plan.txt"
+            "checksum": "036e25d964d0b44d19191fadefd00827",
+            "size": 8477,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_expr_only_join--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_grouping_hum_bind--Debug]": [
         {
-            "checksum": "644c58ae1fa6c2d445799331b38a3074",
-            "size": 13420,
-            "uri": "https://{canondata_backend}/1900335/c7b4d89d0488fd867c17951bd0ade3d7d0ab647a/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum_bind--Debug_/opt.yql_patched"
+            "checksum": "aadcd4a45e5472f3517aec7f1246c2a1",
+            "size": 12499,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum_bind--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_grouping_hum_bind--Plan]": [
         {
-            "checksum": "c36b55d1a5faee071d3bf6f4de678eff",
-            "size": 17571,
-            "uri": "https://{canondata_backend}/1900335/c7b4d89d0488fd867c17951bd0ade3d7d0ab647a/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum_bind--Plan_/plan.txt"
+            "checksum": "4538513645af0d7c1ab6c414669e3fbc",
+            "size": 16335,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping_hum_bind--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_key_check--Debug]": [
         {
-            "checksum": "8f61079f63b66caf22486be507ad2d44",
-            "size": 9286,
-            "uri": "https://{canondata_backend}/1847551/d84e968fa8a66e33f0268ab656a20e2b84ad109c/resource.tar.gz#test.test_aggregate-group_by_rollup_key_check--Debug_/opt.yql_patched"
+            "checksum": "fce030ac68f652275cf2cf2b38d12e60",
+            "size": 8562,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_rollup_key_check--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_key_check--Plan]": [
         {
-            "checksum": "c4f6c08fe27002f2cb604c1f6b74d7d2",
-            "size": 14649,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_aggregate-group_by_rollup_key_check--Plan_/plan.txt"
+            "checksum": "792665c1f523be18dc6270132c2c4cb8",
+            "size": 13619,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_aggregate-group_by_rollup_key_check--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_extended_tuple-default.txt-Debug]": [
@@ -449,30 +449,30 @@
     ],
     "test.test[bigdate-table_arithmetic-default.txt-Debug]": [
         {
-            "checksum": "20a2f72f52d9e94225ab98dddc8d03a1",
-            "size": 14966,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_bigdate-table_arithmetic-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2dd687147f3644579a336b7a65ae8f69",
+            "size": 14450,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_bigdate-table_arithmetic-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_arithmetic-default.txt-Plan]": [
         {
-            "checksum": "9a324f7cb79694d45225b59cbe8e9176",
-            "size": 17602,
-            "uri": "https://{canondata_backend}/1942415/f89807d3c365317c7ae267e707efd66371a666a5/resource.tar.gz#test.test_bigdate-table_arithmetic-default.txt-Plan_/plan.txt"
+            "checksum": "46b24e34f3ecb025d536590c02aed4a1",
+            "size": 17190,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_bigdate-table_arithmetic-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-table_common_type-default.txt-Debug]": [
         {
-            "checksum": "c963c7a40396c154a80b993a18e78c5b",
-            "size": 13224,
-            "uri": "https://{canondata_backend}/1871182/ac171f22ae6cb6e444ea59e878dae0a467fd60c8/resource.tar.gz#test.test_bigdate-table_common_type-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c06fd7dd78b91c1ac1ec9764911f7089",
+            "size": 12524,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_bigdate-table_common_type-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_common_type-default.txt-Plan]": [
         {
-            "checksum": "96f7a64e8ad24bc13081794e4b440a44",
-            "size": 16526,
-            "uri": "https://{canondata_backend}/1871182/ac171f22ae6cb6e444ea59e878dae0a467fd60c8/resource.tar.gz#test.test_bigdate-table_common_type-default.txt-Plan_/plan.txt"
+            "checksum": "c106c4e5b90fb183253f4be15bd6067e",
+            "size": 16114,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_bigdate-table_common_type-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-tz_table_pull--Debug]": [
@@ -505,16 +505,16 @@
     ],
     "test.test[binding-insert_binding--Debug]": [
         {
-            "checksum": "a9d47f02c596301bd0e10a333e25437e",
-            "size": 1801,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_binding-insert_binding--Debug_/opt.yql_patched"
+            "checksum": "e005bcac66f3a646c48b21720d029b07",
+            "size": 1735,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_binding-insert_binding--Debug_/opt.yql_patched"
         }
     ],
     "test.test[binding-insert_binding--Plan]": [
         {
-            "checksum": "c8724b228ad4389dbb1bf8fee5c64d16",
-            "size": 3613,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_binding-insert_binding--Plan_/plan.txt"
+            "checksum": "d0001d3bd2c2eda97c42230016627a5e",
+            "size": 3407,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_binding-insert_binding--Plan_/plan.txt"
         }
     ],
     "test.test[binding-table_concat_binding-default.txt-Debug]": [
@@ -533,58 +533,58 @@
     ],
     "test.test[blocks-add_int16--Debug]": [
         {
-            "checksum": "fb443ec3a4773c44a5a11e815c8521e4",
-            "size": 2199,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-add_int16--Debug_/opt.yql_patched"
+            "checksum": "879ee86355eb0fb6345b3c4054cb9ba6",
+            "size": 2069,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-add_int16--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_int16--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-add_int16--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-add_int16--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-add_int32--Debug]": [
         {
-            "checksum": "1fc1e3dae8bac161512575fdb02cbcad",
-            "size": 2199,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-add_int32--Debug_/opt.yql_patched"
+            "checksum": "118cc4cd479e6266645b486eea055902",
+            "size": 2069,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-add_int32--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_int32--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-add_int32--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-add_int32--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-add_int8--Debug]": [
         {
-            "checksum": "9d51534bd39fe84f838f7b8eba15a5a2",
-            "size": 2192,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-add_int8--Debug_/opt.yql_patched"
+            "checksum": "b8b8527dc0590a393cc8e5c6dbe14ee5",
+            "size": 2062,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-add_int8--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_int8--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-add_int8--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-add_int8--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_count_filter--Debug]": [
         {
-            "checksum": "9c8a47d066a4c1824abf170394c586e5",
-            "size": 3570,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_all_count_filter--Debug_/opt.yql_patched"
+            "checksum": "739f35900f860881010fbe3e2244d35a",
+            "size": 3462,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_all_count_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_count_filter--Plan]": [
         {
-            "checksum": "292233847881b866a7f0f6376dd4bc43",
-            "size": 5589,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_all_count_filter--Plan_/plan.txt"
+            "checksum": "37b39cc33c58de23e77643081a9b7ebe",
+            "size": 5383,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_all_count_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_decimal_max-default.txt-Debug]": [
@@ -603,114 +603,114 @@
     ],
     "test.test[blocks-combine_all_minmax_nested--Debug]": [
         {
-            "checksum": "5d2d9f3790a48d0161d988a8823c100e",
-            "size": 3934,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_all_minmax_nested--Debug_/opt.yql_patched"
+            "checksum": "d3f33a0dfae5d82d3bf9f3c456601d63",
+            "size": 3826,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_all_minmax_nested--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_minmax_nested--Plan]": [
         {
-            "checksum": "ad940930fc7f566294786e577b67f2d8",
-            "size": 5461,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_all_minmax_nested--Plan_/plan.txt"
+            "checksum": "5a26023580863452ea2d8815cfc8d006",
+            "size": 5255,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_all_minmax_nested--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_sum_filter_opt--Debug]": [
         {
-            "checksum": "04aac68d063fcd0444f827d332631be4",
-            "size": 3209,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_all_sum_filter_opt--Debug_/opt.yql_patched"
+            "checksum": "740dd21190a72873d6f57a39807d744b",
+            "size": 3142,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_all_sum_filter_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_sum_filter_opt--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_all_sum_filter_opt--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_all_sum_filter_opt--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_minmax_double--Debug]": [
         {
-            "checksum": "51c66eff27ff31a2f06f657184f9b5b0",
-            "size": 5332,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_hashed_minmax_double--Debug_/opt.yql_patched"
+            "checksum": "506f14b491d5d9ebc290740b35eb582b",
+            "size": 4952,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_hashed_minmax_double--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_minmax_double--Plan]": [
         {
-            "checksum": "b1c42a9475e5bdaf44e3849987108315",
-            "size": 8455,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_hashed_minmax_double--Plan_/plan.txt"
+            "checksum": "ada712974a13f36a82f1e7e9a6b677cd",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_hashed_minmax_double--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_minmax_nested--Debug]": [
         {
-            "checksum": "0b231cb1687e489170e00764088ff899",
-            "size": 5827,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_hashed_minmax_nested--Debug_/opt.yql_patched"
+            "checksum": "55864426b42854ef3b4eb33c3e00249a",
+            "size": 5447,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_hashed_minmax_nested--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_minmax_nested--Plan]": [
         {
-            "checksum": "d4475b4ce49986967e40aeacc55b9d97",
-            "size": 8454,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-combine_hashed_minmax_nested--Plan_/plan.txt"
+            "checksum": "2b8caaa263fad6a40e505e78b6d874b6",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-combine_hashed_minmax_nested--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-compare--Debug]": [
         {
-            "checksum": "c04e728e4a30552e2d593b8d73424909",
-            "size": 7034,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-compare--Debug_/opt.yql_patched"
+            "checksum": "742b2a24f1910ab2ac947506fe3243c2",
+            "size": 5998,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-compare--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-compare--Plan]": [
         {
-            "checksum": "639f3f64a23ce825db3b4695f5f4c872",
-            "size": 6512,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-compare--Plan_/plan.txt"
+            "checksum": "55627862239609353ef7cb8f2a5bec4c",
+            "size": 6100,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-compare--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_add_interval_scalar--Debug]": [
         {
-            "checksum": "17c3d96eb218ee235d93ba722c7226eb",
-            "size": 8296,
-            "uri": "https://{canondata_backend}/1936997/9eff1aad07b28576e9a68bc0e41b226a4ed03f77/resource.tar.gz#test.test_blocks-date_add_interval_scalar--Debug_/opt.yql_patched"
+            "checksum": "1896d05aef708120edfe1eee9277927e",
+            "size": 7620,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-date_add_interval_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_add_interval_scalar--Plan]": [
         {
-            "checksum": "d7dc5671b9ef733316dfc1d26ae18c1f",
-            "size": 7299,
-            "uri": "https://{canondata_backend}/1936997/9eff1aad07b28576e9a68bc0e41b226a4ed03f77/resource.tar.gz#test.test_blocks-date_add_interval_scalar--Plan_/plan.txt"
+            "checksum": "b309ec00eeb6f3f5fa044efec428cf5a",
+            "size": 6887,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-date_add_interval_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_equals_scalar--Debug]": [
         {
-            "checksum": "b760b41b5184b0f977f74daf00b13c50",
-            "size": 20617,
-            "uri": "https://{canondata_backend}/1942525/728e8c7bfbaf38c202cb6540e96c52e91e4b3441/resource.tar.gz#test.test_blocks-date_equals_scalar--Debug_/opt.yql_patched"
+            "checksum": "839ac0a9039d2f080d17175f77a4fcde",
+            "size": 16714,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-date_equals_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_equals_scalar--Plan]": [
         {
-            "checksum": "c2c59fe5fff4e9bf9c6c6a1c9640b948",
-            "size": 8788,
-            "uri": "https://{canondata_backend}/1942525/728e8c7bfbaf38c202cb6540e96c52e91e4b3441/resource.tar.gz#test.test_blocks-date_equals_scalar--Plan_/plan.txt"
+            "checksum": "222ba369728bb74934ed71281f423a9c",
+            "size": 8376,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-date_equals_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_less--Debug]": [
         {
-            "checksum": "1ea2c25dca9697acec994a12be0882ba",
-            "size": 28023,
-            "uri": "https://{canondata_backend}/1942525/728e8c7bfbaf38c202cb6540e96c52e91e4b3441/resource.tar.gz#test.test_blocks-date_less--Debug_/opt.yql_patched"
+            "checksum": "7602a57fbb051f0f012a86f8a9dbd5c9",
+            "size": 24073,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-date_less--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_less--Plan]": [
         {
-            "checksum": "fe66d03c15b37a053205c1b23150a020",
-            "size": 15887,
-            "uri": "https://{canondata_backend}/1942525/728e8c7bfbaf38c202cb6540e96c52e91e4b3441/resource.tar.gz#test.test_blocks-date_less--Plan_/plan.txt"
+            "checksum": "e0b70c711bba0b9a8af7293607a6483c",
+            "size": 15475,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-date_less--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_sub_interval_scalar--Debug]": [
@@ -729,86 +729,86 @@
     ],
     "test.test[blocks-mod_uint64--Debug]": [
         {
-            "checksum": "2af5e2ec36eb44a77d88ee1f5dd055c7",
-            "size": 2259,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-mod_uint64--Debug_/opt.yql_patched"
+            "checksum": "c5ba6fad9e44158ed2b23b5e0d40a25d",
+            "size": 2129,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-mod_uint64--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-mod_uint64--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-mod_uint64--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-mod_uint64--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-mod_uint64_opt2--Debug]": [
         {
-            "checksum": "588231dbf2663e58f998432b92b722f0",
-            "size": 2294,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-mod_uint64_opt2--Debug_/opt.yql_patched"
+            "checksum": "60f2e217441d104a5f6d4382a2d2dea2",
+            "size": 2164,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-mod_uint64_opt2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-mod_uint64_opt2--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-mod_uint64_opt2--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-mod_uint64_opt2--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_from_dates--Debug]": [
         {
-            "checksum": "f1a2be2285d7c35a8a2916cd2c9df35c",
-            "size": 2027,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-pg_from_dates--Debug_/opt.yql_patched"
+            "checksum": "2a27202f1d392fbb66f8f10fd1837ac1",
+            "size": 1921,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-pg_from_dates--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_from_dates--Plan]": [
         {
-            "checksum": "26cb89ac43b37a778a39aa856b165382",
-            "size": 4068,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-pg_from_dates--Plan_/plan.txt"
+            "checksum": "94956c55ba3cd39a4eef2aa2cba1ce06",
+            "size": 3862,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-pg_from_dates--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-sort_one_desc--Debug]": [
         {
-            "checksum": "169f2947be5121c59ac00699c08a482f",
-            "size": 3189,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-sort_one_desc--Debug_/opt.yql_patched"
+            "checksum": "514919bc1f29f6765080e247e6d53d22",
+            "size": 2981,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-sort_one_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-sort_one_desc--Plan]": [
         {
-            "checksum": "a1fef8f61fe11c90dd11c1f890ed823e",
-            "size": 6203,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-sort_one_desc--Plan_/plan.txt"
+            "checksum": "cd27a828adf5519d235a399cbb2df0b9",
+            "size": 5791,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-sort_one_desc--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-string_filter--Debug]": [
         {
-            "checksum": "f3299cfd398405b25d723f2b5e1c0b4b",
-            "size": 3579,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-string_filter--Debug_/opt.yql_patched"
+            "checksum": "6e104ab0498993a31658b0548f84f9a2",
+            "size": 3279,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-string_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-string_filter--Plan]": [
         {
-            "checksum": "3d752a862c8daeef45340a874d5ca650",
-            "size": 6263,
-            "uri": "https://{canondata_backend}/1600758/a0037402be63401435fff64f584873e15fc9edd1/resource.tar.gz#test.test_blocks-string_filter--Plan_/plan.txt"
+            "checksum": "02a7b4afe2adc0be814fafcc72a80b95",
+            "size": 5851,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_blocks-string_filter--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_reorder_without_columnorder--Debug]": [
         {
-            "checksum": "5114a0354b52004a0f348e647f5ee7da",
-            "size": 3293,
-            "uri": "https://{canondata_backend}/1923547/5451f47c75a00d5a13be1b9727e4bd8ab28d3dbc/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Debug_/opt.yql_patched"
+            "checksum": "aa50e5937c084431b22d35c503a39aae",
+            "size": 3088,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_reorder_without_columnorder--Plan]": [
         {
-            "checksum": "ef6f35bbaf81f3538336079d0e53a013",
-            "size": 7612,
-            "uri": "https://{canondata_backend}/1923547/5451f47c75a00d5a13be1b9727e4bd8ab28d3dbc/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Plan_/plan.txt"
+            "checksum": "b3f6017e2c1be72a211a29318c774a0d",
+            "size": 7200,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_column_order-insert_reorder_without_columnorder--Plan_/plan.txt"
         }
     ],
     "test.test[count-count_all_grouped-empty-Debug]": [
@@ -911,16 +911,16 @@
     ],
     "test.test[distinct-distinct_by_tuple-default.txt-Debug]": [
         {
-            "checksum": "3e62781edd1c76d4dda6d6354942352c",
-            "size": 3895,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_distinct-distinct_by_tuple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "13dd2ab5830f661a4929217c861b095e",
+            "size": 3833,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_distinct-distinct_by_tuple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_by_tuple-default.txt-Plan]": [
         {
-            "checksum": "1a8906e8ab203b4e7f49399ac954e19d",
-            "size": 6669,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_distinct-distinct_by_tuple-default.txt-Plan_/plan.txt"
+            "checksum": "1c2545fc20561326bd8fb5fef07830fe",
+            "size": 6463,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_distinct-distinct_by_tuple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[expr-cast_struct-default.txt-Debug]": [
@@ -939,16 +939,16 @@
     ],
     "test.test[expr-double_join_with_list_from_range--Debug]": [
         {
-            "checksum": "feb6f564f03706d6d09044b67116613a",
-            "size": 10000,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_expr-double_join_with_list_from_range--Debug_/opt.yql_patched"
+            "checksum": "8dba59741aa8cd14a2f38337ba16656f",
+            "size": 9593,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_expr-double_join_with_list_from_range--Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-double_join_with_list_from_range--Plan]": [
         {
-            "checksum": "1742cf6fce7fc945f285142ce2066faf",
-            "size": 12544,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_expr-double_join_with_list_from_range--Plan_/plan.txt"
+            "checksum": "3c0c29f69321a0597840119d4d2ac83a",
+            "size": 11926,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_expr-double_join_with_list_from_range--Plan_/plan.txt"
         }
     ],
     "test.test[expr-fallback_filternullmembers-default.txt-Debug]": [
@@ -1093,16 +1093,16 @@
     ],
     "test.test[file-parse_file_in_select_as_str--Debug]": [
         {
-            "checksum": "336b881054afe39b91accd80a205885d",
-            "size": 2470,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_file-parse_file_in_select_as_str--Debug_/opt.yql_patched"
+            "checksum": "7dfaab8ca2c2e6b0705c18a550996ebb",
+            "size": 2344,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_file-parse_file_in_select_as_str--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-parse_file_in_select_as_str--Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_file-parse_file_in_select_as_str--Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_file-parse_file_in_select_as_str--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_expr_struct-default.txt-Debug]": [
@@ -1121,44 +1121,44 @@
     ],
     "test.test[flatten_by-flatten_one_field--Debug]": [
         {
-            "checksum": "1ac2176d33751348556b300e9ea4b704",
-            "size": 5010,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_flatten_by-flatten_one_field--Debug_/opt.yql_patched"
+            "checksum": "4ed2c2f5618aa679772175db3dcc74f8",
+            "size": 4689,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_flatten_by-flatten_one_field--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_one_field--Plan]": [
         {
-            "checksum": "b03d6fcad67631132f0cd58cabadba0a",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_flatten_by-flatten_one_field--Plan_/plan.txt"
+            "checksum": "261b45fcb0c591cd4d8b93883414dec3",
+            "size": 7936,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_flatten_by-flatten_one_field--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-max_in_tables--Debug]": [
         {
-            "checksum": "4c02de126245598cc1ad65301dc94bf2",
-            "size": 4216,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_hor_join-max_in_tables--Debug_/opt.yql_patched"
+            "checksum": "cce16c0e7efc81ca976146630f0dc5d3",
+            "size": 4116,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_hor_join-max_in_tables--Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-max_in_tables--Plan]": [
         {
-            "checksum": "0f97d030a34bddae9025b6cbf9161fbf",
-            "size": 11066,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_hor_join-max_in_tables--Plan_/plan.txt"
+            "checksum": "6d2b033bf7d4e9217dd405657a118db8",
+            "size": 10860,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_hor_join-max_in_tables--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-sorted_out--Debug]": [
         {
-            "checksum": "e7f80a4138e6633b7464b7a2490dcca7",
-            "size": 3991,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_hor_join-sorted_out--Debug_/opt.yql_patched"
+            "checksum": "f21ae16998af8545215eeb252898418f",
+            "size": 3891,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_hor_join-sorted_out--Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-sorted_out--Plan]": [
         {
-            "checksum": "5cf85d7083d1675f826a58a1d8c19dc1",
-            "size": 10093,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_hor_join-sorted_out--Plan_/plan.txt"
+            "checksum": "6d472e6cefbf1ed0fe23c695149f9068",
+            "size": 9887,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_hor_join-sorted_out--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_ansi_dict1-default.txt-Debug]": [
@@ -1191,184 +1191,184 @@
     ],
     "test.test[in-in_types_cast_all-default.txt-Debug]": [
         {
-            "checksum": "bb75d98bb99599a0fade19225eb8be9c",
-            "size": 2238,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_in-in_types_cast_all-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ee9b3053454e8cad98ccf70cbd7774fa",
+            "size": 2115,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_in-in_types_cast_all-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_types_cast_all-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_in-in_types_cast_all-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_in-in_types_cast_all-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_with_tuple-default.txt-Debug]": [
         {
-            "checksum": "9f0522e78f51ebf34a13e1b834e40d5e",
-            "size": 2188,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_in-in_with_tuple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9f16ea59bfd1106f54fd1c30e76fe75b",
+            "size": 2065,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_in-in_with_tuple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_with_tuple-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_in-in_with_tuple-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_in-in_with_tuple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-yql-14677-default.txt-Debug]": [
         {
-            "checksum": "5968545fc70943a6aff4b33c7f80bcbb",
-            "size": 2547,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_in-yql-14677-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e73c4edd15205a000c7c8527253ea6ad",
+            "size": 2424,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_in-yql-14677-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-yql-14677-default.txt-Plan]": [
         {
-            "checksum": "99e89e981a887e834db38d412ab1c44a",
-            "size": 5782,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_in-yql-14677-default.txt-Plan_/plan.txt"
+            "checksum": "659c2c8c602f4af66b27ab448ce3c752",
+            "size": 5576,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_in-yql-14677-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-anonymous_tables-default.txt-Debug]": [
         {
-            "checksum": "3245ba4c0f5198b65db5bd1224f15dc0",
-            "size": 4003,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5f09f07556127c26ed3355d6a7abb677",
+            "size": 3852,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-anonymous_tables-default.txt-Plan]": [
         {
-            "checksum": "37a950ca418b4d27128dd36608cfe20f",
-            "size": 12552,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Plan_/plan.txt"
+            "checksum": "d1edad846d15265b3d07eb8f3667901a",
+            "size": 12140,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-anonymous_tables-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-override-proto-Debug]": [
         {
-            "checksum": "445dfcee36ff1f52586d069269e6b86b",
-            "size": 2308,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_insert-override-proto-Debug_/opt.yql_patched"
+            "checksum": "1b78f64d4445770797ecbf998c871a67",
+            "size": 2185,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-override-proto-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-override-proto-Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_insert-override-proto-Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-override-proto-Plan_/plan.txt"
         }
     ],
     "test.test[insert-replace_inferred_op--Debug]": [
         {
-            "checksum": "3a3a85176cbd487fd2703360d594dd73",
-            "size": 2834,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_insert-replace_inferred_op--Debug_/opt.yql_patched"
+            "checksum": "e3f1dc760e12ddf2d8374d1067fe0cc7",
+            "size": 2645,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-replace_inferred_op--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-replace_inferred_op--Plan]": [
         {
-            "checksum": "fd76338a47a06eda45544a2a9dc7a642",
-            "size": 4919,
-            "uri": "https://{canondata_backend}/1775059/3cb7d014d70b84dbcb84645fa987dd9d47d7fd6c/resource.tar.gz#test.test_insert-replace_inferred_op--Plan_/plan.txt"
+            "checksum": "ceccf2acfc9240b3cbe02176e41fc221",
+            "size": 4713,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-replace_inferred_op--Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_after_replace-default.txt-Debug]": [
         {
-            "checksum": "fabc51ae3d24d4e118b85394c9a208b8",
-            "size": 2284,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Debug_/opt.yql_patched"
+            "checksum": "450d7503661a21507bc61d89e9ea4767",
+            "size": 2161,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_after_replace-default.txt-Plan]": [
         {
-            "checksum": "9f371a18790de00e9f3d14733b37b121",
-            "size": 6466,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Plan_/plan.txt"
+            "checksum": "9bbe1eac068e166dd6d8472f02036357",
+            "size": 6260,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-select_after_replace-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-select_after_replace_unwrap-default.txt-Debug]": [
         {
-            "checksum": "1866cbe17227a271b03d79be63891c03",
-            "size": 3363,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Debug_/opt.yql_patched"
+            "checksum": "848f291c9f8132299c2659ca37ca431b",
+            "size": 3110,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-select_after_replace_unwrap-default.txt-Plan]": [
         {
-            "checksum": "d08a6128ba3f97dddf97bf5ed438a111",
-            "size": 8048,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Plan_/plan.txt"
+            "checksum": "231a2346219ae8acfd3ee4997c3f5c33",
+            "size": 7636,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_insert-select_after_replace_unwrap-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-alias_where_group--Debug]": [
         {
-            "checksum": "c61abc01ac6099c89adca90c3ee843c7",
-            "size": 6714,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_join-alias_where_group--Debug_/opt.yql_patched"
+            "checksum": "f625ac3c3add3a83ae846b5b51d26d24",
+            "size": 6448,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-alias_where_group--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-alias_where_group--Plan]": [
         {
-            "checksum": "982437d3299e25017e9bfa82b3e525b0",
-            "size": 11439,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-alias_where_group--Plan_/plan.txt"
+            "checksum": "f0c39f9a1e8b129cf192a80c1eb30320",
+            "size": 10821,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-alias_where_group--Plan_/plan.txt"
         }
     ],
     "test.test[join-anyjoin_common_dup--Debug]": [
         {
-            "checksum": "d559e03dd610189c4fa5fb6cd7e283b5",
-            "size": 9488,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_join-anyjoin_common_dup--Debug_/opt.yql_patched"
+            "checksum": "0182e414b3d2788a15c7819a77c9c885",
+            "size": 9207,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-anyjoin_common_dup--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-anyjoin_common_dup--Plan]": [
         {
-            "checksum": "c96c6e1ecf084b168805e5c0dab2b334",
-            "size": 25183,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-anyjoin_common_dup--Plan_/plan.txt"
+            "checksum": "58f7f895df77fc396a4683354181fedf",
+            "size": 24359,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-anyjoin_common_dup--Plan_/plan.txt"
         }
     ],
     "test.test[join-force_merge_join-default.txt-Debug]": [
         {
-            "checksum": "1051cdfb02c7cc7ec0375327466e9550",
-            "size": 5244,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_join-force_merge_join-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1e62d19adb9a2c282905e3b7ba1722a0",
+            "size": 5138,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-force_merge_join-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-force_merge_join-default.txt-Plan]": [
         {
-            "checksum": "0adb8751ccaf89dcccf9fabacf0d4717",
-            "size": 10324,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-force_merge_join-default.txt-Plan_/plan.txt"
+            "checksum": "6222a0a4a6b440705e8d1657212d8f98",
+            "size": 9912,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-force_merge_join-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-full_equal_not_null--Debug]": [
         {
-            "checksum": "8bde5668338ec8ab844cc8945a6081f8",
-            "size": 5510,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_join-full_equal_not_null--Debug_/opt.yql_patched"
+            "checksum": "ef6bd5653ab329260f2abd11f2ce5598",
+            "size": 5468,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-full_equal_not_null--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-full_equal_not_null--Plan]": [
         {
-            "checksum": "fdc2c490dc31cf2808e4d4ff26a09a99",
-            "size": 8307,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-full_equal_not_null--Plan_/plan.txt"
+            "checksum": "548c2226e0adba64dcc8db3cc9aeb220",
+            "size": 8101,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-full_equal_not_null--Plan_/plan.txt"
         }
     ],
     "test.test[join-full_trivial--Debug]": [
         {
-            "checksum": "69adf1b36cdaffb83610a344cfbfb6a1",
-            "size": 4863,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_join-full_trivial--Debug_/opt.yql_patched"
+            "checksum": "8333c059b98e28eba2bc5b3848358463",
+            "size": 4751,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-full_trivial--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-full_trivial--Plan]": [
         {
-            "checksum": "13800fd8890f811509a6a562241b5f67",
-            "size": 8040,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-full_trivial--Plan_/plan.txt"
+            "checksum": "a461d574c9327b58de46f3963746637c",
+            "size": 7834,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-full_trivial--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_comp_map_table--Debug]": [
@@ -1387,30 +1387,30 @@
     ],
     "test.test[join-join_key_cmp_udf--Debug]": [
         {
-            "checksum": "abf7c2c52b61efafbf7229ee55254891",
-            "size": 5833,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_join-join_key_cmp_udf--Debug_/opt.yql_patched"
+            "checksum": "266ed8dacbc36935cb993da9a807ae92",
+            "size": 5642,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-join_key_cmp_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_key_cmp_udf--Plan]": [
         {
-            "checksum": "86384991e3b17ef4a09bd0dac79dd3eb",
-            "size": 8941,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-join_key_cmp_udf--Plan_/plan.txt"
+            "checksum": "4a66681582f8baf3e02ceda5e3b03984",
+            "size": 8529,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-join_key_cmp_udf--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_join_right_pushdown_no_opt--Debug]": [
         {
-            "checksum": "cac2ef14ff7bb6fda44e16bf92684037",
-            "size": 8053,
-            "uri": "https://{canondata_backend}/1889210/9134d9e30423bbc1dffa9f6443fbc36d9fb3203d/resource.tar.gz#test.test_join-left_join_right_pushdown_no_opt--Debug_/opt.yql_patched"
+            "checksum": "60063eb27ab8df102f2235c313aa9365",
+            "size": 7692,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-left_join_right_pushdown_no_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_join_right_pushdown_no_opt--Plan]": [
         {
-            "checksum": "77af63713e7259dddfa3c7bed1c21eb3",
-            "size": 9330,
-            "uri": "https://{canondata_backend}/1889210/9134d9e30423bbc1dffa9f6443fbc36d9fb3203d/resource.tar.gz#test.test_join-left_join_right_pushdown_no_opt--Plan_/plan.txt"
+            "checksum": "348bae1fdb09f50939761d8b174ae502",
+            "size": 8918,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-left_join_right_pushdown_no_opt--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_join_right_pushdown_simple--Debug]": [
@@ -1443,58 +1443,58 @@
     ],
     "test.test[join-lookupjoin_bug7646_csee--Debug]": [
         {
-            "checksum": "85dbd843855bf17d420e54e768df3fe1",
-            "size": 6390,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_join-lookupjoin_bug7646_csee--Debug_/opt.yql_patched"
+            "checksum": "9ead1c51e00626a90bf0c972413fab51",
+            "size": 6184,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-lookupjoin_bug7646_csee--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_bug7646_csee--Plan]": [
         {
-            "checksum": "1836c771b77a705ae771999593c9347a",
-            "size": 18570,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-lookupjoin_bug7646_csee--Plan_/plan.txt"
+            "checksum": "dfd6e78b3e7f454a1ea7f3463cc2c02d",
+            "size": 18158,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-lookupjoin_bug7646_csee--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_semi_subq--Debug]": [
         {
-            "checksum": "4329ba9e6336427ea256b1c46730b91e",
-            "size": 3853,
-            "uri": "https://{canondata_backend}/1942173/14b31d44199a2032996041c53ee56b5fd6226218/resource.tar.gz#test.test_join-lookupjoin_semi_subq--Debug_/opt.yql_patched"
+            "checksum": "b2404cb1de5dc1de35d66db9018e136f",
+            "size": 3611,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-lookupjoin_semi_subq--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_semi_subq--Plan]": [
         {
-            "checksum": "b02ced194f7e29073c7d1f442a0d90cf",
-            "size": 7018,
-            "uri": "https://{canondata_backend}/1937001/cad0b1a355329ed527888b621a5d83adca970b38/resource.tar.gz#test.test_join-lookupjoin_semi_subq--Plan_/plan.txt"
+            "checksum": "917187038300b96108959eb3fb0b8c5f",
+            "size": 6606,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-lookupjoin_semi_subq--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_choose_primary_with_retry--Debug]": [
         {
-            "checksum": "c7f547d651cdaa00c7c7edbe936c39fe",
-            "size": 4991,
-            "uri": "https://{canondata_backend}/1871102/0a7045aa428531967c0fb9e37bcb60c2783a95cb/resource.tar.gz#test.test_join-mergejoin_choose_primary_with_retry--Debug_/opt.yql_patched"
+            "checksum": "258cb9e38b306f87a695f1458d197285",
+            "size": 4807,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-mergejoin_choose_primary_with_retry--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_choose_primary_with_retry--Plan]": [
         {
-            "checksum": "0e52abedeb10ef1b31b59e409b1e8cf8",
-            "size": 8534,
-            "uri": "https://{canondata_backend}/1871102/0a7045aa428531967c0fb9e37bcb60c2783a95cb/resource.tar.gz#test.test_join-mergejoin_choose_primary_with_retry--Plan_/plan.txt"
+            "checksum": "46447fa6df5e03a432dfef88cc32fae3",
+            "size": 8328,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-mergejoin_choose_primary_with_retry--Plan_/plan.txt"
         }
     ],
     "test.test[join-pushdown_filter_over_inner_with_assume_strict--Debug]": [
         {
-            "checksum": "57ad30aaf49bbc66cf6323a8b7e96fc2",
-            "size": 6095,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_assume_strict--Debug_/opt.yql_patched"
+            "checksum": "7344713fee69546cf2716d99505a37e2",
+            "size": 5895,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_assume_strict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pushdown_filter_over_inner_with_assume_strict--Plan]": [
         {
-            "checksum": "5de7a13c6697b1815543ca9167c5a119",
-            "size": 10344,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_assume_strict--Plan_/plan.txt"
+            "checksum": "aa7146be2ccbe125c1dfe0c4bf8f31a4",
+            "size": 10138,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_join-pushdown_filter_over_inner_with_assume_strict--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-6297--Debug]": [
@@ -1527,30 +1527,30 @@
     ],
     "test.test[key_filter-contains_optional--Debug]": [
         {
-            "checksum": "6f25f5814ebc7a91d31b136ccac92807",
-            "size": 2283,
-            "uri": "https://{canondata_backend}/1689644/6a5bba622f5e49d57dae1b7ca25f57262d77763d/resource.tar.gz#test.test_key_filter-contains_optional--Debug_/opt.yql_patched"
+            "checksum": "25862b9e05a5a95a2b9088b6e269abf7",
+            "size": 2160,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-contains_optional--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-contains_optional--Plan]": [
         {
-            "checksum": "5f87fb14946b9b4ac407b20b08e82490",
-            "size": 3604,
-            "uri": "https://{canondata_backend}/1942525/d415bca65721ee82d4ffe59460487e99c594f887/resource.tar.gz#test.test_key_filter-contains_optional--Plan_/plan.txt"
+            "checksum": "97c7f373a9ae004b0dd3ae378ecfe558",
+            "size": 3398,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-contains_optional--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-extend_over_map_with_same_schema-default.txt-Debug]": [
         {
-            "checksum": "1537494ce5aa07533566d64ab7282a38",
-            "size": 3393,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_key_filter-extend_over_map_with_same_schema-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0c1570d23203a061bec43ed262809b4c",
+            "size": 3270,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-extend_over_map_with_same_schema-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-extend_over_map_with_same_schema-default.txt-Plan]": [
         {
-            "checksum": "0bcd60634dd942504736b69e2369691f",
-            "size": 10079,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_key_filter-extend_over_map_with_same_schema-default.txt-Plan_/plan.txt"
+            "checksum": "af6cd6f38a50ac4ea980c5434264d400",
+            "size": 9873,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-extend_over_map_with_same_schema-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-multiusage--Debug]": [
@@ -1569,30 +1569,30 @@
     ],
     "test.test[key_filter-nile_pred--Debug]": [
         {
-            "checksum": "0787dd22cb93d83cf5e65b3af29085db",
-            "size": 2111,
-            "uri": "https://{canondata_backend}/1942671/c3a75426bd9c5b07388fba6178bdfffda8aea10d/resource.tar.gz#test.test_key_filter-nile_pred--Debug_/opt.yql_patched"
+            "checksum": "bef7b89e8da449951003efccd70e446d",
+            "size": 1988,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-nile_pred--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-nile_pred--Plan]": [
         {
-            "checksum": "5f87fb14946b9b4ac407b20b08e82490",
-            "size": 3604,
-            "uri": "https://{canondata_backend}/1924537/23fc27eb117173ed15dd52321f506e814cbf6fce/resource.tar.gz#test.test_key_filter-nile_pred--Plan_/plan.txt"
+            "checksum": "97c7f373a9ae004b0dd3ae378ecfe558",
+            "size": 3398,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-nile_pred--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-range_union--Debug]": [
         {
-            "checksum": "dc87a3e2dd40f32b3d2ad99a68095407",
-            "size": 3913,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_key_filter-range_union--Debug_/opt.yql_patched"
+            "checksum": "86e3129d9734a4ee5f2f2d05b9837992",
+            "size": 3790,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-range_union--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-range_union--Plan]": [
         {
-            "checksum": "7429a390eb10a4e397f01a6ba56f1f84",
-            "size": 5323,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_key_filter-range_union--Plan_/plan.txt"
+            "checksum": "58a2af453686e660a69520bd7b0994f2",
+            "size": 5117,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_key_filter-range_union--Plan_/plan.txt"
         }
     ],
     "test.test[library-library_udf--Debug]": [
@@ -1611,44 +1611,44 @@
     ],
     "test.test[limit-insert_with_limit-dynamic-Debug]": [
         {
-            "checksum": "8565a0adfb5d44bdb1843bb5ee6d3dd2",
-            "size": 2223,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Debug_/opt.yql_patched"
+            "checksum": "e84470a0973444ca3deb36de6f479d35",
+            "size": 2100,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-insert_with_limit-dynamic-Plan]": [
         {
-            "checksum": "d8e477b8040cd332124cbb139a498d98",
-            "size": 4411,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Plan_/plan.txt"
+            "checksum": "d6c5e38c24be96c5686cd5a7bf17e870",
+            "size": 4205,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_limit-insert_with_limit-dynamic-Plan_/plan.txt"
         }
     ],
     "test.test[limit-limit_offset-default.txt-Debug]": [
         {
-            "checksum": "edf8e57b8b7e3a27982cbb6036e433ad",
-            "size": 2845,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_limit-limit_offset-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7ab038ae4db9d28b174e51ad402c2e4b",
+            "size": 2694,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_limit-limit_offset-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-limit_offset-default.txt-Plan]": [
         {
-            "checksum": "64d6ea3abebbff1e09ad295798dfdb4e",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_limit-limit_offset-default.txt-Plan_/plan.txt"
+            "checksum": "60f75e83f930ef46872b182deb42c77e",
+            "size": 5326,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_limit-limit_offset-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[limit-yql-8611_calc_peephole--Debug]": [
         {
-            "checksum": "8b10f504bf7d626c1c1e6d6bbbad13ee",
-            "size": 6296,
-            "uri": "https://{canondata_backend}/1937492/30c052c39548e9c6e6d1c863510632526cb9d1be/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Debug_/opt.yql_patched"
+            "checksum": "902951e0c02723f99a84e49c030fe97c",
+            "size": 6105,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-yql-8611_calc_peephole--Plan]": [
         {
-            "checksum": "023f4d2b2ecaa9b67c47ac91bdf5c726",
-            "size": 14193,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Plan_/plan.txt"
+            "checksum": "2a4bfdb890fd1b348bfa10a68548772b",
+            "size": 13575,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_limit-yql-8611_calc_peephole--Plan_/plan.txt"
         }
     ],
     "test.test[match_recognize-simple_paritioning-default.txt-Debug]": [
@@ -1667,30 +1667,30 @@
     ],
     "test.test[optimizers-combinebykey_fields_subset--Debug]": [
         {
-            "checksum": "1674a8e88ee20e7273ad65fc61aecf2e",
-            "size": 3787,
-            "uri": "https://{canondata_backend}/1942100/3e2df5a1d584fe59745d76b96ff3a2b72fc09802/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset--Debug_/opt.yql_patched"
+            "checksum": "1fbc01348cea2e2261dcf5df3d94a163",
+            "size": 3701,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-combinebykey_fields_subset--Plan]": [
         {
-            "checksum": "c9177ce5e3dbc49cc9494b5f975895b1",
-            "size": 6235,
-            "uri": "https://{canondata_backend}/1936842/4727d4c07b1125aa5c1ac864d050caaadaa711bd/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset--Plan_/plan.txt"
+            "checksum": "b82f38dae994c7b5d50e5f904bc16168",
+            "size": 5823,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-combinebykey_fields_subset--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-length_over_merge--Debug]": [
         {
-            "checksum": "57ba5f0a59c18fff43469e3dda21f94f",
-            "size": 2156,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_optimizers-length_over_merge--Debug_/opt.yql_patched"
+            "checksum": "7a1c0a42277d2b059b75ab91d22a2d9c",
+            "size": 2114,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-length_over_merge--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-length_over_merge--Plan]": [
         {
-            "checksum": "d4d0f6d31a50f4a9c7f73e46b6be6b08",
-            "size": 4673,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_optimizers-length_over_merge--Plan_/plan.txt"
+            "checksum": "8e8c2794a5e2fa32e85a49c3e4d6cbbb",
+            "size": 4467,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-length_over_merge--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-multi_to_empty_constraint--Debug]": [
@@ -1709,58 +1709,58 @@
     ],
     "test.test[optimizers-unused_columns_window--Debug]": [
         {
-            "checksum": "712e29c2638feda758c027b5c93e5048",
-            "size": 4815,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_optimizers-unused_columns_window--Debug_/opt.yql_patched"
+            "checksum": "9ac45041bbc8dbf396bad75260050524",
+            "size": 4573,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-unused_columns_window--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-unused_columns_window--Plan]": [
         {
-            "checksum": "b78239cb5543ce5932eb685b61647a73",
-            "size": 5728,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_optimizers-unused_columns_window--Plan_/plan.txt"
+            "checksum": "0e7d661835982348255ac63207c34de8",
+            "size": 5316,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-unused_columns_window--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-7324_duplicate_arg--Debug]": [
         {
-            "checksum": "c1bfa2dae4d911b7f8174184f885a532",
-            "size": 2869,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_optimizers-yql-7324_duplicate_arg--Debug_/opt.yql_patched"
+            "checksum": "03ff4a24988d7c99a51a7c398702ccae",
+            "size": 2763,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-yql-7324_duplicate_arg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-7324_duplicate_arg--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_optimizers-yql-7324_duplicate_arg--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-yql-7324_duplicate_arg--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-7532_wrong_field_subset_for_calcoverwindow-default.txt-Debug]": [
         {
-            "checksum": "58c8fdae06d1306ee369610b6341657d",
-            "size": 5203,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_optimizers-yql-7532_wrong_field_subset_for_calcoverwindow-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a90eb47f43f6b44c23e9e5f49ea0bcdc",
+            "size": 4952,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-yql-7532_wrong_field_subset_for_calcoverwindow-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-7532_wrong_field_subset_for_calcoverwindow-default.txt-Plan]": [
         {
-            "checksum": "10c5a2be2cbdbc749bf6f191863de9f0",
-            "size": 8129,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_optimizers-yql-7532_wrong_field_subset_for_calcoverwindow-default.txt-Plan_/plan.txt"
+            "checksum": "dd406f2c960ac335a6d4160c4dd809c9",
+            "size": 7717,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_optimizers-yql-7532_wrong_field_subset_for_calcoverwindow-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-literal_with_assume--Debug]": [
         {
-            "checksum": "40913173f4813d6a5dc72390f0d3a500",
-            "size": 1819,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_order_by-literal_with_assume--Debug_/opt.yql_patched"
+            "checksum": "f615ba788c5650ff3a2bbf4b7277060e",
+            "size": 1719,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_order_by-literal_with_assume--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-literal_with_assume--Plan]": [
         {
-            "checksum": "f195da512144b9c1e1263ff7883daf1c",
-            "size": 4003,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_order_by-literal_with_assume--Plan_/plan.txt"
+            "checksum": "e16d7e3ac6aba6f5b8f65cb4a2adb1da",
+            "size": 3797,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_order_by-literal_with_assume--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-warn_offset_wo_sort--Debug]": [
@@ -1891,16 +1891,16 @@
     ],
     "test.test[pg-join_using_tables4-default.txt-Debug]": [
         {
-            "checksum": "bc0b25509072a60b4f37f13dfe1f0f45",
-            "size": 7849,
-            "uri": "https://{canondata_backend}/1937150/c1173fbffac4dbe31899e70e2d456d7c7cee69c9/resource.tar.gz#test.test_pg-join_using_tables4-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b2bf0f6317c5fd348b792791158dc4b9",
+            "size": 7736,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-join_using_tables4-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-join_using_tables4-default.txt-Plan]": [
         {
-            "checksum": "56d5a17885a6ee32b78a639ccbd8934a",
-            "size": 9516,
-            "uri": "https://{canondata_backend}/1924537/244b67c156c69250a8a20eb16319f10dea1624e1/resource.tar.gz#test.test_pg-join_using_tables4-default.txt-Plan_/plan.txt"
+            "checksum": "7bbd196fc1c2956a70a16a38fa3b6724",
+            "size": 9310,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-join_using_tables4-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-long_ident-default.txt-Debug]": [
@@ -1933,16 +1933,16 @@
     ],
     "test.test[pg-nulls_native-default.txt-Debug]": [
         {
-            "checksum": "bdcd2e4058e4bd8292534b91b4bb4e8c",
-            "size": 6244,
-            "uri": "https://{canondata_backend}/1937150/c1173fbffac4dbe31899e70e2d456d7c7cee69c9/resource.tar.gz#test.test_pg-nulls_native-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b93d3f4e400ccc61165f83e4a85089a8",
+            "size": 5720,
+            "uri": "https://{canondata_backend}/1937150/8af84cdae63c27872de09da76cddd708de02e35b/resource.tar.gz#test.test_pg-nulls_native-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-nulls_native-default.txt-Plan]": [
         {
-            "checksum": "8d89299346ca5feec62180c974552cbc",
-            "size": 18389,
-            "uri": "https://{canondata_backend}/1937150/c1173fbffac4dbe31899e70e2d456d7c7cee69c9/resource.tar.gz#test.test_pg-nulls_native-default.txt-Plan_/plan.txt"
+            "checksum": "88e370d0a7829339208d6f29639d3494",
+            "size": 17771,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-nulls_native-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-order_by_distinct_same_expr-default.txt-Debug]": [
@@ -2031,16 +2031,16 @@
     ],
     "test.test[pg-point-default.txt-Debug]": [
         {
-            "checksum": "28e5ed7e7364f18c84eb31ee122d8b16",
-            "size": 2812,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_pg-point-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c749d78aebfa5ea720ac4284f3abfa79",
+            "size": 2680,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-point-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-point-default.txt-Plan]": [
         {
-            "checksum": "209966fddba70e84f780c6ea1da62d28",
-            "size": 5126,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_pg-point-default.txt-Plan_/plan.txt"
+            "checksum": "6e0dd54cf46cccef7a96ee65672b6c33",
+            "size": 4920,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-point-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-range_function_multi-default.txt-Debug]": [
@@ -2129,16 +2129,16 @@
     ],
     "test.test[pg-select_from_columns_star-default.txt-Debug]": [
         {
-            "checksum": "9cdd0375c4a178365e08101a4be4fc93",
-            "size": 2121,
-            "uri": "https://{canondata_backend}/1937150/6ed1231d0735e7ff4ac5f603831c10709457ac3b/resource.tar.gz#test.test_pg-select_from_columns_star-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bb3867504f921c36583b247703381de7",
+            "size": 2009,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-select_from_columns_star-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_from_columns_star-default.txt-Plan]": [
         {
-            "checksum": "7bb0824d6fbd0b74944e3b1ce4821dc2",
-            "size": 3611,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_pg-select_from_columns_star-default.txt-Plan_/plan.txt"
+            "checksum": "d5981c0125365db3224dcbe690b62ac9",
+            "size": 3405,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-select_from_columns_star-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_having_same_agg-default.txt-Debug]": [
@@ -2227,16 +2227,16 @@
     ],
     "test.test[pg-select_where-default.txt-Debug]": [
         {
-            "checksum": "c292fc3336d23f71195e14799dc7d169",
-            "size": 2108,
-            "uri": "https://{canondata_backend}/1937150/6ed1231d0735e7ff4ac5f603831c10709457ac3b/resource.tar.gz#test.test_pg-select_where-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1d40fe2d21b440de0ed8acefdbe975f6",
+            "size": 1985,
+            "uri": "https://{canondata_backend}/1937150/8af84cdae63c27872de09da76cddd708de02e35b/resource.tar.gz#test.test_pg-select_where-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_where-default.txt-Plan]": [
         {
-            "checksum": "7bb0824d6fbd0b74944e3b1ce4821dc2",
-            "size": 3611,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_pg-select_where-default.txt-Plan_/plan.txt"
+            "checksum": "d5981c0125365db3224dcbe690b62ac9",
+            "size": 3405,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-select_where-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_win_count_all-default.txt-Debug]": [
@@ -2381,16 +2381,16 @@
     ],
     "test.test[pg-wide_sort--Debug]": [
         {
-            "checksum": "7c1315e1373665b79fecd84493cda493",
-            "size": 3111,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_pg-wide_sort--Debug_/opt.yql_patched"
+            "checksum": "b48fababadd539e4956cf3395ea66b64",
+            "size": 2909,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-wide_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-wide_sort--Plan]": [
         {
-            "checksum": "26d3f3789377649dd4c2116d85dacedc",
-            "size": 5369,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_pg-wide_sort--Plan_/plan.txt"
+            "checksum": "97e28b0722a9fb32a99399d4533b12d1",
+            "size": 5163,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_pg-wide_sort--Plan_/plan.txt"
         }
     ],
     "test.test[pg_catalog-system_columns-default.txt-Debug]": [
@@ -2409,30 +2409,30 @@
     ],
     "test.test[produce-process_streaming_inline_bash-default.txt-Debug]": [
         {
-            "checksum": "c36bae56403c83d463731d55b7ee2f13",
-            "size": 2806,
-            "uri": "https://{canondata_backend}/1599023/d3f3aac0c61556a78e4a3c0cc0a917a8df870837/resource.tar.gz#test.test_produce-process_streaming_inline_bash-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c175a2a7e1c62a64d8c4c37987916c13",
+            "size": 2743,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_produce-process_streaming_inline_bash-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_streaming_inline_bash-default.txt-Plan]": [
         {
-            "checksum": "c17f469e4beffb6d3030179f8cfbb50d",
-            "size": 4404,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_produce-process_streaming_inline_bash-default.txt-Plan_/plan.txt"
+            "checksum": "3044d15db273afa988eb3a58a6012c04",
+            "size": 4198,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_produce-process_streaming_inline_bash-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-reduce--Debug]": [
         {
-            "checksum": "b73639852436dbf130e1f53f033eb296",
-            "size": 4551,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_sampling-reduce--Debug_/opt.yql_patched"
+            "checksum": "db91bd8e6296307cad09d76b3ccedaca",
+            "size": 4240,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_sampling-reduce--Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-reduce--Plan]": [
         {
-            "checksum": "acd22d78538816551e5240676d633b12",
-            "size": 7879,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_sampling-reduce--Plan_/plan.txt"
+            "checksum": "13161e13f9e2710d3c0aa3312fb76610",
+            "size": 7261,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_sampling-reduce--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-system_sampling--Debug]": [
@@ -2451,16 +2451,16 @@
     ],
     "test.test[schema-append_to_desc--Debug]": [
         {
-            "checksum": "720bb377db25b68a519853965eff3d8c",
-            "size": 1852,
-            "uri": "https://{canondata_backend}/1924537/3fd88671fd83acf8b8710ffba88775aacefc5ae4/resource.tar.gz#test.test_schema-append_to_desc--Debug_/opt.yql_patched"
+            "checksum": "375348ff038561e6cb9d9e496bccef36",
+            "size": 1729,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_schema-append_to_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-append_to_desc--Plan]": [
         {
-            "checksum": "b2d6e66e3acef209abbad1dc52e2c938",
-            "size": 4314,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_schema-append_to_desc--Plan_/plan.txt"
+            "checksum": "1683a0285164ddcb9d001ce76eeeb281",
+            "size": 4108,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_schema-append_to_desc--Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-yamred_dsv_raw-Debug]": [
@@ -2507,16 +2507,16 @@
     ],
     "test.test[schema-select_all_inferschema--Debug]": [
         {
-            "checksum": "da270972e7c7accce3a49669b0843b48",
-            "size": 2597,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_schema-select_all_inferschema--Debug_/opt.yql_patched"
+            "checksum": "9081400b1e579248acd581828cd58e2c",
+            "size": 2408,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_schema-select_all_inferschema--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_all_inferschema--Plan]": [
         {
-            "checksum": "271a7659178cf38f1a94409b5140f41d",
-            "size": 3593,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_schema-select_all_inferschema--Plan_/plan.txt"
+            "checksum": "f3fcfbf6cfbb0739880500c7ff9a956d",
+            "size": 3387,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_schema-select_all_inferschema--Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_reordered-default.txt-Debug]": [
@@ -2549,30 +2549,30 @@
     ],
     "test.test[select-const_subrequest_and_select_by_all-default.txt-Debug]": [
         {
-            "checksum": "c1be71115c01e16103846c9d885d7d00",
-            "size": 3314,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-const_subrequest_and_select_by_all-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6ade39177c4b066e0198dac867848d54",
+            "size": 3190,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-const_subrequest_and_select_by_all-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-const_subrequest_and_select_by_all-default.txt-Plan]": [
         {
-            "checksum": "91cf45b9d6a40ba1a5e342736eb0c3b9",
-            "size": 8545,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-const_subrequest_and_select_by_all-default.txt-Plan_/plan.txt"
+            "checksum": "ed6ba7a80fd5ab75eb3e50e9e70dcae4",
+            "size": 8133,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-const_subrequest_and_select_by_all-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-create_structures-default.txt-Debug]": [
         {
-            "checksum": "e16e255e5390b01e5b083b19bf70c710",
-            "size": 2220,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-create_structures-default.txt-Debug_/opt.yql_patched"
+            "checksum": "27ee3473eeeb71e1723ae2ecc09cfdcc",
+            "size": 2114,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-create_structures-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-create_structures-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-create_structures-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-create_structures-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-data_instance-default.txt-Debug]": [
@@ -2591,86 +2591,86 @@
     ],
     "test.test[select-one_unlabeled_column-default.txt-Debug]": [
         {
-            "checksum": "e281bdd12e51301a050afe0ad552cf8e",
-            "size": 1736,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-one_unlabeled_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "87f097698527f000fd1967c71b64a12b",
+            "size": 1674,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-one_unlabeled_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-one_unlabeled_column-default.txt-Plan]": [
         {
-            "checksum": "31d406ffbf435de871b9f93ad9cd55ec",
-            "size": 3440,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-one_unlabeled_column-default.txt-Plan_/plan.txt"
+            "checksum": "4a9722a51fa8c8416dacb8151a8e59d3",
+            "size": 3234,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-one_unlabeled_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-select_all_from_concat_anon-default.txt-Debug]": [
         {
-            "checksum": "c20174b4094655dfe398248c6a37f140",
-            "size": 1826,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-select_all_from_concat_anon-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bbc503bc485095ff1c235b2f6368b2e6",
+            "size": 1760,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-select_all_from_concat_anon-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-select_all_from_concat_anon-default.txt-Plan]": [
         {
-            "checksum": "119c9c419cee7c48c5e80646be77fad2",
-            "size": 5921,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-select_all_from_concat_anon-default.txt-Plan_/plan.txt"
+            "checksum": "d9f0f1cc3e9a3b4b723a0abdd6e336c1",
+            "size": 5715,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-select_all_from_concat_anon-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-struct_members-default.txt-Debug]": [
         {
-            "checksum": "735d4817acf1a001eed3051aa43d76f5",
-            "size": 2249,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-struct_members-default.txt-Debug_/opt.yql_patched"
+            "checksum": "88106f7e9a6a4467149a53102706f87e",
+            "size": 2126,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-struct_members-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-struct_members-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-struct_members-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-struct_members-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-substring_v1-default.txt-Debug]": [
         {
-            "checksum": "69e0baa31ae3a62394a578d781cc6273",
-            "size": 2176,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-substring_v1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9e8992c77fae72419de4faf6dac1c2d4",
+            "size": 2076,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-substring_v1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-substring_v1-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-substring_v1-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-substring_v1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-table_content_from_sort_desc-default.txt-Debug]": [
         {
-            "checksum": "a255c5853011c6c31bcf25876e88edfa",
-            "size": 3731,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a6c04c59a743cce7ad1af932331624ac",
+            "size": 3623,
+            "uri": "https://{canondata_backend}/1937150/8af84cdae63c27872de09da76cddd708de02e35b/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-table_content_from_sort_desc-default.txt-Plan]": [
         {
-            "checksum": "4e96cc46b4aa96031c4ccee5dc8e3cce",
-            "size": 9572,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Plan_/plan.txt"
+            "checksum": "e59bdc9a25ae0dd8b71ca394b0a677c3",
+            "size": 9366,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-table_content_from_sort_desc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-where_with_lambda--Debug]": [
         {
-            "checksum": "76bab4648b8a04913f7a729f0f00ce3a",
-            "size": 1846,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_select-where_with_lambda--Debug_/opt.yql_patched"
+            "checksum": "b16f0f68fd7776f1f6933fc4e01236a4",
+            "size": 1723,
+            "uri": "https://{canondata_backend}/1937150/8af84cdae63c27872de09da76cddd708de02e35b/resource.tar.gz#test.test_select-where_with_lambda--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-where_with_lambda--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_select-where_with_lambda--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_select-where_with_lambda--Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_coalesce_bug8923-default.txt-Debug]": [
@@ -2717,30 +2717,30 @@
     ],
     "test.test[table_range-limit_with_table_path_over_sorted_range--Debug]": [
         {
-            "checksum": "2a2e20ebd090c0fe5074949c0472dcbe",
-            "size": 4042,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_table_range-limit_with_table_path_over_sorted_range--Debug_/opt.yql_patched"
+            "checksum": "f42a009a74b1417485dcde9006042c01",
+            "size": 3788,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_table_range-limit_with_table_path_over_sorted_range--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-limit_with_table_path_over_sorted_range--Plan]": [
         {
-            "checksum": "c7d1db6b7be25b606bbfa7fd2dbd5c6b",
-            "size": 10035,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_table_range-limit_with_table_path_over_sorted_range--Plan_/plan.txt"
+            "checksum": "36620946e5643ff075976e9b842e84dd",
+            "size": 9623,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_table_range-limit_with_table_path_over_sorted_range--Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q15-default.txt-Debug]": [
         {
-            "checksum": "f5366b3499a579493a2fd47929fee0e7",
-            "size": 8000,
-            "uri": "https://{canondata_backend}/1937429/c6cf663d286207336e877922b1b362f0015754fe/resource.tar.gz#test.test_tpch-q15-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c8489d79677696bb5d2500571da51a3b",
+            "size": 7623,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_tpch-q15-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q15-default.txt-Plan]": [
         {
-            "checksum": "9d26566d71fbb6f3744bfce9bc43cfc8",
-            "size": 12527,
-            "uri": "https://{canondata_backend}/1923547/b061d504cd48474f59ceb335225e901a3852457e/resource.tar.gz#test.test_tpch-q15-default.txt-Plan_/plan.txt"
+            "checksum": "e5c833bee8a0762b90af4c25debe16f2",
+            "size": 11909,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_tpch-q15-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_literal-evaluate-default.txt-Debug]": [
@@ -2773,30 +2773,30 @@
     ],
     "test.test[udf-udaf_lambda-default.txt-Debug]": [
         {
-            "checksum": "917b7adebd1c48a52b0ab29b20c5cf0c",
-            "size": 3072,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_udf-udaf_lambda-default.txt-Debug_/opt.yql_patched"
+            "checksum": "89e16b857d3d6696d30e9b375cdc67ac",
+            "size": 3005,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_udf-udaf_lambda-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[udf-udaf_lambda-default.txt-Plan]": [
         {
-            "checksum": "4eb5ebdb8cbf6d6f121ebd0de25bf65e",
-            "size": 5659,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_udf-udaf_lambda-default.txt-Plan_/plan.txt"
+            "checksum": "1a312a7aa25bfbba679141010ab783ef",
+            "size": 5453,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_udf-udaf_lambda-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[udf-udf_call_with_group_and_limit--Debug]": [
         {
-            "checksum": "25e9a731c462948abd8f2a576e87d322",
-            "size": 4892,
-            "uri": "https://{canondata_backend}/1847551/d84e968fa8a66e33f0268ab656a20e2b84ad109c/resource.tar.gz#test.test_udf-udf_call_with_group_and_limit--Debug_/opt.yql_patched"
+            "checksum": "8c3379d00f57fcd6dccf2ca1dc5f1d91",
+            "size": 4589,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_udf-udf_call_with_group_and_limit--Debug_/opt.yql_patched"
         }
     ],
     "test.test[udf-udf_call_with_group_and_limit--Plan]": [
         {
-            "checksum": "fcb3fac66758bdf710add4888459ac6b",
-            "size": 8425,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_udf-udf_call_with_group_and_limit--Plan_/plan.txt"
+            "checksum": "f1f5f9687ade29f7d83e3e95a7f11fd8",
+            "size": 7807,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_udf-udf_call_with_group_and_limit--Plan_/plan.txt"
         }
     ],
     "test.test[udf-udf_result_member--Debug]": [
@@ -2815,16 +2815,16 @@
     ],
     "test.test[union_all-inner_union_all_with_limits-default.txt-Debug]": [
         {
-            "checksum": "baef6761bf866b7cf89ecc55bd7561d0",
-            "size": 2914,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_union_all-inner_union_all_with_limits-default.txt-Debug_/opt.yql_patched"
+            "checksum": "716f0836badc873c4ba79b2b5d2143bc",
+            "size": 2786,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_union_all-inner_union_all_with_limits-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-inner_union_all_with_limits-default.txt-Plan]": [
         {
-            "checksum": "22565e430f12d8e565feb3ad55120d76",
-            "size": 7437,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_union_all-inner_union_all_with_limits-default.txt-Plan_/plan.txt"
+            "checksum": "42a56fd459e6f7f01414f85d33cc66f7",
+            "size": 7025,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_union_all-inner_union_all_with_limits-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_incompatible-default.txt-Debug]": [
@@ -2843,86 +2843,86 @@
     ],
     "test.test[view-init_view_after_eval-default.txt-Debug]": [
         {
-            "checksum": "f5b189cb6969c825414e3485ba4d39b1",
-            "size": 2030,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_view-init_view_after_eval-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1abf046b5a77bebec679df17eeba7e2e",
+            "size": 1964,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_view-init_view_after_eval-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-init_view_after_eval-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_view-init_view_after_eval-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_view-init_view_after_eval-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[view-standalone_view_lambda--Debug]": [
         {
-            "checksum": "3db7e0871d7f71d2dc54e4c6995fa419",
-            "size": 2340,
-            "uri": "https://{canondata_backend}/1871002/b49dbf1dedc3f34115a456d3056c386a6e9ca051/resource.tar.gz#test.test_view-standalone_view_lambda--Debug_/opt.yql_patched"
+            "checksum": "bf39b6ed32143a20fabd3648536d9f1b",
+            "size": 2197,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_view-standalone_view_lambda--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-standalone_view_lambda--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1871002/b49dbf1dedc3f34115a456d3056c386a6e9ca051/resource.tar.gz#test.test_view-standalone_view_lambda--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_view-standalone_view_lambda--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_data--Debug]": [
         {
-            "checksum": "61fdaed066839a45a486bce961fe76c0",
-            "size": 2911,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_weak_field-weak_field_data--Debug_/opt.yql_patched"
+            "checksum": "c90bac63a772384b03b4c67362736bf2",
+            "size": 2792,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_weak_field-weak_field_data--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_data--Plan]": [
         {
-            "checksum": "33971d804c0ec62d21c2e53a215a3e51",
-            "size": 6365,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_weak_field-weak_field_data--Plan_/plan.txt"
+            "checksum": "d236c5f06e34634d809ae2c4ccc727f3",
+            "size": 6159,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_weak_field-weak_field_data--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_join--Debug]": [
         {
-            "checksum": "b02bc1ec8871eb907a65994bf30cf31e",
-            "size": 5638,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_weak_field-weak_field_join--Debug_/opt.yql_patched"
+            "checksum": "4c693d2e3a11d6b0c96eccb3026ff172",
+            "size": 5477,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_weak_field-weak_field_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_join--Plan]": [
         {
-            "checksum": "9dc950d517c0cf0ff9cfcf6ed7d65f70",
-            "size": 9026,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_weak_field-weak_field_join--Plan_/plan.txt"
+            "checksum": "22de714acac670b14e5055d1a430a79b",
+            "size": 8820,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_weak_field-weak_field_join--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_strict--Debug]": [
         {
-            "checksum": "f72019db647dfe3af3fd047a2c08ed5f",
-            "size": 3350,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_weak_field-weak_field_strict--Debug_/opt.yql_patched"
+            "checksum": "b4fc1e0ee7bdb2a0b2a703959feeb40e",
+            "size": 3134,
+            "uri": "https://{canondata_backend}/1937150/8af84cdae63c27872de09da76cddd708de02e35b/resource.tar.gz#test.test_weak_field-weak_field_strict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_strict--Plan]": [
         {
-            "checksum": "cef64a37ffc46669619cf8f6c31830df",
-            "size": 4085,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_weak_field-weak_field_strict--Plan_/plan.txt"
+            "checksum": "b6982bf4ff50b5284fd879b1f4f55b36",
+            "size": 3879,
+            "uri": "https://{canondata_backend}/1937150/8af84cdae63c27872de09da76cddd708de02e35b/resource.tar.gz#test.test_weak_field-weak_field_strict--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_type-default.txt-Debug]": [
         {
-            "checksum": "59a1ad616e8a538f3a63729189b413b7",
-            "size": 2198,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_weak_field-weak_field_type-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8321ad74781570360e342e6cc1053c0f",
+            "size": 2075,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_weak_field-weak_field_type-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_type-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_weak_field-weak_field_type-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_weak_field-weak_field_type-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_member_string_copy-default.txt-Debug]": [
@@ -2941,72 +2941,72 @@
     ],
     "test.test[window-full/aggregations_leadlag--Debug]": [
         {
-            "checksum": "3c011a8763155d85869862ccaa28ba57",
-            "size": 16600,
-            "uri": "https://{canondata_backend}/995452/9c6a5b8922b7ad3c301f1f30c7cd81d628b9791d/resource.tar.gz#test.test_window-full_aggregations_leadlag--Debug_/opt.yql_patched"
+            "checksum": "47fef26856ea53f592222402cedf569f",
+            "size": 16285,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-full_aggregations_leadlag--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/aggregations_leadlag--Plan]": [
         {
-            "checksum": "2c23dfbff36b1ac5a2b2e303264c92c9",
-            "size": 18754,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-full_aggregations_leadlag--Plan_/plan.txt"
+            "checksum": "bf31acb1db326b7b1d5aa35e95cecaa3",
+            "size": 18342,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-full_aggregations_leadlag--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/leadlag--Debug]": [
         {
-            "checksum": "a9405773bb74ea45a8c5bb173d66b26b",
-            "size": 7402,
-            "uri": "https://{canondata_backend}/1809005/b47853281f398102bc55cbe909f162363a844206/resource.tar.gz#test.test_window-full_leadlag--Debug_/opt.yql_patched"
+            "checksum": "587ff42a95b7ba6f2f59f7acd532505d",
+            "size": 7153,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-full_leadlag--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/leadlag--Plan]": [
         {
-            "checksum": "f400a1bd401b7b3cef3f9e74b6c76a34",
-            "size": 10200,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-full_leadlag--Plan_/plan.txt"
+            "checksum": "0e9c92d2999216718159de282207b3ec",
+            "size": 9788,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-full_leadlag--Plan_/plan.txt"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Debug]": [
         {
-            "checksum": "d758a8d1b0c0268fb908997077961da5",
-            "size": 10014,
-            "uri": "https://{canondata_backend}/1937424/1f3cd125c2d8eafb2ebb1dbc7c974f4f15ef1793/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
+            "checksum": "46fd0ef97f806b5141cdd86528976710",
+            "size": 9497,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-generic_aggregations_mixed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_mixed--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-generic_aggregations_mixed--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-generic_aggregations_mixed--Plan_/plan.txt"
         }
     ],
     "test.test[window-lagging/aggregations_leadlag--Debug]": [
         {
-            "checksum": "340c7b666767d5f5ece7c3d51226a534",
-            "size": 8485,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_window-lagging_aggregations_leadlag--Debug_/opt.yql_patched"
+            "checksum": "3a3ead1cd115ec5809b0da4276454bdf",
+            "size": 7985,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-lagging_aggregations_leadlag--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-lagging/aggregations_leadlag--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-lagging_aggregations_leadlag--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-lagging_aggregations_leadlag--Plan_/plan.txt"
         }
     ],
     "test.test[window-mixed/aggregations--Debug]": [
         {
-            "checksum": "b44f64721dc3d2fcb206e50057d78603",
-            "size": 12428,
-            "uri": "https://{canondata_backend}/1130705/3deff34d248db1fb5a54ca6f66a2bd921ca5f5fe/resource.tar.gz#test.test_window-mixed_aggregations--Debug_/opt.yql_patched"
+            "checksum": "003fc21925880226256787afb21191e7",
+            "size": 11813,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-mixed_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-mixed/aggregations--Plan]": [
         {
-            "checksum": "8cccf0000f791a596e847b219789fc6b",
-            "size": 13456,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-mixed_aggregations--Plan_/plan.txt"
+            "checksum": "4c015e38f5ca12373820ccbbcacca858",
+            "size": 12632,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-mixed_aggregations--Plan_/plan.txt"
         }
     ],
     "test.test[window-null_type-default.txt-Debug]": [
@@ -3025,44 +3025,44 @@
     ],
     "test.test[window-rank/plain--Debug]": [
         {
-            "checksum": "e60ee3e11ab3e0ed6711bcefc8921da0",
-            "size": 10333,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_window-rank_plain--Debug_/opt.yql_patched"
+            "checksum": "a9a056ba58fca00bff1ed157c8c1521f",
+            "size": 9742,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-rank_plain--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-rank/plain--Plan]": [
         {
-            "checksum": "921f205f3b2662b51d96fc1a2bdd2a32",
-            "size": 9779,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-rank_plain--Plan_/plan.txt"
+            "checksum": "7437beaa39350581ba057ee83a418001",
+            "size": 9161,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-rank_plain--Plan_/plan.txt"
         }
     ],
     "test.test[window-row_number_no_part_multi_input-default.txt-Debug]": [
         {
-            "checksum": "3b6c9c415f00e89133c8e348bdbf12c0",
-            "size": 9548,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f23b3d70be72b3ab85e89c9a0cb17b2f",
+            "size": 9190,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-row_number_no_part_multi_input-default.txt-Plan]": [
         {
-            "checksum": "4460ca4849ad226fd0422a75140a1717",
-            "size": 14787,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Plan_/plan.txt"
+            "checksum": "f44f99e5d6710dfd5fc1ff45b106342f",
+            "size": 14169,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-row_number_no_part_multi_input-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-row_number_to_map-default.txt-Debug]": [
         {
-            "checksum": "ed249cb2df94ce33d1a4c6813800a04e",
-            "size": 12155,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_window-row_number_to_map-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cbe3b7937c1b4f669cffd81b097a97d7",
+            "size": 11775,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-row_number_to_map-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-row_number_to_map-default.txt-Plan]": [
         {
-            "checksum": "be80f8f78b02e6a0bb0d2b1c0dec03c3",
-            "size": 12980,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-row_number_to_map-default.txt-Plan_/plan.txt"
+            "checksum": "04f79f608bb47715cb55c29894b2ed6d",
+            "size": 12568,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-row_number_to_map-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-udaf_with_def_value-default.txt-Debug]": [
@@ -3109,72 +3109,72 @@
     ],
     "test.test[window-win_func_aggr_with_qualified_all_no_simple_columns--Debug]": [
         {
-            "checksum": "98031d19127b9a9ddf1287160cd599b7",
-            "size": 6125,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all_no_simple_columns--Debug_/opt.yql_patched"
+            "checksum": "cabc340fc8979f436a938b19e4f3a63b",
+            "size": 5642,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all_no_simple_columns--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_aggr_with_qualified_all_no_simple_columns--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all_no_simple_columns--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_aggr_with_qualified_all_no_simple_columns--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_first_last_over_nonopt-default.txt-Debug]": [
         {
-            "checksum": "f382f4fc0d498e74963ac84547d4481c",
-            "size": 8408,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_window-win_func_first_last_over_nonopt-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c46cd40f62297abe56c2a32a69bee649",
+            "size": 8102,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_first_last_over_nonopt-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_first_last_over_nonopt-default.txt-Plan]": [
         {
-            "checksum": "46dcda64316cc2e97de27cf8e41f3fa7",
-            "size": 8443,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-win_func_first_last_over_nonopt-default.txt-Plan_/plan.txt"
+            "checksum": "b4f5d8f837bcaf5742baf44e75ae1fe2",
+            "size": 8237,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_first_last_over_nonopt-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_in_lib--Debug]": [
         {
-            "checksum": "497612f507d07277b086886bf2a3609e",
-            "size": 3309,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_window-win_func_in_lib--Debug_/opt.yql_patched"
+            "checksum": "6a5ba049ec1a8105d9e3803b841cb027",
+            "size": 3168,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_in_lib--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_in_lib--Plan]": [
         {
-            "checksum": "1b1a43669d4239689ab1e83d57303b5d",
-            "size": 3608,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-win_func_in_lib--Plan_/plan.txt"
+            "checksum": "68970918ac0019ed9f395c4e827e415b",
+            "size": 3402,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_in_lib--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_lead_lag_worm--Debug]": [
         {
-            "checksum": "40ff3961f5e54da5c2beed530a251ab0",
-            "size": 7799,
-            "uri": "https://{canondata_backend}/212715/b432e5e1f6dfb8d57fc0e58f2d61005e9bd53c87/resource.tar.gz#test.test_window-win_func_lead_lag_worm--Debug_/opt.yql_patched"
+            "checksum": "2dfc0737f159f2fbfaab44b3d9d1942d",
+            "size": 7408,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_lead_lag_worm--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_lead_lag_worm--Plan]": [
         {
-            "checksum": "aea628af30069aeeb4a62b5b8911f393",
-            "size": 7951,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-win_func_lead_lag_worm--Plan_/plan.txt"
+            "checksum": "96159552d0698eb4d293bd7b842a4fe8",
+            "size": 7539,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_lead_lag_worm--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_lead_lag_worm_with_part--Debug]": [
         {
-            "checksum": "848e175d3e80e8efff1f9f723127dd0c",
-            "size": 9172,
-            "uri": "https://{canondata_backend}/1031349/506ae7e8d4f20418c9124d112729390d56f60276/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part--Debug_/opt.yql_patched"
+            "checksum": "ae909fc2bd372f3c24c6c820d251d284",
+            "size": 8411,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_lead_lag_worm_with_part--Plan]": [
         {
-            "checksum": "cdd8c059068b99ecd28979c162f5d698",
-            "size": 8450,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part--Plan_/plan.txt"
+            "checksum": "d3731dd27ea3b42b6511c7e8d0432c79",
+            "size": 7832,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_lead_lag_worm_with_part--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_ntile-default.txt-Debug]": [
@@ -3193,30 +3193,30 @@
     ],
     "test.test[window-win_func_special--Debug]": [
         {
-            "checksum": "ef45f7755f72965c9140c1a508aad783",
-            "size": 5039,
-            "uri": "https://{canondata_backend}/1130705/93945b8eab3a9363a2b643499ba728fb8ae7a776/resource.tar.gz#test.test_window-win_func_special--Debug_/opt.yql_patched"
+            "checksum": "de74fa03c6b9eda715f9ff8ee97bebeb",
+            "size": 4916,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_special--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_special--Plan]": [
         {
-            "checksum": "6d7b36bc211432cf7c49afbf27ee2362",
-            "size": 5967,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-win_func_special--Plan_/plan.txt"
+            "checksum": "b77410875a3426d7f6f13d79e2624a04",
+            "size": 5761,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_func_special--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_inline_spec-default.txt-Debug]": [
         {
-            "checksum": "6d9cb103207794b5b02d73d099a94470",
-            "size": 4245,
-            "uri": "https://{canondata_backend}/1903885/9d6fab8873a416c30cc3640609b84c698afc5652/resource.tar.gz#test.test_window-win_inline_spec-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0705d74b1f7345384f3f6e68293c1f27",
+            "size": 4093,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_inline_spec-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_inline_spec-default.txt-Plan]": [
         {
-            "checksum": "1e7fa99030bd6b2bb43ce8fb167ee9b2",
-            "size": 5867,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_window-win_inline_spec-default.txt-Plan_/plan.txt"
+            "checksum": "72430b0b35898a9463a50b3407563966",
+            "size": 5661,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_window-win_inline_spec-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-yql-14277-default.txt-Debug]": [
@@ -3235,30 +3235,30 @@
     ],
     "test.test[ypath-limit_with_key-default.txt-Debug]": [
         {
-            "checksum": "52c0e2e86537b65e1ad56f2f5d6ae01c",
-            "size": 2035,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_ypath-limit_with_key-default.txt-Debug_/opt.yql_patched"
+            "checksum": "38865406b916604e1cbc32246a6d29e3",
+            "size": 1924,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_ypath-limit_with_key-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ypath-limit_with_key-default.txt-Plan]": [
         {
-            "checksum": "418086b69ac4a67baa9ed1983d4ecd49",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_ypath-limit_with_key-default.txt-Plan_/plan.txt"
+            "checksum": "fb002ebdc33b29d4424586db2a9ffd02",
+            "size": 3492,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_ypath-limit_with_key-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[ypath-multi_range-default.txt-Debug]": [
         {
-            "checksum": "60275e2ef7eb1c70420ed9a349ec4b69",
-            "size": 2061,
-            "uri": "https://{canondata_backend}/1871102/69be1cf486f07d50c602df988fd0308f3c43bd08/resource.tar.gz#test.test_ypath-multi_range-default.txt-Debug_/opt.yql_patched"
+            "checksum": "84aa1f0b219c4337d02342301dc5e531",
+            "size": 1938,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_ypath-multi_range-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ypath-multi_range-default.txt-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1031349/201452dd8c883b2adcbf46cb075c912d25efe67e/resource.tar.gz#test.test_ypath-multi_range-default.txt-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1937001/601e94a23ec26980c16840b1ec99d6084037513f/resource.tar.gz#test.test_ypath-multi_range-default.txt-Plan_/plan.txt"
         }
     ]
 }

--- a/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part7/canondata/result.json
@@ -1,16 +1,16 @@
 {
     "test.test[action-action_eval_cluster_table--Debug]": [
         {
-            "checksum": "e197d0a388e7caabf3c957ae62140024",
-            "size": 3009,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_action-action_eval_cluster_table--Debug_/opt.yql_patched"
+            "checksum": "f6d496a1d49e365118fd95d6791ec400",
+            "size": 2763,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-action_eval_cluster_table--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-action_eval_cluster_table--Plan]": [
         {
-            "checksum": "c22d75728ebf1dc427e2aae2591ae6c9",
-            "size": 7041,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_action-action_eval_cluster_table--Plan_/plan.txt"
+            "checksum": "fe11af3091c1a4f332793f79f2bd536a",
+            "size": 6629,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-action_eval_cluster_table--Plan_/plan.txt"
         }
     ],
     "test.test[action-empty_do-default.txt-Debug]": [
@@ -85,44 +85,44 @@
     ],
     "test.test[action-eval_unresolved_type_arg-default.txt-Debug]": [
         {
-            "checksum": "1de59b22011c851fd2d5f31227268d23",
-            "size": 2250,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_action-eval_unresolved_type_arg-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b9bf7fa066675acc850985572c8ba80f",
+            "size": 2184,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-eval_unresolved_type_arg-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_unresolved_type_arg-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_action-eval_unresolved_type_arg-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-eval_unresolved_type_arg-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-evaluate_pure--Debug]": [
         {
-            "checksum": "31ce9772e17737963009a437899d25e2",
-            "size": 3780,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_action-evaluate_pure--Debug_/opt.yql_patched"
+            "checksum": "9270f9f557a776b1dcc23e0f71f4db75",
+            "size": 3681,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-evaluate_pure--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-evaluate_pure--Plan]": [
         {
-            "checksum": "ee5ef2b7eaf8b6bf2543de1b917493de",
-            "size": 6916,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_action-evaluate_pure--Plan_/plan.txt"
+            "checksum": "165002b8806237c42eaf0500bd571470",
+            "size": 6710,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-evaluate_pure--Plan_/plan.txt"
         }
     ],
     "test.test[action-process_from_subquery_with_orderby-default.txt-Debug]": [
         {
-            "checksum": "358af6654b98e449737593922c8a9c00",
-            "size": 1980,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_action-process_from_subquery_with_orderby-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8567793b6c76ea486a18416b3878812d",
+            "size": 1857,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-process_from_subquery_with_orderby-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-process_from_subquery_with_orderby-default.txt-Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_action-process_from_subquery_with_orderby-default.txt-Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_action-process_from_subquery_with_orderby-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-runtime_type_kind-default.txt-Debug]": [
@@ -211,58 +211,58 @@
     ],
     "test.test[aggr_factory-bitand-default.txt-Debug]": [
         {
-            "checksum": "e4cbf28441291780f6a792ec56965815",
-            "size": 6632,
-            "uri": "https://{canondata_backend}/1923547/092e77fcdc19bb8a30dbe5eb7f5689c023f1f9b4/resource.tar.gz#test.test_aggr_factory-bitand-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3d8166cfca763da7e774a367794eb353",
+            "size": 6534,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-bitand-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-bitand-default.txt-Plan]": [
         {
-            "checksum": "bc48acda1e477c8daa387d3a1c3e9ef4",
-            "size": 13322,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggr_factory-bitand-default.txt-Plan_/plan.txt"
+            "checksum": "dcd250bb62eed7eae08239d31389e128",
+            "size": 12910,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-bitand-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-bottom-default.txt-Debug]": [
         {
-            "checksum": "ec653f4675df186c6e38df0c16d971bc",
-            "size": 8886,
-            "uri": "https://{canondata_backend}/1931696/e549dc116aea0941ff000c4cc3596d3ba60fbb98/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql_patched"
+            "checksum": "64779c8e6ea848190d9db4f31fcf773e",
+            "size": 8787,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-bottom-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-bottom-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-logariphmic_histogram-default.txt-Debug]": [
         {
-            "checksum": "d62e8b412b8b1bdb05df52afd27dee42",
-            "size": 7135,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_aggr_factory-logariphmic_histogram-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b73a21bc17a710312015a0931daf550a",
+            "size": 7003,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-logariphmic_histogram-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-logariphmic_histogram-default.txt-Plan]": [
         {
-            "checksum": "e80459c6ded6bc35cd5f0fe2d0ec909c",
-            "size": 9892,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggr_factory-logariphmic_histogram-default.txt-Plan_/plan.txt"
+            "checksum": "d6fe32af474c6dd359f446ef8afd7ccb",
+            "size": 9480,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-logariphmic_histogram-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-max-default.txt-Debug]": [
         {
-            "checksum": "13a1b43021c5b8e62921dcd9953a3697",
-            "size": 6597,
-            "uri": "https://{canondata_backend}/1923547/092e77fcdc19bb8a30dbe5eb7f5689c023f1f9b4/resource.tar.gz#test.test_aggr_factory-max-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ef6cdb17e9c4e6f9dd01e094af2c90be",
+            "size": 6499,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-max-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-max-default.txt-Plan]": [
         {
-            "checksum": "ccf18ca9711e9726f4f98db4496c9fcf",
-            "size": 13320,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggr_factory-max-default.txt-Plan_/plan.txt"
+            "checksum": "7515f3ca6f1df66e55553a5553a3a150",
+            "size": 12908,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggr_factory-max-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-multi_list-default.txt-Debug]": [
@@ -281,198 +281,198 @@
     ],
     "test.test[aggregate-aggregate_by_one_column-default.txt-Debug]": [
         {
-            "checksum": "456d09d127459e668f9ca2007bfbc163",
-            "size": 4800,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_aggregate-aggregate_by_one_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f95ccf51c8a09e253682496e6697adb1",
+            "size": 4451,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggregate_by_one_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_by_one_column-default.txt-Plan]": [
         {
-            "checksum": "d4475b4ce49986967e40aeacc55b9d97",
-            "size": 8454,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-aggregate_by_one_column-default.txt-Plan_/plan.txt"
+            "checksum": "2b8caaa263fad6a40e505e78b6d874b6",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggregate_by_one_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_distinct_expr_with_udf--Debug]": [
         {
-            "checksum": "3dc805e34805fa65846e235aa97d6822",
-            "size": 3900,
-            "uri": "https://{canondata_backend}/1937027/d4b027e3068a4afc6042da36789098155afca34d/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_udf--Debug_/opt.yql_patched"
+            "checksum": "926c9a91b89bd70a3086b0b96345ad30",
+            "size": 3814,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_distinct_expr_with_udf--Plan]": [
         {
-            "checksum": "d76ef1040d3ff8c6958cb0bf9c4d5734",
-            "size": 6234,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_udf--Plan_/plan.txt"
+            "checksum": "73c253417c787f031c66a71cff0a3e17",
+            "size": 5822,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggregate_distinct_expr_with_udf--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_subquery_yql_15869-default.txt-Debug]": [
         {
-            "checksum": "32e348f14293e2fca61206ac0888a771",
-            "size": 3052,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_aggregate-aggregate_subquery_yql_15869-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f8b656547743914d5fc3d0ace44d7f38",
+            "size": 2985,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggregate_subquery_yql_15869-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_subquery_yql_15869-default.txt-Plan]": [
         {
-            "checksum": "0e56f2addf2b393236b33f1567613332",
-            "size": 5616,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-aggregate_subquery_yql_15869-default.txt-Plan_/plan.txt"
+            "checksum": "769127c4504c755518199b95d4a783c6",
+            "size": 5410,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggregate_subquery_yql_15869-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggrs_no_grouping--Debug]": [
         {
-            "checksum": "4d4e44b1e6499d89950bdb848ead1741",
-            "size": 28189,
-            "uri": "https://{canondata_backend}/1937429/30d3e476b0604091faf300d00ac05dc03b916b08/resource.tar.gz#test.test_aggregate-aggrs_no_grouping--Debug_/opt.yql_patched"
+            "checksum": "ae4eb7541f15acd4c7d71d93dc282531",
+            "size": 27249,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggrs_no_grouping--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggrs_no_grouping--Plan]": [
         {
-            "checksum": "4368f0a27eb8298520c78bca6f730e81",
-            "size": 5718,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-aggrs_no_grouping--Plan_/plan.txt"
+            "checksum": "0d51005f3fc3a8b56daa5ab863a3b564",
+            "size": 5512,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-aggrs_no_grouping--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-avg_and_sum-default.txt-Debug]": [
         {
-            "checksum": "8077c93d625094340cda1c3b910772eb",
-            "size": 4886,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_aggregate-avg_and_sum-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7361da2e442921853fe05a35aeed1cd9",
+            "size": 4753,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-avg_and_sum-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-avg_and_sum-default.txt-Plan]": [
         {
-            "checksum": "fcb6525099e5b56c8b9d4e737b64e8e3",
-            "size": 5618,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-avg_and_sum-default.txt-Plan_/plan.txt"
+            "checksum": "3e9bfb228114b36c49d75d5db1bf3bf9",
+            "size": 5412,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-avg_and_sum-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_subselect_asterisk-default.txt-Debug]": [
         {
-            "checksum": "a9a017f224a00ff7afed26df9ca1c2a2",
-            "size": 7427,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_aggregate-group_by_gs_subselect_asterisk-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b25e83df764133ab5a2f9fbc2820be4b",
+            "size": 6963,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_gs_subselect_asterisk-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_subselect_asterisk-default.txt-Plan]": [
         {
-            "checksum": "cd5f2c7d9faec30cb837e1041e61bc3a",
-            "size": 11432,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-group_by_gs_subselect_asterisk-default.txt-Plan_/plan.txt"
+            "checksum": "d138d6c4123ed6ed5751e2022ed3b0b8",
+            "size": 10814,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_gs_subselect_asterisk-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_udf--Debug]": [
         {
-            "checksum": "bc0c5fd3fcbbc4eca1645cf565c55660",
-            "size": 11152,
-            "uri": "https://{canondata_backend}/1781765/d2afb8e57da1d063852f6936054e90132dec5d74/resource.tar.gz#test.test_aggregate-group_by_rollup_udf--Debug_/opt.yql_patched"
+            "checksum": "15f3e213d281451a6a427753da77e84e",
+            "size": 10525,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_rollup_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_udf--Plan]": [
         {
-            "checksum": "e5c7a84c6f36e44bb80e305c14695199",
-            "size": 15626,
-            "uri": "https://{canondata_backend}/1781765/d2afb8e57da1d063852f6936054e90132dec5d74/resource.tar.gz#test.test_aggregate-group_by_rollup_udf--Plan_/plan.txt"
+            "checksum": "167430387d86ade79733d177d511c151",
+            "size": 14596,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_rollup_udf--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_join_qualified-default.txt-Debug]": [
         {
-            "checksum": "22bdf338b2681d15af916245c6c55277",
-            "size": 11463,
-            "uri": "https://{canondata_backend}/1937027/ca37dc23c4a42a42fb6cfd05c1ad5ae3f4853941/resource.tar.gz#test.test_aggregate-group_by_ru_join_qualified-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8dd323d211af6b638d8cc7c3250931b3",
+            "size": 11049,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_ru_join_qualified-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_join_qualified-default.txt-Plan]": [
         {
-            "checksum": "0ee6d51eb4e07110f045bbf39b6eb25e",
-            "size": 16835,
-            "uri": "https://{canondata_backend}/1937027/ca37dc23c4a42a42fb6cfd05c1ad5ae3f4853941/resource.tar.gz#test.test_aggregate-group_by_ru_join_qualified-default.txt-Plan_/plan.txt"
+            "checksum": "1a1f89d5458a705094375af4db210860",
+            "size": 16217,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_ru_join_qualified-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_partition_by_grouping-default.txt-Debug]": [
         {
-            "checksum": "de316c64468c3faa986ec5c488025497",
-            "size": 15078,
-            "uri": "https://{canondata_backend}/1942415/e4ebd91d76d6ca7ef12656b64e915b90972caa6e/resource.tar.gz#test.test_aggregate-group_by_ru_partition_by_grouping-default.txt-Debug_/opt.yql_patched"
+            "checksum": "59f8d64a59533453e7b17d481ce2b166",
+            "size": 14076,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_ru_partition_by_grouping-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_partition_by_grouping-default.txt-Plan]": [
         {
-            "checksum": "6c542e611ec25311658464187b4e0271",
-            "size": 17625,
-            "uri": "https://{canondata_backend}/1942415/e4ebd91d76d6ca7ef12656b64e915b90972caa6e/resource.tar.gz#test.test_aggregate-group_by_ru_partition_by_grouping-default.txt-Plan_/plan.txt"
+            "checksum": "831520f7470a6b9576477c16a9263f5c",
+            "size": 16801,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_ru_partition_by_grouping-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_only_distinct--Debug]": [
         {
-            "checksum": "892425a7698d17f84c4b404604e8f1b7",
-            "size": 7117,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_aggregate-group_by_session_only_distinct--Debug_/opt.yql_patched"
+            "checksum": "5c4200175b115d819d5440a5eba0ca53",
+            "size": 6865,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_session_only_distinct--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_only_distinct--Plan]": [
         {
-            "checksum": "5f8ad0b48e185bdba36eda40e95f3580",
-            "size": 10432,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-group_by_session_only_distinct--Plan_/plan.txt"
+            "checksum": "c605dd887d33122444f15fc6011533a5",
+            "size": 9814,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-group_by_session_only_distinct--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-histogram_cdf-default.txt-Debug]": [
         {
-            "checksum": "21426fb445cce08c0cabaf06c224c63e",
-            "size": 8100,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_aggregate-histogram_cdf-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b7427756ba88b48837a54100113f375a",
+            "size": 8014,
+            "uri": "https://{canondata_backend}/1916746/fc9859eda7833569c636bd5c91d3cefea7eb47fa/resource.tar.gz#test.test_aggregate-histogram_cdf-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-histogram_cdf-default.txt-Plan]": [
         {
-            "checksum": "7b8c53ffedffff0baa01954420c15faf",
-            "size": 5691,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-histogram_cdf-default.txt-Plan_/plan.txt"
+            "checksum": "12cac1e722de21356e36e5faeaea9c19",
+            "size": 5485,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-histogram_cdf-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-list_nullable--Debug]": [
         {
-            "checksum": "df1397b6f3ad0638bf860a0bf937e846",
-            "size": 3266,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_aggregate-list_nullable--Debug_/opt.yql_patched"
+            "checksum": "851d9152ef9b5e7189c48c17375f4550",
+            "size": 3199,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-list_nullable--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-list_nullable--Plan]": [
         {
-            "checksum": "1fc289f1cde313e443c94649b94e540a",
-            "size": 5661,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-list_nullable--Plan_/plan.txt"
+            "checksum": "334ac35a87e1dcf3b243634e1e872716",
+            "size": 5455,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-list_nullable--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-percentile_and_avg_grouped--Debug]": [
         {
-            "checksum": "1bf7483f12edeb8c24f2c60daee67f58",
-            "size": 7865,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_aggregate-percentile_and_avg_grouped--Debug_/opt.yql_patched"
+            "checksum": "5c0ed96d4475674dfb6b24e3ac67b969",
+            "size": 7479,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-percentile_and_avg_grouped--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-percentile_and_avg_grouped--Plan]": [
         {
-            "checksum": "b03d6fcad67631132f0cd58cabadba0a",
-            "size": 8554,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_aggregate-percentile_and_avg_grouped--Plan_/plan.txt"
+            "checksum": "261b45fcb0c591cd4d8b93883414dec3",
+            "size": 7936,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_aggregate-percentile_and_avg_grouped--Plan_/plan.txt"
         }
     ],
     "test.test[ansi_idents-escaped_udf_name-default.txt-Debug]": [
         {
-            "checksum": "b217896dea1c1d1811b86d0ec696f868",
-            "size": 3031,
-            "uri": "https://{canondata_backend}/1880306/c1aa0466ddf0d02543125e7a8f308326758dc098/resource.tar.gz#test.test_ansi_idents-escaped_udf_name-default.txt-Debug_/opt.yql_patched"
+            "checksum": "276b68ea2bb7ef51ac804a866815df5c",
+            "size": 2907,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_ansi_idents-escaped_udf_name-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ansi_idents-escaped_udf_name-default.txt-Plan]": [
         {
-            "checksum": "433de0ee5673c2150941aad2daf4efdf",
-            "size": 6171,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_ansi_idents-escaped_udf_name-default.txt-Plan_/plan.txt"
+            "checksum": "162421da4d6cca37f29f18be8af1a14c",
+            "size": 5759,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_ansi_idents-escaped_udf_name-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-arithmetic-default.txt-Debug]": [
@@ -491,16 +491,16 @@
     ],
     "test.test[bigdate-implicit_cast_callable-default.txt-Debug]": [
         {
-            "checksum": "c1d8e11df6455695fe1f46379451c79e",
-            "size": 13301,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_bigdate-implicit_cast_callable-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cceb34780d222ad11cc763b18410875e",
+            "size": 11755,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_bigdate-implicit_cast_callable-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-implicit_cast_callable-default.txt-Plan]": [
         {
-            "checksum": "b52e7d315943f8c3cfc8567aa30de4bb",
-            "size": 17474,
-            "uri": "https://{canondata_backend}/1936947/034b59cedb2cca071a4937b836b50ccd404c8443/resource.tar.gz#test.test_bigdate-implicit_cast_callable-default.txt-Plan_/plan.txt"
+            "checksum": "a35a167e67f3c724f0de9185122d369d",
+            "size": 16238,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_bigdate-implicit_cast_callable-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-int_cast-default.txt-Debug]": [
@@ -519,30 +519,30 @@
     ],
     "test.test[bigdate-table_arithmetic_mul_div-default.txt-Debug]": [
         {
-            "checksum": "48b58158564d3dd01c0d41b8dded6604",
-            "size": 30153,
-            "uri": "https://{canondata_backend}/1925842/7ff9f7f6f9fd763e965f539592431555505139a0/resource.tar.gz#test.test_bigdate-table_arithmetic_mul_div-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d4d5d49978ce482aebef2f3eb7048d9e",
+            "size": 28197,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_bigdate-table_arithmetic_mul_div-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_arithmetic_mul_div-default.txt-Plan]": [
         {
-            "checksum": "8d4eb51ccc2265e97cbfa972d1fe5c82",
-            "size": 34547,
-            "uri": "https://{canondata_backend}/1942671/67264a3daf5a6e18c2683da86d7edf9d9db63432/resource.tar.gz#test.test_bigdate-table_arithmetic_mul_div-default.txt-Plan_/plan.txt"
+            "checksum": "2ceafac9fbbf6a4f53e7e9c9f973f830",
+            "size": 33723,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_bigdate-table_arithmetic_mul_div-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[binding-named_node_corr_names-default.txt-Debug]": [
         {
-            "checksum": "b624733ed1a125f237b38962845fb989",
-            "size": 2146,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_binding-named_node_corr_names-default.txt-Debug_/opt.yql_patched"
+            "checksum": "eeb16b15726640bcde33e486479e5368",
+            "size": 2081,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_binding-named_node_corr_names-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[binding-named_node_corr_names-default.txt-Plan]": [
         {
-            "checksum": "c4e8947fe7a547db382d4365f2dee4c4",
-            "size": 5176,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_binding-named_node_corr_names-default.txt-Plan_/plan.txt"
+            "checksum": "13d8e92aeae6ed7166a60fbebf26295b",
+            "size": 4764,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_binding-named_node_corr_names-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[binding-table_range_strict_binding-default.txt-Debug]": [
@@ -575,114 +575,114 @@
     ],
     "test.test[blocks-add_uint8--Debug]": [
         {
-            "checksum": "e0f0242d9ad2909964a7e94bc8dd85e0",
-            "size": 2199,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-add_uint8--Debug_/opt.yql_patched"
+            "checksum": "97741ebdb614b2446b8d9e6acefb2cda",
+            "size": 2069,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-add_uint8--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_uint8--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-add_uint8--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-add_uint8--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-bitcast_scalar--Debug]": [
         {
-            "checksum": "2bd21d39edf9ff649071db5b3843c93a",
-            "size": 1856,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-bitcast_scalar--Debug_/opt.yql_patched"
+            "checksum": "7a1fd8d7333d8c67946c134fc937d6cb",
+            "size": 1790,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-bitcast_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-bitcast_scalar--Plan]": [
         {
-            "checksum": "5c41b58f8a68c081f47cebbfa8a13331",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-bitcast_scalar--Plan_/plan.txt"
+            "checksum": "c6ed3026b5067eb08a3ae9247dec4859",
+            "size": 3839,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-bitcast_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-boolean_ops--Debug]": [
         {
-            "checksum": "3d3dcf65f6f9324957d4182d15c95b1b",
-            "size": 5481,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-boolean_ops--Debug_/opt.yql_patched"
+            "checksum": "07e129d6fca38fad04d5fcb2412519a6",
+            "size": 4707,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-boolean_ops--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-boolean_ops--Plan]": [
         {
-            "checksum": "900c2e4ae89198fae62bce6ef444dd09",
-            "size": 6277,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-boolean_ops--Plan_/plan.txt"
+            "checksum": "9faf1fe534ed11f8426586ccb2117963",
+            "size": 5865,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-boolean_ops--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_max_filter_opt--Debug]": [
         {
-            "checksum": "2d2a433cc4a1fa6801cd8ad053367568",
-            "size": 3209,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-combine_all_max_filter_opt--Debug_/opt.yql_patched"
+            "checksum": "ca4ae712406e9470cc1c28123fbddda1",
+            "size": 3142,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-combine_all_max_filter_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_max_filter_opt--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-combine_all_max_filter_opt--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-combine_all_max_filter_opt--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_sum--Debug]": [
         {
-            "checksum": "8444cd664d53e6fa2c3d9b69c19c3a5b",
-            "size": 6647,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-combine_all_sum--Debug_/opt.yql_patched"
+            "checksum": "bc25b3d128a71b49c7bbb0d27a99158b",
+            "size": 6389,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-combine_all_sum--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_sum--Plan]": [
         {
-            "checksum": "a1361799631618b84ec6b61887b259c0",
-            "size": 5459,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-combine_all_sum--Plan_/plan.txt"
+            "checksum": "16a0de7e33ba5f70a4588de69a651389",
+            "size": 5253,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-combine_all_sum--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_hashed_count_filter--Debug]": [
         {
-            "checksum": "8c9fee969f2998288ffe5c37e59a74dc",
-            "size": 4893,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-combine_hashed_count_filter--Debug_/opt.yql_patched"
+            "checksum": "836b6818d19c7a7a6d8e1ec29e1c7cdf",
+            "size": 4586,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-combine_hashed_count_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_hashed_count_filter--Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-combine_hashed_count_filter--Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-combine_hashed_count_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_equals--Debug]": [
         {
-            "checksum": "5fc67374ec6c1d97cd4439d0f2c17fb5",
-            "size": 28171,
-            "uri": "https://{canondata_backend}/1917492/cac4bcdcdbfd8c189321d23754f39769ecb64a20/resource.tar.gz#test.test_blocks-date_equals--Debug_/opt.yql_patched"
+            "checksum": "ffe48028f0572164b0170cce1d92dfbd",
+            "size": 24221,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-date_equals--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_equals--Plan]": [
         {
-            "checksum": "fe66d03c15b37a053205c1b23150a020",
-            "size": 15887,
-            "uri": "https://{canondata_backend}/1917492/cac4bcdcdbfd8c189321d23754f39769ecb64a20/resource.tar.gz#test.test_blocks-date_equals--Plan_/plan.txt"
+            "checksum": "e0b70c711bba0b9a8af7293607a6483c",
+            "size": 15475,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-date_equals--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_greater_or_equal_scalar--Debug]": [
         {
-            "checksum": "f3ca9a43292bb7505983e66d7393d256",
-            "size": 26709,
-            "uri": "https://{canondata_backend}/1917492/cac4bcdcdbfd8c189321d23754f39769ecb64a20/resource.tar.gz#test.test_blocks-date_greater_or_equal_scalar--Debug_/opt.yql_patched"
+            "checksum": "e1302cf2e0f571426d20a21d55a997ba",
+            "size": 22693,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-date_greater_or_equal_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_greater_or_equal_scalar--Plan]": [
         {
-            "checksum": "1ac2afa98f4d958a9cca1e31d65a570d",
-            "size": 12272,
-            "uri": "https://{canondata_backend}/1917492/cac4bcdcdbfd8c189321d23754f39769ecb64a20/resource.tar.gz#test.test_blocks-date_greater_or_equal_scalar--Plan_/plan.txt"
+            "checksum": "e81ad78037d8967dd443aa92a9b04411",
+            "size": 11448,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-date_greater_or_equal_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_add_date--Debug]": [
@@ -701,100 +701,100 @@
     ],
     "test.test[blocks-nested_optionals--Debug]": [
         {
-            "checksum": "04bc555cbb4385624f0b32b9ba64f9fb",
-            "size": 2078,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-nested_optionals--Debug_/opt.yql_patched"
+            "checksum": "cf2f95c9fc4c45359066f54bfb75bf13",
+            "size": 1973,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-nested_optionals--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-nested_optionals--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-nested_optionals--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-nested_optionals--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-string_as_agg_key--Debug]": [
         {
-            "checksum": "251fd692560ab3f5a44a0c8ff998476d",
-            "size": 6694,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-string_as_agg_key--Debug_/opt.yql_patched"
+            "checksum": "9df1a35b9e4389e2ab9ff9aea70b6fe7",
+            "size": 6376,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-string_as_agg_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-string_as_agg_key--Plan]": [
         {
-            "checksum": "b0251b6c734bea2c4cbb33e6ca16279e",
-            "size": 13550,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-string_as_agg_key--Plan_/plan.txt"
+            "checksum": "45a583eb7ebea074204f075025a32d4d",
+            "size": 12726,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-string_as_agg_key--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-top_sort_one_asc--Debug]": [
         {
-            "checksum": "49103db9b916d4b2871fe88d6fc74c6a",
-            "size": 3264,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-top_sort_one_asc--Debug_/opt.yql_patched"
+            "checksum": "381d49a5f69417127d8408c552229f41",
+            "size": 3056,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-top_sort_one_asc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-top_sort_one_asc--Plan]": [
         {
-            "checksum": "159ab47c102e7d87cc5fb3d9620dcbc2",
-            "size": 6299,
-            "uri": "https://{canondata_backend}/1031349/8b8964a29e1f3930fc799646d4ad2b51c549588e/resource.tar.gz#test.test_blocks-top_sort_one_asc--Plan_/plan.txt"
+            "checksum": "8617cf1ef0981ed83d7dde0cfb8f22f7",
+            "size": 5887,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-top_sort_one_asc--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-type_and_callable_stats--Debug]": [
         {
-            "checksum": "a01ceb9ea4ea544c1a7e54496bffec41",
-            "size": 3907,
-            "uri": "https://{canondata_backend}/1031349/61ef6576b4067a10cada6609ae12eda1d03e8ab5/resource.tar.gz#test.test_blocks-type_and_callable_stats--Debug_/opt.yql_patched"
+            "checksum": "4979d193cb760aa6d81116da9435dfe4",
+            "size": 3655,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-type_and_callable_stats--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-type_and_callable_stats--Plan]": [
         {
-            "checksum": "4f5ebace275ca31a34ca23bdb57a6dc7",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1031349/61ef6576b4067a10cada6609ae12eda1d03e8ab5/resource.tar.gz#test.test_blocks-type_and_callable_stats--Plan_/plan.txt"
+            "checksum": "c87d63d1e60f55766f1841b9cdc2440e",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_blocks-type_and_callable_stats--Plan_/plan.txt"
         }
     ],
     "test.test[coalesce-coalesce_sugar-default.txt-Debug]": [
         {
-            "checksum": "f6a160186160453bd01f600884397730",
-            "size": 2217,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_coalesce-coalesce_sugar-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3f69c0b5d1576157faa983909c91a0a8",
+            "size": 2115,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_coalesce-coalesce_sugar-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[coalesce-coalesce_sugar-default.txt-Plan]": [
         {
-            "checksum": "5c41b58f8a68c081f47cebbfa8a13331",
-            "size": 4045,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_coalesce-coalesce_sugar-default.txt-Plan_/plan.txt"
+            "checksum": "c6ed3026b5067eb08a3ae9247dec4859",
+            "size": 3839,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_coalesce-coalesce_sugar-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_distinct_star-default.txt-Debug]": [
         {
-            "checksum": "5718e89cc86ef291753a4774fca5bb55",
-            "size": 4650,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_column_order-select_distinct_star-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e8a8ae517324501129b5bf5939c5fe99",
+            "size": 4281,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_column_order-select_distinct_star-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_distinct_star-default.txt-Plan]": [
         {
-            "checksum": "70a581d131de7713de49abdf4b72ae58",
-            "size": 8484,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_column_order-select_distinct_star-default.txt-Plan_/plan.txt"
+            "checksum": "273f7a4de9fa129519555fddb004e20f",
+            "size": 7866,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_column_order-select_distinct_star-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_where-default.txt-Debug]": [
         {
-            "checksum": "a4ae8528a670256c41d543700debcd22",
-            "size": 2194,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_column_order-select_where-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7aa51c16510acc021cba369bf36c0a2b",
+            "size": 2071,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_column_order-select_where-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_where-default.txt-Plan]": [
         {
-            "checksum": "7d91f40f6904b1f8cf30dc70791c8c75",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_column_order-select_where-default.txt-Plan_/plan.txt"
+            "checksum": "dd834b93a9051fd5a759fc47a1a2623f",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_column_order-select_where-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[csee-expr_in_l1_and_l0-default.txt-Debug]": [
@@ -841,30 +841,30 @@
     ],
     "test.test[datetime-date_tz_table_sort_desc--Debug]": [
         {
-            "checksum": "f8ba8a6460d3142e6f23bd128a9486e6",
-            "size": 3236,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Debug_/opt.yql_patched"
+            "checksum": "1d1661f5c683ee29896f3b5579cd8a3c",
+            "size": 3130,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[datetime-date_tz_table_sort_desc--Plan]": [
         {
-            "checksum": "3371497e7f8f9eefe25306e0a844890b",
-            "size": 7919,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Plan_/plan.txt"
+            "checksum": "cfc801d31d01e5ae43add6115add97b3",
+            "size": 7713,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_datetime-date_tz_table_sort_desc--Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_one_count-default.txt-Debug]": [
         {
-            "checksum": "ddb7ad4b0ac97cde30cadf0d2b0f95eb",
-            "size": 6300,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_distinct-distinct_one_count-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ad11e85af5428632c148c30045db4298",
+            "size": 5866,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_distinct-distinct_one_count-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_one_count-default.txt-Plan]": [
         {
-            "checksum": "fe843f906d9e4593fb99e424781f036b",
-            "size": 10824,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_distinct-distinct_one_count-default.txt-Plan_/plan.txt"
+            "checksum": "8ffdefbf5719796285ad866d0a0c336f",
+            "size": 10000,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_distinct-distinct_one_count-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[expr-cast_string_implicit-default.txt-Debug]": [
@@ -1023,44 +1023,44 @@
     ],
     "test.test[flatten_by-flatten_few_fields--Debug]": [
         {
-            "checksum": "7dfddbed6b8370195c970626537e96fe",
-            "size": 6400,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_flatten_by-flatten_few_fields--Debug_/opt.yql_patched"
+            "checksum": "ccfe58bb623b6160f5e05c5d33036b70",
+            "size": 5961,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_flatten_by-flatten_few_fields--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_few_fields--Plan]": [
         {
-            "checksum": "df39d69d33f20580187528cd1c945725",
-            "size": 8584,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_flatten_by-flatten_few_fields--Plan_/plan.txt"
+            "checksum": "32e816388db081ec42e7f951c42b4c18",
+            "size": 7966,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_flatten_by-flatten_few_fields--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_list_on_flatten_by--Debug]": [
         {
-            "checksum": "b1d7616471a17078d84d8556ea43e0f2",
-            "size": 2424,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_flatten_by-flatten_list_on_flatten_by--Debug_/opt.yql_patched"
+            "checksum": "45a0e3f7f05a26afb90c03b405d25f24",
+            "size": 2318,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_flatten_by-flatten_list_on_flatten_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_list_on_flatten_by--Plan]": [
         {
-            "checksum": "b52ee61c536d49ed3faccdaa753243f8",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_flatten_by-flatten_list_on_flatten_by--Plan_/plan.txt"
+            "checksum": "ca151d39e535503503415daf9ca7c00d",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_flatten_by-flatten_list_on_flatten_by--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_two_fields--Debug]": [
         {
-            "checksum": "09c9b0642945589b9b3ccb0d00e134fa",
-            "size": 6367,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_flatten_by-flatten_two_fields--Debug_/opt.yql_patched"
+            "checksum": "9540fc354e435c810dd291acba5f6fa4",
+            "size": 5924,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_flatten_by-flatten_two_fields--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_two_fields--Plan]": [
         {
-            "checksum": "df39d69d33f20580187528cd1c945725",
-            "size": 8584,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_flatten_by-flatten_two_fields--Plan_/plan.txt"
+            "checksum": "32e816388db081ec42e7f951c42b4c18",
+            "size": 7966,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_flatten_by-flatten_two_fields--Plan_/plan.txt"
         }
     ],
     "test.test[in-in_ansi_list1-default.txt-Debug]": [
@@ -1093,100 +1093,100 @@
     ],
     "test.test[in-in_tablesource_to_equijoin--Debug]": [
         {
-            "checksum": "8081abd00821b0e6a704e7189232328a",
-            "size": 19912,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_in-in_tablesource_to_equijoin--Debug_/opt.yql_patched"
+            "checksum": "0917dc63eb1c5a44ff97d0b0ccd58060",
+            "size": 19781,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_in-in_tablesource_to_equijoin--Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-in_tablesource_to_equijoin--Plan]": [
         {
-            "checksum": "8ce2dc4b197d411f820de69d6de45aa2",
-            "size": 27844,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_in-in_tablesource_to_equijoin--Plan_/plan.txt"
+            "checksum": "72a83d5a492af81066f9fcde324fecb1",
+            "size": 27432,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_in-in_tablesource_to_equijoin--Plan_/plan.txt"
         }
     ],
     "test.test[in-yql-10038-default.txt-Debug]": [
         {
-            "checksum": "f419d301255547b178a42c3238078e83",
-            "size": 5997,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_in-yql-10038-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4139e2bf86f17d2badeee54dfa87c855",
+            "size": 5781,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_in-yql-10038-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-yql-10038-default.txt-Plan]": [
         {
-            "checksum": "79ba3df0f629f1cd18553dfc4b27dcf0",
-            "size": 11948,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_in-yql-10038-default.txt-Plan_/plan.txt"
+            "checksum": "5ea1d3bc541e9dbd2837e41fdc02a97b",
+            "size": 11330,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_in-yql-10038-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-drop_sortness--Debug]": [
         {
-            "checksum": "7933d0bf9cfb22274ceb8eea1a0f399d",
-            "size": 2032,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_insert-drop_sortness--Debug_/opt.yql_patched"
+            "checksum": "b719f5af91e6ec84ef5c2ea9c051630b",
+            "size": 1968,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert-drop_sortness--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-drop_sortness--Plan]": [
         {
-            "checksum": "413e79be6c07fac2542dc5026c5796b1",
-            "size": 4257,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_insert-drop_sortness--Plan_/plan.txt"
+            "checksum": "86f38fe8fde6ac5658e36849f3d29a4a",
+            "size": 4051,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert-drop_sortness--Plan_/plan.txt"
         }
     ],
     "test.test[insert-insert_relabeled-default.txt-Debug]": [
         {
-            "checksum": "27a3a8130fb3a54fc4b67271130656b4",
-            "size": 2367,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4e5dff061b4dbfde18d42df2bac1b440",
+            "size": 2209,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-insert_relabeled-default.txt-Plan]": [
         {
-            "checksum": "67f0f828b72d6db96a3edec325914256",
-            "size": 4912,
-            "uri": "https://{canondata_backend}/1781765/028f42f897160b53900546b39900217bb2eb9fb1/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Plan_/plan.txt"
+            "checksum": "0ac4ec57a83ffbf43198e5b64dea16e2",
+            "size": 4706,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert-insert_relabeled-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-keep_meta-default.txt-Debug]": [
         {
-            "checksum": "579e6d7609d546115e4e320a1534d05c",
-            "size": 2157,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b22599c4341dbef6c01c2de8f9ce82f1",
+            "size": 2034,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-keep_meta-default.txt-Plan]": [
         {
-            "checksum": "96c6cc71a8d38390a36c98cbff25b27c",
-            "size": 4421,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Plan_/plan.txt"
+            "checksum": "8760bb861f1f32357c6d5b89898ec4ed",
+            "size": 4215,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert_monotonic-keep_meta-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-several1-default.txt-Debug]": [
         {
-            "checksum": "ceca85f1d3a49b20b9fb745919afd9ab",
-            "size": 2359,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2ab495011015207de9245eec086d262c",
+            "size": 2236,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-several1-default.txt-Plan]": [
         {
-            "checksum": "98ca609b3ead83403e0208f9ca492fe9",
-            "size": 4893,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Plan_/plan.txt"
+            "checksum": "1590ac961118a92ee1073d4f7f28fcf2",
+            "size": 4687,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_insert_monotonic-several1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[join-equi_join_three_asterisk_eval--Debug]": [
         {
-            "checksum": "0645f998ea34ad68605a84e01b2278c1",
-            "size": 8936,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-equi_join_three_asterisk_eval--Debug_/opt.yql_patched"
+            "checksum": "895bac2d9a14756d5b603a2887489588",
+            "size": 8674,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-equi_join_three_asterisk_eval--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-equi_join_three_asterisk_eval--Plan]": [
         {
-            "checksum": "ae0b9b59bd0ae0e83021a001f0f07a85",
-            "size": 12109,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-equi_join_three_asterisk_eval--Plan_/plan.txt"
+            "checksum": "1e6a05df04e081177fc802cc895e6ec9",
+            "size": 11903,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-equi_join_three_asterisk_eval--Plan_/plan.txt"
         }
     ],
     "test.test[join-equi_join_three_simple--Debug]": [
@@ -1205,16 +1205,16 @@
     ],
     "test.test[join-full_join--Debug]": [
         {
-            "checksum": "db42c2ca0d9f2359f2d0ec12293e4bda",
-            "size": 5268,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-full_join--Debug_/opt.yql_patched"
+            "checksum": "ffecf9f5716a1d0fabd7dfb9dd430327",
+            "size": 5118,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-full_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-full_join--Plan]": [
         {
-            "checksum": "713224a967430e45197b1860a0ed532f",
-            "size": 8509,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-full_join--Plan_/plan.txt"
+            "checksum": "3fa3bbd98dfe0ddb3de44cc1879f7fad",
+            "size": 8303,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-full_join--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_comp_inmem--Debug]": [
@@ -1233,86 +1233,86 @@
     ],
     "test.test[join-join_left_cbo--Debug]": [
         {
-            "checksum": "885d161137ba0af00ce2ed9c262dd6e8",
-            "size": 4388,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-join_left_cbo--Debug_/opt.yql_patched"
+            "checksum": "69472f619573b93b7a7cf8f1ee7a9bb1",
+            "size": 4280,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-join_left_cbo--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_left_cbo--Plan]": [
         {
-            "checksum": "d6671209b032ecda51583005660c84a4",
-            "size": 7931,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-join_left_cbo--Plan_/plan.txt"
+            "checksum": "099d20c752b20fc9ca849cb057aaaee4",
+            "size": 7725,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-join_left_cbo--Plan_/plan.txt"
         }
     ],
     "test.test[join-left_trivial--Debug]": [
         {
-            "checksum": "a39cff1c2900527d42d8244832b069f8",
-            "size": 4627,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-left_trivial--Debug_/opt.yql_patched"
+            "checksum": "eff6db68fceb2e4655cd5af142f7c6a9",
+            "size": 4483,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-left_trivial--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-left_trivial--Plan]": [
         {
-            "checksum": "a3d4f41bedd93a4ef96e01f1b554bd5a",
-            "size": 7933,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-left_trivial--Plan_/plan.txt"
+            "checksum": "1b56862a22e31dbd13642854f91bf6a9",
+            "size": 7727,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-left_trivial--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_optional_left_only_single--Debug]": [
         {
-            "checksum": "bb2ad14837fa330a00f09e7ea8672794",
-            "size": 7295,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_only_single--Debug_/opt.yql_patched"
+            "checksum": "af2dd8b57da5915e7023f86de60296b3",
+            "size": 6957,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_only_single--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_optional_left_only_single--Plan]": [
         {
-            "checksum": "2bb9e3446672699ec869e4b3fd719af2",
-            "size": 9952,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_only_single--Plan_/plan.txt"
+            "checksum": "66a0a7364f1ffbfaab7f1ab0b7be1ed6",
+            "size": 9334,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_only_single--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_optional_left_semi_single--Debug]": [
         {
-            "checksum": "c5c938f91134c6192355a97b7ae52132",
-            "size": 7317,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_single--Debug_/opt.yql_patched"
+            "checksum": "3c1fbb7f09c2f56898e5d986fe21ef3d",
+            "size": 6979,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_single--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_optional_left_semi_single--Plan]": [
         {
-            "checksum": "2bb9e3446672699ec869e4b3fd719af2",
-            "size": 9952,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_single--Plan_/plan.txt"
+            "checksum": "66a0a7364f1ffbfaab7f1ab0b7be1ed6",
+            "size": 9334,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_single--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_partial_uniq_keys--Debug]": [
         {
-            "checksum": "44ccde5247d94fc1542df79295af8e8d",
-            "size": 2767,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_join-mapjoin_partial_uniq_keys--Debug_/opt.yql_patched"
+            "checksum": "f559953e1813f0682728f9e7f046b549",
+            "size": 2725,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mapjoin_partial_uniq_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_partial_uniq_keys--Plan]": [
         {
-            "checksum": "35196b3a66008fb867a7ddc078340a18",
-            "size": 5697,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-mapjoin_partial_uniq_keys--Plan_/plan.txt"
+            "checksum": "5b9053955ad98e2267af20b838704a6b",
+            "size": 5491,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mapjoin_partial_uniq_keys--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_saves_output_sort_cross--Debug]": [
         {
-            "checksum": "6908ed6929e48aea8c208c257215a8b7",
-            "size": 7300,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-mergejoin_saves_output_sort_cross--Debug_/opt.yql_patched"
+            "checksum": "9066ed60413a35ad076ebcca13f1725c",
+            "size": 7148,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mergejoin_saves_output_sort_cross--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_saves_output_sort_cross--Plan]": [
         {
-            "checksum": "11233c5bbae23a183281738629079942",
-            "size": 11121,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-mergejoin_saves_output_sort_cross--Plan_/plan.txt"
+            "checksum": "e02b13a42b9e5fdd48e915a3a3b109df",
+            "size": 10915,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mergejoin_saves_output_sort_cross--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_saves_output_sort_nested--Debug]": [
@@ -1331,16 +1331,16 @@
     ],
     "test.test[join-mergejoin_semi_to_inner--Debug]": [
         {
-            "checksum": "6012073217436df8abcf6159ffad1f2c",
-            "size": 4824,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-mergejoin_semi_to_inner--Debug_/opt.yql_patched"
+            "checksum": "30e788f931d6a1e351b2f718079189c0",
+            "size": 4709,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mergejoin_semi_to_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_semi_to_inner--Plan]": [
         {
-            "checksum": "8446aa76f97ccfc270a3dceedf242f4d",
-            "size": 8760,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-mergejoin_semi_to_inner--Plan_/plan.txt"
+            "checksum": "8f4d44baa5d6a8c6ed069046eacce53e",
+            "size": 8554,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-mergejoin_semi_to_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-order_of_qualified--Debug]": [
@@ -1359,72 +1359,72 @@
     ],
     "test.test[join-premap_map_semi--Debug]": [
         {
-            "checksum": "d61d83271eb7168b74f49dc191428411",
-            "size": 4306,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-premap_map_semi--Debug_/opt.yql_patched"
+            "checksum": "ffea9b8374dc0818f69ad5e160433696",
+            "size": 4106,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-premap_map_semi--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_map_semi--Plan]": [
         {
-            "checksum": "efc994e6c4cb311e49f75ecd9fe6a2ad",
-            "size": 8178,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-premap_map_semi--Plan_/plan.txt"
+            "checksum": "3d2d37fc4c3b0a95b2396b71aee5ee28",
+            "size": 7766,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-premap_map_semi--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_merge_with_remap--Debug]": [
         {
-            "checksum": "70764917182f977cb07daead2b8c7972",
-            "size": 8818,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-premap_merge_with_remap--Debug_/opt.yql_patched"
+            "checksum": "6073bc39aa2cdfd3d79880c579a8c783",
+            "size": 8336,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-premap_merge_with_remap--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_merge_with_remap--Plan]": [
         {
-            "checksum": "e30ed9ed0112608f49d932c3d4295e44",
-            "size": 14148,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-premap_merge_with_remap--Plan_/plan.txt"
+            "checksum": "3d743741ff8ca391996983f8e567b32d",
+            "size": 13530,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-premap_merge_with_remap--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_exclusion--Debug]": [
         {
-            "checksum": "cc0790ffebeeec909f04f42b92658b96",
-            "size": 6115,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-pullup_exclusion--Debug_/opt.yql_patched"
+            "checksum": "0e8593c007503962a93ef7eedcde09e8",
+            "size": 5941,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-pullup_exclusion--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_exclusion--Plan]": [
         {
-            "checksum": "cef5473532e0cf83ba979804e9f21fa3",
-            "size": 8366,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-pullup_exclusion--Plan_/plan.txt"
+            "checksum": "b971d5a3dd2b32a5dd52b8d92ce00cd1",
+            "size": 8160,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-pullup_exclusion--Plan_/plan.txt"
         }
     ],
     "test.test[join-three_equalities--Debug]": [
         {
-            "checksum": "4d9b43083896947cab2b4df2ae0ba708",
-            "size": 7175,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-three_equalities--Debug_/opt.yql_patched"
+            "checksum": "64e29f804c6b83e24ae8c1874c1a1626",
+            "size": 6966,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-three_equalities--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-three_equalities--Plan]": [
         {
-            "checksum": "5de7a13c6697b1815543ca9167c5a119",
-            "size": 10344,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-three_equalities--Plan_/plan.txt"
+            "checksum": "aa7146be2ccbe125c1dfe0c4bf8f31a4",
+            "size": 10138,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-three_equalities--Plan_/plan.txt"
         }
     ],
     "test.test[join-trivial_view--Debug]": [
         {
-            "checksum": "ea2bad3b12a12a5708bb33d49e558d23",
-            "size": 4564,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_join-trivial_view--Debug_/opt.yql_patched"
+            "checksum": "8915f829f8725f5296223a9fdc30fe89",
+            "size": 4462,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-trivial_view--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-trivial_view--Plan]": [
         {
-            "checksum": "ff06f69642caf2197823db50fbc3f518",
-            "size": 8067,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_join-trivial_view--Plan_/plan.txt"
+            "checksum": "c92fc803742a54cecf80378c0ac8a3ff",
+            "size": 7861,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_join-trivial_view--Plan_/plan.txt"
         }
     ],
     "test.test[json-json_query/passing-default.txt-Debug]": [
@@ -1471,30 +1471,30 @@
     ],
     "test.test[key_filter-convert--Debug]": [
         {
-            "checksum": "fadeddcc57bce3676fed14c0c2711dfb",
-            "size": 2053,
-            "uri": "https://{canondata_backend}/1942671/0c3552bfb003248e1f09c8cfc51ce4e4eb2307b8/resource.tar.gz#test.test_key_filter-convert--Debug_/opt.yql_patched"
+            "checksum": "e201f37bd6003c7481c9008bfd36410e",
+            "size": 1930,
+            "uri": "https://{canondata_backend}/1916746/fc9859eda7833569c636bd5c91d3cefea7eb47fa/resource.tar.gz#test.test_key_filter-convert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-convert--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1817427/9a63c233668f669b84f1b72cd98b04bc86f37910/resource.tar.gz#test.test_key_filter-convert--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_key_filter-convert--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-pushdown_keyextract_passthrough-default.txt-Debug]": [
         {
-            "checksum": "577a80811199cdf79b289755059beb65",
-            "size": 3254,
-            "uri": "https://{canondata_backend}/1900335/2d2750ef0982ad00b2b4c65d5b57dcf1057211c4/resource.tar.gz#test.test_key_filter-pushdown_keyextract_passthrough-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2e47eca40877c603ab461425aa63c828",
+            "size": 3008,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_key_filter-pushdown_keyextract_passthrough-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-pushdown_keyextract_passthrough-default.txt-Plan]": [
         {
-            "checksum": "ee7d6807c455d83cf4348ef470c6a45e",
-            "size": 6200,
-            "uri": "https://{canondata_backend}/1880306/aa814bebb2d4275812c266943b8764782d3c5bb6/resource.tar.gz#test.test_key_filter-pushdown_keyextract_passthrough-default.txt-Plan_/plan.txt"
+            "checksum": "cfc091e969921c506341adea3cecb504",
+            "size": 5788,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_key_filter-pushdown_keyextract_passthrough-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-utf8_with_legacy--Debug]": [
@@ -1541,30 +1541,30 @@
     ],
     "test.test[lambda-lambda_use_labmda_as_arg-default.txt-Debug]": [
         {
-            "checksum": "b07d4a37adf906561fe5828e94ca9bca",
-            "size": 2582,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_lambda-lambda_use_labmda_as_arg-default.txt-Debug_/opt.yql_patched"
+            "checksum": "483b5be1532e0a12291587f13091a433",
+            "size": 2429,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_lambda-lambda_use_labmda_as_arg-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[lambda-lambda_use_labmda_as_arg-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_lambda-lambda_use_labmda_as_arg-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_lambda-lambda_use_labmda_as_arg-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-test_no_aggregate_split--Debug]": [
         {
-            "checksum": "ed93dd76b9e1a7c37dde0e4b895a887a",
-            "size": 9130,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_optimizers-test_no_aggregate_split--Debug_/opt.yql_patched"
+            "checksum": "4582e8eeb6a0b09e6bb612a1437d1af3",
+            "size": 8673,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_optimizers-test_no_aggregate_split--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-test_no_aggregate_split--Plan]": [
         {
-            "checksum": "dd02271d4664ceab991c3cab8883fc77",
-            "size": 14015,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_optimizers-test_no_aggregate_split--Plan_/plan.txt"
+            "checksum": "0bbd53d5a55187380bf2259306770f66",
+            "size": 13191,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_optimizers-test_no_aggregate_split--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-16134-default.txt-Debug]": [
@@ -1583,30 +1583,30 @@
     ],
     "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Debug]": [
         {
-            "checksum": "7f983c2bd71aacbf8c05a09d8a6ccfec",
-            "size": 4181,
-            "uri": "https://{canondata_backend}/1777230/e81b9e2c64fe4b93a822d7b1454621e0e1f09374/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Debug_/opt.yql_patched"
+            "checksum": "da100aca7f66022d42aa44817ab4f93a",
+            "size": 4121,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-18733_no_filter_multiusage_pushdown--Plan]": [
         {
-            "checksum": "22f22312b28ba379827f031e01ab68d7",
-            "size": 8940,
-            "uri": "https://{canondata_backend}/1777230/e81b9e2c64fe4b93a822d7b1454621e0e1f09374/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Plan_/plan.txt"
+            "checksum": "be45fc5671798e59fe5e0b321c7c0924",
+            "size": 8528,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_optimizers-yql-18733_no_filter_multiusage_pushdown--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql_5830_fuse_outer_with_extra_deps--Debug]": [
         {
-            "checksum": "b38b9309220b31121d36d282c7020cc0",
-            "size": 7033,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_optimizers-yql_5830_fuse_outer_with_extra_deps--Debug_/opt.yql_patched"
+            "checksum": "1d402328250cd2534d326b3da7a507a3",
+            "size": 6899,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_optimizers-yql_5830_fuse_outer_with_extra_deps--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql_5830_fuse_outer_with_extra_deps--Plan]": [
         {
-            "checksum": "f0da4099101d204eb0b17e57691d0510",
-            "size": 11733,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_optimizers-yql_5830_fuse_outer_with_extra_deps--Plan_/plan.txt"
+            "checksum": "0e9cbfab22fb577ddfbd5f7ac4e10d1a",
+            "size": 11527,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_optimizers-yql_5830_fuse_outer_with_extra_deps--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-changed_sort_with_limit--Debug]": [
@@ -1625,16 +1625,16 @@
     ],
     "test.test[order_by-sort--Debug]": [
         {
-            "checksum": "84e466425415b94768e2074c08ef852f",
-            "size": 2490,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_order_by-sort--Debug_/opt.yql_patched"
+            "checksum": "9a70a5de9e2c4ecdf044c79590ced94c",
+            "size": 2324,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_order_by-sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-sort--Plan]": [
         {
-            "checksum": "63bdcd07869d1e4fc448e78e9f2461e3",
-            "size": 3660,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_order_by-sort--Plan_/plan.txt"
+            "checksum": "0ba112bc76808f14fa8d2430c98c506d",
+            "size": 3454,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_order_by-sort--Plan_/plan.txt"
         }
     ],
     "test.test[pg-cast_int_to_bit-default.txt-Debug]": [
@@ -1681,16 +1681,16 @@
     ],
     "test.test[pg-in_mixed--Debug]": [
         {
-            "checksum": "3909489cbf1186458a4c8d09ad86f018",
-            "size": 3652,
-            "uri": "https://{canondata_backend}/1931696/c9c1266872542b2b0fcc0fac437c19e90b016a38/resource.tar.gz#test.test_pg-in_mixed--Debug_/opt.yql_patched"
+            "checksum": "645a53f8ea06920c0c36948a7f5ffcc0",
+            "size": 3588,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-in_mixed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-in_mixed--Plan]": [
         {
-            "checksum": "79f606c26ca3bb49a9e8d9c6a95c637c",
-            "size": 6007,
-            "uri": "https://{canondata_backend}/1775319/46d34f859c1887e0796baa42d4f9e0a64bdda7f0/resource.tar.gz#test.test_pg-in_mixed--Plan_/plan.txt"
+            "checksum": "69a33281c7cfd31e3ea8755706bc0467",
+            "size": 5801,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-in_mixed--Plan_/plan.txt"
         }
     ],
     "test.test[pg-join_using2-default.txt-Debug]": [
@@ -1835,16 +1835,16 @@
     ],
     "test.test[pg-select_from_columns_qstar-default.txt-Debug]": [
         {
-            "checksum": "9cdd0375c4a178365e08101a4be4fc93",
-            "size": 2121,
-            "uri": "https://{canondata_backend}/1903280/6ac862756a9225bab7885d29cf2289a6202a5ff1/resource.tar.gz#test.test_pg-select_from_columns_qstar-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bb3867504f921c36583b247703381de7",
+            "size": 2009,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-select_from_columns_qstar-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_from_columns_qstar-default.txt-Plan]": [
         {
-            "checksum": "7bb0824d6fbd0b74944e3b1ce4821dc2",
-            "size": 3611,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_pg-select_from_columns_qstar-default.txt-Plan_/plan.txt"
+            "checksum": "d5981c0125365db3224dcbe690b62ac9",
+            "size": 3405,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-select_from_columns_qstar-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_from_columns_scalar-default.txt-Debug]": [
@@ -2255,30 +2255,30 @@
     ],
     "test.test[pg-tpch-q20-default.txt-Debug]": [
         {
-            "checksum": "9f28a7f224d42b7043bb7433b26b670d",
-            "size": 23984,
-            "uri": "https://{canondata_backend}/1942100/7d0becfb109a67dff18c8cbc35fb5a60880c7f60/resource.tar.gz#test.test_pg-tpch-q20-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2d8aceab68aff2f9709409153a630852",
+            "size": 23338,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-tpch-q20-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q20-default.txt-Plan]": [
         {
-            "checksum": "b78e8c1e6ca51984df04f64b569e1725",
-            "size": 29083,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_pg-tpch-q20-default.txt-Plan_/plan.txt"
+            "checksum": "04751b7609d1ae90ae62e1ccb2d5700d",
+            "size": 27847,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-tpch-q20-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-wide_top_sort--Debug]": [
         {
-            "checksum": "41856be26da64bdbdfa63c271eab54f5",
-            "size": 3330,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_pg-wide_top_sort--Debug_/opt.yql_patched"
+            "checksum": "8c088c0ed5efb5afbb88b4c7ce376c65",
+            "size": 3128,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-wide_top_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-wide_top_sort--Plan]": [
         {
-            "checksum": "9b4d9293743b40df36f3d405592b87be",
-            "size": 5465,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_pg-wide_top_sort--Plan_/plan.txt"
+            "checksum": "d99a75813aac95593c6a83f52a847aaf",
+            "size": 5259,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pg-wide_top_sort--Plan_/plan.txt"
         }
     ],
     "test.test[pg-with-default.txt-Debug]": [
@@ -2367,16 +2367,16 @@
     ],
     "test.test[pragma-config_exec--Debug]": [
         {
-            "checksum": "8c530c4858623bfd12a1b14c521e8073",
-            "size": 2695,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_pragma-config_exec--Debug_/opt.yql_patched"
+            "checksum": "d04d4c660defa14235cf599feca508f9",
+            "size": 2542,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pragma-config_exec--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pragma-config_exec--Plan]": [
         {
-            "checksum": "47835ddb4fb99591ac00591b7456ec68",
-            "size": 9064,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_pragma-config_exec--Plan_/plan.txt"
+            "checksum": "73126ca8dac5cd4187733c0395bc9364",
+            "size": 8652,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_pragma-config_exec--Plan_/plan.txt"
         }
     ],
     "test.test[pragma-yson_auto_convert--Debug]": [
@@ -2409,16 +2409,16 @@
     ],
     "test.test[produce-process_pure_with_sort-default.txt-Debug]": [
         {
-            "checksum": "da80d21ec403b1a8ad8cad10d2f642c6",
-            "size": 2950,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_produce-process_pure_with_sort-default.txt-Debug_/opt.yql_patched"
+            "checksum": "1b4956da83472ac9f25a8a437a5264ac",
+            "size": 2704,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_produce-process_pure_with_sort-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-process_pure_with_sort-default.txt-Plan]": [
         {
-            "checksum": "f48425e27cea6c99b1bb685c99e2f398",
-            "size": 6003,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_produce-process_pure_with_sort-default.txt-Plan_/plan.txt"
+            "checksum": "77935bff741e87b35c2e665e47820147",
+            "size": 5591,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_produce-process_pure_with_sort-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume--Debug]": [
@@ -2437,100 +2437,100 @@
     ],
     "test.test[produce-reduce_with_assume--Debug]": [
         {
-            "checksum": "c96fe0f70d0d94fc7237f1a660b083b5",
-            "size": 3349,
-            "uri": "https://{canondata_backend}/1847551/acd36ac04bd4a5b96c5ca1824b29d5b8562dc682/resource.tar.gz#test.test_produce-reduce_with_assume--Debug_/opt.yql_patched"
+            "checksum": "b4c940c6614cc87800da228efa52d74e",
+            "size": 3255,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_produce-reduce_with_assume--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_with_assume--Plan]": [
         {
-            "checksum": "c111884233e68b6bed387cc377956b24",
-            "size": 4520,
-            "uri": "https://{canondata_backend}/1847551/acd36ac04bd4a5b96c5ca1824b29d5b8562dc682/resource.tar.gz#test.test_produce-reduce_with_assume--Plan_/plan.txt"
+            "checksum": "f130244f0f55f3867c58827f498854b9",
+            "size": 4314,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_produce-reduce_with_assume--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-bind_topsort-default.txt-Debug]": [
         {
-            "checksum": "9a2cc1460eca71c8df63cdd523c0710c",
-            "size": 3295,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_sampling-bind_topsort-default.txt-Debug_/opt.yql_patched"
+            "checksum": "de0eebfaecf018940106f750e21eb648",
+            "size": 3095,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-bind_topsort-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_topsort-default.txt-Plan]": [
         {
-            "checksum": "4bb8ebc324f946a40734a74ffdc9fca9",
-            "size": 6296,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_sampling-bind_topsort-default.txt-Plan_/plan.txt"
+            "checksum": "0b94c4db48b059715a69cfeeba5e3538",
+            "size": 5884,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-bind_topsort-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-direct_read-dynamic-Debug]": [
         {
-            "checksum": "ce9198f985b3a22821f17ed149a4dbb0",
-            "size": 2150,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_sampling-direct_read-dynamic-Debug_/opt.yql_patched"
+            "checksum": "474016380c2e1c6472d56dfd5911a27b",
+            "size": 2027,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-direct_read-dynamic-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-direct_read-dynamic-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_sampling-direct_read-dynamic-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-direct_read-dynamic-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-read-dynamic-Debug]": [
         {
-            "checksum": "ce9198f985b3a22821f17ed149a4dbb0",
-            "size": 2150,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_sampling-read-dynamic-Debug_/opt.yql_patched"
+            "checksum": "474016380c2e1c6472d56dfd5911a27b",
+            "size": 2027,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-read-dynamic-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-read-dynamic-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_sampling-read-dynamic-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-read-dynamic-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-subquery_multiple_sample-default.txt-Debug]": [
         {
-            "checksum": "7d48b282250c1b208abab54d3771b016",
-            "size": 2198,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_sampling-subquery_multiple_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b6ecc9b61797a4e64101b59c9fa5df40",
+            "size": 2075,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-subquery_multiple_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-subquery_multiple_sample-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_sampling-subquery_multiple_sample-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-subquery_multiple_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-table_content--Debug]": [
         {
-            "checksum": "2dabf0ca17520d0f9f4e5b98c2601498",
-            "size": 2377,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_sampling-table_content--Debug_/opt.yql_patched"
+            "checksum": "8e7ecc8771184937b0affd946d6f201a",
+            "size": 2315,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-table_content--Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-table_content--Plan]": [
         {
-            "checksum": "78c83e44682c22d844fd9be104a02fbb",
-            "size": 6054,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_sampling-table_content--Plan_/plan.txt"
+            "checksum": "28853ed6ae416d99dfc5d0b6b3163de4",
+            "size": 5848,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_sampling-table_content--Plan_/plan.txt"
         }
     ],
     "test.test[schema-copy-other-Debug]": [
         {
-            "checksum": "a8f7f05814da4cc153186230eb59a8f4",
-            "size": 2652,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_schema-copy-other-Debug_/opt.yql_patched"
+            "checksum": "4ee565a692fd036024cefba2ce5189f7",
+            "size": 2463,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_schema-copy-other-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-copy-other-Plan]": [
         {
-            "checksum": "088a4c504382098b21c58ac9e596fd93",
-            "size": 4906,
-            "uri": "https://{canondata_backend}/1781765/028f42f897160b53900546b39900217bb2eb9fb1/resource.tar.gz#test.test_schema-copy-other-Plan_/plan.txt"
+            "checksum": "c88a24c7fccafbe196d8ad195d0baa0b",
+            "size": 4700,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_schema-copy-other-Plan_/plan.txt"
         }
     ],
     "test.test[schema-diffrerent_schemas--Debug]": [
@@ -2549,16 +2549,16 @@
     ],
     "test.test[schema-row_spec_with_default_values--Debug]": [
         {
-            "checksum": "3dba9fd39c252dc46f597ad3538e61f5",
-            "size": 2066,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_schema-row_spec_with_default_values--Debug_/opt.yql_patched"
+            "checksum": "50bbe0f39cbcc586594c7d816b03d9e0",
+            "size": 1943,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_schema-row_spec_with_default_values--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-row_spec_with_default_values--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_schema-row_spec_with_default_values--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_schema-row_spec_with_default_values--Plan_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_bind-default.txt-Debug]": [
@@ -2605,58 +2605,58 @@
     ],
     "test.test[select-dict_lookup_column_names-default.txt-Debug]": [
         {
-            "checksum": "1e1fba49927d215ec340832c154638fd",
-            "size": 2248,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_select-dict_lookup_column_names-default.txt-Debug_/opt.yql_patched"
+            "checksum": "130268f9554f3a92d4b056d899c389ff",
+            "size": 2142,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-dict_lookup_column_names-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-dict_lookup_column_names-default.txt-Plan]": [
         {
-            "checksum": "268f40d4cd05bdaf1da7d54f3cb20944",
-            "size": 4077,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_select-dict_lookup_column_names-default.txt-Plan_/plan.txt"
+            "checksum": "bea2bf2feac939761164aa8b2b8b5923",
+            "size": 3871,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-dict_lookup_column_names-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-host_count--Debug]": [
         {
-            "checksum": "ae3f4d244ea93351ad42afa0ce2ad1ea",
-            "size": 7225,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_select-host_count--Debug_/opt.yql_patched"
+            "checksum": "56b16204d2beb2e593e205690dfba72b",
+            "size": 6872,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-host_count--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-host_count--Plan]": [
         {
-            "checksum": "db444058ee7f519c6d8bc4545b42acc3",
-            "size": 10096,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_select-host_count--Plan_/plan.txt"
+            "checksum": "39cc4ca5d53ffa2b004c382d0cbd9b3b",
+            "size": 9478,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-host_count--Plan_/plan.txt"
         }
     ],
     "test.test[select-logical_ops-default.txt-Debug]": [
         {
-            "checksum": "1b1f8e18e9e686266aa932857636e172",
-            "size": 2273,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_select-logical_ops-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9a6b167b21a5cbc9065c0e9b72ee5720",
+            "size": 2144,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-logical_ops-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-logical_ops-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_select-logical_ops-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-logical_ops-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-match_clause--Debug]": [
         {
-            "checksum": "b3a929e9c11e51f63eeb2c45f8ee7504",
-            "size": 2446,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_select-match_clause--Debug_/opt.yql_patched"
+            "checksum": "fd25eac1b1c062884cd8c59d204748ef",
+            "size": 2323,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-match_clause--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-match_clause--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_select-match_clause--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-match_clause--Plan_/plan.txt"
         }
     ],
     "test.test[select-null_check-default.txt-Debug]": [
@@ -2675,16 +2675,16 @@
     ],
     "test.test[select-swap_columns-default.txt-Debug]": [
         {
-            "checksum": "bffaa264697d4d8b9e21dc406c6457d3",
-            "size": 1963,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_select-swap_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2ce18619fc8ce6f8a69ad92665ebadf9",
+            "size": 1840,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-swap_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-swap_columns-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_select-swap_columns-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-swap_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-unary_op_interval-default.txt-Debug]": [
@@ -2703,16 +2703,16 @@
     ],
     "test.test[select-unlabeled_1000--Debug]": [
         {
-            "checksum": "2ecbbef0dcf245a3c57833299d5bcc24",
-            "size": 2099,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_select-unlabeled_1000--Debug_/opt.yql_patched"
+            "checksum": "b5b0b706cf9683615d7cf2435a896138",
+            "size": 1976,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-unlabeled_1000--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-unlabeled_1000--Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_select-unlabeled_1000--Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_select-unlabeled_1000--Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_coalesce_all_2-default.txt-Debug]": [
@@ -2759,268 +2759,268 @@
     ],
     "test.test[simple_columns-simple_columns_join_qualified-default.txt-Debug]": [
         {
-            "checksum": "29a2dee0923b23c8126e832ea6e13d06",
-            "size": 6268,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_simple_columns-simple_columns_join_qualified-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d92cf5847ccf8768d2a58c5a8f73502e",
+            "size": 5999,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_simple_columns-simple_columns_join_qualified-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_qualified-default.txt-Plan]": [
         {
-            "checksum": "de57a0adf0ee10083b19d62926d4671f",
-            "size": 9103,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_simple_columns-simple_columns_join_qualified-default.txt-Plan_/plan.txt"
+            "checksum": "5c82c7c3687d27008c20b4fdbc252621",
+            "size": 8691,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_simple_columns-simple_columns_join_qualified-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q10-default.txt-Debug]": [
         {
-            "checksum": "9ba59cedcaa98930196ebb46ceba35d2",
-            "size": 11638,
-            "uri": "https://{canondata_backend}/1924537/b20d1bef8dd876bce75fb2dfa266102466709caa/resource.tar.gz#test.test_tpch-q10-default.txt-Debug_/opt.yql_patched"
+            "checksum": "aeaa61ba7008e7c93886b3223856995b",
+            "size": 11072,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_tpch-q10-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q10-default.txt-Plan]": [
         {
-            "checksum": "9f973dda303698210e2b72b45289a676",
-            "size": 14774,
-            "uri": "https://{canondata_backend}/1899731/938ba5ba81b18107fbe6aa1e9a86e1649795eb98/resource.tar.gz#test.test_tpch-q10-default.txt-Plan_/plan.txt"
+            "checksum": "bb3b6e992f1c7d2fb4d0c016051bcdcb",
+            "size": 14362,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_tpch-q10-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q11-default.txt-Debug]": [
         {
-            "checksum": "35f2e663b7ea81a0db00bda1ba306124",
-            "size": 12623,
-            "uri": "https://{canondata_backend}/1937027/ca37dc23c4a42a42fb6cfd05c1ad5ae3f4853941/resource.tar.gz#test.test_tpch-q11-default.txt-Debug_/opt.yql_patched"
+            "checksum": "37c4c672ca3b73d2f760c625cf027163",
+            "size": 12272,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_tpch-q11-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q11-default.txt-Plan]": [
         {
-            "checksum": "541fbb8867ea5b05292051744bc2233f",
-            "size": 21635,
-            "uri": "https://{canondata_backend}/1937027/ca37dc23c4a42a42fb6cfd05c1ad5ae3f4853941/resource.tar.gz#test.test_tpch-q11-default.txt-Plan_/plan.txt"
+            "checksum": "6d823d677e2f9d7df1b4c8fb8a9f5ef6",
+            "size": 21017,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_tpch-q11-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-append_diff_flags--Debug]": [
         {
-            "checksum": "4babb0c574c8270a40357d9f5992cb34",
-            "size": 2531,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_type_v3-append_diff_flags--Debug_/opt.yql_patched"
+            "checksum": "22e15dc18c97decedc63afff0ad924dc",
+            "size": 2430,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_type_v3-append_diff_flags--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-append_diff_flags--Plan]": [
         {
-            "checksum": "5f662d8b7b0b353ab40b7546e58340a7",
-            "size": 9536,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_type_v3-append_diff_flags--Plan_/plan.txt"
+            "checksum": "e4bc3e159773eb4c49b9b606fef52f6d",
+            "size": 9330,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_type_v3-append_diff_flags--Plan_/plan.txt"
         }
     ],
     "test.test[udf-regexp_udf--Debug]": [
         {
-            "checksum": "905faf05118d696da13aa8e6abc4c91e",
-            "size": 2070,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_udf-regexp_udf--Debug_/opt.yql_patched"
+            "checksum": "c08fe0f8dbf26715408a37d49ef2f54b",
+            "size": 1947,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_udf-regexp_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[udf-regexp_udf--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_udf-regexp_udf--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_udf-regexp_udf--Plan_/plan.txt"
         }
     ],
     "test.test[union_all-mix_map_and_project--Debug]": [
         {
-            "checksum": "ea877005345e89f06a3b83a27d55b8e8",
-            "size": 3396,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_union_all-mix_map_and_project--Debug_/opt.yql_patched"
+            "checksum": "fca535bc5b1cf4ecd4fee60fe231dc3d",
+            "size": 3196,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_union_all-mix_map_and_project--Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-mix_map_and_project--Plan]": [
         {
-            "checksum": "0436650285730a52c94c4b9a42b07959",
-            "size": 6752,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_union_all-mix_map_and_project--Plan_/plan.txt"
+            "checksum": "2e2d43d58a7a12cd51a6eef5ff3e35f4",
+            "size": 6340,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_union_all-mix_map_and_project--Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_multiple-default.txt-Debug]": [
         {
-            "checksum": "025a3316fee3800c95e46368f76aec63",
-            "size": 3570,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_union_all-union_all_multiple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "50e3d20cc49e2898e76b9b8f5eff99fa",
+            "size": 3324,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_union_all-union_all_multiple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-union_all_multiple-default.txt-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_union_all-union_all_multiple-default.txt-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_union_all-union_all_multiple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[view-view_with_lambda--Debug]": [
         {
-            "checksum": "335bb742ea1068b69dcea60f6f3e006b",
-            "size": 2329,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_view-view_with_lambda--Debug_/opt.yql_patched"
+            "checksum": "0b7bf68b4569e461a7a790a452c22e51",
+            "size": 2206,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_view-view_with_lambda--Debug_/opt.yql_patched"
         }
     ],
     "test.test[view-view_with_lambda--Plan]": [
         {
-            "checksum": "0bdc229ba4a65aa8bbf04fac7811ed84",
-            "size": 4003,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_view-view_with_lambda--Plan_/plan.txt"
+            "checksum": "82ba93631a802a81398418118a30491b",
+            "size": 3797,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_view-view_with_lambda--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-optimize_weak_fields_combine--Debug]": [
         {
-            "checksum": "8b78867a40a3403d36e1290f301a20a6",
-            "size": 5234,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_weak_field-optimize_weak_fields_combine--Debug_/opt.yql_patched"
+            "checksum": "aa13493d5044a47a007f2fdcffe68687",
+            "size": 4982,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-optimize_weak_fields_combine--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-optimize_weak_fields_combine--Plan]": [
         {
-            "checksum": "4215906d611ad99425fbae2d412ad8fe",
-            "size": 8619,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_weak_field-optimize_weak_fields_combine--Plan_/plan.txt"
+            "checksum": "02a0bfe1f0023ff8aafd03607f74054f",
+            "size": 8207,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-optimize_weak_fields_combine--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-optimize_weak_fields_filter_combine--Debug]": [
         {
-            "checksum": "e5f6a92e88e467ae72b9ff87b84fa372",
-            "size": 5488,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_weak_field-optimize_weak_fields_filter_combine--Debug_/opt.yql_patched"
+            "checksum": "36eeb411bdfe76d0649ab93600ab6743",
+            "size": 5234,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-optimize_weak_fields_filter_combine--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-optimize_weak_fields_filter_combine--Plan]": [
         {
-            "checksum": "57a3421009667c8b2a556aeed1135818",
-            "size": 8719,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_weak_field-optimize_weak_fields_filter_combine--Plan_/plan.txt"
+            "checksum": "22bbf25d0b0582242f4b1d8c1193b623",
+            "size": 8307,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-optimize_weak_fields_filter_combine--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-optimize_weak_fields_map_combine--Debug]": [
         {
-            "checksum": "ac4e3d0e118e305a663681b11d4cfb65",
-            "size": 5367,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_weak_field-optimize_weak_fields_map_combine--Debug_/opt.yql_patched"
+            "checksum": "938a275b8ab581353635e4b82f33b4a1",
+            "size": 5113,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-optimize_weak_fields_map_combine--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-optimize_weak_fields_map_combine--Plan]": [
         {
-            "checksum": "57a3421009667c8b2a556aeed1135818",
-            "size": 8719,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_weak_field-optimize_weak_fields_map_combine--Plan_/plan.txt"
+            "checksum": "22bbf25d0b0582242f4b1d8c1193b623",
+            "size": 8307,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-optimize_weak_fields_map_combine--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_opt--Debug]": [
         {
-            "checksum": "93f4d8da2c0a5550efe0236d4318b293",
-            "size": 2915,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_weak_field-weak_field_opt--Debug_/opt.yql_patched"
+            "checksum": "ad400e4f21e1fd64a79b84129c2c5311",
+            "size": 2786,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-weak_field_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_opt--Plan]": [
         {
-            "checksum": "c8c98b567e0ec7bf925077ff30865099",
-            "size": 6373,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_weak_field-weak_field_opt--Plan_/plan.txt"
+            "checksum": "80102c7b7daf5818f250f82d5e3c1b6c",
+            "size": 6167,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_weak_field-weak_field_opt--Plan_/plan.txt"
         }
     ],
     "test.test[window-current/aggregations_leadlag--Debug]": [
         {
-            "checksum": "9e574032fb0904af358d7a7891cb5834",
-            "size": 7693,
-            "uri": "https://{canondata_backend}/1903280/15c1ac85b776f30a10d52656962dbb8971ea2c08/resource.tar.gz#test.test_window-current_aggregations_leadlag--Debug_/opt.yql_patched"
+            "checksum": "446216fa1963c24cb5648a3ef618aec1",
+            "size": 7336,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-current_aggregations_leadlag--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/aggregations_leadlag--Plan]": [
         {
-            "checksum": "efc6beac27d40e220d3dde8952553183",
-            "size": 7626,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-current_aggregations_leadlag--Plan_/plan.txt"
+            "checksum": "43dd291e992e79c1f6d79c5897d2ab53",
+            "size": 7214,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-current_aggregations_leadlag--Plan_/plan.txt"
         }
     ],
     "test.test[window-current/ansi_current--Debug]": [
         {
-            "checksum": "e18063e85b6f7f6218eed6b37d556331",
-            "size": 5643,
-            "uri": "https://{canondata_backend}/1937027/ca37dc23c4a42a42fb6cfd05c1ad5ae3f4853941/resource.tar.gz#test.test_window-current_ansi_current--Debug_/opt.yql_patched"
+            "checksum": "00cbcbcf520d49f4197cfe83050c6b36",
+            "size": 5343,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-current_ansi_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/ansi_current--Plan]": [
         {
-            "checksum": "a69f6f99fb946191b14b9c371e5d9fbe",
-            "size": 5739,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-current_ansi_current--Plan_/plan.txt"
+            "checksum": "be8c89bfbe10454d24401995ea09e3be",
+            "size": 5327,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-current_ansi_current--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/leadlag_compact--Debug]": [
         {
-            "checksum": "a9405773bb74ea45a8c5bb173d66b26b",
-            "size": 7402,
-            "uri": "https://{canondata_backend}/1903280/16cbfc3fae00d2501a719dda0ea1f3aea6c06f1a/resource.tar.gz#test.test_window-full_leadlag_compact--Debug_/opt.yql_patched"
+            "checksum": "587ff42a95b7ba6f2f59f7acd532505d",
+            "size": 7153,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-full_leadlag_compact--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/leadlag_compact--Plan]": [
         {
-            "checksum": "f400a1bd401b7b3cef3f9e74b6c76a34",
-            "size": 10200,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-full_leadlag_compact--Plan_/plan.txt"
+            "checksum": "0e9c92d2999216718159de282207b3ec",
+            "size": 9788,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-full_leadlag_compact--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/noncompact_with_nulls_tuple_key--Debug]": [
         {
-            "checksum": "6575fc42399ea9243c6c9d59de0e35ae",
-            "size": 10309,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-full_noncompact_with_nulls_tuple_key--Debug_/opt.yql_patched"
+            "checksum": "ec22c92ab30a6cbb9c7a66f375cfe63f",
+            "size": 9746,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-full_noncompact_with_nulls_tuple_key--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/noncompact_with_nulls_tuple_key--Plan]": [
         {
-            "checksum": "472b49b7298d7ef9998f07b1050cfe29",
-            "size": 15845,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-full_noncompact_with_nulls_tuple_key--Plan_/plan.txt"
+            "checksum": "3d8278f26af7d514487ff0c4a3104b83",
+            "size": 14815,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-full_noncompact_with_nulls_tuple_key--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/noncompact_with_tablerow--Debug]": [
         {
-            "checksum": "98b4fd3c2c2b4e233fcefc27c8695c21",
-            "size": 9175,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-full_noncompact_with_tablerow--Debug_/opt.yql_patched"
+            "checksum": "cc263f355e58ff3a934a10147a54d5c5",
+            "size": 8749,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-full_noncompact_with_tablerow--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/noncompact_with_tablerow--Plan]": [
         {
-            "checksum": "33d68a9981e4483f6fcf4ab859c22e06",
-            "size": 11197,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-full_noncompact_with_tablerow--Plan_/plan.txt"
+            "checksum": "d3f714112f9d9bcdbd961b13bf2a96fe",
+            "size": 10579,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-full_noncompact_with_tablerow--Plan_/plan.txt"
         }
     ],
     "test.test[window-generic/session--Debug]": [
         {
-            "checksum": "cc4d656474dd84cde3bcf10d2a1887b3",
-            "size": 7232,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-generic_session--Debug_/opt.yql_patched"
+            "checksum": "e7d8a2bf7bafb7c8d3ecbe9a1b453d46",
+            "size": 6862,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-generic_session--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/session--Plan]": [
         {
-            "checksum": "e7efb3f7edde9656bf810dc99f196601",
-            "size": 5738,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-generic_session--Plan_/plan.txt"
+            "checksum": "c2811c6ab32fd90a6aa5cdabc95cf483",
+            "size": 5326,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-generic_session--Plan_/plan.txt"
         }
     ],
     "test.test[window-leading/aggregations--Debug]": [
         {
-            "checksum": "e8bc7b34260eea19ef0006c340d74822",
-            "size": 9490,
-            "uri": "https://{canondata_backend}/1871102/a033a2e45d429b96c8bce2a68eaeafcfa8c8874a/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql_patched"
+            "checksum": "b714c609f29166cce1d89f217e9106e0",
+            "size": 8969,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-leading_aggregations--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-leading/aggregations--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-leading_aggregations--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-leading_aggregations--Plan_/plan.txt"
         }
     ],
     "test.test[window-presort_window_partition_by_mem-default.txt-Debug]": [
@@ -3039,58 +3039,58 @@
     ],
     "test.test[window-rank/opt--Debug]": [
         {
-            "checksum": "18662af2a176b8e5c42093e2341c35ac",
-            "size": 10582,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-rank_opt--Debug_/opt.yql_patched"
+            "checksum": "4761d4810d1f8216d26fdfc0ec224431",
+            "size": 9990,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-rank_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-rank/opt--Plan]": [
         {
-            "checksum": "921f205f3b2662b51d96fc1a2bdd2a32",
-            "size": 9779,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-rank_opt--Plan_/plan.txt"
+            "checksum": "7437beaa39350581ba057ee83a418001",
+            "size": 9161,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-rank_opt--Plan_/plan.txt"
         }
     ],
     "test.test[window-row_number_to_map_noncompact-default.txt-Debug]": [
         {
-            "checksum": "1b5706f5be9c382aea5475c313a90dea",
-            "size": 5685,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-row_number_to_map_noncompact-default.txt-Debug_/opt.yql_patched"
+            "checksum": "06e786f22bcd76c7bcce18817b69d7e1",
+            "size": 5488,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-row_number_to_map_noncompact-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-row_number_to_map_noncompact-default.txt-Plan]": [
         {
-            "checksum": "827cd055d1dffe354e11aa7d3f20b4d0",
-            "size": 10423,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-row_number_to_map_noncompact-default.txt-Plan_/plan.txt"
+            "checksum": "aed7f3dc3abae83720e177217654243d",
+            "size": 10011,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-row_number_to_map_noncompact-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_extract_members-default.txt-Debug]": [
         {
-            "checksum": "77b14e2a7792f4c8785aad8ceed09122",
-            "size": 5806,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-win_extract_members-default.txt-Debug_/opt.yql_patched"
+            "checksum": "556fa02add536f9d47d8f1517be522a3",
+            "size": 5474,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_extract_members-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_extract_members-default.txt-Plan]": [
         {
-            "checksum": "2bf0f5aca8e9f235db0dbc3a5d0a1a29",
-            "size": 8481,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-win_extract_members-default.txt-Plan_/plan.txt"
+            "checksum": "78f7be891d4a02cc6c20db903a6a9265",
+            "size": 7863,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_extract_members-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_auto_arg-default.txt-Debug]": [
         {
-            "checksum": "3092240ee2869c6a5eede11e353c7e80",
-            "size": 6598,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-win_func_auto_arg-default.txt-Debug_/opt.yql_patched"
+            "checksum": "4f62f0111ccdb12a8a512b7c07d62dfd",
+            "size": 6122,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_auto_arg-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_auto_arg-default.txt-Plan]": [
         {
-            "checksum": "9fe5d04ca51106415daf206f8316baec",
-            "size": 5741,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-win_func_auto_arg-default.txt-Plan_/plan.txt"
+            "checksum": "dac32f27040f48861eaa42e4a228bb5e",
+            "size": 5329,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_auto_arg-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_first_last_rev--Debug]": [
@@ -3109,72 +3109,72 @@
     ],
     "test.test[window-win_func_first_last_with_part--Debug]": [
         {
-            "checksum": "c4129ee73e96a365294143083bef4d7f",
-            "size": 7255,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-win_func_first_last_with_part--Debug_/opt.yql_patched"
+            "checksum": "876943519a6b8102b393c536927a44f0",
+            "size": 6606,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_first_last_with_part--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_first_last_with_part--Plan]": [
         {
-            "checksum": "b5f710872cef57f5559832b18a366f8c",
-            "size": 8451,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-win_func_first_last_with_part--Plan_/plan.txt"
+            "checksum": "fd76233b14536f46e3a091ade8251e90",
+            "size": 7833,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_first_last_with_part--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_on_cloned_source-default.txt-Debug]": [
         {
-            "checksum": "5a85e963851f70b26162872c71c1f423",
-            "size": 1972,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_window-win_func_on_cloned_source-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a74803a693a03c57fc066169ff91fb52",
+            "size": 1907,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_on_cloned_source-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_on_cloned_source-default.txt-Plan]": [
         {
-            "checksum": "e51dda6d9f9a7e9d0373dd0e502071e9",
-            "size": 4588,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-win_func_on_cloned_source-default.txt-Plan_/plan.txt"
+            "checksum": "75dadfcae2eec9206b4647d4de2c318c",
+            "size": 4382,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_on_cloned_source-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_rank_by_opt_part--Debug]": [
         {
-            "checksum": "d9fbd948fe50d1710154cfef399422e1",
-            "size": 6667,
-            "uri": "https://{canondata_backend}/1936842/15d1b251a19a947bc78bcd914d26903ce91d665f/resource.tar.gz#test.test_window-win_func_rank_by_opt_part--Debug_/opt.yql_patched"
+            "checksum": "a3a39ed7d91a40451fce7d8af2b615a9",
+            "size": 6231,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_rank_by_opt_part--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_rank_by_opt_part--Plan]": [
         {
-            "checksum": "d66e2764aff8124e98c47f54f4f91075",
-            "size": 8421,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_window-win_func_rank_by_opt_part--Plan_/plan.txt"
+            "checksum": "30ca8165df10779cb274e78f25373baa",
+            "size": 7803,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_window-win_func_rank_by_opt_part--Plan_/plan.txt"
         }
     ],
     "test.test[ypath-complex-default.txt-Debug]": [
         {
-            "checksum": "1fbb55671d2d73acbd3ce061284b92b1",
-            "size": 2190,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_ypath-complex-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b5ce80bf24b7c3baeda271842c4856ea",
+            "size": 2067,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_ypath-complex-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ypath-complex-default.txt-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_ypath-complex-default.txt-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_ypath-complex-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[ypath-multi_key-default.txt-Debug]": [
         {
-            "checksum": "189855c6a6e8a46e1f305e8ca8aaed2c",
-            "size": 2101,
-            "uri": "https://{canondata_backend}/1784117/3885f0a76b64a32a48487f8866602d3fff1e416a/resource.tar.gz#test.test_ypath-multi_key-default.txt-Debug_/opt.yql_patched"
+            "checksum": "baaff6dc6a468ee076c9ebabb061e7dc",
+            "size": 1978,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_ypath-multi_key-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[ypath-multi_key-default.txt-Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/212715/61f0c59354c0aee96d5e21e3fd5f5993b2817ac3/resource.tar.gz#test.test_ypath-multi_key-default.txt-Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/7478904042df2a3888a84b6a917dd7cf55a05d66/resource.tar.gz#test.test_ypath-multi_key-default.txt-Plan_/plan.txt"
         }
     ]
 }

--- a/ydb/library/yql/tests/sql/hybrid_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part8/canondata/result.json
@@ -1,44 +1,44 @@
 {
     "test.test[action-eval_column--Debug]": [
         {
-            "checksum": "bdee6cb59ff5e1e97dc21264f807b6ab",
-            "size": 14667,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_action-eval_column--Debug_/opt.yql_patched"
+            "checksum": "4d8062ad5b19accfffe334514c5bb65c",
+            "size": 13884,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_action-eval_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_column--Plan]": [
         {
-            "checksum": "d9089ccd044c2cfb2ae902de82100aff",
-            "size": 28033,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_action-eval_column--Plan_/plan.txt"
+            "checksum": "e122d47a9f11fa11c6cf2cef983ad8ee",
+            "size": 26591,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_action-eval_column--Plan_/plan.txt"
         }
     ],
     "test.test[action-eval_input_output_table_subquery--Debug]": [
         {
-            "checksum": "e9253808e3d07578ab01b98a5cc33c37",
-            "size": 3199,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Debug_/opt.yql_patched"
+            "checksum": "af0fabeb9e9de1f83802b692ed03b5e1",
+            "size": 2953,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-eval_input_output_table_subquery--Plan]": [
         {
-            "checksum": "760256deffb030b1d2456d4f27ab342f",
-            "size": 7011,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Plan_/plan.txt"
+            "checksum": "905ef7e67f39874c7c7e646334dd061f",
+            "size": 6599,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_action-eval_input_output_table_subquery--Plan_/plan.txt"
         }
     ],
     "test.test[action-insert_after_eval_xlock--Debug]": [
         {
-            "checksum": "ed241ee5ac5c32e540fc175fb427680b",
-            "size": 1619,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_action-insert_after_eval_xlock--Debug_/opt.yql_patched"
+            "checksum": "bad24e56f8d77be54b854337db7035aa",
+            "size": 1501,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_action-insert_after_eval_xlock--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-insert_after_eval_xlock--Plan]": [
         {
-            "checksum": "69ffe06cf88dd21ae82f8646a5c3eda3",
-            "size": 4190,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_action-insert_after_eval_xlock--Plan_/plan.txt"
+            "checksum": "afc21adffbeb9bfd7ee943e64f1d18a7",
+            "size": 3984,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_action-insert_after_eval_xlock--Plan_/plan.txt"
         }
     ],
     "test.test[action-nested_rewrite_io-default.txt-Debug]": [
@@ -85,16 +85,16 @@
     ],
     "test.test[agg_apply-avg_const_interval--Debug]": [
         {
-            "checksum": "a0b66e119f1555b335acbd416f64f235",
-            "size": 3580,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_agg_apply-avg_const_interval--Debug_/opt.yql_patched"
+            "checksum": "45c1f7c374d38009ad9e8acf5a04a99c",
+            "size": 3513,
+            "uri": "https://{canondata_backend}/1784826/6fb10875fc2d13209580debefd9e32c0586b2ae6/resource.tar.gz#test.test_agg_apply-avg_const_interval--Debug_/opt.yql_patched"
         }
     ],
     "test.test[agg_apply-avg_const_interval--Plan]": [
         {
-            "checksum": "0e56f2addf2b393236b33f1567613332",
-            "size": 5616,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_agg_apply-avg_const_interval--Plan_/plan.txt"
+            "checksum": "769127c4504c755518199b95d4a783c6",
+            "size": 5410,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_agg_apply-avg_const_interval--Plan_/plan.txt"
         }
     ],
     "test.test[agg_apply-pg_text-default.txt-Debug]": [
@@ -183,44 +183,44 @@
     ],
     "test.test[aggr_factory-avg_distinct_expr-default.txt-Debug]": [
         {
-            "checksum": "16b4ad0ca2ac7e30d0eb3bdfb7b74829",
-            "size": 6669,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_aggr_factory-avg_distinct_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "91410f3e5f578ccd72bf57dadf06b9a1",
+            "size": 6455,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-avg_distinct_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-avg_distinct_expr-default.txt-Plan]": [
         {
-            "checksum": "cb61186c10d53efedbaaf7e9fac4202d",
-            "size": 11268,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-avg_distinct_expr-default.txt-Plan_/plan.txt"
+            "checksum": "088afb8c8d67c0e0cd08cb87cc8e208f",
+            "size": 10650,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-avg_distinct_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-bitor-default.txt-Debug]": [
         {
-            "checksum": "af584f25b3d0c707d86992a169b46c70",
-            "size": 6629,
-            "uri": "https://{canondata_backend}/1775059/a3008d08d4d7b6804748026c4d5253e8ed3c0315/resource.tar.gz#test.test_aggr_factory-bitor-default.txt-Debug_/opt.yql_patched"
+            "checksum": "581aa2c6feafe27c5f770de04fa84081",
+            "size": 6531,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-bitor-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-bitor-default.txt-Plan]": [
         {
-            "checksum": "bc48acda1e477c8daa387d3a1c3e9ef4",
-            "size": 13322,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-bitor-default.txt-Plan_/plan.txt"
+            "checksum": "dcd250bb62eed7eae08239d31389e128",
+            "size": 12910,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-bitor-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-bottom_by-default.txt-Debug]": [
         {
-            "checksum": "30d52e833eb8b425d175381127a3761b",
-            "size": 6762,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_aggr_factory-bottom_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bc714f4a3a4aa00a2ad8aa643737cbf2",
+            "size": 6630,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-bottom_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-bottom_by-default.txt-Plan]": [
         {
-            "checksum": "cf63f685a2acddc18a40e51f0ab126dc",
-            "size": 9933,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-bottom_by-default.txt-Plan_/plan.txt"
+            "checksum": "c248b16901202dd588102afce31e70f8",
+            "size": 9521,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-bottom_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-container-default.txt-Debug]": [
@@ -239,240 +239,240 @@
     ],
     "test.test[aggr_factory-corellation-default.txt-Debug]": [
         {
-            "checksum": "aedfad839d887f8610d73777207ce2c6",
-            "size": 6678,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_aggr_factory-corellation-default.txt-Debug_/opt.yql_patched"
+            "checksum": "57f9e876ea854faca22f8eb05083bd70",
+            "size": 6536,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-corellation-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-corellation-default.txt-Plan]": [
         {
-            "checksum": "20f707a94e69450d599220d76809c25f",
-            "size": 9933,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-corellation-default.txt-Plan_/plan.txt"
+            "checksum": "47e5f25399b9c7af047da7e0c9c435e4",
+            "size": 9521,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-corellation-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-count_if-default.txt-Debug]": [
         {
-            "checksum": "e28b6c2ab55fb6b4e2e6f5abac963c06",
-            "size": 6944,
-            "uri": "https://{canondata_backend}/1775059/a3008d08d4d7b6804748026c4d5253e8ed3c0315/resource.tar.gz#test.test_aggr_factory-count_if-default.txt-Debug_/opt.yql_patched"
+            "checksum": "748d5a571c0cc781e70df1ada7f677a3",
+            "size": 6845,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-count_if-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-count_if-default.txt-Plan]": [
         {
-            "checksum": "b04a7b524988f38190d4f7d6f057bd1a",
-            "size": 13318,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-count_if-default.txt-Plan_/plan.txt"
+            "checksum": "d77130b7c4f1b83c7ecedee655385188",
+            "size": 12906,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-count_if-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-linear_histogram-default.txt-Debug]": [
         {
-            "checksum": "c63f12da9554ceb18c781394045e2528",
-            "size": 7099,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_aggr_factory-linear_histogram-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b7c6adddfd9ab10e37510233e1ab7174",
+            "size": 6967,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-linear_histogram-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-linear_histogram-default.txt-Plan]": [
         {
-            "checksum": "e80459c6ded6bc35cd5f0fe2d0ec909c",
-            "size": 9892,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-linear_histogram-default.txt-Plan_/plan.txt"
+            "checksum": "d6fe32af474c6dd359f446ef8afd7ccb",
+            "size": 9480,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-linear_histogram-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-top_by-default.txt-Debug]": [
         {
-            "checksum": "d2ae81e2ccdf5441f53ce7e58b5279e4",
-            "size": 6761,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_aggr_factory-top_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5edf52dd49f949ee2377b3e7926a1ef9",
+            "size": 6629,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-top_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-top_by-default.txt-Plan]": [
         {
-            "checksum": "cf63f685a2acddc18a40e51f0ab126dc",
-            "size": 9933,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-top_by-default.txt-Plan_/plan.txt"
+            "checksum": "c248b16901202dd588102afce31e70f8",
+            "size": 9521,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-top_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-udaf-default.txt-Debug]": [
         {
-            "checksum": "8f876d6e5e31fed853a87996437be910",
-            "size": 7936,
-            "uri": "https://{canondata_backend}/1775059/a3008d08d4d7b6804748026c4d5253e8ed3c0315/resource.tar.gz#test.test_aggr_factory-udaf-default.txt-Debug_/opt.yql_patched"
+            "checksum": "084baccd356d0c62eeb4485f1b02f52e",
+            "size": 7837,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-udaf-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-udaf-default.txt-Plan]": [
         {
-            "checksum": "628f055b0074f38ab936da6bbe98cf0d",
-            "size": 14031,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggr_factory-udaf-default.txt-Plan_/plan.txt"
+            "checksum": "81034cc3d381399ebed3f5769162b53f",
+            "size": 13619,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggr_factory-udaf-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_cube_join_count--Debug]": [
         {
-            "checksum": "0065da558f91ea9f7f85636230896085",
-            "size": 12430,
-            "uri": "https://{canondata_backend}/1917492/cf57bdebe9d9af3fecbb7cd419893dd2ae22667e/resource.tar.gz#test.test_aggregate-group_by_cube_join_count--Debug_/opt.yql_patched"
+            "checksum": "c1047456aa369eee18bb6dc0037f03ab",
+            "size": 11671,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_cube_join_count--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_cube_join_count--Plan]": [
         {
-            "checksum": "dd7d92aef2db47fea393aa931e6faaca",
-            "size": 18953,
-            "uri": "https://{canondata_backend}/1917492/cf57bdebe9d9af3fecbb7cd419893dd2ae22667e/resource.tar.gz#test.test_aggregate-group_by_cube_join_count--Plan_/plan.txt"
+            "checksum": "a5b40c2991ae79cc9a7a2d1e9f0be53c",
+            "size": 17923,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_cube_join_count--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_dict--Debug]": [
         {
-            "checksum": "11813a009758f962f7ddfe454b19f6ff",
-            "size": 6215,
-            "uri": "https://{canondata_backend}/1775059/a3008d08d4d7b6804748026c4d5253e8ed3c0315/resource.tar.gz#test.test_aggregate-group_by_expr_dict--Debug_/opt.yql_patched"
+            "checksum": "1771aaf95ec5d7d703219ff546c2f920",
+            "size": 5989,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_expr_dict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_dict--Plan]": [
         {
-            "checksum": "4309689f41cbcd9b784ad1b380a1f920",
-            "size": 10923,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_expr_dict--Plan_/plan.txt"
+            "checksum": "e02dc818c0ae2002044505b0851c0f66",
+            "size": 10099,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_expr_dict--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_lookup--Debug]": [
         {
-            "checksum": "fbd4a277dd28d7b460a4438bc927459d",
-            "size": 4605,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_aggregate-group_by_expr_lookup--Debug_/opt.yql_patched"
+            "checksum": "67fdeec81e6af67f2fe027953d92a247",
+            "size": 4381,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_expr_lookup--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_lookup--Plan]": [
         {
-            "checksum": "470f331551d27a01a053951a9734a6b4",
-            "size": 8526,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_expr_lookup--Plan_/plan.txt"
+            "checksum": "35a2b04b072e9f2c1642c0f821bea872",
+            "size": 7908,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_expr_lookup--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_expr_with_where-default.txt-Debug]": [
         {
-            "checksum": "c8d4de01adb5317e939f0c8d7028c282",
-            "size": 4982,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_aggregate-group_by_expr_with_where-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d6a7f3ed4119b43d0413c4dca2a2ac9d",
+            "size": 4684,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_expr_with_where-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_expr_with_where-default.txt-Plan]": [
         {
-            "checksum": "5b34466f9dea236e8ef55862f24fbbe9",
-            "size": 8525,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_expr_with_where-default.txt-Plan_/plan.txt"
+            "checksum": "56e5fa0b7e6c6bee32c075c3d9156004",
+            "size": 7907,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_expr_with_where-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_and_having-default.txt-Debug]": [
         {
-            "checksum": "ea47254d2e0c2fae4685a6bb113f557f",
-            "size": 8255,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_aggregate-group_by_gs_and_having-default.txt-Debug_/opt.yql_patched"
+            "checksum": "16f63bf5c6550bea76222c7f052d43b4",
+            "size": 7790,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_gs_and_having-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_and_having-default.txt-Plan]": [
         {
-            "checksum": "75e4ab6bed4cc96fc67e63f6547e65a8",
-            "size": 11434,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_gs_and_having-default.txt-Plan_/plan.txt"
+            "checksum": "51f852989ed257258d8ba65456c307e9",
+            "size": 10816,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_gs_and_having-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_column_ref_same_names--Debug]": [
         {
-            "checksum": "b57beccf64fdf7b7a41ff38d7fc18be8",
-            "size": 9460,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref_same_names--Debug_/opt.yql_patched"
+            "checksum": "b83350496ccb944b0f9220a136b46a1d",
+            "size": 8791,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref_same_names--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_column_ref_same_names--Plan]": [
         {
-            "checksum": "871a11c56cbd17553e0ce6567b87fb96",
-            "size": 14650,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref_same_names--Plan_/plan.txt"
+            "checksum": "6266271dc8c3771ab9ab4cb9f307e435",
+            "size": 13620,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_rollup_column_ref_same_names--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_grouping--Debug]": [
         {
-            "checksum": "1818066532d169e6ad3acadb3c177d88",
-            "size": 12880,
-            "uri": "https://{canondata_backend}/1784826/10061a097232925f711b81d9738330226a30d608/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping--Debug_/opt.yql_patched"
+            "checksum": "6758da763dc15feb86ad944eda990b42",
+            "size": 12254,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_grouping--Plan]": [
         {
-            "checksum": "a8142abe70a341dcb7801418d6390639",
-            "size": 17323,
-            "uri": "https://{canondata_backend}/1784826/10061a097232925f711b81d9738330226a30d608/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping--Plan_/plan.txt"
+            "checksum": "e807ad2745747e89ec5ea4d83c47e877",
+            "size": 16499,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_rollup_grouping--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_with_filter--Debug]": [
         {
-            "checksum": "1abe1bf2bad2186ac810c6840480c946",
-            "size": 9160,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_aggregate-group_by_rollup_with_filter--Debug_/opt.yql_patched"
+            "checksum": "0ef43775cdfa1e1f04edafe871f7fe52",
+            "size": 8493,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_rollup_with_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_with_filter--Plan]": [
         {
-            "checksum": "871a11c56cbd17553e0ce6567b87fb96",
-            "size": 14650,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_rollup_with_filter--Plan_/plan.txt"
+            "checksum": "6266271dc8c3771ab9ab4cb9f307e435",
+            "size": 13620,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_rollup_with_filter--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_join_simple_fs_multiusage--Debug]": [
         {
-            "checksum": "0c642a9df3d0588319df945c94fb363e",
-            "size": 11208,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple_fs_multiusage--Debug_/opt.yql_patched"
+            "checksum": "192bc73e53a393b142ea2171f10f1c14",
+            "size": 10857,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple_fs_multiusage--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_join_simple_fs_multiusage--Plan]": [
         {
-            "checksum": "2d15a60347da94c295a9aec39626159d",
-            "size": 15812,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple_fs_multiusage--Plan_/plan.txt"
+            "checksum": "e029c996864e6c3fb30ed50111ec0dcf",
+            "size": 15194,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple_fs_multiusage--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_extended_subset--Debug]": [
         {
-            "checksum": "bcce4390d94553ff9e1e97a03b7b9255",
-            "size": 5417,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_aggregate-group_by_session_extended_subset--Debug_/opt.yql_patched"
+            "checksum": "6043c6384a5de09d57ce64e780881904",
+            "size": 5224,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_session_extended_subset--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_extended_subset--Plan]": [
         {
-            "checksum": "77f33e25af9e3ae056d44bc4c7a1dde5",
-            "size": 7875,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_session_extended_subset--Plan_/plan.txt"
+            "checksum": "a645f1a1b86973b0c89c38f30b2fe2d2",
+            "size": 7463,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_session_extended_subset--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_session_star--Debug]": [
         {
-            "checksum": "ac86daf38994b68027031ebf922d34f5",
-            "size": 6818,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_aggregate-group_by_session_star--Debug_/opt.yql_patched"
+            "checksum": "63e0d0c9760d3f93077e55e561346618",
+            "size": 6383,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_session_star--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_session_star--Plan]": [
         {
-            "checksum": "677bb5f6f4145252dbd06556c87cce37",
-            "size": 9658,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-group_by_session_star--Plan_/plan.txt"
+            "checksum": "b797b6bd097099499cf317f294727f8a",
+            "size": 8834,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-group_by_session_star--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-having_cast-default.txt-Debug]": [
         {
-            "checksum": "1e3595c9d09c43a016df9a2a55d3bfec",
-            "size": 5373,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_aggregate-having_cast-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2d696db06da68845d6ce96089499da26",
+            "size": 5140,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-having_cast-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-having_cast-default.txt-Plan]": [
         {
-            "checksum": "d4475b4ce49986967e40aeacc55b9d97",
-            "size": 8454,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-having_cast-default.txt-Plan_/plan.txt"
+            "checksum": "2b8caaa263fad6a40e505e78b6d874b6",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-having_cast-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-parsetype_constness-default.txt-Debug]": [
@@ -491,16 +491,16 @@
     ],
     "test.test[aggregate-table_funcs_group_by-default.txt-Debug]": [
         {
-            "checksum": "7a67582c9ae504734e2ca71ddeb7f4d8",
-            "size": 5156,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_aggregate-table_funcs_group_by-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8eb69d4150325ca8948f85e3b1974403",
+            "size": 4835,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-table_funcs_group_by-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-table_funcs_group_by-default.txt-Plan]": [
         {
-            "checksum": "607d1dcc25a269930fdad31b99024743",
-            "size": 8482,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_aggregate-table_funcs_group_by-default.txt-Plan_/plan.txt"
+            "checksum": "b1c63057100b8cd4b17ce96c01ee1fcb",
+            "size": 7864,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_aggregate-table_funcs_group_by-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[ansi_idents-join_using-default.txt-Debug]": [
@@ -561,86 +561,86 @@
     ],
     "test.test[blocks-add_uint16--Debug]": [
         {
-            "checksum": "d68b366b8b93cfb168d39dad9f2039ba",
-            "size": 2206,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-add_uint16--Debug_/opt.yql_patched"
+            "checksum": "4e8d925d4fb16275a1319d3f72b2e15a",
+            "size": 2076,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-add_uint16--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_uint16--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-add_uint16--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-add_uint16--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-add_uint32--Debug]": [
         {
-            "checksum": "68c66ea851128fc0afac03c475815532",
-            "size": 2206,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-add_uint32--Debug_/opt.yql_patched"
+            "checksum": "e9c8cc21b0ae411505ea2769788cd29b",
+            "size": 2076,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-add_uint32--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-add_uint32--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-add_uint32--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-add_uint32--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_avg_filter--Debug]": [
         {
-            "checksum": "4be3a8178238ea2539ecba9bd513b4d6",
-            "size": 3408,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-combine_all_avg_filter--Debug_/opt.yql_patched"
+            "checksum": "5d1590161a01661a1e9d13607733e7ca",
+            "size": 3341,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-combine_all_avg_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_avg_filter--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-combine_all_avg_filter--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-combine_all_avg_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-decimal_op_decimal--Debug]": [
         {
-            "checksum": "d480ca1abe3826553d9cebc7d69dbe52",
-            "size": 2307,
-            "uri": "https://{canondata_backend}/1784117/9a028b554396b6c7b4c994aa1d76185e37e768c0/resource.tar.gz#test.test_blocks-decimal_op_decimal--Debug_/opt.yql_patched"
+            "checksum": "c4237c965b04a3be91838c2c4ccee5cb",
+            "size": 2201,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-decimal_op_decimal--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-decimal_op_decimal--Plan]": [
         {
-            "checksum": "e65c86ba6e55033fe5f47711b65bba6d",
-            "size": 4093,
-            "uri": "https://{canondata_backend}/1784117/9a028b554396b6c7b4c994aa1d76185e37e768c0/resource.tar.gz#test.test_blocks-decimal_op_decimal--Plan_/plan.txt"
+            "checksum": "73e50c3285312f865e29210e7f952098",
+            "size": 3887,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-decimal_op_decimal--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-distinct_mixed_all--Debug]": [
         {
-            "checksum": "6975773fe7a0c24aeba19c9a36ae09a2",
-            "size": 6304,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-distinct_mixed_all--Debug_/opt.yql_patched"
+            "checksum": "03fc20a20e50b4a8457bb8426717bfd4",
+            "size": 6165,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-distinct_mixed_all--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-distinct_mixed_all--Plan]": [
         {
-            "checksum": "854ea7a0301b31915e7a4c390489c720",
-            "size": 7752,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-distinct_mixed_all--Plan_/plan.txt"
+            "checksum": "80cc0a7ba4fba080483b0967edce414f",
+            "size": 7546,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-distinct_mixed_all--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-filter_expr--Debug]": [
         {
-            "checksum": "1ad4f744a0f5f7f9efe4979a7097e63c",
-            "size": 3124,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-filter_expr--Debug_/opt.yql_patched"
+            "checksum": "9962649fbc76e74873091fe0b4b7eb0d",
+            "size": 2922,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-filter_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-filter_expr--Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-filter_expr--Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-filter_expr--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-interval_add_interval--Debug]": [
@@ -659,86 +659,86 @@
     ],
     "test.test[blocks-lazy_nonstrict_basic--Debug]": [
         {
-            "checksum": "568aa9083488a0c4311b2b4236c2d7c0",
-            "size": 3940,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Debug_/opt.yql_patched"
+            "checksum": "ae13ef8c41471de2afc29b81442dd230",
+            "size": 3759,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-lazy_nonstrict_basic--Plan]": [
         {
-            "checksum": "bcbec56b0b098caef23c5dd089aeee0f",
-            "size": 8759,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Plan_/plan.txt"
+            "checksum": "3530fe3117adcdd4833eb4f66cdae59e",
+            "size": 8141,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-lazy_nonstrict_basic--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_call--Debug]": [
         {
-            "checksum": "aaed88da7175202f25691238ba0768fd",
-            "size": 2805,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-pg_call--Debug_/opt.yql_patched"
+            "checksum": "fde7d6f4a04828b4ee90ea532616d8d7",
+            "size": 2603,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-pg_call--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_call--Plan]": [
         {
-            "checksum": "c43b1714c989edbc51580220fc99b3c3",
-            "size": 4068,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-pg_call--Plan_/plan.txt"
+            "checksum": "2e88729fd8f8e63b15367240ca6053f8",
+            "size": 3862,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-pg_call--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_to_interval--Debug]": [
         {
-            "checksum": "b9f5276bba2721e89bfa8bb14b399c1c",
-            "size": 1993,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-pg_to_interval--Debug_/opt.yql_patched"
+            "checksum": "33577a499d8160c5c0bdbc20701dd678",
+            "size": 1887,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-pg_to_interval--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_to_interval--Plan]": [
         {
-            "checksum": "26cb89ac43b37a778a39aa856b165382",
-            "size": 4068,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-pg_to_interval--Plan_/plan.txt"
+            "checksum": "94956c55ba3cd39a4eef2aa2cba1ce06",
+            "size": 3862,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-pg_to_interval--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-sort_one_asc--Debug]": [
         {
-            "checksum": "c454a7fa91c3d90e89548db0b542fbe0",
-            "size": 3193,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-sort_one_asc--Debug_/opt.yql_patched"
+            "checksum": "0cc5536178e7358793b3535630430d19",
+            "size": 2985,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-sort_one_asc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-sort_one_asc--Plan]": [
         {
-            "checksum": "a1fef8f61fe11c90dd11c1f890ed823e",
-            "size": 6203,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-sort_one_asc--Plan_/plan.txt"
+            "checksum": "cd27a828adf5519d235a399cbb2df0b9",
+            "size": 5791,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-sort_one_asc--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-string_pass--Debug]": [
         {
-            "checksum": "8ee7ee758fb1673ef775487af34a6ad2",
-            "size": 3497,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-string_pass--Debug_/opt.yql_patched"
+            "checksum": "fd74065de47d9ae0b1ac72f67a3e42f9",
+            "size": 3197,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-string_pass--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-string_pass--Plan]": [
         {
-            "checksum": "3d752a862c8daeef45340a874d5ca650",
-            "size": 6263,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-string_pass--Plan_/plan.txt"
+            "checksum": "02a7b4afe2adc0be814fafcc72a80b95",
+            "size": 5851,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-string_pass--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-top_sort_two_desc--Debug]": [
         {
-            "checksum": "cbce0fb5d01b028a94b876a2590d7de1",
-            "size": 3501,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-top_sort_two_desc--Debug_/opt.yql_patched"
+            "checksum": "090babbd7bc991334b32d418c2273f22",
+            "size": 3253,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-top_sort_two_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-top_sort_two_desc--Plan]": [
         {
-            "checksum": "7ec9fd674afb45088683be4f80b63673",
-            "size": 6326,
-            "uri": "https://{canondata_backend}/1942173/3bb27fb0a55607bffaebde9a7abc4b2ec4ca0495/resource.tar.gz#test.test_blocks-top_sort_two_desc--Plan_/plan.txt"
+            "checksum": "fca964732d0b2d808bdb66bb8ba035cb",
+            "size": 5914,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_blocks-top_sort_two_desc--Plan_/plan.txt"
         }
     ],
     "test.test[case-case_opt_cond-default.txt-Debug]": [
@@ -757,114 +757,114 @@
     ],
     "test.test[case-case_size_eq_cast-default.txt-Debug]": [
         {
-            "checksum": "31a02b21da0b2700225c6be00cc42bc6",
-            "size": 2105,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_case-case_size_eq_cast-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2af57ed28122277a9159ad739a92c25f",
+            "size": 1982,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_case-case_size_eq_cast-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[case-case_size_eq_cast-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_case-case_size_eq_cast-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_case-case_size_eq_cast-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[coalesce-coalesce--Debug]": [
         {
-            "checksum": "3d99018026b1e75f7b149661542eeaa7",
-            "size": 1953,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_coalesce-coalesce--Debug_/opt.yql_patched"
+            "checksum": "729c97e25158f6a5c9c7be182c6222b7",
+            "size": 1887,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_coalesce-coalesce--Debug_/opt.yql_patched"
         }
     ],
     "test.test[coalesce-coalesce--Plan]": [
         {
-            "checksum": "d118decf89a5561dd4a8172d27e13b62",
-            "size": 4047,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_coalesce-coalesce--Plan_/plan.txt"
+            "checksum": "280a65d38bb94cf48f6d81ef128b0b2f",
+            "size": 3841,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_coalesce-coalesce--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-align_publish_native--Debug]": [
         {
-            "checksum": "7fc155d3af136e97ea89cc6b99836a2f",
-            "size": 5080,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_column_order-align_publish_native--Debug_/opt.yql_patched"
+            "checksum": "ade22839ea10aad06e68a45b75265a1b",
+            "size": 4608,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-align_publish_native--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-align_publish_native--Plan]": [
         {
-            "checksum": "30a6b02a3189ecfcf0b6a1aa3f6d5ebd",
-            "size": 14212,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_column_order-align_publish_native--Plan_/plan.txt"
+            "checksum": "8a8c8b87315fb178b352dc6c65b676d8",
+            "size": 13388,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-align_publish_native--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_groupby_with_star-default.txt-Debug]": [
         {
-            "checksum": "c58fe228c6833093f7f5ee2807579c6a",
-            "size": 7154,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_column_order-select_groupby_with_star-default.txt-Debug_/opt.yql_patched"
+            "checksum": "39d7ae422faaee074f48b3c2329f5894",
+            "size": 6843,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-select_groupby_with_star-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_groupby_with_star-default.txt-Plan]": [
         {
-            "checksum": "bc48725545932ee8b32c6a08a3f8b43a",
-            "size": 13884,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_column_order-select_groupby_with_star-default.txt-Plan_/plan.txt"
+            "checksum": "4496c6e9107801db1a48db883913978e",
+            "size": 13266,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-select_groupby_with_star-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_sample-default.txt-Debug]": [
         {
-            "checksum": "8325500138cca2afe3867a44d437fa35",
-            "size": 2096,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_column_order-select_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "84c99b56f6dc6563099cbdd6fab632d6",
+            "size": 1973,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-select_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_sample-default.txt-Plan]": [
         {
-            "checksum": "ebbd7546cb76695b3c858bfe2d8f0a21",
-            "size": 3504,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_column_order-select_sample-default.txt-Plan_/plan.txt"
+            "checksum": "e9014acf3993c726885a94be423217ee",
+            "size": 3298,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-select_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[column_order-select_win_func-default.txt-Debug]": [
         {
-            "checksum": "7b2821baa26fe531e7827b1dd82201b4",
-            "size": 8558,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_column_order-select_win_func-default.txt-Debug_/opt.yql_patched"
+            "checksum": "210c581a60f492ff39d76bbb9e6afed0",
+            "size": 8290,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-select_win_func-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-select_win_func-default.txt-Plan]": [
         {
-            "checksum": "dd9ce459bbf9f20890341908a5e6b0aa",
-            "size": 10451,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_column_order-select_win_func-default.txt-Plan_/plan.txt"
+            "checksum": "08634454aa56a12fc1eb2cf32a872b6c",
+            "size": 10039,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_column_order-select_win_func-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[count-count--Debug]": [
         {
-            "checksum": "c5e814c25f2fe63a0fe379f248d6670f",
-            "size": 21032,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_count-count--Debug_/opt.yql_patched"
+            "checksum": "d21c4bffcc3ce577c04c72f00dce975e",
+            "size": 19732,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_count-count--Debug_/opt.yql_patched"
         }
     ],
     "test.test[count-count--Plan]": [
         {
-            "checksum": "e4609425bd3b06d9a4090a34f5ff6ffc",
-            "size": 31560,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_count-count--Plan_/plan.txt"
+            "checksum": "47490263549183a212c2d5df1ab5d9d1",
+            "size": 29500,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_count-count--Plan_/plan.txt"
         }
     ],
     "test.test[count-count_all_grouped--Debug]": [
         {
-            "checksum": "f07f57966e0888a6e8dd3ff975fc77ea",
-            "size": 4752,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_count-count_all_grouped--Debug_/opt.yql_patched"
+            "checksum": "3e639c0fc9893d3bcc8998ec069b97be",
+            "size": 4445,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_count-count_all_grouped--Debug_/opt.yql_patched"
         }
     ],
     "test.test[count-count_all_grouped--Plan]": [
         {
-            "checksum": "fcb3fac66758bdf710add4888459ac6b",
-            "size": 8425,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_count-count_all_grouped--Plan_/plan.txt"
+            "checksum": "f1f5f9687ade29f7d83e3e95a7f11fd8",
+            "size": 7807,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_count-count_all_grouped--Plan_/plan.txt"
         }
     ],
     "test.test[csee-expr_in_l0_and_l1-default.txt-Debug]": [
@@ -967,114 +967,114 @@
     ],
     "test.test[distinct-distinct_and_join--Debug]": [
         {
-            "checksum": "490a58dd708fe4a104e45af6ba295fd5",
-            "size": 6046,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_distinct-distinct_and_join--Debug_/opt.yql_patched"
+            "checksum": "6b1561cff5a8c95476001302623dfe1e",
+            "size": 5776,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_and_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_and_join--Plan]": [
         {
-            "checksum": "e7f455853924f91ed3982df0ca0788d8",
-            "size": 9267,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_distinct-distinct_and_join--Plan_/plan.txt"
+            "checksum": "cbf3fa7ca457fc53680c89ef6f49708a",
+            "size": 8855,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_and_join--Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_count_no_gouping-default.txt-Debug]": [
         {
-            "checksum": "a06ae64390cdca3e11b0d836a35ef4e2",
-            "size": 5457,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_distinct-distinct_count_no_gouping-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7ebc7e8ffdb5fac62dec2c48bc9507c7",
+            "size": 5343,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_count_no_gouping-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_count_no_gouping-default.txt-Plan]": [
         {
-            "checksum": "c56c92a3f8495ae5927ada199865ff4b",
-            "size": 7754,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_distinct-distinct_count_no_gouping-default.txt-Plan_/plan.txt"
+            "checksum": "cc05301d16bcd424493475f560df1762",
+            "size": 7548,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_count_no_gouping-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_count_only-default.txt-Debug]": [
         {
-            "checksum": "f04dd69756aff85ccae9f9a5f064a71c",
-            "size": 3515,
-            "uri": "https://{canondata_backend}/1130705/fb84c5fc4e8efe727ed52d6b8bfee38d5500baf7/resource.tar.gz#test.test_distinct-distinct_count_only-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bae375d9fb54af3fb022e35cd320994f",
+            "size": 3429,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_count_only-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_count_only-default.txt-Plan]": [
         {
-            "checksum": "d76ef1040d3ff8c6958cb0bf9c4d5734",
-            "size": 6234,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_distinct-distinct_count_only-default.txt-Plan_/plan.txt"
+            "checksum": "73c253417c787f031c66a71cff0a3e17",
+            "size": 5822,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_count_only-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_groupby-default.txt-Debug]": [
         {
-            "checksum": "62a363eb0dfbf03651a0fbdc30469871",
-            "size": 5765,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_distinct-distinct_groupby-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6710cc6ab88db2bf249275160715b21d",
+            "size": 5367,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_groupby-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_groupby-default.txt-Plan]": [
         {
-            "checksum": "0e336161a10685dfbe012f807c10509d",
-            "size": 10924,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_distinct-distinct_groupby-default.txt-Plan_/plan.txt"
+            "checksum": "fccd3a272e36d61134680be26733bc33",
+            "size": 10100,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_groupby-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_join-default.txt-Debug]": [
         {
-            "checksum": "6676e3f70ca376670729c0435b2aaec3",
-            "size": 8153,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_distinct-distinct_join-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ad4f9b648e3ef9f11aa6a543e50b0ab2",
+            "size": 7657,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_join-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_join-default.txt-Plan]": [
         {
-            "checksum": "9a45686c2e819372ae65f48f696f7270",
-            "size": 12144,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_distinct-distinct_join-default.txt-Plan_/plan.txt"
+            "checksum": "9e4fdf5b366c57860d17147a43b3222b",
+            "size": 11320,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_join-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_list_after_group-default.txt-Debug]": [
         {
-            "checksum": "54f065a3d8e70f03a3503f2467b2a619",
-            "size": 6476,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_distinct-distinct_list_after_group-default.txt-Debug_/opt.yql_patched"
+            "checksum": "74a2e96235e7a5a72bfaf460e6a93a71",
+            "size": 6044,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_list_after_group-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_list_after_group-default.txt-Plan]": [
         {
-            "checksum": "be49c49890fc92e6d2399d8245438c57",
-            "size": 10824,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_distinct-distinct_list_after_group-default.txt-Plan_/plan.txt"
+            "checksum": "5f8441fbcf5db2e122711a30288bf6e0",
+            "size": 10000,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_list_after_group-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_union_all-default.txt-Debug]": [
         {
-            "checksum": "8c3d9faa689837402ac2a215d4f2ae6d",
-            "size": 4151,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_distinct-distinct_union_all-default.txt-Debug_/opt.yql_patched"
+            "checksum": "16ac9a389452639a97529fc3988aa22e",
+            "size": 3851,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_union_all-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_union_all-default.txt-Plan]": [
         {
-            "checksum": "4e575c151519dc5343e942a257aeafd3",
-            "size": 8725,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_distinct-distinct_union_all-default.txt-Plan_/plan.txt"
+            "checksum": "6d859c92fc82b26daa22903195df5941",
+            "size": 8107,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_distinct-distinct_union_all-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[expr-as_table_emptylist--Debug]": [
         {
-            "checksum": "5031d0eacef8ac95ec215470ff37a725",
-            "size": 2200,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_expr-as_table_emptylist--Debug_/opt.yql_patched"
+            "checksum": "1caaa70b4af3bde7a6ef546117f07231",
+            "size": 2158,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_expr-as_table_emptylist--Debug_/opt.yql_patched"
         }
     ],
     "test.test[expr-as_table_emptylist--Plan]": [
         {
-            "checksum": "3ba59385293bb79b5f94a0b5296e1405",
-            "size": 7092,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_expr-as_table_emptylist--Plan_/plan.txt"
+            "checksum": "eced092baecad92f5281e5bd0dd8f3df",
+            "size": 6886,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_expr-as_table_emptylist--Plan_/plan.txt"
         }
     ],
     "test.test[expr-checked_ops-default.txt-Debug]": [
@@ -1261,30 +1261,30 @@
     ],
     "test.test[file-parse_file_in_select_as_int--Debug]": [
         {
-            "checksum": "91143902e715467fd6e5530098bcdb25",
-            "size": 2536,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_file-parse_file_in_select_as_int--Debug_/opt.yql_patched"
+            "checksum": "f4bab3e2a6cfbc73beb43998a97a7572",
+            "size": 2410,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_file-parse_file_in_select_as_int--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-parse_file_in_select_as_int--Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_file-parse_file_in_select_as_int--Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_file-parse_file_in_select_as_int--Plan_/plan.txt"
         }
     ],
     "test.test[file-where_key_in_file_content--Debug]": [
         {
-            "checksum": "b11c270bd5f7459d3d611e7b605e1d2d",
-            "size": 2172,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_file-where_key_in_file_content--Debug_/opt.yql_patched"
+            "checksum": "b61f5d9b23b374632bd9b572cc8ada53",
+            "size": 2049,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_file-where_key_in_file_content--Debug_/opt.yql_patched"
         }
     ],
     "test.test[file-where_key_in_file_content--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_file-where_key_in_file_content--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_file-where_key_in_file_content--Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_mode-default.txt-Debug]": [
@@ -1303,16 +1303,16 @@
     ],
     "test.test[flatten_by-flatten_with_group_by_expr--Debug]": [
         {
-            "checksum": "c1bb6315bf540c5f558b90e6eac49cd2",
-            "size": 8586,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_flatten_by-flatten_with_group_by_expr--Debug_/opt.yql_patched"
+            "checksum": "c75a4a7acb2bee5de4905dde6deb55fd",
+            "size": 8062,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_flatten_by-flatten_with_group_by_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_with_group_by_expr--Plan]": [
         {
-            "checksum": "4309689f41cbcd9b784ad1b380a1f920",
-            "size": 10923,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_flatten_by-flatten_with_group_by_expr--Plan_/plan.txt"
+            "checksum": "e02dc818c0ae2002044505b0851c0f66",
+            "size": 10099,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_flatten_by-flatten_with_group_by_expr--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-group_yamr--Debug]": [
@@ -1345,72 +1345,72 @@
     ],
     "test.test[insert-append_missing_null-default.txt-Debug]": [
         {
-            "checksum": "42fac8c81e8a14f1626eb2940e421cb7",
-            "size": 2627,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_insert-append_missing_null-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7cdd9d670953c76fb683b2033b9c2bc8",
+            "size": 2505,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-append_missing_null-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_missing_null-default.txt-Plan]": [
         {
-            "checksum": "896e170c1c9978f9b9f4728f49405000",
-            "size": 9435,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_insert-append_missing_null-default.txt-Plan_/plan.txt"
+            "checksum": "be845fca3834374f18d38788a0862c24",
+            "size": 9023,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-append_missing_null-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-literals_to_string-default.txt-Debug]": [
         {
-            "checksum": "6b10321fd1acde38562b2de79d32b9a7",
-            "size": 1464,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_insert-literals_to_string-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a262cc1fd30f8c411594c89302056695",
+            "size": 1317,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-literals_to_string-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-literals_to_string-default.txt-Plan]": [
         {
-            "checksum": "f196d46e9ba50bb2c5ce48cff5da851c",
-            "size": 4192,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_insert-literals_to_string-default.txt-Plan_/plan.txt"
+            "checksum": "af9eca9e80748994375492c0a5c9a705",
+            "size": 3986,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-literals_to_string-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-part_sortness--Debug]": [
         {
-            "checksum": "74575b4ae719d57bbcb9434c9aef7278",
-            "size": 2124,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_insert-part_sortness--Debug_/opt.yql_patched"
+            "checksum": "f08c5cc8194c14efbb71bc7330c3aa77",
+            "size": 2024,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-part_sortness--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-part_sortness--Plan]": [
         {
-            "checksum": "02e04cabe6fe6ddce08d1cfa5ef5c88e",
-            "size": 4284,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_insert-part_sortness--Plan_/plan.txt"
+            "checksum": "8b45085710875be445d0bb960360b8d0",
+            "size": 4078,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-part_sortness--Plan_/plan.txt"
         }
     ],
     "test.test[insert-trivial_literals_multirow-default.txt-Debug]": [
         {
-            "checksum": "298706903815a24b1f018d1b7ef73b9d",
-            "size": 1671,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_insert-trivial_literals_multirow-default.txt-Debug_/opt.yql_patched"
+            "checksum": "87443c9ee032892c38adb67189b3303e",
+            "size": 1548,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-trivial_literals_multirow-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-trivial_literals_multirow-default.txt-Plan]": [
         {
-            "checksum": "f196d46e9ba50bb2c5ce48cff5da851c",
-            "size": 4192,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_insert-trivial_literals_multirow-default.txt-Plan_/plan.txt"
+            "checksum": "af9eca9e80748994375492c0a5c9a705",
+            "size": 3986,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-trivial_literals_multirow-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-yql-13083--Debug]": [
         {
-            "checksum": "a03204fb42400236311e0d1fa45930a9",
-            "size": 4551,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_insert-yql-13083--Debug_/opt.yql_patched"
+            "checksum": "417284807f3c10a14e53bcca2ede584f",
+            "size": 4364,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-yql-13083--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-yql-13083--Plan]": [
         {
-            "checksum": "0dfc71f535d6ad38f91ea8e659c702df",
-            "size": 15902,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_insert-yql-13083--Plan_/plan.txt"
+            "checksum": "2aa9f27b1dead7adb133004fad4cd6e4",
+            "size": 15284,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_insert-yql-13083--Plan_/plan.txt"
         }
     ],
     "test.test[join-bush_in_in_in--Debug]": [
@@ -1429,16 +1429,16 @@
     ],
     "test.test[join-equi_join_three_asterisk--Debug]": [
         {
-            "checksum": "5142ff6d51b21957b982c38a460e4932",
-            "size": 8390,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-equi_join_three_asterisk--Debug_/opt.yql_patched"
+            "checksum": "d982eb9885c25d026943c4c01d0d82b3",
+            "size": 8159,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-equi_join_three_asterisk--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-equi_join_three_asterisk--Plan]": [
         {
-            "checksum": "50a6ef1b9ad57909c560e5342489d344",
-            "size": 11821,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-equi_join_three_asterisk--Plan_/plan.txt"
+            "checksum": "660d6f394441984e8d3e85937aba540e",
+            "size": 11615,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-equi_join_three_asterisk--Plan_/plan.txt"
         }
     ],
     "test.test[join-inmem_by_uncomparable_structs--Debug]": [
@@ -1471,226 +1471,226 @@
     ],
     "test.test[join-inner_grouped--Debug]": [
         {
-            "checksum": "5dcfcca541c57e0747d71e798bf30535",
-            "size": 6332,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-inner_grouped--Debug_/opt.yql_patched"
+            "checksum": "e4e2d7d05fb36d0f1a9bcb7087e43b2d",
+            "size": 6123,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-inner_grouped--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-inner_grouped--Plan]": [
         {
-            "checksum": "be5edd6a57dc5c0d62de69f0f05a6e0f",
-            "size": 9968,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-inner_grouped--Plan_/plan.txt"
+            "checksum": "9d260f82b4780598387855541c41259f",
+            "size": 9556,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-inner_grouped--Plan_/plan.txt"
         }
     ],
     "test.test[join-inner_grouped_by_expr--Debug]": [
         {
-            "checksum": "f845684a0dd1e6179c04c8ef6b78b26e",
-            "size": 6390,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-inner_grouped_by_expr--Debug_/opt.yql_patched"
+            "checksum": "2742ea72e67b9c60eedbca7b5bc005b4",
+            "size": 6182,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-inner_grouped_by_expr--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-inner_grouped_by_expr--Plan]": [
         {
-            "checksum": "c8587b90f077c90d3423a0f6b411684d",
-            "size": 10104,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-inner_grouped_by_expr--Plan_/plan.txt"
+            "checksum": "363d2df51b0d11a00638930d9ff7668a",
+            "size": 9692,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-inner_grouped_by_expr--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_inner_empty_subq--Debug]": [
         {
-            "checksum": "700e0282a551099afef3df6a654e08ba",
-            "size": 1769,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_join-lookupjoin_inner_empty_subq--Debug_/opt.yql_patched"
+            "checksum": "3b981a7e77d867f6be338f5a6744d91d",
+            "size": 1585,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-lookupjoin_inner_empty_subq--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_inner_empty_subq--Plan]": [
         {
-            "checksum": "97b2711f4cb2cffe8a9277f349cc9715",
-            "size": 2680,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-lookupjoin_inner_empty_subq--Plan_/plan.txt"
+            "checksum": "ea876bafa8fbd1b6a7e8d3803e596a02",
+            "size": 2474,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-lookupjoin_inner_empty_subq--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_semi_1o2o--Debug]": [
         {
-            "checksum": "cb877967deef4234f6275702dfa262f6",
-            "size": 4004,
-            "uri": "https://{canondata_backend}/1784117/9ac52e457dd37d6685b0cea084018e4ae4afe98f/resource.tar.gz#test.test_join-lookupjoin_semi_1o2o--Debug_/opt.yql_patched"
+            "checksum": "a95ba38c9f888e31bf3dbec71a56391b",
+            "size": 3762,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-lookupjoin_semi_1o2o--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-lookupjoin_semi_1o2o--Plan]": [
         {
-            "checksum": "b02ced194f7e29073c7d1f442a0d90cf",
-            "size": 7018,
-            "uri": "https://{canondata_backend}/1924537/fe0a72f2541bf1bde39817157dd06a460ad76d65/resource.tar.gz#test.test_join-lookupjoin_semi_1o2o--Plan_/plan.txt"
+            "checksum": "917187038300b96108959eb3fb0b8c5f",
+            "size": 6606,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-lookupjoin_semi_1o2o--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_left_null_column--Debug]": [
         {
-            "checksum": "7ea222e641c12ffa2f099c741d9ae94e",
-            "size": 5012,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-mapjoin_left_null_column--Debug_/opt.yql_patched"
+            "checksum": "e66952ff6fcff4e1b65cff9421e1fbc4",
+            "size": 4546,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mapjoin_left_null_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_left_null_column--Plan]": [
         {
-            "checksum": "c1a8f93d91a3cfc2644e14f57241150f",
-            "size": 9116,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mapjoin_left_null_column--Plan_/plan.txt"
+            "checksum": "73206552a305129b5bfb978328728416",
+            "size": 8498,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mapjoin_left_null_column--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_non_optional_left_only_single--Debug]": [
         {
-            "checksum": "4a757a7a367f0dc06514cd3a878893ec",
-            "size": 8011,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-mapjoin_on_complex_type_non_optional_left_only_single--Debug_/opt.yql_patched"
+            "checksum": "21a1c5e5eb32c4f8ad8227d25b55fa19",
+            "size": 7574,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mapjoin_on_complex_type_non_optional_left_only_single--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_non_optional_left_only_single--Plan]": [
         {
-            "checksum": "25d3748076e133727434631982d87a48",
-            "size": 10011,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mapjoin_on_complex_type_non_optional_left_only_single--Plan_/plan.txt"
+            "checksum": "5efb144065890d631c4ee7bf0e4a1f42",
+            "size": 9393,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mapjoin_on_complex_type_non_optional_left_only_single--Plan_/plan.txt"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_optional_left_semi_many--Debug]": [
         {
-            "checksum": "1feda533f6b1bdee66d048c1e50bb892",
-            "size": 9667,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_many--Debug_/opt.yql_patched"
+            "checksum": "ee045fb58e1851c20df9c0825c21487f",
+            "size": 9185,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_many--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_on_complex_type_optional_left_semi_many--Plan]": [
         {
-            "checksum": "25d3748076e133727434631982d87a48",
-            "size": 10011,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_many--Plan_/plan.txt"
+            "checksum": "5efb144065890d631c4ee7bf0e4a1f42",
+            "size": 9393,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mapjoin_on_complex_type_optional_left_semi_many--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_saves_output_sort--Debug]": [
         {
-            "checksum": "a67a1b27ade6b885fbd620277428037b",
-            "size": 18422,
-            "uri": "https://{canondata_backend}/1925821/1873361bb520be4a239fac9059d3043c1d7028a9/resource.tar.gz#test.test_join-mergejoin_saves_output_sort--Debug_/opt.yql_patched"
+            "checksum": "832a3bdfcc579e6509f78794316058ef",
+            "size": 17734,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_saves_output_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_saves_output_sort--Plan]": [
         {
-            "checksum": "5673ea6d9b5fe70caa276e2708f58aca",
-            "size": 45751,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mergejoin_saves_output_sort--Plan_/plan.txt"
+            "checksum": "ef3309bc8283b32ab9082d385a937a19",
+            "size": 44103,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_saves_output_sort--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_small_primary--Debug]": [
         {
-            "checksum": "46ccddb86c3afcba41ba098eb7e736d7",
-            "size": 4920,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-mergejoin_small_primary--Debug_/opt.yql_patched"
+            "checksum": "87fcd2f0aae343d6a432207e89a900be",
+            "size": 4736,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_small_primary--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_small_primary--Plan]": [
         {
-            "checksum": "e7feae111a6d6bef265980f108a98f26",
-            "size": 8534,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mergejoin_small_primary--Plan_/plan.txt"
+            "checksum": "314f66e024870be626f1d3827f6b864f",
+            "size": 8328,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_small_primary--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_with_different_key_names_norename--Debug]": [
         {
-            "checksum": "6b1de7e06acf317fa79e0bd9e7b73426",
-            "size": 11206,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_norename--Debug_/opt.yql_patched"
+            "checksum": "3df9321d43cf73ba275290d67086181a",
+            "size": 10469,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_norename--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_with_different_key_names_norename--Plan]": [
         {
-            "checksum": "2878d339241a715e6058425883749ea3",
-            "size": 21462,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_norename--Plan_/plan.txt"
+            "checksum": "cbe3d19010d1d82190fb1d2382216aa6",
+            "size": 20638,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_with_different_key_names_norename--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_with_reverse_key_order--Debug]": [
         {
-            "checksum": "25c9b847b874438d29ec319e8451d919",
-            "size": 5300,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-mergejoin_with_reverse_key_order--Debug_/opt.yql_patched"
+            "checksum": "609285853a684468893f5e200a2204bc",
+            "size": 5128,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_with_reverse_key_order--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_with_reverse_key_order--Plan]": [
         {
-            "checksum": "efb2a3e33afa3fe0b482b7f17917fde9",
-            "size": 8358,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mergejoin_with_reverse_key_order--Plan_/plan.txt"
+            "checksum": "d524517bd523b100a4f52f93659c0b40",
+            "size": 7946,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_with_reverse_key_order--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_with_table_range--Debug]": [
         {
-            "checksum": "3aad27465f021c158adbdb37cd232868",
-            "size": 4575,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-mergejoin_with_table_range--Debug_/opt.yql_patched"
+            "checksum": "ad4911889bb51d24fc9b39dd2120fc0f",
+            "size": 4425,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_with_table_range--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_with_table_range--Plan]": [
         {
-            "checksum": "291e70eadfe67e4aced2d60224dea850",
-            "size": 10297,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-mergejoin_with_table_range--Plan_/plan.txt"
+            "checksum": "dc6acafbd0c69db5f9c32398bd40e9bd",
+            "size": 10091,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-mergejoin_with_table_range--Plan_/plan.txt"
         }
     ],
     "test.test[join-opt_on_opt_side_with_group--Debug]": [
         {
-            "checksum": "f9a6ce43490fef92e0b934128b39184e",
-            "size": 7035,
-            "uri": "https://{canondata_backend}/1871002/fb3dce8e5e8c0a86fa3b3841c5b4dfd00310d4f2/resource.tar.gz#test.test_join-opt_on_opt_side_with_group--Debug_/opt.yql_patched"
+            "checksum": "cab6a32e3fcfba01f69280c0329c0c08",
+            "size": 6772,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-opt_on_opt_side_with_group--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-opt_on_opt_side_with_group--Plan]": [
         {
-            "checksum": "213bb816363603291e46c62f9162b9ff",
-            "size": 9751,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-opt_on_opt_side_with_group--Plan_/plan.txt"
+            "checksum": "4a5258b7210219550917d6d031bd767f",
+            "size": 9339,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-opt_on_opt_side_with_group--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_merge_extrasort1--Debug]": [
         {
-            "checksum": "d484f8019a8b7907653ba5027e69a526",
-            "size": 5798,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-premap_merge_extrasort1--Debug_/opt.yql_patched"
+            "checksum": "0bf8e9d7a38c5ee9ab06faadf85663ce",
+            "size": 5556,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-premap_merge_extrasort1--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_merge_extrasort1--Plan]": [
         {
-            "checksum": "54f464587f4a901b0221259535ff6f1c",
-            "size": 8326,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-premap_merge_extrasort1--Plan_/plan.txt"
+            "checksum": "5778acb16bcea48e00ebaa4cfd349e29",
+            "size": 7914,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-premap_merge_extrasort1--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_inner--Debug]": [
         {
-            "checksum": "9ed0d2f6b35554d243f1ca3b7dac8cd8",
-            "size": 5125,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-pullup_inner--Debug_/opt.yql_patched"
+            "checksum": "afb152d3b81626071aa2ced9fd641dd3",
+            "size": 4951,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-pullup_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_inner--Plan]": [
         {
-            "checksum": "988d794bda1a2643b81e371363cec386",
-            "size": 8042,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-pullup_inner--Plan_/plan.txt"
+            "checksum": "22a229f3c90f90e9f6972bc7235cdd36",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-pullup_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-pullup_rownumber--Debug]": [
         {
-            "checksum": "666b923ba6bf1313245616570260644c",
-            "size": 5349,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-pullup_rownumber--Debug_/opt.yql_patched"
+            "checksum": "07b7ec0c926dd0e20168b8d060ee3505",
+            "size": 5199,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-pullup_rownumber--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-pullup_rownumber--Plan]": [
         {
-            "checksum": "33e02347f1ceb3386cd1c0ab8e945dd1",
-            "size": 8040,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-pullup_rownumber--Plan_/plan.txt"
+            "checksum": "70051884e01cabf0b10c2a1b3be40e3a",
+            "size": 7834,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-pullup_rownumber--Plan_/plan.txt"
         }
     ],
     "test.test[join-selfjoin_on_sorted_with_rename--Debug]": [
@@ -1723,30 +1723,30 @@
     ],
     "test.test[join-yql-10654_pullup_with_sys_columns--Debug]": [
         {
-            "checksum": "d963e016cb115987b1999fffa495a572",
-            "size": 5202,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_join-yql-10654_pullup_with_sys_columns--Debug_/opt.yql_patched"
+            "checksum": "3cf5f287b54083108a9e2577e8823d95",
+            "size": 5073,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-yql-10654_pullup_with_sys_columns--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-10654_pullup_with_sys_columns--Plan]": [
         {
-            "checksum": "512bb8b45d91cbbba38d2474f14bebac",
-            "size": 8362,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-yql-10654_pullup_with_sys_columns--Plan_/plan.txt"
+            "checksum": "a6fbe1708fe6503a4405ea94b88962bc",
+            "size": 8156,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-yql-10654_pullup_with_sys_columns--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-8125--Debug]": [
         {
-            "checksum": "86f32713bb84e8268a3c3c5395bd95f2",
-            "size": 6070,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_join-yql-8125--Debug_/opt.yql_patched"
+            "checksum": "fd471e2dbaaa0e53272cc59db3fbc1c4",
+            "size": 5942,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-yql-8125--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-8125--Plan]": [
         {
-            "checksum": "e344d0add11dd8635089e7c0966d9af5",
-            "size": 16972,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_join-yql-8125--Plan_/plan.txt"
+            "checksum": "c1a4658fe623f0b62e4ac6d3f8a2feee",
+            "size": 16766,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_join-yql-8125--Plan_/plan.txt"
         }
     ],
     "test.test[json-jsondocument/json_query-default.txt-Debug]": [
@@ -1765,30 +1765,30 @@
     ],
     "test.test[key_filter-between_with_key_filter--Debug]": [
         {
-            "checksum": "46cff843473d35130b7985bb146fd6cc",
-            "size": 3466,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_key_filter-between_with_key_filter--Debug_/opt.yql_patched"
+            "checksum": "3bf6e7b643b42d98e462854d3b51b549",
+            "size": 3220,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_key_filter-between_with_key_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-between_with_key_filter--Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_key_filter-between_with_key_filter--Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_key_filter-between_with_key_filter--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-string_with-default.txt-Debug]": [
         {
-            "checksum": "efb0c83441a280aa3f0a86adbf31c02b",
-            "size": 2221,
-            "uri": "https://{canondata_backend}/1942671/b3497ea14384613aeaf6c621f5fd303cd0b02f64/resource.tar.gz#test.test_key_filter-string_with-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ec44556432dcc842ae13d98652ccf959",
+            "size": 2098,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_key_filter-string_with-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-string_with-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1599023/d6fdd0d80eb129a154a85d684a3390dda5b4e7c9/resource.tar.gz#test.test_key_filter-string_with-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_key_filter-string_with-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[library-library_alias--Debug]": [
@@ -1835,86 +1835,86 @@
     ],
     "test.test[optimizers-field_subset_for_multiusage--Debug]": [
         {
-            "checksum": "789240101ef9b016a46c1dba55234985",
-            "size": 9564,
-            "uri": "https://{canondata_backend}/1917492/cf57bdebe9d9af3fecbb7cd419893dd2ae22667e/resource.tar.gz#test.test_optimizers-field_subset_for_multiusage--Debug_/opt.yql_patched"
+            "checksum": "caca87febb99a7cf9cb88bded18a3474",
+            "size": 9060,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-field_subset_for_multiusage--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-field_subset_for_multiusage--Plan]": [
         {
-            "checksum": "22c018c705cac9d1c64660af699b42df",
-            "size": 15386,
-            "uri": "https://{canondata_backend}/1917492/cf57bdebe9d9af3fecbb7cd419893dd2ae22667e/resource.tar.gz#test.test_optimizers-field_subset_for_multiusage--Plan_/plan.txt"
+            "checksum": "aebbaab83111946aa4d7f13332de0b18",
+            "size": 14562,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-field_subset_for_multiusage--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-passthrough_sortness_over_map-default.txt-Debug]": [
         {
-            "checksum": "6a3d07c817ab46c25bca2b0e28529767",
-            "size": 5264,
-            "uri": "https://{canondata_backend}/1917492/cf57bdebe9d9af3fecbb7cd419893dd2ae22667e/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d5fb7c93e3e04fabf73cc28f53343848",
+            "size": 4984,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-passthrough_sortness_over_map-default.txt-Plan]": [
         {
-            "checksum": "d7153dd3a7b54084b364d0d16ced013b",
-            "size": 15643,
-            "uri": "https://{canondata_backend}/1814674/e782d6756fe1b6b774ca36906ce0a00bc367ef9d/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Plan_/plan.txt"
+            "checksum": "33bfe358352d0f1138128632ebebf9f3",
+            "size": 15025,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-passthrough_sortness_over_map-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-10042_disable_flow_fuse_depends_on-default.txt-Debug]": [
         {
-            "checksum": "1f71dcb5f2ba5afba75a6adf1e52a233",
-            "size": 3226,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_optimizers-yql-10042_disable_flow_fuse_depends_on-default.txt-Debug_/opt.yql_patched"
+            "checksum": "86179780b1e42b10b9bd46b7fc28b795",
+            "size": 3020,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-yql-10042_disable_flow_fuse_depends_on-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-10042_disable_flow_fuse_depends_on-default.txt-Plan]": [
         {
-            "checksum": "519ad2dd6c8463ffe2d6086c69e6586d",
-            "size": 6173,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_optimizers-yql-10042_disable_flow_fuse_depends_on-default.txt-Plan_/plan.txt"
+            "checksum": "9f0973bceca02c22dc615a44f8dfb017",
+            "size": 5761,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-yql-10042_disable_flow_fuse_depends_on-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-18408_filter_multiusage_pushdown-default.txt-Debug]": [
         {
-            "checksum": "413787bd2d3c990ac10835ff27261236",
-            "size": 21219,
-            "uri": "https://{canondata_backend}/1946324/f14625f6090841e4d498eb3efcc87665d3617c25/resource.tar.gz#test.test_optimizers-yql-18408_filter_multiusage_pushdown-default.txt-Debug_/opt.yql_patched"
+            "checksum": "16be350a855c85158f2740b4141d3fb5",
+            "size": 20515,
+            "uri": "https://{canondata_backend}/995452/8909773aae9fc7452e1a7aea8b03d2f2c17164f5/resource.tar.gz#test.test_optimizers-yql-18408_filter_multiusage_pushdown-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-18408_filter_multiusage_pushdown-default.txt-Plan]": [
         {
-            "checksum": "85deff5f593489d59001e1d308d3c607",
-            "size": 36117,
-            "uri": "https://{canondata_backend}/1937424/686478058d4a01eccc043c84a5d7653887ac4a2b/resource.tar.gz#test.test_optimizers-yql-18408_filter_multiusage_pushdown-default.txt-Plan_/plan.txt"
+            "checksum": "42b9ef6c0a2963ebeecb6e48495c60eb",
+            "size": 35293,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-yql-18408_filter_multiusage_pushdown-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-5833-table_content--Debug]": [
         {
-            "checksum": "200043c6d598ee9ed8829299b2bee9b6",
-            "size": 3617,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_optimizers-yql-5833-table_content--Debug_/opt.yql_patched"
+            "checksum": "07d0b96811207ba380f5d75e6448f7ee",
+            "size": 3550,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-yql-5833-table_content--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-5833-table_content--Plan]": [
         {
-            "checksum": "177dcf4c913c6f5756836f92a139ac9d",
-            "size": 7350,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_optimizers-yql-5833-table_content--Plan_/plan.txt"
+            "checksum": "79e9a44c3d287fc175f609f69180349f",
+            "size": 7144,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-yql-5833-table_content--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-8223_direct_row_and_skipnullmembers--Debug]": [
         {
-            "checksum": "6ad231050b3893e76c77629ad7926fd1",
-            "size": 7751,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_optimizers-yql-8223_direct_row_and_skipnullmembers--Debug_/opt.yql_patched"
+            "checksum": "44a355857297d6f5d7a0fbb0fe1643d3",
+            "size": 7584,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-yql-8223_direct_row_and_skipnullmembers--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-8223_direct_row_and_skipnullmembers--Plan]": [
         {
-            "checksum": "81e91af5279d80fe8a493df473f2ee4b",
-            "size": 10924,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_optimizers-yql-8223_direct_row_and_skipnullmembers--Plan_/plan.txt"
+            "checksum": "91f1d25f2aa502ab7d25af1303d7684d",
+            "size": 10512,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_optimizers-yql-8223_direct_row_and_skipnullmembers--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yson_dup_serialize--Debug]": [
@@ -1933,30 +1933,30 @@
     ],
     "test.test[order_by-order_by_tuple_and_member-default.txt-Debug]": [
         {
-            "checksum": "8262eda491a43f7011ae6624136bab5e",
-            "size": 2848,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_order_by-order_by_tuple_and_member-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b19544c78d7a7310d380674228650f34",
+            "size": 2720,
+            "uri": "https://{canondata_backend}/1784826/6fb10875fc2d13209580debefd9e32c0586b2ae6/resource.tar.gz#test.test_order_by-order_by_tuple_and_member-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_tuple_and_member-default.txt-Plan]": [
         {
-            "checksum": "b740c0dff136ac74f26874552a13e039",
-            "size": 5150,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_order_by-order_by_tuple_and_member-default.txt-Plan_/plan.txt"
+            "checksum": "70a49bd65ea8bc6eda627ee61e000b52",
+            "size": 4944,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_order_by-order_by_tuple_and_member-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_with_null-default.txt-Debug]": [
         {
-            "checksum": "6447d858ac65cad73d9b33579920917c",
-            "size": 5501,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_order_by-order_with_null-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b7dba1ab23b95aa545dc8ba4c6b40f01",
+            "size": 5044,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_order_by-order_with_null-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_with_null-default.txt-Plan]": [
         {
-            "checksum": "01e1beae7b7bac33519841ee93e0e434",
-            "size": 11288,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_order_by-order_with_null-default.txt-Plan_/plan.txt"
+            "checksum": "7c4ee257c93bfefa0f2c60a7fe9f6784",
+            "size": 10464,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_order_by-order_with_null-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-union_all--Debug]": [
@@ -2227,16 +2227,16 @@
     ],
     "test.test[pg-select_table1-default.txt-Debug]": [
         {
-            "checksum": "b3c05b286f7f31afd37ee741b858c083",
-            "size": 1868,
-            "uri": "https://{canondata_backend}/1031349/ff2d90d606cdc417d573d7d2f32329f10cf0be11/resource.tar.gz#test.test_pg-select_table1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "dba468b8e02cdbea6ac761804a61338a",
+            "size": 1802,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_pg-select_table1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-select_table1-default.txt-Plan]": [
         {
-            "checksum": "e8af437f4846ae94483622ca284f50c8",
-            "size": 3509,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_pg-select_table1-default.txt-Plan_/plan.txt"
+            "checksum": "61981f1d5df4d0c4ed03339ebc3134b3",
+            "size": 3303,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_pg-select_table1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-select_win_column_partition_by-default.txt-Debug]": [
@@ -2521,16 +2521,16 @@
     ],
     "test.test[pg_catalog-lambda--Debug]": [
         {
-            "checksum": "ce984b40c8d827d2729c3b9655600d55",
-            "size": 2916,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_pg_catalog-lambda--Debug_/opt.yql_patched"
+            "checksum": "0cde5e77392a11af9fab57cd13d4532b",
+            "size": 2786,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_pg_catalog-lambda--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg_catalog-lambda--Plan]": [
         {
-            "checksum": "a1de2da7b1c1083350fc36fdda0f09c5",
-            "size": 5533,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_pg_catalog-lambda--Plan_/plan.txt"
+            "checksum": "38635d00ec4d76be3e6439cbd24f686a",
+            "size": 5327,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_pg_catalog-lambda--Plan_/plan.txt"
         }
     ],
     "test.test[pg_catalog-pg_class-default.txt-Debug]": [
@@ -2591,16 +2591,16 @@
     ],
     "test.test[produce-fuse_reduces_with_presort--Debug]": [
         {
-            "checksum": "a0be01e2962b39871f4097f1d598a1ca",
-            "size": 7199,
-            "uri": "https://{canondata_backend}/1942525/70eec467682e96dfaac0f3c809005b8a22cce54f/resource.tar.gz#test.test_produce-fuse_reduces_with_presort--Debug_/opt.yql_patched"
+            "checksum": "d10bf8b76447af1746993211f3eb4a38",
+            "size": 6967,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_produce-fuse_reduces_with_presort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-fuse_reduces_with_presort--Plan]": [
         {
-            "checksum": "b7d4ddc5c9f07fedb74a72b0789bd050",
-            "size": 7633,
-            "uri": "https://{canondata_backend}/1942525/70eec467682e96dfaac0f3c809005b8a22cce54f/resource.tar.gz#test.test_produce-fuse_reduces_with_presort--Plan_/plan.txt"
+            "checksum": "fd7cae467cc256021bf03209d18ac129",
+            "size": 7015,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_produce-fuse_reduces_with_presort--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_lambda_list_mem-default.txt-Debug]": [
@@ -2619,16 +2619,16 @@
     ],
     "test.test[produce-reduce_multi_in_difftype--Debug]": [
         {
-            "checksum": "7b0990899b58cf455c5b4a49367f5bda",
-            "size": 4107,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_produce-reduce_multi_in_difftype--Debug_/opt.yql_patched"
+            "checksum": "451f8b4157b12a02dc8b9c7d83d17b2f",
+            "size": 3963,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_produce-reduce_multi_in_difftype--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype--Plan]": [
         {
-            "checksum": "2174bad6e946f621c2a3ec5de8409f45",
-            "size": 9249,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_produce-reduce_multi_in_difftype--Plan_/plan.txt"
+            "checksum": "9e5816bf97f2e974c2a19fd92302d35e",
+            "size": 9043,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_produce-reduce_multi_in_difftype--Plan_/plan.txt"
         }
     ],
     "test.test[produce-reduce_multi_in_difftype_assume_keytuple--Debug]": [
@@ -2647,86 +2647,86 @@
     ],
     "test.test[produce-reduce_multi_in_ref--Debug]": [
         {
-            "checksum": "ab84f801b257f54c7b11fee62ea3d260",
-            "size": 4987,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_produce-reduce_multi_in_ref--Debug_/opt.yql_patched"
+            "checksum": "06e62e14fc668c1f75bc8657640388d9",
+            "size": 4875,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_produce-reduce_multi_in_ref--Debug_/opt.yql_patched"
         }
     ],
     "test.test[produce-reduce_multi_in_ref--Plan]": [
         {
-            "checksum": "f27317d46992ea657c57fe83cedc65a8",
-            "size": 9808,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_produce-reduce_multi_in_ref--Plan_/plan.txt"
+            "checksum": "36cb801bef7c048a5f0683730f848311",
+            "size": 9602,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_produce-reduce_multi_in_ref--Plan_/plan.txt"
         }
     ],
     "test.test[sampling-bind_expr_subquery-default.txt-Debug]": [
         {
-            "checksum": "37a4382f66894d3f88d5185c1837d3e6",
-            "size": 2715,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_sampling-bind_expr_subquery-default.txt-Debug_/opt.yql_patched"
+            "checksum": "30c878b7596d82d63fcd13aa5b99f495",
+            "size": 2469,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_sampling-bind_expr_subquery-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-bind_expr_subquery-default.txt-Plan]": [
         {
-            "checksum": "db6039bdce5c6b215f17bdd9f92c85dd",
-            "size": 5630,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_sampling-bind_expr_subquery-default.txt-Plan_/plan.txt"
+            "checksum": "b3c08e41d7c4e952f476ef8e9f7afc47",
+            "size": 5218,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_sampling-bind_expr_subquery-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-insert--Debug]": [
         {
-            "checksum": "b3015c0dae4b7cf56d4d3fd6c7337385",
-            "size": 2403,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_sampling-insert--Debug_/opt.yql_patched"
+            "checksum": "057c3d51da5215e2e89608337c7458dd",
+            "size": 2280,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_sampling-insert--Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-insert--Plan]": [
         {
-            "checksum": "d57fd94794ffd84e9669943bbe67a8a8",
-            "size": 6454,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_sampling-insert--Plan_/plan.txt"
+            "checksum": "da89e568ee66065f691f4ed0a16382b2",
+            "size": 6248,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_sampling-insert--Plan_/plan.txt"
         }
     ],
     "test.test[schema-def_values--Debug]": [
         {
-            "checksum": "0b929a5c4031cfc8d55be6a21085ced3",
-            "size": 1924,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_schema-def_values--Debug_/opt.yql_patched"
+            "checksum": "ec853ee315e7f3fb3263738c67069d3d",
+            "size": 1801,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-def_values--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-def_values--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_schema-def_values--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-def_values--Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert-row_spec-Debug]": [
         {
-            "checksum": "61994ec249f1de092c92f62eba8641bb",
-            "size": 2717,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_schema-insert-row_spec-Debug_/opt.yql_patched"
+            "checksum": "7910e0504bd81d70446b02cd6fc31aef",
+            "size": 2551,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-insert-row_spec-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert-row_spec-Plan]": [
         {
-            "checksum": "4679ad300705e8756401b84e82e41708",
-            "size": 7195,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_schema-insert-row_spec-Plan_/plan.txt"
+            "checksum": "1863ed9cf7592491284072211b0f5960",
+            "size": 6989,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-insert-row_spec-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert_sorted-schema-Debug]": [
         {
-            "checksum": "e86f130206e983c4589a2290fa2d6c71",
-            "size": 3495,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_schema-insert_sorted-schema-Debug_/opt.yql_patched"
+            "checksum": "c67265ca0eb4943f387283ba4bbff3c6",
+            "size": 3329,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-insert_sorted-schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert_sorted-schema-Plan]": [
         {
-            "checksum": "36a657eee9ded15c5098aa8917a739d1",
-            "size": 6691,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_schema-insert_sorted-schema-Plan_/plan.txt"
+            "checksum": "d0450f877aa43e90188f113b7b2b2aff",
+            "size": 6485,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-insert_sorted-schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_all-row_spec_diff_sort-Debug]": [
@@ -2759,30 +2759,30 @@
     ],
     "test.test[schema-select_all_inferschema2--Debug]": [
         {
-            "checksum": "7f4e85e92032601dd36b3601c4950e62",
-            "size": 4404,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_schema-select_all_inferschema2--Debug_/opt.yql_patched"
+            "checksum": "0060cf66a57c4706cc9e6d24966991e0",
+            "size": 4044,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-select_all_inferschema2--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_all_inferschema2--Plan]": [
         {
-            "checksum": "55a7fedc6bae9d041730454cb3a07c82",
-            "size": 6349,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_schema-select_all_inferschema2--Plan_/plan.txt"
+            "checksum": "f3d32bae54b87b500418bb968812728f",
+            "size": 5937,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-select_all_inferschema2--Plan_/plan.txt"
         }
     ],
     "test.test[schema-select_all_inferschema_op--Debug]": [
         {
-            "checksum": "9d91d90b2dbe2e983e16ea2e9b83f0fb",
-            "size": 2710,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_schema-select_all_inferschema_op--Debug_/opt.yql_patched"
+            "checksum": "a86f2da31e581145e187e1bfb87e4966",
+            "size": 2521,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-select_all_inferschema_op--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-select_all_inferschema_op--Plan]": [
         {
-            "checksum": "e1a03243208aa0354b0378cc0b80953d",
-            "size": 3604,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_schema-select_all_inferschema_op--Plan_/plan.txt"
+            "checksum": "eb9d6acb37ccc9f55225a9228285eb9d",
+            "size": 3398,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_schema-select_all_inferschema_op--Plan_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_empty_table_ranges-default.txt-Debug]": [
@@ -2801,16 +2801,16 @@
     ],
     "test.test[select-corr_name_in_select_seq-default.txt-Debug]": [
         {
-            "checksum": "d607002fa602e8ca44eb6eeb0a66f390",
-            "size": 1909,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_select-corr_name_in_select_seq-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b4bbe998dfe956e5176c31fdcbdf52e8",
+            "size": 1847,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-corr_name_in_select_seq-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-corr_name_in_select_seq-default.txt-Plan]": [
         {
-            "checksum": "284bf9266edff51fe82cbeb5be038a08",
-            "size": 3537,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_select-corr_name_in_select_seq-default.txt-Plan_/plan.txt"
+            "checksum": "ba5b09a1389f79cc68674182c1065b9d",
+            "size": 3331,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-corr_name_in_select_seq-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-id_xor-default.txt-Debug]": [
@@ -2829,30 +2829,30 @@
     ],
     "test.test[select-opt_list_access-default.txt-Debug]": [
         {
-            "checksum": "45cd6149f461359813f04c56ac07f12a",
-            "size": 5155,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_select-opt_list_access-default.txt-Debug_/opt.yql_patched"
+            "checksum": "143bc89d727d4a5565c1eb842971e3a9",
+            "size": 4854,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-opt_list_access-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-opt_list_access-default.txt-Plan]": [
         {
-            "checksum": "d4769ae4f3cfb82b0c72e9f4d4ce9d1e",
-            "size": 8555,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_select-opt_list_access-default.txt-Plan_/plan.txt"
+            "checksum": "99e4fc542abc5a5645904b5dcb57362c",
+            "size": 7937,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-opt_list_access-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-scalar_subquery_with_star-default.txt-Debug]": [
         {
-            "checksum": "4ad59b0d5933ed27ced891bba7a63907",
-            "size": 2179,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_select-scalar_subquery_with_star-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e88cff7d36c84408e293a02800d40e64",
+            "size": 2117,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-scalar_subquery_with_star-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-scalar_subquery_with_star-default.txt-Plan]": [
         {
-            "checksum": "e90cda08df248af1b2b3ddb370f1edf3",
-            "size": 4369,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_select-scalar_subquery_with_star-default.txt-Plan_/plan.txt"
+            "checksum": "f36d8d0c99c2b5371a102eb287263d78",
+            "size": 4163,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-scalar_subquery_with_star-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-select_all_from_concat-default.txt-Debug]": [
@@ -2871,16 +2871,16 @@
     ],
     "test.test[select-sum_to_string-default.txt-Debug]": [
         {
-            "checksum": "3eaa0fc90bb5f95c470e72d1b209be43",
-            "size": 1993,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_select-sum_to_string-default.txt-Debug_/opt.yql_patched"
+            "checksum": "eff8547c0dd77f8fa6d40384b4c35c14",
+            "size": 1870,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-sum_to_string-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-sum_to_string-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_select-sum_to_string-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-sum_to_string-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-table_content_with_tmp_folder--Debug]": [
@@ -2899,16 +2899,16 @@
     ],
     "test.test[select-to_dict-default.txt-Debug]": [
         {
-            "checksum": "aa0f446584121648a36c9c5136e104b0",
-            "size": 5503,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_select-to_dict-default.txt-Debug_/opt.yql_patched"
+            "checksum": "57caf29a37d749aa40285c804ab31e28",
+            "size": 5148,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-to_dict-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-to_dict-default.txt-Plan]": [
         {
-            "checksum": "557bc89a85905abb0ed11c3a582e7ca7",
-            "size": 8682,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_select-to_dict-default.txt-Plan_/plan.txt"
+            "checksum": "54088b3737324fad73e00ec915cb733d",
+            "size": 8064,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-to_dict-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-two_select_without_semi-default.txt-Debug]": [
@@ -2927,16 +2927,16 @@
     ],
     "test.test[select-uncorrelated_subqueries--Debug]": [
         {
-            "checksum": "4dab8880954806a7a775332ee6573195",
-            "size": 2666,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_select-uncorrelated_subqueries--Debug_/opt.yql_patched"
+            "checksum": "092166448a7f317f8108aefd7386f44c",
+            "size": 2601,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-uncorrelated_subqueries--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-uncorrelated_subqueries--Plan]": [
         {
-            "checksum": "32e22019712cdfde4f59f220efa7320b",
-            "size": 6194,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_select-uncorrelated_subqueries--Plan_/plan.txt"
+            "checksum": "b2ce1a6d1c422c439e8e7b9dbcbb7c6d",
+            "size": 5988,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_select-uncorrelated_subqueries--Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_coalesce_all_1-default.txt-Debug]": [
@@ -2955,114 +2955,114 @@
     ],
     "test.test[simple_columns-simple_columns_subreq_all-default.txt-Debug]": [
         {
-            "checksum": "d968ba4a0922b616ed6f159470deb54e",
-            "size": 3535,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_simple_columns-simple_columns_subreq_all-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d2477810b945cc5ff5b8eaeaedf4b250",
+            "size": 3167,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_simple_columns-simple_columns_subreq_all-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_subreq_all-default.txt-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_simple_columns-simple_columns_subreq_all-default.txt-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_simple_columns-simple_columns_subreq_all-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[table_range-concat_sorted_with_key_diff--Debug]": [
         {
-            "checksum": "5aa5103c47131666adc9f1218f955017",
-            "size": 3424,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_table_range-concat_sorted_with_key_diff--Debug_/opt.yql_patched"
+            "checksum": "2ec7cdaf17ae6eadc96698dbf08f71fd",
+            "size": 3178,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_table_range-concat_sorted_with_key_diff--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-concat_sorted_with_key_diff--Plan]": [
         {
-            "checksum": "5a115f0397c258cd45cc621afb633fbd",
-            "size": 6321,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_table_range-concat_sorted_with_key_diff--Plan_/plan.txt"
+            "checksum": "a18a31f927149709257b898f4006d841",
+            "size": 5909,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_table_range-concat_sorted_with_key_diff--Plan_/plan.txt"
         }
     ],
     "test.test[table_range-merge_non_strict--Debug]": [
         {
-            "checksum": "d84b332dc70dcde1715e3314c447fa05",
-            "size": 4061,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_table_range-merge_non_strict--Debug_/opt.yql_patched"
+            "checksum": "04c89ff3eec559f809307d4dfb7976fb",
+            "size": 3831,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_table_range-merge_non_strict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[table_range-merge_non_strict--Plan]": [
         {
-            "checksum": "74666c884dd5b5b512019e5adb935f73",
-            "size": 8920,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_table_range-merge_non_strict--Plan_/plan.txt"
+            "checksum": "d040330b0705ca80a0951290a79c6408",
+            "size": 8302,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_table_range-merge_non_strict--Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q17-default.txt-Debug]": [
         {
-            "checksum": "2dddf6574a361bdd32b0e50a9e42eb87",
-            "size": 9341,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_tpch-q17-default.txt-Debug_/opt.yql_patched"
+            "checksum": "6b2f5332d2b39738051e8aab7f7e782c",
+            "size": 8981,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_tpch-q17-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q17-default.txt-Plan]": [
         {
-            "checksum": "936cb78c906cc19489c573111585dbef",
-            "size": 14540,
-            "uri": "https://{canondata_backend}/1923547/178b28d4cf8aabc0acf6bb847c3d033553df586d/resource.tar.gz#test.test_tpch-q17-default.txt-Plan_/plan.txt"
+            "checksum": "462ab794dc9d3f9c4ebe02580a83caff",
+            "size": 13716,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_tpch-q17-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q18-default.txt-Debug]": [
         {
-            "checksum": "2755e861315d7d47877ddf57a2365722",
-            "size": 15081,
-            "uri": "https://{canondata_backend}/1889210/b9b872fe4d03bb7fa4931466c03b2a952c6f7cbd/resource.tar.gz#test.test_tpch-q18-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5e9607a38c37d6ef12a35a219970ee61",
+            "size": 14348,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_tpch-q18-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q18-default.txt-Plan]": [
         {
-            "checksum": "b464537983b7fb4e9dfb29d788e5aa98",
-            "size": 23805,
-            "uri": "https://{canondata_backend}/1936997/3218b0f1e759620616205574c881865fc0a860b7/resource.tar.gz#test.test_tpch-q18-default.txt-Plan_/plan.txt"
+            "checksum": "c807025bcd8745aaa3a51e38b8c1607d",
+            "size": 22981,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_tpch-q18-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-float--Debug]": [
         {
-            "checksum": "81368fd17c52cde65f31e053a6ed08b2",
-            "size": 2565,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_type_v3-float--Debug_/opt.yql_patched"
+            "checksum": "0e4ee83f6e936ba88537fc4b3d2d9433",
+            "size": 2461,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_type_v3-float--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-float--Plan]": [
         {
-            "checksum": "6677253cbf014e7ab2d9d43ddfe2ad6b",
-            "size": 7310,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_type_v3-float--Plan_/plan.txt"
+            "checksum": "5849d11cfb869b261db97a9787aeb3b4",
+            "size": 6898,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_type_v3-float--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-ignore_v3_hint-opt-Debug]": [
         {
-            "checksum": "b355478e362352e540ee7844e6b46699",
-            "size": 3170,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_type_v3-ignore_v3_hint-opt-Debug_/opt.yql_patched"
+            "checksum": "2d9cde10e03af828dfddd75c0e8d507f",
+            "size": 3074,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_type_v3-ignore_v3_hint-opt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-ignore_v3_hint-opt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_type_v3-ignore_v3_hint-opt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_type_v3-ignore_v3_hint-opt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-ignore_v3_pragma--Debug]": [
         {
-            "checksum": "6d13924d3c475cdbc97c94a52166d195",
-            "size": 3217,
-            "uri": "https://{canondata_backend}/1937150/a3ed05ae8ad4fea60a051f6171424c733487f045/resource.tar.gz#test.test_type_v3-ignore_v3_pragma--Debug_/opt.yql_patched"
+            "checksum": "53c096c0121f27ad05b262178789845a",
+            "size": 3121,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_type_v3-ignore_v3_pragma--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-ignore_v3_pragma--Plan]": [
         {
-            "checksum": "39f614d73085188132bd48c388f07c35",
-            "size": 4081,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_type_v3-ignore_v3_pragma--Plan_/plan.txt"
+            "checksum": "11ea9cea4c9b0feb6d21fa78e1a83881",
+            "size": 3875,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_type_v3-ignore_v3_pragma--Plan_/plan.txt"
         }
     ],
     "test.test[union_all-union_all_with_discard_into_result_ansi-default.txt-Debug]": [
@@ -3123,16 +3123,16 @@
     ],
     "test.test[window-generic/aggregations_mixed_leadlag--Debug]": [
         {
-            "checksum": "22441eaf171f80489acd5d268e06ea6e",
-            "size": 7800,
-            "uri": "https://{canondata_backend}/1889210/a6f1d19efb8c2d66757fb3f23bc191e0ff7fca4e/resource.tar.gz#test.test_window-generic_aggregations_mixed_leadlag--Debug_/opt.yql_patched"
+            "checksum": "452d10858874eac2156d32ff8f27cd7f",
+            "size": 7301,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_window-generic_aggregations_mixed_leadlag--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_mixed_leadlag--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1900335/dd59ce09b5b70054bb239659c9dedc5218a4d0cd/resource.tar.gz#test.test_window-generic_aggregations_mixed_leadlag--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1937001/cf2822c292da12910b7e5a0fd062f9cafa22374e/resource.tar.gz#test.test_window-generic_aggregations_mixed_leadlag--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_auto_arg_selective_rank-default.txt-Debug]": [

--- a/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part9/canondata/result.json
@@ -57,16 +57,16 @@
     ],
     "test.test[action-evaluate_match_type-default.txt-Debug]": [
         {
-            "checksum": "ba25f85f517f48c471cf653b9a8a9b45",
-            "size": 1927,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_action-evaluate_match_type-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d18fff04860aa74f049cfbd26910d68b",
+            "size": 1861,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_action-evaluate_match_type-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-evaluate_match_type-default.txt-Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_action-evaluate_match_type-default.txt-Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_action-evaluate_match_type-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[action-evaluate_queries--Debug]": [
@@ -85,16 +85,16 @@
     ],
     "test.test[action-export_action--Debug]": [
         {
-            "checksum": "1fee3099ac8a2b5f52f8863ef349d31a",
-            "size": 4727,
-            "uri": "https://{canondata_backend}/1937429/e11799bc6b03b95f687825951895ae651115cd1d/resource.tar.gz#test.test_action-export_action--Debug_/opt.yql_patched"
+            "checksum": "19e31fe69e4dfa24839093e5efee7e19",
+            "size": 4428,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_action-export_action--Debug_/opt.yql_patched"
         }
     ],
     "test.test[action-export_action--Plan]": [
         {
-            "checksum": "fcb3fac66758bdf710add4888459ac6b",
-            "size": 8425,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_action-export_action--Plan_/plan.txt"
+            "checksum": "f1f5f9687ade29f7d83e3e95a7f11fd8",
+            "size": 7807,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_action-export_action--Plan_/plan.txt"
         }
     ],
     "test.test[action-runtime_for_select-default.txt-Debug]": [
@@ -225,30 +225,30 @@
     ],
     "test.test[aggr_factory-list--Debug]": [
         {
-            "checksum": "c9a04b2ec09ae5adf6085f4f103081aa",
-            "size": 7908,
-            "uri": "https://{canondata_backend}/1936947/3ba513bb137f3de526f55306a2bbecb9e5ed975d/resource.tar.gz#test.test_aggr_factory-list--Debug_/opt.yql_patched"
+            "checksum": "ba952a76c21213f8771ad9c3375c4a45",
+            "size": 7809,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggr_factory-list--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-list--Plan]": [
         {
-            "checksum": "d879d3b8a1ff3e323428ea3c933de406",
-            "size": 13735,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggr_factory-list--Plan_/plan.txt"
+            "checksum": "47fa3f0bf52d23bc83926ebbf299bc5c",
+            "size": 13323,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggr_factory-list--Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-log_histogram-default.txt-Debug]": [
         {
-            "checksum": "d62e8b412b8b1bdb05df52afd27dee42",
-            "size": 7135,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_aggr_factory-log_histogram-default.txt-Debug_/opt.yql_patched"
+            "checksum": "b73a21bc17a710312015a0931daf550a",
+            "size": 7003,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggr_factory-log_histogram-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-log_histogram-default.txt-Plan]": [
         {
-            "checksum": "e80459c6ded6bc35cd5f0fe2d0ec909c",
-            "size": 9892,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggr_factory-log_histogram-default.txt-Plan_/plan.txt"
+            "checksum": "d6fe32af474c6dd359f446ef8afd7ccb",
+            "size": 9480,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggr_factory-log_histogram-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggr_factory-multi_tuple-default.txt-Debug]": [
@@ -267,44 +267,44 @@
     ],
     "test.test[aggr_factory-udaf_distinct_expr-default.txt-Debug]": [
         {
-            "checksum": "ab896cc95679f25bf7b8f2379bdb3302",
-            "size": 6544,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_aggr_factory-udaf_distinct_expr-default.txt-Debug_/opt.yql_patched"
+            "checksum": "0d12560ba59051f65509992693f353f8",
+            "size": 6330,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggr_factory-udaf_distinct_expr-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggr_factory-udaf_distinct_expr-default.txt-Plan]": [
         {
-            "checksum": "cb61186c10d53efedbaaf7e9fac4202d",
-            "size": 11268,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggr_factory-udaf_distinct_expr-default.txt-Plan_/plan.txt"
+            "checksum": "088afb8c8d67c0e0cd08cb87cc8e208f",
+            "size": 10650,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggr_factory-udaf_distinct_expr-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-agg_phases_table1-default.txt-Debug]": [
         {
-            "checksum": "9c13b97a6c046b4a600d2a2bf86a6fa1",
-            "size": 4822,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-agg_phases_table1-default.txt-Debug_/opt.yql_patched"
+            "checksum": "36bfd34c70230a9b801b42563d704b5f",
+            "size": 4515,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-agg_phases_table1-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-agg_phases_table1-default.txt-Plan]": [
         {
-            "checksum": "20c3a8d7228fe03b6d7b9a9c22bd0e58",
-            "size": 8425,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-agg_phases_table1-default.txt-Plan_/plan.txt"
+            "checksum": "422706988f68caa3c767edd60e6255dc",
+            "size": 7807,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-agg_phases_table1-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_distinct_struct_access-default.txt-Debug]": [
         {
-            "checksum": "a7dc8d4eb9e9c4c0018f21e8db73382d",
-            "size": 3508,
-            "uri": "https://{canondata_backend}/1130705/baee881685694e8d43d91a0828f233abde3c3d2e/resource.tar.gz#test.test_aggregate-aggregate_distinct_struct_access-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bcf328f36e86c06c8222140f156b017f",
+            "size": 3422,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-aggregate_distinct_struct_access-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_distinct_struct_access-default.txt-Plan]": [
         {
-            "checksum": "ed669538901101ea150978c909e0bcf9",
-            "size": 6234,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-aggregate_distinct_struct_access-default.txt-Plan_/plan.txt"
+            "checksum": "aa7ddc7569dd121e02027254ada98878",
+            "size": 5822,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-aggregate_distinct_struct_access-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggregate_inmem_list_in_key-default.txt-Debug]": [
@@ -323,58 +323,58 @@
     ],
     "test.test[aggregate-aggregate_key_column-default.txt-Debug]": [
         {
-            "checksum": "f5f9e839378fe79bef01a1a415edb9e1",
-            "size": 4295,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-aggregate_key_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ac7edb5fe8a9d4e87c2fef661357c970",
+            "size": 4058,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-aggregate_key_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggregate_key_column-default.txt-Plan]": [
         {
-            "checksum": "fcb3fac66758bdf710add4888459ac6b",
-            "size": 8425,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-aggregate_key_column-default.txt-Plan_/plan.txt"
+            "checksum": "f1f5f9687ade29f7d83e3e95a7f11fd8",
+            "size": 7807,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-aggregate_key_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-aggrs_no_grouping_via_map-default.txt-Debug]": [
         {
-            "checksum": "126c514da29b9e8e40e1baf313d8b43e",
-            "size": 28516,
-            "uri": "https://{canondata_backend}/1937429/e11799bc6b03b95f687825951895ae651115cd1d/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map-default.txt-Debug_/opt.yql_patched"
+            "checksum": "11626e601311ae6782931a35cfbc6040",
+            "size": 26613,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-aggrs_no_grouping_via_map-default.txt-Plan]": [
         {
-            "checksum": "eefdbea85478f76e97ca6b734238e8d9",
-            "size": 6382,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map-default.txt-Plan_/plan.txt"
+            "checksum": "6fb9d159261e4416169d42ac00976028",
+            "size": 5970,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-aggrs_no_grouping_via_map-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-compare_by--Debug]": [
         {
-            "checksum": "d498574dcdebbcb08e9ff0a7ff593443",
-            "size": 8115,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_aggregate-compare_by--Debug_/opt.yql_patched"
+            "checksum": "5e02021e35541df95ecf7a336cced9cd",
+            "size": 7928,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-compare_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-compare_by--Plan]": [
         {
-            "checksum": "fcb6525099e5b56c8b9d4e737b64e8e3",
-            "size": 5618,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-compare_by--Plan_/plan.txt"
+            "checksum": "3e9bfb228114b36c49d75d5db1bf3bf9",
+            "size": 5412,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-compare_by--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-compare_tuple--Debug]": [
         {
-            "checksum": "55a72670ddb57b0019a909023615b283",
-            "size": 6122,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-compare_tuple--Debug_/opt.yql_patched"
+            "checksum": "ab1da54a54175be204380448952d2420",
+            "size": 5746,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-compare_tuple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-compare_tuple--Plan]": [
         {
-            "checksum": "df39d69d33f20580187528cd1c945725",
-            "size": 8584,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-compare_tuple--Plan_/plan.txt"
+            "checksum": "32e816388db081ec42e7f951c42b4c18",
+            "size": 7966,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-compare_tuple--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-ensure_count-default.txt-Debug]": [
@@ -393,128 +393,128 @@
     ],
     "test.test[aggregate-group_by_column-default.txt-Debug]": [
         {
-            "checksum": "57da909e16c90e7e11e192a740259732",
-            "size": 4720,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-group_by_column-default.txt-Debug_/opt.yql_patched"
+            "checksum": "afa21e9ca7c4f8cf7b924c00f6115af4",
+            "size": 4425,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_column-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_column-default.txt-Plan]": [
         {
-            "checksum": "5b34466f9dea236e8ef55862f24fbbe9",
-            "size": 8525,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-group_by_column-default.txt-Plan_/plan.txt"
+            "checksum": "56e5fa0b7e6c6bee32c075c3d9156004",
+            "size": 7907,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_column-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_flatten-default.txt-Debug]": [
         {
-            "checksum": "cdceae3e11f6932c3979ea44e51626cf",
-            "size": 7087,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-group_by_gs_flatten-default.txt-Debug_/opt.yql_patched"
+            "checksum": "95c79d0d39b03036e315f2d0553298ae",
+            "size": 6690,
+            "uri": "https://{canondata_backend}/1916746/d3717a9cac09b32a4d5ddfdae32677177e3620f2/resource.tar.gz#test.test_aggregate-group_by_gs_flatten-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_flatten-default.txt-Plan]": [
         {
-            "checksum": "04760a14c021e2d326ac5bb6860b30ae",
-            "size": 11170,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-group_by_gs_flatten-default.txt-Plan_/plan.txt"
+            "checksum": "5b896fa1c3d86875af19754f7246e2b1",
+            "size": 10552,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_gs_flatten-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_join_aliases-default.txt-Debug]": [
         {
-            "checksum": "19c1221056c7b054fae79eae0d19123f",
-            "size": 11036,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_aggregate-group_by_gs_join_aliases-default.txt-Debug_/opt.yql_patched"
+            "checksum": "2d3778269ac874ab0fb47403321bbe2f",
+            "size": 10480,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_gs_join_aliases-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_join_aliases-default.txt-Plan]": [
         {
-            "checksum": "d814bfbb41946cb4894c0bf3e4be3f00",
-            "size": 16559,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_aggregate-group_by_gs_join_aliases-default.txt-Plan_/plan.txt"
+            "checksum": "9d6a48c52b9e1358ae85690bc235c7a2",
+            "size": 15735,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_gs_join_aliases-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_simp--Debug]": [
         {
-            "checksum": "c355f20e7e47e26f284be683468d8f9f",
-            "size": 9987,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-group_by_gs_simp--Debug_/opt.yql_patched"
+            "checksum": "61da8fec771b5dd1ba780de27bb31b48",
+            "size": 9359,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_gs_simp--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_simp--Plan]": [
         {
-            "checksum": "c21d322fe68040161279ff77e4fe5f06",
-            "size": 14211,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-group_by_gs_simp--Plan_/plan.txt"
+            "checksum": "11c68bb6aafb2a4b83237630168836e1",
+            "size": 13387,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_gs_simp--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_gs_with_rollup--Debug]": [
         {
-            "checksum": "4ff9badb33b915a84396383b8359eab9",
-            "size": 11111,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-group_by_gs_with_rollup--Debug_/opt.yql_patched"
+            "checksum": "e23dc13c90414884eefafbfb1501926f",
+            "size": 10151,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_gs_with_rollup--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_gs_with_rollup--Plan]": [
         {
-            "checksum": "f4196b2cfa32bc9f61966c8ac44bb7bd",
-            "size": 15769,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-group_by_gs_with_rollup--Plan_/plan.txt"
+            "checksum": "b94b2bc491daf5099e6ae2491fa25b35",
+            "size": 14739,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_gs_with_rollup--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_rollup_duo_opt--Debug]": [
         {
-            "checksum": "d32195a0ed044e174618019328cf5d07",
-            "size": 8959,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_aggregate-group_by_rollup_duo_opt--Debug_/opt.yql_patched"
+            "checksum": "153c31fddd014d91c86bd7e42dfc5cc3",
+            "size": 8327,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_rollup_duo_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_rollup_duo_opt--Plan]": [
         {
-            "checksum": "871a11c56cbd17553e0ce6567b87fb96",
-            "size": 14650,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-group_by_rollup_duo_opt--Plan_/plan.txt"
+            "checksum": "6266271dc8c3771ab9ab4cb9f307e435",
+            "size": 13620,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_rollup_duo_opt--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-group_by_ru_join_simple--Debug]": [
         {
-            "checksum": "134395e8aa7123b92b0a71b7c44e32c3",
-            "size": 11109,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple--Debug_/opt.yql_patched"
+            "checksum": "f6afe9a575bab062389b4099e181b933",
+            "size": 10758,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-group_by_ru_join_simple--Plan]": [
         {
-            "checksum": "f284da35d48a30f75b068c1c025a365c",
-            "size": 15812,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple--Plan_/plan.txt"
+            "checksum": "34e1e49a0922277278ad5672a31c374b",
+            "size": 15194,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-group_by_ru_join_simple--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-percentiles_ungrouped--Debug]": [
         {
-            "checksum": "f6ed4fa85dd6f730a880a244ed718133",
-            "size": 5174,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_aggregate-percentiles_ungrouped--Debug_/opt.yql_patched"
+            "checksum": "5f0d8f736b4b1861e69717886f889d44",
+            "size": 5107,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-percentiles_ungrouped--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-percentiles_ungrouped--Plan]": [
         {
-            "checksum": "1fc289f1cde313e443c94649b94e540a",
-            "size": 5661,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_aggregate-percentiles_ungrouped--Plan_/plan.txt"
+            "checksum": "334ac35a87e1dcf3b243634e1e872716",
+            "size": 5455,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-percentiles_ungrouped--Plan_/plan.txt"
         }
     ],
     "test.test[aggregate-rollup_with_dict--Debug]": [
         {
-            "checksum": "c4ab42d579f992eb748ff83ee0161251",
-            "size": 7296,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_aggregate-rollup_with_dict--Debug_/opt.yql_patched"
+            "checksum": "61cea3cad46f814b2862e4c99fae91a4",
+            "size": 6739,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-rollup_with_dict--Debug_/opt.yql_patched"
         }
     ],
     "test.test[aggregate-rollup_with_dict--Plan]": [
         {
-            "checksum": "e115c542a03464cc7c7dc619afa9c41d",
-            "size": 12932,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_aggregate-rollup_with_dict--Plan_/plan.txt"
+            "checksum": "7c361866a9a0e57add8f9cb2d0d27979",
+            "size": 11902,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_aggregate-rollup_with_dict--Plan_/plan.txt"
         }
     ],
     "test.test[bigdate-compare_big_small-default.txt-Debug]": [
@@ -617,16 +617,16 @@
     ],
     "test.test[bigdate-table_arithmetic_narrow-default.txt-Debug]": [
         {
-            "checksum": "bbf9c57ae1719c03aefecc299a4d8dad",
-            "size": 23839,
-            "uri": "https://{canondata_backend}/1775059/a833e5685cfd840dc11a1c8709b4724a92dd4883/resource.tar.gz#test.test_bigdate-table_arithmetic_narrow-default.txt-Debug_/opt.yql_patched"
+            "checksum": "fd24f2864b965a6f563217c96e96ad09",
+            "size": 22260,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_bigdate-table_arithmetic_narrow-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[bigdate-table_arithmetic_narrow-default.txt-Plan]": [
         {
-            "checksum": "66fb77532913f4860c3e047d57845989",
-            "size": 26957,
-            "uri": "https://{canondata_backend}/1775059/a833e5685cfd840dc11a1c8709b4724a92dd4883/resource.tar.gz#test.test_bigdate-table_arithmetic_narrow-default.txt-Plan_/plan.txt"
+            "checksum": "db406e2b3ccdcf3d300d17cf102432b1",
+            "size": 25927,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_bigdate-table_arithmetic_narrow-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[binding-bind_cast-default.txt-Debug]": [
@@ -673,44 +673,44 @@
     ],
     "test.test[blocks-combine_all_pg--Debug]": [
         {
-            "checksum": "60570f20edb00fc1301c5b5f8292e894",
-            "size": 13941,
-            "uri": "https://{canondata_backend}/1871102/ce9ca47b84115b3facae7bde6b1c6233c95bb023/resource.tar.gz#test.test_blocks-combine_all_pg--Debug_/opt.yql_patched"
+            "checksum": "1f8719cb892a4ec7a45e12c51724b77f",
+            "size": 13566,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-combine_all_pg--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_pg--Plan]": [
         {
-            "checksum": "b9b72ce3fbcc855f188fd422fc36de24",
-            "size": 5890,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-combine_all_pg--Plan_/plan.txt"
+            "checksum": "d1f63391d3dbb7932ce69ad14fb1a908",
+            "size": 5684,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-combine_all_pg--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-combine_all_some_filter--Debug]": [
         {
-            "checksum": "9ed804bec07605188b813ee07bce5ca8",
-            "size": 3095,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-combine_all_some_filter--Debug_/opt.yql_patched"
+            "checksum": "2d98ef6f8622fc4d3c9af0fb8dfa2aa5",
+            "size": 3028,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-combine_all_some_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-combine_all_some_filter--Plan]": [
         {
-            "checksum": "005d7d73057d8a8a31b2815087bf9235",
-            "size": 5789,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-combine_all_some_filter--Plan_/plan.txt"
+            "checksum": "e6abef98f23736f185a622d9e671751c",
+            "size": 5583,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-combine_all_some_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_less_or_equal_scalar--Debug]": [
         {
-            "checksum": "24f9355f7ad73d83397e3ef7ace3e912",
-            "size": 26709,
-            "uri": "https://{canondata_backend}/1942100/5a4da50f1957e2b46d86ab842611060f06cdead0/resource.tar.gz#test.test_blocks-date_less_or_equal_scalar--Debug_/opt.yql_patched"
+            "checksum": "f3f8cd8aebf4abb8255c2acd1ae676f1",
+            "size": 22693,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-date_less_or_equal_scalar--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-date_less_or_equal_scalar--Plan]": [
         {
-            "checksum": "1ac2afa98f4d958a9cca1e31d65a570d",
-            "size": 12272,
-            "uri": "https://{canondata_backend}/1942100/5a4da50f1957e2b46d86ab842611060f06cdead0/resource.tar.gz#test.test_blocks-date_less_or_equal_scalar--Plan_/plan.txt"
+            "checksum": "e81ad78037d8967dd443aa92a9b04411",
+            "size": 11448,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-date_less_or_equal_scalar--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-date_sub_interval--Debug]": [
@@ -743,58 +743,58 @@
     ],
     "test.test[blocks-minmax_strings_filter--Debug]": [
         {
-            "checksum": "66cbfd5757830dc737642143d980262e",
-            "size": 6828,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-minmax_strings_filter--Debug_/opt.yql_patched"
+            "checksum": "200c98eff8de069680446a1bd75f4c9d",
+            "size": 6310,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-minmax_strings_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-minmax_strings_filter--Plan]": [
         {
-            "checksum": "01baa75b19579a5da4eaebd3abe7d5dc",
-            "size": 8579,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-minmax_strings_filter--Plan_/plan.txt"
+            "checksum": "818a9490b4f572309d8808a711afb1ef",
+            "size": 7961,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-minmax_strings_filter--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-not_opt--Debug]": [
         {
-            "checksum": "828f05f9122918b9aeffdcf50c6e4686",
-            "size": 2209,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-not_opt--Debug_/opt.yql_patched"
+            "checksum": "b1251c9c6d1ea11c14eafd850082c2d0",
+            "size": 2084,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-not_opt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-not_opt--Plan]": [
         {
-            "checksum": "cf8cc0a96b3d07be0e502fddc37057a5",
-            "size": 4075,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-not_opt--Plan_/plan.txt"
+            "checksum": "16d2125fbf927ed2c587d977a6d0fa87",
+            "size": 3869,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-not_opt--Plan_/plan.txt"
         }
     ],
     "test.test[blocks-pg_sort--Debug]": [
         {
-            "checksum": "7c1315e1373665b79fecd84493cda493",
-            "size": 3111,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-pg_sort--Debug_/opt.yql_patched"
+            "checksum": "b48fababadd539e4956cf3395ea66b64",
+            "size": 2909,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-pg_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[blocks-pg_sort--Plan]": [
         {
-            "checksum": "26d3f3789377649dd4c2116d85dacedc",
-            "size": 5369,
-            "uri": "https://{canondata_backend}/1946324/ed6ee7d6fc69ad9bb7bca6fae75b12f4f04afab5/resource.tar.gz#test.test_blocks-pg_sort--Plan_/plan.txt"
+            "checksum": "97e28b0722a9fb32a99399d4533b12d1",
+            "size": 5163,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_blocks-pg_sort--Plan_/plan.txt"
         }
     ],
     "test.test[column_order-insert_with_new_cols--Debug]": [
         {
-            "checksum": "0976183c86d13015a556916ed1d3cdec",
-            "size": 5651,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_column_order-insert_with_new_cols--Debug_/opt.yql_patched"
+            "checksum": "6a06fecd04fe91af10c033eb7095dc07",
+            "size": 5549,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_column_order-insert_with_new_cols--Debug_/opt.yql_patched"
         }
     ],
     "test.test[column_order-insert_with_new_cols--Plan]": [
         {
-            "checksum": "be500bed7e2a1f505dc54255d0db2b3a",
-            "size": 7695,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_column_order-insert_with_new_cols--Plan_/plan.txt"
+            "checksum": "d9e4c4f2d08b0b40a379fd5a88324382",
+            "size": 7489,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_column_order-insert_with_new_cols--Plan_/plan.txt"
         }
     ],
     "test.test[csee-const_body_same_lambda-default.txt-Debug]": [
@@ -841,44 +841,44 @@
     ],
     "test.test[distinct-distinct_columns-default.txt-Debug]": [
         {
-            "checksum": "792f6a217193888380ad0432d44fd947",
-            "size": 4385,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_distinct-distinct_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7c0d3f95eb87e76b26cd27ab37ea201b",
+            "size": 4016,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_distinct-distinct_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_columns-default.txt-Plan]": [
         {
-            "checksum": "630b65493c2c4259b59a0ff4eb62a16f",
-            "size": 8486,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_distinct-distinct_columns-default.txt-Plan_/plan.txt"
+            "checksum": "3e9cd01af6d1d07b61469c44426a8a49",
+            "size": 7868,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_distinct-distinct_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[distinct-distinct_columns_after_group-default.txt-Debug]": [
         {
-            "checksum": "cd7b2a09f447f826d197da81a1c966c6",
-            "size": 7199,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_distinct-distinct_columns_after_group-default.txt-Debug_/opt.yql_patched"
+            "checksum": "5bfbf93ea28de0f796387af36e7931f4",
+            "size": 6734,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_distinct-distinct_columns_after_group-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[distinct-distinct_columns_after_group-default.txt-Plan]": [
         {
-            "checksum": "4e4ac8b3e6dff27fca7c1f46a7a612b3",
-            "size": 10854,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_distinct-distinct_columns_after_group-default.txt-Plan_/plan.txt"
+            "checksum": "87b42c63860bd0f4bc2b63b0ec242f55",
+            "size": 10030,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_distinct-distinct_columns_after_group-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[epochs-read_modified--Debug]": [
         {
-            "checksum": "7cbf69d8efd7be7c4032b75cf105fe1a",
-            "size": 3423,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_epochs-read_modified--Debug_/opt.yql_patched"
+            "checksum": "e9d4d374b5527de4f4b7c5bab93f3c09",
+            "size": 3268,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_epochs-read_modified--Debug_/opt.yql_patched"
         }
     ],
     "test.test[epochs-read_modified--Plan]": [
         {
-            "checksum": "0fc914df6138d79f7121d16a5902bd7c",
-            "size": 11491,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_epochs-read_modified--Plan_/plan.txt"
+            "checksum": "4bf047ec3208894439ef8beafe9925d6",
+            "size": 11079,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_epochs-read_modified--Plan_/plan.txt"
         }
     ],
     "test.test[expr-cast_utf8-default.txt-Debug]": [
@@ -995,16 +995,16 @@
     ],
     "test.test[flatten_by-flatten_columns-default.txt-Debug]": [
         {
-            "checksum": "d26d6cde88a2797c68baed2eb75b2bf0",
-            "size": 1939,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_flatten_by-flatten_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a1767d2cc16c381700e3985bcdf21936",
+            "size": 1816,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_flatten_by-flatten_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_columns-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_flatten_by-flatten_columns-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_flatten_by-flatten_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[flatten_by-flatten_columns_non_struct-default.txt-Debug]": [
@@ -1023,44 +1023,44 @@
     ],
     "test.test[flatten_by-flatten_with_join--Debug]": [
         {
-            "checksum": "c22427f32cdb47c18efdab86cf19003c",
-            "size": 7717,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_flatten_by-flatten_with_join--Debug_/opt.yql_patched"
+            "checksum": "e1df6a15628ceefe8f48e0bf39f9b4db",
+            "size": 7491,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_flatten_by-flatten_with_join--Debug_/opt.yql_patched"
         }
     ],
     "test.test[flatten_by-flatten_with_join--Plan]": [
         {
-            "checksum": "ceadddc393a6eaf90e42055954e71b24",
-            "size": 11009,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_flatten_by-flatten_with_join--Plan_/plan.txt"
+            "checksum": "8dacfd08134b173ff1699d96cb7966cd",
+            "size": 10597,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_flatten_by-flatten_with_join--Plan_/plan.txt"
         }
     ],
     "test.test[hor_join-out_max_outtables-default.txt-Debug]": [
         {
-            "checksum": "8bd375302c0bfd177fa12a5e6fa18a96",
-            "size": 3536,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_hor_join-out_max_outtables-default.txt-Debug_/opt.yql_patched"
+            "checksum": "be2329a2ba6945178525b2c8777067b5",
+            "size": 3336,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_hor_join-out_max_outtables-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[hor_join-out_max_outtables-default.txt-Plan]": [
         {
-            "checksum": "ed94eb2c776d5ebc66d9f9c24831a548",
-            "size": 6200,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_hor_join-out_max_outtables-default.txt-Plan_/plan.txt"
+            "checksum": "8b15958bd515239eb3b69f8ef7d6280a",
+            "size": 5788,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_hor_join-out_max_outtables-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-huge_in-default.txt-Debug]": [
         {
-            "checksum": "730eed497f3984291b1e2a7b9c5d8389",
-            "size": 67270,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_in-huge_in-default.txt-Debug_/opt.yql_patched"
+            "checksum": "328e5b891b25ef1d09d1c94ba1805b35",
+            "size": 67147,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_in-huge_in-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[in-huge_in-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_in-huge_in-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_in-huge_in-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[in-in_with_nulls_and_optionals-default.txt-Debug]": [
@@ -1079,72 +1079,72 @@
     ],
     "test.test[insert-append_after_replace-default.txt-Debug]": [
         {
-            "checksum": "a4801eaed681829313dc792294e923b6",
-            "size": 2753,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e053a922f685828f341eb8d8e7a948d4",
+            "size": 2602,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_after_replace-default.txt-Plan]": [
         {
-            "checksum": "331078b1f78b600f2af1ff1f1b2b83c2",
-            "size": 8231,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Plan_/plan.txt"
+            "checksum": "8cb9614ece025ee7e5a91bf6d988361b",
+            "size": 7819,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-append_after_replace-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_sorted--Debug]": [
         {
-            "checksum": "caa78a329af195ad1a0ece4f4d557e37",
-            "size": 3309,
-            "uri": "https://{canondata_backend}/1775059/77965e6f828cf5f627df5d1674836052b7118156/resource.tar.gz#test.test_insert-append_sorted--Debug_/opt.yql_patched"
+            "checksum": "dedf76996ffd9833cb338f5b87bc229c",
+            "size": 3186,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-append_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted--Plan]": [
         {
-            "checksum": "ea2b880a50308a3c86548aaac7e2dfc0",
-            "size": 13283,
-            "uri": "https://{canondata_backend}/1775059/77965e6f828cf5f627df5d1674836052b7118156/resource.tar.gz#test.test_insert-append_sorted--Plan_/plan.txt"
+            "checksum": "c8b7da59f4c9716c37f6bb2361e2448f",
+            "size": 13077,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-append_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_desc-Debug]": [
         {
-            "checksum": "25543cb766674d8147975b6de2b7be0b",
-            "size": 5749,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Debug_/opt.yql_patched"
+            "checksum": "bd22e07fa185becd3ed70c91c731165b",
+            "size": 5403,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-append_sorted-to_sorted_desc-Plan]": [
         {
-            "checksum": "949ea22191cb3931e43b550158ccc2c3",
-            "size": 17340,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Plan_/plan.txt"
+            "checksum": "cd7da9da1034b3892a6a2c3c39bb93c6",
+            "size": 16928,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-append_sorted-to_sorted_desc-Plan_/plan.txt"
         }
     ],
     "test.test[insert-multiappend_sorted-default.txt-Debug]": [
         {
-            "checksum": "a541a7b5079561c24e2326407f24c582",
-            "size": 5902,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Debug_/opt.yql_patched"
+            "checksum": "57c899180b233819038e82334f8dfd69",
+            "size": 5433,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert-multiappend_sorted-default.txt-Plan]": [
         {
-            "checksum": "470985d3df8b3626127d14dc9d4c1c39",
-            "size": 19733,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Plan_/plan.txt"
+            "checksum": "76867bbaec3a2896a4edb68ad22a5b35",
+            "size": 19115,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert-multiappend_sorted-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[insert_monotonic-to_empty--Debug]": [
         {
-            "checksum": "c228317f3660a301dd340fd297e10f11",
-            "size": 2160,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_insert_monotonic-to_empty--Debug_/opt.yql_patched"
+            "checksum": "adf7c613c22578892faafed8865ac3bc",
+            "size": 2037,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert_monotonic-to_empty--Debug_/opt.yql_patched"
         }
     ],
     "test.test[insert_monotonic-to_empty--Plan]": [
         {
-            "checksum": "9b2cee086bbace1ac507285134c4a127",
-            "size": 4429,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_insert_monotonic-to_empty--Plan_/plan.txt"
+            "checksum": "e4256c0569194f6a2a04274ee01d418c",
+            "size": 4223,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_insert_monotonic-to_empty--Plan_/plan.txt"
         }
     ],
     "test.test[join-aggr_diff_order-default.txt-Debug]": [
@@ -1163,58 +1163,58 @@
     ],
     "test.test[join-anyjoin_common_nodata_keys--Debug]": [
         {
-            "checksum": "db8e6974896d3e4e139d669b5452aba7",
-            "size": 6989,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_join-anyjoin_common_nodata_keys--Debug_/opt.yql_patched"
+            "checksum": "935c9f1812a7526bbfffa41bdb753d7b",
+            "size": 6718,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-anyjoin_common_nodata_keys--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-anyjoin_common_nodata_keys--Plan]": [
         {
-            "checksum": "0cba90940881f2a5d9b63d55bb1be496",
-            "size": 19596,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-anyjoin_common_nodata_keys--Plan_/plan.txt"
+            "checksum": "65c54f0243f2b6675b1e41de4a300542",
+            "size": 19184,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-anyjoin_common_nodata_keys--Plan_/plan.txt"
         }
     ],
     "test.test[join-bush_dis_in--Debug]": [
         {
-            "checksum": "5a4e8f4fb6d6b05ca1f790326290d2aa",
-            "size": 9843,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-bush_dis_in--Debug_/opt.yql_patched"
+            "checksum": "dc709d04a9997fb9799e94583827129f",
+            "size": 9560,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-bush_dis_in--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-bush_dis_in--Plan]": [
         {
-            "checksum": "e32cc8ea5d218b9e2d94d14c61a60a59",
-            "size": 19282,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-bush_dis_in--Plan_/plan.txt"
+            "checksum": "40eb7878d2aa44de0fd35e9c3ed271ce",
+            "size": 18664,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-bush_dis_in--Plan_/plan.txt"
         }
     ],
     "test.test[join-bush_dis_in_in--Debug]": [
         {
-            "checksum": "41cc121304be51415285a76a1d79f51b",
-            "size": 10309,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-bush_dis_in_in--Debug_/opt.yql_patched"
+            "checksum": "2bbc35c164f8d4b23e6be19df8439f4b",
+            "size": 10007,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-bush_dis_in_in--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-bush_dis_in_in--Plan]": [
         {
-            "checksum": "e84d6836811058dcc514cb26d04d9199",
-            "size": 15417,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-bush_dis_in_in--Plan_/plan.txt"
+            "checksum": "4fcffd33db8bab4e51936c047f4c200f",
+            "size": 15005,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-bush_dis_in_in--Plan_/plan.txt"
         }
     ],
     "test.test[join-flatten_columns1--Debug]": [
         {
-            "checksum": "884a335d78eced2ca35d67446135f54e",
-            "size": 5598,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-flatten_columns1--Debug_/opt.yql_patched"
+            "checksum": "fd632a7fe7928d5452ea0fd2087971df",
+            "size": 5383,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-flatten_columns1--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-flatten_columns1--Plan]": [
         {
-            "checksum": "1a3e1221d8c4908d2d7ed5eba76cf003",
-            "size": 8690,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-flatten_columns1--Plan_/plan.txt"
+            "checksum": "f9e599b9522940fe72882fad8ab70d5c",
+            "size": 8484,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-flatten_columns1--Plan_/plan.txt"
         }
     ],
     "test.test[join-inner_on_key_only--Debug]": [
@@ -1233,44 +1233,44 @@
     ],
     "test.test[join-join_no_correlation_in_order_by--Debug]": [
         {
-            "checksum": "89e77c6b1f2ed4fc9e72fecc15d918cb",
-            "size": 4013,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-join_no_correlation_in_order_by--Debug_/opt.yql_patched"
+            "checksum": "6b87c1143b437d2a8b4e41f6188a1471",
+            "size": 3692,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-join_no_correlation_in_order_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_no_correlation_in_order_by--Plan]": [
         {
-            "checksum": "39f043d649c6875ddbf4e2ca184a984d",
-            "size": 6851,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-join_no_correlation_in_order_by--Plan_/plan.txt"
+            "checksum": "5af72cb569f258f327686086438fda48",
+            "size": 6439,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-join_no_correlation_in_order_by--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_without_column--Debug]": [
         {
-            "checksum": "39e5d771b727d8ea5cf7ce810ed4971a",
-            "size": 3922,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-join_without_column--Debug_/opt.yql_patched"
+            "checksum": "b358e40c259d52ca2f49a70ae8343cce",
+            "size": 3610,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-join_without_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_without_column--Plan]": [
         {
-            "checksum": "431453e20f67528968d223d46b4bbf61",
-            "size": 6822,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-join_without_column--Plan_/plan.txt"
+            "checksum": "6d7f4415aa2285585b348ecfbb0dab02",
+            "size": 6410,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-join_without_column--Plan_/plan.txt"
         }
     ],
     "test.test[join-join_without_correlation_and_dict_access--Debug]": [
         {
-            "checksum": "6fbe8eccf95f9f84be688ed299e287db",
-            "size": 8347,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-join_without_correlation_and_dict_access--Debug_/opt.yql_patched"
+            "checksum": "67bf6520e9e4305e01443d4fb81edfae",
+            "size": 8107,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-join_without_correlation_and_dict_access--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-join_without_correlation_and_dict_access--Plan]": [
         {
-            "checksum": "8d2f75f6b9532c0f3115d7cb4e36dc03",
-            "size": 11102,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-join_without_correlation_and_dict_access--Plan_/plan.txt"
+            "checksum": "9e27312d6dd4d2c99f5656e058a78235",
+            "size": 10690,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-join_without_correlation_and_dict_access--Plan_/plan.txt"
         }
     ],
     "test.test[join-lookupjoin_semi_empty--Debug]": [
@@ -1289,30 +1289,30 @@
     ],
     "test.test[join-mapjoin_early_rewrite--Debug]": [
         {
-            "checksum": "03d141864d0dd2f410491faccf14b385",
-            "size": 4605,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-mapjoin_early_rewrite--Debug_/opt.yql_patched"
+            "checksum": "00def0a59df48b61fc7b1fd6fa0c94ba",
+            "size": 4313,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mapjoin_early_rewrite--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mapjoin_early_rewrite--Plan]": [
         {
-            "checksum": "f63416fef2cb8dedb23b733fcd6f4f4a",
-            "size": 8005,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-mapjoin_early_rewrite--Plan_/plan.txt"
+            "checksum": "f2edb7e56e875326b8db007a5b8a971e",
+            "size": 7593,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mapjoin_early_rewrite--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_big_primary--Debug]": [
         {
-            "checksum": "ee774cc129c0468965bd557004f381f9",
-            "size": 4923,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-mergejoin_big_primary--Debug_/opt.yql_patched"
+            "checksum": "9cabefb5cb579ebb81f7a26a6ef17d45",
+            "size": 4739,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_big_primary--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_big_primary--Plan]": [
         {
-            "checksum": "3381499d5acba28f455e27a1148d20f2",
-            "size": 8534,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-mergejoin_big_primary--Plan_/plan.txt"
+            "checksum": "65d6404844af7f5cf804f29216a40985",
+            "size": 8328,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_big_primary--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_big_primary_unique--Debug]": [
@@ -1331,198 +1331,198 @@
     ],
     "test.test[join-mergejoin_force_one_sorted--Debug]": [
         {
-            "checksum": "e4ee2637b3fc792d910c1a4a6c8f10d9",
-            "size": 3661,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-mergejoin_force_one_sorted--Debug_/opt.yql_patched"
+            "checksum": "7fa87bbbe4508093c913162bfdca9347",
+            "size": 3599,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_force_one_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_force_one_sorted--Plan]": [
         {
-            "checksum": "c423f38b4a4f39f0c9e6c8214a2ee11a",
-            "size": 6286,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-mergejoin_force_one_sorted--Plan_/plan.txt"
+            "checksum": "5531c879d94be2062756603704fe8704",
+            "size": 6080,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_force_one_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_left_null_column--Debug]": [
         {
-            "checksum": "ec8ec0dd9f98735f50c30e88a7376670",
-            "size": 6525,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-mergejoin_left_null_column--Debug_/opt.yql_patched"
+            "checksum": "fb1821acc48ec9aea3c5f7d633bcfe8b",
+            "size": 6115,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_left_null_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_left_null_column--Plan]": [
         {
-            "checksum": "92e444c18a1a4440c00ea7bb57425127",
-            "size": 9448,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-mergejoin_left_null_column--Plan_/plan.txt"
+            "checksum": "8da939e97c5b640cf0c1a10b26487fde",
+            "size": 8830,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_left_null_column--Plan_/plan.txt"
         }
     ],
     "test.test[join-mergejoin_semi_composite_to_inner--Debug]": [
         {
-            "checksum": "ecec37a83ec3c092af0bffc758920afa",
-            "size": 10716,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-mergejoin_semi_composite_to_inner--Debug_/opt.yql_patched"
+            "checksum": "c90431f03764ddafd9cdc79a0043fc38",
+            "size": 10430,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_semi_composite_to_inner--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-mergejoin_semi_composite_to_inner--Plan]": [
         {
-            "checksum": "faad37bb82256cedc58eecafb9dd8ba2",
-            "size": 18416,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-mergejoin_semi_composite_to_inner--Plan_/plan.txt"
+            "checksum": "4216285b56ab4770c4bb10a55e19866e",
+            "size": 18004,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-mergejoin_semi_composite_to_inner--Plan_/plan.txt"
         }
     ],
     "test.test[join-premap_common_left_cross--Debug]": [
         {
-            "checksum": "a2d6f083b769579809db8c57a9c3a0fe",
-            "size": 8769,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-premap_common_left_cross--Debug_/opt.yql_patched"
+            "checksum": "c835aa5bd6626b02484986563beb2a4b",
+            "size": 8512,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-premap_common_left_cross--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-premap_common_left_cross--Plan]": [
         {
-            "checksum": "df6740a27047fb89bbbee220d42ce5fa",
-            "size": 11387,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-premap_common_left_cross--Plan_/plan.txt"
+            "checksum": "1301e59279116687e1c7dc0916383324",
+            "size": 11181,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-premap_common_left_cross--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql-8980--Debug]": [
         {
-            "checksum": "370febe0c8a0377df225f90305ee54f2",
-            "size": 9719,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_join-yql-8980--Debug_/opt.yql_patched"
+            "checksum": "6a8b403ab7d07e18a4d8ec04a98221c3",
+            "size": 9454,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-yql-8980--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql-8980--Plan]": [
         {
-            "checksum": "4a1af29755ef70a3e67c86bb380a9c7f",
-            "size": 11046,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-yql-8980--Plan_/plan.txt"
+            "checksum": "21999fa0cc82e870eb988e2973b686b1",
+            "size": 10840,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-yql-8980--Plan_/plan.txt"
         }
     ],
     "test.test[join-yql_465--Debug]": [
         {
-            "checksum": "ac572510aa603c214fcced6f09a35d2f",
-            "size": 2359,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_join-yql_465--Debug_/opt.yql_patched"
+            "checksum": "434791cdaec6b409c81d158653d86d64",
+            "size": 2236,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-yql_465--Debug_/opt.yql_patched"
         }
     ],
     "test.test[join-yql_465--Plan]": [
         {
-            "checksum": "8cfcdf9e3ef26175577aa4ad1d1b3e5c",
-            "size": 4838,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_join-yql_465--Plan_/plan.txt"
+            "checksum": "825465ff5b95743ab19ab3023f9c2f5e",
+            "size": 4632,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_join-yql_465--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-dict_contains-default.txt-Debug]": [
         {
-            "checksum": "83b8ac6a0dfb6e989f4b21e7d69d1c2f",
-            "size": 2442,
-            "uri": "https://{canondata_backend}/1871102/ed6e556f8a208e714c4910716bae781cf6074660/resource.tar.gz#test.test_key_filter-dict_contains-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c0d07e2ba42e0682b71328f9fdea88eb",
+            "size": 2319,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-dict_contains-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-dict_contains-default.txt-Plan]": [
         {
-            "checksum": "456cd8def847ff0ac95065b354da3b0e",
-            "size": 3606,
-            "uri": "https://{canondata_backend}/1900335/4d7627b182eb0bc8eb432aaaedbdb8f89e18f3aa/resource.tar.gz#test.test_key_filter-dict_contains-default.txt-Plan_/plan.txt"
+            "checksum": "b9025284a96d051140e0eed82aa8366f",
+            "size": 3400,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-dict_contains-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-dict_contains_optional--Debug]": [
         {
-            "checksum": "efcbda30ed9bc34dca5bba70480b228c",
-            "size": 2439,
-            "uri": "https://{canondata_backend}/1899731/c54c7578a47cc78b69bc71d6fa7c401476ce6b74/resource.tar.gz#test.test_key_filter-dict_contains_optional--Debug_/opt.yql_patched"
+            "checksum": "f24dea69104f35c1cc38b3ec39e46880",
+            "size": 2316,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-dict_contains_optional--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-dict_contains_optional--Plan]": [
         {
-            "checksum": "456cd8def847ff0ac95065b354da3b0e",
-            "size": 3606,
-            "uri": "https://{canondata_backend}/1899731/db7a86c824620aa7e39f661294c7ce637b87a941/resource.tar.gz#test.test_key_filter-dict_contains_optional--Plan_/plan.txt"
+            "checksum": "b9025284a96d051140e0eed82aa8366f",
+            "size": 3400,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-dict_contains_optional--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-is_null_with_condition--Debug]": [
         {
-            "checksum": "be7b3407eced040dac11ee68def98ba9",
-            "size": 2181,
-            "uri": "https://{canondata_backend}/1597364/424e45f15ee25babb50cd9dbb8680dd620d83b98/resource.tar.gz#test.test_key_filter-is_null_with_condition--Debug_/opt.yql_patched"
+            "checksum": "cf49c4cb0f8962d9670eeb07693bd807",
+            "size": 2058,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-is_null_with_condition--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-is_null_with_condition--Plan]": [
         {
-            "checksum": "35bcfd164ecf1a193341efaafa10d71d",
-            "size": 3499,
-            "uri": "https://{canondata_backend}/1031349/157189a59ba7d83d1d89ad07d3315e7de1c00220/resource.tar.gz#test.test_key_filter-is_null_with_condition--Plan_/plan.txt"
+            "checksum": "399c11fa72d1a69da17dcf08513403d4",
+            "size": 3293,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-is_null_with_condition--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-yql-8117-table_key_filter--Debug]": [
         {
-            "checksum": "64c8072eeb871a0204c90f16733c5f36",
-            "size": 3556,
-            "uri": "https://{canondata_backend}/1916746/f94cbf4f8673aa866e4225487800fdf532eb9834/resource.tar.gz#test.test_key_filter-yql-8117-table_key_filter--Debug_/opt.yql_patched"
+            "checksum": "07c7b121041368c7ea331343dcc9aa9d",
+            "size": 3428,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-yql-8117-table_key_filter--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-yql-8117-table_key_filter--Plan]": [
         {
-            "checksum": "943262bbb82fab9c29a70548e79558f8",
-            "size": 7707,
-            "uri": "https://{canondata_backend}/1916746/f94cbf4f8673aa866e4225487800fdf532eb9834/resource.tar.gz#test.test_key_filter-yql-8117-table_key_filter--Plan_/plan.txt"
+            "checksum": "4437bc9ec6c33c6c2f9cf2e04e402278",
+            "size": 7295,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-yql-8117-table_key_filter--Plan_/plan.txt"
         }
     ],
     "test.test[key_filter-yql-8663-dedup_ranges--Debug]": [
         {
-            "checksum": "09f644f02b20204964b9cf520554f1e9",
-            "size": 2255,
-            "uri": "https://{canondata_backend}/1600758/8b67a2e95fbe8af47e0128a4b50bb3a92834db89/resource.tar.gz#test.test_key_filter-yql-8663-dedup_ranges--Debug_/opt.yql_patched"
+            "checksum": "efdc273fbb4037405f6a668e8e0bde2d",
+            "size": 2132,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-yql-8663-dedup_ranges--Debug_/opt.yql_patched"
         }
     ],
     "test.test[key_filter-yql-8663-dedup_ranges--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1600758/bc7f89a1edc97d9250dcd1ade600b26b17bb9c24/resource.tar.gz#test.test_key_filter-yql-8663-dedup_ranges--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_key_filter-yql-8663-dedup_ranges--Plan_/plan.txt"
         }
     ],
     "test.test[lambda-lambda_simple-default.txt-Debug]": [
         {
-            "checksum": "094bc5bfe8c766772c3fae088e7253fd",
-            "size": 2488,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_lambda-lambda_simple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a999644b70c2876d32c51b73eacb7d52",
+            "size": 2335,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_lambda-lambda_simple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[lambda-lambda_simple-default.txt-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_lambda-lambda_simple-default.txt-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_lambda-lambda_simple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[like-regexp_clause--Debug]": [
         {
-            "checksum": "fea2466ec68d965efe7da8fa74ab2691",
-            "size": 2446,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_like-regexp_clause--Debug_/opt.yql_patched"
+            "checksum": "7e3d585be611e5adea5166a319fc55ab",
+            "size": 2323,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_like-regexp_clause--Debug_/opt.yql_patched"
         }
     ],
     "test.test[like-regexp_clause--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_like-regexp_clause--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_like-regexp_clause--Plan_/plan.txt"
         }
     ],
     "test.test[limit-empty_input_after_limit-default.txt-Debug]": [
         {
-            "checksum": "c1abce0036ab8452ee4c8300781d304a",
-            "size": 4131,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_limit-empty_input_after_limit-default.txt-Debug_/opt.yql_patched"
+            "checksum": "164f9206016cea60bcc1bb670f510765",
+            "size": 3857,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_limit-empty_input_after_limit-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[limit-empty_input_after_limit-default.txt-Plan]": [
         {
-            "checksum": "bcf96a427519d6d66bb0ff4666cdf9f0",
-            "size": 10277,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_limit-empty_input_after_limit-default.txt-Plan_/plan.txt"
+            "checksum": "40ba7f7ff3af92d502650c2a73d7e8d2",
+            "size": 9659,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_limit-empty_input_after_limit-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[match_recognize-alerts_without_order-default.txt-Debug]": [
@@ -1541,170 +1541,170 @@
     ],
     "test.test[optimizers-direct_row_after_merge--Debug]": [
         {
-            "checksum": "6db94e68bc8d6ad4ae649044f1b0c9e9",
-            "size": 3440,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_optimizers-direct_row_after_merge--Debug_/opt.yql_patched"
+            "checksum": "c51e278ae3c81010b0cc02b421cd601d",
+            "size": 3242,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-direct_row_after_merge--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-direct_row_after_merge--Plan]": [
         {
-            "checksum": "bfbe76e51727a27d8d9cafa473a78922",
-            "size": 6654,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_optimizers-direct_row_after_merge--Plan_/plan.txt"
+            "checksum": "0df1a2ed611cb46f7f0fc1982015ba19",
+            "size": 6242,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-direct_row_after_merge--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-17413-topsort--Debug]": [
         {
-            "checksum": "e3b7683f418b7832c2d856273c3b70ab",
-            "size": 7660,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_optimizers-yql-17413-topsort--Debug_/opt.yql_patched"
+            "checksum": "99c894d1449c3cc87be525ce2c2a8fa2",
+            "size": 7533,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-yql-17413-topsort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-17413-topsort--Plan]": [
         {
-            "checksum": "1a48e8a2ec143e1ec01de41c9efb7a89",
-            "size": 15092,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_optimizers-yql-17413-topsort--Plan_/plan.txt"
+            "checksum": "098d33405f3882b5ffaa8295bd057ff9",
+            "size": 14474,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-yql-17413-topsort--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-3455_filter_sorted--Debug]": [
         {
-            "checksum": "303a339cd7d7b2903e989f136abfafcd",
-            "size": 5756,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_optimizers-yql-3455_filter_sorted--Debug_/opt.yql_patched"
+            "checksum": "7c88490731291d35085ba826e4d08b82",
+            "size": 5434,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-yql-3455_filter_sorted--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-3455_filter_sorted--Plan]": [
         {
-            "checksum": "1af6a6b661c5e05030fa03bdff63941b",
-            "size": 12588,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_optimizers-yql-3455_filter_sorted--Plan_/plan.txt"
+            "checksum": "f48e80256dca7708f8d6b7b3fcdb2b36",
+            "size": 11764,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-yql-3455_filter_sorted--Plan_/plan.txt"
         }
     ],
     "test.test[optimizers-yql-8041-fuse_with_desc_map--Debug]": [
         {
-            "checksum": "008fc17ec9b49f959717c846ffb08cd4",
-            "size": 6439,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_optimizers-yql-8041-fuse_with_desc_map--Debug_/opt.yql_patched"
+            "checksum": "ff7dbda576bb3c0b492e6b97b5a79c6f",
+            "size": 6130,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-yql-8041-fuse_with_desc_map--Debug_/opt.yql_patched"
         }
     ],
     "test.test[optimizers-yql-8041-fuse_with_desc_map--Plan]": [
         {
-            "checksum": "dc4e407493af9abd276cb92c354112a4",
-            "size": 12479,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_optimizers-yql-8041-fuse_with_desc_map--Plan_/plan.txt"
+            "checksum": "f82f8019d6afcb0f9283a945a8c48223",
+            "size": 11655,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_optimizers-yql-8041-fuse_with_desc_map--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-assume_cut_prefix--Debug]": [
         {
-            "checksum": "72a9c8dc275786ce71cf9b30c133b159",
-            "size": 2291,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-assume_cut_prefix--Debug_/opt.yql_patched"
+            "checksum": "20365c9476ee269267e6356be9cbf701",
+            "size": 2168,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-assume_cut_prefix--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-assume_cut_prefix--Plan]": [
         {
-            "checksum": "fbddd5a33ce1ece709d37f310c9e1ecc",
-            "size": 4419,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-assume_cut_prefix--Plan_/plan.txt"
+            "checksum": "c206de8f5f77c053834faafd200ca9d4",
+            "size": 4213,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-assume_cut_prefix--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-literal_empty_list_sort--Debug]": [
         {
-            "checksum": "b4e6ce66800587d3394058fec57ee52c",
-            "size": 1652,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-literal_empty_list_sort--Debug_/opt.yql_patched"
+            "checksum": "272c4cb3962f46013f03b471c7e1ce17",
+            "size": 1529,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-literal_empty_list_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-literal_empty_list_sort--Plan]": [
         {
-            "checksum": "45f69bde80caae9a36b8eba85fd9ec09",
-            "size": 4398,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-literal_empty_list_sort--Plan_/plan.txt"
+            "checksum": "e86880cd6cbe8c180ebff1d4b59b2b0c",
+            "size": 4192,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-literal_empty_list_sort--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-literal_single_item_sort--Debug]": [
         {
-            "checksum": "ddf47af4a0ca2494bea6fba5bfb8f6d9",
-            "size": 1574,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-literal_single_item_sort--Debug_/opt.yql_patched"
+            "checksum": "f29cb64dd8ea44f52990355eabb9a892",
+            "size": 1474,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-literal_single_item_sort--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-literal_single_item_sort--Plan]": [
         {
-            "checksum": "f195da512144b9c1e1263ff7883daf1c",
-            "size": 4003,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-literal_single_item_sort--Plan_/plan.txt"
+            "checksum": "e16d7e3ac6aba6f5b8f65cb4a2adb1da",
+            "size": 3797,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-literal_single_item_sort--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_dynum-default.txt-Debug]": [
         {
-            "checksum": "4477943b2b6d88a4611d6d513bf3ff97",
-            "size": 2749,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-order_by_dynum-default.txt-Debug_/opt.yql_patched"
+            "checksum": "c5fe72399101085b912f6c305c7b763a",
+            "size": 2596,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_dynum-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_dynum-default.txt-Plan]": [
         {
-            "checksum": "6ddbfeb496edb95f716290d3314cb455",
-            "size": 5317,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-order_by_dynum-default.txt-Plan_/plan.txt"
+            "checksum": "1b4ff335639e427966a02f51ff426c2f",
+            "size": 5111,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_dynum-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_dynum_desc-default.txt-Debug]": [
         {
-            "checksum": "e5c66b7950a8bce2dd681cbdc860e18b",
-            "size": 2745,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-order_by_dynum_desc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "53cb6802532367bf3c69ac4debbcc6ea",
+            "size": 2592,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_dynum_desc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_dynum_desc-default.txt-Plan]": [
         {
-            "checksum": "6ddbfeb496edb95f716290d3314cb455",
-            "size": 5317,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-order_by_dynum_desc-default.txt-Plan_/plan.txt"
+            "checksum": "1b4ff335639e427966a02f51ff426c2f",
+            "size": 5111,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_dynum_desc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_mul_columns-default.txt-Debug]": [
         {
-            "checksum": "985c354cbb3af852a4c204cdcb9361bb",
-            "size": 2084,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-order_by_mul_columns-default.txt-Debug_/opt.yql_patched"
+            "checksum": "bb3175212b1a2a7a4fde4195da590d95",
+            "size": 1961,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_mul_columns-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_mul_columns-default.txt-Plan]": [
         {
-            "checksum": "d83d10e675a437eb2bbcc2b4d9f54d1a",
-            "size": 3596,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-order_by_mul_columns-default.txt-Plan_/plan.txt"
+            "checksum": "f82b819f54377e94395f0c3db7101cf6",
+            "size": 3390,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_mul_columns-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_udf--Debug]": [
         {
-            "checksum": "460540cda4cde3f3c8bbe39ad6227f03",
-            "size": 3038,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-order_by_udf--Debug_/opt.yql_patched"
+            "checksum": "88c8feea337b3b631a26ed74643d2df7",
+            "size": 2885,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_udf--Plan]": [
         {
-            "checksum": "6ddbfeb496edb95f716290d3314cb455",
-            "size": 5317,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-order_by_udf--Plan_/plan.txt"
+            "checksum": "1b4ff335639e427966a02f51ff426c2f",
+            "size": 5111,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_udf--Plan_/plan.txt"
         }
     ],
     "test.test[order_by-order_by_value_desc-default.txt-Debug]": [
         {
-            "checksum": "4ea40a18ec0224341934b993ef41f51a",
-            "size": 2821,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_order_by-order_by_value_desc-default.txt-Debug_/opt.yql_patched"
+            "checksum": "f497cc444e97f0b517de65911c3205e6",
+            "size": 2668,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_value_desc-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[order_by-order_by_value_desc-default.txt-Plan]": [
         {
-            "checksum": "6ddbfeb496edb95f716290d3314cb455",
-            "size": 5317,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_order_by-order_by_value_desc-default.txt-Plan_/plan.txt"
+            "checksum": "1b4ff335639e427966a02f51ff426c2f",
+            "size": 5111,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_order_by-order_by_value_desc-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[params-list--Debug]": [
@@ -1737,16 +1737,16 @@
     ],
     "test.test[pg-aggregate_combine--Debug]": [
         {
-            "checksum": "0960d970985e6ea6ee008cde2ae40450",
-            "size": 4826,
-            "uri": "https://{canondata_backend}/1871102/ce9ca47b84115b3facae7bde6b1c6233c95bb023/resource.tar.gz#test.test_pg-aggregate_combine--Debug_/opt.yql_patched"
+            "checksum": "42277a864eaf593f2bfae92085f931fc",
+            "size": 4726,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-aggregate_combine--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-aggregate_combine--Plan]": [
         {
-            "checksum": "701b8542591121cafa30c40703324d43",
-            "size": 6057,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_pg-aggregate_combine--Plan_/plan.txt"
+            "checksum": "a903452e9f093e37b7200b904ef369d1",
+            "size": 5851,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-aggregate_combine--Plan_/plan.txt"
         }
     ],
     "test.test[pg-cbo_pragma2-default.txt-Debug]": [
@@ -1807,16 +1807,16 @@
     ],
     "test.test[pg-name--Debug]": [
         {
-            "checksum": "dbd08ffd92cfe9e057b65dc3766236e3",
-            "size": 2914,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_pg-name--Debug_/opt.yql_patched"
+            "checksum": "3319327a4ca4d2af68319f737f8310f1",
+            "size": 2784,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-name--Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-name--Plan]": [
         {
-            "checksum": "609ff789cc1c00882fe449db35c6f1f3",
-            "size": 5856,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_pg-name--Plan_/plan.txt"
+            "checksum": "e090f0a54b6870ae7a3bee990630fceb",
+            "size": 5650,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-name--Plan_/plan.txt"
         }
     ],
     "test.test[pg-pg_corr_offset-default.txt-Debug]": [
@@ -2297,44 +2297,44 @@
     ],
     "test.test[pg-tpch-q03-default.txt-Debug]": [
         {
-            "checksum": "e8cefdad0f4057181bad8af5fdf51fd3",
-            "size": 11134,
-            "uri": "https://{canondata_backend}/1937429/40bea338f0033fff8f8ab1b1e4c051fe9d183c26/resource.tar.gz#test.test_pg-tpch-q03-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d473a871f29955c882eb97eb047b62b8",
+            "size": 10993,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-tpch-q03-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q03-default.txt-Plan]": [
         {
-            "checksum": "500bbc81d506e7d7ceeb40515ddfe773",
-            "size": 15267,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_pg-tpch-q03-default.txt-Plan_/plan.txt"
+            "checksum": "2ece43eaccb3c523c1e69b58be6525af",
+            "size": 15061,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-tpch-q03-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q08-default.txt-Debug]": [
         {
-            "checksum": "e9518b4c06989ffb2dbe1328cd8981fd",
-            "size": 11729,
-            "uri": "https://{canondata_backend}/1942525/f4d5a26e0d6f06d4caeae293f551403b119bcf64/resource.tar.gz#test.test_pg-tpch-q08-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3c8febdf8203609a29612510c062584b",
+            "size": 11598,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-tpch-q08-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q08-default.txt-Plan]": [
         {
-            "checksum": "0f734016e21e0d24cacab3d922b99e18",
-            "size": 17110,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_pg-tpch-q08-default.txt-Plan_/plan.txt"
+            "checksum": "57d3331ec009ce81887e419cd8f87e5c",
+            "size": 16904,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-tpch-q08-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-tpch-q21-default.txt-Debug]": [
         {
-            "checksum": "8a55d868db6cb074735be57f04f38d72",
-            "size": 20565,
-            "uri": "https://{canondata_backend}/1937367/068b1fefb703009aeb4f81dcf197f4e07553fc36/resource.tar.gz#test.test_pg-tpch-q21-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e64fdfb1f7cf80f45bae4573e4c87e8c",
+            "size": 20362,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-tpch-q21-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[pg-tpch-q21-default.txt-Plan]": [
         {
-            "checksum": "5337d8976f93cb06da6f51b64ad6cf5a",
-            "size": 31761,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_pg-tpch-q21-default.txt-Plan_/plan.txt"
+            "checksum": "cb5469519d5b92cd6a8421c804501686",
+            "size": 31349,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_pg-tpch-q21-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[pg-with_rec_all_empty-default.txt-Debug]": [
@@ -2437,86 +2437,86 @@
     ],
     "test.test[sampling-mapjoin_left_sample-default.txt-Debug]": [
         {
-            "checksum": "e227515b209e0420f1cf90269f0bd3a9",
-            "size": 3638,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_sampling-mapjoin_left_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3cc1673debfc92951a43ead4acdf66d1",
+            "size": 3315,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-mapjoin_left_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-mapjoin_left_sample-default.txt-Plan]": [
         {
-            "checksum": "d10396f7022d56b440f24134b5dd6eca",
-            "size": 7728,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_sampling-mapjoin_left_sample-default.txt-Plan_/plan.txt"
+            "checksum": "84ed0413fcc770887154ceea8afadcd2",
+            "size": 7316,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-mapjoin_left_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-mapjoin_right_sample-default.txt-Debug]": [
         {
-            "checksum": "843224711e337c2ea1b8835739d8ed2c",
-            "size": 3638,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_sampling-mapjoin_right_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "ab370275221e611d9c81e54a19a85ee3",
+            "size": 3315,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-mapjoin_right_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-mapjoin_right_sample-default.txt-Plan]": [
         {
-            "checksum": "d10396f7022d56b440f24134b5dd6eca",
-            "size": 7728,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_sampling-mapjoin_right_sample-default.txt-Plan_/plan.txt"
+            "checksum": "84ed0413fcc770887154ceea8afadcd2",
+            "size": 7316,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-mapjoin_right_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-orderedjoin_left_sample-default.txt-Debug]": [
         {
-            "checksum": "3bb4bbda385da2a30d129793c248b4bd",
-            "size": 4705,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_sampling-orderedjoin_left_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "500d4db7ec89f3c510664a43153701e6",
+            "size": 4582,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-orderedjoin_left_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-orderedjoin_left_sample-default.txt-Plan]": [
         {
-            "checksum": "1cc5428eaec859d889dbfcbb34636a99",
-            "size": 6399,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_sampling-orderedjoin_left_sample-default.txt-Plan_/plan.txt"
+            "checksum": "c6024385e3a04a17846d70bc042a6519",
+            "size": 6193,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-orderedjoin_left_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-orderedjoin_right_sample-default.txt-Debug]": [
         {
-            "checksum": "fced0339fb165d141f93fa11b1804a6e",
-            "size": 4706,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_sampling-orderedjoin_right_sample-default.txt-Debug_/opt.yql_patched"
+            "checksum": "d22378d39e906f07b3dca31bbcf61c28",
+            "size": 4583,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-orderedjoin_right_sample-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-orderedjoin_right_sample-default.txt-Plan]": [
         {
-            "checksum": "ccea4a4bb3a1a5ebb75dfe12c78e28bc",
-            "size": 6399,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_sampling-orderedjoin_right_sample-default.txt-Plan_/plan.txt"
+            "checksum": "5c37ebd2cd3503319f1e09cf4e4fb4f5",
+            "size": 6193,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-orderedjoin_right_sample-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[sampling-subquery_sort-default.txt-Debug]": [
         {
-            "checksum": "73ef9b060998d9f2ff184ea74bbb688b",
-            "size": 3054,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_sampling-subquery_sort-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cbdecfbf0c4540044f9310fb1cd5bb30",
+            "size": 2930,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-subquery_sort-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[sampling-subquery_sort-default.txt-Plan]": [
         {
-            "checksum": "433de0ee5673c2150941aad2daf4efdf",
-            "size": 6171,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_sampling-subquery_sort-default.txt-Plan_/plan.txt"
+            "checksum": "162421da4d6cca37f29f18be8af1a14c",
+            "size": 5759,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_sampling-subquery_sort-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[schema-insert-read_schema-Debug]": [
         {
-            "checksum": "50ed5c021698508a57c7184228c926b9",
-            "size": 2717,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_schema-insert-read_schema-Debug_/opt.yql_patched"
+            "checksum": "1877b2d216f9189bcb29a483e595a0b0",
+            "size": 2551,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_schema-insert-read_schema-Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-insert-read_schema-Plan]": [
         {
-            "checksum": "4679ad300705e8756401b84e82e41708",
-            "size": 7195,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_schema-insert-read_schema-Plan_/plan.txt"
+            "checksum": "1863ed9cf7592491284072211b0f5960",
+            "size": 6989,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_schema-insert-read_schema-Plan_/plan.txt"
         }
     ],
     "test.test[schema-patchtype--Debug]": [
@@ -2535,44 +2535,44 @@
     ],
     "test.test[schema-remap_desc--Debug]": [
         {
-            "checksum": "4ec79d26cd8fdd0f099d53130f4b7e13",
-            "size": 3562,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_schema-remap_desc--Debug_/opt.yql_patched"
+            "checksum": "2b9276b93117cd9d855fe1a2ddd901d5",
+            "size": 3264,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_schema-remap_desc--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-remap_desc--Plan]": [
         {
-            "checksum": "0849a64cb5ae5d870fcd58ffdac4d862",
-            "size": 6239,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_schema-remap_desc--Plan_/plan.txt"
+            "checksum": "dc2e3ac55a3773c3dd14c1209b0f04b8",
+            "size": 5827,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_schema-remap_desc--Plan_/plan.txt"
         }
     ],
     "test.test[schema-user_schema_override--Debug]": [
         {
-            "checksum": "6a9ff2c7977b6bb8caa0206dd13f48b4",
-            "size": 1910,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_schema-user_schema_override--Debug_/opt.yql_patched"
+            "checksum": "d218806fec4fc7eca4353d8dc8a566dd",
+            "size": 1810,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_schema-user_schema_override--Debug_/opt.yql_patched"
         }
     ],
     "test.test[schema-user_schema_override--Plan]": [
         {
-            "checksum": "fbd6cfc21037b85d8a22f5b66e435123",
-            "size": 4282,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_schema-user_schema_override--Plan_/plan.txt"
+            "checksum": "b856c8ed99c677b1f76ad758dd371adc",
+            "size": 4076,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_schema-user_schema_override--Plan_/plan.txt"
         }
     ],
     "test.test[select-append_to_value--Debug]": [
         {
-            "checksum": "6c05785f3aead564e1eeaa708c7f4603",
-            "size": 2210,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-append_to_value--Debug_/opt.yql_patched"
+            "checksum": "7b812f2ee0dece20ba3347a64325b60b",
+            "size": 2083,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-append_to_value--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-append_to_value--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-append_to_value--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-append_to_value--Plan_/plan.txt"
         }
     ],
     "test.test[select-boolean_where--Debug]": [
@@ -2591,268 +2591,268 @@
     ],
     "test.test[select-deep_udf_call--Debug]": [
         {
-            "checksum": "423cc990b1e35218175aea6f9ce35921",
-            "size": 2768,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-deep_udf_call--Debug_/opt.yql_patched"
+            "checksum": "073a7194c168bc4608935414d46cea18",
+            "size": 2702,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-deep_udf_call--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-deep_udf_call--Plan]": [
         {
-            "checksum": "31bda1ce3e3b1d1d5b6dee8d1e992fa5",
-            "size": 4048,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-deep_udf_call--Plan_/plan.txt"
+            "checksum": "0125e7af019b358950785181cdbafd43",
+            "size": 3842,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-deep_udf_call--Plan_/plan.txt"
         }
     ],
     "test.test[select-dict_lookup-default.txt-Debug]": [
         {
-            "checksum": "625fdf644cab0faaa50b4d76a4d63fad",
-            "size": 2355,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-dict_lookup-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9ee47c4107ad69aece20ea53de4710b8",
+            "size": 2229,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-dict_lookup-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-dict_lookup-default.txt-Plan]": [
         {
-            "checksum": "268f40d4cd05bdaf1da7d54f3cb20944",
-            "size": 4077,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-dict_lookup-default.txt-Plan_/plan.txt"
+            "checksum": "bea2bf2feac939761164aa8b2b8b5923",
+            "size": 3871,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-dict_lookup-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-dict_lookup_by_key_with_def-default.txt-Debug]": [
         {
-            "checksum": "968c7f71a29405e64f77a15145bba45f",
-            "size": 2340,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-dict_lookup_by_key_with_def-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a72bd8be44963c5acfe6f60988516fb9",
+            "size": 2235,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-dict_lookup_by_key_with_def-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-dict_lookup_by_key_with_def-default.txt-Plan]": [
         {
-            "checksum": "b7a05abdbc4de06d3bb9bc201412c0d5",
-            "size": 4074,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-dict_lookup_by_key_with_def-default.txt-Plan_/plan.txt"
+            "checksum": "c2530f6062efb684059762f4a4406db3",
+            "size": 3868,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-dict_lookup_by_key_with_def-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-optional_in_job--Debug]": [
         {
-            "checksum": "4990b1fdaca063823acefcd84ac6628c",
-            "size": 5895,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-optional_in_job--Debug_/opt.yql_patched"
+            "checksum": "52bd62108a98665bbe0f0013c0e4a293",
+            "size": 5284,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-optional_in_job--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-optional_in_job--Plan]": [
         {
-            "checksum": "e5e7b8189e8abf9933f07283e5f43654",
-            "size": 13516,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-optional_in_job--Plan_/plan.txt"
+            "checksum": "02d5a36f624c00c94501c4f9c7403474",
+            "size": 13104,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-optional_in_job--Plan_/plan.txt"
         }
     ],
     "test.test[select-optional_pull--Debug]": [
         {
-            "checksum": "fac217ab00f0c8537ea08645393d6ecc",
-            "size": 5449,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-optional_pull--Debug_/opt.yql_patched"
+            "checksum": "c674f5273956f44553eaad963403e025",
+            "size": 4845,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-optional_pull--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-optional_pull--Plan]": [
         {
-            "checksum": "3aca6b02732942cd4eeb76e8426b8176",
-            "size": 12887,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-optional_pull--Plan_/plan.txt"
+            "checksum": "55ecd20902910a46d474aaa4d4d2b425",
+            "size": 12475,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-optional_pull--Plan_/plan.txt"
         }
     ],
     "test.test[select-reuse_named_node-default.txt-Debug]": [
         {
-            "checksum": "190c689f429cb4bbff471a1f37ad34a5",
-            "size": 1978,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-reuse_named_node-default.txt-Debug_/opt.yql_patched"
+            "checksum": "3f5ad2834c71c8c4190d5db171325750",
+            "size": 1912,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-reuse_named_node-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-reuse_named_node-default.txt-Plan]": [
         {
-            "checksum": "67f73b419a2db72944abc96e60c808fa",
-            "size": 4631,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-reuse_named_node-default.txt-Plan_/plan.txt"
+            "checksum": "6a3463c6b37b9772e3aaebb97d626a0e",
+            "size": 4425,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-reuse_named_node-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-select_all_group_by_column--Debug]": [
         {
-            "checksum": "b24e12ff5d73addddba2054b615f5083",
-            "size": 4226,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_select-select_all_group_by_column--Debug_/opt.yql_patched"
+            "checksum": "01fec74565325628edc8b28122188aa1",
+            "size": 4052,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-select_all_group_by_column--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-select_all_group_by_column--Plan]": [
         {
-            "checksum": "48c743b2745aacf088b6f1d4ae4b57a2",
-            "size": 8428,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-select_all_group_by_column--Plan_/plan.txt"
+            "checksum": "b9f8f848145f34956fd765582f6d785e",
+            "size": 7810,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-select_all_group_by_column--Plan_/plan.txt"
         }
     ],
     "test.test[select-struct_access_without_table_name--Debug]": [
         {
-            "checksum": "e5559929d3628d9145b13f6b237627b2",
-            "size": 3551,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_select-struct_access_without_table_name--Debug_/opt.yql_patched"
+            "checksum": "095ccb4bbb4b7d587acf8f97de8f6338",
+            "size": 3255,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-struct_access_without_table_name--Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-struct_access_without_table_name--Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-struct_access_without_table_name--Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-struct_access_without_table_name--Plan_/plan.txt"
         }
     ],
     "test.test[select-trivial_between-default.txt-Debug]": [
         {
-            "checksum": "5abfe5fb414c51b26dbbca62ac33b38b",
-            "size": 3404,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_select-trivial_between-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a78945b98f8c608e16ee9858ed0969d1",
+            "size": 3158,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-trivial_between-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-trivial_between-default.txt-Plan]": [
         {
-            "checksum": "7dce9b935b44c77cc7e06c865546ad57",
-            "size": 6230,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-trivial_between-default.txt-Plan_/plan.txt"
+            "checksum": "98a10e2d0c9a8d29d87dffa128d459e5",
+            "size": 5818,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-trivial_between-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[select-trivial_where-many-Debug]": [
         {
-            "checksum": "48ff19eb01c827a99b7e2e56dcc9947d",
-            "size": 1875,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-trivial_where-many-Debug_/opt.yql_patched"
+            "checksum": "51fd9f720f0cc3027f6f7e9ed945fb5d",
+            "size": 1752,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-trivial_where-many-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-trivial_where-many-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-trivial_where-many-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-trivial_where-many-Plan_/plan.txt"
         }
     ],
     "test.test[select-trivial_where-one-Debug]": [
         {
-            "checksum": "d39226500a89a0c6bfc972e7aff34d9f",
-            "size": 1871,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_select-trivial_where-one-Debug_/opt.yql_patched"
+            "checksum": "40713e10fe29410d576d6c88d544341a",
+            "size": 1748,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-trivial_where-one-Debug_/opt.yql_patched"
         }
     ],
     "test.test[select-trivial_where-one-Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_select-trivial_where-one-Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_select-trivial_where-one-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_same_key_by_all-default.txt-Debug]": [
         {
-            "checksum": "782014cd1a0e14cbdb141c43bc2d47c9",
-            "size": 6314,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_by_all-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8e4bff02896ffa086379f3b731f0d609",
+            "size": 6053,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_by_all-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_join_subreq_same_key_by_all-default.txt-Plan]": [
         {
-            "checksum": "84d8628991680f471c5fe5d2dd3086b6",
-            "size": 9136,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_by_all-default.txt-Plan_/plan.txt"
+            "checksum": "df2567a82663dc61534169e9aa734411",
+            "size": 8724,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_simple_columns-simple_columns_join_subreq_same_key_by_all-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_subreq-default.txt-Debug]": [
         {
-            "checksum": "9b8e429f95ab7d5654136dd76e88584f",
-            "size": 2975,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_simple_columns-simple_columns_subreq-default.txt-Debug_/opt.yql_patched"
+            "checksum": "be9463f5e66eb1c0e8fb3c1b711d053c",
+            "size": 2781,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_simple_columns-simple_columns_subreq-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_subreq-default.txt-Plan]": [
         {
-            "checksum": "96a1aaa1c90375e854e9749dfded727b",
-            "size": 6203,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_simple_columns-simple_columns_subreq-default.txt-Plan_/plan.txt"
+            "checksum": "f1f3d94de29dba1e33c50e9679a2a6c0",
+            "size": 5791,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_simple_columns-simple_columns_subreq-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[simple_columns-simple_columns_union_all_qualified_star-default.txt-Debug]": [
         {
-            "checksum": "8a563b2485db6310b876510537d49db8",
-            "size": 6778,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_simple_columns-simple_columns_union_all_qualified_star-default.txt-Debug_/opt.yql_patched"
+            "checksum": "e3c12e353e078fefe967723e292ad495",
+            "size": 6646,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_simple_columns-simple_columns_union_all_qualified_star-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[simple_columns-simple_columns_union_all_qualified_star-default.txt-Plan]": [
         {
-            "checksum": "610215d2d98323f2edd7a05609f9fe7d",
-            "size": 17853,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_simple_columns-simple_columns_union_all_qualified_star-default.txt-Plan_/plan.txt"
+            "checksum": "fdd5d785ab896947db9cabef91034c19",
+            "size": 17441,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_simple_columns-simple_columns_union_all_qualified_star-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q5-default.txt-Debug]": [
         {
-            "checksum": "8017b0b2714a343652d350bb4c326a2f",
-            "size": 8702,
-            "uri": "https://{canondata_backend}/1937492/816f15cbf2599eecb66a6b54e0732f8e563fb5d4/resource.tar.gz#test.test_tpch-q5-default.txt-Debug_/opt.yql_patched"
+            "checksum": "290cc1cd745b53bdc75ccc92b1d38f85",
+            "size": 8450,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_tpch-q5-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q5-default.txt-Plan]": [
         {
-            "checksum": "99526d79e3bb7512b70ff16bd79bfbe7",
-            "size": 15530,
-            "uri": "https://{canondata_backend}/1871182/ae5a1a770f9c7349220304e4fd5be84f506a9be5/resource.tar.gz#test.test_tpch-q5-default.txt-Plan_/plan.txt"
+            "checksum": "5cd9a78d77329ee331edfb1d941ee0e7",
+            "size": 15118,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_tpch-q5-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q8-default.txt-Debug]": [
         {
-            "checksum": "d2329d2dd3069d377aaa9f35ef32b8fc",
-            "size": 11790,
-            "uri": "https://{canondata_backend}/1942100/d100af76c0c36a4c867fa82ec45338e6ec675303/resource.tar.gz#test.test_tpch-q8-default.txt-Debug_/opt.yql_patched"
+            "checksum": "a968e72de41ce289c147596b513a0f62",
+            "size": 11429,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_tpch-q8-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q8-default.txt-Plan]": [
         {
-            "checksum": "912d7dae865a0bfa04b21320469f4e4e",
-            "size": 19189,
-            "uri": "https://{canondata_backend}/1937429/63852453d29efffa76c6539dbc3b748bd3ffe32d/resource.tar.gz#test.test_tpch-q8-default.txt-Plan_/plan.txt"
+            "checksum": "3c48b3c0b1e6d5e21c43736f37b66bb4",
+            "size": 18571,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_tpch-q8-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[tpch-q9-default.txt-Debug]": [
         {
-            "checksum": "fe220f41e8ffd7f60b337f5bd6bca3b3",
-            "size": 8201,
-            "uri": "https://{canondata_backend}/1925842/80c4f39e386ae3c979377f1d81a384b37b3ede76/resource.tar.gz#test.test_tpch-q9-default.txt-Debug_/opt.yql_patched"
+            "checksum": "9d12c36d7648f87ac6a55f0b03e46d3d",
+            "size": 7836,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_tpch-q9-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[tpch-q9-default.txt-Plan]": [
         {
-            "checksum": "4d3c61a63b3d74ed73c2ca8ba9e0d9ac",
-            "size": 12739,
-            "uri": "https://{canondata_backend}/1923547/c833ec7694cea9309ddc45306f38267de32f5613/resource.tar.gz#test.test_tpch-q9-default.txt-Plan_/plan.txt"
+            "checksum": "978a2fa92cf1f8a6ea5203667d642bb9",
+            "size": 12121,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_tpch-q9-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-decimal_yt--Debug]": [
         {
-            "checksum": "421791b956ede1c3c8285897fd59e66a",
-            "size": 2862,
-            "uri": "https://{canondata_backend}/1937424/8c25765f83ee7bce38837736aff206ea08e78264/resource.tar.gz#test.test_type_v3-decimal_yt--Debug_/opt.yql_patched"
+            "checksum": "23127653ad7ac3e96473d43d58cf5ef5",
+            "size": 2514,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_type_v3-decimal_yt--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-decimal_yt--Plan]": [
         {
-            "checksum": "a7719199534717e53cbe7a1863a63758",
-            "size": 7940,
-            "uri": "https://{canondata_backend}/1937367/066576e53bdefdb421e04eb342ce21c3fe80fbd4/resource.tar.gz#test.test_type_v3-decimal_yt--Plan_/plan.txt"
+            "checksum": "a5a0bae05b428f9a947a7937b880fd03",
+            "size": 7734,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_type_v3-decimal_yt--Plan_/plan.txt"
         }
     ],
     "test.test[type_v3-mixed_with_columns--Debug]": [
         {
-            "checksum": "7b4ffc452cdac98515c4a16d54008a4f",
-            "size": 2191,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_type_v3-mixed_with_columns--Debug_/opt.yql_patched"
+            "checksum": "261a46564cbfc3cf77744e347746134a",
+            "size": 2045,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_type_v3-mixed_with_columns--Debug_/opt.yql_patched"
         }
     ],
     "test.test[type_v3-mixed_with_columns--Plan]": [
         {
-            "checksum": "48c8d48de50e3c8cbc62de1c0ee18963",
-            "size": 3529,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_type_v3-mixed_with_columns--Plan_/plan.txt"
+            "checksum": "8f8b50cc4cfa98dcf57d542aaecdf244",
+            "size": 3323,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_type_v3-mixed_with_columns--Plan_/plan.txt"
         }
     ],
     "test.test[udf-automap_null--Debug]": [
@@ -2899,16 +2899,16 @@
     ],
     "test.test[udf-udf--Debug]": [
         {
-            "checksum": "9928844f7f330a12d749e73ddb47b01d",
-            "size": 2165,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_udf-udf--Debug_/opt.yql_patched"
+            "checksum": "5738e5fa716c912df9cef4d3b847c7c0",
+            "size": 2042,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_udf-udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[udf-udf--Plan]": [
         {
-            "checksum": "1926c856908f9da5f8fb9a0560324330",
-            "size": 4104,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_udf-udf--Plan_/plan.txt"
+            "checksum": "58b75b6d8acaf910abb37f92f3ca9ce8",
+            "size": 3898,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_udf-udf--Plan_/plan.txt"
         }
     ],
     "test.test[union-union_mix-default.txt-Debug]": [
@@ -2955,30 +2955,30 @@
     ],
     "test.test[union_all-union_all_with_top_level_limits_ansi-default.txt-Debug]": [
         {
-            "checksum": "89aaff30be473aba5ebcdcc1c61e07d0",
-            "size": 3116,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_union_all-union_all_with_top_level_limits_ansi-default.txt-Debug_/opt.yql_patched"
+            "checksum": "7b3c069964f7eb9c5fbed5498757714f",
+            "size": 2965,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_union_all-union_all_with_top_level_limits_ansi-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[union_all-union_all_with_top_level_limits_ansi-default.txt-Plan]": [
         {
-            "checksum": "6ae3d21549f551d223af6e3fff5c032c",
-            "size": 7140,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_union_all-union_all_with_top_level_limits_ansi-default.txt-Plan_/plan.txt"
+            "checksum": "15ec87215f7af1fafa1171519ff75502",
+            "size": 6728,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_union_all-union_all_with_top_level_limits_ansi-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_in_group_by--Debug]": [
         {
-            "checksum": "6cb7d060f0c3ff9c8deb2b458a49d980",
-            "size": 4438,
-            "uri": "https://{canondata_backend}/1937429/e11799bc6b03b95f687825951895ae651115cd1d/resource.tar.gz#test.test_weak_field-weak_field_in_group_by--Debug_/opt.yql_patched"
+            "checksum": "272470917d050b79088db8814dfdf228",
+            "size": 4244,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_weak_field-weak_field_in_group_by--Debug_/opt.yql_patched"
         }
     ],
     "test.test[weak_field-weak_field_in_group_by--Plan]": [
         {
-            "checksum": "31ac3858da60b2a68b49eb32c479618f",
-            "size": 7789,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_weak_field-weak_field_in_group_by--Plan_/plan.txt"
+            "checksum": "7c728a2fac822088ac06c9802cc9095e",
+            "size": 7377,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_weak_field-weak_field_in_group_by--Plan_/plan.txt"
         }
     ],
     "test.test[weak_field-weak_field_long_name--Debug]": [
@@ -2997,128 +2997,128 @@
     ],
     "test.test[window-current/ansi_current_mixed--Debug]": [
         {
-            "checksum": "4369700742ab410f070b2b7bac700ee4",
-            "size": 7657,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_window-current_ansi_current_mixed--Debug_/opt.yql_patched"
+            "checksum": "4736d0c02a187896519662671416c03f",
+            "size": 7211,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-current_ansi_current_mixed--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/ansi_current_mixed--Plan]": [
         {
-            "checksum": "a69f6f99fb946191b14b9c371e5d9fbe",
-            "size": 5739,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-current_ansi_current_mixed--Plan_/plan.txt"
+            "checksum": "be8c89bfbe10454d24401995ea09e3be",
+            "size": 5327,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-current_ansi_current_mixed--Plan_/plan.txt"
         }
     ],
     "test.test[window-current/session_extended--Debug]": [
         {
-            "checksum": "79c3e4e935bac8b658b69db3d2062996",
-            "size": 8155,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_window-current_session_extended--Debug_/opt.yql_patched"
+            "checksum": "ed069073d787c5c57d47011fccd6ee81",
+            "size": 7660,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-current_session_extended--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-current/session_extended--Plan]": [
         {
-            "checksum": "46c765a7b77e1888fa491c1c4f26a09f",
-            "size": 8750,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-current_session_extended--Plan_/plan.txt"
+            "checksum": "7997b480626e4318eed5536f92c2d6ee",
+            "size": 8338,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-current_session_extended--Plan_/plan.txt"
         }
     ],
     "test.test[window-full/noncompact_with_nulls--Debug]": [
         {
-            "checksum": "44375fa89ac3c25834ba49c7e72e60a7",
-            "size": 10720,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_window-full_noncompact_with_nulls--Debug_/opt.yql_patched"
+            "checksum": "c1d4f4e560e004811f6be7f925224665",
+            "size": 10133,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-full_noncompact_with_nulls--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-full/noncompact_with_nulls--Plan]": [
         {
-            "checksum": "840487de934bb98a6b14615f199a2e44",
-            "size": 15703,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-full_noncompact_with_nulls--Plan_/plan.txt"
+            "checksum": "d0e743e007a62828c67f3e7a1daa1d80",
+            "size": 14673,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-full_noncompact_with_nulls--Plan_/plan.txt"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Debug]": [
         {
-            "checksum": "f6ab86e0b8ef924335420010ec1370a9",
-            "size": 10162,
-            "uri": "https://{canondata_backend}/1937424/f451f285fc7754f944209343662da0cffa8b8855/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
+            "checksum": "06de8ba78f5bab328e44dd21c1809c31",
+            "size": 9645,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-generic_aggregations_after_current--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-generic/aggregations_after_current--Plan]": [
         {
-            "checksum": "3c649b14bfe4b594e48a74f901c3dd1e",
-            "size": 8480,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-generic_aggregations_after_current--Plan_/plan.txt"
+            "checksum": "89c1ad86738a5f8457d6066e3493f020",
+            "size": 7862,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-generic_aggregations_after_current--Plan_/plan.txt"
         }
     ],
     "test.test[window-presort_window_order_by_table-default.txt-Debug]": [
         {
-            "checksum": "2d100609140e81a9e4e2aaf9e30bb981",
-            "size": 3179,
-            "uri": "https://{canondata_backend}/1900335/3723346a2da176c5ee65dcf2ea559b19068a6488/resource.tar.gz#test.test_window-presort_window_order_by_table-default.txt-Debug_/opt.yql_patched"
+            "checksum": "cc0c8e7d67be42495e8e9cb971b76df1",
+            "size": 3121,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-presort_window_order_by_table-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-presort_window_order_by_table-default.txt-Plan]": [
         {
-            "checksum": "27081f65d689569823ed8a204e1e54f2",
-            "size": 7412,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-presort_window_order_by_table-default.txt-Plan_/plan.txt"
+            "checksum": "f2bb058a3b143d1de85c87ef85f94edb",
+            "size": 7206,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-presort_window_order_by_table-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-row_number_to_map_multiple-default.txt-Debug]": [
         {
-            "checksum": "552a0fd43f643f81fe7c7938b62e0475",
-            "size": 5531,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_window-row_number_to_map_multiple-default.txt-Debug_/opt.yql_patched"
+            "checksum": "670876fae28d208baddd0c88bb00c130",
+            "size": 5209,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-row_number_to_map_multiple-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-row_number_to_map_multiple-default.txt-Plan]": [
         {
-            "checksum": "6226c35644a8322dc42fac19346ad9d3",
-            "size": 7645,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-row_number_to_map_multiple-default.txt-Plan_/plan.txt"
+            "checksum": "8f6300743a4fe88a4e7933acd4b114dd",
+            "size": 7233,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-row_number_to_map_multiple-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Debug]": [
         {
-            "checksum": "e7556d1abd0367a43c1cec9a3e9e522a",
-            "size": 6352,
-            "uri": "https://{canondata_backend}/1937424/f451f285fc7754f944209343662da0cffa8b8855/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql_patched"
+            "checksum": "8cd982d297631a0227e3788733d2a6e5",
+            "size": 6206,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_by_all_percentile_interval-default.txt-Plan]": [
         {
-            "checksum": "e03207d50afa0ec72bdb20a82af58aa0",
-            "size": 6080,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Plan_/plan.txt"
+            "checksum": "602f862487ddc6577a33ec45851c580c",
+            "size": 5874,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-win_by_all_percentile_interval-default.txt-Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_into_udf--Debug]": [
         {
-            "checksum": "a318de606d43cf48cf072d9217bef944",
-            "size": 4256,
-            "uri": "https://{canondata_backend}/1937367/49c64cc02672876c23ccd5878b5b598389e8c1ca/resource.tar.gz#test.test_window-win_func_into_udf--Debug_/opt.yql_patched"
+            "checksum": "c95e7ef14b77f072876b8464cd84b202",
+            "size": 4062,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-win_func_into_udf--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_into_udf--Plan]": [
         {
-            "checksum": "d9c35fc4249d68f9158b0e130fd31be4",
-            "size": 5710,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-win_func_into_udf--Plan_/plan.txt"
+            "checksum": "53c83b2c69df913e90dd4fd8c1947c28",
+            "size": 5298,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-win_func_into_udf--Plan_/plan.txt"
         }
     ],
     "test.test[window-win_func_over_group_by_compl--Debug]": [
         {
-            "checksum": "e14e420ff10176e247ae20a119d2b53a",
-            "size": 12102,
-            "uri": "https://{canondata_backend}/1936947/d8054c25338962bd038d66c5e7c4fff2edbe535b/resource.tar.gz#test.test_window-win_func_over_group_by_compl--Debug_/opt.yql_patched"
+            "checksum": "3aa5a4c89afe7d10d67192768231111d",
+            "size": 11702,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-win_func_over_group_by_compl--Debug_/opt.yql_patched"
         }
     ],
     "test.test[window-win_func_over_group_by_compl--Plan]": [
         {
-            "checksum": "95023442bc0660e48038a147297073f4",
-            "size": 9696,
-            "uri": "https://{canondata_backend}/1900335/8eba31ae2dcfd9245ad9327a1ac3ca89667336e2/resource.tar.gz#test.test_window-win_func_over_group_by_compl--Plan_/plan.txt"
+            "checksum": "13e93b2369df19578e01865f5da22186",
+            "size": 9284,
+            "uri": "https://{canondata_backend}/1809005/2a59475dc877549ac4197a291aacd77d92f24ab4/resource.tar.gz#test.test_window-win_func_over_group_by_compl--Plan_/plan.txt"
         }
     ],
     "test.test[window-yql-18879-default.txt-Debug]": [


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

1. Move YtDqWrite -> YtDqWideWrite rewrite to peephole (required for p.3)
2. Push Unordered to DqStage lambda before YtDqWrite
3. Remove aux columns before YtDqWrite in case of desc sort

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
