### PR TITLE
Temporarily fix data race in PDisk

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -2485,6 +2485,9 @@ void TPDisk::ProcessFastOperationsQueue() {
             case ERequestType::RequestPushUnformattedMetadataSector:
                 ProcessPushUnformattedMetadataSector(static_cast<TPushUnformattedMetadataSector&>(*req));
                 break;
+            case ERequestType::RequestContinueReadMetadata:
+                static_cast<TContinueReadMetadata&>(*req).Execute(PCtx->ActorSystem);
+                break;
             default:
                 Y_FAIL_S("Unexpected request type# " << (ui64)req->GetType());
                 break;
@@ -3078,6 +3081,7 @@ bool TPDisk::PreprocessRequest(TRequestBase *request) {
         case ERequestType::RequestPushUnformattedMetadataSector:
         case ERequestType::RequestReadMetadata:
         case ERequestType::RequestWriteMetadata:
+        case ERequestType::RequestContinueReadMetadata:
             break;
         case ERequestType::RequestStopDevice:
             BlockDevice->Stop();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_request_id.h
@@ -88,6 +88,7 @@ struct TReqId {
         WriteMetadata = 69,
         WriteMetadataResult = 70,
         PushUnformattedMetadataSector = 71,
+        ContinueReadMetadata = 72,
     };
 
     // 56 bit idx, 8 bit source
@@ -151,6 +152,7 @@ enum class ERequestType {
     RequestWriteMetadata,
     RequestWriteMetadataResult,
     RequestPushUnformattedMetadataSector,
+    RequestContinueReadMetadata,
 };
 
 inline IOutputStream& operator <<(IOutputStream& out, const TReqId& reqId) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
@@ -1095,5 +1095,27 @@ public:
     }
 };
 
+class TContinueReadMetadata : public TRequestBase {
+    std::function<void(bool, TActorSystem*)> Callback;
+
+public:
+    TContinueReadMetadata(std::function<void(bool, TActorSystem*)> callback, TAtomicBase reqIdx)
+        : TRequestBase({}, TReqId(TReqId::ContinueReadMetadata, reqIdx), OwnerSystem, 0, NPriInternal::Other)
+        , Callback(std::move(callback))
+    {}
+
+    ERequestType GetType() const override {
+        return ERequestType::RequestContinueReadMetadata;
+    }
+
+    void Execute(TActorSystem *actorSystem) {
+        Callback(true, actorSystem);
+    }
+
+    void Abort(TActorSystem *actorSystem) override {
+        Callback(false, actorSystem);
+    }
+};
+
 } // NPDisk
 } // NKikimr


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Temporarily fix data race in PDisk

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Temporary workaround to fix problem induced by BlockDevice operation from within PDisk completion thread.
