### PR TITLE
minor changes to groups and nodes handler

### DIFF
--- a/ydb/core/viewer/json_handlers_storage.cpp
+++ b/ydb/core/viewer/json_handlers_storage.cpp
@@ -4,7 +4,7 @@
 namespace NKikimr::NViewer {
 
 void InitStorageGroupsJsonHandler(TJsonHandlers& jsonHandlers) {
-    jsonHandlers.AddHandler("/storage/groups", new TJsonHandler<TStorageGroups>(TStorageGroups::GetSwagger()), 3);
+    jsonHandlers.AddHandler("/storage/groups", new TJsonHandler<TStorageGroups>(TStorageGroups::GetSwagger()), 4);
 }
 
 void InitStorageJsonHandlers(TJsonHandlers& jsonHandlers) {

--- a/ydb/core/viewer/json_handlers_viewer.cpp
+++ b/ydb/core/viewer/json_handlers_viewer.cpp
@@ -243,7 +243,7 @@ void InitViewerHealthCheckJsonHandler(TJsonHandlers& handlers) {
 }
 
 void InitViewerNodesJsonHandler(TJsonHandlers& handlers) {
-    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 2);
+    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 3);
 }
 
 void InitViewerACLJsonHandler(TJsonHandlers &jsonHandlers) {

--- a/ydb/core/viewer/storage_groups.h
+++ b/ydb/core/viewer/storage_groups.h
@@ -165,6 +165,8 @@ public:
 
     EGroupFields SortBy = EGroupFields::PoolName;
     EGroupFields GroupBy = EGroupFields::GroupId;
+    EGroupFields FilterGroupBy = EGroupFields::GroupId;
+    TString FilterGroup;
     EWith With = EWith::Everything;
     bool ReverseSort = false;
     std::optional<std::size_t> Offset;
@@ -475,6 +477,35 @@ public:
         ui64 GetLatencyForSort() const {
             return PutTabletLogLatency;
         }
+
+        TString GetGroupName(EGroupFields groupBy) {
+            switch (groupBy) {
+                case EGroupFields::GroupId:
+                    return ToString(GroupId);
+                case EGroupFields::Erasure:
+                    return Erasure;
+                case EGroupFields::Usage:
+                    return GetUsageForGroup();
+                case EGroupFields::DiskSpaceUsage:
+                    return GetDiskUsageForGroup();
+                case EGroupFields::PoolName:
+                    return PoolName;
+                case EGroupFields::Kind:
+                    return Kind;
+                case EGroupFields::Encryption:
+                    return GetEncryptionForGroup();
+                case EGroupFields::MediaType:
+                    return MediaType;
+                case EGroupFields::MissingDisks:
+                    return GetMissingDisksForGroup();
+                case EGroupFields::State:
+                    return State;
+                case EGroupFields::Latency:
+                    return GetLatencyForGroup();
+                default:
+                    return {};
+            }
+        }
     };
 
     using TGroupData = std::vector<TGroup>;
@@ -640,6 +671,12 @@ public:
             Filter = params.Get("filter");
             FieldsRequired.set(+EGroupFields::PoolName);
             FieldsRequired.set(+EGroupFields::GroupId);
+            NeedFilter = true;
+        }
+        if (params.Has("filter_group") && params.Has("filter_group_by")) {
+            FilterGroup = params.Get("filter_group");
+            FilterGroupBy = ParseEGroupFields(params.Get("filter_group_by"));
+            FieldsRequired.set(+FilterGroupBy);
             NeedFilter = true;
         }
         if (params.Get("with") == "missing") {
@@ -890,17 +927,27 @@ public:
                 Filter.clear();
                 GroupsByGroupId.clear();
             }
