### PR TITLE
task_runner_local: avoid formatting log messages when logging disabled

### DIFF
--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_local.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_local.cpp
@@ -261,11 +261,15 @@ public:
             settings.ReadRanges.push_back(readRange);
         }
         auto ctx = ExecutionContext;
+        TLogFunc logger {};
+        if (YQL_CLOG_ACTIVE(DEBUG, ProviderDq)) {
+            logger = [taskId = task.GetId(), traceId = traceId](const TString& message) {
+                YQL_LOG_CTX_ROOT_SESSION_SCOPE(traceId, ToString(taskId));
+                YQL_CLOG(DEBUG, ProviderDq) << message;
+            };
+        }
         ctx.FuncProvider = TaskTransformFactory(settings.TaskParams, ctx.FuncRegistry);
-        return MakeDqTaskRunner(alloc, ctx, settings, [taskId = task.GetId(), traceId = traceId](const TString& message) {
-            YQL_LOG_CTX_ROOT_SESSION_SCOPE(traceId, ToString(taskId));
-            YQL_CLOG(DEBUG, ProviderDq) << message;
-        });
+        return MakeDqTaskRunner(alloc, ctx, settings, logger);
     }
 
 private:

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_local.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_local.cpp
@@ -225,7 +225,6 @@ public:
     }
 
     TIntrusivePtr<NDq::IDqTaskRunner> Get(std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc, const TDqTaskSettings& task, NDqProto::EDqStatsMode statsMode, const TString& traceId) override {
-        Y_UNUSED(traceId);
         NDq::TDqTaskRunnerSettings settings;
         settings.TerminateOnError = TerminateOnError;
         settings.StatsMode = statsMode;
@@ -261,10 +260,10 @@ public:
             settings.ReadRanges.push_back(readRange);
         }
         auto ctx = ExecutionContext;
-        TLogFunc logger {};
+        TLogFunc logger;
         if (YQL_CLOG_ACTIVE(DEBUG, ProviderDq)) {
-            logger = [taskId = task.GetId(), traceId = traceId](const TString& message) {
-                YQL_LOG_CTX_ROOT_SESSION_SCOPE(traceId, ToString(taskId));
+            logger = [taskId = ToString(task.GetId()), traceId = traceId](const TString& message) {
+                YQL_LOG_CTX_ROOT_SESSION_SCOPE(traceId, taskId);
                 YQL_CLOG(DEBUG, ProviderDq) << message;
             };
         }


### PR DESCRIPTION
Callee depends on `!!logger` to avoid formatting messages that would be thrown out. Setting `logger` unconditionally breaks this logic.

Regression by 59edb07f48920f549bf86b0fe5317a7b144209fd

TODO: turn `TLogFunc` into `std::function<void,std::function<TString>>` and use lazy evaluation.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Performance improvement
* Not for changelog (changelog entry is not required)

### Additional information

...