### PR TITLE
Mute ydb/library/yql/providers/generic/connector/tests/datasource/ydb/ 13 tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -348,3 +348,16 @@ ydb/library/actors/interconnect/ut_huge_cluster HugeCluster.AllToAll
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
 ydb/library/yql/tests/sql/hybrid_file/part1 test.py.test[in-in_noansi_join--Debug]
 ydb/core/kqp/ut/query KqpLimits.QueryExecTimeoutCancel
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_A_b_C_d_E-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_A_b_C_d_E-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_COL1-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_COL1-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_asterisk-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_asterisk-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2_COL1-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2_COL1-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col3-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col3-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[primitive_types-dqrun]


### PR DESCRIPTION

 Owner: [TEAM:@ydb-platform/fq](https://github.com/orgs/ydb-platform/teams/fq)

**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**

**Summary history:** in window 2024-09-11 
 Success rate **93.22709163346613%**
Pass:234 Fail:17 Mute:0 Skip:0

**Test run history:** [link](https://datalens.yandex/34xnbsom67hcq?full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_A_b_C_d_E-dqrun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_A_b_C_d_E-kqprun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_COL1-dqrun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_COL1-kqprun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_asterisk-dqrun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_asterisk-kqprun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_col2-dqrun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_col2-kqprun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_col2_COL1-dqrun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_col2_COL1-kqprun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_col3-dqrun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[column_selection_col3-kqprun]&full_name=__in_ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[primitive_types-dqrun])

More info in [dashboard](https://datalens.yandex/4un3zdm0zcnyr)

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
