### PR TITLE
Revert "Don't run large_serializable in PR"

### DIFF
--- a/ydb/tests/functional/large_serializable/ya.make
+++ b/ydb/tests/functional/large_serializable/ya.make
@@ -12,8 +12,8 @@ REQUIREMENTS(
     ram:32
 )
 
-TIMEOUT(1800)
-SIZE(LARGE)
+TIMEOUT(600)
+SIZE(MEDIUM)
 
 DEPENDS(
     ydb/tests/tools/ydb_serializable


### PR DESCRIPTION
Checks are broken

Revert the problem commit

Error: 
```
Output root is subdirectory of Arcadia root, this may cause non-idempotent build Configuring dependencies for platform default-linux-x86_64-relwithdebinfo Configuring dependencies for platform tools Warn[-WBadDir]: in $B/contrib/restricted/boost/rational/librestricted-boost-rational.a: ADDINCL to non existent source directory $S/contrib/restricted/boost/rational/include Error[-WMisconfiguration]: in $B/ydb/tests/functional/large_serializable/ydb-tests-functional-large_serializable: LARGE test must have ya:fat tag Configure error (use -k to proceed)
```

In
https://github.com/ydb-platform/ydb/pull/8553

