### PR TITLE
Remove TTypeInfo from TRawTypeValue

### DIFF
--- a/ydb/core/engine/minikql/flat_local_tx_read_columns.h
+++ b/ydb/core/engine/minikql/flat_local_tx_read_columns.h
@@ -68,14 +68,14 @@ public:
         TSerializedCellVec fromKeyCells(Ev->Get()->Record.GetFromKey());
         keyFrom.clear();
         for (ui32 i = 0; i < fromKeyCells.GetCells().size(); ++i) {
-            keyFrom.push_back(TRawTypeValue(fromKeyCells.GetCells()[i].AsRef(), keyColumnTypes[i]));
+            keyFrom.push_back(TRawTypeValue(fromKeyCells.GetCells()[i].AsRef(), keyColumnTypes[i].GetTypeId()));
         }
         keyFrom.resize(tableInfo->KeyColumns.size());
 
         TSerializedCellVec toKeyCells(Ev->Get()->Record.GetToKey());
         keyTo.clear();
         for (ui32 i = 0; i < toKeyCells.GetCells().size(); ++i) {
-            keyTo.push_back(TRawTypeValue(toKeyCells.GetCells()[i].AsRef(), keyColumnTypes[i]));
+            keyTo.push_back(TRawTypeValue(toKeyCells.GetCells()[i].AsRef(), keyColumnTypes[i].GetTypeId()));
         }
 
         TVector<NTable::TTag> valueColumns;

