### PR TITLE
Do not paint red for asan

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -538,7 +538,7 @@ runs:
       if: inputs.run_tests
       shell: bash
       run: |
-        if [ $IS_TEST_RESULT_IGNORED == 0 ]
+        if [ $IS_TEST_RESULT_IGNORED == 0 ];then
           .github/scripts/tests/fail-checker.py "$LAST_JUNIT_REPORT_XML"
         fi
 

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -187,6 +187,7 @@ runs:
         )
 
         TEST_RETRY_COUNT=${{ inputs.test_retry_count }}
+        IS_TEST_RESULT_IGNORED=0
         
         case "$BUILD_PRESET" in
           debug)
@@ -212,6 +213,7 @@ runs:
             if [ $TEST_RETRY_COUNT -z ]; then
               TEST_RETRY_COUNT=1
             fi
+            IS_TEST_RESULT_IGNORED=1
             ;;
           release-tsan)
             params+=(
@@ -221,6 +223,7 @@ runs:
             if [ $TEST_RETRY_COUNT -z ]; then
               TEST_RETRY_COUNT=1
             fi
+            IS_TEST_RESULT_IGNORED=1
             ;;
           release-msan)
             params+=(
@@ -230,6 +233,7 @@ runs:
             if [ $TEST_RETRY_COUNT -z ]; then
               TEST_RETRY_COUNT=1
             fi
+            IS_TEST_RESULT_IGNORED=1
             ;;
           *)
             echo "Invalid preset: $BUILD_PRESET"
@@ -434,6 +438,7 @@ runs:
               --status_report_file statusrep.txt \
               --is_retry $IS_RETRY \
               --is_last_retry $IS_LAST_RETRY \
+              --is_test_result_ignored $IS_TEST_RESULT_IGNORED
               --comment_color_file summary_color.txt \
               --comment_text_file summary_text.txt \
               "Tests" $CURRENT_PUBLIC_DIR/ya-test.html "$CURRENT_JUNIT_XML_PATH"

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -86,7 +86,7 @@ runs:
           https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
           -d '{"state":"pending","description":"The check has been started","context":"build_${{inputs.build_preset}}"}'
 
-        if [[ "${{inputs.run_tests}}" == "true" ]];then
+        if [[ "${{inputs.run_tests}}" == "true" ]]; then
           curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
             -d '{"state":"pending","description":"The check has been started","context":"test_${{inputs.build_preset}}"}'
@@ -520,7 +520,7 @@ runs:
         set -x
         if [ true = ${{ inputs.run_tests }} ]; then
           teststatus=$(cat statusrep.txt)
-          if [[ $teststatus == "success" ]];then
+          if [[ $teststatus == "success" ]]; then
             testmessage="The check has been completed successfully"
           else
             testmessage="The check has been failed"
@@ -529,7 +529,7 @@ runs:
               https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
               -d '{"state":"'$teststatus'","description":"'"$testmessage"'","context":"test_${{inputs.build_preset}}"}'
           
-          if [[ $teststatus != "success" ]];then
+          if [[ $teststatus != "success" ]]; then
             echo "status=failed" >> $GITHUB_OUTPUT
           fi
         fi
@@ -538,7 +538,7 @@ runs:
       if: inputs.run_tests
       shell: bash
       run: |
-        if [ $IS_TEST_RESULT_IGNORED == 0 ];then
+        if [ $IS_TEST_RESULT_IGNORED == 0 ]; then
           .github/scripts/tests/fail-checker.py "$LAST_JUNIT_REPORT_XML"
         fi
 
@@ -594,7 +594,7 @@ runs:
         read -ra comment_arr <<< "$comment_raw"
 
         printf "$comment"
-        if [[ ${comment_raw} != "Error"* ]];then
+        if [[ ${comment_raw} != "Error"* ]]; then
           color=${comment_arr[0]}
           replace=$color";;;"
           comment=${comment_raw/$replace/""}

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -438,7 +438,7 @@ runs:
               --status_report_file statusrep.txt \
               --is_retry $IS_RETRY \
               --is_last_retry $IS_LAST_RETRY \
-              --is_test_result_ignored $IS_TEST_RESULT_IGNORED
+              --is_test_result_ignored $IS_TEST_RESULT_IGNORED \
               --comment_color_file summary_color.txt \
               --comment_text_file summary_text.txt \
               "Tests" $CURRENT_PUBLIC_DIR/ya-test.html "$CURRENT_JUNIT_XML_PATH"

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -240,6 +240,8 @@ runs:
             exit 1
             ;;
         esac
