### PR TITLE
switch to json2proto to allow decode of Any

### DIFF
--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -601,7 +601,16 @@ void TViewerPipeClient::InitConfig(const TCgiParameters& params) {
     }
     Direct = FromStringWithDefault<bool>(params.Get("direct"), Direct);
     JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), true);
-    JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), true);
+    JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);
+    if (FromStringWithDefault<bool>(params.Get("enums"), true)) {
+        Proto2JsonConfig.EnumMode = TProto2JsonConfig::EnumValueMode::EnumName;
+    }
+    if (!FromStringWithDefault<bool>(params.Get("ui64"), false)) {
+        Proto2JsonConfig.StringifyNumbers = TProto2JsonConfig::EStringifyNumbersMode::StringifyInt64Always;
+    }
+    Proto2JsonConfig.MapAsObject = true;
+    Proto2JsonConfig.ConvertAny = true;
+    Proto2JsonConfig.WriteNanAsString = true;
     Timeout = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("timeout"), Timeout.MilliSeconds()));
 }
 
@@ -661,7 +670,7 @@ TString TViewerPipeClient::GetHTTPOKJSON(const NJson::TJsonValue& response, TIns
 
 TString TViewerPipeClient::GetHTTPOKJSON(const google::protobuf::Message& response, TInstant lastModified) {
     TStringStream json;
-    TProtoToJson::ProtoToJson(json, response, JsonSettings);
+    NProtobufJson::Proto2Json(response, json, Proto2JsonConfig);
     return GetHTTPOKJSON(json.Str(), lastModified);
 }
 

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -14,11 +14,13 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
 #include <ydb/library/wilson_ids/wilson.h>
+#include <library/cpp/protobuf/json/proto2json.h>
 
 namespace NKikimr::NViewer {
 
 using namespace NKikimr;
 using namespace NSchemeCache;
+using namespace NProtobufJson;
 using NNodeWhiteboard::TNodeId;
 using NNodeWhiteboard::TTabletId;
 
@@ -46,6 +48,7 @@ protected:
     IViewer* Viewer = nullptr;
     NMon::TEvHttpInfo::TPtr Event;
     TJsonSettings JsonSettings;
+    TProto2JsonConfig Proto2JsonConfig;
     TDuration Timeout = TDuration::Seconds(10);
 
     struct TPipeInfo {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

switch to json2proto to allow decode of any

### Changelog category <!-- remove all except one -->

* New feature
* Not for changelog (changelog entry is not required)
