### PR TITLE
Bootstrapper: full node list in TBootstrapperInfo, handle possible duplicates

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1420,33 +1420,28 @@ void TBootstrapperInitializer::InitializeServices(
                     TActorSetupCmd(CreateConfiguredTabletBootstrapper(boot), TMailboxType::HTSwap, appData->SystemPoolId)));
             } else {
                 const bool standby = boot.HasStandBy() && boot.GetStandBy();
-                for (const ui32 bootstrapperNode : boot.GetNode()) {
-                    if (bootstrapperNode == NodeId) {
+                if (Find(boot.GetNode(), NodeId) != boot.GetNode().end()) {
+                    TIntrusivePtr<TTabletStorageInfo> info(TabletStorageInfoFromProto(boot.GetInfo()));
 
-                        TIntrusivePtr<TTabletStorageInfo> info(TabletStorageInfoFromProto(boot.GetInfo()));
+                    auto tabletType = BootstrapperTypeToTabletType(boot.GetType());
 
-                        auto tabletType = BootstrapperTypeToTabletType(boot.GetType());
+                    auto tabletSetupInfo = CreateTablet(
+                        TTabletTypes::TypeToStr(tabletType),
+                        info,
+                        appData);
 
-                        auto tabletSetupInfo = CreateTablet(
-                            TTabletTypes::TypeToStr(tabletType),
-                            info,
-                            appData);
+                    TIntrusivePtr<TBootstrapperInfo> bi = new TBootstrapperInfo(tabletSetupInfo.Get());
+                    bi->Nodes.reserve(boot.NodeSize());
+                    for (ui32 x : boot.GetNode())
+                        bi->Nodes.push_back(x);
+                    if (boot.HasWatchThreshold())
+                        bi->WatchThreshold = TDuration::MilliSeconds(boot.GetWatchThreshold());
+                    if (boot.HasStartFollowers())
+                        bi->StartFollowers = boot.GetStartFollowers();
 
-                        TIntrusivePtr<TBootstrapperInfo> bi = new TBootstrapperInfo(tabletSetupInfo.Get());
-
-                        if (boot.NodeSize() != 1) {
-                            bi->OtherNodes.reserve(boot.NodeSize() - 1);
-                            for (ui32 x : boot.GetNode())
-                                if (x != NodeId)
-                                    bi->OtherNodes.push_back(x);
-                            if (boot.HasWatchThreshold())
-                                bi->WatchThreshold = TDuration::MilliSeconds(boot.GetWatchThreshold());
-                            if (boot.HasStartFollowers())
-                                bi->StartFollowers = boot.GetStartFollowers();
-                        }
-
-                        setup->LocalServices.push_back(std::pair<TActorId, TActorSetupCmd>(MakeBootstrapperID(info->TabletID, bootstrapperNode), TActorSetupCmd(CreateBootstrapper(info.Get(), bi.Get(), standby), TMailboxType::HTSwap, appData->SystemPoolId)));
-                    }
+                    setup->LocalServices.push_back(std::pair<TActorId, TActorSetupCmd>(
+                        MakeBootstrapperID(info->TabletID, NodeId),
+                        TActorSetupCmd(CreateBootstrapper(info.Get(), bi.Get(), standby), TMailboxType::HTSwap, appData->SystemPoolId)));
                 }
             }
         }

--- a/ydb/core/mind/configured_tablet_bootstrapper.cpp
+++ b/ydb/core/mind/configured_tablet_bootstrapper.cpp
@@ -82,16 +82,13 @@ class TConfiguredTabletBootstrapper : public TActorBootstrapped<TConfiguredTable
             TIntrusivePtr<TTabletSetupInfo> tabletSetupInfo = MakeTabletSetupInfo(tabletType, appData->UserPoolId, appData->SystemPoolId);
 
             TIntrusivePtr<TBootstrapperInfo> bi = new TBootstrapperInfo(tabletSetupInfo.Get());
-            if (config.NodeSize() != 1) {
-                for (ui32 node : config.GetNode()) {
-                    if (node != selfNode)
-                        bi->OtherNodes.emplace_back(node);
-                }
-                if (config.HasWatchThreshold())
-                    bi->WatchThreshold = TDuration::MilliSeconds(config.GetWatchThreshold());
-                if (config.HasStartFollowers())
-                    bi->StartFollowers = config.GetStartFollowers();
+            for (ui32 node : config.GetNode()) {
+                bi->Nodes.emplace_back(node);
             }
+            if (config.HasWatchThreshold())
+                bi->WatchThreshold = TDuration::MilliSeconds(config.GetWatchThreshold());
+            if (config.HasStartFollowers())
+                bi->StartFollowers = config.GetStartFollowers();
 
             BootstrapperInstance = Register(CreateBootstrapper(storageInfo.Get(), bi.Get(), false), TMailboxType::HTSwap, appData->SystemPoolId);
 

--- a/ydb/core/tablet/bootstrapper.h
+++ b/ydb/core/tablet/bootstrapper.h
@@ -33,16 +33,13 @@ struct TEvBootstrapper {
 
 struct TBootstrapperInfo : public TThrRefBase {
     TIntrusivePtr<TTabletSetupInfo> SetupInfo;
-    TVector<ui32> OtherNodes;
-    TDuration WatchThreshold;
-    TDuration OfflineDelay;
-    bool StartFollowers;
+    TVector<ui32> Nodes;
+    TDuration WatchThreshold = TDuration::MilliSeconds(200);
+    TDuration OfflineDelay = TDuration::Seconds(3);
+    bool StartFollowers = false;
 
-    TBootstrapperInfo(TTabletSetupInfo* setupInfo)
+    explicit TBootstrapperInfo(TTabletSetupInfo* setupInfo)
         : SetupInfo(setupInfo)
-        , WatchThreshold(TDuration::MilliSeconds(200))
-        , OfflineDelay(TDuration::Seconds(3))
-        , StartFollowers(false)
     {}
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Bootstrapper was not working correctly when configured with node duplicates. Change `TBootstrapperInfo` to specify a full list of nodes, and gracefully handle duplicates by preprocessing this list.

Fixes #9843.