### PR TITLE
YQ-3684 passed database id into workload manager and resource pool classifiers tables

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -27,8 +27,6 @@ ydb/core/kqp/ut/service KqpQueryService.TableSink_OlapRWQueries
 ydb/core/kqp/ut/service KqpQueryService.TableSink_OltpReplace+HasSecondaryIndex
 ydb/core/kqp/ut/query KqpQuery.OlapCreateAsSelect_Complex
 ydb/core/kqp/ut/query KqpQuery.OlapCreateAsSelect_Simple
-ydb/core/kqp/ut/federated_query/s3 KqpFederatedQuery.CreateTableAsSelectFromExternalDataSource
-ydb/core/kqp/ut/federated_query/s3 KqpFederatedQuery.CreateTableAsSelectFromExternalTable
 ydb/core/kqp/ut/scan KqpRequestContext.TraceIdInErrorMessage
 ydb/core/kqp/ut/scheme KqpOlapScheme.TenThousandColumns
 ydb/core/kqp/ut/scheme KqpScheme.AlterAsyncReplication

--- a/ydb/core/kqp/common/events/events.h
+++ b/ydb/core/kqp/common/events/events.h
@@ -111,6 +111,18 @@ struct TEvKqp {
     struct TEvScriptRequest : public TEventLocal<TEvScriptRequest, TKqpEvents::EvScriptRequest> {
         TEvScriptRequest() = default;
 
+        const TString& GetDatabase() const {
+            return Record.GetRequest().GetDatabase();
+        }
+
+        const TString& GetDatabaseId() const {
+            return Record.GetRequest().GetDatabaseId();
+        }
+
+        void SetDatabaseId(const TString& databaseId) {
+            Record.MutableRequest()->SetDatabaseId(databaseId);
+        }
+
         mutable NKikimrKqp::TEvQueryRequest Record;
         TDuration ForgetAfter;
         TDuration ResultsTtl;
@@ -163,6 +175,40 @@ struct TEvKqp {
             issues.AddIssue(message);
             return issues;
         }
+    };
+
+    struct TEvUpdateDatabaseInfo : public TEventLocal<TEvUpdateDatabaseInfo, TKqpEvents::EvUpdateDatabaseInfo> {
+        TEvUpdateDatabaseInfo(const TString& database, Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+            : Status(status)
+            , Database(database)
+            , Issues(std::move(issues))
+        {}
+
+        TEvUpdateDatabaseInfo(const TString& database, const TString& databaseId, bool serverless)
+            : Status(Ydb::StatusIds::SUCCESS)
+            , Database(database)
+            , DatabaseId(databaseId)
+            , Serverless(serverless)
+            , Issues({})
+        {}
+
+        Ydb::StatusIds::StatusCode Status;
+        TString Database;
+        TString DatabaseId;
+        bool Serverless = false;
+        NYql::TIssues Issues;
+    };
+
+    struct TEvDelayedRequestError : public TEventLocal<TEvDelayedRequestError, TKqpEvents::EvDelayedRequestError> {
+        TEvDelayedRequestError(THolder<IEventHandle> requestEvent, Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+            : RequestEvent(std::move(requestEvent))
+            , Status(status)
+            , Issues(std::move(issues))
+        {}
+
+        THolder<IEventHandle> RequestEvent;
+        Ydb::StatusIds::StatusCode Status;
+        NYql::TIssues Issues;
     };
 };
 

--- a/ydb/core/kqp/common/events/query.h
+++ b/ydb/core/kqp/common/events/query.h
@@ -351,6 +351,14 @@ public:
         return PoolConfig;
     }
 
+    const TString& GetDatabaseId() const {
+        return DatabaseId ? DatabaseId : Record.GetRequest().GetDatabaseId();
+    }
+
+    void SetDatabaseId(const TString& databaseId) {
+        DatabaseId = databaseId;
+    }
+
     mutable NKikimrKqp::TEvQueryRequest Record;
 
 private:
@@ -363,6 +371,7 @@ private:
     mutable TIntrusiveConstPtr<NACLib::TUserToken> Token_;
     TActorId RequestActorId;
     TString Database;
+    TString DatabaseId;
     TString SessionId;
     TString YqlText;
     TString QueryId;

--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -22,13 +22,34 @@ enum EFinalizationStatus : i32 {
     FS_ROLLBACK,
 };
 
-struct TEvForgetScriptExecutionOperation : public NActors::TEventLocal<TEvForgetScriptExecutionOperation, TKqpScriptExecutionEvents::EvForgetScriptExecutionOperation> {
-    TEvForgetScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id)
+template <typename TEv, ui32 TEventType>
+struct TEventWithDatabaseId : public NActors::TEventLocal<TEv, TEventType> {
+    TEventWithDatabaseId(const TString& database)
         : Database(database)
+    {}
+
+    const TString& GetDatabase() const {
+        return Database;
+    }
+
+    const TString& GetDatabaseId() const {
+        return DatabaseId;
+    }
+
+    void SetDatabaseId(const TString& databaseId) {
+        DatabaseId = databaseId;
+    }
+
+    const TString Database;
+    TString DatabaseId;
+};
+
+struct TEvForgetScriptExecutionOperation : public TEventWithDatabaseId<TEvForgetScriptExecutionOperation, TKqpScriptExecutionEvents::EvForgetScriptExecutionOperation> {
+    TEvForgetScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id)
+        : TEventWithDatabaseId(database)
         , OperationId(id)
     {}
 
-    const TString Database;
     const NOperationId::TOperationId OperationId;
 };
 
@@ -43,14 +64,12 @@ struct TEvForgetScriptExecutionOperationResponse : public NActors::TEventLocal<T
     NYql::TIssues Issues;
 };
 
-struct TEvGetScriptExecutionOperation : public NActors::TEventLocal<TEvGetScriptExecutionOperation, TKqpScriptExecutionEvents::EvGetScriptExecutionOperation> {
-    explicit TEvGetScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id)
-        : Database(database)
+struct TEvGetScriptExecutionOperation : public TEventWithDatabaseId<TEvGetScriptExecutionOperation, TKqpScriptExecutionEvents::EvGetScriptExecutionOperation> {
+    TEvGetScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id)
+        : TEventWithDatabaseId(database)
         , OperationId(id)
-    {
-    }
+    {}
 
-    TString Database;
     NOperationId::TOperationId OperationId;
 };
 
@@ -97,14 +116,13 @@ struct TEvGetScriptExecutionOperationResponse : public NActors::TEventLocal<TEvG
     TMaybe<google::protobuf::Any> Metadata;
 };
 
-struct TEvListScriptExecutionOperations : public NActors::TEventLocal<TEvListScriptExecutionOperations, TKqpScriptExecutionEvents::EvListScriptExecutionOperations> {
+struct TEvListScriptExecutionOperations : public TEventWithDatabaseId<TEvListScriptExecutionOperations, TKqpScriptExecutionEvents::EvListScriptExecutionOperations> {
     TEvListScriptExecutionOperations(const TString& database, const ui64 pageSize, const TString& pageToken)
-        : Database(database)
+        : TEventWithDatabaseId(database)
         , PageSize(pageSize)
         , PageToken(pageToken)
     {}
 
-    TString Database;
     ui64 PageSize;
     TString PageToken;
 };
@@ -151,14 +169,12 @@ struct TEvCheckAliveRequest : public NActors::TEventPB<TEvCheckAliveRequest, NKi
 struct TEvCheckAliveResponse : public NActors::TEventPB<TEvCheckAliveResponse, NKikimrKqp::TEvCheckAliveResponse, TKqpScriptExecutionEvents::EvCheckAliveResponse> {
 };
 
-struct TEvCancelScriptExecutionOperation : public NActors::TEventLocal<TEvCancelScriptExecutionOperation, TKqpScriptExecutionEvents::EvCancelScriptExecutionOperation> {
-    explicit TEvCancelScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id)
-        : Database(database)
+struct TEvCancelScriptExecutionOperation : public TEventWithDatabaseId<TEvCancelScriptExecutionOperation, TKqpScriptExecutionEvents::EvCancelScriptExecutionOperation> {
+    TEvCancelScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id)
+        : TEventWithDatabaseId(database)
         , OperationId(id)
-    {
-    }
+    {}
 
-    TString Database;
     NOperationId::TOperationId OperationId;
 };
 

