### PR TITLE
Limit reinserts in S3FIFO cache

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1094,6 +1094,7 @@ void TSharedCacheInitializer::InitializeServices(
     config->TotalScanQueueInFlyLimit = cfg.GetScanQueueInFlyLimit();
     config->ReplacementPolicy = cfg.GetReplacementPolicy();
     config->ActivePagesReservationPercent = cfg.GetActivePagesReservationPercent();
+    config->ReplacementPolicyReinsertsLimit = cfg.GetReplacementPolicyReinsertsLimit();
 
     TIntrusivePtr<::NMonitoring::TDynamicCounters> tabletGroup = GetServiceCounters(appData->Counters, "tablets");
     TIntrusivePtr<::NMonitoring::TDynamicCounters> sausageGroup = tabletGroup->GetSubgroup("type", "S_CACHE");

--- a/ydb/core/protos/shared_cache.proto
+++ b/ydb/core/protos/shared_cache.proto
@@ -14,4 +14,5 @@ message TSharedCacheConfig {
     reserved 5;
     optional TReplacementPolicy ReplacementPolicy = 6 [default = ThreeLeveledLRU];
     optional uint32 ReplacementPolicySwitchUniformDelaySeconds = 7 [default = 3600];
+    optional uint64 ReplacementPolicyReinsertsLimit = 8 [default = 20];
 }

--- a/ydb/core/tablet_flat/shared_cache_s3fifo.h
+++ b/ydb/core/tablet_flat/shared_cache_s3fifo.h
@@ -256,7 +256,7 @@ private:
                 if (ui32 frequency = TPageTraits::GetFrequency(page); frequency > 1 && reinserts < ReinsertsLimit) { // load inserts, first read touches, second read touches
                     Push(MainQueue, page);
                 } else {
-                    if (frequency > 0) { // used only once or reinserts limit exceeded
+                    if (frequency > 0) { // the page is used only once or reinserts limit exceeded
                         TPageTraits::SetFrequency(page, 0);
                     }
                     AddGhost(page);

--- a/ydb/core/tablet_flat/shared_cache_s3fifo.h
+++ b/ydb/core/tablet_flat/shared_cache_s3fifo.h
@@ -256,7 +256,7 @@ private:
                 if (ui32 frequency = TPageTraits::GetFrequency(page); frequency > 1 && reinserts < ReinsertsLimit) { // load inserts, first read touches, second read touches
                     Push(MainQueue, page);
                 } else {
-                    if (frequency) { // used only once or reinserts limit exceeded
+                    if (frequency > 0) { // used only once or reinserts limit exceeded
                         TPageTraits::SetFrequency(page, 0);
                     }
                     AddGhost(page);

--- a/ydb/core/tablet_flat/shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/shared_sausagecache.cpp
@@ -269,7 +269,8 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
 
         switch (Config->ReplacementPolicy) {
             case NKikimrSharedCache::S3FIFO:
-                return MakeHolder<TS3FIFOCache<TPage, TS3FIFOPageTraits>>(1);
+                // Note: ReplacementPolicyReinsertsLimit is a cold settings for now
+                return MakeHolder<TS3FIFOCache<TPage, TS3FIFOPageTraits>>(1, Config->ReplacementPolicyReinsertsLimit);
             case NKikimrSharedCache::ThreeLeveledLRU:
             default: {
                 TCacheCacheConfig cacheCacheConfig(1, Config->Counters->FreshBytes, Config->Counters->StagingBytes, Config->Counters->WarmBytes);

--- a/ydb/core/tablet_flat/shared_sausagecache.h
+++ b/ydb/core/tablet_flat/shared_sausagecache.h
@@ -62,6 +62,8 @@ struct TSharedPageCacheConfig {
     ui32 ActivePagesReservationPercent = 50;
 
     TReplacementPolicy ReplacementPolicy = TReplacementPolicy::ThreeLeveledLRU;
+
+    ui64 ReplacementPolicyReinsertsLimit = 20;
 };
 
 IActor* CreateSharedPageCache(THolder<TSharedPageCacheConfig> config);

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
@@ -340,7 +340,7 @@ Y_UNIT_TEST(S3FIFO) {
     }
     LogCounters(counters);
     UNIT_ASSERT_DOUBLES_EQUAL(counters->ActiveBytes->Val(), static_cast<i64>(8_MB), static_cast<i64>(1_MB / 3));
-    UNIT_ASSERT_VALUES_EQUAL(retried, (TVector<ui32>{100, 28}));
+    UNIT_ASSERT_VALUES_EQUAL(retried, (TVector<ui32>{100, 28, 1}));
 
     RestartAndClearCache(env);
 
@@ -383,7 +383,7 @@ Y_UNIT_TEST(S3FIFO) {
     }
     LogCounters(counters);
     UNIT_ASSERT_DOUBLES_EQUAL(counters->ActiveBytes->Val(), static_cast<i64>(8_MB), static_cast<i64>(1_MB / 3));
-    UNIT_ASSERT_VALUES_EQUAL(retried, (TVector<ui32>{100, 28}));
+    UNIT_ASSERT_VALUES_EQUAL(retried, (TVector<ui32>{100, 30}));
 }
 
 Y_UNIT_TEST(ReplacementPolicySwitch) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

As it was suggested in a [comment](https://github.com/ydb-platform/ydb/issues/8447#issuecomment-2346492512) and is done in [Otter](https://github.com/maypok86/otter/blob/5b6058fa936fd88334b351bb26c1d93f0168f537/internal/s3fifo/main.go#L56), apply limit on reinserts and make it configurable.

Btw, I'm not sure why in Otter it is only applied on the main queue, so I apply on both of them.

TODO: simplify ghost queue