### PR TITLE
Conditionally compile the code that uses AWS to pass windows build

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -244,10 +244,13 @@
 
 #include <util/system/hostname.h>
 
+#ifndef KIKIMR_DISABLE_S3_OPS
 #include <aws/core/Aws.h>
+#endif
 
 namespace {
 
+#ifndef KIKIMR_DISABLE_S3_OPS
 struct TAwsApiGuard {
     TAwsApiGuard() {
         Aws::InitAPI(Options);
@@ -260,6 +263,7 @@ struct TAwsApiGuard {
 private:
     Aws::SDKOptions Options;
 };
+#endif
 
 }
 
@@ -2065,8 +2069,8 @@ void TMemoryControllerInitializer::InitializeServices(
         mergeResourceBrokerConfigs(Config.GetResourceBrokerConfig());
     }
 
-    auto* actor = NMemory::CreateMemoryController(TDuration::Seconds(1), ProcessMemoryInfoProvider, 
-        Config.GetMemoryControllerConfig(), resourceBrokerSelfConfig, 
+    auto* actor = NMemory::CreateMemoryController(TDuration::Seconds(1), ProcessMemoryInfoProvider,
+        Config.GetMemoryControllerConfig(), resourceBrokerSelfConfig,
         appData->Counters);
     setup->LocalServices.emplace_back(
         NMemory::MakeMemoryControllerId(0),
@@ -2782,6 +2786,7 @@ void TGraphServiceInitializer::InitializeServices(NActors::TActorSystemSetup* se
         TActorSetupCmd(NGraph::CreateGraphService(appData->TenantName), TMailboxType::HTSwap, appData->UserPoolId));
 }
 
+#ifndef KIKIMR_DISABLE_S3_OPS
 TAwsApiInitializer::TAwsApiInitializer(IGlobalObjectStorage& globalObjects)
     : GlobalObjects(globalObjects)
 {
@@ -2792,6 +2797,7 @@ void TAwsApiInitializer::InitializeServices(NActors::TActorSystemSetup* setup, c
     Y_UNUSED(appData);
     GlobalObjects.AddGlobalObject(std::make_shared<TAwsApiGuard>());
 }
+#endif
 
 } // namespace NKikimrServicesInitializers
 } // namespace NKikimr

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.h
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.h
@@ -625,6 +625,7 @@ public:
     void InitializeServices(NActors::TActorSystemSetup* setup, const NKikimr::TAppData* appData) override;
 };
 
+#ifndef KIKIMR_DISABLE_S3_OPS
 class TAwsApiInitializer : public IServiceInitializer {
     IGlobalObjectStorage& GlobalObjects;
 
@@ -633,6 +634,7 @@ public:
 
     void InitializeServices(NActors::TActorSystemSetup* setup, const NKikimr::TAppData* appData) override;
 };
+#endif
 
 } // namespace NKikimrServicesInitializers
 } // namespace NKikimr

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1676,9 +1676,11 @@ TIntrusivePtr<TServiceInitializersList> TKikimrRunner::CreateServiceInitializers
         sil->AddServiceInitializer(new TGraphServiceInitializer(runConfig));
     }
 
+#ifndef KIKIMR_DISABLE_S3_OPS
     if (serviceMask.EnableAwsService) {
         sil->AddServiceInitializer(new TAwsApiInitializer(*this));
     }
+#endif
 
     return sil;
 }

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -1,5 +1,15 @@
 LIBRARY(run)
 
+IF (OS_WINDOWS)
+    CFLAGS(
+        -DKIKIMR_DISABLE_S3_OPS
+    )
+ELSE()
+    PEERDIR(
+        contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core
+    )
+ENDIF()
+
 SRCS(
     auto_config_initializer.cpp
     config.cpp
@@ -21,7 +31,6 @@ SRCS(
 )
 
 PEERDIR(
-    contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core
     contrib/libs/protobuf
     ydb/library/actors/core
     ydb/library/actors/dnsresolver


### PR DESCRIPTION
This commit (https://github.com/ydb-platform/ydb/pull/8823) breaks:
1. [windows build](https://a.yandex-team.ru/review/6706811/details?checkId=31300000012219&dialogId=CiCard&filter=suiteCategory%28CATEGORY_CHANGED%29&iterationType=FULL&number=0&openedItems=348826972648271046%3ART_BUILD&snippetViewMode=word-wrap&status=STATUS_FAILED) in arcadia
2. [RTMR tests](https://a.yandex-team.ru/review/6543591/details?backwardPath=&backwardSuiteId=&checkId=28700000012070&dialogId=CiCard&filter=suiteCategory%28CATEGORY_CHANGED%29&forwardPath=rtmapreduce%2Fmrtasks%2Fimages_freon_sample%2Ftests&forwardSuiteId=2092635095008845828&iterationType=FULL&number=0&openedItems=2411399038987752400%3ART_TEST_SUITE_MEDIUM&snippetViewMode=word-wrap&status=STATUS_FAILED) in arcadia

This PR [fixes](https://a.yandex-team.ru/review/6706811/details?checkId=51700000012249&dialogId=CiCard&iterationType=FULL&number=1&snippetViewMode=word-wrap&status=STATUS_FAILED&filter=resultType%28RT_BUILD%29%3Bpath%28contrib%252Fydb%252Fapps%252Fydbd%29) the first problem (broken windows build). The second problem cannot be fixed in GitHub and must be fixed in the next import to arcadia/contrib PR. (The fix is [ready](https://a.yandex-team.ru/review/6706811/files/de8eb22c2a764447ee61fb5dd27598c3bf578647).)