### PR TITLE
Simplify TTypeInfo constructors

### DIFF
--- a/ydb/core/engine/mkql_keys.cpp
+++ b/ydb/core/engine/mkql_keys.cpp
@@ -44,7 +44,7 @@ NScheme::TTypeInfo UnpackTypeInfo(NKikimr::NMiniKQL::TType *type, bool &isOption
     if (type->GetKind() == TType::EKind::Pg) {
         auto pgType = static_cast<TPgType*>(type);
         auto pgTypeId = pgType->GetTypeId();
-        return NScheme::TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(pgTypeId));
+        return NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(pgTypeId));
     } else {
         auto dataType = UnpackOptionalData(type, isOptional);
         return NScheme::TTypeInfo(dataType->GetSchemeType());
@@ -198,7 +198,7 @@ THolder<TKeyDesc> ExtractUpdateRow(TCallable& callable, const TTypeEnvironment& 
         if (cmd.GetStaticType()->IsVoid()) {
             // erase
             op.Operation = TKeyDesc::EColumnOperation::Set;
-            op.ExpectedType = NScheme::TTypeInfo(0);
+            op.ExpectedType = NScheme::TTypeInfo();
         } else if (cmd.GetStaticType()->IsTuple()) {
             // inplace update
             TTupleLiteral* tuple = AS_VALUE(TTupleLiteral, cmd);

--- a/ydb/core/grpc_services/rpc_read_rows.cpp
+++ b/ydb/core/grpc_services/rpc_read_rows.cpp
@@ -171,7 +171,7 @@ public:
                     return false;
                 }
 
-                const auto typeInRequest = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, typeDesc);
+                const auto typeInRequest = NScheme::TTypeInfo(typeDesc);
                 if (typeInRequest != colInfo.PType) {
                     errorMessage = Sprintf("Type mismatch for column %s: expected %s, got %s",
                                            name.c_str(), NScheme::TypeName(colInfo.PType).c_str(),

--- a/ydb/core/kqp/common/kqp_resolve.h
+++ b/ydb/core/kqp/common/kqp_resolve.h
@@ -49,8 +49,7 @@ struct TTableConstInfo : public TAtomicRefCount<TTableConstInfo> {
         if (phyColumn.GetTypeId() != NScheme::NTypeIds::Pg) {
             column.Type = NScheme::TTypeInfo(phyColumn.GetTypeId());
         } else {
-            column.Type = NScheme::TTypeInfo(phyColumn.GetTypeId(),
-                NPg::TypeDescFromPgTypeName(phyColumn.GetPgTypeName()));
+            column.Type = NScheme::TTypeInfo(NPg::TypeDescFromPgTypeName(phyColumn.GetPgTypeName()));
         }
         column.NotNull = phyColumn.GetNotNull();
         column.IsBuildInProgress = phyColumn.GetIsBuildInProgress();

--- a/ydb/core/kqp/common/kqp_types.cpp
+++ b/ydb/core/kqp/common/kqp_types.cpp
@@ -20,7 +20,7 @@ TTypeInfo TypeInfoFromProtoMiniKQLType(const NKikimrMiniKQL::TType& type) {
     case NKikimrMiniKQL::Data:
         return TTypeInfo((NScheme::TTypeId)type.GetData().GetScheme());
     case NKikimrMiniKQL::Pg:
-        return TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(type.GetPg().Getoid()));
+        return TTypeInfo(NPg::TypeDescFromPgTypeId(type.GetPg().Getoid()));
     default:
         Y_ENSURE(false, "not a data or pg type");
     }
@@ -39,7 +39,7 @@ TTypeInfo TypeInfoFromMiniKQLType(const NMiniKQL::TType* type) {
     case NMiniKQL::TType::EKind::Data:
         return TTypeInfo((NScheme::TTypeId)AS_TYPE(NMiniKQL::TDataType, type)->GetSchemeType());
     case NMiniKQL::TType::EKind::Pg:
-        return TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(AS_TYPE(NMiniKQL::TPgType, type)->GetTypeId()));
+        return TTypeInfo(NPg::TypeDescFromPgTypeId(AS_TYPE(NMiniKQL::TPgType, type)->GetTypeId()));
     default:
         Y_ENSURE(false, "not a data or pg type");
     }

--- a/ydb/core/kqp/compute_actor/kqp_scan_fetcher_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_fetcher_actor.cpp
@@ -47,7 +47,7 @@ TKqpScanFetcherActor::TKqpScanFetcherActor(const NKikimrKqp::TKqpSnapshot& snaps
     for (size_t i = 0; i < Meta.KeyColumnTypesSize(); i++) {
         NScheme::TTypeId typeId = Meta.GetKeyColumnTypes().at(i);
         NScheme::TTypeInfo typeInfo = typeId == NScheme::NTypeIds::Pg ?
-            NScheme::TTypeInfo(typeId, NPg::TypeDescFromPgTypeId(Meta.GetKeyColumnTypeInfos().at(i).GetPgTypeId())) :
+            NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(Meta.GetKeyColumnTypeInfos().at(i).GetPgTypeId())) :
             NScheme::TTypeInfo(typeId);    
         KeyColumnTypes.push_back(typeInfo);
     }

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1401,7 +1401,7 @@ protected:
                 auto memberType = resultStructType->GetMemberType(i);
                 if (memberType->GetKind() == NKikimr::NMiniKQL::TType::EKind::Pg) {
                     const auto memberPgType = static_cast<NKikimr::NMiniKQL::TPgType*>(memberType);
-                    taskMeta.ReadInfo.ResultColumnsTypes.back() = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(memberPgType->GetTypeId()));
+                    taskMeta.ReadInfo.ResultColumnsTypes.back() = NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(memberPgType->GetTypeId()));
                 } else {
                     if (memberType->GetKind() == NKikimr::NMiniKQL::TType::EKind::Optional) {
                         memberType = static_cast<NKikimr::NMiniKQL::TOptionalType*>(memberType)->GetItemType();

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -906,10 +906,7 @@ virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) over
 
             if (actualType->GetKind() == ETypeAnnotationKind::Pg) {
                 auto pgTypeId = actualType->Cast<TPgExprType>()->GetId();
-                columnMeta.TypeInfo = NKikimr::NScheme::TTypeInfo(
-                    NKikimr::NScheme::NTypeIds::Pg,
-                    NKikimr::NPg::TypeDescFromPgTypeId(pgTypeId)
-                );
+                columnMeta.TypeInfo = NKikimr::NScheme::TTypeInfo(NKikimr::NPg::TypeDescFromPgTypeId(pgTypeId));
             }
 
             if (columnTuple.Size() > 2) {

--- a/ydb/core/kqp/runtime/kqp_read_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_actor.cpp
@@ -379,7 +379,7 @@ public:
         for (size_t i = 0; i < Settings->KeyColumnTypesSize(); ++i) {
             NScheme::TTypeId typeId = Settings->GetKeyColumnTypes(i);
             NScheme::TTypeInfo typeInfo = typeId == NScheme::NTypeIds::Pg ?
-                NScheme::TTypeInfo(typeId, NPg::TypeDescFromPgTypeId(Settings->GetKeyColumnTypeInfos(i).GetPgTypeId())) :
+                NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(Settings->GetKeyColumnTypeInfos(i).GetPgTypeId())) :
                 NScheme::TTypeInfo(typeId);
             KeyColumnTypes.push_back(typeInfo);
         }
@@ -1462,7 +1462,7 @@ private:
     NScheme::TTypeInfo MakeTypeInfo(const NKikimrTxDataShard::TKqpTransaction_TColumnMeta& info) {
         NScheme::TTypeId typeId = info.GetType();
         if (typeId == NScheme::NTypeIds::Pg) {
-            return {typeId, NPg::TypeDescFromPgTypeId(info.GetTypeInfo().GetPgTypeId())};
+            return {NPg::TypeDescFromPgTypeId(info.GetTypeInfo().GetPgTypeId())};
         } else {
             return {typeId};
         }

--- a/ydb/core/kqp/runtime/kqp_read_table.cpp
+++ b/ydb/core/kqp/runtime/kqp_read_table.cpp
@@ -29,7 +29,7 @@ bool StructHoldsPgType(const TStructType& structType, ui32 index) {
 
 NScheme::TTypeInfo UnwrapPgTypeFromStruct(const TStructType& structType, ui32 index) {
     TPgType* type = AS_TYPE(TPgType, structType.GetMemberType(index));
-    return NScheme::TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(type->GetTypeId()));
+    return NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(type->GetTypeId()));
 }
 
 NUdf::TDataTypeId UnwrapDataTypeFromStruct(const TStructType& structType, ui32 index) {

--- a/ydb/core/kqp/runtime/kqp_sequencer_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_sequencer_actor.cpp
@@ -29,7 +29,7 @@ NScheme::TTypeInfo BuildTypeInfo(const ::NKikimrKqp::TKqpColumnMetadataProto& pr
     if (typeId != NKikimr::NScheme::NTypeIds::Pg) {
         return NScheme::TTypeInfo(typeId);
     } else {
-        return NScheme::TTypeInfo(typeId, NPg::TypeDescFromPgTypeId(proto.GetTypeInfo().GetPgTypeId()));
+        return NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(proto.GetTypeInfo().GetPgTypeId()));
     }
 }
 

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -61,7 +61,7 @@ NScheme::TTypeInfo UnpackTypeInfo(NKikimr::NMiniKQL::TType* type) {
     if (type->GetKind() == NMiniKQL::TType::EKind::Pg) {
         auto pgType = static_cast<NMiniKQL::TPgType*>(type);
         auto pgTypeId = pgType->GetTypeId();
-        return NScheme::TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(pgTypeId));
+        return NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(pgTypeId));
     } else {
         bool isOptional = false;
         auto dataType = NMiniKQL::UnpackOptionalData(type, isOptional);
@@ -149,7 +149,7 @@ TKqpStreamLookupWorker::TKqpStreamLookupWorker(NKikimrKqp::TKqpStreamLookupSetti
     i32 keyOrder = 0;
     for (const auto& keyColumn : settings.GetKeyColumns()) {
         NScheme::TTypeInfo typeInfo = keyColumn.GetTypeId() == NScheme::NTypeIds::Pg ?
-            NScheme::TTypeInfo(keyColumn.GetTypeId(), NPg::TypeDescFromPgTypeId(keyColumn.GetTypeInfo().GetPgTypeId())) :
+            NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(keyColumn.GetTypeInfo().GetPgTypeId())) :
             NScheme::TTypeInfo(keyColumn.GetTypeId());
 
         KeyColumns.emplace(
@@ -174,7 +174,7 @@ TKqpStreamLookupWorker::TKqpStreamLookupWorker(NKikimrKqp::TKqpStreamLookupSetti
     Columns.reserve(settings.GetColumns().size());
     for (const auto& column : settings.GetColumns()) {
         NScheme::TTypeInfo typeInfo = column.GetTypeId() == NScheme::NTypeIds::Pg ?
-            NScheme::TTypeInfo(column.GetTypeId(), NPg::TypeDescFromPgTypeId(column.GetTypeInfo().GetPgTypeId())) :
+            NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(column.GetTypeInfo().GetPgTypeId())) :
             NScheme::TTypeInfo(column.GetTypeId());
 
         Columns.emplace_back(TSysTables::TTableColumnInfo{

--- a/ydb/core/kqp/runtime/kqp_write_table.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_table.cpp
@@ -62,7 +62,7 @@ TVector<TSysTables::TTableColumnInfo> BuildColumns(const TConstArrayRef<NKikimrK
     i32 number = 0;
     for (const auto& column : inputColumns) {
         NScheme::TTypeInfo typeInfo = (column.GetTypeId() == NScheme::NTypeIds::Pg) ?
-            NScheme::TTypeInfo(column.GetTypeId(), NPg::TypeDescFromPgTypeId(column.GetTypeInfo().GetPgTypeId())) :
+            NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(column.GetTypeInfo().GetPgTypeId())) :
             NScheme::TTypeInfo(column.GetTypeId());
         result.emplace_back(
             column.GetName(),

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -7853,7 +7853,7 @@ Y_UNIT_TEST_SUITE(KqpOlapScheme) {
         TVector<TTestHelper::TColumnSchema> schema = {
             TTestHelper::TColumnSchema().SetName("id").SetType(NScheme::NTypeIds::Int32).SetNullable(false),
             TTestHelper::TColumnSchema().SetName("resource_id").SetType(NScheme::NTypeIds::Utf8),
-            TTestHelper::TColumnSchema().SetName("level").SetTypeInfo({NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeName("pgint4")})
+            TTestHelper::TColumnSchema().SetName("level").SetTypeInfo({NPg::TypeDescFromPgTypeName("pgint4")})
         };
         TTestHelper::TColumnTableStore testTableStore;
 
@@ -7873,7 +7873,7 @@ Y_UNIT_TEST_SUITE(KqpOlapScheme) {
         testHelper.ReadData("SELECT * FROM `/Root/TableStoreTest/ColumnTableTest` WHERE id=1", "[[1;#;[\"test_res_1\"]]]");
 
         {
-            schema.push_back(TTestHelper::TColumnSchema().SetName("new_column").SetTypeInfo({NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeName("pgfloat4")}));
+            schema.push_back(TTestHelper::TColumnSchema().SetName("new_column").SetTypeInfo({NPg::TypeDescFromPgTypeName("pgfloat4")}));
             auto alterQuery = TStringBuilder() << "ALTER TABLESTORE `" << testTableStore.GetName() << "` ADD COLUMN new_column pgfloat4;";
 
             auto alterResult = testHelper.GetSession().ExecuteSchemeQuery(alterQuery).GetValueSync();

--- a/ydb/core/scheme/scheme_types_proto.cpp
+++ b/ydb/core/scheme/scheme_types_proto.cpp
@@ -36,7 +36,7 @@ TTypeInfoMod TypeInfoModFromProtoColumnType(ui32 typeId, const NKikimrProto::TTy
     case NTypeIds::Pg: {
         Y_ABORT_UNLESS(typeInfo, "no type info for pg type");
         TTypeInfoMod res = {
-            .TypeInfo = {type, NPg::TypeDescFromPgTypeId(typeInfo->GetPgTypeId())},
+            .TypeInfo = {NPg::TypeDescFromPgTypeId(typeInfo->GetPgTypeId())},
             .TypeMod = (typeInfo->HasPgTypeMod() ? typeInfo->GetPgTypeMod() : TProtoStringType{})
         };
         return res;
@@ -44,7 +44,7 @@ TTypeInfoMod TypeInfoModFromProtoColumnType(ui32 typeId, const NKikimrProto::TTy
     case NTypeIds::Decimal: {
         Y_ABORT_UNLESS(typeInfo, "no type info for decimal type");
         TTypeInfoMod res = {
-            .TypeInfo = {type, {typeInfo->GetDecimalPrecision(), typeInfo->GetDecimalScale()}},
+            .TypeInfo = {{typeInfo->GetDecimalPrecision(), typeInfo->GetDecimalScale()}},
             .TypeMod = {}
         };
         return res;

--- a/ydb/core/scheme_types/scheme_raw_type_value.h
+++ b/ydb/core/scheme_types/scheme_raw_type_value.h
@@ -14,7 +14,7 @@ public:
     TRawTypeValue()
         : Buffer(nullptr)
         , BufferSize(0)
-        , ValueType(0)
+        , ValueType()
     {}
 
     TRawTypeValue(const void* buf, ui32 bufSize, NScheme::TTypeInfo vtype)

--- a/ydb/core/scheme_types/scheme_type_info.h
+++ b/ydb/core/scheme_types/scheme_type_info.h
@@ -32,20 +32,16 @@ public:
         //Y_ABORT_UNLESS(NTypeIds::IsParametrizedType(TypeId))
     }
 
-    constexpr TTypeInfo(TTypeId typeId, const NKikimr::NPg::ITypeDesc* typeDesc)
-        : TypeId(typeId)
+    constexpr TTypeInfo(const NKikimr::NPg::ITypeDesc* typeDesc)
+        : TypeId(NTypeIds::Pg)
         , PgTypeDesc(typeDesc)
-    {
-        Y_ABORT_UNLESS(TypeId == NTypeIds::Pg);
-    }
+    {}
 
-    constexpr TTypeInfo(TTypeId typeId, const TDecimalType& decimalType)
-        : TypeId(typeId)
+    constexpr TTypeInfo(const TDecimalType& decimalType)
+        : TypeId(NTypeIds::Decimal)
         // TODO Remove after parametrized decimal in KQP
         , DecimalTypeDesc(decimalType.GetPrecision() == 0 && decimalType.GetScale() == 0 ? TDecimalType(DECIMAL_PRECISION, DECIMAL_SCALE) : decimalType)
-    {
-        Y_ABORT_UNLESS(TypeId == NTypeIds::Decimal);
-    }
+    {}
 
     constexpr bool operator==(const TTypeInfo& other) const {
         return TypeId == other.TypeId && RawDesc == other.RawDesc;

--- a/ydb/core/scheme_types/scheme_type_registry.cpp
+++ b/ydb/core/scheme_types/scheme_type_registry.cpp
@@ -60,9 +60,9 @@ bool TTypeRegistry::GetTypeInfo(const TStringBuf& typeName, const TStringBuf& co
         }
         typeInfo = NScheme::TTypeInfo(type->GetTypeId());
     } else if (const auto decimalType = NScheme::TDecimalType::ParseTypeName(typeName)) {
-        typeInfo = NScheme::TTypeInfo(NScheme::NTypeIds::Decimal, *decimalType);
+        typeInfo = NScheme::TTypeInfo(*decimalType);
     } else if (const auto pgTypeDesc = NPg::TypeDescFromPgTypeName(typeName)) {
-        typeInfo = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, pgTypeDesc);
+        typeInfo = NScheme::TTypeInfo(pgTypeDesc);
     } else {
         errorStr = Sprintf("Type '%s' specified for column '%s' is not supported by storage", typeName.data(), columnName.data());
         return false;

--- a/ydb/core/sys_view/common/schema.cpp
+++ b/ydb/core/sys_view/common/schema.cpp
@@ -21,7 +21,7 @@ TVector<Schema::PgColumn> GetPgStaticTableColumns(const TString& schema, const T
 
 Schema::PgColumn::PgColumn(NIceDb::TColumnId columnId, TStringBuf columnTypeName, TStringBuf columnName)
     : _ColumnId(columnId)
-    , _ColumnTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(NYql::NPg::LookupType(TString(columnTypeName)).TypeId))
+    , _ColumnTypeInfo(NPg::TypeDescFromPgTypeId(NYql::NPg::LookupType(TString(columnTypeName)).TypeId))
     , _ColumnName(columnName)
 {}
 

--- a/ydb/core/tablet_flat/flat_cxx_database.h
+++ b/ydb/core/tablet_flat/flat_cxx_database.h
@@ -244,7 +244,7 @@ template <NScheme::TTypeId ValType>
 class TConvertTypeValue : public TRawTypeValue {
 public:
     TConvertTypeValue(const TRawTypeValue& value)
-        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? NScheme::TTypeInfo(0) : NScheme::TTypeInfo(ValType))
+        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? NScheme::TTypeInfo() : NScheme::TTypeInfo(ValType))
     {}
 
     template <typename ValueType> static typename NSchemeTypeMapper<ValType>::Type ConvertFrom(ValueType value) {
@@ -257,7 +257,7 @@ template <>
 class TConvertTypeValue<NScheme::NTypeIds::String> : public TRawTypeValue {
 public:
     TConvertTypeValue(const TRawTypeValue& value)
-        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? NScheme::TTypeInfo(0) : NScheme::TTypeInfo(NScheme::NTypeIds::String))
+        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? NScheme::TTypeInfo() : NScheme::TTypeInfo(NScheme::NTypeIds::String))
     {}
 
     static typename NSchemeTypeMapper<NScheme::NTypeIds::String>::Type ConvertFrom(const TString& value) {

--- a/ydb/core/tablet_flat/ut/ut_decimal.cpp
+++ b/ydb/core/tablet_flat/ut/ut_decimal.cpp
@@ -21,7 +21,7 @@ Y_UNIT_TEST_SUITE(TFlatDatabaseDecimal) {
         NTest::TDbExec db;
 
         auto makeDecimalTypeInfo = [] (ui32 precision, ui32 scale) {
-            return NScheme::TTypeInfo(NScheme::NTypeIds::Decimal, NScheme::TDecimalType(precision, scale));
+            return NScheme::TTypeInfo(NScheme::TDecimalType(precision, scale));
         };
 
         auto makeDecimalTypeInfoProto = [] (ui32 precision, ui32 scale) {

--- a/ydb/core/tablet_flat/ut_pg/flat_database_pg_ut.cpp
+++ b/ydb/core/tablet_flat/ut_pg/flat_database_pg_ut.cpp
@@ -30,7 +30,7 @@ Y_UNIT_TEST_SUITE(TFlatDatabasePgTest) {
         NTest::TDbExec db;
 
         auto makePgType = [] (ui32 oid) {
-            return NScheme::TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(oid));
+            return NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(oid));
         };
 
         auto makePgTypeInfo = [] (ui32 pgTypeId) {

--- a/ydb/core/tx/columnshard/transactions/operators/schema.cpp
+++ b/ydb/core/tx/columnshard/transactions/operators/schema.cpp
@@ -122,8 +122,7 @@ NKikimr::TConclusionStatus TSchemaTransactionOperator::ValidateTableSchema(const
         NScheme::TTypeId typeId = column.GetTypeId();
         NScheme::TTypeInfo schemeType;
         if (column.GetTypeId() == NTypeIds::Pg && column.HasTypeInfo()) {
-            auto typeDescr = NPg::TypeDescFromPgTypeId(column.GetTypeInfo().GetPgTypeId());
-            schemeType = {typeId, typeDescr};
+            schemeType = {NPg::TypeDescFromPgTypeId(column.GetTypeInfo().GetPgTypeId())};
         } else {
             schemeType = {typeId};
         }

--- a/ydb/core/tx/datashard/datashard_kqp_delete_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_delete_rows.cpp
@@ -148,7 +148,7 @@ IComputationNode* WrapKqpDeleteRows(TCallable& callable, const TComputationNodeF
 
         if (memberType->IsPg()) {
             auto pgType = AS_TYPE(TPgType, memberType);
-            rowTypes[i] = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(pgType->GetTypeId()));
+            rowTypes[i] = NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(pgType->GetTypeId()));
         } else {
             rowTypes[i] = NScheme::TTypeInfo(AS_TYPE(TDataType, memberType)->GetSchemeType());
         }

--- a/ydb/core/tx/datashard/datashard_kqp_lookup_table.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_lookup_table.cpp
@@ -74,7 +74,7 @@ TParseLookupTableResult ParseLookupTable(TCallable& callable) {
         NKikimr::NMiniKQL::TType* type = keyTypes->GetMemberType(i);
         if (type->GetKind() == TType::EKind::Pg) {
             auto itemType = AS_TYPE(TPgType, type);
-            result.KeyTypes[i] = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, NPg::TypeDescFromPgTypeId(itemType->GetTypeId()));
+            result.KeyTypes[i] = NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(itemType->GetTypeId()));
         } else {
             if (type->IsOptional()) {
                 type = AS_TYPE(TOptionalType, keyTypes->GetMemberType(i))->GetItemType();

--- a/ydb/core/tx/schemeshard/olap/columns/schema.cpp
+++ b/ydb/core/tx/schemeshard/olap/columns/schema.cpp
@@ -179,9 +179,9 @@ bool TOlapColumnsDescription::Validate(const NKikimrSchemeOp::TColumnTableSchema
                 errors.AddError("Type '" + colProto.GetType() + "' specified for column '" + colName + "' is not supported");
                 return false;
             }
-            typeInfo = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, typeDesc);
+            typeInfo = NScheme::TTypeInfo(typeDesc);
         } else if (const auto decimalType = NScheme::TDecimalType::ParseTypeName(typeName)) {
-            typeInfo = NScheme::TTypeInfo(NScheme::NTypeIds::Decimal, *decimalType);
+            typeInfo = NScheme::TTypeInfo(*decimalType);
         } else {
             const NScheme::IType* type = typeRegistry->GetType(typeName);
             if (!type || !TOlapColumnAdd::IsAllowedType(type->GetTypeId())) {

--- a/ydb/core/tx/schemeshard/olap/columns/update.cpp
+++ b/ydb/core/tx/schemeshard/olap/columns/update.cpp
@@ -53,9 +53,9 @@ namespace NKikimr::NSchemeShard {
                 errors.AddError(TStringBuilder() << "Type '" << typeName << "' specified for column '" << Name << "' is not supported");
                 return false;
             }
-            Type = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, typeDesc);
+            Type = NScheme::TTypeInfo(typeDesc);
         } else if (const auto decimalType = NScheme::TDecimalType::ParseTypeName(typeName)) {
-            Type = NScheme::TTypeInfo(NScheme::NTypeIds::Decimal, *decimalType);
+            Type = NScheme::TTypeInfo(*decimalType);
         }else {
             Y_ABORT_UNLESS(AppData()->TypeRegistry);
             const NScheme::IType* type = AppData()->TypeRegistry->GetType(typeName);

--- a/ydb/core/tx/tx_proxy/datareq.cpp
+++ b/ydb/core/tx/tx_proxy/datareq.cpp
@@ -177,7 +177,7 @@ struct TReadTableRequest : public TThrRefBase {
         , RequestVersion(tx.HasApiVersion() ? tx.GetApiVersion() : (ui32)NKikimrTxUserProxy::TReadTableTransaction::UNSPECIFIED)
     {
         for (auto &col : tx.GetColumns()) {
-            Columns.emplace_back(col, 0, NScheme::TTypeInfo(0));
+            Columns.emplace_back(col, 0, NScheme::TTypeInfo());
         }
 
         if (tx.HasSnapshotStep() && tx.HasSnapshotTxId()) {

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -525,7 +525,7 @@ private:
                                            name.c_str(), typeName.c_str());
                     return false;
                 }
-                auto typeInRequest = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, typeDesc);
+                auto typeInRequest = NScheme::TTypeInfo(typeDesc);
                 bool ok = SameDstType(typeInRequest, ci.PType, false);
                 if (!ok) {
                     errorMessage = Sprintf("Type mismatch for column %s: expected %s, got %s",

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -625,7 +625,7 @@ bool ExtractColumnTypeInfo(NScheme::TTypeInfo& outTypeInfo, TString& outTypeMod,
                                     NScheme::DECIMAL_SCALE);
                 return false;
             }
-            outTypeInfo = NScheme::TTypeInfo(NYql::NProto::TypeIds::Decimal, {precision, scale});
+            outTypeInfo = NScheme::TTypeInfo(NScheme::TDecimalType(precision, scale));
             return true;
         }
         case Ydb::Type::kPgType: {
@@ -637,7 +637,7 @@ bool ExtractColumnTypeInfo(NScheme::TTypeInfo& outTypeInfo, TString& outTypeMod,
                 error = TStringBuilder() << "Invalid PG type name: " << typeName;
                 return false;
             }
-            outTypeInfo = NScheme::TTypeInfo(NScheme::NTypeIds::Pg, desc);
+            outTypeInfo = NScheme::TTypeInfo(desc);
             outTypeMod = pgType.type_modifier();
             return true;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

If constructor for Pg or Decimal there is not need to pass TypeId

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
