### PR TITLE
The `DescripeTopic` call with the `IncludeStats` flag freezes (#9392)

### DIFF
--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -1511,9 +1511,10 @@ void TPersQueue::Handle(TEvPQ::TEvInitComplete::TPtr& ev, const TActorContext& c
                                               ctx);
         }
         partition.PendingRequests.clear();
+    } else {
+        ++PartitionsInited;
     }
 
-    ++PartitionsInited;
     Y_ABORT_UNLESS(ConfigInited);//partitions are inited only after config
 
     auto allInitialized = AllOriginalPartitionsInited();
@@ -1914,11 +1915,17 @@ void TPersQueue::ProcessStatusRequests(const TActorContext &ctx) {
 
 void TPersQueue::Handle(TEvPersQueue::TEvStatus::TPtr& ev, const TActorContext& ctx)
 {
+    PQ_LOG_D("Handle TEvPersQueue::TEvStatus");
+
     ReadBalancerActorId = ev->Sender;
 
     if (!ConfigInited || !AllOriginalPartitionsInited()) {
-      StatusRequests.push_back(ev);
-      return;
+        PQ_LOG_D("Postpone the request." <<
+                 " ConfigInited " << static_cast<int>(ConfigInited) <<
+                 ", PartitionsInited " << PartitionsInited <<
+                 ", OriginalPartitionsCount " << OriginalPartitionsCount);
+        StatusRequests.push_back(ev);
+        return;
     }
 
     ui32 cnt = 0;

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -60,6 +60,7 @@ protected:
                      const TString& consumer = TEST_CONSUMER,
                      size_t partitionCount = 1,
                      std::optional<size_t> maxPartitionCount = std::nullopt);
+    void DescribeTopic(const TString& path);
 
     void WriteToTopicWithInvalidTxId(bool invalidTxId);
 
@@ -320,6 +321,11 @@ void TFixture::CreateTopic(const TString& path,
 
 {
     Setup->CreateTopic(path, consumer, partitionCount, maxPartitionCount);
+}
+
+void TFixture::DescribeTopic(const TString& path)
+{
+    Setup->DescribeTopic(path);
 }
 
 const TDriver& TFixture::GetDriver() const
@@ -1106,6 +1112,8 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_6, TFixture)
         UNIT_ASSERT_VALUES_EQUAL(messages[0], "message #1");
         UNIT_ASSERT_VALUES_EQUAL(messages[1], "message #2");
     }
+
+    DescribeTopic("topic_A");
 }
 
 Y_UNIT_TEST_F(WriteToTopic_Demo_7, TFixture)

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.cpp
@@ -52,6 +52,18 @@ void TTopicSdkTestSetup::CreateTopic(const TString& path, const TString& consume
     Server.WaitInit(path);
 }
 
+void TTopicSdkTestSetup::DescribeTopic(const TString& path)
+{
+    TTopicClient client(MakeDriver());
+
+    TDescribeTopicSettings settings;
+    settings.IncludeStats(true);
+    settings.IncludeLocation(true);
+
+    auto status = client.DescribeTopic(path, settings).GetValueSync();
+    UNIT_ASSERT(status.IsSuccess());
+}
+
 TString TTopicSdkTestSetup::GetEndpoint() const {
     return "localhost:" + ToString(Server.GrpcPort);
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.h
@@ -21,6 +21,8 @@ public:
     void CreateTopicWithAutoscale(const TString& path = TEST_TOPIC, const TString& consumer = TEST_CONSUMER, size_t partitionCount = 1,
                      size_t maxPartitionCount = 100);
 
+    void DescribeTopic(const TString& path = TEST_TOPIC);
+
     TString GetEndpoint() const;
     TString GetTopicPath(const TString& name = TEST_TOPIC) const;
     TString GetTopicParent() const;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The value of `PartitionsInited` changed for all partitions. As a result, after the first entry in the transaction, the `DescripeTopic` operation hung with the `IncludeStats` flag.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
