### PR TITLE
YMQ: Force upper case for "MD5" and "AWS" in field names

### DIFF
--- a/ydb/core/http_proxy/ut/http_proxy_ut.h
+++ b/ydb/core/http_proxy/ut/http_proxy_ut.h
@@ -1645,7 +1645,7 @@ Y_UNIT_TEST_SUITE(TestHttpProxy) {
         UNIT_ASSERT_VALUES_EQUAL(res.HttpCode, 200);
         UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &json));
         UNIT_ASSERT(!GetByPath<TString>(json, "SequenceNumber").empty());
-        UNIT_ASSERT(!GetByPath<TString>(json, "Md5OfMessageBody").empty());
+        UNIT_ASSERT(!GetByPath<TString>(json, "MD5OfMessageBody").empty());
         UNIT_ASSERT(!GetByPath<TString>(json, "MessageId").empty());
     }
 
@@ -1666,7 +1666,7 @@ Y_UNIT_TEST_SUITE(TestHttpProxy) {
 
         res = SendHttpRequest("/Root", "AmazonSQS.SendMessage", std::move(sendMessageReq), FormAuthorizationStr("ru-central1"));
         UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &json));
-        UNIT_ASSERT(!GetByPath<TString>(json, "Md5OfMessageBody").empty());
+        UNIT_ASSERT(!GetByPath<TString>(json, "MD5OfMessageBody").empty());
         UNIT_ASSERT_VALUES_EQUAL(res.HttpCode, 200);
 
         for (int i = 0; i < 20; ++i) {
@@ -1911,8 +1911,8 @@ Y_UNIT_TEST_SUITE(TestHttpProxy) {
         UNIT_ASSERT(json["Successful"].GetArray().size() == 2);
         auto succesful0 = json["Successful"][0];
         UNIT_ASSERT(succesful0["Id"] == "Id-0");
-        UNIT_ASSERT(!GetByPath<TString>(succesful0, "Md5OfMessageAttributes").empty());
-        UNIT_ASSERT(!GetByPath<TString>(succesful0, "Md5OfMessageBody").empty());
+        UNIT_ASSERT(!GetByPath<TString>(succesful0, "MD5OfMessageAttributes").empty());
+        UNIT_ASSERT(!GetByPath<TString>(succesful0, "MD5OfMessageBody").empty());
         UNIT_ASSERT(!GetByPath<TString>(succesful0, "MessageId").empty());
     }
 

--- a/ydb/public/api/protos/draft/ymq.proto
+++ b/ydb/public/api/protos/draft/ymq.proto
@@ -128,7 +128,7 @@ message GetQueueAttributesResult {
 message GetQueueUrlRequest {
     Ydb.Operations.OperationParams operation_params = 1;
     string queue_name = 2;
-    optional string queue_owner_aws_account_id = 3;
+    optional string queue_owner_a_w_s_account_id = 3;
 }
 
 message GetQueueUrlResponse {
@@ -194,8 +194,8 @@ message ReceiveMessageResponse {
 message Message {
     map<string, string> attributes = 1;
     string body = 2;
-    string md5_of_body = 3;
-    string md5_of_message_attributes = 4;
+    string m_d_5_of_body = 3;
+    string m_d_5_of_message_attributes = 4;
     map<string, MessageAttribute>  message_attributes = 5;
     string  message_id = 6;
     string receipt_handle = 7;
@@ -221,9 +221,9 @@ message SendMessageResponse {
 }
 
 message SendMessageResult {
-    string md5_of_message_attributes = 1;
-    string md5_of_message_body= 2;
-    string md5_of_message_system_attributes= 3;
+    string m_d_5_of_message_attributes = 1;
+    string m_d_5_of_message_body= 2;
+    string m_d_5_of_message_system_attributes= 3;
     string message_id = 4;
     string sequence_number = 5;
 }
@@ -248,10 +248,10 @@ message SendMessageBatchRequestEntry {
 
 message SendMessageBatchResultEntry {
     string id = 1;
-    string md5_of_message_body = 2;
+    string m_d_5_of_message_body = 2;
     string message_id = 3;
-    string md5_of_message_attributes = 4;
-    string md5_of_message_system_attributes = 5;
+    string m_d_5_of_message_attributes = 4;
+    string m_d_5_of_message_system_attributes = 5;
     string sequence_number = 6;
 }
 

--- a/ydb/services/ymq/ymq_proxy.cpp
+++ b/ydb/services/ymq/ymq_proxy.cpp
@@ -260,8 +260,8 @@ namespace NKikimr::NYmq::V1 {
 
         Ydb::Ymq::V1::SendMessageResult GetResult(const NKikimrClient::TSqsResponse& resp) override {
             Ydb::Ymq::V1::SendMessageResult result;
-            result.set_md5_of_message_attributes(GetResponse(resp).GetMD5OfMessageAttributes());
-            result.set_md5_of_message_body(GetResponse(resp).GetMD5OfMessageBody());
+            result.set_m_d_5_of_message_attributes(GetResponse(resp).GetMD5OfMessageAttributes());
+            result.set_m_d_5_of_message_body(GetResponse(resp).GetMD5OfMessageBody());
             result.set_message_id(GetResponse(resp).GetMessageId());
             result.set_sequence_number(std::to_string(GetResponse(resp).GetSequenceNumber()));
             return result;
@@ -348,8 +348,8 @@ namespace NKikimr::NYmq::V1 {
                 }
 
                 dstMessage.set_body(srcMessage.GetData());
-                dstMessage.set_md5_of_body(srcMessage.GetMD5OfMessageBody());
-                dstMessage.set_md5_of_message_attributes(srcMessage.GetMD5OfMessageAttributes());
+                dstMessage.set_m_d_5_of_body(srcMessage.GetMD5OfMessageBody());
+                dstMessage.set_m_d_5_of_message_attributes(srcMessage.GetMD5OfMessageAttributes());
 
                 for (const auto& srcAttribute: srcMessage.GetMessageAttributes()) {
                     Ydb::Ymq::V1::MessageAttribute dstAttribute;
@@ -819,8 +819,8 @@ namespace NKikimr::NYmq::V1 {
                 } else {
                     auto currentSuccessful = result.Addsuccessful();
                     currentSuccessful->Setid(entry.GetId());
-                    currentSuccessful->Setmd5_of_message_attributes(entry.GetMD5OfMessageAttributes());
-                    currentSuccessful->Setmd5_of_message_body(entry.GetMD5OfMessageBody());
+                    currentSuccessful->set_m_d_5_of_message_attributes(entry.GetMD5OfMessageAttributes());
+                    currentSuccessful->set_m_d_5_of_message_body(entry.GetMD5OfMessageBody());
                     currentSuccessful->Setmessage_id(entry.GetMessageId());
                     currentSuccessful->Setsequence_number(std::to_string(entry.GetSequenceNumber()));
                 }


### PR DESCRIPTION
SDKs expect field names like MD5OfMessageBody and not Md5OfMessageBody.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#API_SendMessage_ResponseSyntax