### PR TITLE
add special case for customize nodes for tablet ids

### DIFF
--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -637,7 +637,16 @@ class StaticConfigGenerator(object):
             tablet.AllowDynamicConfiguration = True
 
         if explicit_node_ids:
-            node_ids = explicit_node_ids
+            node_ids = []
+            for item in explicit_node_ids:
+                if type(item) is list:
+                    try:
+                        node_ids.append(item[index])
+                    except IndexError:
+                        logger.error("nodes count for tablet type %s wrong, nodeid for tablet index: %d not found" % (tablet_name, index))
+                        exit(1)
+                else:
+                    node_ids.append(item)
         tablet.Node.extend(node_ids)
 
         for channel_id in range(int(number_of_channels)):


### PR DESCRIPTION
```
  tx_mediator:
    explicit_node_ids:
    - 13    
    - 15    
    - 23    
    - 64    
    - 82    
    - 109 
    - 119 
    - 161   
    - [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
    - [17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]
```
nodes:
```
    - [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
    - [17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]
```
will be assigned individual to each tabelt id of tx_mediator type

...

* Improvement

### Additional information

...
