### PR TITLE
The race between `TEvProposeTransaction` and `TEvLockStatus` (#8517)

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -2167,7 +2167,7 @@ private:
 
     using TDatashardTxs = THashMap<ui64, NKikimrTxDataShard::TKqpTransaction*>;
     using TEvWriteTxs = THashMap<ui64, NKikimrDataEvents::TEvWrite*>;
-    using TTopicTabletTxs = THashMap<ui64, NKikimrPQ::TDataTransaction>;
+    using TTopicTabletTxs = NTopic::TTopicOperationTransactions;
 
     void ContinueExecute() {
         if (Stats) {
@@ -2424,10 +2424,10 @@ private:
                     }
                 }
 
-                for (auto& [_, tx] : topicTxs) {
-                    tx.SetOp(NKikimrPQ::TDataTransaction::Commit);
-                    *tx.MutableSendingShards() = sendingShards;
-                    *tx.MutableReceivingShards() = receivingShards;
+                for (auto& [_, t] : topicTxs) {
+                    t.tx.SetOp(NKikimrPQ::TDataTransaction::Commit);
+                    *t.tx.MutableSendingShards() = sendingShards;
+                    *t.tx.MutableReceivingShards() = receivingShards;
                     YQL_ENSURE(!arbiter);
                 }
             }
@@ -2589,13 +2589,12 @@ private:
             writeId = Request.TopicOperations.GetWriteId();
         }
 
-        for (auto& tx : topicTxs) {
-            auto tabletId = tx.first;
-            auto& transaction = tx.second;
+        for (auto& [tabletId, t] : topicTxs) {
+            auto& transaction = t.tx;
 
             auto ev = std::make_unique<TEvPersQueue::TEvProposeTransaction>();
 
-            if (writeId.Defined()) {
+            if (t.hasWrite && writeId.Defined()) {
                 auto* w = transaction.MutableWriteId();
                 w->SetNodeId(SelfId().NodeId());
                 w->SetKeyId(*writeId);

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -42,6 +42,13 @@ private:
     TDisjointIntervalTree<ui64> Offsets_;
 };
 
+struct TTopicOperationTransaction {
+    NKikimrPQ::TDataTransaction tx;
+    bool hasWrite = false;
+};
+
+using TTopicOperationTransactions = THashMap<ui64, TTopicOperationTransaction>;
+
 class TTopicPartitionOperations {
 public:
     bool IsValid() const;
@@ -52,7 +59,7 @@ public:
     void AddOperation(const TString& topic, ui32 partition,
                       TMaybe<ui32> supportivePartition);
 
-    void BuildTopicTxs(THashMap<ui64, NKikimrPQ::TDataTransaction> &txs);
+    void BuildTopicTxs(TTopicOperationTransactions &txs);
 
     void Merge(const TTopicPartitionOperations& rhs);
 
@@ -109,7 +116,7 @@ public:
                                     Ydb::StatusIds_StatusCode& status,
                                     TString& message);
 
-    void BuildTopicTxs(THashMap<ui64, NKikimrPQ::TDataTransaction> &txs);
+    void BuildTopicTxs(TTopicOperationTransactions &txs);
 
     void Merge(const TTopicOperations& rhs);
 

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -495,11 +495,12 @@ private:
 
     bool AllOriginalPartitionsInited() const;
 
-    void Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev, const TActorContext& ctx);
+    void Handle(NLongTxService::TEvLongTxService::TEvLockStatus::TPtr& ev);
     void Handle(TEvPQ::TEvDeletePartitionDone::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPQ::TEvTransactionCompleted::TPtr& ev, const TActorContext& ctx);
 
     void BeginDeletePartitions(TTxWriteInfo& writeInfo);
+    void BeginDeletePartitions(const TDistributedTransaction& tx);
 
     bool CheckTxWriteOperation(const NKikimrPQ::TPartitionOperation& operation,
                                const TWriteId& writeId) const;
@@ -527,7 +528,7 @@ private:
     void AddCmdDeleteTx(NKikimrClient::TKeyValueRequest& request,
                         ui64 txId);
 
-    bool WriteIdIsDisabled(const TMaybe<TWriteId>& writeId) const;
+    bool AllSupportivePartitionsHaveBeenDeleted(const TMaybe<TWriteId>& writeId) const;
     void DeleteWriteId(const TMaybe<TWriteId>& writeId);
 };
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -1317,7 +1317,7 @@ void TFixture::WaitForTheTabletToDeleteTheWriteInfo(const TActorId& actorId,
         for (size_t i = 0; i < info.TxWritesSize(); ++i) {
             auto& writeInfo = info.GetTxWrites(i);
             UNIT_ASSERT(writeInfo.HasWriteId());
-            if (NPQ::GetWriteId(writeInfo) == writeId) {
+            if ((NPQ::GetWriteId(writeInfo) == writeId) && writeInfo.HasOriginalPartitionId()) {
                 found = true;
                 break;
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Changes from `PR 8517`.

The entry for `WriteId` was not saved if there was an empty list of partitions in `TTxWriteInfo`. As a result, after restoring the tablet, `Y_VERIFY` was triggered.

Now the record of the `WriteId` is saved until the end of the transaction.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
