### PR TITLE
Fix table stats aggregation for OLAP tables

### DIFF
--- a/ydb/core/tx/schemeshard/olap/table/table.h
+++ b/ydb/core/tx/schemeshard/olap/table/table.h
@@ -100,7 +100,6 @@ public:
     }
 
     void UpdateTableStats(const TShardIdx shardIdx, const TPathId& pathId, const TPartitionStats& newStats) {
-        Stats.TableStats[shardIdx]; // insert if none
         Stats.UpdateTableStats(shardIdx, pathId, newStats);
     }
 

--- a/ydb/core/tx/schemeshard/olap/table/table.h
+++ b/ydb/core/tx/schemeshard/olap/table/table.h
@@ -99,8 +99,9 @@ public:
         Stats.UpdateShardStats(shardIdx, newStats);
     }
 
-    void UpdateTableStats(const TPathId& pathId, const TPartitionStats& newStats) {
-        Stats.UpdateTableStats(pathId, newStats);
+    void UpdateTableStats(const TShardIdx shardIdx, const TPathId& pathId, const TPartitionStats& newStats) {
+        Stats.TableStats[shardIdx]; // insert if none
+        Stats.UpdateTableStats(shardIdx, pathId, newStats);
     }
 
     TConclusion<std::shared_ptr<NOlap::NAlter::ISSEntity>> BuildEntity(const TPathId& pathId, const NOlap::NAlter::TEntityInitializationContext& iContext) const;

--- a/ydb/core/tx/schemeshard/olap/table/table.h
+++ b/ydb/core/tx/schemeshard/olap/table/table.h
@@ -100,6 +100,7 @@ public:
     }
 
     void UpdateTableStats(const TShardIdx shardIdx, const TPathId& pathId, const TPartitionStats& newStats) {
+        Stats.TableStats[pathId].Aggregated.PartCount = GetColumnShards().size();
         Stats.UpdateTableStats(shardIdx, pathId, newStats);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -327,7 +327,7 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
                             "add stats for exists table with pathId=" << tablePathId);
 
                 auto columnTable = Self->ColumnTables.TakeVerified(tablePathId);
-                columnTable->UpdateTableStats(tablePathId, newTableStats);
+                columnTable->UpdateTableStats(shardIdx, tablePathId, newTableStats);
             } else {
                 LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                            "failed add stats for table with pathId=" << tablePathId);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1673,37 +1673,6 @@ void TTableInfo::UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats&
     Stats.UpdateShardStats(datashardIdx, newStats);
 }
 
-void OlapTableAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats) {
-    if (!PartitionStats.contains(datashardIdx)) {
-        PartitionStats[datashardIdx] = newStats;
-        return;
-    }
-
-    TPartitionStats& oldStats = PartitionStats[datashardIdx];
-
-    if (newStats.SeqNo <= oldStats.SeqNo) {
-        // Ignore outdated message
-        return;
-    }
-
-    if (newStats.SeqNo.Generation > oldStats.SeqNo.Generation) {
-        // Reset incremental counter baselines if tablet has restarted
-        Aggregated.ImmediateTxCompleted = 0;
-        Aggregated.PlannedTxCompleted = 0;
-        Aggregated.TxRejectedByOverload = 0;
-        Aggregated.TxRejectedBySpace = 0;
-        Aggregated.RowUpdates = 0;
-        Aggregated.RowDeletes = 0;
-        Aggregated.RowReads = 0;
-        Aggregated.RangeReads = 0;
-        Aggregated.RangeReadRows = 0;
-    }
-    Aggregated.RowCount += (newStats.RowCount - oldStats.RowCount);
-    Aggregated.DataSize += (newStats.DataSize - oldStats.DataSize);
-
-    oldStats = newStats;
-}
-
 void TTableAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats) {
     // Ignore stats from unknown datashard (it could have been split)
     if (!PartitionStats.contains(datashardIdx))

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1704,7 +1704,7 @@ void OlapTableAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TP
     oldStats = newStats;
 }
 
-void TAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats) {
+void TTableAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats) {
     // Ignore stats from unknown datashard (it could have been split)
     if (!PartitionStats.contains(datashardIdx))
         return;
@@ -1794,9 +1794,10 @@ void TAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartition
     }
 }
 
