### PR TITLE
24-2: Fix GetAliveChildren with filter by type

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4146,6 +4146,10 @@ ui64 TSchemeShard::GetAliveChildren(TPathElement::TPtr pathEl, const std::option
         Y_ABORT_UNLESS(PathsById.contains(pathId));
         auto childPath = PathsById.at(pathId);
 
+        if (childPath->Dropped()) {
+            continue;
+        }
+
         count += ui64(childPath->PathType == *type);
     }
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -667,6 +667,36 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         env.TestWaitNotification(runtime, {txId, txId - 1});
     }
 
+    Y_UNIT_TEST(CheckLimitWithDroppedIndex) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSchemeLimits lowLimits;
+        lowLimits.MaxTableIndices = 1;
+        SetSchemeshardSchemaLimits(runtime, lowLimits);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key"   Type: "Uint64" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "Index1", {"value"}, Ydb::StatusIds::SUCCESS);
+        env.TestWaitNotification(runtime, txId);
+
+        TestDropTableIndex(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            IndexName: "Index1"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", "Index2", {"value"}, Ydb::StatusIds::SUCCESS);
+        env.TestWaitNotification(runtime, txId);
+    }
+
     Y_UNIT_TEST(Lock) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Exclude dropped indexes from limits.

### Changelog category <!-- remove all except one -->

* Bugfix

### Additional information

...
