### PR TITLE
Add unit-test on eviction column validation when applying tiering rule

### DIFF
--- a/ydb/core/kqp/ut/common/columnshard.cpp
+++ b/ydb/core/kqp/ut/common/columnshard.cpp
@@ -60,7 +60,7 @@ namespace NKqp {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
     }
 
-    TString TTestHelper::CreateTieringRule(const TString& tierName, const TString& columnName) {
+    TString TTestHelper::CreateTieringRule(const TString& tierName, const TString& columnName, const EStatus expectedStatus) {
         const TString ruleName = tierName + "_" + columnName;
         const TString configTieringStr = TStringBuilder() <<  R"({
             "rules" : [
@@ -71,7 +71,7 @@ namespace NKqp {
             ]
         })";
         auto result = Session.ExecuteSchemeQuery("CREATE OBJECT IF NOT EXISTS " + ruleName + " (TYPE TIERING_RULE) WITH (defaultColumn = " + columnName + ", description = `" + configTieringStr + "`)").GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToString());
         return ruleName;
     }
 

--- a/ydb/core/kqp/ut/common/columnshard.cpp
+++ b/ydb/core/kqp/ut/common/columnshard.cpp
@@ -75,10 +75,10 @@ namespace NKqp {
         return ruleName;
     }
 
-    void TTestHelper::SetTiering(const TString& tableName, const TString& ruleName) {
+    void TTestHelper::SetTiering(const TString& tableName, const TString& ruleName, const EStatus expectedStatus) {
         auto alterQuery = TStringBuilder() << "ALTER TABLE `" << tableName <<  "` SET (TIERING = '" << ruleName << "')";
         auto result = Session.ExecuteSchemeQuery(alterQuery).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToString());
     }
 
     void TTestHelper::ResetTiering(const TString& tableName) {

--- a/ydb/core/kqp/ut/common/columnshard.h
+++ b/ydb/core/kqp/ut/common/columnshard.h
@@ -76,7 +76,7 @@ namespace NKqp {
         void DropTable(const TString& tableName);
         void CreateTier(const TString& tierName);
         TString CreateTieringRule(const TString& tierName, const TString& columnName, const NYdb::EStatus expectedStatus = NYdb::EStatus::SUCCESS);
-        void SetTiering(const TString& tableName, const TString& ruleName);
+        void SetTiering(const TString& tableName, const TString& ruleName, const NYdb::EStatus expectedStatus = NYdb::EStatus::SUCCESS);
         void ResetTiering(const TString& tableName);
         void BulkUpsert(const TColumnTable& table, TTestHelper::TUpdatesBuilder& updates, const Ydb::StatusIds_StatusCode& opStatus = Ydb::StatusIds::SUCCESS);
         void BulkUpsert(const TColumnTable& table, std::shared_ptr<arrow::RecordBatch> batch, const Ydb::StatusIds_StatusCode& opStatus = Ydb::StatusIds::SUCCESS);

--- a/ydb/core/kqp/ut/common/columnshard.h
+++ b/ydb/core/kqp/ut/common/columnshard.h
@@ -75,7 +75,7 @@ namespace NKqp {
         void CreateTable(const TColumnTableBase& table, const NYdb::EStatus expectedStatus = NYdb::EStatus::SUCCESS);
         void DropTable(const TString& tableName);
         void CreateTier(const TString& tierName);
-        TString CreateTieringRule(const TString& tierName, const TString& columnName);
+        TString CreateTieringRule(const TString& tierName, const TString& columnName, const NYdb::EStatus expectedStatus = NYdb::EStatus::SUCCESS);
         void SetTiering(const TString& tableName, const TString& ruleName);
         void ResetTiering(const TString& tableName);
         void BulkUpsert(const TColumnTable& table, TTestHelper::TUpdatesBuilder& updates, const Ydb::StatusIds_StatusCode& opStatus = Ydb::StatusIds::SUCCESS);

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -181,10 +181,15 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
             UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
         }
 
-        testHelper.CreateTieringRule("tier1", "XXXwrongColumnXXX", NYdb::EStatus::GENERIC_ERROR);
-        testHelper.CreateTieringRule("tier1", "utfColumn", NYdb::EStatus::GENERIC_ERROR);
-        testHelper.CreateTieringRule("tier1", "nullableColumn", NYdb::EStatus::GENERIC_ERROR);
-        const TString tieringRule = testHelper.CreateTieringRule("tier1", "tempColumn");
+        const TString ruleWithUnknownColumn = testHelper.CreateTieringRule("tier1", "XXXwrongColumnXXX");
+        const TString ruleWithUtfColumn = testHelper.CreateTieringRule("tier1", "utfColumn");
+        const TString ruleWithNullableColumn = testHelper.CreateTieringRule("tier1", "nullableColumn");
+        const TString ruleWithTempColumn = testHelper.CreateTieringRule("tier1", "tempColumn");
+        
+        testHelper.SetTiering("olapStore/olapTable", ruleWithUnknownColumn, NYdb::EStatus::GENERIC_ERROR);
+        testHelper.SetTiering("olapStore/olapTable", ruleWithUtfColumn, NYdb::EStatus::GENERIC_ERROR);
+        testHelper.SetTiering("olapStore/olapTable", ruleWithNullableColumn, NYdb::EStatus::GENERIC_ERROR);
+        testHelper.SetTiering("olapStore/olapTable", ruleWithTempColumn, NYdb::EStatus::SUCCESS);
 
         {
             const TString query = "ALTER TABLE `olapStore/olapTable` DROP COLUMN tempColumn";


### PR DESCRIPTION
Add a muted unit-test.

Issue: applying tiering rule with unknown eviction column breaks column shard: Verify fails and shards can't be initialized.
