### PR TITLE
The consumer's generation number is not stored in the transaction

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -1,5 +1,7 @@
 PROGRAM(ydbd)
 
+SPLIT_DWARF()
+
 IF (NOT SANITIZER_TYPE)  # for some reasons some tests with asan are failed, see comment in CPPCOM-32
     NO_EXPORT_DYNAMIC_SYMBOLS()
 ENDIF()

--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -1,7 +1,5 @@
 PROGRAM(ydbd)
 
-SPLIT_DWARF()
-
 IF (NOT SANITIZER_TYPE)  # for some reasons some tests with asan are failed, see comment in CPPCOM-32
     NO_EXPORT_DYNAMIC_SYMBOLS()
 ENDIF()

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -530,6 +530,8 @@ private:
 
     bool AllSupportivePartitionsHaveBeenDeleted(const TMaybe<TWriteId>& writeId) const;
     void DeleteWriteId(const TMaybe<TWriteId>& writeId);
+
+    void UpdateReadRuleGenerations(NKikimrPQ::TPQTabletConfig& cfg) const;
 };
 
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The consumer's generation number is not stored in the transaction. Because of this, the consumer's reading position may be reset.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
