### PR TITLE
Fix HasValue misuse for computation node state

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_agg.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_agg.cpp
@@ -752,7 +752,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(state, ctx);
 
             auto& s = *static_cast<TState*>(state.AsBoxed().Get());
@@ -1638,7 +1638,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(state, ctx);
 
             auto& s = *static_cast<TState*>(state.AsBoxed().Get());

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_compress.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_compress.cpp
@@ -655,7 +655,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue())
+        if (state.IsInvalid())
             MakeState(ctx, state);
         return *static_cast<TState*>(state.AsBoxed().Get());
     }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -247,7 +247,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
         return *static_cast<TState*>(state.AsBoxed().Get());

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_top.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_top.cpp
@@ -575,7 +575,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             std::vector<bool> dirs(Directions_.size());
             std::transform(Directions_.cbegin(), Directions_.cend(), dirs.begin(), [&ctx](IComputationNode* dir){ return dir->GetValue(ctx).Get<bool>(); });
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
@@ -355,7 +355,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue())
+        if (state.IsInvalid())
             MakeState(ctx, state);
         return *static_cast<TState*>(state.AsBoxed().Get());
     }
@@ -506,7 +506,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue())
+        if (state.IsInvalid())
             MakeState(ctx, state);
         return *static_cast<TState*>(state.AsBoxed().Get());
     }
@@ -786,7 +786,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
 
             const auto s = static_cast<TState*>(state.AsBoxed().Get());
@@ -1132,7 +1132,7 @@ private:
     }
 
     TBlockState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
 
             auto& s = *static_cast<TBlockState*>(state.AsBoxed().Get());

--- a/ydb/library/yql/minikql/comp_nodes/mkql_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_combine.cpp
@@ -176,7 +176,7 @@ public:
     {}
 
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_extend.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_extend.cpp
@@ -210,7 +210,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue())
+        if (state.IsInvalid())
             MakeState(ctx, state);
         return *static_cast<TState*>(state.AsBoxed().Get());
     }
@@ -327,7 +327,7 @@ private:
     }
 
     TState& GetState(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue())
+        if (state.IsInvalid())
             MakeState(ctx, state);
         return *static_cast<TState*>(state.AsBoxed().Get());
     }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_flow.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_flow.cpp
@@ -296,7 +296,7 @@ public:
     {}
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             state = Stream->GetValue(ctx);
         }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -1035,7 +1035,7 @@ class TGraceJoinWrapper : public TStatefulWideFlowCodegeneratorNode<TGraceJoinWr
         {}
 
         EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output)  const {
-            if (!state.HasValue()) {
+            if (state.IsInvalid()) {
                 MakeSpillingSupportState(ctx, state);
             }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_join.cpp
@@ -707,7 +707,7 @@ public:
     }
 
     NUdf::TUnboxedValue DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             state = ctx.HolderFactory.Create<TValue>(ctx, this);
         }
 
@@ -1150,7 +1150,7 @@ public:
     {}
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_squeeze_to_list.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_squeeze_to_list.cpp
@@ -48,7 +48,7 @@ public:
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
         if (state.IsFinish()) {
             return NUdf::TUnboxedValuePod::MakeFinish();
-        } else if (!state.HasValue()) {
+        } else if (state.IsInvalid()) {
             MakeState(ctx, Limit->GetValue(ctx).GetOrDefault(std::numeric_limits<ui64>::max()), state);
         }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_switch.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_switch.cpp
@@ -166,7 +166,7 @@ public:
         for (ui32 handlerIndex = 0; handlerIndex < handlersSize; ++handlerIndex) {
             Handlers[handlerIndex].Item->SetGetter([stateIndex = mutables.CurValueIndex - 1, handlerIndex, this](TComputationContext & context) {
                 NUdf::TUnboxedValue& state = context.MutableValues[stateIndex];
-                if (!state.HasValue()) {
+                if (state.IsInvalid()) {
                     MakeState(context, state);
                 }
 
@@ -183,7 +183,7 @@ public:
     }
 
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_todict.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_todict.cpp
@@ -923,7 +923,7 @@ public:
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
         if (state.IsFinish()) {
             return state.Release();
-        } else if (!state.HasValue()) {
+        } else if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 
@@ -1108,7 +1108,7 @@ public:
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
         if (state.IsFinish()) {
             return state.Release();
-        } else if (!state.HasValue()) {
+        } else if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
         auto** fields = ctx.WideFields.data() + WideFieldsIndex;
@@ -1432,7 +1432,7 @@ public:
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
         if (state.IsFinish()) {
             return state;
-        } else if (!state.HasValue()) {
+        } else if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 
@@ -1625,7 +1625,7 @@ public:
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
         if (state.IsFinish()) {
             return state;
-        } else if (!state.HasValue()) {
+        } else if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
         auto** fields = ctx.WideFields.data() + WideFieldsIndex;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -806,7 +806,7 @@ public:
     {}
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 
@@ -1235,7 +1235,7 @@ public:
     {}
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         } 
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_top_sort.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_top_sort.cpp
@@ -365,7 +365,7 @@ public:
     }
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             const auto count = Count->GetValue(ctx).Get<ui64>();
             std::vector<bool> dirs(Directions.size());
             std::transform(Directions.cbegin(), Directions.cend(), dirs.begin(), [&ctx](IComputationNode* dir){ return dir->GetValue(ctx).Get<bool>(); });
@@ -885,7 +885,7 @@ public:
     }
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             std::vector<bool> dirs(Directions.size());
             std::transform(Directions.cbegin(), Directions.cend(), dirs.begin(), [&ctx](IComputationNode* dir){ return dir->GetValue(ctx).Get<bool>(); });
             MakeState(ctx, state, dirs.data());

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_skiptake_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_skiptake_ut.cpp
@@ -59,7 +59,7 @@ public:
 #endif
 private:
     EFetchResult DoCalculateImpl(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue& val1, NUdf::TUnboxedValue& val2, NUdf::TUnboxedValue& val3) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             state = NUdf::TUnboxedValue::Zero();
         }
 

--- a/ydb/library/yql/providers/yt/comp_nodes/dq/dq_yt_reader_impl.h
+++ b/ydb/library/yql/providers/yt/comp_nodes/dq/dq_yt_reader_impl.h
@@ -92,7 +92,7 @@ public:
     }
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 

--- a/ydb/library/yql/providers/yt/comp_nodes/yql_mkql_input.cpp
+++ b/ydb/library/yql/providers/yt/comp_nodes/yql_mkql_input.cpp
@@ -134,7 +134,7 @@ public:
 
     NUdf::TUnboxedValuePod DoCalculate(TComputationContext& ctx) const {
         auto& state = ctx.MutableValues[StateIndex_];
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 
@@ -189,7 +189,7 @@ public:
     {}
 
     NUdf::TUnboxedValuePod DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 
@@ -256,7 +256,7 @@ public:
     {}
 
     EFetchResult DoCalculate(NUdf::TUnboxedValue& state, NUdf::TUnboxedValue& current, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
-        if (!state.HasValue()) {
+        if (state.IsInvalid()) {
             MakeState(ctx, state);
         }
 


### PR DESCRIPTION
The vector with mutable values in the computation context is initialized with Invalid value, so the only method returning the consistent result is `IsInvalid`. Hence, to check whether the computation node state has been already initialized, `HasValue` method is replaced with `IsInvalid` all over the computation node related codebase.

### Changelog category

* Bugfix 