### PR TITLE
Query workload over query service

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/query_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/query_workload.cpp
@@ -1,6 +1,7 @@
 #include "query_workload.h"
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
+#include <ydb/public/sdk/cpp/client/ydb_query/client.h>
 #include <library/cpp/histogram/hdr/histogram.h>
 #include <util/system/thread.h>
 #include <util/system/mutex.h>
@@ -102,14 +103,15 @@ int TCommandQueryWorkloadRun::Run(TConfig& config) {
         pool.SafeAddFunc([&] {
             try {
                 TDriver driver = CreateDriver(config);
-                NScripting::TScriptingClient client(driver);
+                NQuery::TQueryClient client(driver);
 
-                NScripting::TExecuteYqlRequestSettings settings;
-                settings.CollectQueryStats(NTable::ECollectQueryStatsMode::Basic);
+                NQuery::TExecuteQuerySettings settings;
+                settings.StatsMode(NQuery::EStatsMode::Basic);
 
                 while (!IsInterrupted() && !ThreadTerminated.load()) {
-                    auto asyncResult = client.StreamExecuteYqlScript(
+                    auto asyncResult = client.StreamExecuteQuery(
                         Query,
+                        NQuery::TTxControl::NoTx(),
                         FillSettings(settings)
                     );
 
@@ -129,8 +131,8 @@ int TCommandQueryWorkloadRun::Run(TConfig& config) {
                             ThrowOnError(streamPart);
                         }
 
-                        if (streamPart.HasQueryStats()) {
-                            const auto& queryStats = streamPart.GetQueryStats();
+                        if (streamPart.GetStats()) {
+                            const auto& queryStats = streamPart.GetStats().GetRef();
                             local_duration += queryStats.GetTotalDuration();
                         }
                     }

--- a/ydb/public/lib/ydb_cli/commands/query_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/query_workload.cpp
@@ -78,11 +78,11 @@ TCommandQueryWorkload::TCommandQueryWorkload()
 }
 
 TCommandQueryWorkloadRun::TCommandQueryWorkloadRun()
-    : TYdbCommand("run", {}, "Run YDB query workload")
+    : TYdbSimpleCommand("run", {}, "Run YDB query workload")
 {}
 
 void TCommandQueryWorkloadRun::Config(TConfig& config) {
-    TYdbCommand::Config(config);
+    TYdbSimpleCommand::Config(config);
     config.Opts->AddLongOption('q', "query", "Query to execute") .RequiredArgument("[String]").StoreResult(&Query);
     config.Opts->AddLongOption('t', "threads", "Number of parallel threads; 1 if not specified").DefaultValue(1).StoreResult(&Threads);
     config.Opts->AddLongOption('d', "delay", "Interval delay in seconds; 1 if not specified").DefaultValue(1).StoreResult(&IntervalSeconds);
@@ -112,7 +112,7 @@ int TCommandQueryWorkloadRun::Run(TConfig& config) {
                     auto asyncResult = client.StreamExecuteQuery(
                         Query,
                         NQuery::TTxControl::NoTx(),
-                        settings
+                        FillSettings(settings)
                     );
 
                     auto result = asyncResult.GetValueSync();

--- a/ydb/public/lib/ydb_cli/commands/query_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/query_workload.cpp
@@ -78,11 +78,11 @@ TCommandQueryWorkload::TCommandQueryWorkload()
 }
 
 TCommandQueryWorkloadRun::TCommandQueryWorkloadRun()
-    : TYdbOperationCommand("run", {}, "Run YDB query workload")
+    : TYdbCommand("run", {}, "Run YDB query workload")
 {}
 
 void TCommandQueryWorkloadRun::Config(TConfig& config) {
-    TYdbOperationCommand::Config(config);
+    TYdbCommand::Config(config);
     config.Opts->AddLongOption('q', "query", "Query to execute") .RequiredArgument("[String]").StoreResult(&Query);
     config.Opts->AddLongOption('t', "threads", "Number of parallel threads; 1 if not specified").DefaultValue(1).StoreResult(&Threads);
     config.Opts->AddLongOption('d', "delay", "Interval delay in seconds; 1 if not specified").DefaultValue(1).StoreResult(&IntervalSeconds);
@@ -112,7 +112,7 @@ int TCommandQueryWorkloadRun::Run(TConfig& config) {
                     auto asyncResult = client.StreamExecuteQuery(
                         Query,
                         NQuery::TTxControl::NoTx(),
-                        FillSettings(settings)
+                        settings
                     );
 
                     auto result = asyncResult.GetValueSync();

--- a/ydb/public/lib/ydb_cli/commands/query_workload.h
+++ b/ydb/public/lib/ydb_cli/commands/query_workload.h
@@ -11,7 +11,7 @@ public:
     TCommandQueryWorkload();
 };
 
-class TCommandQueryWorkloadRun : public TYdbCommand, public TInterruptibleCommand
+class TCommandQueryWorkloadRun : public TYdbSimpleCommand, public TInterruptibleCommand
 {
 public:
     TCommandQueryWorkloadRun();

--- a/ydb/public/lib/ydb_cli/commands/query_workload.h
+++ b/ydb/public/lib/ydb_cli/commands/query_workload.h
@@ -11,7 +11,7 @@ public:
     TCommandQueryWorkload();
 };
 
-class TCommandQueryWorkloadRun : public TYdbOperationCommand, public TInterruptibleCommand
+class TCommandQueryWorkloadRun : public TYdbCommand, public TInterruptibleCommand
 {
 public:
     TCommandQueryWorkloadRun();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- `ydb workload query run` command is now working over QueryService instead of ScriptingService

### Changelog category <!-- remove all except one -->

* Improvement