### PR TITLE
Fix PDisk's ColorBorderOccupancy calculation

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
@@ -163,7 +163,7 @@ public:
         str << "</tr>";
     }
 
-    void PrintHTML(IOutputStream &str, TQuotaRecord *sharedQuota, NKikimrBlobStorage::TPDiskSpaceColor::E *colorBorder) {
+    void PrintHTML(IOutputStream &str, TQuotaRecord *sharedQuota, NKikimrBlobStorage::TPDiskSpaceColor::E *colorBorder, double *borderOccupancy) {
         str << "<pre>";
         str << "ColorLimits#\n";
         ColorLimits.Print(str);
@@ -171,8 +171,12 @@ public:
         str << "\nExpectedOwnerCount# " << ExpectedOwnerCount;
         str << "\nActiveOwners# " << ActiveOwnerIds.size();
         if (colorBorder) {
-            str << "\nColorBorder# " << NKikimrBlobStorage::TPDiskSpaceColor::E_Name(*colorBorder) << "\n";
+            str << "\nColorBorder# " << NKikimrBlobStorage::TPDiskSpaceColor::E_Name(*colorBorder);
         }
+        if (borderOccupancy) {
+            str << "\nColorBorderOccupancy# " << *borderOccupancy;
+        }
+        str << "\n";
         str << "</pre>";
         str << "<table class='table table-sortable tablesorter tablesorter-bootstrap table-bordered'>";
         str << R"_(<tr>
@@ -535,9 +539,9 @@ public:
 
     void PrintHTML(IOutputStream &str) {
         str << "<h4>GlobalQuota</h4>";
-        GlobalQuota->PrintHTML(str, nullptr, nullptr);
+        GlobalQuota->PrintHTML(str, nullptr, nullptr, nullptr);
         str << "<h4>OwnerQuota</h4>";
-        OwnerQuota->PrintHTML(str, SharedQuota.Get(), &ColorBorder);
+        OwnerQuota->PrintHTML(str, SharedQuota.Get(), &ColorBorder, &ColorBorderOccupancy);
     }
 
     ui32 ColorFlagLimit(TOwner owner, NKikimrBlobStorage::TPDiskSpaceColor::E color) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_color_limits.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_color_limits.h
@@ -26,7 +26,7 @@ struct TDiskColor {
     }
 
     double CalculateOccupancy(i64 total) const {
-        return (double)CalculateQuota(total) / total;
+        return 1 - (double)CalculateQuota(total) / total;
     }
 };
 
@@ -102,15 +102,15 @@ struct TColorLimits {
 
     double GetOccupancyForColor(NKikimrBlobStorage::TPDiskSpaceColor::E color, i64 total) {
         switch (color) {
-            case NKikimrBlobStorage::TPDiskSpaceColor::GREEN:          return Cyan.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::CYAN:           return LightYellow.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::LIGHT_YELLOW:   return Yellow.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::YELLOW:         return LightOrange.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::LIGHT_ORANGE:   return PreOrange.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::PRE_ORANGE:     return Orange.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::ORANGE:         return Red.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::RED:            return Black.CalculateOccupancy(total);
-            case NKikimrBlobStorage::TPDiskSpaceColor::BLACK:          return 1.0;
+                case NKikimrBlobStorage::TPDiskSpaceColor::GREEN:           return 0.0;
+                case NKikimrBlobStorage::TPDiskSpaceColor::CYAN:            return Cyan.CalculateOccupancy(total);
+                case NKikimrBlobStorage::TPDiskSpaceColor::LIGHT_YELLOW:    return LightYellow.CalculateOccupancy(total);
+                case NKikimrBlobStorage::TPDiskSpaceColor::YELLOW:          return Yellow.CalculateOccupancy(total);
+                case NKikimrBlobStorage::TPDiskSpaceColor::LIGHT_ORANGE:    return LightOrange.CalculateOccupancy(total);
+                case NKikimrBlobStorage::TPDiskSpaceColor::PRE_ORANGE:      return PreOrange.CalculateOccupancy(total);
+                case NKikimrBlobStorage::TPDiskSpaceColor::ORANGE:          return Orange.CalculateOccupancy(total);
+                case NKikimrBlobStorage::TPDiskSpaceColor::RED:             return Red.CalculateOccupancy(total);
+                case NKikimrBlobStorage::TPDiskSpaceColor::BLACK:           return Black.CalculateOccupancy(total);
 
             case NKikimrBlobStorage::TPDiskSpaceColor_E_TPDiskSpaceColor_E_INT_MIN_SENTINEL_DO_NOT_USE_:
             case NKikimrBlobStorage::TPDiskSpaceColor_E_TPDiskSpaceColor_E_INT_MAX_SENTINEL_DO_NOT_USE_:

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -304,6 +304,8 @@ struct TPDiskConfig : public TThrRefBase {
         str << " OrangeLogChunksMultiplier# " << OrangeLogChunksMultiplier << x;
         str << " WarningLogChunksMultiplier# " << WarningLogChunksMultiplier << x;
         str << " YellowLogChunksMultiplier# " << YellowLogChunksMultiplier << x;
+        str << " MaxMetadataMegabytes# " << MaxMetadataMegabytes << x;
+        str << " SpaceColorBorder# " << SpaceColorBorder << x;
         str << "}";
         return str.Str();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Two bugs were found - shift in occupancy borders calculation and error in Occupancy calculation for colors (HardLimit was treated as occupancy, but it is free space)

So, both are fixed

### Changelog category <!-- remove all except one -->


* Bugfix 

### Additional information

...
