### PR TITLE
Interactive cli over query service and some minor improvements

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
@@ -194,7 +194,7 @@ void TInteractiveCLI::Run() {
         }
     }
 
-    std::cout << "Bye" << '\n';
+    std::cout << std::endl << "Bye" << std::endl;
 }
 
 }

--- a/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
@@ -179,9 +179,16 @@ void TInteractiveCLI::Run() {
                 continue;
             }
 
+            TString query = TString(line);
+            TString queryLowerCase = to_lower(query);
+            if (queryLowerCase == "quit" || queryLowerCase == "exit") {
+                std::cout << "Bye" << std::endl;
+                return;
+            }
+
             TString queryStatsMode(NTable::QueryStatsModeToString(interactiveCLIState.CollectStatsMode));
             TCommandSql sqlCommand;
-            sqlCommand.SetScript(TString(line));
+            sqlCommand.SetScript(std::move(query));
             sqlCommand.SetCollectStatsMode(std::move(queryStatsMode));
             sqlCommand.SetSyntax("yql");
             sqlCommand.Run(Config);

--- a/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
@@ -9,7 +9,7 @@
 #include <ydb/public/lib/ydb_cli/commands/interactive/line_reader.h>
 #include <ydb/public/lib/ydb_cli/commands/ydb_service_scheme.h>
 #include <ydb/public/lib/ydb_cli/commands/ydb_service_table.h>
-#include <ydb/public/lib/ydb_cli/commands/ydb_yql.h>
+#include <ydb/public/lib/ydb_cli/commands/ydb_sql.h>
 
 namespace NYdb {
 namespace NConsoleClient {
@@ -180,8 +180,11 @@ void TInteractiveCLI::Run() {
             }
 
             TString queryStatsMode(NTable::QueryStatsModeToString(interactiveCLIState.CollectStatsMode));
-            TCommandYql yqlCommand(TString(line), queryStatsMode);
-            yqlCommand.Run(Config);
+            TCommandSql sqlCommand;
+            sqlCommand.SetScript(TString(line));
+            sqlCommand.SetCollectStatsMode(std::move(queryStatsMode));
+            sqlCommand.SetSyntax("yql");
+            sqlCommand.Run(Config);
         } catch (TYdbErrorException &error) {
             Cerr << error;
         } catch (yexception & error) {

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
@@ -99,6 +99,7 @@ TLineReader::TLineReader(std::string prompt, std::string historyFilePath, Sugges
     Rx.set_word_break_characters(WordBreakCharacters.data());
     Rx.bind_key(replxx::Replxx::KEY::control('N'), [&](char32_t code) { return Rx.invoke(replxx::Replxx::ACTION::HISTORY_NEXT, code); });
     Rx.bind_key(replxx::Replxx::KEY::control('P'), [&](char32_t code) { return Rx.invoke(replxx::Replxx::ACTION::HISTORY_PREVIOUS, code); });
+    Rx.bind_key(replxx::Replxx::KEY::control('C'), [](char32_t) { return replxx::Replxx::ACTION_RESULT::BAIL; });
     auto commit_action = [&](char32_t code) {
         return Rx.invoke(replxx::Replxx::ACTION::COMMIT_LINE, code);
     };

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
@@ -100,6 +100,8 @@ TLineReader::TLineReader(std::string prompt, std::string historyFilePath, Sugges
     Rx.bind_key(replxx::Replxx::KEY::control('N'), [&](char32_t code) { return Rx.invoke(replxx::Replxx::ACTION::HISTORY_NEXT, code); });
     Rx.bind_key(replxx::Replxx::KEY::control('P'), [&](char32_t code) { return Rx.invoke(replxx::Replxx::ACTION::HISTORY_PREVIOUS, code); });
     Rx.bind_key(replxx::Replxx::KEY::control('C'), [](char32_t) { return replxx::Replxx::ACTION_RESULT::BAIL; });
+    // Always disconnect on Ctrl+D (built-in implementation doesn't work if there is already any input text)
+    Rx.bind_key(replxx::Replxx::KEY::control('D'), [](char32_t) { return replxx::Replxx::ACTION_RESULT::BAIL; });
     auto commit_action = [&](char32_t code) {
         return Rx.invoke(replxx::Replxx::ACTION::COMMIT_LINE, code);
     };

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
@@ -99,8 +99,6 @@ TLineReader::TLineReader(std::string prompt, std::string historyFilePath, Sugges
     Rx.set_word_break_characters(WordBreakCharacters.data());
     Rx.bind_key(replxx::Replxx::KEY::control('N'), [&](char32_t code) { return Rx.invoke(replxx::Replxx::ACTION::HISTORY_NEXT, code); });
     Rx.bind_key(replxx::Replxx::KEY::control('P'), [&](char32_t code) { return Rx.invoke(replxx::Replxx::ACTION::HISTORY_PREVIOUS, code); });
-    Rx.bind_key(replxx::Replxx::KEY::control('C'), [](char32_t) { return replxx::Replxx::ACTION_RESULT::BAIL; });
-    // Always disconnect on Ctrl+D (built-in implementation doesn't work if there is already any input text)
     Rx.bind_key(replxx::Replxx::KEY::control('D'), [](char32_t) { return replxx::Replxx::ACTION_RESULT::BAIL; });
     auto commit_action = [&](char32_t code) {
         return Rx.invoke(replxx::Replxx::ACTION::COMMIT_LINE, code);

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -21,13 +21,6 @@ TCommandSql::TCommandSql()
     : TYdbCommand("sql", {}, "Execute SQL query")
 {}
 
-TCommandSql::TCommandSql(TString query, TString collectStatsMode)
-    : TYdbCommand("sql", {}, "Execute SQL query")
-{
-    Query = std::move(query);
-    CollectStatsMode = std::move(collectStatsMode);
-}
-
 void TCommandSql::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->AddLongOption('s', "script", "Script (query) text to execute").RequiredArgument("[String]")
@@ -176,6 +169,18 @@ int TCommandSql::PrintResponse(NQuery::TExecuteQueryIterator& result) {
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;
+}
+
+void TCommandSql::SetScript(TString&& script) {
+    Query = std::move(script);
+}
+
+void TCommandSql::SetCollectStatsMode(TString&& collectStatsMode) {
+    CollectStatsMode = std::move(collectStatsMode);
+}
+
+void TCommandSql::SetSyntax(TString&& syntax) {
+    Syntax = std::move(syntax);
 }
 
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.h
@@ -15,10 +15,12 @@ class TCommandSql : public TYdbCommand, public TCommandWithFormat,
 {
 public:
     TCommandSql();
-    TCommandSql(TString script, TString collectStatsMode);
     virtual void Config(TConfig& config) override;
     virtual void Parse(TConfig& config) override;
     virtual int Run(TConfig& config) override;
+    void SetSyntax(TString&& syntax);
+    void SetCollectStatsMode(TString&& collectStatsMode);
+    void SetScript(TString&& script);
 
 private:
     int RunCommand(TConfig& config);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
- Interactive CLI (`ydb` command) now works over QueryService instead of QueryService
- Interactive CLI now terminates on "quit" or "exit" commands

### Changelog category <!-- remove all except one -->
* Improvement