### PR TITLE
dqrun pq simulation: add queue limit

### DIFF
--- a/ydb/library/yql/providers/pq/gateway/dummy/yql_pq_file_topic_client.cpp
+++ b/ydb/library/yql/providers/pq/gateway/dummy/yql_pq_file_topic_client.cpp
@@ -16,7 +16,7 @@ public:
     }
     void Push(NYdb::NTopic::TReadSessionEvent::TEvent&& e, size_t rows) {
         with_lock(Mutex_) {
-            CanPush_.WaitI(Mutex_, [this] () {return Size_ < MaxSize_;});
+            CanPush_.WaitI(Mutex_, [this] () {return Stopped_ || Size_ < MaxSize_;});
             Events_.emplace_back(std::move(e), rows );
             Size_ += rows;
         }
@@ -52,6 +52,7 @@ public:
         with_lock(Mutex_) {
             Stopped_ = true;
             CanPop_.BroadCast();
+            CanPush_.BroadCast();
         }
     }
     


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Adds hardwired 4 MB limit for queued messages size

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
