### PR TITLE
Views: throw a human-readable error in case of a missing `WITH (security_invoker = true)`

### DIFF
--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -243,7 +243,7 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         fail("");
         fail("WITH security_invoker");
         fail("WITH security_invoker = false");
-        fail("WITH SECURITY_INVOKER = false"); // option name is case-sensitive
+        fail("WITH SECURITY_INVOKER = true"); // option name is case-sensitive
         fail("WITH (security_invoker)");
         fail("WITH (security_invoker = false)");
         fail("WITH (security_invoker = true, security_invoker = false)");

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -243,6 +243,7 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         fail("");
         fail("WITH security_invoker");
         fail("WITH security_invoker = false");
+        fail("WITH SECURITY_INVOKER = false"); // option name is case-sensitive
         fail("WITH (security_invoker)");
         fail("WITH (security_invoker = false)");
         fail("WITH (security_invoker = true, security_invoker = false)");

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -213,6 +213,89 @@ Y_UNIT_TEST_SUITE(TCreateAndDropViewTest) {
         UNIT_ASSERT_STRING_CONTAINS(creationResult.GetIssues().ToString(), "Error: Cannot divide type String and String");
     }
 
+    Y_UNIT_TEST(ParsingSecurityInvoker) {
+        TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
+        EnableViewsFeatureFlag(kikimr);
+        auto session = kikimr.GetQueryClient().GetSession().ExtractValueSync().GetSession();
+
+        constexpr const char* path = "TheView";
+        constexpr const char* query = "SELECT 1";
+
+        auto fail = [&](const char* options) {
+            const TString creationQuery = std::format(R"(
+                    CREATE VIEW {} {} AS {};
+                )",
+                path,
+                options,
+                query
+            );
+
+            const auto creationResult = session.ExecuteQuery(
+                creationQuery,
+                NQuery::TTxControl::NoTx()
+            ).ExtractValueSync();
+
+            UNIT_ASSERT_C(!creationResult.IsSuccess(), creationQuery);
+            UNIT_ASSERT_STRING_CONTAINS(
+                creationResult.GetIssues().ToString(), "security_invoker option must be explicitly enabled"
+            );
+        };
+        fail("");
+        fail("WITH security_invoker");
+        fail("WITH security_invoker = false");
+        fail("WITH (security_invoker)");
+        fail("WITH (security_invoker = false)");
+        fail("WITH (security_invoker = true, security_invoker = false)");
+
+        auto succeed = [&](const char* options) {
+            const TString creationQuery = std::format(R"(
+                    CREATE VIEW {} {} AS {};
+                    DROP VIEW {};
+                )",
+                path,
+                options,
+                query,
+                path
+            );
+            ExecuteQuery(session, creationQuery);
+        };
+        succeed("WITH security_invoker = true");
+        succeed("WITH (security_invoker = true)");
+        succeed("WITH (security_invoker = tRuE)"); // bool parsing is flexible enough
+        succeed("WITH (security_invoker = false, security_invoker = true)");
+
+        {
+            // literal named expression
+            const TString creationQuery = std::format(R"(
+                    $value = "true";
+                    CREATE VIEW {} WITH security_invoker = $value AS {};
+                    DROP VIEW {};
+                )",
+                path,
+                query,
+                path
+            );
+            ExecuteQuery(session, creationQuery);
+        }
+        {
+            // evaluated expression
+            const TString creationQuery = std::format(R"(
+                    $lambda = ($x) -> {{
+                        RETURN CAST($x as String)
+                    }};
+                    $value = $lambda(true);
+
+                    CREATE VIEW {} WITH security_invoker = $value AS {};
+                    DROP VIEW {};
+                )",
+                path,
+                query,
+                path
+            );
+            ExecuteQuery(session, creationQuery);
+        }
+    }
+
     Y_UNIT_TEST(ListCreatedView) {
         TKikimrRunner kikimr(TKikimrSettings().SetWithSampleTables(false));
         EnableViewsFeatureFlag(kikimr);

--- a/ydb/library/yql/sql/v1/SQLv1.g.in
+++ b/ydb/library/yql/sql/v1/SQLv1.g.in
@@ -600,7 +600,7 @@ alter_external_data_source_action:
 drop_external_data_source_stmt: DROP EXTERNAL DATA SOURCE (IF EXISTS)? object_ref;
 
 create_view_stmt: CREATE VIEW object_ref
-    with_table_settings
+    create_object_features?
     AS select_stmt
 ;
 
@@ -628,7 +628,7 @@ drop_object_stmt: DROP OBJECT (IF EXISTS)? object_ref
 ;
 drop_object_features: WITH object_features;
 
-object_feature_value: id_or_type | bind_parameter | STRING_VALUE;
+object_feature_value: id_or_type | bind_parameter | STRING_VALUE | bool_value;
 object_feature_kv: an_id_or_type EQUALS object_feature_value;
 object_feature_flag: an_id_or_type;
 object_feature: object_feature_kv | object_feature_flag;
@@ -750,11 +750,11 @@ local_index: LOCAL;
 
 index_subtype: an_id;
 
-with_index_settings: WITH LPAREN index_setting_entry (COMMA index_setting_entry)* COMMA? RPAREN; 
+with_index_settings: WITH LPAREN index_setting_entry (COMMA index_setting_entry)* COMMA? RPAREN;
 index_setting_entry: an_id EQUALS index_setting_value;
 index_setting_value:
       id_or_type
-    | STRING_VALUE      
+    | STRING_VALUE
     | integer
     | bool_value
 ;

--- a/ydb/library/yql/sql/v1/SQLv1Antlr4.g.in
+++ b/ydb/library/yql/sql/v1/SQLv1Antlr4.g.in
@@ -599,7 +599,7 @@ alter_external_data_source_action:
 drop_external_data_source_stmt: DROP EXTERNAL DATA SOURCE (IF EXISTS)? object_ref;
 
 create_view_stmt: CREATE VIEW object_ref
-    with_table_settings
+    create_object_features?
     AS select_stmt
 ;
 
@@ -627,7 +627,7 @@ drop_object_stmt: DROP OBJECT (IF EXISTS)? object_ref
 ;
 drop_object_features: WITH object_features;
 
-object_feature_value: id_or_type | bind_parameter | STRING_VALUE;
+object_feature_value: id_or_type | bind_parameter | STRING_VALUE | bool_value;
 object_feature_kv: an_id_or_type EQUALS object_feature_value;
 object_feature_flag: an_id_or_type;
 object_feature: object_feature_kv | object_feature_flag;
@@ -749,11 +749,11 @@ local_index: LOCAL;
 
 index_subtype: an_id;
 
-with_index_settings: WITH LPAREN index_setting_entry (COMMA index_setting_entry)* COMMA? RPAREN; 
+with_index_settings: WITH LPAREN index_setting_entry (COMMA index_setting_entry)* COMMA? RPAREN;
 index_setting_entry: an_id EQUALS index_setting_value;
 index_setting_value:
       id_or_type
-    | STRING_VALUE      
+    | STRING_VALUE
     | integer
     | bool_value
 ;

--- a/ydb/library/yql/sql/v1/sql_query.cpp
+++ b/ydb/library/yql/sql/v1/sql_query.cpp
@@ -1239,8 +1239,10 @@ bool TSqlQuery::Statement(TVector<TNodePtr>& blocks, const TRule_sql_stmt_core& 
             }
 
             std::map<TString, TDeferredAtom> features;
-            if (!ParseViewOptions(features, node.GetRule_with_table_settings4())) {
-                return false;
+            if (node.HasBlock4()) {
+                if (!ParseObjectFeatures(features, node.GetBlock4().GetRule_create_object_features1().GetRule_object_features2())) {
+                    return false;
+                }
             }
             if (!ParseViewQuery(features, node.GetRule_select_stmt6())) {
                 return false;

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6705,24 +6705,6 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
     }
 
-    Y_UNIT_TEST(CreateViewNoSecurityInvoker) {
-        NYql::TAstParseResult res = SqlToYql(R"(
-                USE plato;
-                CREATE VIEW TheView AS SELECT 1;
-            )"
-        );
-        UNIT_ASSERT_STRING_CONTAINS(res.Issues.ToString(), "Unexpected token 'AS' : syntax error");
-    }
-
-    Y_UNIT_TEST(CreateViewSecurityInvokerTurnedOff) {
-        NYql::TAstParseResult res = SqlToYql(R"(
-                USE plato;
-                CREATE VIEW TheView WITH (security_invoker = FALSE) AS SELECT 1;
-            )"
-        );
-        UNIT_ASSERT_STRING_CONTAINS(res.Issues.ToString(), "SECURITY_INVOKER option must be explicitly enabled");
-    }
-
     Y_UNIT_TEST(CreateViewFromTable) {
         constexpr const char* path = "/PathPrefix/TheView";
         constexpr const char* query = R"(

--- a/ydb/library/yql/sql/v1/sql_ut_antlr4.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut_antlr4.cpp
@@ -6702,24 +6702,6 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
     }
 
