### PR TITLE
Mute ydb/core/blobstorage/ut_vdisk/ 2 tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -378,3 +378,5 @@ ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.CreateDrop-PQConfigTra
 ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.CreateMultiplePqTablets-PQConfigTransactionsAtSchemeShard-true
 ydb/tests/postgres_integrations/go-libpq [docker_wrapper_test.py] chunk chunk
 ydb/tests/functional/serializable test.py.test_local
+ydb/core/blobstorage/ut_vdisk TBsVDiskGC.GCPutKeepBarrierSync
+ydb/core/blobstorage/ut_vdisk TBsVDiskManyPutGet.ManyPutRangeGetCompactionIndexOnly


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->


 Owner: [TEAM:@ydb-platform/storage](https://github.com/orgs/ydb-platform/teams/storage)

**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**

**Summary history:** in window 2024-09-18 
 Success rate **75%**
Pass:24 Fail:8 Mute:0 Skip:0

**Test run history:** [link](https://datalens.yandex/34xnbsom67hcq?full_name=__in_ydb/core/blobstorage/ut_vdisk/TBsVDiskGC.GCPutKeepBarrierSync&full_name=__in_ydb/core/blobstorage/ut_vdisk/TBsVDiskManyPutGet.ManyPutRangeGetCompactionIndexOnly)

More info in [dashboard](https://datalens.yandex/4un3zdm0zcnyr)

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
