### PR TITLE
Additional validation for queries with "json_list" format and datetime types

### DIFF
--- a/ydb/core/external_sources/object_storage.cpp
+++ b/ydb/core/external_sources/object_storage.cpp
@@ -271,7 +271,6 @@ struct TObjectStorageExternalSource : public IExternalSource {
             return issues;
         }
 
-        Ydb::Column lastColumn;
         TSet<TString> partitionedBySet{partitionedBy.begin(), partitionedBy.end()};
 
         for (const auto& column: schema.column()) {

--- a/ydb/core/external_sources/object_storage.cpp
+++ b/ydb/core/external_sources/object_storage.cpp
@@ -150,6 +150,7 @@ struct TObjectStorageExternalSource : public IExternalSource {
         }
         const bool hasPartitioning = objectStorage.projection_size() || objectStorage.partitioned_by_size();
         issues.AddIssues(ValidateFormatSetting(objectStorage.format(), objectStorage.format_setting(), location, hasPartitioning));
+        issues.AddIssues(ValidateJsonListFormat(objectStorage.format(), schema, objectStorage.partitioned_by()));
         issues.AddIssues(ValidateRawFormat(objectStorage.format(), schema, objectStorage.partitioned_by()));
         if (hasPartitioning) {
             if (NYql::NS3::HasWildcards(location)) {
@@ -260,6 +261,31 @@ struct TObjectStorageExternalSource : public IExternalSource {
                 issues.AddIssue(MakeErrorIssue(Ydb::StatusIds::BAD_REQUEST, "unknown format setting " + key));
             }
         }
+        return issues;
+    }
+
+    template<typename TScheme>
+    static NYql::TIssues ValidateJsonListFormat(const TString& format, const TScheme& schema, const google::protobuf::RepeatedPtrField<TString>& partitionedBy) {
+        NYql::TIssues issues;
+        if (format != "json_list"sv) {
+            return issues;
+        }
+
+        Ydb::Column lastColumn;
+        TSet<TString> partitionedBySet{partitionedBy.begin(), partitionedBy.end()};
+
+        for (const auto& column: schema.column()) {
+            if (partitionedBySet.contains(column.name())) {
+                continue;
+            }
+            if (ValidateDateOrTimeType(column.type())) {
+                issues.AddIssue(MakeErrorIssue(
+                    Ydb::StatusIds::BAD_REQUEST,
+                    TStringBuilder{} << "Date, Timestamp and Interval types are not allowed in json_list format (you have '" 
+                        << column.name() << " " << NYdb::TType(column.type()).ToString() << "' field)"));
+            }
+        }
+
         return issues;
     }
 
@@ -797,6 +823,50 @@ private:
 
     static bool ValidateStringType(const NYdb::TType& columnType) {
         static const std::vector<NYdb::TType> availableTypes = GetStringTypes();
+        return FindIf(availableTypes, [&columnType](const auto& availableType) { return NYdb::TypesEqual(availableType, columnType); }) != availableTypes.end();
+    }
+
+    static std::vector<NYdb::TType> GetDateOrTimeTypes() {
+        NYdb::TType dateType = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Date).Build();
+        NYdb::TType datetimeType = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Datetime).Build();
+        NYdb::TType timestampType = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Timestamp).Build();
+        NYdb::TType intervalType = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Interval).Build();
+        NYdb::TType date32Type = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Date32).Build();
+        NYdb::TType datetime64Type = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Datetime64).Build();
+        NYdb::TType timestamp64Type = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Timestamp64).Build();
+        NYdb::TType interval64Type = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::Interval64).Build();
+        NYdb::TType tzdateType = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::TzDate).Build();
+        NYdb::TType tzdatetimeType = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::TzDatetime).Build();
+        NYdb::TType tztimestampType = NYdb::TTypeBuilder{}.Primitive(NYdb::EPrimitiveType::TzTimestamp).Build();
+        const std::vector<NYdb::TType> result {
+            dateType,
+            datetimeType,
+            timestampType,
+            intervalType,
+            date32Type,
+            datetime64Type,
+            timestamp64Type,
+            interval64Type,
+            tzdateType,
+            tzdatetimeType,
+            tztimestampType,
+            NYdb::TTypeBuilder{}.Optional(dateType).Build(),
+            NYdb::TTypeBuilder{}.Optional(datetimeType).Build(),
+            NYdb::TTypeBuilder{}.Optional(timestampType).Build(),
+            NYdb::TTypeBuilder{}.Optional(intervalType).Build(),
+            NYdb::TTypeBuilder{}.Optional(date32Type).Build(),
+            NYdb::TTypeBuilder{}.Optional(datetime64Type).Build(),
+            NYdb::TTypeBuilder{}.Optional(timestamp64Type).Build(),
+            NYdb::TTypeBuilder{}.Optional(interval64Type).Build(),
+            NYdb::TTypeBuilder{}.Optional(tzdateType).Build(),
+            NYdb::TTypeBuilder{}.Optional(tzdatetimeType).Build(),
+            NYdb::TTypeBuilder{}.Optional(tztimestampType).Build()
+        };
+        return result;
+    }
+
+    static bool ValidateDateOrTimeType(const NYdb::TType& columnType) {
+        static const std::vector<NYdb::TType> availableTypes = GetDateOrTimeTypes();
         return FindIf(availableTypes, [&columnType](const auto& availableType) { return NYdb::TypesEqual(availableType, columnType); }) != availableTypes.end();
     }
 

