### PR TITLE
nbs-issue-176: added EncryptedDataKey field to NKikimrBlockStore::TEncryptionDesc

### DIFF
--- a/ydb/core/protos/blockstore_config.proto
+++ b/ydb/core/protos/blockstore_config.proto
@@ -19,9 +19,16 @@ enum EPartitionType {
     NonReplicated = 1; // directly mapped network partitions
 }
 
+message TEncryptedDataKey
+{
+    optional string KekId = 1;
+    optional bytes Ciphertext = 2;
+};
+
 message TEncryptionDesc {
     optional uint32 Mode = 1;
     optional bytes KeyHash = 2;
+    optional TEncryptedDataKey EncryptedDataKey = 3;
 }
 
 message TVolumeConfig {


### PR DESCRIPTION
This PR relates to https://github.com/ydb-platform/nbs/issues/176

The EncryptedDataKey field is added to TEncryptionDesc to store the encrypted data encryption key.
