### PR TITLE
Split WideCombiners state into buckets earlier

### DIFF
--- a/ydb/library/yql/minikql/aligned_page_pool.h
+++ b/ydb/library/yql/minikql/aligned_page_pool.h
@@ -218,7 +218,7 @@ public:
         IsMaximumLimitValueReached = isReached;
     }
 
-    bool GetMaximumLimitValueReached() noexcept {
+    bool GetMaximumLimitValueReached() const noexcept {
         return IsMaximumLimitValueReached;
     }
 

--- a/ydb/library/yql/minikql/aligned_page_pool.h
+++ b/ydb/library/yql/minikql/aligned_page_pool.h
@@ -218,6 +218,10 @@ public:
         IsMaximumLimitValueReached = isReached;
     }
 
+    bool GetMaximumLimitValueReached() noexcept {
+        return IsMaximumLimitValueReached;
+    }
+
     bool IsMemoryYellowZoneEnabled() const noexcept {
         return IsMemoryYellowZoneReached;
     }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -187,7 +187,7 @@ struct TCombinerNodes {
 class TState : public TComputationValue<TState> {
     typedef TComputationValue<TState> TBase;
 private:
-    using TStates = TRobinHoodHashSet<NUdf::TUnboxedValuePod*, TEqualsFunc, THashFunc, TMKQLAllocator<char, EMemorySubPool::Temporary>>;
+    using TStates = std::unordered_set<NUdf::TUnboxedValuePod*, TEqualsFunc, THashFunc, TMKQLAllocator<char, EMemorySubPool::Temporary>>;
     using TRow = std::vector<NUdf::TUnboxedValuePod, TMKQLAllocator<NUdf::TUnboxedValuePod>>;
     using TStorage = std::deque<TRow, TMKQLAllocator<TRow>>;
 
@@ -322,6 +322,14 @@ public:
         }
         NUdf::TUnboxedValuePod* result = ExtractIt->GetValuePtr();
         return result;
+    }
+
+    ui64 GetNumberOfStoredKeys() const {
+        return States.GetSize();
+    }
+
+    ui64 GetStoredKeysCapacity() const {
+        return States.GetCapacity();
     }
 
     EFetchResult InputStatus = EFetchResult::One;
@@ -710,7 +718,7 @@ private:
     }
 
     bool IsSwitchToSpillingModeCondition() const {
-        return !HasMemoryForProcessing();
+        return TlsAllocState->GetMaximumLimitValueReached();
     }
 
 public:

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -187,7 +187,7 @@ struct TCombinerNodes {
 class TState : public TComputationValue<TState> {
     typedef TComputationValue<TState> TBase;
 private:
-    using TStates = std::unordered_set<NUdf::TUnboxedValuePod*, TEqualsFunc, THashFunc, TMKQLAllocator<char, EMemorySubPool::Temporary>>;
+    using TStates = TRobinHoodHashSet<NUdf::TUnboxedValuePod*, TEqualsFunc, THashFunc, TMKQLAllocator<char, EMemorySubPool::Temporary>>;
     using TRow = std::vector<NUdf::TUnboxedValuePod, TMKQLAllocator<NUdf::TUnboxedValuePod>>;
     using TStorage = std::deque<TRow, TMKQLAllocator<TRow>>;
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -710,7 +710,7 @@ private:
     }
 
     bool IsSwitchToSpillingModeCondition() const {
-        return TlsAllocState->GetMaximumLimitValueReached();
+        return TlsAllocState->IsMemoryYellowZoneEnabled() || TlsAllocState->GetMaximumLimitValueReached();
     }
 
 public:

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -710,7 +710,7 @@ private:
     }
 
     bool IsSwitchToSpillingModeCondition() const {
-        return TlsAllocState->IsMemoryYellowZoneEnabled() || TlsAllocState->GetMaximumLimitValueReached();
+        return !HasMemoryForProcessing() || TlsAllocState->GetMaximumLimitValueReached();
     }
 
 public:

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -324,14 +324,6 @@ public:
         return result;
     }
 
-    ui64 GetNumberOfStoredKeys() const {
-        return States.GetSize();
-    }
-
-    ui64 GetStoredKeysCapacity() const {
-        return States.GetCapacity();
-    }
-
     EFetchResult InputStatus = EFetchResult::One;
     NUdf::TUnboxedValuePod* Tongue = nullptr;
     NUdf::TUnboxedValuePod* Throat = nullptr;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Split wideCombiner's state into buckets earlier - when the memory limit is set. It should prevent OOM after hash table x2 growth
...

### Changelog category <!-- remove all except one -->

* Improvement


### Additional information

...
