### PR TITLE
Revert "Support PG types in CDC (#9337)"

### DIFF
--- a/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
+++ b/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
@@ -182,7 +182,8 @@ protected:
         case NScheme::NTypeIds::Yson:
             return YsonToJson(cell.AsBuf());
         case NScheme::NTypeIds::Pg:
-            return NJson::TJsonValue(PgToString(cell.AsBuf(), type));
+            // TODO: support pg types
+            Y_ABORT("pg types are not supported");
         case NScheme::NTypeIds::Uuid:
             return NJson::TJsonValue(NUuid::UuidBytesToString(cell.Data()));
         default:

--- a/ydb/core/tx/datashard/change_sender_cdc_stream.cpp
+++ b/ydb/core/tx/datashard/change_sender_cdc_stream.cpp
@@ -9,7 +9,6 @@
 #include <ydb/core/persqueue/partition_key_range/partition_key_range.h>
 #include <ydb/core/persqueue/writer/source_id_encoding.h>
 #include <ydb/core/persqueue/writer/writer.h>
-#include <ydb/core/scheme/protos/type_info.pb.h>
 #include <ydb/core/tx/scheme_cache/helpers.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -620,13 +619,8 @@ class TCdcChangeSenderMain
 
         schema.reserve(pqConfig.PartitionKeySchemaSize());
         for (const auto& keySchema : pqConfig.GetPartitionKeySchema()) {
-            if (keySchema.GetTypeId() == NScheme::NTypeIds::Pg) {
-                schema.push_back(NScheme::TTypeInfo(
-                    keySchema.GetTypeId(),
-                    NPg::TypeDescFromPgTypeId(keySchema.GetTypeInfo().GetPgTypeId())));
-            } else {
-                schema.push_back(NScheme::TTypeInfo(keySchema.GetTypeId()));
-            }
+            // TODO: support pg types
+            schema.push_back(NScheme::TTypeInfo(keySchema.GetTypeId()));
         }
 
         TSet<TPQPartitionInfo, TPQPartitionInfo::TLess> partitions(schema);

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -838,9 +838,7 @@ Y_UNIT_TEST_SUITE(Cdc) {
                 .SetEnableChangefeedDebeziumJsonFormat(true)
                 .SetEnableTopicMessageMeta(true)
                 .SetEnableChangefeedInitialScan(true)
-                .SetEnableUuidAsPrimaryKey(true)
-                .SetEnableTablePgTypes(true)
-                .SetEnablePgSyntax(true);
+                .SetEnableUuidAsPrimaryKey(true);
 
             Server = new TServer(settings);
             if (useRealThreads) {
@@ -1974,13 +1972,6 @@ Y_UNIT_TEST_SUITE(Cdc) {
                 {"datetime64_value", "Datetime64", false, false},
                 {"timestamp64_value", "Timestamp64", false, false},
                 {"interval64_value", "Interval64", false, false},
-                {"pgint2_value", "pgint2", false, false},
-                {"pgint4_value", "pgint4", false, false},
-                {"pgint8_value", "pgint8", false, false},
-                {"pgfloat4_value", "pgfloat4", false, false},
-                {"pgfloat8_value", "pgfloat8", false, false},
-                {"pgbytea_value", "pgbytea", false, false},
-                {"pgtext_value", "pgtext", false, false},
             });
         TopicRunner::Read(table, Updates(NKikimrSchemeOp::ECdcStreamFormatJson), {
             R"(UPSERT INTO `/Root/Table` (key, int32_value) VALUES (1, -100500);)",
@@ -2006,13 +1997,6 @@ Y_UNIT_TEST_SUITE(Cdc) {
             R"(UPSERT INTO `/Root/Table` (key, datetime64_value) VALUES (21, CAST(1597235696 AS Datetime64));)",
             R"(UPSERT INTO `/Root/Table` (key, timestamp64_value) VALUES (22, CAST(1597235696123456 AS Timestamp64));)",
             R"(UPSERT INTO `/Root/Table` (key, interval64_value) VALUES (23, CAST(-300500 AS Interval64));)",
-            R"(UPSERT INTO `/Root/Table` (key, pgint2_value) VALUES (24, -42ps);)",
-            R"(UPSERT INTO `/Root/Table` (key, pgint4_value) VALUES (25, -420p);)",
-            R"(UPSERT INTO `/Root/Table` (key, pgint8_value) VALUES (26, -4200pb);)",
-            R"(UPSERT INTO `/Root/Table` (key, pgfloat4_value) VALUES (27, 3.1415pf4);)",
-            R"(UPSERT INTO `/Root/Table` (key, pgfloat8_value) VALUES (28, 2.718pf8);)",
-            R"(UPSERT INTO `/Root/Table` (key, pgbytea_value) VALUES (29, 'lorem "ipsum"'pb);)",
-            R"(UPSERT INTO `/Root/Table` (key, pgtext_value) VALUES (30, 'lorem "ipsum"'p);)",
         }, {
             R"({"key":[1],"update":{"int32_value":-100500}})",
             R"({"key":[2],"update":{"uint32_value":100500}})",
@@ -2037,13 +2021,6 @@ Y_UNIT_TEST_SUITE(Cdc) {
             R"({"key":[21],"update":{"datetime64_value":1597235696}})",
             R"({"key":[22],"update":{"timestamp64_value":1597235696123456}})",
             R"({"key":[23],"update":{"interval64_value":-300500}})",
-            R"({"key":[24],"update":{"pgint2_value":"-42"}})",
-            R"({"key":[25],"update":{"pgint4_value":"-420"}})",
-            R"({"key":[26],"update":{"pgint8_value":"-4200"}})",
-            R"({"key":[27],"update":{"pgfloat4_value":"3.1415"}})",
-            R"({"key":[28],"update":{"pgfloat8_value":"2.718"}})",
-            R"({"key":[29],"update":{"pgbytea_value":"\\x6c6f72656d2022697073756d22"}})",
-            R"({"key":[30],"update":{"pgtext_value":"lorem \"ipsum\""}})",
         });
     }
 

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -113,12 +113,6 @@ TString DyNumberToString(TStringBuf data) {
     return result;
 }
 
