### PR TITLE
streamlookup: fix for left table name is prefix of right table

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -352,15 +352,17 @@ TOutputRowColumnOrder CategorizeOutputRowItems(
     size_t idxRightPayload = 0;
     for (ui32 i = 0; i != type->GetMembersCount(); ++i) {
         const auto prefixedName = type->GetMemberName(i);
-        if (prefixedName.starts_with(leftLabel)) {
-            Y_ABORT_IF(prefixedName.length() == leftLabel.length());
+        if (prefixedName.starts_with(leftLabel) &&
+            prefixedName.length() > leftLabel.length() &&
+            prefixedName[leftLabel.length()] == '.') {
             const auto name = prefixedName.SubStr(leftLabel.length() + 1); //skip prefix and dot
             result[i] = {
                 leftJoinColumns.contains(name) ? EOutputRowItemSource::InputKey : EOutputRowItemSource::InputOther,
                 idxLeft++
             };
-        } else if (prefixedName.starts_with(rightLabel)) {
-            Y_ABORT_IF(prefixedName.length() == rightLabel.length());
+        } else if (prefixedName.starts_with(rightLabel) &&
+                   prefixedName.length() > rightLabel.length() &&
+                   prefixedName[rightLabel.length()] == '.') {
             const auto name = prefixedName.SubStr(rightLabel.length() + 1); //skip prefix and dot
             //presume that indexes in LookupKey, LookupOther has the same relative position as in OutputRow
             if (rightJoinColumns.contains(name)) {


### PR DESCRIPTION
```
SELECT * FROM Foo LEFT JOIN /*+ streamlookup()*/ FooBar ON ...
```
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
