### PR TITLE
Fix PDisks becoming INACTIVE in normal flow

### DIFF
--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -26,6 +26,7 @@ struct TCmsSentinelConfig {
     ui32 ChangeStatusRetries;
 
     ui32 DefaultStateLimit;
+    ui32 GoodStateLimit;
     TMap<EPDiskState, ui32> StateLimits;
 
     ui32 DataCenterRatio;
@@ -44,6 +45,7 @@ struct TCmsSentinelConfig {
         config.SetRetryChangeStatus(RetryChangeStatus.GetValue());
         config.SetChangeStatusRetries(ChangeStatusRetries);
         config.SetDefaultStateLimit(DefaultStateLimit);
+        config.SetGoodStateLimit(GoodStateLimit);
         config.SetDataCenterRatio(DataCenterRatio);
         config.SetRoomRatio(RoomRatio);
         config.SetRackRatio(RackRatio);
@@ -62,6 +64,7 @@ struct TCmsSentinelConfig {
         RetryChangeStatus = TDuration::MicroSeconds(config.GetRetryChangeStatus());
         ChangeStatusRetries = config.GetChangeStatusRetries();
         DefaultStateLimit = config.GetDefaultStateLimit();
+        GoodStateLimit = config.GetGoodStateLimit();
         DataCenterRatio = config.GetDataCenterRatio();
         RoomRatio = config.GetRoomRatio();
         RackRatio = config.GetRackRatio();

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -613,11 +613,11 @@ class TStateUpdater: public TUpdaterBase<TEvSentinel::TEvStateUpdated, TStateUpd
         Reply();
     }
 
-    bool IsNodeLocked(ui32 nodeId) {
-        auto& clusterInfo = CmsState->ClusterInfo;
+    bool IsNodeLocked(ui32 nodeId) const {
+        const auto& clusterInfo = CmsState->ClusterInfo;
 
         if (clusterInfo && clusterInfo->HasNode(nodeId)) {
-            auto& node = clusterInfo->Node(nodeId);
+            const auto& node = clusterInfo->Node(nodeId);
             TErrorInfo unused;
             if (node.IsLocked(unused, TDuration::Zero(), TInstant::Zero(), TDuration::Zero())) {
                 return true;

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -43,14 +43,44 @@ namespace NSentinel {
 
 /// TPDiskStatusComputer
 
-TPDiskStatusComputer::TPDiskStatusComputer(const ui32& defaultStateLimit, const TLimitsMap& stateLimits)
+TPDiskStatusComputer::TPDiskStatusComputer(const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits)
     : DefaultStateLimit(defaultStateLimit)
+    , GoodStateLimit(goodStateLimit)
     , StateLimits(stateLimits)
     , StateCounter(0)
 {
 }
 
-void TPDiskStatusComputer::AddState(EPDiskState state) {
+bool IsGoodState(EPDiskState state) {
+    switch (state) {
+        case NKikimrBlobStorage::TPDiskState::Unknown:
+            return false;
+        case NKikimrBlobStorage::TPDiskState::Initial:
+        case NKikimrBlobStorage::TPDiskState::InitialFormatRead:
+        case NKikimrBlobStorage::TPDiskState::InitialSysLogRead:
+        case NKikimrBlobStorage::TPDiskState::InitialCommonLogRead:
+        case NKikimrBlobStorage::TPDiskState::Normal:
+            return true;
+        case NKikimrBlobStorage::TPDiskState::InitialFormatReadError:
+        case NKikimrBlobStorage::TPDiskState::InitialSysLogReadError:
+        case NKikimrBlobStorage::TPDiskState::InitialSysLogParseError:
+        case NKikimrBlobStorage::TPDiskState::InitialCommonLogReadError:
+        case NKikimrBlobStorage::TPDiskState::InitialCommonLogParseError:
+        case NKikimrBlobStorage::TPDiskState::CommonLoggerInitError:
+        case NKikimrBlobStorage::TPDiskState::OpenFileError:
+        case NKikimrBlobStorage::TPDiskState::ChunkQuotaError:
+        case NKikimrBlobStorage::TPDiskState::DeviceIoError:
+        case NKikimrBlobStorage::TPDiskState::Reserved14:
+        case NKikimrBlobStorage::TPDiskState::Reserved15:
+        case NKikimrBlobStorage::TPDiskState::Reserved16:
+        case NKikimrBlobStorage::TPDiskState::Missing:
+        case NKikimrBlobStorage::TPDiskState::Timeout:
+        case NKikimrBlobStorage::TPDiskState::NodeDisconnected:
+            return false;
+    }
+}
+
+void TPDiskStatusComputer::AddState(EPDiskState state, bool isNodeLocked) {
     if (StateCounter && state == State) {
         if (StateCounter != Max<ui64>()) {
             ++StateCounter;
@@ -58,6 +88,12 @@ void TPDiskStatusComputer::AddState(EPDiskState state) {
     } else {
         PrevState = std::exchange(State, state);
         StateCounter = 1;
+    }
+
+    if (!isNodeLocked && !IsGoodState(state)) {
+        // If node is not locked (i.e. it is not in maintenance mode),
+        // then we should remember that we had a bad state recently
+        HadBadStateRecently = true;
     }
 }
 
@@ -81,12 +117,18 @@ EPDiskStatus TPDiskStatusComputer::Compute(EPDiskStatus current, TString& reason
             << " State# " << State
             << " StateCounter# " << StateCounter
             << " current# " << current;
-        switch (PrevState) {
-            case NKikimrBlobStorage::TPDiskState::Unknown:
-                return current;
-            default:
-                return EPDiskStatus::INACTIVE;
+
+        if (PrevState == NKikimrBlobStorage::TPDiskState::Unknown) {
+            return current;
         }
+
+        if (IsGoodState(PrevState) && State == NKikimrBlobStorage::TPDiskState::Normal) {
+            if (!HadBadStateRecently && (StateCounter >= GoodStateLimit)) {
+                return EPDiskStatus::ACTIVE;
+            }
+        }
+
+        return EPDiskStatus::INACTIVE;
     }
 
     reason = TStringBuilder()
@@ -99,6 +141,7 @@ EPDiskStatus TPDiskStatusComputer::Compute(EPDiskStatus current, TString& reason
 
     switch (State) {
         case NKikimrBlobStorage::TPDiskState::Normal:
+            HadBadStateRecently = false;
             return EPDiskStatus::ACTIVE;
         default:
             return EPDiskStatus::FAULTY;
@@ -135,15 +178,15 @@ void TPDiskStatusComputer::ResetForcedStatus() {
 
 /// TPDiskStatus
 
-TPDiskStatus::TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const TLimitsMap& stateLimits)
-    : TPDiskStatusComputer(defaultStateLimit, stateLimits)
+TPDiskStatus::TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits)
+    : TPDiskStatusComputer(defaultStateLimit, goodStateLimit, stateLimits)
     , Current(initialStatus)
     , ChangingAllowed(true)
 {
 }
 
-void TPDiskStatus::AddState(EPDiskState state) {
-    TPDiskStatusComputer::AddState(state);
+void TPDiskStatus::AddState(EPDiskState state, bool isNodeLocked) {
+    TPDiskStatusComputer::AddState(state, isNodeLocked);
 }
 
 bool TPDiskStatus::IsChanged() const {
@@ -198,15 +241,15 @@ void TPDiskStatus::DisallowChanging() {
 
 /// TPDiskInfo
 
-TPDiskInfo::TPDiskInfo(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const TLimitsMap& stateLimits)
-    : TPDiskStatus(initialStatus, defaultStateLimit, stateLimits)
+TPDiskInfo::TPDiskInfo(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits)
+    : TPDiskStatus(initialStatus, defaultStateLimit, goodStateLimit, stateLimits)
     , ActualStatus(initialStatus)
 {
     Touch();
 }
 
-void TPDiskInfo::AddState(EPDiskState state) {
-    TPDiskStatus::AddState(state);
+void TPDiskInfo::AddState(EPDiskState state, bool isNodeLocked) {
+    TPDiskStatus::AddState(state, isNodeLocked);
     Touch();
 }
 
@@ -476,7 +519,7 @@ class TConfigUpdater: public TUpdaterBase<TEvSentinel::TEvConfigUpdated, TConfig
                     continue;
                 }
 
-                pdisks.emplace(id, new TPDiskInfo(pdisk.GetDriveStatus(), Config.DefaultStateLimit, Config.StateLimits));
+                pdisks.emplace(id, new TPDiskInfo(pdisk.GetDriveStatus(), Config.DefaultStateLimit, Config.GoodStateLimit, Config.StateLimits));
             }
 
             SentinelState->ConfigUpdaterState.GotBSCResponse = true;
@@ -570,16 +613,31 @@ class TStateUpdater: public TUpdaterBase<TEvSentinel::TEvStateUpdated, TStateUpd
         Reply();
     }
 
+    bool IsNodeLocked(ui32 nodeId) {
+        auto& clusterInfo = CmsState->ClusterInfo;
+
+        if (clusterInfo && clusterInfo->HasNode(nodeId)) {
+            auto& node = clusterInfo->Node(nodeId);
+            TErrorInfo unused;
+            if (node.IsLocked(unused, TDuration::Zero(), TInstant::Zero(), TDuration::Zero())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void MarkNodePDisks(ui32 nodeId, EPDiskState state, bool skipTouched = false) {
+        bool isNodeLocked = IsNodeLocked(nodeId);
         auto it = SentinelState->PDisks.lower_bound(TPDiskID(nodeId, 0));
         while (it != SentinelState->PDisks.end() && it->first.NodeId == nodeId) {
             if (skipTouched && it->second->IsTouched()) {
                 ++it;
                 continue;
             }
-
+            
             Y_ABORT_UNLESS(!it->second->IsTouched());
-            it->second->AddState(state);
+            it->second->AddState(state, isNodeLocked);
             ++it;
         }
     }
@@ -613,6 +671,7 @@ class TStateUpdater: public TUpdaterBase<TEvSentinel::TEvStateUpdated, TStateUpd
                 << ": nodeId# " << nodeId);
             MarkNodePDisks(nodeId, NKikimrBlobStorage::TPDiskState::Missing);
         } else {
+            const bool isNodeLocked = IsNodeLocked(nodeId);
             for (const auto& info : record.GetPDiskStateInfo()) {
                 auto it = SentinelState->PDisks.find(TPDiskID(nodeId, info.GetPDiskId()));
                 if (it == SentinelState->PDisks.end()) {
@@ -625,7 +684,7 @@ class TStateUpdater: public TUpdaterBase<TEvSentinel::TEvStateUpdated, TStateUpd
                     << ", original# " << (ui32)info.GetState()
                     << ", safeState# " << safeState);
 
-                it->second->AddState(safeState);
+                it->second->AddState(safeState, isNodeLocked);
             }
 
             MarkNodePDisks(nodeId, NKikimrBlobStorage::TPDiskState::Missing, true);

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -15,9 +15,9 @@ using TLimitsMap = TMap<EPDiskState, ui32>;
 
 class TPDiskStatusComputer {
 public:
-    explicit TPDiskStatusComputer(const ui32& defaultStateLimit, const TLimitsMap& stateLimits);
+    explicit TPDiskStatusComputer(const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits);
 
-    void AddState(EPDiskState state);
+    void AddState(EPDiskState state, bool isNodeLocked);
     EPDiskStatus Compute(EPDiskStatus current, TString& reason) const;
 
     EPDiskState GetState() const;
@@ -32,20 +32,23 @@ public:
 
 private:
     const ui32& DefaultStateLimit;
+    const ui32& GoodStateLimit;
     const TLimitsMap& StateLimits;
 
     EPDiskState State = NKikimrBlobStorage::TPDiskState::Unknown;
     mutable EPDiskState PrevState = State;
     ui64 StateCounter;
     TMaybe<EPDiskStatus> ForcedStatus;
+    
+    mutable bool HadBadStateRecently = false;
 
 }; // TPDiskStatusComputer
 
 class TPDiskStatus: public TPDiskStatusComputer {
 public:
-    explicit TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const TLimitsMap& stateLimits);
+    explicit TPDiskStatus(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits);
 
-    void AddState(EPDiskState state);
+    void AddState(EPDiskState state, bool isNodeLocked);
     bool IsChanged() const;
     void ApplyChanges(TString& reason);
     void ApplyChanges();
@@ -92,13 +95,13 @@ struct TPDiskInfo
     ui32 PrevStatusChangeAttempt = 0;
     EIgnoreReason IgnoreReason = NKikimrCms::TPDiskInfo::NOT_IGNORED;
 
-    explicit TPDiskInfo(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const TLimitsMap& stateLimits);
+    explicit TPDiskInfo(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const ui32& goodStateLimit, const TLimitsMap& stateLimits);
 
     bool IsTouched() const { return Touched; }
     void Touch() { Touched = true; }
     void ClearTouched() { Touched = false; }
 
-    void AddState(EPDiskState state);
+    void AddState(EPDiskState state, bool isNodeLocked);
 
 private:
     bool Touched;

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -19,6 +19,14 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
     using namespace NCms::NSentinel;
     using TPDiskID = NCms::TPDiskID;
 
+    void AddState(TPDiskStatus& st, const EPDiskState state) {
+        st.AddState(state, false);
+    }
+
+    void AddStateNodeLocked(TPDiskStatus& st, const EPDiskState state) {
+        st.AddState(state, true);
+    }
+
     Y_UNIT_TEST(PDiskInitialStatus) {
         const EPDiskStatus AllStatuses[] = {
             EPDiskStatus::UNKNOWN,
@@ -30,7 +38,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
         };
 
         for (const EPDiskStatus status : AllStatuses) {
-            TPDiskStatus st(status, DefaultStateLimit, DefaultStateLimits);
+            TPDiskStatus st(status, DefaultStateLimit, GoodStateLimit, DefaultStateLimits);
 
             UNIT_ASSERT(!st.IsChanged());
             UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), status);
@@ -40,15 +48,15 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
     Y_UNIT_TEST(PDiskErrorState) {
         for (const EPDiskState state : ErrorStates) {
             const EPDiskStatus initialStatus = EPDiskStatus::ACTIVE;
-            TPDiskStatus st(initialStatus, DefaultStateLimit, DefaultStateLimits);
+            TPDiskStatus st(initialStatus, DefaultStateLimit, GoodStateLimit, DefaultStateLimits);
 
             for (ui32 i = 1; i < DefaultStateLimits[state]; ++i) {
-                st.AddState(state);
+                AddState(st, state);
 
                 UNIT_ASSERT(!st.IsChanged());
                 UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), initialStatus);
             }
-            st.AddState(state);
+            AddState(st, state);
             UNIT_ASSERT(st.IsChanged());
 
             st.ApplyChanges();
@@ -59,15 +67,15 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
     Y_UNIT_TEST(PDiskInactiveAfterStateChange) {
         for (const EPDiskState state : ErrorStates) {
             const EPDiskStatus initialStatus = EPDiskStatus::ACTIVE;
-            TPDiskStatus st(initialStatus, DefaultStateLimit, DefaultStateLimits);
+            TPDiskStatus st(initialStatus, DefaultStateLimit, GoodStateLimit, DefaultStateLimits);
 
             for (ui32 i = 1; i < DefaultStateLimits[state]; ++i) {
-                st.AddState(state);
+                AddState(st, state);
 
                 UNIT_ASSERT(!st.IsChanged());
                 UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), initialStatus);
             }
-            st.AddState(state);
+            AddState(st, state);
             UNIT_ASSERT(st.IsChanged());
             st.ApplyChanges();
             UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::FAULTY);
@@ -75,7 +83,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
             auto it = DefaultStateLimits.find(NKikimrBlobStorage::TPDiskState::Normal);
             const ui32 stateLimit = (it != DefaultStateLimits.end()) ? it->second : DefaultStateLimit;
             for (ui32 i = 1; i < stateLimit; ++i) {
-                st.AddState(NKikimrBlobStorage::TPDiskState::Normal);
+                AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
 
                 if (i == 1) {
                     UNIT_ASSERT(st.IsChanged());
@@ -85,7 +93,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
                 }
                 UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::INACTIVE);
             }
-            st.AddState(NKikimrBlobStorage::TPDiskState::Normal);
+            AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
             UNIT_ASSERT(st.IsChanged());
             st.ApplyChanges();
             UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::ACTIVE);
@@ -95,22 +103,166 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
     Y_UNIT_TEST(PDiskFaultyState) {
         for (const EPDiskState state : FaultyStates) {
             const EPDiskStatus initialStatus = EPDiskStatus::ACTIVE;
-            TPDiskStatus st(initialStatus, DefaultStateLimit, DefaultStateLimits);
+            TPDiskStatus st(initialStatus, DefaultStateLimit, GoodStateLimit, DefaultStateLimits);
 
             for (ui32 i = 1; i < DefaultStateLimit; ++i) {
-                st.AddState(state);
+                AddState(st, state);
 
                 UNIT_ASSERT(!st.IsChanged());
                 UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), initialStatus);
             }
 
-            st.AddState(state);
+            AddState(st, state);
 
             UNIT_ASSERT(st.IsChanged());
 
             st.ApplyChanges();
             UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::FAULTY);
         }
+    }
+
+    Y_UNIT_TEST(PDiskStateChangeNormalFlow) {
+        // If disk has only been in good state, then change to Normal state within GoodStateLimit
+        const EPDiskStatus initialStatus = EPDiskStatus::ACTIVE;
+        TPDiskStatus st(initialStatus, 60, GoodStateLimit, DefaultStateLimits);
+
+        AddState(st, NKikimrBlobStorage::TPDiskState::Initial);
+        UNIT_ASSERT(!st.IsChanged());
+
+        AddState(st, NKikimrBlobStorage::TPDiskState::InitialFormatRead);
+        UNIT_ASSERT(st.IsChanged());
+        st.ApplyChanges();
+        UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::INACTIVE);
+
+        AddState(st, NKikimrBlobStorage::TPDiskState::InitialSysLogRead);
+        UNIT_ASSERT(!st.IsChanged());
+
+        AddState(st, NKikimrBlobStorage::TPDiskState::InitialCommonLogRead);
+        UNIT_ASSERT(!st.IsChanged());
+
+        for (ui32 i = 0; i < GoodStateLimit - 1; ++i) {
+            AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
+            UNIT_ASSERT(!st.IsChanged());
+        }
+
+        AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
+
+        UNIT_ASSERT(st.IsChanged());
+        st.ApplyChanges();
+        UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::ACTIVE);
+    }
+
+    Y_UNIT_TEST(PDiskStateChangeNodePermanentlyBad) {
+        // If node is restarting all the time, then disk should never become ACTIVE
+        const EPDiskStatus initialStatus = EPDiskStatus::INACTIVE;
+        TPDiskStatus st(initialStatus, 60, GoodStateLimit, DefaultStateLimits);
+
+        AddState(st, NKikimrBlobStorage::TPDiskState::Unknown);
+        UNIT_ASSERT(!st.IsChanged());
+        UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::INACTIVE);
+
+        auto goodStates = {
+            NKikimrBlobStorage::TPDiskState::InitialFormatRead,
+            NKikimrBlobStorage::TPDiskState::InitialSysLogRead,
+            NKikimrBlobStorage::TPDiskState::InitialCommonLogRead,
+            NKikimrBlobStorage::TPDiskState::Normal,
+        };
+
+        for (ui32 i = 0; i < 10; ++i) {
+            for (auto state : goodStates) {
+                for (ui32 j = 0; j < 2; ++j) {
+                    AddState(st, state);
+                    UNIT_ASSERT(!st.IsChanged());
+                }
+            }
+
+            AddState(st, NKikimrBlobStorage::TPDiskState::NodeDisconnected);
+            UNIT_ASSERT(!st.IsChanged());
+        }
+    }
+
+    Y_UNIT_TEST(PDiskStateChangeNodeNotExpectedRestart) {
+        // Node restarts and it is not planned, so disk should become ACTIVE only after defaultStateLimit
+        const EPDiskStatus initialStatus = EPDiskStatus::INACTIVE;
+        const ui32 defaultStateLimit = 60;
+        TPDiskStatus st(initialStatus, defaultStateLimit, GoodStateLimit, DefaultStateLimits);
+
+        auto nodeStartFn = [&st]() {
+            AddState(st, NKikimrBlobStorage::TPDiskState::Unknown);
+            UNIT_ASSERT(!st.IsChanged());
+            UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::INACTIVE);
+
+            AddState(st, NKikimrBlobStorage::TPDiskState::InitialFormatRead);
+            UNIT_ASSERT(!st.IsChanged());
+
+            AddState(st, NKikimrBlobStorage::TPDiskState::InitialSysLogRead);
+            UNIT_ASSERT(!st.IsChanged());
+
+            AddState(st, NKikimrBlobStorage::TPDiskState::InitialSysLogRead);
+            UNIT_ASSERT(!st.IsChanged());
+
+            for (ui32 i = 0; i < GoodStateLimit; ++i) {
+                AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
+            }
+            UNIT_ASSERT(!st.IsChanged());
+
+            for (ui32 i = 0; i < defaultStateLimit - GoodStateLimit; ++i) {
+                AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
+            }
+
+            UNIT_ASSERT(st.IsChanged());
+            st.ApplyChanges();
+            UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::ACTIVE);
+        };
+
+        nodeStartFn();
+
+        AddState(st, NKikimrBlobStorage::TPDiskState::NodeDisconnected);
+
+        UNIT_ASSERT(st.IsChanged());
+        st.ApplyChanges();
+        UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::INACTIVE);
+
+        nodeStartFn();
+    }
+
+    Y_UNIT_TEST(PDiskStateChangeNodeExpectedRestart) {
+        // Node restarts, but it is planned (node is locked by CMS), so disk should become ACTIVE after GoodStateLimit
+        const EPDiskStatus initialStatus = EPDiskStatus::INACTIVE;
+        TPDiskStatus st(initialStatus, 60, GoodStateLimit, DefaultStateLimits);
+
+        auto nodeStartFn = [&st]() {
+            AddStateNodeLocked(st, NKikimrBlobStorage::TPDiskState::Unknown);
+            UNIT_ASSERT(!st.IsChanged());
+            UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::INACTIVE);
+
+            AddStateNodeLocked(st, NKikimrBlobStorage::TPDiskState::InitialFormatRead);
+            UNIT_ASSERT(!st.IsChanged());
+
+            AddStateNodeLocked(st, NKikimrBlobStorage::TPDiskState::InitialSysLogRead);
+            UNIT_ASSERT(!st.IsChanged());
+
+            AddStateNodeLocked(st, NKikimrBlobStorage::TPDiskState::InitialSysLogRead);
+            UNIT_ASSERT(!st.IsChanged());
+
+            for (ui32 i = 0; i < GoodStateLimit; ++i) {
+                AddStateNodeLocked(st, NKikimrBlobStorage::TPDiskState::Normal);
+            }
+
+            UNIT_ASSERT(st.IsChanged());
+            st.ApplyChanges();
+            UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::ACTIVE);
+        };
+
+        nodeStartFn();
+
+        AddStateNodeLocked(st, NKikimrBlobStorage::TPDiskState::NodeDisconnected);
+
+        UNIT_ASSERT(st.IsChanged());
+        st.ApplyChanges();
+        UNIT_ASSERT_VALUES_EQUAL(st.GetStatus(), EPDiskStatus::INACTIVE);
+
+        nodeStartFn();
     }
 
     std::pair<TCmsStatePtr, TSentinelState::TPtr> MockCmsState(ui16 numDataCenter, ui16 racksPerDataCenter, ui16 nodesPerRack, ui16 pdisksPerNode, bool anyDC, bool anyRack) {

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -21,12 +21,10 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
 
     void AddState(TPDiskStatus& st, const EPDiskState state) {
         st.AddState(state, false);
-        Cerr << st.GetStatus() << " " << st.GetState() << " " << st.GetPrevState() << " " << st.GetStateCounter() << Endl;
     }
 
     void AddStateNodeLocked(TPDiskStatus& st, const EPDiskState state) {
         st.AddState(state, true);
-        Cerr << st.GetStatus() << " " << st.GetState() << " " << st.GetPrevState() << " " << st.GetStateCounter() << Endl;
     }
 
     Y_UNIT_TEST(PDiskInitialStatus) {
@@ -126,7 +124,8 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
     Y_UNIT_TEST(PDiskStateChangeNormalFlow) {
         // If disk has only been in good state, then change to Normal state within GoodStateLimit
         const EPDiskStatus initialStatus = EPDiskStatus::ACTIVE;
-        TPDiskStatus st(initialStatus, 60, GoodStateLimit, DefaultStateLimits);
+        const ui32 defaultStateLimit = 60;
+        TPDiskStatus st(initialStatus, defaultStateLimit, GoodStateLimit, DefaultStateLimits);
 
         AddState(st, NKikimrBlobStorage::TPDiskState::Initial);
         UNIT_ASSERT(!st.IsChanged());
@@ -143,7 +142,6 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
         UNIT_ASSERT(!st.IsChanged());
 
         for (ui32 i = 0; i < GoodStateLimit - 1; ++i) {
-            Cerr << "i = " << i << Endl;
             AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
             UNIT_ASSERT(!st.IsChanged());
         }
@@ -158,7 +156,8 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
     Y_UNIT_TEST(PDiskStateChangeNodePermanentlyBad) {
         // If node is restarting all the time, then disk should never become ACTIVE
         const EPDiskStatus initialStatus = EPDiskStatus::INACTIVE;
-        TPDiskStatus st(initialStatus, 60, GoodStateLimit, DefaultStateLimits);
+        const ui32 defaultStateLimit = 60;
+        TPDiskStatus st(initialStatus, defaultStateLimit, GoodStateLimit, DefaultStateLimits);
 
         AddState(st, NKikimrBlobStorage::TPDiskState::Unknown);
         UNIT_ASSERT(!st.IsChanged());
@@ -232,7 +231,8 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
     Y_UNIT_TEST(PDiskStateChangeNodeExpectedRestart) {
         // Node restarts, but it is planned (node is locked by CMS), so disk should become ACTIVE after GoodStateLimit
         const EPDiskStatus initialStatus = EPDiskStatus::INACTIVE;
-        TPDiskStatus st(initialStatus, 60, GoodStateLimit, DefaultStateLimits);
+        const ui32 defaultStateLimit = 60;
+        TPDiskStatus st(initialStatus, defaultStateLimit, GoodStateLimit, DefaultStateLimits);
 
         auto nodeStartFn = [&st]() {
             AddStateNodeLocked(st, NKikimrBlobStorage::TPDiskState::Unknown);

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -21,10 +21,12 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
 
     void AddState(TPDiskStatus& st, const EPDiskState state) {
         st.AddState(state, false);
+        Cerr << st.GetStatus() << " " << st.GetState() << " " << st.GetPrevState() << " " << st.GetStateCounter() << Endl;
     }
 
     void AddStateNodeLocked(TPDiskStatus& st, const EPDiskState state) {
         st.AddState(state, true);
+        Cerr << st.GetStatus() << " " << st.GetState() << " " << st.GetPrevState() << " " << st.GetStateCounter() << Endl;
     }
 
     Y_UNIT_TEST(PDiskInitialStatus) {
@@ -141,6 +143,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
         UNIT_ASSERT(!st.IsChanged());
 
         for (ui32 i = 0; i < GoodStateLimit - 1; ++i) {
+            Cerr << "i = " << i << Endl;
             AddState(st, NKikimrBlobStorage::TPDiskState::Normal);
             UNIT_ASSERT(!st.IsChanged());
         }

--- a/ydb/core/cms/sentinel_ut_helpers.h
+++ b/ydb/core/cms/sentinel_ut_helpers.h
@@ -17,6 +17,7 @@ const auto& MockConfig = TFakeNodeWhiteboardService::Config;
 auto& MockNodes = TFakeNodeWhiteboardService::Info;
 
 static constexpr ui32 DefaultStateLimit = 5;
+static constexpr ui32 GoodStateLimit = 5;
 static constexpr ui32 DefaultErrorStateLimit = 60;
 auto DefaultStateLimits = NCms::TCmsSentinelConfig::DefaultStateLimits();
 

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -440,6 +440,8 @@ message TCmsConfig {
         optional bool DryRun = 13;
         repeated TStateLimit StateLimits = 14;
         optional EEvictVDisksStatus EvictVDisksStatus = 15;
+        
+        optional uint32 GoodStateLimit = 16 [default = 5];
     }
 
     message TLogConfig {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Improvement

The idea: 
if node recently had bad state, then use old limits as before to change PDisk state (and status). 
If node didn't have a bad state or bad state was acquired while node was locked by CMS, then PDisk's status changes to  ACTIVE earlier (upon hitting `GoodStateLimit`). 
Flag indicating that PDisk had bad state is removed upon PDisk receiving Normal state through old limits.