### PR TITLE
24-3: Add min delay before shutdown (#9688)

### DIFF
--- a/ydb/core/driver_lib/run/run.h
+++ b/ydb/core/driver_lib/run/run.h
@@ -42,6 +42,7 @@ protected:
 
     bool EnabledGrpcService = false;
     bool GracefulShutdownSupported = false;
+    TDuration MinDelayBeforeShutdown;
     THolder<NSQS::TAsyncHttpServer> SqsHttp;
 
     THolder<NYdb::TDriver> YdbDriver;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1822,6 +1822,10 @@ message TMetadataCacheConfig {
     optional uint64 RefreshPeriodMs = 1 [default = 15000];
 }
 
+message TShutdownConfig {
+    optional uint32 MinDelayBeforeShutdownSeconds = 1;
+}
+
 message TLabel {
     optional string Name = 1;
     optional string Value = 2;
@@ -1904,6 +1908,7 @@ message TAppConfig {
     optional TLimiterConfig CompDiskLimiterConfig = 79;
     optional TMetadataCacheConfig MetadataCacheConfig = 80;
     optional NKikimrReplication.TReplicationDefaults ReplicationConfig = 83;
+    optional TShutdownConfig ShutdownConfig = 84;
 
     repeated TNamedConfig NamedConfigs = 100;
     optional string ClusterYamlConfig = 101;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add setting to configure min delay before node shutdown

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

This setting is needed to make sure that clients forget about the node after its removal from discovery
