### PR TITLE
YQ fix cmake library name clash

### DIFF
--- a/ydb/library/formats/arrow/accessor/abstract/ya.make
+++ b/ydb/library/formats/arrow/accessor/abstract/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-accessor-abstract)
 
 PEERDIR(
     ydb/library/formats/arrow/protos

--- a/ydb/library/formats/arrow/accessor/common/ya.make
+++ b/ydb/library/formats/arrow/accessor/common/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-accessor-common)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/accessor/composite/ya.make
+++ b/ydb/library/formats/arrow/accessor/composite/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-accessor-composite)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/accessor/ya.make
+++ b/ydb/library/formats/arrow/accessor/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-accessor)
 
 PEERDIR(
     ydb/library/formats/arrow/accessor/abstract

--- a/ydb/library/formats/arrow/common/ya.make
+++ b/ydb/library/formats/arrow/common/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-common)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/hash/ya.make
+++ b/ydb/library/formats/arrow/hash/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-hash)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/modifier/ya.make
+++ b/ydb/library/formats/arrow/modifier/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-modifier)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/protos/ya.make
+++ b/ydb/library/formats/arrow/protos/ya.make
@@ -1,4 +1,4 @@
-PROTO_LIBRARY()
+PROTO_LIBRARY(library-formats-arrow-protos)
 
 SRCS(
     ssa.proto

--- a/ydb/library/formats/arrow/scalar/ya.make
+++ b/ydb/library/formats/arrow/scalar/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-scalar)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/simple_builder/ya.make
+++ b/ydb/library/formats/arrow/simple_builder/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-simple_builder)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/splitter/ya.make
+++ b/ydb/library/formats/arrow/splitter/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-splitter)
 
 SRCS(
     stats.cpp

--- a/ydb/library/formats/arrow/switch/ya.make
+++ b/ydb/library/formats/arrow/switch/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-switch)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/transformer/ya.make
+++ b/ydb/library/formats/arrow/transformer/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-transformer)
 
 PEERDIR(
     contrib/libs/apache/arrow

--- a/ydb/library/formats/arrow/validation/ya.make
+++ b/ydb/library/formats/arrow/validation/ya.make
@@ -1,4 +1,4 @@
-LIBRARY()
+LIBRARY(library-formats-arrow-validation)
 
 PEERDIR(
     contrib/libs/apache/arrow


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix cmake library name clash

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
