### PR TITLE
Fix use-after-free in CommittingOps tracking

### DIFF
--- a/ydb/core/tx/datashard/operation.h
+++ b/ydb/core/tx/datashard/operation.h
@@ -883,6 +883,12 @@ public:
      */
     virtual void OnCleanup(TDataShard& self, std::vector<std::unique_ptr<IEventHandle>>& replies);
 
+
+    // CommittingOps book keeping
+    const std::optional<TRowVersion>& GetCommittingOpsVersion() const { return CommittingOpsVersion; }
+    void SetCommittingOpsVersion(const TRowVersion& version) { CommittingOpsVersion = version; }
+    void ResetCommittingOpsVersion() { CommittingOpsVersion.reset(); }
+
 protected:
     TOperation()
         : TOperation(TBasicOpInfo())
@@ -955,6 +961,8 @@ private:
     TMonotonic FinishProposeTs;
 
     static NMiniKQL::IEngineFlat::TValidationInfo EmptyKeysInfo;
+
+    std::optional<TRowVersion> CommittingOpsVersion;
 
 public:
     std::optional<TRowVersion> MvccReadWriteVersion;

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -2003,6 +2003,9 @@ void AddValueToCells(ui64 value, const TString& columnType, TVector<TCell>& cell
     } else if (columnType == "Uint32") {
         ui32 value32 = (ui32)value;
         cells.emplace_back(TCell((const char*)&value32, sizeof(ui32)));
+    } else if (columnType == "Int32") {
+        i32 value32 = (i32)value;
+        cells.push_back(TCell::Make(value32));
     } else if (columnType == "Utf8") {
         stringValues.emplace_back(Sprintf("String_%" PRIu64, value));
         cells.emplace_back(TCell(stringValues.back().c_str(), stringValues.back().size()));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

There was a problem with CommittingOps tracking, where a distributed transaction could have failed without adding to this set, but would try to remove itself on completion. When other immediate transactions attached to the same version it could cause refcount underflow and remove the version record with iterators still pointing there, causing use-after-free. Reproducing this issue is very tricky, since distributed tx must finish execution before another immediate tx (non read-only and attached to the same version) executes, which usually cannot happen. However, new EvWrite api uses local mvcc snapshots for uncommitted writes, which makes it possible to attach to a version first and execute out-of-order later.

This patch adds strict validation to CommittingOps tracking, and makes sure Remove (with the same version) is only called once after a corresponding Add.

Fixes KIKIMR-21932.