### PR TITLE
use `TTxControl` to commit transactions

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_table/impl/table_client.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/table_client.h
@@ -180,8 +180,8 @@ private:
         request.set_session_id(session.GetId());
         auto txControlProto = request.mutable_tx_control();
         txControlProto->set_commit_tx(txControl.CommitTx_);
-        if (txControl.TxId_) {
-            txControlProto->set_tx_id(*txControl.TxId_);
+        if (txControl.Tx_.Defined()) {
+            txControlProto->set_tx_id(txControl.Tx_->GetId());
         } else {
             SetTxSettings(txControl.BeginTx_, txControlProto->mutable_begin_tx());
         }

--- a/ydb/public/sdk/cpp/client/ydb_table/impl/table_client.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/table_client.h
@@ -176,7 +176,7 @@ private:
         const TTxControl& txControl, TParamsType params,
         const TExecDataQuerySettings& settings, bool fromCache
     ) {
-        if (!txControl.Tx_.Defined()) {
+        if (!txControl.Tx_.Defined() || !txControl.CommitTx_) {
             return ExecuteDataQueryInternal(session, query, txControl, params, settings, fromCache);
         }
 

--- a/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
@@ -9,10 +9,8 @@ TTransaction::TImpl::TImpl(const TSession& session, const TString& txId)
 {
 }
 
-TAsyncCommitTransactionResult TTransaction::TImpl::Commit(const TCommitTxSettings& settings)
+TAsyncStatus TTransaction::TImpl::Precommit() const
 {
-    ChangesAreAccepted = false;
-
     auto result = NThreading::MakeFuture(TStatus(EStatus::SUCCESS, {}));
 
     for (auto& callback : PrecommitCallbacks) {
@@ -26,6 +24,15 @@ TAsyncCommitTransactionResult TTransaction::TImpl::Commit(const TCommitTxSetting
 
         result = result.Apply(action);
     }
+
+    return result;
+}
+
+TAsyncCommitTransactionResult TTransaction::TImpl::Commit(const TCommitTxSettings& settings)
+{
+    ChangesAreAccepted = false;
+
+    auto result = Precommit();
 
     auto precommitsCompleted = [this, settings](const TAsyncStatus& result) mutable {
         if (const TStatus& status = result.GetValue(); !status.IsSuccess()) {

--- a/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.h
@@ -16,6 +16,7 @@ public:
         return !TxId_.empty();
     }
 
+    TAsyncStatus Precommit() const;
     TAsyncCommitTransactionResult Commit(const TCommitTxSettings& settings = TCommitTxSettings());
     TAsyncStatus Rollback(const TRollbackTxSettings& settings = TRollbackTxSettings());
 

--- a/ydb/public/sdk/cpp/client/ydb_table/table.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.cpp
@@ -2011,6 +2011,11 @@ bool TTransaction::IsActive() const
     return TransactionImpl_->IsActive();
 }
 
+TAsyncStatus TTransaction::Precommit() const
+{
+    return TransactionImpl_->Precommit();
+}
+
 TAsyncCommitTransactionResult TTransaction::Commit(const TCommitTxSettings& settings) {
     return TransactionImpl_->Commit(settings);
 }

--- a/ydb/public/sdk/cpp/client/ydb_table/table.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.cpp
@@ -1988,7 +1988,7 @@ const TString& TSession::GetId() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 TTxControl::TTxControl(const TTransaction& tx)
-    : TxId_(tx.GetId())
+    : Tx_(tx)
 {}
 
 TTxControl::TTxControl(const TTxSettings& begin)

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -1811,6 +1811,7 @@ public:
     const TString& GetId() const;
     bool IsActive() const;
 
+    TAsyncStatus Precommit() const;
     TAsyncCommitTransactionResult Commit(const TCommitTxSettings& settings = TCommitTxSettings());
     TAsyncStatus Rollback(const TRollbackTxSettings& settings = TRollbackTxSettings());
 

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -1274,30 +1274,7 @@ private:
     ETransactionMode Mode_;
 };
 
-class TTxControl {
-    friend class TTableClient;
-
-public:
-    using TSelf = TTxControl;
-
-    static TTxControl Tx(const TTransaction& tx) {
-        return TTxControl(tx);
-    }
-
-    static TTxControl BeginTx(const TTxSettings& settings = TTxSettings()) {
-        return TTxControl(settings);
-    }
-
-    FLUENT_SETTING_FLAG(CommitTx);
-
-private:
-    TTxControl(const TTransaction& tx);
-    TTxControl(const TTxSettings& begin);
-
-private:
-    TMaybe<TString> TxId_;
-    TTxSettings BeginTx_;
-};
+class TTxControl;
 
 enum class EAutoPartitioningPolicy {
     Disabled = 1,
@@ -1847,6 +1824,33 @@ private:
     class TImpl;
 
     std::shared_ptr<TImpl> TransactionImpl_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTxControl {
+    friend class TTableClient;
+
+public:
+    using TSelf = TTxControl;
+
+    static TTxControl Tx(const TTransaction& tx) {
+        return TTxControl(tx);
+    }
+
+    static TTxControl BeginTx(const TTxSettings& settings = TTxSettings()) {
+        return TTxControl(settings);
+    }
+
+    FLUENT_SETTING_FLAG(CommitTx);
+
+private:
+    TTxControl(const TTransaction& tx);
+    TTxControl(const TTxSettings& begin);
+
+private:
+    TMaybe<TTransaction> Tx_;
+    TTxSettings BeginTx_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -1811,7 +1811,6 @@ public:
     const TString& GetId() const;
     bool IsActive() const;
 
-    TAsyncStatus Precommit() const;
     TAsyncCommitTransactionResult Commit(const TCommitTxSettings& settings = TCommitTxSettings());
     TAsyncStatus Rollback(const TRollbackTxSettings& settings = TRollbackTxSettings());
 
@@ -1821,6 +1820,8 @@ public:
 
 private:
     TTransaction(const TSession& session, const TString& txId);
+
+    TAsyncStatus Precommit() const;
 
     class TImpl;
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -2189,6 +2189,29 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
     UNIT_ASSERT_VALUES_EQUAL(messages.size(), 100);
 }
 
+Y_UNIT_TEST_F(WriteToTopic_Demo_44, TFixture)
+{
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #1", &tx);
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID);
+
+    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx));
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 0);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #2", &tx);
+
+    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx).CommitTx(true));
+
+    messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
+}
+
 }
 
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -172,6 +172,8 @@ protected:
     void CheckTabletKeys(const TString& topicName);
     void DumpPQTabletKeys(const TString& topicName);
 
