### PR TITLE
Support Fetch and Replace operations for storage_config.yaml

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
@@ -1,6 +1,9 @@
 #include "distconf.h"
 #include "node_warden_impl.h"
 
+#include <ydb/library/yaml_config/yaml_config_parser.h>
+#include <library/cpp/streams/zstd/zstd.h>
+
 namespace NKikimr::NStorage {
 
     class TDistributedConfigKeeper::TInvokeRequestHandlerActor : public TActorBootstrapped<TInvokeRequestHandlerActor> {
@@ -146,6 +149,12 @@ namespace NKikimr::NStorage {
 
                 case TQuery::kAdvanceGeneration:
                     return AdvanceGeneration();
+
+                case TQuery::kFetchStorageConfig:
+                    return FetchStorageConfig();
+
+                case TQuery::kReplaceStorageConfig:
+                    return ReplaceStorageConfig(record.GetReplaceStorageConfig().GetYAML());
 
                 case TQuery::REQUEST_NOT_SET:
                     return FinishWithError(TResult::ERROR, "Request field not set");
@@ -596,6 +605,54 @@ namespace NKikimr::NStorage {
             F(StateStorage)
             F(StateStorageBoard)
             F(SchemeBoard)
+
+            config.SetGeneration(config.GetGeneration() + 1);
+            StartProposition(&config);
+        }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Storage configuration YAML manipulation
+
+        void FetchStorageConfig() {
+            if (!Self->StorageConfig) {
+                FinishWithError(TResult::ERROR, "no agreed StorageConfig");
+            } else if (!Self->StorageConfig->HasStorageConfigCompressedYAML()) {
+                FinishWithError(TResult::ERROR, "no stored YAML for storage config");
+            } else {
+                auto ev = PrepareResult(TResult::OK, std::nullopt);
+                auto *record = &ev->Record;
+                TStringInput ss(Self->StorageConfig->GetStorageConfigCompressedYAML());
+                record->MutableFetchStorageConfig()->SetYAML(TZstdDecompress(&ss).ReadAll());
+                Finish(Sender, SelfId(), ev.release(), 0, Cookie);
+            }
+        }
+
+        void ReplaceStorageConfig(const TString& yaml) {
+            if (!RunCommonChecks()) {
+                return;
+            }
+
+            NKikimrConfig::TAppConfig appConfig;
+            try {
+                appConfig = NKikimr::NYaml::Parse(yaml);
+            } catch (const std::exception& ex) {
+                return FinishWithError(TResult::ERROR, TStringBuilder() << "exception while parsing YAML: " << ex.what());
+            }
+
+            TString errorReason;
+            NKikimrBlobStorage::TStorageConfig config(*Self->StorageConfig);
+            const bool success = DeriveStorageConfig(appConfig, &config, &errorReason);
+            if (!success) {
+                return FinishWithError(TResult::ERROR, TStringBuilder() << "error while deriving StorageConfig: "
+                    << errorReason);
+            }
+
+            TStringStream ss;
+            {
+                TZstdCompress zstd(&ss);
+                zstd << yaml;
+            }
+            config.SetStorageConfigCompressedYAML(ss.Str());
 
             config.SetGeneration(config.GetGeneration() + 1);
             StartProposition(&config);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -1,4 +1,5 @@
 #include "node_warden_impl.h"
+#include "distconf.h"
 
 #include <ydb/core/blobstorage/crypto/secured_block.h>
 #include <ydb/core/blobstorage/dsproxy/dsproxy_request_reporting.h>
@@ -232,20 +233,13 @@ void TNodeWarden::Bootstrap() {
     // determine if we are running in 'mock' mode
     EnableProxyMock = Cfg->BlobStorageConfig.GetServiceSet().GetEnableProxyMock();
 
-    // fill in a storage config
-    StorageConfig.MutableBlobStorageConfig()->CopyFrom(Cfg->BlobStorageConfig);
-    for (const auto& node : Cfg->NameserviceConfig.GetNode()) {
-        auto *r = StorageConfig.AddAllNodes();
-        r->SetHost(node.GetInterconnectHost());
-        r->SetPort(node.GetPort());
-        r->SetNodeId(node.GetNodeId());
-        if (node.HasLocation()) {
-            r->MutableLocation()->CopyFrom(node.GetLocation());
-        } else if (node.HasWalleLocation()) {
-            r->MutableLocation()->CopyFrom(node.GetWalleLocation());
-        }
-    }
-    StorageConfig.SetClusterUUID(Cfg->NameserviceConfig.GetClusterUUID());
+    // fill in a base storage config (from the file)
+    NKikimrConfig::TAppConfig appConfig;
+    appConfig.MutableBlobStorageConfig()->CopyFrom(Cfg->BlobStorageConfig);
+    appConfig.MutableNameserviceConfig()->CopyFrom(Cfg->NameserviceConfig);
+    TString errorReason;
+    const bool success = DeriveStorageConfig(appConfig, &StorageConfig, &errorReason);
+    Y_VERIFY_S(success, "failed to generate initial TStorageConfig: " << errorReason);
 
     // Start a statically configured set
     if (Cfg->BlobStorageConfig.HasServiceSet()) {
@@ -831,6 +825,175 @@ bool NKikimr::ObtainPDiskKey(NPDisk::TMainKey *mainKey, const NKikimrProto::TKey
     return true;
 }
 
+bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& appConfig,
+        NKikimrBlobStorage::TStorageConfig *config, TString *errorReason) {
+    // copy blob storage config
+    if (!appConfig.HasBlobStorageConfig()) {
+        *errorReason = "original config missing mandatory BlobStorageConfig section";
+        return false;
+    }
+    
+    const auto& bsFrom = appConfig.GetBlobStorageConfig();
+    auto *bsTo = config->MutableBlobStorageConfig();
+    if (bsFrom.HasAutoconfigSettings()) {
+        const auto& acFrom = bsFrom.GetAutoconfigSettings();
+        auto *acTo = bsTo->MutableAutoconfigSettings();
+        if (acFrom.HasGeneration() && acTo->HasGeneration() && acTo->GetGeneration() + 1 != acFrom.GetGeneration()) {
+            *errorReason = TStringBuilder() << "generation mismatch for AutoconfigSettings section existing Generation# "
+                << acTo->GetGeneration() << " newly provided Generation# " << acFrom.GetGeneration();
+            return false;
+        } else if (acTo->HasGeneration() && !acFrom.HasGeneration()) {
+            *errorReason = "existing AutoconfigSettings has set generation, but newly provided one doesn't have it";
+            return false;
+        }
+
+        acTo->CopyFrom(acFrom);
+    } else {
+        bsTo->ClearAutoconfigSettings();
+    }
+
+    if (bsFrom.HasServiceSet()) {
+        const auto& ssFrom = bsFrom.GetServiceSet();
+        auto *ssTo = bsTo->MutableServiceSet();
+
+        ssTo->MutableAvailabilityDomains()->CopyFrom(ssFrom.GetAvailabilityDomains());
+        if (ssFrom.HasReplBrokerConfig()) {
+            ssTo->MutableReplBrokerConfig()->CopyFrom(ssFrom.GetReplBrokerConfig());
+        }
+        if (!ssTo->PDisksSize() && !ssTo->VDisksSize() && !ssTo->GroupsSize()) {
+            ssTo->MutablePDisks()->CopyFrom(ssFrom.GetPDisks());
+            ssTo->MutableVDisks()->CopyFrom(ssFrom.GetVDisks());
+            ssTo->MutableGroups()->CopyFrom(ssFrom.GetGroups());
+        } else {
+            NProtoBuf::util::MessageDifferencer differ;
+
+            auto error = [&](auto&& key, const char *error) {
+                *errorReason = TStringBuilder() << key() << ' ' << error;
+                return false;
+            };
+
+            auto pdiskKey = [](const auto *item) {
+                return TStringBuilder() << "PDisk NodeId# " << item->GetNodeID() << " PDiskId# " << item->GetPDiskID();
+            };
+
+            auto vdiskKey = [](const auto *item) {
+                return TStringBuilder() << "VDisk NodeId# " << item->GetNodeID() << " PDiskId# " << item->GetPDiskID()
+                    << " VDiskSlotId# " << item->GetVDiskSlotID();
+            };
+
+            auto groupKey = [](const auto *item) {
+                return TStringBuilder() << "group GroupId# " << item->GetGroupID();
+            };
+
+            auto duplicateKey = [&](auto&& key) { return error(std::move(key), "duplicate key in existing StorageConfig"); };
+            auto removed = [&](auto&& key) { return error(std::move(key), "was removed from BlobStorageConfig of newly provided configuration"); };
+            auto mismatch = [&](auto&& key) { return error(std::move(key), "configuration item mismatch"); };
+
+            THashMap<std::tuple<ui32, ui32>, const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk*> pdiskMap;
+            for (const auto& item : ssTo->GetPDisks()) {
+                if (const auto [it, inserted] = pdiskMap.emplace(std::make_tuple(item.GetNodeID(), item.GetPDiskID()),
+                        &item); !inserted) {
+                    return duplicateKey(std::bind(pdiskKey, &item));
+                }
+            }
+            for (const auto& item : ssFrom.GetPDisks()) {
+                if (const auto it = pdiskMap.find(std::make_tuple(item.GetNodeID(), item.GetPDiskID())); it == pdiskMap.end()) {
+                    return removed(std::bind(pdiskKey, &item));
+                } else if (!differ.Equals(item, *it->second)) {
+                    return mismatch(std::bind(pdiskKey, &item));
+                } else {
+                    pdiskMap.erase(it);
+                }
+            }
+            if (!pdiskMap.empty()) {
+                *errorReason = "some PDisks were added in newly provided configuration";
+                return false;
+            }
+
+            THashMap<std::tuple<ui32, ui32, ui32>, const NKikimrBlobStorage::TNodeWardenServiceSet::TVDisk*> vdiskMap;
+            for (const auto& item : ssTo->GetVDisks()) {
+                if (!item.HasVDiskLocation()) {
+                    *errorReason = "VDisk in existing StorageConfig doesn't have VDiskLocation field set";
+                    return false;
+                }
+                const auto& loc = item.GetVDiskLocation();
+                if (const auto [it, inserted] = vdiskMap.emplace(std::make_tuple(loc.GetNodeID(), loc.GetPDiskID(),
+                        loc.GetVDiskSlotID()), &item); !inserted) {
+                    return duplicateKey(std::bind(vdiskKey, &loc));
+                }
+            }
+            for (const auto& item : ssFrom.GetVDisks()) {
+                if (!item.HasVDiskLocation()) {
+                    *errorReason = "VDisk in newly provided configuration doesn't have VDiskLocation field set";
+                    return false;
+                }
+                const auto& loc = item.GetVDiskLocation();
+                if (const auto it = vdiskMap.find(std::make_tuple(loc.GetNodeID(), loc.GetPDiskID(),
+                        loc.GetVDiskSlotID())); it == vdiskMap.end()) {
+                    return removed(std::bind(vdiskKey, &loc));
+                } else if (!differ.Equals(item, *it->second)) {
+                    return mismatch(std::bind(vdiskKey, &loc));
+                } else {
+                    vdiskMap.erase(it);
+                }
+            }
+            if (!vdiskMap.empty()) {
+                *errorReason = "some VDisks were added in newly provided configuration";
+                return false;
+            }
+
+            THashMap<ui32, const NKikimrBlobStorage::TGroupInfo*> groupMap;
+            for (const auto& item : ssTo->GetGroups()) {
+                if (const auto [it, inserted] = groupMap.emplace(item.GetGroupID(), &item); !inserted) {
+                    return duplicateKey(std::bind(groupKey, &item));
+                }
+            }
+            for (const auto& item : ssFrom.GetGroups()) {
+                if (const auto it = groupMap.find(item.GetGroupID()); it == groupMap.end()) {
+                    return removed(std::bind(groupKey, &item));
+                } else if (!differ.Equals(item, *it->second)) {
+                    return mismatch(std::bind(groupKey, &item));
+                } else {
+                    groupMap.erase(it);
+                }
+            }
+            if (!groupMap.empty()) {
+                *errorReason = "some groups were added in newly provided configuration";
+                return false;
+            }
+        }
+    }
+
+    // copy nameservice-related things
+    if (!appConfig.HasNameserviceConfig()) {
+        *errorReason = "origin config missing mandatory NameserviceConfig section";
+        return false;
+    }
+
+    const auto& nsFrom = appConfig.GetNameserviceConfig();
+    auto *nodes = config->MutableAllNodes();
+
+    // just copy AllNodes from TAppConfig into TStorageConfig
+    nodes->Clear();
+    for (const auto& node : nsFrom.GetNode()) {
+        auto *r = nodes->Add();
+        r->SetHost(node.GetInterconnectHost());
+        r->SetPort(node.GetPort());
+        r->SetNodeId(node.GetNodeId());
+        if (node.HasLocation()) {
+            r->MutableLocation()->CopyFrom(node.GetLocation());
+        } else if (node.HasWalleLocation()) {
+            r->MutableLocation()->CopyFrom(node.GetWalleLocation());
+        }
+    }
+
+    // and copy ClusterUUID from there too
+    config->SetClusterUUID(nsFrom.GetClusterUUID());
+
+    // TODO(alexvru): apply SS, SSB, SB configs from there too
+
+    return true;
+}
 
 bool NKikimr::ObtainStaticKey(TEncryptionKey *key) {
     // TODO(cthulhu): Replace this with real data

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -718,6 +718,9 @@ namespace NKikimr::NStorage {
         }
     };
 
+    bool DeriveStorageConfig(const NKikimrConfig::TAppConfig& appConfig, NKikimrBlobStorage::TStorageConfig *config,
+        TString *errorReason);
+
 }
 
 template<>

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -42,6 +42,7 @@ PEERDIR(
     ydb/core/blobstorage/pdisk
     ydb/core/control
     ydb/library/pdisk_io
+    ydb/library/yaml_config
 )
 
 END()

--- a/ydb/core/mind/dynamic_nameserver.h
+++ b/ydb/core/mind/dynamic_nameserver.h
@@ -11,6 +11,10 @@ namespace NKikimrConfig {
     class TStaticNameserviceConfig;
 } // NKikimrConfig
 
+namespace NKikimrBlobStorage {
+    class TStorageConfig;
+} // NKikimrBlobStorage
+
 namespace NKikimr {
 namespace NNodeBroker {
 
@@ -25,6 +29,7 @@ IActor *CreateDynamicNameserver(const TIntrusivePtr<TTableNameserverSetup> &setu
                                 ui32 poolId = 0);
 
 TIntrusivePtr<TTableNameserverSetup> BuildNameserverTable(const NKikimrConfig::TStaticNameserviceConfig& nsConfig);
+TIntrusivePtr<TTableNameserverSetup> BuildNameserverTable(const NKikimrBlobStorage::TStorageConfig& config);
 
 } // NNodeBroker
 } // NKikimr

--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -10,6 +10,7 @@
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/cms/console/configs_dispatcher.h>
 #include <ydb/core/cms/console/console.h>
+#include <ydb/core/blobstorage/base/blobstorage_events.h>
 
 #include <ydb/library/services/services.pb.h>
 #include <ydb/library/actors/core/hfunc.h>
@@ -213,10 +214,13 @@ public:
 
             hFunc(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse, Handle);
             hFunc(NConsole::TEvConsole::TEvConfigNotificationRequest, Handle);
+
+            hFunc(TEvNodeWardenStorageConfig, Handle);
         }
     }
 
     void Bootstrap(const TActorContext &ctx);
+    void Handle(TEvNodeWardenStorageConfig::TPtr ev);
     void Die(const TActorContext &ctx) override;
 
 private:
@@ -262,6 +266,7 @@ private:
     THashMap<ui32, ui64> EpochUpdates;
     ui32 ResolvePoolId;
     THashSet<TActorId> StaticNodeChangeSubscribers;
+    bool SubscribedToConsole = false;
 };
 
 } // NNodeBroker

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -29,6 +29,7 @@ message TStorageConfig { // contents of storage metadata
     string ClusterUUID = 6; // cluster GUID as provided in nameservice config
     string SelfAssemblyUUID = 7; // self-assembly UUID generated when config is first created
     TStorageConfig PrevConfig = 8; // previous version of StorageConfig (if any)
+    optional bytes StorageConfigCompressedYAML = 12; // compressed stored storage config YAML (if stored)
 }
 
 message TPDiskMetadataRecord {
@@ -187,6 +188,13 @@ message TEvNodeConfigInvokeOnRoot {
     message TAdvanceGeneration
     {}
 
+    message TFetchStorageConfig
+    {}
+
+    message TReplaceStorageConfig {
+        string YAML = 1;
+    }
+
     oneof Request {
         TUpdateConfig UpdateConfig = 1;
         TQueryConfig QueryConfig = 2;
@@ -195,6 +203,8 @@ message TEvNodeConfigInvokeOnRoot {
         TDropDonor DropDonor = 5;
         TReassignStateStorageNode ReassignStateStorageNode = 6;
         TAdvanceGeneration AdvanceGeneration = 7;
+        TFetchStorageConfig FetchStorageConfig = 8;
+        TReplaceStorageConfig ReplaceStorageConfig = 9;
     }
 }
 
@@ -217,6 +227,10 @@ message TEvNodeConfigInvokeOnRootResult {
         TStorageConfig CurrentProposedStorageConfig = 2;
     }
 
+    message TFetchStorageConfig {
+        string YAML = 1;
+    }
+
     EStatus Status = 1;
     optional string ErrorReason = 2;
     TScepter Scepter = 3;
@@ -225,6 +239,7 @@ message TEvNodeConfigInvokeOnRootResult {
 
     oneof Response {
         TQueryConfig QueryConfig = 5;
+        TFetchStorageConfig FetchStorageConfig = 10;
     }
 }
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -290,6 +290,9 @@ message TBlobStorageConfig {
         // filled in by config parser, not by user; required for automatic static group creation
         repeated NKikimrBlobStorage.TDefineHostConfig DefineHostConfig = 5;
         optional NKikimrBlobStorage.TDefineBox DefineBox = 6;
+
+        // generation of the distconf section; when set, one can automatically apply in-filesystem config
+        optional uint64 Generation = 8;
     }
 
     optional TAutoconfigSettings AutoconfigSettings = 6;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support Fetch and Replace operations for storage_config.yaml

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Distconf now supports special query through InvokeOnRoot that allows to replace existing storage config, or fetch it.
