### PR TITLE
Remove clang14 from PRs and other workflows

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -198,6 +198,12 @@ runs:
           release)  
             params+=(--build "release")
             ;;
+          release-clang14)  # TODO: remove after removing from workflow 
+            params+=(--build "release")
+            params+=(--target-platform="CLANG14-LINUX-X86_64")
+            params+=(-DLLD_VERSION=16)
+            params+=(-DSTRIP)
+            ;;
           release-asan)
             params+=(
               --build "release" --sanitize="address"

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -198,12 +198,6 @@ runs:
           release)  
             params+=(--build "release")
             ;;
-          release-clang14)
-            params+=(--build "release")
-            params+=(--target-platform="CLANG14-LINUX-X86_64")
-            params+=(-DLLD_VERSION=16)
-            params+=(-DSTRIP)
-            ;;
           release-asan)
             params+=(
               --build "release" --sanitize="address"

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -205,7 +205,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_preset: ["relwithdebinfo", "release-asan", "release-clang14"]
+        build_preset: ["relwithdebinfo", "release-asan"]
     runs-on: [ self-hosted, auto-provisioned, "${{ format('build-preset-{0}', matrix.build_preset) }}" ]
     name: Build and test ${{ matrix.build_preset }}
     steps:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Arcadia doesn't need clang14 
Cmake builds are not working at current moment, ignoring them

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
