### PR TITLE
Mute ydb/core/kqp/ut/olap/ 4 tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -13,6 +13,10 @@ ydb/core/kqp/provider/ut KikimrIcGateway.TestLoadBasicSecretValueFromExternalDat
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.*
 ydb/core/kqp/ut/olap KqpOlapStatistics.StatsUsageWithTTL
 ydb/core/kqp/ut/olap KqpOlapSysView.StatsSysViewBytesDictStatActualization
+ydb/core/kqp/ut/olap KqpOlapAggregations.Aggregation_SumL_GroupL_OrderL
+ydb/core/kqp/ut/olap KqpOlapIndexes.IndexesActualization
+ydb/core/kqp/ut/olap KqpOlapIndexes.IndexesInBS
+ydb/core/kqp/ut/olap KqpOlapIndexes.IndexesInLocalMetadata
 ydb/core/kqp/ut/pg KqpPg.CreateIndex
 ydb/core/kqp/ut/query KqpLimits.QueryReplySize
 ydb/core/kqp/ut/query KqpQuery.QueryTimeout


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Mute:<!--mute_list_start-->
ydb/core/kqp/ut/olap/KqpOlapAggregations.Aggregation_SumL_GroupL_OrderL
ydb/core/kqp/ut/olap/KqpOlapIndexes.IndexesActualization
ydb/core/kqp/ut/olap/KqpOlapIndexes.IndexesInBS
ydb/core/kqp/ut/olap/KqpOlapIndexes.IndexesInLocalMetadata<!--mute_list_end-->

**Add line to [muted_ya.txt](https://github.com/ydb-platform/ydb/blob/main/.github/config/muted_ya.txt):**
```
ydb/core/kqp/ut/olap KqpOlapAggregations.Aggregation_SumL_GroupL_OrderL
ydb/core/kqp/ut/olap KqpOlapIndexes.IndexesActualization
ydb/core/kqp/ut/olap KqpOlapIndexes.IndexesInBS
ydb/core/kqp/ut/olap KqpOlapIndexes.IndexesInLocalMetadata
```

 Owner: [TEAM:@ydb-platform/qp](https://github.com/orgs/ydb-platform/teams/qp)

**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**

**Summary history:** in window 2024-10-02 
 Success rate **83.78378378378379%**
Pass:124 Fail:24 Mute:0 Skip:0

**Test run history:** [link](https://datalens.yandex/34xnbsom67hcq?full_name=__in_ydb/core/kqp/ut/olap/KqpOlapAggregations.Aggregation_SumL_GroupL_OrderL&full_name=__in_ydb/core/kqp/ut/olap/KqpOlapIndexes.IndexesActualization&full_name=__in_ydb/core/kqp/ut/olap/KqpOlapIndexes.IndexesInBS&full_name=__in_ydb/core/kqp/ut/olap/KqpOlapIndexes.IndexesInLocalMetadata)

More info in [dashboard](https://datalens.yandex/4un3zdm0zcnyr)

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
