### PR TITLE
Implement computation node for BlockMapJoinCore (Left and Inner) with multi dict

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -380,7 +380,7 @@ private:
             , Current_(NUdf::TUnboxedValue::Invalid())
         {}
 
-        inline explicit operator bool() const { return Iterator_.HasValue(); }
+        inline explicit operator bool() const { return !Iterator_.IsInvalid(); }
         void Reset(const NUdf::TUnboxedValue&& list) {
             List_ = std::move(list);
             Iterator_ = List_.GetListIterator();

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -500,8 +500,8 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
             std::move(joinItems), std::move(leftFlowItems), std::move(leftKeyColumns),
             static_cast<IComputationWideFlowNode*>(flow), dict);
     default:
-        Y_ABORT("BlockMapJoinCore doesn't support %s join type",
-                joinNames.at(joinKind).c_str());
+        Y_ENSURE(false, "BlockMapJoinCore doesn't support %s join type",
+                 joinNames.at(joinKind).c_str());
     }
 }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -397,7 +397,7 @@ private:
     }
 
     TIterator& GetIterator(NUdf::TUnboxedValue& iterator, TComputationContext& ctx) const {
-        if (!iterator.HasValue()) {
+        if (iterator.IsInvalid()) {
             MakeIterator(ctx, iterator);
         }
         return *static_cast<TIterator*>(iterator.AsBoxed().Get());

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -269,6 +269,152 @@ private:
     ui32 WideFieldsIndex_;
 };
 
+template<bool RightRequired>
+class TBlockWideMultiMapJoinWrapper : public TPairStateWideFlowComputationNode<TBlockWideMultiMapJoinWrapper<RightRequired>>
+{
+using TBaseComputation = TPairStateWideFlowComputationNode<TBlockWideMultiMapJoinWrapper<RightRequired>>;
+using TState = TBlockJoinState<RightRequired>;
+public:
+    TBlockWideMultiMapJoinWrapper(TComputationMutables& mutables,
+        const TVector<TType*>&& resultJoinItems, const TVector<TType*>&& leftFlowItems,
+        TVector<ui32>&& leftKeyColumns,
+        IComputationWideFlowNode* flow, IComputationNode* dict)
+        : TBaseComputation(mutables, flow, EValueRepresentation::Boxed, EValueRepresentation::Boxed)
+        , ResultJoinItems_(std::move(resultJoinItems))
+        , LeftFlowItems_(std::move(leftFlowItems))
+        , LeftKeyColumns_(std::move(leftKeyColumns))
+        , Flow_(flow)
+        , Dict_(dict)
+        , WideFieldsIndex_(mutables.IncrementWideFieldsIndex(LeftFlowItems_.size()))
+    {}
+
+    EFetchResult DoCalculate(NUdf::TUnboxedValue& state, NUdf::TUnboxedValue& iterator, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
+        auto& blockState = GetState(state, ctx);
+        auto& iterState = GetIterator(iterator, ctx);
+        auto** fields = ctx.WideFields.data() + WideFieldsIndex_;
+        const auto dict = Dict_->GetValue(ctx);
+
+        do {
+            if (iterState) {
+                NUdf::TUnboxedValue lookupItem;
+                // Process the remaining items from the iterator.
+                while (blockState.IsNotFull() && iterState.Next(lookupItem)) {
+                    blockState.MakeRow(lookupItem);
+                }
+            }
+            if (blockState.IsNotFull() && blockState.NextRow()) {
+                const auto key = MakeKeysTuple(ctx, blockState, LeftKeyColumns_);
+                // Lookup the item in the right dict. If the lookup succeeds,
+                // reset the iterator and proceed the execution from the
+                // beginning of the outer loop. Otherwise, the iterState is
+                // already invalidated (i.e. finished), so the execution will
+                // process the next tuple from the left flow.
+                if (NUdf::TUnboxedValue lookup; key && (lookup = dict.Lookup(key))) {
+                    iterState.Reset(std::move(lookup));
+                }
+                continue;
+            }
+            if (blockState.IsNotFull() && !blockState.IsFinished()) {
+                switch (Flow_->FetchValues(ctx, fields)) {
+                case EFetchResult::Yield:
+                    return EFetchResult::Yield;
+                case EFetchResult::One:
+                    blockState.Reset();
+                    continue;
+                case EFetchResult::Finish:
+                    blockState.Finish();
+                    break;
+                }
+                // Leave the loop, if no values left in the flow.
+                Y_DEBUG_ABORT_UNLESS(blockState.IsFinished());
+                break;
+            }
+            break;
+        } while(true);
+
+        if (blockState.IsEmpty()) {
+            return EFetchResult::Finish;
+        }
+        blockState.MakeBlocks(ctx.HolderFactory);
+        const auto sliceSize = blockState.Slice();
+
+        for (size_t i = 0; i < ResultJoinItems_.size(); i++) {
+            if (const auto out = output[i]) {
+                *out = blockState.Get(sliceSize, ctx.HolderFactory, i);
+            }
+        }
+
+        return EFetchResult::One;
+    }
+
+private:
+    void RegisterDependencies() const final {
+        if (const auto flow = this->FlowDependsOn(Flow_))
+            this->DependsOn(flow, Dict_);
+    }
+
+    void MakeState(TComputationContext& ctx, NUdf::TUnboxedValue& state) const {
+        state = ctx.HolderFactory.Create<TState>(ctx, LeftFlowItems_, ResultJoinItems_, ctx.WideFields.data() + WideFieldsIndex_);
+    }
+
+    TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
+        if (!state.HasValue()) {
+            MakeState(ctx, state);
+        }
+        return *static_cast<TState*>(state.AsBoxed().Get());
+    }
+
+    class TIterator : public TComputationValue<TIterator> {
+    using TBase = TComputationValue<TIterator>;
+        NUdf::TUnboxedValue List_;
+        NUdf::TUnboxedValue Iterator_;
+        NUdf::TUnboxedValue Current_;
+
+    public:
+        TIterator(TMemoryUsageInfo* memInfo)
+            : TBase(memInfo)
+            , List_(NUdf::TUnboxedValue::Invalid())
+            , Iterator_(NUdf::TUnboxedValue::Invalid())
+            , Current_(NUdf::TUnboxedValue::Invalid())
+        {}
+
+        inline explicit operator bool() const { return Iterator_.HasValue(); }
+        void Reset(const NUdf::TUnboxedValue&& list) {
+            List_ = std::move(list);
+            Iterator_ = List_.GetListIterator();
+        }
+        bool Next(NUdf::TUnboxedValue& item) {
+            const auto found = Iterator_.Next(Current_);
+            item = Current_;
+            return found;
+        }
+    };
+
+    void MakeIterator(TComputationContext& ctx, NUdf::TUnboxedValue& iterator) const {
+        iterator = ctx.HolderFactory.Create<TIterator>();
+    }
+
+    TIterator& GetIterator(NUdf::TUnboxedValue& iterator, TComputationContext& ctx) const {
+        if (!iterator.HasValue()) {
+            MakeIterator(ctx, iterator);
+        }
+        return *static_cast<TIterator*>(iterator.AsBoxed().Get());
+    }
+
+    NUdf::TUnboxedValue MakeKeysTuple(const TComputationContext& ctx, const TState& state, const TVector<ui32>& keyColumns) const {
+        // TODO: Handle complex key.
+        // TODO: Handle converters.
+        return state.GetValue(ctx.HolderFactory, keyColumns.front());
+    }
+
+    const TVector<TType*> ResultJoinItems_;
+    const TVector<TType*> LeftFlowItems_;
+    const TVector<ui32> LeftKeyColumns_;
+    IComputationWideFlowNode* const Flow_;
+    IComputationNode* const Dict_;
+    ui32 WideFieldsIndex_;
+};
+
 } // namespace
 
 IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
