### PR TITLE
several fixes for groups and nodes handlers

### DIFF
--- a/ydb/core/viewer/json_handlers_storage.cpp
+++ b/ydb/core/viewer/json_handlers_storage.cpp
@@ -4,7 +4,7 @@
 namespace NKikimr::NViewer {
 
 void InitStorageGroupsJsonHandler(TJsonHandlers& jsonHandlers) {
-    jsonHandlers.AddHandler("/storage/groups", new TJsonHandler<TStorageGroups>(TStorageGroups::GetSwagger()), 4);
+    jsonHandlers.AddHandler("/storage/groups", new TJsonHandler<TStorageGroups>(TStorageGroups::GetSwagger()), 5);
 }
 
 void InitStorageJsonHandlers(TJsonHandlers& jsonHandlers) {

--- a/ydb/core/viewer/json_handlers_viewer.cpp
+++ b/ydb/core/viewer/json_handlers_viewer.cpp
@@ -243,7 +243,7 @@ void InitViewerHealthCheckJsonHandler(TJsonHandlers& handlers) {
 }
 
 void InitViewerNodesJsonHandler(TJsonHandlers& handlers) {
-    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 6);
+    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 7);
 }
 
 void InitViewerACLJsonHandler(TJsonHandlers &jsonHandlers) {

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -1567,10 +1567,13 @@ public:
         }
         if (FilterStorageStage == EFilterStorageStage::VSlots && VSlotsResponse && VSlotsResponse->IsDone()) {
             if (VSlotsResponse->IsOk()) {
+                std::unordered_set<TNodeId> prevFilterNodeIds = std::move(FilterNodeIds);
                 std::unordered_map<std::pair<TNodeId, ui32>, std::size_t> slotsPerDisk;
                 for (const auto& slotEntry : VSlotsResponse->Get()->Record.GetEntries()) {
                     if (FilterGroupIds.count(slotEntry.GetInfo().GetGroupId()) > 0) {
-                        FilterNodeIds.insert(slotEntry.GetKey().GetNodeId());
+                        if (prevFilterNodeIds.empty() || prevFilterNodeIds.count(slotEntry.GetKey().GetNodeId()) > 0) {
+                            FilterNodeIds.insert(slotEntry.GetKey().GetNodeId());
+                        }
                         TNode* node = FindNode(slotEntry.GetKey().GetNodeId());
                         if (node) {
                             node->SysViewVDisks.emplace_back(slotEntry);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Several fixes for groups and nodes handlers:
1. Fixed the filter for node_id + pdisk_id (previously, it operated on an OR principle).
2. Adjusted so that node_id + pdisk_id, node_id, pdisk_id, group_id, and storage_pool_name (for future use) are all considered pre-filters and affect the Total.
3. Fixed AllocationUnits—there was a race condition, and sometimes we didn't wait for the Hive's response.
4. Corrected the combination of node_id + group_id in /viewer/nodes (although, in my opinion, this is strange).

closes https://github.com/ydb-platform/ydb/issues/9658

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)
