### PR TITLE
Add local kmeans actor scan

### DIFF
--- a/ydb/core/protos/out/out.cpp
+++ b/ydb/core/protos/out/out.cpp
@@ -1,5 +1,3 @@
-#include <ydb/public/api/protos/ydb_table.pb.h>
-
 #include <ydb/core/protos/blobstorage.pb.h>
 #include <ydb/core/protos/blobstorage_vdisk_internal.pb.h>
 #include <ydb/core/protos/blobstorage_vdisk_config.pb.h>
@@ -254,6 +252,10 @@ Y_DECLARE_OUT_SPEC(, NKikimrStat::TEvStatisticsResponse::EStatus, stream, value)
     stream << NKikimrStat::TEvStatisticsResponse::EStatus_Name(value);
 }
 
-Y_DECLARE_OUT_SPEC(, Ydb::Table::IndexBuildState_State, stream, value) {
-    stream << IndexBuildState_State_Name(value);
+Y_DECLARE_OUT_SPEC(, NKikimrIndexBuilder::EBuildStatus, stream, value) {
+    stream << NKikimrIndexBuilder::EBuildStatus_Name(value);
+}
+
+Y_DECLARE_OUT_SPEC(, NKikimrTxDataShard::TEvLocalKMeansRequest_EState, stream, value) {
+    stream << NKikimrTxDataShard::TEvLocalKMeansRequest_EState_Name(value);
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1505,6 +1505,7 @@ message TEvLocalKMeansRequest {
     optional uint32 K = 10;
 
     enum EState {
+        UNSPECIFIED = 0;
         SAMPLE = 1;
         KMEANS = 2;
         UPLOAD_MAIN_TO_TMP = 3;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -17,6 +17,7 @@ import "ydb/core/protos/subdomains.proto";
 import "ydb/core/protos/query_stats.proto";
 import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
+import "ydb/public/api/protos/ydb_table.proto";
 import "ydb/library/yql/dq/actors/protos/dq_events.proto";
 import "ydb/library/yql/dq/actors/protos/dq_stats.proto";
 import "ydb/library/yql/dq/proto/dq_tasks.proto";
@@ -1484,6 +1485,71 @@ message TEvSampleKResponse {
 
     repeated uint64 Probabilities = 10;
     repeated bytes Rows = 11;
+}
+
+message TEvLocalKMeansRequest {
+    optional uint64 Id = 1;
+
+    optional uint64 TabletId = 2;
+    optional NKikimrProto.TPathID PathId = 3;
+
+    optional uint64 SnapshotTxId = 4;
+    optional uint64 SnapshotStep = 5;
+
+    optional uint64 SeqNoGeneration = 6;
+    optional uint64 SeqNoRound = 7;
+
+    optional Ydb.Table.VectorIndexSettings Settings = 8;
+
+    optional uint64 Seed = 9;
+    optional uint32 K = 10;
+
+    enum EState {
+        SAMPLE = 1;
+        KMEANS = 2;
+        UPLOAD_MAIN_TO_TMP = 3;
+        UPLOAD_MAIN_TO_POSTING = 4;
+        UPLOAD_TMP_TO_TMP = 5;
+        UPLOAD_TMP_TO_POSTING = 6;
+        DONE = 7;
+    };
+    optional EState Upload = 11;
+    // State != DONE
+    optional EState State = 12;
+    // State != KMEANS || DoneRounds < NeedsRounds
+    optional uint32 DoneRounds = 13;
+    optional uint32 NeedsRounds = 14;
+
+    // id of parent cluster
+    optional uint32 Parent = 15;
+    // [Child ... Child + K] ids reserved for our clusters
+    optional uint32 Child = 16;
+
+    optional string LevelName = 17;
+    optional string PostingName = 18;
+
+    optional string EmbeddingColumn = 19;
+    repeated string DataColumns = 20;
+}
+
+message TEvLocalKMeansProgressResponse {
+    optional uint64 Id = 1;
+
+    optional uint64 TabletId = 2;
+    optional NKikimrProto.TPathID PathId = 3;
+
+    optional uint64 RequestSeqNoGeneration = 4;
+    optional uint64 RequestSeqNoRound = 5;
+
+    optional NKikimrIndexBuilder.EBuildStatus Status = 6;
+    repeated Ydb.Issue.IssueMessage Issues = 7;
+
+    // TODO(mbkkt) implement slow-path (reliable-path)
+    // optional uint64 RowsDelta = 8;
+    // optional uint64 BytesDelta = 9;
+
+    // optional TEvLocalKMeansRequest.EState State = 10;
+    // optional uint32 DoneRounds = 11;
 }
 
 message TEvCdcStreamScanRequest {

--- a/ydb/core/tablet_flat/flat_scan_lead.h
+++ b/ydb/core/tablet_flat/flat_scan_lead.h
@@ -10,8 +10,13 @@ namespace NTable {
     struct TLead {
         void To(TTagsRef tags, TArrayRef<const TCell> key, ESeek seek)
         {
+            To(key, seek);
+            SetTags(tags);
+        }
+
+        void To(TArrayRef<const TCell> key, ESeek seek)
+        {
             Valid = true;
-            Tags.assign(tags.begin(), tags.end());
             Relation = seek;
             Key = TSerializedCellVec(key);
             StopKey = { };
@@ -24,6 +29,10 @@ namespace NTable {
             StopKeyInclusive = inclusive;
         }
 
+        void SetTags(TTagsRef tags) {
+            Tags.assign(tags.begin(), tags.end());
+        }
+
         explicit operator bool() const noexcept
         {
             return Valid;
@@ -34,12 +43,12 @@ namespace NTable {
             Valid = false;
         }
 
-        bool Valid = false;
         ESeek Relation = ESeek::Exact;
+        bool Valid = false;
+        bool StopKeyInclusive = true;
         TVector<ui32> Tags;
         TSerializedCellVec Key;
         TSerializedCellVec StopKey;
-        bool StopKeyInclusive = true;
     };
 
 }

--- a/ydb/core/tx/datashard/buffer_data.h
+++ b/ydb/core/tx/datashard/buffer_data.h
@@ -4,21 +4,17 @@
 
 namespace NKikimr::NDataShard {
 
-using TTypes = NTxProxy::TUploadTypes;
-using TRows = NTxProxy::TUploadRows;
-
 class TBufferData: public IStatHolder, public TNonCopyable {
 public:
     TBufferData()
-        : Rows{std::make_shared<TRows>()}
-    {
+        : Rows{std::make_shared<NTxProxy::TUploadRows>()} {
     }
 
     ui64 GetRows() const override final {
         return Rows->size();
     }
 
-    std::shared_ptr<TRows> GetRowsData() const {
+    auto GetRowsData() const {
         return Rows;
     }
 
@@ -68,7 +64,7 @@ public:
     }
 
 private:
-    std::shared_ptr<TRows> Rows;
+    std::shared_ptr<NTxProxy::TUploadRows> Rows;
     ui64 ByteSize = 0;
     TSerializedCellVec LastKey;
 };

--- a/ydb/core/tx/datashard/buffer_data.h
+++ b/ydb/core/tx/datashard/buffer_data.h
@@ -1,0 +1,76 @@
+#include "ydb/core/scheme/scheme_tablecell.h"
+#include "ydb/core/tx/datashard/upload_stats.h"
+#include "ydb/core/tx/tx_proxy/upload_rows.h"
+
+namespace NKikimr::NDataShard {
+
+using TTypes = NTxProxy::TUploadTypes;
+using TRows = NTxProxy::TUploadRows;
+
+class TBufferData: public IStatHolder, public TNonCopyable {
+public:
+    TBufferData()
+        : Rows{std::make_shared<TRows>()}
+    {
+    }
+
+    ui64 GetRows() const override final {
+        return Rows->size();
+    }
+
+    std::shared_ptr<TRows> GetRowsData() const {
+        return Rows;
+    }
+
+    ui64 GetBytes() const override final {
+        return ByteSize;
+    }
+
+    void FlushTo(TBufferData& other) {
+        Y_ABORT_UNLESS(this != &other);
+        Y_ABORT_UNLESS(other.IsEmpty());
+        other.Rows.swap(Rows);
+        other.ByteSize = std::exchange(ByteSize, 0);
+        other.LastKey = std::exchange(LastKey, {});
+    }
+
+    void Clear() {
+        Rows->clear();
+        ByteSize = 0;
+        LastKey = {};
+    }
+
+    void AddRow(TSerializedCellVec&& key, TSerializedCellVec&& targetPk, TString&& targetValue) {
+        Rows->emplace_back(std::move(targetPk), std::move(targetValue));
+        ByteSize += Rows->back().first.GetBuffer().size() + Rows->back().second.size();
+        LastKey = std::move(key);
+    }
+
+    bool IsEmpty() const {
+        return Rows->empty();
+    }
+
+    size_t Size() const {
+        return Rows->size();
+    }
+
+    bool IsReachLimits(const TUploadLimits& Limits) {
+        // TODO(mbkkt) why [0..BatchRowsLimit) but [0..BatchBytesLimit]
+        return Rows->size() >= Limits.BatchRowsLimit || ByteSize > Limits.BatchBytesLimit;
+    }
+
+    auto&& ExtractLastKey() {
+        return std::move(LastKey);
+    }
+
+    const auto& GetLastKey() const {
+        return LastKey;
+    }
+
+private:
+    std::shared_ptr<TRows> Rows;
+    ui64 ByteSize = 0;
+    TSerializedCellVec LastKey;
+};
+
+}

--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -229,10 +229,8 @@ public:
     }
 
     TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override {
-        auto ctx = TActivationContext::ActorContextFor(TBase::SelfId());
-
         if (Uploader) {
-            ctx.Send(Uploader, new TEvents::TEvPoisonPill);
+            this->Send(Uploader, new TEvents::TEvPoisonPill);
             Uploader = {};
         }
 
@@ -255,7 +253,7 @@ public:
 
         UploadStatusToMessage(progress->Record);
 
-        ctx.Send(ProgressActorId, progress.Release());
+        this->Send(ProgressActorId, progress.Release());
 
         LOG_D("Finish " << Debug());
 
@@ -353,7 +351,7 @@ private:
             progress->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS);
             UploadStatusToMessage(progress->Record);
 
-            ctx.Send(ProgressActorId, progress.Release());
+            this->Send(ProgressActorId, progress.Release());
 
             if (!ReadBuf.IsEmpty() && ReadBuf.IsReachLimits(Limits)) {
                 ReadBuf.FlushTo(WriteBuf);

--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -28,11 +28,11 @@ namespace NKikimr::NDataShard {
 #define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
 #define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
 
-static std::shared_ptr<TTypes> BuildTypes(const TUserTable& tableInfo, const NKikimrIndexBuilder::TColumnBuildSettings& buildSettings) {
+static std::shared_ptr<NTxProxy::TUploadTypes> BuildTypes(const TUserTable& tableInfo, const NKikimrIndexBuilder::TColumnBuildSettings& buildSettings) {
     auto types = GetAllTypes(tableInfo);
 
     Y_ABORT_UNLESS(buildSettings.columnSize() > 0);
-    auto result = std::make_shared<TTypes>();
+    auto result = std::make_shared<NTxProxy::TUploadTypes>();
     result->reserve(tableInfo.KeyColumnIds.size() + buildSettings.columnSize());
 
     for (const auto& keyColId : tableInfo.KeyColumnIds) {
@@ -48,10 +48,10 @@ static std::shared_ptr<TTypes> BuildTypes(const TUserTable& tableInfo, const NKi
     return result;
 }
 
-static std::shared_ptr<TTypes> BuildTypes(const TUserTable& tableInfo, TProtoColumnsCRef indexColumns, TProtoColumnsCRef dataColumns) {
+static std::shared_ptr<NTxProxy::TUploadTypes> BuildTypes(const TUserTable& tableInfo, TProtoColumnsCRef indexColumns, TProtoColumnsCRef dataColumns) {
     auto types = GetAllTypes(tableInfo);
 
-    auto result = std::make_shared<TTypes>();
+    auto result = std::make_shared<NTxProxy::TUploadTypes>();
     result->reserve(indexColumns.size() + dataColumns.size());
 
     for (const auto& colName : indexColumns) {
@@ -110,8 +110,8 @@ protected:
     const ui64 DataShardId;
     const TActorId ProgressActorId;
 
-    TTags ScanTags;                             // first: columns we scan, order as in IndexTable
-    std::shared_ptr<TTypes> UploadColumnsTypes; // columns types we upload to indexTable
+    TTags ScanTags;                                             // first: columns we scan, order as in IndexTable
+    std::shared_ptr<NTxProxy::TUploadTypes> UploadColumnsTypes; // columns types we upload to indexTable
     NTxProxy::EUploadRowsMode UploadMode;
 
     const TTags KeyColumnIds;

--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -388,13 +388,13 @@ private:
         LOG_D("Upload, last key " << DebugPrintPoint(KeyTypes, WriteBuf.GetLastKey().GetCells(), *AppData()->TypeRegistry) << " " << Debug());
 
         auto actor = NTxProxy::CreateUploadRowsInternal(
-            TBase::SelfId(), TargetTable,
+            this->SelfId(), TargetTable,
             UploadColumnsTypes,
             WriteBuf.GetRowsData(),
             UploadMode,
             true /*writeToPrivateTable*/);
 
-        Uploader = TActivationContext::ActorContextFor(TBase::SelfId()).Register(actor);
+        Uploader = this->Register(actor);
     }
 };
 
@@ -523,7 +523,6 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
                                                      std::unique_ptr<IEventHandle>(ev.Release()));
         return;
     }
-
 
     TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
     auto badRequest = [&](const TString& error) {

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -332,6 +332,9 @@ struct TEvDataShard {
         EvSampleKRequest,
         EvSampleKResponse,
 
+        EvLocalKMeansRequest,
+        EvLocalKMeansProgressResponse,
+
         EvEnd
     };
 
@@ -1452,6 +1455,18 @@ struct TEvDataShard {
         : public TEventPB<TEvSampleKResponse,
                           NKikimrTxDataShard::TEvSampleKResponse,
                           TEvDataShard::EvSampleKResponse> {
+    };
+
+    struct TEvLocalKMeansRequest
+        : public TEventPB<TEvLocalKMeansRequest,
+                          NKikimrTxDataShard::TEvLocalKMeansRequest,
+                          TEvDataShard::EvLocalKMeansRequest> {
+    };
+
+    struct TEvLocalKMeansProgressResponse
+        : public TEventPB<TEvLocalKMeansProgressResponse,
+                          NKikimrTxDataShard::TEvLocalKMeansProgressResponse,
+                          TEvDataShard::EvLocalKMeansProgressResponse> {
     };
 
     struct TEvKqpScan

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -253,6 +253,7 @@ class TDataShard
     class TTxHandleSafeKqpScan;
     class TTxHandleSafeBuildIndexScan;
     class TTxHandleSafeSampleKScan;
+    class TTxHandleSafeLocalKMeansScan;
     class TTxHandleSafeStatisticsScan;
 
     class TTxMediatorStateRestored;
@@ -1324,6 +1325,8 @@ class TDataShard
     void HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TActorContext& ctx);
     void HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TActorContext& ctx);
+    void HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvCdcStreamScanRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvCdcStreamScanRegistered::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvCdcStreamScanProgress::TPtr& ev, const TActorContext& ctx);
@@ -3114,6 +3117,7 @@ protected:
             HFunc(TEvDataShard::TEvDiscardVolatileSnapshotRequest, Handle);
             HFuncTraced(TEvDataShard::TEvBuildIndexCreateRequest, Handle);
             HFunc(TEvDataShard::TEvSampleKRequest, Handle);
+            HFunc(TEvDataShard::TEvLocalKMeansRequest, Handle);
             HFunc(TEvDataShard::TEvCdcStreamScanRequest, Handle);
             HFunc(TEvPrivate::TEvCdcStreamScanRegistered, Handle);
             HFunc(TEvPrivate::TEvCdcStreamScanProgress, Handle);

--- a/ydb/core/tx/datashard/datashard_ut_build_index.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_build_index.cpp
@@ -13,11 +13,6 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
-template <>
-inline void Out<NKikimrIndexBuilder::EBuildStatus>(IOutputStream& o, NKikimrIndexBuilder::EBuildStatus status) {
-    o << NKikimrIndexBuilder::EBuildStatus_Name(status);
-}
-
 namespace NKikimr {
 
 using namespace NKikimr::NDataShard::NKqpHelpers;

--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -14,15 +14,15 @@ using namespace Tests;
 using Ydb::Table::VectorIndexSettings;
 using namespace NTableIndex::NTableVectorKmeansTreeIndex;
 
-static ui64 sId = 1;
+static std::atomic<ui64> sId = 1;
 static constexpr const char* kMainTable = "/Root/table-main";
 static constexpr const char* kLevelTable = "/Root/table-level";
 static constexpr const char* kPostingTable = "/Root/table-posting";
 
 Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
-    [[maybe_unused]] static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender, std::unique_ptr<TEvDataShard::TEvLocalKMeansRequest> & ev,
-                                              size_t dims = 2, VectorIndexSettings::VectorType type = VectorIndexSettings::VECTOR_TYPE_FLOAT, VectorIndexSettings::Distance metric = VectorIndexSettings::DISTANCE_COSINE) {
-        auto id = sId++;
+    static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender, std::unique_ptr<TEvDataShard::TEvLocalKMeansRequest> & ev,
+                             size_t dims = 2, VectorIndexSettings::VectorType type = VectorIndexSettings::VECTOR_TYPE_FLOAT, VectorIndexSettings::Distance metric = VectorIndexSettings::DISTANCE_COSINE) {
+        auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
         auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
         auto datashards = GetTableShards(server, sender, kMainTable);
@@ -89,7 +89,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
     static std::tuple<TString, TString> DoLocalKMeans(Tests::TServer::TPtr server, TActorId sender, ui32 parent, ui64 seed, ui64 k,
                                                       NKikimrTxDataShard::TEvLocalKMeansRequest::EState upload,
                                                       VectorIndexSettings::VectorType type, auto metric) {
-        auto id = sId++;
+        auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
         auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
         auto datashards = GetTableShards(server, sender, kMainTable);

--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -697,4 +697,4 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
     }
 }
 
-} // namespace NKikimr
+}

--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -1,0 +1,207 @@
+#include "defs.h"
+#include "datashard_ut_common_kqp.h"
+#include "upload_stats.h"
+
+#include <thread>
+#include <ydb/core/testlib/test_client.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/core/tx/tx_proxy/upload_rows.h>
+#include <ydb/core/protos/index_builder.pb.h>
+
+#include <ydb/library/yql/public/issue/yql_issue_message.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+using namespace Tests;
+using Ydb::Table::VectorIndexSettings;
+using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+
+static ui64 sId = 1;
+static constexpr const char* kMainTable = "/Root/table-main";
+static constexpr const char* kLevelTable = "/Root/table-level";
+static constexpr const char* kPostingTable = "/Root/table-posting";
+
+Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
+    static std::tuple<TString, TString> DoLocalKMeans(Tests::TServer::TPtr server, TActorId sender, ui64 seed, ui64 k,
+                                                      VectorIndexSettings::VectorType type, VectorIndexSettings::Distance distance) {
+        auto id = sId++;
+        auto& runtime = *server->GetRuntime();
+        auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
+        auto datashards = GetTableShards(server, sender, kMainTable);
+        TTableId tableId = ResolveTableId(server, sender, kMainTable);
+
+        TString err;
+
+        for (auto tid : datashards) {
+            auto ev1 = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+            auto ev2 = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+            auto fill = [&](std::unique_ptr<TEvDataShard::TEvLocalKMeansRequest>& ev) {
+                auto& rec = ev->Record;
+                rec.SetId(1);
+
+                rec.SetSeqNoGeneration(id);
+                rec.SetSeqNoRound(1);
+
+                rec.SetTabletId(tid);
+                PathIdFromPathId(tableId.PathId, rec.MutablePathId());
+
+                rec.SetSnapshotTxId(snapshot.TxId);
+                rec.SetSnapshotStep(snapshot.Step);
+
+                VectorIndexSettings settings;
+                settings.set_vector_dimension(2);
+                settings.set_vector_type(type);
+                settings.set_distance(distance);
+                *rec.MutableSettings() = settings;
+
+                rec.SetK(k);
+                rec.SetSeed(seed);
+
+                rec.SetState(NKikimrTxDataShard::TEvLocalKMeansRequest::SAMPLE);
+                rec.SetUpload(NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_POSTING);
+
+                rec.SetDoneRounds(0);
+                rec.SetNeedsRounds(3);
+
+                rec.SetParent(0);
+                rec.SetChild(1);
+
+                rec.SetEmbeddingColumn("embedding");
+                rec.AddDataColumns("data");
+
+                rec.SetLevelName(kLevelTable);
+                rec.SetPostingName(kPostingTable);
+            };
+            fill(ev1);
+            fill(ev2);
+
+            runtime.SendToPipe(tid, sender, ev1.release(), 0, GetPipeConfigWithRetries());
+            runtime.SendToPipe(tid, sender, ev2.release(), 0, GetPipeConfigWithRetries());
+
+            TAutoPtr<IEventHandle> handle;
+            auto reply = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvLocalKMeansProgressResponse>(handle);
+
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(reply->Record.GetIssues(), issues);
+            UNIT_ASSERT_EQUAL_C(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::DONE, issues.ToOneLineString());
+        }
+
+        auto level = ReadShardedTable(server, kLevelTable);
+        auto posting = ReadShardedTable(server, kPostingTable);
+        return {std::move(level), std::move(posting)};
+    }
+
+    static void DropTable(Tests::TServer::TPtr server, TActorId sender, const char* name) {
+        ui64 txId = AsyncDropTable(server, sender, "/Root", name);
+        WaitTxNotification(server, sender, txId);
+    }
+
+    static void CreateLevelTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options) {
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {LevelTable_ParentIdColumn, "Uint32", true, true},
+            {LevelTable_IdColumn, "Uint32", true, true},
+            {LevelTable_EmbeddingColumn, "String", false, true},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-level", options);
+    }
+
+    static void CreatePostingTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options) {
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {PostingTable_ParentIdColumn, "Uint32", true, true},
+            {"key", "Uint32", true, true},
+            {"data", "String", false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-posting", options);
+    }
+
+    Y_UNIT_TEST (RunScan) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);              // single shard request
+
+        options.AllowSystemColumnNames(false);
+        options.Columns({
+            {"key", "Uint32", true, true},
+            {"embedding", "String", false, false},
+            {"data", "String", false, false},
+        });
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+
+        CreateShardedTable(server, sender, "/Root", "table-main", options);
+
+        // Upsert some initial values
+        ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table-main` 
+            (key, embedding, data) 
+        VALUES )"
+                                "(1, \"\x30\x30\3\", \"one\"),"
+                                "(2, \"\x31\x31\3\", \"two\"),"
+                                "(3, \"\x32\x32\3\", \"three\"),"
+                                "(4, \"\x65\x65\3\", \"four\"),"
+                                "(5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreatePostingTable(server, sender, options);
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            k = 2;
+            auto [level, posting] = DoLocalKMeans(server, sender, seed, k, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = mm\3\n"
+                                     "__ydb_parent = 0, __ydb_id = 2, __ydb_embedding = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 4, data = four\n"
+                                     "__ydb_parent = 1, key = 5, data = five\n"
+                                     "__ydb_parent = 2, key = 1, data = one\n"
+                                     "__ydb_parent = 2, key = 2, data = two\n"
+                                     "__ydb_parent = 2, key = 3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            k = 2;
+            auto [level, posting] = DoLocalKMeans(server, sender, seed, k, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = 11\3\n"
+                                     "__ydb_parent = 0, __ydb_id = 2, __ydb_embedding = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 1, data = one\n"
+                                     "__ydb_parent = 1, key = 2, data = two\n"
+                                     "__ydb_parent = 1, key = 3, data = three\n"
+                                     "__ydb_parent = 2, key = 4, data = four\n"
+                                     "__ydb_parent = 2, key = 5, data = five\n");
+            recreate();
+        }
+    }
+}
+
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -1,8 +1,3 @@
-#include "defs.h"
-#include "datashard_ut_common_kqp.h"
-#include "upload_stats.h"
-
-#include <thread>
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
@@ -25,8 +20,75 @@ static constexpr const char* kLevelTable = "/Root/table-level";
 static constexpr const char* kPostingTable = "/Root/table-posting";
 
 Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
-    static std::tuple<TString, TString> DoLocalKMeans(Tests::TServer::TPtr server, TActorId sender, ui64 seed, ui64 k,
-                                                      VectorIndexSettings::VectorType type, VectorIndexSettings::Distance distance) {
+    [[maybe_unused]] static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender, std::unique_ptr<TEvDataShard::TEvLocalKMeansRequest> & ev,
+                                              size_t dims = 2, VectorIndexSettings::VectorType type = VectorIndexSettings::VECTOR_TYPE_FLOAT, VectorIndexSettings::Distance metric = VectorIndexSettings::DISTANCE_COSINE) {
+        auto id = sId++;
+        auto& runtime = *server->GetRuntime();
+        auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
+        auto datashards = GetTableShards(server, sender, kMainTable);
+        TTableId tableId = ResolveTableId(server, sender, kMainTable);
+
+        TStringBuilder data;
+        TString err;
+        UNIT_ASSERT(datashards.size() == 1);
+
+        for (auto tid : datashards) {
+            auto& rec = ev->Record;
+            rec.SetId(1);
+
+            rec.SetSeqNoGeneration(id);
+            rec.SetSeqNoRound(1);
+
+            if (!rec.HasTabletId()) {
+                rec.SetTabletId(tid);
+            }
+            if (!rec.HasPathId()) {
+                PathIdFromPathId(tableId.PathId, rec.MutablePathId());
+            }
+
+            rec.SetSnapshotTxId(snapshot.TxId);
+            rec.SetSnapshotStep(snapshot.Step);
+
+            VectorIndexSettings settings;
+            settings.set_vector_dimension(dims);
+            settings.set_vector_type(type);
+            settings.set_distance(metric);
+            *rec.MutableSettings() = settings;
+
+            if (!rec.HasK()) {
+                rec.SetK(2);
+            }
+            rec.SetSeed(1337);
+
+            rec.SetState(NKikimrTxDataShard::TEvLocalKMeansRequest::SAMPLE);
+            rec.SetUpload(NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_POSTING);
+
+            rec.SetDoneRounds(0);
+            rec.SetNeedsRounds(3);
+
+            rec.SetParent(0);
+            rec.SetChild(1);
+
+            if (rec.HasEmbeddingColumn()) {
+                rec.ClearEmbeddingColumn();
+            } else {
+                rec.SetEmbeddingColumn("embedding");
+            }
+
+            rec.SetLevelName(kLevelTable);
+            rec.SetPostingName(kPostingTable);
+
+            runtime.SendToPipe(tid, sender, ev.release(), 0, GetPipeConfigWithRetries());
+
+            TAutoPtr<IEventHandle> handle;
+            auto reply = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvLocalKMeansProgressResponse>(handle);
+            UNIT_ASSERT_VALUES_EQUAL(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+        }
+    }
+
+    static std::tuple<TString, TString> DoLocalKMeans(Tests::TServer::TPtr server, TActorId sender, ui32 parent, ui64 seed, ui64 k,
+                                                      NKikimrTxDataShard::TEvLocalKMeansRequest::EState upload,
+                                                      VectorIndexSettings::VectorType type, auto metric) {
         auto id = sId++;
         auto& runtime = *server->GetRuntime();
         auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
@@ -54,20 +116,24 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
                 VectorIndexSettings settings;
                 settings.set_vector_dimension(2);
                 settings.set_vector_type(type);
-                settings.set_distance(distance);
+                if constexpr (std::is_same_v<decltype(metric), VectorIndexSettings::Distance>) {
+                    settings.set_distance(metric);
+                } else {
+                    settings.set_similarity(metric);
+                }
                 *rec.MutableSettings() = settings;
 
                 rec.SetK(k);
                 rec.SetSeed(seed);
 
                 rec.SetState(NKikimrTxDataShard::TEvLocalKMeansRequest::SAMPLE);
-                rec.SetUpload(NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_POSTING);
+                rec.SetUpload(upload);
 
                 rec.SetDoneRounds(0);
                 rec.SetNeedsRounds(3);
 
-                rec.SetParent(0);
-                rec.SetChild(1);
+                rec.SetParent(parent);
+                rec.SetChild(parent + 1);
 
                 rec.SetEmbeddingColumn("embedding");
                 rec.AddDataColumns("data");
@@ -99,6 +165,16 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
         WaitTxNotification(server, sender, txId);
     }
 
+    static void CreateMainTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options) {
+        options.AllowSystemColumnNames(false);
+        options.Columns({
+            {"key", "Uint32", true, true},
+            {"embedding", "String", false, false},
+            {"data", "String", false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-main", options);
+    }
+
     static void CreateLevelTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options) {
         options.AllowSystemColumnNames(true);
         options.Columns({
@@ -119,7 +195,104 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
         CreateShardedTable(server, sender, "/Root", "table-posting", options);
     }
 
-    Y_UNIT_TEST (RunScan) {
+    static void CreateTmpTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options, const char* name) {
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {PostingTable_ParentIdColumn, "Uint32", true, true},
+            {"key", "Uint32", true, true},
+            {"embedding", "String", false, false},
+            {"data", "String", false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", name, options);
+    }
+
+    Y_UNIT_TEST (BadRequest) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "table-main", 1);
+
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetK(0);
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetK(1);
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetEmbeddingColumn("some");
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetTabletId(0);
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+            auto& rec = ev->Record;
+
+            PathIdFromPathId({0, 0}, rec.MutablePathId());
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+
+            DoBadRequest(server, sender, ev, 0);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+
+            // TODO(mbkkt) bit vector not supported for now
+            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_BIT);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+
+            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+
+            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_FLOAT, VectorIndexSettings::DISTANCE_UNSPECIFIED);
+        }
+        // TODO(mbkkt) For now all build_index, sample_k, build_columns, local_kmeans doesn't really check this
+        // {
+        //     auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+        //     auto snapshotCopy = snapshot;
+        //     snapshotCopy.Step++;
+        //     DoBadRequest(server, sender, ev);
+        // }
+        // {
+        //     auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+        //     auto snapshotCopy = snapshot;
+        //     snapshotCopy.TxId++;
+        //     DoBadRequest(server, sender, ev);
+        // }
+    }
+
+    Y_UNIT_TEST (MainToPosting) {
         TPortManager pm;
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root");
@@ -134,18 +307,9 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
 
         TShardedTableOptions options;
         options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
-        options.Shards(1);              // single shard request
+        options.Shards(1);
 
-        options.AllowSystemColumnNames(false);
-        options.Columns({
-            {"key", "Uint32", true, true},
-            {"embedding", "String", false, false},
-            {"data", "String", false, false},
-        });
-        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
-
-        CreateShardedTable(server, sender, "/Root", "table-main", options);
-
+        CreateMainTable(server, sender, options);
         // Upsert some initial values
         ExecSQL(server, sender, R"(
         UPSERT INTO `/Root/table-main` 
@@ -169,11 +333,11 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
         };
 
         ui64 seed, k;
+        k = 2;
 
         seed = 0;
         for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
-            k = 2;
-            auto [level, posting] = DoLocalKMeans(server, sender, seed, k, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
             UNIT_ASSERT_VALUES_EQUAL(level,
                                      "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = mm\3\n"
                                      "__ydb_parent = 0, __ydb_id = 2, __ydb_embedding = 11\3\n");
@@ -188,8 +352,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
 
         seed = 111;
         for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
-            k = 2;
-            auto [level, posting] = DoLocalKMeans(server, sender, seed, k, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
             UNIT_ASSERT_VALUES_EQUAL(level,
                                      "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = 11\3\n"
                                      "__ydb_parent = 0, __ydb_id = 2, __ydb_embedding = mm\3\n");
@@ -199,6 +362,336 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
                                      "__ydb_parent = 1, key = 3, data = three\n"
                                      "__ydb_parent = 2, key = 4, data = four\n"
                                      "__ydb_parent = 2, key = 5, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 1, data = one\n"
+                                     "__ydb_parent = 1, key = 2, data = two\n"
+                                     "__ydb_parent = 1, key = 3, data = three\n"
+                                     "__ydb_parent = 1, key = 4, data = four\n"
+                                     "__ydb_parent = 1, key = 5, data = five\n");
+            recreate();
+        }
+        seed = 13;
+        {
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 1, data = one\n"
+                                     "__ydb_parent = 1, key = 2, data = two\n"
+                                     "__ydb_parent = 1, key = 3, data = three\n"
+                                     "__ydb_parent = 1, key = 4, data = four\n"
+                                     "__ydb_parent = 1, key = 5, data = five\n");
+            recreate();
+        }
+    }
+
+    Y_UNIT_TEST (MainToTmp) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+
+        CreateMainTable(server, sender, options);
+        // Upsert some initial values
+        ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table-main` 
+            (key, embedding, data) 
+        VALUES )"
+                                "(1, \"\x30\x30\3\", \"one\"),"
+                                "(2, \"\x31\x31\3\", \"two\"),"
+                                "(3, \"\x32\x32\3\", \"three\"),"
+                                "(4, \"\x65\x65\3\", \"four\"),"
+                                "(5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreateTmpTable(server, sender, options, "table-posting");
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+        k = 2;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = mm\3\n"
+                                     "__ydb_parent = 0, __ydb_id = 2, __ydb_embedding = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 1, key = 5, embedding = \x75\x75\3, data = five\n"
+                                     "__ydb_parent = 2, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 2, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 2, key = 3, embedding = \x32\x32\3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = 11\3\n"
+                                     "__ydb_parent = 0, __ydb_id = 2, __ydb_embedding = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 1, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 1, key = 3, embedding = \x32\x32\3, data = three\n"
+                                     "__ydb_parent = 2, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 2, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 1, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 1, key = 3, embedding = \x32\x32\3, data = three\n"
+                                     "__ydb_parent = 1, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 1, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+        seed = 13;
+        {
+            auto [level, posting] = DoLocalKMeans(server, sender, 0, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 0, __ydb_id = 1, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 1, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 1, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 1, key = 3, embedding = \x32\x32\3, data = three\n"
+                                     "__ydb_parent = 1, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 1, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+    }
+
+    Y_UNIT_TEST (TmpToPosting) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+
+        CreateTmpTable(server, sender, options, "table-main");
+        // Upsert some initial values
+        ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table-main` 
+            (__ydb_parent, key, embedding, data) 
+        VALUES )"
+                                "(39, 1, \"\x30\x30\3\", \"one\"),"
+                                "(40, 1, \"\x30\x30\3\", \"one\"),"
+                                "(40, 2, \"\x31\x31\3\", \"two\"),"
+                                "(40, 3, \"\x32\x32\3\", \"three\"),"
+                                "(40, 4, \"\x65\x65\3\", \"four\"),"
+                                "(40, 5, \"\x75\x75\3\", \"five\"),"
+                                "(41, 5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreatePostingTable(server, sender, options);
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+        k = 2;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = mm\3\n"
+                                     "__ydb_parent = 40, __ydb_id = 42, __ydb_embedding = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 4, data = four\n"
+                                     "__ydb_parent = 41, key = 5, data = five\n"
+                                     "__ydb_parent = 42, key = 1, data = one\n"
+                                     "__ydb_parent = 42, key = 2, data = two\n"
+                                     "__ydb_parent = 42, key = 3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = 11\3\n"
+                                     "__ydb_parent = 40, __ydb_id = 42, __ydb_embedding = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 1, data = one\n"
+                                     "__ydb_parent = 41, key = 2, data = two\n"
+                                     "__ydb_parent = 41, key = 3, data = three\n"
+                                     "__ydb_parent = 42, key = 4, data = four\n"
+                                     "__ydb_parent = 42, key = 5, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 1, data = one\n"
+                                     "__ydb_parent = 41, key = 2, data = two\n"
+                                     "__ydb_parent = 41, key = 3, data = three\n"
+                                     "__ydb_parent = 41, key = 4, data = four\n"
+                                     "__ydb_parent = 41, key = 5, data = five\n");
+            recreate();
+        }
+        seed = 13;
+        {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_POSTING, VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 1, data = one\n"
+                                     "__ydb_parent = 41, key = 2, data = two\n"
+                                     "__ydb_parent = 41, key = 3, data = three\n"
+                                     "__ydb_parent = 41, key = 4, data = four\n"
+                                     "__ydb_parent = 41, key = 5, data = five\n");
+            recreate();
+        }
+    }
+
+    Y_UNIT_TEST (TmpToTmp) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+
+        CreateTmpTable(server, sender, options, "table-main");
+        // Upsert some initial values
+        ExecSQL(server, sender, R"(
+        UPSERT INTO `/Root/table-main` 
+            (__ydb_parent, key, embedding, data) 
+        VALUES )"
+                                "(39, 1, \"\x30\x30\3\", \"one\"),"
+                                "(40, 1, \"\x30\x30\3\", \"one\"),"
+                                "(40, 2, \"\x31\x31\3\", \"two\"),"
+                                "(40, 3, \"\x32\x32\3\", \"three\"),"
+                                "(40, 4, \"\x65\x65\3\", \"four\"),"
+                                "(40, 5, \"\x75\x75\3\", \"five\"),"
+                                "(41, 5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreateTmpTable(server, sender, options, "table-posting");
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+        k = 2;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = mm\3\n"
+                                     "__ydb_parent = 40, __ydb_id = 42, __ydb_embedding = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 41, key = 5, embedding = \x75\x75\3, data = five\n"
+                                     "__ydb_parent = 42, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 42, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 42, key = 3, embedding = \x32\x32\3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = 11\3\n"
+                                     "__ydb_parent = 40, __ydb_id = 42, __ydb_embedding = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 41, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 41, key = 3, embedding = \x32\x32\3, data = three\n"
+                                     "__ydb_parent = 42, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 42, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE}) {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 41, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 41, key = 3, embedding = \x32\x32\3, data = three\n"
+                                     "__ydb_parent = 41, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 41, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+        seed = 13;
+        {
+            auto [level, posting] = DoLocalKMeans(server, sender, 40, seed, k, NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_TMP_TO_TMP, VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_COSINE);
+            UNIT_ASSERT_VALUES_EQUAL(level,
+                                     "__ydb_parent = 40, __ydb_id = 41, __ydb_embedding = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting,
+                                     "__ydb_parent = 41, key = 1, embedding = \x30\x30\3, data = one\n"
+                                     "__ydb_parent = 41, key = 2, embedding = \x31\x31\3, data = two\n"
+                                     "__ydb_parent = 41, key = 3, embedding = \x32\x32\3, data = three\n"
+                                     "__ydb_parent = 41, key = 4, embedding = \x65\x65\3, data = four\n"
+                                     "__ydb_parent = 41, key = 5, embedding = \x75\x75\3, data = five\n");
             recreate();
         }
     }

--- a/ydb/core/tx/datashard/datashard_ut_sample_k.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_sample_k.cpp
@@ -12,11 +12,6 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
-template <>
-inline void Out<NKikimrIndexBuilder::EBuildStatus>(IOutputStream& o, NKikimrIndexBuilder::EBuildStatus status) {
-    o << NKikimrIndexBuilder::EBuildStatus_Name(status);
-}
-
 namespace NKikimr {
 
 static ui64 sId = 1;

--- a/ydb/core/tx/datashard/datashard_ut_sample_k.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_sample_k.cpp
@@ -14,7 +14,7 @@
 
 namespace NKikimr {
 
-static ui64 sId = 1;
+static std::atomic<ui64> sId = 1;
 
 using namespace NKikimr::NDataShard::NKqpHelpers;
 using namespace NSchemeShard;
@@ -23,7 +23,7 @@ using namespace Tests;
 Y_UNIT_TEST_SUITE (TTxDataShardSampleKScan) {
     static void DoSampleKBad(Tests::TServer::TPtr server, TActorId sender,
                              const TString& tableFrom, const TRowVersion& snapshot, std::unique_ptr<TEvDataShard::TEvSampleKRequest>& ev) {
-        auto id = sId++;
+        auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
         auto datashards = GetTableShards(server, sender, tableFrom);
         TTableId tableId = ResolveTableId(server, sender, tableFrom);
@@ -73,7 +73,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardSampleKScan) {
 
     static TString DoSampleK(Tests::TServer::TPtr server, TActorId sender,
                              const TString& tableFrom, const TRowVersion& snapshot, ui64 seed, ui64 k) {
-        auto id = sId++;
+        auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
         auto datashards = GetTableShards(server, sender, tableFrom);
         TTableId tableId = ResolveTableId(server, sender, tableFrom);

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -280,7 +280,7 @@ public:
         return NKikimrServices::TActivity::LOCAL_KMEANS_SCAN_ACTOR;
     }
 
-    TLocalKMeansScanBase(const TUserTable& table, TLead&& lead, NKikimrTxDataShard::TEvLocalKMeansRequest& request, const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvLocalKMeansProgressResponse>&& response)
+    TLocalKMeansScanBase(const TUserTable& table, TLead&& lead, const NKikimrTxDataShard::TEvLocalKMeansRequest& request, const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvLocalKMeansProgressResponse>&& response)
         : TActor{&TThis::StateWork}
         , Parent{request.GetParent()}
         , Child{request.GetChild()}

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -249,8 +249,8 @@ protected:
     std::vector<TString> Clusters;
 
     // Upload
-    std::shared_ptr<TTypes> TargetTypes;
-    std::shared_ptr<TTypes> NextTypes;
+    std::shared_ptr<NTxProxy::TUploadTypes> TargetTypes;
+    std::shared_ptr<NTxProxy::TUploadTypes> NextTypes;
 
     TString TargetTable;
     TString NextTable;

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -608,8 +608,8 @@ public:
                 return FeedUploadTmp2Tmp(key, row);
             case EState::UPLOAD_TMP_TO_POSTING:
                 return FeedUploadTmp2Posting(key, row);
-            case EState::DONE:
-                Y_UNREACHABLE();
+            default:
+                return EScan::Final;
         }
     }
 

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -1,0 +1,919 @@
+#include "datashard_impl.h"
+#include "range_ops.h"
+#include "scan_common.h"
+#include "upload_stats.h"
+#include "buffer_data.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/counters.h>
+#include <ydb/core/kqp/common/kqp_types.h>
+#include <ydb/core/scheme/scheme_tablecell.h>
+#include <ydb/core/tablet_flat/flat_row_state.h>
+
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/core/tx/tx_proxy/upload_rows.h>
+
+#include <ydb/core/ydb_convert/table_description.h>
+#include <ydb/core/ydb_convert/ydb_convert.h>
+#include <ydb/library/yql/public/issue/yql_issue_message.h>
+
+#include <util/generic/algorithm.h>
+#include <util/string/builder.h>
+
+#include <library/cpp/dot_product/dot_product.h>
+#include <library/cpp/l1_distance/l1_distance.h>
+#include <library/cpp/l2_distance/l2_distance.h>
+
+#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
+#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
+#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
+#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
+
+template <typename TRes>
+Y_PURE_FUNCTION TTriWayDotProduct<TRes> CosineImpl(const float* lhs, const float* rhs, size_t length) noexcept {
+    auto r = TriWayDotProduct(lhs, rhs, length);
+    return {static_cast<TRes>(r.LL), static_cast<TRes>(r.LR), static_cast<TRes>(r.RR)};
+}
+
+template <typename TRes>
+Y_PURE_FUNCTION TTriWayDotProduct<TRes> CosineImpl(const i8* lhs, const i8* rhs, size_t length) noexcept {
+    const auto ll = DotProduct(lhs, lhs, length);
+    const auto lr = DotProduct(lhs, rhs, length);
+    const auto rr = DotProduct(rhs, rhs, length);
+    return {static_cast<TRes>(ll), static_cast<TRes>(lr), static_cast<TRes>(rr)};
+}
+
+template <typename TRes>
+Y_PURE_FUNCTION TTriWayDotProduct<TRes> CosineImpl(const ui8* lhs, const ui8* rhs, size_t length) noexcept {
+    const auto ll = DotProduct(lhs, lhs, length);
+    const auto lr = DotProduct(lhs, rhs, length);
+    const auto rr = DotProduct(rhs, rhs, length);
+    return {static_cast<TRes>(ll), static_cast<TRes>(lr), static_cast<TRes>(rr)};
+}
+
+namespace NKikimr::NDataShard {
+
+TTableRange CreateRangeFrom(const TUserTable& table, ui32 parent) {
+    if (parent == 0) {
+        return table.GetTableRange();
+    }
+    const auto parentCell = TCell::Make(parent);
+    const TTableRange parentRange{{&parentCell, 1}};
+    return Intersect(table.KeyColumnTypes, table.GetTableRange(), parentRange);
+}
+
+NTable::TLead CreateLeadFrom(const TTableRange& range) {
+    NTable::TLead lead;
+    if (range.From) {
+        lead.To(range.From, range.InclusiveFrom ? NTable::ESeek::Lower : NTable::ESeek::Upper);
+    } else {
+        lead.To({}, NTable::ESeek::Lower);
+    }
+    if (range.To) {
+        lead.Until(range.To, range.InclusiveTo);
+    }
+    return lead;
+}
+
+// TODO(mbkkt) separate implementation for bit
+template <typename T>
+struct TMetric {
+    using TCoord = T;
+    // TODO(mbkkt) maybe compute floating sum in double? Needs benchmark
+    using TSum = std::conditional_t<std::is_floating_point_v<T>, T, int64_t>;
+
+    ui32 Dimensions = 0;
+
+    bool IsExpectedSize(TArrayRef<const char> data) const noexcept {
+        return data.size() == 1 + sizeof(TCoord) * Dimensions;
+    }
+
+    auto GetCoords(const char* coords) {
+        return std::span{reinterpret_cast<const TCoord*>(coords), Dimensions};
+    }
+
+    auto GetData(char* data) {
+        return std::span{reinterpret_cast<TCoord*>(data), Dimensions};
+    }
+
+    void Fill(TString& d, TSum* embedding, ui64& c) {
+        const auto count = static_cast<TSum>(std::exchange(c, 0));
+        auto data = GetData(d.MutRef().data());
+        for (auto& coord : data) {
+            coord = *embedding / count;
+            *embedding++ = 0;
+        }
+    }
+};
+
+template <typename T>
+struct TCosineSimilarity: TMetric<T> {
+    using TCoord = TMetric<T>::TCoord;
+    using TSum = TMetric<T>::TSum;
+    // double used to avoid precision issues
+    using TRes = double;
+
+    static TRes Init() {
+        return std::numeric_limits<TRes>::max();
+    }
+
+    auto Distance(const char* cluster, const char* embedding) const noexcept {
+        const auto r = CosineImpl<TRes>(reinterpret_cast<const TCoord*>(cluster), reinterpret_cast<const TCoord*>(embedding), this->Dimensions);
+        // sqrt(ll) * sqrt(rr) computed instead of sqrt(ll * rr) to avoid precision issues
+        const auto norm = std::sqrt(r.LL) * std::sqrt(r.RR);
+        const TRes similarity = norm != 0 ? static_cast<TRes>(r.LR) / static_cast<TRes>(norm) : 0;
+        return -similarity;
+    }
+};
+
+template <typename T>
+struct TL1Distance: TMetric<T> {
+    using TCoord = TMetric<T>::TCoord;
+    using TSum = TMetric<T>::TSum;
+    using TRes = std::conditional_t<std::is_floating_point_v<T>, T, ui64>;
+
+    static TRes Init() {
+        return std::numeric_limits<TRes>::max();
+    }
+
+    auto Distance(const char* cluster, const char* embedding) const noexcept {
+        const auto distance = L1Distance(reinterpret_cast<const TCoord*>(cluster), reinterpret_cast<const TCoord*>(embedding), this->Dimensions);
+        return distance;
+    }
+};
+
+template <typename T>
+struct TL2Distance: TMetric<T> {
+    using TCoord = TMetric<T>::TCoord;
+    using TSum = TMetric<T>::TSum;
+    using TRes = std::conditional_t<std::is_floating_point_v<T>, T, ui64>;
+
+    static TRes Init() {
+        return std::numeric_limits<TRes>::max();
+    }
+
+    auto Distance(const char* cluster, const char* embedding) const noexcept {
+        const auto distance = L2SqrDistance(reinterpret_cast<const TCoord*>(cluster), reinterpret_cast<const TCoord*>(embedding), this->Dimensions);
+        return distance;
+    }
+};
+
+template <typename T>
+struct TMaxInnerProductSimilarity: TMetric<T> {
+    using TCoord = TMetric<T>::TCoord;
+    using TSum = TMetric<T>::TSum;
+    using TRes = std::conditional_t<std::is_floating_point_v<T>, T, i64>;
+
+    static TRes Init() {
+        return std::numeric_limits<TRes>::max();
+    }
+
+    auto Distance(const char* cluster, const char* embedding) const noexcept {
+        const TRes similarity = DotProduct(reinterpret_cast<const TCoord*>(cluster), reinterpret_cast<const TCoord*>(embedding), this->Dimensions);
+        return -similarity;
+    }
+};
+
+template <typename TMetric>
+struct TCalculation: TMetric {
+    using TEmbedding = std::vector<typename TMetric::TSum>;
+
+    struct TAggregated {
+        TEmbedding Cluster;
+        ui64 Count = 0;
+    };
+
+    ui32 FindClosest(std::span<const TString> clusters, const char* embedding, std::span<const TAggregated> aggregated) {
+        auto min = TMetric::Init();
+        ui32 closest = std::numeric_limits<ui32>::max();
+        for (size_t i = 0; const auto& cluster : clusters) {
+            auto distance = TMetric::Distance(cluster.data(), embedding);
+            if (distance < min || (distance == min && aggregated[i].Count < aggregated[closest].Count)) {
+                closest = i;
+            }
+            ++i;
+        }
+        return closest;
+    }
+};
+
+template <typename TMetric>
+class TLocalKMeansScan final: public TActor<TLocalKMeansScan<TMetric>>, public NTable::IScan, private TCalculation<TMetric> {
+protected:
+    using EState = NKikimrTxDataShard::TEvLocalKMeansRequest;
+    using TTBase = TActor<TLocalKMeansScan<TMetric>>;
+
+    ui32 Parent = 0;
+    ui32 Child = 0;
+
+    ui32 Round = 0;
+    ui32 MaxRounds = 0;
+
+    ui32 K = 0;
+
+    EState::EState State;
+    EState::EState UploadState;
+
+    IDriver* Driver = nullptr;
+
+    TLead Lead;
+
+    // Sample
+    ui64 ReadRows = 0;
+    ui64 ReadBytes = 0;
+
+    ui64 MaxProbability = std::numeric_limits<ui64>::max();
+    TReallyFastRng32 Rng;
+
+    struct TProbability {
+        ui64 P = 0;
+        ui64 I = 0;
+
+        bool operator==(const TProbability&) const noexcept = default;
+        auto operator<=>(const TProbability&) const noexcept = default;
+    };
+
+    std::vector<TProbability> MaxRows;
+    std::vector<TString> Clusters;
+
+    // KMeans
+    std::vector<typename TCalculation<TMetric>::TAggregated> Aggregated;
+
+    // Upload
+    std::shared_ptr<TTypes> TargetTypes;
+    std::shared_ptr<TTypes> NextTypes;
+
+    TString TargetTable;
+    TString NextTable;
+
+    TBufferData ReadBuf;
+    TBufferData WriteBuf;
+
+    NTable::TPos EmbeddingPos = 0;
+    NTable::TPos DataPos = 1;
+
+    ui32 RetryCount = 0;
+
+    TActorId Uploader;
+    TUploadLimits Limits;
+
+    NTable::TTag KMeansScan;
+    TTags UploadScan;
+
+    TUploadStatus UploadStatus;
+
+    // Response
+    TActorId ResponseActorId;
+    TAutoPtr<TEvDataShard::TEvLocalKMeansProgressResponse> Response;
+
+public:
+    static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
+        return NKikimrServices::TActivity::LOCAL_KMEANS_SCAN_ACTOR;
+    }
+
+    TLocalKMeansScan(const TUserTable& table, TLead&& lead, NKikimrTxDataShard::TEvLocalKMeansRequest& request, const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvLocalKMeansProgressResponse>&& response)
+        : TTBase::TActor{&TTBase::TThis::StateWork}
+        , Parent{request.GetParent()}
+        , Child{request.GetChild()}
+        , MaxRounds{request.GetNeedsRounds() - request.GetDoneRounds()}
+        , K{request.GetK()}
+        , State{request.GetState()}
+        , UploadState{request.GetUpload()}
+        , Lead{std::move(lead)}
+        , Rng{request.GetSeed()}
+        , TargetTable{request.GetLevelName()}
+        , NextTable{request.GetPostingName()}
+        , ResponseActorId{responseActorId}
+        , Response{std::move(response)} {
+        this->Dimensions = request.GetSettings().vector_dimension();
+        const auto& embedding = request.GetEmbeddingColumn();
+        const auto& data = request.GetDataColumns();
+        // scan tags
+        {
+            auto tags = GetAllTags(table);
+            KMeansScan = tags.at(embedding);
+            UploadScan.reserve(1 + data.size());
+            if (auto it = std::find(data.begin(), data.end(), embedding); it != data.end()) {
+                EmbeddingPos = it - data.begin();
+                DataPos = 0;
+            } else {
+                UploadScan.push_back(KMeansScan);
+            }
+            for (const auto& column : data) {
+                UploadScan.push_back(tags.at(column));
+            }
+        }
+        // upload types
+        Ydb::Type type;
+        if (State <= EState::KMEANS) {
+            TargetTypes = std::make_shared<NTxProxy::TUploadTypes>(3);
+            type.set_type_id(Ydb::Type::UINT32);
+            (*TargetTypes)[0] = {NTableIndex::NTableVectorKmeansTreeIndex::LevelTable_ParentIdColumn, type};
+            (*TargetTypes)[1] = {NTableIndex::NTableVectorKmeansTreeIndex::LevelTable_IdColumn, type};
+            type.set_type_id(Ydb::Type::STRING);
+            (*TargetTypes)[2] = {NTableIndex::NTableVectorKmeansTreeIndex::LevelTable_EmbeddingColumn, type};
+        }
+        {
+            auto types = GetAllTypes(table);
+
+            NextTypes = std::make_shared<NTxProxy::TUploadTypes>();
+            NextTypes->reserve(1 + 1 + std::min(table.KeyColumnTypes.size() + data.size(), types.size()));
+
+            type.set_type_id(Ydb::Type::UINT32);
+            NextTypes->emplace_back(NTableIndex::NTableVectorKmeansTreeIndex::PostingTable_ParentIdColumn, type);
+
+            auto addType = [&](const auto& column) {
+                auto it = types.find(column);
+                Y_ABORT_UNLESS(it != types.end());
+                ProtoYdbTypeFromTypeInfo(&type, it->second);
+                NextTypes->emplace_back(it->first, type);
+                types.erase(it);
+            };
+            for (const auto& column : table.KeyColumnIds) {
+                addType(table.Columns.at(column).Name);
+            }
+            switch (UploadState) {
+                case EState::UPLOAD_MAIN_TO_TMP:
+                case EState::UPLOAD_TMP_TO_TMP:
+                    addType(embedding);
+                    [[fallthrough]];
+                case EState::UPLOAD_MAIN_TO_POSTING:
+                case EState::UPLOAD_TMP_TO_POSTING: {
+                    for (const auto& column : data) {
+                        addType(column);
+                    }
+                } break;
+                default:
+                    Y_UNREACHABLE();
+            }
+        }
+    }
+
+    ~TLocalKMeansScan() final = default;
+
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept final {
+        TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
+        LOG_T("Prepare " << Debug());
+
+        Driver = driver;
+        return {EScan::Feed, {}};
+    }
+
+    EScan Seek(TLead& lead, ui64 seq) noexcept final {
+        LOG_T("Seek " << Debug());
+        if (State == UploadState) {
+            if (!WriteBuf.IsEmpty()) {
+                return EScan::Sleep;
+            }
+            if (!ReadBuf.IsEmpty()) {
+                ReadBuf.FlushTo(WriteBuf);
+                Upload(false);
+                return EScan::Sleep;
+            }
+            if (UploadStatus.IsNone()) {
+                UploadStatus.StatusCode = Ydb::StatusIds::SUCCESS;
+            }
+            return EScan::Final;
+        }
+
+        if (State == EState::SAMPLE) {
+            lead = Lead;
+            lead.SetTags({&KMeansScan, 1});
+            if (seq == 0) {
+                return EScan::Feed;
+            }
+            State = EState::KMEANS;
+            if (!InitAggregated()) {
+                // We don't need to do anything,
+                // because this datashard doesn't have valid embeddings for this parent
+                return EScan::Final;
+            }
+            return EScan::Feed;
+        }
+
+        Y_ASSERT(State == EState::KMEANS);
+        RecomputeClusters();
+        if (Round == MaxRounds) {
+            lead = std::move(Lead);
+            lead.SetTags(UploadScan);
+
+            UploadSample();
+            State = UploadState;
+        } else {
+            lead = Lead;
+            lead.SetTags({&KMeansScan, 1});
+            ++Round;
+        }
+        return EScan::Feed;
+    }
+
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final {
+        LOG_T("Feed " << Debug());
+        switch (State) {
+            case EState::SAMPLE:
+                return FeedSample(row);
+            case EState::KMEANS:
+                return FeedKMeans(row);
+            case EState::UPLOAD_MAIN_TO_TMP:
+                return FeedUploadMain2Tmp(key, row);
+            case EState::UPLOAD_MAIN_TO_POSTING:
+                return FeedUploadMain2Posting(key, row);
+            case EState::UPLOAD_TMP_TO_TMP:
+                return FeedUploadTmp2Tmp(key, row);
+            case EState::UPLOAD_TMP_TO_POSTING:
+                return FeedUploadTmp2Posting(key, row);
+            case EState::DONE:
+                Y_UNREACHABLE();
+        }
+    }
+
+    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final {
+        LOG_T("Finish " << Debug());
+        auto ctx = TActivationContext::AsActorContext().MakeFor(this->SelfId());
+
+        if (Uploader) {
+            TAutoPtr<TEvents::TEvPoisonPill> poison = new TEvents::TEvPoisonPill;
+            ctx.Send(Uploader, poison.Release());
+            Uploader = {};
+        }
+
+        auto& record = Response->Record;
+        if (abort != EAbort::None) {
+            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
+        } else if (UploadStatus.IsSuccess()) {
+            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::DONE);
+        } else {
+            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);
+        }
+        NYql::IssuesToMessage(UploadStatus.Issues, record.MutableIssues());
+        ctx.Send(ResponseActorId, Response.Release());
+
+        Driver = nullptr;
+        this->PassAway();
+        return nullptr;
+    }
+
+    void Describe(IOutputStream& out) const noexcept final {
+        out << Debug();
+    }
+
+    TString Debug() const {
+        auto builder = TStringBuilder() << " TLocalKMeansScan";
+        if (Response) {
+            auto& r = Response->Record;
+            builder << " Id: " << r.GetId();
+        }
+        return builder << " State: " << State
+                       << " Round: " << Round
+                       << " MaxRounds: " << MaxRounds
+                       << " ReadBuf size: " << ReadBuf.Size()
+                       << " WriteBuf size: " << WriteBuf.Size()
+                       << " ";
+    }
+
+    EScan PageFault() noexcept final {
+        LOG_T("PageFault " << Debug());
+
+        if (!ReadBuf.IsEmpty() && WriteBuf.IsEmpty()) {
+            ReadBuf.FlushTo(WriteBuf);
+            Upload(false);
+        }
+
+        return EScan::Feed;
+    }
+
+private:
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvTxUserProxy::TEvUploadRowsResponse, Handle);
+            CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
+            default:
+                LOG_E("TLocalKMeansScan: StateWork unexpected event type: " << ev->GetTypeRewrite() << " event: " << ev->ToString() << " " << Debug());
+        }
+    }
+
+    void HandleWakeup(const NActors::TActorContext& /*ctx*/) {
+        LOG_T("Retry upload " << Debug());
+
+        if (!WriteBuf.IsEmpty()) {
+            Upload(true);
+        }
+    }
+
+    void Handle(TEvTxUserProxy::TEvUploadRowsResponse::TPtr& ev, const TActorContext& ctx) {
+        LOG_T("Handle TEvUploadRowsResponse "
+              << Debug()
+              << " Uploader: " << Uploader.ToString()
+              << " ev->Sender: " << ev->Sender.ToString());
+
+        if (Uploader) {
+            Y_VERIFY_S(Uploader == ev->Sender, "Mismatch Uploader: " << Uploader.ToString() << " ev->Sender: " << ev->Sender.ToString() << Debug());
+        } else {
+            Y_ABORT_UNLESS(Driver == nullptr);
+            return;
+        }
+
+        UploadStatus.StatusCode = ev->Get()->Status;
+        UploadStatus.Issues = ev->Get()->Issues;
+        if (UploadStatus.IsSuccess()) {
+            WriteBuf.Clear();
+            if (!ReadBuf.IsEmpty() && ReadBuf.IsReachLimits(Limits)) {
+                ReadBuf.FlushTo(WriteBuf);
+                Upload(true);
+            }
+
+            Driver->Touch(EScan::Feed);
+            return;
+        }
+
+        if (RetryCount < Limits.MaxUploadRowsRetryCount && UploadStatus.IsRetriable()) {
+            LOG_N("Got retriable error, " << Debug() << UploadStatus.ToString());
+
+            ctx.Schedule(Limits.GetTimeoutBackouff(RetryCount), new TEvents::TEvWakeup());
+            return;
+        }
+
+        LOG_N("Got error, abort scan, " << Debug() << UploadStatus.ToString());
+
+        Driver->Touch(EScan::Final);
+    }
+
+    EScan FeedUpload() {
+        if (!ReadBuf.IsReachLimits(Limits)) {
+            return EScan::Feed;
+        }
+        if (!WriteBuf.IsEmpty()) {
+            return EScan::Sleep;
+        }
+        ReadBuf.FlushTo(WriteBuf);
+        Upload(false);
+        return EScan::Feed;
+    }
+
+    bool InitAggregated() {
+        if (Clusters.size() == 0) {
+            return false;
+        }
+        if (Clusters.size() < K) {
+            // if this datashard have smaller than K count of valid embeddings for this parent
+            // lets make single centroid for it
+            K = 1;
+            Clusters.resize(K);
+        }
+        Y_ASSERT(Clusters.size() == K);
+        Aggregated.resize(K);
+        for (auto& aggregate : Aggregated) {
+            aggregate.Cluster.resize(this->Dimensions, 0);
+        }
+        return true;
+    }
+
+    void Aggregate(ui32 pos, const char* embedding) {
+        if (pos >= K) {
+            return;
+        }
+        auto& aggregate = Aggregated[pos];
+        auto* coords = aggregate.Cluster.data();
+        for (auto coord : this->GetCoords(embedding)) {
+            *coords++ += coord;
+        }
+        ++aggregate.Count;
+    }
+
+    void RecomputeClusters() {
+        auto* clusters = Clusters.data();
+        for (auto& aggregate : Aggregated) {
+            auto& cluster = *clusters++;
+            if (aggregate.Count == 0) {
+                continue; // TODO(mbkkt) is it impossible?
+            }
+            this->Fill(cluster, aggregate.Cluster.data(), aggregate.Count);
+        }
+    }
+
+    ui64 GetProbability() {
+        return Rng.GenRand64();
+    }
+
+    ui32 FeedEmbedding(const TRow& row, NTable::TPos embeddingPos) {
+        Y_ASSERT(embeddingPos < row.Size());
+        const auto embedding = row.Get(embeddingPos).AsRef();
+        ++ReadRows;
+        ReadBytes += embedding.size(); // TODO(mbkkt) add some constant overhead?
+        if (!this->IsExpectedSize(embedding)) {
+            return std::numeric_limits<ui32>::max();
+        }
+        return this->FindClosest(Clusters, embedding.data(), Aggregated);
+    }
+
+    EScan FeedSample(const TRow& row) noexcept {
+        Y_ASSERT(row.Size() == 1);
+        const auto embedding = row.Get(0).AsRef();
+        ++ReadRows;
+        ReadBytes += embedding.size(); // TODO(mbkkt) add some constant overhead?
+        if (!this->IsExpectedSize(embedding)) {
+            return EScan::Feed;
+        }
+
+        const auto probability = GetProbability();
+        if (Clusters.size() < K) {
+            MaxRows.push_back({probability, Clusters.size()});
+            Clusters.emplace_back(embedding.data(), embedding.size());
+            if (Clusters.size() == K) {
+                std::make_heap(MaxRows.begin(), MaxRows.end());
+                MaxProbability = MaxRows.front().P;
+            }
+        } else if (probability < MaxProbability) {
+            // TODO(mbkkt) use tournament tree to make less compare and swaps
+            std::pop_heap(MaxRows.begin(), MaxRows.end());
+            Clusters[MaxRows.back().I].assign(embedding.data(), embedding.size());
+            MaxRows.back().P = probability;
+            std::push_heap(MaxRows.begin(), MaxRows.end());
+            MaxProbability = MaxRows.front().P;
+        }
+        return MaxProbability != 0 ? EScan::Feed : EScan::Reset;
+    }
+
+    EScan FeedKMeans(const TRow& row) noexcept {
+        Y_ASSERT(row.Size() == 1);
+        const ui32 pos = FeedEmbedding(row, 0);
+        Aggregate(pos, row.Get(0).Data());
+        return EScan::Feed;
+    }
+
+    EScan FeedUploadMain2Tmp(TArrayRef<const TCell> key, const TRow& row) noexcept {
+        const ui32 pos = FeedEmbedding(row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        std::array<TCell, 1> cells;
+        cells[0] = TCell::Make(Child + pos);
+        auto pk = TSerializedCellVec::Serialize(cells);
+        TSerializedCellVec::UnsafeAppendCells(key, pk);
+        ReadBuf.AddRow(TSerializedCellVec{key}, TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(*row));
+        return FeedUpload();
+    }
+
+    EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept {
+        const ui32 pos = FeedEmbedding(row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        std::array<TCell, 1> cells;
+        cells[0] = TCell::Make(Child + pos);
+        auto pk = TSerializedCellVec::Serialize(cells);
+        TSerializedCellVec::UnsafeAppendCells(key, pk);
+        ReadBuf.AddRow(TSerializedCellVec{key}, TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize((*row).Slice(DataPos)));
+        return FeedUpload();
+    }
+
+    EScan FeedUploadTmp2Tmp(TArrayRef<const TCell> key, const TRow& row) noexcept {
+        const ui32 pos = FeedEmbedding(row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        std::array<TCell, 1> cells;
+        cells[0] = TCell::Make(Child + pos);
+        auto pk = TSerializedCellVec::Serialize(cells);
+        TSerializedCellVec::UnsafeAppendCells(key.Slice(1), pk);
+        ReadBuf.AddRow(TSerializedCellVec{key}, TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(*row));
+        return FeedUpload();
+    }
+
+    EScan FeedUploadTmp2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept {
+        const ui32 pos = FeedEmbedding(row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        std::array<TCell, 1> cells;
+        cells[0] = TCell::Make(Child + pos);
+        auto pk = TSerializedCellVec::Serialize(cells);
+        TSerializedCellVec::UnsafeAppendCells(key.Slice(1), pk);
+        ReadBuf.AddRow(TSerializedCellVec{key}, TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize((*row).Slice(DataPos)));
+        return FeedUpload();
+    }
+
+    void Upload(bool isRetry) {
+        if (isRetry) {
+            ++RetryCount;
+        } else {
+            RetryCount = 0;
+            if (State != EState::KMEANS && NextTypes) {
+                TargetTypes = std::exchange(NextTypes, {});
+                TargetTable = std::move(NextTable);
+            }
+        }
+
+        auto actor = NTxProxy::CreateUploadRowsInternal(
+            this->SelfId(), TargetTable,
+            TargetTypes,
+            WriteBuf.GetRowsData(),
+            NTxProxy::EUploadRowsMode::WriteToTableShadow,
+            true /*writeToPrivateTable*/);
+
+        Uploader = TActivationContext::AsActorContext().MakeFor(this->SelfId()).Register(actor);
+    }
+
+    void UploadSample() {
+        Y_ASSERT(ReadBuf.IsEmpty());
+        Y_ASSERT(WriteBuf.IsEmpty());
+        std::array<TCell, 2> pk;
+        std::array<TCell, 1> data;
+        for (NTable::TPos pos = 0; const auto& row : Clusters) {
+            pk[0] = TCell::Make(Parent);
+            pk[1] = TCell::Make(Child + pos);
+            data[0] = TCell{row};
+            WriteBuf.AddRow({}, TSerializedCellVec{pk}, TSerializedCellVec::Serialize(data));
+            ++pos;
+        }
+        Upload(false);
+    }
+};
+
+class TDataShard::TTxHandleSafeLocalKMeansScan final: public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+public:
+    TTxHandleSafeLocalKMeansScan(TDataShard* self, TEvDataShard::TEvLocalKMeansRequest::TPtr&& ev)
+        : TTransactionBase(self)
+        , Ev(std::move(ev)) {
+    }
+
+    bool Execute(TTransactionContext&, const TActorContext& ctx) final {
+        Self->HandleSafe(Ev, ctx);
+        return true;
+    }
+
+    void Complete(const TActorContext&) final {
+    }
+
+private:
+    TEvDataShard::TEvLocalKMeansRequest::TPtr Ev;
+};
+
+void TDataShard::Handle(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TActorContext&) {
+    Execute(new TTxHandleSafeLocalKMeansScan(this, std::move(ev)));
+}
+
+void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TActorContext& ctx) {
+    auto& record = ev->Get()->Record;
+    TRowVersion rowVersion(record.GetSnapshotStep(), record.GetSnapshotTxId());
+
+    // Note: it's very unlikely that we have volatile txs before this snapshot
+    if (VolatileTxManager.HasVolatileTxsAtSnapshot(rowVersion)) {
+        VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion,
+                                                     std::unique_ptr<IEventHandle>(ev.Release()));
+        return;
+    }
+    const ui64 id = record.GetId();
+
+    auto response = MakeHolder<TEvDataShard::TEvLocalKMeansProgressResponse>();
+    response->Record.SetId(id);
+    response->Record.SetTabletId(TabletID());
+
+    TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
+    response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
+    response->Record.SetRequestSeqNoRound(seqNo.Round);
+
+    auto badRequest = [&](const TString& error) {
+        response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+        auto issue = response->Record.AddIssues();
+        issue->set_severity(NYql::TSeverityIds::S_ERROR);
+        issue->set_message(error);
+        ctx.Send(ev->Sender, std::move(response));
+    };
+
+    if (const ui64 shardId = record.GetTabletId(); shardId != TabletID()) {
+        badRequest(TStringBuilder() << "Wrong shard " << shardId << " this is " << TabletID());
+        return;
+    }
+
+    const auto pathId = PathIdFromPathId(record.GetPathId());
+    const auto* userTableIt = GetUserTables().FindPtr(pathId.LocalPathId);
+    if (!userTableIt) {
+        badRequest(TStringBuilder() << "Unknown table id: " << pathId.LocalPathId);
+        return;
+    }
+    Y_ABORT_UNLESS(*userTableIt);
+    const auto& userTable = **userTableIt;
+
+    if (const auto* recCard = ScanManager.Get(id)) {
+        if (recCard->SeqNo == seqNo) {
+            // do no start one more scan
+            return;
+        }
+
+        CancelScan(userTable.LocalTid, recCard->ScanId);
+        ScanManager.Drop(id);
+    }
+
+    const auto range = CreateRangeFrom(userTable, record.GetParent());
+    if (range.IsEmptyRange(userTable.KeyColumnTypes)) {
+        badRequest(TStringBuilder() << " requested range doesn't intersect with table range");
+        return;
+    }
+
+    if (!record.HasSnapshotStep() || !record.HasSnapshotTxId()) {
+        badRequest(TStringBuilder() << " request doesn't have Shapshot Step or TxId");
+        return;
+    }
+
+    const TSnapshotKey snapshotKey(pathId, rowVersion.Step, rowVersion.TxId);
+    const TSnapshot* snapshot = SnapshotManager.FindAvailable(snapshotKey);
+    if (!snapshot) {
+        badRequest(TStringBuilder()
+                   << "no snapshot has been found"
+                   << " , path id is " << pathId.OwnerId << ":" << pathId.LocalPathId
+                   << " , snapshot step is " << snapshotKey.Step
+                   << " , snapshot tx is " << snapshotKey.TxId);
+        return;
+    }
+
+    if (!IsStateActive()) {
+        badRequest(TStringBuilder() << "Shard " << TabletID() << " is not ready for requests");
+        return;
+    }
+
+    if (record.GetK() < 1) {
+        badRequest(TStringBuilder() << "Should be requested at least single row");
+        return;
+    }
+
+    if (!record.HasEmbeddingColumn()) {
+        badRequest(TStringBuilder() << "Should be specified embedding column");
+        return;
+    }
+
+    TScanOptions scanOpts;
+    scanOpts.SetSnapshotRowVersion(rowVersion);
+    scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
+
+    const auto& settings = record.GetSettings();
+    TAutoPtr<NTable::IScan> scan;
+
+    auto createScan = [&]<typename T> {
+        scan = new TLocalKMeansScan<T>{
+            userTable,
+            CreateLeadFrom(range),
+            record,
+            ev->Sender,
+            std::move(response),
+        };
+    };
+
+    auto handleType = [&]<template <typename...> typename T>() {
+        switch (settings.vector_type()) {
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT:
+                return createScan.operator()<T<float>>();
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8:
+                return createScan.operator()<T<ui8>>();
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_INT8:
+                return createScan.operator()<T<i8>>();
+            case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_BIT:
+                return badRequest("TODO(mbkkt) bit vector type is not supported");
+            default:
+                return badRequest("Wrong vector type");
+        }
+    };
+
+    if (settings.has_similarity() && settings.has_distance()) {
+        badRequest("Shouldn't be specified similarity and distance at the same time");
+    } else if (settings.has_similarity()) {
+        switch (settings.similarity()) {
+            case Ydb::Table::VectorIndexSettings::SIMILARITY_COSINE:
+                handleType.template operator()<TCosineSimilarity>();
+                break;
+            case Ydb::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT:
+                handleType.template operator()<TMaxInnerProductSimilarity>();
+                break;
+            default:
+                badRequest("Wrong similarity");
+                break;
+        }
+    } else if (settings.has_distance()) {
+        switch (settings.distance()) {
+            case Ydb::Table::VectorIndexSettings::DISTANCE_COSINE:
+                // We don't need to have separate implementation for distance, because clusters will be same as for similarity
+                handleType.template operator()<TCosineSimilarity>();
+                break;
+            case Ydb::Table::VectorIndexSettings::DISTANCE_MANHATTAN:
+                handleType.template operator()<TL1Distance>();
+                break;
+            case Ydb::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN:
+                handleType.template operator()<TL2Distance>();
+                break;
+            default:
+                badRequest("Wrong distance");
+                break;
+        }
+    } else {
+        badRequest("Should be specified similarity or distance");
+    }
+    if (!scan) {
+        return;
+    }
+
+    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), ev->Cookie, scanOpts);
+    TScanRecord recCard = {scanId, seqNo};
+    ScanManager.Set(id, recCard);
+}
+
+} //namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -367,10 +367,9 @@ public:
 
     TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final {
         LOG_T("Finish " << Debug());
-        auto ctx = TActivationContext::ActorContextFor(this->SelfId());
 
         if (Uploader) {
-            ctx.Send(Uploader, new TEvents::TEvPoisonPill);
+            Send(Uploader, new TEvents::TEvPoisonPill);
             Uploader = {};
         }
 
@@ -383,7 +382,7 @@ public:
             record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);
         }
         NYql::IssuesToMessage(UploadStatus.Issues, record.MutableIssues());
-        ctx.Send(ResponseActorId, Response.Release());
+        Send(ResponseActorId, Response.Release());
 
         Driver = nullptr;
         this->PassAway();

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -508,7 +508,7 @@ protected:
             NTxProxy::EUploadRowsMode::WriteToTableShadow,
             true /*writeToPrivateTable*/);
 
-        Uploader = TActivationContext::ActorContextFor(this->SelfId()).Register(actor);
+        Uploader = this->Register(actor);
     }
 
     void UploadSample() {

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -153,7 +153,7 @@ public:
             Response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
         }
         LOG_T("Finish " << Debug());
-        TActivationContext::ActorContextFor(SelfId()).Send(ResponseActorId, Response.Release());
+        Send(ResponseActorId, Response.Release());
         Driver = nullptr;
         PassAway();
         return nullptr;

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -78,8 +78,7 @@ public:
         , RequestedRange(range)
         , K(k)
         , MaxProbability(maxProbability)
-        , Rng(seed)
-    {
+        , Rng(seed) {
         Y_ASSERT(MaxProbability != 0);
     }
 
@@ -154,7 +153,7 @@ public:
             Response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
         }
         LOG_T("Finish " << Debug());
-        TActivationContext::AsActorContext().MakeFor(SelfId()).Send(ResponseActorId, Response.Release());
+        TActivationContext::ActorContextFor(SelfId()).Send(ResponseActorId, Response.Release());
         Driver = nullptr;
         PassAway();
         return nullptr;
@@ -224,8 +223,7 @@ class TDataShard::TTxHandleSafeSampleKScan: public NTabletFlatExecutor::TTransac
 public:
     TTxHandleSafeSampleKScan(TDataShard* self, TEvDataShard::TEvSampleKRequest::TPtr&& ev)
         : TTransactionBase(self)
-        , Ev(std::move(ev))
-    {
+        , Ev(std::move(ev)) {
     }
 
     bool Execute(TTransactionContext&, const TActorContext& ctx) {

--- a/ydb/core/tx/datashard/scan_common.cpp
+++ b/ydb/core/tx/datashard/scan_common.cpp
@@ -19,4 +19,25 @@ void AddTags(TTags& tags, const TColumnsTags& allTags, TProtoColumnsCRef columns
     }
 }
 
+TColumnsTypes GetAllTypes(const TUserTable& tableInfo) {
+    TColumnsTypes result;
+
+    for (const auto& it : tableInfo.Columns) {
+        result[it.second.Name] = it.second.Type;
+    }
+
+    return result;
+}
+
+void ProtoYdbTypeFromTypeInfo(Ydb::Type* type, const NScheme::TTypeInfo typeInfo) {
+    if (typeInfo.GetTypeId() == NScheme::NTypeIds::Pg) {
+        auto* typeDesc = typeInfo.GetTypeDesc();
+        auto* pg = type->mutable_pg_type();
+        pg->set_type_name(NPg::PgTypeNameFromTypeDesc(typeDesc));
+        pg->set_oid(NPg::PgTypeIdFromTypeDesc(typeDesc));
+    } else {
+        type->set_type_id((Ydb::Type::PrimitiveTypeId)typeInfo.GetTypeId());
+    }
+}
+
 }

--- a/ydb/core/tx/datashard/scan_common.h
+++ b/ydb/core/tx/datashard/scan_common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/public/api/protos/ydb_value.pb.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
 #include <ydb/core/util/intrusive_heap.h>
 
@@ -74,5 +75,11 @@ TTags BuildTags(const TUserTable& tableInfo, Args&&... columns) {
 
     return tags;
 }
+
+using TColumnsTypes = THashMap<TString, NScheme::TTypeInfo>;
+
+TColumnsTypes GetAllTypes(const TUserTable& tableInfo);
+
+void ProtoYdbTypeFromTypeInfo(Ydb::Type* type, const NScheme::TTypeInfo typeInfo);
 
 }

--- a/ydb/core/tx/datashard/ut_local_kmeans/ya.make
+++ b/ydb/core/tx/datashard/ut_local_kmeans/ya.make
@@ -1,0 +1,39 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+FORK_SUBTESTS()
+
+SPLIT_FACTOR(1)
+
+IF (SANITIZER_TYPE)
+    REQUIREMENTS(ram:32)
+ENDIF()
+
+IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+    TIMEOUT(3600)
+    SIZE(LARGE)
+    TAG(ya:fat)
+ELSE()
+    TIMEOUT(600)
+    SIZE(MEDIUM)
+ENDIF()
+
+PEERDIR(
+    ydb/core/tx/datashard/ut_common
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/default
+    ydb/core/tx
+    ydb/library/yql/public/udf/service/exception_policy
+    ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/client/ydb_result
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    datashard_ut_local_kmeans.cpp
+)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -166,6 +166,7 @@ SRCS(
     load_and_wait_in_rs_unit.cpp
     load_tx_details_unit.cpp
     load_write_details_unit.cpp
+    local_kmeans.cpp
     make_scan_snapshot_unit.cpp
     make_snapshot_unit.cpp
     move_index_unit.cpp
@@ -238,6 +239,9 @@ PEERDIR(
     library/cpp/monlib/service/pages
     library/cpp/string_utils/base64
     library/cpp/string_utils/quote
+    library/cpp/dot_product
+    library/cpp/l1_distance
+    library/cpp/l2_distance
     ydb/core/actorlib_impl
     ydb/core/base
     ydb/core/change_exchange

--- a/ydb/library/services/services.proto
+++ b/ydb/library/services/services.proto
@@ -1053,5 +1053,6 @@ message TActivity {
         MEMORY_CONTROLLER = 644;
         BUILD_COLUMNS_SCAN_ACTOR = 645;
         SAMPLE_K_UPLOAD_ACTOR = 646;
+        LOCAL_KMEANS_SCAN_ACTOR = 647;
     };
 };

--- a/ydb/public/api/protos/out/out.cpp
+++ b/ydb/public/api/protos/out/out.cpp
@@ -42,3 +42,7 @@ Y_DECLARE_OUT_SPEC(, Ydb::Table::VectorIndexSettings::Similarity, stream, value)
 Y_DECLARE_OUT_SPEC(, Ydb::Table::VectorIndexSettings::VectorType, stream, value) {
     stream << Ydb::Table::VectorIndexSettings::VectorType_Name(value);
 }
+
+Y_DECLARE_OUT_SPEC(, Ydb::Table::IndexBuildState_State, stream, value) {
+    stream << IndexBuildState_State_Name(value);
+}


### PR DESCRIPTION
It run kmeans for datashard with embeddings.

This scan contains 3 phases:
1. First iteration collect sample of clusters
2. Then N iterations recompute clusters (main cycle of batched kmeans)
3. Finally last iteration upload clusters to level table and postings to corresponding posting table


Important note, that this code doesn't contains slow-path (that can store some intermediate results to LocalDB).
Because in general slow-path will be run only if this code fails and at the same time, datashards are small enough to don't think about this in first implementation of vector index (another words granularity of work that needed to be re-done in case datashard restart <= datashard size)