-    Y_UNIT_TEST(CreateViewNoSecurityInvoker) {
-        NYql::TAstParseResult res = SqlToYql(R"(
-                USE plato;
-                CREATE VIEW TheView AS SELECT 1;
-            )"
-        );
-        UNIT_ASSERT_STRING_CONTAINS(res.Issues.ToString(), "mismatched input 'AS' expecting WITH");
-    }
-
-    Y_UNIT_TEST(CreateViewSecurityInvokerTurnedOff) {
-        NYql::TAstParseResult res = SqlToYql(R"(
-                USE plato;
-                CREATE VIEW TheView WITH (security_invoker = FALSE) AS SELECT 1;
-            )"
-        );
-        UNIT_ASSERT_STRING_CONTAINS(res.Issues.ToString(), "SECURITY_INVOKER option must be explicitly enabled");
-    }
-
     Y_UNIT_TEST(CreateViewFromTable) {
         constexpr const char* path = "/PathPrefix/TheView";
         constexpr const char* query = R"(

--- a/ydb/services/metadata/abstract/parsing.h
+++ b/ydb/services/metadata/abstract/parsing.h
@@ -74,8 +74,10 @@ public:
                 NNodes::TCoNameValueTuple tuple = maybeTuple.Cast();
                 if (auto maybeAtom = tuple.Value().template Maybe<NNodes::TCoAtom>()) {
                     Features.emplace(tuple.Name().Value(), maybeAtom.Cast().Value());
-                } else if (auto maybeDataCtor = tuple.Value().template Maybe<NNodes::TCoIntegralCtor>()) {
-                    Features.emplace(tuple.Name().Value(), maybeDataCtor.Cast().Literal().Cast<NNodes::TCoAtom>().Value());
+                } else if (auto maybeInt = tuple.Value().template Maybe<NNodes::TCoIntegralCtor>()) {
+                    Features.emplace(tuple.Name().Value(), maybeInt.Cast().Literal().Cast<NNodes::TCoAtom>().Value());
+                } else if (auto maybeBool = tuple.Value().template Maybe<NNodes::TCoBool>()) {
+                    Features.emplace(tuple.Name().Value(), maybeBool.Cast().Literal().Cast<NNodes::TCoAtom>().Value());
                 }
             }
         }


