### PR TITLE
Add multikey support for BlockMapJoinCore computation node

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -207,7 +207,7 @@ public:
 
         while (!blockState.HasBlocks()) {
             while (blockState.IsNotFull() && blockState.NextRow()) {
-                const auto key = MakeKeysTuple(ctx, blockState, LeftKeyColumns_);
+                const auto key = MakeKeysTuple(ctx, blockState);
                 if constexpr (WithoutRight) {
                     if (key && dict.Contains(key) == RightRequired) {
                         blockState.CopyRow();
@@ -270,11 +270,11 @@ private:
         return *static_cast<TState*>(state.AsBoxed().Get());
     }
 
-    NUdf::TUnboxedValue MakeKeysTuple(const TComputationContext& ctx, const TState& state, const TVector<ui32>& keyColumns) const {
+    NUdf::TUnboxedValue MakeKeysTuple(const TComputationContext& ctx, const TState& state) const {
         // TODO: Handle complex key.
         // TODO: Handle converters.
         Y_ABORT_IF(IsTuple);
-        return state.GetValue(ctx.HolderFactory, keyColumns.front());
+        return state.GetValue(ctx.HolderFactory, LeftKeyColumns_.front());
     }
 
     const TVector<TType*> ResultJoinItems_;
@@ -321,7 +321,7 @@ public:
                 }
             }
             if (blockState.IsNotFull() && blockState.NextRow()) {
-                const auto key = MakeKeysTuple(ctx, blockState, LeftKeyColumns_);
+                const auto key = MakeKeysTuple(ctx, blockState);
                 // Lookup the item in the right dict. If the lookup succeeds,
                 // reset the iterator and proceed the execution from the
                 // beginning of the outer loop. Otherwise, the iterState is
@@ -420,11 +420,11 @@ private:
         return *static_cast<TIterator*>(iterator.AsBoxed().Get());
     }
 
-    NUdf::TUnboxedValue MakeKeysTuple(const TComputationContext& ctx, const TState& state, const TVector<ui32>& keyColumns) const {
+    NUdf::TUnboxedValue MakeKeysTuple(const TComputationContext& ctx, const TState& state) const {
         // TODO: Handle complex key.
         // TODO: Handle converters.
         Y_ABORT_IF(IsTuple);
-        return state.GetValue(ctx.HolderFactory, keyColumns.front());
+        return state.GetValue(ctx.HolderFactory, LeftKeyColumns_.front());
     }
 
     const TVector<TType*> ResultJoinItems_;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -517,7 +517,6 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
     const auto dict = LocateNode(ctx.NodeLocator, callable, 1);
 
     switch (joinKind) {
-    static const auto joinNames = GetEnumNames<EJoinKind>();
     case EJoinKind::Inner:
         if (isMulti) {
             return new TBlockWideMultiMapJoinWrapper<true, false>(ctx.Mutables,
@@ -551,8 +550,9 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
             std::move(leftKeyColumns), std::move(leftIOMap),
             static_cast<IComputationWideFlowNode*>(flow), dict);
     default:
-        MKQL_ENSURE(false, "BlockMapJoinCore doesn't support %s join type"
-                    << joinNames.at(joinKind));
+        // TODO: Display the human-readable join kind name.
+        MKQL_ENSURE(false, "BlockMapJoinCore doesn't support join type #"
+                    << static_cast<ui32>(joinKind));
     }
 }
 


### PR DESCRIPTION
This patchset implements multikey support for `BlockMapJoinCore` computation node.

To avoid copy-pasting of join kind dispatcher, `DISPATCH_JOIN` macro is introduced (similar to the one, that handles join kind dispatch for MapJoinCore computation node). While rewriting this part, a misuse of `GetEnumNames` was found, so the message in MKQL_ENSURE, that handles misdispatch, is no longer as fancy as it used to be.

### Changelog category

* Improvement