### PR TITLE
YQ-3678 support all arrow types in size calcer

### DIFF
--- a/ydb/library/formats/arrow/simple_builder/array.h
+++ b/ydb/library/formats/arrow/simple_builder/array.h
@@ -134,4 +134,23 @@ public:
 
     }
 };
+
+class TStaticArrayConstructor: public IArrayBuilder {
+private:
+    using TBase = IArrayBuilder;
+
+    const std::shared_ptr<arrow::Array> Array;
+
+protected:
+    virtual std::shared_ptr<arrow::Array> DoBuildArray(const ui32 /*recordsCount*/) const override {
+        return Array;
+    }
+
+public:
+    TStaticArrayConstructor(const TString& fieldName, std::shared_ptr<arrow::Array> array)
+        : TBase(fieldName)
+        , Array(array)
+    {}
+};
+
 }

--- a/ydb/library/formats/arrow/simple_builder/batch.cpp
+++ b/ydb/library/formats/arrow/simple_builder/batch.cpp
@@ -11,7 +11,8 @@ std::shared_ptr<arrow::RecordBatch> TRecordBatchConstructor::BuildBatch(const ui
     }
     auto batch = arrow::RecordBatch::Make(std::make_shared<arrow::Schema>(fields), numRows, columns);
     Y_ABORT_UNLESS(batch);
-    Y_DEBUG_ABORT_UNLESS(batch->ValidateFull().ok());
+    arrow::Status valudateStatus = batch->ValidateFull();
+    Y_DEBUG_ABORT_UNLESS(valudateStatus.ok(), "BuildBatch failed: %s", valudateStatus.ToString().data());
     return batch;
 }
 

--- a/ydb/library/formats/arrow/simple_builder/batch.cpp
+++ b/ydb/library/formats/arrow/simple_builder/batch.cpp
@@ -11,8 +11,7 @@ std::shared_ptr<arrow::RecordBatch> TRecordBatchConstructor::BuildBatch(const ui
     }
     auto batch = arrow::RecordBatch::Make(std::make_shared<arrow::Schema>(fields), numRows, columns);
     Y_ABORT_UNLESS(batch);
-    arrow::Status valudateStatus = batch->ValidateFull();
-    Y_DEBUG_ABORT_UNLESS(valudateStatus.ok(), "BuildBatch failed: %s", valudateStatus.ToString().data());
+    Y_DEBUG_ABORT_UNLESS(batch->ValidateFull().ok());
     return batch;
 }
 

