### PR TITLE
Add utilization and starvation sensors

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -9,6 +9,26 @@ namespace NActors {
 
 namespace {
 
+    static constexpr std::initializer_list<ui32> UtilizationPPM{
+        1'000, 5'000, 10'000, 50'000, 100'000, 200'000, 300'000, 400'000, 500'000, 600'000, 700'000, 800'000,
+        900'000, 950'000, 990'000, 999'000, Max<ui32>()
+    };
+
+    namespace {
+        void UpdateUtilization(auto& prevIndex, auto& array, ui32 value) {
+            auto comp = [](const auto& x, ui32 y) { return std::get<0>(x) < y; };
+            auto it = std::lower_bound(array.begin(), array.end(), value, comp);
+            Y_ABORT_UNLESS(it != array.end());
+            if (const ui32 index = it - array.begin(); index != prevIndex) {
+                auto& [_1, prev] = array[prevIndex];
+                prev->Dec();
+                auto& [_2, cur] = *it;
+                cur->Inc();
+                prevIndex = index;
+            }
+        };
+    }
+
     class TInterconnectCounters: public IInterconnectMetrics {
     public:
         struct TOutputChannel {
@@ -236,6 +256,11 @@ namespace {
             }
         }
 
+        void SetUtilization(ui32 total, ui32 starvation) override {
+            UpdateUtilization(PrevUtilization, Utilization, total);
+            UpdateUtilization(PrevStarvation, Starvation, starvation);
+        }
+
         void SetPeerInfo(const TString& name, const TString& dataCenterId) override {
             if (name != std::exchange(HumanFriendlyPeerHostName, name)) {
                 PerSessionCounters.Reset();
@@ -308,6 +333,17 @@ namespace {
                 for (const char *reason : TDisconnectReason::Reasons) {
                     DisconnectByReason[reason] = disconnectReasonGroup->GetCounter(reason, true);
                 }
+
+                auto group = Counters->GetSubgroup("subsystem", "utilization");
+                auto util = group->GetSubgroup("sensor", "utilization");
+                auto starv = group->GetSubgroup("sensor", "starvation");
+                for (ui32 ppm : UtilizationPPM) {
+                    const TString name = ppm != Max<ui32>() ? ToString(ppm) : "inf";
+                    Utilization.emplace_back(ppm, util->GetNamedCounter("bin", name, false));
+                    Starvation.emplace_back(ppm, starv->GetNamedCounter("bin", name, false));
+                }
+                ++*std::get<1>(Utilization[PrevUtilization]);
+                ++*std::get<1>(Starvation[PrevStarvation]);
             }
 
             Initialized = true;
@@ -346,6 +382,11 @@ namespace {
         THashMap<TString, NMonitoring::TDynamicCounters::TCounterPtr> DisconnectByReason;
 
         NMonitoring::TDynamicCounters::TCounterPtr TotalBytesWritten, TotalBytesRead;
+
+        ui32 PrevUtilization = 0;
+        std::vector<std::tuple<ui32, NMonitoring::TDynamicCounters::TCounterPtr>> Utilization;
+        ui32 PrevStarvation = 0;
+        std::vector<std::tuple<ui32, NMonitoring::TDynamicCounters::TCounterPtr>> Starvation;
     };
 
     class TInterconnectMetrics: public IInterconnectMetrics {
@@ -555,6 +596,11 @@ namespace {
             }
         }
 
+        void SetUtilization(ui32 total, ui32 starvation) override {
+            UpdateUtilization(PrevUtilization_, Utilization_, total);
+            UpdateUtilization(PrevStarvation_, Starvation_, starvation);
+        }
+
         void SetPeerInfo(const TString& name, const TString& dataCenterId) override {
             if (name != std::exchange(HumanFriendlyPeerHostName, name)) {
                 PerSessionMetrics_.reset();
@@ -638,6 +684,26 @@ namespace {
                                 {"reason", reason},
                             }));
                 }
+
+                for (ui32 ppm : UtilizationPPM) {
+                    const TString name = ppm != Max<ui32>() ? ToString(ppm) : "inf";
+                    Utilization_.emplace_back(ppm, Metrics_->IntGauge(
+                        NMonitoring::MakeLabels({
+                            {"subsystem", "utilization"},
+                            {"sensor", "utilization"},
+                            {"bin", name},
+                        })
+                    ));
+                    Starvation_.emplace_back(ppm, Metrics_->IntGauge(
+                        NMonitoring::MakeLabels({
+                            {"subsystem", "utilization"},
+                            {"sensor", "starvation"},
+                            {"bin", name},
+                        })
+                    ));
+                }
+                std::get<1>(Utilization_[PrevUtilization_])->Inc();
+                std::get<1>(Starvation_[PrevStarvation_])->Inc();
             }
 
             Initialized_ = true;
@@ -690,6 +756,11 @@ namespace {
 
         NMonitoring::IRate* TotalBytesWritten_;
         NMonitoring::IRate* TotalBytesRead_;
+
+        ui32 PrevUtilization_ = 0;
+        std::vector<std::tuple<ui32, NMonitoring::IIntGauge*>> Utilization_;
+        ui32 PrevStarvation_ = 0;
+        std::vector<std::tuple<ui32, NMonitoring::IIntGauge*>> Starvation_;
     };
 
 } // namespace

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -43,6 +43,7 @@ public:
     virtual void UpdatePingTimeHistogram(ui64 value) = 0;
     virtual void UpdateOutputChannelTraffic(ui16 channel, ui64 value) = 0;
     virtual void UpdateOutputChannelEvents(ui16 channel) = 0;
+    virtual void SetUtilization(ui32 total, ui32 starvation) = 0;
     TString GetHumanFriendlyPeerHostName() const {
         return HumanFriendlyPeerHostName.value_or(TString());
     }

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -39,6 +39,7 @@ namespace NActors {
         , OutputCounter(0ULL)
     {
         Proxy->Metrics->SetConnected(0);
+        PartUpdateTimestamp = GetCycleCountFast();
         ReceiveContext.Reset(new TReceiveContext);
     }
 
@@ -143,6 +144,9 @@ namespace NActors {
 
         SetOutputStuckFlag(true);
         ++NumEventsInQueue;
+        if (State == EState::Idle) {
+            UpdateState(EState::Utilized);
+        }
         RearmCloseOnIdle();
 
         LWTRACK(EnqueueEvent, event->Orbit, Proxy->PeerNodeId, NumEventsInQueue, GetWriteBlockedTotal(), evChannel, oChannel.GetQueueSize(), oChannel.GetBufferedAmountOfData());
@@ -408,8 +412,14 @@ namespace NActors {
             TimeLimit.emplace(GetMaxCyclesPerEvent());
         }
 
+        if (NumEventsInQueue || OutgoingStream || OutOfBandStream || XdcStream) {
+            UpdateState(EState::Utilized);
+        }
+
         // generate ping request, if needed
         IssuePingRequest();
+
+        bool notEnoughCpu = false;
 
         while (Socket) {
             ProducePackets();
@@ -438,6 +448,7 @@ namespace NActors {
             } else if (TimeLimit->CheckExceeded()) {
                 SetEnoughCpu(++StarvingInRow < StarvingInRowForNotEnoughCpu);
                 IssueRam(false);
+                notEnoughCpu = true;
                 break;
             }
         }
@@ -449,6 +460,10 @@ namespace NActors {
 
         // equalize channel weights
         EqualizeCounter += ChannelScheduler->Equalize();
+
+        // update state
+        const bool finished = !NumEventsInQueue && !OutgoingStream && !OutOfBandStream && !XdcStream;
+        UpdateState(finished ? EState::Idle : notEnoughCpu ? EState::WaitingCpu : EState::Utilized);
     }
 
     void TInterconnectSessionTCP::ProducePackets() {
@@ -533,6 +548,7 @@ namespace NActors {
             XdcSocket->Shutdown(SHUT_RDWR);
             XdcSocket.Reset();
         }
+        UpdateState(EState::Idle);
     }
 
     void TInterconnectSessionTCP::ReestablishConnectionExecute() {
@@ -1120,6 +1136,10 @@ namespace NActors {
         }
     }
 
+    void TInterconnectSessionTCP::UpdateUtilization() {
+        Proxy->Metrics->SetUtilization(1'000'000 * Utilized, 1'000'000 * Starving);
+    }
+
     void TInterconnectSessionTCP::GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr& ev) {
         TStringStream str;
         ev->Get()->Output(str);
@@ -1331,6 +1351,15 @@ namespace NActors {
 
                             MON_VAR(CpuStarvationEvents)
                             MON_VAR(CpuStarvationEventsOnWriteData)
+
+                            UpdateState();
+
+                            TABLER() {
+                                TABLED() { str << "Utilization"; }
+                                TABLED() {
+                                    str << Sprintf("%.1f%%", 100 * Utilized) << " / " << Sprintf("%.1f%%", Starving);
+                                }
+                            }
 
                             TString clockSkew;
                             i64 x = GetClockSkew();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add utilization and starvation sensors

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Additional sensors were added to monitor IC outgoing session usage and CPU starvation.
