### PR TITLE
Configure BufferPool size depending on device type, second attempt

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -123,9 +123,9 @@ struct TPDiskConfig : public TThrRefBase {
     ui64 CostLimitNs;
 
     // AsyncBlockDevice settings
-    ui32 BufferPoolBufferSizeBytes = 512 << 10;
-    ui32 BufferPoolBufferCount = 256;
-    ui32 MaxQueuedCompletionActions = 128; // BufferPoolBufferCount / 2;
+    ui32 BufferPoolBufferSizeBytes = 256 << 10;
+    ui32 BufferPoolBufferCount = 2048;
+    ui32 MaxQueuedCompletionActions = BufferPoolBufferCount / 2;
     bool UseSpdkNvmeDriver;
 
     ui64 ExpectedSlotCount = 0;
@@ -210,6 +210,10 @@ struct TPDiskConfig : public TThrRefBase {
         const ui64 hddInFlight = FeatureFlags.GetEnablePDiskHighHDDInFlight() ? 32 : 4;
         DeviceInFlight = choose(128, 4, hddInFlight);
         CostLimitNs = choose(500'000ull, 20'000'000ull, 50'000'000ull);
+
+        BufferPoolBufferSizeBytes = choose(128 << 10, 256 << 10, 512 << 10);
+        BufferPoolBufferCount = choose(1024, 512, 256);
+        MaxQueuedCompletionActions = BufferPoolBufferCount / 2;
 
         UseSpdkNvmeDriver = Path.StartsWith("PCIe:");
         Y_ABORT_UNLESS(!UseSpdkNvmeDriver || deviceType == NPDisk::DEVICE_TYPE_NVME,

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -123,9 +123,9 @@ struct TPDiskConfig : public TThrRefBase {
     ui64 CostLimitNs;
 
     // AsyncBlockDevice settings
-    ui32 BufferPoolBufferSizeBytes = 256 << 10;
-    ui32 BufferPoolBufferCount = 2048;
-    ui32 MaxQueuedCompletionActions = BufferPoolBufferCount / 2;
+    ui32 BufferPoolBufferSizeBytes;
+    ui32 BufferPoolBufferCount;
+    ui32 MaxQueuedCompletionActions;
     bool UseSpdkNvmeDriver;
 
     ui64 ExpectedSlotCount = 0;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -60,9 +60,11 @@ TPDisk::TPDisk(std::shared_ptr<TPDiskCtx> pCtx, const TIntrusivePtr<TPDiskConfig
             0, 64 * 1024 * 1024);
     ForsetiMaxLogBatchNs = TControlWrapper((PDiskCategory.IsSolidState() ? 50'000ll : 500'000ll), 0, 100'000'000ll);
     ForsetiMaxLogBatchNsCached = ForsetiMaxLogBatchNs;
-    ForsetiOpPieceSizeSsd = TControlWrapper(64 * 1024, 1, 512 * 1024);
-    ForsetiOpPieceSizeRot = TControlWrapper(512 * 1024, 1, 512 * 1024);
+    ForsetiOpPieceSizeSsd = TControlWrapper(64 * 1024, 1, Cfg->BufferPoolBufferSizeBytes);
+    ForsetiOpPieceSizeRot = TControlWrapper(512 * 1024, 1, Cfg->BufferPoolBufferSizeBytes);
     ForsetiOpPieceSizeCached = PDiskCategory.IsSolidState() ?  ForsetiOpPieceSizeSsd : ForsetiOpPieceSizeRot;
+
+    
 
     if (Cfg->SectorMap) {
         auto diskModeParams = Cfg->SectorMap->GetDiskModeParams();
@@ -3422,12 +3424,12 @@ void TPDisk::Update() {
     Mon.UpdateDurationTracker.UpdateStarted();
     LWTRACK(PDiskUpdateStarted, UpdateCycleOrbit, PCtx->PDiskId);
 
+    ForsetiMaxLogBatchNsCached = ForsetiMaxLogBatchNs;
+    ForsetiOpPieceSizeCached = PDiskCategory.IsSolidState() ? ForsetiOpPieceSizeSsd : ForsetiOpPieceSizeRot;
+    ForsetiOpPieceSizeCached = Min<i64>(ForsetiOpPieceSizeCached, Cfg->BufferPoolBufferSizeBytes);
+    ForsetiOpPieceSizeCached = AlignDown<i64>(ForsetiOpPieceSizeCached, Format.SectorSize);
     {
         TGuard<TMutex> guard(StateMutex);
-        ForsetiMaxLogBatchNsCached = ForsetiMaxLogBatchNs;
-        ForsetiOpPieceSizeCached = PDiskCategory.IsSolidState() ? ForsetiOpPieceSizeSsd : ForsetiOpPieceSizeRot;
-        ForsetiOpPieceSizeCached = Min<i64>(ForsetiOpPieceSizeCached, Cfg->BufferPoolBufferSizeBytes);
-        ForsetiOpPieceSizeCached = AlignDown<i64>(ForsetiOpPieceSizeCached, Format.SectorSize);
         // Switch the scheduler when possible
         ForsetiScheduler.SetIsBinLogEnabled(EnableForsetiBinLog);
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -64,8 +64,6 @@ TPDisk::TPDisk(std::shared_ptr<TPDiskCtx> pCtx, const TIntrusivePtr<TPDiskConfig
     ForsetiOpPieceSizeRot = TControlWrapper(512 * 1024, 1, Cfg->BufferPoolBufferSizeBytes);
     ForsetiOpPieceSizeCached = PDiskCategory.IsSolidState() ?  ForsetiOpPieceSizeSsd : ForsetiOpPieceSizeRot;
 
-    
-
     if (Cfg->SectorMap) {
         auto diskModeParams = Cfg->SectorMap->GetDiskModeParams();
         if (diskModeParams) {
@@ -3424,12 +3422,13 @@ void TPDisk::Update() {
     Mon.UpdateDurationTracker.UpdateStarted();
     LWTRACK(PDiskUpdateStarted, UpdateCycleOrbit, PCtx->PDiskId);
 
-    ForsetiMaxLogBatchNsCached = ForsetiMaxLogBatchNs;
-    ForsetiOpPieceSizeCached = PDiskCategory.IsSolidState() ? ForsetiOpPieceSizeSsd : ForsetiOpPieceSizeRot;
-    ForsetiOpPieceSizeCached = Min<i64>(ForsetiOpPieceSizeCached, Cfg->BufferPoolBufferSizeBytes);
-    ForsetiOpPieceSizeCached = AlignDown<i64>(ForsetiOpPieceSizeCached, Format.SectorSize);
     {
         TGuard<TMutex> guard(StateMutex);
+
+        ForsetiMaxLogBatchNsCached = ForsetiMaxLogBatchNs;
+        ForsetiOpPieceSizeCached = PDiskCategory.IsSolidState() ? ForsetiOpPieceSizeSsd : ForsetiOpPieceSizeRot;
+        ForsetiOpPieceSizeCached = Min<i64>(ForsetiOpPieceSizeCached, Cfg->BufferPoolBufferSizeBytes);
+        ForsetiOpPieceSizeCached = AlignDown<i64>(ForsetiOpPieceSizeCached, Format.SectorSize);
         // Switch the scheduler when possible
         ForsetiScheduler.SetIsBinLogEnabled(EnableForsetiBinLog);
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -3424,7 +3424,6 @@ void TPDisk::Update() {
 
     {
         TGuard<TMutex> guard(StateMutex);
-
         ForsetiMaxLogBatchNsCached = ForsetiMaxLogBatchNs;
         ForsetiOpPieceSizeCached = PDiskCategory.IsSolidState() ? ForsetiOpPieceSizeSsd : ForsetiOpPieceSizeRot;
         ForsetiOpPieceSizeCached = Min<i64>(ForsetiOpPieceSizeCached, Cfg->BufferPoolBufferSizeBytes);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.cpp
@@ -1139,7 +1139,7 @@ void TLogReader::Reply() {
             PDisk->Format.Offset(ChunkIdx + 1, 0)
         );
     }
-    P_LOG(PRI_DEBUG, BPD01, "Reply to owner", (OwnerId, (ui32)Owner), (Result, Result->ToString()));
+    P_LOG(PRI_NOTICE, BPD01, "Reply to owner", (OwnerId, (ui32)Owner), (Result, Result->ToString()));
     PCtx->ActorSystem->Send(ReplyTo, Result.Release());
     if (!IsInitial) {
         PDisk->Mon.LogRead.CountResponse(ResultSize);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.cpp
@@ -202,8 +202,8 @@ struct TLogReader::TSectorData {
         , PreparedSize(0)
         , IsScheduled(false)
     {
-      Y_VERIFY_S(buffer && dataSize <= buffer->Size(), "buffer has size less than log reader's sector, dataSize# "
-                     << dataSize << " bufferSize# " << (buffer ? (i64)buffer->Size() : -1));
+        Y_VERIFY_S(buffer && dataSize <= buffer->Size(), "buffer has size less than log reader's sector, dataSize# "
+                << dataSize << " bufferSize# " << (buffer ? (i64)buffer->Size() : -1));
     }
 
     TString ToString() {
@@ -255,15 +255,17 @@ struct TLogReader::TSectorData {
 };
 
 class TLogReader::TDoubleBuffer {
+    const ui64 PDiskSectorSize;
+    const ui32 BufferSizeSectors;
     THolder<TSectorData> SectorA;
     THolder<TSectorData> SectorB;
-    const ui64 PDiskSectorSize;
 
 public:
-    TDoubleBuffer(TPDisk *pdisk)
-        : SectorA(MakeHolder<TSectorData>(pdisk->BufferPool->Pop(), pdisk->Format.SectorSize * BufferSizeSectors))
-        , SectorB(MakeHolder<TSectorData>(pdisk->BufferPool->Pop(), pdisk->Format.SectorSize * BufferSizeSectors))
-        , PDiskSectorSize(pdisk->Format.SectorSize)
+    TDoubleBuffer(TPDisk *pdisk, ui32 bufferSizeSectors)
+        : PDiskSectorSize(pdisk->Format.SectorSize)
+        , BufferSizeSectors(bufferSizeSectors)
+        , SectorA(MakeHolder<TSectorData>(pdisk->BufferPool->Pop(), PDiskSectorSize * BufferSizeSectors))
+        , SectorB(MakeHolder<TSectorData>(pdisk->BufferPool->Pop(), PDiskSectorSize * BufferSizeSectors))
     {}
 
     ui64 BufferIdxFromOffset(ui64 innerOffset) const {
@@ -299,7 +301,8 @@ TLogReader::TLogReader(bool isInitial,TPDisk *pDisk, TActorSystem * const actorS
         NKikimrProto::ERROR, position, TLogPosition::Invalid(), false,
         pDisk->GetStatusFlags(owner, ownerGroupType), "", owner))
     , ChunkInfo(nullptr)
-    , Sector(new TDoubleBuffer(pDisk))
+    , BufferSizeSectors(pDisk->BufferPool->GetBufferSize() / pDisk->Format.SectorSize)
+    , Sector(new TDoubleBuffer(pDisk, BufferSizeSectors))
     , ChunkOwnerMap(IsInitial ? new TMap<ui32, TChunkState>() : nullptr)
     , State(ELogReaderState::PrepareToRead)
     , IsReplied(false)

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_logreader.h
@@ -47,8 +47,6 @@ struct TLogChunkItem {
 };
 
 class TLogReader : public TLogReaderBase {
-    static constexpr ui32 BufferSizeSectors = 105;
-
     struct TSectorData;
     class TDoubleBuffer;
 
@@ -72,6 +70,7 @@ class TLogReader : public TLogReaderBase {
     THolder<TEvReadLogResult> Result;
     TLogChunkInfo *ChunkInfo;
 
+    const ui32 BufferSizeSectors;
     THolder<TDoubleBuffer> Sector;
 
     THolder<TMap<ui32, TChunkState>> ChunkOwnerMap;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -697,7 +697,8 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
 
     Y_UNIT_TEST(DeviceHaltTooLong) {
         TActorTestContext testCtx({ false });
-        testCtx.TestCtx.SectorMap->ImitateRandomWait = {TDuration::Seconds(1), TDuration::Seconds(2)};
+        // testCtx.TestCtx.SectorMap->ImitateRandomWait = std::make_shared<std::pair<TDuration, TDuration>>(TDuration::Seconds(1), TDuration::Seconds(2));
+        testCtx.TestCtx.SectorMap->ImitateRandomWait = std::make_pair(TDuration::Seconds(1), TDuration::Seconds(2));
 
         TVDiskMock mock(&testCtx);
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_actions.cpp
@@ -172,7 +172,7 @@ void TTestIncorrectRequests::TestFSM(const TActorContext &ctx) {
     case 70:
         TEST_RESPONSE(EvChunkReadResult, ERROR);
         VERBOSE_COUT(" Sending TEvChunkRead");
-        ctx.Send(Yard, new NPDisk::TEvChunkRead(Owner, OwnerRound, 3, 100500, 128, 1, nullptr));
+        ctx.Send(Yard, new NPDisk::TEvChunkRead(Owner, OwnerRound, ChunkIdx0 + 1, 100500, 128, 1, nullptr));
         break;
     case 80:
     {
@@ -190,7 +190,7 @@ void TTestIncorrectRequests::TestFSM(const TActorContext &ctx) {
         TEST_RESPONSE(EvLogResult, ERROR);
         VERBOSE_COUT(" Sending TEvLog to commit");
         NPDisk::TCommitRecord commitRecord;
-        commitRecord.CommitChunks.push_back(3);
+        commitRecord.CommitChunks.push_back(ChunkIdx0 + 1);
         auto lsn = NextLsn();
         ctx.Send(Yard, new NPDisk::TEvLog(Owner, OwnerRound, 0, commitRecord, TRcBuf(), TLsnSeg(lsn, lsn),
                     (void*)43));
@@ -223,7 +223,7 @@ void TTestIncorrectRequests::TestFSM(const TActorContext &ctx) {
         TEST_RESPONSE(EvLogResult, ERROR);
         VERBOSE_COUT(" Sending TEvLog to commit");
         NPDisk::TCommitRecord commitRecord;
-        commitRecord.DeleteChunks.push_back(3);
+        commitRecord.DeleteChunks.push_back(ChunkIdx0 + 1);
         auto lsn = NextLsn();
         ctx.Send(Yard, new NPDisk::TEvLog(Owner, OwnerRound, 0, commitRecord, TRcBuf(), TLsnSeg(lsn, lsn),
                     (void*)43));

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
@@ -126,9 +126,7 @@ YARD_UNIT_TEST(TestLogWriteCutEqual) {
 YARD_UNIT_TEST(TestLogWriteCutEqualRandomWait) {
     for (int i = 0; i < 10; ++i) {
         TTestContext tc(false, true);
-        tc.SectorMap->ImitateRandomWait = {};
-        //tc.SectorMap->ImitateRandomWait = std::make_shared<std::pair<TDuration, TDuration>>(TDuration::MicroSeconds(500), TDuration::MicroSeconds(1000));
-        tc.SectorMap->ImitateRandomWait = std::make_pair(TDuration::MicroSeconds(500), TDuration::MicroSeconds(1000));
+        tc.SectorMap->ImitateRandomWait = {TDuration::MicroSeconds(500), TDuration::MicroSeconds(1000)};
         FillDeviceWithZeroes(&tc, MIN_CHUNK_SIZE);
         Run<TTestLogWriteCut<true>>(&tc, 2, MIN_CHUNK_SIZE);
         TTestLogWriteCut<true>::Reset();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
@@ -126,7 +126,9 @@ YARD_UNIT_TEST(TestLogWriteCutEqual) {
 YARD_UNIT_TEST(TestLogWriteCutEqualRandomWait) {
     for (int i = 0; i < 10; ++i) {
         TTestContext tc(false, true);
-        tc.SectorMap->ImitateRandomWait = {TDuration::MicroSeconds(500), TDuration::MicroSeconds(1000)};
+        tc.SectorMap->ImitateRandomWait = {};
+        //tc.SectorMap->ImitateRandomWait = std::make_shared<std::pair<TDuration, TDuration>>(TDuration::MicroSeconds(500), TDuration::MicroSeconds(1000));
+        tc.SectorMap->ImitateRandomWait = std::make_pair(TDuration::MicroSeconds(500), TDuration::MicroSeconds(1000));
         FillDeviceWithZeroes(&tc, MIN_CHUNK_SIZE);
         Run<TTestLogWriteCut<true>>(&tc, 2, MIN_CHUNK_SIZE);
         TTestLogWriteCut<true>::Reset();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

PDisk will choose different BufferPool sizes based on underlying device type - it's important for NVMe to have more buffers with less size

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

previous PR with bug - https://github.com/ydb-platform/ydb/pull/9764
