### PR TITLE
YQ-3471 support resource pool classifiers

### DIFF
--- a/ydb/core/kqp/common/events/workload_service.h
+++ b/ydb/core/kqp/common/events/workload_service.h
@@ -12,6 +12,16 @@
 
 namespace NKikimr::NKqp::NWorkload {
 
+struct TEvSubscribeOnPoolChanges : public NActors::TEventLocal<TEvSubscribeOnPoolChanges, TKqpWorkloadServiceEvents::EvSubscribeOnPoolChanges> {
+    TEvSubscribeOnPoolChanges(const TString& database, const TString& poolId)
+        : Database(database)
+        , PoolId(poolId)
+    {}
+
+    const TString Database;
+    const TString PoolId;
+};
+
 struct TEvPlaceRequestIntoPool : public NActors::TEventLocal<TEvPlaceRequestIntoPool, TKqpWorkloadServiceEvents::EvPlaceRequestIntoPool> {
     TEvPlaceRequestIntoPool(const TString& database, const TString& sessionId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
         : Database(database)
@@ -78,6 +88,16 @@ struct TEvUpdatePoolInfo : public NActors::TEventLocal<TEvUpdatePoolInfo, TKqpWo
     const TString PoolId;
     const std::optional<NResourcePool::TPoolSettings> Config;
     const std::optional<NACLib::TSecurityObject> SecurityObject;
+};
+
+struct TEvUpdateDatabaseInfo : public NActors::TEventLocal<TEvUpdateDatabaseInfo, TKqpWorkloadServiceEvents::EvUpdateDatabaseInfo> {
+    TEvUpdateDatabaseInfo(const TString& database, bool serverless)
+        : Database(database)
+        , Serverless(serverless)
+    {}
+
+    const TString Database;
+    const bool Serverless;
 };
 
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/common/simple/kqp_event_ids.h
+++ b/ydb/core/kqp/common/simple/kqp_event_ids.h
@@ -175,6 +175,8 @@ struct TKqpWorkloadServiceEvents {
         EvCleanupRequest,
         EvCleanupResponse,
         EvUpdatePoolInfo,
+        EvUpdateDatabaseInfo,
+        EvSubscribeOnPoolChanges,
     };
 };
 

--- a/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
@@ -275,7 +275,7 @@ private:
 
         KqpHost = CreateKqpHost(Gateway, QueryId.Cluster, QueryId.Database, Config, ModuleResolverState->ModuleResolver,
             FederatedQuerySetup, UserToken, GUCSettings, QueryServiceConfig, ApplicationName, AppData(ctx)->FunctionRegistry,
-            false, false, std::move(TempTablesState), nullptr, SplitCtx);
+            false, false, std::move(TempTablesState), nullptr, SplitCtx, UserRequestContext);
 
         IKqpHost::TPrepareSettings prepareSettings;
         prepareSettings.DocumentApiRestricted = QueryId.Settings.DocumentApiRestricted;

--- a/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
@@ -118,10 +118,10 @@ void FillResourcePoolDescription(NKikimrSchemeOp::TResourcePoolDescription& reso
 
     TPoolSettings resourcePoolSettings;
     auto& properties = *resourcePoolDescription.MutableProperties()->MutableProperties();
-    for (const auto& [property, setting] : GetPropertiesMap(resourcePoolSettings, true)) {
+    for (const auto& [property, setting] : resourcePoolSettings.GetPropertiesMap(true)) {
         if (std::optional<TString> value = featuresExtractor.Extract(property)) {
             try {
-                std::visit(TSettingsParser{*value}, setting);
+                std::visit(TPoolSettings::TParser{*value}, setting);
             } catch (...) {
                 throw yexception() << "Failed to parse property " << property << ": " << CurrentExceptionMessage();
             }
@@ -129,7 +129,7 @@ void FillResourcePoolDescription(NKikimrSchemeOp::TResourcePoolDescription& reso
             continue;
         }
 
-        TString value = std::visit(TSettingsExtractor(), setting);
+        const TString value = std::visit(TPoolSettings::TExtractor(), setting);
         properties.insert({property, value});
     }
 

--- a/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool/manager.cpp
@@ -241,7 +241,7 @@ void TResourcePoolManager::PrepareCreateResourcePool(NKqpProto::TKqpSchemeOperat
     }
 
     auto& schemeTx = *schemeOperation.MutableCreateResourcePool();
-    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".resource_pools/"}));
+    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".metadata/workload_manager/pools/"}));
     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateResourcePool);
 
     FillResourcePoolDescription(*schemeTx.MutableCreateResourcePool(), settings);
@@ -249,7 +249,7 @@ void TResourcePoolManager::PrepareCreateResourcePool(NKqpProto::TKqpSchemeOperat
 
 void TResourcePoolManager::PrepareAlterResourcePool(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TDropObjectSettings& settings, TInternalModificationContext& context) const {
     auto& schemeTx = *schemeOperation.MutableAlterResourcePool();
-    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".resource_pools/"}));
+    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".metadata/workload_manager/pools/"}));
     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpAlterResourcePool);
 
     FillResourcePoolDescription(*schemeTx.MutableCreateResourcePool(), settings);
@@ -257,7 +257,7 @@ void TResourcePoolManager::PrepareAlterResourcePool(NKqpProto::TKqpSchemeOperati
 
 void TResourcePoolManager::PrepareDropResourcePool(NKqpProto::TKqpSchemeOperation& schemeOperation, const NYql::TDropObjectSettings& settings, TInternalModificationContext& context) const {
     auto& schemeTx = *schemeOperation.MutableDropResourcePool();
-    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".resource_pools/"}));
+    schemeTx.SetWorkingDir(JoinPath({context.GetExternalData().GetDatabase(), ".metadata/workload_manager/pools/"}));
     schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpDropResourcePool);
 
     schemeTx.MutableDrop()->SetName(settings.GetObjectId());

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
@@ -16,7 +16,7 @@ NMetadata::NModifications::IOperationsManager::TPtr TResourcePoolClassifierBehav
 }
 
 TString TResourcePoolClassifierBehaviour::GetInternalStorageTablePath() const {
-    return "resource_pools/resource_pools_classifiers";
+    return "workload_manager/classifiers/resource_pool_classifiers";
 }
 
 TString TResourcePoolClassifierBehaviour::GetTypeId() const {

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.cpp
@@ -1,0 +1,31 @@
+#include "behaviour.h"
+#include "initializer.h"
+#include "manager.h"
+
+
+namespace NKikimr::NKqp {
+
+TResourcePoolClassifierBehaviour::TFactory::TRegistrator<TResourcePoolClassifierBehaviour> TResourcePoolClassifierBehaviour::Registrator(TResourcePoolClassifierConfig::GetTypeId());
+
+NMetadata::NInitializer::IInitializationBehaviour::TPtr TResourcePoolClassifierBehaviour::ConstructInitializer() const {
+    return std::make_shared<TResourcePoolClassifierInitializer>();
+}
+
+NMetadata::NModifications::IOperationsManager::TPtr TResourcePoolClassifierBehaviour::ConstructOperationsManager() const {
+    return std::make_shared<TResourcePoolClassifierManager>();
+}
+
+TString TResourcePoolClassifierBehaviour::GetInternalStorageTablePath() const {
+    return "resource_pools/resource_pools_classifiers";
+}
+
+TString TResourcePoolClassifierBehaviour::GetTypeId() const {
+    return TResourcePoolClassifierConfig::GetTypeId();
+}
+
+NMetadata::IClassBehaviour::TPtr TResourcePoolClassifierBehaviour::GetInstance() {
+    static std::shared_ptr<TResourcePoolClassifierBehaviour> result = std::make_shared<TResourcePoolClassifierBehaviour>();
+    return result;
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/behaviour.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "object.h"
+
+#include <ydb/services/metadata/abstract/initialization.h>
+#include <ydb/services/metadata/abstract/kqp_common.h>
+
+
+namespace NKikimr::NKqp {
+
+class TResourcePoolClassifierBehaviour : public NMetadata::TClassBehaviour<TResourcePoolClassifierConfig> {
+    static TFactory::TRegistrator<TResourcePoolClassifierBehaviour> Registrator;
+
+protected:
+    virtual NMetadata::NInitializer::IInitializationBehaviour::TPtr ConstructInitializer() const override;
+    virtual NMetadata::NModifications::IOperationsManager::TPtr ConstructOperationsManager() const override;
+    virtual TString GetInternalStorageTablePath() const override;
+
+public:
+    virtual TString GetTypeId() const override;
+
+    static IClassBehaviour::TPtr GetInstance();
+};
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/checker.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/checker.cpp
@@ -1,0 +1,300 @@
+#include "checker.h"
+
+#include <ydb/core/base/path.h>
+#include <ydb/core/cms/console/configs_dispatcher.h>
+#include <ydb/core/kqp/workload_service/actors/actors.h>
+#include <ydb/core/kqp/workload_service/common/events.h>
+#include <ydb/core/protos/console_config.pb.h>
+#include <ydb/core/resource_pools/resource_pool_classifier_settings.h>
+
+#include <ydb/library/query_actor/query_actor.h>
+
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+using namespace NActors;
+using namespace NResourcePool;
+using namespace NWorkload;
+
+
+class TRanksCheckerActor : public NKikimr::TQueryBase {
+    using TBase = NKikimr::TQueryBase;
+
+public:
+    TRanksCheckerActor(const TString& database, const TString& sessionId, const TString& transactionId, const std::unordered_map<i64, TString>& ranksToCheck)
+        : TBase(NKikimrServices::KQP_GATEWAY, sessionId)
+        , Database(database)
+        , RanksToCheck(ranksToCheck)
+    {
+        TxId = transactionId;
+        SetOperationInfo(__func__, Database);
+    }
+
+    void OnRunQuery() override {
+        const auto& tablePath = TResourcePoolClassifierConfig::GetBehaviour()->GetStorageTablePath();
+
+        TStringBuilder sql = TStringBuilder() << R"(
+            -- TRanksCheckerActor::OnRunQuery
+            DECLARE $database AS Text;
+        )";
+
+        NYdb::TParamsBuilder params;
+        params
+            .AddParam("$database")
+                .Utf8(CanonizePath(Database))
+                .Build();
+
+        if (!RanksToCheck.empty()) {
+            sql << R"(
+                DECLARE $ranks AS List<Int64>;
+                PRAGMA AnsiInForEmptyOrNullableItemsCollections;
+
+                SELECT
+                    rank, name
+                FROM `)" << tablePath << R"(`
+                WHERE database = $database
+                  AND rank IN $ranks;
+            )";
+
+            auto& param = params.AddParam("$ranks").BeginList();
+            for (const auto& [rank, _] : RanksToCheck) {
+                param.AddListItem().Int64(rank);
+            }
+            param.EndList().Build();
+
+            ExpectedResultSets++;
+        }
+
+        sql << R"(
+            SELECT
+                MAX(rank) AS MaxRank,
+                COUNT(*) AS NumberClassifiers
+            FROM `)" << tablePath << R"(`
+            WHERE database = $database;
+        )";
+
+        RunDataQuery(sql, &params, TTxControl::ContinueTx());
+    }
+
+    void OnQueryResult() override {
+        if (ResultSets.size() != ExpectedResultSets) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
+            return;
+        }
+
+        ui64 resultSetId = 0;
+        if (!RanksToCheck.empty()) {
+            NYdb::TResultSetParser result(ResultSets[resultSetId++]);
+            while (result.TryNextRow()) {
+                TMaybe<i64> rank = result.ColumnParser("rank").GetOptionalInt64();
+                if (!rank) {
+                    continue;
+                }
+
+                TMaybe<TString> name = result.ColumnParser("name").GetOptionalUtf8();
+                if (!name) {
+                    continue;
+                }
+
+                if (auto it = RanksToCheck.find(*rank); it != RanksToCheck.end() && it->second != *name) {
+                    Finish(Ydb::StatusIds::ALREADY_EXISTS, TStringBuilder() << "Classifier with rank " << *rank << " already exists, its name " << *name);
+                    return;
+                }
+            }
+        }
+
+        {   // Classifiers stats
+            NYdb::TResultSetParser result(ResultSets[resultSetId++]);
+            if (!result.TryNextRow()) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
+                return;
+            }
+
+            MaxRank = result.ColumnParser("MaxRank").GetOptionalInt64().GetOrElse(0);
+            NumberClassifiers = result.ColumnParser("NumberClassifiers").GetUint64();
+        }
+
+        Finish();
+    }
+
+    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+        Send(Owner, new TEvPrivate::TEvRanksCheckerResponse(status, MaxRank, NumberClassifiers, std::move(issues)));
+    }
+
+private:
+    const TString Database;
+    const std::unordered_map<i64, TString> RanksToCheck;
+
+    ui64 ExpectedResultSets = 1;
+    i64 MaxRank = 0;
+    ui64 NumberClassifiers = 0;
+};
+
+class TResourcePoolClassifierPreparationActor : public TActorBootstrapped<TResourcePoolClassifierPreparationActor> {
+public:
+    TResourcePoolClassifierPreparationActor(std::vector<TResourcePoolClassifierConfig>&& patchedObjects, NMetadata::NModifications::IAlterPreparationController<TResourcePoolClassifierConfig>::TPtr controller, const NMetadata::NModifications::IOperationsManager::TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext)
+        : Context(context)
+        , AlterContext(alterContext)
+        , Controller(std::move(controller))
+        , PatchedObjects(std::move(patchedObjects))
+    {}
+
+    void Bootstrap() {
+        Become(&TResourcePoolClassifierPreparationActor::StateFunc);
+        ValidateRanks();
+        GetDatabaseInfo();
+    }
+
+    void Handle(TEvPrivate::TEvRanksCheckerResponse::TPtr& ev) {
+        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+            FailAndPassAway("Resource pool classifier rank check failed", ev->Get()->Status, ev->Get()->Issues);
+            return;
+        }
+
+        if (ev->Get()->NumberClassifiers >= CLASSIFIER_COUNT_LIMIT) {
+            FailAndPassAway(TStringBuilder() << "Number of resource pool classifiers reached limit in " << CLASSIFIER_COUNT_LIMIT);
+            return;
+        }
+
+        i64 maxRank = ev->Get()->MaxRank;
+        for (auto& object : PatchedObjects) {
+            if (object.GetRank() != -1) {
+                continue;
+            }
+            if (maxRank > std::numeric_limits<i64>::max() - CLASSIFIER_RANK_OFFSET) {
+                FailAndPassAway(TStringBuilder() << "The rank could not be set automatically, the maximum rank of the resource pool classifier is too high: " << ev->Get()->MaxRank);
+                return;
+            }
+
+            maxRank += CLASSIFIER_RANK_OFFSET;
+            object.SetRank(maxRank);
+        }
+
+        RanksChecked = true;
+        TryFinish();
+    }
+
+    void Handle(TEvPrivate::TEvFetchDatabaseResponse::TPtr& ev) {
+        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+            FailAndPassAway("Database check failed", ev->Get()->Status, ev->Get()->Issues);
+            return;
+        }
+
+        Serverless = ev->Get()->Serverless;
+
+        Send(NConsole::MakeConfigsDispatcherID(SelfId().NodeId()), new NConsole::TEvConfigsDispatcher::TEvGetConfigRequest(
+            (ui32)NKikimrConsole::TConfigItem::FeatureFlagsItem
+        ), IEventHandle::FlagTrackDelivery);
+    }
+
+    void Handle(TEvents::TEvUndelivered::TPtr& ev) {
+        switch (ev->Get()->SourceType) {
+            case NConsole::TEvConfigsDispatcher::EvGetConfigRequest:
+                CheckFeatureFlag(AppData()->FeatureFlags);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    void Handle(NConsole::TEvConfigsDispatcher::TEvGetConfigResponse::TPtr& ev) {
+        CheckFeatureFlag(ev->Get()->Config->GetFeatureFlags());
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvPrivate::TEvRanksCheckerResponse, Handle);
+        hFunc(TEvPrivate::TEvFetchDatabaseResponse, Handle);
+        hFunc(TEvents::TEvUndelivered, Handle);
+        hFunc(NConsole::TEvConfigsDispatcher::TEvGetConfigResponse, Handle);
+    )
+
+private:
+    void GetDatabaseInfo() const {
+        const auto& externalContext = Context.GetExternalData();
+        const auto userToken = externalContext.GetUserToken() ? MakeIntrusive<NACLib::TUserToken>(*externalContext.GetUserToken()) : nullptr;
+        Register(CreateDatabaseFetcherActor(SelfId(), externalContext.GetDatabase(), userToken, NACLib::EAccessRights::GenericFull));
+    }
+
+    void ValidateRanks() {
+        if (Context.GetActivityType() == NMetadata::NModifications::IOperationsManager::EActivityType::Drop) {
+            RanksChecked = true;
+            TryFinish();
+            return;
+        }
+
+        std::unordered_map<i64, TString> ranksToNames;
+        for (const auto& object : PatchedObjects) {
+            const auto rank = object.GetRank();
+            if (rank == -1) {
+                continue;
+            }
+            if (!ranksToNames.insert({rank, object.GetName()}).second) {
+                FailAndPassAway(TStringBuilder() << "Found duplicate rank " << rank);
+            }
+        }
+
+        Register(new TQueryRetryActor<TRanksCheckerActor, TEvPrivate::TEvRanksCheckerResponse, TString, TString, TString, std::unordered_map<i64, TString>>(
+            SelfId(), Context.GetExternalData().GetDatabase(), AlterContext.SessionId, AlterContext.TransactionId, ranksToNames
+        ));
+    }
+
+    void CheckFeatureFlag(const NKikimrConfig::TFeatureFlags& featureFlags) {
+        if (Context.GetActivityType() == NMetadata::NModifications::IOperationsManager::EActivityType::Drop) {
+            FeatureFlagChecked = true;
+            TryFinish();
+            return;
+        }
+
+        if (!featureFlags.GetEnableResourcePools()) {
+            FailAndPassAway("Resource pool classifiers are disabled. Please contact your system administrator to enable it");
+            return;
+        }
+        if (Serverless && !featureFlags.GetEnableResourcePoolsOnServerless()) {
+            FailAndPassAway("Resource pool classifiers are disabled for serverless domains. Please contact your system administrator to enable it");
+            return;
+        }
+
+        FeatureFlagChecked = true;
+        TryFinish();
+    }
+
+    void FailAndPassAway(const TString& message, Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
+        FailAndPassAway(TStringBuilder() << message << ", status: " << status << ", reason: " << issues.ToOneLineString());
+    }
+
+    void FailAndPassAway(const TString& message) {
+        Controller->OnPreparationProblem(message);
+        PassAway();
+    }
+
+    void TryFinish() {
+        if (!FeatureFlagChecked || !RanksChecked) {
+            return;
+        }
+
+        Controller->OnPreparationFinished(std::move(PatchedObjects));
+        PassAway();
+    }
+
+private:
+    const NMetadata::NModifications::IOperationsManager::TInternalModificationContext Context;
+    const NMetadata::NModifications::TAlterOperationContext AlterContext;
+
+    bool Serverless = false;
+    bool FeatureFlagChecked = false;
+    bool RanksChecked = false;
+
+    NMetadata::NModifications::IAlterPreparationController<TResourcePoolClassifierConfig>::TPtr Controller;
+    std::vector<TResourcePoolClassifierConfig> PatchedObjects;
+};
+
+}  // anonymous namespace
+
+IActor* CreateResourcePoolClassifierPreparationActor(std::vector<TResourcePoolClassifierConfig>&& patchedObjects, NMetadata::NModifications::IAlterPreparationController<TResourcePoolClassifierConfig>::TPtr controller, const NMetadata::NModifications::IOperationsManager::TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) {
+    return new TResourcePoolClassifierPreparationActor(std::move(patchedObjects), std::move(controller), context, alterContext);
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/checker.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/checker.cpp
@@ -1,4 +1,5 @@
 #include "checker.h"
+#include "fetcher.h"
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/cms/console/configs_dispatcher.h>
@@ -153,7 +154,7 @@ public:
             return;
         }
 
-        if (ev->Get()->NumberClassifiers >= CLASSIFIER_COUNT_LIMIT) {
+        if (Context.GetActivityType() == NMetadata::NModifications::IOperationsManager::EActivityType::Create && ev->Get()->NumberClassifiers >= CLASSIFIER_COUNT_LIMIT) {
             FailAndPassAway(TStringBuilder() << "Number of resource pool classifiers reached limit in " << CLASSIFIER_COUNT_LIMIT);
             return;
         }
@@ -204,11 +205,28 @@ public:
         CheckFeatureFlag(ev->Get()->Config->GetFeatureFlags());
     }
 
+    void Handle(NMetadata::NProvider::TEvRefreshSubscriberData::TPtr& ev) {
+        const auto& snapshot = ev->Get()->GetSnapshotAs<TResourcePoolClassifierSnapshot>();
+        for (const auto& objectRecord : AlterContext.GetRestoreObjectIds().GetTableRecords()) {
+            TResourcePoolClassifierConfig object;
+            TResourcePoolClassifierConfig::TDecoder::DeserializeFromRecord(object, objectRecord);
+
+            if (!snapshot->GetClassifierConfig(CanonizePath(object.GetDatabase()), object.GetName())) {
+                FailAndPassAway(TStringBuilder() << "Classifier with name " << object.GetName() << " not found in database " << object.GetDatabase());
+                return;
+            }
+        }
+
+        ExistenceChecked = true;
+        TryFinish();
+    }
+
     STRICT_STFUNC(StateFunc,
         hFunc(TEvPrivate::TEvRanksCheckerResponse, Handle);
         hFunc(TEvPrivate::TEvFetchDatabaseResponse, Handle);
         hFunc(TEvents::TEvUndelivered, Handle);
         hFunc(NConsole::TEvConfigsDispatcher::TEvGetConfigResponse, Handle);
+        hFunc(NMetadata::NProvider::TEvRefreshSubscriberData, Handle)
     )
 
 private:
@@ -237,14 +255,14 @@ private:
         }
 
         Register(new TQueryRetryActor<TRanksCheckerActor, TEvPrivate::TEvRanksCheckerResponse, TString, TString, TString, std::unordered_map<i64, TString>>(
-            SelfId(), Context.GetExternalData().GetDatabase(), AlterContext.SessionId, AlterContext.TransactionId, ranksToNames
+            SelfId(), Context.GetExternalData().GetDatabase(), AlterContext.GetSessionId(), AlterContext.GetTransactionId(), ranksToNames
         ));
     }
 
     void CheckFeatureFlag(const NKikimrConfig::TFeatureFlags& featureFlags) {
         if (Context.GetActivityType() == NMetadata::NModifications::IOperationsManager::EActivityType::Drop) {
             FeatureFlagChecked = true;
-            TryFinish();
+            ValidateExistence();
             return;
         }
 
@@ -258,6 +276,16 @@ private:
         }
 
         FeatureFlagChecked = true;
+        ValidateExistence();
+    }
+
+    void ValidateExistence() {
+        if (Context.GetActivityType() != NMetadata::NModifications::IOperationsManager::EActivityType::Create && NMetadata::NProvider::TServiceOperator::IsEnabled()) {
+            Send(NMetadata::NProvider::MakeServiceId(SelfId().NodeId()), new NMetadata::NProvider::TEvAskSnapshot(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>()));
+            return;
+        }
+
+        ExistenceChecked = true;
         TryFinish();
     }
 
