### PR TITLE
Stop generating legacy readset format in CopyTable

### DIFF
--- a/ydb/core/tx/datashard/build_scheme_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_scheme_tx_out_rs_unit.cpp
@@ -71,64 +71,55 @@ EExecutionStatus TBuildSchemeTxOutRSUnit::Execute(TOperation::TPtr op,
 
         Y_ABORT_UNLESS(snapBody, "Failed to make full borrow snap. w/o tx restarts");
 
-        TString rsBody;
-        bool extended = false;
-
         TRowVersion minVersion = TRowVersion(op->GetStep(), op->GetTxId()).Next();
         TRowVersion completeEdge = DataShard.GetSnapshotManager().GetCompleteEdge();
         TRowVersion incompleteEdge = DataShard.GetSnapshotManager().GetIncompleteEdge();
         TRowVersion immediateWriteEdge = DataShard.GetSnapshotManager().GetImmediateWriteEdge();
         TRowVersion lowWatermark = DataShard.GetSnapshotManager().GetLowWatermark();
 
-        if (minVersion || completeEdge || incompleteEdge || immediateWriteEdge || lowWatermark || txSnapshot->HasOpenTxs())
-            extended = true; // Must use an extended format
+        // New format, wrap in an additional protobuf layer
+        NKikimrTxDataShard::TSnapshotTransferReadSet rs;
 
-        if (extended) {
-            // New format, wrap in an additional protobuf layer
-            NKikimrTxDataShard::TSnapshotTransferReadSet rs;
+        // Use lz4 compression so snapshots use less bandwidth
+        TString compressedBody = NBlockCodecs::Codec("lz4fast")->Encode(snapBody);
 
-            // Use lz4 compression so snapshots use less bandwidth
-            TString compressedBody = NBlockCodecs::Codec("lz4fast")->Encode(snapBody);
+        // TODO: make it possible to send multiple tables
+        rs.SetBorrowedSnapshot(std::move(compressedBody));
 
-            // TODO: make it possible to send multiple tables
-            rs.SetBorrowedSnapshot(compressedBody);
-
-            if (minVersion) {
-                rs.SetMinWriteVersionStep(minVersion.Step);
-                rs.SetMinWriteVersionTxId(minVersion.TxId);
-            }
-
-            if (completeEdge) {
-                rs.SetMvccCompleteEdgeStep(completeEdge.Step);
-                rs.SetMvccCompleteEdgeTxId(completeEdge.TxId);
-            }
-
-            if (incompleteEdge) {
-                rs.SetMvccIncompleteEdgeStep(incompleteEdge.Step);
-                rs.SetMvccIncompleteEdgeTxId(incompleteEdge.TxId);
-            }
-
-            if (immediateWriteEdge) {
-                rs.SetMvccImmediateWriteEdgeStep(immediateWriteEdge.Step);
-                rs.SetMvccImmediateWriteEdgeTxId(immediateWriteEdge.TxId);
-            }
-
-            if (lowWatermark) {
-                rs.SetMvccLowWatermarkStep(lowWatermark.Step);
-                rs.SetMvccLowWatermarkTxId(lowWatermark.TxId);
-            }
-
-            if (txSnapshot->HasOpenTxs()) {
-                rs.SetWithOpenTxs(true);
-            }
-
-            rsBody.reserve(SnapshotTransferReadSetMagic.size() + rs.ByteSizeLong());
-            rsBody.append(SnapshotTransferReadSetMagic);
-            Y_PROTOBUF_SUPPRESS_NODISCARD rs.AppendToString(&rsBody);
-        } else {
-            // Legacy format, no additional protobuf layer
-            rsBody = snapBody;
+        if (minVersion) {
+            rs.SetMinWriteVersionStep(minVersion.Step);
+            rs.SetMinWriteVersionTxId(minVersion.TxId);
         }
+
+        if (completeEdge) {
+            rs.SetMvccCompleteEdgeStep(completeEdge.Step);
+            rs.SetMvccCompleteEdgeTxId(completeEdge.TxId);
+        }
+
+        if (incompleteEdge) {
+            rs.SetMvccIncompleteEdgeStep(incompleteEdge.Step);
+            rs.SetMvccIncompleteEdgeTxId(incompleteEdge.TxId);
+        }
+
+        if (immediateWriteEdge) {
+            rs.SetMvccImmediateWriteEdgeStep(immediateWriteEdge.Step);
+            rs.SetMvccImmediateWriteEdgeTxId(immediateWriteEdge.TxId);
+        }
+
+        if (lowWatermark) {
+            rs.SetMvccLowWatermarkStep(lowWatermark.Step);
+            rs.SetMvccLowWatermarkTxId(lowWatermark.TxId);
+        }
+
+        if (txSnapshot->HasOpenTxs()) {
+            rs.SetWithOpenTxs(true);
+        }
+
+        TString rsBody;
+        rsBody.reserve(SnapshotTransferReadSetMagic.size() + rs.ByteSizeLong());
+        rsBody.append(SnapshotTransferReadSetMagic);
+        bool ok = rs.AppendToString(&rsBody);
+        Y_ABORT_UNLESS(ok, "Failed to serialize schema readset");
 
         outReadSets[std::make_pair(srcTablet, targetTablet)] = rsBody;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Stop generating legacy readset format in CopyTable. DataShards have been able to parse the new format since 2019, it's time to unconditionally use the new format.