### PR TITLE
Prepare for testmo retries

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -105,6 +105,9 @@ runs:
           TESTMO_PROXY_PID=$!
           echo "TESTMO_PROXY_ADDR=$TESTMO_PROXY_ADDR" >> $GITHUB_ENV
           echo "TESTMO_PROXY_PID=$TESTMO_PROXY_PID" >> $GITHUB_ENV
+
+          # testmo rejects self-signed cert without this setting
+          echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> $GITHUB_ENV
         fi
 
     - name: ya build and test

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -89,6 +89,24 @@ runs:
 
         python3 -m pip install ydb ydb[yc] codeowners
 
+        if [ ${{ inputs.testman_token }} ]; then
+          TESTMO_PROXY_ADDR=127.0.0.1:8888
+          openssl req -x509 -newkey rsa:2048 \
+            -keyout $TMP_DIR/key.pem -out $TMP_DIR/cert.pem \
+            -sha256 -days 1 -nodes -subj "/CN=127.0.0.1"
+          
+          TESTMO_TOKEN=${{ inputs.testman_token }} ./ydb/ci/testmo-proxy/testmo-proxy.py -l $TESTMO_PROXY_ADDR \
+            --cert-file "$TMP_DIR/cert.pem" \
+            --cert-key "$TMP_DIR/key.pem" \
+            --target-timeout 3,10 \
+            --max-request-time 55 \
+            "$TESTMO_URL" &
+            
+          TESTMO_PROXY_PID=$!
+          echo "TESTMO_PROXY_ADDR=$TESTMO_PROXY_ADDR" >> $GITHUB_ENV
+          echo "TESTMO_PROXY_PID=$TESTMO_PROXY_PID" >> $GITHUB_ENV
+        fi
+
     - name: ya build and test
       id: build
       shell: bash
@@ -260,7 +278,7 @@ runs:
             TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:resources:add-link --name build --url "$TESTMO_RUN_URL" --resources testmo.json
             TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:resources:add-field --name git-sha --type string --value "${GITHUB_SHA:0:7}" --resources testmo.json
             TESTMO_RUN_ID=$(
-              TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:create --instance "$TESTMO_URL" --project-id ${{ inputs.testman_project_id }} \
+              TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:create --instance "https://$TESTMO_PROXY_ADDR" --project-id ${{ inputs.testman_project_id }} \
                 --name "$TESTMO_RUN_NAME" --source "$TESTMO_SOURCE" --resources testmo.json \
                 --tags "$TESTMO_BRANCH_TAG" --tags "$TESTMO_EXTRA_TAG"
             )
@@ -373,29 +391,12 @@ runs:
             .github/scripts/tests/split-junit.py -o "$TESTMO_JUNIT_REPORT_PARTS" "$CURRENT_JUNIT_XML_PATH"
             # archive unitest reports (transformed)
             tar -C $TESTMO_JUNIT_REPORT_PARTS/.. -czf $PUBLIC_DIR/junit_parts.xml.tar.gz $(basename $TESTMO_JUNIT_REPORT_PARTS)
-
-            TESTMO_PROXY_ADDR=127.0.0.1:8888
-
-            openssl req -x509 -newkey rsa:2048 \
-              -keyout $TMP_DIR/key.pem -out $TMP_DIR/cert.pem \
-              -sha256 -days 1 -nodes -subj "/CN=127.0.0.1"
-            
-            TESTMO_TOKEN=${{ inputs.testman_token }} ./ydb/ci/testmo-proxy/testmo-proxy.py -l $TESTMO_PROXY_ADDR \
-              --cert-file "$TMP_DIR/cert.pem" \
-              --cert-key "$TMP_DIR/key.pem" \
-              --target-timeout 3,10 \
-              --max-request-time 55 \
-              "$TESTMO_URL" &
-            
-            testmo_proxy_pid=$!
             
             TESTMO_TOKEN=${{ inputs.testman_token }} NODE_TLS_REJECT_UNAUTHORIZED=0 testmo automation:run:submit-thread \
               --instance "https://$TESTMO_PROXY_ADDR" --run-id "$TESTMO_RUN_ID" \
               --results "$TESTMO_JUNIT_REPORT_PARTS/*.xml"