@@ -271,7 +299,7 @@ private:
     }
 
     void TryFinish() {
-        if (!FeatureFlagChecked || !RanksChecked) {
+        if (!FeatureFlagChecked || !RanksChecked || !ExistenceChecked) {
             return;
         }
 
@@ -286,6 +314,7 @@ private:
     bool Serverless = false;
     bool FeatureFlagChecked = false;
     bool RanksChecked = false;
+    bool ExistenceChecked = false;
 
     NMetadata::NModifications::IAlterPreparationController<TResourcePoolClassifierConfig>::TPtr Controller;
     std::vector<TResourcePoolClassifierConfig> PatchedObjects;

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/checker.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/checker.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "object.h"
+
+#include <ydb/services/metadata/manager/generic_manager.h>
+
+
+namespace NKikimr::NKqp {
+
+NActors::IActor* CreateResourcePoolClassifierPreparationActor(std::vector<TResourcePoolClassifierConfig>&& patchedObjects, NMetadata::NModifications::IAlterPreparationController<TResourcePoolClassifierConfig>::TPtr controller, const NMetadata::NModifications::IOperationsManager::TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext);
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.cpp
@@ -1,0 +1,10 @@
+#include "fetcher.h"
+
+
+namespace NKikimr::NKqp {
+
+std::vector<NMetadata::IClassBehaviour::TPtr> TResourcePoolClassifierSnapshotsFetcher::DoGetManagers() const {
+    return {TResourcePoolClassifierConfig::GetBehaviour()};
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "snapshot.h"
+
+
+namespace NKikimr::NKqp {
+
+class TResourcePoolClassifierSnapshotsFetcher : public NMetadata::NFetcher::TSnapshotsFetcher<TResourcePoolClassifierSnapshot> {
+protected:
+    virtual std::vector<NMetadata::IClassBehaviour::TPtr> DoGetManagers() const override;
+};
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/initializer.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/initializer.cpp
@@ -1,0 +1,41 @@
+#include "initializer.h"
+#include "object.h"
+
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+void AddColumn(Ydb::Table::CreateTableRequest& request, const TString& name, Ydb::Type::PrimitiveTypeId type, bool primary = false) {
+    if (primary) {
+        request.add_primary_key(name);
+    }
+
+    auto& column = *request.add_columns();
+    column.set_name(name);
+    column.mutable_type()->mutable_optional_type()->mutable_item()->set_type_id(type);
+}
+
+}  // anonymous namespace
+
+void TResourcePoolClassifierInitializer::DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const {
+    TVector<NMetadata::NInitializer::ITableModifier::TPtr> result;
+    {
+        Ydb::Table::CreateTableRequest request;
+        request.set_session_id("");
+        request.set_path(TResourcePoolClassifierConfig::GetBehaviour()->GetStorageTablePath());
+        AddColumn(request, TResourcePoolClassifierConfig::TDecoder::Database, Ydb::Type::UTF8, true);
+        AddColumn(request, TResourcePoolClassifierConfig::TDecoder::Name, Ydb::Type::UTF8, true);
+        AddColumn(request, TResourcePoolClassifierConfig::TDecoder::Rank, Ydb::Type::INT64);
+        AddColumn(request, TResourcePoolClassifierConfig::TDecoder::ConfigJson, Ydb::Type::JSON_DOCUMENT);
+        result.emplace_back(std::make_shared<NMetadata::NInitializer::TGenericTableModifier<NMetadata::NRequest::TDialogCreateTable>>(request, "create"));
+
+        auto historyRequest = TResourcePoolClassifierConfig::AddHistoryTableScheme(request);
+        result.emplace_back(std::make_shared<NMetadata::NInitializer::TGenericTableModifier<NMetadata::NRequest::TDialogCreateTable>>(historyRequest, "create_history"));
+    }
+    result.emplace_back(NMetadata::NInitializer::TACLModifierConstructor::GetReadOnlyModifier(TResourcePoolClassifierConfig::GetBehaviour()->GetStorageTablePath(), "acl"));
+    result.emplace_back(NMetadata::NInitializer::TACLModifierConstructor::GetReadOnlyModifier(TResourcePoolClassifierConfig::GetBehaviour()->GetStorageHistoryTablePath(), "acl_history"));
+    controller->OnPreparationFinished(result);
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/initializer.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/initializer.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ydb/services/metadata/abstract/initialization.h>
+
+
+namespace NKikimr::NKqp {
+
+class TResourcePoolClassifierInitializer : public NMetadata::NInitializer::IInitializationBehaviour {
+protected:
+    virtual void DoPrepare(NMetadata::NInitializer::IInitializerInput::TPtr controller) const override;
+};
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
@@ -1,0 +1,93 @@
+#include "manager.h"
+#include "checker.h"
+
+#include <ydb/core/base/path.h>
+#include <ydb/core/resource_pools/resource_pool_classifier_settings.h>
+
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+using namespace NResourcePool;
+
+NMetadata::NInternal::TTableRecord GetResourcePoolClassifierRecord(const NYql::TObjectSettingsImpl& settings, const NMetadata::NModifications::IOperationsManager::TInternalModificationContext& context) {
+    NMetadata::NInternal::TTableRecord result;
+    result.SetColumn(TResourcePoolClassifierConfig::TDecoder::Database, NMetadata::NInternal::TYDBValue::Utf8(CanonizePath(context.GetExternalData().GetDatabase())));
+    result.SetColumn(TResourcePoolClassifierConfig::TDecoder::Name, NMetadata::NInternal::TYDBValue::Utf8(settings.GetObjectId()));
+    return result;
+}
+
+}  // anonymous namespace
+
+NMetadata::NModifications::TOperationParsingResult TResourcePoolClassifierManager::DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings, TInternalModificationContext& context) const {
+    try {
+        switch (context.GetActivityType()) {
+            case EActivityType::Create:
+            case EActivityType::Alter:
+                return FillResourcePoolClassifierInfo(settings, context);
+            case EActivityType::Drop:
+                return FillDropInfo(settings, context);
+            case EActivityType::Upsert:
+                return TConclusionStatus::Fail("Upsert operation for RESOURCE_POOL_CLASSIFIER objects is not implemented");
+            case EActivityType::Undefined:
+                return TConclusionStatus::Fail("Undefined operation for RESOURCE_POOL_CLASSIFIER object");
+        }
+    } catch (...) {
+        return TConclusionStatus::Fail(CurrentExceptionMessage());
+    }
+}
+
+NMetadata::NModifications::TOperationParsingResult TResourcePoolClassifierManager::FillResourcePoolClassifierInfo(const NYql::TObjectSettingsImpl& settings, const TInternalModificationContext& context) const {
+    NMetadata::NInternal::TTableRecord result = GetResourcePoolClassifierRecord(settings, context);
+
+    auto& featuresExtractor = settings.GetFeaturesExtractor();
+    featuresExtractor.ValidateResetFeatures();
+
+    NJson::TJsonValue configJson = NJson::JSON_MAP;
+    TClassifierSettings resourcePoolClassifierSettings;
+    for (const auto& [property, setting] : resourcePoolClassifierSettings.GetPropertiesMap()) {
+        if (std::optional<TString> value = featuresExtractor.Extract(property)) {
+            try {
+                std::visit(TClassifierSettings::TParser{*value}, setting);
+            } catch (...) {
+                throw yexception() << "Failed to parse property " << property << ": " << CurrentExceptionMessage();
+            }
+        } else if (!featuresExtractor.ExtractResetFeature(property)) {
+            continue;
+        }
+
+        const TString value = std::visit(TClassifierSettings::TExtractor(), setting);
+        if (property == TResourcePoolClassifierConfig::TDecoder::Rank) {
+            result.SetColumn(property, NMetadata::NInternal::TYDBValue::Int64(FromString<i64>(value)));
+        } else {
+            configJson.InsertValue(property, value);
+        }
+    }
+
+    NJsonWriter::TBuf writer;
+    writer.WriteJsonValue(&configJson);
+    result.SetColumn(TResourcePoolClassifierConfig::TDecoder::ConfigJson, NMetadata::NInternal::TYDBValue::Utf8(writer.Str()));
+
+    if (!featuresExtractor.IsFinished()) {
+        ythrow yexception() << "Unknown property: " << featuresExtractor.GetRemainedParamsString();
+    }
+
+    return result;
+}
+
+NMetadata::NModifications::TOperationParsingResult TResourcePoolClassifierManager::FillDropInfo(const NYql::TObjectSettingsImpl& settings, const TInternalModificationContext& context) const {
+    return GetResourcePoolClassifierRecord(settings, context);
+}
+
+void TResourcePoolClassifierManager::DoPrepareObjectsBeforeModification(std::vector<TResourcePoolClassifierConfig>&& patchedObjects, NMetadata::NModifications::IAlterPreparationController<TResourcePoolClassifierConfig>::TPtr controller, const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const {
+    auto* actorSystem = context.GetExternalData().GetActorSystem();
+    if (!actorSystem) {
+        controller->OnPreparationProblem("This place needs an actor system. Please contact internal support");
+        return;
+    }
+
+    actorSystem->Register(CreateResourcePoolClassifierPreparationActor(std::move(patchedObjects), std::move(controller), context, alterContext));
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "object.h"
+
+#include <ydb/services/metadata/manager/generic_manager.h>
+
+
+namespace NKikimr::NKqp {
+
+class TResourcePoolClassifierManager : public NMetadata::NModifications::TGenericOperationsManager<TResourcePoolClassifierConfig> {
+protected:
+    virtual NMetadata::NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings, TInternalModificationContext& context) const override;
+
+    virtual void DoPrepareObjectsBeforeModification(std::vector<TResourcePoolClassifierConfig>&& patchedObjects, NMetadata::NModifications::IAlterPreparationController<TResourcePoolClassifierConfig>::TPtr controller, const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const override;
+
+private:
+    NMetadata::NModifications::TOperationParsingResult FillResourcePoolClassifierInfo(const NYql::TObjectSettingsImpl& settings, const TInternalModificationContext& context) const;
+    NMetadata::NModifications::TOperationParsingResult FillDropInfo(const NYql::TObjectSettingsImpl& settings, const TInternalModificationContext& context) const;
+};
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
@@ -1,0 +1,137 @@
+#include "object.h"
+#include "behaviour.h"
+
+#include <library/cpp/json/json_reader.h>
+
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+using namespace NResourcePool;
+
+
+class TJsonConfigsMerger : public NMetadata::NModifications::IColumnValuesMerger {
+public:
+    virtual TConclusionStatus Merge(Ydb::Value& value, const Ydb::Value& patch) const override {
+        NJson::TJsonValue selfConfigJson;
+        if (!NJson::ReadJsonTree(value.text_value(), &selfConfigJson)) {
+            return TConclusionStatus::Fail("Failed to parse object json config");
+        }
+
+        NJson::TJsonValue otherConfigJson;
+        if (!NJson::ReadJsonTree(patch.text_value(), &otherConfigJson)) {
+            return TConclusionStatus::Fail("Failed to parse patch json config");
+        }
+
+        for (const auto& [key, value] : otherConfigJson.GetMap()) {
+            selfConfigJson.InsertValue(key, value);
+        }
+
+        NJsonWriter::TBuf writer;
+        writer.WriteJsonValue(&selfConfigJson);
+        *value.mutable_text_value() = writer.Str();
+
+        return TConclusionStatus::Success();
+    }
+};
+
+}  // anonymous namespace
+
+
+//// TResourcePoolClassifierConfig::TDecoder
+
+TResourcePoolClassifierConfig::TDecoder::TDecoder(const Ydb::ResultSet& rawData)
+    : DatabaseIdx(GetFieldIndex(rawData, Database))
+    , NameIdx(GetFieldIndex(rawData, Name))
+    , RankIdx(GetFieldIndex(rawData, Rank))
+    , ConfigJsonIdx(GetFieldIndex(rawData, ConfigJson))
+{}
+
+//// TResourcePoolClassifierConfig
+
+NMetadata::NModifications::IColumnValuesMerger::TPtr TResourcePoolClassifierConfig::BuildMerger(const TString& columnName) const {
+    if (columnName == TDecoder::ConfigJson) {
+        return std::make_shared<TJsonConfigsMerger>();
+    }
+    return TBase::BuildMerger(columnName);
+}
+
+bool TResourcePoolClassifierConfig::DeserializeFromRecord(const TDecoder& decoder, const Ydb::Value& rawData) {
+    if (!decoder.Read(decoder.GetDatabaseIdx(), Database, rawData)) {
+        return false;
+    }
+    if (!decoder.Read(decoder.GetNameIdx(), Name, rawData)) {
+        return false;
+    }
+    if (!decoder.Read(decoder.GetRankIdx(), Rank, rawData)) {
+        Rank = -1;
+    }
+
+    TString configJsonString;
+    if (!decoder.Read(decoder.GetConfigJsonIdx(), configJsonString, rawData)) {
+        return false;
+    }
+    if (!NJson::ReadJsonTree(configJsonString, &ConfigJson)) {
+        return false;
+    }
+
+    return true;
+}
+
+NMetadata::NInternal::TTableRecord TResourcePoolClassifierConfig::SerializeToRecord() const {
+    NMetadata::NInternal::TTableRecord result;
+    result.SetColumn(TDecoder::Database, NMetadata::NInternal::TYDBValue::Utf8(Database));
+    result.SetColumn(TDecoder::Name, NMetadata::NInternal::TYDBValue::Utf8(Name));
+    result.SetColumn(TDecoder::Rank, NMetadata::NInternal::TYDBValue::Int64(Rank));
+
+    NJsonWriter::TBuf writer;
+    writer.WriteJsonValue(&ConfigJson);
+    result.SetColumn(TDecoder::ConfigJson, NMetadata::NInternal::TYDBValue::Utf8(writer.Str()));
+
+    return result;
+}
+
+TClassifierSettings TResourcePoolClassifierConfig::GetClassifierSettings() const {
+    TClassifierSettings resourcePoolClassifierSettings;
+
+    resourcePoolClassifierSettings.Rank = Rank;
+
+    const auto& properties = resourcePoolClassifierSettings.GetPropertiesMap();
+    for (const auto& [propery, value] : ConfigJson.GetMap()) {
+        const auto it = properties.find(propery);
+        if (it == properties.end()) {
+            continue;
+        }
+        try {
+            std::visit(TClassifierSettings::TParser{value.GetString()}, it->second);
+        } catch (...) {
+            continue;
+        }
+    }
+
+    return resourcePoolClassifierSettings;
+}
+
+NJson::TJsonValue TResourcePoolClassifierConfig::GetDebugJson() const {
+    NJson::TJsonValue result = NJson::JSON_MAP;
+    result.InsertValue(TDecoder::Database, Database);
+    result.InsertValue(TDecoder::Name, Name);
+    result.InsertValue(TDecoder::Rank, Rank);
+    result.InsertValue(TDecoder::ConfigJson, ConfigJson);
+    return result;
+}
+
+bool TResourcePoolClassifierConfig::operator==(const TResourcePoolClassifierConfig& other) const {
+    return std::tie(Database, Name, Rank, ConfigJson) != std::tie(other.Database, other.Name, other.Rank, other.ConfigJson);
+}
+
+NMetadata::IClassBehaviour::TPtr TResourcePoolClassifierConfig::GetBehaviour() {
+    return TResourcePoolClassifierBehaviour::GetInstance();
+}
+
+TString TResourcePoolClassifierConfig::GetTypeId() {
+    return "RESOURCE_POOL_CLASSIFIER";
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.cpp
@@ -123,7 +123,7 @@ NJson::TJsonValue TResourcePoolClassifierConfig::GetDebugJson() const {
 }
 
 bool TResourcePoolClassifierConfig::operator==(const TResourcePoolClassifierConfig& other) const {
-    return std::tie(Database, Name, Rank, ConfigJson) != std::tie(other.Database, other.Name, other.Rank, other.ConfigJson);
+    return std::tie(Database, Name, Rank, ConfigJson) == std::tie(other.Database, other.Name, other.Rank, other.ConfigJson);
 }
 
 NMetadata::IClassBehaviour::TPtr TResourcePoolClassifierConfig::GetBehaviour() {

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <ydb/core/resource_pools/resource_pool_classifier_settings.h>
+
+#include <ydb/services/metadata/abstract/decoder.h>
+#include <ydb/services/metadata/manager/object.h>
+
+
+namespace NKikimr::NKqp {
+
+class TResourcePoolClassifierConfig : public NMetadata::NModifications::TObject<TResourcePoolClassifierConfig> {
+    using TBase = NMetadata::NModifications::TObject<TResourcePoolClassifierConfig>;
+
+    YDB_ACCESSOR_DEF(TString, Database);
+    YDB_ACCESSOR_DEF(TString, Name);
+    YDB_ACCESSOR_DEF(i64, Rank);
+    YDB_ACCESSOR_DEF(NJson::TJsonValue, ConfigJson);
+
+public:
+    class TDecoder : public NMetadata::NInternal::TDecoderBase {
+    private:
+        YDB_READONLY(i32, DatabaseIdx, -1);
+        YDB_READONLY(i32, NameIdx, -1);
+        YDB_READONLY(i32, RankIdx, -1);
+        YDB_READONLY(i32, ConfigJsonIdx, -1);
+
+    public:
+        static inline const TString Database = "database";
+        static inline const TString Name = "name";
+        static inline const TString Rank = "rank";
+        static inline const TString ConfigJson = "config";
+
+        explicit TDecoder(const Ydb::ResultSet& rawData);
+    };
+
+    virtual NMetadata::NModifications::IColumnValuesMerger::TPtr BuildMerger(const TString& columnName) const override;
+    NMetadata::NInternal::TTableRecord SerializeToRecord() const;
+    bool DeserializeFromRecord(const TDecoder& decoder, const Ydb::Value& rawData);
+
+    NResourcePool::TClassifierSettings GetClassifierSettings() const;
+    NJson::TJsonValue GetDebugJson() const;
+
+    bool operator==(const TResourcePoolClassifierConfig& other) const;
+
+    static NMetadata::IClassBehaviour::TPtr GetBehaviour();
+    static TString GetTypeId();
+};
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.cpp
@@ -1,0 +1,25 @@
+#include "snapshot.h"
+
+
+namespace NKikimr::NKqp {
+
+bool TResourcePoolClassifierSnapshot::DoDeserializeFromResultSet(const Ydb::Table::ExecuteQueryResult& rawData) {
+    Y_ABORT_UNLESS(rawData.result_sets().size() == 1);
+    ParseSnapshotObjects<TResourcePoolClassifierConfig>(rawData.result_sets()[0], [this](TResourcePoolClassifierConfig&& config) {
+        ResourcePoolClassifierConfigs[config.GetDatabase()].emplace(config.GetName(), config);
+    });
+    return true;
+}
+
+TString TResourcePoolClassifierSnapshot::DoSerializeToString() const {
+    NJson::TJsonValue result = NJson::JSON_MAP;
+    auto& jsonResourcePoolClassifiers = result.InsertValue("resource_pool_classifiers", NJson::JSON_ARRAY);
+    for (const auto& [_, configsMap] : ResourcePoolClassifierConfigs) {
+        for (const auto& [_, config] : configsMap) {
+            jsonResourcePoolClassifiers.AppendValue(config.GetDebugJson());
+        }
+    }
+    return result.GetStringRobust();
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.cpp
@@ -22,4 +22,16 @@ TString TResourcePoolClassifierSnapshot::DoSerializeToString() const {
     return result.GetStringRobust();
 }
 
+std::optional<TResourcePoolClassifierConfig> TResourcePoolClassifierSnapshot::GetClassifierConfig(const TString& database, const TString& name) const {
+    const auto databaseIt = ResourcePoolClassifierConfigs.find(database);
+    if (databaseIt == ResourcePoolClassifierConfigs.end()) {
+        return std::nullopt;
+    }
+    const auto configIt = databaseIt->second.find(name);
+    if (configIt == databaseIt->second.end()) {
+        return std::nullopt;
+    }
+    return configIt->second;
+}
+
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "object.h"
+
+#include <ydb/services/metadata/abstract/fetcher.h>
+
+
+namespace NKikimr::NKqp {
+
+class TResourcePoolClassifierSnapshot : public NMetadata::NFetcher::ISnapshot {
+    using TBase = NMetadata::NFetcher::ISnapshot;
+    using TConfigsMap = std::unordered_map<TString, std::unordered_map<TString, TResourcePoolClassifierConfig>>;
+
+    YDB_ACCESSOR_DEF(TConfigsMap, ResourcePoolClassifierConfigs);
+
+protected:
+    virtual bool DoDeserializeFromResultSet(const Ydb::Table::ExecuteQueryResult& rawData) override;
+    virtual TString DoSerializeToString() const override;
+
+public:
+    using TBase::TBase;
+};
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.h
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/snapshot.h
@@ -19,6 +19,8 @@ protected:
 
 public:
     using TBase::TBase;
+
+    std::optional<TResourcePoolClassifierConfig> GetClassifierConfig(const TString& database, const TString& name) const;
 };
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/ya.make
@@ -1,0 +1,26 @@
+LIBRARY()
+
+SRCS(
+    GLOBAL behaviour.cpp
+    checker.cpp
+    fetcher.cpp
+    initializer.cpp
+    manager.cpp
+    object.cpp
+    snapshot.cpp
+)
+
+PEERDIR(
+    ydb/core/cms/console
+    ydb/core/kqp/workload_service/actors
+    ydb/core/protos
+    ydb/core/resource_pools
+    ydb/library/query_actor
+    ydb/services/metadata/abstract
+    ydb/services/metadata/initializer
+    ydb/services/metadata/manager
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/kqp/gateway/behaviour/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/ya.make
@@ -1,6 +1,7 @@
 RECURSE(
     external_data_source
     resource_pool
+    resource_pool_classifier
     table
     tablestore
 )

--- a/ydb/core/kqp/gateway/ya.make
+++ b/ydb/core/kqp/gateway/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     ydb/core/kqp/gateway/behaviour/table
     ydb/core/kqp/gateway/behaviour/external_data_source
     ydb/core/kqp/gateway/behaviour/resource_pool
+    ydb/core/kqp/gateway/behaviour/resource_pool_classifier
     ydb/core/kqp/gateway/behaviour/view
     ydb/core/kqp/gateway/utils
     ydb/core/statistics/service    

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1033,7 +1033,8 @@ public:
         std::optional<TKqpFederatedQuerySetup> federatedQuerySetup, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken,
         const NKikimr::NMiniKQL::IFunctionRegistry* funcRegistry, bool keepConfigChanges, bool isInternalCall,
         TKqpTempTablesState::TConstPtr tempTablesState = nullptr, NActors::TActorSystem* actorSystem = nullptr,
-        NYql::TExprContext* ctx = nullptr, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig = NKikimrConfig::TQueryServiceConfig())
+        NYql::TExprContext* ctx = nullptr, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig = NKikimrConfig::TQueryServiceConfig(),
+        const TIntrusivePtr<TUserRequestContext>& userRequestContext = nullptr)
         : Gateway(gateway)
         , Cluster(cluster)
         , GUCSettings(gUCSettings)
@@ -1044,7 +1045,7 @@ public:
         , KeepConfigChanges(keepConfigChanges)
         , IsInternalCall(isInternalCall)
         , FederatedQuerySetup(federatedQuerySetup)
-        , SessionCtx(new TKikimrSessionContext(funcRegistry, config, TAppData::TimeProvider, TAppData::RandomProvider, userToken))
+        , SessionCtx(new TKikimrSessionContext(funcRegistry, config, TAppData::TimeProvider, TAppData::RandomProvider, userToken, nullptr, userRequestContext))
         , Config(config)
         , TypesCtx(MakeIntrusive<TTypeAnnotationContext>())
         , PlanBuilder(CreatePlanBuilder(*TypesCtx))
@@ -1957,10 +1958,10 @@ TIntrusivePtr<IKqpHost> CreateKqpHost(TIntrusivePtr<IKqpGateway> gateway, const 
     const TString& database, TKikimrConfiguration::TPtr config, IModuleResolver::TPtr moduleResolver,
     std::optional<TKqpFederatedQuerySetup> federatedQuerySetup, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, const TGUCSettings::TPtr& gUCSettings,
     const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, const TMaybe<TString>& applicationName, const NKikimr::NMiniKQL::IFunctionRegistry* funcRegistry, bool keepConfigChanges,
-    bool isInternalCall, TKqpTempTablesState::TConstPtr tempTablesState, NActors::TActorSystem* actorSystem, NYql::TExprContext* ctx)
+    bool isInternalCall, TKqpTempTablesState::TConstPtr tempTablesState, NActors::TActorSystem* actorSystem, NYql::TExprContext* ctx, const TIntrusivePtr<TUserRequestContext>& userRequestContext)
 {
     return MakeIntrusive<TKqpHost>(gateway, cluster, database, gUCSettings, applicationName, config, moduleResolver, federatedQuerySetup, userToken, funcRegistry,
-                                   keepConfigChanges, isInternalCall, std::move(tempTablesState), actorSystem, ctx, queryServiceConfig);
+                                   keepConfigChanges, isInternalCall, std::move(tempTablesState), actorSystem, ctx, queryServiceConfig, userRequestContext);
 }
 
 } // namespace NKqp

--- a/ydb/core/kqp/host/kqp_host.h
+++ b/ydb/core/kqp/host/kqp_host.h
@@ -123,7 +123,7 @@ TIntrusivePtr<IKqpHost> CreateKqpHost(TIntrusivePtr<IKqpGateway> gateway,
     const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, const TMaybe<TString>& applicationName = Nothing(), const NKikimr::NMiniKQL::IFunctionRegistry* funcRegistry = nullptr,
     bool keepConfigChanges = false, bool isInternalCall = false, TKqpTempTablesState::TConstPtr tempTablesState = nullptr,
     NActors::TActorSystem* actorSystem = nullptr /*take from TLS by default*/,
-    NYql::TExprContext* ctx = nullptr);
+    NYql::TExprContext* ctx = nullptr, const TIntrusivePtr<TUserRequestContext>& userRequestContext = nullptr);
 
 } // namespace NKqp
 } // namespace NKikimr

--- a/ydb/core/kqp/host/kqp_runner.cpp
+++ b/ydb/core/kqp/host/kqp_runner.cpp
@@ -146,7 +146,7 @@ public:
         , Config(sessionCtx->ConfigPtr())
         , TransformCtx(transformCtx)
         , OptimizeCtx(MakeIntrusive<TKqpOptimizeContext>(cluster, Config, sessionCtx->QueryPtr(),
-            sessionCtx->TablesPtr()))
+            sessionCtx->TablesPtr(), sessionCtx->GetUserRequestContext()))
         , BuildQueryCtx(MakeIntrusive<TKqpBuildQueryContext>())
         , Pctx(TKqpProviderContext(*OptimizeCtx, Config->CostBasedOptimizationLevel.Get().GetOrElse(TDqSettings::TDefault::CostBasedOptimizationLevel)))
     {

--- a/ydb/core/kqp/opt/kqp_opt.h
+++ b/ydb/core/kqp/opt/kqp_opt.h
@@ -10,11 +10,13 @@ namespace NKikimr::NKqp::NOpt {
 
 struct TKqpOptimizeContext : public TSimpleRefCount<TKqpOptimizeContext> {
     TKqpOptimizeContext(const TString& cluster, const NYql::TKikimrConfiguration::TPtr& config,
-        const TIntrusivePtr<NYql::TKikimrQueryContext> queryCtx, const TIntrusivePtr<NYql::TKikimrTablesData>& tables)
+        const TIntrusivePtr<NYql::TKikimrQueryContext> queryCtx, const TIntrusivePtr<NYql::TKikimrTablesData>& tables,
+        const TIntrusivePtr<NKikimr::NKqp::TUserRequestContext>& userRequestContext)
         : Cluster(cluster)
         , Config(config)
         , QueryCtx(queryCtx)
         , Tables(tables)
+        , UserRequestContext(userRequestContext)
     {
         YQL_ENSURE(QueryCtx);
         YQL_ENSURE(Tables);
@@ -24,6 +26,7 @@ struct TKqpOptimizeContext : public TSimpleRefCount<TKqpOptimizeContext> {
     const NYql::TKikimrConfiguration::TPtr Config;
     const TIntrusivePtr<NYql::TKikimrQueryContext> QueryCtx;
     const TIntrusivePtr<NYql::TKikimrTablesData> Tables;
+    const TIntrusivePtr<NKikimr::NKqp::TUserRequestContext> UserRequestContext;
     int JoinsCount{};
     int EquiJoinsCount{};
 

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -2363,11 +2363,21 @@ void PhyQuerySetTxPlans(NKqpProto::TKqpPhyQuery& queryProto, const TKqpPhysicalQ
         txPlans.emplace_back(phyTx.GetPlan());
     }
 
+    TString queryStats = "";
+    if (optCtx && optCtx->UserRequestContext && optCtx->UserRequestContext->PoolId) {
+        NJsonWriter::TBuf writer;
+        writer.BeginObject();
+        writer.WriteKey("ResourcePoolId").WriteString(optCtx->UserRequestContext->PoolId);
+        writer.EndObject();
+
+        queryStats = writer.Str();
+    }
+
     NJsonWriter::TBuf writer;
     writer.SetIndentSpaces(2);
     WriteCommonTablesInfo(writer, serializerCtx.Tables);
 
-    queryProto.SetQueryPlan(SerializeTxPlans(txPlans, optCtx, writer.Str()));
+    queryProto.SetQueryPlan(SerializeTxPlans(txPlans, optCtx, writer.Str(), queryStats));
 }
 
 void FillAggrStat(NJson::TJsonValue& node, const NYql::NDqProto::TDqStatsAggr& aggr, const TString& name) {
@@ -2707,7 +2717,7 @@ TString AddExecStatsToTxPlan(const TString& txPlanJson, const NYql::NDqProto::TD
     return AddExecStatsToTxPlan(txPlanJson, stats, TIntrusivePtr<NOpt::TKqpOptimizeContext>());
 }
 
-TString SerializeAnalyzePlan(const NKqpProto::TKqpStatsQuery& queryStats) {
+TString SerializeAnalyzePlan(const NKqpProto::TKqpStatsQuery& queryStats, const TString& poolId) {
     TVector<const TString> txPlans;
     for (const auto& execStats: queryStats.GetExecutions()) {
         for (const auto& txPlan: execStats.GetTxPlansWithStats()) {
@@ -2731,7 +2741,10 @@ TString SerializeAnalyzePlan(const NKqpProto::TKqpStatsQuery& queryStats) {
 
     writer.WriteKey("ProcessCpuTimeUs").WriteLongLong(queryStats.GetWorkerCpuTimeUs());
     writer.WriteKey("TotalDurationUs").WriteLongLong(queryStats.GetDurationUs());
-    writer.WriteKey("QueuedTimeUs").WriteLongLong(queryStats.GetQueuedTimeUs());
+    if (poolId) {
+        writer.WriteKey("QueuedTimeUs").WriteLongLong(queryStats.GetQueuedTimeUs());
+        writer.WriteKey("ResourcePoolId").WriteString(poolId);
+    }
     writer.EndObject();
 
     return SerializeTxPlans(txPlans, TIntrusivePtr<NOpt::TKqpOptimizeContext>(), "", writer.Str());

--- a/ydb/core/kqp/opt/kqp_query_plan.h
+++ b/ydb/core/kqp/opt/kqp_query_plan.h
@@ -44,7 +44,7 @@ void PhyQuerySetTxPlans(NKqpProto::TKqpPhyQuery& queryProto, const NYql::NNodes:
  */
 TString AddExecStatsToTxPlan(const TString& txPlan, const NYql::NDqProto::TDqExecutionStats& stats);
 
-TString SerializeAnalyzePlan(const NKqpProto::TKqpStatsQuery& queryStats);
+TString SerializeAnalyzePlan(const NKqpProto::TKqpStatsQuery& queryStats, const TString& poolId = "");
 
 TString SerializeScriptPlan(const TVector<const TString>& queryPlans);
 

--- a/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
@@ -232,7 +232,7 @@ void TestCreateResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGat
         {"concurrent_query_limit", "10"},
         {"queue_size", "100"}
     });
-    const auto& resourcePool = TestCreateObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.resource_pools/" << poolId);
+    const auto& resourcePool = TestCreateObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.metadata/workload_manager/pools/" << poolId);
 
     UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
     UNIT_ASSERT(resourcePool.ResourcePoolInfo);
@@ -249,7 +249,7 @@ void TestAlterResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGate
     }, {
         "queue_size"
     });
-    const auto& resourcePool = TestAlterObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.resource_pools/" << poolId);
+    const auto& resourcePool = TestAlterObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.metadata/workload_manager/pools/" << poolId);
 
     UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
     UNIT_ASSERT(resourcePool.ResourcePoolInfo);
@@ -262,7 +262,7 @@ void TestAlterResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGate
 
 void TestDropResourcePool(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGateway> gateway, const TString& poolId) {
     TDropObjectSettings settings("RESOURCE_POOL", poolId, {});
-    TestDropObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.resource_pools/" << poolId);
+    TestDropObjectCommon(runtime, gateway, settings, TStringBuilder() << "/Root/.metadata/workload_manager/pools/" << poolId);
 }
 
 TKikimrRunner GetKikimrRunnerWithResourcePools() {

--- a/ydb/core/kqp/provider/yql_kikimr_provider.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.h
@@ -5,6 +5,7 @@
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/external_sources/external_source_factory.h>
+#include <ydb/core/kqp/common/kqp_user_request_context.h>
 #include <ydb/core/kqp/common/simple/temp_tables.h>
 #include <ydb/core/kqp/query_data/kqp_query_data.h>
 #include <ydb/library/yql/ast/yql_gc_nodes.h>
@@ -462,12 +463,14 @@ public:
         TIntrusivePtr<ITimeProvider> timeProvider,
         TIntrusivePtr<IRandomProvider> randomProvider,
         const TIntrusiveConstPtr<NACLib::TUserToken>& userToken,
-        TIntrusivePtr<TKikimrTransactionContextBase> txCtx = nullptr)
+        TIntrusivePtr<TKikimrTransactionContextBase> txCtx = nullptr,
+        const TIntrusivePtr<NKikimr::NKqp::TUserRequestContext>& userRequestContext = nullptr)
         : Configuration(config)
         , TablesData(MakeIntrusive<TKikimrTablesData>())
         , QueryCtx(MakeIntrusive<TKikimrQueryContext>(functionRegistry, timeProvider, randomProvider))
         , TxCtx(txCtx)
         , UserToken(userToken)
+        , UserRequestContext(userRequestContext)
     {}
 
     TKikimrSessionContext(const TKikimrSessionContext&) = delete;
@@ -549,6 +552,10 @@ public:
         return UserToken;
     }
 
+    const TIntrusivePtr<NKikimr::NKqp::TUserRequestContext>& GetUserRequestContext() const {
+        return UserRequestContext;
+    }
+
 private:
     TString UserName;
     TString Cluster;
@@ -560,6 +567,7 @@ private:
     TIntrusivePtr<TKikimrTransactionContextBase> TxCtx;
     NKikimr::NKqp::TKqpTempTablesState::TConstPtr TempTablesState;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    TIntrusivePtr<NKikimr::NKqp::TUserRequestContext> UserRequestContext;
 };
 
 TIntrusivePtr<IDataProvider> CreateKikimrDataSource(

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -233,6 +233,7 @@ public:
             IEventHandle::FlagTrackDelivery);
 
         WhiteBoardService = NNodeWhiteboard::MakeNodeWhiteboardServiceId(SelfId().NodeId());
+        ResourcePoolsCache.UpdateFeatureFlags(FeatureFlags, ActorContext());
 
         if (auto& cfg = TableServiceConfig.GetSpillingServiceConfig().GetLocalFileConfig(); cfg.GetEnable()) {
             SpillingService = TlsActivationContext->ExecutorThread.RegisterActor(NYql::NDq::CreateDqLocalFileSpillingService(
@@ -475,6 +476,8 @@ public:
             Send(TActivationContext::InterconnectProxy(node), new TEvents::TEvUnsubscribe);
         });
 
+        ResourcePoolsCache.UnsubscribeFromResourcePoolClassifiers(ActorContext());
+
         return TActor::PassAway();
     }
 
@@ -492,6 +495,7 @@ public:
         UpdateYqlLogLevels();
 
         FeatureFlags.Swap(event.MutableConfig()->MutableFeatureFlags());
+        ResourcePoolsCache.UpdateFeatureFlags(FeatureFlags, ActorContext());
 
         auto responseEv = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationResponse>(event);
         Send(ev->Sender, responseEv.Release(), IEventHandle::FlagTrackDelivery, ev->Cookie);
@@ -1347,6 +1351,8 @@ public:
             hFunc(TEvKqp::TEvListSessionsRequest, Handle);
             hFunc(TEvKqp::TEvListProxyNodesRequest, Handle);
             hFunc(NWorkload::TEvUpdatePoolInfo, Handle);
+            hFunc(NWorkload::TEvUpdateDatabaseInfo, Handle);
+            hFunc(NMetadata::NProvider::TEvRefreshSubscriberData, Handle);
         default:
             Y_ABORT("TKqpProxyService: unexpected event type: %" PRIx32 " event: %s",
                 ev->GetTypeRewrite(), ev->ToString().data());
@@ -1570,23 +1576,26 @@ private:
     }
 
     bool TryFillPoolInfoFromCache(TEvKqp::TEvQueryRequest::TPtr& ev, ui64 requestId) {
-        if (!FeatureFlags.GetEnableResourcePools()) {
+        ResourcePoolsCache.UpdateFeatureFlags(FeatureFlags, ActorContext());
+
+        const auto& database = ev->Get()->GetDatabase();
+        if (!ResourcePoolsCache.ResourcePoolsEnabled(database)) {
             ev->Get()->SetPoolId("");
             return true;
         }
 
+        const auto& userToken = ev->Get()->GetUserToken();
         if (!ev->Get()->GetPoolId()) {
-            ev->Get()->SetPoolId(NResourcePool::DEFAULT_POOL_ID);
+            ev->Get()->SetPoolId(ResourcePoolsCache.GetPoolId(database, userToken, ActorContext()));
         }
 
         const auto& poolId = ev->Get()->GetPoolId();
-        const auto& poolInfo = ResourcePoolsCache.GetPoolInfo(ev->Get()->GetDatabase(), poolId);
+        const auto& poolInfo = ResourcePoolsCache.GetPoolInfo(database, poolId, ActorContext());
         if (!poolInfo) {
             return true;
         }
 
         const auto& securityObject = poolInfo->SecurityObject;
-        const auto& userToken = ev->Get()->GetUserToken();
         if (securityObject && userToken && !userToken->GetSerializedToken().empty()) {
             if (!securityObject->CheckAccess(NACLib::EAccessRights::DescribeSchema, *userToken)) {
                 ReplyProcessError(Ydb::StatusIds::NOT_FOUND, TStringBuilder() << "Resource pool " << poolId << " not found or you don't have access permissions", requestId);
@@ -1801,7 +1810,15 @@ private:
     }
 
     void Handle(NWorkload::TEvUpdatePoolInfo::TPtr& ev) {
-        ResourcePoolsCache.UpdatePoolInfo(ev->Get()->Database, ev->Get()->PoolId, ev->Get()->Config, ev->Get()->SecurityObject);
+        ResourcePoolsCache.UpdatePoolInfo(ev->Get()->Database, ev->Get()->PoolId, ev->Get()->Config, ev->Get()->SecurityObject, ActorContext());
+    }
+
+    void Handle(NWorkload::TEvUpdateDatabaseInfo::TPtr& ev) {
+        ResourcePoolsCache.UpdateDatabaseInfo(ev->Get()->Database, ev->Get()->Serverless);
+    }
+
+    void Handle(NMetadata::NProvider::TEvRefreshSubscriberData::TPtr& ev) {
+        ResourcePoolsCache.UpdateResourcePoolClassifiersInfo(ev->Get()->GetSnapshotAs<TResourcePoolClassifierSnapshot>(), ActorContext());
     }
 
 private:

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -3,7 +3,9 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/kqp/common/kqp.h>
+#include <ydb/core/kqp/common/events/workload_service.h>
 #include <ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
 #include <ydb/core/protos/kqp.pb.h>
 
@@ -417,39 +419,223 @@ private:
 };
 
 class TResourcePoolsCache {
+    struct TClassifierInfo {
+        const TString Membername;
+        const TString PoolId;
+
+        TClassifierInfo(const NResourcePool::TClassifierSettings& classifierSettings)
+            : Membername(classifierSettings.Membername)
+            , PoolId(classifierSettings.ResourcePool)
+        {}
+    };
+
+    struct TDatabaseInfo {
+        std::unordered_map<TString, TResourcePoolClassifierConfig> ResourcePoolsClassifiers = {};
+        std::map<i64, TClassifierInfo> RankToClassifierInfo = {};
+        std::unordered_map<TString, TString> UserToResourcePool = {};
+        bool Serverless = false;
+    };
+
     struct TPoolInfo {
         NResourcePool::TPoolSettings Config;
         std::optional<NACLib::TSecurityObject> SecurityObject;
+        bool Expired = false;
     };
 
 public:
-    std::optional<TPoolInfo> GetPoolInfo(const TString& database, const TString& poolId) const {
+    bool ResourcePoolsEnabled(const TString& database) const {
+        if (!EnableResourcePools) {
+            return false;
+        }
+
+        if (EnableResourcePoolsOnServerless) {
+            return true;
+        }
+
+        const auto databaseInfo = GetDatabaseInfo(database); 
+        return !databaseInfo || !databaseInfo->Serverless;
+    }
+
+    TString GetPoolId(const TString& database, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) {
+        if (!userToken || userToken->GetUserSID().empty()) {
+            return NResourcePool::DEFAULT_POOL_ID;
+        }
+
+        TDatabaseInfo& databaseInfo = *GetOrCreateDatabaseInfo(database);
+        if (const auto& poolId = GetPoolIdFromClassifiers(database, userToken->GetUserSID(), databaseInfo, userToken, actorContext)) {
+            return poolId;
+        }
+        for (const auto& userSID : userToken->GetGroupSIDs()) {
+            if (const auto& poolId = GetPoolIdFromClassifiers(database, userSID, databaseInfo, userToken, actorContext)) {
+                return poolId;
+            }
+        }
+
+        return NResourcePool::DEFAULT_POOL_ID;
+    }
+
+    std::optional<TPoolInfo> GetPoolInfo(const TString& database, const TString& poolId, TActorContext actorContext) const {
         auto it = PoolsCache.find(GetPoolKey(database, poolId));
         if (it == PoolsCache.end()) {
+            actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, poolId));
             return std::nullopt;
         }
         return it->second;
     }
 
-    void UpdatePoolInfo(const TString& database, const TString& poolId, const std::optional<NResourcePool::TPoolSettings>& config, const std::optional<NACLib::TSecurityObject>& securityObject) {
+    void UpdateFeatureFlags(const NKikimrConfig::TFeatureFlags& featureFlags, TActorContext actorContext) {
+        EnableResourcePools = featureFlags.GetEnableResourcePools();
+        EnableResourcePoolsOnServerless = featureFlags.GetEnableResourcePoolsOnServerless();
+        UpdateResourcePoolClassifiersSubscription(actorContext);
+    }
+
+    void UpdateDatabaseInfo(const TString& database, bool serverless) {
+        GetOrCreateDatabaseInfo(database)->Serverless = serverless;
+    }
+
+    void UpdatePoolInfo(const TString& database, const TString& poolId, const std::optional<NResourcePool::TPoolSettings>& config, const std::optional<NACLib::TSecurityObject>& securityObject, TActorContext actorContext) {
+        bool clearClassifierCache = false;
+
         const TString& poolKey = GetPoolKey(database, poolId);
         if (!config) {
-            PoolsCache.erase(poolKey);
-            return;
+            auto it = PoolsCache.find(poolKey);
+            if (it == PoolsCache.end()) {
+                return;
+            }
+            if (it->second.Expired) {
+                // Pool was dropped
+                clearClassifierCache = true;
+                PoolsCache.erase(it);
+            } else {
+                // Refresh pool subscription
+                it->second.Expired = true;
+                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, poolId));
+            }
+        } else {
+            auto& poolInfo = PoolsCache[poolKey];
+            clearClassifierCache = poolInfo.SecurityObject != securityObject;
+            poolInfo.Config = *config;
+            poolInfo.SecurityObject = securityObject;
+            poolInfo.Expired = false;
         }
 
-        auto& poolInfo = PoolsCache[poolKey];
-        poolInfo.Config = *config;
-        poolInfo.SecurityObject = securityObject;
+        if (clearClassifierCache) {
+            GetOrCreateDatabaseInfo(database)->UserToResourcePool.clear();
+        }
+    }
+
+    void UpdateResourcePoolClassifiersInfo(const TResourcePoolClassifierSnapshot* snapsot, TActorContext actorContext) {
+        auto resourcePoolClassifierConfigs = snapsot->GetResourcePoolClassifierConfigs();
+        for (auto& [database, databaseInfo] : DatabasesCache) {
+            auto it = resourcePoolClassifierConfigs.find(database);
+            if (it != resourcePoolClassifierConfigs.end()) {
+                UpdateDatabaseResourcePoolClassifiers(database, databaseInfo, std::move(it->second), actorContext);
+                resourcePoolClassifierConfigs.erase(it);
+            } else if (!databaseInfo.ResourcePoolsClassifiers.empty()) {
+                databaseInfo.ResourcePoolsClassifiers.clear();
+                databaseInfo.RankToClassifierInfo.clear();
+                databaseInfo.UserToResourcePool.clear();
+            }
+        }
+        for (auto& [database, configsMap] : resourcePoolClassifierConfigs) {
+            UpdateDatabaseResourcePoolClassifiers(database, *GetOrCreateDatabaseInfo(database), std::move(configsMap), actorContext);
+        }
+    }
+
+    void UnsubscribeFromResourcePoolClassifiers(TActorContext actorContext) {
+        if (SubscribedOnResourcePoolClassifiers) {
+            SubscribedOnResourcePoolClassifiers = false;
+            actorContext.Send(NMetadata::NProvider::MakeServiceId(actorContext.SelfID.NodeId()), new NMetadata::NProvider::TEvUnsubscribeExternal(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>()));
+        }
     }
 
 private:
+    void UpdateResourcePoolClassifiersSubscription(TActorContext actorContext) {
+        if (EnableResourcePools) {
+            SubscribeOnResourcePoolClassifiers(actorContext);
+        } else {
+            UnsubscribeFromResourcePoolClassifiers(actorContext);
+        }
+    }
+
+    void SubscribeOnResourcePoolClassifiers(TActorContext actorContext) {
+        if (!SubscribedOnResourcePoolClassifiers && NMetadata::NProvider::TServiceOperator::IsEnabled()) {
+            SubscribedOnResourcePoolClassifiers = true;
+            actorContext.Send(NMetadata::NProvider::MakeServiceId(actorContext.SelfID.NodeId()), new NMetadata::NProvider::TEvSubscribeExternal(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>()));
+        }
+    }
+
+    void UpdateDatabaseResourcePoolClassifiers(const TString& database, TDatabaseInfo& databaseInfo, std::unordered_map<TString, TResourcePoolClassifierConfig>&& configsMap, TActorContext actorContext) {
+        if (databaseInfo.ResourcePoolsClassifiers == configsMap) {
+            return;
+        }
+
+        databaseInfo.ResourcePoolsClassifiers.swap(configsMap);
+        databaseInfo.UserToResourcePool.clear();
+        databaseInfo.RankToClassifierInfo.clear();
+        for (const auto& [_, classifier] : databaseInfo.ResourcePoolsClassifiers) {
+            const auto& classifierSettings = classifier.GetClassifierSettings();
+            databaseInfo.RankToClassifierInfo.insert({classifier.GetRank(), TClassifierInfo(classifierSettings)});
+            if (!PoolsCache.contains(classifierSettings.ResourcePool)) {
+                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, classifierSettings.ResourcePool));
+            }
+        }
+    }
+
+    TString GetPoolIdFromClassifiers(const TString& database, const TString& userSID, TDatabaseInfo& databaseInfo, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) const {
+        auto& usersMap = databaseInfo.UserToResourcePool;
+        if (const auto it = usersMap.find(userSID); it != usersMap.end()) {
+            return it->second;
+        }
+
+        TString poolId = "";
+        for (const auto& [_, classifier] : databaseInfo.RankToClassifierInfo) {
+            if (classifier.Membername != userSID) {
+                continue;
+            }
+
+            auto it = PoolsCache.find(GetPoolKey(database, classifier.PoolId));
+            if (it == PoolsCache.end()) {
+                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, classifier.PoolId));
+                continue;
+            }
+
+            if (userToken && !userToken->GetSerializedToken().empty() && !it->second.SecurityObject->CheckAccess(NACLib::DescribeSchema | NACLib::SelectRow, *userToken)) {
+                continue;
+            }
+
+            poolId = classifier.PoolId;
+            break;
+        }
+
+        usersMap[userSID] = poolId;
+        return poolId;
+    }
+
+    TDatabaseInfo* GetOrCreateDatabaseInfo(const TString& database) {
+        const TString& path = CanonizePath(database);
+        if (const auto it = DatabasesCache.find(path); it != DatabasesCache.end()) {
+            return &it->second;
+        }
+        return &DatabasesCache.insert({path, TDatabaseInfo{}}).first->second;
+    }
+
+    const TDatabaseInfo* GetDatabaseInfo(const TString& database) const {
+        const auto it = DatabasesCache.find(CanonizePath(database));
+        return it != DatabasesCache.end() ? &it->second : nullptr;
+    }
+
     static TString GetPoolKey(const TString& database, const TString& poolId) {
         return CanonizePath(TStringBuilder() << database << "/" << poolId);
     }
 
 private:
     std::unordered_map<TString, TPoolInfo> PoolsCache;
+    std::unordered_map<TString, TDatabaseInfo> DatabasesCache;
+
+    bool EnableResourcePools = false;
+    bool EnableResourcePoolsOnServerless = false;
+    bool SubscribedOnResourcePoolClassifiers = false;
 };
 
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/ya.make
+++ b/ydb/core/kqp/proxy_service/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
     ydb/core/kqp/common
     ydb/core/kqp/common/events
     ydb/core/kqp/counters
+    ydb/core/kqp/gateway/behaviour/resource_pool_classifier
     ydb/core/kqp/proxy_service/proto
     ydb/core/kqp/run_script_actor
     ydb/core/kqp/workload_service

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -1359,7 +1359,7 @@ public:
                     executionStats.Swap(&stats);
                     stats = QueryState->QueryStats.ToProto();
                     stats.MutableExecutions()->MergeFrom(executionStats.GetExecutions());
-                    ev->Get()->Record.SetQueryPlan(SerializeAnalyzePlan(stats));
+                    ev->Get()->Record.SetQueryPlan(SerializeAnalyzePlan(stats, QueryState->UserRequestContext->PoolId));
                 }
             }
 
