### PR TITLE
Move stability test into manual (because it is a cluster test)

### DIFF
--- a/ydb/tests/stability/ydb/ya.make
+++ b/ydb/tests/stability/ydb/ya.make
@@ -1,4 +1,3 @@
-SUBSCRIBER(g:kikimr)
 PY3TEST()
 
 TEST_SRCS(
@@ -7,7 +6,7 @@ TEST_SRCS(
 
 TIMEOUT(18000)
 SIZE(LARGE)
-TAG(ya:not_autocheck ya:fat)
+TAG(ya:manual)
 
 DATA(
     arcadia/ydb/tests/stability/resources


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Test is not intended to run in standard workflows, because cluster is needed

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