--- a/ydb/core/external_sources/object_storage_ut.cpp
+++ b/ydb/core/external_sources/object_storage_ut.cpp
@@ -30,6 +30,31 @@ Y_UNIT_TEST_SUITE(ObjectStorageTest) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(source->Pack(schema, general), NExternalSource::TExternalSourceException, "Partition by must always be specified");
     }
 
+    Y_UNIT_TEST(FailedJsonListValidation) {
+        static auto invalidTypes = {
+            Ydb::Type::DATE,
+            Ydb::Type::DATETIME,
+            Ydb::Type::TIMESTAMP,
+            Ydb::Type::INTERVAL,
+            Ydb::Type::DATE32,
+            Ydb::Type::DATETIME64,
+            Ydb::Type::TIMESTAMP64,
+            Ydb::Type::INTERVAL64,
+            Ydb::Type::TZ_DATE,
+            Ydb::Type::TZ_DATETIME,
+            Ydb::Type::TZ_TIMESTAMP,
+        };
+        auto source = NExternalSource::CreateObjectStorageExternalSource({}, nullptr, 1000, nullptr, false, false);
+        NKikimrExternalSources::TSchema schema;
+        for (const auto typeId : invalidTypes) {
+            auto newColumn = schema.add_column();
+            newColumn->mutable_type()->set_type_id(typeId);
+        }
+        NKikimrExternalSources::TGeneral general;
+        general.mutable_attributes()->insert({"format", "json_list"});
+        UNIT_ASSERT_EXCEPTION_CONTAINS(source->Pack(schema, general), NExternalSource::TExternalSourceException, "Date, Timestamp and Interval types are not allowed in json_list format");
+    }
+
     Y_UNIT_TEST(WildcardsValidation) {
         auto source = NExternalSource::CreateObjectStorageExternalSource({}, nullptr, 1000, nullptr, false, false);
         NKikimrExternalSources::TSchema schema;

--- a/ydb/library/yql/providers/common/provider/yql_provider.cpp
+++ b/ydb/library/yql/providers/common/provider/yql_provider.cpp
@@ -1652,6 +1652,30 @@ bool ValidateFormatForInput(
             return false;
         }
     }
+    else if (schemaStructRowType && format == TStringBuf("json_list")) {
+        ui64 failedSchemaColumnsCount = 0;
+
+        for (const TItemExprType* item : schemaStructRowType->GetItems()) {
+            if (excludeFields && excludeFields(item->GetName())) {
+                continue;
+            }
+            const TTypeAnnotationNode* rowType = item->GetItemType();
+            if (rowType->GetKind() == ETypeAnnotationKind::Optional) {
+                rowType = rowType->Cast<TOptionalExprType>()->GetItemType();
+            }
+
+            if (rowType->GetKind() == ETypeAnnotationKind::Data
+                && IsDataTypeDateOrTzDateOrInterval(rowType->Cast<TDataExprType>()->GetSlot())) {
+                ctx.AddError(TIssue(TStringBuilder() << "Date, Timestamp and Interval types are not allowed in json_list format (you have '"
+                    << item->GetName() << " " << FormatType(rowType) << "' field)"));
+                failedSchemaColumnsCount++;
+            }
+        }
+
+        if (failedSchemaColumnsCount > 0) {
+            return false;
+        }
+    }
     return true;
 }
 

