### PR TITLE
Add hints to TEvRead for scan queries

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1827,6 +1827,24 @@ message TEvRead {
     // Limits total number of rows which iterator can read.
     optional uint64 TotalRowsLimit = 12;
 
+    enum EHint {
+        // No hits. This is the default.
+        HINT_NONE = 0;
+
+        // This hint should be specified for batch queries. DataShard will
+        // attempt to run this query as a scan when possible, minimizing
+        // effects on concurrent OLTP queries.
+        HINT_BATCH = 1;
+
+        // This hint should be specified for low priority queries. DataShard
+        // will attempt to use low-priority reads when possible, minimizing
+        // effects on concurrent OLTP queries.
+        HINT_LOW_PRIORITY = 2;
+    }
+
+    // Optional bit flags with hints
+    optional uint32 Hints = 13;
+
     // Request must contain either keys, queries or program
     // mixed requests are not supported
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Add hints to TEvRead. This would allow KQP to switch to TEvRead for scan queries when these hints are implemented.

Related to #10306.