### PR TITLE
Move type serialization functions to a separate type_serialization.h

### DIFF
--- a/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
+++ b/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
@@ -1,6 +1,6 @@
 #include "change_record_cdc_serializer.h"
 #include "change_record.h"
-#include "export_common.h"
+#include "type_serialization.h"
 
 #include <ydb/core/protos/change_exchange.pb.h>
 #include <ydb/core/protos/grpc_pq_old.pb.h>
@@ -9,6 +9,7 @@
 #include <ydb/library/binary_json/read.h>
 #include <ydb/library/uuid/uuid.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/public/api/protos/ydb_topic.pb.h>
 
 #include <library/cpp/digest/md5/md5.h>
 #include <library/cpp/json/json_reader.h>

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -3,13 +3,6 @@
 #include <ydb/core/engine/mkql_proto.h>
 #include <ydb/core/ydb_convert/table_description.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
-#include <ydb/library/dynumber/dynumber.h>
-#include <ydb/library/yql/parser/pg_wrapper/interface/type_desc.h>
-#include <ydb/public/lib/scheme_types/scheme_type_id.h>
-
-#include <ydb/library/yql/public/decimal/yql_decimal.h>
-
-#include <util/generic/algorithm.h>
 
 namespace NKikimr {
 namespace NDataShard {
@@ -93,69 +86,6 @@ TMaybe<Ydb::Scheme::ModifyPermissionsRequest> GenYdbPermissions(const NKikimrSch
     }
 
     return permissions;
-}
-
-TString DecimalToString(const std::pair<ui64, i64>& loHi) {
-    using namespace NYql::NDecimal;
-
-    TInt128 val = FromHalfs(loHi.first, loHi.second);
-    return ToString(val, NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE);
-}
-
-TString DyNumberToString(TStringBuf data) {
-    TString result;
-    TStringOutput out(result);
-    TStringBuilder err;
-
-    bool success = DyNumberToStream(data, out, err);
-    Y_ABORT_UNLESS(success);
-
-    return result;
-}
-
-TString PgToString(TStringBuf data, const NScheme::TTypeInfo& typeInfo) {
-    const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(data, typeInfo.GetPgTypeDesc());
-    Y_ABORT_UNLESS(pgResult.Error.Empty());
-    return pgResult.Str;
-}
-
-bool DecimalToStream(const std::pair<ui64, i64>& loHi, IOutputStream& out, TString& err) {
-    Y_UNUSED(err);
-    using namespace NYql::NDecimal;
-
-    TInt128 val = FromHalfs(loHi.first, loHi.second);
-    out << ToString(val, NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE);
-    return true;
-}
-
-bool DyNumberToStream(TStringBuf data, IOutputStream& out, TString& err) {
-    auto result = NDyNumber::DyNumberToString(data);
-    if (!result.Defined()) {
-        err = "Invalid DyNumber binary representation";
-        return false;
-    }
-    out << *result;
-    return true;
-}
-
-bool PgToStream(TStringBuf data, const NScheme::TTypeInfo& typeInfo, IOutputStream& out, TString& err) {
-    const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(data, typeInfo.GetPgTypeDesc());
-    if (pgResult.Error) {
-        err = *pgResult.Error;
-        return false;
-    }
-    out << '"' << CGIEscapeRet(pgResult.Str) << '"';
-    return true;
-}
-
-bool UuidToStream(const std::pair<ui64, ui64>& loHi, IOutputStream& out, TString& err) {
-    Y_UNUSED(err);
-
-    NYdb::TUuidValue uuid(loHi.first, loHi.second);
-    
-    out << uuid.ToString();
-    
-    return true;
 }
 
 } // NDataShard

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -4,6 +4,8 @@
 #include <ydb/core/ydb_convert/table_description.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
 
