### PR TITLE
Enlarge cache size (keep it between retries)

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -278,7 +278,7 @@ runs:
         params+=(
           --stat -DCONSISTENT_DEBUG --no-dir-outputs
           --test-failure-code 0 --build-all 
-          --cache-size 2TB --force-build-depends
+          --cache-size 5TB --force-build-depends
         )
 
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

In contrib update cache size is more than 2TB

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information


