### PR TITLE
24-3: Enable CMS request priorities by default (#8380)

### DIFF
--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -1810,7 +1810,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(EmergencyDuringRollingRestart)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         // Start rolling restart
         auto rollingRestart = env.CheckPermissionRequest
@@ -1839,7 +1839,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(ScheduledEmergencyDuringRollingRestart)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         // Start rolling restart
         auto rollingRestart = env.CheckPermissionRequest
@@ -1871,7 +1871,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(WalleRequestDuringRollingRestart)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         // Start rolling restart
         auto rollingRestart = env.CheckPermissionRequest
@@ -1899,7 +1899,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(ScheduledWalleRequestDuringRollingRestart)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         // Start rolling restart
         auto rollingRestart = env.CheckPermissionRequest
@@ -1930,7 +1930,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(EnableCMSRequestPrioritiesFeatureFlag)
     {
-        TCmsTestEnv env(8);
+        TCmsTestEnv env(TTestEnvOpts(8).WithoutEnableCMSRequestPriorities());
         // Start rolling restart with specified priority
         auto rollingRestart = env.CheckPermissionRequest
             ("user", true, false, true, true, -80, TStatus::WRONG_REQUEST,
@@ -1943,7 +1943,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(SamePriorityRequest)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         // Start rolling restart
         auto rollingRestart = env.CheckPermissionRequest
@@ -1973,7 +1973,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(SamePriorityRequest2)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         // Start rolling restart
         auto rollingRestart = env.CheckPermissionRequest
@@ -2003,7 +2003,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(PriorityRange)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         const TString expectedReason = "Priority value is out of range";
         
@@ -2024,7 +2024,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
 
     Y_UNIT_TEST(WalleTasksDifferentPriorities)
     {
-        TCmsTestEnv env(TTestEnvOpts(8).WithEnableCMSRequestPriorities());
+        TCmsTestEnv env(8);
 
         // Without node limits
         NKikimrCms::TCmsConfig config;

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -107,7 +107,7 @@ struct TTestEnvOpts {
         , UseMirror3dcErasure(false)
         , AdvanceCurrentTime(false)
         , EnableSentinel(false)
-        , EnableCMSRequestPriorities(false)
+        , EnableCMSRequestPriorities(true)
         , EnableSingleCompositeActionGroup(true)
     {
     }
@@ -122,8 +122,8 @@ struct TTestEnvOpts {
         return *this;
     }
 
-    TTestEnvOpts& WithEnableCMSRequestPriorities() {
-        EnableCMSRequestPriorities = true;
+    TTestEnvOpts& WithoutEnableCMSRequestPriorities() {
+        EnableCMSRequestPriorities = false;
         return *this;
     }
 };

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -129,7 +129,7 @@ message TFeatureFlags {
     optional bool EnableAccessServiceBulkAuthorization = 114 [default = false];
     optional bool EnableAddColumsWithDefaults = 115 [ default = false];
     optional bool EnableReplaceIfExistsForExternalEntities = 116 [ default = false];
-    optional bool EnableCMSRequestPriorities = 117 [default = false];
+    optional bool EnableCMSRequestPriorities = 117 [default = true];
     optional bool EnableKeyvalueLogBatching = 118 [default = false];
     optional bool EnableLocalDBFlatIndex = 119 [default = true];
     optional bool ExtendedVDiskCounters = 120 [default = true];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

CMS request priorities is enabled by default

### Changelog category <!-- remove all except one -->

* Improvement