--- a/ydb/library/formats/arrow/size_calcer.cpp
+++ b/ydb/library/formats/arrow/size_calcer.cpp
@@ -4,6 +4,7 @@
 #include <contrib/libs/apache/arrow/cpp/src/arrow/visitor_inline.h>
 #include <util/system/yassert.h>
 #include <util/string/builder.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
 
 namespace NKikimr::NArrow {
 
@@ -165,7 +166,7 @@ public:
     template <typename TType>
         requires arrow::is_base_binary_type<TType>::value
     arrow::Status Visit(const TType&) {
-        using TArray = arrow::TypeTraits<TType>::ArrayType;
+        using TArray = typename arrow::TypeTraits<TType>::ArrayType;
 
         auto typedColumn = std::static_pointer_cast<TArray>(Column);
         Bytes += typedColumn->total_values_length() + sizeof(typename TArray::offset_type) * Column->length();
@@ -175,7 +176,7 @@ public:
     template <typename TType>
         requires arrow::is_fixed_size_binary_type<TType>::value
     arrow::Status Visit(const TType&) {
-        using TArray = arrow::TypeTraits<TType>::ArrayType;
+        using TArray = typename arrow::TypeTraits<TType>::ArrayType;
 
         auto typedColumn = std::static_pointer_cast<TArray>(Column);
         Bytes += typedColumn->byte_width() * typedColumn->length();
@@ -194,7 +195,7 @@ public:
     template <typename TType>
         requires arrow::is_var_length_list_type<TType>::value
     arrow::Status Visit(const TType&) {
-        using TArray = arrow::TypeTraits<TType>::ArrayType;
+        using TArray = typename arrow::TypeTraits<TType>::ArrayType;
 
         auto typedColumn = std::static_pointer_cast<TArray>(Column);
         auto numberElements = typedColumn->length();
@@ -239,7 +240,7 @@ ui64 GetArrayDataSize(const std::shared_ptr<arrow::Array>& column) {
 
     TSizeVisitor visitor(column);
     auto status = arrow::VisitTypeInline(*type, &visitor);
-    Y_DEBUG_ABORT_UNLESS(status.ok(), "Failed to calculate array size: %s", status.ToString().data());
+    Y_VERIFY_S(status.ok(), "Failed to calculate array size: " << status.ToString());
 
     ui64 bytes = visitor.GetBytes();
 

--- a/ydb/library/formats/arrow/ut/ut_size_calcer.cpp
+++ b/ydb/library/formats/arrow/ut/ut_size_calcer.cpp
@@ -5,6 +5,15 @@
 #include <ydb/library/formats/arrow/simple_builder/filler.h>
 #include <ydb/library/formats/arrow/size_calcer.h>
 
+
+namespace {
+
+void CheckStatus(arrow::Status status) {
+    UNIT_ASSERT_C(status.ok(), status.ToString());
+}
+
+}
+
 Y_UNIT_TEST_SUITE(SizeCalcer) {
 
     using namespace NKikimr::NArrow;
@@ -61,4 +70,150 @@ Y_UNIT_TEST_SUITE(SizeCalcer) {
         UNIT_ASSERT(GetBatchDataSize(batch) == 2048 * 8);
     }
 
+    Y_UNIT_TEST(NestedFixedSizeList) {
+        constexpr i32 elementSize = 512;
+        constexpr i32 listSize = 16;
+        constexpr i32 recordsCount = 2048;
+
+        auto valueBuilder = std::make_shared<arrow::StringBuilder>();
+        CheckStatus(valueBuilder->Reserve(listSize * recordsCount));
+
+        arrow::FixedSizeListBuilder listBuilder(arrow::default_memory_pool(), valueBuilder, listSize);
+        CheckStatus(listBuilder.Reserve(recordsCount));
+
+        NConstruction::TStringPoolFiller filler(8, elementSize);
+        for (i32 recordId = 0; recordId < recordsCount; ++recordId) {
+            CheckStatus(listBuilder.Append());
+            for (i32 elementId = 0; elementId < listSize; ++elementId) {
+                CheckStatus(valueBuilder->Append(filler.GetValue(recordId * listSize + elementId)));
+            }
+        }
+        NConstruction::IArrayBuilder::TPtr column = std::make_shared<NConstruction::TStaticArrayConstructor>("field", *listBuilder.Finish());
+        std::shared_ptr<arrow::RecordBatch> batch = NConstruction::TRecordBatchConstructor({column}).BuildBatch(recordsCount);
+
+        constexpr i32 amountSize = recordsCount * listSize * (elementSize + 4);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(batch), amountSize);
+        auto slice05 = batch->Slice(batch->num_rows() / 2, batch->num_rows() / 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(slice05), amountSize / 2);
+        auto slice025 = slice05->Slice(slice05->num_rows() / 3, slice05->num_rows() / 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(slice025), amountSize / 4);
+    }
+
+    Y_UNIT_TEST(NestedList) {
+        constexpr i32 elementSize = 512;
+        constexpr i32 awerageListSize = 16;
+        constexpr i32 recordsCount = 2048;
+
+        auto valueBuilder = std::make_shared<arrow::StringBuilder>();
+        CheckStatus(valueBuilder->Reserve(2 * awerageListSize * recordsCount));
+
+        arrow::ListBuilder listBuilder(arrow::default_memory_pool(), valueBuilder);
+        CheckStatus(listBuilder.Reserve(recordsCount));
+
+        i32 amountListsSize = 0;
+        i32 halfListsSize = 0;
+        NConstruction::TStringPoolFiller filler(8, elementSize);
+        for (i32 recordId = 0; recordId < recordsCount; ++recordId) {
+            CheckStatus(listBuilder.Append());
+
+            TReallyFastRng32 rand(recordId);
+            i32 listSize = rand.Uniform(awerageListSize / 2, 3 * awerageListSize / 2);
+            for (i32 elementId = 0; elementId < listSize; ++elementId) {
+                CheckStatus(valueBuilder->Append(filler.GetValue(2 * recordId * awerageListSize + elementId)));
+            }
+
+            amountListsSize += listSize;
+            if (recordId >= recordsCount / 2) {
+                halfListsSize += listSize;
+            }
+        }
+        NConstruction::IArrayBuilder::TPtr column = std::make_shared<NConstruction::TStaticArrayConstructor>("field", *listBuilder.Finish());
+        std::shared_ptr<arrow::RecordBatch> batch = NConstruction::TRecordBatchConstructor({column}).BuildBatch(recordsCount);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(batch), amountListsSize * (elementSize + 4) + recordsCount * 4);
+        auto slice05 = batch->Slice(batch->num_rows() / 2, batch->num_rows() / 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(slice05), halfListsSize * (elementSize + 4) + recordsCount * 2);
+    }
+
+    Y_UNIT_TEST(NestedStruct) {
+        constexpr i32 stringSize = 512;
+        constexpr i32 recordsCount = 2048;
+
+        auto stringBuilder = std::make_shared<arrow::StringBuilder>();
+        CheckStatus(stringBuilder->Reserve(recordsCount));
+
+        auto intBuilder = std::make_shared<arrow::Int32Builder>();
+        CheckStatus(intBuilder->Reserve(recordsCount));
+
+        auto structType = std::make_shared<arrow::StructType>(std::vector{
+            std::make_shared<arrow::Field>("string_field", stringBuilder->type()),
+            std::make_shared<arrow::Field>("int32_field", intBuilder->type()),
+        });
+
+        arrow::StructBuilder structBuilder(structType, arrow::default_memory_pool(), {
+            stringBuilder,
+            intBuilder
+        });
+        CheckStatus(structBuilder.Reserve(recordsCount));
+
+        NConstruction::TIntSeqFiller<arrow::Int32Type> intFiller(42);
+        NConstruction::TStringPoolFiller stringFiller(8, stringSize);
+        for (i32 recordId = 0; recordId < recordsCount; ++recordId) {
+            CheckStatus(structBuilder.Append());
+            CheckStatus(intBuilder->Append(intFiller.GetValue(recordId)));
+            CheckStatus(stringBuilder->Append(stringFiller.GetValue(recordId)));
+        }
+        NConstruction::IArrayBuilder::TPtr column = std::make_shared<NConstruction::TStaticArrayConstructor>("field", *structBuilder.Finish());
+        std::shared_ptr<arrow::RecordBatch> batch = NConstruction::TRecordBatchConstructor({column}).BuildBatch(recordsCount);
+
+        constexpr i32 amountSize = recordsCount * (stringSize + 8);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(batch), amountSize);
+        auto slice05 = batch->Slice(batch->num_rows() / 2, batch->num_rows() / 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(slice05), amountSize / 2);
+        auto slice025 = slice05->Slice(slice05->num_rows() / 3, slice05->num_rows() / 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(slice025), amountSize / 4);
+    }
+
+    Y_UNIT_TEST(NestedSparseUnion) {
+        constexpr i32 stringSize = 512;
+        constexpr i32 recordsCount = 2048;
+
+        auto stringBuilder = std::make_shared<arrow::StringBuilder>();
+        CheckStatus(stringBuilder->Reserve(recordsCount));
+
+        auto intBuilder = std::make_shared<arrow::Int32Builder>();
+        CheckStatus(intBuilder->Reserve(recordsCount));
+
+        arrow::SparseUnionBuilder sparseUnionBuilder(arrow::default_memory_pool());
+        sparseUnionBuilder.AppendChild(stringBuilder);
+        sparseUnionBuilder.AppendChild(intBuilder);
+        CheckStatus(sparseUnionBuilder.Reserve(recordsCount));
+
+        i32 amountStrings = 0;
+        i32 halfStrings = 0;
+        NConstruction::TIntSeqFiller<arrow::Int32Type> intFiller(42);
+        NConstruction::TStringPoolFiller stringFiller(8, stringSize);
+        for (i32 recordId = 0; recordId < recordsCount; ++recordId) {
+            TReallyFastRng32 rand(recordId);
+            i32 typeId = rand.Uniform(0, 2);
+
+            CheckStatus(sparseUnionBuilder.Append(typeId));
+            if (typeId) {
+                CheckStatus(intBuilder->Append(intFiller.GetValue(recordId)));
+                CheckStatus(stringBuilder->AppendEmptyValue());
+            } else {
+                CheckStatus(intBuilder->AppendEmptyValue());
+                CheckStatus(stringBuilder->Append(stringFiller.GetValue(recordId)));
+
+                amountStrings++;
+                halfStrings += recordId >= recordsCount / 2;
+            }
+        }
+        NConstruction::IArrayBuilder::TPtr column = std::make_shared<NConstruction::TStaticArrayConstructor>("field", *sparseUnionBuilder.Finish());
+        std::shared_ptr<arrow::RecordBatch> batch = NConstruction::TRecordBatchConstructor({column}).BuildBatch(recordsCount);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(batch), recordsCount * 9 + amountStrings * stringSize);
+        auto slice05 = batch->Slice(batch->num_rows() / 2, batch->num_rows() / 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetBatchDataSize(slice05), (recordsCount / 2) * 9 + halfStrings * stringSize);
+    }
 };

--- a/ydb/library/formats/arrow/ya.make
+++ b/ydb/library/formats/arrow/ya.make
@@ -35,6 +35,10 @@ ELSE()
     )
 ENDIF()
 
+CFLAGS(
+    -Wno-unused-parameter
+)
+
 YQL_LAST_ABI_VERSION()
 
 SRCS(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support all arrow types in size calcer except of:
* DENSE_UNION
* DICTIONARY
* EXTENSION

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information