### PR TITLE
fix streamlookup keys join on unmatched rows

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -111,7 +111,7 @@ private: //events
                         outputRowItems[i] = wideInputRow[index];
                         break;
                     case EOutputRowItemSource::LookupKey:
-                        outputRowItems[i] = lookupKey.GetElement(index);
+                        outputRowItems[i] = lookupPayload && *lookupPayload ? lookupKey.GetElement(index) : NUdf::TUnboxedValue {};
                         break;
                     case EOutputRowItemSource::LookupOther:
                         if (lookupPayload && *lookupPayload) {

--- a/ydb/tests/fq/generic/test_streaming_join.py
+++ b/ydb/tests/fq/generic/test_streaming_join.py
@@ -10,6 +10,7 @@ from ydb.tests.tools.fq_runner.fq_client import FederatedQueryClient
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.fq.generic.utils.settings import Settings
 
+DEBUG = 0
 TESTCASES = [
     # 0
     (
@@ -370,9 +371,10 @@ class TestStreamingJoin(TestYdsBase):
             offset += 500
 
         read_data = self.read_stream(len(messages))
-        # print(streamlookup, testcase, file=sys.stderr)
-        # print(sql, file=sys.stderr)
-        # print(*zip(messages, read_data), file=sys.stderr, sep="\n")
+        if DEBUG:
+            print(streamlookup, testcase, file=sys.stderr)
+            print(sql, file=sys.stderr)
+            print(*zip(messages, read_data), file=sys.stderr, sep="\n")
         for r, exp in zip(read_data, messages):
             r = json.loads(r)
             exp = json.loads(exp[1])

--- a/ydb/tests/fq/generic/test_streaming_join.py
+++ b/ydb/tests/fq/generic/test_streaming_join.py
@@ -324,9 +324,9 @@ class TestStreamingJoin(TestYdsBase):
             offset += 500
 
         read_data = self.read_stream(len(messages))
-        print(streamlookup, testcase, file=sys.stderr)
-        print(sql, file=sys.stderr)
-        print(*zip(messages, read_data), file=sys.stderr, sep="\n")
+        # print(streamlookup, testcase, file=sys.stderr)
+        # print(sql, file=sys.stderr)
+        # print(*zip(messages, read_data), file=sys.stderr, sep="\n")
         for r, exp in zip(read_data, messages):
             r = json.loads(r)
             exp = json.loads(exp[1])


### PR DESCRIPTION
```
SELECT s.id, db.id FROM yds.`in` AS s
  LEFT JOIN /*+ streamlookup() */ ydb.`db` as db
    ON s.id = db.id;
```
returned `db.id` equal to `s.id` on unmatched rows, it should've been NULL

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
