### PR TITLE
Revert "Fix hash spreading in HashPartitionConsumer (#4364)"

### DIFF
--- a/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
@@ -21,11 +21,6 @@ using namespace NKikimr;
 using namespace NMiniKQL;
 using namespace NUdf;
 
-inline ui64 SpreadHash(ui64 hash) {
-    // https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
-    return ((unsigned __int128)hash * 11400714819323198485llu) >> 64;
-}
-
 
 class TDqOutputMultiConsumer : public IDqOutputConsumer {
 public:
@@ -195,9 +190,6 @@ private:
             hash = CombineHashes(hash, HashColumn(keyId, columnValue));
         }
 
-
-        hash = SpreadHash(hash);
-
         return hash % Outputs.size();
     }
 
@@ -208,8 +200,6 @@ private:
             MKQL_ENSURE_S(KeyColumns[keyId].Index < OutputWidth);
             hash = CombineHashes(hash, HashColumn(keyId, values[KeyColumns[keyId].Index]));
         }
-
-        hash = SpreadHash(hash);
 
         return hash % Outputs.size();
     }
@@ -313,8 +303,6 @@ private:
             YQL_ENSURE(KeyColumns_[keyId].Index < OutputWidth_);
             hash = CombineHashes(hash, HashColumn(keyId, values[KeyColumns_[keyId].Index]));
         }
-
-        hash = SpreadHash(hash);
 
         return hash % Outputs_.size();
     }
@@ -513,9 +501,6 @@ private:
             }
             hash = CombineHashes(hash, keyHash);
         }
-
-        hash = SpreadHash(hash);
-
         return hash % Outputs_.size();
     }
 


### PR DESCRIPTION
This reverts commit e3c776faf566de3104335dfa71b2507b43447ebd.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Additional information

...
