### PR TITLE
Delay making EquiJoin inputs unordered until CROSS JOIN is rewritten to inner

### DIFF
--- a/ydb/library/yql/core/common_opt/yql_co_last.cpp
+++ b/ydb/library/yql/core/common_opt/yql_co_last.cpp
@@ -1,7 +1,59 @@
 #include "yql_co.h"
+#include <ydb/library/yql/core/expr_nodes/yql_expr_nodes.h>
 #include <ydb/library/yql/core/yql_opt_utils.h>
+#include <ydb/library/yql/utils/log/log.h>
 
 namespace NYql {
+
+namespace {
+
+using namespace NNodes;
+
+std::unordered_set<ui32> GetUselessSortedJoinInputs(const TCoEquiJoin& equiJoin) {
+    std::unordered_map<std::string_view, std::tuple<ui32, const TSortedConstraintNode*, const TChoppedConstraintNode*>> sorteds(equiJoin.ArgCount() - 2U);
+    for (ui32 i = 0U; i + 2U < equiJoin.ArgCount(); ++i) {
+        if (const auto joinInput = equiJoin.Arg(i).Cast<TCoEquiJoinInput>(); joinInput.Scope().Ref().IsAtom()) {
+            const auto sorted = joinInput.List().Ref().GetConstraint<TSortedConstraintNode>();
+            const auto chopped = joinInput.List().Ref().GetConstraint<TChoppedConstraintNode>();
+            if (sorted || chopped)
+                sorteds.emplace(joinInput.Scope().Ref().Content(), std::make_tuple(i, sorted, chopped));
+        }
+    }
+
+    for (std::vector<const TExprNode*> joinTreeNodes(1U, equiJoin.Arg(equiJoin.ArgCount() - 2).Raw()); !joinTreeNodes.empty();) {
+        const auto joinTree = joinTreeNodes.back();
+        joinTreeNodes.pop_back();
+
+        if (!joinTree->Child(1)->IsAtom())
+            joinTreeNodes.emplace_back(joinTree->Child(1));
+
+        if (!joinTree->Child(2)->IsAtom())
+            joinTreeNodes.emplace_back(joinTree->Child(2));
+
+        if (!joinTree->Head().IsAtom("Cross")) {
+            std::unordered_map<std::string_view, TPartOfConstraintBase::TSetType> tableJoinKeys;
+            for (const auto keys : {joinTree->Child(3), joinTree->Child(4)})
+                for (ui32 i = 0U; i < keys->ChildrenSize(); i += 2)
+                    tableJoinKeys[keys->Child(i)->Content()].insert_unique(TPartOfConstraintBase::TPathType(1U, keys->Child(i + 1)->Content()));
+
+            for (const auto& [label, joinKeys]: tableJoinKeys) {
+                if (const auto it = sorteds.find(label); sorteds.cend() != it) {
+                    const auto sorted = std::get<const TSortedConstraintNode*>(it->second);
+                    const auto chopped = std::get<const TChoppedConstraintNode*>(it->second);
+                    if (sorted && sorted->StartsWith(joinKeys) || chopped && chopped->Equals(joinKeys))
+                        sorteds.erase(it);
+                }
+            }
+        }
+    }
+
+    std::unordered_set<ui32> result(sorteds.size());
+    for (const auto& sort : sorteds)
+        result.emplace(std::get<ui32>(sort.second));
+    return result;
+}
+
+} // namespace
 
 void RegisterCoFinalCallables(TCallableOptimizerMap& map) {
     map["UnorderedSubquery"] = [](const TExprNode::TPtr& node, TExprContext& ctx, TOptimizeContext& optCtx) {
@@ -11,7 +63,25 @@ void RegisterCoFinalCallables(TCallableOptimizerMap& map) {
                 return TExprNode::TPtr();
             }
         }
+        YQL_CLOG(DEBUG, Core) << "Replace " << node->Content() << " with Unordered";
         return ctx.RenameNode(*node, "Unordered");
+    };
+
+    map["EquiJoin"] = [](const TExprNode::TPtr& node, TExprContext& ctx, TOptimizeContext& /*optCtx*/) {
+        if (const auto indexes = GetUselessSortedJoinInputs(TCoEquiJoin(node)); !indexes.empty()) {
+            YQL_CLOG(DEBUG, Core) << "Suppress order on " << indexes.size() << ' ' << node->Content() << " inputs";
+            auto children = node->ChildrenList();
+            for (const auto idx : indexes)
+                children[idx] = ctx.Builder(children[idx]->Pos())
+                    .List()
+                        .Callable(0, "Unordered")
+                            .Add(0, children[idx]->HeadPtr())
+                        .Seal()
+                        .Add(1, children[idx]->TailPtr())
+                    .Seal().Build();
+            return ctx.ChangeChildren(*node, std::move(children));
+        }
+        return node;
     };
 }
 

