### PR TITLE
In CBO, when calling ComputeJoinStats() on the provider context, prov…

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_dphyp_solver.h
+++ b/ydb/library/yql/dq/opt/dq_opt_dphyp_solver.h
@@ -425,7 +425,7 @@ template <typename TNodeSet> std::shared_ptr<TJoinOptimizerNodeInternal> TDPHypS
 
     for (auto joinAlgo : AllJoinAlgos) {
         if (ctx.IsJoinApplicable(left, right, joinConditions, leftJoinKeys, rightJoinKeys, joinAlgo, joinKind)){
-            auto cost = ctx.ComputeJoinStats(*left->Stats, *right->Stats, leftJoinKeys, rightJoinKeys, joinAlgo, joinKind, maybeHint).Cost;
+            auto cost = ctx.ComputeJoinStats(*left->Stats, *right->Stats, joinConditions, joinAlgo, joinKind, maybeHint).Cost;
             if (maybeJoinHint) {
                 if (joinAlgo == maybeJoinHint->JoinHint) {
                     cost = -1;
@@ -440,7 +440,7 @@ template <typename TNodeSet> std::shared_ptr<TJoinOptimizerNodeInternal> TDPHypS
 
         if (isCommutative) {
             if (ctx.IsJoinApplicable(right, left, reversedJoinConditions, rightJoinKeys, leftJoinKeys, joinAlgo, joinKind)){
-                auto cost = ctx.ComputeJoinStats(*right->Stats, *left->Stats,  rightJoinKeys, leftJoinKeys, joinAlgo, joinKind, maybeHint).Cost;
+                auto cost = ctx.ComputeJoinStats(*right->Stats, *left->Stats,  reversedJoinConditions, joinAlgo, joinKind, maybeHint).Cost;
                 if (maybeJoinHint) {
                     if (joinAlgo == maybeJoinHint->JoinHint) {
                         cost = -1;

--- a/ydb/library/yql/dq/opt/dq_opt_join_tree_node.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join_tree_node.cpp
@@ -14,7 +14,7 @@ std::shared_ptr<TJoinOptimizerNodeInternal> MakeJoinInternal(
     TCardinalityHints::TCardinalityHint* maybeHint) {
 
     auto res = std::make_shared<TJoinOptimizerNodeInternal>(left, right, joinConditions, leftJoinKeys, rightJoinKeys, joinKind, joinAlgo);
-    res->Stats = std::make_shared<TOptimizerStatistics>(ctx.ComputeJoinStats(*left->Stats, *right->Stats, leftJoinKeys, rightJoinKeys, joinAlgo, joinKind, maybeHint));
+    res->Stats = std::make_shared<TOptimizerStatistics>(ctx.ComputeJoinStats(*left->Stats, *right->Stats, joinConditions, joinAlgo, joinKind, maybeHint));
     return res;
 }
 


### PR DESCRIPTION
…ide relation names with join keys.