+#include <util/generic/algorithm.h>
+
 namespace NKikimr {
 namespace NDataShard {
 

--- a/ydb/core/tx/datashard/export_common.h
+++ b/ydb/core/tx/datashard/export_common.h
@@ -8,8 +8,6 @@
 
 #include <util/generic/map.h>
 #include <util/generic/maybe.h>
-#include <util/generic/string.h>
-#include <util/generic/vector.h>
 
 #if defined EXPORT_LOG_T || \
     defined EXPORT_LOG_D || \
@@ -29,8 +27,7 @@
 #define EXPORT_LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::DATASHARD_BACKUP, "[Export] [" << LogPrefix() << "] " << stream)
 #define EXPORT_LOG_C(stream) LOG_CRIT_S(*TlsActivationContext, NKikimrServices::DATASHARD_BACKUP, "[Export] [" << LogPrefix() << "] " << stream)
 
-namespace NKikimr {
-namespace NDataShard {
+namespace NKikimr::NDataShard {
 
 TMaybe<Ydb::Table::CreateTableRequest> GenYdbScheme(
     const TMap<ui32, TUserTable::TUserColumn>& columns,
@@ -39,13 +36,4 @@ TMaybe<Ydb::Table::CreateTableRequest> GenYdbScheme(
 TMaybe<Ydb::Scheme::ModifyPermissionsRequest> GenYdbPermissions(
     const NKikimrSchemeOp::TPathDescription& pathDesc);
 
-TString DecimalToString(const std::pair<ui64, i64>& loHi);
-TString DyNumberToString(TStringBuf data);
-TString PgToString(TStringBuf data, const NScheme::TTypeInfo& typeInfo);
-bool DecimalToStream(const std::pair<ui64, i64>& loHi, IOutputStream& out, TString& err);
-bool DyNumberToStream(TStringBuf data, IOutputStream& out, TString& err);
-bool PgToStream(TStringBuf data, const NScheme::TTypeInfo& typeInfo, IOutputStream& out, TString& err);
-bool UuidToStream(const std::pair<ui64, ui64>& loHi, IOutputStream& out, TString& err);
-
-} // NDataShard
-} // NKikimr
+} // NKikimr::NDataShard

--- a/ydb/core/tx/datashard/export_s3_buffer_raw.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer_raw.cpp
@@ -1,6 +1,6 @@
 #ifndef KIKIMR_DISABLE_S3_OPS
 
-#include "export_common.h"
+#include "type_serialization.h"
 #include "export_s3_buffer_raw.h"
 
 #include <ydb/core/tablet_flat/flat_row_state.h>

--- a/ydb/core/tx/datashard/export_s3_buffer_raw.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer_raw.cpp
@@ -1,7 +1,7 @@
 #ifndef KIKIMR_DISABLE_S3_OPS
 
-#include "type_serialization.h"
 #include "export_s3_buffer_raw.h"
+#include "type_serialization.h"
 
 #include <ydb/core/tablet_flat/flat_row_state.h>
 #include <ydb/library/binary_json/read.h>

--- a/ydb/core/tx/datashard/type_serialization.cpp
+++ b/ydb/core/tx/datashard/type_serialization.cpp
@@ -1,0 +1,77 @@
+#include "type_serialization.h"
+
+#include <ydb/library/dynumber/dynumber.h>
+#include <ydb/library/yql/parser/pg_wrapper/interface/type_desc.h>
+#include <ydb/library/yql/public/decimal/yql_decimal.h>
+#include <ydb/public/sdk/cpp/client/ydb_value/value.h>
+
+#include <library/cpp/string_utils/quote/quote.h>
+
+#include <util/string/builder.h>
+
+namespace NKikimr::NDataShard {
+
+TString DecimalToString(const std::pair<ui64, i64>& loHi) {
+    using namespace NYql::NDecimal;
+
+    TInt128 val = FromHalfs(loHi.first, loHi.second);
+    return ToString(val, NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE);
+}
+
+TString DyNumberToString(TStringBuf data) {
+    TString result;
+    TStringOutput out(result);
+    TStringBuilder err;
+
+    bool success = DyNumberToStream(data, out, err);
+    Y_ABORT_UNLESS(success);
+
+    return result;
+}
+
+TString PgToString(TStringBuf data, const NScheme::TTypeInfo& typeInfo) {
+    const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(data, typeInfo.GetPgTypeDesc());
+    Y_ABORT_UNLESS(pgResult.Error.Empty());
+    return pgResult.Str;
+}
+
+bool DecimalToStream(const std::pair<ui64, i64>& loHi, IOutputStream& out, TString& err) {
+    Y_UNUSED(err);
+    using namespace NYql::NDecimal;
+
+    TInt128 val = FromHalfs(loHi.first, loHi.second);
+    out << ToString(val, NScheme::DECIMAL_PRECISION, NScheme::DECIMAL_SCALE);
+    return true;
+}
+
+bool DyNumberToStream(TStringBuf data, IOutputStream& out, TString& err) {
+    auto result = NDyNumber::DyNumberToString(data);
+    if (!result.Defined()) {
+        err = "Invalid DyNumber binary representation";
+        return false;
+    }
+    out << *result;
+    return true;
+}
+
+bool PgToStream(TStringBuf data, const NScheme::TTypeInfo& typeInfo, IOutputStream& out, TString& err) {
+    const NPg::TConvertResult& pgResult = NPg::PgNativeTextFromNativeBinary(data, typeInfo.GetPgTypeDesc());
+    if (pgResult.Error) {
+        err = *pgResult.Error;
+        return false;
+    }
+    out << '"' << CGIEscapeRet(pgResult.Str) << '"';
+    return true;
+}
+
+bool UuidToStream(const std::pair<ui64, ui64>& loHi, IOutputStream& out, TString& err) {
+    Y_UNUSED(err);
+
+    NYdb::TUuidValue uuid(loHi.first, loHi.second);
+    
+    out << uuid.ToString();
+    
+    return true;
+}
+
+} // NKikimr::NDataShard

--- a/ydb/core/tx/datashard/type_serialization.h
+++ b/ydb/core/tx/datashard/type_serialization.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ydb/core/scheme_types/scheme_type_info.h>
+
+#include <util/generic/string.h>
+
+namespace NKikimr::NDataShard {
+
+TString DecimalToString(const std::pair<ui64, i64>& loHi);
+TString DyNumberToString(TStringBuf data);
+TString PgToString(TStringBuf data, const NScheme::TTypeInfo& typeInfo);
+bool DecimalToStream(const std::pair<ui64, i64>& loHi, IOutputStream& out, TString& err);
+bool DyNumberToStream(TStringBuf data, IOutputStream& out, TString& err);
+bool PgToStream(TStringBuf data, const NScheme::TTypeInfo& typeInfo, IOutputStream& out, TString& err);
+bool UuidToStream(const std::pair<ui64, ui64>& loHi, IOutputStream& out, TString& err);
+
+} // NKikimr::NDataShard

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -208,6 +208,7 @@ SRCS(
     store_snapshot_tx_unit.cpp
     store_write_unit.cpp
     stream_scan_common.cpp
+    type_serialization.cpp
     upload_stats.cpp
     volatile_tx.cpp
     wait_for_plan_unit.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Small refactoring: move type serialization functions from export_common.h to type_serialization.h

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
