### PR TITLE
Use WideStream instead of WideFlow in BlockMapJoinCore computation node

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -468,10 +468,9 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
     MKQL_ENSURE(joinComponents.size() > 0, "Expected at least one column");
     const TVector<TType*> joinItems(joinComponents.cbegin(), joinComponents.cend());
 
-    const auto leftFlowNode = callable.GetInput(0);
-    MKQL_ENSURE(leftFlowNode.GetStaticType()->IsFlow(),
-                "Expected WideFlow as a left stream");
-    const auto leftFlowType = AS_TYPE(TFlowType, leftFlowNode);
+    const auto leftType = callable.GetInput(0).GetStaticType();
+    MKQL_ENSURE(leftType->IsFlow(), "Expected WideFlow as a left stream");
+    const auto leftFlowType = AS_TYPE(TFlowType, leftType);
     MKQL_ENSURE(leftFlowType->GetItemType()->IsMulti(),
                 "Expected Multi as a left stream item type");
     const auto leftFlowComponents = GetWideComponents(leftFlowType);

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -152,6 +152,10 @@ public:
         return IsFinished_;
     }
 
+    NUdf::TUnboxedValue* GetRawInputFields() {
+        return Inputs_.data();
+    }
+
 private:
     void AddItem(const TBlockItem& item, size_t idx) {
         Builders_[idx]->Add(item);

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -566,7 +566,7 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
         leftIOMap.push_back(i);
     }
 
-    const auto flow = LocateNode(ctx.NodeLocator, callable, 0);
+    const auto stream = LocateNode(ctx.NodeLocator, callable, 0);
     const auto dict = LocateNode(ctx.NodeLocator, callable, 1);
 
 #define DISPATCH_JOIN(IS_TUPLE) do {                                                \
@@ -575,34 +575,28 @@ IComputationNode* WrapBlockMapJoinCore(TCallable& callable, const TComputationNo
         if (isMulti) {                                                              \
             return new TBlockWideMultiMapJoinWrapper<true, IS_TUPLE>(ctx.Mutables,  \
                 std::move(joinItems), std::move(leftStreamItems),                   \
-                std::move(leftKeyColumns), std::move(leftIOMap),                    \
-                static_cast<IComputationWideFlowNode*>(flow), dict);                \
+                std::move(leftKeyColumns), std::move(leftIOMap), stream, dict);     \
         }                                                                           \
         return new TBlockWideMapJoinWrapper<false, true, IS_TUPLE>(ctx.Mutables,    \
             std::move(joinItems), std::move(leftStreamItems),                       \
-            std::move(leftKeyColumns), std::move(leftIOMap),                        \
-            static_cast<IComputationWideFlowNode*>(flow), dict);                    \
+            std::move(leftKeyColumns), std::move(leftIOMap), stream, dict);         \
     case EJoinKind::Left:                                                           \
         if (isMulti) {                                                              \
             return new TBlockWideMultiMapJoinWrapper<false, IS_TUPLE>(ctx.Mutables, \
                 std::move(joinItems), std::move(leftStreamItems),                   \
-                std::move(leftKeyColumns), std::move(leftIOMap),                    \
-                static_cast<IComputationWideFlowNode*>(flow), dict);                \
+                std::move(leftKeyColumns), std::move(leftIOMap), stream, dict);     \
         }                                                                           \
         return new TBlockWideMapJoinWrapper<false, false, IS_TUPLE>(ctx.Mutables,   \
             std::move(joinItems), std::move(leftStreamItems),                       \
-            std::move(leftKeyColumns), std::move(leftIOMap),                        \
-            static_cast<IComputationWideFlowNode*>(flow), dict);                    \
+            std::move(leftKeyColumns), std::move(leftIOMap), stream, dict);         \
     case EJoinKind::LeftSemi:                                                       \
         return new TBlockWideMapJoinWrapper<true, true, IS_TUPLE>(ctx.Mutables,     \
             std::move(joinItems), std::move(leftStreamItems),                       \
-            std::move(leftKeyColumns), std::move(leftIOMap),                        \
-            static_cast<IComputationWideFlowNode*>(flow), dict);                    \
+            std::move(leftKeyColumns), std::move(leftIOMap), stream, dict);         \
     case EJoinKind::LeftOnly:                                                       \
         return new TBlockWideMapJoinWrapper<true, false, IS_TUPLE>(ctx.Mutables,    \
             std::move(joinItems), std::move(leftStreamItems),                       \
-            std::move(leftKeyColumns), std::move(leftIOMap),                        \
-            static_cast<IComputationWideFlowNode*>(flow), dict);                    \
+            std::move(leftKeyColumns), std::move(leftIOMap), stream, dict);         \
     default:                                                                        \
         /* TODO: Display the human-readable join kind name. */                      \
         MKQL_ENSURE(false, "BlockMapJoinCore doesn't support join type #"           \

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_map_join.cpp
@@ -29,8 +29,7 @@ public:
     TBlockJoinState(TMemoryUsageInfo* memInfo, TComputationContext& ctx,
                     const TVector<TType*>& inputItems,
                     const TVector<ui32>& leftIOMap,
-                    const TVector<TType*> outputItems,
-                    NUdf::TUnboxedValue**const fields = nullptr)
+                    const TVector<TType*> outputItems)
         : TBlockState(memInfo, outputItems.size())
         , InputWidth_(inputItems.size() - 1)
         , OutputWidth_(outputItems.size() - 1)