--- a/ydb/library/yql/core/common_opt/yql_co_simple1.cpp
+++ b/ydb/library/yql/core/common_opt/yql_co_simple1.cpp
@@ -3321,50 +3321,6 @@ TExprNode::TPtr PullAssumeColumnOrderOverEquiJoin(const TExprNode::TPtr& node, T
     return node;
 }
 
-std::unordered_set<ui32> GetUselessSortedJoinInputs(const TCoEquiJoin& equiJoin) {
-    std::unordered_map<std::string_view, std::tuple<ui32, const TSortedConstraintNode*, const TChoppedConstraintNode*>> sorteds(equiJoin.ArgCount() - 2U);
-    for (ui32 i = 0U; i + 2U < equiJoin.ArgCount(); ++i) {
-        if (const auto joinInput = equiJoin.Arg(i).Cast<TCoEquiJoinInput>(); joinInput.Scope().Ref().IsAtom()) {
-            const auto sorted = joinInput.List().Ref().GetConstraint<TSortedConstraintNode>();
-            const auto chopped = joinInput.List().Ref().GetConstraint<TChoppedConstraintNode>();
-            if (sorted || chopped)
-                sorteds.emplace(joinInput.Scope().Ref().Content(), std::make_tuple(i, sorted, chopped));
-        }
-    }
-
-    for (std::vector<const TExprNode*> joinTreeNodes(1U, equiJoin.Arg(equiJoin.ArgCount() - 2).Raw()); !joinTreeNodes.empty();) {
-        const auto joinTree = joinTreeNodes.back();
-        joinTreeNodes.pop_back();
-
-        if (!joinTree->Child(1)->IsAtom())
-            joinTreeNodes.emplace_back(joinTree->Child(1));
-
-        if (!joinTree->Child(2)->IsAtom())
-            joinTreeNodes.emplace_back(joinTree->Child(2));
-
-        if (!joinTree->Head().IsAtom("Cross")) {
-            std::unordered_map<std::string_view, TPartOfConstraintBase::TSetType> tableJoinKeys;
-            for (const auto keys : {joinTree->Child(3), joinTree->Child(4)})
-                for (ui32 i = 0U; i < keys->ChildrenSize(); i += 2)
-                    tableJoinKeys[keys->Child(i)->Content()].insert_unique(TPartOfConstraintBase::TPathType(1U, keys->Child(i + 1)->Content()));
-
-            for (const auto& [label, joinKeys]: tableJoinKeys) {
-                if (const auto it = sorteds.find(label); sorteds.cend() != it) {
-                    const auto sorted = std::get<const TSortedConstraintNode*>(it->second);
-                    const auto chopped = std::get<const TChoppedConstraintNode*>(it->second);
-                    if (sorted && sorted->StartsWith(joinKeys) || chopped && chopped->Equals(joinKeys))
-                        sorteds.erase(it);
-                }
-            }
-        }
-    }
-
-    std::unordered_set<ui32> result(sorteds.size());
-    for (const auto& sort : sorteds)
-        result.emplace(std::get<ui32>(sort.second));
-    return result;
-}
-
 TExprNode::TPtr FoldParseAfterSerialize(const TExprNode::TPtr& node, const TStringBuf parseUdfName, const THashSet<TStringBuf>& serializeUdfNames) {
     auto apply = TExprBase(node).Cast<TCoApply>();
 
@@ -5139,20 +5095,6 @@ void RegisterCoSimpleCallables1(TCallableOptimizerMap& map) {
         if (ret != node) {
             YQL_CLOG(DEBUG, Core) << "HandleEmptyListInJoin";
             return ret;
-        }
-
-        if (const auto indexes = GetUselessSortedJoinInputs(TCoEquiJoin(node)); !indexes.empty()) {
-            YQL_CLOG(DEBUG, Core) << "Suppress order on " << indexes.size() << ' ' << node->Content() << " inputs.";
-            auto children = node->ChildrenList();
-            for (const auto idx : indexes)
-                children[idx] = ctx.Builder(children[idx]->Pos())
-                    .List()
-                        .Callable(0, "Unordered")
-                            .Add(0, children[idx]->HeadPtr())
-                        .Seal()
-                        .Add(1, children[idx]->TailPtr())
-                    .Seal().Build();
-            return ctx.ChangeChildren(*node, std::move(children));
         }
 
         for (ui32 i = 0U; i < node->ChildrenSize() - 2U; ++i) {

--- a/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
+++ b/ydb/library/yql/tests/sql/sql2yql/canondata/result.json
@@ -8273,6 +8273,13 @@
             "uri": "https://{canondata_backend}/1784117/d56ae82ad9d30397a41490647be1bd2124718f98/resource.tar.gz#test_sql2yql.test_join-cross_join_with_lazy_list_/sql.yql"
         }
     ],
+    "test_sql2yql.test[join-do_not_suppres_equijoin_input_sorts]": [
+        {
+            "checksum": "f0414b010a5b710a7b4e40eb58c281a6",
+            "size": 1677,
+            "uri": "https://{canondata_backend}/1942415/648a56e0787ca3112c139c169f33c33294672c1c/resource.tar.gz#test_sql2yql.test_join-do_not_suppres_equijoin_input_sorts_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[join-emptyjoin_unused_keys]": [
         {
             "checksum": "a10f3ec3492bdb510c3dbdf0892a77d4",
@@ -27885,6 +27892,13 @@
             "checksum": "02b2c8d65c090ccd68d72a454400686b",
             "size": 318,
             "uri": "https://{canondata_backend}/1880306/64654158d6bfb1289c66c626a8162239289559d0/resource.tar.gz#test_sql_format.test_join-cross_join_with_lazy_list_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[join-do_not_suppres_equijoin_input_sorts]": [
+        {
+            "checksum": "d3e970630b591a773a59ed5ec3c33861",
+            "size": 183,
+            "uri": "https://{canondata_backend}/1942415/648a56e0787ca3112c139c169f33c33294672c1c/resource.tar.gz#test_sql_format.test_join-do_not_suppres_equijoin_input_sorts_/formatted.sql"
         }
     ],
     "test_sql_format.test[join-emptyjoin_unused_keys]": [

--- a/ydb/library/yql/tests/sql/suites/join/do_not_suppres_equijoin_input_sorts.cfg
+++ b/ydb/library/yql/tests/sql/suites/join/do_not_suppres_equijoin_input_sorts.cfg
@@ -1,0 +1,3 @@
+in Input1 sorted_by_kv1_opt.txt
+in Input2 sorted_by_kv1.txt
+providers yt

--- a/ydb/library/yql/tests/sql/suites/join/do_not_suppres_equijoin_input_sorts.sql
+++ b/ydb/library/yql/tests/sql/suites/join/do_not_suppres_equijoin_input_sorts.sql
@@ -1,0 +1,8 @@
+USE plato;
+pragma yt.JoinMergeTablesLimit="10";
+pragma DisableSimpleColumns;
+
+select
+   *
+from Input1 as t1 cross join Input2 as t2
+where t1.k1 == t2.k1 and t1.k1 < "zzz";

--- a/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
@@ -1627,6 +1627,27 @@
             "uri": "https://{canondata_backend}/1809005/40931b4ca83c5d01d9f04e8de1077ebd3a376c59/resource.tar.gz#test.test_join-bush_dis_in_in--Results_/results.txt"
         }
     ],
+    "test.test[join-do_not_suppres_equijoin_input_sorts--Debug]": [
+        {
+            "checksum": "39a7da36195278939749cfd0c802df2d",
+            "size": 4192,
+            "uri": "https://{canondata_backend}/212715/554ca8a35165199bfbc0a64aabd14c9754eff60c/resource.tar.gz#test.test_join-do_not_suppres_equijoin_input_sorts--Debug_/opt.yql"
+        }
+    ],
+    "test.test[join-do_not_suppres_equijoin_input_sorts--Plan]": [
+        {
+            "checksum": "e4e688e829f56ef3283334c1505715f8",
+            "size": 7890,
+            "uri": "https://{canondata_backend}/212715/554ca8a35165199bfbc0a64aabd14c9754eff60c/resource.tar.gz#test.test_join-do_not_suppres_equijoin_input_sorts--Plan_/plan.txt"
+        }
+    ],
+    "test.test[join-do_not_suppres_equijoin_input_sorts--Results]": [
+        {
+            "checksum": "c2c4e691738140477a271621492ad396",
+            "size": 3576,
+            "uri": "https://{canondata_backend}/212715/554ca8a35165199bfbc0a64aabd14c9754eff60c/resource.tar.gz#test.test_join-do_not_suppres_equijoin_input_sorts--Results_/results.txt"
+        }
+    ],
     "test.test[join-join_no_correlation_in_order_by--Debug]": [
         {
             "checksum": "dce49c61f91b07c0e490de4e4cbd1a1b",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* Delay making EquiJoin inputs unordered until CROSS JOIN is rewritten to inner

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