@@ -296,9 +442,12 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
     const auto rightDictNode = callable.GetInput(1);
     MKQL_ENSURE(rightDictNode.GetStaticType()->IsDict(),
                 "Expected Dict as a right join part");
-    const auto rightDictType = AS_TYPE(TDictType, rightDictNode);
-    MKQL_ENSURE(rightDictType->GetPayloadType()->IsVoid() ||
-                rightDictType->GetPayloadType()->IsTuple(),
+    const auto rightDictType = AS_TYPE(TDictType, rightDictNode)->GetPayloadType();
+    const auto isMulti = rightDictType->IsList();
+    const auto rightDictItemType = isMulti
+                                 ? AS_TYPE(TListType, rightDictType)->GetItemType()
+                                 : rightDictType;
+    MKQL_ENSURE(rightDictItemType->IsVoid() || rightDictItemType->IsTuple(),
                 "Expected Void or Tuple as a right dict item type");
 
     const auto joinKindNode = callable.GetInput(2);
@@ -321,7 +470,13 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
     const auto dict = LocateNode(ctx.NodeLocator, callable, 1);
 
     switch (joinKind) {
+    static const auto joinNames = GetEnumNames<EJoinKind>();
     case EJoinKind::Inner:
+        if (isMulti) {
+            return new TBlockWideMultiMapJoinWrapper<true>(ctx.Mutables,
+                std::move(joinItems), std::move(leftFlowItems), std::move(leftKeyColumns),
+                static_cast<IComputationWideFlowNode*>(flow), dict);
+        }
         return new TBlockWideMapJoinWrapper<false, true>(ctx.Mutables,
             std::move(joinItems), std::move(leftFlowItems), std::move(leftKeyColumns),
             static_cast<IComputationWideFlowNode*>(flow), dict);

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -500,8 +500,8 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
             std::move(joinItems), std::move(leftFlowItems), std::move(leftKeyColumns),
             static_cast<IComputationWideFlowNode*>(flow), dict);
     default:
-        Y_ENSURE(false, "BlockMapJoinCore doesn't support %s join type",
-                 joinNames.at(joinKind).c_str());
+        MKQL_ENSURE(false, "BlockMapJoinCore doesn't support %s join type"
+                    << joinNames.at(joinKind));
     }
 }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -8,6 +8,8 @@
 #include <ydb/library/yql/minikql/mkql_node_cast.h>
 #include <ydb/library/yql/minikql/mkql_program_builder.h>
 
