### PR TITLE
Improve lock-free bucket: use relaxed memory order, set to min/max in CAS

### DIFF
--- a/ydb/library/lockfree_bucket/lockfree_bucket.h
+++ b/ydb/library/lockfree_bucket/lockfree_bucket.h
@@ -24,7 +24,7 @@ public:
     }
 
     void FillAndTake(ui64 tokens) {
-        TTime prev = LastUpdate.load(std::memory_order_relaxed);
+        TTime prev = LastUpdate.load(std::memory_order_acquire);
         TTime now = TTimer::Now();
         i64 duration = TTimer::Duration(prev, now);
 
@@ -35,13 +35,13 @@ public:
             }
 
             if (LastUpdate.compare_exchange_weak(prev, now,
-                    std::memory_order_relaxed,
-                    std::memory_order_relaxed)) {
+                    std::memory_order_release,
+                    std::memory_order_acquire)) {
                 break;
             }
         }
 
-        i64 currentTokens = Tokens.load(std::memory_order_relaxed);
+        i64 currentTokens = Tokens.load(std::memory_order_acquire);
 
         ui64 rawInflow = InflowPerSecond.load(std::memory_order_relaxed) * duration;
         i64 minTokens = MinTokens.load(std::memory_order_relaxed);
@@ -58,8 +58,8 @@ public:
                 break;
             }
 
-            if (Tokens.compare_exchange_weak(currentTokens, newTokens, std::memory_order_relaxed,
-                    std::memory_order_relaxed)) {
+            if (Tokens.compare_exchange_weak(currentTokens, newTokens, std::memory_order_release,
+                    std::memory_order_acquire)) {
                 break;
             }
         }

--- a/ydb/library/lockfree_bucket/lockfree_bucket.h
+++ b/ydb/library/lockfree_bucket/lockfree_bucket.h
@@ -47,8 +47,11 @@ public:
         Y_DEBUG_ABORT_UNLESS(minTokens <= maxTokens);
 
         while (true) {
-            i64 newTokens = currentTokens - tokens + rawInflow / TTimer::Resolution;
-            newTokens = std::max(std::min(newTokens, maxTokens), minTokens);
+            i64 newTokens = currentTokens + rawInflow / TTimer::Resolution;
+            newTokens = std::min(newTokens, maxTokens);
+            newTokens = newTokens - tokens;
+            newTokens = std::max(newTokens, minTokens);
+
             if (newTokens == currentTokens) {
                 break;
             }

--- a/ydb/library/lockfree_bucket/lockfree_bucket.h
+++ b/ydb/library/lockfree_bucket/lockfree_bucket.h
@@ -26,10 +26,12 @@ public:
     void FillAndTake(ui64 tokens) {
         TTime prev = LastUpdate.load(std::memory_order_relaxed);
         TTime now = TTimer::Now();
+        i64 duration = TTimer::Duration(prev, now);
 
         while (true) {
             if (prev >= now) {
-                return;
+                duration = 0;
+                break;
             }
 
             if (LastUpdate.compare_exchange_weak(prev, now,
@@ -41,7 +43,7 @@ public:
 
         i64 currentTokens = Tokens.load(std::memory_order_relaxed);
 
-        ui64 rawInflow = InflowPerSecond.load(std::memory_order_relaxed) * TTimer::Duration(prev, now);
+        ui64 rawInflow = InflowPerSecond.load(std::memory_order_relaxed) * duration;
         i64 minTokens = MinTokens.load(std::memory_order_relaxed);
         i64 maxTokens = MaxTokens.load(std::memory_order_relaxed);
         Y_DEBUG_ABORT_UNLESS(minTokens <= maxTokens);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Improve lock-free bucket: use relaxed memory order, set to min/max in CAS

### Changelog category <!-- remove all except one -->

* Improvement
* Performance improvement

### Additional information

...
