### PR TITLE
Implement different modes of Arrow memory tracking

### DIFF
--- a/ydb/core/formats/arrow/arrow_helpers.cpp
+++ b/ydb/core/formats/arrow/arrow_helpers.cpp
@@ -58,7 +58,7 @@ arrow::Result<std::shared_ptr<arrow::DataType>> GetArrowType(NScheme::TTypeInfo 
     if (success) {
         return result;
     }
-    
+
     return arrow::Status::TypeError("unsupported type ", NKikimr::NScheme::TypeName(typeInfo));
 }
 
@@ -223,14 +223,16 @@ std::shared_ptr<arrow::RecordBatch> ReallocateBatch(std::shared_ptr<arrow::Recor
     return DeserializeBatch(SerializeBatch(original, arrow::ipc::IpcWriteOptions::Defaults()), original->schema());
 }
 
-std::shared_ptr<arrow::Table> ReallocateBatch(const std::shared_ptr<arrow::Table>& original) {
+std::shared_ptr<arrow::Table> ReallocateBatch(const std::shared_ptr<arrow::Table>& original, arrow::MemoryPool* pool) {
     if (!original) {
         return original;
     }
+
     auto batches = NArrow::SliceToRecordBatches(original);
+
     for (auto&& i : batches) {
         i = NArrow::TStatusValidator::GetValid(
-            NArrow::NSerialization::TNativeSerializer().Deserialize(NArrow::NSerialization::TNativeSerializer().SerializeFull(i)));
+            NArrow::NSerialization::TNativeSerializer(pool).Deserialize(NArrow::NSerialization::TNativeSerializer(pool).SerializeFull(i)));
     }
     return NArrow::TStatusValidator::GetValid(arrow::Table::FromRecordBatches(batches));
 }

--- a/ydb/core/formats/arrow/arrow_helpers.h
+++ b/ydb/core/formats/arrow/arrow_helpers.h
@@ -41,6 +41,6 @@ void DedupSortedBatch(const std::shared_ptr<arrow::RecordBatch>& batch,
                        std::vector<std::shared_ptr<arrow::RecordBatch>>& out);
 
 std::shared_ptr<arrow::RecordBatch> ReallocateBatch(std::shared_ptr<arrow::RecordBatch> original);
-std::shared_ptr<arrow::Table> ReallocateBatch(const std::shared_ptr<arrow::Table>& original);
+std::shared_ptr<arrow::Table> ReallocateBatch(const std::shared_ptr<arrow::Table>& original, arrow::MemoryPool* pool = arrow::default_memory_pool());
 
 }

--- a/ydb/core/formats/arrow/serializer/native.cpp
+++ b/ydb/core/formats/arrow/serializer/native.cpp
@@ -19,6 +19,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> TNativeSerializer::DoDeserial
     arrow::ipc::DictionaryMemo dictMemo;
     auto options = arrow::ipc::IpcReadOptions::Defaults();
     options.use_threads = false;
+    options.memory_pool = Options.memory_pool;
 
     std::shared_ptr<arrow::Buffer> buffer(std::make_shared<TBufferOverString>(data));
     arrow::io::BufferReader readerStream(buffer);
@@ -61,6 +62,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> TNativeSerializer::DoDeserial
     arrow::ipc::DictionaryMemo dictMemo;
     auto options = arrow::ipc::IpcReadOptions::Defaults();
     options.use_threads = false;
+    options.memory_pool = Options.memory_pool;
 
     std::shared_ptr<arrow::Buffer> buffer(std::make_shared<TBufferOverString>(data));
     arrow::io::BufferReader reader(buffer);

--- a/ydb/core/formats/arrow/serializer/native.h
+++ b/ydb/core/formats/arrow/serializer/native.h
@@ -85,7 +85,11 @@ public:
     TNativeSerializer(const arrow::ipc::IpcWriteOptions& options = GetDefaultOptions())
         : Options(options) {
         Options.use_threads = false;
+    }
 
