### PR TITLE
Fix mime type in build artifacts

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -135,7 +135,7 @@ runs:
             --cert-key "$TMP_DIR/key.pem" \
             --target-timeout 3,60 \
             --max-request-time 200 \
-            "$TESTMO_URL" > $PUBLIC_DIR/testmo_proxy.log 2>&1 &
+            "$TESTMO_URL" > $PUBLIC_DIR/testmo_proxy_log.txt 2>&1 &
             
           TESTMO_PROXY_PID=$!
           echo "TESTMO_PROXY_ADDR=$TESTMO_PROXY_ADDR" >> $GITHUB_ENV
@@ -162,8 +162,8 @@ runs:
         ORIGINAL_HEAD=$(git rev-parse HEAD)
         
         if [ "${{ inputs.increment }}" = "true" ]; then
-          GRAPH_COMPARE_OUTPUT="$PUBLIC_DIR/graph_compare.log"
-          GRAPH_COMPARE_OUTPUT_URL="$PUBLIC_DIR_URL/graph_compare.log"
+          GRAPH_COMPARE_OUTPUT="$PUBLIC_DIR/graph_compare_log.txt"
+          GRAPH_COMPARE_OUTPUT_URL="$PUBLIC_DIR_URL/graph_compare_log.txt"
 
           set +e
           ./.github/scripts/graph_compare.sh $ORIGINAL_HEAD~1 $ORIGINAL_HEAD |& tee $GRAPH_COMPARE_OUTPUT
@@ -307,8 +307,8 @@ runs:
 
         YA_MAKE_OUT_DIR=$TMP_DIR/out
 
-        YA_MAKE_OUTPUT="$PUBLIC_DIR/ya_make_output.log"
-        YA_MAKE_OUTPUT_URL="$PUBLIC_DIR_URL/ya_make_output.log"
+        YA_MAKE_OUTPUT="$PUBLIC_DIR/ya_make_output.txt"
+        YA_MAKE_OUTPUT_URL="$PUBLIC_DIR_URL/ya_make_output.txt"
         echo "20 [Ya make output]($YA_MAKE_OUTPUT_URL)" >> $SUMMARY_LINKS
 
         BUILD_FAILED=0
@@ -387,7 +387,7 @@ runs:
           CURRENT_REPORT=$CURRENT_PUBLIC_DIR/report.json
           set +e
           (./ya make $YA_MAKE_TARGET "${params[@]}" \
-            $RERUN_FAILED_OPT --log-file "$PUBLIC_DIR/ya_log.log"  \
+            $RERUN_FAILED_OPT --log-file "$PUBLIC_DIR/ya_log.txt"  \
             --evlog-file "$CURRENT_PUBLIC_DIR/ya_evlog.jsonl" \
             --junit "$CURRENT_JUNIT_XML_PATH" --build-results-report "$CURRENT_REPORT" --output "$YA_MAKE_OUT_DIR"; echo $? > exit_code) |& cat >> $YA_MAKE_OUTPUT
           set -e


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

After the following change
https://github.com/ydb-platform/ydb/pull/9948/files#diff-8e41dac1844247f16cc005544180c6c5e95e58cef2c60afe65a62a2058dc85daR459
`*.log` is treated as binary files in s3 storage

It is not handy because browser downloads it, instead of opening in a separate tab 

An example of "bad" behaviour: in https://github.com/ydb-platform/ydb/pull/10007#issuecomment-2389214035  

    Build failed, see the [logs](https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/11148552056/ya-x86-64/ya_make_output.log).
 
After click on `logs` link logs are not opening in a new tab 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
