### PR TITLE
YQ kqprun fixed AS pools and added validations

### DIFF
--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -430,7 +430,6 @@ namespace Tests {
         GRpcServer->AddService(new NGRpcService::TGRpcYdbObjectStorageService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NQuoter::TRateLimiterGRpcService(system, counters, grpcRequestProxies[0]));
         GRpcServer->AddService(new NGRpcService::TGRpcDataStreamsService(system, counters, grpcRequestProxies[0], true));
-        GRpcServer->AddService(new NGRpcService::TGRpcYmqService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NGRpcService::TGRpcMonitoringService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NGRpcService::TGRpcYdbQueryService(system, counters, grpcRequestProxies, true, 1));
         GRpcServer->AddService(new NGRpcService::TGRpcYdbTabletService(system, counters, grpcRequestProxies, true, 1));

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -975,7 +975,7 @@ namespace Tests {
 
         {
             IActor* txProxy = CreateTxProxy(Runtime->GetTxAllocatorTabletIds());
-            TActorId txProxyId = Runtime->Register(txProxy, nodeIdx, userPoolId);
+            TActorId txProxyId = Runtime->Register(txProxy, nodeIdx);
             Runtime->RegisterService(MakeTxProxyID(), txProxyId, nodeIdx);
         }
 
@@ -1000,7 +1000,7 @@ namespace Tests {
         if (BusServer && nodeIdx == 0) { // MsgBus and GRPC are run now only on first node
             {
                 IActor* proxy = BusServer->CreateProxy();
-                TActorId proxyId = Runtime->Register(proxy, nodeIdx, userPoolId, TMailboxType::Revolving, 0);
+                TActorId proxyId = Runtime->Register(proxy, nodeIdx, Runtime->GetAppData(nodeIdx).SystemPoolId, TMailboxType::Revolving, 0);
                 Runtime->RegisterService(NMsgBusProxy::CreateMsgBusProxyId(), proxyId, nodeIdx);
             }
         }

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -295,8 +295,8 @@ namespace Tests {
         TServer& operator =(TServer&& server) = default;
         virtual ~TServer();
 
-        void EnableGRpc(const NYdbGrpc::TServerOptions& options);
-        void EnableGRpc(ui16 port);
+        void EnableGRpc(const NYdbGrpc::TServerOptions& options, ui32 grpcServiceNodeId = 0);
+        void EnableGRpc(ui16 port, ui32 grpcServiceNodeId = 0);
         void SetupRootStoragePools(const TActorId sender) const;
 
         void SetupDefaultProfiles();

--- a/ydb/tests/tools/kqprun/.gitignore
+++ b/ydb/tests/tools/kqprun/.gitignore
@@ -6,3 +6,4 @@ udfs
 *.sql
 *.bin
 *.txt
+*.svg

--- a/ydb/tests/tools/kqprun/.gitignore
+++ b/ydb/tests/tools/kqprun/.gitignore
@@ -7,3 +7,4 @@ udfs
 *.bin
 *.txt
 *.svg
+*.old

--- a/ydb/tests/tools/kqprun/configuration/app_config.conf
+++ b/ydb/tests/tools/kqprun/configuration/app_config.conf
@@ -1,3 +1,49 @@
+ActorSystemConfig {
+  Executor {
+    Type: BASIC
+    Threads: 1
+    SpinThreshold: 10
+    Name: "System"
+  }
+  Executor {
+    Type: BASIC
+    Threads: 6
+    SpinThreshold: 1
+    Name: "User"
+  }
+  Executor {
+    Type: BASIC
+    Threads: 1
+    SpinThreshold: 1
+    Name: "Batch"
+  }
+  Executor {
+    Type: IO
+    Threads: 1
+    Name: "IO"
+  }
+  Executor {
+    Type: BASIC
+    Threads: 2
+    SpinThreshold: 10
+    Name: "IC"
+    TimePerMailboxMicroSecs: 100
+  }
+  Scheduler {
+    Resolution: 64
+    SpinThreshold: 0
+    ProgressThreshold: 10000
+  }
+  SysExecutor: 0
+  UserExecutor: 1
+  IoExecutor: 3
+  BatchExecutor: 2
+  ServiceExecutor {
+    ServiceName: "Interconnect"
+    ExecutorId: 4
+  }
+}
+
 ColumnShardConfig {
   DisabledOnSchemeShard: false
 }

--- a/ydb/tests/tools/kqprun/flame_graph.sh
+++ b/ydb/tests/tools/kqprun/flame_graph.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# For svg graph download https://github.com/brendangregg/FlameGraph
+# and run `FlameGraph/stackcollapse-perf.pl profdata.txt | FlameGraph/flamegraph.pl > profdata.svg`
+
+pid=$(pgrep -u $USER kqprun)
+
+echo "Target process id: ${pid}"
+
+sudo perf record -F 50 --call-graph dwarf -g --proc-map-timeout=10000 --pid $pid -v -o profdata -- sleep 30
+sudo perf script -i profdata > profdata.txt

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -568,9 +568,14 @@ protected:
             .Choices(planFormat.GetChoices())
             .StoreMappedResultT<TString>(&RunnerOptions.PlanOutputFormat, planFormat);
 
-        options.AddLongOption("script-timeline-svg", "File with script query timline in svg format (use '-' to write in stdout)")
+        options.AddLongOption("script-timeline-file", "File with script query timline in svg format")
             .RequiredArgument("file")
-            .StoreMappedResultT<TString>(&RunnerOptions.ScriptQueryTimelineOutput, &GetDefaultOutput);
+            .StoreMappedResultT<TString>(&RunnerOptions.ScriptQueryTimelineFile, [](const TString& file) {
+                if (file == "-") {
+                    ythrow yexception() << "Script timline cannot be printed to stdout, please specify file name";
+                }
+                return file;
+            });
 
         // Pipeline settings
 

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -44,23 +44,27 @@ struct TExecutionOptions {
     std::vector<TString> TraceIds;
     std::vector<TString> PoolIds;
     std::vector<TString> UserSIDs;
+    ui64 ResultsRowsLimit = 0;
 
     const TString DefaultTraceId = "kqprun";
 
     bool HasResults() const {
-        if (ScriptQueries.empty()) {
-            return false;
-        }
-
-        for (size_t i = 0; i < ExecutionCases.size(); ++i) {
+        for (size_t i = 0; i < ScriptQueries.size(); ++i) {
             if (GetScriptQueryAction(i) != NKikimrKqp::EQueryAction::QUERY_ACTION_EXECUTE) {
                 continue;
             }
-            if (ExecutionCases[i] != EExecutionCase::AsyncQuery) {
+            if (GetExecutionCase(i) != EExecutionCase::AsyncQuery) {
                 return true;
             }
         }
         return false;
+    }
+
+    bool HasExecutionCase(EExecutionCase executionCase) const {
+        if (ExecutionCases.empty()) {
+            return executionCase == EExecutionCase::GenericScript;
+        }
+        return std::find(ExecutionCases.begin(), ExecutionCases.end(), executionCase) != ExecutionCases.end();
     }
 
     EExecutionCase GetExecutionCase(size_t index) const {
@@ -104,6 +108,113 @@ struct TExecutionOptions {
             .UserSID = GetValue(index, UserSIDs, TString(BUILTIN_ACL_ROOT)),
             .Database = GetValue(index, Databases, TString())
         };
+    }
+
+    void Validate(const NKqpRun::TRunnerOptions& runnerOptions) const {
+        if (!SchemeQuery && ScriptQueries.empty() && !runnerOptions.YdbSettings.MonitoringEnabled && !runnerOptions.YdbSettings.GrpcEnabled) {
+            ythrow yexception() << "Nothing to execute and is not running as daemon";
+        }
+
+        ValidateOptionsSizes();
+        ValidateSchemeQueryOptions(runnerOptions);
+        ValidateScriptExecutionOptions(runnerOptions);
+        ValidateAsyncOptions(runnerOptions.YdbSettings.AsyncQueriesSettings);
+        ValidateTraceOpt(runnerOptions.TraceOptType);
+    }
+
+private:
+    void ValidateOptionsSizes() const {
+        const auto checker = [numberQueries = ScriptQueries.size()](size_t checkSize, const TString& optionName) {
+            if (checkSize > numberQueries) {
+                ythrow yexception() << "Too many " << optionName << ". Specified " << checkSize << ", when number of queries is " << numberQueries;
+            }
+        };
+
+        checker(ExecutionCases.size(), "execution cases");
+        checker(ScriptQueryActions.size(), "script query actions");
+        checker(Databases.size(), "databases");
+        checker(TraceIds.size(), "trace ids");
+        checker(PoolIds.size(), "pool ids");
+        checker(UserSIDs.size(), "user SIDs");
+    }
+
+    void ValidateSchemeQueryOptions(const NKqpRun::TRunnerOptions& runnerOptions) const {
+        if (SchemeQuery) {
+            return;
+        }
+        if (runnerOptions.SchemeQueryAstOutput) {
+            ythrow yexception() << "Scheme query AST output can not be used without scheme query";
+        }
+    }
+
+    void ValidateScriptExecutionOptions(const NKqpRun::TRunnerOptions& runnerOptions) const {
+        // Script specific
+        if (HasExecutionCase(EExecutionCase::GenericScript)) {
+            return;
+        }
+        if (ForgetExecution) {
+            ythrow yexception() << "Forget execution can not be used without generic script queries";
+        }
+        if (runnerOptions.ScriptCancelAfter) {
+            ythrow yexception() << "Cancel after can not be used without generic script queries";
+        }
+
+        // Script/Query specific
+        if (HasExecutionCase(EExecutionCase::GenericQuery)) {
+            return;
+        }
+        if (ResultsRowsLimit) {
+            ythrow yexception() << "Result rows limit can not be used without script queries";
+        }
+        if (runnerOptions.InProgressStatisticsOutputFile) {
+            ythrow yexception() << "Script statistics can not be used without script queries";
+        }
+
+        // Common specific
+        if (HasExecutionCase(EExecutionCase::YqlScript)) {
+            return;
+        }
+        if (runnerOptions.ScriptQueryAstOutput) {
+            ythrow yexception() << "Script query AST output can not be used without script/yql queries";
+        }
+        if (runnerOptions.ScriptQueryPlanOutput) {
+            ythrow yexception() << "Script query plan output can not be used without script/yql queries";
+        }
+    }
+
+    void ValidateAsyncOptions(const NKqpRun::TAsyncQueriesSettings& asyncQueriesSettings) const {
+        if (asyncQueriesSettings.InFlightLimit && !HasExecutionCase(EExecutionCase::AsyncQuery)) {
+            ythrow yexception() << "In flight limit can not be used without async queries";
+        }
+
+        NColorizer::TColors colors = NColorizer::AutoColors(Cout);
+        if (LoopCount && asyncQueriesSettings.InFlightLimit && asyncQueriesSettings.InFlightLimit > ScriptQueries.size() * LoopCount) {
+            Cout << colors.Red() << "Warning: inflight limit is " << asyncQueriesSettings.InFlightLimit << ", that is larger than max possible number of queries " << ScriptQueries.size() * LoopCount << colors.Default() << Endl;
+        }
+    }
+
+    void ValidateTraceOpt(NKqpRun::TRunnerOptions::ETraceOptType traceOptType) const {
+        switch (traceOptType) {
+            case NKqpRun::TRunnerOptions::ETraceOptType::Scheme: {
+                if (!SchemeQuery) {
+                    ythrow yexception() << "Trace opt type scheme cannot be used without scheme query";
+                }
+                break;
+            }
+            case NKqpRun::TRunnerOptions::ETraceOptType::Script: {
+                if (ScriptQueries.empty()) {
+                    ythrow yexception() << "Trace opt type script cannot be used without script queries";
+                }
+            }
+            case NKqpRun::TRunnerOptions::ETraceOptType::All: {
+                if (!SchemeQuery && ScriptQueries.empty()) {
+                    ythrow yexception() << "Trace opt type all cannot be used without any queries";
+                }
+            }
+            case NKqpRun::TRunnerOptions::ETraceOptType::Disabled: {
+                break;
+            }
+        }
     }
 
 private:
@@ -278,7 +389,6 @@ class TMain : public TMainClassArgs {
     TVector<TString> UdfsPaths;
     TString UdfsDirectory;
     bool ExcludeLinkedUdfs = false;
-    ui64 ResultsRowsLimit = 1000;
     bool EmulateYt = false;
 
     static TString LoadFile(const TString& file) {
@@ -415,8 +525,8 @@ protected:
             .StoreMappedResultT<TString>(&RunnerOptions.ResultOutput, &GetDefaultOutput);
         options.AddLongOption('L', "result-rows-limit", "Rows limit for script execution results")
             .RequiredArgument("uint")
-            .DefaultValue(ResultsRowsLimit)
-            .StoreResult(&ResultsRowsLimit);
+            .DefaultValue(0)
+            .StoreResult(&ExecutionOptions.ResultsRowsLimit);
         TChoices<NKqpRun::TRunnerOptions::EResultOutputFormat> resultFormat({
             {"rows", NKqpRun::TRunnerOptions::EResultOutputFormat::RowsJson},
             {"full-json", NKqpRun::TRunnerOptions::EResultOutputFormat::FullJson},
@@ -441,7 +551,12 @@ protected:
             .StoreMappedResultT<TString>(&RunnerOptions.ScriptQueryPlanOutput, &GetDefaultOutput);
         options.AddLongOption("script-statistics", "File with script inprogress statistics")
             .RequiredArgument("file")
-            .StoreResult(&RunnerOptions.InProgressStatisticsOutputFile);
+            .StoreMappedResultT<TString>(&RunnerOptions.InProgressStatisticsOutputFile, [](const TString& file) {
+                if (file == "-") {
+                    ythrow yexception() << "Script in progress statistics cannot be printed to stdout, please specify file name";
+                }
+                return file;
+            });
         TChoices<NYdb::NConsoleClient::EDataFormat> planFormat({
             {"pretty", NYdb::NConsoleClient::EDataFormat::Pretty},
             {"table", NYdb::NConsoleClient::EDataFormat::PrettyTable},
@@ -453,6 +568,10 @@ protected:
             .Choices(planFormat.GetChoices())
             .StoreMappedResultT<TString>(&RunnerOptions.PlanOutputFormat, planFormat);
 
+        options.AddLongOption("script-timeline-svg", "File with script query timline in svg format (use '-' to write in stdout)")
+            .RequiredArgument("file")
+            .StoreMappedResultT<TString>(&RunnerOptions.ScriptQueryTimelineOutput, &GetDefaultOutput);
+
         // Pipeline settings
 
         TChoices<TExecutionOptions::EExecutionCase> executionCase({
@@ -463,7 +582,6 @@ protected:
         });
         options.AddLongOption('C', "execution-case", "Type of query for -p argument")
             .RequiredArgument("query-type")
-            .DefaultValue("script")
             .Choices(executionCase.GetChoices())
             .Handler1([this, executionCase](const NLastGetopt::TOptsParser* option) {
                 TString choice(option->CurValOrDef());
@@ -489,12 +607,15 @@ protected:
         });
         options.AddLongOption('A', "script-action", "Script query execute action")
             .RequiredArgument("script-action")
-            .DefaultValue("execute")
             .Choices(scriptAction.GetChoices())
             .Handler1([this, scriptAction](const NLastGetopt::TOptsParser* option) {
                 TString choice(option->CurValOrDef());
                 ExecutionOptions.ScriptQueryActions.emplace_back(scriptAction(choice));
             });
+
+        options.AddLongOption("timeout", "Reauests timeout in milliseconds")
+            .RequiredArgument("uint")
+            .StoreMappedResultT<ui64>(&RunnerOptions.YdbSettings.RequestsTimeout, &TDuration::MilliSeconds<ui64>);
 
         options.AddLongOption("cancel-after", "Cancel script execution operation after specified delay in milliseconds")
             .RequiredArgument("uint")
@@ -510,7 +631,7 @@ protected:
             .StoreResult(&ExecutionOptions.LoopCount);
         options.AddLongOption("loop-delay", "Delay in milliseconds between loop steps")
             .RequiredArgument("uint")
-            .DefaultValue(1000)
+            .DefaultValue(0)
             .StoreMappedResultT<ui64>(&ExecutionOptions.LoopDelay, &TDuration::MilliSeconds<ui64>);
 
         options.AddLongOption('D', "database", "Database path for -p queries")
@@ -576,6 +697,21 @@ protected:
             .RequiredArgument("path")
             .InsertTo(&RunnerOptions.YdbSettings.ServerlessTenants);
 
+        options.AddLongOption("storage-size", "Domain storage size in gigabytes")
+            .RequiredArgument("uint")
+            .DefaultValue(32)
+            .StoreMappedResultT<ui32>(&RunnerOptions.YdbSettings.DiskSize, [](ui32 diskSize) {
+                return static_cast<ui64>(diskSize) << 30;
+            });
+
+        options.AddLongOption("real-pdisks", "Use real PDisks instead of in memory PDisks (also disable disk mock)")
+            .NoArgument()
+            .SetFlag(&RunnerOptions.YdbSettings.UseRealPDisks);
+
+        options.AddLongOption("disable-disk-mock", "Disable disk mock on single node cluster")
+            .NoArgument()
+            .SetFlag(&RunnerOptions.YdbSettings.DisableDiskMock);
+
         TChoices<std::function<void()>> backtrace({
             {"heavy", &NKikimr::EnableYDBBacktraceFormat},
             {"light", []() { SetFormatBackTraceFn(FormatBackTrace); }}
@@ -591,13 +727,17 @@ protected:
     }
 
     int DoRun(NLastGetopt::TOptsParseResult&&) override {
-        if (!ExecutionOptions.SchemeQuery && ExecutionOptions.ScriptQueries.empty() && !RunnerOptions.YdbSettings.MonitoringEnabled && !RunnerOptions.YdbSettings.GrpcEnabled) {
-            ythrow yexception() << "Nothing to execute";
+        ExecutionOptions.Validate(RunnerOptions);
+
+        if (RunnerOptions.YdbSettings.DisableDiskMock && RunnerOptions.YdbSettings.NodeCount + RunnerOptions.YdbSettings.SharedTenants.size() + RunnerOptions.YdbSettings.DedicatedTenants.size() > 1) {
+            ythrow yexception() << "Disable disk mock cannot be used for multi node clusters";
         }
 
         RunnerOptions.YdbSettings.YqlToken = YqlToken;
         RunnerOptions.YdbSettings.FunctionRegistry = CreateFunctionRegistry(UdfsDirectory, UdfsPaths, ExcludeLinkedUdfs).Get();
-        RunnerOptions.YdbSettings.AppConfig.MutableQueryServiceConfig()->SetScriptResultRowsLimit(ResultsRowsLimit);
+        if (ExecutionOptions.ResultsRowsLimit) {
+            RunnerOptions.YdbSettings.AppConfig.MutableQueryServiceConfig()->SetScriptResultRowsLimit(ExecutionOptions.ResultsRowsLimit);
+        }
 
         if (EmulateYt) {
             const auto& fileStorageConfig = RunnerOptions.YdbSettings.AppConfig.GetQueryServiceConfig().GetFileStorage();

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -74,7 +74,7 @@ struct TRunnerOptions {
     IOutputStream* SchemeQueryAstOutput = nullptr;
     IOutputStream* ScriptQueryAstOutput = nullptr;
     IOutputStream* ScriptQueryPlanOutput = nullptr;
-    IOutputStream* ScriptQueryTimelineOutput = nullptr;
+    TString ScriptQueryTimelineFile;
     TString InProgressStatisticsOutputFile;
 
     EResultOutputFormat ResultOutputFormat = EResultOutputFormat::RowsJson;

--- a/ydb/tests/tools/kqprun/src/common.h
+++ b/ydb/tests/tools/kqprun/src/common.h
@@ -32,6 +32,11 @@ struct TYdbSetupSettings {
     std::unordered_set<TString> SharedTenants;
     std::unordered_set<TString> ServerlessTenants;
     TDuration InitializationTimeout = TDuration::Seconds(10);
+    TDuration RequestsTimeout;
+
+    bool DisableDiskMock = false;
+    bool UseRealPDisks = false;
+    ui64 DiskSize = 32_GB;
 
     bool MonitoringEnabled = false;
     ui16 MonitoringPortOffset = 0;
@@ -69,6 +74,7 @@ struct TRunnerOptions {
     IOutputStream* SchemeQueryAstOutput = nullptr;
     IOutputStream* ScriptQueryAstOutput = nullptr;
     IOutputStream* ScriptQueryPlanOutput = nullptr;
+    IOutputStream* ScriptQueryTimelineOutput = nullptr;
     TString InProgressStatisticsOutputFile;
 
     EResultOutputFormat ResultOutputFormat = EResultOutputFormat::RowsJson;

--- a/ydb/tests/tools/kqprun/src/kqp_runner.cpp
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.cpp
@@ -9,6 +9,7 @@
 
 #include <ydb/public/lib/json_value/ydb_json_value.h>
 #include <ydb/public/lib/ydb_cli/common/format.h>
+#include <ydb/public/lib/ydb_cli/common/plan2svg.h>
 
 
 namespace NKqpRun {
@@ -159,8 +160,12 @@ public:
 
         TYdbSetup::StopTraceOpt();
 
+        if (!meta.Plan) {
+            meta.Plan = ExecutionMeta_.Plan;
+        }
+
         PrintScriptAst(meta.Ast);
-        PrintScriptProgress(ExecutionMeta_.Plan);
+        PrintScriptProgress(meta.Plan);
         PrintScriptPlan(meta.Plan);
         PrintScriptFinish(meta, queryTypeStr);
 
@@ -322,6 +327,12 @@ private:
         if (Options_.ScriptQueryPlanOutput) {
             Cout << CoutColors_.Cyan() << "Writing script query plan" << CoutColors_.Default() << Endl;
             PrintPlan(plan, Options_.ScriptQueryPlanOutput);
+        }
+        if (Options_.ScriptQueryTimelineOutput) {
+            Cout << CoutColors_.Cyan() << "Writing script query timeline" << CoutColors_.Default() << Endl;
+            TPlanVisualizer planVisualizer;
+            planVisualizer.LoadPlans(plan);
+            Options_.ScriptQueryTimelineOutput->Write(planVisualizer.PrintSvg());
         }
     }
 

--- a/ydb/tests/tools/kqprun/src/kqp_runner.cpp
+++ b/ydb/tests/tools/kqprun/src/kqp_runner.cpp
@@ -267,6 +267,7 @@ private:
         }
 
         PrintScriptAst(ExecutionMeta_.Ast);
+        PrintScriptProgress(ExecutionMeta_.Plan);
         PrintScriptPlan(ExecutionMeta_.Plan);
         PrintScriptFinish(ExecutionMeta_, "Script");
 
@@ -328,12 +329,6 @@ private:
             Cout << CoutColors_.Cyan() << "Writing script query plan" << CoutColors_.Default() << Endl;
             PrintPlan(plan, Options_.ScriptQueryPlanOutput);
         }
-        if (Options_.ScriptQueryTimelineOutput) {
-            Cout << CoutColors_.Cyan() << "Writing script query timeline" << CoutColors_.Default() << Endl;
-            TPlanVisualizer planVisualizer;
-            planVisualizer.LoadPlans(plan);
-            Options_.ScriptQueryTimelineOutput->Write(planVisualizer.PrintSvg());
-        }
     }
 
     void PrintScriptProgress(const TString& plan) const {
@@ -362,6 +357,15 @@ private:
 
             outputStream << "\nPlan visualization:" << Endl;
             PrintPlan(convertedPlan, &outputStream);
+
+            outputStream.Finish();
+        }
+        if (Options_.ScriptQueryTimelineFile) {
+            TFileOutput outputStream(Options_.ScriptQueryTimelineFile);
+
+            TPlanVisualizer planVisualizer;
+            planVisualizer.LoadPlans(plan);
+            outputStream.Write(planVisualizer.PrintSvg());
 
             outputStream.Finish();
         }

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -321,7 +321,7 @@ public:
 
     NKikimr::NKqp::TEvKqp::TEvScriptResponse::TPtr ScriptRequest(const TRequestOptions& script) const {
         auto event = MakeHolder<NKikimr::NKqp::TEvKqp::TEvScriptRequest>();
-        FillScriptRequest(script, event->Record);
+        FillQueryRequest(script, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, event->Record);
 
         return RunKqpProxyRequest<NKikimr::NKqp::TEvKqp::TEvScriptRequest, NKikimr::NKqp::TEvKqp::TEvScriptResponse>(std::move(event), script.Database);
     }
@@ -442,16 +442,6 @@ private:
 
         if (Settings_.RequestsTimeout) {
             request->SetTimeoutMs(Settings_.RequestsTimeout.MilliSeconds());
-        }
-    }
-
-    void FillScriptRequest(const TRequestOptions& script, NKikimrKqp::TEvQueryRequest& event) const {
-        FillQueryRequest(script, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, event);
-
-        auto request = event.MutableRequest();
-        if (script.Action == NKikimrKqp::QUERY_ACTION_EXECUTE) {
-            request->MutableTxControl()->mutable_begin_tx()->mutable_serializable_read_write();
-            request->MutableTxControl()->set_commit_tx(true);
         }
     }
 

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/kqp/common/kqp_script_executions.h>
 #include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
 
+#include <ydb/core/testlib/basics/storage.h>
 #include <ydb/core/testlib/test_client.h>
 
 #include <ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.h>
@@ -121,6 +122,18 @@ private:
         serverSettings.SetFrFactory(functionRegistryFactory);
     }
 
+    void SetStorageSettings(NKikimr::Tests::TServerSettings& serverSettings) const {
+        const NKikimr::NFake::TStorage storage = {
+            .UseDisk = Settings_.UseRealPDisks,
+            .SectorSize = NKikimr::TTestStorageFactory::SECTOR_SIZE,
+            .ChunkSize = Settings_.UseRealPDisks ? NKikimr::TTestStorageFactory::CHUNK_SIZE : NKikimr::TTestStorageFactory::MEM_CHUNK_SIZE,
+            .DiskSize = Settings_.DiskSize
+        };
+
+        serverSettings.SetEnableMockOnSingleNode(!Settings_.DisableDiskMock && !Settings_.UseRealPDisks);
+        serverSettings.SetCustomDiskParams(storage);
+    }
+
     NKikimr::Tests::TServerSettings GetServerSettings(ui32 grpcPort) {
         const ui32 msgBusPort = PortManager_.GetPort();
 
@@ -147,6 +160,7 @@ private:
 
         SetLoggerSettings(serverSettings);
         SetFunctionRegistry(serverSettings);
+        SetStorageSettings(serverSettings);
 
         if (Settings_.MonitoringEnabled) {
             serverSettings.InitKikimrRunConfig();
@@ -425,6 +439,10 @@ private:
         request->SetCollectStats(Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL);
         request->SetDatabase(GetDatabasePath(query.Database));
         request->SetPoolId(query.PoolId);
+
+        if (Settings_.RequestsTimeout) {
+            request->SetTimeoutMs(Settings_.RequestsTimeout.MilliSeconds());
+        }
     }
 
     void FillScriptRequest(const TRequestOptions& script, NKikimrKqp::TEvQueryRequest& event) const {

--- a/ydb/tests/tools/kqprun/src/ydb_setup.cpp
+++ b/ydb/tests/tools/kqprun/src/ydb_setup.cpp
@@ -329,7 +329,7 @@ public:
     TQueryResponse QueryRequest(const TRequestOptions& query, TProgressCallback progressCallback) const {
         auto request = GetQueryRequest(query);
         auto promise = NThreading::NewPromise<TQueryResponse>();
-        GetRuntime()->Register(CreateRunScriptActorMock(std::move(request), promise, progressCallback), 0, GetRuntime()->GetAppData().UserPoolId);
+        GetRuntime()->Register(CreateRunScriptActorMock(std::move(request), promise, progressCallback), request.TargetNode - GetRuntime()->GetFirstNodeId(), GetRuntime()->GetAppData().UserPoolId);
 
         return promise.GetFuture().GetValueSync();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed AS pools and added validations

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

#### AS fixes
* Fixed AS pools in testlib (make it such as ydbd)
* Added AS configuration in default config (copied from YQ prod)

#### New flags
* Added options for storage settings
* Added option for timeline printing
* Added timeout option for requests

#### Other
* Added validations on invalid flags combinations
* Added script for flame graph extracting
* Changed default ResultsRowsLimit to 0 (from 1000)
* Fixed query plan printing after fail
