### PR TITLE
No newline in bazel cache password

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -149,7 +149,7 @@ runs:
       shell: bash
       run: |
         export BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
-        echo "${{ inputs.bazel_remote_password }}" > $BAZEL_REMOTE_PASSWORD_FILE
+        echo -n "${{ inputs.bazel_remote_password }}" > $BAZEL_REMOTE_PASSWORD_FILE
         echo "BAZEL_REMOTE_PASSWORD_FILE=$BAZEL_REMOTE_PASSWORD_FILE" >> $GITHUB_ENV
 
     - name: ya build and test


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Remove newline, because it is not a part of the password

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