-            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.empty() || !FilterPDiskIds.empty() || !FilterGroupIds.empty();
+            if (!FilterGroup.empty() && FieldsAvailable.test(+FilterGroupBy)) {
+                TGroupView groupView;
+                for (TGroup* group : GroupView) {
+                    if (group->GetGroupName(FilterGroupBy) == FilterGroup) {
+                        groupView.push_back(group);
+                    }
+                }
+                GroupView.swap(groupView);
+                FilterGroup.clear();
+                GroupsByGroupId.clear();
+            }
+            NeedFilter = (With != EWith::Everything) || !Filter.empty() || !FilterStoragePools.empty() || !FilterNodeIds.empty() || !FilterPDiskIds.empty() || !FilterGroupIds.empty() || !FilterGroup.empty();
             FoundGroups = GroupView.size();
         }
     }
 
-    template<typename F>
-    void GroupCollection(F&& groupBy) {
+    void GroupCollection() {
         std::unordered_map<TString, size_t> groupGroups;
         GroupGroups.clear();
         for (TGroup* group : GroupView) {
-            auto gb = groupBy(group);
+            auto gb = group->GetGroupName(GroupBy);
             TGroupGroup* groupGroup = nullptr;
             auto it = groupGroups.find(gb);
             if (it == groupGroups.end()) {
@@ -918,48 +965,23 @@ public:
         if (!NeedFilter && NeedGroup && FieldsAvailable.test(+GroupBy)) {
             switch (GroupBy) {
                 case EGroupFields::GroupId:
-                    GroupCollection([](const TGroup* group) { return ToString(group->GroupId); });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; });
-                    break;
                 case EGroupFields::Erasure:
-                    GroupCollection([](const TGroup* group) { return group->Erasure; });
+                case EGroupFields::PoolName:
+                case EGroupFields::Kind:
+                case EGroupFields::Encryption:
+                case EGroupFields::MediaType:
+                case EGroupFields::State:
+                    GroupCollection();
                     SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; });
+                    NeedGroup = false;
                     break;
                 case EGroupFields::Usage:
-                    GroupCollection([](const TGroup* group) { return group->GetUsageForGroup(); });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; }, true);
-                    break;
                 case EGroupFields::DiskSpaceUsage:
-                    GroupCollection([](const TGroup* group) { return group->GetDiskUsageForGroup(); });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; }, true);
-                    break;
-                case EGroupFields::PoolName:
-                    GroupCollection([](const TGroup* group) { return group->PoolName; });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; });
-                    break;
-                case EGroupFields::Kind:
-                    GroupCollection([](const TGroup* group) { return group->Kind; });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; });
-                    break;
-                case EGroupFields::Encryption:
-                    GroupCollection([](const TGroup* group) { return group->GetEncryptionForGroup(); });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; });
-                    break;
-                case EGroupFields::MediaType:
-                    GroupCollection([](const TGroup* group) { return group->MediaType; });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; });
-                    break;
                 case EGroupFields::MissingDisks:
-                    GroupCollection([](const TGroup* group) { return group->GetMissingDisksForGroup(); });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; }, true);
-                    break;
-                case EGroupFields::State:
-                    GroupCollection([](const TGroup* group) { return group->State; });
-                    SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; });
-                    break;
                 case EGroupFields::Latency:
-                    GroupCollection([](const TGroup* group) { return group->GetLatencyForGroup(); });
+                    GroupCollection();
                     SortCollection(GroupGroups, [](const TGroupGroup& groupGroup) { return groupGroup.Name; }, true);
+                    NeedGroup = false;
                     break;
                 case EGroupFields::Read:
                 case EGroupFields::Write:
@@ -974,7 +996,6 @@ public:
                 case EGroupFields::PDiskId:
                     break;
             }
-            NeedGroup = false;
         }
     }
 
@@ -1940,6 +1961,9 @@ public:
                 if (FieldsAvailable.test(+EGroupFields::Available)) {
                     jsonGroup.SetAvailable(group->Available);
                 }