### PR DESCRIPTION
- https://github.com/ydb-platform/ydb/issues/9616

You can see by the [changes](https://github.com/ydb-platform/ydb/pull/9320/files#diff-da9841af6f1d7080978f07a57e637d20976d93aea22689c60f18d6c5ec10ea65R603) in the YQL grammar that previously `with_table_settings` clause was mandatory for the `CREATE VIEW` statement. It caused a grammar mismatch error whenever a user forgot to add the `WITH (security_invoker = true)` clause. We want the error to be easy to understand, so we made the `with_table_settings`⭐ clause an optional parameter in the grammar (i.e. added a `?` sign after the `with_table_settings` clause) and are [validating](https://github.com/ydb-platform/ydb/pull/9320/files#diff-9f13bac971e91e9e62b415a7a2c33834e46e02d5d79e6282f728f31ee6db3f68R46) the contents of this clause later during compilation of the `CREATE VIEW` statement.

⭐ The other interesting part of the PR is the [change](https://github.com/ydb-platform/ydb/pull/9320/files#diff-da9841af6f1d7080978f07a57e637d20976d93aea22689c60f18d6c5ec10ea65R603) of the `with_table_settings` clause to the `create_object_features` clause in the `create_view_stmt`. I don't remember why I have chosen `with_table_settings` initially, but now it seems an error. (Probably, the reason was that the old `create_object_features` clause couldn't handle `bool` object features. I have [corrected](https://github.com/ydb-platform/ydb/pull/9320/files#diff-da9841af6f1d7080978f07a57e637d20976d93aea22689c60f18d6c5ec10ea65R631) this flaw in this PR too.) All objects can be created with a generic `CREATE OBJECT` statement, so in order to support this scenario for views, we need to use the generic `create_object_features` in the `create_view_stmt`.

Lastly, I have moved the view options [validation](https://github.com/ydb-platform/ydb/pull/9320/files#diff-9f13bac971e91e9e62b415a7a2c33834e46e02d5d79e6282f728f31ee6db3f68R46) to KQP which have [enabled](https://github.com/ydb-platform/ydb/pull/9320/files#diff-e2c215c313c97ee447485bdc905cdf205d9e04896432e030e3b76b8097a2c3d2R271) us to use [named expressions](https://ydb.tech/docs/en/yql/reference/syntax/expressions#named-nodes) for the `security_invoker` option. It would not be possible if the validation stayed in the parser.