### PR TITLE
merge the additional yaml config to the main yaml config

### DIFF
--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -8,6 +8,8 @@ import random
 import string
 import typing  # noqa: F401
 import sys
+import yaml
+import copy
 from six.moves.urllib.parse import urlparse
 
 from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
@@ -310,6 +312,54 @@ def enable_pqcd(arguments):
     return (getattr(arguments, 'enable_pqcd', False) or os.getenv('YDB_ENABLE_PQCD') == 'true')
 
 
+def merge_two_yaml_configs(data_1, data_2):
+    _check_types_for_merge(data_1, data_2)
+    if isinstance(data_1, dict) and isinstance(data_2, dict):
+        data_1, data_2 = data_1.copy(), data_2.copy()
+        new_dict = {}
+        d2_keys = list(data_2.keys())
+        for d1k in data_1.keys():
+            if d1k in d2_keys:
+                d2_keys.remove(d1k)
+                new_dict[d1k] = merge_two_yaml_configs(data_1.get(d1k), data_2.get(d1k))
+            else:
+                new_dict[d1k] = copy.deepcopy(data_1.get(d1k))
+
+        for d2k in d2_keys:
+            new_dict[d2k] = copy.deepcopy(data_2.get(d2k))
+
+        return new_dict
+    else:
+        if data_2 is None:
+            return copy.deepcopy(data_1)
+        else:
+            return copy.deepcopy(data_2)
+
+
+def _check_types_for_merge(data_1, data_2):
+    if isinstance(data_1, dict) and isinstance(data_2, dict):
+        return
+    if isinstance(data_1, list) and isinstance(data_2, list):
+        return
+    if data_1 is None and data_2 is None:
+        return
+    if (data_1 is None and isinstance(data_2, list)) or (data_2 is None and isinstance(data_1, list)):
+        return
+    if (data_1 is None and isinstance(data_2, dict)) or (data_2 is None and isinstance(data_1, dict)):
+        return
+    raise TypeError("Type mismatch - " + str(type(data_1)) + " data_1 cannot be merged with " + str(type(data_2)) + " data_2")
+
+
+def get_additional_yaml_config(arguments, path):
+    if arguments.ydb_working_dir:
+        with open(os.path.join(arguments.ydb_working_dir, path)) as fh:
+            additional_yaml_config = yaml.load(fh, Loader=yaml.FullLoader)
+    else:
+        raise Exception("No working directory")
+
+    return additional_yaml_config
+
+
 def deploy(arguments):
     initialize_working_dir(arguments)
     recipe = Recipe(arguments)
@@ -373,6 +423,10 @@ def deploy(arguments):
         generic_connector_config=generic_connector_config(),
         **optionals
     )
+
+    if os.getenv("YDB_CONFIG_PATCH") is not None:
+        additional_yaml_config = get_additional_yaml_config(arguments, os.getenv("YDB_CONFIG_PATCH"))
+        configuration.yaml_config = merge_two_yaml_configs(configuration.yaml_config, additional_yaml_config)
 
     cluster = kikimr_cluster_factory(configuration)
     cluster.start()

--- a/ydb/public/tools/lib/cmds/ut/canondata/result.json
+++ b/ydb/public/tools/lib/cmds/ut/canondata/result.json
@@ -1,0 +1,5 @@
+{
+    "test.test_merge_two_yaml_configs": {
+        "uri": "file://test.test_merge_two_yaml_configs/patched.yaml"
+    }
+}

