### PR TITLE
remove no export for profile memory allocations builds

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -1,6 +1,6 @@
 PROGRAM(ydbd)
 
-IF (NOT SANITIZER_TYPE)  # for some reasons some tests with asan are failed, see comment in CPPCOM-32
+IF (NOT SANITIZER_TYPE AND NOT PROFILE_MEMORY_ALLOCATIONS)  # for some reasons some tests with asan are failed, see comment in CPPCOM-32
     NO_EXPORT_DYNAMIC_SYMBOLS()
 ENDIF()
 


### PR DESCRIPTION
### Changelog entry 

remove no export for profile memory allocations builds

### Changelog category 

* Not for changelog (changelog entry is not required)

### Additional information

mon alloc for tcmalloc isn't working https://github.com/ydb-platform/ydb/blob/main/ydb/core/mon_alloc/tcmalloc.cpp
it diplays question marks for all symbols ??