+    void ExecuteDataQuery(NTable::TSession session, const TString& query, const NTable::TTxControl& control);
+
 private:
     template<class E>
     E ReadEvent(TTopicReadSessionPtr reader, NTable::TTransaction& tx);
@@ -1535,6 +1537,12 @@ void TFixture::TestTheCompletionOfATransaction(const TTransactionCompletionTestD
     }
 }
 
+void TFixture::ExecuteDataQuery(NTable::TSession session, const TString& query, const NTable::TTxControl& control)
+{
+    auto status = session.ExecuteDataQuery(query, control).GetValueSync();
+    UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+}
+
 Y_UNIT_TEST_F(WriteToTopic_Demo_11, TFixture)
 {
     for (auto endOfTransaction : {Commit, Rollback, CloseTableSession}) {
@@ -2146,6 +2154,39 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_41, TFixture)
     CloseTopicWriteSession("topic_A", TEST_MESSAGE_GROUP_ID, true); // force close
 
     CommitTx(tx, EStatus::SESSION_EXPIRED);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_42, TFixture)
+{
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #1", &tx);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #2", &tx);
+
+    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx).CommitTx(true));
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
+{
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx).CommitTx(true));
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(60));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 100);
 }
 
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -2156,24 +2156,10 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_41, TFixture)
     CommitTx(tx, EStatus::SESSION_EXPIRED);
 }
 
