### PR TITLE
Remove yds from asan PR checks

### DIFF
--- a/ydb/tests/fq/yds/ya.make
+++ b/ydb/tests/fq/yds/ya.make
@@ -53,7 +53,7 @@ TEST_SRCS(
     test_yq_streaming.py
 )
 
-IF (SANITIZER_TYPE == "thread")
+IF (SANITIZER_TYPE)
     TIMEOUT(2400)
     SIZE(LARGE)
     TAG(ya:fat)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It takes ~10000 sec to execute, and @uzhastik  said there is no reason to run that tests with asan

LARGE tests are not ran in PR checks 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
