### PR TITLE
[CLI] Bugfix: remove item prefix correctly

### DIFF
--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -491,9 +491,9 @@ void TQueryPlanPrinter::PrintPrettyTableImpl(const NJson::TJsonValue& plan, TStr
                     else if (key == "Predicate" || key == "Condition" || key == "SortBy") {
                         info.emplace_back(TStringBuilder() << ReplaceAll(ReplaceAll(JsonToString(value), " item.", ""), " state.", ""));
                     } else if (key == "Table") {
-                        info.insert(info.begin(), TStringBuilder() << colors.LightYellow() << key << colors.Default() << ":" << colors.LightGreen() << " " << ReplaceAll(ReplaceAll(JsonToString(value), "item.", ""), "state.", "") << colors.Default());
+                        info.insert(info.begin(), TStringBuilder() << colors.LightYellow() << key << colors.Default() << ":" << colors.LightGreen() << " " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", ""), " state.", "") << colors.Default());
                     } else {
-                        info.emplace_back(TStringBuilder() << colors.LightYellow() << key << colors.Default() << ": " << ReplaceAll(ReplaceAll(JsonToString(value), "item.", ""), "state.", ""));
+                        info.emplace_back(TStringBuilder() << colors.LightYellow() << key << colors.Default() << ": " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", ""), " state.", ""));
                     }
                 }
             }

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -489,7 +489,7 @@ void TQueryPlanPrinter::PrintPrettyTableImpl(const NJson::TJsonValue& plan, TStr
                         // skip this attribute
                     }
                     else if (key == "Predicate" || key == "Condition" || key == "SortBy") {
-                        info.emplace_back(TStringBuilder() << ReplaceAll(ReplaceAll(JsonToString(value), "item.", ""), "state.", ""));
+                        info.emplace_back(TStringBuilder() << ReplaceAll(ReplaceAll(JsonToString(value), " item.", ""), " state.", ""));
                     } else if (key == "Table") {
                         info.insert(info.begin(), TStringBuilder() << colors.LightYellow() << key << colors.Default() << ":" << colors.LightGreen() << " " << ReplaceAll(ReplaceAll(JsonToString(value), "item.", ""), "state.", "") << colors.Default());
                     } else {

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -8,6 +8,7 @@
 
 #include <iomanip>
 #include <strstream>
+#include <regex>
 
 namespace NYdb {
 namespace NConsoleClient {
@@ -485,15 +486,18 @@ void TQueryPlanPrinter::PrintPrettyTableImpl(const NJson::TJsonValue& plan, TStr
                 } else if (key == "E-Size") {
                     eSize = FormatPrettyTableDouble(value.GetString());
                 } else if (key != "Name") {
+                    std::string valueWithoutInnerVars = JsonToString(value);
+                    valueWithoutInnerVars = std::regex_replace(valueWithoutInnerVars, std::regex(R"((\b(item|state)\.\b))"), "");
+
                     if (key == "SsaProgram") {
                         // skip this attribute
                     }
                     else if (key == "Predicate" || key == "Condition" || key == "SortBy") {
-                        info.emplace_back(TStringBuilder() << ReplaceAll(ReplaceAll(JsonToString(value), " item.", " "), " state.", " "));
+                        info.emplace_back(TStringBuilder() << valueWithoutInnerVars);
                     } else if (key == "Table") {
-                        info.insert(info.begin(), TStringBuilder() << colors.LightYellow() << key << colors.Default() << ":" << colors.LightGreen() << " " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", " "), " state.", " ") << colors.Default());
+                        info.insert(info.begin(), TStringBuilder() << colors.LightYellow() << key << colors.Default() << ":" << colors.LightGreen() << " " << valueWithoutInnerVars << colors.Default());
                     } else {
-                        info.emplace_back(TStringBuilder() << colors.LightYellow() << key << colors.Default() << ": " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", " "), " state.", " "));
+                        info.emplace_back(TStringBuilder() << colors.LightYellow() << key << colors.Default() << ": " << valueWithoutInnerVars);
                     }
                 }
             }

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -489,11 +489,11 @@ void TQueryPlanPrinter::PrintPrettyTableImpl(const NJson::TJsonValue& plan, TStr
                         // skip this attribute
                     }
                     else if (key == "Predicate" || key == "Condition" || key == "SortBy") {
-                        info.emplace_back(TStringBuilder() << ReplaceAll(ReplaceAll(JsonToString(value), " item.", ""), " state.", ""));
+                        info.emplace_back(TStringBuilder() << ReplaceAll(ReplaceAll(JsonToString(value), " item.", " "), " state.", " "));
                     } else if (key == "Table") {
-                        info.insert(info.begin(), TStringBuilder() << colors.LightYellow() << key << colors.Default() << ":" << colors.LightGreen() << " " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", ""), " state.", "") << colors.Default());
+                        info.insert(info.begin(), TStringBuilder() << colors.LightYellow() << key << colors.Default() << ":" << colors.LightGreen() << " " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", " "), " state.", " ") << colors.Default());
                     } else {
-                        info.emplace_back(TStringBuilder() << colors.LightYellow() << key << colors.Default() << ": " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", ""), " state.", ""));
+                        info.emplace_back(TStringBuilder() << colors.LightYellow() << key << colors.Default() << ": " << ReplaceAll(ReplaceAll(JsonToString(value), " item.", " "), " state.", " "));
                     }
                 }
             }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Bugfix 

Only remove an "item." prefix in variables in the plan if the first character is not alphanum. 
We remove the excessive "item." prefix (which is a synthetic variable inside the plan) to clean up the plans.
However, current rules screws up valid variables, such as "lineitem.key"