### PR TITLE
Mute ydb/core/statistics/service/ut/ 1 tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -213,3 +213,4 @@ ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.CreateMultiplePqTablet
 ydb/tests/functional/serializable test.py.test_local
 ydb/core/blobstorage/ut_vdisk TBsVDiskGC.GCPutKeepBarrierSync
 ydb/core/blobstorage/ut_vdisk TBsVDiskManyPutGet.ManyPutRangeGetCompactionIndexOnly
+ydb/core/statistics/service/ut StatisticsService.ChildNodesShouldBeInvalidateByTimeout


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
ydb/core/statistics/service/ut StatisticsService.ChildNodesShouldBeInvalidateByTimeout
 Owner: [TEAM:@ydb-platform/datashard](https://github.com/orgs/ydb-platform/teams/datashard)

**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**

**Summary history:** in window 2024-10-02 
 Success rate **59.183673469387756%**
Pass:29 Fail:20 Mute:0 Skip:0

**Test run history:** [link](https://datalens.yandex/34xnbsom67hcq?full_name=__in_ydb/core/statistics/service/ut/StatisticsService.ChildNodesShouldBeInvalidateByTimeout)

More info in [dashboard](https://datalens.yandex/4un3zdm0zcnyr)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
