### PR TITLE
Fix wrong YQL_ENSURE in PushdownComplexFiltersOverAggregate

### DIFF
--- a/ydb/library/yql/core/common_opt/yql_co_flow2.cpp
+++ b/ydb/library/yql/core/common_opt/yql_co_flow2.cpp
@@ -1366,7 +1366,9 @@ TExprBase FilterOverAggregate(const TCoFlatMapBase& node, TExprContext& ctx, TOp
             const TNodeMap<ESubgraphType> marked = MarkSubgraphForAggregate(p, arg, keyColumns);
             auto rootIt = marked.find(p.Get());
             YQL_ENSURE(rootIt != marked.end());
-            YQL_ENSURE(rootIt->second == EXPR_MIXED, "Key-only or const predicates should be handled earlier");
+            if (rootIt->second != EXPR_MIXED) {
+                continue;
+            }
 
             TNodeMap<ICalcualtor::TPtr> calcCache;
             TExprNodeList keyPredicates;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* Fix wrong YQL_ENSURE in PushdownComplexFiltersOverAggregate

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
