### PR TITLE
Remove excess RegisterDqPqReadActorFactory call in mrrun

### DIFF
--- a/ydb/library/yql/tools/mrrun/mrrun.cpp
+++ b/ydb/library/yql/tools/mrrun/mrrun.cpp
@@ -243,7 +243,6 @@ NDq::IDqAsyncIoFactory::TPtr CreateAsyncIoFactory(const NYdb::TDriver& driver, I
         std::make_shared<TPqGatewayConfig>(),
         nullptr
     );
-    RegisterDqPqReadActorFactory(*factory, driver, nullptr, CreatePqNativeGateway(pqServices));
     RegisterDqPqReadActorFactory(*factory, driver, nullptr, CreatePqNativeGateway(std::move(pqServices)));
     RegisterYdbReadActorFactory(*factory, driver, nullptr);
     RegisterClickHouseReadActorFactory(*factory, nullptr, httpGateway);


### PR DESCRIPTION
There was a typo in `mrrun` sources, introduced in #9349.

### Changelog category

* Bugfix