--- a/ydb/public/tools/lib/cmds/ut/canondata/test.test_merge_two_yaml_configs/patched.yaml
+++ b/ydb/public/tools/lib/cmds/ut/canondata/test.test_merge_two_yaml_configs/patched.yaml
@@ -1,0 +1,325 @@
+actor_system_config:
+  batch_executor: 2
+  executor:
+  - name: System
+    spin_threshold: 0
+    threads: 2
+    type: BASIC
+  - name: User
+    spin_threshold: 0
+    threads: 3
+    type: BASIC
+  - name: Batch
+    spin_threshold: 0
+    threads: 2
+    type: BASIC
+  - name: IO
+    threads: 1
+    time_per_mailbox_micro_secs: 100
+    type: IO
+  - name: IC
+    spin_threshold: 10
+    threads: 1
+    time_per_mailbox_micro_secs: 100
+    type: BASIC
+  io_executor: 3
+  scheduler:
+    progress_threshold: 10000
+    resolution: 256
+    spin_threshold: 0
+  service_executor:
+  - executor_id: 4
+    service_name: Interconnect
+  sys_executor: 0
+  user_executor: 1
+blob_storage_config:
+  service_set:
+    availability_domains: 1
+    groups:
+    - erasure_species: 0
+      group_generation: 1
+      group_id: 0
+      rings:
+      - fail_domains:
+        - vdisk_locations:
+          - node_id: 1
+            pdisk_guid: 1
+            pdisk_id: 1
+            vdisk_slot_id: 0
+    pdisks:
+    - node_id: 1
+      path: SectorMap:1:64
+      pdisk_category: 0
+      pdisk_guid: 1
+      pdisk_id: 1
+    vdisks:
+    - vdisk_id:
+        domain: 0
+        group_generation: 1
+        group_id: 0
+        ring: 0
+        vdisk: 0
+      vdisk_location:
+        node_id: 1
+        pdisk_guid: 1
+        pdisk_id: 1
+        vdisk_slot_id: 0
+channel_profile_config:
+  profile:
+  - channel:
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    profile_id: 0
+  - channel:
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    profile_id: 1
+domains_config:
+  domain:
+  - domain_id: 1
+    name: local
+    scheme_root: 72075186232723360
+    storage_pool_types:
+    - kind: hdd
+      pool_config:
+        box_id: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+    - kind: hdd1
+      pool_config:
+        box_id: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+    - kind: hdd2
+      pool_config:
+        box_id: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+    - kind: hdde
+      pool_config:
+        box_id: 1
+        encryption_mode: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+  security_config:
+    default_users:
+    - name: user
+      password: P@ssw0rd
+  state_storage:
+  - ring:
+      nto_select: 1
+      ring:
+      - node:
+        - 1
+        use_ring_specific_node_selection: true
+    ssid: 1
+feature_flags:
+  enable_mvcc_snapshot_reads: true
+  enable_persistent_query_stats: true
+  enable_public_api_external_blobs: false
+  enable_scheme_transactions_at_scheme_shard: true
+  enable_views: true
+federated_query_config:
+  audit:
+    enabled: false
+    uaconfig:
+      uri: ''
+  checkpoint_coordinator:
+    checkpointing_period_millis: 1000
+    enabled: true
+    max_inflight: 1
+    storage:
+      endpoint: ''
+  common:
+    ids_prefix: pt
+    use_bearer_for_ydb: true
+  control_plane_proxy:
+    enabled: true
+    request_timeout: 30s
+  control_plane_storage:
+    available_binding:
+    - DATA_STREAMS
+    - OBJECT_STORAGE
+    available_connection:
+    - YDB_DATABASE
+    - CLICKHOUSE_CLUSTER
+    - DATA_STREAMS
+    - OBJECT_STORAGE
+    - MONITORING
+    enabled: true
+    storage:
+      endpoint: ''
+  db_pool:
+    enabled: true
+    storage:
+      endpoint: ''
+  enabled: false
+  gateways:
+    dq:
+      default_settings: []
+    enabled: true
+    pq:
+      cluster_mapping: []
+    solomon:
+      cluster_mapping: []
+  nodes_manager:
+    enabled: true
+  pending_fetcher:
+    enabled: true
+  pinger:
+    ping_period: 30s
+  private_api:
+    enabled: true
+  private_proxy:
+    enabled: true
+  resource_manager:
+    enabled: true
+  token_accessor:
+    enabled: true
+grpc_config:
+  ca: /ydb_certs/ca.pem
+  cert: /ydb_certs/cert.pem
+  host: '[::]'
+  key: /ydb_certs/key.pem
+  services:
+  - legacy
+  - yql
+  - discovery
+  - cms
+  - locking
+  - kesus
+  - pq
+  - pqcd
+  - pqv1
+  - topic
+  - datastreams
+  - scripting
+  - clickhouse_internal
+  - rate_limiter
+  - analytics
+  - export
+  - import
+  - yq
+  - keyvalue
+  - monitoring
+  - auth
+  - query_service
+interconnect_config:
+  start_tcp: true
+kqpconfig:
+  settings:
+  - name: _ResultRowsLimit
+    value: '1000'
+  - name: _KqpYqlSyntaxVersion
+    value: '1'
+  - name: _KqpAllowNewEngine
+    value: 'true'
+  - name: _KqpForceNewEngine
+    value: 'true'
+log_config:
+  default_level: 5
+  entry: []
+  sys_log: false
+memory_controller_config:
+  hard_limit_bytes: 4294967296
+nameservice_config:
+  node:
+  - address: ::1
+    host: localhost
+    node_id: 1
+    port: 19001
+    walle_location:
+      body: 1
+      data_center: '1'
+      rack: '1'
+net_classifier_config:
+  cms_config_timeout_seconds: 30
+  net_data_file_path: /ydb_data/netData.tsv
+  updater_config:
+    net_data_update_interval_seconds: 60
+    retry_interval_seconds: 30
+pqcluster_discovery_config:
+  enabled: false
+pqconfig:
+  check_acl: false
+  cluster_table_path: ''
+  clusters_update_timeout_sec: 1
+  enable_proto_source_id_info: true
+  enabled: true
+  max_storage_node_port: 65535
+  meta_cache_timeout_sec: 1
+  quoting_config:
+    enable_quoting: false
+  require_credentials_in_new_protocol: false
+  root: ''
+  topics_are_first_class_citizen: true
+  version_table_path: ''
+sqs_config:
+  enable_dead_letter_queues: true
+  enable_sqs: false
+  force_queue_creation_v2: true
+  force_queue_deletion_v2: true
+  scheme_cache_hard_refresh_time_seconds: 0
+  scheme_cache_soft_refresh_time_seconds: 0
+static_erasure: none
+system_tablets:
+  default_node:
+  - 1
+  flat_schemeshard:
+  - info:
+      tablet_id: 72075186232723360
+  flat_tx_coordinator:
+  - node:
+    - 1
+  tx_allocator:
+  - node:
+    - 1
+  tx_mediator:
+  - node:
+    - 1
+table_service_config:
+  enable_kqp_data_query_stream_lookup: true
+  index_auto_choose_mode: MAX_USED_PREFIX
+  sql_version: 1

