### PR TITLE
Revert "Mute ydb/core/statistics/service/ut/ 1 tests"

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -218,4 +218,3 @@ ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.CreateMultiplePqTablet
 ydb/tests/functional/serializable test.py.test_local
 ydb/core/blobstorage/ut_vdisk TBsVDiskGC.GCPutKeepBarrierSync
 ydb/core/blobstorage/ut_vdisk TBsVDiskManyPutGet.ManyPutRangeGetCompactionIndexOnly
-ydb/core/statistics/service/ut StatisticsService.ChildNodesShouldBeInvalidateByTimeout


### PR DESCRIPTION
### Changelog entry

This test has already been fixed in [PR](https://github.com/ydb-platform/ydb/pull/9953).
After the changes were made, there were no more falls. [Testmo](https://nebius.testmo.net/automation/runs/results/66519?group_id=21851616&test_id=1148429454&filter=eyJtb2RlIjoyLCJjb25kaXRpb25zIjp7ImF1dG9tYXRpb25fcnVuX3Rlc3RzOnRocmVhZF9pZCI6eyJ2YWx1ZXMiOls2MDY1MV19fX0)

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information