--- a/ydb/core/engine/minikql/minikql_engine_host.cpp
+++ b/ydb/core/engine/minikql/minikql_engine_host.cpp
@@ -23,12 +23,12 @@ void ConvertTableKeys(const TScheme& scheme, const TScheme::TTableInfo* tableInf
     for (size_t keyIdx = 0; keyIdx < row.size(); keyIdx++) {
         const TCell& cell = row[keyIdx];
         ui32 keyCol = tableInfo->KeyColumns[keyIdx];
-        NScheme::TTypeInfo vtypeInfo = scheme.GetColumnInfo(tableInfo, keyCol)->PType;
+        NScheme::TTypeId vtypeId = scheme.GetColumnInfo(tableInfo, keyCol)->PType.GetTypeId();
         if (cell.IsNull()) {
             key.emplace_back();
             bytes += 1;
         } else {
-            key.emplace_back(cell.Data(), cell.Size(), vtypeInfo);
+            key.emplace_back(cell.Data(), cell.Size(), vtypeId);
             bytes += cell.Size();
         }
     }
@@ -42,8 +42,8 @@ void ConvertTableValues(const TScheme& scheme, const TScheme::TTableInfo* tableI
     for (size_t i = 0; i < commands.size(); i++) {
         const IEngineFlatHost::TUpdateCommand& upd = commands[i];
         Y_ABORT_UNLESS(upd.Operation == TKeyDesc::EColumnOperation::Set);
-        auto vtypeinfo = scheme.GetColumnInfo(tableInfo, upd.Column)->PType;
-        ops.emplace_back(upd.Column, NTable::ECellOp::Set, upd.Value.IsNull() ? TRawTypeValue() : TRawTypeValue(upd.Value.Data(), upd.Value.Size(), vtypeinfo));
+        NScheme::TTypeId vtypeId = scheme.GetColumnInfo(tableInfo, upd.Column)->PType.GetTypeId();
+        ops.emplace_back(upd.Column, NTable::ECellOp::Set, upd.Value.IsNull() ? TRawTypeValue() : TRawTypeValue(upd.Value.Data(), upd.Value.Size(), vtypeId));
         bytes += upd.Value.IsNull() ? 1 : upd.Value.Size();
     }
     if (valueBytes)

--- a/ydb/core/grpc_services/rpc_read_columns.cpp
+++ b/ydb/core/grpc_services/rpc_read_columns.cpp
@@ -513,8 +513,8 @@ private:
 
         for (size_t i = 0; i < cells.size(); ++i) {
             if (!cells[i].IsNull() &&
-                NScheme::GetFixedSize(types[i].GetTypeId()) != 0 &&
-                NScheme::GetFixedSize(types[i].GetTypeId()) != cells[i].Size())
+                NScheme::GetFixedSize(types[i]) != 0 &&
+                NScheme::GetFixedSize(types[i]) != cells[i].Size())
             {
                 return false;
             }

--- a/ydb/core/grpc_services/rpc_read_columns.cpp
+++ b/ydb/core/grpc_services/rpc_read_columns.cpp
@@ -513,8 +513,8 @@ private:
 
         for (size_t i = 0; i < cells.size(); ++i) {
             if (!cells[i].IsNull() &&
-                NScheme::GetFixedSize(types[i]) != 0 &&
-                NScheme::GetFixedSize(types[i]) != cells[i].Size())
+                NScheme::GetFixedSize(types[i].GetTypeId()) != 0 &&
+                NScheme::GetFixedSize(types[i].GetTypeId()) != cells[i].Size())
             {
                 return false;
             }

--- a/ydb/core/scheme/scheme_tablecell.h
+++ b/ydb/core/scheme/scheme_tablecell.h
@@ -196,7 +196,7 @@ inline int CompareCellsAsByteString(const TCell& a, const TCell& b, bool isDesce
 
 // NULL is considered equal to another NULL and less than non-NULL
 // ATTENTION!!! return value is int!! (NOT just -1,0,1)
-inline int CompareTypedCells(const TCell& a, const TCell& b, NScheme::TTypeInfoOrder type) {
+inline int CompareTypedCells(const TCell& a, const TCell& b, const NScheme::TTypeInfoOrder& type) {
     using TPair = std::pair<ui64, ui64>;
     if (a.IsNull())
         return b.IsNull() ? 0 : -1;

--- a/ydb/core/scheme/scheme_types_defs.cpp
+++ b/ydb/core/scheme/scheme_types_defs.cpp
@@ -31,7 +31,7 @@ namespace NNames {
         ::TString result;
 
         if (value) {
-            const ui32 fixedSize = GetFixedSize(typeInfo.GetTypeId());
+            const ui32 fixedSize = GetFixedSize(typeInfo);
             if (fixedSize > 0 && value.Size() != fixedSize) {
                 result = ::TStringBuilder()
                     << "Cell with declared type " << NScheme::TypeName(typeInfo)

--- a/ydb/core/scheme/scheme_types_defs.cpp
+++ b/ydb/core/scheme/scheme_types_defs.cpp
@@ -15,10 +15,10 @@ namespace NNames {
         ::TString result;
 
         if (value) {
-            const ui32 fixedSize = GetFixedSize(value.TypeInfo());
+            const ui32 fixedSize = GetFixedSize(value.Type());
             if (fixedSize > 0 && value.Size() != fixedSize) {
                 result = ::TStringBuilder()
-                    << "Value with declared type " << NScheme::TypeName(value.TypeInfo())
+                    << "Value with declared type " << NScheme::TypeName(value.Type())
                     << " has unexpected size " << value.Size()
                     << " (expected " << fixedSize << ")";
             }
@@ -27,11 +27,11 @@ namespace NNames {
         return result;
     }
 
-    ::TString HasUnexpectedValueSize(const ::NKikimr::TCell& value, TTypeInfo typeInfo) {
+    ::TString HasUnexpectedValueSize(const ::NKikimr::TCell& value, const TTypeInfo& typeInfo) {
         ::TString result;
 
         if (value) {
-            const ui32 fixedSize = GetFixedSize(typeInfo);
+            const ui32 fixedSize = GetFixedSize(typeInfo.GetTypeId());
             if (fixedSize > 0 && value.Size() != fixedSize) {
                 result = ::TStringBuilder()
                     << "Cell with declared type " << NScheme::TypeName(typeInfo)

--- a/ydb/core/scheme/scheme_types_defs.h
+++ b/ydb/core/scheme/scheme_types_defs.h
@@ -54,13 +54,15 @@ class TStepOrderId : public IIntegerPair<ui64, ui64, NTypeIds::StepOrderId, NNam
 
 ////////////////////////////////////////////////////////
 
-inline ui32 GetFixedSize(TTypeInfo typeInfo) {
-    switch (typeInfo.GetTypeId()) {
+inline ui32 GetFixedSize(TTypeId typeId) {
+    switch (typeId) {
 #define KIKIMR_TYPE_MACRO(typeEnum, typeType, ...) case NTypeIds::typeEnum: return typeType::GetFixedSize();
     KIKIMR_FOREACH_TYPE(KIKIMR_TYPE_MACRO)
 #undef KIKIMR_TYPE_MACRO
     case NTypeIds::Pg:
-        return NPg::TypeDescGetStoredSize(typeInfo.GetPgTypeDesc());
+        // We can't get fixed size for Pg
+        // Redo log (NTable::NRedo::TValue) doesn't contain pg type descriptor
+        return 0;
     default:
         return 0;
     }
@@ -78,7 +80,7 @@ inline ui32 GetFixedSize(TTypeInfo typeInfo) {
  * 
  * Returns empty string on success or an error description in case of failure
  */
-::TString HasUnexpectedValueSize(const ::NKikimr::TCell& value, TTypeInfo typeInfo);
+::TString HasUnexpectedValueSize(const ::NKikimr::TCell& value, const TTypeInfo& typeInfo);
 
 } // namespace NScheme
 } // namespace NKikimr

--- a/ydb/core/scheme/scheme_types_defs.h
+++ b/ydb/core/scheme/scheme_types_defs.h
@@ -59,10 +59,18 @@ inline ui32 GetFixedSize(TTypeId typeId) {
 #define KIKIMR_TYPE_MACRO(typeEnum, typeType, ...) case NTypeIds::typeEnum: return typeType::GetFixedSize();
     KIKIMR_FOREACH_TYPE(KIKIMR_TYPE_MACRO)
 #undef KIKIMR_TYPE_MACRO
-    case NTypeIds::Pg:
-        // We can't get fixed size for Pg
-        // Redo log (NTable::NRedo::TValue) doesn't contain pg type descriptor
+    default:
         return 0;
+    }
+}
+
+inline ui32 GetFixedSize(const TTypeInfo& typeInfo) {
+    switch (typeInfo.GetTypeId()) {
+#define KIKIMR_TYPE_MACRO(typeEnum, typeType, ...) case NTypeIds::typeEnum: return typeType::GetFixedSize();
+    KIKIMR_FOREACH_TYPE(KIKIMR_TYPE_MACRO)
+#undef KIKIMR_TYPE_MACRO
+    case NTypeIds::Pg:
+        return NPg::TypeDescGetStoredSize(typeInfo.GetPgTypeDesc());
     default:
         return 0;
     }

--- a/ydb/core/scheme_types/scheme_raw_type_value.h
+++ b/ydb/core/scheme_types/scheme_raw_type_value.h
@@ -17,22 +17,21 @@ public:
         , ValueType()
     {}
 
-    TRawTypeValue(const void* buf, ui32 bufSize, NScheme::TTypeInfo vtype)
+    TRawTypeValue(const void* buf, ui32 bufSize, NScheme::TTypeId vtype)
         : Buffer(buf)
         , BufferSize(bufSize)
         , ValueType(vtype)
     {
-        Y_DEBUG_ABORT_UNLESS(!buf || vtype.GetTypeId() != 0);
+        Y_DEBUG_ABORT_UNLESS(!buf || vtype != 0);
     }
 
-    TRawTypeValue(TArrayRef<const char> ref, NScheme::TTypeInfo vtype)
+    TRawTypeValue(TArrayRef<const char> ref, NScheme::TTypeId vtype)
         : TRawTypeValue((void*)ref.data(), ref.size(), vtype)
     {}
 
     const void* Data() const { return Buffer; }
     ui32 Size() const { return BufferSize; }
-    NScheme::TTypeId Type() const { return ValueType.GetTypeId(); }
-    NScheme::TTypeInfo TypeInfo() const { return ValueType; }
+    NScheme::TTypeId Type() const { return ValueType; }
 
     // we must distinguish empty raw type value (nothing, buffer == nullptr)
     // and zero-length string (value exists, but zero-length)
@@ -41,7 +40,7 @@ public:
 
     TString ToString() const {
         TStringBuilder builder;
-        builder << "(type:" << ValueType.GetTypeId();
+        builder << "(type:" << ValueType;
         if (!IsEmpty()) {
             builder << ", value:" << TString((const char*)Buffer, BufferSize).Quote();
         }
@@ -60,7 +59,7 @@ public:
 private:
     const void* Buffer;
     ui32 BufferSize;
-    NScheme::TTypeInfo ValueType;
+    NScheme::TTypeId ValueType;
 };
 
 } // namspace NKikimr

--- a/ydb/core/scheme_types/scheme_types_defs.h
+++ b/ydb/core/scheme_types/scheme_types_defs.h
@@ -49,7 +49,7 @@ public:
     }
     TTypeId GetTypeId() const override { return TypeId; }
     static TRawTypeValue ToRawTypeValue(const T& value) {
-        return TRawTypeValue((void*)&value, sizeof(T), TTypeInfo(TypeId));
+        return TRawTypeValue((void*)&value, sizeof(T), TypeId);
     }
 
     static const char* TypeName() {
@@ -166,7 +166,7 @@ public:
     }
 
     static TRawTypeValue ToRawTypeValue(const ::TString& value) {
-        return TRawTypeValue((const void*)value.data(), value.size(), TTypeInfo(TypeId));
+        return TRawTypeValue((const void*)value.data(), value.size(), TypeId);
     }
 };
 
@@ -213,7 +213,7 @@ public:
 
     static TRawTypeValue ToRawTypeValue(const ::TString& value) {
         Y_ABORT_UNLESS(value.size() <= MaxSize);
-        return TRawTypeValue((const void*)value.data(), value.size(), TTypeInfo(TypeId));
+        return TRawTypeValue((const void*)value.data(), value.size(), TypeId);
     }
 };
 

--- a/ydb/core/tablet_flat/flat_cxx_database.h
+++ b/ydb/core/tablet_flat/flat_cxx_database.h
@@ -25,64 +25,64 @@ public:
     {}
 
     TTypeValue(const ui64& value, NScheme::TTypeId type = NScheme::NTypeIds::Uint64)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const i64& value, NScheme::TTypeId type = NScheme::NTypeIds::Int64)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const ui32& value, NScheme::TTypeId type = NScheme::NTypeIds::Uint32)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const i32& value, NScheme::TTypeId type = NScheme::NTypeIds::Int32)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const ui16& value, NScheme::TTypeId type = NScheme::NTypeIds::Date)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const ui8& value, NScheme::TTypeId type = NScheme::NTypeIds::Byte)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const bool& value, NScheme::TTypeId type = NScheme::NTypeIds::Bool)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const double& value, NScheme::TTypeId type = NScheme::NTypeIds::Double)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     template <typename ElementType>
     TTypeValue(const TVector<ElementType> &value, NScheme::TTypeId type = NScheme::NTypeIds::String)
-        : TRawTypeValue(value.empty() ? (const ElementType*)0xDEADBEEFDEADBEEF : value.data(), value.size() * sizeof(ElementType), NScheme::TTypeInfo(type))
+        : TRawTypeValue(value.empty() ? (const ElementType*)0xDEADBEEFDEADBEEF : value.data(), value.size() * sizeof(ElementType), type)
     {}
 
     TTypeValue(const TActorId& value, NScheme::TTypeId type = NScheme::NTypeIds::ActorId)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const std::pair<ui64, ui64>& value, NScheme::TTypeId type = NScheme::NTypeIds::PairUi64Ui64)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const std::pair<ui64, i64>& value, NScheme::TTypeId type = NScheme::NTypeIds::Decimal)
-        : TRawTypeValue(&value, sizeof(value), NScheme::TTypeInfo(type))
+        : TRawTypeValue(&value, sizeof(value), type)
     {}
 
     TTypeValue(const TString& value, NScheme::TTypeId type = NScheme::NTypeIds::Utf8)
-        : TRawTypeValue(value.data(), value.size(), NScheme::TTypeInfo(type))
+        : TRawTypeValue(value.data(), value.size(), type)
     {}
 
     TTypeValue(const TBuffer& value, NScheme::TTypeId type = NScheme::NTypeIds::String)
-        : TRawTypeValue(value.Empty() ? (const char*)0xDEADBEEFDEADBEEF : value.Data(), value.Size(), NScheme::TTypeInfo(type))
+        : TRawTypeValue(value.Empty() ? (const char*)0xDEADBEEFDEADBEEF : value.Data(), value.Size(), type)
     {}
 
     TTypeValue(const TStringBuf& value, NScheme::TTypeId type = NScheme::NTypeIds::String)
-        : TRawTypeValue(value.empty() ? (const char*)0xDEADBEEFDEADBEEF : value.data(), value.size(), NScheme::TTypeInfo(type))
+        : TRawTypeValue(value.empty() ? (const char*)0xDEADBEEFDEADBEEF : value.data(), value.size(), type)
     {}
 
     explicit TTypeValue(const TRawTypeValue& rawTypeValue)
@@ -244,7 +244,7 @@ template <NScheme::TTypeId ValType>
 class TConvertTypeValue : public TRawTypeValue {
 public:
     TConvertTypeValue(const TRawTypeValue& value)
-        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? NScheme::TTypeInfo() : NScheme::TTypeInfo(ValType))
+        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? 0 : ValType)
     {}
 
     template <typename ValueType> static typename NSchemeTypeMapper<ValType>::Type ConvertFrom(ValueType value) {
@@ -257,7 +257,7 @@ template <>
 class TConvertTypeValue<NScheme::NTypeIds::String> : public TRawTypeValue {
 public:
     TConvertTypeValue(const TRawTypeValue& value)
-        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? NScheme::TTypeInfo() : NScheme::TTypeInfo(NScheme::NTypeIds::String))
+        : TRawTypeValue(value.Data(), value.Size(), value.IsEmpty() ? 0 : NScheme::NTypeIds::String)
     {}
 
     static typename NSchemeTypeMapper<NScheme::NTypeIds::String>::Type ConvertFrom(const TString& value) {
@@ -530,7 +530,7 @@ struct TConvertValue<TColumnType, TRawTypeValue, TStringBuf> {
     TRawTypeValue Value;
 
     TConvertValue(TStringBuf value)
-        : Value(value.data(), value.size(), NScheme::TTypeInfo(TColumnType::ColumnType))
+        : Value(value.data(), value.size(), TColumnType::ColumnType)
     {
         static_assert(TColumnType::ColumnType == NScheme::NTypeIds::String
                       || TColumnType::ColumnType == NScheme::NTypeIds::Utf8,
@@ -1494,7 +1494,7 @@ struct Schema {
                     auto type = tuple.Types[index];
                     if (cell.IsNull())
                         return GetNullValue<ColumnType>();
-                    return TConvert<ColumnType, typename ColumnType::Type>::Convert(TRawTypeValue(cell.Data(), cell.Size(), type));
+                    return TConvert<ColumnType, typename ColumnType::Type>::Convert(TRawTypeValue(cell.Data(), cell.Size(), type.GetTypeId()));
                 }
 
                 KeyIterator Iterator;

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -323,7 +323,7 @@ void TDatabase::Update(ui32 table, ERowOp rop, TRawVals key, TArrayRef<const TUp
             if (auto got = annex->Place(table, op.Tag, raw)) {
                 ModifiedRefs[index] = got.Ref;
                 const auto payload = NUtil::NBin::ToRef(ModifiedRefs[index]);
-                op.Value = TRawTypeValue(payload, NScheme::TTypeInfo(op.Value.Type()));
+                op.Value = TRawTypeValue(payload, op.Value.Type());
                 op.Op = ELargeObj::Extern;
             }
         }

--- a/ydb/core/tablet_flat/flat_executor_db_mon.cpp
+++ b/ydb/core/tablet_flat/flat_executor_db_mon.cpp
@@ -86,7 +86,7 @@ public:
                                 vals.emplace_back();
                                 TBuffer& buf = vals.back();
                                 buf.Assign(reinterpret_cast<const char*>(&v), sizeof(v));
-                                key.emplace_back(buf.Data(), buf.Size(), NScheme::TTypeInfo(type));
+                                key.emplace_back(buf.Data(), buf.Size(), type);
                                 break;
                             }
                             case NScheme::NTypeIds::Uint64:
@@ -95,7 +95,7 @@ public:
                                 vals.emplace_back();
                                 TBuffer& buf = vals.back();
                                 buf.Assign(reinterpret_cast<const char*>(&v), sizeof(v));
-                                key.emplace_back(buf.Data(), buf.Size(), NScheme::TTypeInfo(type));
+                                key.emplace_back(buf.Data(), buf.Size(), type);
                                 break;
                             }
                             case NScheme::NTypeIds::String:
@@ -104,7 +104,7 @@ public:
                                 vals.emplace_back();
                                 TBuffer& buf = vals.back();
                                 buf.Assign(val.data(), val.size());
-                                key.emplace_back(buf.Data(), buf.Size(), NScheme::TTypeInfo(type));
+                                key.emplace_back(buf.Data(), buf.Size(), type);
                                 break;
                             }
                             default:

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -695,7 +695,7 @@ Y_UNIT_TEST_SUITE(TFlatTableReschedule) {
                 TVector<NTable::TTag> tags;
                 tags.push_back(TRowsModel::ColumnValueId);
                 TVector<TRawTypeValue> key;
-                key.emplace_back(&keyId, sizeof(keyId), NScheme::TTypeInfo(NScheme::TInt64::TypeId));
+                key.emplace_back(&keyId, sizeof(keyId), NScheme::TInt64::TypeId);
                 NTable::TRowState row;
                 auto ready = txc.DB.Select(TRowsModel::TableId, key, tags, row);
                 if (ready == NTable::EReady::Page) {
@@ -1347,7 +1347,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorResourceProfile) {
             if (!req.Keys.empty()) {
                 for (auto val : req.Keys) {
                     ui64 key1 = val;
-                    TRawTypeValue key[] = {TRawTypeValue(&key1, sizeof(key1), NScheme::TTypeInfo(NScheme::NTypeIds::Int64))};
+                    TRawTypeValue key[] = {TRawTypeValue(&key1, sizeof(key1), NScheme::NTypeIds::Int64)};
                     NTable::TTag tags[] = {TRowsModel::ColumnKeyId};
                     NTable::TRowState row;
                     txc.DB.Select(TRowsModel::TableId, {key, 1}, {tags, 1}, row);
@@ -2048,7 +2048,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorCompressedSelectRows) {
             TVector<NTable::TTag> tags;
             tags.push_back(TRowsModel::ColumnValueId);
             TVector<TRawTypeValue> key;
-            key.emplace_back(&keyId, sizeof(keyId), NScheme::TTypeInfo(NScheme::TInt64::TypeId));
+            key.emplace_back(&keyId, sizeof(keyId), NScheme::TInt64::TypeId);
 
             for (keyId = 1000000; keyId < 1000512; ++keyId) {
                 NTable::TRowState row;
@@ -2696,7 +2696,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutorKeepEraseMarkers) {
             TVector<NTable::TTag> tags;
             tags.push_back(TRowsModel::ColumnValueId);
             TVector<TRawTypeValue> key;
-            key.emplace_back(&keyId, sizeof(keyId), NScheme::TTypeInfo(NScheme::TInt64::TypeId));
+            key.emplace_back(&keyId, sizeof(keyId), NScheme::TInt64::TypeId);
 
             for (keyId = 100; keyId <= 400; keyId += 100) {
                 NTable::TRowState row;
@@ -4933,7 +4933,7 @@ Y_UNIT_TEST_SUITE(TFlatTableSnapshotWithCommits) {
             TVector<NTable::TTag> tags;
             tags.push_back(TRowsModel::ColumnValueId);
             TVector<TRawTypeValue> key;
-            key.emplace_back(&keyId, sizeof(keyId), NScheme::TTypeInfo(NScheme::TInt64::TypeId));
+            key.emplace_back(&keyId, sizeof(keyId), NScheme::TInt64::TypeId);
 
             for (keyId = 1; keyId <= 104; ++keyId) {
                 NTable::TRowState row;

--- a/ydb/core/tablet_flat/flat_table_part.cpp
+++ b/ydb/core/tablet_flat/flat_table_part.cpp
@@ -174,7 +174,7 @@ size_t TPartScheme::InitInfo(TVector<TColumn>& cols, TPgSize headerSize)
     size_t offset = 0;
 
     for (auto &col: cols) {
-        const ui32 fixed = NScheme::GetFixedSize(col.TypeInfo);
+        const ui32 fixed = NScheme::GetFixedSize(col.TypeInfo.GetTypeId());
 
         col.Offset = offset;
         col.IsFixed = fixed > 0;

--- a/ydb/core/tablet_flat/flat_table_part.cpp
+++ b/ydb/core/tablet_flat/flat_table_part.cpp
@@ -174,7 +174,7 @@ size_t TPartScheme::InitInfo(TVector<TColumn>& cols, TPgSize headerSize)
     size_t offset = 0;
 
     for (auto &col: cols) {
-        const ui32 fixed = NScheme::GetFixedSize(col.TypeInfo.GetTypeId());
+        const ui32 fixed = NScheme::GetFixedSize(col.TypeInfo);
 
         col.Offset = offset;
         col.IsFixed = fixed > 0;

--- a/ydb/core/tablet_flat/test/libs/rows/rows.h
+++ b/ydb/core/tablet_flat/test/libs/rows/rows.h
@@ -53,7 +53,7 @@ namespace NTest {
 
             TRawTypeValue Raw() const
             {
-                return { Cell.Data(), Cell.Size(), NScheme::TTypeInfo(Type) };
+                return { Cell.Data(), Cell.Size(), Type };
             }
 
             NTable::TTag Tag = Max<TTag>();

--- a/ydb/core/tablet_flat/test/libs/rows/tool.h
+++ b/ydb/core/tablet_flat/test/libs/rows/tool.h
@@ -66,7 +66,7 @@ namespace NTest {
             for (auto &value: *tagged) {
                 auto * const info = ColFor(value);
 
-                TRawTypeValue raw(value.Cell.AsRef(), NScheme::TTypeInfo(value.Type));
+                TRawTypeValue raw(value.Cell.AsRef(), value.Type);
 
                 if (info->IsKey()) {
                     Y_ABORT_UNLESS(value.Op == ECellOp::Set || value.Op == ECellOp::Null);

--- a/ydb/core/tablet_flat/ut/flat_test_db_helpers.h
+++ b/ydb/core/tablet_flat/ut/flat_test_db_helpers.h
@@ -33,7 +33,7 @@ public:
     void Set(const TRawTypeValue& v) {
         if (!v.IsEmpty()) {
             Buf = TString((const char*)v.Data(), v.Size());
-            Val = TRawTypeValue(Buf.data(), Buf.size(), v.TypeInfo());
+            Val = TRawTypeValue(Buf.data(), Buf.size(), v.Type());
         } else {
             Val = TRawTypeValue();
         }
@@ -72,7 +72,7 @@ inline TFakeTableCell FromVal(NScheme::TTypeId t, i64 val) {
         break;
     }
 
-    c.Set(TRawTypeValue(&val, sz, NScheme::TTypeInfo(t)));
+    c.Set(TRawTypeValue(&val, sz, t));
     return c;
 }
 
@@ -88,7 +88,7 @@ inline TFakeTableCell FromVal(NScheme::TTypeId, std::nullptr_t) {
 
 inline TFakeTableCell FromVal(NScheme::TTypeId t, TString val) {
     TFakeTableCell c;
-    c.Set(TRawTypeValue(val.data(), val.size(), NScheme::TTypeInfo(t)));
+    c.Set(TRawTypeValue(val.data(), val.size(), t));
     return c;
 }
 

--- a/ydb/core/tablet_flat/ut/ut_decimal.cpp
+++ b/ydb/core/tablet_flat/ut/ut_decimal.cpp
@@ -113,6 +113,9 @@ Y_UNIT_TEST_SUITE(TFlatDatabaseDecimal) {
         db.Snap(tableId).Compact(tableId, false);
 
         readDatabase();
+
+        db.Replay(NTest::EPlay::Boot);
+        db.Replay(NTest::EPlay::Redo);
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ut_decimal.cpp
+++ b/ydb/core/tablet_flat/ut/ut_decimal.cpp
@@ -20,10 +20,6 @@ Y_UNIT_TEST_SUITE(TFlatDatabaseDecimal) {
 
         NTest::TDbExec db;
 
-        auto makeDecimalTypeInfo = [] (ui32 precision, ui32 scale) {
-            return NScheme::TTypeInfo(NScheme::TDecimalType(precision, scale));
-        };
-
         auto makeDecimalTypeInfoProto = [] (ui32 precision, ui32 scale) {
             NKikimrProto::TTypeInfo typeInfo;
             typeInfo.SetDecimalPrecision(precision);
@@ -58,15 +54,15 @@ Y_UNIT_TEST_SUITE(TFlatDatabaseDecimal) {
             db.Begin();
 
             TVector<TRawTypeValue> key;
-            key.emplace_back(&decimalKey229, sizeof(TDecimalPair), makeDecimalTypeInfo(22, 9));
-            key.emplace_back(&decimalKey356, sizeof(TDecimalPair), makeDecimalTypeInfo(35, 6));
+            key.emplace_back(&decimalKey229, sizeof(TDecimalPair), NScheme::NTypeIds::Decimal);
+            key.emplace_back(&decimalKey356, sizeof(TDecimalPair), NScheme::NTypeIds::Decimal);
             key.emplace_back(&intKey, sizeof(i32), NScheme::NTypeIds::Int32);
 
             TVector<NTable::TUpdateOp> ops;
             ops.emplace_back(IdValueDecimal229, NTable::ECellOp::Set,
-                TRawTypeValue(&decimalVal229, sizeof(TDecimalPair), makeDecimalTypeInfo(22, 9)));
+                TRawTypeValue(&decimalVal229, sizeof(TDecimalPair), NScheme::NTypeIds::Decimal));
             ops.emplace_back(IdValueDecimal356, NTable::ECellOp::Set,
-                TRawTypeValue(&decimalVal356, sizeof(TDecimalPair), makeDecimalTypeInfo(35, 6)));
+                TRawTypeValue(&decimalVal356, sizeof(TDecimalPair), NScheme::NTypeIds::Decimal));
             ops.emplace_back(IdValueInt, NTable::ECellOp::Set,
                 TRawTypeValue(&intVal, sizeof(i32), NScheme::NTypeIds::Int32));
 
@@ -85,8 +81,8 @@ Y_UNIT_TEST_SUITE(TFlatDatabaseDecimal) {
             db.Begin();
 
             TVector<TRawTypeValue> key;
-            key.emplace_back(&decimalKey229, sizeof(TDecimalPair), makeDecimalTypeInfo(22, 9));
-            key.emplace_back(&decimalKey356, sizeof(TDecimalPair), makeDecimalTypeInfo(35, 6));
+            key.emplace_back(&decimalKey229, sizeof(TDecimalPair), NScheme::NTypeIds::Decimal);
+            key.emplace_back(&decimalKey356, sizeof(TDecimalPair), NScheme::NTypeIds::Decimal);
             key.emplace_back(&intKey, sizeof(i32), NScheme::NTypeIds::Int32);
 
             auto it = db->Iterate(tableId, key, tags, ELookup::GreaterOrEqualThan);

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
@@ -86,7 +86,7 @@ struct TTxReadRow : public ITransaction {
         Attempts++;
 
         TVector<TRawTypeValue> rawKey;
-        rawKey.emplace_back(&Key, sizeof(Key), NScheme::TTypeInfo(NScheme::TInt64::TypeId));
+        rawKey.emplace_back(&Key, sizeof(Key), NScheme::TInt64::TypeId);
 
         TVector<NTable::TTag> tags;
         tags.push_back(KeyColumnId);

--- a/ydb/core/tablet_flat/ut_pg/flat_database_pg_ut.cpp
+++ b/ydb/core/tablet_flat/ut_pg/flat_database_pg_ut.cpp
@@ -142,6 +142,9 @@ Y_UNIT_TEST_SUITE(TFlatDatabasePgTest) {
         db.Snap(tableId).Compact(tableId, false);
 
         readDatabase();
+
+        db.Replay(NTest::EPlay::Boot);
+        db.Replay(NTest::EPlay::Redo);        
     }
 }
 

--- a/ydb/core/tablet_flat/ut_pg/flat_database_pg_ut.cpp
+++ b/ydb/core/tablet_flat/ut_pg/flat_database_pg_ut.cpp
@@ -29,10 +29,6 @@ Y_UNIT_TEST_SUITE(TFlatDatabasePgTest) {
 
         NTest::TDbExec db;
 
-        auto makePgType = [] (ui32 oid) {
-            return NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(oid));
-        };
-
         auto makePgTypeInfo = [] (ui32 pgTypeId) {
             NKikimrProto::TTypeInfo typeInfo;
             typeInfo.SetPgTypeId(pgTypeId);
@@ -74,25 +70,25 @@ Y_UNIT_TEST_SUITE(TFlatDatabasePgTest) {
             db.Begin();
 
             TVector<TRawTypeValue> key;
-            key.emplace_back(strText.data(), strText.size(), makePgType(TEXTOID));
-            key.emplace_back(strBytea.data(), strBytea.size(), makePgType(BYTEAOID));
-            key.emplace_back(&i16Val, sizeof(i16), makePgType(INT2OID));
+            key.emplace_back(strText.data(), strText.size(), NScheme::NTypeIds::Pg);
+            key.emplace_back(strBytea.data(), strBytea.size(), NScheme::NTypeIds::Pg);
+            key.emplace_back(&i16Val, sizeof(i16), NScheme::NTypeIds::Pg);
             float f = (float)i;
-            key.emplace_back(&f, sizeof(float), makePgType(FLOAT4OID));
+            key.emplace_back(&f, sizeof(float), NScheme::NTypeIds::Pg);
 
             TVector<NTable::TUpdateOp> ops;
             ops.emplace_back(IdBool, NTable::ECellOp::Set,
-                TRawTypeValue(&boolVal, sizeof(bool), makePgType(BOOLOID)));
+                TRawTypeValue(&boolVal, sizeof(bool), NScheme::NTypeIds::Pg));
             ops.emplace_back(IdChar, NTable::ECellOp::Set,
-                TRawTypeValue(&charVal, sizeof(char), makePgType(CHAROID)));
+                TRawTypeValue(&charVal, sizeof(char), NScheme::NTypeIds::Pg));
             ops.emplace_back(IdInt4, NTable::ECellOp::Set,
-                TRawTypeValue(&i32Val, sizeof(i32), makePgType(INT4OID)));
+                TRawTypeValue(&i32Val, sizeof(i32), NScheme::NTypeIds::Pg));
             ops.emplace_back(IdInt8, NTable::ECellOp::Set,
-                TRawTypeValue(&i64Val, sizeof(i64), makePgType(INT8OID)));
+                TRawTypeValue(&i64Val, sizeof(i64), NScheme::NTypeIds::Pg));
             ops.emplace_back(IdFloat8, NTable::ECellOp::Set,
-                TRawTypeValue(&doubleVal, sizeof(double), makePgType(FLOAT8OID)));
+                TRawTypeValue(&doubleVal, sizeof(double), NScheme::NTypeIds::Pg));
             ops.emplace_back(IdBpchar, NTable::ECellOp::Set,
-                TRawTypeValue(strBpchar.data(), strBpchar.size(), makePgType(BPCHAROID)));
+                TRawTypeValue(strBpchar.data(), strBpchar.size(), NScheme::NTypeIds::Pg));
 
             db->Update(tableId, NTable::ERowOp::Upsert, key, ops);
 
@@ -108,10 +104,10 @@ Y_UNIT_TEST_SUITE(TFlatDatabasePgTest) {
             db.Begin();
 
             TVector<TRawTypeValue> key;
-            key.emplace_back(strText.data(), strText.size(), makePgType(TEXTOID));
-            key.emplace_back(strBytea.data(), strBytea.size(), makePgType(BYTEAOID));
-            key.emplace_back(&i16Val, sizeof(i16), makePgType(INT2OID));
-            key.emplace_back(&floatVal, sizeof(float), makePgType(FLOAT4OID));
+            key.emplace_back(strText.data(), strText.size(), NScheme::NTypeIds::Pg);
+            key.emplace_back(strBytea.data(), strBytea.size(), NScheme::NTypeIds::Pg);
+            key.emplace_back(&i16Val, sizeof(i16), NScheme::NTypeIds::Pg);
+            key.emplace_back(&floatVal, sizeof(float), NScheme::NTypeIds::Pg);
 
             auto it = db->Iterate(tableId, key, tags, ELookup::GreaterThan);
             size_t count = 0;

--- a/ydb/core/tx/datashard/cdc_stream_scan.cpp
+++ b/ydb/core/tx/datashard/cdc_stream_scan.cpp
@@ -193,7 +193,7 @@ class TDataShard::TTxCdcStreamScanProgress
             const auto tag = tags.at(pos);
             auto it = table->Columns.find(tag);
             Y_ABORT_UNLESS(it != table->Columns.end());
-            updates.emplace_back(tag, ECellOp::Set, TRawTypeValue(cells.at(pos).AsRef(), it->second.Type));
+            updates.emplace_back(tag, ECellOp::Set, TRawTypeValue(cells.at(pos).AsRef(), it->second.Type.GetTypeId()));
         }
 
         return updates;

--- a/ydb/core/tx/datashard/change_collector_async_index.cpp
+++ b/ydb/core/tx/datashard/change_collector_async_index.cpp
@@ -232,11 +232,11 @@ void TAsyncIndexChangeCollector::AddRawValue(TVector<TUpdateOp>& out, TTag tag, 
     AddValue(out, TUpdateOp(tag, ECellOp::Set, value));
 }
 
-void TAsyncIndexChangeCollector::AddCellValue(TVector<TUpdateOp>& out, TTag tag, const TCell& cell, NScheme::TTypeInfo type) {
-    AddRawValue(out, tag, TRawTypeValue(cell.AsRef(), type));
+void TAsyncIndexChangeCollector::AddCellValue(TVector<TUpdateOp>& out, TTag tag, const TCell& cell, const NScheme::TTypeInfo& type) {
+    AddRawValue(out, tag, TRawTypeValue(cell.AsRef(), type.GetTypeId()));
 }
 
-void TAsyncIndexChangeCollector::AddNullValue(TVector<TUpdateOp>& out, TTag tag, NScheme::TTypeInfo type) {
+void TAsyncIndexChangeCollector::AddNullValue(TVector<TUpdateOp>& out, TTag tag, const NScheme::TTypeInfo& type) {
     AddCellValue(out, tag, {}, type);
 }
 

--- a/ydb/core/tx/datashard/change_collector_async_index.h
+++ b/ydb/core/tx/datashard/change_collector_async_index.h
@@ -32,8 +32,8 @@ class TAsyncIndexChangeCollector: public TBaseChangeCollector {
 
     void AddValue(TVector<NTable::TUpdateOp>& out, const NTable::TUpdateOp& update);
     void AddRawValue(TVector<NTable::TUpdateOp>& out, NTable::TTag tag, const TRawTypeValue& value);
-    void AddCellValue(TVector<NTable::TUpdateOp>& out, NTable::TTag tag, const TCell& cell, NScheme::TTypeInfo type);
-    void AddNullValue(TVector<NTable::TUpdateOp>& out, NTable::TTag tag, NScheme::TTypeInfo type);
+    void AddCellValue(TVector<NTable::TUpdateOp>& out, NTable::TTag tag, const TCell& cell, const NScheme::TTypeInfo& type);
+    void AddNullValue(TVector<NTable::TUpdateOp>& out, NTable::TTag tag, const NScheme::TTypeInfo& type);
 
     void Persist(const TTableId& tableId, const TPathId& pathId, NTable::ERowOp rop,
         TArrayRef<const NTable::TUpdateOp> key, TArrayRef<const NTable::TUpdateOp> data);

--- a/ydb/core/tx/datashard/change_collector_cdc_stream.cpp
+++ b/ydb/core/tx/datashard/change_collector_cdc_stream.cpp
@@ -53,7 +53,7 @@ namespace {
         Y_ABORT_UNLESS(cells.size() == types.size());
 
         for (TPos pos = 0; pos < cells.size(); ++pos) {
-            result.emplace_back(tags.at(pos), ECellOp::Set, TRawTypeValue(cells.at(pos).AsRef(), types.at(pos)));
+            result.emplace_back(tags.at(pos), ECellOp::Set, TRawTypeValue(cells.at(pos).AsRef(), types.at(pos).GetTypeId()));
         }
 
         return result;

--- a/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
+++ b/ydb/core/tx/datashard/datashard__object_storage_listing.cpp
@@ -68,7 +68,7 @@ public:
         for (ui32 ki = 0; ki < prefixColumns.GetCells().size(); ++ki) {
             // TODO: check prefix column type
             auto &cell = prefixColumns.GetCells()[ki];
-            auto &type = tableInfo.KeyColumnTypes[ki];
+            NScheme::TTypeId type = tableInfo.KeyColumnTypes[ki].GetTypeId();
             key.emplace_back(cell.Data(), cell.Size(), type);
             endKey.emplace_back(cell.Data(), cell.Size(), type);
         }
@@ -87,12 +87,12 @@ public:
             if (Ev->Get()->Record.HasLastPath()) {
                 TString reqLastPath = Ev->Get()->Record.GetLastPath();
 
-                key.emplace_back(reqLastPath, NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+                key.emplace_back(reqLastPath, NScheme::NTypeIds::Utf8);
 
                 startAfterPath = reqLastPath;
             } else {
                 minKeyInclusive = true;
-                key.emplace_back(pathPrefix.data(), pathPrefix.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+                key.emplace_back(pathPrefix.data(), pathPrefix.size(), NScheme::NTypeIds::Utf8);
                 key.resize(columnCount);
             }
         } else {
@@ -102,18 +102,18 @@ public:
             if (Ev->Get()->Record.HasLastPath()) {
                 TString reqLastPath = Ev->Get()->Record.GetLastPath();
                 
-                key.emplace_back(reqLastPath, tableInfo.KeyColumnTypes[prefixSize]);
+                key.emplace_back(reqLastPath, tableInfo.KeyColumnTypes[prefixSize].GetTypeId());
 
                 for (size_t i = 1; i < suffixColumns.GetCells().size(); ++i) {
                     size_t ki = prefixSize + i;
-                    key.emplace_back(suffixColumns.GetCells()[i].Data(), suffixColumns.GetCells()[i].Size(), tableInfo.KeyColumnTypes[ki]);
+                    key.emplace_back(suffixColumns.GetCells()[i].Data(), suffixColumns.GetCells()[i].Size(), tableInfo.KeyColumnTypes[ki].GetTypeId());
                 }
                 
                 startAfterPath = reqLastPath;
             } else {
                 for (size_t i = 0; i < suffixColumns.GetCells().size(); ++i) {
                     size_t ki = prefixSize + i;
-                    key.emplace_back(suffixColumns.GetCells()[i].Data(), suffixColumns.GetCells()[i].Size(), tableInfo.KeyColumnTypes[ki]);
+                    key.emplace_back(suffixColumns.GetCells()[i].Data(), suffixColumns.GetCells()[i].Size(), tableInfo.KeyColumnTypes[ki].GetTypeId());
                 }
                 startAfterPath = TString(suffixColumns.GetCells()[0].Data(), suffixColumns.GetCells()[0].Size());
             }
@@ -128,7 +128,7 @@ public:
         if (LastPath) {
             const size_t pathColIdx =  prefixColumns.GetCells().size();
             key.resize(pathColIdx);
-            key.emplace_back(LastPath.data(), LastPath.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+            key.emplace_back(LastPath.data(), LastPath.size(), NScheme::NTypeIds::Utf8);
             key.resize(columnCount);
 
             lastCommonPath = LastCommonPath;
@@ -138,7 +138,7 @@ public:
 
         const TString pathEndPrefix = NextPrefix(pathPrefix);
         if (pathEndPrefix) {
-            endKey.emplace_back(pathEndPrefix.data(), pathEndPrefix.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+            endKey.emplace_back(pathEndPrefix.data(), pathEndPrefix.size(), NScheme::NTypeIds::Utf8);
             while (endKey.size() < tableInfo.KeyColumnTypes.size()) {
                 endKey.emplace_back();
             }
@@ -354,7 +354,7 @@ public:
 
                 // Skip to the next key after path+separator
                 key.resize(prefixColumns.GetCells().size());
-                key.emplace_back(lookup.data(), lookup.size(), NScheme::TTypeInfo(NScheme::NTypeIds::Utf8));
+                key.emplace_back(lookup.data(), lookup.size(), NScheme::NTypeIds::Utf8);
                 key.resize(columnCount);
 
                 if (!iter->SkipTo(key, /* inclusive = */ true)) {

--- a/ydb/core/tx/datashard/datashard__read_columns.cpp
+++ b/ydb/core/tx/datashard/datashard__read_columns.cpp
@@ -284,7 +284,7 @@ public:
         TSerializedCellVec fromKeyCells(Ev->Get()->Record.GetFromKey());
         KeyFrom.clear();
         for (ui32 i = 0; i < fromKeyCells.GetCells().size(); ++i) {
-            KeyFrom.push_back(TRawTypeValue(fromKeyCells.GetCells()[i].AsRef(), tableInfo.KeyColumnTypes[i]));
+            KeyFrom.push_back(TRawTypeValue(fromKeyCells.GetCells()[i].AsRef(), tableInfo.KeyColumnTypes[i].GetTypeId()));
         }
         KeyFrom.resize(tableInfo.KeyColumnTypes.size());
         InclusiveFrom = Ev->Get()->Record.GetFromKeyInclusive();

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -228,7 +228,7 @@ std::vector<TRawTypeValue> ToRawTypeValue(
     result.reserve(keyCells.size());
 
     for (ui32 i = 0; i < keyCells.size(); ++i) {
-        result.push_back(TRawTypeValue(keyCells[i].AsRef(), tableInfo.KeyColumnTypes[i]));
+        result.push_back(TRawTypeValue(keyCells[i].AsRef(), tableInfo.KeyColumnTypes[i].GetTypeId()));
     }
 
     // note that currently without nulls it is [prefix, +inf, +inf],

--- a/ydb/core/tx/datashard/datashard_change_receiving.cpp
+++ b/ydb/core/tx/datashard/datashard_change_receiving.cpp
@@ -235,10 +235,10 @@ class TDataShard::TTxApplyChangeRecords: public TTransactionBase<TDataShard> {
 
         ui64 keyBytes = 0;
         for (size_t i = 0; i < tableInfo.KeyColumnTypes.size(); ++i) {
-            const auto type = tableInfo.KeyColumnTypes.at(i);
+            const NScheme::TTypeId type = tableInfo.KeyColumnTypes.at(i).GetTypeId();
             const auto& cell = KeyCells.GetCells().at(i);
 
-            if (type.GetTypeId() == NScheme::NTypeIds::Uint8 && !cell.IsNull() && cell.AsValue<ui8>() > 127) {
+            if (type == NScheme::NTypeIds::Uint8 && !cell.IsNull() && cell.AsValue<ui8>() > 127) {
                 AddRecordStatus(ctx, record.GetOrder(), NKikimrChangeExchange::TEvStatus::STATUS_REJECT,
                     NKikimrChangeExchange::TEvStatus::REASON_SCHEME_ERROR,
                     "Keys with Uint8 column values >127 are currently prohibited");
@@ -300,7 +300,7 @@ class TDataShard::TTxApplyChangeRecords: public TTransactionBase<TDataShard> {
                         return false;
                     }
 
-                    Value.emplace_back(tag, NTable::ECellOp::Set, TRawTypeValue(cell.AsRef(), column->Type));
+                    Value.emplace_back(tag, NTable::ECellOp::Set, TRawTypeValue(cell.AsRef(), column->Type.GetTypeId()));
                 }
 
                 break;

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -137,7 +137,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             }
 
             keyBytes += c.Size();
-            key.emplace_back(TRawTypeValue(c.AsRef(), kt));
+            key.emplace_back(TRawTypeValue(c.AsRef(), kt.GetTypeId()));
             ++ki;
         }
 
@@ -200,7 +200,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             }
 
             if (allowUpdate) {
-                value.emplace_back(NTable::TUpdateOp(vt.first, NTable::ECellOp::Set, TRawTypeValue(valueCells.GetCells()[vi].AsRef(), vt.second)));
+                value.emplace_back(NTable::TUpdateOp(vt.first, NTable::ECellOp::Set, TRawTypeValue(valueCells.GetCells()[vi].AsRef(), vt.second.GetTypeId())));
             }
             ++vi;
         }

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -103,10 +103,10 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
         ui64 keyBytes = 0;
         TVector<TRawTypeValue> key;
         for (size_t ki : xrange(tableInfo.KeyColumnTypes.size())) {
-            const auto& kt = tableInfo.KeyColumnTypes[ki];
+            const NScheme::TTypeId kt = tableInfo.KeyColumnTypes[ki].GetTypeId();
             const TCell& cell = keyCells.GetCells()[ki];
 
-            if (kt.GetTypeId() == NScheme::NTypeIds::Uint8 && !cell.IsNull() && cell.AsValue<ui8>() > 127) {
+            if (kt == NScheme::NTypeIds::Uint8 && !cell.IsNull() && cell.AsValue<ui8>() > 127) {
                 status = NKikimrTxDataShard::TEvEraseRowsResponse::BAD_REQUEST;
                 error = "Keys with Uint8 column values >127 are currently prohibited";
                 return EStatus::Error;

--- a/ydb/core/tx/datashard/datashard_repl_apply.cpp
+++ b/ydb/core/tx/datashard/datashard_repl_apply.cpp
@@ -157,7 +157,7 @@ public:
         TVector<TRawTypeValue> key;
         key.reserve(keyCellVec.GetCells().size());
         for (size_t i = 0; i < keyCellVec.GetCells().size(); ++i) {
-            key.emplace_back(keyCellVec.GetCells()[i].AsRef(), userTable.KeyColumnTypes[i]);
+            key.emplace_back(keyCellVec.GetCells()[i].AsRef(), userTable.KeyColumnTypes[i].GetTypeId());
         }
 
         NTable::ERowOp rop = NTable::ERowOp::Absent;
@@ -245,7 +245,7 @@ public:
                     TStringBuilder() << "Update at " << EscapeC(source.Name) << ":" << sourceOffset << " is updating a primary key column " << tag);
                 return false;
             }
-            update.emplace_back(tag, NTable::ECellOp::Set, TRawTypeValue(updateCellVec.GetCells()[i].AsRef(), it->second.Type));
+            update.emplace_back(tag, NTable::ECellOp::Set, TRawTypeValue(updateCellVec.GetCells()[i].AsRef(), it->second.Type.GetTypeId()));
         }
         return true;
     }

--- a/ydb/core/tx/datashard/datashard_split_src.cpp
+++ b/ydb/core/tx/datashard/datashard_split_src.cpp
@@ -303,7 +303,7 @@ public:
                             rawVals.push_back(
                                         cells.GetCells()[ki].IsNull() ?
                                             TRawTypeValue() :
-                                            TRawTypeValue(cells.GetCells()[ki].Data(), cells.GetCells()[ki].Size(), tableInfo.KeyColumnTypes[ki])
+                                            TRawTypeValue(cells.GetCells()[ki].Data(), cells.GetCells()[ki].Size(), tableInfo.KeyColumnTypes[ki].GetTypeId())
                                             );
                         }
                         // Extend with NULLs if needed

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -90,7 +90,7 @@ void TDataShardUserDb::UpsertRow(
         }
 
         auto addExtendedOp = [&scheme, &tableInfo, &extendedOps](const ui64 columnTag, const ui64& columnValue) {
-            const NScheme::TTypeInfo vtype = scheme.GetColumnInfo(tableInfo, columnTag)->PType;
+            const NScheme::TTypeId vtype = scheme.GetColumnInfo(tableInfo, columnTag)->PType.GetTypeId();
             const char* ptr = static_cast<const char*>(static_cast<const void*>(&columnValue));
             TRawTypeValue rawTypeValue(ptr, sizeof(ui64), vtype);
             NIceDb::TUpdateOp extOp(columnTag, NTable::ECellOp::Set, rawTypeValue);

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -153,9 +153,9 @@ public:
 
             TVector<TRawTypeValue> key;
             for (size_t ki : xrange(tableInfo.KeyColumnTypes.size())) {
-                const auto& kt = tableInfo.KeyColumnTypes[ki];
+                const NScheme::TTypeId vtype = tableInfo.KeyColumnTypes[ki].GetTypeId();
                 const TCell& cell = keyCells.GetCells()[ki];
-                key.emplace_back(TRawTypeValue(cell.AsRef(), kt));
+                key.emplace_back(TRawTypeValue(cell.AsRef(), vtype));
             }
 
             if (breakWriteConflicts || checkVolatileDependencies) {

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -124,8 +124,8 @@ public:
                 ui32 columnTag = validatedOperation.GetColumnIds()[valueColIdx];
                 const TCell& cell = matrix.GetCell(rowIdx, valueColIdx);
 
-                NScheme::TTypeInfo vtypeInfo = scheme.GetColumnInfo(tableInfo, columnTag)->PType;
-                ops.emplace_back(columnTag, NTable::ECellOp::Set, cell.IsNull() ? TRawTypeValue() : TRawTypeValue(cell.Data(), cell.Size(), vtypeInfo));
+                const NScheme::TTypeId vtypeId = scheme.GetColumnInfo(tableInfo, columnTag)->PType.GetTypeId();
+                ops.emplace_back(columnTag, NTable::ECellOp::Set, cell.IsNull() ? TRawTypeValue() : TRawTypeValue(cell.Data(), cell.Size(), vtypeId));
             }
         };
 
@@ -139,8 +139,8 @@ public:
                 if (cell.IsNull()) {
                     key.emplace_back();
                 } else {
-                    NScheme::TTypeInfo vtypeInfo = scheme.GetColumnInfo(tableInfo, keyCol)->PType;
-                    key.emplace_back(cell.Data(), cell.Size(), vtypeInfo);
+                    NScheme::TTypeId vtypeId = scheme.GetColumnInfo(tableInfo, keyCol)->PType.GetTypeId();
+                    key.emplace_back(cell.Data(), cell.Size(), vtypeId);
                 }
             }
 

--- a/ydb/core/tx/datashard/incr_restore_helpers.cpp
+++ b/ydb/core/tx/datashard/incr_restore_helpers.cpp
@@ -19,7 +19,7 @@ std::optional<TVector<TUpdateOp>> MakeRestoreUpdates(TArrayRef<const TCell> cell
             foundSpecialColumn = true;
             continue;
         }
-        updates.emplace_back(tag, ECellOp::Set, TRawTypeValue(cells.at(pos).AsRef(), it->second.Type));
+        updates.emplace_back(tag, ECellOp::Set, TRawTypeValue(cells.at(pos).AsRef(), it->second.Type.GetTypeId()));
     }
     Y_ABORT_UNLESS(foundSpecialColumn);
 

--- a/ydb/core/tx/datashard/stream_scan_common.cpp
+++ b/ydb/core/tx/datashard/stream_scan_common.cpp
@@ -18,7 +18,7 @@ TVector<TRawTypeValue> MakeKey(TArrayRef<const TCell> cells, const TVector<NSche
 
     Y_ABORT_UNLESS(cells.size() == keyColumnTypes.size());
     for (TPos pos = 0; pos < cells.size(); ++pos) {
-        key.emplace_back(cells.at(pos).AsRef(), keyColumnTypes.at(pos));
+        key.emplace_back(cells.at(pos).AsRef(), keyColumnTypes.at(pos).GetTypeId());
     }
 
     return key;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Redo log (NTable::NRedo::TValue) doesn't contain TypeInfo only TypeId.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
