### PR TITLE
Do not invalidate request with INTERNAL_ERROR in case of cancelation tx on the follower using depended reads

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -621,10 +621,11 @@ private:
                 state.State = TShardState::EState::Finished;
 
                 YQL_ENSURE(state.DatashardState.Defined());
-                YQL_ENSURE(!state.DatashardState->Follower);
-
-                Send(MakePipePerNodeCacheID(/* allowFollowers */ false), new TEvPipeCache::TEvForward(
-                    new TEvDataShard::TEvCancelTransactionProposal(TxId), shardId, /* subscribe */ false));
+                //nothing to cancel on follower
+                if (!state.DatashardState->Follower) {
+                    Send(MakePipePerNodeCacheID(/* allowFollowers */ false), new TEvPipeCache::TEvForward(
+                        new TEvDataShard::TEvCancelTransactionProposal(TxId), shardId, /* subscribe */ false));
+                }
             }
         }
     }


### PR DESCRIPTION


The data query on the table with READ_REPLICA_SETTINGS set and STALE_RO one shard tx in case of depended reads (for example joint table with itself) can perform via legacy propose transaction routine on the follower. It can cause YQL_ENSURE if the query was cancelled.

Actually no need to send TEvCancelTransactionProposal event on the folower datashard, we can just skip such shards.



### Changelog category
* Bugfix 
