### PR TITLE
Support address hints in pipe clients and designated initializers for TClientConfig

### DIFF
--- a/ydb/core/base/tablet_resolver.h
+++ b/ydb/core/base/tablet_resolver.h
@@ -137,17 +137,17 @@ struct TEvTabletResolver {
 
     struct TEvTabletProblem : public TEventLocal<TEvTabletProblem, EvTabletProblem> {
         const ui64 TabletID;
-        const TActorId TabletActor;
+        const TActorId Actor;
 
-        TEvTabletProblem(ui64 tabletId, const TActorId &tabletActor)
+        TEvTabletProblem(ui64 tabletId, const TActorId &actor)
             : TabletID(tabletId)
-            , TabletActor(tabletActor)
+            , Actor(actor)
         {}
 
         TString ToString() const {
             TStringStream str;
             str << "{EvTabletProblem TabletID: " << TabletID;
-            str << " TabletActor: " << TabletActor.ToString();
+            str << " Actor: " << Actor;
             str << "}";
             return str.Str();
         }

--- a/ydb/core/client/server/msgbus_server_pq_metacache.cpp
+++ b/ydb/core/client/server/msgbus_server_pq_metacache.cpp
@@ -185,7 +185,7 @@ private:
         LOG_DEBUG_S(ctx, NKikimrServices::PQ_METACACHE, "Start pipe to hive tablet: " << hiveTabletId);
         auto pipeRetryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries();
         pipeRetryPolicy.MaxRetryTime = TDuration::Seconds(1);
-        NTabletPipe::TClientConfig pipeConfig{pipeRetryPolicy};
+        NTabletPipe::TClientConfig pipeConfig{.RetryPolicy = pipeRetryPolicy};
         HivePipeClient = ctx.RegisterWithSameMailbox(
                 NTabletPipe::CreateClient(ctx.SelfID, hiveTabletId, pipeConfig)
         );

--- a/ydb/core/statistics/service/service_impl.cpp
+++ b/ydb/core/statistics/service/service_impl.cpp
@@ -261,7 +261,7 @@ private:
 
         auto policy = NTabletPipe::TClientRetryPolicy::WithRetries();
         policy.RetryLimitCount = 2;
-        NTabletPipe::TClientConfig pipeConfig{policy};
+        NTabletPipe::TClientConfig pipeConfig{.RetryPolicy = policy};
         pipeConfig.ForceLocal = true;
         localTablets.TabletsPipes[tabletId] = Register(NTabletPipe::CreateClient(SelfId(), tabletId, pipeConfig));
     }
@@ -1115,7 +1115,7 @@ private:
             return;
         }
         auto policy = NTabletPipe::TClientRetryPolicy::WithRetries();
-        NTabletPipe::TClientConfig pipeConfig{policy};
+        NTabletPipe::TClientConfig pipeConfig{.RetryPolicy = policy};
         SAPipeClientId = Register(NTabletPipe::CreateClient(SelfId(), StatisticsAggregatorId, pipeConfig));
 
         LOG_DEBUG_S(TlsActivationContext->AsActorContext(), NKikimrServices::STATISTICS,

--- a/ydb/core/tablet/tablet_resolver.cpp
+++ b/ydb/core/tablet/tablet_resolver.cpp
@@ -540,14 +540,14 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         case TEntry::StInitResolve:
             break;
         case TEntry::StNormal:
-            if (!msg->TabletActor || entry.KnownLeaderTablet == msg->TabletActor) {
+            if (!msg->Actor || entry.KnownLeader == msg->Actor || entry.KnownLeaderTablet == msg->Actor) {
                 ResolveRequest(tabletId, ctx);
                 entry.State = TEntry::StProblemResolve;
                 MoveEntryToUnresolved(tabletId, *entryHolder);
             } else {
                 // find in follower list
                 for (auto it = entry.KnownFollowers.begin(), end = entry.KnownFollowers.end(); it != end; ++it) {
-                    if (it->second == msg->TabletActor) {
+                    if (it->first == msg->Actor || it->second == msg->Actor) {
                         entry.KnownFollowers.erase(it);
                         ResolveRequest(tabletId, ctx);
                         entry.State = TEntry::StFollowerUpdate;
@@ -561,7 +561,7 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         case TEntry::StProblemPing:
         case TEntry::StFollowerUpdate:
             for (auto it = entry.KnownFollowers.begin(), end = entry.KnownFollowers.end(); it != end; ++it) {
-                if (it->second == msg->TabletActor) {
+                if (it->first == msg->Actor || it->second == msg->Actor) {
                     entry.KnownFollowers.erase(it);
                     break;
                 }

--- a/ydb/core/tx/datashard/datashard__cleanup_borrowed.cpp
+++ b/ydb/core/tx/datashard/datashard__cleanup_borrowed.cpp
@@ -28,12 +28,14 @@ public:
     { }
 
     void Bootstrap(const TActorContext& ctx) {
-        NTabletPipe::TClientConfig config({
-            .RetryLimitCount = 5,
-            .MinRetryTime = TDuration::MilliSeconds(10),
-            .MaxRetryTime = TDuration::MilliSeconds(100)
-        });
-        config.CheckAliveness = true;
+        NTabletPipe::TClientConfig config{
+            .CheckAliveness = true,
+            .RetryPolicy = {
+                .RetryLimitCount = 5,
+                .MinRetryTime = TDuration::MilliSeconds(10),
+                .MaxRetryTime = TDuration::MilliSeconds(100),
+            },
+        };
 
         for (const auto& kv : BorrowedParts) {
             for (const ui64 tabletId : kv.second) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -7381,7 +7381,7 @@ void TSchemeShard::ConnectToSA() {
         return;
     }
     auto policy = NTabletPipe::TClientRetryPolicy::WithRetries();
-    NTabletPipe::TClientConfig pipeConfig{policy};
+    NTabletPipe::TClientConfig pipeConfig{.RetryPolicy = policy};
     SAPipeClientId = Register(NTabletPipe::CreateClient(SelfId(), (ui64)StatisticsAggregatorId, pipeConfig));
 
     auto connect = std::make_unique<NStat::TEvStatistics::TEvConnectSchemeShard>();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Make it possible to specify a known address hint in pipe client config, e.g. when it is resolved separately, or when we need to ensure connect to a particular address.

Related to #9369.