### PR TITLE
Add tablet version info to pipes

### DIFF
--- a/ydb/core/base/tablet.h
+++ b/ydb/core/base/tablet.h
@@ -338,7 +338,13 @@ struct TEvTablet {
         {}
     };
 
-    struct TEvTabletActive : public TEventLocal<TEvTabletActive, EvTabletActive> {};
+    struct TEvTabletActive : public TEventLocal<TEvTabletActive, EvTabletActive> {
+        TString VersionInfo;
+
+        explicit TEvTabletActive(TString&& versionInfo)
+            : VersionInfo(std::move(versionInfo))
+        {}
+    };
 
     struct TEvDemoted : public TEventLocal<TEvDemoted, EvDemoted> {
         const bool ByIsolation;

--- a/ydb/core/base/tablet_pipe.h
+++ b/ydb/core/base/tablet_pipe.h
@@ -54,7 +54,10 @@ namespace NKikimr {
         struct TEvConnectResult : public TEventPB<TEvConnectResult, NKikimrTabletPipe::TEvConnectResult, EvConnectResult> {
             TEvConnectResult() {}
 
-            TEvConnectResult(NKikimrProto::EReplyStatus status, ui64 tabletId, const TActorId& clientId, const TActorId& serverId, bool leader, ui32 generation)
+            TEvConnectResult(NKikimrProto::EReplyStatus status, ui64 tabletId,
+                    const TActorId& clientId, const TActorId& serverId,
+                    bool leader, ui32 generation,
+                    TString&& versionInfo)
             {
                 Record.SetStatus(status);
                 Record.SetTabletId(tabletId);
@@ -63,6 +66,9 @@ namespace NKikimr {
                 Record.SetLeader(leader);
                 Record.SetSupportsDataInPayload(true);
                 Record.SetGeneration(generation);
+                if (!versionInfo.empty()) {
+                    Record.SetVersionInfo(std::move(versionInfo));
+                }
             }
         };
 
@@ -121,7 +127,10 @@ namespace NKikimr {
         };
 
         struct TEvClientConnected : public TEventLocal<TEvClientConnected, EvClientConnected> {
-            TEvClientConnected(ui64 tabletId, NKikimrProto::EReplyStatus status, const TActorId& clientId, const TActorId& serverId, bool leader, bool dead, ui64 generation)
+            TEvClientConnected(ui64 tabletId, NKikimrProto::EReplyStatus status,
+                    const TActorId& clientId, const TActorId& serverId,
+                    bool leader, bool dead, ui64 generation,
+                    TString&& versionInfo = {})
                 : TabletId(tabletId)
                 , Status(status)
                 , ClientId(clientId)
@@ -129,6 +138,7 @@ namespace NKikimr {
                 , Leader(leader)
                 , Dead(dead)
                 , Generation(generation)
+                , VersionInfo(std::move(versionInfo))
             {}
 
             const ui64 TabletId;
@@ -138,6 +148,7 @@ namespace NKikimr {
             const bool Leader;
             const bool Dead;
             const ui64 Generation;
+            TString VersionInfo;
         };
 
         struct TEvServerConnected : public TEventLocal<TEvServerConnected, EvServerConnected> {
@@ -206,13 +217,13 @@ namespace NKikimr {
         };
 
         struct TEvActivate : public TEventLocal<TEvActivate, EvActivate> {
-            TEvActivate(ui64 tabletId, const TActorId& ownerId, const TActorId& recipientId, bool leader, ui32 generation)
+            TEvActivate(ui64 tabletId, const TActorId& ownerId, const TActorId& recipientId, bool leader, ui32 generation, const TString& versionInfo)
                 : TabletId(tabletId)
                 , OwnerId(ownerId)
                 , RecipientId(recipientId)
                 , Leader(leader)
                 , Generation(generation)
-                
+                , VersionInfo(versionInfo)
             {}
 
             const ui64 TabletId;
@@ -220,6 +231,7 @@ namespace NKikimr {
             const TActorId RecipientId;
             const bool Leader;
             const ui32 Generation;
+            TString VersionInfo;
         };
 
         struct TEvShutdown : public TEventLocal<TEvShutdown, EvShutdown> {
@@ -297,7 +309,7 @@ namespace NKikimr {
             // Creates and activated server, returns serverId.
             // Created server will forward messages to the specified recipent.
             virtual TActorId Accept(TEvTabletPipe::TEvConnect::TPtr &ev, TActorIdentity owner, TActorId recipient,
-                                    bool leader = true, ui64 generation = 0) = 0;
+                                    bool leader = true, ui64 generation = 0, const TString &versionInfo = {}) = 0;
 
             // Rejects connect with an error.
             virtual void Reject(TEvTabletPipe::TEvConnect::TPtr &ev, TActorIdentity owner, NKikimrProto::EReplyStatus status, bool leader = true) = 0;
@@ -314,7 +326,8 @@ namespace NKikimr {
 
             // Activates all inactive servers, created by Enqueue.
             // All activated servers will forward messages to the specified recipent.
-            virtual void Activate(TActorIdentity owner, TActorId recipientId, bool leader = true, ui64 generation = 0) = 0;
+            virtual void Activate(TActorIdentity owner, TActorId recipientId,
+                                  bool leader = true, ui64 generation = 0, const TString &versionInfo = {}) = 0;
 
             // Cleanup resources after reset
             virtual void Erase(TEvTabletPipe::TEvServerDestroyed::TPtr &ev) = 0;
@@ -402,7 +415,8 @@ namespace NKikimr {
         IActor* CreateServer(ui64 tabletId, const TActorId& clientId, const TActorId& interconnectSession, ui32 features, ui64 connectCookie);
 
         // Promotes server actor to the active state.
-        void ActivateServer(ui64 tabletId, TActorId serverId, TActorIdentity owner, TActorId recipientId, bool leader, ui64 generation = 0);
+        void ActivateServer(ui64 tabletId, TActorId serverId, TActorIdentity owner, TActorId recipientId,
+                bool leader, ui64 generation, const TString& versionInfo);
 
         // Destroys server actor.
         void CloseServer(TActorIdentity owner, TActorId serverId);

--- a/ydb/core/protos/tablet_pipe.proto
+++ b/ydb/core/protos/tablet_pipe.proto
@@ -22,6 +22,7 @@ message TEvConnectResult {
     optional bool Leader = 5 [default = true];
     optional bool SupportsDataInPayload = 6;
     optional uint32 Generation = 7;
+    optional bytes VersionInfo = 8;
 };
 
 message TEvPush {

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -214,6 +214,7 @@ class TTablet : public TActor<TTablet> {
     bool NeedCleanupOnLockedPath;
     ui32 GcCounter;
     THolder<NTabletPipe::IConnectAcceptor> PipeConnectAcceptor;
+    TString TabletVersionInfo;
     TInstant BoostrapTime;
     TInstant ActivateTime;
     bool Leader;

--- a/ydb/core/tablet_flat/tablet_flat_executed.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executed.cpp
@@ -152,12 +152,12 @@ void TTabletExecutedFlat::HandleLocalReadColumns(TEvTablet::TEvLocalReadColumns:
     Execute(Factory->Make(ev), ctx);
 }
 
-void TTabletExecutedFlat::SignalTabletActive(const TActorIdentity &id) {
-    id.Send(Tablet(), new TEvTablet::TEvTabletActive());
+void TTabletExecutedFlat::SignalTabletActive(const TActorIdentity &id, TString &&versionInfo) {
+    id.Send(Tablet(), new TEvTablet::TEvTabletActive(std::move(versionInfo)));
 }
 
-void TTabletExecutedFlat::SignalTabletActive(const TActorContext &ctx) {
-    ctx.Send(Tablet(), new TEvTablet::TEvTabletActive());
+void TTabletExecutedFlat::SignalTabletActive(const TActorContext &ctx, TString &&versionInfo) {
+    ctx.Send(Tablet(), new TEvTablet::TEvTabletActive(std::move(versionInfo)));
 }
 
 void TTabletExecutedFlat::Enqueue(STFUNC_SIG) {

--- a/ydb/core/tablet_flat/tablet_flat_executed.h
+++ b/ydb/core/tablet_flat/tablet_flat_executed.h
@@ -42,8 +42,8 @@ protected:
     /**
      * Signal tablet as active and ready to process requests (from pipes).
      */
-    void SignalTabletActive(const TActorIdentity &id);
-    void SignalTabletActive(const TActorContext &ctx);
+    void SignalTabletActive(const TActorIdentity &id, TString &&versionInfo = {});
+    void SignalTabletActive(const TActorContext &ctx, TString &&versionInfo = {});
 
     /**
      * Must be overriden as an empty method. Previously default implementation


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Experimental feature

### Additional information

It is now possible to specify version info for pipes to tablets, allowing clients to decide which protocol version to use depending on the connected tablet.

Fixes #8971.