### PR TITLE
Mute ydb/library/yql/providers/generic/connector/tests/join/ 1 tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -193,6 +193,7 @@ ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
 ydb/library/yql/tests/sql/hybrid_file/part1 test.py.test[in-in_noansi_join--Debug]
 ydb/core/kqp/ut/query KqpLimits.QueryExecTimeoutCancel
 ydb/library/yql/providers/generic/connector/tests/datasource/* *
+ydb/library/yql/providers/generic/connector/tests/join test.py.test_join[join_ch_ch-dqrun]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-1-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-2-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-3-True-3-fq_client0-mvp_external_ydb_endpoint0]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Mute:<!--mute_list_start-->
ydb/library/yql/providers/generic/connector/tests/join/test.py.test_join[join_ch_ch-dqrun]<!--mute_list_end-->

**Add line to [muted_ya.txt](https://github.com/ydb-platform/ydb/blob/main/.github/config/muted_ya.txt):**
```
ydb/library/yql/providers/generic/connector/tests/join test.py.test_join[join_ch_ch-dqrun]
```

 Owner: [TEAM:@ydb-platform/fq](https://github.com/orgs/ydb-platform/teams/fq)

**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**

**Summary history:** in window 2024-10-02 
 Success rate **87.17948717948718%**
Pass:34 Fail:5 Mute:0 Skip:0

**Test run history:** [link](https://datalens.yandex/34xnbsom67hcq?full_name=__in_ydb/library/yql/providers/generic/connector/tests/join/test.py.test_join[join_ch_ch-dqrun])

More info in [dashboard](https://datalens.yandex/4un3zdm0zcnyr)

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