+    TNativeSerializer(arrow::MemoryPool* pool) {
+        Options.use_threads = false;
+        Options.memory_pool = pool;
     }
 };
 

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor.cpp
@@ -134,9 +134,11 @@ using namespace NYql::NDqProto;
 IActor* CreateKqpScanComputeActor(const TActorId& executerId, ui64 txId, TMaybe<ui64> lockTxId, ui32 lockNodeId,
     TDqTask* task, IDqAsyncIoFactory::TPtr asyncIoFactory,
     const NYql::NDq::TComputeRuntimeSettings& settings, const TComputeMemoryLimits& memoryLimits, NWilson::TTraceId traceId,
-    TIntrusivePtr<NActors::TProtoArenaHolder> arena, TComputeActorSchedulingOptions schedulingOptions) {
+    TIntrusivePtr<NActors::TProtoArenaHolder> arena, TComputeActorSchedulingOptions schedulingOptions,
+    NKikimrConfig::TTableServiceConfig::EBlockTrackingMode mode)
+{
     return new NScanPrivate::TKqpScanComputeActor(std::move(schedulingOptions), executerId, txId, lockTxId, lockNodeId, task, std::move(asyncIoFactory),
-        settings, memoryLimits, std::move(traceId), std::move(arena));
+        settings, memoryLimits, std::move(traceId), std::move(arena), mode);
 }
 
 IActor* CreateKqpScanFetcher(const NKikimrKqp::TKqpSnapshot& snapshot, std::vector<NActors::TActorId>&& computeActors,

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor.h
@@ -49,12 +49,13 @@ IActor* CreateKqpComputeActor(const TActorId& executerId, ui64 txId, NYql::NDqPr
     const NYql::NDq::TComputeRuntimeSettings& settings, const NYql::NDq::TComputeMemoryLimits& memoryLimits,
     NWilson::TTraceId traceId,
     TIntrusivePtr<NActors::TProtoArenaHolder> arena,
-    const std::optional<TKqpFederatedQuerySetup>& federatedQuerySetup, const TGUCSettings::TPtr& GUCSettings, TComputeActorSchedulingOptions);
+    const std::optional<TKqpFederatedQuerySetup>& federatedQuerySetup, const TGUCSettings::TPtr& GUCSettings,
+    TComputeActorSchedulingOptions, NKikimrConfig::TTableServiceConfig::EBlockTrackingMode);
 
 IActor* CreateKqpScanComputeActor(const TActorId& executerId, ui64 txId, TMaybe<ui64> lockTxId, ui32 lockNodeId,
     NYql::NDqProto::TDqTask* task, NYql::NDq::IDqAsyncIoFactory::TPtr asyncIoFactory,
     const NYql::NDq::TComputeRuntimeSettings& settings, const NYql::NDq::TComputeMemoryLimits& memoryLimits, NWilson::TTraceId traceId,
-    TIntrusivePtr<NActors::TProtoArenaHolder> arena, TComputeActorSchedulingOptions);
+    TIntrusivePtr<NActors::TProtoArenaHolder> arena, TComputeActorSchedulingOptions, NKikimrConfig::TTableServiceConfig::EBlockTrackingMode mode);
 
 IActor* CreateKqpScanFetcher(const NKikimrKqp::TKqpSnapshot& snapshot, std::vector<NActors::TActorId>&& computeActors,
     const NKikimrTxDataShard::TKqpTransaction::TScanTaskMeta& meta, const NYql::NDq::TComputeRuntimeSettings& settings,

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -213,7 +213,7 @@ public:
             IActor* computeActor = CreateKqpScanComputeActor(args.ExecuterId, args.TxId, args.LockTxId, args.LockNodeId, args.Task,
                 AsyncIoFactory, runtimeSettings, memoryLimits,
                 std::move(args.TraceId), std::move(args.Arena),
-                std::move(args.SchedulingOptions));
+                std::move(args.SchedulingOptions), args.BlockTrackingMode);
             TActorId result = TlsActivationContext->Register(computeActor);
             info.MutableActorIds().emplace_back(result);
             return result;