-            
-            kill $testmo_proxy_pid
 
-            TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "$TESTMO_URL" --run-id $TESTMO_RUN_ID
+            TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "$https://$TESTMO_PROXY_ADDR" --run-id $TESTMO_RUN_ID
             echo "runid=" >> $GITHUB_OUTPUT
           fi
 
@@ -435,8 +436,9 @@ runs:
       shell: bash
       run: |
         if [ ${{ steps.build.outputs.runid }} ]; then
-          TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "$TESTMO_URL" --run-id ${{ steps.build.outputs.runid }}
+          TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "https://$TESTMO_PROXY_ADDR" --run-id ${{ steps.build.outputs.runid }}
         fi
+        kill $TESTMO_PROXY_PID
     - name: analyze tests results
       shell: bash
       env:

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -83,7 +83,8 @@ runs:
         mkdir -p $PUBLIC_DIR
 
         echo "LAST_JUNIT_REPORT_XML=$PUBLIC_DIR/last_junit.xml" >> $GITHUB_ENV
-        echo "TESTMO_URL=${{ inputs.testman_url }}" >> $GITHUB_ENV
+        export TESTMO_URL=${{ inputs.testman_url }}
+        echo "TESTMO_URL=$TESTMO_URL" >> $GITHUB_ENV
         echo "SUMMARY_LINKS=$PUBLIC_DIR/summary_links.txt" >> $GITHUB_ENV
         echo "BUILD_PRESET=${{ inputs.build_preset }}" >> $GITHUB_ENV
 

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -400,7 +400,7 @@ runs:
               --instance "https://$TESTMO_PROXY_ADDR" --run-id "$TESTMO_RUN_ID" \
               --results "$TESTMO_JUNIT_REPORT_PARTS/*.xml"
 
-            TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "https://$TESTMO_PROXY_ADDR" --run-id $TESTMO_RUN_ID
+            TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "https://$TESTMO_PROXY_ADDR" --run-id $TESTMO_RUN_ID || true
             echo "runid=" >> $GITHUB_OUTPUT
           fi
 
@@ -440,7 +440,7 @@ runs:
       shell: bash
       run: |
         if [ ${{ steps.build.outputs.runid }} ]; then
-          TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "https://$TESTMO_PROXY_ADDR" --run-id ${{ steps.build.outputs.runid }}
+          TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "https://$TESTMO_PROXY_ADDR" --run-id ${{ steps.build.outputs.runid }} || true
         fi
         if [ ${{ inputs.testman_token }} ]; then
           kill $TESTMO_PROXY_PID

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -400,7 +400,7 @@ runs:
               --instance "https://$TESTMO_PROXY_ADDR" --run-id "$TESTMO_RUN_ID" \
               --results "$TESTMO_JUNIT_REPORT_PARTS/*.xml"
 
-            TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "$https://$TESTMO_PROXY_ADDR" --run-id $TESTMO_RUN_ID
+            TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "https://$TESTMO_PROXY_ADDR" --run-id $TESTMO_RUN_ID
             echo "runid=" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -99,8 +99,8 @@ runs:
           TESTMO_TOKEN=${{ inputs.testman_token }} ./ydb/ci/testmo-proxy/testmo-proxy.py -l $TESTMO_PROXY_ADDR \
             --cert-file "$TMP_DIR/cert.pem" \
             --cert-key "$TMP_DIR/key.pem" \
-            --target-timeout 3,10 \
-            --max-request-time 55 \
+            --target-timeout 3,60 \
+            --max-request-time 200 \
             "$TESTMO_URL" > $PUBLIC_DIR/testmo_proxy.log 2>&1 &
             
           TESTMO_PROXY_PID=$!

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -100,7 +100,7 @@ runs:
             --cert-key "$TMP_DIR/key.pem" \
             --target-timeout 3,10 \
             --max-request-time 55 \
