### PR TITLE
Improve in-test tpc benchs

### DIFF
--- a/ydb/library/benchmarks/runner/run_tests/run_tests.py
+++ b/ydb/library/benchmarks/runner/run_tests/run_tests.py
@@ -105,7 +105,7 @@ class Runner:
         if self.args.clean_old or not self.queries_dir.exists():
             self.prepare_queries_dir([
                 f"dq.MaxTasksPerStage={self.args.tasks}",
-                "dq.OptLLVM=OFF"
+                "dq.OptLLVM=ON"
             ] + [
                 "dq.UseFinalizeByKey=true",
                 "dq.EnableSpillingNodes=All",

--- a/ydb/library/benchmarks/runner/run_tests/run_tests.py
+++ b/ydb/library/benchmarks/runner/run_tests/run_tests.py
@@ -23,6 +23,7 @@ def parse_args():
     subparser.add_argument('--datasize', type=int, default=1)
     subparser.add_argument('--variant', type=variant, default='h')
     subparser.add_argument('--tasks', type=int, default=1)
+    subparser.add_argument('--perf', action="store_true", default=False)
 
     subparser.add_argument('-o', '--output', default="./results")
     subparser.add_argument('--clean-old', action="store_true", default=False)
@@ -49,16 +50,24 @@ def parse_args():
 
         parser.add_argument('--ydb-root', type=lambda path: pathlib.Path(path).resolve(), default="../../../../")
 
-        args = parser.parse_args(argv, namespace=args)
+        args, argv = parser.parse_known_args(argv, namespace=args)
 
-        args.dqrun = args.ydb_root / "ydb" / "library" / "yql" / "tools" / "dqrun" / "dqrun"
         args.gen_queries = args.ydb_root / "ydb" / "library" / "benchmarks" / "gen_queries" / "gen_queries"
         args.downloaders_dir = args.ydb_root / "ydb" / "library" / "benchmarks" / "runner"
-        args.fs_cfg = args.ydb_root / "ydb" / "library" / "yql" / "tools" / "dqrun" / "examples" / "fs.conf"
         args.flame_graph = args.ydb_root / "contrib" / "tools" / "flame-graph"
         args.result_compare = args.ydb_root / "ydb" / "library" / "benchmarks" / "runner" / "result_compare" / "result_compare"
-        args.gateways_cfg = args.ydb_root / "ydb" / "library" / "benchmarks" / "runner" / "runner" / "test-gateways.conf"
         args.runner_path = args.ydb_root / "ydb" / "library" / "benchmarks" / "runner" / "runner" / "runner"
+
+        def_dqrun = args.ydb_root / "ydb" / "library" / "yql" / "tools" / "dqrun" / "dqrun"
+        def_fs_cfg = args.ydb_root / "ydb" / "library" / "yql" / "tools" / "dqrun" / "examples" / "fs.conf"
+        def_gateways_cfg = args.ydb_root / "ydb" / "library" / "benchmarks" / "runner" / "runner" / "test-gateways.conf"
+
+        override_parser = argparse.ArgumentParser()
+        override_parser.add_argument('--dqrun', type=pathlib.Path, default=def_dqrun)
+        override_parser.add_argument('--fs-cfg', type=pathlib.Path, default=def_fs_cfg)
+        override_parser.add_argument('--gateways-cfg', type=pathlib.Path, default=def_gateways_cfg)
+
+        args = override_parser.parse_args(argv, namespace=args)
 
         udfs_prefix = args.ydb_root / "ydb" / "library" / "yql" / "udfs" / "common"
         args.udfs_dir = [udfs_prefix / name for name in ["set", "url_base", "datetime2", "re2", "math", "unicode_base"]]
@@ -96,13 +105,13 @@ class Runner:
         if self.args.clean_old or not self.queries_dir.exists():
             self.prepare_queries_dir([
                 f"dq.MaxTasksPerStage={self.args.tasks}",
-                "dq.OptLLVM=ON"
+                "dq.OptLLVM=OFF"
             ] + [
                 "dq.UseFinalizeByKey=true",
                 "dq.EnableSpillingNodes=All",
             ] if self.enable_spilling else [])
         self.tpc_dir = pathlib.Path(f"{self.args.downloaders_dir}/tpc/{self.args.variant}/{self.args.datasize}")
-        if self.args.clean_old or not self.tpc_dir.exists():
+        if not self.tpc_dir.exists():
             self.prepare_tpc_dir()
         if not pathlib.Path("./tpc").exists():
             os.symlink(f"{self.args.downloaders_dir}/tpc", f"{pathlib.Path("./tpc")}", target_is_directory=True)
@@ -112,7 +121,7 @@ class Runner:
 
     def run(self):
         cmd = ["/usr/bin/time", f"{str(self.args.runner_path)}"]
-        # cmd += ["--perf"]
+        cmd += ["--perf"] if self.args.perf else []
         for it in self.args.query_filter:
             cmd += ["--include-q", it]
         cmd += ["--query-dir", f"{str(self.queries_dir)}/{self.args.variant}"]

--- a/ydb/library/benchmarks/runner/tpc_tests.py
+++ b/ydb/library/benchmarks/runner/tpc_tests.py
@@ -71,7 +71,7 @@ def test_tpc():
     is_ci = os.environ.get("CURRENT_PUBLIC_DIR") is not None
 
     runner = Runner()
-    runner.wrapped_run("h", 1, 1, r"q1\.sql")
+    runner.wrapped_run("h", 1, 1, None)
     result_path = runner.results_path.resolve()
     print("Results path: ", result_path, file=sys.stderr)
 

--- a/ydb/library/benchmarks/runner/tpc_tests.py
+++ b/ydb/library/benchmarks/runner/tpc_tests.py
@@ -68,7 +68,7 @@ def upload(result_path, s3_folder, try_num):
 
 
 def test_tpc():
-    is_ci = os.environ.get("PUBLIC_DIR") is not None
+    is_ci = os.environ.get("CURRENT_PUBLIC_DIR") is not None
 
     runner = Runner()
     runner.wrapped_run("h", 1, 1, r"q1\.sql")

--- a/ydb/library/benchmarks/runner/tpc_tests.py
+++ b/ydb/library/benchmarks/runner/tpc_tests.py
@@ -70,7 +70,7 @@ def test_tpc():
     is_ci = os.environ.get("PUBLIC_DIR") is not None
 
     runner = Runner()
-    runner.wrapped_run("h", 1, 1, None)
+    runner.wrapped_run("h", 1, 1, r"q1\.sql")
     result_path = runner.results_path.resolve()
     print("Results path: ", result_path, file=sys.stderr)
 
@@ -78,3 +78,5 @@ def test_tpc():
         s3_folder = pathlib.Path(os.environ["PUBLIC_DIR"]).resolve()
 
         upload(result_path, s3_folder)
+
+    exit(1)

--- a/ydb/library/benchmarks/runner/tpc_tests.py
+++ b/ydb/library/benchmarks/runner/tpc_tests.py
@@ -58,11 +58,12 @@ class Runner:
         yatest.common.execute(cmd, stdout=sys.stdout, stderr=sys.stderr)
 
 
-def upload(result_path, s3_folder):
+def upload(result_path, s3_folder, try_num):
     uploader = pathlib.Path(yatest.common.source_path("ydb/library/benchmarks/runner/upload_results.py")).resolve()
     cmd = ["python3", str(uploader)]
     cmd += ["--result-path", str(result_path)]
     cmd += ["--s3-folder", str(s3_folder)]
+    cmd += ["--try-num", str(try_num)] if try_num else []
     yatest.common.execute(cmd, stdout=sys.stdout, stderr=sys.stderr)
 
 
@@ -75,6 +76,10 @@ def test_tpc():
     print("Results path: ", result_path, file=sys.stderr)
 
     if is_ci:
-        s3_folder = pathlib.Path(os.environ["PUBLIC_DIR"]).resolve()
+        s3_folder = pathlib.Path(os.environ["CURRENT_PUBLIC_DIR"]).resolve()
+        try:
+            try_num = int(s3_folder.name.split("try_")[-1])
+        except Exception:
+            try_num = None
 
-        upload(result_path, s3_folder)
+        upload(result_path, s3_folder, try_num)

--- a/ydb/library/benchmarks/runner/tpc_tests.py
+++ b/ydb/library/benchmarks/runner/tpc_tests.py
@@ -78,5 +78,3 @@ def test_tpc():
         s3_folder = pathlib.Path(os.environ["PUBLIC_DIR"]).resolve()
 
         upload(result_path, s3_folder)
-
-    exit(1)

--- a/ydb/library/benchmarks/runner/upload_results.py
+++ b/ydb/library/benchmarks/runner/upload_results.py
@@ -162,12 +162,14 @@ def upload_results(result_path, s3_folder, test_start):
                     "WasSpillingInJoin" : None,
                     "WasSpillingInChannels" : None,
                     "MaxTasksPerStage" : params.tasks,
-                    "PerfFileLink" : results.perf_file_path,
                     "ExitCode" : results.exitcode,
                     "ResultHash" : results.result_hash,
                     "SpilledBytes" : results.read_bytes,
                     "UserTime" : results.user_time,
-                    "SystemTime" : results.system_time
+                    "SystemTime" : results.system_time,
+                    "StdoutFileLink" : results.stdout_file_path,
+                    "StderrFileLink" : results.stderr_file_path,
+                    "PerfFileLink" : results.perf_file_path
                 }
                 sql = 'UPSERT INTO `perfomance/olap/dq_spilling_nightly_runs`\n\t({columns})\nVALUES\n\t({values})'.format(
                     columns=", ".join(map(str, mapping.keys())),

--- a/ydb/library/benchmarks/runner/upload_results.py
+++ b/ydb/library/benchmarks/runner/upload_results.py
@@ -193,9 +193,9 @@ def main():
 
     args = parser.parse_args()
 
-    if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
-        raise AttributeError("Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping uploading")
-    os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ["CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"]
+    # if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
+        # raise AttributeError("Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping uploading")
+    # os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ["CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"]
 
     upload_results(args.result_path, args.s3_folder, upload_time, args.try_num)
 

--- a/ydb/library/benchmarks/runner/upload_results.py
+++ b/ydb/library/benchmarks/runner/upload_results.py
@@ -67,7 +67,7 @@ def pretty_print(value):
     if type(value) == datetime.timedelta:
         return f"DateTime::IntervalFromMicroseconds({int(value / datetime.timedelta(microseconds=1))})"
     if isinstance(value, pathlib.Path):
-        return str(value)
+        return f'\"{value}\"'
     if type(value) == str:
         return f'\"{value}\"'
     if type(value) in [int, float]:

--- a/ydb/library/benchmarks/runner/upload_results.py
+++ b/ydb/library/benchmarks/runner/upload_results.py
@@ -193,9 +193,9 @@ def main():
 
     args = parser.parse_args()
 
-    # if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
-        # raise AttributeError("Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping uploading")
-    # os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ["CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"]
+    if "CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS" not in os.environ:
+        raise AttributeError("Env variable CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS is missing, skipping uploading")
+    os.environ["YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"] = os.environ["CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS"]
 
     upload_results(args.result_path, args.s3_folder, upload_time, args.try_num)
 

--- a/ydb/library/benchmarks/runner/ya.make
+++ b/ydb/library/benchmarks/runner/ya.make
@@ -1,10 +1,6 @@
 PY3TEST()
 
-SIZE(LARGE)
-
-TAG(
-    ya:fat
-)
+SIZE(MEDIUM)
 
 TEST_SRCS(
     tpc_tests.py

--- a/ydb/library/benchmarks/runner/ya.make
+++ b/ydb/library/benchmarks/runner/ya.make
@@ -1,6 +1,10 @@
 PY3TEST()
 
-SIZE(MEDIUM)
+SIZE(LARGE)
+
+TAG(
+    ya:fat
+)
 
 TEST_SRCS(
     tpc_tests.py


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

General improvements for in-test tpc benchs that run in nightly-run

### Changelog category <!-- remove all except one -->

* Improvement
* Not for changelog (changelog entry is not required)

### Additional information

- some bugfixes
- upload to s3 stdout and and stderr produced by queries and store those path in ydb
- made run_tests more usable for running queries with dqrun
