### PR TITLE
Use IS_CTX_LOG_PRIORITY_ENABLED in STLOGX to get actual logger settings

### DIFF
--- a/ydb/core/util/stlog.h
+++ b/ydb/core/util/stlog.h
@@ -66,7 +66,7 @@ namespace NKikimr::NStLog {
         auto& ctx = (CTX); \
         const auto priority = [&]{ using namespace NActors::NLog; return (PRIO); }(); \
         const auto component = [&]{ using namespace NKikimrServices; using namespace NActorsServices; return (COMP); }(); \
-        if (IS_LOG_PRIORITY_ENABLED(priority, component)) { \
+        if (IS_CTX_LOG_PRIORITY_ENABLED(ctx, priority, component, 0ull)) { \
             STLOG_STREAM(__stream, __VA_ARGS__); \
             ::NActors::MemLogAdapter(ctx, priority, component, __stream.Str(), ::NKikimr::NStLog::OutputLogJson); \
         }; \


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
