### PR TITLE
Export current_public_dir in test_ya

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -335,6 +335,7 @@ runs:
           fi
 
           CURRENT_PUBLIC_DIR_RELATIVE=try_$RETRY
+          # Can be used in tests in which you want to publish the results in s3 for each retry separately (for not separate see PUBLIC_DIR)
           export CURRENT_PUBLIC_DIR=$PUBLIC_DIR/$CURRENT_PUBLIC_DIR_RELATIVE
           mkdir $CURRENT_PUBLIC_DIR
 

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -335,7 +335,7 @@ runs:
           fi
 
           CURRENT_PUBLIC_DIR_RELATIVE=try_$RETRY
-          # Can be used in tests in which you want to publish the results in s3 for each retry separately (for not separate see PUBLIC_DIR)
+          # Can be used in tests in which you want to publish the results in s3 for each retry separately
           export CURRENT_PUBLIC_DIR=$PUBLIC_DIR/$CURRENT_PUBLIC_DIR_RELATIVE
           mkdir $CURRENT_PUBLIC_DIR
 

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -335,7 +335,7 @@ runs:
           fi
 
           CURRENT_PUBLIC_DIR_RELATIVE=try_$RETRY
-          CURRENT_PUBLIC_DIR=$PUBLIC_DIR/$CURRENT_PUBLIC_DIR_RELATIVE
+          export CURRENT_PUBLIC_DIR=$PUBLIC_DIR/$CURRENT_PUBLIC_DIR_RELATIVE
           mkdir $CURRENT_PUBLIC_DIR
 
           if [ ${{ inputs.testman_token }} ]; then


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Export current_public_dir in test_ya for use in tests in which you want to publish the results in s3 for each retry separately.

### Changelog category <!-- remove all except one -->

* New feature
* Improvement
* Not for changelog (changelog entry is not required)

### Additional information

For example this test (https://github.com/ydb-platform/ydb/blob/main/ydb/library/benchmarks/runner/tpc_tests.py)
