### PR TITLE
The `--supported-codecs` option for the `topic create` and `topic consumer add` commands

### DIFF
--- a/ydb/apps/ydb/ut/supported_codecs.cpp
+++ b/ydb/apps/ydb/ut/supported_codecs.cpp
@@ -5,7 +5,7 @@ Y_UNIT_TEST_SUITE(YdbTopic) {
 
 Y_UNIT_TEST_F(SupportedCodecs_TopicCreate_DefaultValue, TSupportedCodecsFixture)
 {
-    TestTopicCreate(GetTopicName(), {}, {"RAW"});
+    TestTopicCreate(GetTopicName(), {}, {});
 }
 
 Y_UNIT_TEST_F(SupportedCodecs_TopicCreate_UserValue, TSupportedCodecsFixture)
@@ -19,7 +19,7 @@ Y_UNIT_TEST_F(SupportedCodecs_TopicAlter, TSupportedCodecsFixture)
 
     YdbTopicCreate(topicName);
 
-    TestTopicAlter(topicName, {}, {"RAW"});
+    TestTopicAlter(topicName, {}, {});
     TestTopicAlter(topicName, {"GZIP", "ZSTD"}, {"GZIP", "ZSTD"});
     TestTopicAlter(topicName, {}, {"GZIP", "ZSTD"});
 }
@@ -31,7 +31,7 @@ Y_UNIT_TEST_F(SupportedCodecs_TopicConsumerAdd_DefaultValue, TSupportedCodecsFix
 
     YdbTopicCreate(topicName);
 
-    TestTopicConsumerAdd(topicName, consumerName, {}, {"RAW"});
+    TestTopicConsumerAdd(topicName, consumerName, {}, {});
 }
 
 Y_UNIT_TEST_F(SupportedCodecs_TopicConsumerAdd_UserValue, TSupportedCodecsFixture)

--- a/ydb/apps/ydb/ut/supported_codecs_fixture.cpp
+++ b/ydb/apps/ydb/ut/supported_codecs_fixture.cpp
@@ -209,7 +209,9 @@ auto TSupportedCodecsFixture::GetTopicConsumerSupportedCodecs(const TString& des
                 TVector<TString> codecs;
                 Split(fields[1], ",", codecs);
                 for (auto& codec : codecs) {
-                    result.insert(Strip(codec));
+                    if (auto c = Strip(codec); !c.empty()) {
+                        result.insert(c);
+                    }
                 }
 
                 return result;

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -895,7 +895,6 @@ namespace {
         TString description = PrepareAllowedCodecsDescription("Client-side compression algorithm. When read, data will be uncompressed transparently with a codec used on write", allowedCodecs);
         config.Opts->AddLongOption("codec", description)
             .Optional()
-            .DefaultValue((TStringBuilder() << NTopic::ECodec::RAW))
             .StoreResult(&CodecStr_);
         AllowedCodecs_ = allowedCodecs;
     }
@@ -908,7 +907,7 @@ namespace {
         Codec_ = ::NYdb::NConsoleClient::ParseCodec(CodecStr_, AllowedCodecs_);
     }
 
-    NTopic::ECodec TCommandWithCodec::GetCodec() const {
+    TMaybe<NTopic::ECodec> TCommandWithCodec::GetCodec() const {
         return Codec_;
     }
 
@@ -958,7 +957,9 @@ namespace {
 
     NTopic::TWriteSessionSettings TCommandTopicWrite::PrepareWriteSessionSettings() {
         NTopic::TWriteSessionSettings settings;
-        settings.Codec(GetCodec());
+        if (auto codec = GetCodec(); codec.Defined()) {
+            settings.Codec(*codec);
+        }
         settings.Path(TopicName);
 
         if (!MessageGroupId_.Defined()) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -337,10 +337,9 @@ namespace {
         settings.PartitionWriteSpeedBytesPerSecond(PartitionWriteSpeedKbps_ * 1_KB);
 
         auto codecs = GetCodecs();
-        if (codecs.empty()) {
-            codecs.push_back(NTopic::ECodec::RAW);
+        if (!codecs.empty()) {
+            settings.SetSupportedCodecs(codecs);
         }
-        settings.SetSupportedCodecs(codecs);
 
         if (GetMeteringMode() != NTopic::EMeteringMode::Unspecified) {
             settings.MeteringMode(GetMeteringMode());
@@ -546,11 +545,10 @@ namespace {
             consumerSettings.ReadFrom(TInstant::Seconds(*StartingMessageTimestamp_));
         }
 
-        TVector<NTopic::ECodec> codecs = GetCodecs();
-        if (codecs.empty()) {
-            codecs.push_back(NTopic::ECodec::RAW);
+        auto codecs = GetCodecs();
+        if (!codecs.empty()) {
+            consumerSettings.SetSupportedCodecs(codecs);
         }
-        consumerSettings.SetSupportedCodecs(codecs);
         consumerSettings.SetImportant(IsImportant_);
 
         readRuleSettings.AppendAddConsumers(consumerSettings);

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.h
@@ -225,12 +225,12 @@ namespace NYdb::NConsoleClient {
     protected:
         void AddAllowedCodecs(TClientCommand::TConfig& config, const TVector<NTopic::ECodec>& allowedCodecs);
         void ParseCodec();
-        NTopic::ECodec GetCodec() const;
+        TMaybe<NTopic::ECodec> GetCodec() const;
 
     private:
         TVector<NTopic::ECodec> AllowedCodecs_;
         TString CodecStr_;
-        NTopic::ECodec Codec_ = NTopic::ECodec::RAW;
+        TMaybe<NTopic::ECodec> Codec_;
     };
 
     class TCommandTopicWrite: public TYdbCommand,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

When creating a topic or a consumer, if the user does not specify the `--supported-codecs` option, then the `Codecs__` field remains empty.

When writing to the topic, if the user does not specify the `--codec` option, the default value for the `Codec_` field is used.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
