### PR TITLE
Remove YT migration helper

### DIFF
--- a/ydb/library/yql/providers/dq/actors/yt/yt_wrapper.cpp
+++ b/ydb/library/yql/providers/dq/actors/yt/yt_wrapper.cpp
@@ -29,24 +29,6 @@ using namespace NYT::NApi;
 using namespace NActors;
 
 namespace NYql {
-    // This is compat function. YT changed returned type of IClient::GetJobStder.
-    // This function is used to be compatible both with new and old versions.
-    //
-    // Can be removed once arcadia and github both use new version of YT client.
-    template <typename T>
-    TFuture<NYT::TSharedRef> ToStderrDataFuture(const NYT::TFuture<T>& jobStderrResponse) {
-        if constexpr (std::is_same_v<T, NYT::TSharedRef>) {
-            return jobStderrResponse.Apply(BIND([] (const NYT::TSharedRef& rsp) {
-                return rsp;
-            }));
-        } else {
-            // T must be TGetJobStderrResponse
-            return jobStderrResponse.Apply(BIND([] (const T& rsp) {
-                return rsp.Data;
-            }));
-        }
-    }
-
     struct TRequest: public NYT::TRefCounted {
         const TActorId SelfId;
         const TActorId Sender;
@@ -642,13 +624,13 @@ namespace NYql {
                         for (const auto& job : result.Jobs) {
                             YQL_CLOG(DEBUG, ProviderDq) << "Printing stderr (" << ToString(operationId) << "," << ToString(job.Id) << ")";
 
-                            auto jobStderrData = ToStderrDataFuture(cli->GetJobStderr(operationId, job.Id));
-                            YT_UNUSED_FUTURE(jobStderrData.Apply(BIND([jobId = job.Id, operationId](const NYT::TSharedRef& data) {
+                            YT_UNUSED_FUTURE(cli->GetJobStderr(operationId, job.Id)
+                                .Apply(BIND([jobId = job.Id, operationId](const TGetJobStderrResponse& response) {
                                     YQL_CLOG(DEBUG, ProviderDq)
                                         << "Stderr ("
                                         << ToString(operationId) << ","
                                         << ToString(jobId) << ")"
-                                        << TString(data.Begin(), data.Size());
+                                        << TString(response.Data.Begin(), response.Data.Size());
                                 })));
                         }
                     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It was added in https://github.com/ydb-platform/ydb/pull/8627 and now useless because of synced YT 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

