### PR TITLE
Prepare cpp-protobuf migration

### DIFF
--- a/ydb/library/yql/parser/proto_ast/gen/multiproto.py
+++ b/ydb/library/yql/parser/proto_ast/gen/multiproto.py
@@ -73,7 +73,7 @@ def main(argv):
                         if type_name in current_types:
                             out_file.write(line)
                         continue
-                    if line.startswith("static ") or (line.startswith("const ") and ("[]" in line or "=" in line)) or line.startswith("PROTOBUF_ATTRIBUTE_WEAK"):
+                    if line.startswith("static ") or (line.startswith("const ") and ("[]" in line or "=" in line)) or line.startswith("PROTOBUF_ATTRIBUTE_WEAK") or line.startswith("PROTOBUF_ATTRIBUTE_INIT_PRIORITY2"):
                         is_data_stmt = True
                         extern_data = "file_level_metadata" in line or ("descriptor_table" in line and "once" in line)
                         extern_code = line.startswith("PROTOBUF_ATTRIBUTE_WEAK")

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
@@ -5,6 +5,7 @@
 #include <ydb/public/lib/ydb_cli/common/print_utils.h>
 #include <ydb/public/lib/ydb_cli/common/scheme_printers.h>
 #include <ydb/public/sdk/cpp/client/ydb_proto/accessor.h>
+#include <google/protobuf/port_def.inc>
 
 #include <util/string/join.h>
 
@@ -303,7 +304,11 @@ static int PrintProtoJsonBase64(const T& msg) {
     const auto status = MessageToJsonString(msg, &json, opts);
 
     if (!status.ok()) {
+        #if PROTOBUF_VERSION >= 4022005
+        Cerr << "Error occurred while converting proto to json: " << status.message() << Endl;
+        #else
         Cerr << "Error occurred while converting proto to json: " << status.message().ToString() << Endl;
+        #endif
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
This PR is preparation for cpp-protobuf library migration:
- Fix protoc's plugin for splitting .pb.cc files
- Migrate to abseil::Status class