-TString PgToString(TStringBuf data, const NScheme::TTypeInfo& typeInfo) {
-    const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(data, typeInfo.GetPgTypeDesc());
-    Y_ABORT_UNLESS(pgResult.Error.Empty());
-    return pgResult.Str;
-}
-
 bool DecimalToStream(const std::pair<ui64, i64>& loHi, IOutputStream& out, TString& err) {
     Y_UNUSED(err);
     using namespace NYql::NDecimal;

--- a/ydb/core/tx/datashard/export_common.h
+++ b/ydb/core/tx/datashard/export_common.h
@@ -41,7 +41,6 @@ TMaybe<Ydb::Scheme::ModifyPermissionsRequest> GenYdbPermissions(
 
 TString DecimalToString(const std::pair<ui64, i64>& loHi);
 TString DyNumberToString(TStringBuf data);
-TString PgToString(TStringBuf data, const NScheme::TTypeInfo& typeInfo);
 bool DecimalToStream(const std::pair<ui64, i64>& loHi, IOutputStream& out, TString& err);
 bool DyNumberToStream(TStringBuf data, IOutputStream& out, TString& err);
 bool PgToStream(TStringBuf data, const NScheme::TTypeInfo& typeInfo, IOutputStream& out, TString& err);

--- a/ydb/core/tx/datashard/ut_change_exchange/ya.make
+++ b/ydb/core/tx/datashard/ut_change_exchange/ya.make
@@ -23,7 +23,7 @@ PEERDIR(
     library/cpp/regex/pcre
     library/cpp/svnversion
     ydb/core/kqp/ut/common
-    ydb/core/testlib/pg
+    ydb/core/testlib/default
     ydb/core/tx
     ydb/library/yql/public/udf/service/exception_policy
     ydb/public/lib/yson_value


### PR DESCRIPTION
main is broken, revert problem commit

```
|77.0%| [CC] {BAZEL_UPLOAD} $(S)/ydb/core/tx/datashard/export_common.cpp
------- [CC] {default-linux-x86_64, release, asan, FAILED} $(S)/ydb/core/tx/datashard/change_sender_cdc_stream.cpp
command /home/runner/.ya/tools/v4/6495238978/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/runner/.ya/tools/v4/243881345 -B/home/runner/.ya/tools/v4/243881345/usr/bin -c -o /home/runner/.ya/build/build_root/uuf9/002922/ydb/core/tx/datashard/change_sender_cdc_stream.cpp.o -I/home/runner/.ya/build/build_root/uuf9/002922 -I/home/runner/actions_runner/_work/ydb/ydb -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/linux-headers -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/linux-headers/_nf -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/cxxsupp/libcxx/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/cxxsupp/libcxxrt/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/clang16-rt/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/zlib/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/double-conversion -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libc_compat/include/readpassphrase -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libc_compat/reallocarray -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libc_compat/random -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/abseil-cpp -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/tcmalloc -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libiconv/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/protobuf/src -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/abseil-cpp-tstring -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/grpc/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/c-ares/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/openssl/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/re2/include -I/home/runner/.ya/build/build_root/uuf9/002922/library/cpp/build_info -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libidn/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/brotli/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/snappy/include -I/home/runner/.ya/build/build_root/uuf9/002922/contrib/libs/opentelemetry-proto -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libaio/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/liburing/src/include -I/home/runner/.ya/build/build_root/uuf9/002922/contrib/libs/apache/arrow/cpp/src -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/apache/arrow/cpp/src -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/apache/arrow/src -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/apache/orc/c++/include -I/home/runner/.ya/build/build_root/uuf9/002922/contrib/libs/apache/orc-format/src/main/proto/orc/proto -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/thrift -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libevent/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/interprocess/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/assert/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/config/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/container/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/intrusive/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/move/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/core/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/static_assert/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/throw_exception/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/integer/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/type_traits/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/unordered/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/container_hash/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/describe/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/mp11/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/detail/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/preprocessor/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/predef/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/smart_ptr/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/tuple/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/winapi/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/locale/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/icu/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/iterator/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/concept_check/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/function_types/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/mpl/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/utility/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/io/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/fusion/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/functional/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/function/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/bind/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/typeof/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/optional/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/thread/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/atomic/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/align/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/chrono/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/ratio/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/system/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/variant2/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/date_time/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/algorithm/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/array/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/exception/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/range/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/conversion/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/regex/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/lexical_cast/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/numeric_conversion/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/tokenizer/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/math/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/random/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/dynamic_bitset/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/uriparser/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/cctz/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/sparsehash/src -I/home/runner/.ya/build/build_root/uuf9/002922/contrib/libs/googleapis-common-protos -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/graph/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/any/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/type_index/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/bimap/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/lambda/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/multi_index/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/foreach/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/parameter/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/property_map/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/property_tree/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/serialization/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/spirit/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/endian/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/phoenix/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/proto/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/pool/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/variant/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/tti/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/xpressive/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/icl/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/rational/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/boost/multi_array/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/antlr3_cpp_runtime/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/antlr4_cpp_runtime/src -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/jsonpath/org/antlr/codegen/templates/Cpp -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/jsonpath/org/antlr/codegen/templates/protobuf -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/farmhash/include -I/home/runner/.ya/build/build_root/uuf9/002922/yt/yt/build -I/home/runner/.ya/build/build_root/uuf9/002922/yt -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v0/org/antlr/codegen/templates/Cpp -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v0_proto_split/org/antlr/codegen/templates/protobuf -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1/org/antlr/codegen/templates/Cpp -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1 -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_proto_split/org/antlr/codegen/templates/protobuf -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_proto_split -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_ansi/org/antlr/codegen/templates/Cpp -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_ansi -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_antlr4/org/antlr/v4/tool/templates/codegen/Cpp -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_antlr4 -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_ansi_antlr4/org/antlr/v4/tool/templates/codegen/Cpp -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/parser/proto_ast/gen/v1_ansi_antlr4 -I/home/runner/actions_runner/_work/ydb/ydb/ydb/library/arrow_clickhouse/base -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/cityhash-1.0.2 -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/minikql/computation/llvm14 -I/home/runner/.ya/build/build_root/uuf9/002922/ydb/library/yql/minikql/computation/llvm14/ydb/library/yql/minikql/computation -I/home/runner/.ya/build/build_root/uuf9/002922/contrib/libs/llvm14/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/llvm14/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/aws-sdk-cpp/aws-cpp-sdk-core/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/curl/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/nghttp2/lib/includes -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-auth/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-cal/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-common/generated/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-common/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-http/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-compression/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-io/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/s2n -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/s2n/api -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-sdkutils/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-event-stream/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-checksums/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-mqtt/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-crt-cpp/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/restricted/aws/aws-c-s3/include -I/home/runner/actions_runner/_work/ydb/ydb/contrib/libs/libxml/include -fdebug-prefix-map=/home/runner/.ya/build/build_root/uuf9/002922=/-B -fdebug-prefix-map=/home/runner/actions_runner/_work/ydb/ydb=/-S -fdebug-prefix-map=/home/runner/.ya/tools/v4=/-T -Xclang -fdebug-compilation-dir -Xclang /tmp -pipe -m64 -O3 -gline-tables-only -fexceptions -fno-common -ffunction-sections -fdata-sections -fuse-init-array -fcolor-diagnostics -faligned-allocation -fdebug-default-version=4 -Wall -Wextra -Wno-parentheses -Wno-implicit-const-int-float-conversion -Wno-unknown-warning-option -Werror -DARCADIA_ROOT=/home/runner/actions_runner/_work/ydb/ydb -DARCADIA_BUILD_ROOT=/home/runner/.ya/build/build_root/uuf9/002922 -D_THREAD_SAFE -D_PTHREADS -D_REENTRANT -D_LARGEFILE_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_YNDX_LIBUNWIND_ENABLE_EXCEPTION_BACKTRACE -D__LONG_LONG_SUPPORTED -DSSE_ENABLED=1 -DSSE3_ENABLED=1 -DSSSE3_ENABLED=1 -DSSE41_ENABLED=1 -DSSE42_ENABLED=1 -DPOPCNT_ENABLED=1 -DCX16_ENABLED=1 -fno-omit-frame-pointer -D_libunwind_ -DLIBCXX_BUILDING_LIBCXXRT -DCARES_STATICLIB -DBOOST_ALL_NO_LIB -DBOOST_THREAD_USE_LIB -DBOOST_THREAD_POSIX -DARROW_STATIC -DPARQUET_STATIC -DANTLR4CPP_STATIC -DCURL_STATICLIB -DLIBXML_STATIC -DNDEBUG -Wno-array-parameter -Wno-deprecate-lax-vec-conv-all -Wno-unqualified-std-cast-call -Wno-unused-but-set-parameter -Wno-implicit-function-declaration -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-address-of-packed-member -DCATBOOST_OPENSOURCE=yes -fsanitize=address -Daddress_sanitizer_enabled -fno-omit-frame-pointer -fsanitize-blacklist=/home/runner/actions_runner/_work/ydb/ydb/build/sanitize-blacklist.txt -fno-sanitize-link-runtime -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -DNDEBUG -Wno-array-parameter -Wno-deprecate-lax-vec-conv-all -Wno-unqualified-std-cast-call -Wno-unused-but-set-parameter -Wno-implicit-function-declaration -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-address-of-packed-member -std=c++20 -Woverloaded-virtual -Wimport-preprocessor-directive-pedantic -Wno-ambiguous-reversed-operator -Wno-defaulted-function-deleted -Wno-deprecated-anon-enum-enum-conversion -Wno-deprecated-enum-enum-conversion -Wno-deprecated-enum-float-conversion -Wno-deprecated-volatile -Wno-pessimizing-move -Wno-return-std-move -Wno-undefined-var-template -DUSE_CURRENT_UDF_ABI_VERSION -nostdinc++ -DCATBOOST_OPENSOURCE=yes -nostdinc++ /home/runner/actions_runner/_work/ydb/ydb/ydb/core/tx/datashard/change_sender_cdc_stream.cpp failed with exit code 1 in /home/runner/.ya/build/build_root/uuf9/002922
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/tx/datashard/change_sender_cdc_stream.cpp:624:34: error: no matching constructor for initialization of 'NScheme::TTypeInfo'
                schema.push_back(NScheme::TTypeInfo(
                                 ^
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/scheme_types/scheme_type_info.h:81:15: note: candidate constructor not viable: cannot convert argument of incomplete type 'const ITypeDesc *' to 'const TRawTypeDesc' (aka 'const unsigned long') for 2nd argument
    constexpr TTypeInfo(TTypeId typeId, const TRawTypeDesc typeDesc)
              ^
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/scheme_types/scheme_type_info.h:21:15: note: candidate constructor not viable: requires single argument 'typeInfo', but 2 arguments were provided
    constexpr TTypeInfo(const TTypeInfo& typeInfo)
              ^
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/scheme_types/scheme_type_info.h:26:15: note: candidate constructor not viable: requires single argument 'typeId', but 2 arguments were provided
    constexpr TTypeInfo(TTypeId typeId)
              ^
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/scheme_types/scheme_type_info.h:35:15: note: candidate constructor not viable: requires single argument 'typeDesc', but 2 arguments were provided
    constexpr TTypeInfo(const NKikimr::NPg::ITypeDesc* typeDesc)
              ^
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/scheme_types/scheme_type_info.h:40:15: note: candidate constructor not viable: requires single argument 'decimalType', but 2 arguments were provided
    constexpr TTypeInfo(const TDecimalType& decimalType)
              ^
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/scheme_types/scheme_type_info.h:16:15: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
    constexpr TTypeInfo()
              ^
1 error generated.
Number of suites skipped due to a failed build: 302, skipped by size: 46
```