@@ -224,7 +224,7 @@ public:
             }
             IActor* computeActor = ::NKikimr::NKqp::CreateKqpComputeActor(args.ExecuterId, args.TxId, args.Task, AsyncIoFactory,
                 runtimeSettings, memoryLimits, std::move(args.TraceId), std::move(args.Arena), FederatedQuerySetup, GUCSettings,
-                std::move(args.SchedulingOptions));
+                std::move(args.SchedulingOptions), args.BlockTrackingMode);
             return args.ShareMailbox ? TlsActivationContext->AsActorContext().RegisterWithSameMailbox(computeActor) :
                 TlsActivationContext->AsActorContext().Register(computeActor);
         }

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.h
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.h
@@ -124,6 +124,7 @@ public:
         const TInstant& Deadline;
         const bool ShareMailbox;
         const TMaybe<NYql::NDqProto::TRlPath>& RlPath;
+        const NKikimrConfig::TTableServiceConfig::EBlockTrackingMode BlockTrackingMode;
 
         TComputeStagesWithScan* ComputesByStages = nullptr;
         std::shared_ptr<IKqpNodeState> State = nullptr;

--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.h
@@ -29,7 +29,7 @@ public:
         const TComputeRuntimeSettings& settings, const TComputeMemoryLimits& memoryLimits,
         NWilson::TTraceId traceId, TIntrusivePtr<NActors::TProtoArenaHolder> arena,
         const std::optional<TKqpFederatedQuerySetup>& federatedQuerySetup, const TGUCSettings::TPtr& GUCSettings,
-        TComputeActorSchedulingOptions);
+        TComputeActorSchedulingOptions, NKikimrConfig::TTableServiceConfig::EBlockTrackingMode mode);
 
     void DoBootstrap();
 
@@ -48,7 +48,7 @@ private:
 
 private:
     void HandleExecute(TEvKqpCompute::TEvScanInitActor::TPtr& ev);
-    
+
     void HandleExecute(TEvKqpCompute::TEvScanData::TPtr& ev);
 
     void HandleExecute(TEvKqpCompute::TEvScanError::TPtr& ev);
@@ -62,14 +62,8 @@ private:
     TActorId SysViewActorId;
     const TDqTaskRunnerParameterProvider ParameterProvider;
     const std::optional<TKqpFederatedQuerySetup> FederatedQuerySetup;
+    const NKikimrConfig::TTableServiceConfig::EBlockTrackingMode BlockTrackingMode;
 };
-
-IActor* CreateKqpComputeActor(const TActorId& executerId, ui64 txId, NDqProto::TDqTask* task,
-    IDqAsyncIoFactory::TPtr asyncIoFactory,
-    const TComputeRuntimeSettings& settings, const TComputeMemoryLimits& memoryLimits,
-    NWilson::TTraceId traceId, TIntrusivePtr<NActors::TProtoArenaHolder> arena,
-    const std::optional<TKqpFederatedQuerySetup>& federatedQuerySetup, const TGUCSettings::TPtr& GUCSettings,
-    TComputeActorSchedulingOptions);
 
 } // namespace NKqp
 } // namespace NKikimr

--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
@@ -62,6 +62,9 @@ private:
         return TBase::CalcMkqlMemoryLimit() + ComputeCtx.GetTableScans().size() * MemoryLimits.ChannelBufferSize;
     }
 
