### PR TITLE
add default scope for mkql counters

### DIFF
--- a/ydb/core/base/pool_stats_collector.cpp
+++ b/ydb/core/base/pool_stats_collector.cpp
@@ -30,6 +30,11 @@ private:
     class TMiniKQLPoolStats {
     public:
         void Init(::NMonitoring::TDynamicCounters* group) {
+            auto counters = TAlignedPagePoolCounters();
+            if (counters.CountersRoot) {
+                group->RegisterSubgroup("subsystem", "mkqlalloc", counters.CountersRoot);
+            }
+
             CounterGroup = group->GetSubgroup("subsystem", "mkqlalloc");
             TotalBytes = CounterGroup->GetCounter("GlobalPoolTotalBytes", false);
         }

--- a/ydb/library/yql/minikql/aligned_page_pool.h
+++ b/ydb/library/yql/minikql/aligned_page_pool.h
@@ -23,6 +23,7 @@ struct TAlignedPagePoolCounters {
     ::NMonitoring::TDynamicCounters::TCounterPtr AllocationsCntr;
     ::NMonitoring::TDynamicCounters::TCounterPtr PoolsCntr;
     ::NMonitoring::TDynamicCounters::TCounterPtr LostPagesBytesFreeCntr;
+    ::NMonitoring::TDynamicCounterPtr CountersRoot;
 
     void Swap(TAlignedPagePoolCounters& other) {
         DoSwap(TotalBytesAllocatedCntr, other.TotalBytesAllocatedCntr);


### PR DESCRIPTION
### Changelog entry

currently all instances of TScopedAlloc holds default TAlignedPagePoolCounters which doesn't provide any info about allocations. fixing that story

### Changelog category 

* Not for changelog (changelog entry is not required)

### Additional information

...
