### PR TITLE
Remove DEFINE_SIMPLE_NONLOCAL_EVENT, add TEventSimpleNonLocal

### DIFF
--- a/ydb/core/tablet/bootstrapper.h
+++ b/ydb/core/tablet/bootstrapper.h
@@ -3,6 +3,7 @@
 #include <ydb/core/tablet/tablet_setup.h>
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/library/actors/core/event_simple_non_local.h>
 
 namespace NKikimr {
 

--- a/ydb/core/tablet/bootstrapper.h
+++ b/ydb/core/tablet/bootstrapper.h
@@ -19,12 +19,10 @@ struct TEvBootstrapper {
 
     static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_BOOTSTRAPPER), "event space overrun");
 
-    struct TEvActivate : public TEventBase<TEvActivate, EvActivate> {
-        DEFINE_SIMPLE_NONLOCAL_EVENT(TEvActivate, "TEvBootstrapper::Activate");
+    struct TEvActivate : public TEventSimpleNonLocal<TEvActivate, EvActivate> {
     };
 
-    struct TEvStandBy : public TEventBase<TEvStandBy, EvStandBy> {
-        DEFINE_SIMPLE_NONLOCAL_EVENT(TEvStandBy, "TEvBootstrapper::StandBy");
+    struct TEvStandBy : public TEventSimpleNonLocal<TEvStandBy, EvStandBy> {
     };
 
     struct TEvWatch;

--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -373,26 +373,4 @@ namespace NActors {
         typedef TEventHandle<TEventType> THandle;
         typedef TAutoPtr<THandle> TPtr;
     };
-
-
-    // Non-local event with empty serialization 
-    template <typename TEv, ui32 TEventType>
-    class TEventSimpleNonLocal: public TEventBase<TEv, TEventType> {
-    public:
-        TString ToStringHeader() const override {
-            return TypeName<TEv>();
-        }
-
-        bool SerializeToArcadiaStream(TChunkSerializer* /*serializer*/) const override {
-            return true;
-        }
-
-        bool IsSerializable() const override {
-            return true;
-        }
-
-        static IEventBase* Load(TEventSerializedData*) {
-            return new TEv();
-        }
-    };
 }

--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -374,17 +374,25 @@ namespace NActors {
         typedef TAutoPtr<THandle> TPtr;
     };
 
-#define DEFINE_SIMPLE_NONLOCAL_EVENT(eventType, header)                 \
-    TString ToStringHeader() const override {                           \
-        return TString(header);                                         \
-    }                                                                   \
-    bool SerializeToArcadiaStream(NActors::TChunkSerializer*) const override { \
-        return true;                                                    \
-    }                                                                   \
-    static IEventBase* Load(NActors::TEventSerializedData*) {           \
-        return new eventType();                                         \
-    }                                                                   \
-    bool IsSerializable() const override {                              \
-        return true;                                                    \
-    }
+
+    // Non-local event with empty serialization 
+    template <typename TEv, ui32 TEventType>
+    class TEventSimpleNonLocal: public TEventBase<TEv, TEventType> {
+    public:
+        TString ToStringHeader() const override {
+            return TypeName<TEv>();
+        }
+
+        bool SerializeToArcadiaStream(TChunkSerializer* /*serializer*/) const override {
+            return true;
+        }
+
+        bool IsSerializable() const override {
+            return true;
+        }
+
+        static IEventBase* Load(TEventSerializedData*) {
+            return new TEv();
+        }
+    };
 }

--- a/ydb/library/actors/core/event_simple_non_local.h
+++ b/ydb/library/actors/core/event_simple_non_local.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "event.h"
+#include "event_load.h"
+#include <util/system/type_name.h>
+
+namespace NActors {
+    // Non-local event with empty serialization 
+    template <typename TEv, ui32 TEventType>
+    class TEventSimpleNonLocal: public TEventBase<TEv, TEventType> {
+    public:
+        TString ToStringHeader() const override {
+            return TypeName<TEv>();
+        }
+
+        bool SerializeToArcadiaStream(TChunkSerializer* /*serializer*/) const override {
+            return true;
+        }
+
+        bool IsSerializable() const override {
+            return true;
+        }
+
+        static IEventBase* Load(TEventSerializedData*) {
+            return new TEv();
+        }
+    };
+}

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "event_local.h"
+#include "event_simple_non_local.h"
 #include "event_pb.h"
 
 #include <util/system/unaligned_mem.h>

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -48,12 +48,10 @@ namespace NActors {
             static_assert(End < EventSpaceEnd(ES_HELLOWORLD), "expect End < EventSpaceEnd(ES_HELLOWORLD)");
         };
 