+    using EBlockTrackingMode = NKikimrConfig::TTableServiceConfig::EBlockTrackingMode;
+    const EBlockTrackingMode BlockTrackingMode;
+
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::KQP_SCAN_COMPUTE_ACTOR;
@@ -70,7 +73,7 @@ public:
     TKqpScanComputeActor(TComputeActorSchedulingOptions, const TActorId& executerId, ui64 txId, TMaybe<ui64> lockTxId, ui32 lockNodeId,
         NYql::NDqProto::TDqTask* task, NYql::NDq::IDqAsyncIoFactory::TPtr asyncIoFactory,
         const NYql::NDq::TComputeRuntimeSettings& settings, const NYql::NDq::TComputeMemoryLimits& memoryLimits, NWilson::TTraceId traceId,
-        TIntrusivePtr<NActors::TProtoArenaHolder> arena);
+        TIntrusivePtr<NActors::TProtoArenaHolder> arena, EBlockTrackingMode mode);
 
     STFUNC(StateFunc) {
         try {

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -92,6 +92,7 @@ TKqpPlanner::TKqpPlanner(TKqpPlanner::TArgs&& args)
     , MayRunTasksLocally(args.MayRunTasksLocally)
     , ResourceManager_(args.ResourceManager_)
     , CaFactory_(args.CaFactory_)
+    , BlockTrackingMode(args.BlockTrackingMode)
 {
     if (GUCSettings) {
         SerializedGUCSettings = GUCSettings->SerializeToString();
@@ -466,6 +467,7 @@ TString TKqpPlanner::ExecuteDataComputeTask(ui64 taskId, ui32 computeTasksSize) 
         .Deadline = Deadline,
         .ShareMailbox = (computeTasksSize <= 1),
         .RlPath = Nothing(),
+        .BlockTrackingMode = BlockTrackingMode
     });
 
     if (const auto* rmResult = std::get_if<NRm::TKqpRMAllocateResult>(&startResult)) {

--- a/ydb/core/kqp/executer_actor/kqp_planner.h
+++ b/ydb/core/kqp/executer_actor/kqp_planner.h
@@ -68,6 +68,7 @@ public:
         const bool MayRunTasksLocally = false;
         const std::shared_ptr<NKikimr::NKqp::NRm::IKqpResourceManager>& ResourceManager_;
         const std::shared_ptr<NKikimr::NKqp::NComputeActor::IKqpNodeComputeActorFactory>& CaFactory_;
+        const NKikimrConfig::TTableServiceConfig::EBlockTrackingMode BlockTrackingMode;
     };
 
     TKqpPlanner(TKqpPlanner::TArgs&& args);
@@ -144,6 +145,7 @@ private:
     std::shared_ptr<NKikimr::NKqp::NComputeActor::IKqpNodeComputeActorFactory> CaFactory_;
     TIntrusivePtr<NRm::TTxState> TxInfo;
     TVector<TProgressStat> LastStats;
+    const NKikimrConfig::TTableServiceConfig::EBlockTrackingMode BlockTrackingMode;
 
 public:
     static bool UseMockEmptyPlanner;  // for tests: if true then use TKqpMockEmptyPlanner that leads to the error

--- a/ydb/core/kqp/runtime/kqp_arrow_memory_pool.cpp
+++ b/ydb/core/kqp/runtime/kqp_arrow_memory_pool.cpp
@@ -1,0 +1,32 @@
+#include "kqp_arrow_memory_pool.h"
+
+#include <ydb/library/yql/minikql/mkql_alloc.h>
+
+#include <util/generic/yexception.h>
+
+namespace NKikimr::NMiniKQL {
+
+arrow::Status TArrowMemoryPool::Allocate(int64_t size, uint8_t** out) {
+    Y_ENSURE(size >= 0 && out);
+    *out = (uint8_t*)NMiniKQL::MKQLArrowAllocate(size);
+    UpdateAllocatedBytes(size);
+    return arrow::Status::OK();
+}
+
+arrow::Status TArrowMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
+    Y_ENSURE(old_size >= 0 && new_size >= 0 && ptr);
+    auto* res = NMiniKQL::MKQLArrowAllocate(new_size);
+    memcpy(res, *ptr, Min(old_size, new_size));
+    NMiniKQL::MKQLArrowFree(*ptr, old_size);
+    *ptr = (uint8_t*)res;
+    UpdateAllocatedBytes(new_size - old_size);
+    return arrow::Status::OK();
+}
+
+void TArrowMemoryPool::Free(uint8_t* buffer, int64_t size) {
+    Y_ENSURE(size >= 0);
+    NMiniKQL::MKQLArrowFree(buffer, size);
+    UpdateAllocatedBytes(-size);
+}
+
+} // namespace NKikimr::NMiniKQL

--- a/ydb/core/kqp/runtime/kqp_arrow_memory_pool.h
+++ b/ydb/core/kqp/runtime/kqp_arrow_memory_pool.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <util/generic/singleton.h>
+
+#include <arrow/memory_pool.h>
+
+namespace NKikimr::NMiniKQL {
+
+class TArrowMemoryPool : public arrow::MemoryPool {
+public:
+    arrow::Status Allocate(int64_t size, uint8_t** out) final;
+    arrow::Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) final;
+    void Free(uint8_t* buffer, int64_t size) final;
+
+    int64_t max_memory() const final {
+        return MaxMemory_.load();
+    }
+
+    int64_t bytes_allocated() const final {
+        return BytesAllocated_.load();
+    }
+
+    std::string backend_name() const final {
+        return "MKQL";
+    }
+
+private:
+    inline void UpdateAllocatedBytes(int64_t diff) {
+        // inspired by arrow/memory_pool.h impl.
+        int64_t allocated = BytesAllocated_.fetch_add(diff) + diff;
+        if (diff > 0 && allocated > MaxMemory_) {
+            MaxMemory_ = allocated;
+        }
+    }
+
+private:
+    std::atomic<int64_t> BytesAllocated_{0};
+    std::atomic<int64_t> MaxMemory_{0};
+};
+
+static inline arrow::MemoryPool* GetArrowMemoryPool() {
+    return Singleton<TArrowMemoryPool>();
+}
+
+} // namespace NKikimr::NMiniKQL