-void TAggregatedStats::UpdateTableStats(TShardIdx datashardIdx, const TPathId& pathId, const TPartitionStats& newStats) {
+void TAggregatedStats::UpdateTableStats(TShardIdx shardIdx, const TPathId& pathId, const TPartitionStats& newStats) {
     auto& tableStats = TableStats[pathId];
-    tableStats.UpdateShardStats(datashardIdx, newStats);
+    tableStats.PartitionStats[shardIdx]; // insert if none
+    tableStats.UpdateShardStats(shardIdx, newStats);
 }
 
 void TTableInfo::RegisterSplitMergeOp(TOperationId opId, const TTxState& txState) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1674,6 +1674,11 @@ void TTableInfo::UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats&
 }
 
 void OlapTableAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats) {
+    if (!PartitionStats.contains(datashardIdx)) {
+        PartitionStats[datashardIdx] = newStats;
+        return;
+    }
+
     TPartitionStats& oldStats = PartitionStats[datashardIdx];
 
     if (newStats.SeqNo <= oldStats.SeqNo) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -321,10 +321,17 @@ private:
     ui64 CPU = 0;
 };
 
+struct OlapTableAggregatedStats {
+    TPartitionStats Aggregated;
+    THashMap<TShardIdx, TPartitionStats> PartitionStats;
+
+    void UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats);
+};
+
 struct TAggregatedStats {
     TPartitionStats Aggregated;
     THashMap<TShardIdx, TPartitionStats> PartitionStats;
-    THashMap<TShardIdx, THashMap<TPathId, TPartitionStats>> TableStats;
+    THashMap<TPathId, OlapTableAggregatedStats> TableStats;
     size_t PartitionStatsUpdated = 0;
 
     void UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -324,11 +324,11 @@ private:
 struct TAggregatedStats {
     TPartitionStats Aggregated;
     THashMap<TShardIdx, TPartitionStats> PartitionStats;
-    THashMap<TPathId, TPartitionStats> TableStats;
+    THashMap<TShardIdx, THashMap<TPathId, TPartitionStats>> TableStats;
     size_t PartitionStatsUpdated = 0;
 
     void UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats);
-    void UpdateTableStats(const TPathId& pathId, const TPartitionStats& newStats);
+    void UpdateTableStats(TShardIdx datashardIdx, const TPathId& pathId, const TPartitionStats& newStats);
 };
 
 struct TSubDomainInfo;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -328,13 +328,17 @@ struct OlapTableAggregatedStats {
     void UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats);
 };
 
-struct TAggregatedStats {
+struct TTableAggregatedStats {
     TPartitionStats Aggregated;
     THashMap<TShardIdx, TPartitionStats> PartitionStats;
-    THashMap<TPathId, OlapTableAggregatedStats> TableStats;
     size_t PartitionStatsUpdated = 0;
 
     void UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats);
+};
+
+struct TAggregatedStats : public TTableAggregatedStats {
+    THashMap<TPathId, TTableAggregatedStats> TableStats;
+
     void UpdateTableStats(TShardIdx datashardIdx, const TPathId& pathId, const TPartitionStats& newStats);
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -321,13 +321,6 @@ private:
     ui64 CPU = 0;
 };
 
-struct OlapTableAggregatedStats {
-    TPartitionStats Aggregated;
-    THashMap<TShardIdx, TPartitionStats> PartitionStats;
-
-    void UpdateShardStats(TShardIdx datashardIdx, const TPartitionStats& newStats);
-};
-
 struct TTableAggregatedStats {
     TPartitionStats Aggregated;
     THashMap<TShardIdx, TPartitionStats> PartitionStats;

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -570,7 +570,7 @@ void TPathDescriber::DescribeColumnTable(TPathId pathId, TPathElement::TPtr path
             description->MutableSchema()->SetVersion(description->GetSchema().GetVersion() + description->GetSchemaPresetVersionAdj());
         }
         if (tableInfo->GetStats().TableStats.contains(pathId)) {
-            FillTableStats(*pathDescription, tableInfo->GetStats().TableStats.at(pathId));
+            FillTableStats(*pathDescription, tableInfo->GetStats().TableStats.at(pathId).Aggregated);
         } else {
             FillTableStats(*pathDescription, TPartitionStats());
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix aggregation of table stats for OLAP tables.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fixed:
- Resource consumption metrics, Access time, Update time and PartCount did not update for column tables.
- Data size and rows count were incorrect (too small) if there were multiple column table shards.
