### PR TITLE
Improve column groups calculation

### DIFF
--- a/ydb/library/yql/providers/yt/gateway/native/yql_yt_native.cpp
+++ b/ydb/library/yql/providers/yt/gateway/native/yql_yt_native.cpp
@@ -3224,7 +3224,7 @@ private:
 
     TFuture<void> DoMerge(TYtMerge merge, const TExecContext<TRunOptions>::TPtr& execCtx) {
         YQL_ENSURE(execCtx->OutTables_.size() == 1);
-        bool forceTransform = NYql::HasSetting(merge.Settings().Ref(), EYtSettingType::ForceTransform);
+        bool forceTransform = NYql::HasAnySetting(merge.Settings().Ref(), EYtSettingType::ForceTransform | EYtSettingType::TransformColGroups);
         bool combineChunks = NYql::HasSetting(merge.Settings().Ref(), EYtSettingType::CombineChunks);
         TMaybe<ui64> limit = GetLimit(merge.Settings().Ref());
 

--- a/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt.cpp
+++ b/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt.cpp
@@ -76,8 +76,8 @@ TYtPhysicalOptProposalTransformer::TYtPhysicalOptProposalTransformer(TYtState::T
     AddHandler(2, &TYtMap::Match, HNDL(MapToMerge));
     AddHandler(2, &TYtPublish::Match, HNDL(UnorderedPublishTarget));
     AddHandler(2, &TYtMap::Match, HNDL(PushDownYtMapOverSortedMerge));
-    AddHandler(2, &TYtMerge::Match, HNDL(MergeToCopy));
     AddHandler(2, &TYtMerge::Match, HNDL(ForceTransform));
+    AddHandler(2, &TYtMerge::Match, HNDL(MergeToCopy));
 #undef HNDL
 }
 

--- a/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt_merge.cpp
+++ b/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt_merge.cpp
@@ -405,7 +405,7 @@ TMaybeNode<TExprBase> TYtPhysicalOptProposalTransformer::MergeToCopy(TExprBase n
         return node;
     }
 
-    if (NYql::HasAnySetting(merge.Settings().Ref(), EYtSettingType::ForceTransform | EYtSettingType::CombineChunks)) {
+    if (NYql::HasAnySetting(merge.Settings().Ref(), EYtSettingType::ForceTransform | EYtSettingType::TransformColGroups | EYtSettingType::CombineChunks)) {
         return node;
     }
 
@@ -475,26 +475,47 @@ TMaybeNode<TExprBase> TYtPhysicalOptProposalTransformer::ForceTransform(TExprBas
         return node;
     }
 
-    if (NYql::HasSetting(merge.Settings().Ref(), EYtSettingType::ForceTransform)) {
-        return node;
+    if (!NYql::HasSetting(merge.Settings().Ref(), EYtSettingType::ForceTransform)
+        && NYql::HasSetting(merge.Input().Item(0).Settings().Ref(), EYtSettingType::Sample)) {
+        return TExprBase(ctx.ChangeChild(merge.Ref(), TYtMerge::idx_Settings, NYql::AddSetting(merge.Settings().Ref(), EYtSettingType::ForceTransform, {}, ctx)));
     }
 
     const auto cluster = merge.DataSink().Cluster().StringValue();
-    const bool hasOutGroup = NYql::HasSetting(merge.Output().Item(0).Settings().Ref(), EYtSettingType::ColumnGroups);
-    const bool lookup = State_->Configuration->OptimizeFor.Get(cluster).GetOrElse(NYT::OF_LOOKUP_ATTR) == NYT::OF_LOOKUP_ATTR;
-    const bool enabledColGroup = State_->Configuration->ColumnGroupMode.Get().GetOrElse(EColumnGroupMode::Disable) != EColumnGroupMode::Disable;
-    const bool hasNonTmpInput = AnyOf(merge.Input().Item(0).Paths(), [](const TYtPath& path) {
-        return path.Table().Maybe<TYtTable>() && !NYql::HasSetting(path.Table().Cast<TYtTable>().Settings().Ref(), EYtSettingType::Anonymous);
-    });
-    const bool hasSampling = NYql::HasSetting(merge.Input().Item(0).Settings().Ref(), EYtSettingType::Sample);
+    if (State_->Configuration->OptimizeFor.Get(cluster).GetOrElse(NYT::OF_LOOKUP_ATTR) == NYT::OF_LOOKUP_ATTR) {
+        return node;
+    }
 
-    const bool addForceTransform = hasSampling
-        || (!lookup && enabledColGroup != hasOutGroup)
-        || (!lookup && hasOutGroup && hasNonTmpInput)
-    ;
+    TString outGroup;
+    if (auto setting = NYql::GetSetting(merge.Output().Item(0).Settings().Ref(), EYtSettingType::ColumnGroups)) {
+        outGroup = setting->Tail().Content();
+    }
 
-    if (addForceTransform) {
-        return TExprBase(ctx.ChangeChild(merge.Ref(), TYtMerge::idx_Settings, NYql::AddSetting(merge.Settings().Ref(), EYtSettingType::ForceTransform, {}, ctx)));
+    std::vector<TString> inputColGroupSpecs;
+    for (const auto& path: merge.Input().Item(0).Paths()) {
+        inputColGroupSpecs.emplace_back();
+        if (auto table = path.Table().Maybe<TYtTable>()) {
+            if (auto tableDesc = State_->TablesData->FindTable(cluster, TString{TYtTableInfo::GetTableLabel(table.Cast())}, TEpochInfo::Parse(table.Cast().Epoch().Ref()))) {
+                inputColGroupSpecs.back() = tableDesc->ColumnGroupSpec;
+            }
+        } else if (auto out = path.Table().Maybe<TYtOutput>()) {
+            if (auto setting = NYql::GetSetting(GetOutputOp(out.Cast()).Output().Item(FromString<ui32>(out.Cast().OutIndex().Value())).Settings().Ref(), EYtSettingType::ColumnGroups)) {
+                inputColGroupSpecs.back() = setting->Tail().Content();
+            }
+        }
+    }
+
+    bool needTransformColGroups = false;
+    if (!outGroup.empty() && AnyOf(inputColGroupSpecs, [&outGroup](const auto& g) { return outGroup != g; })) {
+        needTransformColGroups = true;
+    }
+    if (outGroup.empty() && AnyOf(inputColGroupSpecs, [](const auto& g) { return !g.empty(); })) {
+        needTransformColGroups = true;
+    }
+
+    if (needTransformColGroups && !NYql::HasSetting(merge.Settings().Ref(), EYtSettingType::TransformColGroups)) {
+        return TExprBase(ctx.ChangeChild(merge.Ref(), TYtMerge::idx_Settings, NYql::AddSetting(merge.Settings().Ref(), EYtSettingType::TransformColGroups, {}, ctx)));
+    } else if (!needTransformColGroups && NYql::HasSetting(merge.Settings().Ref(), EYtSettingType::TransformColGroups)) {
+        return TExprBase(ctx.ChangeChild(merge.Ref(), TYtMerge::idx_Settings, NYql::RemoveSetting(merge.Settings().Ref(), EYtSettingType::TransformColGroups, ctx)));
     }
     return node;
 }

--- a/ydb/library/yql/providers/yt/provider/yql_yt_op_settings.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_op_settings.cpp
@@ -422,6 +422,7 @@ bool ValidateSettings(const TExprNode& settingsNode, EYtSettingTypes accepted, T
         case EYtSettingType::IgnoreNonExisting:
         case EYtSettingType::WarnNonExisting:
         case EYtSettingType::ForceTransform:
+        case EYtSettingType::TransformColGroups:
         case EYtSettingType::CombineChunks:
         case EYtSettingType::WithQB:
         case EYtSettingType::Inline:

--- a/ydb/library/yql/providers/yt/provider/yql_yt_op_settings.h
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_op_settings.h
@@ -70,11 +70,11 @@ enum class EYtSettingType: ui64 {
     StatColumns              /* "statcolumns" */,
     SysColumns               /* "syscolumns" */,
     IgnoreTypeV3             /* "ignoretypev3" "ignore_type_v3" */,
-    // Table content         
+    // Table content
     MemUsage                 /* "memUsage" */,
     ItemsCount               /* "itemsCount" */,
     RowFactor                /* "rowFactor" */,
-    // Operations            
+    // Operations
     Ordered                  /* "ordered" */,                  // hybrid supported
     KeyFilter                /* "keyFilter" */,
     KeyFilter2               /* "keyFilter2" */,
@@ -86,6 +86,7 @@ enum class EYtSettingType: ui64 {
     ReduceBy                 /* "reduceBy" */,                 // hybrid supported
     ReduceFilterBy           /* "reduceFilterBy" */,
     ForceTransform           /* "forceTransform" */,           // hybrid supported
+    TransformColGroups       /* "transformColGroups" */,       // hybrid supported
     WeakFields               /* "weakFields" */,
     Sharded                  /* "sharded" */,
     CombineChunks            /* "combineChunks" */,
@@ -95,16 +96,16 @@ enum class EYtSettingType: ui64 {
     Flow                     /* "flow" */,                     // hybrid supported
     KeepSorted               /* "keepSorted" */,               // hybrid supported
     KeySwitch                /* "keySwitch" */,                // hybrid supported
-    // Out tables            
+    // Out tables
     UniqueBy                 /* "uniqueBy" */,
     OpHash                   /* "opHash" */,
-    // Operations            
+    // Operations
     MapOutputType            /* "mapOutputType" */,            // hybrid supported
     ReduceInputType          /* "reduceInputType" */,          // hybrid supported
     NoDq                     /* "noDq" */,
-    // Read      
+    // Read
     Split                    /* "split" */,
-    // Write hints           
+    // Write hints
     CompressionCodec         /* "compression_codec" "compressioncodec"*/,
     ErasureCodec             /* "erasure_codec" "erasurecodec" */,
     Expiration               /* "expiration" */,
@@ -133,7 +134,7 @@ public:
     using ::NYql::EYtSettingTypes::bitset::bitset;
 
     EYtSettingTypes(EYtSettingType type)
-        : TBase(std::bitset<YtSettingTypesCount>(1) << static_cast<ui64>(type)) 
+        : TBase(std::bitset<YtSettingTypesCount>(1) << static_cast<ui64>(type))
     {}
 
     EYtSettingTypes& operator|=(const EYtSettingTypes& other) {
@@ -165,7 +166,7 @@ const auto DqReadSupportedSettings = EYtSettingType::SysColumns | EYtSettingType
 const auto DqOpSupportedSettings = EYtSettingType::Ordered | EYtSettingType::Limit | EYtSettingType::SortLimitBy | EYtSettingType::SortBy |
                                        EYtSettingType::ReduceBy | EYtSettingType::ForceTransform | EYtSettingType::JobCount | EYtSettingType::JoinReduce |
                                        EYtSettingType::FirstAsPrimary | EYtSettingType::Flow | EYtSettingType::KeepSorted | EYtSettingType::KeySwitch |
-                                       EYtSettingType::ReduceInputType | EYtSettingType::MapOutputType | EYtSettingType::Sharded;
+                                       EYtSettingType::ReduceInputType | EYtSettingType::MapOutputType | EYtSettingType::Sharded | EYtSettingType::TransformColGroups;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/library/yql/providers/yt/provider/yql_yt_physical_finalizing.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_physical_finalizing.cpp
@@ -30,6 +30,8 @@
 
 #include <utility>
 #include <unordered_set>
+#include <iterator>
+#include <algorithm>
 
 namespace NYql {
 
@@ -423,7 +425,7 @@ public:
         }
 
         if (const auto mode = State_->Configuration->ColumnGroupMode.Get().GetOrElse(EColumnGroupMode::Disable); mode != EColumnGroupMode::Disable) {
-            status = CalculateColumnGroups(input, output, opDeps, mode, ctx);
+            status = CalculateColumnGroups(input, output, opDepsOrder, opDeps, mode, ctx);
             if (status.Level != TStatus::Ok) {
                 return status;
             }
@@ -2662,166 +2664,279 @@ private:
         if (newOutput != origOutput) {
             return ctx.ChangeChild(op.Ref(), TYtOutputOpBase::idx_Output, std::move(newOutput));
         }
+        if (auto copy = op.Maybe<TYtCopy>()) {
+            TStringBuf inputColGroup;
+            const auto& path = copy.Cast().Input().Item(0).Paths().Item(0);
+            if (auto table = path.Table().Maybe<TYtTable>()) {
+                if (auto tableDesc = State_->TablesData->FindTable(copy.Cast().DataSink().Cluster().StringValue(), TString{TYtTableInfo::GetTableLabel(table.Cast())}, TEpochInfo::Parse(table.Cast().Epoch().Ref()))) {
+                    inputColGroup = tableDesc->ColumnGroupSpec;
+                }
+            } else if (auto out = path.Table().Maybe<TYtOutput>()) {
+                if (auto setting = NYql::GetSetting(GetOutputOp(out.Cast()).Output().Item(FromString<ui32>(out.Cast().OutIndex().Value())).Settings().Ref(), EYtSettingType::ColumnGroups)) {
+                    inputColGroup = setting->Tail().Content();
+                }
+            }
+            TStringBuf outGroup;
+            if (auto setting = GetSetting(op.Output().Item(0).Settings().Ref(), EYtSettingType::ColumnGroups)) {
+                outGroup = setting->Tail().Content();
+            }
+            if (inputColGroup != outGroup) {
+                return ctx.RenameNode(op.Ref(), TYtMerge::CallableName());
+            }
+        }
         return {};
     }
 
-    TStatus CalculateColumnGroups(TExprNode::TPtr input, TExprNode::TPtr& output, const TOpDeps& opDeps, EColumnGroupMode mode, TExprContext& ctx) {
+    struct TColumnUsage {
+        bool GenerateGroups;
+        std::vector<const TStructExprType*> OutTypes;
+        std::vector<std::unordered_map<TString, std::set<size_t>>> ColumnUsage;
+        std::vector<bool> FullUsage;
+        std::vector<std::unordered_set<TString>> PublishUsage;
+        std::vector<std::vector<const TExprNode*>> UsedByMerges;
+    };
+
+    void GatherColumnUsage(EColumnGroupMode mode, const TExprNode* writer, const TOpDeps::mapped_type& readers, TColumnUsage& usage, TNodeMap<size_t>& uniquePaths) {
+        for (const auto& outTable: GetRealOperation(TExprBase(writer)).Output()) {
+            usage.OutTypes.push_back(outTable.Ref().GetTypeAnn()->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>());
+        }
+
+        usage.ColumnUsage.resize(usage.OutTypes.size());
+        usage.FullUsage.resize(usage.OutTypes.size());
+        usage.PublishUsage.resize(usage.OutTypes.size());
+        usage.UsedByMerges.resize(usage.OutTypes.size());
+        // Collect column usage per consumer
+        for (auto& item: readers) {
+            const auto out = TYtOutput(std::get<2>(item));
+            const auto outIndex = FromString<size_t>(out.OutIndex().Value());
+            YQL_ENSURE(outIndex < usage.OutTypes.size());
+            auto rawPath = std::get<3>(item);
+            if (!rawPath) {
+                if (TYtLength::Match(std::get<0>(item))) {
+                    continue;
+                }
+                if (auto maybePublish = TMaybeNode<TYtPublish>(std::get<0>(item))) {
+                    TYtTableInfo dstInfo = maybePublish.Cast().Publish();
+                    const auto& desc = State_->TablesData->GetTable(dstInfo.Cluster, dstInfo.Name, dstInfo.CommitEpoch);
+                    usage.PublishUsage[outIndex].insert(desc.ColumnGroupSpec);
+                } else if (TResPull::Match(std::get<0>(item))) {
+                    usage.PublishUsage[outIndex].emplace();
+                } else {
+                    usage.FullUsage[outIndex] = true;
+                }
+            } else if (auto maybeMerge = TMaybeNode<TYtMerge>(std::get<0>(item)); maybeMerge && AllOf(maybeMerge.Cast().Input().Item(0).Paths(),
+                [](const TYtPath& path) { return path.Ref().GetTypeAnn()->Equals(*path.Table().Ref().GetTypeAnn()); })) {
+
+                usage.UsedByMerges[outIndex].push_back(std::get<0>(item));
+
+            } else if (TYtCopy::Match(std::get<0>(item))) {
+
+                usage.UsedByMerges[outIndex].push_back(std::get<0>(item));
+
+            } else if (EColumnGroupMode::Single == mode) {
+                usage.FullUsage[outIndex] = true;
+            } else {
+                auto path = TYtPath(rawPath);
+                auto columns = TYtColumnsInfo(path.Columns());
+                if (!columns.HasColumns() || usage.OutTypes[outIndex]->GetSize() <= columns.GetColumns()->size()) {
+                    usage.FullUsage[outIndex] = true;
+                } else {
+                    const size_t pathNdx = uniquePaths.emplace(rawPath, uniquePaths.size()).first->second;
+                    auto& cu = usage.ColumnUsage[outIndex];
+                    std::for_each(columns.GetColumns()->cbegin(), columns.GetColumns()->cend(),
+                        [&cu, pathNdx](const TYtColumnsInfo::TColumn& c) {
+                            cu[c.Name].insert(pathNdx);
+                        }
+                    );
+                }
+            }
+        }
+    }
+
+    TStatus CalculateColumnGroups(TExprNode::TPtr input, TExprNode::TPtr& output, std::vector<const TExprNode*> opDepsOrder, const TOpDeps& opDeps, EColumnGroupMode mode, TExprContext& ctx) {
         const auto maxGroups = State_->Configuration->MaxColumnGroups.Get().GetOrElse(DEFAULT_MAX_COLUMN_GROUPS);
         const auto minGroupSize = State_->Configuration->MinColumnGroupSize.Get().GetOrElse(DEFAULT_MIN_COLUMN_GROUP_SIZE);
-        TNodeOnNodeOwnedMap remap;
-        for (auto& x: opDeps) {
-            auto writer = x.first;
+
+        TNodeMap<TColumnUsage> colUsages;
+        TNodeMap<size_t> uniquePaths;
+        std::vector<const TExprNode*> mergesToProcess;
+        std::vector<const TExprNode*> withMergeDeps;
+
+        for (auto writer: opDepsOrder) {
             if (TYtEquiJoin::Match(writer) || IsBeingExecuted(*writer)) {
                 continue;
             }
-            if (!ProcessedCalculateColumnGroups.insert(writer->UniqueId()).second) {
+            const auto& readers = opDeps.at(writer);
+
+            // Check all counsumers are known
+            auto& processed = ProcessedCalculateColumnGroups[writer];
+            if (processed.size() == readers.size() && AllOf(readers, [&processed](const auto& item) { return processed.contains(std::get<0>(item)->UniqueId()); })) {
                 continue;
             }
+            processed.clear();
+            std::transform(readers.begin(), readers.end(),
+                std::inserter(processed, processed.end()),
+                [](const auto& item) { return std::get<0>(item)->UniqueId(); }
+            );
 
-            std::vector<const TStructExprType*> outTypes;
-            for (const auto& outTable: GetRealOperation(TExprBase(writer)).Output()) {
-                outTypes.push_back(outTable.Ref().GetTypeAnn()->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>());
+            TColumnUsage& usage = colUsages[writer];
+            usage.GenerateGroups = true;
+
+            GatherColumnUsage(mode, writer, readers, usage, uniquePaths);
+            bool hasMergeDep = false;
+            for (const auto& item: usage.UsedByMerges) {
+                hasMergeDep = hasMergeDep || !item.empty();
+                mergesToProcess.insert(mergesToProcess.end(), item.begin(), item.end());
             }
+            if (hasMergeDep) {
+                withMergeDeps.push_back(writer);
+            }
+        }
 
-            TNodeMap<size_t> uniquePaths;
-            std::vector<std::unordered_map<TString, std::set<size_t>>> columnUsage;
-            columnUsage.resize(outTypes.size());
-            std::vector<bool> fullUsage;
-            fullUsage.resize(outTypes.size());
-            std::vector<std::unordered_set<TString>> publishUsage;
-            publishUsage.resize(outTypes.size());
-            // Collect column usage per consumer
-            for (auto& item: x.second) {
-                const auto out = TYtOutput(std::get<2>(item));
-                const auto outIndex = FromString<size_t>(out.OutIndex().Value());
-                auto rawPath = std::get<3>(item);
-                if (!rawPath) {
-                    if (TYtLength::Match(std::get<0>(item))) {
+        while (!mergesToProcess.empty()) {
+            std::vector<const TExprNode*> nextMergesToProcess;
+            for (auto merge: mergesToProcess) {
+                auto res = colUsages.emplace(merge, TColumnUsage{});
+                if (res.second) { // Not processed before
+                    TColumnUsage& usage = res.first->second;
+                    usage.GenerateGroups = TYtCopy::Match(merge); // Maybe we need to rewrite YtCopy to YtMerge
+                    GatherColumnUsage(mode, merge, opDeps.at(merge), usage, uniquePaths);
+                    bool hasMergeDep = false;
+                    for (const auto& item: usage.UsedByMerges) {
+                        hasMergeDep = hasMergeDep || !item.empty();
+                        nextMergesToProcess.insert(nextMergesToProcess.end(), item.begin(), item.end());
+                    }
+                    if (hasMergeDep) {
+                        withMergeDeps.push_back(merge);
+                    }
+                }
+            }
+            nextMergesToProcess.swap(mergesToProcess);
+        }
+
+        // In case of [YtOp -> YtMerge -> ...consumers] inherit column usage from YtMerge to YtOp
+        // Iterate in reverse order - from top-level operations to deeper
+        for (auto ri = withMergeDeps.rbegin(); ri != withMergeDeps.rend(); ++ri) {
+            TColumnUsage& usage = colUsages.at(*ri);
+            for (size_t outIndex = 0; outIndex < usage.UsedByMerges.size(); ++outIndex) {
+                for (auto merge: usage.UsedByMerges[outIndex]) {
+                    const TColumnUsage& mergeUsage = colUsages.at(merge);
+                    usage.FullUsage[outIndex] = usage.FullUsage[outIndex] || mergeUsage.FullUsage.at(0);
+                    usage.PublishUsage[outIndex].insert(mergeUsage.PublishUsage.at(0).cbegin(), mergeUsage.PublishUsage.at(0).cend());
+                    auto& cu = usage.ColumnUsage[outIndex];
+                    for (const auto& p: mergeUsage.ColumnUsage.at(0)) {
+                        cu[p.first].insert(p.second.cbegin(), p.second.cend());
+                    }
+                }
+            }
+        }
+
+        TNodeOnNodeOwnedMap remap;
+        for (auto& x: colUsages) {
+            auto writer = x.first;
+            TColumnUsage& usage = x.second;
+            if (usage.GenerateGroups) {
+
+                std::map<size_t, TString> groupSpecs;
+                for (size_t i = 0; i < usage.OutTypes.size(); ++i) {
+                    if (!usage.PublishUsage[i].empty()) {
+                        if (usage.PublishUsage[i].size() == 1) {
+                            if (auto spec = *usage.PublishUsage[i].cbegin(); !spec.empty()) {
+                                groupSpecs[i] = spec;
+                            }
+                        }
                         continue;
                     }
-                    if (auto maybePublish = TMaybeNode<TYtPublish>(std::get<0>(item))) {
-                        TYtTableInfo dstInfo = maybePublish.Cast().Publish();
-                        const auto& desc = State_->TablesData->GetTable(dstInfo.Cluster, dstInfo.Name, dstInfo.CommitEpoch);
-                        publishUsage.at(outIndex).insert(desc.ColumnGroupSpec);
-                    } else {
-                        fullUsage.at(outIndex) = true;
-                    }
-                } else if (EColumnGroupMode::Single == mode) {
-                    fullUsage.at(outIndex) = true;
-                } else {
-                    auto path = TYtPath(rawPath);
-                    auto columns = TYtColumnsInfo(path.Columns());
-                    if (!columns.HasColumns() || outTypes[outIndex]->GetSize() <= columns.GetColumns()->size()) {
-                        fullUsage.at(outIndex) = true;
-                    } else {
-                        const size_t pathNdx = uniquePaths.emplace(rawPath, uniquePaths.size()).first->second;
-                        std::for_each(columns.GetColumns()->cbegin(), columns.GetColumns()->cend(),
-                            [&columnUsage, outIndex, pathNdx](const TYtColumnsInfo::TColumn& c) {
-                                 columnUsage.at(outIndex)[c.Name].insert(pathNdx);
-                            }
-                        );
-                    }
-                }
-            }
-
-            std::map<size_t, TString> groupSpecs;
-            for (size_t i = 0; i < columnUsage.size(); ++i) {
-                if (!publishUsage[i].empty()) {
-                    if (publishUsage[i].size() == 1) {
-                        if (auto spec = *publishUsage[i].cbegin(); !spec.empty()) {
-                            groupSpecs[i] = spec;
+                    if (EColumnGroupMode::Single == mode) {
+                        if (usage.FullUsage[i]) {
+                            groupSpecs[i] = NYql::GetSingleColumnGroupSpec();
                         }
-                    }
-                    continue;
-                }
-                if (EColumnGroupMode::Single == mode) {
-                    if (fullUsage[i]) {
-                        groupSpecs[i] = NYql::GetSingleColumnGroupSpec();
-                    }
-                } else {
-                    if (fullUsage[i]) {
-                        // Add all columns for tables with entire usage
-                        const size_t pathNdx = uniquePaths.emplace(nullptr, uniquePaths.size()).first->second;
-                        std::for_each(outTypes[i]->GetItems().cbegin(), outTypes[i]->GetItems().cend(),
-                            [&columnUsage, i, pathNdx](const TItemExprType* itemType) {
-                                columnUsage.at(i)[TString{itemType->GetName()}].insert(pathNdx);
-                            }
-                        );
-                    }
-
-                    if (!columnUsage.at(i).empty()) {
-                        auto groupSpec = NYT::TNode();
-
-                        // Find unique groups. Use ordered collections for stable names
-                        std::map<std::set<size_t>, std::set<TString>> groups;
-                        for (const auto& item: columnUsage.at(i)) {
-                            groups[item.second].insert(item.first);
-                            if (groups.size() > maxGroups) {
-                                groups.clear();
-                                break;
-                            }
+                    } else {
+                        if (usage.FullUsage[i]) {
+                            // Add all columns for tables with entire usage
+                            const size_t pathNdx = uniquePaths.emplace(nullptr, uniquePaths.size()).first->second;
+                            auto& cu = usage.ColumnUsage[i];
+                            std::for_each(usage.OutTypes[i]->GetItems().cbegin(), usage.OutTypes[i]->GetItems().cend(),
+                                [&cu, pathNdx](const TItemExprType* itemType) {
+                                    cu[TString{itemType->GetName()}].insert(pathNdx);
+                                }
+                            );
                         }
-                        if (!groups.empty()) {
-                            bool allGroups = true;
-                            size_t maxSize = 0;
-                            auto maxGrpIt = groups.end();
-                            // Delete too short groups and find a group with max size
-                            for (auto it = groups.begin(); it != groups.end();) {
-                                if (it->second.size() < minGroupSize) {
-                                    it = groups.erase(it);
-                                    allGroups = false;
-                                } else {
-                                    if (it->second.size() > maxSize) {
-                                        maxSize = it->second.size();
-                                        maxGrpIt = it;
-                                    }
-                                    ++it;
+
+                        if (!usage.ColumnUsage[i].empty()) {
+                            auto groupSpec = NYT::TNode();
+
+                            // Find unique groups. Use ordered collections for stable names
+                            std::map<std::set<size_t>, std::set<TString>> groups;
+                            for (const auto& item: usage.ColumnUsage[i]) {
+                                groups[item.second].insert(item.first);
+                                if (groups.size() > maxGroups) {
+                                    groups.clear();
+                                    break;
                                 }
                             }
                             if (!groups.empty()) {
-                                groupSpec = NYT::TNode::CreateMap();
-                                // If we keep all groups then use the group with max size as default
-                                if (allGroups && maxGrpIt != groups.end()) {
-                                    groupSpec["default"] = NYT::TNode::CreateEntity();
-                                    groups.erase(maxGrpIt);
-                                }
-                                TStringBuilder nameBuilder;
-                                nameBuilder.reserve(8); // "group" + 2 digit number + zero-terminator
-                                nameBuilder << "group";
-                                size_t num = 0;
-                                for (const auto& g: groups) {
-                                    nameBuilder.resize(5);
-                                    nameBuilder << num++;
-                                    auto columns = NYT::TNode::CreateList();
-                                    for (const auto& n: g.second) {
-                                        columns.Add(n);
+                                bool allGroups = true;
+                                size_t maxSize = 0;
+                                auto maxGrpIt = groups.end();
+                                // Delete too short groups and find a group with max size
+                                for (auto it = groups.begin(); it != groups.end();) {
+                                    if (it->second.size() < minGroupSize) {
+                                        it = groups.erase(it);
+                                        allGroups = false;
+                                    } else {
+                                        if (it->second.size() > maxSize) {
+                                            maxSize = it->second.size();
+                                            maxGrpIt = it;
+                                        }
+                                        ++it;
                                     }
-                                    groupSpec[nameBuilder] = std::move(columns);
+                                }
+                                if (!groups.empty()) {
+                                    groupSpec = NYT::TNode::CreateMap();
+                                    // If we keep all groups then use the group with max size as default
+                                    if (allGroups && maxGrpIt != groups.end()) {
+                                        groupSpec["default"] = NYT::TNode::CreateEntity();
+                                        groups.erase(maxGrpIt);
+                                    }
+                                    TStringBuilder nameBuilder;
+                                    nameBuilder.reserve(8); // "group" + 2 digit number + zero-terminator
+                                    nameBuilder << "group";
+                                    size_t num = 0;
+                                    for (const auto& g: groups) {
+                                        nameBuilder.resize(5);
+                                        nameBuilder << num++;
+                                        auto columns = NYT::TNode::CreateList();
+                                        for (const auto& n: g.second) {
+                                            columns.Add(n);
+                                        }
+                                        groupSpec[nameBuilder] = std::move(columns);
+                                    }
                                 }
                             }
-                        }
-                        if (!groupSpec.IsUndefined()) {
-                            groupSpecs[i] = NYT::NodeToCanonicalYsonString(groupSpec, NYson::EYsonFormat::Text);
+                            if (!groupSpec.IsUndefined()) {
+                                groupSpecs[i] = NYT::NodeToCanonicalYsonString(groupSpec, NYson::EYsonFormat::Text);
+                            }
                         }
                     }
                 }
-            }
-            if (!groupSpecs.empty()) {
-                TExprNode::TPtr newOp;
-                if (const auto mayTry = TExprBase(writer).Maybe<TYtTryFirst>()) {
-                    TExprNode::TPtr newOpFirst = UpdateColumnGroups(mayTry.Cast().First(), groupSpecs, ctx);
-                    TExprNode::TPtr newOpSecond = UpdateColumnGroups(mayTry.Cast().Second(), groupSpecs, ctx);
-                    if (newOpFirst || newOpSecond) {
-                        newOp = Build<TYtTryFirst>(ctx, writer->Pos())
-                            .First(newOpFirst ? std::move(newOpFirst) : mayTry.Cast().First().Ptr())
-                            .Second(newOpSecond ? std::move(newOpSecond) : mayTry.Cast().Second().Ptr())
-                            .Done().Ptr();
+                if (!groupSpecs.empty()) {
+                    TExprNode::TPtr newOp;
+                    if (const auto mayTry = TExprBase(writer).Maybe<TYtTryFirst>()) {
+                        TExprNode::TPtr newOpFirst = UpdateColumnGroups(mayTry.Cast().First(), groupSpecs, ctx);
+                        TExprNode::TPtr newOpSecond = UpdateColumnGroups(mayTry.Cast().Second(), groupSpecs, ctx);
+                        if (newOpFirst || newOpSecond) {
+                            newOp = Build<TYtTryFirst>(ctx, writer->Pos())
+                                .First(newOpFirst ? std::move(newOpFirst) : mayTry.Cast().First().Ptr())
+                                .Second(newOpSecond ? std::move(newOpSecond) : mayTry.Cast().Second().Ptr())
+                                .Done().Ptr();
+                        }
+                    } else {
+                        newOp = UpdateColumnGroups(TYtOutputOpBase(writer), groupSpecs, ctx);
                     }
-                } else {
-                    newOp = UpdateColumnGroups(TYtOutputOpBase(writer), groupSpecs, ctx);
-                }
-                if (newOp) {
-                    remap[writer] = newOp;
+                    if (newOp) {
+                        remap[writer] = newOp;
+                    }
                 }
             }
         }
@@ -2845,7 +2960,7 @@ private:
     TProcessedNodesSet ProcessedMultiOuts;
     TProcessedNodesSet ProcessedHorizontalJoin;
     TProcessedNodesSet ProcessedFieldSubsetForMultiUsage;
-    TProcessedNodesSet ProcessedCalculateColumnGroups;
+    TNodeMap<TProcessedNodesSet> ProcessedCalculateColumnGroups;
     std::unordered_set<std::pair<ui64, ui64>, THash<std::pair<ui64, ui64>>> ProcessedFuseWithOuterMaps;
 };
 

--- a/ydb/library/yql/tests/sql/yt_native_file/part0/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part0/canondata/result.json
@@ -696,9 +696,9 @@
     ],
     "test.test[column_group-hint_anon_groups-single-Debug]": [
         {
-            "checksum": "5bf348df7ae8b5d8d99880c86ad09f56",
-            "size": 3097,
-            "uri": "https://{canondata_backend}/1936997/1750231bef89e714f3a763cde6bbd783904ec892/resource.tar.gz#test.test_column_group-hint_anon_groups-single-Debug_/opt.yql"
+            "checksum": "23355961656630c3be55757a6f61fa32",
+            "size": 3069,
+            "uri": "https://{canondata_backend}/1130705/1c0d4f9dc449d81d42c314c8e83bf50ca2f2b199/resource.tar.gz#test.test_column_group-hint_anon_groups-single-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-hint_anon_groups-single-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part1/canondata/result.json
@@ -849,9 +849,9 @@
     ],
     "test.test[column_group-groups-perusage-Debug]": [
         {
-            "checksum": "214e7071606aac1456349c1150df1150",
-            "size": 2768,
-            "uri": "https://{canondata_backend}/1924537/17afe574d103f7107068c27fa5f981e3d765940a/resource.tar.gz#test.test_column_group-groups-perusage-Debug_/opt.yql"
+            "checksum": "7e11f1b8d524a5bd15834a803d795239",
+            "size": 2740,
+            "uri": "https://{canondata_backend}/1937424/4f260a5a4a8f20159852fc2ff1df6b222822bfad/resource.tar.gz#test.test_column_group-groups-perusage-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-groups-perusage-Plan]": [
@@ -877,9 +877,9 @@
     ],
     "test.test[column_group-publish-single-Debug]": [
         {
-            "checksum": "d42d6a6b2e9305265ae84a7620e8388b",
-            "size": 2987,
-            "uri": "https://{canondata_backend}/1924537/17afe574d103f7107068c27fa5f981e3d765940a/resource.tar.gz#test.test_column_group-publish-single-Debug_/opt.yql"
+            "checksum": "c74ac8193d41b7da199c5b4e0493c87a",
+            "size": 2921,
+            "uri": "https://{canondata_backend}/1937424/4f260a5a4a8f20159852fc2ff1df6b222822bfad/resource.tar.gz#test.test_column_group-publish-single-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-publish-single-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part10/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part10/canondata/result.json
@@ -614,9 +614,9 @@
     ],
     "test.test[column_group-hint_anon-perusage-Debug]": [
         {
-            "checksum": "5f5e08c3a416f96ca6bcc239dc03e269",
-            "size": 3034,
-            "uri": "https://{canondata_backend}/1942525/38bbc64977eadbcbd7d9c11e7e100eb2855ed8a2/resource.tar.gz#test.test_column_group-hint_anon-perusage-Debug_/opt.yql"
+            "checksum": "870a1992d65fa275ac517f47ce26e6b4",
+            "size": 3058,
+            "uri": "https://{canondata_backend}/1814674/1779e1e2193dc14e2285789eef133a1b21c18c85/resource.tar.gz#test.test_column_group-hint_anon-perusage-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-hint_anon-perusage-Plan]": [
@@ -635,9 +635,9 @@
     ],
     "test.test[column_group-hint_anon-single-Debug]": [
         {
-            "checksum": "25861ef6a274b795deea5b87d107a3b1",
-            "size": 3032,
-            "uri": "https://{canondata_backend}/1942525/38bbc64977eadbcbd7d9c11e7e100eb2855ed8a2/resource.tar.gz#test.test_column_group-hint_anon-single-Debug_/opt.yql"
+            "checksum": "810b577e57afa890e39082a5e9733a3a",
+            "size": 3056,
+            "uri": "https://{canondata_backend}/1814674/1779e1e2193dc14e2285789eef133a1b21c18c85/resource.tar.gz#test.test_column_group-hint_anon-single-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-hint_anon-single-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part13/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part13/canondata/result.json
@@ -589,9 +589,9 @@
     ],
     "test.test[column_group-groups-single-Debug]": [
         {
-            "checksum": "e38c8b8e9b462a7639862f55b72f4312",
-            "size": 2676,
-            "uri": "https://{canondata_backend}/1903280/6513ce3d3496dad440926c6388274ab336422ca4/resource.tar.gz#test.test_column_group-groups-single-Debug_/opt.yql"
+            "checksum": "fb868bb4f6617d3e753e2a2718a6ffaf",
+            "size": 2700,
+            "uri": "https://{canondata_backend}/1903280/3d786e345d64c2fad77d6df0319e7969bf3df069/resource.tar.gz#test.test_column_group-groups-single-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-groups-single-Plan]": [
@@ -610,9 +610,9 @@
     ],
     "test.test[column_group-length-perusage-Debug]": [
         {
-            "checksum": "98bac5055bb801d1df5c761676401d58",
-            "size": 2988,
-            "uri": "https://{canondata_backend}/1903280/6513ce3d3496dad440926c6388274ab336422ca4/resource.tar.gz#test.test_column_group-length-perusage-Debug_/opt.yql"
+            "checksum": "71dd2316cd011a8ca4499d1933835c50",
+            "size": 2960,
+            "uri": "https://{canondata_backend}/1903280/3d786e345d64c2fad77d6df0319e7969bf3df069/resource.tar.gz#test.test_column_group-length-perusage-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-length-perusage-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part14/canondata/result.json
@@ -882,9 +882,9 @@
     ],
     "test.test[column_group-min_group-default.txt-Debug]": [
         {
-            "checksum": "e773cf7052b0fc660a18e8315628900d",
-            "size": 2755,
-            "uri": "https://{canondata_backend}/1814674/38d85c1805c6536b3e75cfe9e8d9b3260b17f2bc/resource.tar.gz#test.test_column_group-min_group-default.txt-Debug_/opt.yql"
+            "checksum": "2dc807806c646bd66c686f8d0734b9a8",
+            "size": 2721,
+            "uri": "https://{canondata_backend}/1130705/bbf1be5ec066b11c871e94e396f579f46e775b24/resource.tar.gz#test.test_column_group-min_group-default.txt-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-min_group-default.txt-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part15/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part15/canondata/result.json
@@ -720,9 +720,9 @@
     ],
     "test.test[column_group-groups-lookup-Debug]": [
         {
-            "checksum": "81ea96f82489be2a18dd3971d295ffd7",
-            "size": 2770,
-            "uri": "https://{canondata_backend}/1899731/7897b30eef0bb27e4ec2a81827074c48697423a5/resource.tar.gz#test.test_column_group-groups-lookup-Debug_/opt.yql"
+            "checksum": "4596262be89842240e238e1caf56d85b",
+            "size": 2704,
+            "uri": "https://{canondata_backend}/1937424/76220321015a525a6d6ba6e26477a4c8e59fe581/resource.tar.gz#test.test_column_group-groups-lookup-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-groups-lookup-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part16/canondata/result.json
@@ -628,9 +628,9 @@
     ],
     "test.test[column_group-groups-max-Debug]": [
         {
-            "checksum": "b8490cfcc144397ce01d6fdbdf002216",
-            "size": 2744,
-            "uri": "https://{canondata_backend}/1903280/eb283d0f727ad6b47e74773d702ec57f7bc5cc7a/resource.tar.gz#test.test_column_group-groups-max-Debug_/opt.yql"
+            "checksum": "146d85bcb7c915cf378683e7f9669a73",
+            "size": 2678,
+            "uri": "https://{canondata_backend}/1130705/8c4f982eeb3055502f0771337ab9a4ff0bf02381/resource.tar.gz#test.test_column_group-groups-max-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-groups-max-Plan]": [
@@ -649,9 +649,9 @@
     ],
     "test.test[column_group-hint-perusage-Debug]": [
         {
-            "checksum": "d4bd4dfe79ac9e8df29d2f18aa9df3af",
-            "size": 4428,
-            "uri": "https://{canondata_backend}/1925842/f50b288f59b69a78ae19cf4b9dc5839e0faf06a4/resource.tar.gz#test.test_column_group-hint-perusage-Debug_/opt.yql"
+            "checksum": "d313a9c21438f076873e0b6730ec1d78",
+            "size": 4400,
+            "uri": "https://{canondata_backend}/1130705/8c4f982eeb3055502f0771337ab9a4ff0bf02381/resource.tar.gz#test.test_column_group-hint-perusage-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-hint-perusage-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part17/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part17/canondata/result.json
@@ -627,9 +627,9 @@
     ],
     "test.test[column_group-publish-perusage-Debug]": [
         {
-            "checksum": "b78a3fa386c93c906943521c253050bf",
-            "size": 2989,
-            "uri": "https://{canondata_backend}/1903280/b86c4aadc621c70d39f1e59de2ec7c62c09982b6/resource.tar.gz#test.test_column_group-publish-perusage-Debug_/opt.yql"
+            "checksum": "ae6ed207f5c433d59cee7aac18a9b320",
+            "size": 2923,
+            "uri": "https://{canondata_backend}/1814674/c4a59d7a13470919860f431338451dced3b409c0/resource.tar.gz#test.test_column_group-publish-perusage-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-publish-perusage-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part5/canondata/result.json
@@ -784,9 +784,9 @@
     ],
     "test.test[column_group-length-single-Debug]": [
         {
-            "checksum": "484e419ceeb6fbe15ed3ceb1d9e0b583",
-            "size": 2896,
-            "uri": "https://{canondata_backend}/1903885/73e660a0776ebf0e5955c10820c8b380b3a342f0/resource.tar.gz#test.test_column_group-length-single-Debug_/opt.yql"
+            "checksum": "25774ae411b6e89b3b568bf807c0e40d",
+            "size": 2920,
+            "uri": "https://{canondata_backend}/1937424/b2d5a2ca7d4bef7cbd2e32d6bacd495b36779b0c/resource.tar.gz#test.test_column_group-length-single-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-length-single-Plan]": [

--- a/ydb/library/yql/tests/sql/yt_native_file/part8/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part8/canondata/result.json
@@ -907,9 +907,9 @@
     ],
     "test.test[column_group-hint-single-Debug]": [
         {
-            "checksum": "60e01634e43d30f4292a7a30171a800e",
-            "size": 4426,
-            "uri": "https://{canondata_backend}/1936947/6469ab3aaa99f60b405aa2666072d6a1eafe6655/resource.tar.gz#test.test_column_group-hint-single-Debug_/opt.yql"
+            "checksum": "5165c31dbbf851b25ecd260a02405962",
+            "size": 4398,
+            "uri": "https://{canondata_backend}/1946324/ad30fe3e4a7e31f276a1b13c1d2436bd1b99f047/resource.tar.gz#test.test_column_group-hint-single-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-hint-single-Plan]": [
@@ -968,9 +968,9 @@
     ],
     "test.test[column_group-hint_anon_groups-perusage-Debug]": [
         {
-            "checksum": "067590e2391e0f451c071056a74b0ceb",
-            "size": 3099,
-            "uri": "https://{canondata_backend}/1925842/34f87e31ea17797037a02652cf384114b03d7912/resource.tar.gz#test.test_column_group-hint_anon_groups-perusage-Debug_/opt.yql"
+            "checksum": "9eeb09bebf9be8f9664f06645b510b8f",
+            "size": 3071,
+            "uri": "https://{canondata_backend}/1946324/ad30fe3e4a7e31f276a1b13c1d2436bd1b99f047/resource.tar.gz#test.test_column_group-hint_anon_groups-perusage-Debug_/opt.yql"
         }
     ],
     "test.test[column_group-hint_anon_groups-perusage-Plan]": [


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
1. Inherit column group usage from YtMerge/YtCopy consumers to minimize data transformations in merge ops
2.  Validate that YtCopy has equal input/output column groups
3. ResPull behaves like YtPublish without column group hint - a possible full result should have no column groups

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
