### PR TITLE
[docs] changed link name from "docker" to "source code"

### DIFF
--- a/ydb/docs/ru/core/downloads/index.md
+++ b/ydb/docs/ru/core/downloads/index.md
@@ -40,7 +40,7 @@
 
 - Исходный код
 
-  {% include notitle [docker](_includes/server/source_code.md) %}
+  {% include notitle [source_code](_includes/server/source_code.md) %}
 
 {% endlist %}
 


### PR DESCRIPTION
changed link name from "docker" to "source code"

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

changed link name from "docker" to "source code"
...

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)

### Additional information

...