@@ -1601,7 +1601,7 @@ public:
         if (QueryState->ReportStats()) {
             auto stats = QueryState->QueryStats.ToProto();
             if (QueryState->GetStatsMode() >= Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL) {
-                response->SetQueryPlan(SerializeAnalyzePlan(stats));
+                response->SetQueryPlan(SerializeAnalyzePlan(stats, QueryState->UserRequestContext->PoolId));
                 response->SetQueryAst(QueryState->CompileResult->PreparedQuery->GetPhysicalQuery().GetQueryAst());
             }
             response->MutableQueryStats()->Swap(&stats);

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -6214,8 +6214,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // ALTER RESOURCE POOL
         checkDisabled(R"(
             ALTER RESOURCE POOL MyResourcePool
-                SET (CONCURRENT_QUERY_LIMIT = 30),
-                SET QUEUE_SIZE 100,
+                SET (CONCURRENT_QUERY_LIMIT = 30, QUEUE_SIZE = 100),
                 RESET (QUERY_MEMORY_LIMIT_PERCENT_PER_NODE);
             )");
 
@@ -6252,7 +6251,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
         result = session.ExecuteSchemeQuery(R"(
             ALTER RESOURCE POOL MyResourcePool
-                SET ANOTHER_LIMIT 5,
+                SET (ANOTHER_LIMIT = 5),
                 RESET (SOME_LIMIT);
             )").GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
@@ -6365,8 +6364,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         {
             auto query = R"(
                 ALTER RESOURCE POOL MyResourcePool
-                    SET (CONCURRENT_QUERY_LIMIT = 30),
-                    SET QUEUE_SIZE 100,
+                    SET (CONCURRENT_QUERY_LIMIT = 30, QUEUE_SIZE = 100),
                     RESET (QUERY_MEMORY_LIMIT_PERCENT_PER_NODE);
                 )";
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
@@ -6395,8 +6393,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
         auto query = R"(
             ALTER RESOURCE POOL MyResourcePool
-                SET (CONCURRENT_QUERY_LIMIT = 30),
-                SET QUEUE_SIZE 100,
+                SET (CONCURRENT_QUERY_LIMIT = 30, QUEUE_SIZE = 100),
                 RESET (QUERY_MEMORY_LIMIT_PERCENT_PER_NODE);
             )";
         auto result = session.ExecuteSchemeQuery(query).GetValueSync();

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -6287,7 +6287,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         auto& runtime = *kikimr.GetTestServer().GetRuntime();
-        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
         const auto& resourcePool = resourcePoolDesc->ResultSet.at(0);
         UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
         UNIT_ASSERT(resourcePool.ResourcePoolInfo);
