### PR TITLE
Optimization of the `UpdateOffsetsInTransaction` calls

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
@@ -14,12 +14,15 @@ TAsyncStatus TTransaction::TImpl::Precommit() const
     auto result = NThreading::MakeFuture(TStatus(EStatus::SUCCESS, {}));
 
     for (auto& callback : PrecommitCallbacks) {
-        auto action = [curr = callback()](const TAsyncStatus& prev) {
+        // If you send multiple requests in parallel, the `KQP` service can respond with `SESSION_BUSY`.
+        // Therefore, precommit operations are performed sequentially. Here we capture the closure to
+        // trigger it later.
+        auto action = [callback](const TAsyncStatus& prev) {
             if (const TStatus& status = prev.GetValue(); !status.IsSuccess()) {
                 return prev;
             }
 
-            return curr;
+            return callback();
         };
 
         result = result.Apply(action);
@@ -38,6 +41,8 @@ TAsyncCommitTransactionResult TTransaction::TImpl::Commit(const TCommitTxSetting
         if (const TStatus& status = result.GetValue(); !status.IsSuccess()) {
             return NThreading::MakeFuture(TCommitTransactionResult(TStatus(status), Nothing()));
         }
+
+        PrecommitCallbacks.clear();
 
         return Session_.Client_->CommitTransaction(Session_,
                                                    TxId_,

--- a/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
@@ -17,7 +17,7 @@ TAsyncStatus TTransaction::TImpl::Precommit() const
         // If you send multiple requests in parallel, the `KQP` service can respond with `SESSION_BUSY`.
         // Therefore, precommit operations are performed sequentially. Here we capture the closure to
         // trigger it later.
-        auto action = [callback](const TAsyncStatus& prev) {
+        auto action = [callback = std::move(callback)](const TAsyncStatus& prev) {
             if (const TStatus& status = prev.GetValue(); !status.IsSuccess()) {
                 return prev;
             }

--- a/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.cpp
@@ -14,6 +14,10 @@ TAsyncStatus TTransaction::TImpl::Precommit() const
     auto result = NThreading::MakeFuture(TStatus(EStatus::SUCCESS, {}));
 
     for (auto& callback : PrecommitCallbacks) {
+        if (!callback) {
+            continue;
+        }
+
         // If you send multiple requests in parallel, the `KQP` service can respond with `SESSION_BUSY`.
         // Therefore, precommit operations are performed sequentially. Here we capture the closure to
         // trigger it later.

--- a/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/impl/transaction.h
@@ -31,7 +31,7 @@ private:
     TString TxId_;
 
     bool ChangesAreAccepted = true; // haven't called Commit or Rollback yet
-    TVector<TPrecommitTransactionCallback> PrecommitCallbacks;
+    mutable TVector<TPrecommitTransactionCallback> PrecommitCallbacks;
 };
 
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/offsets_collector.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/offsets_collector.cpp
@@ -1,0 +1,103 @@
+#include "offsets_collector.h"
+
+namespace NYdb::NTopic {
+
+void TOffsetsCollector::CollectOffsets(const TTransactionId& txId,
+                                       const TVector<TReadSessionEvent::TEvent>& events)
+{
+    TTransactionInfoPtr txInfo = GetOrCreateTransactionInfo(txId);
+    for (auto& event : events) {
+        CollectOffsets(txInfo, event);
+    }
+}
+
+void TOffsetsCollector::CollectOffsets(const TTransactionId& txId,
+                                       const TReadSessionEvent::TEvent& event)
+{
+    TTransactionInfoPtr txInfo = GetOrCreateTransactionInfo(txId);
+    CollectOffsets(txInfo, event);
+}
+
+TVector<TTopicOffsets> TOffsetsCollector::ExtractOffsets(const TTransactionId& txId)
+{
+    auto p = Txs.find(txId);
+    Y_ABORT_UNLESS(p != Txs.end(), "txId=%s", GetTxId(txId).data());
+
+    const TTransactionInfoPtr txInfo = p->second;
+    Y_ABORT_UNLESS(txInfo);
+
+    TVector<TTopicOffsets> topics;
+
+    for (auto& [path, partitions] : txInfo->Ranges) {
+        TTopicOffsets topic;
+        topic.Path = path;
+
+        topics.push_back(std::move(topic));
+
+        for (auto& [id, ranges] : partitions) {
+            TPartitionOffsets partition;
+            partition.PartitionId = id;
+
+            TTopicOffsets& t = topics.back();
+            t.Partitions.push_back(std::move(partition));
+
+            for (auto& range : ranges) {
+                TPartitionOffsets& p = t.Partitions.back();
+
+                TOffsetsRange r;
+                r.Start = range.first;
+                r.End = range.second;
+
+                p.Offsets.push_back(r);
+            }
+        }
+    }
+
+    Txs.erase(txId);
+
+    return topics;
+}
+
+auto TOffsetsCollector::GetOrCreateTransactionInfo(const TTransactionId& txId) -> TTransactionInfoPtr
+{
+    auto p = Txs.find(txId);
+    if (p == Txs.end()) {
+        TTransactionInfoPtr& txInfo = Txs[txId];
+        txInfo = std::make_shared<TTransactionInfo>();
+        txInfo->Subscribed = false;
+        p = Txs.find(txId);
+    }
+    return p->second;
+}
+
+void TOffsetsCollector::CollectOffsets(TTransactionInfoPtr txInfo,
+                                       const TReadSessionEvent::TEvent& event)
+{
+    if (auto* e = std::get_if<TReadSessionEvent::TDataReceivedEvent>(&event)) {
+        CollectOffsets(txInfo, *e);
+    }
+}
+
+void TOffsetsCollector::CollectOffsets(TTransactionInfoPtr txInfo,
+                                       const TReadSessionEvent::TDataReceivedEvent& event)
+{
+    const auto& session = *event.GetPartitionSession();
+    const TString& topicPath = session.GetTopicPath();
+    ui32 partitionId = session.GetPartitionId();
+
+    with_lock (txInfo->Lock) {
+        if (event.HasCompressedMessages()) {
+            for (auto& message : event.GetCompressedMessages()) {
+                ui64 offset = message.GetOffset();
+                txInfo->Ranges[topicPath][partitionId].InsertInterval(offset, offset + 1);
+            }
+        } else {
+            for (auto& message : event.GetMessages()) {
+                ui64 offset = message.GetOffset();
+                txInfo->Ranges[topicPath][partitionId].InsertInterval(offset, offset + 1);
+            }
+        }
+    }
+}
+
+}

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/offsets_collector.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/offsets_collector.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "topic_impl.h"
+#include "transaction.h"
+
+#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
+#include <ydb/public/sdk/cpp/client/ydb_topic/include/read_events.h>
+
+#include <library/cpp/containers/disjoint_interval_tree/disjoint_interval_tree.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+#include <memory>
+
+namespace NYdb::NTopic {
+
+class TOffsetsCollector {
+public:
+    // topic -> partition -> (begin, end)
+    using TOffsetRanges = THashMap<TString, THashMap<ui64, TDisjointIntervalTree<ui64>>>;
+
+    struct TTransactionInfo {
+        TSpinLock Lock;
+        bool IsActive = false;
+        bool Subscribed = false;
+        TOffsetRanges Ranges;
+    };
+
+    using TTransactionInfoPtr = std::shared_ptr<TTransactionInfo>;
+
+    TTransactionInfoPtr GetOrCreateTransactionInfo(const TTransactionId& txId);
+
+    TVector<TTopicOffsets> ExtractOffsets(const TTransactionId& txId);
+
+    void CollectOffsets(const TTransactionId& txId,
+                        const TVector<TReadSessionEvent::TEvent>& events);
+    void CollectOffsets(const TTransactionId& txId,
+                        const TReadSessionEvent::TEvent& event);
+
+private:
+    using TTransactionMap = THashMap<TTransactionId, TTransactionInfoPtr>;
+
+    void CollectOffsets(TTransactionInfoPtr txInfo,
+                        const TReadSessionEvent::TEvent& event);
+    void CollectOffsets(TTransactionInfoPtr txInfo,
+                        const TReadSessionEvent::TDataReceivedEvent& event);
+
+    TTransactionMap Txs;
+};
+
+}

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/offsets_collector.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/offsets_collector.h
@@ -18,36 +18,18 @@ namespace NYdb::NTopic {
 
 class TOffsetsCollector {
 public:
+    TVector<TTopicOffsets> GetOffsets() const;
+
+    void CollectOffsets(const TVector<TReadSessionEvent::TEvent>& events);
+    void CollectOffsets(const TReadSessionEvent::TEvent& event);
+
+private:
     // topic -> partition -> (begin, end)
     using TOffsetRanges = THashMap<TString, THashMap<ui64, TDisjointIntervalTree<ui64>>>;
 
-    struct TTransactionInfo {
-        TSpinLock Lock;
-        bool IsActive = false;
-        bool Subscribed = false;
-        TOffsetRanges Ranges;
-    };
+    void CollectOffsets(const TReadSessionEvent::TDataReceivedEvent& event);
 
-    using TTransactionInfoPtr = std::shared_ptr<TTransactionInfo>;
-
-    TTransactionInfoPtr GetOrCreateTransactionInfo(const TTransactionId& txId);
-
-    TVector<TTopicOffsets> ExtractOffsets(const TTransactionId& txId);
-
-    void CollectOffsets(const TTransactionId& txId,
-                        const TVector<TReadSessionEvent::TEvent>& events);
-    void CollectOffsets(const TTransactionId& txId,
-                        const TReadSessionEvent::TEvent& event);
-
-private:
-    using TTransactionMap = THashMap<TTransactionId, TTransactionInfoPtr>;
-
-    void CollectOffsets(TTransactionInfoPtr txInfo,
-                        const TReadSessionEvent::TEvent& event);
-    void CollectOffsets(TTransactionInfoPtr txInfo,
-                        const TReadSessionEvent::TDataReceivedEvent& event);
-
-    TTransactionMap Txs;
+    TOffsetRanges Ranges;
 };
 
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.cpp
@@ -28,7 +28,7 @@ TReadSession::TReadSession(const TReadSessionSettings& settings,
 
     MakeCountersIfNeeded();
 
-    Txs = std::make_shared<TTransactionList>();
+    Txs = std::make_shared<TTransactionMap>();
 }
 
 TReadSession::~TReadSession() {

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.cpp
@@ -188,8 +188,11 @@ void TReadSession::CollectOffsets(NTable::TTransaction& tx,
 {
     const TString& sessionId = tx.GetSession().GetId();
     const TString& txId = tx.GetId();
-    TOffsetRanges& ranges = OffsetRanges[std::make_pair(sessionId, txId)];
-    ranges[topicPath][partitionId].InsertInterval(offset, offset + 1);
+    TOffsetRangesPtr& ranges = OffsetRanges[std::make_pair(sessionId, txId)];
+    if (!ranges) {
+        ranges = std::make_shared<TOffsetRanges>();
+    }
+    (*ranges)[topicPath][partitionId].InsertInterval(offset, offset + 1);
 }
 
 void TReadSession::UpdateOffsets(const NTable::TTransaction& tx)
@@ -203,7 +206,7 @@ void TReadSession::UpdateOffsets(const NTable::TTransaction& tx)
     }
 
     TVector<TTopicOffsets> topics;
-    for (auto& [path, partitions] : p->second) {
+    for (auto& [path, partitions] : *p->second) {
         TTopicOffsets topic;
         topic.Path = path;
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -3,7 +3,6 @@
 #include "counters_logger.h"
 #include "read_session_impl.ipp"
 #include "topic_impl.h"
-#include "transaction.h"
 
 #include <ydb/public/sdk/cpp/client/ydb_topic/common/callback_context.h>
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -66,7 +66,6 @@ private:
 private:
     // topic -> partition -> (begin, end)
     using TOffsetRanges = THashMap<TString, THashMap<ui64, TDisjointIntervalTree<ui64>>>;
-//    using TOffsetRangesPtr = std::shared_ptr<TOffsetRanges>;
 
     struct TTransactionInfo {
         TSpinLock Lock;
@@ -84,18 +83,11 @@ private:
                         const TReadSessionEvent::TDataReceivedEvent& event);
     void CollectOffsets(NTable::TTransaction& tx,
                         const TString& topicPath, ui32 partitionId, ui64 offset);
-    //void UpdateOffsets(const NTable::TTransaction& tx);
 
-//    void TrySubscribeOnTransactionCommit(TTransaction& tx, TOffsetRangesPtr ranges);
     TTransactionInfoPtr GetOrCreateTxInfo(const TTransactionId& txId);
     TAsyncStatus AsyncUpdateOffsets(const TTransactionId& txId);
 
     auto MakeUpdateOffsetsInTransactionCaller(const TTransactionId& txId);
-
-//    //
-//    // (session, tx) -> topic -> partition -> (begin, end)
-//    //
-//    THashMap<TTransactionId, TOffsetRangesPtr> OffsetRanges;
 
     TReadSessionSettings Settings;
     const TString SessionId;

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -66,15 +66,19 @@ private:
 private:
     // topic -> partition -> (begin, end)
     using TOffsetRanges = THashMap<TString, THashMap<ui64, TDisjointIntervalTree<ui64>>>;
-    using TOffsetRangesPtr = std::shared_ptr<TOffsetRanges>;
+//    using TOffsetRangesPtr = std::shared_ptr<TOffsetRanges>;
 
     struct TTransactionInfo {
         TSpinLock Lock;
         bool IsActive = false;
         bool Subscribed = false;
+        TOffsetRanges Ranges;
     };
 
     using TTransactionInfoPtr = std::shared_ptr<TTransactionInfo>;
+
+    using TTransactionList = THashMap<TTransactionId, TTransactionInfoPtr>;
+    using TTransactionListPtr = std::shared_ptr<TTransactionList>;
 
     void CollectOffsets(NTable::TTransaction& tx,
                         const TReadSessionEvent::TDataReceivedEvent& event);
@@ -82,17 +86,16 @@ private:
                         const TString& topicPath, ui32 partitionId, ui64 offset);
     //void UpdateOffsets(const NTable::TTransaction& tx);
 
-    void TrySubscribeOnTransactionCommit(TTransaction& tx, TOffsetRangesPtr ranges);
+//    void TrySubscribeOnTransactionCommit(TTransaction& tx, TOffsetRangesPtr ranges);
     TTransactionInfoPtr GetOrCreateTxInfo(const TTransactionId& txId);
     TAsyncStatus AsyncUpdateOffsets(const TTransactionId& txId);
 
-    auto MakeUpdateOffsetsInTransactionCaller(const TTransactionId& txId,
-                                              TOffsetRangesPtr offsets);
+    auto MakeUpdateOffsetsInTransactionCaller(const TTransactionId& txId);
 
-    //
-    // (session, tx) -> topic -> partition -> (begin, end)
-    //
-    THashMap<TTransactionId, TOffsetRangesPtr> OffsetRanges;
+//    //
+//    // (session, tx) -> topic -> partition -> (begin, end)
+//    //
+//    THashMap<TTransactionId, TOffsetRangesPtr> OffsetRanges;
 
     TReadSessionSettings Settings;
     const TString SessionId;
@@ -113,9 +116,6 @@ private:
     // Exiting.
     bool Aborting = false;
     bool Closing = false;
-
-    using TTransactionList = THashMap<TTransactionId, TTransactionInfoPtr>;
-    using TTransactionListPtr = std::shared_ptr<TTransactionList>;
 
     TTransactionListPtr Txs;
 };

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -64,6 +64,7 @@ private:
 
 private:
     using TOffsetRanges = THashMap<TString, THashMap<ui64, TDisjointIntervalTree<ui64>>>;
+    using TOffsetRangesPtr = std::shared_ptr<TOffsetRanges>;
 
     void CollectOffsets(NTable::TTransaction& tx,
                         const TReadSessionEvent::TDataReceivedEvent& event);
@@ -74,7 +75,7 @@ private:
     //
     // (session, tx) -> topic -> partition -> (begin, end)
     //
-    THashMap<std::pair<TString, TString>, TOffsetRanges> OffsetRanges;
+    THashMap<std::pair<TString, TString>, TOffsetRangesPtr> OffsetRanges;
 
     TReadSessionSettings Settings;
     const TString SessionId;

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -64,33 +64,6 @@ private:
     void AbortImpl(EStatus statusCode, const TString& message, TDeferredActions<false>& deferred);
 
 private:
-    // topic -> partition -> (begin, end)
-    using TOffsetRanges = THashMap<TString, THashMap<ui64, TDisjointIntervalTree<ui64>>>;
-
-    struct TTransactionInfo {
-        TSpinLock Lock;
-        bool IsActive = false;
-        bool Subscribed = false;
-        TOffsetRanges Ranges;
-    };
-
-    using TTransactionInfoPtr = std::shared_ptr<TTransactionInfo>;
-
-    using TTransactionMap = THashMap<TTransactionId, TTransactionInfoPtr>;
-    using TTransactionMapPtr = std::shared_ptr<TTransactionMap>;
-
-    void CollectOffsets(NTable::TTransaction& tx,
-                        const TReadSessionEvent::TDataReceivedEvent& event);
-    void CollectOffsets(NTable::TTransaction& tx,
-                        const TString& topicPath, ui32 partitionId, ui64 offset);
-
-    TTransactionInfoPtr GetOrCreateTxInfo(const TTransactionId& txId);
-    TAsyncStatus AsyncUpdateOffsets(const TTransactionId& txId);
-
-    using TUpdateOffsetsInTransactionCaller = std::function<TAsyncStatus (TTransactionInfoPtr)>;
-
-    TUpdateOffsetsInTransactionCaller MakeUpdateOffsetsInTransactionCaller(const TTransactionId& txId);
-
     TReadSessionSettings Settings;
     const TString SessionId;
     const TInstant StartSessionTime = TInstant::Now();
@@ -110,8 +83,6 @@ private:
     // Exiting.
     bool Aborting = false;
     bool Closing = false;
-
-    TTransactionMapPtr Txs;
 };
 
 }  // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -76,8 +76,8 @@ private:
 
     using TTransactionInfoPtr = std::shared_ptr<TTransactionInfo>;
 
-    using TTransactionList = THashMap<TTransactionId, TTransactionInfoPtr>;
-    using TTransactionListPtr = std::shared_ptr<TTransactionList>;
+    using TTransactionMap = THashMap<TTransactionId, TTransactionInfoPtr>;
+    using TTransactionMapPtr = std::shared_ptr<TTransactionMap>;
 
     void CollectOffsets(NTable::TTransaction& tx,
                         const TReadSessionEvent::TDataReceivedEvent& event);
@@ -111,7 +111,7 @@ private:
     bool Aborting = false;
     bool Closing = false;
 
-    TTransactionListPtr Txs;
+    TTransactionMapPtr Txs;
 };
 
 }  // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -86,10 +86,8 @@ private:
     TTransactionInfoPtr GetOrCreateTxInfo(const TTransactionId& txId);
     TAsyncStatus AsyncUpdateOffsets(const TTransactionId& txId);
 
-    auto MakeUpdateOffsetsInTransactionCaller(std::shared_ptr<TTopicClient::TImpl> client,
-                                              const TTransactionId& txId,
-                                              TOffsetRangesPtr offsets,
-                                              const TString& consumer);
+    auto MakeUpdateOffsetsInTransactionCaller(const TTransactionId& txId,
+                                              TOffsetRangesPtr offsets);
 
     //
     // (session, tx) -> topic -> partition -> (begin, end)
@@ -116,7 +114,10 @@ private:
     bool Aborting = false;
     bool Closing = false;
 
-    THashMap<TTransactionId, TTransactionInfoPtr> Txs;
+    using TTransactionList = THashMap<TTransactionId, TTransactionInfoPtr>;
+    using TTransactionListPtr = std::shared_ptr<TTransactionList>;
+
+    TTransactionListPtr Txs;
 };
 
 }  // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session.h
@@ -87,7 +87,9 @@ private:
     TTransactionInfoPtr GetOrCreateTxInfo(const TTransactionId& txId);
     TAsyncStatus AsyncUpdateOffsets(const TTransactionId& txId);
 
-    auto MakeUpdateOffsetsInTransactionCaller(const TTransactionId& txId);
+    using TUpdateOffsetsInTransactionCaller = std::function<TAsyncStatus (TTransactionInfoPtr)>;
+
+    TUpdateOffsetsInTransactionCaller MakeUpdateOffsetsInTransactionCaller(const TTransactionId& txId);
 
     TReadSessionSettings Settings;
     const TString SessionId;

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.h
@@ -12,6 +12,9 @@
 #include <ydb/public/sdk/cpp/client/ydb_topic/include/read_session.h>
 #include <ydb/public/sdk/cpp/client/ydb_persqueue_public/include/read_session.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/common/callback_context.h>
+#include <ydb/public/sdk/cpp/client/ydb_topic/impl/topic_impl.h>
+
+#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 
 #include <ydb/public/sdk/cpp/client/ydb_common_client/impl/client.h>
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.h
@@ -1329,6 +1329,7 @@ private:
     void TrySubscribeOnTransactionCommit(NTable::TTransaction& tx,
                                          std::shared_ptr<TTopicClient::TImpl> client);
     TTransactionInfoPtr GetOrCreateTxInfo(const TTransactionId& txId);
+    void DeleteTx(const TTransactionId& txId);
 
     const TAReadSessionSettings<UseMigrationProtocol> Settings;
     const TString Database;

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.ipp
@@ -1965,7 +1965,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::TrySubscribeOnTransact
             }
 
             if (auto self = cbContext->LockShared()) {
-                self->Txs.erase(txId);
+                self->DeleteTx(txId);
             }
 
             return client->UpdateOffsetsInTransaction(txId,
@@ -1994,6 +1994,14 @@ auto TSingleClusterReadSessionImpl<UseMigrationProtocol>::GetOrCreateTxInfo(cons
             p = Txs.find(txId);
         }
         return p->second;
+    }
+}
+
+template <bool UseMigrationProtocol>
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::DeleteTx(const TTransactionId& txId)
+{
+    with_lock (Lock) {
+        Txs.erase(txId);
     }
 }
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_impl.ipp
@@ -5,8 +5,6 @@
 #undef INCLUDE_READ_SESSION_IMPL_H
 
 #include <ydb/public/sdk/cpp/client/ydb_topic/common/log_lazy.h>