--- a/ydb/core/kqp/runtime/kqp_scan_data.h
+++ b/ydb/core/kqp/runtime/kqp_scan_data.h
@@ -97,14 +97,16 @@ public:
         AFL_VERIFY(Batch->num_rows());
     }
 
-    TBatchDataAccessor(const std::shared_ptr<arrow::Table>& batch, EBlockTrackingMode mode)
+    TBatchDataAccessor(const std::shared_ptr<arrow::Table>& batch,
+        EBlockTrackingMode mode = NKikimrConfig::TTableServiceConfig::BLOCK_TRACKING_NONE)
         : Batch(HandleBatch(mode, batch)) {
         AFL_VERIFY(Batch);
         AFL_VERIFY(Batch->num_rows());
 
     }
 
-    TBatchDataAccessor(const std::shared_ptr<arrow::RecordBatch>& batch, EBlockTrackingMode mode)
+    TBatchDataAccessor(const std::shared_ptr<arrow::RecordBatch>& batch,
+        EBlockTrackingMode mode = NKikimrConfig::TTableServiceConfig::BLOCK_TRACKING_NONE)
         : Batch(HandleBatch(mode, NArrow::TStatusValidator::GetValid(arrow::Table::FromRecordBatches({batch})))) {
         AFL_VERIFY(Batch);
         AFL_VERIFY(Batch->num_rows());

--- a/ydb/core/kqp/runtime/kqp_scan_data.h
+++ b/ydb/core/kqp/runtime/kqp_scan_data.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "kqp_arrow_memory_pool.h"
 #include "kqp_compute.h"
 #include "kqp_scan_data_meta.h"
 
@@ -8,6 +9,7 @@
 #include <ydb/core/engine/minikql/minikql_engine_host.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/permutations.h>
+#include <ydb/core/protos/table_service_config.pb.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 #include <ydb/core/tablet_flat/flat_database.h>
 
@@ -85,26 +87,40 @@ public:
         return DataIndexes.size() ? DataIndexes.size() : Batch->num_rows();
     }
 
-    TBatchDataAccessor(const std::shared_ptr<arrow::Table>& batch, std::vector<ui32>&& dataIndexes)
-        : Batch(batch)
+    using EBlockTrackingMode = NKikimrConfig::TTableServiceConfig::EBlockTrackingMode;
+
+    TBatchDataAccessor(const std::shared_ptr<arrow::Table>& batch, std::vector<ui32>&& dataIndexes, EBlockTrackingMode mode)
+        : Batch(HandleBatch(mode, batch))
         , DataIndexes(std::move(dataIndexes))
     {
         AFL_VERIFY(Batch);
         AFL_VERIFY(Batch->num_rows());
     }
 
