### PR TITLE
24-2: create_time, end_time & created_by for operations

### DIFF
--- a/ydb/core/grpc_services/rpc_export_base.h
+++ b/ydb/core/grpc_services/rpc_export_base.h
@@ -45,10 +45,14 @@ struct TExportConv {
         }
 
         if (exprt.HasStartTime()) {
-            *operation.mutable_start_time() = exprt.GetStartTime();
+            *operation.mutable_create_time() = exprt.GetStartTime();
         }
         if (exprt.HasEndTime()) {
             *operation.mutable_end_time() = exprt.GetEndTime();
+        }
+
+        if (exprt.HasUserSID()) {
+            operation.set_created_by(exprt.GetUserSID());
         }
 
         using namespace Ydb::Export;

--- a/ydb/core/grpc_services/rpc_export_base.h
+++ b/ydb/core/grpc_services/rpc_export_base.h
@@ -44,6 +44,13 @@ struct TExportConv {
             operation.mutable_issues()->CopyFrom(exprt.GetIssues());
         }
 
+        if (exprt.HasStartTime()) {
+            *operation.mutable_start_time() = exprt.GetStartTime();
+        }
+        if (exprt.HasEndTime()) {
+            *operation.mutable_end_time() = exprt.GetEndTime();
+        }
+
         using namespace Ydb::Export;
         switch (exprt.GetSettingsCase()) {
         case NKikimrExport::TExport::kExportToYtSettings:

--- a/ydb/core/grpc_services/rpc_import_base.h
+++ b/ydb/core/grpc_services/rpc_import_base.h
@@ -41,6 +41,13 @@ struct TImportConv {
             operation.mutable_issues()->CopyFrom(import.GetIssues());
         }
 
+        if (import.HasStartTime()) {
+            *operation.mutable_start_time() = import.GetStartTime();
+        }
+        if (import.HasEndTime()) {
+            *operation.mutable_end_time() = import.GetEndTime();
+        }
+
         using namespace Ydb::Import;
         switch (import.GetSettingsCase()) {
         case NKikimrImport::TImport::kImportFromS3Settings:

--- a/ydb/core/grpc_services/rpc_import_base.h
+++ b/ydb/core/grpc_services/rpc_import_base.h
@@ -42,10 +42,14 @@ struct TImportConv {
         }
 
         if (import.HasStartTime()) {
-            *operation.mutable_start_time() = import.GetStartTime();
+            *operation.mutable_create_time() = import.GetStartTime();
         }
         if (import.HasEndTime()) {
             *operation.mutable_end_time() = import.GetEndTime();
+        }
+
+        if (import.HasUserSID()) {
+            operation.set_created_by(import.GetUserSID());
         }
 
         using namespace Ydb::Import;

--- a/ydb/core/protos/export.proto
+++ b/ydb/core/protos/export.proto
@@ -20,6 +20,7 @@ message TExport {
         Ydb.Export.ExportToYtSettings ExportToYtSettings = 5;
         Ydb.Export.ExportToS3Settings ExportToS3Settings = 6;
     }
+    optional string UserSID = 10;
 }
 
 message TCreateExportRequest {

--- a/ydb/core/protos/export.proto
+++ b/ydb/core/protos/export.proto
@@ -3,6 +3,8 @@ import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/ydb_operation.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
 
+import "google/protobuf/timestamp.proto";
+
 package NKikimrExport;
 option java_package = "ru.yandex.kikimr.proto";
 
@@ -11,6 +13,8 @@ message TExport {
     optional Ydb.StatusIds.StatusCode Status = 2;
     repeated Ydb.Issue.IssueMessage Issues = 3;
     optional Ydb.Export.ExportProgress.Progress Progress = 4;
+    optional google.protobuf.Timestamp StartTime = 8;
+    optional google.protobuf.Timestamp EndTime = 9;
     repeated Ydb.Export.ExportItemProgress ItemsProgress = 7;
     oneof Settings {
         Ydb.Export.ExportToYtSettings ExportToYtSettings = 5;

--- a/ydb/core/protos/import.proto
+++ b/ydb/core/protos/import.proto
@@ -19,6 +19,7 @@ message TImport {
     oneof Settings {
         Ydb.Import.ImportFromS3Settings ImportFromS3Settings = 6;
     }
+    optional string UserSID = 9;
 }
 
 message TCreateImportRequest {

--- a/ydb/core/protos/import.proto
+++ b/ydb/core/protos/import.proto
@@ -3,6 +3,8 @@ import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/ydb_operation.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
 
+import "google/protobuf/timestamp.proto";
+
 package NKikimrImport;
 option java_package = "ru.yandex.kikimr.proto";
 
@@ -11,6 +13,8 @@ message TImport {
     optional Ydb.StatusIds.StatusCode Status = 2;
     repeated Ydb.Issue.IssueMessage Issues = 3;
     optional Ydb.Import.ImportProgress.Progress Progress = 4;
+    optional google.protobuf.Timestamp StartTime = 7;
+    optional google.protobuf.Timestamp EndTime = 8;
     repeated Ydb.Import.ImportItemProgress ItemsProgress = 5;
     oneof Settings {
         Ydb.Import.ImportFromS3Settings ImportFromS3Settings = 6;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4166,6 +4166,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     exportInfo->WaitTxId = rowset.GetValueOrDefault<Schema::Exports::WaitTxId>(InvalidTxId);
                     exportInfo->Issue = rowset.GetValueOrDefault<Schema::Exports::Issue>(TString());
 
+                    exportInfo->StartTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Exports::StartTime>());
+                    exportInfo->EndTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Exports::EndTime>());
+
                     Self->Exports[id] = exportInfo;
                     if (uid) {
                         Self->ExportsByUid[uid] = exportInfo;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4261,6 +4261,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     importInfo->State = static_cast<TImportInfo::EState>(rowset.GetValue<Schema::Imports::State>());
                     importInfo->Issue = rowset.GetValueOrDefault<Schema::Imports::Issue>(TString());
 
+                    importInfo->StartTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Imports::StartTime>());
+                    importInfo->EndTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Imports::EndTime>());
+
                     Self->Imports[id] = importInfo;
                     if (uid) {
                         Self->ImportsByUid[uid] = importInfo;

--- a/ydb/core/tx/schemeshard/schemeshard_export.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export.cpp
@@ -81,6 +81,11 @@ namespace {
 void TSchemeShard::FromXxportInfo(NKikimrExport::TExport& exprt, const TExportInfo::TPtr exportInfo) {
     exprt.SetId(exportInfo->Id);
     exprt.SetStatus(Ydb::StatusIds::SUCCESS);
+    
+    *exprt.MutableStartTime() = SecondsToProtoTimeStamp(exportInfo->StartTime.Seconds());
+    if (exportInfo->EndTime != TInstant::Zero()) {
+        *exprt.MutableEndTime() = SecondsToProtoTimeStamp(exportInfo->EndTime.Seconds());
+    }
 
     switch (exportInfo->State) {
     case TExportInfo::EState::CreateExportDir:
@@ -180,7 +185,9 @@ void TSchemeShard::PersistExportState(NIceDb::TNiceDb& db, const TExportInfo::TP
     db.Table<Schema::Exports>().Key(exportInfo->Id).Update(
         NIceDb::TUpdate<Schema::Exports::State>(static_cast<ui8>(exportInfo->State)),
         NIceDb::TUpdate<Schema::Exports::WaitTxId>(exportInfo->WaitTxId),
-        NIceDb::TUpdate<Schema::Exports::Issue>(exportInfo->Issue)
+        NIceDb::TUpdate<Schema::Exports::Issue>(exportInfo->Issue),
+        NIceDb::TUpdate<Schema::Exports::StartTime>(exportInfo->StartTime.Seconds()),
+        NIceDb::TUpdate<Schema::Exports::EndTime>(exportInfo->EndTime.Seconds())
     );
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_export.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export.cpp
@@ -89,6 +89,10 @@ void TSchemeShard::FromXxportInfo(NKikimrExport::TExport& exprt, const TExportIn
         *exprt.MutableEndTime() = SecondsToProtoTimeStamp(exportInfo->EndTime.Seconds());
     }
 
+    if (exportInfo->UserSID) {
+        exprt.SetUserSID(*exportInfo->UserSID);
+    }
+
     switch (exportInfo->State) {
     case TExportInfo::EState::CreateExportDir:
     case TExportInfo::EState::CopyTables:

--- a/ydb/core/tx/schemeshard/schemeshard_export.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export.cpp
@@ -82,7 +82,9 @@ void TSchemeShard::FromXxportInfo(NKikimrExport::TExport& exprt, const TExportIn
     exprt.SetId(exportInfo->Id);
     exprt.SetStatus(Ydb::StatusIds::SUCCESS);
     
-    *exprt.MutableStartTime() = SecondsToProtoTimeStamp(exportInfo->StartTime.Seconds());
+    if (exportInfo->StartTime != TInstant::Zero()) {
+        *exprt.MutableStartTime() = SecondsToProtoTimeStamp(exportInfo->StartTime.Seconds());
+    }
     if (exportInfo->EndTime != TInstant::Zero()) {
         *exprt.MutableEndTime() = SecondsToProtoTimeStamp(exportInfo->EndTime.Seconds());
     }

--- a/ydb/core/tx/schemeshard/schemeshard_export__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__cancel.cpp
@@ -79,6 +79,10 @@ struct TSchemeShard::TExport::TTxCancel: public TSchemeShard::TXxport::TTxBase {
             }
         }
 
+        if (exportInfo->State == TExportInfo::EState::Cancelled) {
+            exportInfo->EndTime = TAppData::TimeProvider->Now();
+        }
+
         NIceDb::TNiceDb db(txc.DB);
         Self->PersistExportState(db, exportInfo);
 
@@ -158,6 +162,7 @@ struct TSchemeShard::TExport::TTxCancelAck: public TSchemeShard::TXxport::TTxBas
 
         if (cancelledItems == cancellableItems) {
             exportInfo->State = TExportInfo::EState::Cancelled;
+            exportInfo->EndTime = TAppData::TimeProvider->Now();
             Self->PersistExportState(db, exportInfo);
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
@@ -142,6 +142,7 @@ struct TSchemeShard::TExport::TTxCreate: public TSchemeShard::TXxport::TTxBase {
         Self->PersistCreateExport(db, exportInfo);
 
         exportInfo->State = TExportInfo::EState::CreateExportDir;
+        exportInfo->StartTime = TAppData::TimeProvider->Now();
         Self->PersistExportState(db, exportInfo);
 
         Self->Exports[id] = exportInfo;
@@ -485,6 +486,10 @@ private:
 
             CancelTransferring(exportInfo, i);
         }
+
+        if (exportInfo->State == EState::Cancelled) {
+            exportInfo->EndTime = TAppData::TimeProvider->Now();
+        }
     }
 
     TMaybe<TString> GetIssues(const TPathId& itemPathId, TTxId backupTxId) {
@@ -579,6 +584,10 @@ private:
 
                     Self->PersistExportItemState(db, exportInfo, itemIdx);
                 }
+            }
+
+            if (exportInfo->State == EState::Cancelled) {
+                exportInfo->EndTime = TAppData::TimeProvider->Now();
             }
 
             Self->PersistExportState(db, exportInfo);
@@ -804,6 +813,7 @@ private:
 
                     exportInfo->Issue = record.GetReason();
                     exportInfo->State = EState::Cancelled;
+                    exportInfo->EndTime = TAppData::TimeProvider->Now();
                 }
 
                 Self->PersistExportState(db, exportInfo);
@@ -948,6 +958,7 @@ private:
             } else {
                 if (AllOf(exportInfo->Items, &TExportInfo::TItem::IsDone)) {
                     exportInfo->State = EState::Done;
+                    exportInfo->EndTime = TAppData::TimeProvider->Now();
                 }
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -55,6 +55,10 @@ void TSchemeShard::FromXxportInfo(NKikimrImport::TImport& import, const TImportI
         *import.MutableEndTime() = SecondsToProtoTimeStamp(importInfo->EndTime.Seconds());
     }
 
+    if (importInfo->UserSID) {
+        import.SetUserSID(*importInfo->UserSID);
+    }
+
     switch (importInfo->State) {
     case TImportInfo::EState::Waiting:
         switch (GetMinState(importInfo)) {

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -21,6 +21,13 @@ namespace {
         }
     }
 
+    NProtoBuf::Timestamp SecondsToProtoTimeStamp(ui64 sec) {
+        NProtoBuf::Timestamp timestamp;
+        timestamp.set_seconds((i64)(sec));
+        timestamp.set_nanos(0);
+        return timestamp;
+    }
+
     TImportInfo::EState GetMinState(TImportInfo::TPtr importInfo) {
         TImportInfo::EState state = TImportInfo::EState::Invalid;
 
@@ -40,6 +47,11 @@ namespace {
 void TSchemeShard::FromXxportInfo(NKikimrImport::TImport& import, const TImportInfo::TPtr importInfo) {
     import.SetId(importInfo->Id);
     import.SetStatus(Ydb::StatusIds::SUCCESS);
+
+    *import.MutableStartTime() = SecondsToProtoTimeStamp(importInfo->StartTime.Seconds());
+    if (importInfo->EndTime != TInstant::Zero()) {
+        *import.MutableEndTime() = SecondsToProtoTimeStamp(importInfo->EndTime.Seconds());
+    }
 
     switch (importInfo->State) {
     case TImportInfo::EState::Waiting:
@@ -131,7 +143,9 @@ void TSchemeShard::PersistRemoveImport(NIceDb::TNiceDb& db, const TImportInfo::T
 void TSchemeShard::PersistImportState(NIceDb::TNiceDb& db, const TImportInfo::TPtr importInfo) {
     db.Table<Schema::Imports>().Key(importInfo->Id).Update(
         NIceDb::TUpdate<Schema::Imports::State>(static_cast<ui8>(importInfo->State)),
-        NIceDb::TUpdate<Schema::Imports::Issue>(importInfo->Issue)
+        NIceDb::TUpdate<Schema::Imports::Issue>(importInfo->Issue),
+        NIceDb::TUpdate<Schema::Imports::StartTime>(importInfo->StartTime.Seconds()),
+        NIceDb::TUpdate<Schema::Imports::EndTime>(importInfo->EndTime.Seconds())
     );
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -48,7 +48,9 @@ void TSchemeShard::FromXxportInfo(NKikimrImport::TImport& import, const TImportI
     import.SetId(importInfo->Id);
     import.SetStatus(Ydb::StatusIds::SUCCESS);
 
-    *import.MutableStartTime() = SecondsToProtoTimeStamp(importInfo->StartTime.Seconds());
+    if (importInfo->StartTime != TInstant::Zero()) {
+        *import.MutableStartTime() = SecondsToProtoTimeStamp(importInfo->StartTime.Seconds());
+    }
     if (importInfo->EndTime != TInstant::Zero()) {
         *import.MutableEndTime() = SecondsToProtoTimeStamp(importInfo->EndTime.Seconds());
     }

--- a/ydb/core/tx/schemeshard/schemeshard_import__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__cancel.cpp
@@ -85,6 +85,10 @@ struct TSchemeShard::TImport::TTxCancel: public TSchemeShard::TXxport::TTxBase {
                 }
             }
 
+            if (importInfo->State == TImportInfo::EState::Cancelled) {
+                importInfo->EndTime = TAppData::TimeProvider->Now();
+            }
+
             Self->PersistImportState(db, importInfo);
             SendNotificationsIfFinished(importInfo);
             return respond(Ydb::StatusIds::SUCCESS);
@@ -183,6 +187,7 @@ struct TSchemeShard::TImport::TTxCancelAck: public TSchemeShard::TXxport::TTxBas
         }
 
         importInfo->State = TImportInfo::EState::Cancelled;
+        importInfo->EndTime = TAppData::TimeProvider->Now();
         Self->PersistImportState(db, importInfo);
 
         SendNotificationsIfFinished(importInfo);

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -124,6 +124,7 @@ struct TSchemeShard::TImport::TTxCreate: public TSchemeShard::TXxport::TTxBase {
         Self->PersistCreateImport(db, importInfo);
 
         importInfo->State = TImportInfo::EState::Waiting;
+        importInfo->StartTime = TAppData::TimeProvider->Now();
         Self->PersistImportState(db, importInfo);
 
         Self->Imports[id] = importInfo;
@@ -510,6 +511,10 @@ private:
             default:
                 break;
             }
+        }
+
+        if (importInfo->State == EState::Cancelled) {
+            importInfo->EndTime = TAppData::TimeProvider->Now();
         }
     }
 
@@ -1004,6 +1009,7 @@ private:
 
         if (AllOf(importInfo->Items, &TImportInfo::TItem::IsDone)) {
             importInfo->State = EState::Done;
+            importInfo->EndTime = TAppData::TimeProvider->Now();
         }
 
         Self->PersistImportItemState(db, importInfo, itemIdx);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2776,6 +2776,9 @@ struct TExportInfo: public TSimpleRefCount<TExportInfo> {
     ui64 SnapshotStep = 0;
     ui64 SnapshotTxId = 0;
 
+    TInstant StartTime = TInstant::Zero();
+    TInstant EndTime = TInstant::Zero();
+
     explicit TExportInfo(
             const ui64 id,
             const TString& uid,

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2924,6 +2924,9 @@ struct TImportInfo: public TSimpleRefCount<TImportInfo> {
 
     TSet<TActorId> Subscribers;
 
+    TInstant StartTime = TInstant::Zero();
+    TInstant EndTime = TInstant::Zero();
+
     explicit TImportInfo(
             const ui64 id,
             const TString& uid,

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1467,6 +1467,9 @@ struct Schema : NIceDb::Schema {
         struct State : Column<8, NScheme::NTypeIds::Byte> {};
         struct Issue : Column<9, NScheme::NTypeIds::Utf8> {};
 
+        struct StartTime : Column<11, NScheme::NTypeIds::Uint64> {};
+        struct EndTime : Column<12, NScheme::NTypeIds::Uint64> {};
+
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<
             Id,
@@ -1478,7 +1481,9 @@ struct Schema : NIceDb::Schema {
             Items,
             State,
             Issue,
-            UserSID
+            UserSID,
+            StartTime,
+            EndTime
         >;
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1145,6 +1145,9 @@ struct Schema : NIceDb::Schema {
         struct ExportOwnerPathId : Column<10, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
         struct DomainPathOwnerId : Column<11, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; };
 
+        struct StartTime : Column<14, NScheme::NTypeIds::Uint64> {};
+        struct EndTime : Column<15, NScheme::NTypeIds::Uint64> {};
+
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<
             Id,
@@ -1159,7 +1162,9 @@ struct Schema : NIceDb::Schema {
             ExportOwnerPathId,
             DomainPathOwnerId,
             Kind,
-            UserSID
+            UserSID,
+            StartTime,
+            EndTime
         >;
     };
 

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -1570,7 +1570,7 @@ partitioning_settings {
             }
         )", port));
 
-        runtime.AdvanceCurrentTime(TDuration::Seconds(30)); // doing backup
+        runtime.AdvanceCurrentTime(TDuration::Seconds(30)); // doing export
 
         env.TestWaitNotification(runtime, txId);
 
@@ -1631,7 +1631,7 @@ partitioning_settings {
         )", port));
         const ui64 exportId = txId;
 
-        runtime.AdvanceCurrentTime(TDuration::Seconds(30)); // doing backup
+        runtime.AdvanceCurrentTime(TDuration::Seconds(30)); // doing export
 
         if (!delayed) {
             TDispatchOptions opts;

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -1506,6 +1506,7 @@ partitioning_settings {
     Y_UNIT_TEST(ExportStartTime) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
@@ -1543,6 +1544,7 @@ partitioning_settings {
     Y_UNIT_TEST(CompletedExportEndTime) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
@@ -1585,6 +1587,7 @@ partitioning_settings {
     Y_UNIT_TEST(CancelledExportEndTime) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -1663,4 +1663,42 @@ partitioning_settings {
         UNIT_ASSERT(entry.HasEndTime());
         UNIT_ASSERT_LT(entry.GetStartTime().seconds(), entry.GetEndTime().seconds());
     }
+    
+    Y_UNIT_TEST(UserSID) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Utf8" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock({}, TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        const TString request = Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_path: "/MyRoot/Table"
+                destination_prefix: ""
+              }
+            }
+        )", port);
+        const TString userSID = "user@builtin";
+        TestExport(runtime, ++txId, "/MyRoot", request, userSID);
+
+        const auto desc = TestGetExport(runtime, txId, "/MyRoot");
+        const auto& entry = desc.GetResponse().GetEntry();
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetProgress(), Ydb::Export::ExportProgress::PROGRESS_PREPARING);
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetUserSID(), userSID);
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -3105,6 +3105,48 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         UNIT_ASSERT(entry.HasEndTime());
         UNIT_ASSERT_LT(entry.GetStartTime().seconds(), entry.GetEndTime().seconds());
     }
+
+    Y_UNIT_TEST(UserSID) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        const auto data = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+        )", {{"a", 1}});
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock(ConvertTestData(data), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        const TString request = Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )", port);
+        const TString userSID = "user@builtin";
+        TestImport(runtime, ++txId, "/MyRoot", request, userSID);
+
+        const auto desc = TestGetImport(runtime, txId, "/MyRoot");
+        const auto& entry = desc.GetResponse().GetEntry();
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetProgress(), Ydb::Import::ImportProgress::PROGRESS_PREPARING);
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetUserSID(), userSID);
+    }
 }
 
 Y_UNIT_TEST_SUITE(TImportWithRebootsTests) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -2948,7 +2948,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(ImportStartTime) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions());
+        TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(
@@ -2989,7 +2990,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(CompletedImportEndTime) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions());
+        TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(
@@ -3035,7 +3037,8 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
     Y_UNIT_TEST(CancelledImportEndTime) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, TTestEnvOptions());
+        TTestEnv env(runtime);
+        runtime.UpdateCurrentTime(TInstant::Now());
         ui64 txId = 100;
 
         const auto data = GenerateTestData(R"(

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -12,6 +12,7 @@
 #include <ydb/core/wrappers/ut_helpers/s3_mock.h>
 #include <ydb/core/metering/metering.h>
 #include <ydb/core/ydb_convert/table_description.h>
+#include <ydb/public/api/protos/ydb_import.pb.h>
 
 #include <contrib/libs/zstd/include/zstd.h>
 #include <library/cpp/string_utils/quote/quote.h>
@@ -2945,6 +2946,162 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         env.TestWaitNotification(runtime, importId);
     }
 
+    Y_UNIT_TEST(ImportStartTime) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions());
+        ui64 txId = 100;
+
+        const auto data = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+        )", {{"a", 1}});
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock(ConvertTestData(data), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TestImport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )", port));
+
+        const auto desc = TestGetImport(runtime, txId, "/MyRoot");
+        const auto& entry = desc.GetResponse().GetEntry();
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetProgress(), Ydb::Import::ImportProgress::PROGRESS_PREPARING);
+        UNIT_ASSERT(entry.HasStartTime());
+        UNIT_ASSERT(!entry.HasEndTime());
+    }
+
+    Y_UNIT_TEST(CompletedImportEndTime) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions());
+        ui64 txId = 100;
+
+        const auto data = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+        )", {{"a", 1}});
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock(ConvertTestData(data), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TestImport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )", port));
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(30)); // doing import
+
+        env.TestWaitNotification(runtime, txId);
+
+        const auto desc = TestGetImport(runtime, txId, "/MyRoot");
+        const auto& entry = desc.GetResponse().GetEntry();
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetProgress(), Ydb::Import::ImportProgress::PROGRESS_DONE);
+        UNIT_ASSERT(entry.HasStartTime());
+        UNIT_ASSERT(entry.HasEndTime());
+        UNIT_ASSERT_LT(entry.GetStartTime().seconds(), entry.GetEndTime().seconds());
+    }
+
+    Y_UNIT_TEST(CancelledImportEndTime) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions());
+        ui64 txId = 100;
+
+        const auto data = GenerateTestData(R"(
+            columns {
+              name: "key"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "value"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            primary_key: "key"
+        )", {{"a", 1}});
+
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock(ConvertTestData(data), TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        auto delayFunc = [](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() != TEvSchemeShard::EvModifySchemeTransaction) {
+                return false;
+            }
+
+            return ev->Get<TEvSchemeShard::TEvModifySchemeTransaction>()->Record
+                .GetTransaction(0).GetOperationType() == NKikimrSchemeOp::ESchemeOpRestore;
+        };
+
+        THolder<IEventHandle> delayed;
+        auto prevObserver = SetDelayObserver(runtime, delayed, delayFunc);
+
+        TestImport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )", port));
+        const ui64 importId = txId;
+
+        runtime.AdvanceCurrentTime(TDuration::Seconds(30)); // doing import
+
+        WaitForDelayed(runtime, delayed, prevObserver);
+
+        TestCancelImport(runtime, ++txId, "/MyRoot", importId);
+
+        auto desc = TestGetImport(runtime, importId, "/MyRoot");
+        auto entry = desc.GetResponse().GetEntry();
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetProgress(), Ydb::Import::ImportProgress::PROGRESS_CANCELLATION);
+        UNIT_ASSERT(entry.HasStartTime());
+        UNIT_ASSERT(!entry.HasEndTime());
+
+        runtime.Send(delayed.Release(), 0, true);
+        env.TestWaitNotification(runtime, importId);
+
+        desc = TestGetImport(runtime, importId, "/MyRoot", Ydb::StatusIds::CANCELLED);
+        entry = desc.GetResponse().GetEntry();
+        UNIT_ASSERT_VALUES_EQUAL(entry.GetProgress(), Ydb::Import::ImportProgress::PROGRESS_CANCELLED);
+        UNIT_ASSERT(entry.HasStartTime());
+        UNIT_ASSERT(entry.HasEndTime());
+        UNIT_ASSERT_LT(entry.GetStartTime().seconds(), entry.GetEndTime().seconds());
+    }
 }
 
 Y_UNIT_TEST_SUITE(TImportWithRebootsTests) {

--- a/ydb/public/api/protos/out/out.cpp
+++ b/ydb/public/api/protos/out/out.cpp
@@ -1,6 +1,7 @@
 #include <ydb/public/api/protos/ydb_cms.pb.h>
 #include <ydb/public/api/protos/ydb_monitoring.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
+#include <ydb/public/api/protos/ydb_export.pb.h>
 
 #include <util/stream/output.h>
 
@@ -18,4 +19,8 @@ Y_DECLARE_OUT_SPEC(, Ydb::Monitoring::SelfCheck::Result, stream, value) {
 
 Y_DECLARE_OUT_SPEC(, Ydb::Monitoring::StatusFlag::Status, stream, value) {
     stream << Ydb::Monitoring::StatusFlag_Status_Name(value);
+}
+
+Y_DECLARE_OUT_SPEC(, Ydb::Export::ExportProgress::Progress, stream, value) {
+    stream << Ydb::Export::ExportProgress_Progress_Name(value);
 }

--- a/ydb/public/api/protos/out/out.cpp
+++ b/ydb/public/api/protos/out/out.cpp
@@ -2,6 +2,7 @@
 #include <ydb/public/api/protos/ydb_monitoring.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 #include <ydb/public/api/protos/ydb_export.pb.h>
+#include <ydb/public/api/protos/ydb_import.pb.h>
 
 #include <util/stream/output.h>
 
@@ -23,4 +24,8 @@ Y_DECLARE_OUT_SPEC(, Ydb::Monitoring::StatusFlag::Status, stream, value) {
 
 Y_DECLARE_OUT_SPEC(, Ydb::Export::ExportProgress::Progress, stream, value) {
     stream << Ydb::Export::ExportProgress_Progress_Name(value);
+}
+
+Y_DECLARE_OUT_SPEC(, Ydb::Import::ImportProgress::Progress, stream, value) {
+    stream << Ydb::Import::ImportProgress_Progress_Name(value);
 }

--- a/ydb/public/api/protos/ydb_operation.proto
+++ b/ydb/public/api/protos/ydb_operation.proto
@@ -122,9 +122,12 @@ message Operation {
     // For operations in progress, it might indicate the current cost of the operation (if supported).
     CostInfo cost_info = 7;
 
-    // The time at which this operation was started (if supported).
-    google.protobuf.Timestamp start_time = 8;
+    // The time at which this operation was created (if supported).
+    google.protobuf.Timestamp create_time = 8;
 
     // The time at which this operation was completed, doesn't matter successful or not (if supported).
     google.protobuf.Timestamp end_time = 9;
+
+    // User SID (Security ID) of the user who created this operation (if supported).
+    string created_by = 10;
 }

--- a/ydb/public/api/protos/ydb_operation.proto
+++ b/ydb/public/api/protos/ydb_operation.proto
@@ -3,6 +3,7 @@ option cc_enable_arenas = true;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 import "ydb/public/api/protos/annotations/validation.proto";
 import "ydb/public/api/protos/ydb_common.proto";
@@ -103,7 +104,7 @@ message Operation {
     // not created in the first place, as in SYNC operation mode).
     string id = 1;
 
-    // true - this operation has beed finished (doesn't matter successful or not),
+    // true - this operation has been completed (doesn't matter successful or not),
     // so Status field has status code, and Result field can contains result data.
     // false - this operation still running. You can repeat request using operation Id.
     bool ready = 2;
@@ -120,4 +121,10 @@ message Operation {
     // For completed operations, it shows the final cost of the operation.
     // For operations in progress, it might indicate the current cost of the operation (if supported).
     CostInfo cost_info = 7;
+
+    // The time at which this operation was started (if supported).
+    google.protobuf.Timestamp start_time = 8;
+
+    // The time at which this operation was completed, doesn't matter successful or not (if supported).
+    google.protobuf.Timestamp end_time = 9;
 }

--- a/ydb/public/lib/ydb_cli/common/print_operation.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_operation.cpp
@@ -37,8 +37,12 @@ namespace {
             }
         }
         
-        if (operation.StartTime() != TInstant::Zero()) {
-            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        if (!operation.CreatedBy().Empty()) {
+            freeText << "Created by: " << operation.CreatedBy() << Endl;
+        }
+
+        if (operation.CreateTime() != TInstant::Zero()) {
+            freeText << "Create time: " << operation.CreateTime().ToStringUpToSeconds() << Endl;
         }
 
         if (operation.EndTime() != TInstant::Zero()) {
@@ -122,8 +126,12 @@ namespace {
 
         freeText << "TypeV3: " << (settings.UseTypeV3_ ? "true" : "false") << Endl;
 
-        if (operation.StartTime() != TInstant::Zero()) {
-            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        if (!operation.CreatedBy().Empty()) {
+            freeText << "Created by: " << operation.CreatedBy() << Endl;
+        }
+
+        if (operation.CreateTime() != TInstant::Zero()) {
+            freeText << "Create time: " << operation.CreateTime().ToStringUpToSeconds() << Endl;
         }
 
         if (operation.EndTime() != TInstant::Zero()) {
@@ -184,8 +192,12 @@ namespace {
             freeText << "Number of retries: " << settings.NumberOfRetries_.GetRef() << Endl;
         }
 
-        if (operation.StartTime() != TInstant::Zero()) {
-            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        if (!operation.CreatedBy().Empty()) {
+            freeText << "Created by: " << operation.CreatedBy() << Endl;
+        }
+
+        if (operation.CreateTime() != TInstant::Zero()) {
+            freeText << "Create time: " << operation.CreateTime().ToStringUpToSeconds() << Endl;
         }
 
         if (operation.EndTime() != TInstant::Zero()) {

--- a/ydb/public/lib/ydb_cli/common/print_operation.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_operation.cpp
@@ -36,6 +36,14 @@ namespace {
                 freeText << "  - " << issue << Endl;
             }
         }
+        
+        if (operation.StartTime() != TInstant::Zero()) {
+            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        }
+
+        if (operation.EndTime() != TInstant::Zero()) {
+            freeText << "End time: " << operation.EndTime().ToStringUpToSeconds() << Endl;
+        }
 
         row.FreeText(freeText);
     }
@@ -114,6 +122,14 @@ namespace {
 
         freeText << "TypeV3: " << (settings.UseTypeV3_ ? "true" : "false") << Endl;
 
+        if (operation.StartTime() != TInstant::Zero()) {
+            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        }
+
+        if (operation.EndTime() != TInstant::Zero()) {
+            freeText << "End time: " << operation.EndTime().ToStringUpToSeconds() << Endl;
+        }
+
         row.FreeText(freeText);
     }
 
@@ -166,6 +182,14 @@ namespace {
 
         if (settings.NumberOfRetries_) {
             freeText << "Number of retries: " << settings.NumberOfRetries_.GetRef() << Endl;
+        }
+
+        if (operation.StartTime() != TInstant::Zero()) {
+            freeText << "Start time: " << operation.StartTime().ToStringUpToSeconds() << Endl;
+        }
+
+        if (operation.EndTime() != TInstant::Zero()) {
+            freeText << "End time: " << operation.EndTime().ToStringUpToSeconds() << Endl;
         }
 
         row.FreeText(freeText);

--- a/ydb/public/sdk/cpp/client/ydb_export/export.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_export/export.cpp
@@ -24,12 +24,6 @@ using namespace Ydb::Export;
 /// Common
 namespace {
 
-TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp) {
-    ui64 us = timestamp.seconds() * 1000000;
-    us += timestamp.nanos() / 1000;
-    return TInstant::MicroSeconds(us);
-}
-
 TVector<TExportItemProgress> ItemsProgressFromProto(const google::protobuf::RepeatedPtrField<ExportItemProgress>& proto) {
     TVector<TExportItemProgress> result(Reserve(proto.size()));
 

--- a/ydb/public/sdk/cpp/client/ydb_import/import.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_import/import.cpp
@@ -19,12 +19,6 @@ using namespace Ydb::Import;
 /// Common
 namespace {
 
-TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp) {
-    ui64 us = timestamp.seconds() * 1000000;
-    us += timestamp.nanos() / 1000;
-    return TInstant::MicroSeconds(us);
-}
-
 TVector<TImportItemProgress> ItemsProgressFromProto(const google::protobuf::RepeatedPtrField<Ydb::Import::ImportItemProgress>& proto) {
     TVector<TImportItemProgress> result(Reserve(proto.size()));
 

--- a/ydb/public/sdk/cpp/client/ydb_types/operation/operation.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/operation/operation.cpp
@@ -17,8 +17,9 @@ public:
         : Id_(operation.id(), true /* allowEmpty */)
         , Status_(std::move(status))
         , Ready_(operation.ready())
-        , StartTime_(ProtoTimestampToInstant(operation.start_time()))
+        , CreateTime_(ProtoTimestampToInstant(operation.create_time()))
         , EndTime_(ProtoTimestampToInstant(operation.end_time()))
+        , CreatedBy_(operation.created_by())
         , Operation_(std::move(operation))
     {
     }
@@ -35,12 +36,16 @@ public:
         return Status_;
     }
 
-    TInstant StartTime() const {
-        return StartTime_;
+    TInstant CreateTime() const {
+        return CreateTime_;
     }
 
     TInstant EndTime() const {
         return EndTime_;
+    }
+
+    const TString& CreatedBy() const {
+        return CreatedBy_;
     }
 
     const Ydb::Operations::Operation& GetProto() const {
@@ -51,8 +56,9 @@ private:
     const TOperationId Id_;
     const TStatus Status_;
     const bool Ready_;
-    const TInstant StartTime_;
+    const TInstant CreateTime_;
     const TInstant EndTime_;
+    const TString CreatedBy_;
     const Ydb::Operations::Operation Operation_;
 };
 
@@ -76,12 +82,16 @@ const TStatus& TOperation::Status() const {
     return Impl_->Status();
 }
 
-TInstant TOperation::StartTime() const {
-    return Impl_->StartTime();
+TInstant TOperation::CreateTime() const {
+    return Impl_->CreateTime();
 }
 
 TInstant TOperation::EndTime() const {
     return Impl_->EndTime();
+}
+
+const TString& TOperation::CreatedBy() const {
+    return Impl_->CreatedBy();
 }
 
 TString TOperation::ToString() const {

--- a/ydb/public/sdk/cpp/client/ydb_types/operation/operation.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_types/operation/operation.cpp
@@ -17,6 +17,8 @@ public:
         : Id_(operation.id(), true /* allowEmpty */)
         , Status_(std::move(status))
         , Ready_(operation.ready())
+        , StartTime_(ProtoTimestampToInstant(operation.start_time()))
+        , EndTime_(ProtoTimestampToInstant(operation.end_time()))
         , Operation_(std::move(operation))
     {
     }
@@ -33,6 +35,14 @@ public:
         return Status_;
     }
 
+    TInstant StartTime() const {
+        return StartTime_;
+    }
+
+    TInstant EndTime() const {
+        return EndTime_;
+    }
+
     const Ydb::Operations::Operation& GetProto() const {
         return Operation_;
     }
@@ -41,6 +51,8 @@ private:
     const TOperationId Id_;
     const TStatus Status_;
     const bool Ready_;
+    const TInstant StartTime_;
+    const TInstant EndTime_;
     const Ydb::Operations::Operation Operation_;
 };
 
@@ -62,6 +74,14 @@ bool TOperation::Ready() const {
 
 const TStatus& TOperation::Status() const {
     return Impl_->Status();
+}
+
+TInstant TOperation::StartTime() const {
+    return Impl_->StartTime();
+}
+
+TInstant TOperation::EndTime() const {
+    return Impl_->EndTime();
 }
 
 TString TOperation::ToString() const {
@@ -86,6 +106,12 @@ TString TOperation::ToJsonString() const {
 
 const Ydb::Operations::Operation& TOperation::GetProto() const {
     return Impl_->GetProto();
+}
+
+TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp) {
+    ui64 us = timestamp.seconds() * 1000000;
+    us += timestamp.nanos() / 1000;
+    return TInstant::MicroSeconds(us);
 }
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/client/ydb_types/operation/operation.h
+++ b/ydb/public/sdk/cpp/client/ydb_types/operation/operation.h
@@ -32,8 +32,9 @@ public:
     const TOperationId& Id() const;
     bool Ready() const;
     const TStatus& Status() const;
-    TInstant StartTime() const;
+    TInstant CreateTime() const;
     TInstant EndTime() const;
+    const TString& CreatedBy() const;
 
     TString ToString() const;
     TString ToJsonString() const;

--- a/ydb/public/sdk/cpp/client/ydb_types/operation/operation.h
+++ b/ydb/public/sdk/cpp/client/ydb_types/operation/operation.h
@@ -5,6 +5,7 @@
 #include <library/cpp/threading/future/future.h>
 
 #include <google/protobuf/stubs/status.h>
+#include <google/protobuf/timestamp.pb.h>
 #include <google/protobuf/util/json_util.h>
 
 namespace Ydb {
@@ -31,6 +32,8 @@ public:
     const TOperationId& Id() const;
     bool Ready() const;
     const TStatus& Status() const;
+    TInstant StartTime() const;
+    TInstant EndTime() const;
 
     TString ToString() const;
     TString ToJsonString() const;
@@ -45,6 +48,8 @@ private:
 };
 
 using TAsyncOperation = NThreading::TFuture<TOperation>;
+
+TInstant ProtoTimestampToInstant(const NProtoBuf::Timestamp& timestamp);
 
 } // namespace NYdb
 

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -2936,6 +2936,16 @@
                 "ColumnId": 13,
                 "ColumnName": "UserSID",
                 "ColumnType": "Utf8"
+            },
+            {
+                "ColumnId": 14,
+                "ColumnName": "StartTime",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 15,
+                "ColumnName": "EndTime",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -2954,7 +2964,9 @@
                     10,
                     11,
                     12,
-                    13
+                    13,
+                    14,
+                    15
                 ],
                 "RoomID": 0,
                 "Codec": 0,

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -5695,6 +5695,16 @@
                 "ColumnId": 10,
                 "ColumnName": "UserSID",
                 "ColumnType": "Utf8"
+            },
+            {
+                "ColumnId": 11,
+                "ColumnName": "StartTime",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "EndTime",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -5710,7 +5720,9 @@
                     7,
                     8,
                     9,
-                    10
+                    10,
+                    11,
+                    12
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add create time, end time and UserSID (Security ID) who created for long-running operation (export, import).

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

```
$ ydb export s3 --user root
┌───────────────────────────────────────────┬───────┬─────────┬───────────┬───────────┬────────┐
│ id                                        │ ready │ status  │ progress  │ endpoint  │ bucket │
├───────────────────────────────────────────┼───────┼─────────┼───────────┼───────────┼────────┤
│ ydb://export/6?id=844425031076972&kind=s3 │ false │ SUCCESS │ Preparing │ localhost │ 1      │
├╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴┤
│ StorageClass: NOT_SET                                                                        │
│ Items:                                                                                       │
│   - source: /Root/pixcc-slice-db/users                                                       │
│     destination: 1                                                                           │
│ Description:                                                                                 │
│ Number of retries: 10                                                                        │
| Created by: root                                                                             |
│ Create time: 2024-06-10T23:55:57Z                                                            │
└──────────────────────────────────────────────────────────────────────────────────────────────┘

$ ydb operation cancel "ydb://export/6?id=844425031076972&kind=s3"

$ ydb operation get "ydb://export/6?id=844425031076972&kind=s3"
┌───────────────────────────────────────────┬───────┬───────────┬───────────┬───────────┬────────┐
│ id                                        │ ready │ status    │ progress  │ endpoint  │ bucket │
├───────────────────────────────────────────┼───────┼───────────┼───────────┼───────────┼────────┤
│ ydb://export/6?id=844425031076972&kind=s3 │ true  │ CANCELLED │ Cancelled │ localhost │ 1      │
├╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴╴╴╴┴╴╴╴╴╴╴╴╴┤
│ StorageClass: NOT_SET                                                                          │
│ Issues:                                                                                        │
│   - <main>: Error: Cancelled manually                                                          │
│ Items:                                                                                         │
│   - source: /Root/pixcc-slice-db/users                                                         │
│     destination: 1                                                                             │
│ Description:                                                                                   │
│ Number of retries: 10                                                                          │
| Created by: root                                                                               |  
│ Create time: 2024-06-10T23:55:57Z                                                              │
│ End time: 2024-06-10T23:57:30Z                                                                 │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
```
