### PR TITLE
YQ-3617: fix GROUP BY HOP + AS_TABLE

### DIFF
--- a/ydb/library/yql/core/yql_aggregate_expander.cpp
+++ b/ydb/library/yql/core/yql_aggregate_expander.cpp
@@ -32,7 +32,7 @@ TExprNode::TPtr TAggregateExpander::ExpandAggregateWithFullOutput()
     auto settings = Node->Child(3);
 
     bool allTraitsCollected = CollectTraits();
-    YQL_ENSURE(!HasSetting(*settings, "hopping"), "Aggregate with hopping unsupported here.");
+    // YQL_ENSURE(!HasSetting(*settings, "hopping"), "Aggregate with hopping unsupported here."); // TODO(YQ-3661): uncomment
 
     HaveDistinct = AnyOf(AggregatedColumns->ChildrenList(),
         [](const auto& child) { return child->ChildrenSize() == 3; });

--- a/ydb/library/yql/tests/sql/dq_file/part4/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part4/canondata/result.json
@@ -362,6 +362,34 @@
             "uri": "https://{canondata_backend}/1899731/d439cec3e297e3dd031f751fd90f3935129a1094/resource.tar.gz#test.test_aggregate-group_by_hop--Results_/results.txt"
         }
     ],
+    "test.test[aggregate-group_by_hop_small-default.txt-Analyze]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1847551/2209c2969854610c404ebe58fe3bfaa092239305/resource.tar.gz#test.test_aggregate-group_by_hop_small-default.txt-Analyze_/plan.txt"
+        }
+    ],
+    "test.test[aggregate-group_by_hop_small-default.txt-Debug]": [
+        {
+            "checksum": "4eb73aa6ee121bbad859125d3cfd5a95",
+            "size": 1015,
+            "uri": "https://{canondata_backend}/1847551/2209c2969854610c404ebe58fe3bfaa092239305/resource.tar.gz#test.test_aggregate-group_by_hop_small-default.txt-Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[aggregate-group_by_hop_small-default.txt-Plan]": [
+        {
+            "checksum": "b4dd508a329723c74293d80f0278c705",
+            "size": 505,
+            "uri": "https://{canondata_backend}/1847551/2209c2969854610c404ebe58fe3bfaa092239305/resource.tar.gz#test.test_aggregate-group_by_hop_small-default.txt-Plan_/plan.txt"
+        }
+    ],
+    "test.test[aggregate-group_by_hop_small-default.txt-Results]": [
+        {
+            "checksum": "b204692654e9a175f23dc8efd761e05b",
+            "size": 696,
+            "uri": "https://{canondata_backend}/1847551/2209c2969854610c404ebe58fe3bfaa092239305/resource.tar.gz#test.test_aggregate-group_by_hop_small-default.txt-Results_/results.txt"
+        }
+    ],
     "test.test[aggregate-group_by_hop_star--Analyze]": [
         {
             "checksum": "9221cc272d85bbacaaea3595e69b6b17",

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -21806,9 +21806,9 @@
     ],
     "test_sql_format.test[aggregate-group_by_hop_small]": [
         {
-            "checksum": "903e8ccb669e336929fb9a3f9bc25424",
-            "size": 427,
-            "uri": "https://{canondata_backend}/1920236/bb2301e85eb73fecf6260a9c1294520fbf1e952e/resource.tar.gz#test_sql_format.test_aggregate-group_by_hop_small_/formatted.sql"
+            "checksum": "27fdd7af224a36c15155f7f69f14ad07",
+            "size": 393,
+            "uri": "https://{canondata_backend}/1942173/9d793e788c391df831fae057e65f63b2b147c4d4/resource.tar.gz#test_sql_format.test_aggregate-group_by_hop_small_/formatted.sql"
         }
     ],
     "test_sql_format.test[aggregate-group_by_hop_star]": [

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -2183,6 +2183,13 @@
             "uri": "https://{canondata_backend}/1784117/d56ae82ad9d30397a41490647be1bd2124718f98/resource.tar.gz#test_sql2yql.test_aggregate-group_by_hop_only_start_/sql.yql"
         }
     ],
+    "test_sql2yql.test[aggregate-group_by_hop_small]": [
+        {
+            "checksum": "91dd52bcee5be9d4f5f9638eb801db32",
+            "size": 2149,
+            "uri": "https://{canondata_backend}/1920236/bb2301e85eb73fecf6260a9c1294520fbf1e952e/resource.tar.gz#test_sql2yql.test_aggregate-group_by_hop_small_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[aggregate-group_by_hop_star]": [
         {
             "checksum": "e777f280db84a47b4cdfe9176e6d9d1f",
@@ -21795,6 +21802,13 @@
             "checksum": "04fb3a4f364780a3011de8496b4132b6",
             "size": 248,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_aggregate-group_by_hop_only_start_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[aggregate-group_by_hop_small]": [
+        {
+            "checksum": "903e8ccb669e336929fb9a3f9bc25424",
+            "size": 427,
+            "uri": "https://{canondata_backend}/1920236/bb2301e85eb73fecf6260a9c1294520fbf1e952e/resource.tar.gz#test_sql_format.test_aggregate-group_by_hop_small_/formatted.sql"
         }
     ],
     "test_sql_format.test[aggregate-group_by_hop_star]": [

--- a/ydb/library/yql/tests/sql/suites/aggregate/group_by_hop_small.sql
+++ b/ydb/library/yql/tests/sql/suites/aggregate/group_by_hop_small.sql
@@ -1,0 +1,16 @@
+/* syntax version 1 */
+/* postgres can not */
+/* ytfile can not */
+/* yt can not */
+
+$input = SELECT * FROM AS_TABLE([
+    <|"time":"2024-01-01T00:00:01Z"|>,
+    <|"time":"2024-01-02T00:00:01Z"|>,
+    <|"time":"2024-01-03T00:00:01Z"|>
+]);
+
+SELECT
+    COUNT(*),
+    -- HOP_START()
+FROM $input
+GROUP BY HOP(CAST(time as Timestamp), 'PT60S', 'PT86400S', 'PT60S')


### PR DESCRIPTION
### Changelog entry

Temporarily removed assert in a peephole optimisation. Now SELECTs without `HOP_START()` and `HOP_END()` can be used

### Changelog category <!-- remove all except one -->

* Bugfix 