### PR TITLE
Fix PDisk race in restart

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -1069,7 +1069,7 @@ public:
     void Handle(TEvBlobStorage::TEvAskWardenRestartPDiskResult::TPtr &ev) {
         bool restartAllowed = ev->Get()->RestartAllowed;
 
-        EInitPhase initPhase = PDisk->InitPhase;
+        EInitPhase initPhase = PDisk->InitPhase.load();
 
         bool isReadingLog = initPhase == EInitPhase::ReadingSysLog || initPhase == EInitPhase::ReadingLog;
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -1069,7 +1069,9 @@ public:
     void Handle(TEvBlobStorage::TEvAskWardenRestartPDiskResult::TPtr &ev) {
         bool restartAllowed = ev->Get()->RestartAllowed;
 
-        bool isReadingLog = PDisk->InitPhase == EInitPhase::ReadingSysLog || PDisk->InitPhase == EInitPhase::ReadingLog;
+        EInitPhase initPhase = PDisk->InitPhase;
+
+        bool isReadingLog = initPhase == EInitPhase::ReadingSysLog || initPhase == EInitPhase::ReadingLog;
 
         if ((isReadingLog && CurrentStateFunc() != &TPDiskActor::StateError) || IsFormattingNow) {
             // If disk is in the process of initialization (reading log) and it is not in error state, or disk is being formatted,

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -168,7 +168,7 @@ public:
 
     // Initialization data
     ui64 InitialSysLogWritePosition = 0;
-    EInitPhase InitPhase = EInitPhase::Uninitialized;
+    std::atomic<EInitPhase> InitPhase = EInitPhase::Uninitialized;
     TBuffer *InitialTailBuffer = nullptr;
     TLogPosition InitialLogPosition{0, 0};
     volatile ui64 InitialPreviousNonce = 0;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -1313,7 +1313,7 @@ void TPDisk::MarkChunksAsReleased(TReleaseChunks& req) {
 void TPDisk::InitiateReadSysLog(const TActorId &pDiskActor) {
     Y_VERIFY_S(PDiskThread.Running(), "expect PDiskThread to be running");
     Y_VERIFY_S(InitPhase == EInitPhase::Uninitialized, "expect InitPhase to be Uninitialized, but InitPhase# "
-            << InitPhase);
+            << InitPhase.load());
     ui32 formatSectorsSize = FormatSectorSize * ReplicationFactor;
     THolder<TEvReadFormatResult> evReadFormatResult(new TEvReadFormatResult(formatSectorsSize, UseHugePages));
     ui8 *formatSectors = evReadFormatResult->FormatSectors.Get();
@@ -1329,7 +1329,7 @@ void TPDisk::ProcessReadLogResult(const NPDisk::TEvReadLogResult &evReadLogResul
     if (evReadLogResult.Status != NKikimrProto::OK) {
         P_LOG(PRI_ERROR, BPD01, "Error on log read",
             (evReadLogResult, evReadLogResult.ToString()),
-            (InitPhase, InitPhase));
+            (InitPhase, InitPhase.load()));
         switch (InitPhase) {
             case EInitPhase::ReadingSysLog:
                 *Mon.PDiskState = NKikimrBlobStorage::TPDiskState::InitialSysLogReadError;
@@ -1509,7 +1509,7 @@ void TPDisk::ProcessReadLogResult(const NPDisk::TEvReadLogResult &evReadLogResul
             return;
         }
         default:
-            Y_FAIL_S("Unexpected InitPhase# " << InitPhase);
+            Y_FAIL_S("Unexpected InitPhase# " << InitPhase.load());
     }
 }
 

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -153,7 +153,6 @@ struct TEnvironmentSetup {
     }
 
     static void SetupEnv() {
-        TAppData::TimeProvider = TTestActorSystem::CreateTimeProvider();
         ui64 seed = RandomNumber<ui64>();
         if (const TString& s = GetEnv("SEED", "")) {
             seed = FromString<ui64>(s);
@@ -202,6 +201,7 @@ struct TEnvironmentSetup {
 
     void Initialize() {
         Runtime = MakeRuntime();
+        TAppData::TimeProvider = TTestActorSystem::CreateTimeProvider();
         if (Settings.PrepareRuntime) {
             Settings.PrepareRuntime(*Runtime);
         }

--- a/ydb/core/util/testactorsys.cpp
+++ b/ydb/core/util/testactorsys.cpp
@@ -263,11 +263,17 @@ IExecutorPool *TTestActorSystem::CreateTestExecutorPool(ui32 nodeId) {
 thread_local TTestActorSystem *TTestActorSystem::CurrentTestActorSystem = nullptr;
 
 TIntrusivePtr<ITimeProvider> TTestActorSystem::CreateTimeProvider() {
+    auto& clock = CurrentTestActorSystem->Clock;
     class TTestActorTimeProvider : public ITimeProvider {
     public:
-        TInstant Now() override { return CurrentTestActorSystem->Clock; }
+        TTestActorTimeProvider(TInstant& clock)
+            : Clock(clock)
+        {}
+        TInstant Now() override { return Clock; }
+    private:
+        TInstant& Clock;
     };
-    return MakeIntrusive<TTestActorTimeProvider>();
+    return MakeIntrusive<TTestActorTimeProvider>(clock);
 }
 
 TIntrusivePtr<IMonotonicTimeProvider> TTestActorSystem::CreateMonotonicTimeProvider() {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Bugfix 

```
Oct  2 15:13:38 ydb-vla-dev01-000 kikimr[2635698]:   Read of size 4 at 0x7efe270b9d10 by thread T86:
Oct  2 15:13:38 ydb-vla-dev01-000 kikimr[2635698]:     #0 NKikimr::NPDisk::TPDiskActor::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::TEvBlobStorage::TEvAskWardenRestartPDiskResult>, TDelete>&) /home/alexvru/work/ydb/core/blobstor
age/pdisk/blobstorage_pdisk_actor.cpp:1072:36 (kikimr+0x2a185fdd) 
```