### PR TITLE
[backport/yql-stable-2024-09-03] Make error for impossible TzDate casts more friendly (again)

### DIFF
--- a/ydb/library/yql/tests/sql/yt_native_file/part18/canondata/test.test_datetime-date_tz_impossible_cast--Results_/extracted
+++ b/ydb/library/yql/tests/sql/yt_native_file/part18/canondata/test.test_datetime-date_tz_impossible_cast--Results_/extracted
@@ -3,7 +3,6 @@
     <tmp_path>/program.sql:<main>:1:1: Fatal: Execution of node: Result
     	SELECT
 	^
-        <tmp_path>/program.sql:<main>:2:5: Fatal: (yexception) ydb/library/yql/minikql/datetime/datetime.h:xxx: Error in MakeDatetime
-[MakeTzDate]
+        <tmp_path>/program.sql:<main>:2:5: Fatal: Timestamp 1970-01-01T23:59:59.000000,Europe/Moscow cannot be casted to TzDate
         	    CAST(AddTimezone(
 	    ^

--- a/ydb/library/yql/udfs/common/datetime2/datetime_udf.cpp
+++ b/ydb/library/yql/udfs/common/datetime2/datetime_udf.cpp
@@ -848,9 +848,16 @@ TValue DoAddYears(const TValue& date, i64 years, const NUdf::IDateBuilder& build
     BEGIN_SIMPLE_STRICT_ARROW_UDF(TMakeTzDate, TTzDate(TAutoMap<TResource<TMResourceName>>)) {
         auto& builder = valueBuilder->GetDateBuilder();
         auto& storage = Reference(args[0]);
-        TUnboxedValuePod result(storage.ToDate(builder, true));
-        result.SetTimezoneId(storage.TimezoneId);
-        return result;
+        try {
+            TUnboxedValuePod result(storage.ToDate(builder, true));
+            result.SetTimezoneId(storage.TimezoneId);
+            return result;
+        } catch (const std::exception& e) {
+            UdfTerminate((TStringBuilder() << Pos_ << "Timestamp "
+                                           << storage.ToString()
+                                           << " cannot be casted to TzDate"
+            ).data());
+        }
     }
     END_SIMPLE_ARROW_UDF(TMakeTzDate, TMakeDateKernelExec<TTzDate>::Do);
 


### PR DESCRIPTION
The patch introduced in #5805 was reverted by mistake in #6472. This patch returns the user friendly error with diagnostics back again.

Follows up #6472
Relates to #5805

(cherry picked from commit 55fc639a96e8440002775afe16689b42fe1a8a7d)

### Changelog category

* Bugfix