### PR TITLE
YMQ: fix GetQueueAttributesResult builder

### DIFF
--- a/ydb/core/http_proxy/ut/http_proxy_ut.h
+++ b/ydb/core/http_proxy/ut/http_proxy_ut.h
@@ -1698,16 +1698,58 @@ Y_UNIT_TEST_SUITE(TestHttpProxy) {
         TString resultQueueUrl = GetByPath<TString>(json, "QueueUrl");
         UNIT_ASSERT(resultQueueUrl.EndsWith("ExampleQueueName"));
 
-        NJson::TJsonValue getQueueAttributes;
-        getQueueAttributes["QueueUrl"] = resultQueueUrl;
-        NJson::TJsonArray attributeNames = {"DelaySeconds"};
-        getQueueAttributes["AttributeNames"] = attributeNames;
+        {
+            NJson::TJsonValue getQueueAttributes;
+            getQueueAttributes["QueueUrl"] = resultQueueUrl;
+            NJson::TJsonArray attributeNames = {"DelaySeconds"};
+            getQueueAttributes["AttributeNames"] = attributeNames;
 
-        res = SendHttpRequest("/Root", "AmazonSQS.GetQueueAttributes", std::move(getQueueAttributes), FormAuthorizationStr("ru-central1"));
-        UNIT_ASSERT_VALUES_EQUAL(res.HttpCode, 200);
-        NJson::TJsonValue resultJson;
-        UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &resultJson));
-        UNIT_ASSERT_VALUES_EQUAL(resultJson["Attributes"]["DelaySeconds"], "1");
+            res = SendHttpRequest("/Root", "AmazonSQS.GetQueueAttributes", std::move(getQueueAttributes), FormAuthorizationStr("ru-central1"));
+            UNIT_ASSERT_VALUES_EQUAL(res.HttpCode, 200);
+            NJson::TJsonValue resultJson;
+            UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &resultJson));
+            UNIT_ASSERT_VALUES_EQUAL(resultJson["Attributes"]["DelaySeconds"], "1");
+        }
+
+        {
+            NJson::TJsonValue getQueueAttributes;
+            getQueueAttributes["QueueUrl"] = resultQueueUrl;
+            NJson::TJsonArray attributeNames = {
+                "ApproximateNumberOfMessages",
+                "ApproximateNumberOfMessagesDelayed",
+                "ApproximateNumberOfMessagesNotVisible",
+                "CreatedTimestamp",
+                "DelaySeconds",
+                "MaximumMessageSize",
+                "MessageRetentionPeriod",
+                "ReceiveMessageWaitTimeSeconds",
+                "RedrivePolicy",
+                "VisibilityTimeout",
+                "FifoQueue",
+                "ContentBasedDeduplication",
+                "QueueArn"
+            };
+            getQueueAttributes["AttributeNames"] = attributeNames;
+
+            res = SendHttpRequest("/Root", "AmazonSQS.GetQueueAttributes", std::move(getQueueAttributes), FormAuthorizationStr("ru-central1"));
+            UNIT_ASSERT_VALUES_EQUAL(res.HttpCode, 200);
+            NJson::TJsonValue resultJson;
+            UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &resultJson));
+            UNIT_ASSERT_VALUES_EQUAL(resultJson["Attributes"]["DelaySeconds"], "1");
+        }
+
+        {
+            NJson::TJsonValue getQueueAttributes;
+            getQueueAttributes["QueueUrl"] = resultQueueUrl;
+            NJson::TJsonArray attributeNames = {"All"};
+            getQueueAttributes["AttributeNames"] = attributeNames;
+
+            res = SendHttpRequest("/Root", "AmazonSQS.GetQueueAttributes", std::move(getQueueAttributes), FormAuthorizationStr("ru-central1"));
+            UNIT_ASSERT_VALUES_EQUAL(res.HttpCode, 200);
+            NJson::TJsonValue resultJson;
+            UNIT_ASSERT(NJson::ReadJsonTree(res.Body, &resultJson));
+            UNIT_ASSERT_VALUES_EQUAL(resultJson["Attributes"]["DelaySeconds"], "1");
+        }
     }
 
     Y_UNIT_TEST_F(TestListQueues, THttpProxyTestMock) {

--- a/ydb/services/ymq/ymq_proxy.cpp
+++ b/ydb/services/ymq/ymq_proxy.cpp
@@ -449,75 +449,41 @@ namespace NKikimr::NYmq::V1 {
 
         Ydb::Ymq::V1::GetQueueAttributesResult GetResult(const NKikimrClient::TSqsResponse& resp) override {
             Ydb::Ymq::V1::GetQueueAttributesResult result;
-            for (const auto& attributeName : Attributes) {
-                if (attributeName == APPROXIMATE_NUMBER_OF_MESSAGES) {
-                    AddAttribute(
-                        result,
-                        APPROXIMATE_NUMBER_OF_MESSAGES,
-                        GetResponse(resp).GetApproximateNumberOfMessages()
-                    );
-                } else if (attributeName == APPROXIMATE_NUMBER_OF_MESSAGES_DELAYED) {
-                    AddAttribute(
-                        result,
-                        APPROXIMATE_NUMBER_OF_MESSAGES_DELAYED,
-                        GetResponse(resp).GetApproximateNumberOfMessagesDelayed()
-                    );
-                } else if (attributeName == CREATED_TIMESTAMP) {
-                    AddAttribute(
-                        result,
-                        CREATED_TIMESTAMP,
-                        GetResponse(resp).GetCreatedTimestamp()
-                    );
-                } else if (attributeName == DELAY_SECONDS) {
-                    AddAttribute(
-                        result,
-                        DELAY_SECONDS,
-                        GetResponse(resp).GetDelaySeconds()
-                    );
-                } else if (attributeName == LAST_MODIFIED_TIMESTAMP) {
-                    AddAttribute(
-                        result,
-                        LAST_MODIFIED_TIMESTAMP,
-                        GetResponse(resp).GetLastModifiedTimestamp()
-                    );
-                } else if (attributeName == MAXIMUM_MESSAGE_SIZE) {
-                    AddAttribute(
-                        result,
-                        MAXIMUM_MESSAGE_SIZE,
-                        GetResponse(resp).GetMaximumMessageSize()
-                    );
-                } else if (attributeName == MESSAGE_RETENTION_PERIOD) {
-                    AddAttribute(
-                        result,
-                        MESSAGE_RETENTION_PERIOD,
-                        GetResponse(resp).GetMessageRetentionPeriod()
-                    );
-                } else if (attributeName == QUEUE_ARN) {
-                    AddAttribute(
-                        result,
-                        QUEUE_ARN,
-                        GetResponse(resp).GetQueueArn()
-                    );
-                } else if (attributeName == RECEIVE_MESSAGE_WAIT_TIME_SECONDS) {
-                    AddAttribute(
-                        result,
-                        RECEIVE_MESSAGE_WAIT_TIME_SECONDS,
-                        GetResponse(resp).GetReceiveMessageWaitTimeSeconds()
-                    );
-                } else if (attributeName == VISIBILITY_TIMEOUT) {
-                    AddAttribute(
-                        result,
-                        VISIBILITY_TIMEOUT,
-                        GetResponse(resp).GetVisibilityTimeout()
-                    );
-                } else if (attributeName == REDRIVE_POLICY) {
-                    AddAttribute(
-                        result,
-                        REDRIVE_POLICY,
-                        GetResponse(resp).GetRedrivePolicy()
-                    );
-                }
+            const auto& attrs = resp.GetGetQueueAttributes();
+            if (attrs.HasApproximateNumberOfMessages()) {
+                AddAttribute(result, APPROXIMATE_NUMBER_OF_MESSAGES, attrs.GetApproximateNumberOfMessages());
             }
+            if (attrs.HasApproximateNumberOfMessagesDelayed()) {
+                AddAttribute(result, APPROXIMATE_NUMBER_OF_MESSAGES_DELAYED, attrs.GetApproximateNumberOfMessagesDelayed());
+            }
+            if (attrs.HasCreatedTimestamp()) {
+                AddAttribute(result, CREATED_TIMESTAMP, attrs.GetCreatedTimestamp());
+            }
+            if (attrs.HasDelaySeconds()) {
+                AddAttribute(result, DELAY_SECONDS, attrs.GetDelaySeconds());
+            }
+            if (attrs.HasLastModifiedTimestamp()) {
+                AddAttribute(result, LAST_MODIFIED_TIMESTAMP, attrs.GetLastModifiedTimestamp());
+            }
+            if (attrs.HasMaximumMessageSize()) {
+                AddAttribute(result, MAXIMUM_MESSAGE_SIZE, attrs.GetMaximumMessageSize());
+            }
+            if (attrs.HasMessageRetentionPeriod()) {
+                AddAttribute(result, MESSAGE_RETENTION_PERIOD, attrs.GetMessageRetentionPeriod());
+            }
+            if (attrs.HasQueueArn()) {
+                AddAttribute(result, QUEUE_ARN, attrs.GetQueueArn());
+            }
+            if (attrs.HasReceiveMessageWaitTimeSeconds()) {
+                AddAttribute(result, RECEIVE_MESSAGE_WAIT_TIME_SECONDS, attrs.GetReceiveMessageWaitTimeSeconds());
+            }
+            if (attrs.HasVisibilityTimeout()) {
+                AddAttribute(result, VISIBILITY_TIMEOUT, attrs.GetVisibilityTimeout());
+            }
+            if (attrs.HasRedrivePolicy()) {
+                AddAttribute(result, REDRIVE_POLICY, attrs.GetRedrivePolicy());
+            }
+
             return result;
         }
 


### PR DESCRIPTION
The next query does not work correctly with JSON API and returns an empty result:

```
GetQueueAttributes {
    "QueueUrl": "https://message-queue.api.cloud.yandex.net/b1g******/dj6******/queueName",
    "AttributeNames": ["All"]
}
```

XML API works as expected.