### PR TITLE
Remove default decimal parameters in C++ SDK

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_value/value.h
+++ b/ydb/public/sdk/cpp/client/ydb_value/value.h
@@ -224,7 +224,7 @@ private:
 struct TDecimalValue {
     TString ToString() const;
     TDecimalValue(const Ydb::Value& decimalValueProto, const TDecimalType& decimalType);
-    TDecimalValue(const TString& decimalString, ui8 precision = 22, ui8 scale = 9);
+    TDecimalValue(const TString& decimalString, ui8 precision, ui8 scale);
 
     TDecimalType DecimalType_;
     ui64 Low_;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Now decimal type is parametrized so we can remove default parameters in SDK

### Changelog category <!-- remove all except one -->

### Additional information

...