--- a/ydb/library/yql/providers/common/provider/yql_provider.cpp
+++ b/ydb/library/yql/providers/common/provider/yql_provider.cpp
@@ -1653,7 +1653,7 @@ bool ValidateFormatForInput(
         }
     }
     else if (schemaStructRowType && format == TStringBuf("json_list")) {
-        ui64 failedSchemaColumnsCount = 0;
+        bool failedSchemaColumns = false;
 
         for (const TItemExprType* item : schemaStructRowType->GetItems()) {
             if (excludeFields && excludeFields(item->GetName())) {
@@ -1668,11 +1668,11 @@ bool ValidateFormatForInput(
                 && IsDataTypeDateOrTzDateOrInterval(rowType->Cast<TDataExprType>()->GetSlot())) {
                 ctx.AddError(TIssue(TStringBuilder() << "Date, Timestamp and Interval types are not allowed in json_list format (you have '"
                     << item->GetName() << " " << FormatType(rowType) << "' field)"));
-                failedSchemaColumnsCount++;
+                failedSchemaColumns = true;
             }
         }
 
-        if (failedSchemaColumnsCount > 0) {
+        if (failedSchemaColumns) {
             return false;
         }
     }

--- a/ydb/tests/fq/s3/test_s3_0.py
+++ b/ydb/tests/fq/s3/test_s3_0.py
@@ -684,9 +684,9 @@ Pear,15,33'''
         )
 
         fruits = '''[
-    { "a" : "2024-01-01 10:10:10", "b" : "2024-01-01" },
-    { "a" : "2024-01-01 10:10:10", "b" : "2024-01-01" },
-    { "a" : "2024-01-01 10:10:10", "b" : "2024-01-01" }
+    { "date" : "0", "datetime" : "0", "timestamp" : "0", "interval" : "0", "date32" : "0", "datetime64" : "0", "timestamp64" : "0", "interval64" : "0", "tzDate" : "0", "tzDateTime" : "0", "tzTimestamp" : "0" },
+    { "date" : "0", "datetime" : "0", "timestamp" : "0", "interval" : "0", "date32" : "0", "datetime64" : "0", "timestamp64" : "0", "interval64" : "0", "tzDate" : "0", "tzDateTime" : "0", "tzTimestamp" : "0" },
+    { "date" : "0", "datetime" : "0", "timestamp" : "0", "interval" : "0", "date32" : "0", "datetime64" : "0", "timestamp64" : "0", "interval64" : "0", "tzDate" : "0", "tzDateTime" : "0", "tzTimestamp" : "0" }
 ]'''
         s3_client.put_object(Body=fruits, Bucket='fbucket', Key='timestamp.json', ContentType='text/plain')
 
@@ -700,8 +700,17 @@ Pear,15,33'''
             WITH (
                 format="json_list",
                 schema=(
-                    a timestamp,
-                    b datetime
+                    `date` date,
+                    `datetime` datetime,
+                    `timestamp` timestamp,
+                    `interval` interval,
+                    `date32` date32,
+                    `datetime64` datetime64,
+                    `timestamp64` timestamp64,
+                    `interval64` interval64,
+                    `tzDate` tzDate,
+                    `tzDateTime` tzDateTime,
+                    `tzTimestamp` tzTimestamp
                 ));
             '''
 
@@ -710,8 +719,17 @@ Pear,15,33'''
 
         error_message = str(client.describe_query(query_id).result)
         assert "Date, Timestamp and Interval types are not allowed in json_list format" in error_message
-        assert "Timestamp" in error_message
+        assert "Date" in error_message
         assert "Datetime" in error_message
+        assert "Timestamp" in error_message
+        assert "Interval" in error_message
+        assert "Date32" in error_message
+        assert "Datetime64" in error_message
+        assert "Timestamp64" in error_message
+        assert "Interval64" in error_message
+        assert "TzDate" in error_message
+        assert "TzDatetime" in error_message
+        assert "TzTimestamp" in error_message
 
     @yq_all
     @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)

--- a/ydb/tests/fq/s3/test_s3_0.py
+++ b/ydb/tests/fq/s3/test_s3_0.py
@@ -684,9 +684,9 @@ Pear,15,33'''
         )
 
         fruits = '''[
-    { "date" : "0", "datetime" : "0", "timestamp" : "0", "interval" : "0", "date32" : "0", "datetime64" : "0", "timestamp64" : "0", "interval64" : "0", "tzDate" : "0", "tzDateTime" : "0", "tzTimestamp" : "0" },
-    { "date" : "0", "datetime" : "0", "timestamp" : "0", "interval" : "0", "date32" : "0", "datetime64" : "0", "timestamp64" : "0", "interval64" : "0", "tzDate" : "0", "tzDateTime" : "0", "tzTimestamp" : "0" },
-    { "date" : "0", "datetime" : "0", "timestamp" : "0", "interval" : "0", "date32" : "0", "datetime64" : "0", "timestamp64" : "0", "interval64" : "0", "tzDate" : "0", "tzDateTime" : "0", "tzTimestamp" : "0" }
+    { "date" : "", "datetime" : "", "timestamp" : "", "interval" : "", "date32" : "", "datetime64" : "", "timestamp64" : "", "interval64" : "", "tzDate" : "", "tzDateTime" : "", "tzTimestamp" : "" },
+    { "date" : "", "datetime" : "", "timestamp" : "", "interval" : "", "date32" : "", "datetime64" : "", "timestamp64" : "", "interval64" : "", "tzDate" : "", "tzDateTime" : "", "tzTimestamp" : "" },
+    { "date" : "", "datetime" : "", "timestamp" : "", "interval" : "", "date32" : "", "datetime64" : "", "timestamp64" : "", "interval64" : "", "tzDate" : "", "tzDateTime" : "", "tzTimestamp" : "" }
 ]'''
         s3_client.put_object(Body=fruits, Bucket='fbucket', Key='timestamp.json', ContentType='text/plain')
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Date, timestamp or time interval types are currently not supported with `json_list` format

Fix for [YQ-3193](https://st.yandex-team.ru/YQ-3193)

### Changelog category <!-- remove all except one -->

* Bugfix 