### PR TITLE
Reduce huge amount of PDisk's chunks info printed into log

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -474,6 +474,28 @@ bool TPDisk::ProcessChunk0(const NPDisk::TEvReadLogResult &readLogResult, TStrin
     return true;
 }
 
+static void PrintCondensedChunksList(TStringStream& str, const std::vector<ui32>& chunks) {
+    str << " [";
+    bool first = true;
+    std::optional<TChunkIdx> begin;
+    for (size_t i = 0; i < chunks.size(); ++i) {
+        if (!begin) {
+            begin = chunks[i];
+        }
+        if (i + 1 < chunks.size() && chunks[i] + 1 == chunks[i + 1]) {
+            continue;
+        }
+        str << (std::exchange(first, false) ? "" : " ");
+        if (*begin == chunks[i]) {
+            str << chunks[i];
+        } else {
+            str << *begin << "-" << chunks[i];
+        }
+        begin.reset();
+    }
+    str << "];";
+}
+
 void TPDisk::PrintChunksDebugInfo() {
     auto print = [&] () {
         std::map<TOwner, std::vector<ui32>> ownerToChunks;
@@ -487,17 +509,13 @@ void TPDisk::PrintChunksDebugInfo() {
         str << "PDiskId# " << PDiskId << " PrintChunksDebugInfo; ";
         for (auto& [owner, chunks] : ownerToChunks) {
             std::sort(chunks.begin(), chunks.end());
-            str << " Owner# " << owner << " [";
-            bool first = true;
-            for (auto idx : chunks) {
-                str << (std::exchange(first, false) ? "" : " ") << idx;
-            }
-            str << "];";
+            str << " Owner# " << owner;
+            PrintCondensedChunksList(str, chunks);
         }
         return str.Str();
     };
 
-    LOG_INFO_S(*ActorSystem, NKikimrServices::BS_PDISK, print());
+    LOG_DEBUG_S(*ActorSystem, NKikimrServices::BS_PDISK, print());
 }
 
 TRcBuf TPDisk::ProcessReadSysLogResult(ui64 &outWritePosition, ui64 &outLsn,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Currently PDisk write a lot of excessive information about chunks into log with INFO priority, so this PR reduces level to DEBUG and condenses chunks list

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