-            "$TESTMO_URL" &
+            "$TESTMO_URL" > $PUBLIC_DIR/testmo_proxy.log 2>&1 &
             
           TESTMO_PROXY_PID=$!
           echo "TESTMO_PROXY_ADDR=$TESTMO_PROXY_ADDR" >> $GITHUB_ENV
@@ -281,7 +281,7 @@ runs:
             TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:resources:add-link --name build --url "$TESTMO_RUN_URL" --resources testmo.json
             TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:resources:add-field --name git-sha --type string --value "${GITHUB_SHA:0:7}" --resources testmo.json
             TESTMO_RUN_ID=$(
-              TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:create --debug --instance "https://$TESTMO_PROXY_ADDR" --project-id ${{ inputs.testman_project_id }} \
+              TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:create --instance "https://$TESTMO_PROXY_ADDR" --project-id ${{ inputs.testman_project_id }} \
                 --name "$TESTMO_RUN_NAME" --source "$TESTMO_SOURCE" --resources testmo.json \
                 --tags "$TESTMO_BRANCH_TAG" --tags "$TESTMO_EXTRA_TAG"
             )

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -281,7 +281,7 @@ runs:
             TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:resources:add-link --name build --url "$TESTMO_RUN_URL" --resources testmo.json
             TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:resources:add-field --name git-sha --type string --value "${GITHUB_SHA:0:7}" --resources testmo.json
             TESTMO_RUN_ID=$(
-              TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:create --instance "https://$TESTMO_PROXY_ADDR" --project-id ${{ inputs.testman_project_id }} \
+              TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:create --debug --instance "https://$TESTMO_PROXY_ADDR" --project-id ${{ inputs.testman_project_id }} \
                 --name "$TESTMO_RUN_NAME" --source "$TESTMO_SOURCE" --resources testmo.json \
                 --tags "$TESTMO_BRANCH_TAG" --tags "$TESTMO_EXTRA_TAG"
             )

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -395,7 +395,7 @@ runs:
             # archive unitest reports (transformed)
             tar -C $TESTMO_JUNIT_REPORT_PARTS/.. -czf $PUBLIC_DIR/junit_parts.xml.tar.gz $(basename $TESTMO_JUNIT_REPORT_PARTS)
             
-            TESTMO_TOKEN=${{ inputs.testman_token }} NODE_TLS_REJECT_UNAUTHORIZED=0 testmo automation:run:submit-thread \
+            TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:submit-thread \
               --instance "https://$TESTMO_PROXY_ADDR" --run-id "$TESTMO_RUN_ID" \
               --results "$TESTMO_JUNIT_REPORT_PARTS/*.xml"
 
@@ -441,7 +441,9 @@ runs:
         if [ ${{ steps.build.outputs.runid }} ]; then
           TESTMO_TOKEN=${{ inputs.testman_token }} testmo automation:run:complete --instance "https://$TESTMO_PROXY_ADDR" --run-id ${{ steps.build.outputs.runid }}
         fi
-        kill $TESTMO_PROXY_PID
+        if [ ${{ inputs.testman_token }} ]; then
+          kill $TESTMO_PROXY_PID
+        fi
     - name: analyze tests results
       shell: bash
       env:

--- a/ydb/ci/testmo-proxy/testmo-proxy.py
+++ b/ydb/ci/testmo-proxy/testmo-proxy.py
@@ -83,6 +83,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         self._proxy_request("POST")
 
+    def do_PUT(self):
+        self._proxy_request("PUT")
+
+    def do_DELETE(self):
+        self._proxy_request("DELETE")
+
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- all testmo interaction with proxy 
- add separate log
- ignore session finalization result (see screenshot below)

It was evidence then 
automation:run:complete at first time returned 500
And after second try returned 422
![telegram-cloud-photo-size-2-5368389806817664576-y](https://github.com/user-attachments/assets/3b3865b3-98cf-43f1-b4d9-08e94b1c7c9a)
So we just ignore automation:run:complete 

Next steps: add retries for 5XX 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Sample check with tests:
https://github.com/ydb-platform/ydb/pull/8496 