--- a/ydb/public/tools/lib/cmds/ut/config.yaml
+++ b/ydb/public/tools/lib/cmds/ut/config.yaml
@@ -1,0 +1,321 @@
+actor_system_config:
+  batch_executor: 2
+  executor:
+  - name: System
+    spin_threshold: 0
+    threads: 2
+    type: BASIC
+  - name: User
+    spin_threshold: 0
+    threads: 3
+    type: BASIC
+  - name: Batch
+    spin_threshold: 0
+    threads: 2
+    type: BASIC
+  - name: IO
+    threads: 1
+    time_per_mailbox_micro_secs: 100
+    type: IO
+  - name: IC
+    spin_threshold: 10
+    threads: 1
+    time_per_mailbox_micro_secs: 100
+    type: BASIC
+  io_executor: 3
+  scheduler:
+    progress_threshold: 10000
+    resolution: 256
+    spin_threshold: 0
+  service_executor:
+  - executor_id: 4
+    service_name: Interconnect
+  sys_executor: 0
+  user_executor: 1
+blob_storage_config:
+  service_set:
+    availability_domains: 1
+    groups:
+    - erasure_species: 0
+      group_generation: 1
+      group_id: 0
+      rings:
+      - fail_domains:
+        - vdisk_locations:
+          - node_id: 1
+            pdisk_guid: 1
+            pdisk_id: 1
+            vdisk_slot_id: 0
+    pdisks:
+    - node_id: 1
+      path: SectorMap:1:64
+      pdisk_category: 0
+      pdisk_guid: 1
+      pdisk_id: 1
+    vdisks:
+    - vdisk_id:
+        domain: 0
+        group_generation: 1
+        group_id: 0
+        ring: 0
+        vdisk: 0
+      vdisk_location:
+        node_id: 1
+        pdisk_guid: 1
+        pdisk_id: 1
+        vdisk_slot_id: 0
+channel_profile_config:
+  profile:
+  - channel:
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    profile_id: 0
+  - channel:
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    - erasure_species: none
+      pdisk_category: 0
+      storage_pool_kind: hdd
+    profile_id: 1
+domains_config:
+  domain:
+  - domain_id: 1
+    name: local
+    scheme_root: 72075186232723360
+    storage_pool_types:
+    - kind: hdd
+      pool_config:
+        box_id: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+    - kind: hdd1
+      pool_config:
+        box_id: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+    - kind: hdd2
+      pool_config:
+        box_id: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+    - kind: hdde
+      pool_config:
+        box_id: 1
+        encryption_mode: 1
+        erasure_species: none
+        kind: hdd
+        pdisk_filter:
+        - property:
+          - type: ROT
+        vdisk_kind: Default
+  security_config:
+    default_users:
+    - name: root
+      password: '1234'
+  state_storage:
+  - ring:
+      nto_select: 1
+      ring:
+      - node:
+        - 1
+        use_ring_specific_node_selection: true
+    ssid: 1
+feature_flags:
+  enable_mvcc_snapshot_reads: true
+  enable_persistent_query_stats: true
+  enable_public_api_external_blobs: false
+  enable_scheme_transactions_at_scheme_shard: true
+federated_query_config:
+  audit:
+    enabled: false
+    uaconfig:
+      uri: ''
+  checkpoint_coordinator:
+    checkpointing_period_millis: 1000
+    enabled: true
+    max_inflight: 1
+    storage:
+      endpoint: ''
+  common:
+    ids_prefix: pt
+    use_bearer_for_ydb: true
+  control_plane_proxy:
+    enabled: true
+    request_timeout: 30s
+  control_plane_storage:
+    available_binding:
+    - DATA_STREAMS
+    - OBJECT_STORAGE
+    available_connection:
+    - YDB_DATABASE
+    - CLICKHOUSE_CLUSTER
+    - DATA_STREAMS
+    - OBJECT_STORAGE
+    - MONITORING
+    enabled: true
+    storage:
+      endpoint: ''
+  db_pool:
+    enabled: true
+    storage:
+      endpoint: ''
+  enabled: false
+  gateways:
+    dq:
+      default_settings: []
+    enabled: true
+    pq:
+      cluster_mapping: []
+    solomon:
+      cluster_mapping: []
+  nodes_manager:
+    enabled: true
+  pending_fetcher:
+    enabled: true
+  pinger:
+    ping_period: 30s
+  private_api:
+    enabled: true
+  private_proxy:
+    enabled: true
+  resource_manager:
+    enabled: true
+  token_accessor:
+    enabled: true
+grpc_config:
+  ca: /ydb_certs/ca.pem
+  cert: /ydb_certs/cert.pem
+  host: '[::]'
+  key: /ydb_certs/key.pem
+  services:
+  - legacy
+  - yql
+  - discovery
+  - cms
+  - locking
+  - kesus
+  - pq
+  - pqcd
+  - pqv1
+  - topic
+  - datastreams
+  - scripting
+  - clickhouse_internal
+  - rate_limiter
+  - analytics
+  - export
+  - import
+  - yq
+  - keyvalue
+  - monitoring
+  - auth
+  - query_service
+interconnect_config:
+  start_tcp: true
+kqpconfig:
+  settings:
+  - name: _ResultRowsLimit
+    value: '1000'
+  - name: _KqpYqlSyntaxVersion
+    value: '1'
+  - name: _KqpAllowNewEngine
+    value: 'true'
+  - name: _KqpForceNewEngine
+    value: 'true'
+log_config:
+  default_level: 5
+  entry: []
+  sys_log: false
+memory_controller_config:
+  hard_limit_bytes: 4294967296
+nameservice_config:
+  node:
+  - address: ::1
+    host: localhost
+    node_id: 1
+    port: 19001
+    walle_location:
+      body: 1
+      data_center: '1'
+      rack: '1'
+net_classifier_config:
+  cms_config_timeout_seconds: 30
+  net_data_file_path: /ydb_data/netData.tsv
+  updater_config:
+    net_data_update_interval_seconds: 60
+    retry_interval_seconds: 30
+pqcluster_discovery_config:
+  enabled: false
+pqconfig:
+  check_acl: false
+  cluster_table_path: ''
+  clusters_update_timeout_sec: 1
+  enable_proto_source_id_info: true
+  enabled: true
+  max_storage_node_port: 65535
+  meta_cache_timeout_sec: 1
+  quoting_config:
+    enable_quoting: false
+  require_credentials_in_new_protocol: false
+  root: ''
+  topics_are_first_class_citizen: true
+  version_table_path: ''
+sqs_config:
+  enable_dead_letter_queues: true
+  enable_sqs: false
+  force_queue_creation_v2: true
+  force_queue_deletion_v2: true
+  scheme_cache_hard_refresh_time_seconds: 0
+  scheme_cache_soft_refresh_time_seconds: 0
+static_erasure: none
+system_tablets:
+  default_node:
+  - 1
+  flat_schemeshard:
+  - info:
+      tablet_id: 72075186232723360
+  flat_tx_coordinator:
+  - node:
+    - 1
+  tx_allocator:
+  - node:
+    - 1
+  tx_mediator:
+  - node:
+    - 1
+table_service_config: {}

