### PR TITLE
Long name domain test

### DIFF
--- a/ydb/library/yql/parser/pg_wrapper/syscache.cpp
+++ b/ydb/library/yql/parser/pg_wrapper/syscache.cpp
@@ -756,10 +756,10 @@ namespace NMiniKQL {
 void PgCreateSysCacheEntries(void* ctx) {
     auto main = (TMainContext*)ctx;
     if (main->GUCSettings) {
-        if (main->GUCSettings->Get("ydb_database")) {
+        if (main->GUCSettings->Get("ydb_database")) && main->GUCSettings->Get("ydb_database")->size() < NAMEDATALEN) {
             main->CurrentDatabaseName = NYql::TSysCache::MakePgDatabaseHeapTuple(NYql::PG_CURRENT_DATABASE_ID, main->GUCSettings->Get("ydb_database")->c_str());
         }
-        if (main->GUCSettings->Get("ydb_user")) {
+        if (main->GUCSettings->Get("ydb_user")) && main->GUCSettings->Get("ydb_user")->size() < NAMEDATALEN) {
             main->CurrentUserName = NYql::TSysCache::MakePgRolesHeapTuple(NYql::PG_CURRENT_USER_ID, main->GUCSettings->Get("ydb_user")->c_str());
         }
     }


### PR DESCRIPTION
- **Intermediate changes**
- **YT-22751: Drop custom CopyConfig methods f5788694973061a735a7b65e45abe9ce6d889a87**
- **FixNamespaceComments in /util**
- **Native transaction externalization/replication**
- **Enable clang-format FixNamespaceComments option**
- **Fix USE_ANNOTATION_PROCESSOR**
- **Fill SWIG_LIB manually in conanfile.py**
- **YT-21709: Empty template for shuffle service**
- **Automatic release build for test_tool, ya_bin, os_ya, os_test_tool**
- **Patch OpenSSL target name under Conan2**
- **Introduce PHOENIX_REGISTER_FIELD c521034e724d6ed4145a1cfa5c46b231589c9013**
- **fix grammar in healthcheck messages (#8839)**
- **Fix resolve cluster in pg parser (#8835)**
- **Mute ydb/tests/functional/hive/test_drain.py.TestHive.test_drain_on_stop (#8852)**
- **build: refresh Embedded UI (v6.18.0) (#8797)**
- **Add CRC64 to docs (#8842)**
- **Data Integrity trails in DataShard (#6288)**
- **Restore the commit fixing a memory leak in AWS SDK (#8823)**
- **Build secondary index/table columns: remove unnecessary message (#8219)**
- **Enable production features in tests (#8709)**
- **Import libraries 240906-1233**
- **Validate protos from antlr4 (#8832)**
- **add missing enum value to win-specific code (#8854)**
- **Fix Date32 json serialization for column store (#8848)**
- **Fix resolved timestamp emitted too early for some displaced upserts (#8847)**
- **Fix reporting of initial VDisk status to SysView (#8853)**
- **mute rules upd (#8865)**
- **Update github.com/ydb-platform/fq-connector-go to 0.5.8-rc.1 (#8866)**
- **NodesManager cleanup (#8863)**
- **Fix MakeBlocks usage in BlockMapJoinCore computation node (#8686)**
- **Update summary.html build type (#8879)**
- **Post graph_compare.sh logs (#8787)**
- **Fix error message about merge conflicts (#8883)**
- **add report (#8556)**
- **Fix crash on ic counters (#8880)**
- **[yt provider] Add ForceTransform optimizer (#8874)**
- **Inference projections support (#8744)**
- **Bugfixes (#8676)**
- **Fix typo (#7564)**
- **Fix log message in GenerateCookie (#8890)**
- **Fix YQL knn udf docs (#8425)**
- **Olap TableStore read/write test (#8858)**
- **Avoid block aggregation in auto mode for YT (#8894)**
- **Fix wrong YQL_ENSURE in PushdownComplexFiltersOverAggregate (#8899)**
- **Do not try to call IsComplete() on Arguments (#8901)**
- **Handle non-ascii in comments (#8902)**
- **Better handling of antlr4 errors, fixed use after free (#8903)**
- **fix cluster tablets grouping (#8904)**
- **remove table only for empty insert table (#8822)**
- **Fix write ids usage (#8909)**
- **YQ-3597 disable metadata objects on serverless (#8806)**
- **speed up column ids checkers and finder (#8906)**
- **Fix locks tests (#8733)**
- **Add parallel description (#8585)**
- **YDBDOCS-740: mention column-oriented tables in the Grafana article (#8705)**
- **Fixed antlr4 build warnings (#8912)**
- **Show tests with max RSS (#8888)**
- **Remove unused imports in proto (#8885)**
- **restore old behaviour of mapping space disk issues to group issues (#8767)**
- **Update github.com/ydb-platform/fq-connector-go to 0.5.8-rc.2 (#8932)**
- **Fix CLI max partitions default (#8944)**
- **Move some into test_ya action (#8937)**
- **Restructured the integrations chapter (#8905)**
- **fix for YQ-3632 (#8762)**
- **YQ-3644 added validations for resource pool parametres (#8831)**
- **[yt provider] Fix join output sort mismatch (#8896)**
- **Add PARTITIONS_COUNT setting to yql (#7602)**
- **Collect security tags properly from table content files (#8542)**
- **Fix tx tests (#8945)**
- **Added ensure Node != nullptr. (#8855)**
- **Add local kmeans actor scan (#8756)**
- **Fix spacing in logs (#8954)**
- **Print long request history to log (#8131)**
- **Mute ydb/core/kqp/ut/tx tests (#8969)**
- **Use lock-free Bucket in CostTracker with limited underflow (#8637)**
- **Support of out of code builds (#8962)**
- **fix typo (#8985)**
- **Conditionally compile the code that uses AWS to pass windows build (#8966)**
- **Implemented limit on olap table columnt count (#8742)**
- **Split WideCombiners state into buckets earlier (#8804)**
- **Support schemaname in sequence name (#8988)**
- **Add incremental restore type in ChangeExchange (#8986)**
- **Microfix in DQ (#8968)**
- **Remove templates.h (#8746)**
- **The code has been got rid of the TS3ReadActorFactoryConfig (#8181)**
- **Text of the DescribePath error has been improved (#8868)**
- **unmute tests (#8993)**
- **YDB FQ: Use `--tmpfs` flag when running docker containers (#8951)**
- **move redirects to base class (#8934)**
- **skip long tx writing to in control locks (#8924)**
- **Add link to s3 artifacts (#9001)**
- **Disallow disabling of topic autopartitioning (#8871) (#8949)**
- **fix decimal output for builtin query requests (#8950)**
- **return 0 when field is zero (#8955)**
- **Fix empty table name error (#8907)**
- **Support type_v3 UUIDs (#8179)**
- **HLL in YT statistics (#8184)**
- **golang pg test (#8132)**
- **Mute ydb/library/yql/tests/sql/hybrid_file/part1/test.py.test[in-in_noansi_join--Debug] (#9016)**
- **Make change sender identity explicit (#8995)**
- **Mute ydb/core/kqp/ut/query/KqpLimits.QueryExecTimeoutCancel (#9018)**
- **Optimize waiting for index creation during restore in YDB CLI (#8936)**
- **Fix PARTITION_COUNT option name and add tests (#9012)**
- **CODEOWNERS CS (#9025)**
- **Integrity trails helper (#8964)**
- **Replaced client cache to server cache in ydb tools restore command (#9031)**
- **Fix missing include? (#9023)**
- **fix concurrent rw hash map (#9008)**
- **Remove some from kikimr_config (#9032)**
- **Add feature flag: enable olap compression (#8726)**
- **Mute ydb/tests/postgres_integrations/go-libpq/docker_wrapper_test.py * (#9047)**
- **Support of table functions in pg syntax (#9040)**
- **Multiplans (#9053)**
- **Fix restore data option in YDB CLI (#9009)**
- **Normalizer insert records (#9010)**
- **correct EvWrite locks processing (#8931)**
- **Add decimal tests for columnshard (#8959)**
- **HTAP: Query Processor (#8917)**
- **Balancing: fix fresh blobs ingress merging (#9035)**
- **auditlog: add logouts (#9050)**
- **YDB FQ: split `ydb/tests/fq/generic` into two folders (#9029)**
- **Update muted_ya.txt (#9060)**
- **Add TPC-DS generator (#9033)**
- **YQ-3653 added resource pools classifiers validations (#9037)**
- **Nemesis statistics workload (#8919)**
- **Fix json (#9034)**
- **[docs] markdown and build fixes (#9028)**
- **ydb_federated_topic: Move fds_mock to separate directory (#9070)**
- **Added test with disabled feature flag "EnableOlapCompression" (#9077)**
- **Disable CTAS by default (#9057)**
- **Change verify to verify_debug in group_info (#9038)**
- **Fix harmonizer when it works with shared threads (#9069)**
- **[oidc proxy] Improve handling of redirects from protected resource (#9080)**
- **Fix backtick matching for antlr4 (#8941)**
- **Move sanitizer to separate flag (#8999)**
- **fix autocomplete to work with directories, optimize a little (#9074)**
- **Initial commit**

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Additional information

...
