### PR TITLE
Fix wrong links to stderr in html report 

### DIFF
--- a/.github/scripts/tests/transform-ya-junit.py
+++ b/.github/scripts/tests/transform-ya-junit.py
@@ -9,6 +9,7 @@ import argparse
 import re
 import json
 import os
+import shutil
 import sys
 import urllib.parse
 import zipfile
@@ -145,7 +146,7 @@ def save_log(build_root, fn, out_dir, log_url_prefix, trunc_size):
                             break
                         out_fp.write(buf)
         else:
-            os.symlink(fn, out_fn)
+            shutil.copyfile(fn, out_fn)
     quoted_fpath = urllib.parse.quote(fpath)
     return f"{log_url_prefix}{quoted_fpath}"
 
@@ -234,7 +235,7 @@ def main():
     parser.add_argument(
         "--log_truncate_size",
         type=int,
-        default=134217728,
+        default=134217728,  # 128 kb
         help="truncate log after specific size, 0 disables truncation",
     )
     parser.add_argument("--ya_out", help="ya make output dir (for searching logs and artifacts)")


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The problem is stderr in prev retries are broken and linked with newer reruns. 
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
Example of bad behaviour: 
https://github.com/ydb-platform/ydb/pull/8672#issuecomment-2326372555
See 
https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/10682134846/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/columnshard/ut_rw/test-results/unittest/testing_out_stuff/EvWrite.AbortInTransaction.err

https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/10682134846/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/columnshard/ut_rw/test-results/unittest/testing_out_stuff/EvWrite.AbortInTransaction.err

https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/10682134846/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/columnshard/ut_rw/test-results/unittest/testing_out_stuff/EvWrite.AbortInTransaction.err
-- there all stderrs are the same (test ydb/core/tx/columnshard/ut_rw/EvWrite.AbortInTransaction )

Fixed behaviour is here:
https://github.com/ydb-platform/ydb/pull/8673#issuecomment-2326378892
See
https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/10682154121/ya-x86-64/try_1/artifacts/logs/ydb/core/tx/columnshard/ut_rw/test-results/unittest/testing_out_stuff/EvWrite.AbortInTransaction.err

https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/10682154121/ya-x86-64/try_2/artifacts/logs/ydb/core/tx/columnshard/ut_rw/test-results/unittest/testing_out_stuff/EvWrite.AbortInTransaction.err

https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/10682154121/ya-x86-64/try_3/artifacts/logs/ydb/core/tx/columnshard/ut_rw/test-results/unittest/testing_out_stuff/EvWrite.AbortInTransaction.err


