### PR TITLE
Add reinit step for build vector index

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -33,7 +33,7 @@ message TMkDir {
 
 enum EDropWaitPolicy {
     EDropFailOnChanges = 0;
-    EDropAbortChanges = 1; //depricated
+    EDropAbortChanges = 1; //deprecated
     EDropWaitChanges = 2;
 }
 

--- a/ydb/core/protos/flat_tx_scheme.proto
+++ b/ydb/core/protos/flat_tx_scheme.proto
@@ -53,7 +53,7 @@ message TEvModifySchemeTransaction {
     optional uint64 TxId = 2;
     optional uint64 TabletId = 3;
     optional string Owner = 5;
-    optional bool FailOnExist = 6; // depricated, TModifyScheme.FailOnExist is recomended
+    optional bool FailOnExist = 6; // deprecated, TModifyScheme.FailOnExist is recomended
     optional string UserToken = 7 [(Ydb.sensitive) = true]; // serialized NACLib::TUserToken
     optional string PeerName = 8;
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1335,7 +1335,7 @@ TVector<ISubOperation::TPtr> TOperation::ConstructParts(const TTxTransaction& tx
         Y_ABORT("multipart operations are handled before, also they require transaction details");
 
     case NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexImplTable:
-        Y_ABORT("multipart operations are handled before, also they require transaction details");
+        return {CreateInitializeBuildIndexImplTable(NextPartId(), tx)};
     case NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexImplTable:
         Y_ABORT("multipart operations are handled before, also they require transaction details");
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_apply_build_index.cpp
@@ -28,7 +28,7 @@ ISubOperation::TPtr FinalizeIndexImplTable(TOperationContext& context, const TPa
     return CreateFinalizeBuildIndexImplTable(partId, transaction);
 }
 
-ISubOperation::TPtr DropIndexImplTable(TOperationContext& /*context*/, const TPath& index, const TOperationId& nextId, const TOperationId& partId, const TString& name, const TPathId& pathId) {
+ISubOperation::TPtr DropIndexImplTable(const TPath& index, const TOperationId& nextId, const TOperationId& partId, const TString& name, const TPathId& pathId, bool& rejected) {
     TPath implTable = index.Child(name);
     Y_ABORT_UNLESS(implTable->PathId == pathId);
     Y_ABORT_UNLESS(implTable.LeafName() == name);
@@ -41,8 +41,10 @@ ISubOperation::TPtr DropIndexImplTable(TOperationContext& /*context*/, const TPa
         .NotUnderDeleting()
         .NotUnderOperation();
     if (!checks) {
-        return {CreateReject(nextId, checks.GetStatus(), checks.GetError())};
+        rejected = true;
+        return CreateReject(nextId, checks.GetStatus(), checks.GetError());
     }
+    rejected = false;
     auto transaction = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpDropTable);
     auto operation = transaction.MutableDrop();
     operation->SetName(name);
@@ -93,7 +95,12 @@ TVector<ISubOperation::TPtr> ApplyBuildIndex(TOperationId nextId, const TTxTrans
             const auto& indexImplTableName = indexChildItems.first;
             const auto partId = NextPartId(nextId, result);
             if (NTableIndex::IsTmpImplTable(indexImplTableName)) {
-                result.push_back(DropIndexImplTable(context, index, nextId, partId, indexImplTableName, indexChildItems.second));
+                bool rejected = false;
+                auto op = DropIndexImplTable(index, nextId, partId, indexImplTableName, indexChildItems.second, rejected);
+                if (rejected) {
+                    return {std::move(op)};
+                }
+                result.push_back(std::move(op));
             } else {
                 result.push_back(FinalizeIndexImplTable(context, index, partId, indexImplTableName, indexChildItems.second));
             }
@@ -143,7 +150,12 @@ TVector<ISubOperation::TPtr> CancelBuildIndex(TOperationId nextId, const TTxTran
         Y_ABORT_UNLESS(index.Base()->GetChildren().size() >= 1);
         for (auto& indexChildItems : index.Base()->GetChildren()) {
             const auto partId = NextPartId(nextId, result);
-            result.push_back(DropIndexImplTable(context, index, nextId, partId, indexChildItems.first, indexChildItems.second));
+            bool rejected = false;
+            auto op = DropIndexImplTable(index, nextId, partId, indexChildItems.first, indexChildItems.second, rejected);
+            if (rejected) {
+                return {std::move(op)};
+            }
+            result.push_back(std::move(op));
         }
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -59,6 +59,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
                 .NotResolved();
         }
 
+        // TODO(mbkkt) less than necessary for vector index
         checks
             .IsValidLeafName()
             .PathsLimit(2) // index and impl-table

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -447,9 +447,13 @@ public:
 
             if (checks) {
                 if (parentPath.Base()->IsTableIndex()) {
-                    checks.IsInsideTableIndexPath()
-                          .IsUnderCreating(NKikimrScheme::StatusNameConflict)
-                          .IsUnderTheSameOperation(OperationId.GetTxId()); //allow only as part of creating base table
+                    checks.IsInsideTableIndexPath();
+                   // Not tmp index impl tables can be created only as part of create index
+                    if (!NTableIndex::IsTmpImplTable(name)) {
+                        checks
+                            .IsUnderCreating(NKikimrScheme::StatusNameConflict)
+                            .IsUnderTheSameOperation(OperationId.GetTxId());
+                    }
                 } else if (!Transaction.GetAllowAccessToPrivatePaths()) {
                     checks.IsCommonSensePath()
                           .IsLikeDirectory();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -448,7 +448,8 @@ public:
             if (checks) {
                 if (parentPath.Base()->IsTableIndex()) {
                     checks.IsInsideTableIndexPath();
-                   // Not tmp index impl tables can be created only as part of create index
+                    // Not tmp index impl tables can be created only as part of create index
+                    // tmp index impl tables created multiple times during index construction
                     if (!NTableIndex::IsTmpImplTable(name)) {
                         checks
                             .IsUnderCreating(NKikimrScheme::StatusNameConflict)

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_indexed_table.cpp
@@ -396,11 +396,10 @@ TVector<ISubOperation::TPtr> CreateDropIndexedTable(TOperationId nextId, const T
     auto dropOperation = tx.GetDrop();
 
     const TString parentPathStr = tx.GetWorkingDir();
-    const TString name = dropOperation.GetName();
 
     TPath table = dropOperation.HasId()
         ? TPath::Init(TPathId(context.SS->TabletID(), dropOperation.GetId()), context.SS)
-        : TPath::Resolve(parentPathStr, context.SS).Dive(name);
+        : TPath::Resolve(parentPathStr, context.SS).Dive(dropOperation.GetName());
 
     {
         TPath::TChecker checks = table.Check();
@@ -425,8 +424,10 @@ TVector<ISubOperation::TPtr> CreateDropIndexedTable(TOperationId nextId, const T
                 checks
                     .IsTable()
                     .NotUnderDeleting()
-                    .NotUnderOperation()
-                    .IsCommonSensePath();
+                    .NotUnderOperation();
+                if (!NTableIndex::IsTmpImplTable(table.LeafName())) {
+                    checks.IsCommonSensePath();                    
+                }
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_indexed_table.cpp
@@ -425,7 +425,7 @@ TVector<ISubOperation::TPtr> CreateDropIndexedTable(TOperationId nextId, const T
                     .IsTable()
                     .NotUnderDeleting()
                     .NotUnderOperation();
-                if (!NTableIndex::IsTmpImplTable(table.LeafName())) {
+                if (!table.Parent()->IsTableIndex() || !NTableIndex::IsTmpImplTable(table.LeafName())) {
                     checks.IsCommonSensePath();                    
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
@@ -532,6 +532,7 @@ public:
                         .IsTableIndex()
                         .IsInsideTableIndexPath();
                     // Not tmp index impl tables can be dropped only as part of drop index
+                    // tmp index impl tables dropped multiple times during index construction
                     if (!NTableIndex::IsTmpImplTable(name)) {
                         checks
                             .IsUnderDeleting()

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -372,12 +372,16 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTmpPropose(
         Y_ASSERT(step == 1);
     }
 
-    auto& partition = *op.MutablePartitionConfig()->MutablePartitioningPolicy();
-    partition.SetSizeToSplit(0); // disable auto split/merge
-    partition.SetMinPartitionsCount(parts);
-    partition.SetMaxPartitionsCount(parts);
-    partition.ClearFastSplitSettings();
-    partition.ClearSplitByLoadSettings();
+    auto& config = *op.MutablePartitionConfig();
+    config.Clear();
+    config.SetShadowData(true);
+
+    auto& policy = *config.MutablePartitioningPolicy();
+    policy.SetSizeToSplit(0); // disable auto split/merge
+    policy.SetMinPartitionsCount(parts);
+    policy.SetMaxPartitionsCount(parts);
+    policy.ClearFastSplitSettings();
+    policy.ClearSplitByLoadSettings();
 
     op.ClearSplitBoundary();
     if (parts <= 1) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -232,14 +232,6 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> LockPropose(
     modifyScheme.SetWorkingDir(path.Parent().PathString());
     modifyScheme.MutableLockConfig()->SetName(path.LeafName());
 
-    if (buildInfo.IsBuildIndex()) {
-        buildInfo.SerializeToProto(ss, modifyScheme.MutableInitiateIndexBuild());
-    } else if (buildInfo.IsBuildColumns()) {
-        buildInfo.SerializeToProto(ss, modifyScheme.MutableInitiateColumnBuild());
-    } else {
-        Y_ABORT("Unknown operation kind while building LockPropose");
-    }
-
     return propose;
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -60,7 +60,7 @@ static constexpr const char* Name(TIndexBuildInfo::EState state) noexcept {
 }
 
 // return count, parts, step
-static std::tuple<ui32, ui32, ui32> ComputeKMeansBoundaries(TSchemeShard* ss, const TPathId& tableId, const TIndexBuildInfo& buildInfo) {
+static std::tuple<ui32, ui32, ui32> ComputeKMeansBoundaries(const NSchemeShard::TTableInfo& tableInfo, const TIndexBuildInfo& buildInfo) {
     const auto& kmeans = buildInfo.KMeans;
     Y_ASSERT(kmeans.K != 0);
     Y_ASSERT((kmeans.K & (kmeans.K - 1)) == 0);
@@ -78,7 +78,7 @@ static std::tuple<ui32, ui32, ui32> ComputeKMeansBoundaries(TSchemeShard* ss, co
     const auto count = pow(kmeans.K, kmeans.Level + 1);
     ui32 step = 1;
     auto parts = count;
-    auto shards = ss->Tables.at(tableId)->GetShard2PartitionIdx().size();
+    auto shards = tableInfo.GetShard2PartitionIdx().size();
     if (buildInfo.KMeans.Level + 1 == buildInfo.KMeans.Levels || shards <= 1) {
         shards = 1;
         parts = 1;
@@ -324,53 +324,35 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTmpPropose(
 
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
-
-    auto path = TPath::Init(buildInfo.TablePathId, ss);
-    auto tableId = path->PathId;
-    path.Dive(buildInfo.IndexName);
-
     NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
     modifyScheme.SetInternal(true);
-    modifyScheme.SetWorkingDir(path.PathString());
 
-    using namespace NTableIndex::NTableVectorKmeansTreeIndex;
-    TString name0 = PostingTable;
-    TString name1 = PostingTable;
-    const char* suffix0 = buildInfo.KMeans.Level % 2 == 0 ? TmpPostingTableSuffix0 : TmpPostingTableSuffix1;
-    const char* suffix1 = buildInfo.KMeans.Level % 2 == 0 ? TmpPostingTableSuffix1 : TmpPostingTableSuffix0;
-    name0.append(suffix0);
-    name1.append(suffix1);
+    auto path = TPath::Init(buildInfo.TablePathId, ss);
+    const auto& tableInfo = ss->Tables.at(path->PathId);
+    NTableIndex::TTableColumns implTableColumns;
+    {
+        buildInfo.SerializeToProto(ss, modifyScheme.MutableInitiateIndexBuild());
+        const auto& indexDesc = modifyScheme.GetInitiateIndexBuild().GetIndex();
+        NKikimrScheme::EStatus status;
+        TString errStr;
+        Y_ABORT_UNLESS(NTableIndex::CommonCheck(tableInfo, indexDesc, path.DomainInfo()->GetSchemeLimits(), false, implTableColumns, status, errStr));
+        modifyScheme.ClearInitiateIndexBuild();
+    }
 
     // TODO(mbkkt) for levels greater than zero we need to disable split/merge completely
     // For now it's not guranteed, but very likely
     // But lock is really unconvinient approach (needs to store TxId/etc)
     // So maybe best way to do this is specify something in defintion, that will prevent these operations like IsBackup
-
+    using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+    modifyScheme.SetWorkingDir(path.Dive(buildInfo.IndexName).PathString());
     modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpInitiateBuildIndexImplTable);
     auto& op = *modifyScheme.MutableCreateTable();
+    const char* suffix = buildInfo.KMeans.Level % 2 == 0 ? TmpPostingTableSuffix0 : TmpPostingTableSuffix1;
+    op = CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, {}, suffix);
 
-    op = ss->Tables.at(path.Dive(name1)->PathId)->TableDescription;
-    op.ClearPath();
-    op.SetName(name0);
-
-    THashMap<ui32, TString> keyColumns;
-    for (auto& column : *op.MutableColumns()) {
-        column.ClearFamily();
-        column.ClearFamilyName();
-        auto [typeInfo, typeMod] = NScheme::TypeInfoModFromProtoColumnType(column.GetTypeId(), &column.GetTypeInfo());
-        column.SetType(NScheme::TypeName(typeInfo, typeMod));
-        keyColumns.emplace(column.GetId(), column.GetName());
-    }
-    op.ClearKeyColumnNames();
-    for (auto id : op.GetKeyColumnIds()) {
-        op.AddKeyColumnNames(keyColumns[id]);
-    }
-
-    op.SetSystemColumnNamesAllowed(true);
-    const auto [count, parts, step] = ComputeKMeansBoundaries(ss, tableId, buildInfo);
+    const auto [count, parts, step] = ComputeKMeansBoundaries(*tableInfo, buildInfo);
 
     auto& config = *op.MutablePartitionConfig();
-    config.Clear();
     config.SetShadowData(true);
 
     auto& policy = *config.MutablePartitioningPolicy();

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -4,6 +4,7 @@
 #include "schemeshard_build_index_tx_base.h"
 
 #include <ydb/core/base/table_vector_index.h>
+#include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/tx/datashard/range_ops.h>
 #include <ydb/core/tx/datashard/upload_stats.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
@@ -33,6 +34,10 @@ constexpr const char* Name(TIndexBuildInfo::EState state) noexcept {
         return "Initiating";
     case TIndexBuildInfo::EState::Filling:
         return "Filling";
+    case TIndexBuildInfo::EState::DropTmp:
+        return "DropTmp";
+    case TIndexBuildInfo::EState::CreateTmp:
+        return "CreateTmp";
     case TIndexBuildInfo::EState::Applying:
         return "Applying";
     case TIndexBuildInfo::EState::Unlocking:
@@ -112,7 +117,7 @@ public:
         return UploadStatus.ToString();
     }
 
-    void Bootstrap(const NActors::TActorContext& ctx) {
+    void Bootstrap() {
         Rows = std::make_shared<NTxProxy::TUploadRows>();
         Rows->reserve(Init.size());
         std::array<TCell, 2> PrimaryKeys;
@@ -136,28 +141,28 @@ public:
 
         Become(&TThis::StateWork);
 
-        Upload(ctx, false);
+        Upload(false);
     }
 
 private:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(TEvTxUserProxy::TEvUploadRowsResponse, Handle);
-            CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
+            hFunc(TEvTxUserProxy::TEvUploadRowsResponse, Handle);
+            cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
             default:
                 LOG_E("StateWork unexpected event type: " << ev->GetTypeRewrite() << " event: " << ev->ToString());
         }
     }
 
-    void HandleWakeup(const NActors::TActorContext& ctx) {
+    void HandleWakeup() {
         LOG_D("Retry upload " << Debug());
 
         if (Rows) {
-            Upload(ctx, true);
+            Upload(true);
         }
     }
 
-    void Handle(TEvTxUserProxy::TEvUploadRowsResponse::TPtr& ev, const TActorContext& ctx) {
+    void Handle(TEvTxUserProxy::TEvUploadRowsResponse::TPtr& ev) {
         LOG_T("Handle TEvUploadRowsResponse "
               << Debug()
               << " Uploader: " << Uploader.ToString()
@@ -179,7 +184,7 @@ private:
         if (UploadStatus.IsRetriable() && RetryCount < Limits.MaxUploadRowsRetryCount) {
             LOG_N("Got retriable error, " << Debug() << " RetryCount: " << RetryCount);
 
-            ctx.Schedule(Limits.GetTimeoutBackouff(RetryCount), new TEvents::TEvWakeup());
+            this->Schedule(Limits.GetTimeoutBackouff(RetryCount), new TEvents::TEvWakeup());
             return;
         }
         TAutoPtr<TEvIndexBuilder::TEvUploadSampleKResponse> response = new TEvIndexBuilder::TEvUploadSampleKResponse;
@@ -190,10 +195,11 @@ private:
 
         UploadStatusToMessage(response->Record);
 
-        ctx.Send(ResponseActorId, response.Release());
+        this->Send(ResponseActorId, response.Release());
+        this->PassAway();
     }
 
-    void Upload(const NActors::TActorContext& ctx, bool isRetry) {
+    void Upload(bool isRetry) {
         if (isRetry) {
             ++RetryCount;
         } else {
@@ -208,7 +214,7 @@ private:
             NTxProxy::EUploadRowsMode::WriteToTableShadow, // TODO(mbkkt) is it fastest?
             true /*writeToPrivateTable*/);
 
-        Uploader = ctx.Register(actor);
+        Uploader = this->Register(actor);
     }
 };
 
@@ -259,6 +265,134 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> InitiatePropose(
     }
 
     return propose;
+}
+
+THolder<TEvSchemeShard::TEvModifySchemeTransaction> DropTmpPropose(
+    TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
+{
+    Y_ASSERT(buildInfo.IsBuildVectorIndex());
+
+    auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
+    propose->Record.SetFailOnExist(true);
+
+    auto path = TPath::Init(buildInfo.TablePathId, ss).Dive(buildInfo.IndexName);
+
+    NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
+    modifyScheme.SetInternal(true);
+    modifyScheme.SetWorkingDir(path.PathString());
+
+    using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+    TString name = PostingTable;
+    const char* suffix = buildInfo.KMeans.Level % 2 == 0 ? TmpPostingTableSuffix0 : TmpPostingTableSuffix1;
+    name.append(suffix);
+
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpDropTable);
+    modifyScheme.MutableDrop()->SetName(name);
+
+    return propose;
+}
+
+THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTmpPropose(
+    TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
+{
+    Y_ASSERT(buildInfo.IsBuildVectorIndex());
+
+    auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
+    propose->Record.SetFailOnExist(true);
+
+    auto path = TPath::Init(buildInfo.TablePathId, ss);
+    auto tableId = path->PathId;
+    path.Dive(buildInfo.IndexName);
+
+    NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
+    modifyScheme.SetInternal(true);
+    modifyScheme.SetWorkingDir(path.PathString());
+
+    using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+    TString name0 = PostingTable;
+    TString name1 = PostingTable;
+    const char* suffix0 = buildInfo.KMeans.Level % 2 == 0 ? TmpPostingTableSuffix0 : TmpPostingTableSuffix1;
+    const char* suffix1 = buildInfo.KMeans.Level % 2 == 0 ? TmpPostingTableSuffix1 : TmpPostingTableSuffix0;
+    name0.append(suffix0);
+    name1.append(suffix1);
+
+    // TODO(mbkkt) for levels greater than zero we need to disable split/merge completely
+    // For now it's not guranteed, but very likely
+    // But lock is really unconvinient approach (needs to store TxId/etc)
+    // So maybe best way to do this is specify something in defintion, that will prevent these operations like IsBackup
+
+    modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpInitiateBuildIndexImplTable);
+    auto& op = *modifyScheme.MutableCreateTable();
+
+    op = ss->Tables.at(path.Dive(name1)->PathId)->TableDescription;
+    op.ClearPath();
+    op.SetName(name0);
+
+    THashMap<ui32, TString> keyColumns;
+    for (auto& column : *op.MutableColumns()) {
+        column.ClearFamily();
+        column.ClearFamilyName();
+        auto [typeInfo, typeMod] = NScheme::TypeInfoModFromProtoColumnType(column.GetTypeId(), &column.GetTypeInfo());
+        column.SetType(NScheme::TypeName(typeInfo, typeMod));
+        keyColumns.emplace(column.GetId(), column.GetName());
+    }
+    op.ClearKeyColumnNames();
+    for (auto id : op.GetKeyColumnIds()) {
+        op.AddKeyColumnNames(keyColumns[id]);
+    }
+
+    op.SetSystemColumnNamesAllowed(true);
+
+    const auto& kmeans = buildInfo.KMeans;
+    Y_ASSERT(kmeans.K != 0);
+    Y_ASSERT((kmeans.K & (kmeans.K - 1)) == 0);
+    auto pow = [](ui32 k, ui32 l) {
+        ui32 r = 1;
+        while (l != 0) {
+            if (l % 2 != 0) {
+                r *= k;
+            }
+            k *= k;
+            l /= 2;
+        }
+        return r;
+    };
+    const auto count = pow(kmeans.K, kmeans.Level + 1);
+    auto step = 1;
+    auto parts = count;
+    auto shards = ss->Tables.at(tableId)->GetShard2PartitionIdx().size();
+    if (buildInfo.KMeans.Level + 1 == buildInfo.KMeans.Levels || shards <= 1) {
+        shards = 1;
+        parts = 1;
+    }
+    for (; shards < parts; parts /= 2) {
+        step *= 2;
+    }
+    for (; parts < shards / 2; parts *= 2) {
+        Y_ASSERT(step == 1);
+    }
+
+    auto& partition = *op.MutablePartitionConfig()->MutablePartitioningPolicy();
+    partition.SetSizeToSplit(0); // disable auto split/merge
+    partition.SetMinPartitionsCount(parts);
+    partition.SetMaxPartitionsCount(parts);
+    partition.ClearFastSplitSettings();
+    partition.ClearSplitByLoadSettings();
+
+    op.ClearSplitBoundary();
+    if (parts <= 1) {
+        return propose;
+    }
+    auto i = kmeans.Parent;
+    for (const auto end = i + count;;) {
+        i += step;
+        if (i >= end) {
+            Y_ASSERT(op.SplitBoundarySize() == std::min(count, parts) - 1);
+            return propose;
+        }
+        auto cell = TCell::Make(i);
+        op.AddSplitBoundary()->SetSerializedKeyPrefix(TSerializedCellVec::Serialize({&cell, 1}));
+    }
 }
 
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterMainTablePropose(
@@ -412,7 +546,7 @@ private:
 
         PathIdFromPathId(buildInfo.TablePathId, ev->Record.MutablePathId());        
 
-        ev->Record.SetK(buildInfo.KMeansSettings.K);
+        ev->Record.SetK(buildInfo.KMeans.K);
         ev->Record.SetMaxProbability(buildInfo.Sample.MaxProbability);
 
         ev->Record.AddColumns(buildInfo.IndexColumns[0]);
@@ -544,7 +678,12 @@ public:
             } else if (!buildInfo.InitiateTxDone) {
                 Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.InitiateTxId)));
             } else {
-                ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
+                if (buildInfo.IsBuildVectorIndex()) {
+                    Y_ASSERT(buildInfo.KMeans.NeedsAnotherLevel());
+                    ChangeState(BuildId, TIndexBuildInfo::EState::DropTmp);
+                } else {
+                    ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
+                }
 
                 Progress(BuildId);
             }
@@ -609,7 +748,7 @@ public:
             }
 
             if (buildInfo.IsBuildVectorIndex()) {
-                buildInfo.Sample.MakeStrictTop(buildInfo.KMeansSettings.K);
+                buildInfo.Sample.MakeStrictTop(buildInfo.KMeans.K);
                 if (buildInfo.Sample.MaxProbability == 0) {
                     makeDone(buildInfo.Shards.size());
                 }
@@ -634,12 +773,18 @@ public:
                 && buildInfo.DoneShardsSize == buildInfo.Shards.size()) {
                 // all done
                 Y_ABORT_UNLESS(0 == Self->IndexBuildPipes.CloseAll(BuildId, ctx));
-
-                if (buildInfo.IsBuildVectorIndex() && SendUploadSampleKRequest(buildInfo)) {
-                    AskToScheduleBilling(buildInfo);
-                    break;
+                if (buildInfo.IsBuildVectorIndex()) {
+                    if (SendUploadSampleKRequest(buildInfo)) {
+                        AskToScheduleBilling(buildInfo);
+                        break;
+                    }
+                    if (buildInfo.KMeans.NeedsAnotherLevel()) {
+                        AskToScheduleBilling(buildInfo);
+                        ChangeState(BuildId, TIndexBuildInfo::EState::DropTmp);
+                        Progress(BuildId);
+                        break;
+                    }
                 }
-
                 ChangeState(BuildId, TIndexBuildInfo::EState::Applying);
                 Progress(BuildId);
 
@@ -651,6 +796,52 @@ public:
 
             break;
         }
+        case TIndexBuildInfo::EState::DropTmp:
+            Y_ASSERT(buildInfo.IsBuildVectorIndex());
+            if (buildInfo.ApplyTxId == InvalidTxId) {
+                Send(Self->TxAllocatorClient, MakeHolder<TEvTxAllocatorClient::TEvAllocate>(), 0, ui64(BuildId));
+            } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
+                Send(Self->SelfId(), DropTmpPropose(Self, buildInfo), 0, ui64(BuildId));
+            } else if (!buildInfo.ApplyTxDone) {
+                Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.ApplyTxId)));
+            } else {
+                buildInfo.ApplyTxId = {};
+                buildInfo.ApplyTxStatus = NKikimrScheme::StatusSuccess;
+                buildInfo.ApplyTxDone = false;
+
+                NIceDb::TNiceDb db(txc.DB);
+                Self->PersistBuildIndexApplyTxId(db, buildInfo);
+                Self->PersistBuildIndexApplyTxStatus(db, buildInfo);
+                Self->PersistBuildIndexApplyTxDone(db, buildInfo);
+
+                ChangeState(BuildId, TIndexBuildInfo::EState::CreateTmp);
+                Progress(BuildId);
+            }
+            break;
+        case TIndexBuildInfo::EState::CreateTmp:
+            Y_ASSERT(buildInfo.IsBuildVectorIndex());
+            if (buildInfo.ApplyTxId == InvalidTxId) {
+                Send(Self->TxAllocatorClient, MakeHolder<TEvTxAllocatorClient::TEvAllocate>(), 0, ui64(BuildId));
+            } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
+                Send(Self->SelfId(), CreateTmpPropose(Self, buildInfo), 0, ui64(BuildId));
+            } else if (!buildInfo.ApplyTxDone) {
+                Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.ApplyTxId)));
+            } else {
+                buildInfo.ApplyTxId = {};
+                buildInfo.ApplyTxStatus = NKikimrScheme::StatusSuccess;
+                buildInfo.ApplyTxDone = false;
+                ++buildInfo.KMeans.Level;
+                
+                NIceDb::TNiceDb db(txc.DB);
+                Self->PersistBuildIndexApplyTxId(db, buildInfo);
+                Self->PersistBuildIndexApplyTxStatus(db, buildInfo);
+                Self->PersistBuildIndexApplyTxDone(db, buildInfo);
+                // TODO(mbkkt) persist buildInfo.KMeans.Level
+
+                ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
+                Progress(BuildId);
+            }
+            break;
         case TIndexBuildInfo::EState::Applying:
             if (buildInfo.ApplyTxId == InvalidTxId) {
                 Send(Self->TxAllocatorClient, MakeHolder<TEvTxAllocatorClient::TEvAllocate>(), 0, ui64(BuildId));
@@ -875,6 +1066,8 @@ public:
         case TIndexBuildInfo::EState::Locking:
         case TIndexBuildInfo::EState::GatheringStatistics:
         case TIndexBuildInfo::EState::Initiating:
+        case TIndexBuildInfo::EState::DropTmp:
+        case TIndexBuildInfo::EState::CreateTmp:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
@@ -962,7 +1155,7 @@ public:
                     }
                     buildInfo.Sample.Rows.emplace_back(probabilities[i], std::move(rows[i]));
                 }
-                buildInfo.Sample.MakeWeakTop(buildInfo.KMeansSettings.K);
+                buildInfo.Sample.MakeWeakTop(buildInfo.KMeans.K);
             }
 
             if (record.HasRowsDelta() || record.HasBytesDelta()) {
@@ -1025,6 +1218,8 @@ public:
         case TIndexBuildInfo::EState::Locking:
         case TIndexBuildInfo::EState::GatheringStatistics:
         case TIndexBuildInfo::EState::Initiating:
+        case TIndexBuildInfo::EState::DropTmp:
+        case TIndexBuildInfo::EState::CreateTmp:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
@@ -1085,11 +1280,8 @@ public:
             NIceDb::TNiceDb db(txc.DB);
             auto status = record.GetUploadStatus();
             if (status == Ydb::StatusIds::SUCCESS) {
-                // TODO(mbkkt) next rounds of build vector index
-                ChangeState(buildInfo.Id, TIndexBuildInfo::EState::Applying);
+                ChangeState(buildInfo.Id, TIndexBuildInfo::EState::Filling);
                 Progress(buildId);
-                // make final bill
-                Bill(buildInfo);
             } else {
                 NYql::TIssues issues;
                 NYql::IssuesFromMessage(record.GetIssues(), issues);
@@ -1105,6 +1297,8 @@ public:
         case TIndexBuildInfo::EState::Locking:
         case TIndexBuildInfo::EState::GatheringStatistics:
         case TIndexBuildInfo::EState::Initiating:
+        case TIndexBuildInfo::EState::DropTmp:
+        case TIndexBuildInfo::EState::CreateTmp:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
@@ -1280,6 +1474,8 @@ public:
         case TIndexBuildInfo::EState::Locking:
         case TIndexBuildInfo::EState::GatheringStatistics:
         case TIndexBuildInfo::EState::Initiating:
+        case TIndexBuildInfo::EState::DropTmp:
+        case TIndexBuildInfo::EState::CreateTmp:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
@@ -1357,6 +1553,8 @@ public:
             Self->PersistBuildIndexInitiateTxDone(db, buildInfo);
             break;
         }
+        case TIndexBuildInfo::EState::DropTmp:
+        case TIndexBuildInfo::EState::CreateTmp:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Rejection_Applying:
@@ -1522,6 +1720,8 @@ public:
             ifErrorMoveTo(TIndexBuildInfo::EState::Rejection_Unlocking);
             break;
         }
+        case TIndexBuildInfo::EState::DropTmp:
+        case TIndexBuildInfo::EState::CreateTmp:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Rejection_Applying:
         {
@@ -1634,6 +1834,8 @@ public:
                 Self->PersistBuildIndexInitiateTxId(db, buildInfo);
             }
             break;
+        case TIndexBuildInfo::EState::DropTmp:
+        case TIndexBuildInfo::EState::CreateTmp:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Rejection_Applying:

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -209,6 +209,8 @@ void TSchemeShard::TIndexBuilder::TTxBase::Fill(NKikimrIndexBuilder::TIndexBuild
         index.SetProgress(0.0);
         break;
     case TIndexBuildInfo::EState::Filling:
+    case TIndexBuildInfo::EState::DropTmp:
+    case TIndexBuildInfo::EState::CreateTmp:
         index.SetState(Ydb::Table::IndexBuildState::STATE_TRANSFERING_DATA);
         index.SetProgress(indexInfo.CalcProgressPercent());
         break;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -305,7 +305,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         }
 
         if (!IsValidColumnName(colName, allowSystemColumns)) {
-            errStr = Sprintf("Invalid name for column '%s'", colName.data());
+            errStr = Sprintf("Invalid name for %s column '%s'", allowSystemColumns ? "any" : "user", colName.data());
             return nullptr;
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2988,30 +2988,29 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
     bool CancelRequested = false;
 
-    TTxId AlterMainTableTxId = TTxId();
-    NKikimrScheme::EStatus AlterMainTableTxStatus = NKikimrScheme::StatusSuccess;
     bool AlterMainTableTxDone = false;
-
-    TTxId LockTxId = TTxId();
-    NKikimrScheme::EStatus LockTxStatus = NKikimrScheme::StatusSuccess;
     bool LockTxDone = false;
-
-    TTxId InitiateTxId = TTxId();
-    NKikimrScheme::EStatus InitiateTxStatus = NKikimrScheme::StatusSuccess;
     bool InitiateTxDone = false;
+    bool ApplyTxDone = false;
+    bool UnlockTxDone = false;
+
+    bool BillingEventIsScheduled = false;
+
+    TTxId AlterMainTableTxId = TTxId();
+    TTxId LockTxId = TTxId();
+    TTxId InitiateTxId = TTxId();
+    TTxId ApplyTxId = TTxId();
+    TTxId UnlockTxId = TTxId();
+
+    NKikimrScheme::EStatus AlterMainTableTxStatus = NKikimrScheme::StatusSuccess;
+    NKikimrScheme::EStatus LockTxStatus = NKikimrScheme::StatusSuccess;
+    NKikimrScheme::EStatus InitiateTxStatus = NKikimrScheme::StatusSuccess;
+    NKikimrScheme::EStatus ApplyTxStatus = NKikimrScheme::StatusSuccess;
+    NKikimrScheme::EStatus UnlockTxStatus = NKikimrScheme::StatusSuccess;
 
     TStepId SnapshotStep;
     TTxId SnapshotTxId;
 
-    TTxId ApplyTxId = TTxId();
-    NKikimrScheme::EStatus ApplyTxStatus = NKikimrScheme::StatusSuccess;
-    bool ApplyTxDone = false;
-
-    TTxId UnlockTxId = TTxId();
-    NKikimrScheme::EStatus UnlockTxStatus = NKikimrScheme::StatusSuccess;
-    bool UnlockTxDone = false;
-
-    bool BillingEventIsScheduled = false;
     TDuration ReBillPeriod = TDuration::Seconds(10);
 
     struct TShardStatus {

--- a/ydb/core/tx/schemeshard/schemeshard_tx_infly.h
+++ b/ydb/core/tx/schemeshard/schemeshard_tx_infly.h
@@ -739,6 +739,14 @@ struct TTxState {
             case NKikimrSchemeOp::ESchemeOpCreateResourcePool: return TxCreateResourcePool;
             case NKikimrSchemeOp::ESchemeOpAlterResourcePool: return TxAlterResourcePool;
             case NKikimrSchemeOp::ESchemeOpDropResourcePool: return TxDropResourcePool;
+            case NKikimrSchemeOp::ESchemeOpAlterExtSubDomainCreateHive: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpDropExternalTable: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpDropExternalDataSource: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpCreateColumnBuild: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpCreateContinuousBackup: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpAlterContinuousBackup: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpDropContinuousBackup: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpRestoreIncrementalBackup: return TxInvalid;
             default: return TxInvalid;
         }
     }

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -125,7 +125,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":0,"quantity":292,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-328-5075-328-5075","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
+        const TString meteringData = R"({"usage":{"start":1,"quantity":292,"finish":1,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-328-5075-328-5075","cloud_id":"CLOUD_ID_VAL","source_wt":1,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
 

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -213,8 +213,10 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             return *modifyScheme.MutableUpgradeSubDomain()->MutableName();
 
         case NKikimrSchemeOp::ESchemeOpCreateColumnBuild:
+            Y_ABORT("no implementation for ESchemeOpCreateColumnBuild");
+
         case NKikimrSchemeOp::ESchemeOpCreateIndexBuild:
-            Y_ABORT("no implementation for ESchemeOpCreateIndexBuild/ESchemeOpCreateColumnBuild");
+            Y_ABORT("no implementation for ESchemeOpCreateIndexBuild");
 
         case NKikimrSchemeOp::ESchemeOpInitiateBuildIndexMainTable:
             Y_ABORT("no implementation for ESchemeOpInitiateBuildIndexMainTable");


### PR DESCRIPTION
Main loop for vector index build looks like:
```
shards = mainTable shards;
for (int level = 0; level < neededLevels; ++level) {
   outputTable = postingTable;
   if ((level + 1) != neededLevels) {
      outputTable = tmp level % 2 table
      outputTable.clear()
   }
   for (int parent = 0; parent < k^level; ++parent) {
    if (parent is local for some shard) {
      run LocalKmeans
    } else {
      // for all shards responsible for this parent
      run SampleK
      n times run RecomputeEmbeddings
      run ReshuffleEmbeddings
    }
   }
   shards = outputTable shards;
}
```

This PR implements this part
```
for (int level = 0; level < neededLevels; ++level) {
   outputTable = postingTable;
   if ((level + 1) != neededLevels) {
      outputTable = tmp level % 2 table
      outputTable.clear()
   }
```

It's about make implicit cycle over levels and clear temprorary output tables.
Also we know expected counted of shards for temprorary tables very well, so we also specifying partition