@@ -41,8 +40,6 @@ public:
         const auto& pgBuilder = ctx.Builder->GetPgBuilder();
         MaxLength_ = CalcMaxBlockLength(outputItems);
         for (size_t i = 0; i < inputItems.size(); i++) {
-            if (fields != nullptr)
-                fields[i] = &Inputs_[i];
             const TType* blockItemType = AS_TYPE(TBlockType, inputItems[i])->GetItemType();
             Readers_.push_back(MakeBlockReader(TTypeInfoHelper(), blockItemType));
             Converters_.push_back(MakeBlockItemConverter(TTypeInfoHelper(), blockItemType, pgBuilder));

--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -375,7 +375,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
     Y_UNIT_TEST(TestInnerOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -424,7 +424,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
     Y_UNIT_TEST(TestInnerMultiOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -478,7 +478,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
     Y_UNIT_TEST(TestLeftOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -529,7 +529,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
     Y_UNIT_TEST(TestLeftMultiOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -588,7 +588,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
     Y_UNIT_TEST(TestLeftSemiOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -627,7 +627,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinBasicTest) {
     Y_UNIT_TEST(TestLeftOnlyOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -675,7 +675,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMoreTest) {
     Y_UNIT_TEST(TestInnerOn1) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::fill(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -722,7 +722,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMoreTest) {
     Y_UNIT_TEST(TestInnerMultiOn1) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::fill(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -772,7 +772,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMoreTest) {
     Y_UNIT_TEST(TestLeftOn1) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::fill(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -821,7 +821,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMoreTest) {
     Y_UNIT_TEST(TestLeftMultiOn1) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::fill(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -876,7 +876,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMoreTest) {
     Y_UNIT_TEST(TestLeftSemiOn1) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::fill(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -915,7 +915,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMoreTest) {
     Y_UNIT_TEST(TestLeftOnlyOn1) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::fill(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -963,7 +963,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinDropKeyColumns) {
     Y_UNIT_TEST(TestInnerOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1010,7 +1010,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinDropKeyColumns) {
     Y_UNIT_TEST(TestInnerMultiOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1062,7 +1062,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinDropKeyColumns) {
     Y_UNIT_TEST(TestLeftOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1111,7 +1111,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinDropKeyColumns) {
     Y_UNIT_TEST(TestLeftMultiOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1167,7 +1167,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinDropKeyColumns) {
     Y_UNIT_TEST(TestLeftSemiOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1204,7 +1204,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinDropKeyColumns) {
     Y_UNIT_TEST(TestLeftOnlyOnUint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1250,7 +1250,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMultiKeyBasicTest) {
     Y_UNIT_TEST(TestInnerOnUint64Uint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1304,7 +1304,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMultiKeyBasicTest) {
     Y_UNIT_TEST(TestInnerMultiOnUint64Uint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1363,7 +1363,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMultiKeyBasicTest) {
     Y_UNIT_TEST(TestLeftOnUint64Uint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1419,7 +1419,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMultiKeyBasicTest) {
     Y_UNIT_TEST(TestLeftMultiOnUint64Uint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1483,7 +1483,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMultiKeyBasicTest) {
     Y_UNIT_TEST(TestLeftSemiOnUint64Uint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;
@@ -1529,7 +1529,7 @@ Y_UNIT_TEST_SUITE(TMiniKQLBlockMapJoinMultiKeyBasicTest) {
     Y_UNIT_TEST(TestLeftOnlyOnUint64Uint64) {
         TSetup<false> setup;
         TProgramBuilder& pgmBuilder = *setup.PgmBuilder;
-        // 1. Make input for the "left" flow.
+        // 1. Make input for the "left" stream.
         TVector<ui64> keyInit(testSize);
         std::iota(keyInit.begin(), keyInit.end(), 1);
         TVector<ui64> subkeyInit;


### PR DESCRIPTION
This patchset reimplements `BlockMapJoinCore` computation node to make it process WideStream I/O instead of WideFlow I/O. As a result, it allows to omit all the adventures with implementing LLVM part for this computation node in future, since block processing doesn't require it.

### Changelog category

* Improvement