-    TBatchDataAccessor(const std::shared_ptr<arrow::Table>& batch)
-        : Batch(batch) {
+    TBatchDataAccessor(const std::shared_ptr<arrow::Table>& batch, EBlockTrackingMode mode)
+        : Batch(HandleBatch(mode, batch)) {
         AFL_VERIFY(Batch);
         AFL_VERIFY(Batch->num_rows());
 
     }
 
-    TBatchDataAccessor(const std::shared_ptr<arrow::RecordBatch>& batch)
-        : Batch(NArrow::TStatusValidator::GetValid(arrow::Table::FromRecordBatches({batch}))) {
+    TBatchDataAccessor(const std::shared_ptr<arrow::RecordBatch>& batch, EBlockTrackingMode mode)
+        : Batch(HandleBatch(mode, NArrow::TStatusValidator::GetValid(arrow::Table::FromRecordBatches({batch})))) {
         AFL_VERIFY(Batch);
         AFL_VERIFY(Batch->num_rows());
 
+    }
+
+private:
+    static inline std::shared_ptr<arrow::Table> HandleBatch(EBlockTrackingMode mode, const std::shared_ptr<arrow::Table>& batch) {
+        switch(mode) {
+            case NKikimrConfig::TTableServiceConfig::BLOCK_TRACKING_NONE:
+                return batch;
+            case NKikimrConfig::TTableServiceConfig::BLOCK_TRACKING_DEEP_COPY:
+                return NArrow::DeepCopy(batch, GetArrowMemoryPool());
+            case NKikimrConfig::TTableServiceConfig::BLOCK_TRACKING_SERIALIZE:
+                return NArrow::ReallocateBatch(batch, GetArrowMemoryPool());
+        }
     }
 };
 

--- a/ydb/core/kqp/runtime/ya.make
+++ b/ydb/core/kqp/runtime/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    kqp_arrow_memory_pool.cpp
     kqp_compute.cpp
     kqp_effects.cpp
     kqp_output_stream.cpp

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -339,4 +339,12 @@ message TTableServiceConfig {
     }
 
     optional TWriteActorSettings WriteActorSettings = 72;
+
+    enum EBlockTrackingMode {
+        BLOCK_TRACKING_NONE      = 0;
+        BLOCK_TRACKING_SERIALIZE = 1;
+        BLOCK_TRACKING_DEEP_COPY = 2;
+    }
+
+    optional EBlockTrackingMode BlockTrackingMode = 73 [ default = BLOCK_TRACKING_SERIALIZE ];
 };

--- a/ydb/library/formats/arrow/arrow_helpers.cpp
+++ b/ydb/library/formats/arrow/arrow_helpers.cpp
@@ -804,4 +804,15 @@ std::vector<std::string> ConvertStrings(const std::vector<TString>& input) {
     return result;
 }
 
+std::shared_ptr<arrow::Table> DeepCopy(const std::shared_ptr<arrow::Table>& table, arrow::MemoryPool* pool) {
+    arrow::ArrayVector arrays;
+
+    for (const auto& column: table->columns()) {
+        auto&& array = TStatusValidator::GetValid(arrow::Concatenate(column->chunks(), pool));
+        arrays.push_back(std::move(array));
+    }
+
+    return arrow::Table::Make(table->schema(), arrays);
 }
+
+} // namespace NKikimr::NArrow

--- a/ydb/library/formats/arrow/arrow_helpers.h
+++ b/ydb/library/formats/arrow/arrow_helpers.h
@@ -98,4 +98,7 @@ NJson::TJsonValue DebugJson(std::shared_ptr<arrow::RecordBatch> array, const ui3
 std::shared_ptr<arrow::RecordBatch> Reorder(const std::shared_ptr<arrow::RecordBatch>& batch,
                                             const std::shared_ptr<arrow::UInt64Array>& permutation, const bool canRemove);
 
-}
+// Deep-copies all internal arrow::buffers - and makes sure that new buffers don't have any parents.
+std::shared_ptr<arrow::Table> DeepCopy(const std::shared_ptr<arrow::Table>& table, arrow::MemoryPool* pool = arrow::default_memory_pool());
+
+} // namespace NKikimr::NArrow


### PR DESCRIPTION
### Changelog entry

Enable 3 modes for Arrow memory tracking:
- serialization-deserialization (default)
- deep-copy
- no tracking

### Changelog category

* New feature

### Important note

Both memory tracking mechanisms may lead to occasional SEGFAULTs at the moment. DO NOT USE THEM IN PRODUCTION!