### PR TITLE
Describe view using legacy msg bus service

### DIFF
--- a/ydb/apps/ydb/ya.make
+++ b/ydb/apps/ydb/ya.make
@@ -40,8 +40,15 @@ CHECK_DEPENDENT_DIRS(
     tools/rorescompiler
     util
     ydb/apps/ydb
+    ydb/core/config/protos
+    ydb/core/fq/libs/config/protos
     ydb/core/fq/libs/protos
     ydb/core/grpc_services/validation
+    ydb/core/protos
+    ydb/core/scheme/protos
+    ydb/core/tx/columnshard/common/protos
+    ydb/core/tx/columnshard/engines/protos
+    ydb/core/tx/columnshard/engines/scheme/defaults/protos
     ydb/library
     ydb/public
     ydb/library/yql/public/decimal

--- a/ydb/public/lib/ydb_cli/commands/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/ya.make
@@ -37,6 +37,8 @@ PEERDIR(
     ydb/library/backup
     ydb/library/workload
     ydb/library/yaml_config/public
+    ydb/public/lib/base
+    ydb/public/lib/deprecated/client
     ydb/public/lib/operation_id
     ydb/public/lib/stat_visualization
     ydb/public/lib/ydb_cli/common

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.h
@@ -13,6 +13,10 @@
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/topic.h>
 
+namespace NKikimrSchemeOp {
+    class TViewDescription;
+}
+
 namespace NYdb {
 
 namespace NTopic {
@@ -84,7 +88,7 @@ public:
     virtual int Run(TConfig& config) override;
 
 private:
-    int PrintPathResponse(TDriver& driver, const NScheme::TDescribePathResult& result);
+    int PrintPathResponse(TDriver& driver, const NScheme::TDescribePathResult& result, TConfig& config);
     int DescribeEntryDefault(NScheme::TSchemeEntry entry);
     int DescribeTable(TDriver& driver);
     int DescribeColumnTable(TDriver& driver);
@@ -99,6 +103,9 @@ private:
 
     int DescribeReplication(const TDriver& driver);
     int PrintReplicationResponsePretty(const NYdb::NReplication::TDescribeReplicationResult& result) const;
+
+    int DescribeView(TConfig& config);
+    int PrintViewResponsePretty(const NKikimrSchemeOp::TViewDescription& result) const;
 
     int TryTopicConsumerDescribeOrFail(NYdb::TDriver& driver, const NScheme::TDescribePathResult& result);
     std::pair<TString, TString> ParseTopicConsumer() const;


### PR DESCRIPTION
We want YDB CLI to return view query text on `ydb scheme describe view_to_describe` command.

There is no generic GRPC service that can return SchemeShard's private protobuf info to YDB CLI. We have to choose from the following options:
1. Create a dedicated GRPC service for views and add only the `DescribeView` call there. This approach seems to be the currently adopted one. See the recently added [replication](https://github.com/ydb-platform/ydb/pull/4904/files#diff-bf2791eba66b7e5364bbd71a7eec8828509fce5456bb00685df8efa8238c7d1b) service and [object storage](https://github.com/ydb-platform/ydb/pull/4434/files#diff-05f77927ddda0bfc47eff950d8e1bb74edd298e1ed3a575aacbbb4dc7ca24cae) service which both have a single RPC in them.
2. Add the `DescribeView` call to the [TableService](https://github.com/ydb-platform/ydb/blob/main/ydb/public/api/grpc/ydb_table_v1.proto). I'm not sure if adding the `DescribeView` call here is a good option since this service is concerned with tables only.
3. Use the legacy GRPC service (a.k.a. Message Bus) to issue a generic [SchemeDescribe](https://github.com/ydb-platform/ydb/blame/d8ee31dd2a8eb84c5487dc662917b2a0099251cf/ydb/public/lib/deprecated/client/grpc_client.h#L57) request that returns a private SchemeShard's protobuf. It would differ significantly from what YDB CLI is currently doing to describe a scheme object, but it would provide a good solution for a generic describe scheme object problem. Whenever we decide that we are ready to remove the legacy `TGrpcClient` we would have to rewrite this code too. However, I don't think it would take too much time to rewrite it.

The current PR implements the third approach.