### PR TITLE
Harden huge blob placement checks in VDisk, fix HugeKeeper WAL

### DIFF
--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
@@ -693,8 +693,8 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             NHuge::THugeSlot hugeSlot;
             ui32 slotSize;
             if (State.Pers->Heap->Allocate(msg.Data.GetSize(), &hugeSlot, &slotSize)) {
-                const bool inserted = State.Pers->AllocatedSlots.insert(hugeSlot).second;
-                Y_ABORT_UNLESS(inserted);
+                State.Pers->AddSlotInFlight(hugeSlot);
+                State.Pers->AddChunkSize(hugeSlot);
                 const ui64 lsnInfimum = HugeKeeperCtx->LsnMngr->GetLsn();
                 CheckLsn(lsnInfimum, "WriteHugeBlob");
                 const ui64 wId = State.LsnFifo.Push(lsnInfimum);
@@ -889,6 +889,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             for (const auto &x : msg->HugeBlobs) {
                 slotSizes.insert(State.Pers->Heap->SlotSizeOfThisSize(x.Size));
                 NHuge::TFreeRes freeRes = State.Pers->Heap->Free(x);
+                State.Pers->DeleteChunkSize(State.Pers->Heap->ConvertDiskPartToHugeSlot(x));
                 LOG_DEBUG(ctx, BS_HULLHUGE,
                           VDISKP(HugeKeeperCtx->VCtx->VDiskLogPrefix,
                                 "THullHugeKeeper: TEvHullFreeHugeSlots: one slot: addr# %s",
@@ -961,8 +962,8 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             // manage allocated slots
             const TDiskPart &hugeBlob = msg->HugeBlob;
             NHuge::THugeSlot hugeSlot(State.Pers->Heap->ConvertDiskPartToHugeSlot(hugeBlob));
-            auto nErased = State.Pers->AllocatedSlots.erase(hugeSlot);
-            Y_ABORT_UNLESS(nErased == 1);
+            const bool deleted = State.Pers->DeleteSlotInFlight(hugeSlot);
+            Y_ABORT_UNLESS(deleted);
             // depending on SlotIsUsed...
             if (msg->SlotIsUsed) {
                 Y_VERIFY_S(State.Pers->LogPos.HugeBlobLoggedLsn < msg->RecLsn,
@@ -972,6 +973,8 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             } else {
                 // ...free slot
                 State.Pers->Heap->Free(hugeBlob);
+                // and remove chunk size record
+                State.Pers->DeleteChunkSize(hugeSlot);
             }
         }
 
@@ -1090,8 +1093,7 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             : HugeKeeperCtx(std::move(hugeKeeperCtx))
             , State(std::move(persState))
         {
-            Y_ABORT_UNLESS(State.Pers->Recovered &&
-                     State.Pers->AllocatedSlots.empty());
+            Y_ABORT_UNLESS(State.Pers->Recovered && State.Pers->SlotsInFlight.empty());
         }
 
         void Bootstrap(const TActorContext &ctx) {

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge_ut.cpp
@@ -34,8 +34,6 @@ namespace NKikimr {
                         overhead, freeChunksReservation, logf));
 
             state->LogPos = THullHugeRecoveryLogPos(0, 0, 100500, 50000, 70000, 56789, 39482);
-            NHuge::THugeSlot hugeSlot(453, 0, 234);
-            state->AllocatedSlots.insert(hugeSlot);
 
             TString serialized(state->Serialize());
             UNIT_ASSERT(THullHugeKeeperPersState::CheckEntryPoint(serialized));

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugedefs.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugedefs.h
@@ -23,12 +23,14 @@ namespace NKikimr {
             ui32 ChunkId = 0;
             TMask Mask;
             ui32 MaskSize = 0;
+            bool InLockedChunks = false;
 
             TFreeRes() = default;
-            TFreeRes(ui32 chunkId, TMask mask, ui32 maskSize)
+            TFreeRes(ui32 chunkId, TMask mask, ui32 maskSize, bool inLockedChunks)
                 : ChunkId(chunkId)
                 , Mask(mask)
                 , MaskSize(maskSize)
+                , InLockedChunks(inLockedChunks)
             {}
 
             void Output(IOutputStream &str) const;

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap.h
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap.h
@@ -124,7 +124,7 @@ namespace NKikimr {
             THeapStat GetStat() const;
             // returns true is allocated, false otherwise
             bool RecoveryModeAllocate(const NPrivate::TChunkSlot &id);
-            void RecoveryModeAllocate(const NPrivate::TChunkSlot &id, TChunkID chunkId);
+            void RecoveryModeAllocate(const NPrivate::TChunkSlot &id, TChunkID chunkId, bool inLockedChunks);
             void Save(IOutputStream *s) const;
             void Load(IInputStream *s);
             bool HaveBeenUsed() const;
@@ -158,6 +158,7 @@ namespace NKikimr {
             TChainDelegator &operator =(const TChainDelegator &) = delete;
             THugeSlot Convert(const NPrivate::TChunkSlot &id) const;
             NPrivate::TChunkSlot Convert(const TDiskPart &addr) const;
+            NPrivate::TChunkSlot Convert(const THugeSlot &slot) const;
             void Save(IOutputStream *s) const;
             void Load(IInputStream *s);
             bool HaveBeenUsed() const;
@@ -299,6 +300,8 @@ namespace NKikimr {
             void RecoveryModeAllocate(const TDiskPart &addr);
             void RecoveryModeAddChunk(ui32 chunkId);
             void RecoveryModeRemoveChunks(const TVector<ui32> &chunkIds);
+            bool ReleaseSlot(THugeSlot slot);
+            void OccupySlot(THugeSlot slot, bool inLockedChunks);
 
             //////////////////////////////////////////////////////////////////////////////////////////
             // Serialize/Parse/Check

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhugeheap_ut.cpp
@@ -17,13 +17,13 @@ namespace NKikimr {
             TMask mask;
             mask.Set(0, 8);
             mask.Reset(1);
-            TFreeRes res = {15, mask, 8};
+            TFreeRes res = {15, mask, 8, false};
 
             STR << "TFreeRes# " << res.ToString() << "\n";
             UNIT_ASSERT_EQUAL(res.ToString(), "{ChunkIdx: 15 Mask# 10111111}");
 
             TMask constMask = TChain::BuildConstMask("", 8);
-            TFreeRes constRes = {0, constMask, 8};
+            TFreeRes constRes = {0, constMask, 8, false};
             STR << "constMask# " << constRes.ToString() << "\n";
             UNIT_ASSERT_EQUAL(constRes.ToString(), "{ChunkIdx: 0 Mask# 11111111}");
 

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_logreplay.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_logreplay.cpp
@@ -230,6 +230,9 @@ namespace NKikimr {
                 TLogoBlobID genId(id, 0);
                 LocRecCtx->HullDbRecovery->ReplayAddHugeLogoBlobCmd(ctx, genId, ingress, diskAddr, lsn,
                         THullDbRecovery::RECOVERY);
+                if (diskAddr.ChunkIdx && diskAddr.Size) {
+                    LocRecCtx->RepairedHuge->RegisterBlob(diskAddr);
+                }
             }
 
             // skip records that already in synclog


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Harden huge blob placement checks in VDisk, fix HugeKeeper WAL

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Checks to ensure that huge blobs share the correct chunk were added. Also WAL format of HugeBlobKeeper has been optimized to skip writing SlotsInFlight.