@@ -6319,7 +6319,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
             auto& runtime = *kikimr.GetTestServer().GetRuntime();
-            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
             UNIT_ASSERT_VALUES_EQUAL(resourcePoolDesc->ResultSet.at(0).Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindResourcePool);
         }
 
@@ -6330,7 +6330,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                 );)";
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Check failed: path: '/Root/.resource_pools/MyResourcePool', error: path exist");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Check failed: path: '/Root/.metadata/workload_manager/pools/MyResourcePool', error: path exist");
         }
     }
 
@@ -6355,7 +6355,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
             auto& runtime = *kikimr.GetTestServer().GetRuntime();
-            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
             const auto& properties = resourcePoolDesc->ResultSet.at(0).ResourcePoolInfo->Description.GetProperties().GetProperties();
             UNIT_ASSERT_VALUES_EQUAL(properties.size(), 2);
             UNIT_ASSERT_VALUES_EQUAL(properties.at("concurrent_query_limit"), "20");
@@ -6372,7 +6372,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
             auto& runtime = *kikimr.GetTestServer().GetRuntime();
-            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
             const auto& properties = resourcePoolDesc->ResultSet.at(0).ResourcePoolInfo->Description.GetProperties().GetProperties();
             UNIT_ASSERT_VALUES_EQUAL(properties.size(), 3);
             UNIT_ASSERT_VALUES_EQUAL(properties.at("concurrent_query_limit"), "30");
@@ -6428,7 +6428,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         }
 
         auto& runtime = *kikimr.GetTestServer().GetRuntime();
-        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.resource_pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+        auto resourcePoolDesc = Navigate(runtime, runtime.AllocateEdgeActor(), "Root/.metadata/workload_manager/pools/MyResourcePool", NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
         const auto& resourcePool = resourcePoolDesc->ResultSet.at(0);
         UNIT_ASSERT_VALUES_EQUAL(resourcePoolDesc->ErrorCount, 1);
         UNIT_ASSERT_VALUES_EQUAL(resourcePool.Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown);

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -6490,7 +6490,8 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
         // DROP RESOURCE POOL CLASSIFIER
         checkQuery("DROP RESOURCE POOL CLASSIFIER MyResourcePoolClassifier;",
-            EStatus::SUCCESS);
+            EStatus::GENERIC_ERROR,
+            "Classifier with name MyResourcePoolClassifier not found in database /Root");
     }
 
     Y_UNIT_TEST(ResourcePoolClassifiersValidation) {
@@ -6715,6 +6716,27 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         }
     }
 
+    Y_UNIT_TEST(AlterNonExistingResourcePoolClassifier) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto query = R"(
+            ALTER RESOURCE POOL CLASSIFIER MyResourcePoolClassifier
+                SET (MEMBERNAME = "test@user", RANK = 100),
+                RESET (RESOURCE_POOL);
+            )";
+        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Classifier with name MyResourcePoolClassifier not found in database /Root");
+    }
+
     Y_UNIT_TEST(DropResourcePoolClassifier) {
         NKikimrConfig::TAppConfig config;
         config.MutableFeatureFlags()->SetEnableResourcePools(true);
@@ -6742,6 +6764,23 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[]}");
         }
+    }
+
+    Y_UNIT_TEST(DropNonExistingResourcePoolClassifier) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto query = "DROP RESOURCE POOL CLASSIFIER MyResourcePoolClassifier;";
+        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Classifier with name MyResourcePoolClassifier not found in database /Root");
     }
 }
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/ut/common/columnshard.h>
 #include <ydb/core/tx/columnshard/hooks/testing/controller.h>
@@ -6447,6 +6448,300 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         auto query = "DROP RESOURCE POOL MyResourcePool";
         auto result = session.ExecuteSchemeQuery(query).GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST(DisableResourcePoolClassifiers) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(false);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(false));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto checkQuery = [&session](const TString& query, EStatus status, const TString& error = "") {
+            Cerr << "Check query:\n" << query << "\n";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), status);
+            if (status != EStatus::SUCCESS) {
+                UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), error);
+            }
+        };
+
+        auto checkDisabled = [checkQuery](const TString& query) {
+            checkQuery(query, EStatus::GENERIC_ERROR, "Resource pool classifiers are disabled. Please contact your system administrator to enable it");
+        };
+
+        // CREATE RESOURCE POOL CLASSIFIER
+        checkDisabled(R"(
+            CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                RANK=20,
+                RESOURCE_POOL="test_pool"
+            );)");
+
+        // ALTER RESOURCE POOL CLASSIFIER
+        checkDisabled(R"(
+            ALTER RESOURCE POOL CLASSIFIER MyResourcePoolClassifier
+                SET (RANK = 1, MEMBERNAME = "test@user"),
+                RESET (RESOURCE_POOL);
+            )");
+
+        // DROP RESOURCE POOL CLASSIFIER
+        checkQuery("DROP RESOURCE POOL CLASSIFIER MyResourcePoolClassifier;",
+            EStatus::SUCCESS);
+    }
+
+    Y_UNIT_TEST(ResourcePoolClassifiersValidation) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto result = session.ExecuteSchemeQuery(R"(
+            CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                ANOTHER_PROPERTY=20
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unknown property: another_property");
+
+        result = session.ExecuteSchemeQuery(R"(
+            ALTER RESOURCE POOL CLASSIFIER MyResourcePoolClassifier
+                SET (ANOTHER_PROPERTY = 5),
+                RESET (SOME_PROPERTY);
+            )").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Unknown property: another_property, some_property");
+
+        result = session.ExecuteSchemeQuery(R"(
+            CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                RANK="StringValue"
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Failed to parse property rank:");
+    }
+
+    Y_UNIT_TEST(ResourcePoolClassifiersRankValidation) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // Create with sample rank
+        auto result = session.ExecuteSchemeQuery(R"(
+            CREATE RESOURCE POOL CLASSIFIER ClassifierRank42 WITH (
+                RANK=42
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+
+        // Try to create with same rank
+        result = session.ExecuteSchemeQuery(R"(
+            CREATE RESOURCE POOL CLASSIFIER AnotherClassifierRank42 WITH (
+                RANK=42
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Resource pool classifier rank check failed, status: ALREADY_EXISTS, reason: { <main>: Error: Classifier with rank 42 already exists, its name ClassifierRank42 }");
+
+        // Create with high rank
+        result = session.ExecuteSchemeQuery(R"(
+            CREATE RESOURCE POOL CLASSIFIER `ClassifierRank2^63` WITH (
+                RANK=9223372036854775807
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+
+        // Try to create with auto rank
+        result = session.ExecuteSchemeQuery(R"(
+            CREATE RESOURCE POOL CLASSIFIER ClassifierRankAuto WITH (
+                MEMBERNAME="test@user"
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "The rank could not be set automatically, the maximum rank of the resource pool classifier is too high: 9223372036854775807");
+
+        // Try to alter to exist rank
+        result = session.ExecuteSchemeQuery(R"(
+            ALTER RESOURCE POOL CLASSIFIER `ClassifierRank2^63` SET (
+                RANK=42
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Resource pool classifier rank check failed, status: ALREADY_EXISTS, reason: { <main>: Error: Classifier with rank 42 already exists, its name ClassifierRank42 }");
+
+        // Try to reset classifier rank
+        result = session.ExecuteSchemeQuery(R"(
+            ALTER RESOURCE POOL CLASSIFIER ClassifierRank42 RESET (
+                RANK
+            );)").GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "The rank could not be set automatically, the maximum rank of the resource pool classifier is too high: 9223372036854775807");
+    }
+
+    TString FetchResourcePoolClassifiers(TKikimrRunner& kikimr) {
+        auto& runtime = *kikimr.GetTestServer().GetRuntime();
+        const TActorId edgeActor = runtime.AllocateEdgeActor();
+        runtime.Send(NMetadata::NProvider::MakeServiceId(runtime.GetNodeId()), edgeActor, new NMetadata::NProvider::TEvAskSnapshot(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>()));
+
+        const auto response = runtime.GrabEdgeEvent<NMetadata::NProvider::TEvRefreshSubscriberData>(edgeActor);
+        UNIT_ASSERT(response);
+        return response->Get()->GetSnapshotAs<TResourcePoolClassifierSnapshot>()->SerializeToString();
+    }
+
+    Y_UNIT_TEST(CreateResourcePoolClassifier) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // Explicit rank
+        auto query = R"(
+            CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                RANK=20,
+                RESOURCE_POOL="test_pool",
+                MEMBERNAME="test@user"
+            );)";
+        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"membername\":\"test@user\",\"resource_pool\":\"test_pool\"},\"database\":\"\\/Root\"}]}");
+
+        // Auto rank
+        query = R"(
+            CREATE RESOURCE POOL CLASSIFIER AnotherResourcePoolClassifier WITH (
+                MEMBERNAME="another@user"
+            );)";
+        result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"membername\":\"test@user\",\"resource_pool\":\"test_pool\"},\"database\":\"\\/Root\"},{\"rank\":1020,\"name\":\"AnotherResourcePoolClassifier\",\"config\":{\"membername\":\"another@user\"},\"database\":\"\\/Root\"}]}");
+    }
+
+    Y_UNIT_TEST(DoubleCreateResourcePoolClassifier) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                    RANK=20
+                );)";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            auto query = R"(
+                CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                    RANK=1
+                );)";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Conflict with existing key");
+        }
+    }
+
+    Y_UNIT_TEST(AlterResourcePoolClassifier) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // Create sample pool
+        {
+            auto query = R"(
+                CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                    RANK=20,
+                    RESOURCE_POOL="test_pool"
+                );)";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"resource_pool\":\"test_pool\"},\"database\":\"\\/Root\"}]}");
+        }
+
+        // Test update one property
+        {
+            auto query = R"(
+                ALTER RESOURCE POOL CLASSIFIER MyResourcePoolClassifier
+                    SET (MEMBERNAME = "test@user")
+                )";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"membername\":\"test@user\",\"resource_pool\":\"test_pool\"},\"database\":\"\\/Root\"}]}");
+        }
+
+        // Create another pool
+        {
+            auto query = R"(
+                CREATE RESOURCE POOL CLASSIFIER AnotherResourcePoolClassifier WITH (
+                    RANK=42
+                );)";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"membername\":\"test@user\",\"resource_pool\":\"test_pool\"},\"database\":\"\\/Root\"},{\"rank\":42,\"name\":\"AnotherResourcePoolClassifier\",\"config\":{},\"database\":\"\\/Root\"}]}");
+        }
+
+        // Test reset
+        {
+            auto query = R"(
+                ALTER RESOURCE POOL CLASSIFIER MyResourcePoolClassifier
+                    RESET (RANK, RESOURCE_POOL);
+                )";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":1042,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"membername\":\"test@user\",\"resource_pool\":\"default\"},\"database\":\"\\/Root\"},{\"rank\":42,\"name\":\"AnotherResourcePoolClassifier\",\"config\":{},\"database\":\"\\/Root\"}]}");
+        }
+    }
+
+    Y_UNIT_TEST(DropResourcePoolClassifier) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableFeatureFlags()->SetEnableResourcePools(true);
+
+        TKikimrRunner kikimr(NKqp::TKikimrSettings()
+            .SetAppConfig(config)
+            .SetEnableResourcePools(true));
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto query = R"(
+                CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                    RANK=20
+                );)";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{},\"database\":\"\\/Root\"}]}");
+        }
+
+        {
+            auto query = "DROP RESOURCE POOL CLASSIFIER MyResourcePoolClassifier";
+            auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[]}");
+        }
     }
 }
 

--- a/ydb/core/kqp/workload_service/actors/actors.h
+++ b/ydb/core/kqp/workload_service/actors/actors.h
@@ -16,7 +16,7 @@ NActors::IActor* CreatePoolFetcherActor(const NActors::TActorId& replyActorId, c
 NActors::IActor* CreatePoolCreatorActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl);
 
 // Checks that database is serverless
-NActors::IActor* CreateDatabaseFetcherActor(const NActors::TActorId& replyActorId, const TString& database);
+NActors::IActor* CreateDatabaseFetcherActor(const NActors::TActorId& replyActorId, const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr, NACLib::EAccessRights checkAccess = NACLib::EAccessRights::NoAccess);
 
 // Cpu load fetcher actor
 NActors::IActor* CreateCpuLoadFetcherActor(const NActors::TActorId& replyActorId);

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -221,7 +221,7 @@ private:
         }
 
         Issues.AddIssues(std::move(issues));
-        Send(ReplyActorId, new TEvPrivate::TEvFetchPoolResponse(status, PoolConfig, PathIdFromPathId(PathId), std::move(Issues)));
+        Send(ReplyActorId, new TEvPrivate::TEvFetchPoolResponse(status, Database, PoolId, PoolConfig, PathIdFromPathId(PathId), std::move(Issues)));
         PassAway();
     }
 

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -179,7 +179,7 @@ protected:
     void StartRequest() override {
         LOG_D("Start pool fetching");
         auto event = NTableCreator::BuildSchemeCacheNavigateRequest(
-            {{".resource_pools", PoolId}},
+            {{".metadata/workload_manager/pools", PoolId}},
             Database,
             UserToken
         );
@@ -326,7 +326,7 @@ protected:
         auto event = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
 
         auto& schemeTx = *event->Record.MutableTransaction()->MutableModifyScheme();
-        schemeTx.SetWorkingDir(JoinPath({Database, ".resource_pools"}));
+        schemeTx.SetWorkingDir(JoinPath({Database, ".metadata/workload_manager/pools"}));
         schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateResourcePool);
         schemeTx.SetInternal(true);
 

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -390,10 +390,10 @@ private:
 
     void BuildCreatePoolRequest(NKikimrSchemeOp::TResourcePoolDescription& poolDescription) {
         poolDescription.SetName(PoolId);
-        for (auto& [property, value] : NResourcePool::GetPropertiesMap(PoolConfig)) {
+        for (auto& [property, value] : PoolConfig.GetPropertiesMap()) {
             poolDescription.MutableProperties()->MutableProperties()->insert({
                 property,
-                std::visit(NResourcePool::TSettingsExtractor{}, value)
+                std::visit(NResourcePool::TPoolSettings::TExtractor{}, value)
             });
         }
     }
@@ -445,9 +445,11 @@ private:
 
 class TDatabaseFetcherActor : public TSchemeActorBase<TDatabaseFetcherActor> {
 public:
-    TDatabaseFetcherActor(const TActorId& replyActorId, const TString& database)
+    TDatabaseFetcherActor(const TActorId& replyActorId, const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLib::EAccessRights checkAccess)
         : ReplyActorId(replyActorId)
         , Database(database)
+        , UserToken(userToken)
+        , CheckAccess(checkAccess)
     {}
 
     void DoBootstrap() {
@@ -467,10 +469,12 @@ public:
             case EStatus::PathNotTable:
             case EStatus::PathNotPath:
             case EStatus::RedirectLookupError:
-            case EStatus::AccessDenied:
             case EStatus::RootUnknown:
             case EStatus::PathErrorUnknown:
                 Reply(Ydb::StatusIds::NOT_FOUND, TStringBuilder() << "Database " << Database << " not found or you don't have access permissions");
+                return;
+            case EStatus::AccessDenied:
+                Reply(Ydb::StatusIds::UNAUTHORIZED, TStringBuilder() << "You don't have access permissions for database " << Database);
                 return;
             case EStatus::LookupError:
             case EStatus::TableCreationNotComplete:
@@ -496,8 +500,9 @@ public:
 protected:
     void StartRequest() override {
         LOG_D("Start database fetching");
-        auto event = NTableCreator::BuildSchemeCacheNavigateRequest({{}}, Database, nullptr);
+        auto event = NTableCreator::BuildSchemeCacheNavigateRequest({{}}, Database, UserToken);
         event->ResultSet[0].Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
+        event->ResultSet[0].Access |= CheckAccess;
         Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(event.Release()), IEventHandle::FlagTrackDelivery);
     }
 
@@ -529,6 +534,8 @@ private:
 private:
     const TActorId ReplyActorId;
     const TString Database;
+    const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    const NACLib::EAccessRights CheckAccess;
 
     bool Serverless = false;
 };
@@ -547,8 +554,8 @@ IActor* CreatePoolCreatorActor(const TActorId& replyActorId, const TString& data
     return new TPoolCreatorActor(replyActorId, database, poolId, poolConfig, userToken, diffAcl);
 }
 
-IActor* CreateDatabaseFetcherActor(const TActorId& replyActorId, const TString& database) {
-    return new TDatabaseFetcherActor(replyActorId, database);
+IActor* CreateDatabaseFetcherActor(const TActorId& replyActorId, const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLib::EAccessRights checkAccess) {
+    return new TDatabaseFetcherActor(replyActorId, database, userToken, checkAccess);
 }
 
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -483,12 +483,12 @@ public:
                 }
                 return;
             case EStatus::Ok:
+                if (!IsSubDomainPath(result)) {
+                    Reply(Ydb::StatusIds::UNSUPPORTED, TStringBuilder() << "Invalid database path " << Database << ", please check the correctness of the path");
+                    return;
+                }
                 if (result.DomainInfo) {
                     Serverless = result.DomainInfo->IsServerless();
-                    if (result.Self->Info.GetPathId() != result.DomainInfo->DomainKey.LocalPathId) {
-                        Reply(Ydb::StatusIds::UNSUPPORTED, TStringBuilder() << "Invalid database " << Database << ", domain path id is different");
-                        return;
-                    }
                 }
                 Reply(Ydb::StatusIds::SUCCESS);
                 return;
@@ -539,6 +539,18 @@ private:
         Issues.AddIssues(std::move(issues));
         Send(ReplyActorId, new TEvPrivate::TEvFetchDatabaseResponse(status, Database, Serverless, std::move(Issues)));
         PassAway();
+    }
+
+    static bool IsSubDomainPath(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry) {
+        switch (entry.Kind) {
+            case NSchemeCache::TSchemeCacheNavigate::EKind::KindSubdomain:
+            case NSchemeCache::TSchemeCacheNavigate::EKind::KindExtSubdomain:
+                return true;
+            case NSchemeCache::TSchemeCacheNavigate::EKind::KindPath:
+                return entry.Self->Info.GetPathId() == NSchemeShard::RootPathId;
+            default:
+                return false;
+        }
     }
 
 private:

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -180,7 +180,7 @@ protected:
         LOG_D("Start pool fetching");
         auto event = NTableCreator::BuildSchemeCacheNavigateRequest(
             {{".metadata/workload_manager/pools", PoolId}},
-            Database,
+            Database ? Database : AppData()->TenantName,
             UserToken
         );
         event->ResultSet[0].Access |= NACLib::SelectRow;
@@ -326,7 +326,7 @@ protected:
         auto event = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
 
         auto& schemeTx = *event->Record.MutableTransaction()->MutableModifyScheme();
-        schemeTx.SetWorkingDir(JoinPath({Database, ".metadata/workload_manager/pools"}));
+        schemeTx.SetWorkingDir(JoinPath({Database ? Database : AppData()->TenantName, ".metadata/workload_manager/pools"}));
         schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateResourcePool);
         schemeTx.SetInternal(true);
 
@@ -483,7 +483,13 @@ public:
                 }
                 return;
             case EStatus::Ok:
-                Serverless = result.DomainInfo && result.DomainInfo->IsServerless();
+                if (result.DomainInfo) {
+                    Serverless = result.DomainInfo->IsServerless();
+                    if (result.Self->Info.GetPathId() != result.DomainInfo->DomainKey.LocalPathId) {
+                        Reply(Ydb::StatusIds::UNSUPPORTED, TStringBuilder() << "Invalid database " << Database << ", domain path id is different");
+                        return;
+                    }
+                }
                 Reply(Ydb::StatusIds::SUCCESS);
                 return;
         }
