### PR TITLE
Fix ListFromRange signatures in docs

### DIFF
--- a/ydb/docs/en/core/yql/reference/yql-core/builtins/_includes/list.md
+++ b/ydb/docs/en/core/yql/reference/yql-core/builtins/_includes/list.md
@@ -470,10 +470,13 @@ Specifics:
 
 * The end is not included, i.e. `ListFromRange(1,3) == AsList(1,2)`.
 * The type for the resulting elements is selected as the broadest from the argument types. For example, `ListFromRange(1, 2, 0.5)` results in a `Double` list.
+* If the start and the end is one of the date representing type, the step has to be `Interval`.
 * The list is "lazy", but if it's used incorrectly, it can still consume a lot of RAM.
 * If the step is positive and the end is less than or equal to the start, the result list is empty.
 * If the step is negative and the end is greater than or equal to the start, the result list is empty.
 * If the step is neither positive nor negative (0 or NaN), the result list is empty.
+* If any of the parameters is optional, the result list is optional.
+* If any of the parameters is `NULL`, the result is `NULL`.
 
 ### Examples
 
@@ -481,6 +484,13 @@ Specifics:
 SELECT
     ListFromRange(-2, 2), -- [-2, -1, 0, 1]
     ListFromRange(2, 1, -0.5); -- [2.0, 1.5]
+```
+
+### Signature
+
+```yql
+ListFromRange(T{Flags:AutoMap}, T{Flags:AutoMap}, T?)->LazyList<T> -- T — numeric type
+ListFromRange(T{Flags:AutoMap}, T{Flags:AutoMap}, I?)->LazyList<T> -- T — type, representing date/time, I — interval
 ```
 
 ## ListReplicate {#listreplicate}

--- a/ydb/docs/ru/core/yql/reference/yql-core/builtins/_includes/list.md
+++ b/ydb/docs/ru/core/yql/reference/yql-core/builtins/_includes/list.md
@@ -749,7 +749,8 @@ SELECT ListFromRange(Datetime("2022-05-23T15:30:00Z"), Datetime("2022-05-30T15:3
 ### Сигнатура
 
 ```yql
-ListFromRange(T, T)->LazyList<T> -- T - числовой тип или тип, представляющий дату/время
+ListFromRange(T{Flags:AutoMap}, T{Flags:AutoMap}, T?)->LazyList<T> -- T — числовой тип
+ListFromRange(T{Flags:AutoMap}, T{Flags:AutoMap}, I?)->LazyList<T> -- T — тип, представляющий дату/время, I — интервал
 ```
 
 ## ListReplicate {#listreplicate}


### PR DESCRIPTION
The reference for `ListFromRange` builtin is missing the signature for parameters being optional YQL type. This specialization is worth mentioning since in that case the optional type is propagated further to the `ListFromRange` resulting type.

### Changelog category

* Documentation