-#include <ydb/public/sdk/cpp/client/ydb_topic/impl/topic_impl.h>
-#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 
 #define INCLUDE_YDB_INTERNAL_H
 #include <ydb/public/sdk/cpp/client/impl/ydb_internal/logger/log.h>

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/topic_impl.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/topic_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "transaction.h"
+
 #include <ydb/public/sdk/cpp/client/ydb_topic/impl/common.h>
 
 #define INCLUDE_YDB_INTERNAL_H
@@ -330,15 +332,15 @@ public:
             TRpcRequestSettings::Make(settings));
     }
 
-    TAsyncStatus UpdateOffsetsInTransaction(const NTable::TTransaction& tx,
+    TAsyncStatus UpdateOffsetsInTransaction(const TTransactionId& tx,
                                             const TVector<TTopicOffsets>& topics,
                                             const TString& consumerName,
                                             const TUpdateOffsetsInTransactionSettings& settings)
     {
         auto request = MakeOperationRequest<Ydb::Topic::UpdateOffsetsInTransactionRequest>(settings);
 
-        request.mutable_tx()->set_id(tx.GetId());
-        request.mutable_tx()->set_session(tx.GetSession().GetId());
+        request.mutable_tx()->set_id(GetTxId(tx));
+        request.mutable_tx()->set_session(GetSessionId(tx));
 
         for (auto& t : topics) {
             auto* topic = request.mutable_topics()->Add();

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/transaction.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/transaction.cpp
@@ -1,0 +1,26 @@
+#include "transaction.h"
+#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
+
+namespace NYdb::NTopic {
+
+TTransactionId MakeTransactionId(const NTable::TTransaction& tx)
+{
+    return {tx.GetSession().GetId(), tx.GetId()};
+}
+
+TStatus MakeStatus(EStatus code, NYql::TIssues&& issues)
+{
+    return {code, std::move(issues)};
+}
+
+TStatus MakeSessionExpiredError()
+{
+    return MakeStatus(EStatus::SESSION_EXPIRED, {});
+}
+
+TStatus MakeCommitTransactionSuccess()
+{
+    return MakeStatus(EStatus::SUCCESS, {});
+}
+
+}

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/transaction.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/transaction.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ydb/public/sdk/cpp/client/ydb_types/status/status.h>
+
+#include <util/generic/string.h>
+
+namespace NYdb::NTable {
+
+class TTransaction;
+
+}
+
+namespace NYdb::NTopic {
+
+using TTransactionId = std::pair<TString, TString>;
+
+inline
+const TString& GetSessionId(const TTransactionId& x)
+{
+    return x.first;
+}
+
+inline
+const TString& GetTxId(const TTransactionId& x)
+{
+    return x.second;
+}
+
+TTransactionId MakeTransactionId(const NTable::TTransaction& tx);
+
+TStatus MakeSessionExpiredError();
+TStatus MakeCommitTransactionSuccess();
+
+}

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.cpp
@@ -1,5 +1,4 @@
 #include "write_session_impl.h"
-#include "transaction.h"
 
 #include <ydb/public/sdk/cpp/client/ydb_topic/common/log_lazy.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/common/trace_lazy.h>

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.h
@@ -424,8 +424,7 @@ private:
     void CancelTransactions();
     TTransactionInfoPtr GetOrCreateTxInfo(const TTransactionId& txId);
     void TrySignalAllAcksReceived(ui64 seqNo);
-
-    void OnTransactionCommit();
+    void DeleteTx(const TTransactionId& txId);
 
 private:
     TWriteSessionSettings Settings;

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/write_session_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "transaction.h"
+
 #include <ydb/public/sdk/cpp/client/ydb_topic/common/callback_context.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/impl/common.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/impl/topic_impl.h>
@@ -313,7 +315,6 @@ private:
         ui64 AckCount = 0;
     };
 
-    using TTransactionId = std::pair<TString, TString>; // SessionId, TxId
     using TTransactionInfoPtr = std::shared_ptr<TTransactionInfo>;
 
     THandleResult OnErrorImpl(NYdb::TPlainStatus&& status); // true - should Start(), false - should Close(), empty - no action

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/ya.make
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/ya.make
@@ -13,6 +13,7 @@ SRCS(
     topic_impl.h
     topic_impl.cpp
     topic.cpp
+    transaction.cpp
     write_session_impl.h
     write_session_impl.cpp
     write_session.h

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/ya.make
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/ya.make
@@ -6,6 +6,7 @@ SRCS(
     counters_logger.h
     deferred_commit.cpp
     event_handlers.cpp
+    offsets_collector.cpp
     read_session_event.cpp
     read_session_impl.ipp
     read_session.h

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -487,27 +487,19 @@ Y_UNIT_TEST_F(TwoSessionOneConsumer, TFixture)
     auto session1 = CreateTableSession();
     auto tx1 = BeginTx(session1);
 
-    {
-        auto reader = CreateReader();
-
-        StartPartitionSession(reader, tx1, 0);
-
-        ReadMessage(reader, tx1, 0);
-    }
+    auto reader = CreateReader();
+    StartPartitionSession(reader, tx1, 0);
+    ReadMessage(reader, tx1, 0);
 
     auto session2 = CreateTableSession();
     auto tx2 = BeginTx(session2);
 
-    {
-        auto reader = CreateReader();
-
-        StartPartitionSession(reader, tx2, 0);
-
-        ReadMessage(reader, tx2, 0);
-    }
+    reader = CreateReader();
+    StartPartitionSession(reader, tx2, 0);
+    ReadMessage(reader, tx2, 0);
 
     CommitTx(tx2, EStatus::SUCCESS);
-    CommitTx(tx1, EStatus::ABORTED);
+    CommitTx(tx1, EStatus::SESSION_EXPIRED);
 }
 
 //Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -1948,10 +1948,12 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_27, TFixture)
 
         auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2), &tx, 0);
         UNIT_ASSERT_VALUES_EQUAL(messages.size(), 1);
+
         WriteToTopic("topic_C", TEST_MESSAGE_GROUP_ID, messages[0], &tx, 0);
 
         messages = ReadFromTopic("topic_B", TEST_CONSUMER, TDuration::Seconds(2), &tx, 0);
         UNIT_ASSERT_VALUES_EQUAL(messages.size(), 1);
+
         WriteToTopic("topic_C", TEST_MESSAGE_GROUP_ID, messages[0], &tx, 0);
 
         CommitTx(tx, EStatus::SUCCESS);

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -487,19 +487,23 @@ Y_UNIT_TEST_F(TwoSessionOneConsumer, TFixture)
     auto session1 = CreateTableSession();
     auto tx1 = BeginTx(session1);
 
-    auto reader = CreateReader();
-    StartPartitionSession(reader, tx1, 0);
-    ReadMessage(reader, tx1, 0);
+    {
+        auto reader = CreateReader();
+        StartPartitionSession(reader, tx1, 0);
+        ReadMessage(reader, tx1, 0);
+    }
 
     auto session2 = CreateTableSession();
     auto tx2 = BeginTx(session2);
 
-    reader = CreateReader();
-    StartPartitionSession(reader, tx2, 0);
-    ReadMessage(reader, tx2, 0);
+    {
+        auto reader = CreateReader();
+        StartPartitionSession(reader, tx2, 0);
+        ReadMessage(reader, tx2, 0);
+    }
 
     CommitTx(tx2, EStatus::SUCCESS);
-    CommitTx(tx1, EStatus::SESSION_EXPIRED);
+    CommitTx(tx1, EStatus::ABORTED);
 }
 
 //Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The `UpdateOffsetsInTransaction` method is retrieved once before COMMIT.

### Changelog category <!-- remove all except one -->

* Performance improvement
* Not for changelog (changelog entry is not required)

### Additional information

...