@@ -500,7 +506,11 @@ public:
 protected:
     void StartRequest() override {
         LOG_D("Start database fetching");
-        auto event = NTableCreator::BuildSchemeCacheNavigateRequest({{}}, Database, UserToken);
+        auto event = NTableCreator::BuildSchemeCacheNavigateRequest(
+            {{}},
+            Database ? Database : AppData()->TenantName,
+            UserToken
+        );
         event->ResultSet[0].Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
         event->ResultSet[0].Access |= CheckAccess;
         Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(event.Release()), IEventHandle::FlagTrackDelivery);

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -166,6 +166,11 @@ struct TEvPrivate {
     };
 
     struct TEvStopPoolHandler : public NActors::TEventLocal<TEvStopPoolHandler, EvStopPoolHandler> {
+        explicit TEvStopPoolHandler(bool resetCounters)
+            : ResetCounters(resetCounters)
+        {}
+
+        const bool ResetCounters;
     };
 
     struct TEvCancelRequest : public NActors::TEventLocal<TEvCancelRequest, EvCancelRequest> {
@@ -196,11 +201,15 @@ struct TEvPrivate {
     };
 
     struct TEvCpuQuotaResponse : public NActors::TEventLocal<TEvCpuQuotaResponse, EvCpuQuotaResponse> {
-        explicit TEvCpuQuotaResponse(bool quotaAccepted)
+        explicit TEvCpuQuotaResponse(bool quotaAccepted, double maxClusterLoad, NYql::TIssues issues)
             : QuotaAccepted(quotaAccepted)
+            , MaxClusterLoad(maxClusterLoad)
+            , Issues(std::move(issues))
         {}
 
         const bool QuotaAccepted;
+        const double MaxClusterLoad;
+        const NYql::TIssues Issues;
     };
 
     struct TEvCpuLoadResponse : public NActors::TEventLocal<TEvCpuLoadResponse, EvCpuLoadResponse> {

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -30,6 +30,7 @@ struct TEvPrivate {
         EvResignPoolHandler,
         EvStopPoolHandler,
         EvCancelRequest,
+        EvUpdatePoolSubscription,
 
         EvCpuQuotaRequest,
         EvCpuQuotaResponse,
@@ -75,14 +76,18 @@ struct TEvPrivate {
     };
 
     struct TEvFetchPoolResponse : public NActors::TEventLocal<TEvFetchPoolResponse, EvFetchPoolResponse> {
-        TEvFetchPoolResponse(Ydb::StatusIds::StatusCode status, const NResourcePool::TPoolSettings& poolConfig, TPathId pathId, NYql::TIssues issues)
+        TEvFetchPoolResponse(Ydb::StatusIds::StatusCode status, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TPathId pathId, NYql::TIssues issues)
             : Status(status)
+            , Database(database)
+            , PoolId(poolId)
             , PoolConfig(poolConfig)
             , PathId(pathId)
             , Issues(std::move(issues))
         {}
 
         const Ydb::StatusIds::StatusCode Status;
+        const TString Database;
+        const TString PoolId;
         const NResourcePool::TPoolSettings PoolConfig;
         const TPathId PathId;
         const NYql::TIssues Issues;
@@ -169,6 +174,16 @@ struct TEvPrivate {
         {}
 
         const TString SessionId;
+    };
+
+    struct TEvUpdatePoolSubscription : public NActors::TEventLocal<TEvUpdatePoolSubscription, EvUpdatePoolSubscription> {
+        explicit TEvUpdatePoolSubscription(TPathId pathId, const std::unordered_set<TActorId>& subscribers)
+            : PathId(pathId)
+            , Subscribers(subscribers)
+        {}
+
+        const TPathId PathId;
+        const std::unordered_set<TActorId> Subscribers;
     };
 
     // Cpu load requests

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -45,6 +45,8 @@ struct TEvPrivate {
         EvStartRequestResponse,
         EvCleanupRequestsResponse,
 
+        EvRanksCheckerResponse,
+
         EvEnd
     };
 
@@ -293,6 +295,21 @@ struct TEvPrivate {
 
         const Ydb::StatusIds::StatusCode Status;
         const std::vector<TString> SesssionIds;
+        const NYql::TIssues Issues;
+    };
+
+    // Resource pool classifier events
+    struct TEvRanksCheckerResponse : public TEventLocal<TEvRanksCheckerResponse, EvRanksCheckerResponse> {
+        TEvRanksCheckerResponse(Ydb::StatusIds::StatusCode status, i64 maxRank, ui64 numberClassifiers, NYql::TIssues issues)
+            : Status(status)
+            , MaxRank(maxRank)
+            , NumberClassifiers(numberClassifiers)
+            , Issues(std::move(issues))
+        {}
+
+        const Ydb::StatusIds::StatusCode Status;
+        const i64 MaxRank;
+        const ui64 NumberClassifiers;
         const NYql::TIssues Issues;
     };
 };

--- a/ydb/core/kqp/workload_service/common/helpers.cpp
+++ b/ydb/core/kqp/workload_service/common/helpers.cpp
@@ -13,9 +13,9 @@ NYql::TIssues GroupIssues(const NYql::TIssues& issues, const TString& message) {
 
 void ParsePoolSettings(const NKikimrSchemeOp::TResourcePoolDescription& description, NResourcePool::TPoolSettings& poolConfig) {
     const auto& properties = description.GetProperties().GetProperties();
-    for (auto& [property, value] : NResourcePool::GetPropertiesMap(poolConfig)) {
+    for (auto& [property, value] : poolConfig.GetPropertiesMap()) {
         if (auto propertyIt = properties.find(property); propertyIt != properties.end()) {
-            std::visit(NResourcePool::TSettingsParser{propertyIt->second}, value);
+            std::visit(NResourcePool::TPoolSettings::TParser{propertyIt->second}, value);
         }
     }
 }

--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -381,7 +381,7 @@ private:
 
         if (auto poolState = GetPoolState(database, poolId)) {
             if (poolState->NewPoolHandler) {
-                Send(*poolState->NewPoolHandler, new TEvPrivate::TEvStopPoolHandler());
+                Send(*poolState->NewPoolHandler, new TEvPrivate::TEvStopPoolHandler(false));
             }
             poolState->NewPoolHandler = ev->Get()->NewHandler;
             poolState->UpdateHandler();
@@ -443,7 +443,7 @@ private:
         for (const auto& [poolKey, poolState] : PoolIdToState) {
             if (!poolState.InFlightRequests && TInstant::Now() - poolState.LastUpdateTime > IDLE_DURATION) {
                 CpuQuotaManager->CleanupHandler(poolState.PoolHandler);
-                Send(poolState.PoolHandler, new TEvPrivate::TEvStopPoolHandler());
+                Send(poolState.PoolHandler, new TEvPrivate::TEvStopPoolHandler(true));
                 poolsToDelete.emplace_back(poolKey);
             }
         }

--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -74,6 +74,7 @@ public:
 
         EnabledResourcePools = AppData()->FeatureFlags.GetEnableResourcePools();
         EnabledResourcePoolsOnServerless = AppData()->FeatureFlags.GetEnableResourcePoolsOnServerless();
+        EnableResourcePoolsCounters = AppData()->FeatureFlags.GetEnableResourcePoolsCounters();
         if (EnabledResourcePools) {
             InitializeWorkloadService();
         }
@@ -101,6 +102,7 @@ public:
 
         EnabledResourcePools = event.GetConfig().GetFeatureFlags().GetEnableResourcePools();
         EnabledResourcePoolsOnServerless = event.GetConfig().GetFeatureFlags().GetEnableResourcePoolsOnServerless();
+        EnableResourcePoolsCounters = event.GetConfig().GetFeatureFlags().GetEnableResourcePoolsCounters();
         if (EnabledResourcePools) {
             LOG_I("Resource pools was enanbled");
             InitializeWorkloadService();
@@ -526,7 +528,7 @@ private:
 
         LOG_I("Creating new handler for pool " << poolKey);
 
-        const auto poolHandler = Register(CreatePoolHandlerActor(database, poolId, poolConfig, Counters.Counters));
+        const auto poolHandler = Register(CreatePoolHandlerActor(database, poolId, poolConfig, EnableResourcePoolsCounters ? Counters.Counters : MakeIntrusive<NMonitoring::TDynamicCounters>()));
         const auto poolState = &PoolIdToState.insert({poolKey, TPoolState{.PoolHandler = poolHandler, .ActorContext = ActorContext()}}).first->second;
 
         Counters.ActivePools->Inc();
@@ -560,6 +562,7 @@ private:
 
     bool EnabledResourcePools = false;
     bool EnabledResourcePoolsOnServerless = false;
+    bool EnableResourcePoolsCounters = false;
     bool ServiceInitialized = false;
     bool IdleChecksStarted = false;
     ETablesCreationStatus TablesCreationStatus = ETablesCreationStatus::Cleanup;

--- a/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
+++ b/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
@@ -121,7 +121,7 @@ struct TPoolState {
             return;
         }
 
-        ActorContext.Send(PoolHandler, new TEvPrivate::TEvStopPoolHandler());
+        ActorContext.Send(PoolHandler, new TEvPrivate::TEvStopPoolHandler(false));
         PoolHandler = *NewPoolHandler;
         NewPoolHandler = std::nullopt;
         InFlightRequests = 0;
@@ -160,7 +160,7 @@ struct TCpuQuotaManagerState {
         auto response = CpuQuotaManager.RequestCpuQuota(0.0, maxClusterLoad);
 
         bool quotaAccepted = response.Status == NYdb::EStatus::SUCCESS;
-        ActorContext.Send(poolHandler, new TEvPrivate::TEvCpuQuotaResponse(quotaAccepted), 0, coockie);
+        ActorContext.Send(poolHandler, new TEvPrivate::TEvCpuQuotaResponse(quotaAccepted, maxClusterLoad, std::move(response.Issues)), 0, coockie);
 
         // Schedule notification
         if (!quotaAccepted) {

--- a/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
+++ b/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
@@ -2,6 +2,7 @@
 
 #include <queue>
 
+#include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/workload_service/actors/actors.h>
 #include <ydb/core/kqp/workload_service/common/cpu_quota_manager.h>
 #include <ydb/core/kqp/workload_service/common/events.h>
@@ -18,10 +19,21 @@ struct TDatabaseState {
     bool& EnabledResourcePoolsOnServerless;
 
     std::vector<TEvPlaceRequestIntoPool::TPtr> PendingRequersts = {};
+    std::unordered_map<TString, std::unordered_set<TActorId>> PendingSubscriptions = {};
     bool HasDefaultPool = false;
     bool Serverless = false;
 
     TInstant LastUpdateTime = TInstant::Zero();
+
+    void DoSubscribeRequest(TEvSubscribeOnPoolChanges::TPtr ev) {
+        const TString& poolId = ev->Get()->PoolId;
+        auto& subscribers = PendingSubscriptions[poolId];
+        if (subscribers.empty()) {
+            ActorContext.Register(CreatePoolFetcherActor(ActorContext.SelfID, ev->Get()->Database, poolId, nullptr));
+        }
+
+        subscribers.emplace(ev->Sender);
+    }
 
     void DoPlaceRequest(TEvPlaceRequestIntoPool::TPtr ev) {
         TString database = ev->Get()->Database;
@@ -34,10 +46,32 @@ struct TDatabaseState {
         }
     }
 
+    void UpdatePoolInfo(const TEvPrivate::TEvFetchPoolResponse::TPtr& ev, NActors::TActorId poolHandler) {
+        const TString& poolId = ev->Get()->PoolId;
+        auto& subscribers = PendingSubscriptions[poolId];
+        if (subscribers.empty()) {
+            return;
+        }
+
+        if (ev->Get()->Status == Ydb::StatusIds::SUCCESS && poolHandler) {
+            ActorContext.Send(poolHandler, new TEvPrivate::TEvUpdatePoolSubscription(ev->Get()->PathId, subscribers));
+        } else {
+            const TString& database = ev->Get()->Database;
+            for (const auto& subscriber : subscribers) {
+                ActorContext.Send(subscriber, new TEvUpdatePoolInfo(database, poolId, std::nullopt, std::nullopt));
+            }
+        }
+        subscribers.clear();
+    }
+
     void UpdateDatabaseInfo(const TEvPrivate::TEvFetchDatabaseResponse::TPtr& ev) {
         if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
             ReplyContinueError(ev->Get()->Status, GroupIssues(ev->Get()->Issues, "Failed to fetch database info"));
             return;
+        }
+
+        if (Serverless != ev->Get()->Serverless) {
+            ActorContext.Send(MakeKqpProxyID(ActorContext.SelfID.NodeId()), new TEvUpdateDatabaseInfo(ev->Get()->Database, ev->Get()->Serverless));
         }
 
         LastUpdateTime = TInstant::Now();

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -230,6 +230,7 @@ private:
     TAppConfig GetAppConfig() const {
         TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetEnableResourcePools(Settings_.EnableResourcePools_);
+        appConfig.MutableFeatureFlags()->SetEnableResourcePoolsCounters(true);
 
         return appConfig;
     }

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -354,7 +354,7 @@ public:
         auto token = NACLib::TUserToken(userSID, {});
 
         WaitFor(FUTURE_WAIT_TIMEOUT, "pool acl", [this, token, access, poolId](TString& errorString) {
-            auto response = Navigate(TStringBuilder() << ".resource_pools/" << (poolId ? poolId : Settings_.PoolId_));
+            auto response = Navigate(TStringBuilder() << ".metadata/workload_manager/pools/" << (poolId ? poolId : Settings_.PoolId_));
             if (!response) {
                 errorString = "empty response";
                 return false;

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -14,7 +14,7 @@
 
 namespace NKikimr::NKqp::NWorkload {
 
-inline constexpr TDuration FUTURE_WAIT_TIMEOUT = TDuration::Seconds(30);
+inline constexpr TDuration FUTURE_WAIT_TIMEOUT = TDuration::Seconds(60);
 
 
 // Query runner

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -122,12 +122,6 @@ struct TSampleQueries {
     }
 
     template <typename TResult>
-    static void CheckOverloaded(const TResult& result, const TString& poolId) {
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::OVERLOADED, result.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), TStringBuilder() << "Too many pending requests for pool " << poolId);
-    }
-
-    template <typename TResult>
     static void CheckCancelled(const TResult& result) {
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::CANCELLED, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Request timeout exceeded, cancelling after");

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -24,7 +24,7 @@ struct TQueryRunnerSettings {
 
     // Query settings
     FLUENT_SETTING_DEFAULT(ui32, NodeIndex, 0);
-    FLUENT_SETTING_DEFAULT(TString, PoolId, "");
+    FLUENT_SETTING_DEFAULT(std::optional<TString>, PoolId, std::nullopt);
     FLUENT_SETTING_DEFAULT(TString, UserSID, "user@" BUILTIN_SYSTEM_DOMAIN);
 
     // Runner settings
@@ -76,6 +76,7 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(double, QueryMemoryLimitPercentPerNode, -1);
     FLUENT_SETTING_DEFAULT(double, DatabaseLoadCpuThreshold, -1);
 
+    NResourcePool::TPoolSettings GetDefaultPoolSettings() const;
     TIntrusivePtr<IYdbSetup> Create() const;
 };
 

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
@@ -1,5 +1,6 @@
 #include <ydb/core/base/appdata_fwd.h>
 
+#include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/workload_service/actors/actors.h>
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
 
@@ -161,6 +162,94 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
         UNIT_ASSERT_VALUES_EQUAL_C(response->Get()->Status, Ydb::StatusIds::SUCCESS, response->Get()->Issues.ToOneLineString());
         UNIT_ASSERT_VALUES_EQUAL(response->Get()->CpuNumber, threads * nodeCount);
         UNIT_ASSERT_DOUBLES_EQUAL(response->Get()->InstantLoad, usage, 0.01);
+    }
+}
+
+Y_UNIT_TEST_SUITE(KqpWorkloadServiceSubscriptions) {
+    TActorId SubscribeOnPool(TIntrusivePtr<IYdbSetup> ydb) {
+        const auto& settings = ydb->GetSettings();
+        auto& runtime = *ydb->GetRuntime();
+        const auto& edgeActor = runtime.AllocateEdgeActor();
+
+        runtime.Send(MakeKqpWorkloadServiceId(runtime.GetNodeId()), edgeActor, new TEvSubscribeOnPoolChanges(settings.DomainName_, settings.PoolId_));
+        const auto& response = runtime.GrabEdgeEvent<TEvUpdatePoolInfo>(edgeActor, FUTURE_WAIT_TIMEOUT);
+        UNIT_ASSERT_C(response, "Subscription update not found");
+
+        const auto& config = response->Get()->Config;
+        UNIT_ASSERT_C(config, "Pool config not found");
+        UNIT_ASSERT_C(*config == settings.GetDefaultPoolSettings(), "Unexpected pool config");
+
+        const auto& securityObject = response->Get()->SecurityObject;
+        UNIT_ASSERT_C(securityObject, "Security object not found");
+        UNIT_ASSERT_VALUES_EQUAL_C(securityObject->GetOwnerSID(), BUILTIN_ACL_ROOT, "Unexpected owner user SID");
+
+        return edgeActor;
+    }
+
+    Y_UNIT_TEST(TestResourcePoolSubscription) {
+        auto ydb = TYdbSetupSettings()
+            .QueueSize(10)
+            .ConcurrentQueryLimit(5)
+            .QueryCancelAfter(TDuration::Seconds(42))
+            .QueryMemoryLimitPercentPerNode(55.0)
+            .DatabaseLoadCpuThreshold(30.0)
+            .Create();
+
+        SubscribeOnPool(ydb);
+    }
+
+    Y_UNIT_TEST(TestResourcePoolSubscriptionAfterAlter) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const auto& subscriber = SubscribeOnPool(ydb);
+
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            ALTER RESOURCE POOL )" << ydb->GetSettings().PoolId_ << R"( SET (
+                QUEUE_SIZE=42
+            );
+        )");
+
+        const auto& response = ydb->GetRuntime()->GrabEdgeEvent<TEvUpdatePoolInfo>(subscriber, FUTURE_WAIT_TIMEOUT);
+        UNIT_ASSERT_C(response, "Subscription update not found");
+
+        const auto& config = response->Get()->Config;
+        UNIT_ASSERT_C(config, "Pool config not found");
+        UNIT_ASSERT_VALUES_EQUAL(config->QueueSize, 42);
+    }
+
+    Y_UNIT_TEST(TestResourcePoolSubscriptionAfterAclChange) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const auto& subscriber = SubscribeOnPool(ydb);
+
+        const TString& userSID = "test@user";
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            GRANT ALL ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << R"(` TO `)" << userSID << R"(`;
+        )");
+
+        const auto& response = ydb->GetRuntime()->GrabEdgeEvent<TEvUpdatePoolInfo>(subscriber, FUTURE_WAIT_TIMEOUT);
+        UNIT_ASSERT_C(response, "Subscription update not found");
+
+        const auto& securityObject = response->Get()->SecurityObject;
+        UNIT_ASSERT_C(securityObject, "Security object not found");
+
+        NACLib::TUserToken token("", userSID, {});
+        UNIT_ASSERT_C(securityObject->CheckAccess(NACLib::GenericFull, token), TStringBuilder() << "Unexpected pool access rights: " << securityObject->ToString());
+    }
+
+    Y_UNIT_TEST(TestResourcePoolSubscriptionAfterDrop) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const auto& subscriber = SubscribeOnPool(ydb);
+
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            DROP RESOURCE POOL )" << ydb->GetSettings().PoolId_ << R"(;
+        )");
+
+        const auto& response = ydb->GetRuntime()->GrabEdgeEvent<TEvUpdatePoolInfo>(subscriber, FUTURE_WAIT_TIMEOUT);
+        UNIT_ASSERT_C(response, "Subscription update not found");
+        UNIT_ASSERT_C(!response->Get()->Config, "Unexpected pool config");
+        UNIT_ASSERT_C(!response->Get()->SecurityObject, "Unexpected security object");
     }
 }
 

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
@@ -58,7 +58,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
 
         const TString& userSID = "user@test";
         TSampleQueries::CheckSuccess(ydb->ExecuteQuery(TStringBuilder() << R"(
-            GRANT DESCRIBE SCHEMA ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
+            GRANT DESCRIBE SCHEMA ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
         ));
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::DescribeSchema);
 
@@ -67,7 +67,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
         UNIT_ASSERT_STRING_CONTAINS(failedResponse->Get()->Issues.ToString(), TStringBuilder() << "You don't have access permissions for resource pool " << ydb->GetSettings().PoolId_);
 
         TSampleQueries::CheckSuccess(ydb->ExecuteQuery(TStringBuilder() << R"(
-            GRANT SELECT ROW ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
+            GRANT SELECT ROW ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
         ));
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::SelectRow);
 
@@ -86,7 +86,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
     Y_UNIT_TEST(TestCreateDefaultPool) {
         auto ydb = TYdbSetupSettings().Create();
 
-        const TString path = TStringBuilder() << ".resource_pools/" << NResourcePool::DEFAULT_POOL_ID;
+        const TString path = TStringBuilder() << ".metadata/workload_manager/pools/" << NResourcePool::DEFAULT_POOL_ID;
         auto response = ydb->Navigate(path, NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
         UNIT_ASSERT_VALUES_EQUAL(response->ErrorCount, 1);
         UNIT_ASSERT_VALUES_EQUAL(response->ResultSet.at(0).Kind, NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown);
@@ -224,7 +224,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceSubscriptions) {
 
         const TString& userSID = "test@user";
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
-            GRANT ALL ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << R"(` TO `)" << userSID << R"(`;
+            GRANT ALL ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << R"(` TO `)" << userSID << R"(`;
         )");
 
         const auto& response = ydb->GetRuntime()->GrabEdgeEvent<TEvUpdatePoolInfo>(subscriber, FUTURE_WAIT_TIMEOUT);

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
@@ -70,7 +70,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceTables) {
             CanonizePath({ydb->GetSettings().DomainName_, ".metadata/workload_manager"})
         ).GetValue(FUTURE_WAIT_TIMEOUT);
         UNIT_ASSERT_VALUES_EQUAL_C(listResult.GetStatus(), NYdb::EStatus::SUCCESS, listResult.GetIssues().ToString());
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 3);
     }
 
     Y_UNIT_TEST(TestTablesIsNotCreatingForUnlimitedPool) {
@@ -83,12 +83,11 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceTables) {
 
         // Check that there is no .metadata folder
         auto listResult = ydb->GetSchemeClient().ListDirectory(
-            CanonizePath(ydb->GetSettings().DomainName_)
+            CanonizePath({ydb->GetSettings().DomainName_, ".metadata", "workload_manager"})
         ).GetValue(FUTURE_WAIT_TIMEOUT);
         UNIT_ASSERT_VALUES_EQUAL_C(listResult.GetStatus(), NYdb::EStatus::SUCCESS, listResult.GetIssues().ToString());
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[0].Name, ".resource_pools");
-        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[1].Name, ".sys");
+        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren().size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(listResult.GetChildren()[0].Name, "pools");
     }
 
     Y_UNIT_TEST(TestPoolStateFetcherActor) {

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -480,7 +480,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolsDdl) {
         );
 
         IYdbSetup::WaitFor(FUTURE_WAIT_TIMEOUT, "pool drop", [ydb, poolId](TString& errorString) {
-            auto kind = ydb->Navigate(TStringBuilder() << ".resource_pools/" << poolId)->ResultSet.at(0).Kind;
+            auto kind = ydb->Navigate(TStringBuilder() << ".metadata/workload_manager/pools/" << poolId)->ResultSet.at(0).Kind;
 
             errorString = TStringBuilder() << "kind = " << kind;
             return kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown;
@@ -500,7 +500,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolsDdl) {
             CREATE RESOURCE POOL )" << poolId << R"( WITH (
                 CONCURRENT_QUERY_LIMIT=1
             );
-            GRANT DESCRIBE SCHEMA ON `/Root/.resource_pools/)" << poolId << "` TO `" << userSID << "`;"
+            GRANT DESCRIBE SCHEMA ON `/Root/.metadata/workload_manager/pools/)" << poolId << "` TO `" << userSID << "`;"
         );
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::DescribeSchema, poolId);
 
@@ -510,7 +510,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolsDdl) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), TStringBuilder() << "You don't have access permissions for resource pool " << poolId);
 
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
-            GRANT SELECT ROW ON `/Root/.resource_pools/)" << poolId << "` TO `" << userSID << "`;"
+            GRANT SELECT ROW ON `/Root/.metadata/workload_manager/pools/)" << poolId << "` TO `" << userSID << "`;"
         );
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::SelectRow, poolId);
         TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings));
