### PR TITLE
Allow SelfHeal operation while in DEGRADED state

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -270,6 +270,13 @@ void TBlobStorageController::Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev) {
     const bool initial = !HostRecords;
     HostRecords = std::make_shared<THostRecordMap::element_type>(ev->Get());
     if (initial) {
+        if (auto *appData = AppData()) {
+            if (appData->Icb) {
+                EnableSelfHealWithDegraded = std::make_shared<TControlWrapper>(0, 0, 1);
+                appData->Icb->RegisterSharedControl(*EnableSelfHealWithDegraded,
+                    "BlobStorageControllerControls.EnableSelfHealWithDegraded");
+            }
+        }
         SelfHealId = Register(CreateSelfHealActor());
         PushStaticGroupsToSelfHeal();
         if (StorageConfigObtained) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1516,6 +1516,7 @@ private:
     bool AllowMultipleRealmsOccupation = true;
     bool StorageConfigObtained = false;
     bool Loaded = false;
+    std::shared_ptr<TControlWrapper> EnableSelfHealWithDegraded;
 
     std::set<std::tuple<TGroupId, TNodeId>> GroupToNode;
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1343,6 +1343,14 @@ message TImmediateControlsConfig {
             DefaultValue: 200 }];
     }
 
+    message TBlobStorageControllerControls {
+        optional uint64 EnableSelfHealWithDegraded = 1 [(ControlOptions) = {
+            Description: "Should SelfHeal automatically process groups that are in DEGRADED status (one step from nonworking)",
+            MinValue: 0,
+            MaxValue: 1,
+            DefaultValue: 0 }];
+    }
+
     optional TDataShardControls DataShardControls = 1;
     optional TTxLimitControls TxLimitControls = 2;
     optional TCoordinatorControls CoordinatorControls = 3;
@@ -1353,6 +1361,7 @@ message TImmediateControlsConfig {
     optional TTabletControls TabletControls = 8;
     optional TDSProxyControls DSProxyControls = 9;
     optional TPDiskControls PDiskControls = 10;
+    optional TBlobStorageControllerControls BlobStorageControllerControls = 11;
 };
 
 message TMeteringConfig {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Allow SelfHeal operation while in DEGRADED state

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

SelfHeal now can accept groups in DEGRADED state and operate on them.
