### PR TITLE
Add min delay before shutdown

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1772,8 +1772,10 @@ void TKikimrRunner::KikimrStop(bool graceful) {
     }
 
     // Wait for a minimum delay to make sure that clients forget about this node
-    auto timeLeftBeforeShutdown = MinDelayBeforeShutdown - TDuration::Seconds(timer.Passed());
-    Sleep(timeLeftBeforeShutdown);
+    auto passedTime = TDuration::Seconds(timer.Passed());
+    if (MinDelayBeforeShutdown > passedTime) {
+        Sleep(MinDelayBeforeShutdown - passedTime);
+    }
 
     if (ActorSystem) {
         ActorSystem->BroadcastToProxies([](const TActorId& proxyId) {

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -504,6 +504,9 @@ static TString ReadFile(const TString& fileName) {
 void TKikimrRunner::InitializeGracefulShutdown(const TKikimrRunConfig& runConfig) {
     Y_UNUSED(runConfig);
     GracefulShutdownSupported = true;
+    if (runConfig.AppConfig.HasDelayBeforeShutdownSeconds()) {
+        DelayBeforeShutdown = TDuration::Seconds(runConfig.AppConfig.GetDelayBeforeShutdownSeconds());
+    }
 }
 
 void TKikimrRunner::InitializeKqpController(const TKikimrRunConfig& runConfig) {
@@ -1732,6 +1735,7 @@ void TKikimrRunner::KikimrStop(bool graceful) {
 
     if (EnabledGrpcService) {
         ActorSystem->Send(new IEventHandle(NGRpcService::CreateGrpcPublisherServiceActorId(), {}, new TEvents::TEvPoisonPill));
+        Sleep(DelayBeforeShutdown);
     }
 
     TIntrusivePtr<TDrainProgress> drainProgress(new TDrainProgress());

--- a/ydb/core/driver_lib/run/run.h
+++ b/ydb/core/driver_lib/run/run.h
@@ -44,7 +44,6 @@ protected:
     bool EnabledGrpcService = false;
     bool GracefulShutdownSupported = false;
     TDuration MinDelayBeforeShutdown;
-    TDuration DelayBeforeShutdown2;
     THolder<NSQS::TAsyncHttpServer> SqsHttp;
 
     THolder<NYdb::TDriver> YdbDriver;

--- a/ydb/core/driver_lib/run/run.h
+++ b/ydb/core/driver_lib/run/run.h
@@ -43,6 +43,7 @@ protected:
 
     bool EnabledGrpcService = false;
     bool GracefulShutdownSupported = false;
+    TDuration DelayBeforeShutdown;
     THolder<NSQS::TAsyncHttpServer> SqsHttp;
 
     THolder<NYdb::TDriver> YdbDriver;

--- a/ydb/core/driver_lib/run/run.h
+++ b/ydb/core/driver_lib/run/run.h
@@ -43,7 +43,8 @@ protected:
 
     bool EnabledGrpcService = false;
     bool GracefulShutdownSupported = false;
-    TDuration DelayBeforeShutdown;
+    TDuration MinDelayBeforeShutdown;
+    TDuration DelayBeforeShutdown2;
     THolder<NSQS::TAsyncHttpServer> SqsHttp;
 
     THolder<NYdb::TDriver> YdbDriver;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1905,6 +1905,10 @@ message TMetadataCacheConfig {
     optional uint64 RefreshPeriodMs = 1 [default = 15000];
 }
 
+message TShutdownConfig {
+    optional uint32 MinDelayBeforeShutdownSeconds = 1;
+}
+
 message TLabel {
     optional string Name = 1;
     optional string Value = 2;
@@ -1989,7 +1993,7 @@ message TAppConfig {
     optional TMemoryControllerConfig MemoryControllerConfig = 81;
 	optional TGroupedMemoryLimiterConfig GroupedMemoryLimiterConfig = 82;
     optional NKikimrReplication.TReplicationDefaults ReplicationConfig = 83;
-    optional uint32 DelayBeforeShutdownSeconds = 108;
+    optional TShutdownConfig ShutdownConfig = 84;
 
     repeated TNamedConfig NamedConfigs = 100;
     optional string ClusterYamlConfig = 101;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1989,6 +1989,7 @@ message TAppConfig {
     optional TMemoryControllerConfig MemoryControllerConfig = 81;
 	optional TGroupedMemoryLimiterConfig GroupedMemoryLimiterConfig = 82;
     optional NKikimrReplication.TReplicationDefaults ReplicationConfig = 83;
+    optional uint32 DelayBeforeShutdownSeconds = 108;
 
     repeated TNamedConfig NamedConfigs = 100;
     optional string ClusterYamlConfig = 101;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add setting to configure min delay before node shutdown

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

This setting is needed to make sure that clients forget about the node after its removal from discovery
