### PR TITLE
24-3: Add evict vdisks for a rack (#9740)

### DIFF
--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -92,6 +92,9 @@ struct TTestEnvOpts {
     bool EnableCMSRequestPriorities;
     bool EnableSingleCompositeActionGroup;
 
+    using TNodeLocationCallback = std::function<TNodeLocation(ui32)>;
+    TNodeLocationCallback NodeLocationCallback;
+
     TTestEnvOpts() = default;
 
     TTestEnvOpts(ui32 nodeCount, 
@@ -126,6 +129,12 @@ struct TTestEnvOpts {
         EnableCMSRequestPriorities = true;
         return *this;
     }
+
+    TTestEnvOpts& WithNodeLocationCallback(TNodeLocationCallback nodeLocationCallback) {
+        NodeLocationCallback = nodeLocationCallback;
+        return *this;
+    }
+
 };
 
 class TCmsTestEnv : public TTestBasicRuntime {
@@ -322,6 +331,8 @@ public:
     {
         return CheckRequest(user, id, dry, NKikimrCms::MODE_MAX_AVAILABILITY, res, count);
     }
+
+    void CheckBSCUpdateRequests(std::set<ui32> expectedNodes, NKikimrBlobStorage::EDriveStatus expectedStatus);
 
     void CheckWalleStoreTaskIsFailed(NCms::TEvCms::TEvStoreWalleTask *req);
 

--- a/ydb/core/cms/pdisk_status.h
+++ b/ydb/core/cms/pdisk_status.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/core/protos/blobstorage_config.pb.h>
+
+namespace NKikimr::NCms {
+
+using EPDiskStatus = NKikimrBlobStorage::EDriveStatus;
+
+} // namespace NKikimr::NCms

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -125,6 +125,10 @@ void TPDiskStatusComputer::SetForcedStatus(EPDiskStatus status) {
     ForcedStatus = status;
 }
 
+bool TPDiskStatusComputer::HasForcedStatus() const {
+    return ForcedStatus.Defined();
+}
+
 void TPDiskStatusComputer::ResetForcedStatus() {
     ForcedStatus.Clear();
 }
@@ -196,6 +200,7 @@ void TPDiskStatus::DisallowChanging() {
 
 TPDiskInfo::TPDiskInfo(EPDiskStatus initialStatus, const ui32& defaultStateLimit, const TLimitsMap& stateLimits)
     : TPDiskStatus(initialStatus, defaultStateLimit, stateLimits)
+    , ActualStatus(initialStatus)
 {
     Touch();
 }
@@ -898,7 +903,7 @@ class TSentinel: public TActorBootstrapped<TSentinel> {
 
             all.AddPDisk(id);
             if (info.IsChanged()) {
-                if (info.IsNewStatusGood()) {
+                if (info.IsNewStatusGood() || info.HasForcedStatus()) {
                     alwaysAllowed.insert(id);
                 } else {
                     changed.AddPDisk(id);

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -3,8 +3,7 @@
 #include "defs.h"
 #include "pdiskid.h"
 #include "pdisk_state.h"
-
-#include <ydb/core/protos/blobstorage_config.pb.h>
+#include "pdisk_status.h"
 
 #include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
@@ -12,7 +11,6 @@
 
 namespace NKikimr::NCms::NSentinel {
 
-using EPDiskStatus = NKikimrBlobStorage::EDriveStatus;
 using TLimitsMap = TMap<EPDiskState, ui32>;
 
 class TPDiskStatusComputer {
@@ -29,6 +27,7 @@ public:
     void Reset();
 
     void SetForcedStatus(EPDiskStatus status);
+    bool HasForcedStatus() const;
     void ResetForcedStatus();
 
 private:
@@ -84,7 +83,7 @@ struct TPDiskInfo
     using EIgnoreReason = NKikimrCms::TPDiskInfo::EIgnoreReason;
 
     EPDiskStatus ActualStatus = EPDiskStatus::ACTIVE;
-    EPDiskStatus PrevStatus = EPDiskStatus::ACTIVE;
+    EPDiskStatus PrevStatus = EPDiskStatus::UNKNOWN;
     TInstant LastStatusChange;
     bool StatusChangeFailed = false;
     // means that this pdisk status change last time was the reason of whole request failure


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

CMS allows to evict all vdisks from a rack

### Changelog category <!-- remove all except one -->

* Improvement
