### PR TITLE
#9227 Fix bug with UTF-8 highlighting in YDB CLI

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/interactive/yql_highlight.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/yql_highlight.cpp
@@ -121,15 +121,18 @@ namespace NYdb {
         void YQLHighlight::Apply(std::string_view query, Colors& colors) {
             Reset(query);
 
-            for (std::size_t i = 0; i < Tokens.size(); ++i) {
+            std::ptrdiff_t start = 0;
+            for (std::size_t i = 0; i < Tokens.size() - 1; ++i) {
                 const auto* token = Tokens.get(i);
                 const auto color = ColorOf(token);
 
-                const std::ptrdiff_t start = token->getStartIndex();
-                const std::ptrdiff_t stop = token->getStopIndex() + 1;
+                const std::ptrdiff_t length = token->getText().length();
+                const std::ptrdiff_t stop = start + length;
 
                 std::fill(std::next(std::begin(colors), start),
                           std::next(std::begin(colors), stop), color);
+
+                start += length;
             }
         }
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/yql_highlight_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/yql_highlight_ut.cpp
@@ -69,6 +69,14 @@ Y_UNIT_TEST_SUITE(YqlHighlightTests) {
         Check(highlight, "   ", "   ");
     }
 
+    Y_UNIT_TEST(Invalid) {
+        YQLHighlight highlight(Coloring);
+        Check(highlight, "!", "u");
+        Check(highlight, "й", "uu");
+        Check(highlight, "编", "uuu");
+        Check(highlight, "🥲", "uuuu");
+    }
+
     Y_UNIT_TEST(Keyword) {
         YQLHighlight highlight(Coloring);
         Check(highlight, "SELECT", "kkkkkk");
@@ -152,8 +160,11 @@ Y_UNIT_TEST_SUITE(YqlHighlightTests) {
     Y_UNIT_TEST(Emoji) {
         YQLHighlight highlight(Coloring);
         Check(highlight, "☺", "uuu");
-        Check(highlight, "\"☺\"", "sssuu");
-        Check(highlight, "`☺`", "qqquu");
+        Check(highlight, "\"☺\"", "sssss");
+        Check(highlight, "`☺`", "qqqqq");
+        Check(highlight, "SELECT \"😁\" FROM test", "kkkkkk ssssss kkkk vvvv");
+        Check(highlight, "SELECT \"编码\" FROM test", "kkkkkk ssssssss kkkk vvvv");
+        Check(highlight, "SELECT \"ай\" FROM test", "kkkkkk ssssss kkkk vvvv");
     }
 
     Y_UNIT_TEST(Typing) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix bug with UTF-8 highlighting in YDB CLI

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

- Added tests with queries containing UTF-8 characters with length 2, 3, 4
- Fixed a bug in the color filling procedure
- Outcome: ANTLR `Token::(Start|End)Index` returns an index of character in a `TVector<int>`, not `TVector<char>`.
- Connected with #9227 
- Was found during MR #9404, thanks to @nepal 
