### PR TITLE
24-3: Limit inflight cross-database scheme requests in the replication controller

### DIFF
--- a/ydb/core/protos/replication.proto
+++ b/ydb/core/protos/replication.proto
@@ -6,7 +6,13 @@ package NKikimrReplication;
 option java_package = "ru.yandex.kikimr.proto";
 
 message TReplicationDefaults {
+    message TSchemeOperationLimits {
+        optional uint32 InflightCreateStreamLimit = 1 [default = 1];
+        optional uint32 InflightDropStreamLimit = 2 [default = 1];
+    }
+
     optional int32 RetentionPeriodSeconds = 1 [default = 86400]; // 1d
+    optional TSchemeOperationLimits SchemeOperationLimits = 2;
 }
 
 message TStaticCredentials {

--- a/ydb/core/tx/replication/controller/controller.cpp
+++ b/ydb/core/tx/replication/controller/controller.cpp
@@ -1,6 +1,7 @@
 #include "controller.h"
 #include "controller_impl.h"
 
+#include <ydb/core/base/appdata.h>
 #include <ydb/core/discovery/discovery.h>
 #include <ydb/core/engine/minikql/flat_local_tx_factory.h>
 
@@ -60,6 +61,8 @@ STFUNC(TController::StateWork) {
         HFunc(TEvPrivate::TEvProcessQueues, Handle);
         HFunc(TEvPrivate::TEvRemoveWorker, Handle);
         HFunc(TEvPrivate::TEvDescribeTargetsResult, Handle);
+        HFunc(TEvPrivate::TEvRequestCreateStream, Handle);
+        HFunc(TEvPrivate::TEvRequestDropStream, Handle);
         HFunc(TEvDiscovery::TEvDiscoveryData, Handle);
         HFunc(TEvDiscovery::TEvError, Handle);
         HFunc(TEvService::TEvStatus, Handle);
@@ -148,13 +151,53 @@ void TController::Handle(TEvPrivate::TEvAssignStreamName::TPtr& ev, const TActor
     RunTxAssignStreamName(ev, ctx);
 }
 
+template <typename TEvent>
+void ProcessLimiterQueue(TDeque<TActorId>& requested, THashSet<TActorId>& inflight, ui32 limit, const TActorContext& ctx) {
+    while (!requested.empty() && inflight.size() < limit) {
+        const auto& actorId = requested.front();
+        ctx.Send(actorId, new TEvent());
+        inflight.insert(actorId);
+        requested.pop_front();
+    }
+}
+
+void TController::ProcessCreateStreamQueue(const TActorContext& ctx) {
+    const auto& limits = AppData()->ReplicationConfig.GetSchemeOperationLimits();
+    ProcessLimiterQueue<TEvPrivate::TEvAllowCreateStream>(RequestedCreateStream, InflightCreateStream, limits.GetInflightCreateStreamLimit(), ctx);
+}
+
+void TController::ProcessDropStreamQueue(const TActorContext& ctx) {
+    const auto& limits = AppData()->ReplicationConfig.GetSchemeOperationLimits();
+    ProcessLimiterQueue<TEvPrivate::TEvAllowDropStream>(RequestedDropStream, InflightDropStream, limits.GetInflightDropStreamLimit(), ctx);
+}
+
+void TController::Handle(TEvPrivate::TEvRequestCreateStream::TPtr& ev, const TActorContext& ctx) {
+    CLOG_T(ctx, "Handle " << ev->Get()->ToString());
+
+    RequestedCreateStream.push_back(ev->Sender);
+    ProcessCreateStreamQueue(ctx);
+}
+
 void TController::Handle(TEvPrivate::TEvCreateStreamResult::TPtr& ev, const TActorContext& ctx) {
     CLOG_T(ctx, "Handle " << ev->Get()->ToString());
+
+    InflightCreateStream.erase(ev->Sender);
+    ProcessCreateStreamQueue(ctx);
     RunTxCreateStreamResult(ev, ctx);
+}
+
+void TController::Handle(TEvPrivate::TEvRequestDropStream::TPtr& ev, const TActorContext& ctx) {
+    CLOG_T(ctx, "Handle " << ev->Get()->ToString());
+
+    RequestedDropStream.push_back(ev->Sender);
+    ProcessDropStreamQueue(ctx);
 }
 
 void TController::Handle(TEvPrivate::TEvDropStreamResult::TPtr& ev, const TActorContext& ctx) {
     CLOG_T(ctx, "Handle " << ev->Get()->ToString());
+
+    InflightDropStream.erase(ev->Sender);
+    ProcessDropStreamQueue(ctx);
     RunTxDropStreamResult(ev, ctx);
 }
 

--- a/ydb/core/tx/replication/controller/controller_impl.h
+++ b/ydb/core/tx/replication/controller/controller_impl.h
@@ -17,6 +17,7 @@
 #include <ydb/library/actors/core/interconnect.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
 
+#include <util/generic/deque.h>
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
 
@@ -83,6 +84,8 @@ private:
     void Handle(TEvPrivate::TEvProcessQueues::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvRemoveWorker::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvDescribeTargetsResult::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvRequestCreateStream::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvRequestDropStream::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDiscovery::TEvDiscoveryData::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDiscovery::TEvError::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvService::TEvStatus::TPtr& ev, const TActorContext& ctx);
@@ -103,6 +106,8 @@ private:
     void RemoveWorker(const TWorkerId& id, const TActorContext& ctx);
     bool MaybeRemoveWorker(const TWorkerId& id, const TActorContext& ctx);
     void UpdateLag(const TWorkerId& id, TDuration lag);
+    void ProcessCreateStreamQueue(const TActorContext& ctx);
+    void ProcessDropStreamQueue(const TActorContext& ctx);
 
     // local transactions
     class TTxInitSchema;
@@ -177,6 +182,13 @@ private:
 
     bool ProcessQueuesScheduled = false;
     static constexpr ui32 ProcessBatchLimit = 100;
+
+    // create stream limiter
+    TDeque<TActorId> RequestedCreateStream;
+    THashSet<TActorId> InflightCreateStream;
+    // drop stream limiter
+    TDeque<TActorId> RequestedDropStream;
+    THashSet<TActorId> InflightDropStream;
 
 }; // TController
 

--- a/ydb/core/tx/replication/controller/private_events.h
+++ b/ydb/core/tx/replication/controller/private_events.h
@@ -32,6 +32,10 @@ struct TEvPrivate {
         EvAlterDstResult,
         EvRemoveWorker,
         EvDescribeTargetsResult,
+        EvRequestCreateStream,
+        EvAllowCreateStream,
+        EvRequestDropStream,
+        EvAllowDropStream,
 
         EvEnd,
     };
@@ -219,6 +223,18 @@ struct TEvPrivate {
 
         explicit TEvDescribeTargetsResult(const TActorId& sender, ui64 rid, TResult&& result);
         TString ToString() const override;
+    };
+
+    struct TEvRequestCreateStream: public TEventLocal<TEvRequestCreateStream, EvRequestCreateStream> {
+    };
+
+    struct TEvAllowCreateStream: public TEventLocal<TEvAllowCreateStream, EvAllowCreateStream> {
+    };
+
+    struct TEvRequestDropStream: public TEventLocal<TEvRequestDropStream, EvRequestDropStream> {
+    };
+
+    struct TEvAllowDropStream: public TEventLocal<TEvAllowDropStream, EvAllowDropStream> {
     };
 
 }; // TEvPrivate


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Limit inflight cross-database scheme requests in the replication controller.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