+        
+        echo "IS_TEST_RESULT_IGNORED=$IS_TEST_RESULT_IGNORED" >> $GITHUB_ENV
 
         if [ $TEST_RETRY_COUNT -z ]; then
           # default is 3 for ordinary build and 1 for sanitizer builds
@@ -536,7 +538,9 @@ runs:
       if: inputs.run_tests
       shell: bash
       run: |
-        .github/scripts/tests/fail-checker.py "$LAST_JUNIT_REPORT_XML"
+        if [ $IS_TEST_RESULT_IGNORED == 0 ]
+          .github/scripts/tests/fail-checker.py "$LAST_JUNIT_REPORT_XML"
+        fi
 
     - name: sync results to s3 and publish links
       if: always()

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -422,7 +422,7 @@ def main():
     else:
         overall_status = "success"
 
-    color, text = get_comment_text(summary, args.summary_links, is_last_retry=bool(args.is_last_retry), is_test_result_ignored=(bool.is_test_result_ignored))
+    color, text = get_comment_text(summary, args.summary_links, is_last_retry=bool(args.is_last_retry), is_test_result_ignored=(args.is_test_result_ignored))
 
     with open(args.comment_color_file, "w") as f:
         f.write(color)

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -417,7 +417,7 @@ def main():
     summary = gen_summary(args.public_dir, args.public_dir_url, title_path, is_retry=bool(args.is_retry),build_preset=args.build_preset)
     write_summary(summary)
 
-    if summary.is_failed and not bool.is_test_result_ignored:
+    if summary.is_failed and not args.is_test_result_ignored:
         overall_status = "failure"
     else:
         overall_status = "success"

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -346,11 +346,15 @@ def gen_summary(public_dir, public_dir_url, paths, is_retry: bool, build_preset)
     return summary
 
 
-def get_comment_text(summary: TestSummary, summary_links: str, is_last_retry: bool)->tuple[str, list[str]]:
+def get_comment_text(summary: TestSummary, summary_links: str, is_last_retry: bool, is_test_result_ignored: bool)->tuple[str, list[str]]:
     color = "red"
     if summary.is_failed:
-        color = "red" if is_last_retry else "yellow"
-        result = f"Some tests failed, follow the links below."
+        if is_test_result_ignored:
+            color = "yellow"
+            result = f"Some tests failed, follow the links below. This fail is not in blocking policy yet"
+        else:
+            color = "red" if is_last_retry else "yellow"
+            result = f"Some tests failed, follow the links below."
         if not is_last_retry:
             result += " Going to retry failed tests..."
     else:
@@ -397,6 +401,7 @@ def main():
     parser.add_argument('--status_report_file', required=False)
     parser.add_argument('--is_retry', required=True, type=int)
     parser.add_argument('--is_last_retry', required=True, type=int)
+    parser.add_argument('--is_test_result_ignored', required=True, type=int)
     parser.add_argument('--comment_color_file', required=True)
     parser.add_argument('--comment_text_file', required=True)
     parser.add_argument("args", nargs="+", metavar="TITLE html_out path")
@@ -412,12 +417,12 @@ def main():
     summary = gen_summary(args.public_dir, args.public_dir_url, title_path, is_retry=bool(args.is_retry),build_preset=args.build_preset)
     write_summary(summary)
 
-    if summary.is_failed:
+    if summary.is_failed and not bool.is_test_result_ignored:
         overall_status = "failure"
     else:
         overall_status = "success"
 
-    color, text = get_comment_text(summary, args.summary_links, is_last_retry=bool(args.is_last_retry))
+    color, text = get_comment_text(summary, args.summary_links, is_last_retry=bool(args.is_last_retry), is_test_result_ignored=(bool.is_test_result_ignored))
 
     with open(args.comment_color_file, "w") as f:
         f.write(color)

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -422,7 +422,7 @@ def main():
     else:
         overall_status = "success"
 
-    color, text = get_comment_text(summary, args.summary_links, is_last_retry=bool(args.is_last_retry), is_test_result_ignored=(args.is_test_result_ignored))
+    color, text = get_comment_text(summary, args.summary_links, is_last_retry=bool(args.is_last_retry), is_test_result_ignored=args.is_test_result_ignored)
 
     with open(args.comment_color_file, "w") as f:
         f.write(color)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Do not paint red for asan in case of fail, because it is not blocking policy yet

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

https://github.com/ydb-platform/ydb/pull/9706#issuecomment-2371643835 -- example of usage 
