### PR TITLE
24-3: Reset __async_replica attr after changing REPLICATION_MODE to NONE

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1825,7 +1825,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     Y_ABORT_UNLESS(parseOk);
 
                     if (tableInfo->IsAsyncReplica()) {
-                        Self->PathsById.at(pathId)->SetAsyncReplica();
+                        Self->PathsById.at(pathId)->SetAsyncReplica(true);
                     }
                 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -365,6 +365,10 @@ public:
         TTableInfo::TPtr table = context.SS->Tables.at(pathId);
         table->FinishAlter();
 
+        if (!table->IsAsyncReplica()) {
+            path->SetAsyncReplica(false);
+        }
+
         auto ttlIt = context.SS->TTLEnabledTables.find(pathId);
         if (table->IsTTLEnabled() && ttlIt == context.SS->TTLEnabledTables.end()) {
             context.SS->TTLEnabledTables[pathId] = table;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -641,7 +641,7 @@ public:
         Y_ABORT_UNLESS(tableInfo->GetPartitions().back().EndOfRange.empty(), "End of last range must be +INF");
 
         if (tableInfo->IsAsyncReplica()) {
-            newTable->SetAsyncReplica();
+            newTable->SetAsyncReplica(true);
         }
 
         context.SS->Tables[newTable->PathId] = tableInfo;

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -411,8 +411,8 @@ bool TPathElement::CheckFileStoreSpaceChange(TFileStoreSpace newSpace, TFileStor
             CheckSpaceChanged(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD, errStr, "filestore", " (hdd)"));
 }
 
-void TPathElement::SetAsyncReplica() {
-    IsAsyncReplica = true;
+void TPathElement::SetAsyncReplica(bool value) {
+    IsAsyncReplica = value;
 }
 
 bool TPathElement::HasRuntimeAttrs() const {

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -160,7 +160,7 @@ public:
     void ChangeFileStoreSpaceBegin(TFileStoreSpace newSpace, TFileStoreSpace oldSpace);
     void ChangeFileStoreSpaceCommit(TFileStoreSpace newSpace, TFileStoreSpace oldSpace);
     bool CheckFileStoreSpaceChange(TFileStoreSpace newSpace, TFileStoreSpace oldSpace, TString& errStr);
-    void SetAsyncReplica();
+    void SetAsyncReplica(bool value);
     bool HasRuntimeAttrs() const;
     void SerializeRuntimeAttrs(google::protobuf::RepeatedPtrField<NKikimrSchemeOp::TUserAttribute>* userAttrs) const;
 };

--- a/ydb/core/tx/schemeshard/ut_replication/ut_replication.cpp
+++ b/ydb/core/tx/schemeshard/ut_replication/ut_replication.cpp
@@ -344,6 +344,7 @@ Y_UNIT_TEST_SUITE(TReplicationTests) {
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"), {
             NLs::ReplicationMode(NKikimrSchemeOp::TTableReplicationConfig::REPLICATION_MODE_NONE),
+            NLs::UserAttrsEqual({}),
         });
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Reset `__async_replica` attribute after changing `REPLICATION_MODE` to `NONE`.

### Changelog category <!-- remove all except one -->

* Bugfix

### Additional information

...