--- a/ydb/core/kqp/common/events/workload_service.h
+++ b/ydb/core/kqp/common/events/workload_service.h
@@ -14,24 +14,24 @@
 namespace NKikimr::NKqp::NWorkload {
 
 struct TEvSubscribeOnPoolChanges : public NActors::TEventLocal<TEvSubscribeOnPoolChanges, TKqpWorkloadServiceEvents::EvSubscribeOnPoolChanges> {
-    TEvSubscribeOnPoolChanges(const TString& database, const TString& poolId)
-        : Database(database)
+    TEvSubscribeOnPoolChanges(const TString& databaseId, const TString& poolId)
+        : DatabaseId(databaseId)
         , PoolId(poolId)
     {}
 
-    const TString Database;
+    const TString DatabaseId;
     const TString PoolId;
 };
 
 struct TEvPlaceRequestIntoPool : public NActors::TEventLocal<TEvPlaceRequestIntoPool, TKqpWorkloadServiceEvents::EvPlaceRequestIntoPool> {
-    TEvPlaceRequestIntoPool(const TString& database, const TString& sessionId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
-        : Database(database)
+    TEvPlaceRequestIntoPool(const TString& databaseId, const TString& sessionId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
+        : DatabaseId(databaseId)
         , SessionId(sessionId)
         , PoolId(poolId)
         , UserToken(userToken)
     {}
 
-    const TString Database;
+    const TString DatabaseId;
     const TString SessionId;
     TString PoolId;  // Can be changed to default pool id
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
@@ -52,15 +52,15 @@ struct TEvContinueRequest : public NActors::TEventLocal<TEvContinueRequest, TKqp
 };
 
 struct TEvCleanupRequest : public NActors::TEventLocal<TEvCleanupRequest, TKqpWorkloadServiceEvents::EvCleanupRequest> {
-    TEvCleanupRequest(const TString& database, const TString& sessionId, const TString& poolId, TDuration duration, TDuration cpuConsumed)
-        : Database(database)
+    TEvCleanupRequest(const TString& databaseId, const TString& sessionId, const TString& poolId, TDuration duration, TDuration cpuConsumed)
+        : DatabaseId(databaseId)
         , SessionId(sessionId)
         , PoolId(poolId)
         , Duration(duration)
         , CpuConsumed(cpuConsumed)
     {}
 
-    const TString Database;
+    const TString DatabaseId;
     const TString SessionId;
     const TString PoolId;
     const TDuration Duration;
@@ -78,23 +78,24 @@ struct TEvCleanupResponse : public NActors::TEventLocal<TEvCleanupResponse, TKqp
 };
 
 struct TEvUpdatePoolInfo : public NActors::TEventLocal<TEvUpdatePoolInfo, TKqpWorkloadServiceEvents::EvUpdatePoolInfo> {
-    TEvUpdatePoolInfo(const TString& database, const TString& poolId, const std::optional<NResourcePool::TPoolSettings>& config, const std::optional<NACLib::TSecurityObject>& securityObject)
-        : Database(database)
+    TEvUpdatePoolInfo(const TString& databaseId, const TString& poolId, const std::optional<NResourcePool::TPoolSettings>& config, const std::optional<NACLib::TSecurityObject>& securityObject)
+        : DatabaseId(databaseId)
         , PoolId(poolId)
         , Config(config)
         , SecurityObject(securityObject)
     {}
 
-    const TString Database;
+    const TString DatabaseId;
     const TString PoolId;
     const std::optional<NResourcePool::TPoolSettings> Config;
     const std::optional<NACLib::TSecurityObject> SecurityObject;
 };
 
 struct TEvFetchDatabaseResponse : public NActors::TEventLocal<TEvFetchDatabaseResponse, TKqpWorkloadServiceEvents::EvFetchDatabaseResponse> {
-    TEvFetchDatabaseResponse(Ydb::StatusIds::StatusCode status, const TString& database, bool serverless, TPathId pathId, NYql::TIssues issues)
+    TEvFetchDatabaseResponse(Ydb::StatusIds::StatusCode status, const TString& database, const TString& databaseId, bool serverless, TPathId pathId, NYql::TIssues issues)
         : Status(status)
         , Database(database)
+        , DatabaseId(databaseId)
         , Serverless(serverless)
         , PathId(pathId)
         , Issues(std::move(issues))
@@ -102,6 +103,7 @@ struct TEvFetchDatabaseResponse : public NActors::TEventLocal<TEvFetchDatabaseRe
 
     const Ydb::StatusIds::StatusCode Status;
     const TString Database;
+    const TString DatabaseId;
     const bool Serverless;
     const TPathId PathId;
     const NYql::TIssues Issues;

--- a/ydb/core/kqp/common/events/workload_service.h
+++ b/ydb/core/kqp/common/events/workload_service.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/kqp/common/simple/kqp_event_ids.h>
 #include <ydb/core/resource_pools/resource_pool_settings.h>
+#include <ydb/core/scheme/scheme_pathid.h>
 
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/library/actors/core/event_local.h>
@@ -90,14 +91,20 @@ struct TEvUpdatePoolInfo : public NActors::TEventLocal<TEvUpdatePoolInfo, TKqpWo
     const std::optional<NACLib::TSecurityObject> SecurityObject;
 };
 
-struct TEvUpdateDatabaseInfo : public NActors::TEventLocal<TEvUpdateDatabaseInfo, TKqpWorkloadServiceEvents::EvUpdateDatabaseInfo> {
-    TEvUpdateDatabaseInfo(const TString& database, bool serverless)
-        : Database(database)
+struct TEvFetchDatabaseResponse : public NActors::TEventLocal<TEvFetchDatabaseResponse, TKqpWorkloadServiceEvents::EvFetchDatabaseResponse> {
+    TEvFetchDatabaseResponse(Ydb::StatusIds::StatusCode status, const TString& database, bool serverless, TPathId pathId, NYql::TIssues issues)
+        : Status(status)
+        , Database(database)
         , Serverless(serverless)
+        , PathId(pathId)
+        , Issues(std::move(issues))
     {}
 
+    const Ydb::StatusIds::StatusCode Status;
     const TString Database;
     const bool Serverless;
+    const TPathId PathId;
+    const NYql::TIssues Issues;
 };
 
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/common/events/ya.make
+++ b/ydb/core/kqp/common/events/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     ydb/core/kqp/common/shutdown
     ydb/core/kqp/common/compilation
     ydb/core/resource_pools
+    ydb/core/scheme
 
     ydb/library/yql/dq/actors
     ydb/public/api/protos

--- a/ydb/core/kqp/common/kqp_event_impl.cpp
+++ b/ydb/core/kqp/common/kqp_event_impl.cpp
@@ -90,6 +90,10 @@ void TEvKqp::TEvQueryRequest::PrepareRemote() const {
             Record.MutableRequest()->SetPoolId(PoolId);
         }
 
+        if (!DatabaseId.empty()) {
+            Record.MutableRequest()->SetDatabaseId(DatabaseId);
+        }
+
         Record.MutableRequest()->SetSessionId(SessionId);
         Record.MutableRequest()->SetAction(QueryAction);
         Record.MutableRequest()->SetType(QueryType);

--- a/ydb/core/kqp/common/kqp_user_request_context.cpp
+++ b/ydb/core/kqp/common/kqp_user_request_context.cpp
@@ -3,12 +3,13 @@
 namespace NKikimr::NKqp {
     
     void TUserRequestContext::Out(IOutputStream& o) const {
-        o << "{" << " TraceId: " << TraceId << ", Database: " << Database << ", SessionId: " << SessionId << ", CurrentExecutionId: " << CurrentExecutionId << ", CustomerSuppliedId: " << CustomerSuppliedId  << ", PoolId: " << PoolId  << "}";
+        o << "{" << " TraceId: " << TraceId << ", Database: " << Database << ", DatabaseId: " << DatabaseId << ", SessionId: " << SessionId << ", CurrentExecutionId: " << CurrentExecutionId << ", CustomerSuppliedId: " << CustomerSuppliedId  << ", PoolId: " << PoolId  << "}";
     }
 
     void SerializeCtxToMap(const TUserRequestContext& ctx, google::protobuf::Map<TString, TString>& resultMap) {
         resultMap["TraceId"] = ctx.TraceId;
         resultMap["Database"] = ctx.Database;
+        resultMap["DatabaseId"] = ctx.DatabaseId;
         resultMap["SessionId"] = ctx.SessionId;
         resultMap["CurrentExecutionId"] = ctx.CurrentExecutionId;
         resultMap["CustomerSuppliedId"] = ctx.CustomerSuppliedId;

--- a/ydb/core/kqp/common/kqp_user_request_context.h
+++ b/ydb/core/kqp/common/kqp_user_request_context.h
@@ -11,6 +11,7 @@ namespace NKikimr::NKqp {
     struct TUserRequestContext : public TAtomicRefCount<TUserRequestContext> {
         TString TraceId;
         TString Database;
+        TString DatabaseId;
         TString SessionId;
         TString CurrentExecutionId;
         TString CustomerSuppliedId;

--- a/ydb/core/kqp/common/simple/kqp_event_ids.h
+++ b/ydb/core/kqp/common/simple/kqp_event_ids.h
@@ -44,7 +44,9 @@ struct TKqpEvents {
         EvListSessionsRequest,
         EvListSessionsResponse,
         EvListProxyNodesRequest,
-        EvListProxyNodesResponse
+        EvListProxyNodesResponse,
+        EvUpdateDatabaseInfo,
+        EvDelayedRequestError
     };
 
     static_assert (EvCompileInvalidateRequest + 1 == EvAbortExecution);
@@ -175,8 +177,8 @@ struct TKqpWorkloadServiceEvents {
         EvCleanupRequest,
         EvCleanupResponse,
         EvUpdatePoolInfo,
-        EvUpdateDatabaseInfo,
         EvSubscribeOnPoolChanges,
+        EvFetchDatabaseResponse,
     };
 };
 

--- a/ydb/core/kqp/common/simple/query_id.cpp
+++ b/ydb/core/kqp/common/simple/query_id.cpp
@@ -9,11 +9,12 @@
 
 namespace NKikimr::NKqp {
 
-TKqpQueryId::TKqpQueryId(const TString& cluster, const TString& database, const TString& text,
+TKqpQueryId::TKqpQueryId(const TString& cluster, const TString& database, const TString& databaseId, const TString& text,
     const TKqpQuerySettings& settings, std::shared_ptr<std::map<TString, Ydb::Type>> queryParameterTypes,
     const TGUCSettings& gUCSettings)
     : Cluster(cluster)
     , Database(database)
+    , DatabaseId(databaseId)
     , Text(text)
     , Settings(settings)
     , QueryParameterTypes(queryParameterTypes)
@@ -41,6 +42,7 @@ bool TKqpQueryId::IsSql() const {
 bool TKqpQueryId::operator==(const TKqpQueryId& other) const {
     if (!(Cluster == other.Cluster &&
         Database == other.Database &&
+        DatabaseId == other.DatabaseId &&
         UserSid == other.UserSid &&
         Text == other.Text &&
         Settings == other.Settings &&

--- a/ydb/core/kqp/common/simple/query_id.h
+++ b/ydb/core/kqp/common/simple/query_id.h
@@ -13,6 +13,7 @@ namespace NKikimr::NKqp {
 struct TKqpQueryId {
     TString Cluster;
     TString Database;
+    TString DatabaseId;
     TString UserSid;
     TString Text;
     TKqpQuerySettings Settings;
@@ -21,7 +22,7 @@ struct TKqpQueryId {
     TGUCSettings GUCSettings;
 
 public:
-    TKqpQueryId(const TString& cluster, const TString& database, const TString& text,
+    TKqpQueryId(const TString& cluster, const TString& database, const TString& databaseId, const TString& text,
         const TKqpQuerySettings& settings, std::shared_ptr<std::map<TString, Ydb::Type>> queryParameterTypes,
         const TGUCSettings& gUCSettings);
 

--- a/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
@@ -265,7 +265,7 @@ private:
         std::shared_ptr<NYql::IKikimrGateway::IKqpTableMetadataLoader> loader =
             std::make_shared<TKqpTableMetadataLoader>(
                 QueryId.Cluster, TlsActivationContext->ActorSystem(), Config, true, TempTablesState);
-        Gateway = CreateKikimrIcGateway(QueryId.Cluster, QueryId.Settings.QueryType, QueryId.Database, std::move(loader),
+        Gateway = CreateKikimrIcGateway(QueryId.Cluster, QueryId.Settings.QueryType, QueryId.Database, QueryId.DatabaseId, std::move(loader),
             ctx.ExecutorThread.ActorSystem, ctx.SelfID.NodeId(), counters, QueryServiceConfig);
         Gateway->SetToken(QueryId.Cluster, UserToken);
 

--- a/ydb/core/kqp/compile_service/kqp_compile_service.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_service.cpp
@@ -149,7 +149,7 @@ public:
                 }
             }
         }
-        return TKqpQueryId{query.Cluster, query.Database, ast.Root->ToString(), query.Settings, astPgParams, query.GUCSettings};
+        return TKqpQueryId{query.Cluster, query.Database, query.DatabaseId, ast.Root->ToString(), query.Settings, astPgParams, query.GUCSettings};
     }
 
     TKqpCompileResult::TConstPtr FindByQuery(const TKqpQueryId& query, bool promote) {

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -236,6 +236,7 @@ std::unique_ptr<TEvKqpNode::TEvStartKqpTasksRequest> TKqpPlanner::SerializeReque
 
     request.SetSchedulerGroup(UserRequestContext->PoolId);
     request.SetDatabase(Database);
+    request.SetDatabaseId(UserRequestContext->DatabaseId);
     if (UserRequestContext->PoolConfig.has_value()) {
         request.SetMemoryPoolPercent(UserRequestContext->PoolConfig->QueryMemoryLimitPercentPerNode);
         request.SetMaxCpuShare(UserRequestContext->PoolConfig->TotalCpuLimitPercentPerNode / 100.0);

--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -72,6 +72,7 @@ public:
         , RequestType(requestType)
         , KqpTempTablesAgentActor(kqpTempTablesAgentActor)
     {
+        YQL_ENSURE(RequestContext);
         YQL_ENSURE(PhyTx);
         YQL_ENSURE(PhyTx->GetType() == NKqpProto::TKqpPhyTx::TYPE_SCHEME);
 
@@ -402,6 +403,7 @@ public:
 
         NMetadata::NModifications::IOperationsManager::TExternalModificationContext context;
         context.SetDatabase(Database);
+        context.SetDatabaseId(RequestContext->DatabaseId);
         context.SetActorSystem(actorSystem);
         if (UserToken) {
             context.SetUserToken(*UserToken);

--- a/ydb/core/kqp/executer_actor/ut/kqp_executer_ut.cpp
+++ b/ydb/core/kqp/executer_actor/ut/kqp_executer_ut.cpp
@@ -42,7 +42,7 @@ NKqpProto::TKqpPhyTx BuildTxPlan(const TString& sql, TIntrusivePtr<IKqpGateway> 
 [[maybe_unused]]
 TIntrusivePtr<IKqpGateway> MakeIcGateway(const TKikimrRunner& kikimr) {
     auto actorSystem = kikimr.GetTestServer().GetRuntime()->GetAnyNodeActorSystem();
-    return CreateKikimrIcGateway(TString(DefaultKikimrClusterName), "/Root", TKqpGatewaySettings(),
+    return CreateKikimrIcGateway(TString(DefaultKikimrClusterName), "/Root", "/Root", TKqpGatewaySettings(),
         actorSystem, kikimr.GetTestServer().GetRuntime()->GetNodeId(0),
         TAlignedPagePoolCounters(), kikimr.GetTestServer().GetSettings().AppConfig->GetQueryServiceConfig());
 }

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
@@ -13,7 +13,7 @@ using namespace NResourcePool;
 
 NMetadata::NInternal::TTableRecord GetResourcePoolClassifierRecord(const NYql::TObjectSettingsImpl& settings, const NMetadata::NModifications::IOperationsManager::TInternalModificationContext& context) {
     NMetadata::NInternal::TTableRecord result;
-    result.SetColumn(TResourcePoolClassifierConfig::TDecoder::Database, NMetadata::NInternal::TYDBValue::Utf8(CanonizePath(context.GetExternalData().GetDatabase())));
+    result.SetColumn(TResourcePoolClassifierConfig::TDecoder::Database, NMetadata::NInternal::TYDBValue::Utf8(context.GetExternalData().GetDatabaseId()));
     result.SetColumn(TResourcePoolClassifierConfig::TDecoder::Name, NMetadata::NInternal::TYDBValue::Utf8(settings.GetObjectId()));
     return result;
 }

--- a/ydb/core/kqp/gateway/kqp_gateway.h
+++ b/ydb/core/kqp/gateway/kqp_gateway.h
@@ -188,6 +188,7 @@ public:
 
 public:
     virtual TString GetDatabase() = 0;
+    virtual TString GetDatabaseId() = 0;
     virtual bool GetDomainLoginOnly() = 0;
     virtual TMaybe<TString> GetDomainName() = 0;
 
@@ -231,7 +232,7 @@ public:
         const Ydb::Table::TransactionSettings& txSettings, const NActors::TActorId& target) = 0;
 };
 
-TIntrusivePtr<IKqpGateway> CreateKikimrIcGateway(const TString& cluster, NKikimrKqp::EQueryType queryType, const TString& database,
+TIntrusivePtr<IKqpGateway> CreateKikimrIcGateway(const TString& cluster, NKikimrKqp::EQueryType queryType, const TString& database, const TString& databaseId,
     std::shared_ptr<IKqpGateway::IKqpTableMetadataLoader>&& metadataLoader, NActors::TActorSystem* actorSystem,
     ui32 nodeId, TKqpRequestCounters::TPtr counters, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig = NKikimrConfig::TQueryServiceConfig());
 

--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -538,10 +538,11 @@ public:
     using TResult = IKqpGateway::TGenericResult;
 
     TKqpSchemeExecuterRequestHandler(TKqpPhyTxHolder::TConstPtr phyTx, NKikimrKqp::EQueryType queryType, const TMaybe<TString>& requestType, const TString& database,
-        TIntrusiveConstPtr<NACLib::TUserToken> userToken, TPromise<TResult> promise)
+        const TString& databaseId, TIntrusiveConstPtr<NACLib::TUserToken> userToken, TPromise<TResult> promise)
         : PhyTx(std::move(phyTx))
         , QueryType(queryType)
         , Database(database)
+        , DatabaseId(databaseId)
         , UserToken(std::move(userToken))
         , Promise(promise)
         , RequestType(requestType)
@@ -549,6 +550,7 @@ public:
 
     void Bootstrap() {
         auto ctx = MakeIntrusive<TUserRequestContext>();
+        ctx->DatabaseId = DatabaseId;
         IActor* actor = CreateKqpSchemeExecuter(PhyTx, QueryType, SelfId(), RequestType, Database, UserToken, false /* temporary */, TString() /* sessionId */, ctx);
         Register(actor);
         Become(&TThis::WaitState);
@@ -580,6 +582,7 @@ private:
     TKqpPhyTxHolder::TConstPtr PhyTx;
     const NKikimrKqp::EQueryType QueryType;
     const TString Database;
+    const TString DatabaseId;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     TPromise<TResult> Promise;
     const TMaybe<TString> RequestType;
@@ -702,11 +705,12 @@ private:
     using TNavigate = NSchemeCache::TSchemeCacheNavigate;
 
 public:
-    TKikimrIcGateway(const TString& cluster, NKikimrKqp::EQueryType queryType, const TString& database, std::shared_ptr<IKqpTableMetadataLoader>&& metadataLoader,
+    TKikimrIcGateway(const TString& cluster, NKikimrKqp::EQueryType queryType, const TString& database, const TString& databaseId, std::shared_ptr<IKqpTableMetadataLoader>&& metadataLoader,
         TActorSystem* actorSystem, ui32 nodeId, TKqpRequestCounters::TPtr counters, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig)
         : Cluster(cluster)
         , QueryType(queryType)
         , Database(database)
+        , DatabaseId(databaseId)
         , ActorSystem(actorSystem)
         , NodeId(nodeId)
         , Counters(counters)
@@ -727,6 +731,10 @@ public:
 
     TString GetDatabase() override {
         return Database;
+    }
+
+    TString GetDatabaseId() override {
+        return DatabaseId;
     }
 
     TMaybe<TString> GetSetting(const TString& cluster, const TString& name) override {
@@ -1473,6 +1481,7 @@ public:
                     context.SetUserToken(*GetUserToken());
                 }
                 context.SetDatabase(Owner.Database);
+                context.SetDatabaseId(Owner.DatabaseId);
                 context.SetActorSystem(Owner.ActorSystem);
                 return DoExecute(cBehaviour, settings, context).Apply([](const NThreading::TFuture<TYqlConclusionStatus>& f) {
                     if (f.HasValue() && !f.HasException() && f.GetValue().Ok()) {
@@ -2224,7 +2233,7 @@ private:
 
     TFuture<TGenericResult> SendSchemeExecuterRequest(const TString&, const TMaybe<TString>& requestType, const std::shared_ptr<const NKikimr::NKqp::TKqpPhyTxHolder>& phyTx) override {
         auto promise = NewPromise<TGenericResult>();
-        IActor* requestHandler = new TKqpSchemeExecuterRequestHandler(phyTx, QueryType, requestType, Database, UserToken, promise);
+        IActor* requestHandler = new TKqpSchemeExecuterRequestHandler(phyTx, QueryType, requestType, Database, DatabaseId, UserToken, promise);
         RegisterActor(requestHandler);
         return promise.GetFuture();
     }
@@ -2304,6 +2313,7 @@ private:
     TString Cluster;
     const NKikimrKqp::EQueryType QueryType;
     TString Database;
+    TString DatabaseId;
     TActorSystem* ActorSystem;
     ui32 NodeId;
     TKqpRequestCounters::TPtr Counters;
@@ -2315,11 +2325,11 @@ private:
 
 } // namespace
 
-TIntrusivePtr<IKqpGateway> CreateKikimrIcGateway(const TString& cluster, NKikimrKqp::EQueryType queryType, const TString& database,
+TIntrusivePtr<IKqpGateway> CreateKikimrIcGateway(const TString& cluster, NKikimrKqp::EQueryType queryType, const TString& database, const TString& databaseId,
     std::shared_ptr<NYql::IKikimrGateway::IKqpTableMetadataLoader>&& metadataLoader, TActorSystem* actorSystem,
     ui32 nodeId, TKqpRequestCounters::TPtr counters, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig)
 {
-    return MakeIntrusive<TKikimrIcGateway>(cluster, queryType, database, std::move(metadataLoader), actorSystem, nodeId,
+    return MakeIntrusive<TKikimrIcGateway>(cluster, queryType, database, databaseId, std::move(metadataLoader), actorSystem, nodeId,
         counters, queryServiceConfig);
 }
 

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1262,6 +1262,7 @@ public:
 
             NMetadata::NModifications::IOperationsManager::TExternalModificationContext context;
             context.SetDatabase(SessionCtx->GetDatabase());
+            context.SetDatabaseId(SessionCtx->GetDatabaseId());
             context.SetActorSystem(ActorSystem);
             if (SessionCtx->GetUserToken()) {
                 context.SetUserToken(*SessionCtx->GetUserToken());

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1062,6 +1062,7 @@ public:
         }
 
         SessionCtx->SetDatabase(database);
+        SessionCtx->SetDatabaseId(Gateway->GetDatabaseId());
         SessionCtx->SetCluster(cluster);
         if (tempTablesState) {
             SessionCtx->SetSessionId(tempTablesState->SessionId);

--- a/ydb/core/kqp/node_service/kqp_node_service.cpp
+++ b/ydb/core/kqp/node_service/kqp_node_service.cpp
@@ -228,7 +228,7 @@ private:
                 auto share = msg.GetMaxCpuShare();
                 if (share > 0) {
                     Scheduler->UpdateMaxShare(group, share, schedulerNow);
-                    Send(SchedulerActorId, new TEvSchedulerNewPool(msg.GetDatabase(), group, share));
+                    Send(SchedulerActorId, new TEvSchedulerNewPool(msg.GetDatabaseId(), group, share));
                 } else {
                     schedulingTaskOptions.NoThrottle = true;
                 }

--- a/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
@@ -74,7 +74,7 @@ TIntrusivePtr<IKqpGateway> GetIcGateway(Tests::TServer& server) {
     counters->TxProxyMon = new NTxProxy::TTxProxyMon(server.GetRuntime()->GetAppData(0).Counters);
 
     std::shared_ptr<NYql::IKikimrGateway::IKqpTableMetadataLoader> loader = std::make_shared<TKqpTableMetadataLoader>(TestCluster, server.GetRuntime()->GetAnyNodeActorSystem(),TIntrusivePtr<NYql::TKikimrConfiguration>(nullptr), false);
-    return CreateKikimrIcGateway(TestCluster, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY, "/Root", std::move(loader), server.GetRuntime()->GetAnyNodeActorSystem(),
+    return CreateKikimrIcGateway(TestCluster, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY, "/Root", "/Root", std::move(loader), server.GetRuntime()->GetAnyNodeActorSystem(),
         server.GetRuntime()->GetNodeId(0), counters, server.GetSettings().AppConfig->GetQueryServiceConfig());
 }
 

--- a/ydb/core/kqp/provider/yql_kikimr_provider.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.h
@@ -509,6 +509,10 @@ public:
         return Database;
     }
 
+    TString GetDatabaseId() const {
+        return DatabaseId;
+    }
+
     const TString& GetSessionId() const {
         return SessionId;
     }
@@ -519,6 +523,10 @@ public:
 
     void SetDatabase(const TString& database) {
         Database = database;
+    }
+
+    void SetDatabaseId(const TString& databaseId) {
+        DatabaseId = databaseId;
     }
 
     void SetSessionId(const TString& sessionId) {
@@ -559,6 +567,7 @@ private:
     TString UserName;
     TString Cluster;
     TString Database;
+    TString DatabaseId;
     TString SessionId;
     TKikimrConfiguration::TPtr Configuration;
     TIntrusivePtr<TKikimrTablesData> TablesData;

--- a/ydb/core/kqp/proxy_service/kqp_proxy_databases_cache.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_databases_cache.cpp
@@ -94,7 +94,9 @@ public:
         }
 
         databaseStateIt->FetchRequestIsRunning = false;
-        UpdateDatabaseState(*databaseStateIt, ev->Get()->PathId, ev->Get()->Serverless);
+        databaseStateIt->LastUpdateTime = TInstant::Now();
+        databaseStateIt->DatabaseId = ev->Get()->DatabaseId;
+        databaseStateIt->Serverless = ev->Get()->Serverless;
         SendSubscriberInfo(*databaseStateIt, ev->Get()->Status, ev->Get()->Issues);
 
         if (ev->Get()->Status == Ydb::StatusIds::SUCCESS) {
@@ -151,12 +153,6 @@ public:
     )
 
 private:
-    static void UpdateDatabaseState(TDatabaseState& databaseState, TPathId pathId, bool serverless) {
-        databaseState.LastUpdateTime = TInstant::Now();
-        databaseState.DatabaseId = (serverless ? TStringBuilder() << pathId.OwnerId << ":" << pathId.LocalPathId << ":" : TStringBuilder()) << databaseState.Database;
-        databaseState.Serverless = serverless;
-    }
-
     void UnsubscribeFromSchemeCache(TDatabaseState& databaseState) const {
         if (databaseState.WatchKey) {
             Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvWatchRemove(databaseState.WatchKey));
@@ -197,13 +193,6 @@ private:
 TDatabasesCache::TDatabasesCache(TDuration idleTimeout)
     : IdleTimeout(idleTimeout)
 {}
-
-const TString& TDatabasesCache::GetTenantName() {
-    if (!TenantName) {
-        TenantName = CanonizePath(AppData()->TenantName);
-    }
-    return TenantName;
-}
 
 void TDatabasesCache::UpdateDatabaseInfo(TEvKqp::TEvUpdateDatabaseInfo::TPtr& event, TActorContext actorContext) {
     auto it = DatabasesCache.find(event->Get()->Database);

--- a/ydb/core/kqp/proxy_service/kqp_proxy_databases_cache.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_databases_cache.cpp
@@ -1,0 +1,249 @@
+#include "kqp_proxy_service_impl.h"
+
+#include <ydb/core/kqp/workload_service/actors/actors.h>
+
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+
+
+namespace NKikimr::NKqp {
+
+namespace {
+
+
+struct TEvPrivate {
+    // Event ids
+    enum EEv : ui32 {
+        EvSubscribeOnDatabase = EventSpaceBegin(TEvents::ES_PRIVATE),
+        EvPingDatabaseSubscription,
+
+        EvEnd
+    };
+
+    static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
+
+    struct TEvSubscribeOnDatabase : public TEventLocal<TEvSubscribeOnDatabase, EvSubscribeOnDatabase> {
+        explicit TEvSubscribeOnDatabase(const TString& database)
+            : Database(database)
+        {}
+
+        const TString Database;
+    };
+
+    struct TEvPingDatabaseSubscription : public TEventLocal<TEvPingDatabaseSubscription, EvPingDatabaseSubscription> {
+        explicit TEvPingDatabaseSubscription(const TString& database)
+            : Database(database)
+        {}
+
+        const TString Database;
+    };
+};
+
+class TDatabaseSubscriberActor : public TActor<TDatabaseSubscriberActor> {
+    struct TDatabaseState {
+        TString Database;
+        TString DatabaseId = "";
+        bool Serverless = false;
+
+        bool FetchRequestIsRunning = true;
+        TInstant LastUpdateTime = TInstant::Now();
+        ui32 WatchKey = 0;
+    };
+
+    using TBase = TActor<TDatabaseSubscriberActor>;
+
+public:
+    TDatabaseSubscriberActor(TDuration idleTimeout)
+        : TBase(&TDatabaseSubscriberActor::StateFunc)
+        , IdleTimeout(idleTimeout)
+        , DatabaseStates(std::numeric_limits<size_t>::max())
+    {}
+
+    void Registered(TActorSystem* sys, const TActorId& owner) {
+        TBase::Registered(sys, owner);
+        Owner = owner;
+    }
+
+    void Handle(TEvPrivate::TEvSubscribeOnDatabase::TPtr& ev) {
+        const TString& database = ev->Get()->Database;
+        auto databaseStateIt = DatabaseStates.Find(database);
+
+        if (databaseStateIt == DatabaseStates.End()) {
+            DatabaseStates.Insert({database, TDatabaseState{.Database = database}});
+            Register(NWorkload::CreateDatabaseFetcherActor(SelfId(), database));
+            StartIdleCheck();
+            return;
+        }
+
+        databaseStateIt->LastUpdateTime = TInstant::Now();
+        if (databaseStateIt->DatabaseId) {
+            SendSubscriberInfo(*databaseStateIt, Ydb::StatusIds::SUCCESS);
+        }
+    }
+
+    void Handle(TEvPrivate::TEvPingDatabaseSubscription::TPtr& ev) {
+        auto databaseStateIt = DatabaseStates.Find(ev->Get()->Database);
+        if (databaseStateIt != DatabaseStates.End()) {
+            databaseStateIt->LastUpdateTime = TInstant::Now();
+        }
+    }
+
+    void Handle(NWorkload::TEvFetchDatabaseResponse::TPtr& ev) {
+        auto databaseStateIt = DatabaseStates.Find(ev->Get()->Database);
+        if (databaseStateIt == DatabaseStates.End()) {
+            return;
+        }
+
+        databaseStateIt->FetchRequestIsRunning = false;
+        UpdateDatabaseState(*databaseStateIt, ev->Get()->PathId, ev->Get()->Serverless);
+        SendSubscriberInfo(*databaseStateIt, ev->Get()->Status, ev->Get()->Issues);
+
+        if (ev->Get()->Status == Ydb::StatusIds::SUCCESS) {
+            FreeWatchKey++;
+            databaseStateIt->WatchKey = FreeWatchKey;
+            Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvWatchPathId(ev->Get()->PathId, FreeWatchKey));
+        }
+    }
+
+    void Handle(TEvTxProxySchemeCache::TEvWatchNotifyDeleted::TPtr& ev) {
+        auto databaseStateIt = DatabaseStates.Find(ev->Get()->Path);
+        if (databaseStateIt == DatabaseStates.End()) {
+            return;
+        }
+
+        UnsubscribeFromSchemeCache(*databaseStateIt);
+        SendSubscriberInfo(*databaseStateIt, Ydb::StatusIds::NOT_FOUND, {NYql::TIssue{"Database was dropped"}});
+        DatabaseStates.Erase(databaseStateIt);
+    }
+
+    void HandlePoison() {
+        Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvWatchRemove(0));
+        TBase::PassAway();
+    }
+
+    void HandleWakeup() {
+        IdleCheckStarted = false;
+        const auto minimalTime = TInstant::Now() - IdleTimeout;
+        while (!DatabaseStates.Empty()) {
+            auto oldestIt = DatabaseStates.FindOldest();
+            if (oldestIt->LastUpdateTime > minimalTime) {
+                break;
+            }
+
+            UnsubscribeFromSchemeCache(*oldestIt);
+            SendSubscriberInfo(*oldestIt, Ydb::StatusIds::ABORTED, {NYql::TIssue{"Database subscription was dropped by idle timeout"}});
+            DatabaseStates.Erase(oldestIt);
+        }
+
+        if (!DatabaseStates.Empty()) {
+            StartIdleCheck();
+        }
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvPrivate::TEvSubscribeOnDatabase, Handle);
+        hFunc(TEvPrivate::TEvPingDatabaseSubscription, Handle);
+        hFunc(NWorkload::TEvFetchDatabaseResponse, Handle);
+        sFunc(TEvents::TEvPoison, HandlePoison);
+        sFunc(TEvents::TEvWakeup, HandleWakeup);
+
+        hFunc(TEvTxProxySchemeCache::TEvWatchNotifyDeleted, Handle);
+        IgnoreFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated);
+    )
+
+private:
+    static void UpdateDatabaseState(TDatabaseState& databaseState, TPathId pathId, bool serverless) {
+        databaseState.LastUpdateTime = TInstant::Now();
+        databaseState.DatabaseId = (serverless ? TStringBuilder() << pathId.OwnerId << ":" << pathId.LocalPathId << ":" : TStringBuilder()) << databaseState.Database;
+        databaseState.Serverless = serverless;
+    }
+
+    void UnsubscribeFromSchemeCache(TDatabaseState& databaseState) const {
+        if (databaseState.WatchKey) {
+            Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvWatchRemove(databaseState.WatchKey));
+            databaseState.WatchKey = 0;
+        }
+    }
+
+    void SendSubscriberInfo(const TDatabaseState& databaseState, Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {}) {
+        if (status == Ydb::StatusIds::SUCCESS || status == Ydb::StatusIds::UNSUPPORTED) {
+            Send(Owner, new TEvKqp::TEvUpdateDatabaseInfo(databaseState.Database, databaseState.DatabaseId, databaseState.Serverless));
+        } else {
+            NYql::TIssue rootIssue(TStringBuilder() << "Failed to describe database " << databaseState.Database);
+            for (const auto& issue : issues) {
+                rootIssue.AddSubIssue(MakeIntrusive<NYql::TIssue>(issue));
+            }
+            Send(Owner, new TEvKqp::TEvUpdateDatabaseInfo(databaseState.Database, status, {rootIssue}));
+        }
+    }
+
+    void StartIdleCheck() {
+        if (!IdleCheckStarted) {
+            IdleCheckStarted = true;
+            Schedule(IdleTimeout, new TEvents::TEvWakeup());
+        }
+    }
+
+private:
+    const TDuration IdleTimeout;
+    TActorId Owner;
+    bool IdleCheckStarted = false;
+
+    TLRUCache<TString, TDatabaseState> DatabaseStates;
+    ui32 FreeWatchKey = 0;
+};
+
+}  // anonymous namespace
+
+TDatabasesCache::TDatabasesCache(TDuration idleTimeout)
+    : IdleTimeout(idleTimeout)
+{}
+
+const TString& TDatabasesCache::GetTenantName() {
+    if (!TenantName) {
+        TenantName = CanonizePath(AppData()->TenantName);
+    }
+    return TenantName;
+}
+
+void TDatabasesCache::UpdateDatabaseInfo(TEvKqp::TEvUpdateDatabaseInfo::TPtr& event, TActorContext actorContext) {
+    auto it = DatabasesCache.find(event->Get()->Database);
+    if (it == DatabasesCache.end()) {
+        return;
+    }
+    it->second.DatabaseId = event->Get()->DatabaseId;
+
+    const bool success = event->Get()->Status == Ydb::StatusIds::SUCCESS;
+    for (auto& delayedEvent : it->second.DelayedEvents) {
+        if (success) {
+            actorContext.Send(std::move(delayedEvent.Event));
+        } else {
+            actorContext.Send(actorContext.SelfID, new TEvKqp::TEvDelayedRequestError(std::move(delayedEvent.Event), event->Get()->Status, event->Get()->Issues), 0, delayedEvent.RequestType);
+        }
+    }
+    it->second.DelayedEvents.clear();
+
+    if (!success) {
+        DatabasesCache.erase(it);
+    }
+}
+
+void TDatabasesCache::SubscribeOnDatabase(const TString& database, TActorContext actorContext) {
+    if (!SubscriberActor) {
+        SubscriberActor = actorContext.Register(new TDatabaseSubscriberActor(IdleTimeout));
+    }
+    actorContext.Send(SubscriberActor, new TEvPrivate::TEvSubscribeOnDatabase(database));
+}
+
+void TDatabasesCache::PingDatabaseSubscription(const TString& database, TActorContext actorContext) const {
+    if (SubscriberActor) {
+        actorContext.Send(SubscriberActor, new TEvPrivate::TEvPingDatabaseSubscription(database));
+    }
+}
+
+void TDatabasesCache::StopSubscriberActor(TActorContext actorContext) const {
+    if (SubscriberActor) {
+        actorContext.Send(SubscriberActor, new TEvents::TEvPoison());
+    }
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -174,6 +174,15 @@ class TKqpProxyService : public TActorBootstrapped<TKqpProxyService> {
         };
     };
 
+    enum class EDelayedRequestType {
+        QueryRequest,
+        ScriptRequest,
+        ForgetScriptExecutionOperation,
+        GetScriptExecutionOperation,
+        ListScriptExecutionOperations,
+        CancelScriptExecutionOperation,
+    };
+
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::KQP_PROXY_ACTOR;
@@ -484,6 +493,7 @@ public:
         });
 
         ResourcePoolsCache.UnsubscribeFromResourcePoolClassifiers(ActorContext());
+        DatabasesCache.StopSubscriberActor(ActorContext());
 
         return TActor::PassAway();
     }
@@ -633,6 +643,10 @@ public:
     }
 
     void Handle(TEvKqp::TEvQueryRequest::TPtr& ev) {
+        if (!DatabasesCache.SetDatabaseIdOrDefer(ev, static_cast<i32>(EDelayedRequestType::QueryRequest), ActorContext())) {
+            return;
+        }
+
         const TString& database = ev->Get()->GetDatabase();
         const TString& traceId = ev->Get()->GetTraceId();
         const auto queryType = ev->Get()->GetType();
@@ -733,7 +747,7 @@ public:
     }
 
     void Handle(TEvKqp::TEvScriptRequest::TPtr& ev) {
-        if (CheckScriptExecutionsTablesReady<TEvKqp::TEvScriptResponse>(ev)) {
+        if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::ScriptRequest)) {
             auto req = ev->Get()->Record.MutableRequest();
             auto maxRunTime = GetQueryTimeout(req->GetType(), req->GetTimeoutMs(), TableServiceConfig, QueryServiceConfig);
             req->SetTimeoutMs(maxRunTime.MilliSeconds());
@@ -1358,7 +1372,8 @@ public:
             hFunc(TEvKqp::TEvListSessionsRequest, Handle);
             hFunc(TEvKqp::TEvListProxyNodesRequest, Handle);
             hFunc(NWorkload::TEvUpdatePoolInfo, Handle);
-            hFunc(NWorkload::TEvUpdateDatabaseInfo, Handle);
+            hFunc(TEvKqp::TEvUpdateDatabaseInfo, Handle);
+            hFunc(TEvKqp::TEvDelayedRequestError, Handle);
             hFunc(NMetadata::NProvider::TEvRefreshSubscriberData, Handle);
         default:
             Y_ABORT("TKqpProxyService: unexpected event type: %" PRIx32 " event: %s",
@@ -1641,12 +1656,53 @@ private:
         NYql::NDq::SetYqlLogLevels(yqlPriority);
     }
 
-    template<typename TResponse, typename TEvent>
-    bool CheckScriptExecutionsTablesReady(TEvent& ev) {
+    void HanleDelayedRequestError(EDelayedRequestType requestType, THolder<IEventHandle> requestEvent, Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
+        switch (requestType) {
+            case EDelayedRequestType::QueryRequest: {
+                auto response = std::make_unique<TEvKqp::TEvQueryResponse>();
+                response->Record.GetRef().SetYdbStatus(status);
+                NYql::IssuesToMessage(issues, response->Record.GetRef().MutableResponse()->MutableQueryIssues());
+                Send(requestEvent->Sender, std::move(response), 0, requestEvent->Cookie);
+                break;
+            }
+
+            case EDelayedRequestType::ScriptRequest:
+                HanleDelayedScriptRequestError<TEvKqp::TEvScriptResponse>(std::move(requestEvent), status, std::move(issues));
+                break;
+
+            case EDelayedRequestType::ForgetScriptExecutionOperation:
+                HanleDelayedScriptRequestError<TEvForgetScriptExecutionOperationResponse>(std::move(requestEvent), status, std::move(issues));
+                break;
+
+            case EDelayedRequestType::GetScriptExecutionOperation:
+                HanleDelayedScriptRequestError<TEvGetScriptExecutionOperationResponse>(std::move(requestEvent), status, std::move(issues));
+                break;
+
+            case EDelayedRequestType::ListScriptExecutionOperations:
+                HanleDelayedScriptRequestError<TEvListScriptExecutionOperationsResponse>(std::move(requestEvent), status, std::move(issues));
+                break;
+
+            case EDelayedRequestType::CancelScriptExecutionOperation:
+                HanleDelayedScriptRequestError<TEvCancelScriptExecutionOperationResponse>(std::move(requestEvent), status, std::move(issues));
+                break;
+        }
+    }
+
+    template<typename TResponse>
+    void HanleDelayedScriptRequestError(THolder<IEventHandle> requestEvent, Ydb::StatusIds::StatusCode status, NYql::TIssues issues) const {
+        Send(requestEvent->Sender, new TResponse(status, std::move(issues)), 0, requestEvent->Cookie);
+    }
+
+    template<typename TEvent>
+    bool CheckScriptExecutionsTablesReady(TEvent& ev, EDelayedRequestType requestType) {
         if (!AppData()->FeatureFlags.GetEnableScriptExecutionOperations()) {
             NYql::TIssues issues;
             issues.AddIssue("ExecuteScript feature is not enabled");
-            Send(ev->Sender, new TResponse(Ydb::StatusIds::UNSUPPORTED, std::move(issues)));
+            HanleDelayedRequestError(requestType, std::move(ev), Ydb::StatusIds::UNSUPPORTED, std::move(issues));
+            return false;
+        }
+
+        if (!DatabasesCache.SetDatabaseIdOrDefer(ev, static_cast<i32>(requestType), ActorContext())) {
             return false;
         }
 
@@ -1659,14 +1715,12 @@ private:
                 if (DelayedEventsQueue.size() < 10000) {
                     DelayedEventsQueue.push_back({
                         .Event = std::move(ev),
-                        .ResponseBuilder = [](Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
-                            return new TResponse(status, std::move(issues));
-                        }
+                        .RequestType = static_cast<i32>(requestType)
                     });
                 } else {
                     NYql::TIssues issues;
                     issues.AddIssue("Too many queued requests");
-                    Send(ev->Sender, new TResponse(Ydb::StatusIds::OVERLOADED, std::move(issues)));
+                    HanleDelayedRequestError(requestType, std::move(ev), Ydb::StatusIds::OVERLOADED, std::move(issues));
                 }
                 return false;
             case EScriptExecutionsCreationStatus::Finished:
@@ -1691,32 +1745,32 @@ private:
             if (ev->Get()->Success) {
                 Send(std::move(delayedEvent.Event));
             } else {
-                Send(delayedEvent.Event->Sender, delayedEvent.ResponseBuilder(Ydb::StatusIds::INTERNAL_ERROR, {rootIssue}));
+                HanleDelayedRequestError(static_cast<EDelayedRequestType>(delayedEvent.RequestType), std::move(delayedEvent.Event), Ydb::StatusIds::INTERNAL_ERROR, {rootIssue});
             }
             DelayedEventsQueue.pop_front();
         }
     }
 
     void Handle(NKqp::TEvForgetScriptExecutionOperation::TPtr& ev) {
-        if (CheckScriptExecutionsTablesReady<TEvForgetScriptExecutionOperationResponse>(ev)) {
+        if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::ForgetScriptExecutionOperation)) {
             Register(CreateForgetScriptExecutionOperationActor(std::move(ev)), TMailboxType::HTSwap, AppData()->SystemPoolId);
         }
     }
 
     void Handle(NKqp::TEvGetScriptExecutionOperation::TPtr& ev) {
-        if (CheckScriptExecutionsTablesReady<TEvGetScriptExecutionOperationResponse>(ev)) {
+        if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::GetScriptExecutionOperation)) {
             Register(CreateGetScriptExecutionOperationActor(std::move(ev)), TMailboxType::HTSwap, AppData()->SystemPoolId);
         }
     }
 
     void Handle(NKqp::TEvListScriptExecutionOperations::TPtr& ev) {
-        if (CheckScriptExecutionsTablesReady<TEvListScriptExecutionOperationsResponse>(ev)) {
+        if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::ListScriptExecutionOperations)) {
             Register(CreateListScriptExecutionOperationsActor(std::move(ev)), TMailboxType::HTSwap, AppData()->SystemPoolId);
         }
     }
 
     void Handle(NKqp::TEvCancelScriptExecutionOperation::TPtr& ev) {
-        if (CheckScriptExecutionsTablesReady<TEvCancelScriptExecutionOperationResponse>(ev)) {
+        if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::CancelScriptExecutionOperation)) {
             Register(CreateCancelScriptExecutionOperationActor(std::move(ev)), TMailboxType::HTSwap, AppData()->SystemPoolId);
         }
     }
@@ -1820,8 +1874,15 @@ private:
         ResourcePoolsCache.UpdatePoolInfo(ev->Get()->Database, ev->Get()->PoolId, ev->Get()->Config, ev->Get()->SecurityObject, ActorContext());
     }
 
-    void Handle(NWorkload::TEvUpdateDatabaseInfo::TPtr& ev) {
-        ResourcePoolsCache.UpdateDatabaseInfo(ev->Get()->Database, ev->Get()->Serverless);
+    void Handle(TEvKqp::TEvUpdateDatabaseInfo::TPtr& ev) {
+        if (ev->Get()->Status == Ydb::StatusIds::SUCCESS) {
+            ResourcePoolsCache.UpdateDatabaseInfo(ev->Get()->Database, ev->Get()->Serverless);
+        }
+        DatabasesCache.UpdateDatabaseInfo(ev, ActorContext());
+    }
+
+    void Handle(TEvKqp::TEvDelayedRequestError::TPtr& ev) {
+        HanleDelayedRequestError(static_cast<EDelayedRequestType>(ev->Cookie), std::move(ev->Get()->RequestEvent), ev->Get()->Status, std::move(ev->Get()->Issues));
     }
 
     void Handle(NMetadata::NProvider::TEvRefreshSubscriberData::TPtr& ev) {
@@ -1881,16 +1942,13 @@ private:
         Pending,
         Finished,
     };
-    struct TDelayedEvent {
-        THolder<IEventHandle> Event;
-        std::function<IEventBase*(Ydb::StatusIds::StatusCode, NYql::TIssues)> ResponseBuilder;
-    };
     EScriptExecutionsCreationStatus ScriptExecutionsCreationStatus = EScriptExecutionsCreationStatus::NotStarted;
-    std::deque<TDelayedEvent> DelayedEventsQueue;
+    std::deque<TDatabasesCache::TDelayedEvent> DelayedEventsQueue;
     bool IsLookupByRmScheduled = false;
     TActorId KqpTempTablesAgentActor;
 
     TResourcePoolsCache ResourcePoolsCache;
+    TDatabasesCache DatabasesCache;
 };
 
 } // namespace

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -1600,19 +1600,19 @@ private:
     bool TryFillPoolInfoFromCache(TEvKqp::TEvQueryRequest::TPtr& ev, ui64 requestId) {
         ResourcePoolsCache.UpdateFeatureFlags(FeatureFlags, ActorContext());
 
-        const auto& database = ev->Get()->GetDatabase();
-        if (!ResourcePoolsCache.ResourcePoolsEnabled(database)) {
+        const auto& databaseId = ev->Get()->GetDatabaseId();
+        if (!ResourcePoolsCache.ResourcePoolsEnabled(databaseId)) {
             ev->Get()->SetPoolId("");
             return true;
         }
 
         const auto& userToken = ev->Get()->GetUserToken();
         if (!ev->Get()->GetPoolId()) {
-            ev->Get()->SetPoolId(ResourcePoolsCache.GetPoolId(database, userToken, ActorContext()));
+            ev->Get()->SetPoolId(ResourcePoolsCache.GetPoolId(databaseId, userToken, ActorContext()));
         }
 
         const auto& poolId = ev->Get()->GetPoolId();
-        const auto& poolInfo = ResourcePoolsCache.GetPoolInfo(database, poolId, ActorContext());
+        const auto& poolInfo = ResourcePoolsCache.GetPoolInfo(databaseId, poolId, ActorContext());
         if (!poolInfo) {
             return true;
         }
@@ -1871,12 +1871,12 @@ private:
     }
 
     void Handle(NWorkload::TEvUpdatePoolInfo::TPtr& ev) {
-        ResourcePoolsCache.UpdatePoolInfo(ev->Get()->Database, ev->Get()->PoolId, ev->Get()->Config, ev->Get()->SecurityObject, ActorContext());
+        ResourcePoolsCache.UpdatePoolInfo(ev->Get()->DatabaseId, ev->Get()->PoolId, ev->Get()->Config, ev->Get()->SecurityObject, ActorContext());
     }
 
     void Handle(TEvKqp::TEvUpdateDatabaseInfo::TPtr& ev) {
         if (ev->Get()->Status == Ydb::StatusIds::SUCCESS) {
-            ResourcePoolsCache.UpdateDatabaseInfo(ev->Get()->Database, ev->Get()->Serverless);
+            ResourcePoolsCache.UpdateDatabaseInfo(ev->Get()->DatabaseId, ev->Get()->Serverless);
         }
         DatabasesCache.UpdateDatabaseInfo(ev, ActorContext());
     }

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -432,9 +432,9 @@ class TResourcePoolsCache {
     };
 
     struct TDatabaseInfo {
-        std::unordered_map<TString, TResourcePoolClassifierConfig> ResourcePoolsClassifiers = {};
-        std::map<i64, TClassifierInfo> RankToClassifierInfo = {};
-        std::unordered_map<TString, std::pair<TString, i64>> UserToResourcePool = {};
+        std::unordered_map<TString, TResourcePoolClassifierConfig> ResourcePoolsClassifiers = {};  // Classifier name to config
+        std::map<i64, TClassifierInfo> RankToClassifierInfo = {};  // Classifier rank to config
+        std::unordered_map<TString, std::pair<TString, i64>> UserToResourcePool = {};  // UserSID to (resource pool, classifier rank)
         bool Serverless = false;
     };
 
@@ -445,7 +445,7 @@ class TResourcePoolsCache {
     };
 
 public:
-    bool ResourcePoolsEnabled(const TString& database) const {
+    bool ResourcePoolsEnabled(const TString& databaseId) const {
         if (!EnableResourcePools) {
             return false;
         }
@@ -454,19 +454,19 @@ public:
             return true;
         }
 
-        const auto databaseInfo = GetDatabaseInfo(database); 
+        const auto databaseInfo = GetDatabaseInfo(databaseId);
         return !databaseInfo || !databaseInfo->Serverless;
     }
 
-    TString GetPoolId(const TString& database, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) {
+    TString GetPoolId(const TString& databaseId, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) {
         if (!userToken || userToken->GetUserSID().empty()) {
             return NResourcePool::DEFAULT_POOL_ID;
         }
 
-        TDatabaseInfo& databaseInfo = *GetOrCreateDatabaseInfo(database);
-        auto [resultPoolId, resultRank] = GetPoolIdFromClassifiers(database, userToken->GetUserSID(), databaseInfo, userToken, actorContext);
+        TDatabaseInfo& databaseInfo = *GetOrCreateDatabaseInfo(databaseId);
+        auto [resultPoolId, resultRank] = GetPoolIdFromClassifiers(databaseId, userToken->GetUserSID(), databaseInfo, userToken, actorContext);
         for (const auto& userSID : userToken->GetGroupSIDs()) {
-            const auto& [poolId, rank] = GetPoolIdFromClassifiers(database, userSID, databaseInfo, userToken, actorContext);
+            const auto& [poolId, rank] = GetPoolIdFromClassifiers(databaseId, userSID, databaseInfo, userToken, actorContext);
             if (poolId && (!resultPoolId || resultRank > rank)) {
                 resultPoolId = poolId;
                 resultRank = rank;
@@ -476,10 +476,10 @@ public:
         return resultPoolId ? resultPoolId : NResourcePool::DEFAULT_POOL_ID;
     }
 
-    std::optional<TPoolInfo> GetPoolInfo(const TString& database, const TString& poolId, TActorContext actorContext) const {
-        auto it = PoolsCache.find(GetPoolKey(database, poolId));
+    std::optional<TPoolInfo> GetPoolInfo(const TString& databaseId, const TString& poolId, TActorContext actorContext) const {
+        auto it = PoolsCache.find(GetPoolKey(databaseId, poolId));
         if (it == PoolsCache.end()) {
-            actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, poolId));
+            actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(databaseId, poolId));
             return std::nullopt;
         }
         return it->second;
@@ -491,14 +491,14 @@ public:
         UpdateResourcePoolClassifiersSubscription(actorContext);
     }
 
-    void UpdateDatabaseInfo(const TString& database, bool serverless) {
-        GetOrCreateDatabaseInfo(database)->Serverless = serverless;
+    void UpdateDatabaseInfo(const TString& databaseId, bool serverless) {
+        GetOrCreateDatabaseInfo(databaseId)->Serverless = serverless;
     }
 
-    void UpdatePoolInfo(const TString& database, const TString& poolId, const std::optional<NResourcePool::TPoolSettings>& config, const std::optional<NACLib::TSecurityObject>& securityObject, TActorContext actorContext) {
+    void UpdatePoolInfo(const TString& databaseId, const TString& poolId, const std::optional<NResourcePool::TPoolSettings>& config, const std::optional<NACLib::TSecurityObject>& securityObject, TActorContext actorContext) {
         bool clearClassifierCache = false;
 
-        const TString& poolKey = GetPoolKey(database, poolId);
+        const TString& poolKey = GetPoolKey(databaseId, poolId);
         if (!config) {
             auto it = PoolsCache.find(poolKey);
             if (it == PoolsCache.end()) {
@@ -511,7 +511,7 @@ public:
             } else {
                 // Refresh pool subscription
                 it->second.Expired = true;
-                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, poolId));
+                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(databaseId, poolId));
             }
         } else {
             auto& poolInfo = PoolsCache[poolKey];
@@ -522,16 +522,16 @@ public:
         }
 
         if (clearClassifierCache) {
-            GetOrCreateDatabaseInfo(database)->UserToResourcePool.clear();
+            GetOrCreateDatabaseInfo(databaseId)->UserToResourcePool.clear();
         }
     }
 
     void UpdateResourcePoolClassifiersInfo(const TResourcePoolClassifierSnapshot* snapsot, TActorContext actorContext) {
         auto resourcePoolClassifierConfigs = snapsot->GetResourcePoolClassifierConfigs();
-        for (auto& [database, databaseInfo] : DatabasesCache) {
-            auto it = resourcePoolClassifierConfigs.find(database);
+        for (auto& [databaseId, databaseInfo] : DatabasesCache) {
+            auto it = resourcePoolClassifierConfigs.find(databaseId);
             if (it != resourcePoolClassifierConfigs.end()) {
-                UpdateDatabaseResourcePoolClassifiers(database, databaseInfo, std::move(it->second), actorContext);
+                UpdateDatabaseResourcePoolClassifiers(databaseId, databaseInfo, std::move(it->second), actorContext);
                 resourcePoolClassifierConfigs.erase(it);
             } else if (!databaseInfo.ResourcePoolsClassifiers.empty()) {
                 databaseInfo.ResourcePoolsClassifiers.clear();
@@ -539,8 +539,8 @@ public:
                 databaseInfo.UserToResourcePool.clear();
             }
         }
-        for (auto& [database, configsMap] : resourcePoolClassifierConfigs) {
-            UpdateDatabaseResourcePoolClassifiers(database, *GetOrCreateDatabaseInfo(database), std::move(configsMap), actorContext);
+        for (auto& [databaseId, configsMap] : resourcePoolClassifierConfigs) {
+            UpdateDatabaseResourcePoolClassifiers(databaseId, *GetOrCreateDatabaseInfo(databaseId), std::move(configsMap), actorContext);
         }
     }
 
@@ -567,7 +567,7 @@ private:
         }
     }
 
-    void UpdateDatabaseResourcePoolClassifiers(const TString& database, TDatabaseInfo& databaseInfo, std::unordered_map<TString, TResourcePoolClassifierConfig>&& configsMap, TActorContext actorContext) {
+    void UpdateDatabaseResourcePoolClassifiers(const TString& databaseId, TDatabaseInfo& databaseInfo, std::unordered_map<TString, TResourcePoolClassifierConfig>&& configsMap, TActorContext actorContext) {
         if (databaseInfo.ResourcePoolsClassifiers == configsMap) {
             return;
         }
@@ -579,12 +579,12 @@ private:
             const auto& classifierSettings = classifier.GetClassifierSettings();
             databaseInfo.RankToClassifierInfo.insert({classifier.GetRank(), TClassifierInfo(classifierSettings)});
             if (!PoolsCache.contains(classifierSettings.ResourcePool)) {
-                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, classifierSettings.ResourcePool));
+                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(databaseId, classifierSettings.ResourcePool));
             }
         }
     }
 
-    std::pair<TString, i64> GetPoolIdFromClassifiers(const TString& database, const TString& userSID, TDatabaseInfo& databaseInfo, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) const {
+    std::pair<TString, i64> GetPoolIdFromClassifiers(const TString& databaseId, const TString& userSID, TDatabaseInfo& databaseInfo, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, TActorContext actorContext) const {
         auto& usersMap = databaseInfo.UserToResourcePool;
         if (const auto it = usersMap.find(userSID); it != usersMap.end()) {
             return it->second;
@@ -597,9 +597,9 @@ private:
                 continue;
             }
 
-            auto it = PoolsCache.find(GetPoolKey(database, classifier.PoolId));
+            auto it = PoolsCache.find(GetPoolKey(databaseId, classifier.PoolId));
             if (it == PoolsCache.end()) {
-                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(database, classifier.PoolId));
+                actorContext.Send(MakeKqpWorkloadServiceId(actorContext.SelfID.NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(databaseId, classifier.PoolId));
                 continue;
             }
 
@@ -616,21 +616,20 @@ private:
         return {poolId, rank};
     }
 
-    TDatabaseInfo* GetOrCreateDatabaseInfo(const TString& database) {
-        const TString& path = CanonizePath(database);
-        if (const auto it = DatabasesCache.find(path); it != DatabasesCache.end()) {
+    TDatabaseInfo* GetOrCreateDatabaseInfo(const TString& databaseId) {
+        if (const auto it = DatabasesCache.find(databaseId); it != DatabasesCache.end()) {
             return &it->second;
         }
-        return &DatabasesCache.insert({path, TDatabaseInfo{}}).first->second;
+        return &DatabasesCache.insert({databaseId, TDatabaseInfo{}}).first->second;
     }
 
-    const TDatabaseInfo* GetDatabaseInfo(const TString& database) const {
-        const auto it = DatabasesCache.find(CanonizePath(database));
+    const TDatabaseInfo* GetDatabaseInfo(const TString& databaseId) const {
+        const auto it = DatabasesCache.find(databaseId);
         return it != DatabasesCache.end() ? &it->second : nullptr;
     }
 
-    static TString GetPoolKey(const TString& database, const TString& poolId) {
-        return CanonizePath(TStringBuilder() << database << "/" << poolId);
+    static TString GetPoolKey(const TString& databaseId, const TString& poolId) {
+        return TStringBuilder() << databaseId << "/" << poolId;
     }
 
 private:
@@ -660,13 +659,10 @@ public:
 
     template <typename TEvent>
     bool SetDatabaseIdOrDefer(TEvent& event, i32 requestType, TActorContext actorContext) {
-        if (!event->Get()->GetDatabaseId().empty()) {
-            return true;
-        }
-
         const auto& database = CanonizePath(event->Get()->GetDatabase());
-        if (database.empty() || database == GetTenantName()) {
-            event->Get()->SetDatabaseId(GetTenantName());
+        const auto& tenantName = CanonizePath(AppData()->TenantName);
+        if (database.empty() || database == tenantName) {
+            event->Get()->SetDatabaseId(tenantName);
             return true;
         }
 
@@ -690,7 +686,6 @@ public:
     void StopSubscriberActor(TActorContext actorContext) const;
 
 private:
-    const TString& GetTenantName();
     void SubscribeOnDatabase(const TString& database, TActorContext actorContext);
     void PingDatabaseSubscription(const TString& database, TActorContext actorContext) const;
 

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service_impl.h
@@ -642,4 +642,63 @@ private:
     bool SubscribedOnResourcePoolClassifiers = false;
 };
 
+class TDatabasesCache {
+public:
+    struct TDelayedEvent {
+        THolder<IEventHandle> Event;
+        i32 RequestType;
+    };
+
+private:
+    struct TDatabaseInfo {
+        TString DatabaseId;  // string "<scheme shard id>:<domain path id>:<database path>"
+        std::vector<TDelayedEvent> DelayedEvents;
+    };
+
+public:
+    TDatabasesCache(TDuration idleTimeout = TDuration::Seconds(60));
+
+    template <typename TEvent>
+    bool SetDatabaseIdOrDefer(TEvent& event, i32 requestType, TActorContext actorContext) {
+        if (!event->Get()->GetDatabaseId().empty()) {
+            return true;
+        }
+
+        const auto& database = CanonizePath(event->Get()->GetDatabase());
+        if (database.empty() || database == GetTenantName()) {
+            event->Get()->SetDatabaseId(GetTenantName());
+            return true;
+        }
+
+        auto& databaseInfo = DatabasesCache[database];
+        if (databaseInfo.DatabaseId) {
+            PingDatabaseSubscription(database, actorContext);
+            event->Get()->SetDatabaseId(databaseInfo.DatabaseId);
+            return true;
+        }
+
+        SubscribeOnDatabase(database, actorContext);
+        databaseInfo.DelayedEvents.push_back(TDelayedEvent{
+            .Event = std::move(event),
+            .RequestType = requestType
+        });
+
+        return false;
+    }
+
+    void UpdateDatabaseInfo(TEvKqp::TEvUpdateDatabaseInfo::TPtr& event, TActorContext actorContext);
+    void StopSubscriberActor(TActorContext actorContext) const;
+
+private:
+    const TString& GetTenantName();
+    void SubscribeOnDatabase(const TString& database, TActorContext actorContext);
+    void PingDatabaseSubscription(const TString& database, TActorContext actorContext) const;
+
+private:
+    const TDuration IdleTimeout;
+    std::unordered_map<TString, TDatabaseInfo> DatabasesCache;
+    TActorId SubscriberActor;
+    TString TenantName;
+};
+
 }  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/ut/ya.make
+++ b/ydb/core/kqp/proxy_service/ut/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
     ydb/core/kqp/run_script_actor
     ydb/core/kqp/proxy_service
     ydb/core/kqp/ut/common
+    ydb/core/kqp/workload_service/ut/common
     ydb/library/yql/sql/pg_dummy
     ydb/public/sdk/cpp/client/ydb_query
     ydb/public/sdk/cpp/client/ydb_driver

--- a/ydb/core/kqp/proxy_service/ya.make
+++ b/ydb/core/kqp/proxy_service/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     kqp_proxy_service.cpp
+    kqp_proxy_databases_cache.cpp
     kqp_proxy_peer_stats_calculator.cpp
     kqp_script_executions.cpp
     kqp_session_info.cpp

--- a/ydb/core/kqp/runtime/kqp_compute_scheduler.cpp
+++ b/ydb/core/kqp/runtime/kqp_compute_scheduler.cpp
@@ -461,7 +461,7 @@ public:
             Opts.Scheduler->UpdateMaxShare(ev->Get()->PoolId, ev->Get()->Config->TotalCpuLimitPercentPerNode / 100.0, TlsActivationContext->Monotonic());
         } else {
             if (!Opts.Scheduler->Disable(ev->Get()->PoolId, TlsActivationContext->Monotonic())) {
-                Schedule(Opts.ActivePoolPollingTimeout.ToDeadLine(), new TEvPingPool(ev->Get()->Database, ev->Get()->PoolId));
+                Schedule(Opts.ActivePoolPollingTimeout.ToDeadLine(), new TEvPingPool(ev->Get()->DatabaseId, ev->Get()->PoolId));
             }
         }
     }

--- a/ydb/core/kqp/runtime/kqp_compute_scheduler.cpp
+++ b/ydb/core/kqp/runtime/kqp_compute_scheduler.cpp
@@ -387,11 +387,11 @@ void TComputeScheduler::UpdateMaxShare(TString group, double share, TMonotonic n
 
 
 struct TEvPingPool : public TEventLocal<TEvPingPool, TKqpComputeSchedulerEvents::EvPingPool> {
-    TString Database;
+    TString DatabaseId;
     TString Pool;
 
-    TEvPingPool(TString database, TString pool)
-        : Database(database)
+    TEvPingPool(TString databaseId, TString pool)
+        : DatabaseId(databaseId)
         , Pool(pool)
     {
     }
@@ -448,12 +448,12 @@ public:
     }
 
     void Handle(TEvSchedulerNewPool::TPtr& ev) {
-        Send(MakeKqpWorkloadServiceId(SelfId().NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(ev->Get()->Database, ev->Get()->Pool));
+        Send(MakeKqpWorkloadServiceId(SelfId().NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(ev->Get()->DatabaseId, ev->Get()->Pool));
         Opts.Scheduler->UpdateMaxShare(ev->Get()->Pool, ev->Get()->MaxShare, TlsActivationContext->Monotonic());
     }
 
     void Handle(TEvPingPool::TPtr& ev) {
-        Send(MakeKqpWorkloadServiceId(SelfId().NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(ev->Get()->Database, ev->Get()->Pool));
+        Send(MakeKqpWorkloadServiceId(SelfId().NodeId()), new NWorkload::TEvSubscribeOnPoolChanges(ev->Get()->DatabaseId, ev->Get()->Pool));
     }
 
     void Handle(NWorkload::TEvUpdatePoolInfo::TPtr& ev) {

--- a/ydb/core/kqp/runtime/kqp_compute_scheduler.h
+++ b/ydb/core/kqp/runtime/kqp_compute_scheduler.h
@@ -110,12 +110,12 @@ struct TEvSchedulerDeregister : public TEventLocal<TEvSchedulerDeregister, TKqpC
 };
 
 struct TEvSchedulerNewPool : public TEventLocal<TEvSchedulerNewPool, TKqpComputeSchedulerEvents::EvNewPool> {
-    TString Database;
+    TString DatabaseId;
     TString Pool;
     double MaxShare;
 
-    TEvSchedulerNewPool(TString database, TString pool, double maxShare)
-        : Database(database)
+    TEvSchedulerNewPool(TString databaseId, TString pool, double maxShare)
+        : DatabaseId(databaseId)
         , Pool(pool)
         , MaxShare(maxShare)
     {

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -198,12 +198,12 @@ std::unique_ptr<TEvKqp::TEvCompileRequest> TKqpQueryState::BuildCompileRequest(s
     TGUCSettings gUCSettings = gUCSettingsPtr ? *gUCSettingsPtr : TGUCSettings();
     switch (GetAction()) {
         case NKikimrKqp::QUERY_ACTION_EXECUTE:
-            query = TKqpQueryId(Cluster, Database, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
+            query = TKqpQueryId(Cluster, Database, UserRequestContext->DatabaseId, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
             keepInCache = GetQueryKeepInCache() && query->IsSql();
             break;
 
         case NKikimrKqp::QUERY_ACTION_PREPARE:
-            query = TKqpQueryId(Cluster, Database, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
+            query = TKqpQueryId(Cluster, Database, UserRequestContext->DatabaseId, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
             keepInCache = query->IsSql();
             break;
 
@@ -213,7 +213,7 @@ std::unique_ptr<TEvKqp::TEvCompileRequest> TKqpQueryState::BuildCompileRequest(s
             break;
 
         case NKikimrKqp::QUERY_ACTION_EXPLAIN:
-            query = TKqpQueryId(Cluster, Database, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
+            query = TKqpQueryId(Cluster, Database, UserRequestContext->DatabaseId, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
             keepInCache = false;
             break;
 
@@ -254,11 +254,11 @@ std::unique_ptr<TEvKqp::TEvRecompileRequest> TKqpQueryState::BuildReCompileReque
     switch (GetAction()) {
         case NKikimrKqp::QUERY_ACTION_EXPLAIN:
         case NKikimrKqp::QUERY_ACTION_EXECUTE:
-            query = TKqpQueryId(Cluster, Database, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
+            query = TKqpQueryId(Cluster, Database, UserRequestContext->DatabaseId, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
             break;
 
         case NKikimrKqp::QUERY_ACTION_PREPARE:
-            query = TKqpQueryId(Cluster, Database, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
+            query = TKqpQueryId(Cluster, Database, UserRequestContext->DatabaseId, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
             break;
 
         case NKikimrKqp::QUERY_ACTION_EXECUTE_PREPARED:
@@ -304,7 +304,7 @@ std::unique_ptr<TEvKqp::TEvCompileRequest> TKqpQueryState::BuildCompileSplittedR
 
     switch (GetAction()) {
         case NKikimrKqp::QUERY_ACTION_EXECUTE:
-            query = TKqpQueryId(Cluster, Database, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
+            query = TKqpQueryId(Cluster, Database, UserRequestContext->DatabaseId, GetQuery(), settings, GetQueryParameterTypes(), gUCSettings);
             break;
         default:
             YQL_ENSURE(false);

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -88,6 +88,7 @@ public:
         }
         UserRequestContext->PoolId = RequestEv->GetPoolId();
         UserRequestContext->PoolConfig = RequestEv->GetPoolConfig();
+        UserRequestContext->DatabaseId = RequestEv->GetDatabaseId();
     }
 
     // the monotonously growing counter, the ordinal number of the query,

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -255,6 +255,7 @@ public:
             QueryState->UserToken
         ), IEventHandle::FlagTrackDelivery);
 
+        QueryState->PoolHandlerActor = MakeKqpWorkloadServiceId(SelfId().NodeId());
         Become(&TKqpSessionActor::ExecuteState);
     }
 
@@ -2418,6 +2419,7 @@ public:
                 hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleNoop);
                 hFunc(TEvents::TEvUndelivered, HandleNoop);
                 hFunc(TEvTxUserProxy::TEvAllocateTxIdResult, HandleNoop);
+                hFunc(TEvKqpExecuter::TEvStreamData, HandleNoop);
                 hFunc(NWorkload::TEvContinueRequest, HandleNoop);
 
                 // always come from WorkerActor

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -249,7 +249,7 @@ public:
         }
 
         Send(MakeKqpWorkloadServiceId(SelfId().NodeId()), new NWorkload::TEvPlaceRequestIntoPool(
-            QueryState->Database,
+            QueryState->UserRequestContext->DatabaseId,
             SessionId,
             QueryState->UserRequestContext->PoolId,
             QueryState->UserToken
@@ -415,6 +415,7 @@ public:
             << " text: " << QueryState->GetQuery()
             << " rpcActor: " << QueryState->RequestActorId
             << " database: " << QueryState->GetDatabase()
+            << " databaseId: " << QueryState->UserRequestContext->DatabaseId
             << " pool id: " << QueryState->UserRequestContext->PoolId
         );
 
@@ -2126,7 +2127,7 @@ public:
 
             const auto& stats = QueryState->QueryStats;
             auto event = std::make_unique<NWorkload::TEvCleanupRequest>(
-                QueryState->Database, SessionId, QueryState->UserRequestContext->PoolId,
+                QueryState->UserRequestContext->DatabaseId, SessionId, QueryState->UserRequestContext->PoolId,
                 TDuration::MicroSeconds(stats.DurationUs), TDuration::MicroSeconds(stats.WorkerCpuTimeUs)
             );
 

--- a/ydb/core/kqp/session_actor/kqp_worker_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_worker_actor.cpp
@@ -182,7 +182,7 @@ public:
 
         std::shared_ptr<NYql::IKikimrGateway::IKqpTableMetadataLoader> loader = std::make_shared<TKqpTableMetadataLoader>(
             Settings.Cluster, TlsActivationContext->ActorSystem(), Config, false, nullptr);
-        Gateway = CreateKikimrIcGateway(Settings.Cluster, QueryState->RequestEv->GetType(), Settings.Database, std::move(loader),
+        Gateway = CreateKikimrIcGateway(Settings.Cluster, QueryState->RequestEv->GetType(), Settings.Database, QueryState->RequestEv->GetDatabaseId(), std::move(loader),
             ctx.ExecutorThread.ActorSystem, ctx.SelfID.NodeId(), RequestCounters, QueryServiceConfig);
 
         Config->FeatureFlags = AppData(ctx)->FeatureFlags;

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -35,7 +35,7 @@ TIntrusivePtr<NKqp::IKqpGateway> GetIcGateway(Tests::TServer& server) {
     counters->Counters = new TKqpCounters(server.GetRuntime()->GetAppData(0).Counters);
     counters->TxProxyMon = new NTxProxy::TTxProxyMon(server.GetRuntime()->GetAppData(0).Counters);
     std::shared_ptr<NYql::IKikimrGateway::IKqpTableMetadataLoader> loader = std::make_shared<TKqpTableMetadataLoader>(TestCluster, server.GetRuntime()->GetAnyNodeActorSystem(),TIntrusivePtr<NYql::TKikimrConfiguration>(nullptr),false);
-    return NKqp::CreateKikimrIcGateway(TestCluster, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY, "/Root", std::move(loader), server.GetRuntime()->GetAnyNodeActorSystem(),
+    return NKqp::CreateKikimrIcGateway(TestCluster, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY, "/Root", "/Root", std::move(loader), server.GetRuntime()->GetAnyNodeActorSystem(),
         server.GetRuntime()->GetNodeId(0), counters, server.GetSettings().AppConfig->GetQueryServiceConfig());
 }
 

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -1433,6 +1433,8 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
         Tests::TServer::TPtr server = new Tests::TServer(settings);
 
         auto runtime = server->GetRuntime();
+        runtime->SetScheduledLimit(1000000);
+
         auto sender = runtime->AllocateEdgeActor();
 
         InitRoot(server, sender);

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/ut/common/columnshard.h>
+#include <ydb/core/kqp/workload_service/actors/actors.h>
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
 #include <ydb/core/tx/columnshard/hooks/testing/controller.h>
 #include <ydb/core/tx/columnshard/test_helper/controllers.h>
@@ -6618,7 +6619,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // DROP RESOURCE POOL CLASSIFIER
         checkQuery("DROP RESOURCE POOL CLASSIFIER MyResourcePoolClassifier;",
             EStatus::GENERIC_ERROR,
-            "Classifier with name MyResourcePoolClassifier not found in database /Root");
+            "Classifier with name MyResourcePoolClassifier not found in database with id /Root");
     }
 
     Y_UNIT_TEST(DisableResourcePoolClassifiersOnServerless) {
@@ -6799,14 +6800,17 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "The rank could not be set automatically, the maximum rank of the resource pool classifier is too high: 9223372036854775807");
     }
 
-    TString FetchResourcePoolClassifiers(TKikimrRunner& kikimr) {
-        auto& runtime = *kikimr.GetTestServer().GetRuntime();
-        const TActorId edgeActor = runtime.AllocateEdgeActor();
-        runtime.Send(NMetadata::NProvider::MakeServiceId(runtime.GetNodeId()), edgeActor, new NMetadata::NProvider::TEvAskSnapshot(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>()));
+    TString FetchResourcePoolClassifiers(TTestActorRuntime& runtime, ui32 nodeIndex) {
+        const TActorId edgeActor = runtime.AllocateEdgeActor(nodeIndex);
+        runtime.Send(NMetadata::NProvider::MakeServiceId(runtime.GetNodeId(nodeIndex)), edgeActor, new NMetadata::NProvider::TEvAskSnapshot(std::make_shared<TResourcePoolClassifierSnapshotsFetcher>()), nodeIndex);
 
         const auto response = runtime.GrabEdgeEvent<NMetadata::NProvider::TEvRefreshSubscriberData>(edgeActor);
         UNIT_ASSERT(response);
         return response->Get()->GetSnapshotAs<TResourcePoolClassifierSnapshot>()->SerializeToString();
+    }
+
+    TString FetchResourcePoolClassifiers(TKikimrRunner& kikimr) {
+        return FetchResourcePoolClassifiers(*kikimr.GetTestServer().GetRuntime(), 0);
     }
 
     Y_UNIT_TEST(CreateResourcePoolClassifier) {
@@ -6840,6 +6844,31 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         result = session.ExecuteSchemeQuery(query).GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
         UNIT_ASSERT_VALUES_EQUAL(FetchResourcePoolClassifiers(kikimr), "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"member_name\":\"test@user\",\"resource_pool\":\"test_pool\"},\"database\":\"\\/Root\"},{\"rank\":1020,\"name\":\"AnotherResourcePoolClassifier\",\"config\":{\"member_name\":\"another@user\",\"resource_pool\":\"test_pool\"},\"database\":\"\\/Root\"}]}");
+    }
+
+    Y_UNIT_TEST(CreateResourcePoolClassifierOnServerless) {
+        auto ydb = NWorkload::TYdbSetupSettings()
+            .CreateSampleTenants(true)
+            .EnableResourcePoolsOnServerless(true)
+            .Create();
+
+        const auto& serverlessTenant = ydb->GetSettings().GetServerlessTenantName();
+        NWorkload::TSampleQueries::CheckSuccess(ydb->ExecuteQuery(R"(
+            CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
+                RANK=20,
+                RESOURCE_POOL="test_pool"
+            );)",
+            NWorkload::TQueryRunnerSettings()
+                .PoolId("")
+                .Database(serverlessTenant)
+                .NodeIndex(1)
+        ));
+
+        const auto pathId = ydb->FetchDatabase(serverlessTenant)->Get()->PathId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            FetchResourcePoolClassifiers(*ydb->GetRuntime(), 1),
+            TStringBuilder() << "{\"resource_pool_classifiers\":[{\"rank\":20,\"name\":\"MyResourcePoolClassifier\",\"config\":{\"resource_pool\":\"test_pool\"},\"database\":\"" << pathId.OwnerId << ":" << pathId.LocalPathId << ":\\/Root\\/test-serverless\"}]}"
+        );
     }
 
     Y_UNIT_TEST(DoubleCreateResourcePoolClassifier) {
@@ -6951,7 +6980,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             )";
         auto result = session.ExecuteSchemeQuery(query).GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Classifier with name MyResourcePoolClassifier not found in database /Root");
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Classifier with name MyResourcePoolClassifier not found in database with id /Root");
     }
 
     Y_UNIT_TEST(DropResourcePoolClassifier) {
@@ -6998,7 +7027,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         auto query = "DROP RESOURCE POOL CLASSIFIER MyResourcePoolClassifier;";
         auto result = session.ExecuteSchemeQuery(query).GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Classifier with name MyResourcePoolClassifier not found in database /Root");
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Classifier with name MyResourcePoolClassifier not found in database with id /Root");
     }
 
     Y_UNIT_TEST(DisableMetadataObjectsOnServerless) {

--- a/ydb/core/kqp/workload_service/actors/actors.h
+++ b/ydb/core/kqp/workload_service/actors/actors.h
@@ -6,16 +6,16 @@
 namespace NKikimr::NKqp::NWorkload {
 
 // Pool state holder
-NActors::IActor* CreatePoolHandlerActor(const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters);
+NActors::IActor* CreatePoolHandlerActor(const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters);
 
 // Fetch pool and create default pool if needed
 NActors::IActor* CreatePoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaultPoolExists);
 
 // Fetch and create pool in scheme shard
-NActors::IActor* CreatePoolFetcherActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken);
-NActors::IActor* CreatePoolCreatorActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl);
+NActors::IActor* CreatePoolFetcherActor(const NActors::TActorId& replyActorId, const TString& databaseId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken);
+NActors::IActor* CreatePoolCreatorActor(const NActors::TActorId& replyActorId, const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl);
 
-// Checks that database is serverless
+// Checks that database is serverless and return database id
 NActors::IActor* CreateDatabaseFetcherActor(const NActors::TActorId& replyActorId, const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr, NACLib::EAccessRights checkAccess = NACLib::EAccessRights::NoAccess);
 
 // Cpu load fetcher actor

--- a/ydb/core/kqp/workload_service/actors/pool_handlers_acors.cpp
+++ b/ydb/core/kqp/workload_service/actors/pool_handlers_acors.cpp
@@ -46,9 +46,9 @@ class TPoolHandlerActorBase : public TActor<TDerived> {
         NMonitoring::TDynamicCounters::TCounterPtr QueueSizeLimit;
         NMonitoring::TDynamicCounters::TCounterPtr LoadCpuThreshold;
 
-        TCommonCounters(NMonitoring::TDynamicCounterPtr counters, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig)
+        TCommonCounters(NMonitoring::TDynamicCounterPtr counters, const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig)
             : CountersRoot(counters)
-            , CountersSubgroup(counters->GetSubgroup("pool", CanonizePath(TStringBuilder() << database << "/" << poolId)))
+            , CountersSubgroup(counters->GetSubgroup("pool", TStringBuilder() << databaseId << "/" << poolId))
         {
             Register();
             UpdateConfigCounters(poolConfig);
@@ -125,10 +125,10 @@ protected:
     };
 
 public:
-    TPoolHandlerActorBase(void (TDerived::* requestFunc)(TAutoPtr<IEventHandle>& ev), const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters)
+    TPoolHandlerActorBase(void (TDerived::* requestFunc)(TAutoPtr<IEventHandle>& ev), const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters)
         : TBase(requestFunc)
-        , Counters(counters, database, poolId, poolConfig)
-        , Database(database)
+        , Counters(counters, databaseId, poolId, poolConfig)
+        , DatabaseId(databaseId)
         , PoolId(poolId)
         , QueueSizeLimit(GetMaxQueueSize(poolConfig))
         , InFlightLimit(GetMaxInFlight(poolConfig))
@@ -161,7 +161,7 @@ public:
         }
 
         SendPoolInfoUpdate(std::nullopt, std::nullopt, Subscribers);
-        this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvStopPoolHandlerResponse(Database, PoolId));
+        this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvStopPoolHandlerResponse(DatabaseId, PoolId));
 
         Counters.OnCleanup(ResetCountersOnStrop);
 
@@ -187,7 +187,7 @@ private:
     void Handle(TEvPrivate::TEvResolvePoolResponse::TPtr& ev) {
         auto event = std::move(ev->Get()->Event);
         const TString& sessionId = event->Get()->SessionId;
-        this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvPlaceRequestIntoPoolResponse(Database, PoolId, sessionId));
+        this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvPlaceRequestIntoPoolResponse(DatabaseId, PoolId, sessionId));
 
         const TActorId& workerActorId = event->Sender;
         if (!InFlightLimit) {
@@ -360,7 +360,7 @@ public:
 
     void SendPoolInfoUpdate(const std::optional<NResourcePool::TPoolSettings>& config, const std::optional<NACLib::TSecurityObject>& securityObject, const std::unordered_set<TActorId>& subscribers) const {
         for (const auto& subscriber : subscribers) {
-            this->Send(subscriber, new TEvUpdatePoolInfo(Database, PoolId, config, securityObject));
+            this->Send(subscriber, new TEvUpdatePoolInfo(DatabaseId, PoolId, config, securityObject));
         }
     }
 
@@ -390,7 +390,7 @@ protected:
 
     void RemoveRequest(TRequest* request) {
         auto event = std::make_unique<TEvPrivate::TEvFinishRequestInPool>(
-            Database, PoolId, request->Duration, request->CpuConsumed, request->UsedCpuQuota
+            DatabaseId, PoolId, request->Duration, request->CpuConsumed, request->UsedCpuQuota
         );
         this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), event.release());
 
@@ -424,7 +424,7 @@ protected:
     }
 
     TString LogPrefix() const {
-        return TStringBuilder() << "[TPoolHandlerActorBase] ActorId: " << this->SelfId() << ", Database: " << Database << ", PoolId: " << PoolId << ", ";
+        return TStringBuilder() << "[TPoolHandlerActorBase] ActorId: " << this->SelfId() << ", DatabaseId: " << DatabaseId << ", PoolId: " << PoolId << ", ";
     }
 
 private:
@@ -482,8 +482,8 @@ private:
         RefreshState(true);
 
         if (ShouldResign()) {
-            const TActorId& newHandler = this->RegisterWithSameMailbox(CreatePoolHandlerActor(Database, PoolId, poolConfig, Counters.CountersRoot));
-            this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvResignPoolHandler(Database, PoolId, newHandler));
+            const TActorId& newHandler = this->RegisterWithSameMailbox(CreatePoolHandlerActor(DatabaseId, PoolId, poolConfig, Counters.CountersRoot));
+            this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvResignPoolHandler(DatabaseId, PoolId, newHandler));
         }
     }
 
@@ -501,7 +501,7 @@ protected:
     TCommonCounters Counters;
 
     // Configuration
-    const TString Database;
+    const TString DatabaseId;
     const TString PoolId;
     ui64 QueueSizeLimit = std::numeric_limits<ui64>::max();
     ui64 InFlightLimit = std::numeric_limits<ui64>::max();
@@ -527,8 +527,8 @@ class TUnlimitedPoolHandlerActor : public TPoolHandlerActorBase<TUnlimitedPoolHa
     using TBase = TPoolHandlerActorBase<TUnlimitedPoolHandlerActor>;
 
 public:
-    TUnlimitedPoolHandlerActor(const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters)
-        : TBase(&TBase::StateFuncBase, database, poolId, poolConfig, counters)
+    TUnlimitedPoolHandlerActor(const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters)
+        : TBase(&TBase::StateFuncBase, databaseId, poolId, poolConfig, counters)
     {
         Y_ENSURE(!ShouldResign());
     }
@@ -591,8 +591,8 @@ class TFifoPoolHandlerActor : public TPoolHandlerActorBase<TFifoPoolHandlerActor
     static constexpr ui64 MAX_PENDING_REQUESTS = 1000;
 
 public:
-    TFifoPoolHandlerActor(const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters)
-        : TBase(&TFifoPoolHandlerActor::StateFunc, database, poolId, poolConfig, counters)
+    TFifoPoolHandlerActor( const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters)
+        : TBase(&TFifoPoolHandlerActor::StateFunc, databaseId, poolId, poolConfig, counters)
         , FifoCounters(Counters.CountersSubgroup)
     {
         Y_ENSURE(!ShouldResign());
@@ -641,7 +641,7 @@ protected:
         FifoCounters.PendingRequestsCount->Inc();
 
         if (!PreparingFinished) {
-            this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvPrepareTablesRequest(Database, PoolId));
+            this->Send(MakeKqpWorkloadServiceId(this->SelfId().NodeId()), new TEvPrivate::TEvPrepareTablesRequest(DatabaseId, PoolId));
         }
 
         RefreshState();
@@ -679,7 +679,7 @@ protected:
         if (RefreshRequired) {
             RefreshRequired = false;
             RunningOperation = true;
-            this->Register(CreateRefreshPoolStateActor(this->SelfId(), Database, PoolId, LEASE_DURATION, Counters.CountersSubgroup));
+            this->Register(CreateRefreshPoolStateActor(this->SelfId(), DatabaseId, PoolId, LEASE_DURATION, Counters.CountersSubgroup));
         }
     }
 
@@ -813,7 +813,7 @@ private:
                 if (!RunningOperation && !DelayedRequests.empty()) {
                     RunningOperation = true;
                     const TString& sessionId = DelayedRequests.front();
-                    this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, sessionId, LEASE_DURATION, Counters.CountersSubgroup));
+                    this->Register(CreateStartRequestActor(this->SelfId(), DatabaseId, PoolId, sessionId, LEASE_DURATION, Counters.CountersSubgroup));
                     GetRequest(sessionId)->CleanupRequired = true;
                 }
                 break;
@@ -846,7 +846,7 @@ private:
             LOG_D("first request in queue is remote, send notification to node " << nodeId);
             auto event = std::make_unique<TEvPrivate::TEvRefreshPoolState>();
             event->Record.SetPoolId(PoolId);
-            event->Record.SetDatabase(Database);
+            event->Record.SetDatabase(DatabaseId);
             this->Send(MakeKqpWorkloadServiceId(nodeId), std::move(event));
             RefreshState();
             return;
@@ -911,7 +911,7 @@ private:
             if (loadCpuThreshold) {
                 RequestCpuQuota(*loadCpuThreshold, EStartRequestCase::Pending);
             } else {
-                this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, sessionId, LEASE_DURATION, Counters.CountersSubgroup));
+                this->Register(CreateStartRequestActor(this->SelfId(), DatabaseId, PoolId, sessionId, LEASE_DURATION, Counters.CountersSubgroup));
                 GetRequest(sessionId)->CleanupRequired = true;
             }
         }
@@ -928,7 +928,7 @@ private:
             if (loadCpuThreshold) {
                 RequestCpuQuota(*loadCpuThreshold, EStartRequestCase::Delayed);
             } else {
-                this->Register(CreateStartRequestActor(this->SelfId(), Database, PoolId, std::nullopt, LEASE_DURATION, Counters.CountersSubgroup));
+                this->Register(CreateStartRequestActor(this->SelfId(), DatabaseId, PoolId, std::nullopt, LEASE_DURATION, Counters.CountersSubgroup));
             }
         }
     }
@@ -943,7 +943,7 @@ private:
             RunningOperation = true;
             const TString& sessionId = PopPendingRequest();
             TRequest* request = GetRequest(sessionId);
-            this->Register(CreateDelayRequestActor(this->SelfId(), Database, PoolId, sessionId, request->StartTime, GetWaitDeadline(request->StartTime), LEASE_DURATION, Counters.CountersSubgroup));
+            this->Register(CreateDelayRequestActor(this->SelfId(), DatabaseId, PoolId, sessionId, request->StartTime, GetWaitDeadline(request->StartTime), LEASE_DURATION, Counters.CountersSubgroup));
             DelayedRequests.emplace_back(sessionId);
             request->CleanupRequired = true;
         }
@@ -956,7 +956,7 @@ private:
 
         if (!FinishedRequests.empty()) {
             RunningOperation = true;
-            this->Register(CreateCleanupRequestsActor(this->SelfId(), Database, PoolId, FinishedRequests, Counters.CountersSubgroup));
+            this->Register(CreateCleanupRequestsActor(this->SelfId(), DatabaseId, PoolId, FinishedRequests, Counters.CountersSubgroup));
             FinishedRequests.clear();
             FifoCounters.FinishingRequestsCount->Set(0);
         }
@@ -1054,11 +1054,11 @@ private:
 
 }  // anonymous namespace
 
-IActor* CreatePoolHandlerActor(const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters) {
+IActor* CreatePoolHandlerActor(const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, NMonitoring::TDynamicCounterPtr counters) {
     if (poolConfig.ConcurrentQueryLimit == 0 || (poolConfig.ConcurrentQueryLimit == -1 && poolConfig.DatabaseLoadCpuThreshold < 0.0)) {
-        return new TUnlimitedPoolHandlerActor(database, poolId, poolConfig, counters);
+        return new TUnlimitedPoolHandlerActor(databaseId, poolId, poolConfig, counters);
     }
-    return new TFifoPoolHandlerActor(database, poolId, poolConfig, counters);
+    return new TFifoPoolHandlerActor(databaseId, poolId, poolConfig, counters);
 }
 
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -38,7 +38,7 @@ public:
 
     void StartPoolFetchRequest() const {
         LOG_D("Start pool fetching");
-        Register(CreatePoolFetcherActor(SelfId(), Event->Get()->Database, Event->Get()->PoolId, Event->Get()->UserToken));
+        Register(CreatePoolFetcherActor(SelfId(), Event->Get()->DatabaseId, Event->Get()->PoolId, Event->Get()->UserToken));
     }
 
     void Handle(TEvPrivate::TEvFetchPoolResponse::TPtr& ev) {
@@ -74,13 +74,13 @@ public:
         diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, BUILTIN_ACL_ROOT);
 
         auto token = MakeIntrusive<NACLib::TUserToken>(BUILTIN_ACL_METADATA, TVector<NACLib::TSID>{});
-        Register(CreatePoolCreatorActor(SelfId(), Event->Get()->Database, Event->Get()->PoolId, NResourcePool::TPoolSettings(), token, diffAcl));
+        Register(CreatePoolCreatorActor(SelfId(), Event->Get()->DatabaseId, Event->Get()->PoolId, NResourcePool::TPoolSettings(), token, diffAcl));
     }
 
     void Handle(TEvPrivate::TEvCreatePoolResponse::TPtr& ev) {
         if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
             LOG_E("Failed to create default pool " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
-            Reply(ev->Get()->Status, GroupIssues(ev->Get()->Issues, "Failed to create default pool"));
+            Reply(ev->Get()->Status, GroupIssues(ev->Get()->Issues, TStringBuilder() << "Failed to create default pool in database " << Event->Get()->DatabaseId));
             return;
         }
 
@@ -96,7 +96,7 @@ public:
 
 private:
     TString LogPrefix() const {
-        return TStringBuilder() << "[TPoolResolverActor] ActorId: " << SelfId() << ", Database: " << Event->Get()->Database << ", PoolId: " << Event->Get()->PoolId << ", SessionId: " << Event->Get()->SessionId << ", ";
+        return TStringBuilder() << "[TPoolResolverActor] ActorId: " << SelfId() << ", DatabaseId: " << Event->Get()->DatabaseId << ", PoolId: " << Event->Get()->PoolId << ", SessionId: " << Event->Get()->SessionId << ", ";
     }
 
     void Reply(NResourcePool::TPoolSettings poolConfig, TPathId pathId) {
@@ -122,9 +122,9 @@ private:
 
 class TPoolFetcherActor : public TSchemeActorBase<TPoolFetcherActor> {
 public:
-    TPoolFetcherActor(const TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
+    TPoolFetcherActor(const TActorId& replyActorId, const TString& databaseId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
         : ReplyActorId(replyActorId)
-        , Database(database)
+        , DatabaseId(databaseId)
         , PoolId(poolId)
         , UserToken(userToken)
     {}
@@ -180,7 +180,7 @@ protected:
         LOG_D("Start pool fetching");
         auto event = NTableCreator::BuildSchemeCacheNavigateRequest(
             {{".metadata/workload_manager/pools", PoolId}},
-            Database ? Database : AppData()->TenantName,
+            DatabaseIdToDatabase(DatabaseId),
             UserToken
         );
         event->ResultSet[0].Access |= NACLib::SelectRow;
@@ -193,7 +193,7 @@ protected:
     }
 
     TString LogPrefix() const override {
-        return TStringBuilder() << "[TPoolFetcherActor] ActorId: " << SelfId() << ", Database: " << Database << ", PoolId: " << PoolId << ", ";
+        return TStringBuilder() << "[TPoolFetcherActor] ActorId: " << SelfId() << ", DatabaseId: " << DatabaseId << ", PoolId: " << PoolId << ", ";
     }
 
 private:
@@ -221,13 +221,13 @@ private:
         }
 
         Issues.AddIssues(std::move(issues));
-        Send(ReplyActorId, new TEvPrivate::TEvFetchPoolResponse(status, Database, PoolId, PoolConfig, PathIdFromPathId(PathId), std::move(Issues)));
+        Send(ReplyActorId, new TEvPrivate::TEvFetchPoolResponse(status, DatabaseId, PoolId, PoolConfig, PathIdFromPathId(PathId), std::move(Issues)));
         PassAway();
     }
 
 private:
     const TActorId ReplyActorId;
-    const TString Database;
+    const TString DatabaseId;
     const TString PoolId;
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
 
@@ -240,9 +240,9 @@ class TPoolCreatorActor : public TSchemeActorBase<TPoolCreatorActor> {
     using TBase = TSchemeActorBase<TPoolCreatorActor>;
 
 public:
-    TPoolCreatorActor(const TActorId& replyActorId, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl)
+    TPoolCreatorActor(const TActorId& replyActorId, const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl)
         : ReplyActorId(replyActorId)
-        , Database(database)
+        , DatabaseId(databaseId)
         , PoolId(poolId)
         , UserToken(userToken)
         , DiffAcl(diffAcl)
@@ -326,7 +326,7 @@ protected:
         auto event = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
 
         auto& schemeTx = *event->Record.MutableTransaction()->MutableModifyScheme();
-        schemeTx.SetWorkingDir(JoinPath({Database ? Database : AppData()->TenantName, ".metadata/workload_manager/pools"}));
+        schemeTx.SetWorkingDir(JoinPath({DatabaseIdToDatabase(DatabaseId), ".metadata/workload_manager/pools"}));
         schemeTx.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateResourcePool);
         schemeTx.SetInternal(true);
 
@@ -345,7 +345,7 @@ protected:
     }
 
     TString LogPrefix() const override {
-        return TStringBuilder() << "[TPoolCreatorActor] ActorId: " << SelfId() << ", Database: " << Database << ", PoolId: " << PoolId << ", ";
+        return TStringBuilder() << "[TPoolCreatorActor] ActorId: " << SelfId() << ", DatabaseId: " << DatabaseId << ", PoolId: " << PoolId << ", ";
     }
 
 private:
@@ -432,7 +432,7 @@ private:
 
 private:
     const TActorId ReplyActorId;
-    const TString Database;
+    const TString DatabaseId;
     const TString PoolId;
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     const NACLibProto::TDiffACL DiffAcl;
@@ -532,13 +532,13 @@ private:
 
     void Reply(Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {}) {
         if (status == Ydb::StatusIds::SUCCESS) {
-            LOG_D("Database info successfully fetched");
+            LOG_D("Database info successfully fetched, serverless: " << Serverless);
         } else {
             LOG_W("Failed to fetch database info, " << status << ", issues: " << issues.ToOneLineString());
         }
 
         Issues.AddIssues(std::move(issues));
-        Send(ReplyActorId, new TEvFetchDatabaseResponse(status, Database, Serverless, PathId, std::move(Issues)));
+        Send(ReplyActorId, new TEvFetchDatabaseResponse(status, Database, CreateDatabaseId(Database, Serverless, PathId), Serverless, PathId, std::move(Issues)));
         PassAway();
     }
 
@@ -570,12 +570,12 @@ IActor* CreatePoolResolverActor(TEvPlaceRequestIntoPool::TPtr event, bool defaul
     return new TPoolResolverActor(std::move(event), defaultPoolExists);
 }
 
-IActor* CreatePoolFetcherActor(const TActorId& replyActorId, const TString& database, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken) {
-    return new TPoolFetcherActor(replyActorId, database, poolId, userToken);
+IActor* CreatePoolFetcherActor(const TActorId& replyActorId, const TString& databaseId, const TString& poolId, TIntrusiveConstPtr<NACLib::TUserToken> userToken) {
+    return new TPoolFetcherActor(replyActorId, databaseId, poolId, userToken);
 }
 
-IActor* CreatePoolCreatorActor(const TActorId& replyActorId, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl) {
-    return new TPoolCreatorActor(replyActorId, database, poolId, poolConfig, userToken, diffAcl);
+IActor* CreatePoolCreatorActor(const TActorId& replyActorId, const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLibProto::TDiffACL diffAcl) {
+    return new TPoolCreatorActor(replyActorId, databaseId, poolId, poolConfig, userToken, diffAcl);
 }
 
 IActor* CreateDatabaseFetcherActor(const TActorId& replyActorId, const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken, NACLib::EAccessRights checkAccess) {

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -489,6 +489,7 @@ public:
                 }
                 if (result.DomainInfo) {
                     Serverless = result.DomainInfo->IsServerless();
+                    PathId = result.DomainInfo->DomainKey;
                 }
                 Reply(Ydb::StatusIds::SUCCESS);
                 return;
@@ -537,7 +538,7 @@ private:
         }
 
         Issues.AddIssues(std::move(issues));
-        Send(ReplyActorId, new TEvPrivate::TEvFetchDatabaseResponse(status, Database, Serverless, std::move(Issues)));
+        Send(ReplyActorId, new TEvFetchDatabaseResponse(status, Database, Serverless, PathId, std::move(Issues)));
         PassAway();
     }
 
@@ -560,6 +561,7 @@ private:
     const NACLib::EAccessRights CheckAccess;
 
     bool Serverless = false;
+    TPathId PathId;
 };
 
 }  // anonymous namespace

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -29,6 +29,7 @@ struct TEvPrivate {
         EvFinishRequestInPool,
         EvResignPoolHandler,
         EvStopPoolHandler,
+        EvStopPoolHandlerResponse,
         EvCancelRequest,
         EvUpdatePoolSubscription,
 
@@ -128,13 +129,15 @@ struct TEvPrivate {
     };
 
     struct TEvPlaceRequestIntoPoolResponse : public NActors::TEventLocal<TEvPlaceRequestIntoPoolResponse, EvPlaceRequestIntoPoolResponse> {
-        TEvPlaceRequestIntoPoolResponse(const TString& database, const TString& poolId)
+        TEvPlaceRequestIntoPoolResponse(const TString& database, const TString& poolId, const TString& sessionId)
             : Database(database)
             , PoolId(poolId)
+            , SessionId(sessionId)
         {}
 
         const TString Database;
         const TString PoolId;
+        const TString SessionId;
     };
 
     struct TEvFinishRequestInPool : public NActors::TEventLocal<TEvFinishRequestInPool, EvFinishRequestInPool> {
@@ -171,6 +174,16 @@ struct TEvPrivate {
         {}
 
         const bool ResetCounters;
+    };
+
+    struct TEvStopPoolHandlerResponse : public NActors::TEventLocal<TEvStopPoolHandlerResponse, EvStopPoolHandlerResponse> {
+        TEvStopPoolHandlerResponse(const TString& database, const TString& poolId)
+            : Database(database)
+            , PoolId(poolId)
+        {}
+
+        const TString Database;
+        const TString PoolId;
     };
 
     struct TEvCancelRequest : public NActors::TEventLocal<TEvCancelRequest, EvCancelRequest> {

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -22,7 +22,6 @@ struct TEvPrivate {
         EvRefreshPoolState = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
         EvResolvePoolResponse,
         EvFetchPoolResponse,
-        EvFetchDatabaseResponse,
         EvCreatePoolResponse,
         EvPrepareTablesRequest,
         EvPlaceRequestIntoPoolResponse,
@@ -46,8 +45,6 @@ struct TEvPrivate {
         EvDelayRequestResponse,
         EvStartRequestResponse,
         EvCleanupRequestsResponse,
-
-        EvRanksCheckerResponse,
 
         EvEnd
     };
@@ -91,20 +88,6 @@ struct TEvPrivate {
         const TString PoolId;
         const NResourcePool::TPoolSettings PoolConfig;
         const TPathId PathId;
-        const NYql::TIssues Issues;
-    };
-
-    struct TEvFetchDatabaseResponse : public NActors::TEventLocal<TEvFetchDatabaseResponse, EvFetchDatabaseResponse> {
-        TEvFetchDatabaseResponse(Ydb::StatusIds::StatusCode status, const TString& database, bool serverless, NYql::TIssues issues)
-            : Status(status)
-            , Database(database)
-            , Serverless(serverless)
-            , Issues(std::move(issues))
-        {}
-
-        const Ydb::StatusIds::StatusCode Status;
-        const TString Database;
-        const bool Serverless;
         const NYql::TIssues Issues;
     };
 
@@ -332,21 +315,6 @@ struct TEvPrivate {
 
         const Ydb::StatusIds::StatusCode Status;
         const std::vector<TString> SesssionIds;
-        const NYql::TIssues Issues;
-    };
-
-    // Resource pool classifier events
-    struct TEvRanksCheckerResponse : public TEventLocal<TEvRanksCheckerResponse, EvRanksCheckerResponse> {
-        TEvRanksCheckerResponse(Ydb::StatusIds::StatusCode status, i64 maxRank, ui64 numberClassifiers, NYql::TIssues issues)
-            : Status(status)
-            , MaxRank(maxRank)
-            , NumberClassifiers(numberClassifiers)
-            , Issues(std::move(issues))
-        {}
-
-        const Ydb::StatusIds::StatusCode Status;
-        const i64 MaxRank;
-        const ui64 NumberClassifiers;
         const NYql::TIssues Issues;
     };
 };

--- a/ydb/core/kqp/workload_service/common/events.h
+++ b/ydb/core/kqp/workload_service/common/events.h
@@ -74,9 +74,9 @@ struct TEvPrivate {
     };
 
     struct TEvFetchPoolResponse : public NActors::TEventLocal<TEvFetchPoolResponse, EvFetchPoolResponse> {
-        TEvFetchPoolResponse(Ydb::StatusIds::StatusCode status, const TString& database, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TPathId pathId, NYql::TIssues issues)
+        TEvFetchPoolResponse(Ydb::StatusIds::StatusCode status, const TString& databaseId, const TString& poolId, const NResourcePool::TPoolSettings& poolConfig, TPathId pathId, NYql::TIssues issues)
             : Status(status)
-            , Database(database)
+            , DatabaseId(databaseId)
             , PoolId(poolId)
             , PoolConfig(poolConfig)
             , PathId(pathId)
@@ -84,7 +84,7 @@ struct TEvPrivate {
         {}
 
         const Ydb::StatusIds::StatusCode Status;
-        const TString Database;
+        const TString DatabaseId;
         const TString PoolId;
         const NResourcePool::TPoolSettings PoolConfig;
         const TPathId PathId;
@@ -102,37 +102,37 @@ struct TEvPrivate {
     };
 
     struct TEvPrepareTablesRequest : public NActors::TEventLocal<TEvPrepareTablesRequest, EvPrepareTablesRequest> {
-        TEvPrepareTablesRequest(const TString& database, const TString& poolId)
-            : Database(database)
+        TEvPrepareTablesRequest(const TString& databaseId, const TString& poolId)
+            : DatabaseId(databaseId)
             , PoolId(poolId)
         {}
 
-        const TString Database;
+        const TString DatabaseId;
         const TString PoolId;
     };
 
     struct TEvPlaceRequestIntoPoolResponse : public NActors::TEventLocal<TEvPlaceRequestIntoPoolResponse, EvPlaceRequestIntoPoolResponse> {
-        TEvPlaceRequestIntoPoolResponse(const TString& database, const TString& poolId, const TString& sessionId)
-            : Database(database)
+        TEvPlaceRequestIntoPoolResponse(const TString& databaseId, const TString& poolId, const TString& sessionId)
+            : DatabaseId(databaseId)
             , PoolId(poolId)
             , SessionId(sessionId)
         {}
 
-        const TString Database;
+        const TString DatabaseId;
         const TString PoolId;
         const TString SessionId;
     };
 
     struct TEvFinishRequestInPool : public NActors::TEventLocal<TEvFinishRequestInPool, EvFinishRequestInPool> {
-        TEvFinishRequestInPool(const TString& database, const TString& poolId, TDuration duration, TDuration cpuConsumed, bool adjustCpuQuota)
-            : Database(database)
+        TEvFinishRequestInPool(const TString& databaseId, const TString& poolId, TDuration duration, TDuration cpuConsumed, bool adjustCpuQuota)
+            : DatabaseId(databaseId)
             , PoolId(poolId)
             , Duration(duration)
             , CpuConsumed(cpuConsumed)
             , AdjustCpuQuota(adjustCpuQuota)
         {}
 
-        const TString Database;
+        const TString DatabaseId;
         const TString PoolId;
         const TDuration Duration;
         const TDuration CpuConsumed;
@@ -140,13 +140,13 @@ struct TEvPrivate {
     };
 
     struct TEvResignPoolHandler : public NActors::TEventLocal<TEvResignPoolHandler, EvResignPoolHandler> {
-        TEvResignPoolHandler(const TString& database, const TString& poolId, const TActorId& newHandler)
-            : Database(database)
+        TEvResignPoolHandler(const TString& databaseId, const TString& poolId, const TActorId& newHandler)
+            : DatabaseId(databaseId)
             , PoolId(poolId)
             , NewHandler(newHandler)
         {}
 
-        const TString Database;
+        const TString DatabaseId;
         const TString PoolId;
         const TActorId NewHandler;
     };
@@ -160,12 +160,12 @@ struct TEvPrivate {
     };
 
     struct TEvStopPoolHandlerResponse : public NActors::TEventLocal<TEvStopPoolHandlerResponse, EvStopPoolHandlerResponse> {
-        TEvStopPoolHandlerResponse(const TString& database, const TString& poolId)
-            : Database(database)
+        TEvStopPoolHandlerResponse(const TString& databaseId, const TString& poolId)
+            : DatabaseId(databaseId)
             , PoolId(poolId)
         {}
 
-        const TString Database;
+        const TString DatabaseId;
         const TString PoolId;
     };
 

--- a/ydb/core/kqp/workload_service/common/helpers.cpp
+++ b/ydb/core/kqp/workload_service/common/helpers.cpp
@@ -1,7 +1,31 @@
 #include "helpers.h"
 
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/base/path.h>
+
 
 namespace NKikimr::NKqp::NWorkload {
+
+TString CreateDatabaseId(const TString& database, bool serverless, TPathId pathId) {
+    TString databasePath = CanonizePath(database);
+    TString tennantPath = CanonizePath(AppData()->TenantName);
+    if (databasePath.empty() || databasePath == tennantPath) {
+        return tennantPath;
+    }
+
+    if (serverless) {
+        databasePath = TStringBuilder() << pathId.OwnerId << ":" << pathId.LocalPathId << ":" << databasePath;
+    }
+    return databasePath;
+}
+
+TString DatabaseIdToDatabase(TStringBuf databaseId) {
+    TStringBuf id;
+    TStringBuf database;
+    return databaseId.TrySplit("/", id, database)
+        ? CanonizePath(TString(database))     // Serverless
+        : CanonizePath(TString(databaseId));  // Dedicated
+}
 
 NYql::TIssues GroupIssues(const NYql::TIssues& issues, const TString& message) {
     NYql::TIssue rootIssue(message);

--- a/ydb/core/kqp/workload_service/common/helpers.h
+++ b/ydb/core/kqp/workload_service/common/helpers.h
@@ -99,6 +99,9 @@ private:
 };
 
 
+TString CreateDatabaseId(const TString& database, bool serverless, TPathId pathId);
+TString DatabaseIdToDatabase(TStringBuf databaseId);
+
 NYql::TIssues GroupIssues(const NYql::TIssues& issues, const TString& message);
 
 void ParsePoolSettings(const NKikimrSchemeOp::TResourcePoolDescription& description, NResourcePool::TPoolSettings& poolConfig);

--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -214,7 +214,7 @@ public:
         hFunc(TEvCleanupRequest, Handle);
         hFunc(TEvents::TEvWakeup, Handle);
 
-        hFunc(TEvPrivate::TEvFetchDatabaseResponse, Handle);
+        hFunc(TEvFetchDatabaseResponse, Handle);
         hFunc(TEvPrivate::TEvFetchPoolResponse, Handle);
         hFunc(TEvPrivate::TEvResolvePoolResponse, Handle);
         hFunc(TEvPrivate::TEvPlaceRequestIntoPoolResponse, Handle);
@@ -231,7 +231,7 @@ public:
     )
 
 private:
-    void Handle(TEvPrivate::TEvFetchDatabaseResponse::TPtr& ev) {
+    void Handle(TEvFetchDatabaseResponse::TPtr& ev) {
         GetOrCreateDatabaseState(ev->Get()->Database)->UpdateDatabaseInfo(ev);
     }
 

--- a/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
+++ b/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
@@ -19,6 +19,8 @@ struct TDatabaseState {
     bool& EnabledResourcePoolsOnServerless;
 
     std::vector<TEvPlaceRequestIntoPool::TPtr> PendingRequersts = {};
+    std::unordered_set<TString> PendingSessionIds = {};
+    std::unordered_map<TString, std::vector<TEvCleanupRequest::TPtr>> PendingCancelRequests = {};
     std::unordered_map<TString, std::unordered_set<TActorId>> PendingSubscriptions = {};
     bool HasDefaultPool = false;
     bool Serverless = false;
@@ -38,6 +40,7 @@ struct TDatabaseState {
 
     void DoPlaceRequest(TEvPlaceRequestIntoPool::TPtr ev) {
         TString database = ev->Get()->Database;
+        PendingSessionIds.emplace(ev->Get()->SessionId);
         PendingRequersts.emplace_back(std::move(ev));
 
         if (!EnabledResourcePoolsOnServerless && (TInstant::Now() - LastUpdateTime) > IDLE_DURATION) {
@@ -83,6 +86,14 @@ struct TDatabaseState {
         StartPendingRequests();
     }
 
+    void RemovePendingSession(const TString& sessionId, std::function<void(TEvCleanupRequest::TPtr)> callback) {
+        for (auto& event : PendingCancelRequests[sessionId]) {
+            callback(std::move(event));
+        }
+        PendingCancelRequests.erase(sessionId);
+        PendingSessionIds.erase(sessionId);
+    }
+
 private:
     void StartPendingRequests() {
         if (!EnabledResourcePoolsOnServerless && Serverless) {
@@ -98,6 +109,9 @@ private:
 
     void ReplyContinueError(Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
         for (const auto& ev : PendingRequersts) {
+            RemovePendingSession(ev->Get()->SessionId, [this](TEvCleanupRequest::TPtr event) {
+                ActorContext.Send(event->Sender, new TEvCleanupResponse(Ydb::StatusIds::NOT_FOUND, {NYql::TIssue(TStringBuilder() << "Pool " << event->Get()->PoolId << " not found")}));
+            });
             ActorContext.Send(ev->Sender, new TEvContinueRequest(status, {}, {}, issues));
         }
         PendingRequersts.clear();
@@ -112,6 +126,7 @@ struct TPoolState {
     bool WaitingInitialization = false;
     bool PlaceRequestRunning = false;
     std::optional<TActorId> NewPoolHandler = std::nullopt;
+    std::unordered_set<TActorId> PreviousPoolHandlers = {};
 
     ui64 InFlightRequests = 0;
     TInstant LastUpdateTime = TInstant::Now();
@@ -122,6 +137,7 @@ struct TPoolState {
         }
 
         ActorContext.Send(PoolHandler, new TEvPrivate::TEvStopPoolHandler(false));
+        PreviousPoolHandlers.insert(PoolHandler);
         PoolHandler = *NewPoolHandler;
         NewPoolHandler = std::nullopt;
         InFlightRequests = 0;
@@ -142,6 +158,16 @@ struct TPoolState {
         Y_ENSURE(InFlightRequests);
         InFlightRequests--;
         LastUpdateTime = TInstant::Now();
+    }
+
+    void DoCleanupRequest(TEvCleanupRequest::TPtr event) {
+        for (const auto& poolHandler : PreviousPoolHandlers) {
+            ActorContext.Send(poolHandler, new TEvCleanupRequest(
+                event->Get()->Database, event->Get()->SessionId, event->Get()->PoolId,
+                event->Get()->Duration, event->Get()->CpuConsumed
+            ));
+        }
+        ActorContext.Send(event->Forward(PoolHandler));
     }
 };
 

--- a/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
+++ b/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
@@ -70,15 +70,11 @@ struct TDatabaseState {
         subscribers.clear();
     }
 
-    void UpdateDatabaseInfo(const TEvPrivate::TEvFetchDatabaseResponse::TPtr& ev) {
+    void UpdateDatabaseInfo(const TEvFetchDatabaseResponse::TPtr& ev) {
         DatabaseUnsupported = ev->Get()->Status == Ydb::StatusIds::UNSUPPORTED;
         if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
             ReplyContinueError(ev->Get()->Status, GroupIssues(ev->Get()->Issues, "Failed to fetch database info"));
             return;
-        }
-
-        if (Serverless != ev->Get()->Serverless) {
-            ActorContext.Send(MakeKqpProxyID(ActorContext.SelfID.NodeId()), new TEvUpdateDatabaseInfo(ev->Get()->Database, ev->Get()->Serverless));
         }
 
         LastUpdateTime = TInstant::Now();

--- a/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
+++ b/ydb/core/kqp/workload_service/kqp_workload_service_impl.h
@@ -2,6 +2,7 @@
 
 #include <queue>
 
+#include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/workload_service/actors/actors.h>
 #include <ydb/core/kqp/workload_service/common/cpu_quota_manager.h>
@@ -20,8 +21,8 @@ struct TDatabaseState {
 
     std::vector<TEvPlaceRequestIntoPool::TPtr> PendingRequersts = {};
     std::unordered_set<TString> PendingSessionIds = {};
-    std::unordered_map<TString, std::vector<TEvCleanupRequest::TPtr>> PendingCancelRequests = {};
-    std::unordered_map<TString, std::unordered_set<TActorId>> PendingSubscriptions = {};
+    std::unordered_map<TString, std::vector<TEvCleanupRequest::TPtr>> PendingCancelRequests = {};  // Session ID to requests
+    std::unordered_map<TString, std::unordered_set<TActorId>> PendingSubscriptions = {};  // Pool ID to subscribers
     bool HasDefaultPool = false;
     bool Serverless = false;
     bool DatabaseUnsupported = false;
@@ -32,23 +33,23 @@ struct TDatabaseState {
         const TString& poolId = ev->Get()->PoolId;
         auto& subscribers = PendingSubscriptions[poolId];
         if (subscribers.empty()) {
-            ActorContext.Register(CreatePoolFetcherActor(ActorContext.SelfID, ev->Get()->Database, poolId, nullptr));
+            ActorContext.Register(CreatePoolFetcherActor(ActorContext.SelfID, ev->Get()->DatabaseId, poolId, nullptr));
         }
 
         subscribers.emplace(ev->Sender);
     }
 
     void DoPlaceRequest(TEvPlaceRequestIntoPool::TPtr ev) {
-        TString database = ev->Get()->Database;
+        TString databaseId = ev->Get()->DatabaseId;
         PendingSessionIds.emplace(ev->Get()->SessionId);
         PendingRequersts.emplace_back(std::move(ev));
 
         if (!EnabledResourcePoolsOnServerless && (TInstant::Now() - LastUpdateTime) > IDLE_DURATION) {
-            ActorContext.Register(CreateDatabaseFetcherActor(ActorContext.SelfID, database));
+            ActorContext.Register(CreateDatabaseFetcherActor(ActorContext.SelfID, DatabaseIdToDatabase(databaseId)));
         } else if (!DatabaseUnsupported) {
             StartPendingRequests();
         } else {
-            ReplyContinueError(Ydb::StatusIds::UNSUPPORTED, {NYql::TIssue(TStringBuilder() << "Unsupported database: " << database)});
+            ReplyContinueError(Ydb::StatusIds::UNSUPPORTED, {NYql::TIssue(TStringBuilder() << "Unsupported database: " << databaseId)});
         }
     }
 
@@ -62,9 +63,9 @@ struct TDatabaseState {
         if (ev->Get()->Status == Ydb::StatusIds::SUCCESS && poolHandler) {
             ActorContext.Send(poolHandler, new TEvPrivate::TEvUpdatePoolSubscription(ev->Get()->PathId, subscribers));
         } else {
-            const TString& database = ev->Get()->Database;
+            const TString& databaseId = ev->Get()->DatabaseId;
             for (const auto& subscriber : subscribers) {
-                ActorContext.Send(subscriber, new TEvUpdatePoolInfo(database, poolId, std::nullopt, std::nullopt));
+                ActorContext.Send(subscriber, new TEvUpdatePoolInfo(databaseId, poolId, std::nullopt, std::nullopt));
             }
         }
         subscribers.clear();
@@ -75,6 +76,10 @@ struct TDatabaseState {
         if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
             ReplyContinueError(ev->Get()->Status, GroupIssues(ev->Get()->Issues, "Failed to fetch database info"));
             return;
+        }
+
+        if (Serverless != ev->Get()->Serverless) {
+            ActorContext.Send(MakeKqpProxyID(ActorContext.SelfID.NodeId()), new TEvKqp::TEvUpdateDatabaseInfo(ev->Get()->Database, ev->Get()->DatabaseId, ev->Get()->Serverless));
         }
 
         LastUpdateTime = TInstant::Now();
@@ -159,8 +164,8 @@ struct TPoolState {
     void DoCleanupRequest(TEvCleanupRequest::TPtr event) {
         for (const auto& poolHandler : PreviousPoolHandlers) {
             ActorContext.Send(poolHandler, new TEvCleanupRequest(
-                event->Get()->Database, event->Get()->SessionId, event->Get()->PoolId,
-                event->Get()->Duration, event->Get()->CpuConsumed
+                event->Get()->DatabaseId, event->Get()->SessionId,
+                event->Get()->PoolId, event->Get()->Duration, event->Get()->CpuConsumed
             ));
         }
         ActorContext.Send(event->Forward(PoolHandler));

--- a/ydb/core/kqp/workload_service/tables/table_queries.h
+++ b/ydb/core/kqp/workload_service/tables/table_queries.h
@@ -12,11 +12,11 @@ NActors::IActor* CreateTablesCreator();
 NActors::IActor* CreateCleanupTablesActor();
 
 // Updates pool lease and returns pool description
-NActors::IActor* CreateRefreshPoolStateActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, TDuration leaseDuration, NMonitoring::TDynamicCounterPtr counters);
+NActors::IActor* CreateRefreshPoolStateActor(const NActors::TActorId& replyActorId, const TString& databaseId, const TString& poolId, TDuration leaseDuration, NMonitoring::TDynamicCounterPtr counters);
 
 // Push / Start / Finish requests in pool
-NActors::IActor* CreateDelayRequestActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, const TString& sessionId, TInstant startTime, TMaybe<TInstant> waitDeadline, TDuration leaseDuration, NMonitoring::TDynamicCounterPtr counters);
-NActors::IActor* CreateStartRequestActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, const std::optional<TString>& sessionId, TDuration leaseDuration, NMonitoring::TDynamicCounterPtr counters);
-NActors::IActor* CreateCleanupRequestsActor(const NActors::TActorId& replyActorId, const TString& database, const TString& poolId, const std::vector<TString>& sessionIds, NMonitoring::TDynamicCounterPtr counters);
+NActors::IActor* CreateDelayRequestActor(const NActors::TActorId& replyActorId, const TString& databaseId, const TString& poolId, const TString& sessionId, TInstant startTime, TMaybe<TInstant> waitDeadline, TDuration leaseDuration, NMonitoring::TDynamicCounterPtr counters);
+NActors::IActor* CreateStartRequestActor(const NActors::TActorId& replyActorId, const TString& databaseId, const TString& poolId, const std::optional<TString>& sessionId, TDuration leaseDuration, NMonitoring::TDynamicCounterPtr counters);
+NActors::IActor* CreateCleanupRequestsActor(const NActors::TActorId& replyActorId, const TString& databaseId, const TString& poolId, const std::vector<TString>& sessionIds, NMonitoring::TDynamicCounterPtr counters);
 
 }  // NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -116,6 +116,7 @@ public:
     virtual void WaitPoolHandlersCount(i64 finalCount, std::optional<i64> initialCount = std::nullopt, TDuration timeout = FUTURE_WAIT_TIMEOUT) const = 0;
     virtual void StopWorkloadService(ui64 nodeIndex = 0) const = 0;
     virtual void ValidateWorkloadServiceCounters(bool checkTableCounters = true, const TString& poolId = "") const = 0;
+    virtual TEvFetchDatabaseResponse::TPtr FetchDatabase(const TString& database) const = 0;
 
     // Coomon helpers
     virtual TTestActorRuntime* GetRuntime() const = 0;

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_tables_ut.cpp
@@ -27,7 +27,7 @@ void DelayRequest(TIntrusivePtr<IYdbSetup> ydb, const TString& sessionId, TDurat
     auto runtime = ydb->GetRuntime();
     const auto& edgeActor = runtime->AllocateEdgeActor();
 
-    runtime->Register(CreateDelayRequestActor(edgeActor, settings.DomainName_, settings.PoolId_, sessionId, TInstant::Now(), Nothing(), leaseDuration, runtime->GetAppData().Counters));
+    runtime->Register(CreateDelayRequestActor(edgeActor, CanonizePath(settings.DomainName_), settings.PoolId_, sessionId, TInstant::Now(), Nothing(), leaseDuration, runtime->GetAppData().Counters));
     auto response = runtime->GrabEdgeEvent<TEvPrivate::TEvDelayRequestResponse>(edgeActor, FUTURE_WAIT_TIMEOUT);
     UNIT_ASSERT_VALUES_EQUAL_C(response->Get()->Status, Ydb::StatusIds::SUCCESS, response->Get()->Issues.ToOneLineString());
     UNIT_ASSERT_VALUES_EQUAL(response->Get()->SessionId, sessionId);
@@ -38,7 +38,7 @@ void StartRequest(TIntrusivePtr<IYdbSetup> ydb, const TString& sessionId, TDurat
     auto runtime = ydb->GetRuntime();
     const auto& edgeActor = runtime->AllocateEdgeActor();
 
-    runtime->Register(CreateStartRequestActor(edgeActor, settings.DomainName_, settings.PoolId_, sessionId, leaseDuration, runtime->GetAppData().Counters));
+    runtime->Register(CreateStartRequestActor(edgeActor, CanonizePath(settings.DomainName_), settings.PoolId_, sessionId, leaseDuration, runtime->GetAppData().Counters));
     auto response = runtime->GrabEdgeEvent<TEvPrivate::TEvStartRequestResponse>(edgeActor, FUTURE_WAIT_TIMEOUT);
     UNIT_ASSERT_VALUES_EQUAL_C(response->Get()->Status, Ydb::StatusIds::SUCCESS, response->Get()->Issues.ToOneLineString());
     UNIT_ASSERT_VALUES_EQUAL(response->Get()->SessionId, sessionId);

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -422,6 +422,56 @@ Y_UNIT_TEST_SUITE(ResourcePoolsDdl) {
         TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
     }
 
+    Y_UNIT_TEST(TestCreateResourcePoolOnServerless) {
+        auto ydb = TYdbSetupSettings()
+            .CreateSampleTenants(true)
+            .EnableResourcePoolsOnServerless(true)
+            .Create();
+
+        const auto& serverlessTenant = ydb->GetSettings().GetServerlessTenantName();
+        auto settings = TQueryRunnerSettings()
+            .PoolId("")
+            .Database(serverlessTenant)
+            .NodeIndex(1);
+
+        const TString& poolId = "my_pool";
+        TSampleQueries::CheckSuccess(ydb->ExecuteQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL )" << poolId << R"( WITH (
+                CONCURRENT_QUERY_LIMIT=1,
+                QUEUE_SIZE=0
+            );
+        )", settings));
+        settings.PoolId(poolId);
+
+        auto hangingRequest = ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, settings.HangUpDuringExecution(true));
+        ydb->WaitQueryExecution(hangingRequest);
+
+        settings.HangUpDuringExecution(false);
+
+        {  // Rejected result
+            auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings.PoolId(poolId));
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::OVERLOADED, result.GetIssues().ToOneLineString());
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), TStringBuilder() << "Request was rejected, number of local pending requests is 1, number of global delayed/running requests is 1, sum of them is larger than allowed limit 0 (including concurrent query limit 1) for pool " << poolId);
+        }
+
+        {  // Check tables
+            auto result = ydb->ExecuteQuery(R"(
+                SELECT * FROM `.metadata/workload_manager/running_requests`
+            )", settings.PoolId(NResourcePool::DEFAULT_POOL_ID).Database(ydb->GetSettings().GetSharedTenantName()));
+            TSampleQueries::CheckSuccess(result);
+
+            NYdb::TResultSetParser resultSet(result.GetResultSet(0));
+            UNIT_ASSERT_C(resultSet.TryNextRow(), "Unexpected row count");
+
+            const auto& databaseId = resultSet.ColumnParser("database").GetOptionalUtf8();
+            UNIT_ASSERT_C(databaseId, "Unexpected database response");
+            UNIT_ASSERT_VALUES_EQUAL_C(*databaseId, ydb->FetchDatabase(serverlessTenant)->Get()->DatabaseId, "Unexpected database id");
+        }
+
+        ydb->ContinueQueryExecution(hangingRequest);
+        TSampleQueries::TSelect42::CheckResult(hangingRequest.GetResult());
+    }
+
     Y_UNIT_TEST(TestDefaultPoolRestrictions) {
         auto ydb = TYdbSetupSettings().Create();
 
@@ -615,22 +665,27 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
         UNIT_ASSERT_STRING_CONTAINS(alterResult.GetIssues().ToOneLineString(), "You don't have access permissions for database Root");
     }
 
-    void CreateSampleResourcePoolClassifier(TIntrusivePtr<IYdbSetup> ydb, const TString& classifierId, const TString& userSID, const TString& poolId) {
-        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
-            GRANT ALL ON `/Root` TO `)" << userSID << R"(`;
+    void CreateSampleResourcePoolClassifier(TIntrusivePtr<IYdbSetup> ydb, const TString& classifierId, const TQueryRunnerSettings& settings, const TString& poolId) {
+        TSampleQueries::CheckSuccess(ydb->ExecuteQuery(TStringBuilder() << R"(
+            GRANT ALL ON `)" << CanonizePath(settings.Database_ ? settings.Database_ : ydb->GetSettings().DomainName_) << R"(` TO `)" << settings.UserSID_ << R"(`;
             CREATE RESOURCE POOL )" << poolId << R"( WITH (
                 CONCURRENT_QUERY_LIMIT=0
             );
             CREATE RESOURCE POOL CLASSIFIER )" << classifierId << R"( WITH (
                 RESOURCE_POOL=")" << poolId << R"(",
-                MEMBER_NAME=")" << userSID << R"("
+                MEMBER_NAME=")" << settings.UserSID_ << R"("
             );
-        )");
+        )", TQueryRunnerSettings()
+            .UserSID(BUILTIN_ACL_METADATA)
+            .Database(settings.Database_)
+            .NodeIndex(settings.NodeIndex_)
+            .PoolId(NResourcePool::DEFAULT_POOL_ID)
+        ));
     }
 
     TString CreateSampleResourcePoolClassifier(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings, const TString& poolId) {
         const TString& classifierId = "my_pool_classifier";
-        CreateSampleResourcePoolClassifier(ydb, classifierId, settings.UserSID_, poolId);
+        CreateSampleResourcePoolClassifier(ydb, classifierId, settings, poolId);
         return classifierId;
     }
 
@@ -656,6 +711,24 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
         auto ydb = TYdbSetupSettings().Create();
 
         auto settings = TQueryRunnerSettings().PoolId("").UserSID("test@user");
+        const TString& poolId = "my_pool";
+        CreateSampleResourcePoolClassifier(ydb, settings, poolId);
+
+        WaitForFail(ydb, settings, poolId);
+    }
+
+    Y_UNIT_TEST(TestCreateResourcePoolClassifierOnServerless) {
+        auto ydb = TYdbSetupSettings()
+            .CreateSampleTenants(true)
+            .EnableResourcePoolsOnServerless(true)
+            .Create();
+
+        auto settings = TQueryRunnerSettings()
+            .PoolId("")
+            .UserSID("test@user")
+            .Database(ydb->GetSettings().GetServerlessTenantName())
+            .NodeIndex(1);
+
         const TString& poolId = "my_pool";
         CreateSampleResourcePoolClassifier(ydb, settings, poolId);
 

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -635,7 +635,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
     }
 
     void WaitForFail(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings, const TString& poolId) {
-        ydb->WaitFor(TDuration::Seconds(5), "Resource pool classifier fail", [ydb, settings, poolId](TString& errorString) {
+        ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier fail", [ydb, settings, poolId](TString& errorString) {
             auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
 
             errorString = result.GetIssues().ToOneLineString();
@@ -644,7 +644,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
     }
 
     void WaitForSuccess(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings) {
-        ydb->WaitFor(TDuration::Seconds(5), "Resource pool classifier success", [ydb, settings](TString& errorString) {
+        ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier success", [ydb, settings](TString& errorString) {
             auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
 
             errorString = result.GetIssues().ToOneLineString();

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -123,6 +123,7 @@ message TQueryRequest {
     optional string UserSID = 33;
     optional uint64 OutputChunkMaxSize = 34;
     optional string PoolId = 35;
+    optional string DatabaseId = 36;
 }
 
 message TKqpPathIdProto {

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -589,6 +589,7 @@ message TEvStartKqpTasksRequest {
     optional double MemoryPoolPercent = 10 [default = 100];
     optional string Database = 11;
     optional double MaxCpuShare = 12;
+    optional string DatabaseId = 17;
     optional uint64 LockTxId = 13;
     optional uint32 LockNodeId = 14;
 }

--- a/ydb/services/metadata/manager/abstract.h
+++ b/ydb/services/metadata/manager/abstract.h
@@ -75,6 +75,7 @@ public:
     private:
         YDB_ACCESSOR_DEF(std::optional<NACLib::TUserToken>, UserToken);
         YDB_ACCESSOR_DEF(TString, Database);
+        YDB_ACCESSOR_DEF(TString, DatabaseId);
         using TActorSystemPtr = TActorSystem*;
         YDB_ACCESSOR_DEF(TActorSystemPtr, ActorSystem);
     };

--- a/ydb/tools/query_replay/query_compiler.cpp
+++ b/ydb/tools/query_replay/query_compiler.cpp
@@ -254,9 +254,11 @@ public:
         }
 
         TKqpQuerySettings settings(queryType);
+        const auto& database = ReplayDetails["query_database"].GetStringSafe();
         Query = std::make_unique<NKikimr::NKqp::TKqpQueryId>(
             ReplayDetails["query_cluster"].GetStringSafe(),
-            ReplayDetails["query_database"].GetStringSafe(),
+            database,
+            database,
             queryText,
             settings,
             !queryParameterTypes.empty()
@@ -288,7 +290,7 @@ public:
         counters->Counters = new TKqpCounters(c);
         counters->TxProxyMon = new NTxProxy::TTxProxyMon(c);
 
-        Gateway = CreateKikimrIcGateway(Query->Cluster, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY, Query->Database, std::move(loader),
+        Gateway = CreateKikimrIcGateway(Query->Cluster, NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY, Query->Database, Query->DatabaseId, std::move(loader),
             TlsActivationContext->ExecutorThread.ActorSystem, SelfId().NodeId(), counters);
         auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({NYql::IHTTPGateway::Make(), nullptr, nullptr, nullptr, {}, {}, {}, nullptr, nullptr});
         KqpHost = CreateKqpHost(Gateway, Query->Cluster, Query->Database, Config, ModuleResolverState->ModuleResolver,

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -589,9 +589,11 @@ private:
         }
 
         TKqpQuerySettings settings(queryType);
+        const auto& database = ReplayDetails["query_database"].GetStringSafe();
         Query = std::make_unique<NKikimr::NKqp::TKqpQueryId>(
             ReplayDetails["query_cluster"].GetStringSafe(),
-            ReplayDetails["query_database"].GetStringSafe(),
+            database,
+            database,
             queryText,
             settings,
             !queryParameterTypes.empty()
@@ -621,7 +623,7 @@ private:
         counters->Counters = new TKqpCounters(c);
         counters->TxProxyMon = new NTxProxy::TTxProxyMon(c);
 
-        Gateway = CreateKikimrIcGateway(Query->Cluster, queryType, Query->Database, std::move(loader),
+        Gateway = CreateKikimrIcGateway(Query->Cluster, queryType, Query->Database, Query->DatabaseId, std::move(loader),
             TlsActivationContext->ExecutorThread.ActorSystem, SelfId().NodeId(), counters);
         auto federatedQuerySetup = std::make_optional<TKqpFederatedQuerySetup>({HttpGateway, nullptr, nullptr, nullptr, {}, {}, {}, nullptr, nullptr});
         KqpHost = CreateKqpHost(Gateway, Query->Cluster, Query->Database, Config, ModuleResolverState->ModuleResolver,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Passed database id into workload manager and resource pool classifiers tables only for serverless databases; in format:
"\<scheme shard id\>:\<path id\>:\<database path\>"

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information
