### PR TITLE
Implement excess key columns drop for BlockMapJoinCore computation node

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -27,7 +27,7 @@ template <bool RightRequired>
 class TBlockJoinState : public TBlockState {
 public:
     TBlockJoinState(TMemoryUsageInfo* memInfo, TComputationContext& ctx,
-                    const TVector<TType*>& inputItems, const TSet<ui32>& keyDrops,
+                    const TVector<TType*>& inputItems, const THashSet<ui32>& keyDrops,
                     const TVector<TType*> outputItems,
                     NUdf::TUnboxedValue**const fields)
         : TBlockState(memInfo, outputItems.size())
@@ -175,7 +175,7 @@ private:
     size_t InputWidth_;
     size_t OutputWidth_;
     TUnboxedValueVector Inputs_;
-    const TSet<ui32> KeyDrops_;
+    const THashSet<ui32> KeyDrops_;
     const std::vector<arrow::ValueDescr> InputsDescr_;
     TVector<std::unique_ptr<IBlockReader>> Readers_;
     TVector<std::unique_ptr<IBlockItemConverter>> Converters_;
@@ -281,7 +281,7 @@ private:
     const TVector<TType*> ResultJoinItems_;
     const TVector<TType*> LeftFlowItems_;
     const TVector<ui32> LeftKeyColumns_;
-    const TSet<ui32> LeftKeyDrops_;
+    const THashSet<ui32> LeftKeyDrops_;
     IComputationWideFlowNode* const Flow_;
     IComputationNode* const Dict_;
     ui32 WideFieldsIndex_;
@@ -430,7 +430,7 @@ private:
     const TVector<TType*> ResultJoinItems_;
     const TVector<TType*> LeftFlowItems_;
     const TVector<ui32> LeftKeyColumns_;
-    const TSet<ui32> LeftKeyDrops_;
+    const THashSet<ui32> LeftKeyDrops_;
     IComputationWideFlowNode* const Flow_;
     IComputationNode* const Dict_;
     ui32 WideFieldsIndex_;
@@ -497,7 +497,7 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
         leftKeyDrops.emplace_back(item->AsValue().Get<ui32>());
     }
 
-    const TSet<ui32> leftKeySet(leftKeyColumns.cbegin(), leftKeyColumns.cend());
+    const THashSet<ui32> leftKeySet(leftKeyColumns.cbegin(), leftKeyColumns.cend());
     for (const auto& drop : leftKeyDrops) {
         MKQL_ENSURE(leftKeySet.contains(drop),
                     "Only key columns has to be specified in drop column set");

--- a/ydb/library/yql/minikql/mkql_program_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_program_builder.cpp
@@ -5903,7 +5903,7 @@ TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode d
                 joinKind == EJoinKind::LeftSemi || joinKind == EJoinKind::LeftOnly,
                 "Unsupported join kind");
     MKQL_ENSURE(!leftKeyColumns.empty(), "At least one key column must be specified");
-    const TSet<ui32> leftKeySet(leftKeyColumns.cbegin(), leftKeyColumns.cend());
+    const THashSet<ui32> leftKeySet(leftKeyColumns.cbegin(), leftKeyColumns.cend());
     for (const auto& drop : leftKeyDrops) {
         MKQL_ENSURE(leftKeySet.contains(drop),
                     "Only key columns has to be specified in drop column set");
@@ -5924,7 +5924,7 @@ TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode d
         });
 
     const auto leftFlowItems = ValidateBlockFlowType(flow.GetStaticType(), false);