+#include <util/generic/serialized_enum.h>
+
 namespace NKikimr {
 namespace NMiniKQL {
 
@@ -336,7 +338,8 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
             std::move(joinItems), std::move(leftFlowItems), std::move(leftKeyColumns),
             static_cast<IComputationWideFlowNode*>(flow), dict);
     default:
-        Y_ABORT();
+        Y_ABORT("BlockMapJoinCore doesn't support %s join type",
+                joinNames.at(joinKind).c_str());
     }
 }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -360,7 +360,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
         return *static_cast<TState*>(state.AsBoxed().Get());

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -394,7 +394,10 @@ void TestBlockMultiJoinWithRightOnUint64(EJoinKind joinKind) {
     TVector<TKSW<true>> expectedKSW;
     for (const auto& ksv : testKSV) {
         const auto found = fibMultiMap.find(std::get<0>(ksv));
-        if (found != fibMultiMap.cend()) {
+        if (found == fibMultiMap.cend() && joinKind == EJoinKind::Left) {
+            expectedKSW.push_back(std::make_tuple(std::get<0>(ksv), std::get<1>(ksv),
+                                                  std::get<2>(ksv), std::nullopt));
+        } else {
             for (const auto& right : found->second) {
                 expectedKSW.push_back(std::make_tuple(std::get<0>(ksv), std::get<1>(ksv),
                                                       std::get<2>(ksv), right));
@@ -421,6 +424,10 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
 
     Y_UNIT_TEST(TestLeftOnUint64) {
         TestBlockJoinWithRightOnUint64(EJoinKind::Left);
+    }
+
+    Y_UNIT_TEST(TestLeftMultiOnUint64) {
+        TestBlockMultiJoinWithRightOnUint64(EJoinKind::Left);
     }
 
     Y_UNIT_TEST(TestLeftSemiOnUint64) {

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -23,24 +23,6 @@ using TKSWMultiMap = TMap<std::tuple_element_t<0, TKSW<true>>, TVector<TString>>
 template <typename TupleType>
 using TArrays = std::array<std::shared_ptr<arrow::ArrayData>, std::tuple_size_v<TupleType>>;
 
-TVector<TString> GenerateValues(size_t level) {
-    constexpr size_t alphaSize = 'Z' - 'A' + 1;
-    if (level == 1) {
-        TVector<TString> alphabet(alphaSize);
-        std::iota(alphabet.begin(), alphabet.end(), 'A');
-        return alphabet;
-    }
-    const auto subValues = GenerateValues(level - 1);
-    TVector<TString> values;
-    values.reserve(alphaSize * subValues.size());
-    for (char ch = 'A'; ch <= 'Z'; ch++) {
-        for (const auto& tail : subValues) {
-            values.emplace_back(ch + tail);
-        }
-    }
-    return values;
-}
-
 template <typename T, bool isOptional = false>
 const TRuntimeNode MakeSimpleKey(TProgramBuilder& pgmBuilder, T value, bool isEmpty = false) {
     if constexpr (!isOptional) {
@@ -310,133 +292,182 @@ TVector<TOutputTuple> DoTestBlockJoinOnUint64(EJoinKind joinKind,
     return resultTuples;
 }
 
-void TestBlockJoinWithoutRightOnUint64(EJoinKind joinKind) {
-    constexpr size_t testSize = 1 << 14;
-    constexpr size_t valueSize = 3;
-    static const TVector<TString> threeLetterValues = GenerateValues(valueSize);
-    static const TSet<ui64> fibSet = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144,
-        233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711};
-
-    TVector<TKSV> testKSV;
-    for (size_t k = 0; k < testSize; k++) {
-        testKSV.push_back(std::make_tuple(k, k * 1001, threeLetterValues[k]));
+template <typename TDictPayloadType, typename TGotTupleType
+    = std::conditional<std::is_same_v<TDictPayloadType, TKSVSet>, TKSV,
+      std::conditional<std::is_same_v<TDictPayloadType, TKSWMap>, TKSW<false>,
+      std::conditional<std::is_same_v<TDictPayloadType, TKSWMultiMap>, TKSW<true>,
+          void>>>>
+void RunTestBlockJoinOnUint64(const TVector<TGotTupleType>& expected,
+    EJoinKind joinKind, const TVector<TKSV>& leftFlow, const TDictPayloadType& rightDict
+) {
+    const size_t testSize = leftFlow.size();
+    for (size_t blockSize = 8; blockSize <= testSize; blockSize <<= 1) {
+        const auto got = DoTestBlockJoinOnUint64<TGotTupleType>(joinKind, leftFlow, rightDict, blockSize);
+        UNIT_ASSERT_EQUAL(expected, got);
     }
+}
+
+//
+// Join type specific test wrappers.
+//
+
+void TestBlockJoinWithoutRightOnUint64(EJoinKind joinKind,
+    const TVector<TKSV>& leftFlow, const TKSVSet& rightSet
+) {
     TVector<TKSV> expectedKSV;
-    std::copy_if(testKSV.cbegin(), testKSV.cend(), std::back_inserter(expectedKSV),
-        [&joinKind](const auto& ksv) {
-            const auto contains = fibSet.contains(std::get<0>(ksv));
+    std::copy_if(leftFlow.cbegin(), leftFlow.cend(), std::back_inserter(expectedKSV),
+        [joinKind, rightSet](const auto& ksv) {
+            const auto contains = rightSet.contains(std::get<0>(ksv));
             return joinKind == EJoinKind::LeftSemi ? contains : !contains;
         });
-    for (size_t blockSize = 8; blockSize <= testSize; blockSize <<= 1) {
-        const auto gotKSV = DoTestBlockJoinOnUint64<TKSV>(joinKind, testKSV, fibSet, blockSize);
-        UNIT_ASSERT_EQUAL(expectedKSV, gotKSV);
-    }
+    RunTestBlockJoinOnUint64(expectedKSV, joinKind, leftFlow, rightSet);
 }
 
-void TestBlockJoinWithRightOnUint64(EJoinKind joinKind) {
-    constexpr size_t testSize = 1 << 14;
-    constexpr size_t valueSize = 3;
-    static const TVector<TString> threeLetterValues = GenerateValues(valueSize);
-    static const TSet<ui64> fibSet = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144,
-        233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711};
-
-    TVector<TKSV> testKSV;
-    for (size_t k = 0; k < testSize; k++) {
-        testKSV.push_back(std::make_tuple(k, k * 1001, threeLetterValues[k]));
-    }
-
-    static TKSWMap fibMap;
-    for (const auto& key : fibSet) {
-        fibMap[key] = std::to_string(key);
-    }
-    TVector<TKSW<false>> testKSW;
-    std::transform(testKSV.cbegin(), testKSV.cend(), std::back_inserter(testKSW),
-        [](const auto& ksv) {
-            const auto found = fibMap.find(std::get<0>(ksv));
-            const auto right = found == fibMap.cend() ? std::nullopt
-                             : std::optional<TStringBuf>(found->second);
-            return std::make_tuple(std::get<0>(ksv), std::get<1>(ksv),
-                                   std::get<2>(ksv), right);
-        });
+void TestBlockJoinWithRightOnUint64(EJoinKind joinKind,
+    const TVector<TKSV>& leftFlow, const TKSWMap& rightMap
+) {
     TVector<TKSW<false>> expectedKSW;
-    if (joinKind == EJoinKind::Inner) {
-        std::copy_if(testKSW.cbegin(), testKSW.cend(), std::back_inserter(expectedKSW),
-            [](const auto& ksw) { return fibSet.contains(std::get<0>(ksw)); });
-    } else {
-        expectedKSW = testKSW;
-    }
-
-    for (size_t blockSize = 8; blockSize <= testSize; blockSize <<= 1) {
-        const auto gotKSW = DoTestBlockJoinOnUint64<TKSW<false>>(joinKind, testKSV, fibMap, blockSize);
-        UNIT_ASSERT_EQUAL(expectedKSW, gotKSW);
-    }
-}
-
-void TestBlockMultiJoinWithRightOnUint64(EJoinKind joinKind) {
-    constexpr size_t testSize = 1 << 14;
-    constexpr size_t valueSize = 3;
-    static const TVector<TString> threeLetterValues = GenerateValues(valueSize);
-    static const TSet<ui64> fibSet = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144,
-        233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711};
-
-    TVector<TKSV> testKSV;
-    for (size_t k = 0; k < testSize; k++) {
-        testKSV.push_back(std::make_tuple(k, k * 1001, threeLetterValues[k]));
-    }
-
-    static TKSWMultiMap fibMultiMap;
-    for (const auto& key : fibSet) {
-        if (key < threeLetterValues.size()) {
-            fibMultiMap[key] = {std::to_string(key), threeLetterValues[key]};
-        }
-    }
-
-    TVector<TKSW<true>> expectedKSW;
-    for (const auto& ksv : testKSV) {
-        const auto found = fibMultiMap.find(std::get<0>(ksv));
-        if (found == fibMultiMap.cend() && joinKind == EJoinKind::Left) {
+    for (const auto& ksv : leftFlow) {
+        const auto found = rightMap.find(std::get<0>(ksv));
+        if (found != rightMap.cend()) {
+            expectedKSW.push_back(std::make_tuple(std::get<0>(ksv), std::get<1>(ksv),
+                                                  std::get<2>(ksv), found->second));
+        } else if (joinKind == EJoinKind::Left) {
             expectedKSW.push_back(std::make_tuple(std::get<0>(ksv), std::get<1>(ksv),
                                                   std::get<2>(ksv), std::nullopt));
-        } else {
+        }
+    }
+    RunTestBlockJoinOnUint64(expectedKSW, joinKind, leftFlow, rightMap);
+}
+
+void TestBlockMultiJoinWithRightOnUint64(EJoinKind joinKind,
+    const TVector<TKSV>& leftFlow, const TKSWMultiMap& rightMultiMap
+) {
+    TVector<TKSW<true>> expectedKSW;
+    for (const auto& ksv : leftFlow) {
+        const auto found = rightMultiMap.find(std::get<0>(ksv));
+        if (found != rightMultiMap.cend()) {
             for (const auto& right : found->second) {
                 expectedKSW.push_back(std::make_tuple(std::get<0>(ksv), std::get<1>(ksv),
                                                       std::get<2>(ksv), right));
             }
+        } else if (joinKind == EJoinKind::Left) {
+            expectedKSW.push_back(std::make_tuple(std::get<0>(ksv), std::get<1>(ksv),
+                                                  std::get<2>(ksv), std::nullopt));
         }
     }
+    RunTestBlockJoinOnUint64(expectedKSW, joinKind, leftFlow, rightMultiMap);
+}
 
-    for (size_t blockSize = 8; blockSize <= testSize; blockSize <<= 1) {
-        const auto gotKSW = DoTestBlockJoinOnUint64<TKSW<true>>(joinKind, testKSV, fibMultiMap, blockSize);
-        UNIT_ASSERT_EQUAL(expectedKSW, gotKSW);
+TVector<TString> GenerateValues(size_t level) {
+    constexpr size_t alphaSize = 'Z' - 'A' + 1;
+    if (level == 1) {
+        TVector<TString> alphabet(alphaSize);
+        std::iota(alphabet.begin(), alphabet.end(), 'A');
+        return alphabet;
     }
+    const auto subValues = GenerateValues(level - 1);
+    TVector<TString> values;
+    values.reserve(alphaSize * subValues.size());
+    for (char ch = 'A'; ch <= 'Z'; ch++) {
+        for (const auto& tail : subValues) {
+            values.emplace_back(ch + tail);
+        }
+    }
+    return values;
+}
+
+TSet<ui64> GenerateFibonacci(size_t count) {
+    TSet<ui64> fibSet;
+    ui64 a = 0, b = 1, c;
+    while (count--) {
+        fibSet.insert(c = a + b);
+        a = b;
+        b = c;
+    }
+    return fibSet;
 }
 
 } // namespace
 
 Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
+
+    constexpr size_t testSize = 1 << 14;
+    constexpr size_t valueSize = 3;
+    static const TVector<TString> threeLetterValues = GenerateValues(valueSize);
+    static const TSet<ui64> fibonacci = GenerateFibonacci(21);
+
+    const TVector<TKSV> MakeIotaTKSV(const TVector<ui64>& keyInit,
+        const ui64 subkeyMultiplier, const TVector<TString>& valuePayload
+    ) {
+        TVector<TKSV> testKSV;
+        std::transform(keyInit.cbegin(), keyInit.cend(), std::back_inserter(testKSV),
+            [subkeyMultiplier, valuePayload](const auto& key) {
+                return std::make_tuple(key, key * subkeyMultiplier, valuePayload[key]);
+            });
+        return testKSV;
+    }
+
     Y_UNIT_TEST(TestInnerOnUint64) {
-        TestBlockJoinWithRightOnUint64(EJoinKind::Inner);
+        TVector<ui64> keyInit(testSize);
+        std::iota(keyInit.begin(), keyInit.end(), 1);
+        const auto leftFlow = MakeIotaTKSV(keyInit, 1001, threeLetterValues);
+        TKSWMap rightMap;
+        for (const auto& key : fibonacci) {
+            rightMap[key] = std::to_string(key);
+        }
+        TestBlockJoinWithRightOnUint64(EJoinKind::Inner, leftFlow, rightMap);
     }
 
     Y_UNIT_TEST(TestInnerMultiOnUint64) {
-        TestBlockMultiJoinWithRightOnUint64(EJoinKind::Inner);
+        TVector<ui64> keyInit(testSize);
+        std::iota(keyInit.begin(), keyInit.end(), 1);
+        const auto leftFlow = MakeIotaTKSV(keyInit, 1001, threeLetterValues);
+        TKSWMultiMap rightMultiMap;
+        for (const auto& key : fibonacci) {
+            rightMultiMap[key] = {std::to_string(key), std::to_string(key * 1001)};
+        }
+        TestBlockMultiJoinWithRightOnUint64(EJoinKind::Inner, leftFlow, rightMultiMap);
     }
 
     Y_UNIT_TEST(TestLeftOnUint64) {
-        TestBlockJoinWithRightOnUint64(EJoinKind::Left);
+        TVector<ui64> keyInit(testSize);
+        std::iota(keyInit.begin(), keyInit.end(), 1);
+        const auto leftFlow = MakeIotaTKSV(keyInit, 1001, threeLetterValues);
+        TKSWMap rightMap;
+        for (const auto& key : fibonacci) {
+            rightMap[key] = std::to_string(key);
+        }
+        TestBlockJoinWithRightOnUint64(EJoinKind::Left, leftFlow, rightMap);;
     }
 
     Y_UNIT_TEST(TestLeftMultiOnUint64) {
-        TestBlockMultiJoinWithRightOnUint64(EJoinKind::Left);
+        TVector<ui64> keyInit(testSize);
+        std::iota(keyInit.begin(), keyInit.end(), 1);
+        const auto leftFlow = MakeIotaTKSV(keyInit, 1001, threeLetterValues);
+        TKSWMultiMap rightMultiMap;
+        for (const auto& key : fibonacci) {
+            rightMultiMap[key] = {std::to_string(key), std::to_string(key * 1001)};
+        }
+        TestBlockMultiJoinWithRightOnUint64(EJoinKind::Left, leftFlow, rightMultiMap);
     }
 
     Y_UNIT_TEST(TestLeftSemiOnUint64) {
-        TestBlockJoinWithoutRightOnUint64(EJoinKind::LeftSemi);
+        TVector<ui64> keyInit(testSize);
+        std::iota(keyInit.begin(), keyInit.end(), 1);
+        const auto leftFlow = MakeIotaTKSV(keyInit, 1001, threeLetterValues);
+        const TKSVSet rightSet(fibonacci);
+        TestBlockJoinWithoutRightOnUint64(EJoinKind::LeftSemi, leftFlow, rightSet);
     }
 
     Y_UNIT_TEST(TestLeftOnlyOnUint64) {
-        TestBlockJoinWithoutRightOnUint64(EJoinKind::LeftOnly);
+        TVector<ui64> keyInit(testSize);
+        std::iota(keyInit.begin(), keyInit.end(), 1);
+        const auto leftFlow = MakeIotaTKSV(keyInit, 1001, threeLetterValues);
+        const TKSVSet rightSet(fibonacci);
+        TestBlockJoinWithoutRightOnUint64(EJoinKind::LeftOnly, leftFlow, rightSet);
     }
+
 } // Y_UNIT_TEST_SUITE
 
 } // namespace NMiniKQL

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -113,7 +113,7 @@ const TRuntimeNode MakeRightNode(TProgramBuilder& pgmBuilder, const TRightPayloa
     } else if constexpr (std::is_same_v<TRightPayload, TKSWMultiMap>) {
         return MakeMultiDict(pgmBuilder, values);
     } else {
-        Y_ABORT("Not supported payload type");
+        Y_ENSURE(false, "Not supported payload type");
     }
 }
 


### PR DESCRIPTION
This patchset is the second part of the series implementing `BlockMapJoinCore` MKQL callable. This part implements `BlockMapJoinCore` computation node for the join types, that require "multi dict" payload (i.e. Inner and Left with possible cartesian product).

### Changelog category

* New feature