### PR TITLE
streamlookup, generic lookup, yt lookup: remove TUVMap usage from events

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -213,41 +213,26 @@ struct IDqAsyncLookupSource {
             NKikimr::NMiniKQL::TMKQLAllocator<std::pair<const NUdf::TUnboxedValue, NUdf::TUnboxedValue>>
     >;
     struct TEvLookupRequest: NActors::TEventLocal<TEvLookupRequest, TDqComputeEvents::EvLookupRequest> {
-        TEvLookupRequest(std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc, TUnboxedValueMap&& request)
-            : Alloc(alloc)
-            , Request(std::move(request))
+        TEvLookupRequest(std::weak_ptr<TUnboxedValueMap> request)
+            : Request(request)
         {
         }
-        ~TEvLookupRequest() {
-            auto guard = Guard(*Alloc);
-            TKeyTypeHelper empty;
-            Request = TUnboxedValueMap{0, empty.GetValueHash(), empty.GetValueEqual()};
-        }
-        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
-        TUnboxedValueMap Request;
+        std::weak_ptr<TUnboxedValueMap> Request;
     };
 
     struct TEvLookupResult: NActors::TEventLocal<TEvLookupResult, TDqComputeEvents::EvLookupResult> {
-        TEvLookupResult(std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc, TUnboxedValueMap&& result)
-            : Alloc(alloc)
-            , Result(std::move(result))
+        TEvLookupResult(std::weak_ptr<TUnboxedValueMap> result)
+            : Result(result)
         {
         }
-        ~TEvLookupResult() {
-            auto guard = Guard(*Alloc.get());
-            TKeyTypeHelper empty;
-            Result = TUnboxedValueMap{0, empty.GetValueHash(), empty.GetValueEqual()};
-        }
-
-        std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
-        TUnboxedValueMap Result;
+        std::weak_ptr<TUnboxedValueMap> Result;
     };
 
     virtual size_t GetMaxSupportedKeysInRequest() const = 0;
     //Initiate lookup for requested keys
     //Only one request at a time is allowed. Request must contain no more than GetMaxSupportedKeysInRequest() keys
-    //Upon completion, results are sent in TEvLookupResult event to the preconfigured actor
-    virtual void AsyncLookup(TUnboxedValueMap&& request) = 0;
+    //Upon completion, TEvLookupResult event is sent to the preconfigured actor
+    virtual void AsyncLookup(std::weak_ptr<TUnboxedValueMap> request) = 0;
 protected:
     ~IDqAsyncLookupSource() {}
 };

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h
@@ -214,7 +214,7 @@ struct IDqAsyncLookupSource {
     >;
     struct TEvLookupRequest: NActors::TEventLocal<TEvLookupRequest, TDqComputeEvents::EvLookupRequest> {
         TEvLookupRequest(std::weak_ptr<TUnboxedValueMap> request)
-            : Request(request)
+            : Request(std::move(request))
         {
         }
         std::weak_ptr<TUnboxedValueMap> Request;
@@ -222,7 +222,7 @@ struct IDqAsyncLookupSource {
 
     struct TEvLookupResult: NActors::TEventLocal<TEvLookupResult, TDqComputeEvents::EvLookupResult> {
         TEvLookupResult(std::weak_ptr<TUnboxedValueMap> result)
-            : Result(result)
+            : Result(std::move(result))
         {
         }
         std::weak_ptr<TUnboxedValueMap> Result;

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -90,9 +90,9 @@ public:
             .MaxKeysInRequest = 1000 // TODO configure me
         };
         auto guard = Guard(*Alloc);
-        auto LookupSource = Factory->CreateDqLookupSource(Settings.GetRightSource().GetProviderName(), std::move(lookupSourceArgs));
-        MaxKeysInRequest = LookupSource.first->GetMaxSupportedKeysInRequest();
-        LookupSourceId = RegisterWithSameMailbox(LookupSource.second);
+        auto [lookupSource, lookupSourceActor] = Factory->CreateDqLookupSource(Settings.GetRightSource().GetProviderName(), std::move(lookupSourceArgs));
+        MaxKeysInRequest = lookupSource->GetMaxSupportedKeysInRequest();
+        LookupSourceId = RegisterWithSameMailbox(lookupSourceActor);
     }
 protected:
     virtual NUdf::EFetchStatus FetchWideInputValue(NUdf::TUnboxedValue* inputRowItems) = 0;

--- a/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/generic/actors/ut/yql_generic_lookup_actor_ut.cpp
@@ -201,7 +201,7 @@ Y_UNIT_TEST_SUITE(GenericProviderLookupActor) {
 
         auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);
         auto guard2 = Guard(*alloc.get());
-        auto lookupResult = std::move(ev->Get()->Result.lock());
+        auto lookupResult = ev->Get()->Result.lock();
         UNIT_ASSERT(lookupResult);
 
         UNIT_ASSERT_EQUAL(3, lookupResult->size());

--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -128,6 +128,7 @@ namespace NYql::NDq {
 
     private: // events
         STRICT_STFUNC(StateFunc,
+                      hFunc(TEvLookupRequest, Handle);
                       hFunc(TEvListSplitsIterator, Handle);
                       hFunc(TEvListSplitsPart, Handle);
                       hFunc(TEvReadSplitsIterator, Handle);
@@ -199,6 +200,11 @@ namespace NYql::NDq {
 
         void Handle(NActors::TEvents::TEvPoison::TPtr) {
             PassAway();
+        }
+
+        void Handle(TEvLookupRequest::TPtr ev) {
+            auto guard = Guard(*Alloc);
+            CreateRequest(ev->Get()->Request.lock());
         }
 
     private:

--- a/ydb/library/yql/providers/yt/actors/ut/yql_yt_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/yt/actors/ut/yql_yt_lookup_actor_ut.cpp
@@ -147,7 +147,7 @@ Y_UNIT_TEST(Lookup) {
         typeEnv,
         holderFactory,
         1'000'000);
-    runtime.Register(lookupActor);
+    auto lookupActorId = runtime.Register(lookupActor);
 
     auto request = std::make_shared<NDq::IDqAsyncLookupSource::TUnboxedValueMap>(4, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
     request->emplace(CreateStructValue(holderFactory, {"host1", "vpc1"}), NUdf::TUnboxedValue{});
@@ -157,7 +157,7 @@ Y_UNIT_TEST(Lookup) {
 
     guard.Release(); //let actors use alloc
 
-    auto callLookupActor = new TCallLookupActor(alloc, lookupActor->SelfId(), request);
+    auto callLookupActor = new TCallLookupActor(alloc, lookupActorId, request);
     runtime.Register(callLookupActor);
 
     auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);

--- a/ydb/library/yql/providers/yt/actors/ut/yql_yt_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/yt/actors/ut/yql_yt_lookup_actor_ut.cpp
@@ -49,16 +49,25 @@ public:
     TCallLookupActor(
         std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
         const NActors::TActorId& lookupActor,
-        NDq::IDqAsyncLookupSource::TUnboxedValueMap&& request)
+        std::shared_ptr<NDq::IDqAsyncLookupSource::TUnboxedValueMap> request)
         : Alloc(alloc)
         , LookupActor(lookupActor)
-        , Request(std::move(request))
+        , Request(request)
     {
     }
 
     void Bootstrap() {
-        auto ev = new NDq::IDqAsyncLookupSource::TEvLookupRequest(Alloc, std::move(Request));
+        auto ev = new NDq::IDqAsyncLookupSource::TEvLookupRequest(Request);
         TActivationContext::ActorSystem()->Send(new NActors::IEventHandle(LookupActor, SelfId(), ev));
+    }
+
+    ~TCallLookupActor() {
+        PassAway();
+    }
+
+    void PassAway() override {
+        auto guard = Guard(*Alloc);
+        Request.reset();
     }
 
 private:
@@ -67,7 +76,7 @@ private:
 private:
     std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
     const NActors::TActorId LookupActor;
-    NDq::IDqAsyncLookupSource::TUnboxedValueMap Request;
+    std::shared_ptr<NDq::IDqAsyncLookupSource::TUnboxedValueMap> Request;
 };
 
 Y_UNIT_TEST(Lookup) {
@@ -140,38 +149,38 @@ Y_UNIT_TEST(Lookup) {
         1'000'000);
     runtime.Register(lookupActor);
 
-    NDq::IDqAsyncLookupSource::TUnboxedValueMap request{4, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual()};
-    request.emplace(CreateStructValue(holderFactory, {"host1", "vpc1"}), NUdf::TUnboxedValue{});
-    request.emplace(CreateStructValue(holderFactory, {"host2", "vpc1"}), NUdf::TUnboxedValue{});
-    request.emplace(CreateStructValue(holderFactory, {"host2", "vpc2"}), NUdf::TUnboxedValue{}); //NOT_FOUND expected
-    request.emplace(CreateStructValue(holderFactory, {"very very long hostname to for test 2", "vpc2"}), NUdf::TUnboxedValue{});
+    auto request = std::make_shared<NDq::IDqAsyncLookupSource::TUnboxedValueMap>(4, keyTypeHelper->GetValueHash(), keyTypeHelper->GetValueEqual());
+    request->emplace(CreateStructValue(holderFactory, {"host1", "vpc1"}), NUdf::TUnboxedValue{});
+    request->emplace(CreateStructValue(holderFactory, {"host2", "vpc1"}), NUdf::TUnboxedValue{});
+    request->emplace(CreateStructValue(holderFactory, {"host2", "vpc2"}), NUdf::TUnboxedValue{}); //NOT_FOUND expected
+    request->emplace(CreateStructValue(holderFactory, {"very very long hostname to for test 2", "vpc2"}), NUdf::TUnboxedValue{});
 
     guard.Release(); //let actors use alloc
 
-    auto callLookupActor = new TCallLookupActor(alloc, lookupActor->SelfId(), std::move(request));
+    auto callLookupActor = new TCallLookupActor(alloc, lookupActor->SelfId(), request);
     runtime.Register(callLookupActor);
 
     auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);
     auto guard2 = Guard(*alloc.get());
-    auto lookupResult = std::move(ev->Get()->Result);
-    UNIT_ASSERT_EQUAL(4, lookupResult.size());
+    auto lookupResult = std::move(ev->Get()->Result.lock());
+    UNIT_ASSERT_EQUAL(4, lookupResult->size());
     {
-        const auto* v = lookupResult.FindPtr(CreateStructValue(holderFactory, {"host1", "vpc1"}));
+        const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {"host1", "vpc1"}));
         UNIT_ASSERT(v);
         UNIT_ASSERT(CheckStructValue(*v, {"host1.vpc1.net", "192.168.1.1"}));
     }
     {
-        const auto* v = lookupResult.FindPtr(CreateStructValue(holderFactory, {"host2", "vpc1"}));
+        const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {"host2", "vpc1"}));
         UNIT_ASSERT(v);
         UNIT_ASSERT(CheckStructValue(*v, {"host2.vpc1.net", "192.168.1.2"}));
     }
     {
-        const auto* v = lookupResult.FindPtr(CreateStructValue(holderFactory, {"host2", "vpc2"}));
+        const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {"host2", "vpc2"}));
         UNIT_ASSERT(v);
         UNIT_ASSERT(!*v);
     }
     {
-        const auto* v = lookupResult.FindPtr(CreateStructValue(holderFactory, {"very very long hostname to for test 2", "vpc2"}));
+        const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {"very very long hostname to for test 2", "vpc2"}));
         UNIT_ASSERT(v);
         UNIT_ASSERT(CheckStructValue(*v, {"very very long fqdn for test 2", "192.168.100.2"}));
     }

--- a/ydb/library/yql/providers/yt/actors/ut/yql_yt_lookup_actor_ut.cpp
+++ b/ydb/library/yql/providers/yt/actors/ut/yql_yt_lookup_actor_ut.cpp
@@ -162,7 +162,7 @@ Y_UNIT_TEST(Lookup) {
 
     auto ev = runtime.GrabEdgeEventRethrow<NYql::NDq::IDqAsyncLookupSource::TEvLookupResult>(edge);
     auto guard2 = Guard(*alloc.get());
-    auto lookupResult = std::move(ev->Get()->Result.lock());
+    auto lookupResult = ev->Get()->Result.lock();
     UNIT_ASSERT_EQUAL(4, lookupResult->size());
     {
         const auto* v = lookupResult->FindPtr(CreateStructValue(holderFactory, {"host1", "vpc1"}));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Using TUnboxedValueMap in actor system events is UB. Use `std::weak_ptr` for events and store `std::shared_ptr` in actors.
Using actors directly after registration is UB. Use events instead.