-    const TSet<ui32> leftKeyDropsSet(leftKeyDrops.cbegin(), leftKeyDrops.cend());
+    const THashSet<ui32> leftKeyDropsSet(leftKeyDrops.cbegin(), leftKeyDrops.cend());
     TVector<TType*> returnJoinItems;
     for (size_t i = 0; i < leftFlowItems.size(); i++) {
         if (leftKeyDropsSet.contains(i)) {

--- a/ydb/library/yql/minikql/mkql_program_builder.cpp
+++ b/ydb/library/yql/minikql/mkql_program_builder.cpp
@@ -5893,7 +5893,8 @@ TRuntimeNode TProgramBuilder::ScalarApply(const TArrayRef<const TRuntimeNode>& a
 }
 
 TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode dict,
-    EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns
+    EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns,
+    const TArrayRef<const ui32>& leftKeyDrops
 ) {
     if constexpr (RuntimeVersion < 51U) {
         THROW yexception() << "Runtime version (" << RuntimeVersion << ") too old for " << __func__;
@@ -5902,6 +5903,11 @@ TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode d
                 joinKind == EJoinKind::LeftSemi || joinKind == EJoinKind::LeftOnly,
                 "Unsupported join kind");
     MKQL_ENSURE(!leftKeyColumns.empty(), "At least one key column must be specified");
+    const TSet<ui32> leftKeySet(leftKeyColumns.cbegin(), leftKeyColumns.cend());
+    for (const auto& drop : leftKeyDrops) {
+        MKQL_ENSURE(leftKeySet.contains(drop),
+                    "Only key columns has to be specified in drop column set");
+    }
 
     TRuntimeNode::TList leftKeyColumnsNodes;
     leftKeyColumnsNodes.reserve(leftKeyColumns.size());
@@ -5910,7 +5916,23 @@ TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode d
             return NewDataLiteral(idx);
         });
 
-    auto returnJoinItems = ValidateBlockFlowType(flow.GetStaticType(), false);
+    TRuntimeNode::TList leftKeyDropsNodes;
+    leftKeyDropsNodes.reserve(leftKeyDrops.size());
+    std::transform(leftKeyDrops.cbegin(), leftKeyDrops.cend(),
+        std::back_inserter(leftKeyDropsNodes), [this](const ui32 idx) {
+            return NewDataLiteral(idx);
+        });
+
+    const auto leftFlowItems = ValidateBlockFlowType(flow.GetStaticType(), false);
+    const TSet<ui32> leftKeyDropsSet(leftKeyDrops.cbegin(), leftKeyDrops.cend());
+    TVector<TType*> returnJoinItems;
+    for (size_t i = 0; i < leftFlowItems.size(); i++) {
+        if (leftKeyDropsSet.contains(i)) {
+            continue;
+        }
+        returnJoinItems.push_back(leftFlowItems[i]);
+    }
+
     const auto payloadType = AS_TYPE(TDictType, dict.GetStaticType())->GetPayloadType();
     const auto payloadItemType = payloadType->IsList()
                                ? AS_TYPE(TListType, payloadType)->GetItemType()
@@ -5945,6 +5967,7 @@ TRuntimeNode TProgramBuilder::BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode d
     callableBuilder.Add(dict);
     callableBuilder.Add(NewDataLiteral((ui32)joinKind));
     callableBuilder.Add(NewTuple(leftKeyColumnsNodes));
+    callableBuilder.Add(NewTuple(leftKeyDropsNodes));
 
     return TRuntimeNode(callableBuilder.Build(), false);
 }

--- a/ydb/library/yql/minikql/mkql_program_builder.h
+++ b/ydb/library/yql/minikql/mkql_program_builder.h
@@ -256,7 +256,8 @@ public:
     TRuntimeNode BlockPgResolvedCall(const std::string_view& name, ui32 id,
         const TArrayRef<const TRuntimeNode>& args, TType* returnType);
     TRuntimeNode BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode dict,
-        EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns);
+        EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns,
+        const TArrayRef<const ui32>& leftKeyDrops = {});
 
     //-- logical functions
     TRuntimeNode BlockNot(TRuntimeNode data);


### PR DESCRIPTION
This patchset implements drop of the specified key columns, to reduce excess data in the result, produced by the `BlockMapJoinCore` computation node. As a result of the patch, program builder handler for `BlockMapJoinCore` accepts the vector with the specified key columns, that match indices of the corresponding "left" wide flow fields.

It's worth mentioning why only **left key** columns are processed:
* Right key columns are dropped by default, since they are the same as the left ones;
* Right payload columns respect the following contract: input type provides only those fields, required by output wide type;
* Left non-key columns also respect the aforementioned contract.

All in all, only the key columns used to process the join, but not required in the output type, should be processed by this computation node.

**NB**: MKQL version is not bumped, since there is no way to emit `BlockMapJoinCore` at the moment.

### Changelog category

* Improvement