+                if (FieldsAvailable.test(+EGroupFields::DiskSpaceUsage)) {
+                    jsonGroup.SetDiskSpaceUsage(group->DiskSpaceUsage);
+                }
                 if (FieldsAvailable.test(+EGroupFields::Latency)) {
                     jsonGroup.SetLatencyPutTabletLog(group->PutTabletLogLatency);
                     jsonGroup.SetLatencyPutUserData(group->PutUserDataLatency);
@@ -2017,6 +2041,28 @@ public:
                     type: string
                   - name: filter
                     description: filter to search for in group ids and pool names
+                    required: false
+                    type: string
+                  - name: filter_group_by
+                    in: query
+                    description: >
+                        filter group by:
+                          * `GroupId`
+                          * `Erasure`
+                          * `Usage`
+                          * `DiskSpaceUsage`
+                          * `PoolName`
+                          * `Kind`
+                          * `Encryption`
+                          * `MediaType`
+                          * `MissingDisks`
+                          * `State`
+                          * `Latency`
+                    required: false
+                    type: string
+                  - name: filter_group
+                    in: query
+                    description: content for filter group by
                     required: false
                     type: string
                   - name: sort

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -22,6 +22,7 @@ enum class ENodeFields : ui8 {
     Tablets,
     NodeId,
     HostName,
+    NodeName,
     DC,
     Rack,
     Version,
@@ -176,6 +177,10 @@ class TJsonNodes : public TViewerPipeClient {
                 return NodeInfo.ResolveHost;
             }
             return {};
+        }
+
+        TString GetNodeName() const {
+            return SystemState.GetNodeName();
         }
 
         TString GetDataCenter() const {
@@ -402,6 +407,33 @@ class TJsonNodes : public TViewerPipeClient {
         bool HasSubDomainKey(const TSubDomainKey& subDomainKey) const {
             return SubDomainKey == subDomainKey;
         }
+
+        TString GetGroupName(ENodeFields groupBy, TInstant now) const {
+            switch (groupBy) {
+                case ENodeFields::NodeId:
+                    return ToString(GetNodeId());
+                case ENodeFields::HostName:
+                    return GetHostName();
+                case ENodeFields::NodeName:
+                    return GetNodeName();
+                case ENodeFields::Database:
+                    return Database;
+                case ENodeFields::DiskSpaceUsage:
+                    return GetDiskUsageForGroup();
+                case ENodeFields::DC:
+                    return GetDataCenter();
+                case ENodeFields::Rack:
+                    return GetRack();
+                case ENodeFields::Missing:
+                    return ToString(MissingDisks);
+                case ENodeFields::Uptime:
+                    return GetUptimeForGroup(now);
+                case ENodeFields::Version:
+                    return GetVersionForGroup();
+                default:
+                    return {};
+            }
+        }
     };
 
     struct TNodeGroup {
@@ -442,6 +474,7 @@ class TJsonNodes : public TViewerPipeClient {
                                                     .set(+ENodeFields::Rack);
     const TFieldsType FieldsSystemState = TFieldsType().set(+ENodeFields::SystemState)
                                                        .set(+ENodeFields::Database)
+                                                       .set(+ENodeFields::NodeName)
                                                        .set(+ENodeFields::Version)
                                                        .set(+ENodeFields::Uptime)
                                                        .set(+ENodeFields::Memory)
@@ -460,6 +493,7 @@ class TJsonNodes : public TViewerPipeClient {
         { ENodeFields::Rack, TFieldsType().set(+ENodeFields::SystemState) },
         { ENodeFields::Uptime, TFieldsType().set(+ENodeFields::SystemState) },
         { ENodeFields::Version, TFieldsType().set(+ENodeFields::SystemState) },
+        { ENodeFields::NodeName, TFieldsType().set(+ENodeFields::SystemState) },
         { ENodeFields::Missing, TFieldsType().set(+ENodeFields::PDisks) },
     };
 
@@ -470,6 +504,8 @@ class TJsonNodes : public TViewerPipeClient {
     ENodeFields SortBy = ENodeFields::NodeId;
     bool ReverseSort = false;
     ENodeFields GroupBy = ENodeFields::NodeId;
+    ENodeFields FilterGroupBy = ENodeFields::NodeId;
+    TString FilterGroup;
     bool NeedFilter = false;
     bool NeedGroup = false;
     bool NeedSort = false;
@@ -495,6 +531,8 @@ class TJsonNodes : public TViewerPipeClient {
             result = ENodeFields::NodeId;
         } else if (field == "Host") {
             result = ENodeFields::HostName;
+        } else if (field == "NodeName") {
+            result = ENodeFields::NodeName;
         } else if (field == "DC") {
             result = ENodeFields::DC;
         } else if (field == "Rack") {
@@ -562,6 +600,11 @@ public:
         if (FilterPath == Database) {
             FilterPath.clear();
         }
+        if (params.Has("filter_group") && params.Has("filter_group_by")) {
+            FilterGroup = params.Get("filter_group");
+            FilterGroupBy = ParseENodeFields(params.Get("filter_group_by"));
+            FieldsRequired.set(+FilterGroupBy);
+        }
 
         OffloadMerge = FromStringWithDefault<bool>(params.Get("offload_merge"), OffloadMerge);
         OffloadMergeAttempts = FromStringWithDefault<bool>(params.Get("offload_merge_attempts"), OffloadMergeAttempts);
@@ -595,7 +638,7 @@ public:
         } else if (params.Get("type") == "any") {
             Type = EType::Any;
         }
-        NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0;
+        NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0 || !FilterGroup.empty();
         if (params.Has("offset")) {
             Offset = FromStringWithDefault<ui32>(params.Get("offset"), 0);
             NeedLimit = true;
@@ -879,17 +922,29 @@ public:
                 Filter.clear();
                 InvalidateNodes();
             }
-            NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0;
+            if (!FilterGroup.empty() && FieldsAvailable.test(+FilterGroupBy)) {
+                TNodeView nodeView;
+                auto now = TInstant::Now();
+                for (TNode* node : NodeView) {
+                    if (node->GetGroupName(FilterGroupBy, now) == FilterGroup) {
+                        nodeView.push_back(node);
+                    }
+                }
+                NodeView.swap(nodeView);
+                FilterGroup.clear();
+                InvalidateNodes();
+            }
+            NeedFilter = (With != EWith::Everything) || (Type != EType::Any) || !Filter.empty() || !FilterNodeIds.empty() || ProblemNodesOnly || UptimeSeconds > 0 || !FilterGroup.empty();
             FoundNodes = NodeView.size();
         }
     }
 
-    template<typename F>
-    void GroupCollection(F&& groupBy) {
+    void GroupCollection() {
+        auto now = TInstant::Now();
         std::unordered_map<TString, size_t> nodeGroups;
         NodeGroups.clear();
         for (TNode* node : NodeView) {
-            auto gb = groupBy(node);
+            auto gb = node->GetGroupName(GroupBy, now);
             TNodeGroup* nodeGroup = nullptr;
             auto it = nodeGroups.find(gb);
             if (it == nodeGroups.end()) {
@@ -907,40 +962,18 @@ public:
         if (FilterDone() && NeedGroup && FieldsAvailable.test(+GroupBy)) {
             switch (GroupBy) {
                 case ENodeFields::NodeId:
-                    GroupCollection([](const TNode* node) { return ToString(node->GetNodeId()); });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
                 case ENodeFields::HostName:
-                    GroupCollection([](const TNode* node) { return node->GetHostName(); });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
+                case ENodeFields::NodeName:
                 case ENodeFields::Database:
-                    GroupCollection([](const TNode* node) { return node->Database; });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
                 case ENodeFields::DiskSpaceUsage:
-                    GroupCollection([](const TNode* node) { return node->GetDiskUsageForGroup(); });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
                 case ENodeFields::DC:
-                    GroupCollection([](const TNode* node) { return node->GetDataCenter(); });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
                 case ENodeFields::Rack:
-                    GroupCollection([](const TNode* node) { return node->GetRack(); });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
                 case ENodeFields::Missing:
-                    GroupCollection([](const TNode* node) { return ToString(node->MissingDisks); });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
                 case ENodeFields::Uptime:
-                    GroupCollection([now = TInstant::Now()](const TNode* node) { return node->GetUptimeForGroup(now); });
-                    SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
-                    break;
                 case ENodeFields::Version:
-                    GroupCollection([](const TNode* node) { return node->GetVersionForGroup(); });
+                    GroupCollection();
                     SortCollection(NodeGroups, [](const TNodeGroup& nodeGroup) { return nodeGroup.Name; });
+                    NeedGroup = false;
                     break;
                 case ENodeFields::NodeInfo:
                 case ENodeFields::SystemState:
@@ -955,7 +988,6 @@ public:
                 case ENodeFields::DisconnectTime:
                     break;
             }
-            NeedGroup = false;
         }
     }
 
@@ -967,6 +999,9 @@ public:
                     break;
                 case ENodeFields::HostName:
                     SortCollection(NodeView, [](const TNode* node) { return node->GetHostName(); }, ReverseSort);
+                    break;
+                case ENodeFields::NodeName:
+                    SortCollection(NodeView, [](const TNode* node) { return node->GetNodeName(); }, ReverseSort);
                     break;
                 case ENodeFields::DC:
                     SortCollection(NodeView, [](const TNode* node) { return node->NodeInfo.Location.GetDataCenterId(); }, ReverseSort);
@@ -2061,7 +2096,7 @@ public:
         AddEvent("ReplyAndPassAway");
         ApplyEverything();
         NKikimrViewer::TNodesInfo json;
-        json.SetVersion(2);
+        json.SetVersion(Viewer->GetCapabilityVersion("/viewer/nodes"));
         json.SetFieldsAvailable(FieldsAvailable.to_string());
         json.SetFieldsRequired(FieldsRequired.to_string());
         if (NeedFilter) {
@@ -2172,12 +2207,12 @@ public:
         });
         yaml.AddParameter({
             .Name = "sort",
-            .Description = "sort by (NodeId,Host,DC,Rack,Version,Uptime,Missing)",
+            .Description = "sort by (NodeId,Host,NodeName,DC,Rack,Version,Uptime,Missing)",
             .Type = "string",
         });
         yaml.AddParameter({
             .Name = "group",
-            .Description = "group by (NodeId,Host,DC,Rack,Version,Uptime,Missing)",
+            .Description = "group by (NodeId,Host,NodeName,DC,Rack,Version,Uptime,Missing)",
             .Type = "string",
         });
         yaml.AddParameter({
@@ -2208,6 +2243,16 @@ public:
         yaml.AddParameter({
             .Name = "filter",
             .Description = "filter nodes by id or host",
+            .Type = "string",
+        });
+        yaml.AddParameter({
+            .Name = "filter_group_by",
+            .Description = "filter group by (NodeId,Host,NodeName,DC,Rack,Version,Uptime,Missing)",
+            .Type = "string",
+        });
+        yaml.AddParameter({
+            .Name = "filter_group",
+            .Description = "content for filter group by",
             .Type = "string",
         });
         yaml.SetResponseSchema(TProtoToYaml::ProtoToYamlSchema<NKikimrViewer::TNodesInfo>());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

add easier way to get content of a group:
 - filter_group_by = group kind
 - filter_group = content for filtering

for example, if we had ?group=Latency and got 2 groups:
 - 1ms
 - 5ms

to get content of the first group we execute ?filter_group_by=Latency&filter_group=1ms

and this change also adds NodeName as a first-class field in Nodes view

### Changelog category <!-- remove all except one -->

* Improvement
* Not for changelog (changelog entry is not required)
