### PR TITLE
24-3: Forbid scheme ops on backup table

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -523,8 +523,10 @@ public:
                 .IsTable()
                 .NotUnderOperation();
 
-            if (!Transaction.GetInternal()) {
-                checks.NotAsyncReplicaTable();
+            if (checks && !Transaction.GetInternal()) {
+                checks
+                    .NotAsyncReplicaTable()
+                    .NotBackupTable();
             }
 
             if (!context.IsAllowedPrivateTables) {
@@ -723,6 +725,10 @@ TVector<ISubOperation::TPtr> CreateConsistentAlterTable(TOperationId id, const T
     }
 
     if (path.IsCommonSensePath()) {
+        return {CreateAlterTable(id, tx)};
+    }
+
+    if (path.IsBackupTable()) {
         return {CreateAlterTable(id, tx)};
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
@@ -131,6 +131,7 @@ public:
                 .IsResolved()
                 .NotDeleted()
                 .IsTable()
+                .NotBackupTable()
                 .NotAsyncReplicaTable()
                 .NotUnderDeleting();
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
@@ -139,7 +139,8 @@ public:
                 .NotDeleted()
                 .NotUnderDeleting()
                 .IsCommonSensePath()
-                .IsTable();
+                .IsTable()
+                .NotBackupTable();
 
             if (!internal) {
                 checks.NotAsyncReplicaTable();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
@@ -376,6 +376,7 @@ public:
 
             if (checks) {
                 if (parentPath->IsTable()) {
+                    checks.NotBackupTable();
                     // allow immediately inside a normal table
                     if (parentPath.IsUnderOperation()) {
                         checks.IsUnderTheSameOperation(OperationId.GetTxId()); // allowed only as part of consistent operations


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Scheme operations (e.g. AlterTable) are now forbidden on backup tables.

### Changelog category <!-- remove all except one -->

* Bugfix

### Additional information

...