@@ -524,7 +524,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
         const TString& userSID = "user@test";
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             GRANT DESCRIBE SCHEMA ON `/Root` TO `)" << userSID << R"(`;
-            GRANT DESCRIBE SCHEMA, SELECT ROW ON `/Root/.resource_pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
+            GRANT DESCRIBE SCHEMA, SELECT ROW ON `/Root/.metadata/workload_manager/pools/)" << ydb->GetSettings().PoolId_ << "` TO `" << userSID << "`;"
         );
         ydb->WaitPoolAccess(userSID, NACLib::EAccessRights::DescribeSchema | NACLib::EAccessRights::SelectRow);
 

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
@@ -1,0 +1,40 @@
+#include "resource_pool_classifier_settings.h"
+
+
+namespace NKikimr::NResourcePool {
+
+//// TClassifierSettings::TParser
+
+void TClassifierSettings::TParser::operator()(i64* setting) const {
+    *setting = FromString<i64>(Value);
+    if (*setting < -1) {
+        throw yexception() << "Invalid integer value " << *setting << ", it is should be greater or equal -1";
+    }
+}
+
+void TClassifierSettings::TParser::operator()(TString* setting) const {
+    *setting = Value;
+}
+
+//// TClassifierSettings::TExtractor
+
+TString TClassifierSettings::TExtractor::operator()(i64* setting) const {
+    return ToString(*setting);
+}
+
+TString TClassifierSettings::TExtractor::operator()(TString* setting) const {
+    return *setting;
+}
+
+//// TPoolSettings
+
+std::unordered_map<TString, TClassifierSettings::TProperty> TClassifierSettings::GetPropertiesMap() {
+    std::unordered_map<TString, TProperty> properties = {
+        {"rank", &Rank},
+        {"resource_pool", &ResourcePool},
+        {"membername", &Membername}
+    };
+    return properties;
+}
+
+}  // namespace NKikimr::NResourcePool

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.h
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "resource_pool_settings.h"
+
+#include <unordered_map>
+
+
+namespace NKikimr::NResourcePool {
+
+inline constexpr i64 CLASSIFIER_RANK_OFFSET = 1000;
+inline constexpr i64 CLASSIFIER_COUNT_LIMIT = 1000;
+
+struct TClassifierSettings : public TSettingsBase {
+    using TBase = TSettingsBase;
+    using TProperty = std::variant<i64*, TString*>;
+
+    struct TParser : public TBase::TParser {
+        void operator()(i64* setting) const;
+        void operator()(TString* setting) const;
+    };
+
+    struct TExtractor : public TBase::TExtractor {
+        TString operator()(i64* setting) const;
+        TString operator()(TString* setting) const;
+    };
+
+    bool operator==(const TClassifierSettings& other) const = default;
+    std::unordered_map<TString, TProperty> GetPropertiesMap();
+
+    i64 Rank = -1;  // -1 = max rank + CLASSIFIER_RANK_OFFSET
+    TString ResourcePool = DEFAULT_POOL_ID;
+    TString Membername = "";
+};
+
+}  // namespace NKikimr::NResourcePool

--- a/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
@@ -1,0 +1,52 @@
+#include "resource_pool_classifier_settings.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+
+namespace NKikimr {
+
+using namespace NResourcePool;
+
+
+Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
+    Y_UNIT_TEST(IntSettingsParsing) {
+        TClassifierSettings settings;
+        auto propertiesMap = settings.GetPropertiesMap();
+
+        std::visit(TClassifierSettings::TParser{"0"}, propertiesMap["rank"]);
+        UNIT_ASSERT_VALUES_EQUAL(settings.Rank, 0);
+
+        std::visit(TClassifierSettings::TParser{"123"}, propertiesMap["rank"]);
+        UNIT_ASSERT_VALUES_EQUAL(settings.Rank, 123);
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TClassifierSettings::TParser{"string_value"}, propertiesMap["rank"]), TFromStringException, "Unexpected symbol \"s\" at pos 0 in string \"string_value\".");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TClassifierSettings::TParser{"9223372036854775808"}, propertiesMap["rank"]), TFromStringException, "Integer overflow in string \"9223372036854775808\".");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TClassifierSettings::TParser{"-2"}, propertiesMap["rank"]), yexception, "Invalid integer value -2, it is should be greater or equal -1");
+    }
+
+    Y_UNIT_TEST(StringSettingsParsing) {
+        TClassifierSettings settings;
+        auto propertiesMap = settings.GetPropertiesMap();
+
+        std::visit(TClassifierSettings::TParser{"test_pool"}, propertiesMap["resource_pool"]);
+        UNIT_ASSERT_VALUES_EQUAL(settings.ResourcePool, "test_pool");
+
+        std::visit(TClassifierSettings::TParser{"test@user"}, propertiesMap["membername"]);
+        UNIT_ASSERT_VALUES_EQUAL(settings.Membername, "test@user");
+    }
+
+    Y_UNIT_TEST(SettingsExtracting) {
+        TClassifierSettings settings;
+        settings.Rank = 123;
+        settings.ResourcePool = "test_pool";
+        settings.Membername = "test@user";
+        auto propertiesMap = settings.GetPropertiesMap();
+
+        TClassifierSettings::TExtractor extractor;
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["rank"]), "123");
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["resource_pool"]), "test_pool");
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["membername"]), "test@user");
+    }
+}
+
+}  // namespace NKikimr

--- a/ydb/core/resource_pools/resource_pool_settings.cpp
+++ b/ydb/core/resource_pools/resource_pool_settings.cpp
@@ -3,15 +3,55 @@
 
 namespace NKikimr::NResourcePool {
 
-std::unordered_map<TString, TProperty> GetPropertiesMap(TPoolSettings& settings, bool restricted) {
+//// TPoolSettings::TParser
+
+void TPoolSettings::TParser::operator()(i32* setting) const {
+    *setting = FromString<i32>(Value);
+    if (*setting < -1) {
+        throw yexception() << "Invalid integer value " << *setting << ", it is should be greater or equal -1";
+    }
+}
+
+void TPoolSettings::TParser::operator()(TDuration* setting) const {
+    ui64 seconds = FromString<ui64>(Value);
+    if (seconds > std::numeric_limits<ui64>::max() / 1000) {
+        throw yexception() << "Invalid seconds value " << seconds << ", it is should be less or equal than " << std::numeric_limits<ui64>::max() / 1000;
+    }
+    *setting = TDuration::Seconds(seconds);
+}
+
+void TPoolSettings::TParser::operator()(TPercent* setting) const {
+    *setting = FromString<TPercent>(Value);
+    if (*setting != -1 && (*setting < 0 || 100 < *setting)) {
+        throw yexception() << "Invalid percent value " << *setting << ", it is should be between 0 and 100 or -1";
+    }
+}
+
+//// TPoolSettings::TExtractor
+
+TString TPoolSettings::TExtractor::operator()(i32* setting) const {
+    return ToString(*setting);
+}
+
+TString TPoolSettings::TExtractor::operator()(double* setting) const {
+    return ToString(*setting);
+}
+
+TString TPoolSettings::TExtractor::operator()(TDuration* setting) const {
+    return ToString(setting->Seconds());
+}
+
+//// TPoolSettings
+
+std::unordered_map<TString, TPoolSettings::TProperty> TPoolSettings::GetPropertiesMap(bool restricted) {
     std::unordered_map<TString, TProperty> properties = {
-        {"concurrent_query_limit", &settings.ConcurrentQueryLimit},
-        {"queue_size", &settings.QueueSize},
-        {"query_memory_limit_percent_per_node", &settings.QueryMemoryLimitPercentPerNode},
-        {"database_load_cpu_threshold", &settings.DatabaseLoadCpuThreshold}
+        {"concurrent_query_limit", &ConcurrentQueryLimit},
+        {"queue_size", &QueueSize},
+        {"query_memory_limit_percent_per_node", &QueryMemoryLimitPercentPerNode},
+        {"database_load_cpu_threshold", &DatabaseLoadCpuThreshold}
     };
     if (!restricted) {
-        properties.insert({"query_cancel_after_seconds", &settings.QueryCancelAfter});
+        properties.insert({"query_cancel_after_seconds", &QueryCancelAfter});
     }
     return properties;
 }

--- a/ydb/core/resource_pools/resource_pool_settings.h
+++ b/ydb/core/resource_pools/resource_pool_settings.h
@@ -1,66 +1,40 @@
 #pragma once
 
+#include "settings_common.h"
+
 #include <util/datetime/base.h>
-#include <util/string/cast.h>
 
 
 namespace NKikimr::NResourcePool {
 
 inline constexpr char DEFAULT_POOL_ID[] = "default";
 
-typedef double TPercent;
+struct TPoolSettings : public TSettingsBase {
+    typedef double TPercent;
 
-struct TPoolSettings {
+    using TBase = TSettingsBase;
+    using TProperty = std::variant<i32*, TDuration*, TPercent*>;
+
+    struct TParser : public TBase::TParser {
+        void operator()(i32* setting) const;
+        void operator()(TDuration* setting) const;
+        void operator()(TPercent* setting) const;
+    };
+
+    struct TExtractor : public TBase::TExtractor {
+        TString operator()(i32* setting) const;
+        TString operator()(double* setting) const;
+        TString operator()(TDuration* setting) const;
+    };
+
+    bool operator==(const TPoolSettings& other) const = default;
+    std::unordered_map<TString, TProperty> GetPropertiesMap(bool restricted = false);
+
     i32 ConcurrentQueryLimit = -1;  // -1 = disabled
     i32 QueueSize = -1;  // -1 = disabled
     TDuration QueryCancelAfter = TDuration::Zero();  // 0 = disabled
-
     TPercent QueryMemoryLimitPercentPerNode = -1;  // Percent from node memory capacity, -1 = disabled
-
     TPercent DatabaseLoadCpuThreshold = -1;  // -1 = disabled
-
-    bool operator==(const TPoolSettings& other) const = default;
 };
-
-struct TSettingsParser {
-    const TString& value;
-
-    void operator()(i32* setting) const {
-        *setting = FromString<i32>(value);
-        if (*setting < -1) {
-            throw yexception() << "Invalid integer value " << *setting << ", it is should be greater or equal -1";
-        }
-    }
-
-    void operator()(TDuration* setting) const {
-        ui64 seconds = FromString<ui64>(value);
-        if (seconds > std::numeric_limits<ui64>::max() / 1000) {
-            throw yexception() << "Invalid seconds value " << seconds << ", it is should be less or equal than " << std::numeric_limits<ui64>::max() / 1000;
-        }
-        *setting = TDuration::Seconds(seconds);
-    }
-
-    void operator()(TPercent* setting) const {
-        *setting = FromString<TPercent>(value);
-        if (*setting != -1 && (*setting < 0 || 100 < *setting)) {
-            throw yexception() << "Invalid percent value " << *setting << ", it is should be between 0 and 100 or -1";
-        }
-    }
-};
-
-struct TSettingsExtractor {
-    template <typename T>
-    TString operator()(T* setting) const {
-        return ToString(*setting);
-    }
-
-    template <>
-    TString operator()(TDuration* setting) const {
-        return ToString(setting->Seconds());
-    }
-};
-
-using TProperty = std::variant<i32*, TDuration*, TPercent*>;
-std::unordered_map<TString, TProperty> GetPropertiesMap(TPoolSettings& settings, bool restricted = false);
 
 }  // namespace NKikimr::NResourcePool

--- a/ydb/core/resource_pools/resource_pool_settings_ut.cpp
+++ b/ydb/core/resource_pools/resource_pool_settings_ut.cpp
@@ -11,52 +11,52 @@ using namespace NResourcePool;
 Y_UNIT_TEST_SUITE(ResourcePoolTest) {
     Y_UNIT_TEST(IntSettingsParsing) {
         TPoolSettings settings;
-        auto propertiesMap = GetPropertiesMap(settings);
+        auto propertiesMap = settings.GetPropertiesMap();
 
-        std::visit(TSettingsParser{"-1"}, propertiesMap["queue_size"]);
+        std::visit(TPoolSettings::TParser{"-1"}, propertiesMap["queue_size"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueueSize, -1);
 
-        std::visit(TSettingsParser{"10"}, propertiesMap["queue_size"]);
+        std::visit(TPoolSettings::TParser{"10"}, propertiesMap["queue_size"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueueSize, 10);
 
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"string_value"}, propertiesMap["queue_size"]), TFromStringException, "Unexpected symbol \"s\" at pos 0 in string \"string_value\".");
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"2147483648"}, propertiesMap["queue_size"]), TFromStringException, "Integer overflow in string \"2147483648\".");
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"-2"}, propertiesMap["queue_size"]), yexception, "Invalid integer value -2, it is should be greater or equal -1");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"string_value"}, propertiesMap["queue_size"]), TFromStringException, "Unexpected symbol \"s\" at pos 0 in string \"string_value\".");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"2147483648"}, propertiesMap["queue_size"]), TFromStringException, "Integer overflow in string \"2147483648\".");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"-2"}, propertiesMap["queue_size"]), yexception, "Invalid integer value -2, it is should be greater or equal -1");
     }
 
     Y_UNIT_TEST(SecondsSettingsParsing) {
         TPoolSettings settings;
-        auto propertiesMap = GetPropertiesMap(settings);
+        auto propertiesMap = settings.GetPropertiesMap();
 
-        std::visit(TSettingsParser{"0"}, propertiesMap["query_cancel_after_seconds"]);
+        std::visit(TPoolSettings::TParser{"0"}, propertiesMap["query_cancel_after_seconds"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueryCancelAfter, TDuration::Zero());
 
-        std::visit(TSettingsParser{"10"}, propertiesMap["query_cancel_after_seconds"]);
+        std::visit(TPoolSettings::TParser{"10"}, propertiesMap["query_cancel_after_seconds"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueryCancelAfter, TDuration::Seconds(10));
 
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"-1"}, propertiesMap["query_cancel_after_seconds"]), TFromStringException, "Unexpected symbol \"-\" at pos 0 in string \"-1\".");
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"18446744073709552"}, propertiesMap["query_cancel_after_seconds"]), yexception, "Invalid seconds value 18446744073709552, it is should be less or equal than 18446744073709551");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"-1"}, propertiesMap["query_cancel_after_seconds"]), TFromStringException, "Unexpected symbol \"-\" at pos 0 in string \"-1\".");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"18446744073709552"}, propertiesMap["query_cancel_after_seconds"]), yexception, "Invalid seconds value 18446744073709552, it is should be less or equal than 18446744073709551");
     }
 
     Y_UNIT_TEST(PercentSettingsParsing) {
         TPoolSettings settings;
-        auto propertiesMap = GetPropertiesMap(settings);
+        auto propertiesMap = settings.GetPropertiesMap();
 
-        std::visit(TSettingsParser{"-1"}, propertiesMap["query_memory_limit_percent_per_node"]);
+        std::visit(TPoolSettings::TParser{"-1"}, propertiesMap["query_memory_limit_percent_per_node"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueryMemoryLimitPercentPerNode, -1);
 
-        std::visit(TSettingsParser{"0"}, propertiesMap["query_memory_limit_percent_per_node"]);
+        std::visit(TPoolSettings::TParser{"0"}, propertiesMap["query_memory_limit_percent_per_node"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueryMemoryLimitPercentPerNode, 0);
 
-        std::visit(TSettingsParser{"55.5"}, propertiesMap["query_memory_limit_percent_per_node"]);
+        std::visit(TPoolSettings::TParser{"55.5"}, propertiesMap["query_memory_limit_percent_per_node"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueryMemoryLimitPercentPerNode, 55.5);
 
-        std::visit(TSettingsParser{"100"}, propertiesMap["query_memory_limit_percent_per_node"]);
+        std::visit(TPoolSettings::TParser{"100"}, propertiesMap["query_memory_limit_percent_per_node"]);
         UNIT_ASSERT_VALUES_EQUAL(settings.QueryMemoryLimitPercentPerNode, 100);
 
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"-1.5"}, propertiesMap["query_memory_limit_percent_per_node"]), yexception, "Invalid percent value -1.5, it is should be between 0 and 100 or -1");
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"-0.5"}, propertiesMap["query_memory_limit_percent_per_node"]), yexception, "Invalid percent value -0.5, it is should be between 0 and 100 or -1");
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TSettingsParser{"101.5"}, propertiesMap["query_memory_limit_percent_per_node"]), yexception, "Invalid percent value 101.5, it is should be between 0 and 100 or -1");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"-1.5"}, propertiesMap["query_memory_limit_percent_per_node"]), yexception, "Invalid percent value -1.5, it is should be between 0 and 100 or -1");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"-0.5"}, propertiesMap["query_memory_limit_percent_per_node"]), yexception, "Invalid percent value -0.5, it is should be between 0 and 100 or -1");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TPoolSettings::TParser{"101.5"}, propertiesMap["query_memory_limit_percent_per_node"]), yexception, "Invalid percent value 101.5, it is should be between 0 and 100 or -1");
     }
 
     Y_UNIT_TEST(SettingsExtracting) {
@@ -65,9 +65,9 @@ Y_UNIT_TEST_SUITE(ResourcePoolTest) {
         settings.QueueSize = -1;
         settings.QueryCancelAfter = TDuration::Seconds(15);
         settings.QueryMemoryLimitPercentPerNode = 0.5;
-        auto propertiesMap = GetPropertiesMap(settings);
+        auto propertiesMap = settings.GetPropertiesMap();
 
-        TSettingsExtractor extractor;
+        TPoolSettings::TExtractor extractor;
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["concurrent_query_limit"]), "10");
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["queue_size"]), "-1");
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["query_cancel_after_seconds"]), "15");

--- a/ydb/core/resource_pools/settings_common.h
+++ b/ydb/core/resource_pools/settings_common.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <util/string/cast.h>
+
+
+namespace NKikimr::NResourcePool {
+
+struct TSettingsBase {
+    struct TParser {
+        const TString& Value;
+    };
+
+    struct TExtractor {
+    };
+
+    bool operator==(const TSettingsBase& other) const = default;
+};
+
+}  // namespace NKikimr::NResourcePool

--- a/ydb/core/resource_pools/ut/ya.make
+++ b/ydb/core/resource_pools/ut/ya.make
@@ -7,6 +7,7 @@ PEERDIR(
 )
 
 SRCS(
+    resource_pool_classifier_settings_ut.cpp
     resource_pool_settings_ut.cpp
 )
 

--- a/ydb/core/resource_pools/ya.make
+++ b/ydb/core/resource_pools/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    resource_pool_classifier_settings.cpp
     resource_pool_settings.cpp
 )
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.cpp
@@ -34,7 +34,7 @@ TPath::TChecker IsParentPathValid(const TPath& parentPath) {
 }
 
 bool IsParentPathValid(const THolder<TProposeResponse>& result, const TPath& parentPath) {
-    const TString& resourcePoolsDir = JoinPath({parentPath.GetDomainPathString(), ".resource_pools"});
+    const TString& resourcePoolsDir = JoinPath({parentPath.GetDomainPathString(), ".metadata/workload_manager/pools"});
     if (parentPath.PathString() != resourcePoolsDir) {
         result->SetError(NKikimrScheme::EStatus::StatusSchemeError, TStringBuilder() << "Resource pools shoud be placed in " << resourcePoolsDir);
         return false;

--- a/ydb/core/tx/schemeshard/ut_resource_pool/ut_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/ut_resource_pool/ut_resource_pool.cpp
@@ -9,16 +9,16 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
             )", {NKikimrScheme::StatusAccepted});
 
         env.TestWaitNotification(runtime, txId);
 
-        TestLs(runtime, "/MyRoot/.resource_pools/MyResourcePool", false, NLs::PathExist);
+        TestLs(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool", false, NLs::PathExist);
     }
 
     Y_UNIT_TEST(CreateResourcePoolWithProperties) {
@@ -26,10 +26,10 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {
@@ -49,7 +49,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         properties.MutableProperties()->insert({"concurrent_query_limit", "10"});
         properties.MutableProperties()->insert({"query_cancel_after_seconds", "60"});
 
-        auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+        auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
         TestDescribeResult(describeResult, {NLs::PathExist});
         UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
         const auto& resourcePoolDescription = describeResult.GetPathDescription().GetResourcePoolDescription();
@@ -63,21 +63,21 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
             )", {NKikimrScheme::StatusAccepted});
 
         env.TestWaitNotification(runtime, txId);
 
-        TestLs(runtime, "/MyRoot/.resource_pools/MyResourcePool", false, NLs::PathExist);
+        TestLs(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool", false, NLs::PathExist);
 
-        TestDropResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", "MyResourcePool");
+        TestDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "MyResourcePool");
         env.TestWaitNotification(runtime, txId);
 
-        TestLs(runtime, "/MyRoot/.resource_pools/MyResourcePool", false, NLs::PathNotExist);
+        TestLs(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool", false, NLs::PathNotExist);
     }
 
     Y_UNIT_TEST(DropResourcePoolTwice) {
@@ -85,16 +85,16 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
             Name: "MyResourcePool"
         )");
         env.TestWaitNotification(runtime, txId);
 
-        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", "MyResourcePool");
-        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", "MyResourcePool");
+        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "MyResourcePool");
+        AsyncDropResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", "MyResourcePool");
         TestModificationResult(runtime, txId - 1);
 
         auto ev = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>();
@@ -106,7 +106,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         UNIT_ASSERT_VALUES_EQUAL(record.GetPathDropTxId(), txId - 1);
 
         env.TestWaitNotification(runtime, txId - 1);
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool"), {
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool"), {
             NLs::PathNotExist
         });
     }
@@ -116,11 +116,11 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 123;
 
-        AsyncMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        AsyncMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool1"
             )");
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool2"
             )");
         TestModificationResult(runtime, txId-2, NKikimrScheme::StatusAccepted);
@@ -129,14 +129,14 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
 
         env.TestWaitNotification(runtime, {txId, txId-1, txId-2});
 
-        TestDescribe(runtime, "/MyRoot/.resource_pools/MyResourcePool1");
-        TestDescribe(runtime, "/MyRoot/.resource_pools/MyResourcePool2");
+        TestDescribe(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool1");
+        TestDescribe(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool2");
 
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools"),
                            {NLs::PathVersionEqual(7)});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool1"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool1"),
                            {NLs::PathVersionEqual(2)});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool2"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool2"),
                            {NLs::PathVersionEqual(2)});
     }
 
@@ -151,12 +151,12 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
                 Name: "NilNoviSubLuna"
             )";
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig);
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig);
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig);
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig);
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig);
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig);
 
         ui64 sts[3];
         sts[0] = TestModificationResults(runtime, txId-2, {ESts::StatusAccepted, ESts::StatusMultipleModifications, ESts::StatusAlreadyExists});
@@ -165,13 +165,13 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
 
         for (ui32 i=0; i<3; ++i) {
             if (sts[i] == ESts::StatusAlreadyExists) {
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/NilNoviSubLuna"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/NilNoviSubLuna"),
                                    {NLs::Finished,
                                     NLs::IsResourcePool});
             }
 
             if (sts[i] == ESts::StatusMultipleModifications) {
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/NilNoviSubLuna"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/NilNoviSubLuna"),
                                    {NLs::Finished,
                                     NLs::IsResourcePool});
             }
@@ -179,12 +179,12 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
 
         env.TestWaitNotification(runtime, {txId-2, txId-1, txId});
 
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/NilNoviSubLuna"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/NilNoviSubLuna"),
                            {NLs::Finished,
                             NLs::IsResourcePool,
                             NLs::PathVersionEqual(2)});
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", resourcePoolConfig, {ESts::StatusAlreadyExists});
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", resourcePoolConfig, {ESts::StatusAlreadyExists});
     }
 
     Y_UNIT_TEST(ReadOnlyMode) {
@@ -192,11 +192,11 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 123;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
         AsyncMkDir(runtime, ++txId, "/MyRoot", "SubDirA");
-        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        AsyncCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
             )");
 
@@ -211,13 +211,13 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         // Check that describe works
         TestDescribeResult(DescribePath(runtime, "/MyRoot/SubDirA"),
                            {NLs::Finished});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool"),
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool"),
                            {NLs::Finished,
                             NLs::IsResourcePool});
 
         // Check that new modifications fail
         TestMkDir(runtime, ++txId, "/MyRoot", "SubDirBBBB", {NKikimrScheme::StatusReadOnly});
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool2"
             )", {NKikimrScheme::StatusReadOnly});
 
@@ -235,18 +235,18 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 123;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
         TestCreateResourcePool(runtime, ++txId, "/MyRoot", R"(
                 Name: "AnotherDir/MyResourcePool"
-            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.resource_pools"}});
+            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.metadata/workload_manager/pools"}});
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "AnotherDir/MyResourcePool"
-            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.resource_pools"}});
+            )", {{NKikimrScheme::StatusSchemeError, "Resource pools shoud be placed in /MyRoot/.metadata/workload_manager/pools"}});
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: ""
             )", {{NKikimrScheme::StatusSchemeError, "error: path part shouldn't be empty"}});
     }
@@ -256,10 +256,10 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestCreateResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {
@@ -280,7 +280,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         properties.MutableProperties()->insert({"query_count_limit", "50"});
 
         {
-            auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+            auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
             TestDescribeResult(describeResult, {NLs::PathExist});
             UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
             const auto& resourcePoolDescription = describeResult.GetPathDescription().GetResourcePoolDescription();
@@ -289,7 +289,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
             UNIT_ASSERT_VALUES_EQUAL(resourcePoolDescription.GetProperties().DebugString(), properties.DebugString());
         }
 
-        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {
@@ -309,7 +309,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         properties.MutableProperties()->insert({"query_cancel_after_seconds", "60"});
 
         {
-            auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+            auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
             TestDescribeResult(describeResult, {NLs::PathExist});
             UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
             const auto& resourcePoolDescription = describeResult.GetPathDescription().GetResourcePoolDescription();
@@ -324,10 +324,10 @@ Y_UNIT_TEST_SUITE(TResourcePoolTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestMkDir(runtime, ++txId, "/MyRoot", ".resource_pools");
+        TestMkDir(runtime, ++txId, "/MyRoot", ".metadata/workload_manager/pools");
         env.TestWaitNotification(runtime, txId);
 
-        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.resource_pools", R"(
+        TestAlterResourcePool(runtime, ++txId, "/MyRoot/.metadata/workload_manager/pools", R"(
                 Name: "MyResourcePool"
                 Properties {
                     Properties {

--- a/ydb/core/tx/schemeshard/ut_resource_pool_reboots/ut_resource_pool_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_resource_pool_reboots/ut_resource_pool_reboots.cpp
@@ -7,9 +7,9 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
     Y_UNIT_TEST(CreateResourcePoolWithReboots) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
-            AsyncMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+            AsyncMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
 
-            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                     Name: "MyResourcePool"
                     Properties {
                         Properties {
@@ -31,7 +31,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
 
             {
                 TInactiveZone inactive(activeZone);
-                auto describeResult =  DescribePath(runtime, "/MyRoot/.resource_pools/MyResourcePool");
+                auto describeResult =  DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/MyResourcePool");
                 TestDescribeResult(describeResult, {NLs::Finished});
 
                 UNIT_ASSERT(describeResult.GetPathDescription().HasResourcePoolDescription());
@@ -46,22 +46,22 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
     Y_UNIT_TEST(ParallelCreateDrop) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
-            TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+            TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+            AsyncCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                     Name: "DropMe"
                 )");
-            AsyncDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "DropMe");
+            AsyncDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "DropMe");
             t.TestEnv->TestWaitNotification(runtime, t.TxId-1);
 
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "DropMe");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "DropMe");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/DropMe"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/DropMe"),
                                    {NLs::PathNotExist});
             }
         });
@@ -71,22 +71,22 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
                 TInactiveZone inactive(activeZone);
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });
@@ -98,21 +98,21 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });
@@ -124,32 +124,32 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });
@@ -161,19 +161,19 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+            TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                     Name: "ResourcePool"
                 )");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
@@ -181,7 +181,7 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
         });
@@ -193,29 +193,29 @@ Y_UNIT_TEST_SUITE(TResourcePoolTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".resource_pools");
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".metadata/workload_manager/pools");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+                TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", R"(
+                TestCreateResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", R"(
                         Name: "ResourcePool"
                     )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.resource_pools", "ResourcePool");
+            TestDropResourcePool(runtime, ++t.TxId, "/MyRoot/.metadata/workload_manager/pools", "ResourcePool");
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
-                TestDescribeResult(DescribePath(runtime, "/MyRoot/.resource_pools/ResourcePool"),
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.metadata/workload_manager/pools/ResourcePool"),
                                    {NLs::PathNotExist});
             }
         });

--- a/ydb/core/tx/tiering/rule/manager.cpp
+++ b/ydb/core/tx/tiering/rule/manager.cpp
@@ -6,7 +6,7 @@ namespace NKikimr::NColumnShard::NTiers {
 
 void TTieringRulesManager::DoPrepareObjectsBeforeModification(std::vector<TTieringRule>&& objects,
     NMetadata::NModifications::IAlterPreparationController<TTieringRule>::TPtr controller,
-    const TInternalModificationContext& context) const {
+    const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& /*alterContext*/) const {
     TActivationContext::Register(new TRulePreparationActor(std::move(objects), controller, context));
 }
 

--- a/ydb/core/tx/tiering/rule/manager.h
+++ b/ydb/core/tx/tiering/rule/manager.h
@@ -9,7 +9,7 @@ class TTieringRulesManager: public NMetadata::NModifications::TGenericOperations
 protected:
     virtual void DoPrepareObjectsBeforeModification(std::vector<TTieringRule>&& objects,
         NMetadata::NModifications::IAlterPreparationController<TTieringRule>::TPtr controller,
-        const TInternalModificationContext& context) const override;
+        const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const override;
 
     virtual NMetadata::NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings,
         TInternalModificationContext& context) const override;

--- a/ydb/core/tx/tiering/tier/manager.cpp
+++ b/ydb/core/tx/tiering/tier/manager.cpp
@@ -65,7 +65,7 @@ NMetadata::NModifications::TOperationParsingResult TTiersManager::DoBuildPatchFr
 
 void TTiersManager::DoPrepareObjectsBeforeModification(std::vector<TTierConfig>&& patchedObjects,
     NMetadata::NModifications::IAlterPreparationController<TTierConfig>::TPtr controller,
-    const TInternalModificationContext& context) const
+    const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& /*alterContext*/) const
 {
     TActivationContext::Register(new TTierPreparationActor(std::move(patchedObjects), controller, context));
 }

--- a/ydb/core/tx/tiering/tier/manager.h
+++ b/ydb/core/tx/tiering/tier/manager.h
@@ -9,7 +9,7 @@ class TTiersManager: public NMetadata::NModifications::TGenericOperationsManager
 protected:
     virtual void DoPrepareObjectsBeforeModification(std::vector<TTierConfig>&& patchedObjects,
         NMetadata::NModifications::IAlterPreparationController<TTierConfig>::TPtr controller,
-        const TInternalModificationContext& context) const override;
+        const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const override;
 
     virtual NMetadata::NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings,
         TInternalModificationContext& context) const override;

--- a/ydb/library/yql/sql/v1/SQLv1.g.in
+++ b/ydb/library/yql/sql/v1/SQLv1.g.in
@@ -67,6 +67,9 @@ sql_stmt_core:
   | alter_resource_pool_stmt
   | drop_resource_pool_stmt
   | analyze_stmt
+  | create_resource_pool_classifier_stmt
+  | alter_resource_pool_classifier_stmt
+  | drop_resource_pool_classifier_stmt
 ;
 
 expr:
@@ -810,12 +813,25 @@ alter_resource_pool_stmt: ALTER RESOURCE POOL object_ref
   alter_resource_pool_action (COMMA alter_resource_pool_action)*
 ;
 alter_resource_pool_action:
-    alter_table_set_table_setting_uncompat
-  | alter_table_set_table_setting_compat
+    alter_table_set_table_setting_compat
   | alter_table_reset_table_setting
 ;
 
 drop_resource_pool_stmt: DROP RESOURCE POOL object_ref;
+
+create_resource_pool_classifier_stmt: CREATE RESOURCE POOL CLASSIFIER object_ref
+  with_table_settings
+;
+
+alter_resource_pool_classifier_stmt: ALTER RESOURCE POOL CLASSIFIER object_ref
+  alter_resource_pool_classifier_action (COMMA alter_resource_pool_classifier_action)*
+;
+alter_resource_pool_classifier_action:
+    alter_table_set_table_setting_compat
+  | alter_table_reset_table_setting
+;
+
+drop_resource_pool_classifier_stmt: DROP RESOURCE POOL CLASSIFIER object_ref;
 
 create_replication_stmt: CREATE ASYNC REPLICATION object_ref
     FOR replication_target (COMMA replication_target)*
@@ -1205,6 +1221,7 @@ keyword_as_compat:
   | CASCADE
   | CHANGEFEED
   | CHECK
+  | CLASSIFIER
   // | COLLATE
   | COMMIT
   | CONDITIONAL
@@ -1417,6 +1434,7 @@ keyword_compat: (
   | CASCADE
   | CHANGEFEED
   | CHECK
+  | CLASSIFIER
   | COLLATE
   | COMMIT
   | CONDITIONAL
@@ -1733,6 +1751,7 @@ CASE: C A S E;
 CAST: C A S T;
 CHANGEFEED: C H A N G E F E E D;
 CHECK: C H E C K;
+CLASSIFIER: C L A S S I F I E R;
 COLLATE: C O L L A T E;
 COLUMN: C O L U M N;
 COLUMNS: C O L U M N S;

--- a/ydb/library/yql/sql/v1/format/sql_format.cpp
+++ b/ydb/library/yql/sql/v1/format/sql_format.cpp
@@ -1535,6 +1535,39 @@ private:
         VisitAllFields(TRule_drop_resource_pool_stmt::GetDescriptor(), msg);
     }
 
+    void VisitCreateResourcePoolClassifier(const TRule_create_resource_pool_classifier_stmt& msg) {
+        PosFromToken(msg.GetToken1());
+        NewLine();
+        VisitAllFields(TRule_create_resource_pool_classifier_stmt::GetDescriptor(), msg);
+    }
+
+    void VisitAlterResourcePoolClassifier(const TRule_alter_resource_pool_classifier_stmt& msg) {
+        PosFromToken(msg.GetToken1());
+        NewLine();
+        VisitToken(msg.GetToken1());
+        VisitToken(msg.GetToken2());
+        VisitToken(msg.GetToken3());
+        VisitToken(msg.GetToken4());
+        Visit(msg.GetRule_object_ref5());
+
+        NewLine();
+        PushCurrentIndent();
+        Visit(msg.GetRule_alter_resource_pool_classifier_action6());
+        for (const auto& action : msg.GetBlock7()) {
+            Visit(action.GetToken1()); // comma
+            NewLine();
+            Visit(action.GetRule_alter_resource_pool_classifier_action2());
+        }
+
+        PopCurrentIndent();
+    }
+
+    void VisitDropResourcePoolClassifier(const TRule_drop_resource_pool_classifier_stmt& msg) {
+        PosFromToken(msg.GetToken1());
+        NewLine();
+        VisitAllFields(TRule_drop_resource_pool_classifier_stmt::GetDescriptor(), msg);
+    }
+
     void VisitAllFields(const NProtoBuf::Descriptor* descr, const NProtoBuf::Message& msg) {
         VisitAllFieldsImpl<TPrettyVisitor, &TPrettyVisitor::Visit>(this, descr, msg);
     }
@@ -2752,7 +2785,10 @@ TStaticData::TStaticData()
         {TRule_create_resource_pool_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitCreateResourcePool)},
         {TRule_alter_resource_pool_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitAlterResourcePool)},
         {TRule_drop_resource_pool_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitDropResourcePool)},
-        {TRule_analyze_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitAnalyze)}
+        {TRule_analyze_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitAnalyze)},
+        {TRule_create_resource_pool_classifier_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitCreateResourcePoolClassifier)},
+        {TRule_alter_resource_pool_classifier_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitAlterResourcePoolClassifier)},
+        {TRule_drop_resource_pool_classifier_stmt::GetDescriptor(), MakePrettyFunctor(&TPrettyVisitor::VisitDropResourcePoolClassifier)}
         })
     , ObfuscatingVisitDispatch({
         {TToken::GetDescriptor(), MakeObfuscatingFunctor(&TObfuscatingVisitor::VisitToken)},

--- a/ydb/library/yql/sql/v1/format/sql_format_ut.cpp
+++ b/ydb/library/yql/sql/v1/format/sql_format_ut.cpp
@@ -1604,8 +1604,8 @@ FROM Input MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS A);
              "CREATE RESOURCE POOL naMe WITH (a = \"b\");\n"},
              {"create resource pool eds with (a=\"a\",b=\"b\",c = true)",
              "CREATE RESOURCE POOL eds WITH (\n\ta = \"a\",\n\tb = \"b\",\n\tc = TRUE\n);\n"},
-             {"alTer reSOurcE poOl naMe sEt a tRue, resEt (b, c), seT (x=y, z=false)",
-             "ALTER RESOURCE POOL naMe\n\tSET a TRUE,\n\tRESET (b, c),\n\tSET (x = y, z = FALSE);\n"},
+             {"alTer reSOurcE poOl naMe resEt (b, c), seT (x=y, z=false)",
+             "ALTER RESOURCE POOL naMe\n\tRESET (b, c),\n\tSET (x = y, z = FALSE);\n"},
              {"alter resource pool eds reset (a), set (x=y)",
              "ALTER RESOURCE POOL eds\n\tRESET (a),\n\tSET (x = y);\n"},
             {"dRop reSourCe poOl naMe",
@@ -1616,14 +1616,30 @@ FROM Input MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS A);
         setup.Run(cases);
     }
 
-
-
     Y_UNIT_TEST(Analyze) {
         TCases cases = {
             {"analyze table (col1, col2, col3)",
              "ANALYZE table (col1, col2, col3);\n"},
              {"analyze table",
              "ANALYZE table;\n"}
+        };
+
+        TSetup setup;
+        setup.Run(cases);
+    }
+
+    Y_UNIT_TEST(ResourcePoolClassifierOperations) {
+        TCases cases = {
+            {"creAte reSourCe poOl ClaSsiFIer naMe With (a = \"b\")",
+             "CREATE RESOURCE POOL CLASSIFIER naMe WITH (a = \"b\");\n"},
+             {"create resource pool classifier eds with (a=\"a\",b=\"b\",c = true)",
+             "CREATE RESOURCE POOL CLASSIFIER eds WITH (\n\ta = \"a\",\n\tb = \"b\",\n\tc = TRUE\n);\n"},
+             {"alTer reSOurcE poOl ClaSsiFIer naMe resEt (b, c), seT (x=y, z=false)",
+             "ALTER RESOURCE POOL CLASSIFIER naMe\n\tRESET (b, c),\n\tSET (x = y, z = FALSE);\n"},
+             {"alter resource pool classifier eds reset (a), set (x=y)",
+             "ALTER RESOURCE POOL CLASSIFIER eds\n\tRESET (a),\n\tSET (x = y);\n"},
+            {"dRop reSourCe poOl ClaSsiFIer naMe",
+             "DROP RESOURCE POOL CLASSIFIER naMe;\n"},
         };
 
         TSetup setup;

--- a/ydb/library/yql/sql/v1/sql.cpp
+++ b/ydb/library/yql/sql/v1/sql.cpp
@@ -168,6 +168,9 @@ bool NeedUseForAllStatements(const TRule_sql_stmt_core::AltCase& subquery) {
         case TRule_sql_stmt_core::kAltSqlStmtCore46: // alter resource pool
         case TRule_sql_stmt_core::kAltSqlStmtCore47: // drop resource pool
         case TRule_sql_stmt_core::kAltSqlStmtCore48: // analyze
+        case TRule_sql_stmt_core::kAltSqlStmtCore49: // create resource pool classifier
+        case TRule_sql_stmt_core::kAltSqlStmtCore50: // alter resource pool classifier
+        case TRule_sql_stmt_core::kAltSqlStmtCore51: // drop resource pool classifier
             return false;
     }
 }

--- a/ydb/library/yql/sql/v1/sql_query.cpp
+++ b/ydb/library/yql/sql/v1/sql_query.cpp
@@ -1395,6 +1395,69 @@ bool TSqlQuery::Statement(TVector<TNodePtr>& blocks, const TRule_sql_stmt_core& 
             AddStatementToBlocks(blocks, BuildAnalyze(Ctx.Pos(), tr.Service, tr.Cluster, params, Ctx.Scoped));
             break;
         }
+        case TRule_sql_stmt_core::kAltSqlStmtCore49: {
+            // create_resource_pool_classifier_stmt: CREATE RESOURCE POOL CLASSIFIER name WITH (k=v,...);
+            auto& node = core.GetAlt_sql_stmt_core49().GetRule_create_resource_pool_classifier_stmt1();
+            TObjectOperatorContext context(Ctx.Scoped);
+            if (node.GetRule_object_ref5().HasBlock1()) {
+                if (!ClusterExpr(node.GetRule_object_ref5().GetBlock1().GetRule_cluster_expr1(),
+                    false, context.ServiceId, context.Cluster)) {
+                    return false;
+                }
+            }
+
+            const TString& objectId = Id(node.GetRule_object_ref5().GetRule_id_or_at2(), *this).second;
+            std::map<TString, TDeferredAtom> kv;
+            if (!ParseResourcePoolClassifierSettings(kv, node.GetRule_with_table_settings6())) {
+                return false;
+            }
+
+            AddStatementToBlocks(blocks, BuildCreateObjectOperation(Ctx.Pos(), objectId, "RESOURCE_POOL_CLASSIFIER", false, false, std::move(kv), context));
+            break;
+        }
+        case TRule_sql_stmt_core::kAltSqlStmtCore50: {
+            // alter_resource_pool_classifier_stmt: ALTER RESOURCE POOL CLASSIFIER object_ref alter_resource_pool_classifier_action (COMMA alter_resource_pool_classifier_action)*
+            Ctx.BodyPart();
+            const auto& node = core.GetAlt_sql_stmt_core50().GetRule_alter_resource_pool_classifier_stmt1();
+            TObjectOperatorContext context(Ctx.Scoped);
+            if (node.GetRule_object_ref5().HasBlock1()) {
+                if (!ClusterExpr(node.GetRule_object_ref5().GetBlock1().GetRule_cluster_expr1(),
+                    false, context.ServiceId, context.Cluster)) {
+                    return false;
+                }
+            }
+
+            const TString& objectId = Id(node.GetRule_object_ref5().GetRule_id_or_at2(), *this).second;
+            std::map<TString, TDeferredAtom> kv;
+            std::set<TString> toReset;
+            if (!ParseResourcePoolClassifierSettings(kv, toReset, node.GetRule_alter_resource_pool_classifier_action6())) {
+                return false;
+            }
+
+            for (const auto& action : node.GetBlock7()) {
+                if (!ParseResourcePoolClassifierSettings(kv, toReset, action.GetRule_alter_resource_pool_classifier_action2())) {
+                    return false;
+                }
+            }
+
+            AddStatementToBlocks(blocks, BuildAlterObjectOperation(Ctx.Pos(), objectId, "RESOURCE_POOL_CLASSIFIER", std::move(kv), std::move(toReset), context));
+            break;
+        }
+        case TRule_sql_stmt_core::kAltSqlStmtCore51: {
+            // drop_resource_pool_classifier_stmt: DROP RESOURCE POOL CLASSIFIER name;
+            auto& node = core.GetAlt_sql_stmt_core51().GetRule_drop_resource_pool_classifier_stmt1();
+            TObjectOperatorContext context(Ctx.Scoped);
+            if (node.GetRule_object_ref5().HasBlock1()) {
+                if (!ClusterExpr(node.GetRule_object_ref5().GetBlock1().GetRule_cluster_expr1(),
+                    false, context.ServiceId, context.Cluster)) {
+                    return false;
+                }
+            }
+
+            const TString& objectId = Id(node.GetRule_object_ref5().GetRule_id_or_at2(), *this).second;
+            AddStatementToBlocks(blocks, BuildDropObjectOperation(Ctx.Pos(), objectId, "RESOURCE_POOL_CLASSIFIER", false, {}, context));
+            break;
+        }
         case TRule_sql_stmt_core::ALT_NOT_SET:
             Ctx.IncrementMonCounter("sql_errors", "UnknownStatement" + internalStatementName);
             AltNotImplemented("sql_stmt_core", core);

--- a/ydb/library/yql/sql/v1/sql_translation.cpp
+++ b/ydb/library/yql/sql/v1/sql_translation.cpp
@@ -4712,14 +4712,7 @@ bool TSqlTranslation::ParseResourcePoolSettings(std::map<TString, TDeferredAtom>
 bool TSqlTranslation::ParseResourcePoolSettings(std::map<TString, TDeferredAtom>& result, std::set<TString>& toReset, const TRule_alter_resource_pool_action& alterAction) {
     switch (alterAction.Alt_case()) {
         case TRule_alter_resource_pool_action::kAltAlterResourcePoolAction1: {
-            const auto& action = alterAction.GetAlt_alter_resource_pool_action1().GetRule_alter_table_set_table_setting_uncompat1();
-            if (!StoreResourcePoolSettingsEntry(IdEx(action.GetRule_an_id2(), *this), &action.GetRule_table_setting_value3(), result)) {
-                return false;
-            }
-            return true;
-        }
-        case TRule_alter_resource_pool_action::kAltAlterResourcePoolAction2: {
-            const auto& action = alterAction.GetAlt_alter_resource_pool_action2().GetRule_alter_table_set_table_setting_compat1();
+            const auto& action = alterAction.GetAlt_alter_resource_pool_action1().GetRule_alter_table_set_table_setting_compat1();
             if (!StoreResourcePoolSettingsEntry(action.GetRule_alter_table_setting_entry3(), result)) {
                 return false;
             }
@@ -4730,8 +4723,8 @@ bool TSqlTranslation::ParseResourcePoolSettings(std::map<TString, TDeferredAtom>
             }
             return true;
         }
-        case TRule_alter_resource_pool_action::kAltAlterResourcePoolAction3: {
-            const auto& action = alterAction.GetAlt_alter_resource_pool_action3().GetRule_alter_table_reset_table_setting1();
+        case TRule_alter_resource_pool_action::kAltAlterResourcePoolAction2: {
+            const auto& action = alterAction.GetAlt_alter_resource_pool_action2().GetRule_alter_table_reset_table_setting1();
             const TString firstKey = to_lower(IdEx(action.GetRule_an_id3(), *this).Name);
             toReset.insert(firstKey);
             for (const auto& key : action.GetBlock4()) {
@@ -4740,6 +4733,77 @@ bool TSqlTranslation::ParseResourcePoolSettings(std::map<TString, TDeferredAtom>
             return true;
         }
         case TRule_alter_resource_pool_action::ALT_NOT_SET:
+            Y_ABORT("You should change implementation according to grammar changes");
+    }
+}
+
+bool TSqlTranslation::StoreResourcePoolClassifierSettingsEntry(const TIdentifier& id, const TRule_table_setting_value* value, std::map<TString, TDeferredAtom>& result) {
+    YQL_ENSURE(value);
+
+    const TString key = to_lower(id.Name);
+    if (result.find(key) != result.end()) {
+        Ctx.Error() << to_upper(key) << " duplicate keys";
+        return false;
+    }
+
+    switch (value->Alt_case()) {
+        case TRule_table_setting_value::kAltTableSettingValue2:
+            return StoreString(*value, result[key], Ctx, to_upper(key));
+
+        case TRule_table_setting_value::kAltTableSettingValue3:
+            return StoreInt(*value, result[key], Ctx, to_upper(key));
+
+        default:
+            Ctx.Error() << to_upper(key) << " value should be a string literal or integer";
+            return false;
+    }
+
+    return true;
+}
+
+bool TSqlTranslation::StoreResourcePoolClassifierSettingsEntry(const TRule_alter_table_setting_entry& entry, std::map<TString, TDeferredAtom>& result) {
+    const TIdentifier id = IdEx(entry.GetRule_an_id1(), *this);
+    return StoreResourcePoolClassifierSettingsEntry(id, &entry.GetRule_table_setting_value3(), result);
+}
+
+bool TSqlTranslation::ParseResourcePoolClassifierSettings(std::map<TString, TDeferredAtom>& result, const TRule_with_table_settings& settingsNode) {
+    const auto& firstEntry = settingsNode.GetRule_table_settings_entry3();
+    if (!StoreResourcePoolClassifierSettingsEntry(IdEx(firstEntry.GetRule_an_id1(), *this), &firstEntry.GetRule_table_setting_value3(), result)) {
+        return false;
+    }
+    for (const auto& block : settingsNode.GetBlock4()) {
+        const auto& entry = block.GetRule_table_settings_entry2();
+        if (!StoreResourcePoolClassifierSettingsEntry(IdEx(entry.GetRule_an_id1(), *this), &entry.GetRule_table_setting_value3(), result)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool TSqlTranslation::ParseResourcePoolClassifierSettings(std::map<TString, TDeferredAtom>& result, std::set<TString>& toReset, const TRule_alter_resource_pool_classifier_action& alterAction) {
+    switch (alterAction.Alt_case()) {
+        case TRule_alter_resource_pool_classifier_action::kAltAlterResourcePoolClassifierAction1: {
+            const auto& action = alterAction.GetAlt_alter_resource_pool_classifier_action1().GetRule_alter_table_set_table_setting_compat1();
+            if (!StoreResourcePoolClassifierSettingsEntry(action.GetRule_alter_table_setting_entry3(), result)) {
+                return false;
+            }
+            for (const auto& entry : action.GetBlock4()) {
+                if (!StoreResourcePoolClassifierSettingsEntry(entry.GetRule_alter_table_setting_entry2(), result)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        case TRule_alter_resource_pool_classifier_action::kAltAlterResourcePoolClassifierAction2: {
+            const auto& action = alterAction.GetAlt_alter_resource_pool_classifier_action2().GetRule_alter_table_reset_table_setting1();
+            const TString firstKey = to_lower(IdEx(action.GetRule_an_id3(), *this).Name);
+            toReset.insert(firstKey);
+            for (const auto& key : action.GetBlock4()) {
+                toReset.insert(to_lower(IdEx(key.GetRule_an_id2(), *this).Name));
+            }
+            return true;
+        }
+        case TRule_alter_resource_pool_classifier_action::ALT_NOT_SET:
             Y_ABORT("You should change implementation according to grammar changes");
     }
 }

--- a/ydb/library/yql/sql/v1/sql_translation.h
+++ b/ydb/library/yql/sql/v1/sql_translation.h
@@ -177,6 +177,8 @@ protected:
     bool StoreDataSourceSettingsEntry(const TRule_alter_table_setting_entry& entry, std::map<TString, TDeferredAtom>& result);
     bool StoreResourcePoolSettingsEntry(const TIdentifier& id, const TRule_table_setting_value* value, std::map<TString, TDeferredAtom>& result);
     bool StoreResourcePoolSettingsEntry(const TRule_alter_table_setting_entry& entry, std::map<TString, TDeferredAtom>& result);
+    bool StoreResourcePoolClassifierSettingsEntry(const TIdentifier& id, const TRule_table_setting_value* value, std::map<TString, TDeferredAtom>& result);
+    bool StoreResourcePoolClassifierSettingsEntry(const TRule_alter_table_setting_entry& entry, std::map<TString, TDeferredAtom>& result);
     bool ResetTableSettingsEntry(const TIdentifier& id, TTableSettings& settings, ETableType tableType);
 
     TIdentifier GetTopicConsumerId(const TRule_topic_consumer_ref& node);
@@ -233,6 +235,8 @@ protected:
     bool ParseViewQuery(std::map<TString, TDeferredAtom>& features, const TRule_select_stmt& query);
     bool ParseResourcePoolSettings(std::map<TString, TDeferredAtom>& result, const TRule_with_table_settings& settings);
     bool ParseResourcePoolSettings(std::map<TString, TDeferredAtom>& result, std::set<TString>& toReset, const TRule_alter_resource_pool_action& alterAction);
+    bool ParseResourcePoolClassifierSettings(std::map<TString, TDeferredAtom>& result, const TRule_with_table_settings& settings);
+    bool ParseResourcePoolClassifierSettings(std::map<TString, TDeferredAtom>& result, std::set<TString>& toReset, const TRule_alter_resource_pool_classifier_action& alterAction);
     bool RoleNameClause(const TRule_role_name& node, TDeferredAtom& result, bool allowSystemRoles);
     bool RoleParameters(const TRule_create_user_option& node, TRoleParameters& result);
     bool PermissionNameClause(const TRule_permission_name_target& node, TVector<TDeferredAtom>& result, bool withGrantOption);

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -2494,7 +2494,7 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
 
     Y_UNIT_TEST(AlterTableAddIndexWithIsNotSupported) {
         ExpectFailWithError("USE plato; ALTER TABLE table ADD INDEX idx LOCAL WITH (a=b, c=d, e=f) ON (col)",
-            "<main>:1:40: Error: local: alternative is not implemented yet: 726:7: local_index\n");
+            "<main>:1:40: Error: local: alternative is not implemented yet: 729:7: local_index\n");
     }
 
     Y_UNIT_TEST(AlterTableAlterIndexSetPartitioningIsCorrect) {
@@ -6877,8 +6877,7 @@ Y_UNIT_TEST_SUITE(ResourcePool) {
         NYql::TAstParseResult res = SqlToYql(R"sql(
                 USE plato;
                 ALTER RESOURCE POOL MyResourcePool
-                    SET (CONCURRENT_QUERY_LIMIT = 30, Weight = 5),
-                    SET QUEUE_TYPE "UNORDERED",
+                    SET (CONCURRENT_QUERY_LIMIT = 30, Weight = 5, QUEUE_TYPE = "UNORDERED"),
                     RESET (Query_Cancel_After_Seconds, Query_Count_Limit);
             )sql");
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
@@ -6901,6 +6900,90 @@ Y_UNIT_TEST_SUITE(ResourcePool) {
         NYql::TAstParseResult res = SqlToYql(R"sql(
                 USE plato;
                 DROP RESOURCE POOL MyResourcePool;
+            )sql");
+        UNIT_ASSERT(res.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            if (word == "Write") {
+                UNIT_ASSERT_VALUES_EQUAL(TString::npos, line.find("'features"));
+                UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("dropObject"));
+            }
+        };
+
+        TWordCountHive elementStat = { {TString("Write"), 0}};
+        VerifyProgram(res, elementStat, verifyLine);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["Write"]);
+    }
+}
+
+Y_UNIT_TEST_SUITE(ResourcePoolClassifier) {
+    Y_UNIT_TEST(CreateResourcePoolClassifier) {
+        NYql::TAstParseResult res = SqlToYql(R"sql(
+                USE plato;
+                CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                    RANK=20,
+                    RESOURCE_POOL='wgUserQueries',
+                    MEMBERNAME='yandex_query@abc'
+                );
+            )sql");
+        UNIT_ASSERT_C(res.Root, res.Issues.ToString());
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            if (word == "Write") {
+                UNIT_ASSERT_STRING_CONTAINS(line, R"#('('('"membername" '"yandex_query@abc") '('"rank" (Int32 '"20")) '('"resource_pool" '"wgUserQueries"))#");
+                UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("createObject"));
+            }
+        };
+
+        TWordCountHive elementStat = { {TString("Write"), 0} };
+        VerifyProgram(res, elementStat, verifyLine);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["Write"]);
+    }
+
+    Y_UNIT_TEST(CreateResourcePoolClassifierWithBadArguments) {
+        ExpectFailWithError(R"sql(
+                USE plato;
+                CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier;
+            )sql" , "<main>:3:72: Error: Unexpected token ';' : syntax error...\n\n");
+
+        ExpectFailWithError(R"sql(
+                USE plato;
+                CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                    DUPLICATE_SETTING="first_value",
+                    DUPLICATE_SETTING="second_value"
+                );
+            )sql" , "<main>:5:21: Error: DUPLICATE_SETTING duplicate keys\n");
+    }
+
+    Y_UNIT_TEST(AlterResourcePoolClassifier) {
+        NYql::TAstParseResult res = SqlToYql(R"sql(
+                USE plato;
+                ALTER RESOURCE POOL CLASSIFIER MyResourcePoolClassifier
+                    SET (RANK = 30, Weight = 5, MEMBERNAME = "test@user"),
+                    RESET (Resource_Pool);
+            )sql");
+        UNIT_ASSERT_C(res.Root, res.Issues.ToString());
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            if (word == "Write") {
+                UNIT_ASSERT_STRING_CONTAINS(line, R"#(('mode 'alterObject))#");
+                UNIT_ASSERT_STRING_CONTAINS(line, R"#('('features '('('"membername" '"test@user") '('"rank" (Int32 '"30")) '('"weight" (Int32 '"5")))))#");
+                UNIT_ASSERT_STRING_CONTAINS(line, R"#('('resetFeatures '('"resource_pool")))#");
+            }
+        };
+
+        TWordCountHive elementStat = { {TString("Write"), 0} };
+        VerifyProgram(res, elementStat, verifyLine);
+
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["Write"]);
+    }
+
+    Y_UNIT_TEST(DropResourcePoolClassifier) {
+        NYql::TAstParseResult res = SqlToYql(R"sql(
+                USE plato;
+                DROP RESOURCE POOL CLASSIFIER MyResourcePoolClassifier;
             )sql");
         UNIT_ASSERT(res.Root);
 

--- a/ydb/services/ext_index/metadata/manager.cpp
+++ b/ydb/services/ext_index/metadata/manager.cpp
@@ -32,7 +32,7 @@ public:
 
 void TManager::DoPrepareObjectsBeforeModification(std::vector<TObject>&& patchedObjects,
     NModifications::IAlterPreparationController<TObject>::TPtr controller,
-    const TInternalModificationContext& /*context*/) const {
+    const TInternalModificationContext& /*context*/, const NMetadata::NModifications::TAlterOperationContext& /*alterContext*/) const {
     if (patchedObjects.size() != 1) {
         controller->OnPreparationProblem("modification possible for one object only");
         return;

--- a/ydb/services/ext_index/metadata/manager.h
+++ b/ydb/services/ext_index/metadata/manager.h
@@ -10,7 +10,7 @@ class TManager: public NModifications::TGenericOperationsManager<TObject> {
 protected:
     virtual void DoPrepareObjectsBeforeModification(std::vector<TObject>&& patchedObjects,
         NModifications::IAlterPreparationController<TObject>::TPtr controller,
-        const TInternalModificationContext& context) const override;
+        const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const override;
 
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(
         const NYql::TObjectSettingsImpl& settings, TInternalModificationContext& context) const override;

--- a/ydb/services/metadata/abstract/decoder.cpp
+++ b/ydb/services/metadata/abstract/decoder.cpp
@@ -43,6 +43,17 @@ bool TDecoderBase::Read(const i32 columnIdx, ui64& result, const Ydb::Value& r) 
     return false;
 }
 
+bool TDecoderBase::Read(const i32 columnIdx, i64& result, const Ydb::Value& r) const {
+    if (columnIdx >= (i32)r.items().size() || columnIdx < 0) {
+        return false;
+    }
+    if (r.items()[columnIdx].has_int64_value()) {
+        result = r.items()[columnIdx].int64_value();
+        return true;
+    }
+    return false;
+}
+
 bool TDecoderBase::Read(const i32 columnIdx, ui32& result, const Ydb::Value& r) const {
     if (columnIdx >= (i32)r.items().size() || columnIdx < 0) {
         return false;

--- a/ydb/services/metadata/abstract/decoder.h
+++ b/ydb/services/metadata/abstract/decoder.h
@@ -14,6 +14,7 @@ protected:
 public:
     bool Read(const i32 columnIdx, TString& result, const Ydb::Value& r) const;
     bool Read(const i32 columnIdx, ui64& result, const Ydb::Value& r) const;
+    bool Read(const i32 columnIdx, i64& result, const Ydb::Value& r) const;
     bool Read(const i32 columnIdx, ui32& result, const Ydb::Value& r) const;
     bool ReadDebugProto(const i32 columnIdx, ::google::protobuf::Message& result, const Ydb::Value& r) const;
     bool ReadJson(const i32 columnIdx, NJson::TJsonValue& result, const Ydb::Value& r) const;

--- a/ydb/services/metadata/initializer/manager.cpp
+++ b/ydb/services/metadata/initializer/manager.cpp
@@ -5,7 +5,7 @@ namespace NKikimr::NMetadata::NInitializer {
 
 void TManager::DoPrepareObjectsBeforeModification(std::vector<TDBInitialization>&& objects,
     NModifications::IAlterPreparationController<TDBInitialization>::TPtr controller,
-    const TInternalModificationContext& /*context*/) const
+    const TInternalModificationContext& /*context*/, const NMetadata::NModifications::TAlterOperationContext& /*alterContext*/) const
 {
     controller->OnPreparationFinished(std::move(objects));
 }

--- a/ydb/services/metadata/initializer/manager.h
+++ b/ydb/services/metadata/initializer/manager.h
@@ -15,7 +15,7 @@ private:
 protected:
     virtual void DoPrepareObjectsBeforeModification(std::vector<TDBInitialization>&& objects,
         NModifications::IAlterPreparationController<TDBInitialization>::TPtr controller,
-        const TInternalModificationContext& context) const override;
+        const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const override;
 
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& /*settings*/,
         TInternalModificationContext& context) const override;

--- a/ydb/services/metadata/manager/abstract.h
+++ b/ydb/services/metadata/manager/abstract.h
@@ -19,9 +19,17 @@ namespace NKikimr::NMetadata::NModifications {
 
 using TOperationParsingResult = TConclusion<NInternal::TTableRecord>;
 
-struct TAlterOperationContext {
-    TString SessionId;
-    TString TransactionId;
+class TAlterOperationContext {
+private:
+    YDB_READONLY_DEF(TString, SessionId);
+    YDB_READONLY_DEF(TString, TransactionId);
+    YDB_READONLY_DEF(NInternal::TTableRecords, RestoreObjectIds);
+public:
+    TAlterOperationContext(const TString& sessionId, const TString& transactionId, const NInternal::TTableRecords& RestoreObjectIds)
+        : SessionId(sessionId)
+        , TransactionId(transactionId)
+        , RestoreObjectIds(RestoreObjectIds) {
+        }
 };
 
 class TColumnInfo {

--- a/ydb/services/metadata/manager/abstract.h
+++ b/ydb/services/metadata/manager/abstract.h
@@ -19,6 +19,11 @@ namespace NKikimr::NMetadata::NModifications {
 
 using TOperationParsingResult = TConclusion<NInternal::TTableRecord>;
 
+struct TAlterOperationContext {
+    TString SessionId;
+    TString TransactionId;
+};
+
 class TColumnInfo {
 private:
     YDB_READONLY_FLAG(Primary, false);
@@ -132,7 +137,7 @@ protected:
         TInternalModificationContext& context) const = 0;
     virtual void DoPrepareObjectsBeforeModification(std::vector<TObject>&& patchedObjects,
         typename IAlterPreparationController<TObject>::TPtr controller,
-        const TInternalModificationContext& context) const = 0;
+        const TInternalModificationContext& context, const TAlterOperationContext& alterContext) const = 0;
 public:
     using TPtr = std::shared_ptr<IObjectOperationsManager<TObject>>;
 
@@ -149,8 +154,8 @@ public:
 
     void PrepareObjectsBeforeModification(std::vector<TObject>&& patchedObjects,
         typename NModifications::IAlterPreparationController<TObject>::TPtr controller,
-        const TInternalModificationContext& context) const {
-        return DoPrepareObjectsBeforeModification(std::move(patchedObjects), controller, context);
+        const TInternalModificationContext& context, const TAlterOperationContext& alterContext) const {
+        return DoPrepareObjectsBeforeModification(std::move(patchedObjects), controller, context, alterContext);
     }
 };
 

--- a/ydb/services/metadata/manager/alter_impl.h
+++ b/ydb/services/metadata/manager/alter_impl.h
@@ -148,8 +148,7 @@ public:
         if (!PrepareRestoredObjects(objects)) {
             TBase::PassAway();
         } else {
-            const TAlterOperationContext alterContext = {.SessionId = SessionId, .TransactionId = TransactionId};
-            Manager->PrepareObjectsBeforeModification(std::move(objects), InternalController, Context, alterContext);
+            Manager->PrepareObjectsBeforeModification(std::move(objects), InternalController, Context, TAlterOperationContext(SessionId, TransactionId, RestoreObjectIds));
         }
     }
 

--- a/ydb/services/metadata/manager/alter_impl.h
+++ b/ydb/services/metadata/manager/alter_impl.h
@@ -148,7 +148,8 @@ public:
         if (!PrepareRestoredObjects(objects)) {
             TBase::PassAway();
         } else {
-            Manager->PrepareObjectsBeforeModification(std::move(objects), InternalController, Context);
+            const TAlterOperationContext alterContext = {.SessionId = SessionId, .TransactionId = TransactionId};
+            Manager->PrepareObjectsBeforeModification(std::move(objects), InternalController, Context, alterContext);
         }
     }
 
@@ -235,8 +236,8 @@ public:
             if (!trPatch) {
                 TBase::ExternalController->OnAlteringProblem("cannot found patch for object");
                 return false;
-            } else if (!trObject.TakeValuesFrom(*trPatch)) {
-                TBase::ExternalController->OnAlteringProblem("cannot patch object");
+            } else if (const TConclusionStatus& status = objectPatched.MergeRecords(trObject, *trPatch); status.IsFail()) {
+                TBase::ExternalController->OnAlteringProblem(status.GetErrorMessage());
                 return false;
             } else if (!TObject::TDecoder::DeserializeFromRecord(objectPatched, trObject)) {
                 TBase::ExternalController->OnAlteringProblem("cannot parse object after patch");

--- a/ydb/services/metadata/manager/common.h
+++ b/ydb/services/metadata/manager/common.h
@@ -1,8 +1,21 @@
 #pragma once
 #include <ydb/core/base/events.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/conclusion/status.h>
+
+namespace Ydb {
+
+class Value;
+
+};
 
 namespace NKikimr::NMetadata {
+
+namespace NInternal {
+
+class TTableRecord;
+
+};
 
 namespace NModifications {
 
@@ -24,6 +37,23 @@ public:
     virtual void OnAlteringProblem(const TString& errorMessage) = 0;
     virtual void OnAlteringFinished() = 0;
 
+};
+
+class IColumnValuesMerger {
+public:
+    using TPtr = std::shared_ptr<IColumnValuesMerger>;
+    virtual ~IColumnValuesMerger() = default;
+
+    virtual TConclusionStatus Merge(Ydb::Value& value, const Ydb::Value& patch) const = 0;
+};
+
+class IRecordsMerger {
+protected:
+    virtual IColumnValuesMerger::TPtr BuildMerger(const TString& columnName) const = 0;
+
+public:
+    virtual ~IRecordsMerger() = default;
+    virtual TConclusionStatus MergeRecords(NInternal::TTableRecord& value, const NInternal::TTableRecord& patch) const = 0;
 };
 
 enum EEvents {

--- a/ydb/services/metadata/manager/object.cpp
+++ b/ydb/services/metadata/manager/object.cpp
@@ -2,6 +2,34 @@
 
 namespace NKikimr::NMetadata::NModifications {
 
+namespace {
+
+class TDefaultColumnValuesMerger : public IColumnValuesMerger {
+public:
+    virtual TConclusionStatus Merge(Ydb::Value& value, const Ydb::Value& patch) const override {
+        value = patch;
+        return TConclusionStatus::Success();
+    }
+};
+
+}
+
+IColumnValuesMerger::TPtr TBaseObject::BuildMerger(const TString& columnName) const {
+    Y_UNUSED(columnName);
+    return std::make_shared<TDefaultColumnValuesMerger>();
+}
+
+TConclusionStatus TBaseObject::MergeRecords(NInternal::TTableRecord& value, const NInternal::TTableRecord& patch) const {
+    for (const auto& [columnId, patchValue] : patch.GetValues()) {
+        const auto& merger = BuildMerger(columnId);
+        const auto& status = merger->Merge(*value.GetMutableValuePtr(columnId), patchValue);
+        if (status.IsFail()) {
+            return status;
+        }
+    }
+    return TConclusionStatus::Success();
+}
+
 Ydb::Table::CreateTableRequest TBaseObject::AddHistoryTableScheme(const Ydb::Table::CreateTableRequest& baseScheme, const TString& tableName) {
     Ydb::Table::CreateTableRequest result = baseScheme;
     result.add_primary_key("historyInstant");

--- a/ydb/services/metadata/manager/object.h
+++ b/ydb/services/metadata/manager/object.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include "common.h"
+
 #include <ydb/core/base/appdata.h>
 
 #include <ydb/public/api/protos/ydb_table.pb.h>
@@ -6,10 +9,13 @@
 
 namespace NKikimr::NMetadata::NModifications {
 
-class TBaseObject {
+class TBaseObject : public IRecordsMerger {
+protected:
+    virtual IColumnValuesMerger::TPtr BuildMerger(const TString& columnName) const override;
+
 public:
     static Ydb::Table::CreateTableRequest AddHistoryTableScheme(const Ydb::Table::CreateTableRequest& baseScheme, const TString& tableName);
-
+    virtual TConclusionStatus MergeRecords(NInternal::TTableRecord& value, const NInternal::TTableRecord& patch) const override;
 };
 
 template <class TDerived>

--- a/ydb/services/metadata/manager/table_record.cpp
+++ b/ydb/services/metadata/manager/table_record.cpp
@@ -49,19 +49,16 @@ ui32 TTableRecord::CountIntersectColumns(const std::vector<TString>& columnIds) 
     return result;
 }
 
-bool TTableRecord::TakeValuesFrom(const TTableRecord& item) {
-    for (auto&& i : item.Values) {
-        Values[i.first] = i.second;
-    }
-    return true;
-}
-
 const Ydb::Value* TTableRecord::GetValuePtr(const TString& columnId) const {
     auto it = Values.find(columnId);
     if (it == Values.end()) {
         return nullptr;
     }
     return &it->second;
+}
+
+Ydb::Value* TTableRecord::GetMutableValuePtr(const TString& columnId) {
+    return &Values[columnId];
 }
 
 TTableRecord& TTableRecord::SetColumn(const TString& columnId, const Ydb::Value& v) {

--- a/ydb/services/metadata/manager/table_record.cpp
+++ b/ydb/services/metadata/manager/table_record.cpp
@@ -288,4 +288,16 @@ TTableRecords TTableRecords::SelectColumns(const std::vector<TString>& columnIds
     return result;
 }
 
+std::vector<TTableRecord> TTableRecords::GetTableRecords() const {
+    std::vector<TTableRecord> result;
+    result.reserve(Records.size());
+    for (const Ydb::Value& record : Records) {
+        result.emplace_back();
+        for (size_t i = 0; i < std::min(Columns.size(), static_cast<size_t>(record.items_size())); ++i) {
+            result.back().SetColumn(Columns[i].name(), record.items(i));
+        }
+    }
+    return result;
+}
+
 }

--- a/ydb/services/metadata/manager/table_record.h
+++ b/ydb/services/metadata/manager/table_record.h
@@ -21,8 +21,8 @@ public:
     bool HasColumns(const std::vector<TString>& columnIds) const;
     ui32 CountIntersectColumns(const std::vector<TString>& columnIds) const;
     bool SameColumns(const TTableRecord& item) const;
-    bool TakeValuesFrom(const TTableRecord& item);
     const Ydb::Value* GetValuePtr(const TString& columnId) const;
+    Ydb::Value* GetMutableValuePtr(const TString& columnId);
 };
 
 class TTableRecords {

--- a/ydb/services/metadata/manager/table_record.h
+++ b/ydb/services/metadata/manager/table_record.h
@@ -45,6 +45,7 @@ private:
 
 public:
     TTableRecords SelectColumns(const std::vector<TString>& columnIds) const;
+    std::vector<TTableRecord> GetTableRecords() const;
 
     Ydb::Table::ExecuteDataQueryRequest BuildInsertQuery(const TString& tablePath) const;
     Ydb::Table::ExecuteDataQueryRequest BuildUpsertQuery(const TString& tablePath) const;

--- a/ydb/services/metadata/manager/ydb_value_operator.cpp
+++ b/ydb/services/metadata/manager/ydb_value_operator.cpp
@@ -16,7 +16,7 @@ bool TYDBValue::IsSameType(const Ydb::Value& v, const Ydb::Type& type) {
         return v.has_uint64_value();
     } else if (type.type_id() == Ydb::Type::STRING) {
         return v.has_bytes_value();
-    } else if (type.type_id() == Ydb::Type::UTF8) {
+    } else if (type.type_id() == Ydb::Type::UTF8 || type.type_id() == Ydb::Type::JSON_DOCUMENT) {
         return v.has_text_value();
     }
     Y_ABORT_UNLESS(false);
@@ -60,13 +60,15 @@ TString TYDBValue::TypeToString(const Ydb::Type& type) {
     } else if (type.type_id() == Ydb::Type::UINT32) {
         return "Uint32";
     } else if (type.type_id() == Ydb::Type::INT64) {
-        return "Uint64";
+        return "Int64";
     } else if (type.type_id() == Ydb::Type::UINT64) {
         return "Uint64";
     } else if (type.type_id() == Ydb::Type::STRING) {
         return "String";
     } else if (type.type_id() == Ydb::Type::UTF8) {
         return "Utf8";
+    } else if (type.type_id() == Ydb::Type::JSON_DOCUMENT) {
+        return "JsonDocument";
     } else {
         Y_ABORT_UNLESS(false);
     }
@@ -117,6 +119,12 @@ Ydb::Value TYDBValue::Utf8(const char* value) {
 Ydb::Value TYDBValue::UInt64(const ui64 value) {
     Ydb::Value result;
     result.set_uint64_value(value);
+    return result;
+}
+
+Ydb::Value TYDBValue::Int64(const i64 value) {
+    Ydb::Value result;
+    result.set_int64_value(value);
     return result;
 }
 

--- a/ydb/services/metadata/manager/ydb_value_operator.h
+++ b/ydb/services/metadata/manager/ydb_value_operator.h
@@ -41,6 +41,7 @@ public:
     static Ydb::Value Utf8(const TString& value);
     static Ydb::Value Utf8(const TStringBuf& value);
     static Ydb::Value UInt64(const ui64 value);
+    static Ydb::Value Int64(const i64 value);
     static Ydb::Value UInt32(const ui32 value);
     static Ydb::Value Bool(const bool value);
 };

--- a/ydb/services/metadata/secret/manager.cpp
+++ b/ydb/services/metadata/secret/manager.cpp
@@ -6,7 +6,7 @@
 namespace NKikimr::NMetadata::NSecret {
 
 void TAccessManager::DoPrepareObjectsBeforeModification(std::vector<TAccess>&& patchedObjects, NModifications::IAlterPreparationController<TAccess>::TPtr controller,
-    const TInternalModificationContext& context) const {
+    const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& /*alterContext*/) const {
     if (context.GetActivityType() == IOperationsManager::EActivityType::Alter) {
         controller->OnPreparationProblem("access object cannot be modified");
         return;
@@ -88,7 +88,7 @@ NModifications::TOperationParsingResult TSecretManager::DoBuildPatchFromSettings
 }
 
 void TSecretManager::DoPrepareObjectsBeforeModification(std::vector<TSecret>&& patchedObjects, NModifications::IAlterPreparationController<TSecret>::TPtr controller,
-    const TInternalModificationContext& context) const {
+    const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& /*alterContext*/) const {
     if (!!context.GetExternalData().GetUserToken()) {
         for (auto&& i : patchedObjects) {
             if (i.GetOwnerUserId() != context.GetExternalData().GetUserToken()->GetUserSID()) {

--- a/ydb/services/metadata/secret/manager.h
+++ b/ydb/services/metadata/secret/manager.h
@@ -10,7 +10,7 @@ class TSecretManager: public NModifications::TGenericOperationsManager<TSecret> 
 protected:
     virtual void DoPrepareObjectsBeforeModification(std::vector<TSecret>&& patchedObjects,
         NModifications::IAlterPreparationController<TSecret>::TPtr controller,
-        const TInternalModificationContext& context) const override;
+        const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const override;
 
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(
         const NYql::TObjectSettingsImpl& settings, TInternalModificationContext& context) const override;
@@ -20,7 +20,7 @@ class TAccessManager: public NModifications::TGenericOperationsManager<TAccess> 
 protected:
     virtual void DoPrepareObjectsBeforeModification(std::vector<TAccess>&& patchedObjects,
         NModifications::IAlterPreparationController<TAccess>::TPtr controller,
-        const TInternalModificationContext& context) const override;
+        const TInternalModificationContext& context, const NMetadata::NModifications::TAlterOperationContext& alterContext) const override;
 
     virtual NModifications::TOperationParsingResult DoBuildPatchFromSettings(const NYql::TObjectSettingsImpl& settings,
         TInternalModificationContext& context) const override;


### PR DESCRIPTION
- **YQ-3491 support sql for resource pool classifiers (#7389)**
- **YQ-3492 support resource pool classifiers objects saving (#7491)**
- **YQ-3493 support resource pool classifiers kqp_proxy cache (#7688)**
- **YQ WM increase future wait timeout (#7780)**
- **YQ WM move resource pools into metadata folder (#7741)**
- **YQ-3556 move workload manager sensors under feature flag (#7768)**
- **YQ-3555 added validations on not existing for alter/drop object (#7757)**
- **Fixed sqs tests**
- **YQ WM fixed databse checking (#8251)**
- **YQ WM fixed cleanup table retries (#8369)**
- **YQ WM improved overload issues (#8437)**

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support resource pool classifiers

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Эти изменения нужны в пределах задачи [YQ-3222](https://st.yandex-team.ru/YQ-3222): workload manager v1 (YDB DWH к скейлу), все фичи которые должны быть к скейлу согласовали с @fomichev3000 в этой дельте:
https://delta.yandex-team.ru/page/epad/page/oq95gk1890527ptp