### PR TITLE
streamlookupjoin: fix joining from multi-partition stream

### DIFF
--- a/ydb/library/yql/dq/tasks/dq_connection_builder.h
+++ b/ydb/library/yql/dq/tasks/dq_connection_builder.h
@@ -216,7 +216,7 @@ void BuildStreamLookupChannels(TGraph& graph, const NNodes::TDqPhyStage& stage, 
     auto& originStageInfo = graph.GetStageInfo(cnStreamLookup.Output().Stage());
     auto outputIndex = FromString<ui32>(cnStreamLookup.Output().Index().Value());
 
-    BuildMapChannels(graph, stageInfo, inputIndex, originStageInfo, outputIndex, false /*spilling*/, logFunc);
+    BuildUnionAllChannels(graph, stageInfo, inputIndex, originStageInfo, outputIndex, false /*spilling*/, logFunc);
 }
 
 template <typename TGraph>

--- a/ydb/tests/fq/generic/test_join_streaming.py
+++ b/ydb/tests/fq/generic/test_join_streaming.py
@@ -11,6 +11,22 @@ from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.fq.generic.utils.settings import Settings
 
 DEBUG = 0
+
+
+def ResequenceId(messages):
+    res = []
+    i = 1
+    for pair in messages:
+        rpair = []
+        for it in pair:
+            src = json.loads(it)
+            src["id"] = i
+            rpair += [json.dumps(src)]
+        res += [tuple(rpair)]
+        i += 1
+    return res
+
+
 TESTCASES = [
     # 0
     (
@@ -96,17 +112,19 @@ TESTCASES = [
             insert into myyds.`{output_topic}`
             select Unwrap(Yson::SerializeJson(Yson::From(TableRow()))) from $enriched;
             ''',
-        [
-            ('{"id":3,"user":5}', '{"id":3,"user_id":5,"lookup":null}'),
-            ('{"id":9,"user":3}', '{"id":9,"user_id":3,"lookup":"ydb30"}'),
-            ('{"id":2,"user":2}', '{"id":2,"user_id":2,"lookup":"ydb20"}'),
-            ('{"id":1,"user":1}', '{"id":1,"user_id":1,"lookup":"ydb10"}'),
-            ('{"id":4,"user":3}', '{"id":4,"user_id":3,"lookup":"ydb30"}'),
-            ('{"id":5,"user":3}', '{"id":5,"user_id":3,"lookup":"ydb30"}'),
-            ('{"id":6,"user":1}', '{"id":6,"user_id":1,"lookup":"ydb10"}'),
-            ('{"id":7,"user":2}', '{"id":7,"user_id":2,"lookup":"ydb20"}'),
-        ]
-        * 20,
+        ResequenceId(
+            [
+                ('{"id":3,"user":5}', '{"id":3,"user_id":5,"lookup":null}'),
+                ('{"id":9,"user":3}', '{"id":9,"user_id":3,"lookup":"ydb30"}'),
+                ('{"id":2,"user":2}', '{"id":2,"user_id":2,"lookup":"ydb20"}'),
+                ('{"id":1,"user":1}', '{"id":1,"user_id":1,"lookup":"ydb10"}'),
+                ('{"id":4,"user":3}', '{"id":4,"user_id":3,"lookup":"ydb30"}'),
+                ('{"id":5,"user":3}', '{"id":5,"user_id":3,"lookup":"ydb30"}'),
+                ('{"id":6,"user":1}', '{"id":6,"user_id":1,"lookup":"ydb10"}'),
+                ('{"id":7,"user":2}', '{"id":7,"user_id":2,"lookup":"ydb20"}'),
+            ]
+            * 20
+        ),
     ),
     # 3
     (
@@ -137,37 +155,39 @@ TESTCASES = [
             insert into myyds.`{output_topic}`
             select Unwrap(Yson::SerializeJson(Yson::From(TableRow()))) from $enriched;
             ''',
-        [
-            (
-                '{"id":2,"ts":"20240701T113344","ev_type":"foo1","user":2}',
-                '{"id":2,"ts":"11:33:44","user_id":2,"lookup":"ydb20"}',
-            ),
-            (
-                '{"id":1,"ts":"20240701T112233","ev_type":"foo2","user":1}',
-                '{"id":1,"ts":"11:22:33","user_id":1,"lookup":"ydb10"}',
-            ),
-            (
-                '{"id":3,"ts":"20240701T113355","ev_type":"foo3","user":5}',
-                '{"id":3,"ts":"11:33:55","user_id":5,"lookup":null}',
-            ),
-            (
-                '{"id":4,"ts":"20240701T113356","ev_type":"foo4","user":3}',
-                '{"id":4,"ts":"11:33:56","user_id":3,"lookup":"ydb30"}',
-            ),
-            (
-                '{"id":5,"ts":"20240701T113357","ev_type":"foo5","user":3}',
-                '{"id":5,"ts":"11:33:57","user_id":3,"lookup":"ydb30"}',
-            ),
-            (
-                '{"id":6,"ts":"20240701T112238","ev_type":"foo6","user":1}',
-                '{"id":6,"ts":"11:22:38","user_id":1,"lookup":"ydb10"}',
-            ),
-            (
-                '{"id":7,"ts":"20240701T113349","ev_type":"foo7","user":2}',
-                '{"id":7,"ts":"11:33:49","user_id":2,"lookup":"ydb20"}',
-            ),
-        ]
-        * 10,
+        ResequenceId(
+            [
+                (
+                    '{"id":2,"ts":"20240701T113344","ev_type":"foo1","user":2}',
+                    '{"id":2,"ts":"11:33:44","user_id":2,"lookup":"ydb20"}',
+                ),
+                (
+                    '{"id":1,"ts":"20240701T112233","ev_type":"foo2","user":1}',
+                    '{"id":1,"ts":"11:22:33","user_id":1,"lookup":"ydb10"}',
+                ),
+                (
+                    '{"id":3,"ts":"20240701T113355","ev_type":"foo3","user":5}',
+                    '{"id":3,"ts":"11:33:55","user_id":5,"lookup":null}',
+                ),
+                (
+                    '{"id":4,"ts":"20240701T113356","ev_type":"foo4","user":3}',
+                    '{"id":4,"ts":"11:33:56","user_id":3,"lookup":"ydb30"}',
+                ),
+                (
+                    '{"id":5,"ts":"20240701T113357","ev_type":"foo5","user":3}',
+                    '{"id":5,"ts":"11:33:57","user_id":3,"lookup":"ydb30"}',
+                ),
+                (
+                    '{"id":6,"ts":"20240701T112238","ev_type":"foo6","user":1}',
+                    '{"id":6,"ts":"11:22:38","user_id":1,"lookup":"ydb10"}',
+                ),
+                (
+                    '{"id":7,"ts":"20240701T113349","ev_type":"foo7","user":2}',
+                    '{"id":7,"ts":"11:33:49","user_id":2,"lookup":"ydb20"}',
+                ),
+            ]
+            * 10
+        ),
     ),
     # 4
     (
@@ -200,37 +220,39 @@ TESTCASES = [
             insert into myyds.`{output_topic}`
             select Unwrap(Yson::SerializeJson(Yson::From(TableRow()))) from $enriched;
             ''',
-        [
-            (
-                '{"id":1,"ts":"20240701T113344","ev_type":"foo1","user":2}',
-                '{"id":1,"ts":"11:33:44","uid":2,"user_id":2,"name":"Petr","age":25}',
-            ),
-            (
-                '{"id":2,"ts":"20240701T112233","ev_type":"foo2","user":1}',
-                '{"id":2,"ts":"11:22:33","uid":1,"user_id":1,"name":"Anya","age":15}',
-            ),
-            (
-                '{"id":3,"ts":"20240701T113355","ev_type":"foo3","user":100}',
-                '{"id":3,"ts":"11:33:55","uid":null,"user_id":100,"name":null,"age":null}',
-            ),
-            (
-                '{"id":4,"ts":"20240701T113356","ev_type":"foo4","user":3}',
-                '{"id":4,"ts":"11:33:56","uid":3,"user_id":3,"name":"Masha","age":17}',
-            ),
-            (
-                '{"id":5,"ts":"20240701T113357","ev_type":"foo5","user":3}',
-                '{"id":5,"ts":"11:33:57","uid":3,"user_id":3,"name":"Masha","age":17}',
-            ),
-            (
-                '{"id":6,"ts":"20240701T112238","ev_type":"foo6","user":1}',
-                '{"id":6,"ts":"11:22:38","uid":1,"user_id":1,"name":"Anya","age":15}',
-            ),
-            (
-                '{"id":7,"ts":"20240701T113349","ev_type":"foo7","user":2}',
-                '{"id":7,"ts":"11:33:49","uid":2,"user_id":2,"name":"Petr","age":25}',
-            ),
-        ]
-        * 1000,
+        ResequenceId(
+            [
+                (
+                    '{"id":1,"ts":"20240701T113344","ev_type":"foo1","user":2}',
+                    '{"id":1,"ts":"11:33:44","uid":2,"user_id":2,"name":"Petr","age":25}',
+                ),
+                (
+                    '{"id":2,"ts":"20240701T112233","ev_type":"foo2","user":1}',
+                    '{"id":2,"ts":"11:22:33","uid":1,"user_id":1,"name":"Anya","age":15}',
+                ),
+                (
+                    '{"id":3,"ts":"20240701T113355","ev_type":"foo3","user":100}',
+                    '{"id":3,"ts":"11:33:55","uid":null,"user_id":100,"name":null,"age":null}',
+                ),
+                (
+                    '{"id":4,"ts":"20240701T113356","ev_type":"foo4","user":3}',
+                    '{"id":4,"ts":"11:33:56","uid":3,"user_id":3,"name":"Masha","age":17}',
+                ),
+                (
+                    '{"id":5,"ts":"20240701T113357","ev_type":"foo5","user":3}',
+                    '{"id":5,"ts":"11:33:57","uid":3,"user_id":3,"name":"Masha","age":17}',
+                ),
+                (
+                    '{"id":6,"ts":"20240701T112238","ev_type":"foo6","user":1}',
+                    '{"id":6,"ts":"11:22:38","uid":1,"user_id":1,"name":"Anya","age":15}',
+                ),
+                (
+                    '{"id":7,"ts":"20240701T113349","ev_type":"foo7","user":2}',
+                    '{"id":7,"ts":"11:33:49","uid":2,"user_id":2,"name":"Petr","age":25}',
+                ),
+            ]
+            * 1000
+        ),
     ),
     # 5
     (

--- a/ydb/tests/fq/generic/test_join_streaming.py
+++ b/ydb/tests/fq/generic/test_join_streaming.py
@@ -368,7 +368,7 @@ class TestJoinStreaming(TestYdsBase):
     @pytest.mark.parametrize("mvp_external_ydb_endpoint", [{"endpoint": "tests-fq-generic-ydb:2136"}], indirect=True)
     @pytest.mark.parametrize("fq_client", [{"folder_id": "my_folder_slj"}], indirect=True)
     @pytest.mark.parametrize("partitions_count", [1, 3])
-    @pytest.mark.parametrize("streamlookup", [False, True])
+    @pytest.mark.parametrize("streamlookup", [False, True] if DEBUG else [True])
     @pytest.mark.parametrize("testcase", [*range(len(TESTCASES))])
     def test_streamlookup(
         self,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

Fixes error joining from stream with multiple segments/partitions
```
Fatal
Query failed with code ABORTED at 2024-08-30T16:51:16.629344Z
Fatal
Run query failed: Error
Fatal
contrib/ydb/library/yql/dq/tasks/dq_connection_builder.h:167  BuildMapChannels(): requirement originTasks.size() == targetTasks.size() failed, message: 2 != 1
```