### PR TITLE
24-2: NodeBroker: use deltas when returning recently added nodes

### DIFF
--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -295,6 +295,7 @@ void TDynamicNameserver::UpdateState(const NKikimrNodeBroker::TNodesInfo &rec,
         ctx.Schedule(config->Epoch.End - ctx.Now(),
                      new TEvPrivate::TEvUpdateEpoch(domain, config->Epoch.Id + 1));
     } else {
+        // Note: this update may be optimized to only include new nodes
         for (auto &node : rec.GetNodes()) {
             auto nodeId = node.GetNodeId();
             if (!config->DynamicNodes.contains(nodeId))

--- a/ydb/core/mind/node_broker_impl.h
+++ b/ydb/core/mind/node_broker_impl.h
@@ -337,6 +337,10 @@ private:
     TSchedulerCookieHolder EpochTimerCookieHolder;
     TString EpochCache;
 
+    TString EpochDeltasCache;
+    TVector<ui64> EpochDeltasVersions;
+    TVector<ui64> EpochDeltasEndOffsets;
+
     bool SingleDomain = false;
     bool SingleDomainAlloc = false;
 

--- a/ydb/core/mind/node_broker_ut.cpp
+++ b/ydb/core/mind/node_broker_ut.cpp
@@ -854,6 +854,53 @@ Y_UNIT_TEST_SUITE(TNodeBrokerTest) {
         UNIT_ASSERT_VALUES_EQUAL(epoch1.GetId(), epoch.GetId() + 5);
     }
 
+    Y_UNIT_TEST(TestListNodesEpochDeltas)
+    {
+        TTestBasicRuntime runtime(8, false);
+        Setup(runtime, 10);
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        WaitForEpochUpdate(runtime, sender);
+        WaitForEpochUpdate(runtime, sender);
+
+        const ui32 NODE1 = 1024 + 0 * 32;
+        const ui32 NODE2 = 1024 + 1 * 32;
+        const ui32 NODE3 = 1024 + 2 * 32;
+        const ui32 NODE4 = 1024 + 3 * 32;
+
+        auto epoch0 = GetEpoch(runtime, sender);
+        CheckRegistration(runtime, sender, "host1", 1001, "host1.yandex.net", "1.2.3.4",
+                          1, 2, 3, 4, TStatus::OK, NODE1, epoch0.GetNextEnd());
+        auto epoch1 = CheckFilteredNodesList(runtime, sender, {NODE1}, {}, 0, epoch0.GetVersion());
+        CheckRegistration(runtime, sender, "host2", 1001, "host2.yandex.net", "1.2.3.5",
+                          1, 2, 3, 5, TStatus::OK, NODE2, epoch1.GetNextEnd());
+        auto epoch2 = CheckFilteredNodesList(runtime, sender, {NODE2}, {}, 0, epoch1.GetVersion());
+        CheckRegistration(runtime, sender, "host3", 1001, "host3.yandex.net", "1.2.3.6",
+                          1, 2, 3, 6, TStatus::OK, NODE3, epoch2.GetNextEnd());
+        auto epoch3 = CheckFilteredNodesList(runtime, sender, {NODE3}, {}, 0, epoch2.GetVersion());
+
+        CheckFilteredNodesList(runtime, sender, {NODE1, NODE2, NODE3}, {}, 0, epoch0.GetVersion());
+        CheckFilteredNodesList(runtime, sender, {NODE2, NODE3}, {}, 0, epoch1.GetVersion());
+        CheckFilteredNodesList(runtime, sender, {}, {}, 0, epoch3.GetVersion());
+
+        RebootTablet(runtime, MakeNodeBrokerID(0), sender);
+        CheckFilteredNodesList(runtime, sender, {}, {}, 0, epoch3.GetVersion());
+
+        CheckRegistration(runtime, sender, "host4", 1001, "host4.yandex.net", "1.2.3.7",
+                          1, 2, 3, 7, TStatus::OK, NODE4, epoch3.GetNextEnd());
+        auto epoch4 = CheckFilteredNodesList(runtime, sender, {NODE4}, {}, 0, epoch3.GetVersion());
+
+        // NodeBroker doesn't have enough history in memory and replies with the full node list
+        CheckFilteredNodesList(runtime, sender, {NODE1, NODE2, NODE3, NODE4}, {}, 0, epoch2.GetVersion());
+
+        WaitForEpochUpdate(runtime, sender);
+        auto epoch5 = GetEpoch(runtime, sender);
+        CheckFilteredNodesList(runtime, sender, {}, {}, 0, epoch5.GetVersion());
+
+        // New epoch may remove nodes, so deltas are not returned on epoch change
+        CheckFilteredNodesList(runtime, sender, {NODE1, NODE2, NODE3, NODE4}, {}, 0, epoch3.GetVersion());
+    }
+
     Y_UNIT_TEST(TestRandomActions)
     {
         TTestBasicRuntime runtime(8, false);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

NodeBroker now sends deltas when listing recently added nodes.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

This fixes one of the issues where a blue-green deploy is stalled in big clusters due to cached node lists becoming invalidated with each new added node and excessive traffic when it is repeatedly resent to all nodes in the cluster. With a minor backwards compatible change to TEvListNodes it becomes possible to only send recently added nodes.

Related to #8942.