### PR TITLE
Fix buggy IC setting leading to performance degradation (merge from main #9707)

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -55,14 +55,6 @@ namespace NActors {
         TDuration MaxErrorSleep = TDuration::Seconds(1);
         double ErrorSleepRetryMultiplier = 4.0;
         TDuration EventDelay = TDuration::Zero();
-
-        ui32 GetSendBufferSize() const {
-            ui32 res = 512 * 1024; // 512 kb is the default value for send buffer
-            if (TCPSocketBufferSize) {
-                res = TCPSocketBufferSize;
-            }
-            return res;
-        }
     };
 
     struct TWhiteboardSessionStatus {

--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -150,7 +150,9 @@ namespace NActors {
                 }
 
                 // setup send buffer size
-                Socket->SetSendBufferSize(Actor->Common->Settings.GetSendBufferSize());
+                if (const auto& buffer = Actor->Common->Settings.TCPSocketBufferSize) {
+                    Socket->SetSendBufferSize(buffer);
+                }
             }
 
             void RegisterInPoller() {

--- a/ydb/library/actors/interconnect/interconnect_tcp_server.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_server.cpp
@@ -41,7 +41,9 @@ namespace NActors {
                 return error;
             }
             SetNonBlock(*Listener);
-            Listener->SetSendBufferSize(ProxyCommonCtx->Settings.GetSendBufferSize()); // TODO(alexvru): WTF?
+            if (const auto& buffer = ProxyCommonCtx->Settings.TCPSocketBufferSize) {
+                Listener->SetSendBufferSize(buffer);
+            }
             SetSockOpt(*Listener, SOL_SOCKET, SO_REUSEADDR, 1);
             if (addr.GetFamily() == AF_INET6) {
                 SetSockOpt(*Listener, IPPROTO_IPV6, IPV6_V6ONLY, 0);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix buggy IC setting leading to performance degradation

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

Default setting of 512k send buffer size leads to performance degradation on modern networks, making IC unable to reach its top performance. Default setting has been removed.
