### PR TITLE
Retry 5xx in testmo interaction (Server response (503): Account is in maintenance mode)

### DIFF
--- a/ydb/ci/testmo-proxy/testmo-proxy.py
+++ b/ydb/ci/testmo-proxy/testmo-proxy.py
@@ -45,7 +45,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         start_time = time.monotonic()
 
         response = None
-        sleep_for_5xx = 10  # sec
+        sleep_for_5xx = 30  # sec
         sleep_for_timeout = 0.25  # sec
 
         while time.monotonic() - start_time < self._max_request_time:

--- a/ydb/ci/testmo-proxy/testmo-proxy.py
+++ b/ydb/ci/testmo-proxy/testmo-proxy.py
@@ -52,7 +52,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             try:
                 response = requests.request(method, url, data=body, headers=headers, timeout=self._timeout)
                 if 500 <= response.status_code < 600:
-                    self.log_message(f"going to retry {response} after sleeping {sleep_for_5xx} sec")
+                    self.log_message(f"! received status={response.status_code}, content={response.content}")
+                    self.log_message(f"sleep for {sleep_for_5xx} sec")
                     time.sleep(sleep_for_5xx)
                 else:
                     break

--- a/ydb/ci/testmo-proxy/testmo-proxy.py
+++ b/ydb/ci/testmo-proxy/testmo-proxy.py
@@ -45,17 +45,20 @@ class Handler(http.server.BaseHTTPRequestHandler):
         start_time = time.monotonic()
 
         response = None
+        sleep_for_5xx = 10  # sec
+        sleep_for_timeout = 0.25  # sec
 
         while time.monotonic() - start_time < self._max_request_time:
             try:
                 response = requests.request(method, url, data=body, headers=headers, timeout=self._timeout)
                 if 500 <= response.status_code < 600:
-                    self.log_message(f"going to retry {response}")
+                    self.log_message(f"going to retry {response} after sleeping {sleep_for_5xx} sec")
+                    time.sleep(sleep_for_5xx)
                 else:
                     break
             except requests.exceptions.RequestException as e:
                 self.log_message("! catch %s, retry", e)
-                time.sleep(0.25)
+                time.sleep(sleep_for_timeout)
                 continue
 
         if response is None:

--- a/ydb/ci/testmo-proxy/testmo-proxy.py
+++ b/ydb/ci/testmo-proxy/testmo-proxy.py
@@ -49,7 +49,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
         while time.monotonic() - start_time < self._max_request_time:
             try:
                 response = requests.request(method, url, data=body, headers=headers, timeout=self._timeout)
-                break
+                if 500 <= response.status_code < 600:
+                    self.log_message(f"going to retry {response}")
+                else:
+                    break
             except requests.exceptions.RequestException as e:
                 self.log_message("! catch %s, retry", e)
                 time.sleep(0.25)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Retrying 5xx

It needed because there are fails in checks:
```
++ testmo automation:run:create --instance https://nebius.testmo.net/ --project-id 1 --name '10628532669 PR #8510' --source ya-x86-64-clang14 --resources testmo.json --tags '' --tags pr
Server response (503): Account is in maintenance mode
+ TESTMO_RUN_ID=
Error: Process completed with exit code 1.
```

So, going to retry that

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
Locally works OK
<img width="1343" alt="image" src="https://github.com/user-attachments/assets/f4c2f06f-c5d8-4dcf-81ae-5b9a88c412f0">

Check with tests run: https://github.com/ydb-platform/ydb/pull/8521