-        struct TEvPing: public TEventBase<TEvPing, THelloWorld::Ping> {
-            DEFINE_SIMPLE_NONLOCAL_EVENT(TEvPing, "HelloWorld: Ping");
+        struct TEvPing: public TEventSimpleNonLocal<TEvPing, THelloWorld::Ping> {
         };
 
-        struct TEvPong: public TEventBase<TEvPong, THelloWorld::Pong> {
-            DEFINE_SIMPLE_NONLOCAL_EVENT(TEvPong, "HelloWorld: Pong");
+        struct TEvPong: public TEventSimpleNonLocal<TEvPong, THelloWorld::Pong> {
         };
 
         struct TEvBlob: public TEventBase<TEvBlob, THelloWorld::Blob> {
@@ -116,8 +114,7 @@ namespace NActors {
         struct TEvBootstrap: public TEventLocal<TEvBootstrap, TSystem::Bootstrap> {
         };
 
-        struct TEvPoison : public TEventBase<TEvPoison, TSystem::Poison> {
-            DEFINE_SIMPLE_NONLOCAL_EVENT(TEvPoison, "System: TEvPoison")
+        struct TEvPoison : public TEventSimpleNonLocal<TEvPoison, TSystem::Poison> {
         };
 
         struct TEvWakeup: public TEventLocal<TEvWakeup, TSystem::Wakeup> {

--- a/ydb/library/actors/core/ut/ask_ut.cpp
+++ b/ydb/library/actors/core/ut/ask_ut.cpp
@@ -92,7 +92,7 @@ Y_UNIT_TEST_SUITE(AskActor) {
             UNIT_ASSERT_EXCEPTION_CONTAINS(
                 fut.ExtractValueSync(),
                 yexception,
-                "received unexpected response HelloWorld: Pong");
+                "received unexpected response NActors::TEvents::TEvPong");
         }
     }
 

--- a/ydb/library/yql/providers/dq/actors/events.h
+++ b/ydb/library/yql/providers/dq/actors/events.h
@@ -10,6 +10,7 @@
 
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/core/event_simple_non_local.h>
 #include <ydb/library/actors/core/events.h>
 
 namespace NYql::NDqs {

--- a/ydb/library/yql/providers/dq/actors/events.h
+++ b/ydb/library/yql/providers/dq/actors/events.h
@@ -50,8 +50,7 @@ namespace NYql::NDqs {
         explicit TEvReadyState(NDqProto::TReadyState&& proto);
     };
 
-    struct TEvPullResult : NActors::TEventBase<TEvPullResult, TDqExecuterEvents::ES_PULL_RESULT> {
-        DEFINE_SIMPLE_NONLOCAL_EVENT(TEvPullResult, "");
+    struct TEvPullResult : NActors::TEventSimpleNonLocal<TEvPullResult, TDqExecuterEvents::ES_PULL_RESULT> {
     };
 
     struct TEvGraphExecutionEvent
@@ -99,8 +98,7 @@ namespace NYql::NDqs {
         explicit TEvFullResultWriterStatusResponse(NDqProto::TFullResultWriterStatusResponse& data);
     };
 
-    struct TEvGraphFinished : NActors::TEventBase<TEvGraphFinished, TDqExecuterEvents::ES_GRAPH_FINISHED> {
-        DEFINE_SIMPLE_NONLOCAL_EVENT(TEvGraphFinished, "");
+    struct TEvGraphFinished : NActors::TEventSimpleNonLocal<TEvGraphFinished, TDqExecuterEvents::ES_GRAPH_FINISHED> {
     };
 
     struct TEvFullResultWriterWriteRequest


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Replace DEFINE_SIMPLE_NONLOCAL_EVENT to TEventSimpleNonLocal (because c++ classes are better than macroses)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
