### PR TITLE
ci: unified-agent: export preset name

### DIFF
--- a/ydb/ci/gh-runner-controller/src/scaler/cloud_config.py
+++ b/ydb/ci/gh-runner-controller/src/scaler/cloud_config.py
@@ -3,7 +3,7 @@ import pkgutil
 import yaml
 
 
-def create_userdata(repo_url, gh_token, runner_name, runner_labels, ssh_keys, agent_mirror_url_prefix):
+def create_userdata(repo_url, gh_token, runner_name, runner_labels, ssh_keys, agent_mirror_url_prefix, preset_name):
     runner_username = "runner"
 
     install_script = pkgutil.get_data(__name__, "scripts/install_runner.sh")
@@ -17,6 +17,7 @@ GITHUB_TOKEN="{gh_token}"
 RUNNER_NAME="{runner_name}"
 RUNNER_LABELS="{runner_labels}"
 AGENT_MIRROR_URL_PREFIX="{agent_mirror_url_prefix}"
+PRESET_NAME="{preset_name}"
 """.strip().encode(
         "utf8"
     )

--- a/ydb/ci/gh-runner-controller/src/scaler/controller.py
+++ b/ydb/ci/gh-runner-controller/src/scaler/controller.py
@@ -190,7 +190,7 @@ class ScaleController:
 
         vm_labels = {self.prefix: runner_name}
         user_data = create_userdata(self.gh.html_url, new_runner_token, runner_name, labels, self.cfg.ssh_keys,
-                                    self.cfg.agent_mirror_url_prefix)
+                                    self.cfg.agent_mirror_url_prefix, preset_name)
 
         placement = random.choice(self.cfg.yc_zones)
         zone_id = placement['zone_id']

--- a/ydb/ci/gh-runner-controller/src/scaler/scripts/install_runner.sh
+++ b/ydb/ci/gh-runner-controller/src/scaler/scripts/install_runner.sh
@@ -50,5 +50,9 @@ systemctl daemon-reload || fail "failed to reload systemd"
 systemctl enable $SVC_NAME
 systemctl start $SVC_NAME
 
-echo "GH_RUNNER_NAME=${RUNNER_NAME}"> /etc/default/unified_agent
+cat <<EOF > /etc/default/unified_agent
+GH_RUNNER_NAME=${RUNNER_NAME}
+GH_PRESET_NAME=${PRESET_NAME}
+EOF
+
 systemctl restart unified-agent.service

--- a/ydb/ci/gh-runner-image/conf/unified-agent-linux.yml
+++ b/ydb/ci/gh-runner-image/conf/unified-agent-linux.yml
@@ -16,7 +16,7 @@ channels:
             plugin: transform_metric_labels
             config:
               labels:
-                - gh_runner_name: "{$env('GH_RUNNER_NAME')}"
+                - gh_preset: "{$env('GH_PRESET_NAME')}"
       output:
         plugin: yc_metrics
         config:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add github preset name metrics export. For calculate average memory usage per preset for example. Remove redundant gh_runner_name (already exported as host name)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