--- a/ydb/public/tools/lib/cmds/ut/patch.yaml
+++ b/ydb/public/tools/lib/cmds/ut/patch.yaml
@@ -1,0 +1,13 @@
+table_service_config:
+  sql_version: 1
+  index_auto_choose_mode: MAX_USED_PREFIX
+  enable_kqp_data_query_stream_lookup: true
+
+feature_flags:
+  enable_views: true
+
+domains_config:
+  security_config:
+    default_users:
+    - name: user
+      password: 'P@ssw0rd'

--- a/ydb/public/tools/lib/cmds/ut/test.py
+++ b/ydb/public/tools/lib/cmds/ut/test.py
@@ -30,8 +30,6 @@ def test_kikimr_config_generator_generic_connector_config():
 
 
 def test_merge_two_yaml_configs():
-Nikita-Levuskin marked this conversation as resolved.
-Nikita-Levuskin marked this conversation as resolved.
     patched_yaml = yatest.common.output_path("patched.yaml")
 
     with open(yatest.common.source_path("ydb/public/tools/lib/cmds/ut/config.yaml"), 'r') as fh:

--- a/ydb/public/tools/lib/cmds/ut/test.py
+++ b/ydb/public/tools/lib/cmds/ut/test.py
@@ -1,6 +1,9 @@
 import os
