### PR TITLE
Fix reporting of initial VDisk status to SysView (#8853)

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -131,6 +131,8 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     auto prevStaticVSlots = std::exchange(StaticVSlots, {});
     StaticVDiskMap.clear();
 
+    const TMonotonic mono = TActivationContext::Monotonic();
+
     if (StorageConfig.HasBlobStorageConfig()) {
         if (const auto& bsConfig = StorageConfig.GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
             const auto& ss = bsConfig.GetServiceSet();
@@ -143,7 +145,7 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
                 const auto& location = vslot.GetVDiskLocation();
                 const TPDiskId pdiskId(location.GetNodeID(), location.GetPDiskID());
                 const TVSlotId vslotId(pdiskId, location.GetVDiskSlotID());
-                StaticVSlots.try_emplace(vslotId, vslot, prevStaticVSlots);
+                StaticVSlots.try_emplace(vslotId, vslot, prevStaticVSlots, mono);
                 const TVDiskID& vdiskId = VDiskIDFromVDiskID(vslot.GetVDiskID());
                 StaticVDiskMap.emplace(vdiskId, vslotId);
                 StaticVDiskMap.emplace(TVDiskID(vdiskId.GroupID, 0, vdiskId), vslotId);

--- a/ydb/core/mind/bscontroller/config.h
+++ b/ydb/core/mind/bscontroller/config.h
@@ -101,6 +101,7 @@ namespace NKikimr {
 
             // when the config cmd received
             const TInstant Timestamp;
+            const TMonotonic Mono;
 
             // various settings from controller
             const bool DonorMode;
@@ -124,7 +125,8 @@ namespace NKikimr {
             bool PushStaticGroupsToSelfHeal = false;
 
         public:
-            TConfigState(TBlobStorageController &controller, const THostRecordMap &hostRecords, TInstant timestamp)
+            TConfigState(TBlobStorageController &controller, const THostRecordMap &hostRecords, TInstant timestamp,
+                    TMonotonic mono)
                 : Self(controller)
                 , HostConfigs(&controller.HostConfigs)
                 , Boxes(&controller.Boxes)
@@ -142,6 +144,7 @@ namespace NKikimr {
                 , NextStoragePoolId(&controller.NextStoragePoolId)
                 , HostRecords(hostRecords)
                 , Timestamp(timestamp)
+                , Mono(mono)
                 , DonorMode(controller.DonorMode)
                 , DefaultMaxSlots(controller.DefaultMaxSlots)
                 , StaticVSlots(controller.StaticVSlots)

--- a/ydb/core/mind/bscontroller/config_cmd.cpp
+++ b/ydb/core/mind/bscontroller/config_cmd.cpp
@@ -180,7 +180,7 @@ namespace NKikimr::NBsController {
                     Response->MutableStatus()->RemoveLast();
                 }
 
-                State.emplace(*Self, Self->HostRecords, TActivationContext::Now());
+                State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
                 State->CheckConsistency();
 
                 TString m;

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -607,6 +607,7 @@ namespace NKikimr {
                                     groupInfo->ID, 0, groupInfo->Generation, StoragePool.VDiskKind, failRealmIdx,
                                     failDomainIdx, vdiskIdx, TMood::Normal, groupInfo, &VSlotReadyTimestampQ,
                                     TInstant::Zero(), TDuration::Zero());
+                                vslotInfo->VDiskStatusTimestamp = State.Mono;
 
                                 // mark as uncommitted
                                 State.UncommittedVSlots.insert(vslotId);

--- a/ydb/core/mind/bscontroller/drop_donor.cpp
+++ b/ydb/core/mind/bscontroller/drop_donor.cpp
@@ -18,7 +18,7 @@ public:
     TTxType GetTxType() const override { return NBlobStorageController::TXTYPE_DROP_DONOR; }
 
     bool Execute(TTransactionContext &txc, const TActorContext&) override {
-        State.emplace(*Self, Self->HostRecords, TActivationContext::Now());
+        State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
         State->CheckConsistency();
         for (const TVSlotId& vslotId : VSlotIds) {
             if (const TVSlotInfo *vslot = State->VSlots.Find(vslotId); vslot && !vslot->IsBeingDeleted()) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -125,7 +125,7 @@ public:
 
     public:
         std::optional<NKikimrBlobStorage::EVDiskStatus> VDiskStatus;
-        NHPTimer::STime VDiskStatusTimestamp = GetCycleCountFast();
+        TMonotonic VDiskStatusTimestamp;
         bool IsReady = false;
         bool OnlyPhantomsRemain = false;
 
@@ -2308,11 +2308,11 @@ public:
 
         std::optional<NKikimrBlobStorage::TVDiskMetrics> VDiskMetrics;
         std::optional<NKikimrBlobStorage::EVDiskStatus> VDiskStatus;
-        NHPTimer::STime VDiskStatusTimestamp = GetCycleCountFast();
+        TMonotonic VDiskStatusTimestamp;
         TMonotonic ReadySince = TMonotonic::Max(); // when IsReady becomes true for this disk; Max() in non-READY state
 
         TStaticVSlotInfo(const NKikimrBlobStorage::TNodeWardenServiceSet::TVDisk& vdisk,
-                std::map<TVSlotId, TStaticVSlotInfo>& prev)
+                std::map<TVSlotId, TStaticVSlotInfo>& prev, TMonotonic mono)
             : VDiskId(VDiskIDFromVDiskID(vdisk.GetVDiskID()))
             , VDiskKind(vdisk.GetVDiskKind())
         {
@@ -2324,6 +2324,8 @@ public:
                 VDiskStatus = item.VDiskStatus;
                 VDiskStatusTimestamp = item.VDiskStatusTimestamp;
                 ReadySince = item.ReadySince;
+            } else {
+                VDiskStatusTimestamp = mono;
             }
         }
     };

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -352,6 +352,7 @@ public:
         }
 
         // VSlots
+        const TMonotonic mono = TActivationContext::Monotonic();
         Self->VSlots.clear();
         {
             using T = Schema::VSlot;
@@ -374,6 +375,7 @@ public:
                 if (x.LastSeenReady != TInstant::Zero()) {
                     Self->NotReadyVSlotIds.insert(x.VSlotId);
                 }
+                x.VDiskStatusTimestamp = mono;
 
                 if (!slot.Next()) {
                     return false;

--- a/ydb/core/mind/bscontroller/node_report.cpp
+++ b/ydb/core/mind/bscontroller/node_report.cpp
@@ -26,7 +26,7 @@ public:
             return true;
         }
 
-        State.emplace(*Self, Self->HostRecords, TActivationContext::Now());
+        State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
         State->CheckConsistency();
 
         NIceDb::TNiceDb db(txc.DB);

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -160,7 +160,7 @@ public:
     bool Execute(TTransactionContext& txc, const TActorContext&) override {
         const TNodeId nodeId = Record.GetNodeId();
 
-        State.emplace(*Self, Self->HostRecords, TActivationContext::Now());
+        State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
         State->CheckConsistency();
 
         auto updateIsSuccessful = true;

--- a/ydb/core/mind/bscontroller/virtual_group.cpp
+++ b/ydb/core/mind/bscontroller/virtual_group.cpp
@@ -248,7 +248,7 @@ namespace NKikimr::NBsController {
                 if (const TGroupInfo *group = Self->FindGroup(GroupId); !group || group->VirtualGroupSetupMachineId != MachineId) {
                     return true; // another machine is already running
                 }
-                State.emplace(*Self, Self->HostRecords, TActivationContext::Now());
+                State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
                 TGroupInfo *group = State->Groups.FindForUpdate(GroupId);
                 Y_ABORT_UNLESS(group);
                 if (!Callback(*group, *State)) {
@@ -294,7 +294,7 @@ namespace NKikimr::NBsController {
                 if (Token.expired()) {
                     return true; // actor is already dead
                 }
-                State.emplace(*Self, Self->HostRecords, TActivationContext::Now());
+                State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
                 const size_t n = State->BlobDepotDeleteQueue.Unshare().erase(GroupId);
                 Y_ABORT_UNLESS(n == 1);
                 TString error;
@@ -897,7 +897,7 @@ namespace NKikimr::NBsController {
             TTxType GetTxType() const override { return NBlobStorageController::TXTYPE_DECOMMIT_GROUP; }
 
             bool Execute(TTransactionContext& txc, const TActorContext&) override {
-                State.emplace(*Self, Self->HostRecords, TActivationContext::Now());
+                State.emplace(*Self, Self->HostRecords, TActivationContext::Now(), TActivationContext::Monotonic());
                 Action(*State);
                 TString error;
                 if (State->Changed() && !Self->CommitConfigUpdates(*State, true, true, true, txc, &error)) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix reporting of initial VDisk status to SysView

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fixed reporting mechanism for just-created VDisks and just-loaded BSC to prevent false-positives in system views.
