### PR TITLE
Change all PerSessionCounters to AdaptiveCounters

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -237,7 +237,7 @@ namespace {
         }
 
         void SetPeerInfo(const TString& name, const TString& dataCenterId) override {
-            if (HasSessionCounters && name != std::exchange(HumanFriendlyPeerHostName, name)) {
+            if (name != std::exchange(HumanFriendlyPeerHostName, name)) {
                 PerSessionCounters.Reset();
             }
             VALGRIND_MAKE_READABLE(&DataCenterId, sizeof(DataCenterId));

--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -86,6 +86,7 @@ namespace {
         const TInterconnectProxyCommon::TPtr Common;
         const bool MergePerDataCenterCounters;
         const bool MergePerPeerCounters;
+        const bool HasSessionCounters;
         NMonitoring::TDynamicCounterPtr Counters;
         NMonitoring::TDynamicCounterPtr PerSessionCounters;
         NMonitoring::TDynamicCounterPtr PerDataCenterCounters;
@@ -102,6 +103,7 @@ namespace {
             : Common(common)
             , MergePerDataCenterCounters(common->Settings.MergePerDataCenterCounters)
             , MergePerPeerCounters(common->Settings.MergePerPeerCounters)
+            , HasSessionCounters(!MergePerDataCenterCounters && !MergePerPeerCounters)
             , Counters(common->MonCounters)
             , AdaptiveCounters(MergePerDataCenterCounters
                     ? PerDataCenterCounters :
@@ -235,7 +237,7 @@ namespace {
         }
 
         void SetPeerInfo(const TString& name, const TString& dataCenterId) override {
-            if (name != std::exchange(HumanFriendlyPeerHostName, name)) {
+            if (HasSessionCounters && name != std::exchange(HumanFriendlyPeerHostName, name)) {
                 PerSessionCounters.Reset();
             }
             VALGRIND_MAKE_READABLE(&DataCenterId, sizeof(DataCenterId));
@@ -248,7 +250,7 @@ namespace {
                 PerDataCenterCounters = Counters->GetSubgroup("dataCenterId", *DataCenterId);
             }
 
-            const bool updatePerSession = !PerSessionCounters || updatePerDataCenter;
+            const bool updatePerSession = HasSessionCounters && (!PerSessionCounters || updatePerDataCenter);
             if (updatePerSession) {
                 auto base = MergePerDataCenterCounters ? PerDataCenterCounters : Counters;
                 PerSessionCounters = base->GetSubgroup("peer", *HumanFriendlyPeerHostName);
@@ -263,12 +265,12 @@ namespace {
                 false;
 
             if (updatePerSession) {
-                Connected = PerSessionCounters->GetCounter("Connected");
-                Disconnections = PerSessionCounters->GetCounter("Disconnections", true);
-                ClockSkewMicrosec = PerSessionCounters->GetCounter("ClockSkewMicrosec");
-                Traffic = PerSessionCounters->GetCounter("Traffic", true);
-                Events = PerSessionCounters->GetCounter("Events", true);
-                ScopeErrors = PerSessionCounters->GetCounter("ScopeErrors", true);
+                Connected = AdaptiveCounters->GetCounter("Connected");
+                Disconnections = AdaptiveCounters->GetCounter("Disconnections", true);
+                ClockSkewMicrosec = AdaptiveCounters->GetCounter("ClockSkewMicrosec");
+                Traffic = AdaptiveCounters->GetCounter("Traffic", true);
+                Events = AdaptiveCounters->GetCounter("Events", true);
+                ScopeErrors = AdaptiveCounters->GetCounter("ScopeErrors", true);
 
                 for (const auto& [id, name] : Common->ChannelName) {
                     OutputChannels.try_emplace(id, Counters->GetSubgroup("channel", name), Traffic, Events);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It will allow us to use interconnect metrics in the big clusters

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