+import pytest
+import yaml
+import yatest.common
 
-from ydb.public.tools.lib.cmds import generic_connector_config
+from ydb.public.tools.lib.cmds import generic_connector_config, merge_two_yaml_configs
 from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
 
 
@@ -24,3 +27,31 @@ def test_kikimr_config_generator_generic_connector_config():
 
     actual = generic_connector_config()
     assert actual == expected
+
+
+def test_merge_two_yaml_configs():
+Nikita-Levuskin marked this conversation as resolved.
+Nikita-Levuskin marked this conversation as resolved.
+    patched_yaml = yatest.common.output_path("patched.yaml")
+
+    with open(yatest.common.source_path("ydb/public/tools/lib/cmds/ut/config.yaml"), 'r') as fh:
+        data_1 = yaml.load(fh, Loader=yaml.FullLoader)
+
+    with open(yatest.common.source_path("ydb/public/tools/lib/cmds/ut/patch.yaml"), 'r') as fh:
+        data_2 = yaml.load(fh, Loader=yaml.FullLoader)
+
+    with open(patched_yaml, "w") as res:
+        res.write(yaml.dump(merge_two_yaml_configs(data_1, data_2), default_flow_style=False))
+
+    return yatest.common.canonical_file(patched_yaml, local=True)
+
+
+@pytest.mark.parametrize("dict_1, dict_2, dict_final", [
+    ({'data': [{'user': 'root', 'password': '1234'}]}, {'data': [{'user': 'root', 'password': '12345678'}]}, {'data': [{'user': 'root', 'password': '12345678'}]}),
+    ({'data': [{'user': 'root', 'password': '1234'}]}, {'second_data': {'user': 'user', 'password': '12345'}},
+     {'data': [{'user': 'root', 'password': '1234'}], 'second_data': {'user': 'user', 'password': '12345'}}),
+    ({'data': None}, {'data': {'user': 'root', 'password': '12345678'}}, {'data': {'user': 'root', 'password': '12345678'}}),
+    ({'data': [{'user': 'root', 'password': '1234'}]}, {'data': None}, {'data': [{'user': 'root', 'password': '1234'}]})
+    ])
+def test_merge_two_dicts(dict_1, dict_2, dict_final):
+    assert merge_two_yaml_configs(dict_1, dict_2) == dict_final

--- a/ydb/public/tools/lib/cmds/ut/ya.make
+++ b/ydb/public/tools/lib/cmds/ut/ya.make
@@ -9,4 +9,9 @@ TEST_SRCS(
     test.py
 )
 
+FILES(
+    ydb/public/tools/lib/cmds/ut/config.yaml
+    ydb/public/tools/lib/cmds/ut/patch.yaml
+)
+
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Added the ability to merge additional config to the main config

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

When starting a container without configs, you can specify the environment variable "YDB_CONFIG_YAML_PATCH", which should point to the config file relative to the workdir(default "ydb_data") and, if this variable is present, the additional config is combined with the main config. If there is no file specified in the environment variable, the application will not start
