### PR TITLE
Take the return type of BlockMapJoinCore computation node as an argument

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/ut/mkql_block_map_join_ut.cpp
@@ -77,6 +77,10 @@ const std::vector<TType*> ValidateBlockStreamType(const TType* streamType) {
     return items;
 }
 
+bool IsOptionalOrNull(const TType* type) {
+    return type->IsOptional() || type->IsNull() || type->IsPg();
+}
+
 const TRuntimeNode BuildBlockJoin(TProgramBuilder& pgmBuilder, EJoinKind joinKind,
     const TVector<ui32>& leftKeyColumns, const TVector<ui32>& leftKeyDrops,
     TRuntimeNode& leftArg, TType* leftTuple, const TRuntimeNode& dictNode
@@ -122,6 +126,7 @@ const TRuntimeNode BuildBlockJoin(TProgramBuilder& pgmBuilder, EJoinKind joinKin
         for (const auto& payloadItem : payloadItems) {
             MKQL_ENSURE(!payloadItem->IsBlock(), "Dict payload item has to be non-block");
             const auto itemType = joinKind == EJoinKind::Inner ? payloadItem
+                                : IsOptionalOrNull(payloadItem) ? payloadItem
                                 : pgmBuilder.NewOptionalType(payloadItem);
             dictBlockItems.emplace_back(pgmBuilder.NewBlockType(itemType, TBlockType::EShape::Many));
         }

--- a/ydb/library/yql/minikql/mkql_program_builder.h
+++ b/ydb/library/yql/minikql/mkql_program_builder.h
@@ -257,7 +257,7 @@ public:
         const TArrayRef<const TRuntimeNode>& args, TType* returnType);
     TRuntimeNode BlockMapJoinCore(TRuntimeNode flow, TRuntimeNode dict,
         EJoinKind joinKind, const TArrayRef<const ui32>& leftKeyColumns,
-        const TArrayRef<const ui32>& leftKeyDrops = {});
+        const TArrayRef<const ui32>& leftKeyDrops, TType* returnType);
 
     //-- logical functions
     TRuntimeNode BlockNot(TRuntimeNode data);


### PR DESCRIPTION
This patch changes the signature of the program builder for `BlockMapJoinCore` computation node to make it more similar to `MapJoinCore`. As a result of the patch, the return type resolution is removed from the program builder routine, to implement it in the proper phase (e.g. type annotation) to handle all tricky cases (such as optionals) the right way. 

### Changelog category

* Improvement