### PR TITLE
Do not ignore configure errors

### DIFF
--- a/build/internal/ya.conf
+++ b/build/internal/ya.conf
@@ -4,6 +4,7 @@ bazel_remote_baseuri = "http://cachesrv.ydb.tech:8081"
 bazel_remote_client_decompress = true
 dist_cache_late_fetch = true
 test_fakeid = "r13102898"
+ignore_configure_errors = false  # YA-1456
 
 [host_platform_flags]
 OPENSOURCE = "yes"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Do not mask configure errors 

The problem is in script 
https://github.com/ydb-platform/ydb/blob/1af55dfd2469751be894c4db2a0c692905595490/.github/scripts/graph_compare.sh
It uses `ya make ... -k` switch  which hides configure errors

See YA-1456 and https://github.com/yandex/yatool/issues/7 for details

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Original problem was in 
https://github.com/ydb-platform/ydb/pull/8549 
https://github.com/ydb-platform/ydb/pull/8560 