-Y_UNIT_TEST_F(WriteToTopic_Demo_42, TFixture)
-{
-    CreateTopic("topic_A", TEST_CONSUMER);
-
-    NTable::TSession tableSession = CreateTableSession();
-    NTable::TTransaction tx = BeginTx(tableSession);
-
-    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #1", &tx);
-    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #2", &tx);
-
-    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx).CommitTx(true));
-
-    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
-    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
-}
-
 Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
 {
+    // The recording stream will run into a quota. Before the commit, the client will receive confirmations
+    // for some of the messages. The `ExecuteDataQuery` call will wait for the rest.
     CreateTopic("topic_A", TEST_CONSUMER);
 
     NTable::TSession tableSession = CreateTableSession();
@@ -2191,6 +2177,7 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
 
 Y_UNIT_TEST_F(WriteToTopic_Demo_44, TFixture)
 {
+    // the `ExecuteDataQuery` call waits if the `CommitTx` flag is set
     CreateTopic("topic_A", TEST_CONSUMER);
 
     NTable::TSession tableSession = CreateTableSession();

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -2156,6 +2156,25 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_41, TFixture)
     CommitTx(tx, EStatus::SESSION_EXPIRED);
 }
 
+Y_UNIT_TEST_F(WriteToTopic_Demo_42, TFixture)
+{
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    CloseTopicWriteSession("topic_A", TEST_MESSAGE_GROUP_ID); // gracefully close
+
+    CommitTx(tx, EStatus::SUCCESS);
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 100);
+}
+
 Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
 {
     // The recording stream will run into a quota. Before the commit, the client will receive confirmations

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -2194,30 +2194,6 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
     UNIT_ASSERT_VALUES_EQUAL(messages.size(), 100);
 }
 
-Y_UNIT_TEST_F(WriteToTopic_Demo_44, TFixture)
-{
-    // the `ExecuteDataQuery` call waits if the `CommitTx` flag is set
-    CreateTopic("topic_A", TEST_CONSUMER);
-
-    NTable::TSession tableSession = CreateTableSession();
-    NTable::TTransaction tx = BeginTx(tableSession);
-
-    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #1", &tx);
-    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID);
-
-    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx));
-
-    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
-    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 0);
-
-    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, "message #2", &tx);
-
-    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx).CommitTx(true));
-
-    messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
-    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
-}
-
 }
 
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -172,7 +172,7 @@ protected:
     void CheckTabletKeys(const TString& topicName);
     void DumpPQTabletKeys(const TString& topicName);
 
-    void ExecuteDataQuery(NTable::TSession session, const TString& query, const NTable::TTxControl& control);
+    NTable::TDataQueryResult ExecuteDataQuery(NTable::TSession session, const TString& query, const NTable::TTxControl& control);
 
 private:
     template<class E>
@@ -1537,10 +1537,11 @@ void TFixture::TestTheCompletionOfATransaction(const TTransactionCompletionTestD
     }
 }
 
-void TFixture::ExecuteDataQuery(NTable::TSession session, const TString& query, const NTable::TTxControl& control)
+NTable::TDataQueryResult TFixture::ExecuteDataQuery(NTable::TSession session, const TString& query, const NTable::TTxControl& control)
 {
     auto status = session.ExecuteDataQuery(query, control).GetValueSync();
     UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+    return status;
 }
 
 Y_UNIT_TEST_F(WriteToTopic_Demo_11, TFixture)
@@ -2191,6 +2192,31 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
     ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx).CommitTx(true));
 
     auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(60));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 100);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_44, TFixture)
+{
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+
+    auto result = ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::BeginTx());
+
+    NTable::TTransaction tx = *result.GetTransaction();
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID);
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(60));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 0);
+
+    ExecuteDataQuery(tableSession, "SELECT 2", NTable::TTxControl::Tx(tx).CommitTx(true));
+
+    messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(60));
     UNIT_ASSERT_VALUES_EQUAL(messages.size(), 100);
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

You can use `TTxControl` to commit a transaction. The SDK waits for the recording session to receive all ACKs for written messages.

### Changelog category <!-- remove all except one -->

* New feature
* Not for changelog (changelog entry is not required)

### Additional information

...
