### PR TITLE
Don't run large_serializable in PR (2nd attempt)

### DIFF
--- a/ydb/tests/functional/large_serializable/ya.make
+++ b/ydb/tests/functional/large_serializable/ya.make
@@ -14,6 +14,7 @@ REQUIREMENTS(
 
 TIMEOUT(1800)
 SIZE(LARGE)
+TAG(ya:fat)
 
 DEPENDS(
     ydb/tests/tools/ydb_serializable

--- a/ydb/tests/functional/large_serializable/ya.make
+++ b/ydb/tests/functional/large_serializable/ya.make
@@ -12,8 +12,8 @@ REQUIREMENTS(
     ram:32
 )
 
-TIMEOUT(600)
-SIZE(MEDIUM)
+TIMEOUT(1800)
+SIZE(LARGE)
 
 DEPENDS(
     ydb/tests/tools/ydb_serializable


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It is useless to run on PRs, because of 
- retries 
- it takes too long (10 min)
- too flaky
- also enlarge timeout

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
