### PR TITLE
Put spilling stats in metrics

### DIFF
--- a/ydb/library/yql/providers/dq/actors/task_controller_impl.h
+++ b/ydb/library/yql/providers/dq/actors/task_controller_impl.h
@@ -385,6 +385,13 @@ private:
         ADD_COUNTER(WaitInputTimeUs)
         ADD_COUNTER(WaitOutputTimeUs)
 
+        ADD_COUNTER(SpillingComputeWriteBytes)
+        ADD_COUNTER(SpillingChannelWriteBytes)
+        ADD_COUNTER(SpillingComputeReadTimeUs)
+        ADD_COUNTER(SpillingComputeWriteTimeUs)
+        ADD_COUNTER(SpillingChannelReadTimeUs)
+        ADD_COUNTER(SpillingChannelWriteTimeUs)
+
         // profile stats
         ADD_COUNTER(BuildCpuTimeUs)
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Put spilling stats in metrics in order to get those from dqrun

### Changelog category <!-- remove all except one -->

* Improvement
* Not for changelog (changelog entry is not required)

### Additional information

Spilling stats "Spilling{Compute|Channel}WriteBytes" and "Spilling{Compute|Channel}{Read|Write}TimeUs" were added in https://github.com/ydb-platform/ydb/pull/7505
