### PR TITLE
Fix vulnerabilities in yql_plan.cpp reported by coverity

### DIFF
--- a/ydb/library/yql/core/services/yql_plan.cpp
+++ b/ydb/library/yql/core/services/yql_plan.cpp
@@ -414,7 +414,9 @@ public:
         THashMap<TPinKey, ui32, TPinKey::THash> allInputs;
         THashMap<TPinKey, ui32, TPinKey::THash> allOutputs;
         for (auto node : order) {
-            auto& info = nodes.find(node.Get())->second;
+            const auto found = nodes.find(node.Get());
+            YQL_ENSURE(found != nodes.cend());
+            auto& info = found->second;
             if (!info.IsVisible) {
                 continue;
             }

--- a/ydb/library/yql/core/services/yql_plan.cpp
+++ b/ydb/library/yql/core/services/yql_plan.cpp
@@ -127,7 +127,9 @@ void WriteProviders(const TString& tag, const TProviderInfoMap& providers, NYson
             writer.OnListItem();
             writer.OnBeginMap();
             writer.OnKeyedItem("Id");
-            writer.OnUint64Scalar(p.second.Pin.find(pin)->second);
+            const auto found = p.second.Pin.find(pin);
+            YQL_ENSURE(found != p.second.Pin.cend());
+            writer.OnUint64Scalar(found->second);
             p.second.Provider->GetPlanFormatter().WritePinDetails(*pin, writer);
             writer.OnEndMap();
         }


### PR DESCRIPTION
Previous implementation didn't check whether the lookup succeeded. As a result of the patch `YQL_ENSURE` for the lookup result is added prior to dereferencing the obtained iterator.

### Changelog category

* Bugfix