### PR TITLE
Forbid scheme ops on backup table

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -524,8 +524,10 @@ public:
                 .IsTable()
                 .NotUnderOperation();
 
-            if (!Transaction.GetInternal()) {
-                checks.NotAsyncReplicaTable();
+            if (checks && !Transaction.GetInternal()) {
+                checks
+                    .NotAsyncReplicaTable()
+                    .NotBackupTable();
             }
 
             if (!context.IsAllowedPrivateTables) {
@@ -724,6 +726,10 @@ TVector<ISubOperation::TPtr> CreateConsistentAlterTable(TOperationId id, const T
     }
 
     if (path.IsCommonSensePath()) {
+        return {CreateAlterTable(id, tx)};
+    }
+
+    if (path.IsBackupTable()) {
         return {CreateAlterTable(id, tx)};
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
@@ -131,6 +131,7 @@ public:
                 .IsResolved()
                 .NotDeleted()
                 .IsTable()
+                .NotBackupTable()
                 .NotAsyncReplicaTable()
                 .NotUnderDeleting();
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
@@ -139,7 +139,8 @@ public:
                 .NotDeleted()
                 .NotUnderDeleting()
                 .IsCommonSensePath()
-                .IsTable();
+                .IsTable()
+                .NotBackupTable();
 
             if (!internal) {
                 checks.NotAsyncReplicaTable();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
@@ -393,6 +393,7 @@ public:
 
             if (checks) {
                 if (parentPath->IsTable()) {
+                    checks.NotBackupTable();
                     // allow immediately inside a normal table
                     if (parentPath.IsUnderOperation()) {
                         checks.IsUnderTheSameOperation(OperationId.GetTxId()); // allowed only as part of consistent operations

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -3597,6 +3597,35 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
             NLs::IsBackupTable(true),
         });
 
+        // cannot alter backup table
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "CopyTable"
+            DropColumns { Name: "value" }
+        )", {NKikimrScheme::StatusSchemeError});
+
+        // cannot add cdc stream to backup table
+        TestCreateCdcStream(runtime, ++txId, "/MyRoot", R"(
+            TableName: "CopyTable"
+            StreamDescription {
+              Name: "Stream"
+              Mode: ECdcStreamModeKeysOnly
+              Format: ECdcStreamFormatProto
+            }
+        )", {NKikimrScheme::StatusSchemeError});
+
+        // cannot add sequence to backup table
+        TestCreateSequence(runtime, ++txId, "/MyRoot/CopyTable", R"(
+            Name: "Sequence"
+        )", {NKikimrScheme::StatusSchemeError});
+
+        // cannot add index to backup table
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/CopyTable", "Index", {"value"});
+        env.TestWaitNotification(runtime, txId);
+        {
+            auto desc = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", txId);
+            UNIT_ASSERT_EQUAL(desc.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_REJECTED);
+        }
+
         // consistent copy table
         TestConsistentCopyTables(runtime, ++txId, "/", R"(
             CopyTableDescriptions {
@@ -3735,16 +3764,18 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
         )", {NKikimrScheme::StatusInvalidParameter});
 
         // cannot remove 'IsBackup' property from existent table
-        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, InternalTransaction(AlterTableRequest(++txId, "/MyRoot", R"(
             Name: "CopyTable"
             IsBackup: false
-        )", {NKikimrScheme::StatusInvalidParameter});
+        )")));
+        TestModificationResults(runtime, txId, {NKikimrScheme::StatusInvalidParameter});
 
-        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, InternalTransaction(AlterTableRequest(++txId, "/MyRoot", R"(
             Name: "CopyTable"
             IsBackup: false
             DropColumns { Name: "value" }
-        )", {NKikimrScheme::StatusInvalidParameter});
+        )")));
+        TestModificationResults(runtime, txId, {NKikimrScheme::StatusInvalidParameter});
 
         // sanity check
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Scheme operations (e.g. AlterTable) are now forbidden on backup tables.

### Changelog category <!-- remove all except one -->

* Bugfix

### Additional information

...
