### PR TITLE
Grace join fixes and improvements backports

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -589,7 +589,7 @@ public:
     ,   IsSpillingAllowed(isSpillingAllowed)
     {
         YQL_LOG(GRACEJOIN_DEBUG) << (const void *)&*JoinedTablePtr << "# AnyJoinSettings=" << (int)anyJoinSettings << " JoinKind=" << (int)joinKind;
-        if (JoinKind == EJoinKind::Full || JoinKind == EJoinKind::Exclusion || IsSelfJoin_) {
+        if (IsSelfJoin_) {
             LeftPacker->BatchSize = std::numeric_limits<ui64>::max();
             RightPacker->BatchSize = std::numeric_limits<ui64>::max();
         }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -584,7 +584,6 @@ public:
     ,   PartialJoinCompleted(std::make_unique<bool>(false))
     ,   HaveMoreLeftRows(std::make_unique<bool>(true))
     ,   HaveMoreRightRows(std::make_unique<bool>(true))
-    ,   JoinedTuple(std::make_unique<std::vector<NUdf::TUnboxedValue*>>() )
     ,   IsSelfJoin_(isSelfJoin)
     ,   SelfJoinSameKeys_(isSelfJoin && (leftKeyColumns == rightKeyColumns))
     ,   IsSpillingAllowed(isSpillingAllowed)
@@ -989,7 +988,6 @@ private:
     const std::unique_ptr<bool> PartialJoinCompleted;
     const std::unique_ptr<bool> HaveMoreLeftRows;
     const std::unique_ptr<bool> HaveMoreRightRows;
-    const std::unique_ptr<std::vector<NUdf::TUnboxedValue*>> JoinedTuple;
     const bool IsSelfJoin_;
     const bool SelfJoinSameKeys_;
     const bool IsSpillingAllowed;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -197,7 +197,6 @@ TColumnDataPackInfo GetPackInfo(TType* type) {
 void TGraceJoinPacker::Pack()  {
 
     TuplesPacked++;
-    TuplesBatchPacked++;
     std::fill(TupleIntVals.begin(), TupleIntVals.end(), 0);
 
     for (ui64 i = 0; i < ColumnsPackInfo.size(); i++) {
@@ -590,6 +589,7 @@ public:
     ,   SelfJoinSameKeys_(isSelfJoin && (leftKeyColumns == rightKeyColumns))
     ,   IsSpillingAllowed(isSpillingAllowed)
     {
+        YQL_LOG(GRACEJOIN_DEBUG) << (const void *)&*JoinedTablePtr << "# AnyJoinSettings=" << (int)anyJoinSettings << " JoinKind=" << (int)joinKind;
         if (JoinKind == EJoinKind::Full || JoinKind == EJoinKind::Exclusion || IsSelfJoin_) {
             LeftPacker->BatchSize = std::numeric_limits<ui64>::max();
             RightPacker->BatchSize = std::numeric_limits<ui64>::max();
@@ -607,7 +607,9 @@ public:
                     break;
                 }
                 case EOperatingMode::Spilling: {
-                    DoCalculateWithSpilling(ctx);
+                    auto r = DoCalculateWithSpilling(ctx, output);
+                    if (r == EFetchResult::One)
+                        return r;
                     if (GetMode() == EOperatingMode::Spilling) {
                         return EFetchResult::Yield;
                     }
@@ -657,9 +659,40 @@ private:
         Mode = mode;
     }
 
-    bool FetchAndPackData(TComputationContext& ctx) {
+    EFetchResult FetchAndPackData(TComputationContext& ctx, NUdf::TUnboxedValue*const* output) {
         const NKikimr::NMiniKQL::EFetchResult resultLeft = FlowLeft->FetchValues(ctx, LeftPacker->TuplePtrs.data());
         NKikimr::NMiniKQL::EFetchResult resultRight;
+
+        if (resultLeft == EFetchResult::One) {
+            if (LeftPacker->TuplesPacked == 0) {
+                LeftPacker->StartTime = std::chrono::system_clock::now();
+            }
+            LeftPacker->Pack();
+            {
+                auto added = LeftPacker->TablePtr->AddTuple(LeftPacker->TupleIntVals.data(), LeftPacker->TupleStrings.data(), LeftPacker->TupleStrSizes.data(), LeftPacker->IColumnsHolder.data(), *RightPacker->TablePtr);
+                if (added == GraceJoin::TTable::EAddTupleResult::Added)
+                    ++LeftPacker->TuplesBatchPacked;
+                else if (added == GraceJoin::TTable::EAddTupleResult::AnyMatch)
+                    ; // row dropped
+                else if (JoinKind == EJoinKind::Inner || JoinKind == EJoinKind::Right || JoinKind == EJoinKind::RightSemi || JoinKind == EJoinKind::RightOnly || JoinKind == EJoinKind::LeftSemi)
+                    ; // row dropped
+                else { // Left, LeftOnly, Full, Exclusion: output row
+                    for (size_t i = 0; i < LeftRenames.size() / 2; i++) {
+                        auto & valPtr = output[LeftRenames[2 * i + 1]];
+                        if ( valPtr ) {
+                            *valPtr = *LeftPacker->TuplePtrs[LeftRenames[2 * i]];
+                        }
+                    }
+                    for (size_t i = 0; i < RightRenames.size() / 2; i++) {
+                        auto & valPtr = output[RightRenames[2 * i + 1]];
+                        if ( valPtr ) {
+                            *valPtr = NYql::NUdf::TUnboxedValue();
+                        }
+                    }
+                    return EFetchResult::One;
+                }
+            }
+        }
 
         if (IsSelfJoin_) {
             resultRight = resultLeft;
@@ -670,14 +703,6 @@ private:
             resultRight = FlowRight->FetchValues(ctx, RightPacker->TuplePtrs.data());
         }
 
-        if (resultLeft == EFetchResult::One) {
-            if (LeftPacker->TuplesPacked == 0) {
-                LeftPacker->StartTime = std::chrono::system_clock::now();
-            }
-            LeftPacker->Pack();
-            LeftPacker->TablePtr->AddTuple(LeftPacker->TupleIntVals.data(), LeftPacker->TupleStrings.data(), LeftPacker->TupleStrSizes.data(), LeftPacker->IColumnsHolder.data());
-        }
-
         if (resultRight == EFetchResult::One) {
             if (RightPacker->TuplesPacked == 0) {
                 RightPacker->StartTime = std::chrono::system_clock::now();
@@ -685,12 +710,33 @@ private:
 
             if ( !SelfJoinSameKeys_ ) {
                 RightPacker->Pack();
-                RightPacker->TablePtr->AddTuple(RightPacker->TupleIntVals.data(), RightPacker->TupleStrings.data(), RightPacker->TupleStrSizes.data(), RightPacker->IColumnsHolder.data());
+                auto added = RightPacker->TablePtr->AddTuple(RightPacker->TupleIntVals.data(), RightPacker->TupleStrings.data(), RightPacker->TupleStrSizes.data(), RightPacker->IColumnsHolder.data(), *LeftPacker->TablePtr);
+                if (added == GraceJoin::TTable::EAddTupleResult::Added)
+                    ++RightPacker->TuplesBatchPacked;
+                else if (added == GraceJoin::TTable::EAddTupleResult::AnyMatch)
+                    ; // row dropped
+                else if (JoinKind == EJoinKind::Inner || JoinKind == EJoinKind::Left || JoinKind == EJoinKind::LeftSemi || JoinKind == EJoinKind::LeftOnly || JoinKind == EJoinKind::RightSemi)
+                    ; // row dropped
+                else { // Right, RightOnly, Full, Exclusion: output row
+                    for (size_t i = 0; i < LeftRenames.size() / 2; i++) {
+                        auto & valPtr = output[LeftRenames[2 * i + 1]];
+                        if ( valPtr ) {
+                            *valPtr = NYql::NUdf::TUnboxedValue();
+                        }
+                    }
+                    for (size_t i = 0; i < RightRenames.size() / 2; i++) {
+                        auto & valPtr = output[RightRenames[2 * i + 1]];
+                        if ( valPtr ) {
+                            *valPtr = *RightPacker->TuplePtrs[RightRenames[2 * i]];
+                        }
+                    }
+                    return EFetchResult::One;
+                }
             }
         }
 
         if (resultLeft == EFetchResult::Yield || resultRight == EFetchResult::Yield) {
-            return true;
+            return EFetchResult::Yield;
         }
 
         if (resultLeft == EFetchResult::Finish ) {
@@ -702,7 +748,7 @@ private:
             *HaveMoreRightRows = false;
         }
 
-        return false;
+        return EFetchResult::Finish;
     }
 
     void UnpackJoinedData(NUdf::TUnboxedValue*const* output) {
@@ -762,33 +808,29 @@ private:
                 break;
             }
 
-            bool isYield = FetchAndPackData(ctx);
+            auto isYield = FetchAndPackData(ctx, output);
             if (IsSpillingAllowed && ctx.SpillerFactory && IsSwitchToSpillingModeCondition()) {
                 const auto used = TlsAllocState->GetUsed();
                 const auto limit = TlsAllocState->GetLimit();
 
                 YQL_LOG(INFO) << "yellow zone reached " << (used*100/limit) << "%=" << used << "/" << limit;
-                YQL_LOG(INFO) << "switching Memory mode to Spilling";
+                YQL_LOG(INFO) << (const void *)&*JoinedTablePtr << "# switching Memory mode to Spilling";
 
                 SwitchMode(EOperatingMode::Spilling, ctx);
                 return EFetchResult::Yield;
             }
-            if (isYield) return EFetchResult::Yield;
+            if (isYield != EFetchResult::Finish) return isYield;
 
-            if (!*HaveMoreRightRows && !*PartialJoinCompleted && LeftPacker->TuplesBatchPacked >= LeftPacker->BatchSize ) {
-                *PartialJoinCompleted = true;
-                JoinedTablePtr->Join(*LeftPacker->TablePtr, *RightPacker->TablePtr, JoinKind, *HaveMoreLeftRows, *HaveMoreRightRows);
-                JoinedTablePtr->ResetIterator();
-            }
 
-            if (!*HaveMoreLeftRows && !*PartialJoinCompleted && RightPacker->TuplesBatchPacked >= RightPacker->BatchSize ) {
-                *PartialJoinCompleted = true;
-                JoinedTablePtr->Join(*LeftPacker->TablePtr, *RightPacker->TablePtr, JoinKind, *HaveMoreLeftRows, *HaveMoreRightRows);
-                JoinedTablePtr->ResetIterator();
+            if (!*PartialJoinCompleted && (
+                (!*HaveMoreRightRows && (!*HaveMoreLeftRows || LeftPacker->TuplesBatchPacked >= LeftPacker->BatchSize )) ||
+                (!*HaveMoreLeftRows && RightPacker->TuplesBatchPacked >= RightPacker->BatchSize))) {
 
-            }
-
-            if (!*HaveMoreRightRows && !*HaveMoreLeftRows && !*PartialJoinCompleted) {
+                YQL_LOG(GRACEJOIN_TRACE)
+                    << (const void *)&*JoinedTablePtr << '#'
+                    << " HaveLeft " << *HaveMoreLeftRows << " LeftPacked " << LeftPacker->TuplesBatchPacked << " LeftBatch " << LeftPacker->BatchSize
+                    << " HaveRight " << *HaveMoreRightRows << " RightPacked " << RightPacker->TuplesBatchPacked << " RightBatch " << RightPacker->BatchSize
+                    ;
                 *PartialJoinCompleted = true;
                 LeftPacker->StartTime = std::chrono::system_clock::now();
                 RightPacker->StartTime = std::chrono::system_clock::now();
@@ -832,7 +874,7 @@ private:
         return LeftPacker->TablePtr->IsRestoringSpilledBuckets() || RightPacker->TablePtr->IsRestoringSpilledBuckets();
     }
 
-void DoCalculateWithSpilling(TComputationContext& ctx) {
+EFetchResult DoCalculateWithSpilling(TComputationContext& ctx, NUdf::TUnboxedValue*const* output) {
     UpdateSpilling();
 
     ui32 cnt = 0;
@@ -841,15 +883,15 @@ void DoCalculateWithSpilling(TComputationContext& ctx) {
             if (!HasMemoryForProcessing() && !IsSpillingFinalized) {
                 bool isWaitingForReduce = TryToReduceMemoryAndWait();
      
-                if (isWaitingForReduce) return;
+                if (isWaitingForReduce) return EFetchResult::Yield;
             }
         }
-        bool isYield = FetchAndPackData(ctx);
-        if (isYield) return;
+        auto isYield = FetchAndPackData(ctx, output);
+        if (isYield != EFetchResult::Finish) return isYield;
     }
 
     if (!*HaveMoreLeftRows && !*HaveMoreRightRows) {
-        if (!IsSpillingFinished()) return;
+        if (!IsSpillingFinished()) return EFetchResult::Yield;
         if (!IsSpillingFinalized) {
             LeftPacker->TablePtr->FinalizeSpilling();
             RightPacker->TablePtr->FinalizeSpilling();
@@ -857,12 +899,13 @@ void DoCalculateWithSpilling(TComputationContext& ctx) {
 
             UpdateSpilling();
         }
-        if (!IsReadyForSpilledDataProcessing()) return;
+        if (!IsReadyForSpilledDataProcessing()) return EFetchResult::Yield;
 
-        YQL_LOG(INFO) << "switching to ProcessSpilled";
+        YQL_LOG(INFO) << (const void *)&*JoinedTablePtr << "# switching to ProcessSpilled";
         SwitchMode(EOperatingMode::ProcessSpilled, ctx);
-        return;
+        return EFetchResult::Finish;
     }
+    return EFetchResult::Yield;
 }
 
 EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const* output) {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join.cpp
@@ -808,6 +808,8 @@ private:
             }
 
             auto isYield = FetchAndPackData(ctx, output);
+            if (isYield == EFetchResult::One)
+                return isYield;
             if (IsSpillingAllowed && ctx.SpillerFactory && IsSwitchToSpillingModeCondition()) {
                 const auto used = TlsAllocState->GetUsed();
                 const auto limit = TlsAllocState->GetLimit();

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -75,18 +75,13 @@ TTable::EAddTupleResult TTable::AddTuple(  ui64 * intColumns, char ** stringColu
         }
     }
 
-    TempTuple[0] &= ui64(0x1); // Setting only nulls in key bit, all other bits are ignored for key hash
-    for (ui32 i = 1; i < NullsBitmapSize_; i ++) {
-        TempTuple[i] = 0;
-    }
-
     XXH64_hash_t hash = XXH64(TempTuple.data() + NullsBitmapSize_, (TempTuple.size() - NullsBitmapSize_) * sizeof(ui64), 0);
 
     if (!hash) hash = 1;
 
     ui64 bucket = hash & BucketsMask;
 
-    if (other.TableBucketsStats[bucket].BloomFilter.IsFinalized())  {
+    if (!IsAny_ && other.TableBucketsStats[bucket].BloomFilter.IsFinalized())  {
         auto bucket2 = &other.TableBucketsStats[bucket];
         auto &bloomFilter = bucket2->BloomFilter;
         ++BloomLookups_;
@@ -105,14 +100,24 @@ TTable::EAddTupleResult TTable::AddTuple(  ui64 * intColumns, char ** stringColu
     ui32 offset = keyIntVals.size();  // Offset of tuple inside the keyIntVals vector
 
     keyIntVals.push_back(hash);
-    keyIntVals.insert(keyIntVals.end(), intColumns, intColumns + NullsBitmapSize_);
-    keyIntVals.insert(keyIntVals.end(), TempTuple.begin() + NullsBitmapSize_, TempTuple.end());
+    keyIntVals.insert(keyIntVals.end(), TempTuple.begin(), TempTuple.end());
 
     if (IsAny_) {
         if ( !AddKeysToHashTable(kh, keyIntVals.begin() + offset, iColumns) ) {
             keyIntVals.resize(offset);
             ++AnyFiltered_;
             return EAddTupleResult::AnyMatch;
+        }
+
+        if (other.TableBucketsStats[bucket].BloomFilter.IsFinalized())  {
+            auto bucket2 = &other.TableBucketsStats[bucket];
+            auto &bloomFilter = bucket2->BloomFilter;
+            ++BloomLookups_;
+            if (bloomFilter.IsMissing(hash)) {
+                keyIntVals.resize(offset);
+                ++BloomHits_;
+                return EAddTupleResult::Unmatched;
+            }
         }
     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -462,6 +462,8 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
                 if (*slotIt != hash)
                     continue;
 
+                tuple2Idx = slotIt[slotSize - 1];
+
                 if (table1HasKeyIColumns || !(keysValSize - nullsSize1 <= slotSize - 1 - nullsSize2)) {
                     // 2nd condition cannot be true unless HasKeyStringColumns or HasKeyIColumns, hence size at the end of header is present
 
@@ -500,8 +502,6 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
                     if (!std::equal(it1 + keyIntOffset1, it1 + keysValSize, slotIt + keyIntOffset2))
                         continue;
                 }
-
-                tuple2Idx = slotIt[slotSize - 1];
 
                 tuplesFound++;
                 JoinTuplesIds joinIds;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -321,6 +321,9 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
     if( hasMoreRightTuples )
         RightTableBatch_ = true;
 
+    auto table1Batch = LeftTableBatch_;
+    auto table2Batch = RightTableBatch_;
+
     JoinTable1 = &t1;
     JoinTable2 = &t2;
 
@@ -333,13 +336,11 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
 
     if ( JoinKind == EJoinKind::Right || JoinKind == EJoinKind::RightOnly || JoinKind == EJoinKind::RightSemi ) {
         std::swap(JoinTable1, JoinTable2);
+        std::swap(table1Batch, table2Batch);
     }
 
     ui64 tuplesFound = 0;
 
-    std::vector<ui64, TMKQLAllocator<ui64, EMemorySubPool::Temporary>> joinSlots;
-    ui64 reservedSize = 6 * (DefaultTupleBytes * DefaultTuplesNum) / sizeof(ui64);
-    joinSlots.reserve( reservedSize );
     std::vector<JoinTuplesIds, TMKQLAllocator<JoinTuplesIds, EMemorySubPool::Temporary>> joinResults;
 
 
@@ -361,9 +362,10 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
         bool table2HasKeyStringColumns = (JoinTable2->NumberOfKeyStringColumns != 0);
         bool table1HasKeyIColumns = (JoinTable1->NumberOfKeyIColumns != 0);
         bool table2HasKeyIColumns = (JoinTable2->NumberOfKeyIColumns != 0);
+        bool swapTables = tuplesNum2 > tuplesNum1 && !table1Batch || table2Batch;
 
 
-        if (tuplesNum2 > tuplesNum1) {
+        if (swapTables) {
             std::swap(bucket1, bucket2);
             std::swap(headerSize1, headerSize2);
             std::swap(nullsSize1, nullsSize2);
@@ -373,7 +375,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             std::swap(tuplesNum1, tuplesNum2);
        }
 
-        if (tuplesNum2 == 0)
+        if (tuplesNum2 == 0 || tuplesNum1 == 0)
             continue;
 
         ui64 slotSize = headerSize2 + 1;
@@ -384,10 +386,15 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             slotSize = slotSize + avgStringsSize;
         }
 
-        
-        ui64 nSlots = (3 * tuplesNum2 + 1) | 1;
-        joinSlots.clear();
-        joinSlots.resize(nSlots*slotSize, 0);
+        ui64 &nSlots = bucket2->NSlots;
+        auto &joinSlots = bucket2->JoinSlots;
+        bool initHashTable = false;
+
+        if (!nSlots) {
+            nSlots = (3 * tuplesNum2 + 1) | 1;
+            joinSlots.resize(nSlots*slotSize, 0);
+            initHashTable = true;
+        }
 
         auto firstSlot = [begin = joinSlots.begin(), slotSize, nSlots](auto hash) {
                 ui64 slotNum = hash % nSlots;
@@ -401,35 +408,37 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             return it;
         };
 
-        ui32 tuple2Idx = 0;
-        auto it2 = bucket2->KeyIntVals.begin();
-        for (ui64 keysValSize = headerSize2; it2 != bucket2->KeyIntVals.end(); it2 += keysValSize, ++tuple2Idx) {
-            if ( table2HasKeyStringColumns || table2HasKeyIColumns) {
-                keysValSize = headerSize2 + *(it2 + headerSize2 - 1) ;
+        if (initHashTable) {
+            ui32 tuple2Idx = 0;
+            auto it2 = bucket2->KeyIntVals.begin();
+            for (ui64 keysValSize = headerSize2; it2 != bucket2->KeyIntVals.end(); it2 += keysValSize, ++tuple2Idx) {
+                if ( table2HasKeyStringColumns || table2HasKeyIColumns) {
+                    keysValSize = headerSize2 + *(it2 + headerSize2 - 1) ;
+                }
+
+                ui64 hash = *it2;
+                ui64 * nullsPtr = it2+1;
+                if (HasBitSet(nullsPtr, 1))
+                    continue;
+
+                auto slotIt = firstSlot(hash);
+
+                for (; *slotIt != 0; slotIt = nextSlot(slotIt))
+                {
+                }
+
+                if (keysValSize <= slotSize - 1)
+                {
+                    std::copy_n(it2, keysValSize, slotIt);
+                }
+                else
+                {
+                    std::copy_n(it2, headerSize2, slotIt);
+
+                    *(slotIt + headerSize2) = it2 + headerSize2 - bucket2->KeyIntVals.begin();
+                }
+                slotIt[slotSize - 1] = tuple2Idx;
             }
-
-            ui64 hash = *it2;
-            ui64 * nullsPtr = it2+1;
-            if (HasBitSet(nullsPtr, 1))
-                continue;
-
-            auto slotIt = firstSlot(hash);
-
-            for (; *slotIt != 0; slotIt = nextSlot(slotIt))
-            {
-            }
-
-            if (keysValSize <= slotSize - 1)
-            {
-                std::copy_n(it2, keysValSize, slotIt);
-            }
-            else
-            {
-                std::copy_n(it2, headerSize2, slotIt);
-
-                *(slotIt + headerSize2) = it2 + headerSize2 - bucket2->KeyIntVals.begin();
-            }
-            slotIt[slotSize - 1] = tuple2Idx;
         }
 
 
@@ -462,7 +471,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
                 if (*slotIt != hash)
                     continue;
 
-                tuple2Idx = slotIt[slotSize - 1];
+                auto tuple2Idx = slotIt[slotSize - 1];
 
                 if (table1HasKeyIColumns || !(keysValSize - nullsSize1 <= slotSize - 1 - nullsSize2)) {
                     // 2nd condition cannot be true unless HasKeyStringColumns or HasKeyIColumns, hence size at the end of header is present
@@ -505,14 +514,16 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
 
                 tuplesFound++;
                 JoinTuplesIds joinIds;
-                joinIds.id1 = tuple1Idx;
-                joinIds.id2 = tuple2Idx;
-                if (JoinTable2->TableBucketsStats[bucket].TuplesNum > JoinTable1->TableBucketsStats[bucket].TuplesNum)
-                {
-                    std::swap(joinIds.id1, joinIds.id2);
-                }
+                joinIds.id1 = swapTables ? tuple2Idx : tuple1Idx;
+                joinIds.id2 = swapTables ? tuple1Idx : tuple2Idx;
                 joinResults.emplace_back(joinIds);
             }
+        }
+
+        if (!hasMoreLeftTuples && !hasMoreRightTuples) {
+            joinSlots.clear();
+            joinSlots.shrink_to_fit();
+            nSlots = 0;
         }
 
         std::sort(joinResults.begin(), joinResults.end(), [](JoinTuplesIds a, JoinTuplesIds b)
@@ -560,7 +571,6 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             }
 
         }
-
     }
 
     HasMoreLeftTuples_ = hasMoreLeftTuples;
@@ -1111,6 +1121,8 @@ void TTable::ClearBucket(ui64 bucket) {
     tb.InterfaceOffsets.clear();
     tb.JoinIds.clear();
     tb.RightIds.clear();
+    tb.JoinSlots.clear();
+    tb.NSlots = 0;
 
     TTableBucketStats & tbs = TableBucketsStats[bucket];
     tbs.TuplesNum = 0;
@@ -1128,6 +1140,7 @@ void TTable::ShrinkBucket(ui64 bucket) {
     tb.InterfaceOffsets.shrink_to_fit();
     tb.JoinIds.shrink_to_fit();
     tb.RightIds.shrink_to_fit();
+    tb.JoinSlots.shrink_to_fit();
 }
 
 void TTable::InitializeBucketSpillers(ISpiller::TPtr spiller) {
@@ -1138,6 +1151,7 @@ void TTable::InitializeBucketSpillers(ISpiller::TPtr spiller) {
 
 ui64 TTable::GetSizeOfBucket(ui64 bucket) const {
     return TableBuckets[bucket].KeyIntVals.size() * sizeof(ui64)
+    + TableBuckets[bucket].JoinSlots.size() * sizeof(ui64)
     + TableBuckets[bucket].DataIntVals.size() * sizeof(ui64)
     + TableBuckets[bucket].StringsValues.size()
     + TableBuckets[bucket].StringsOffsets.size() * sizeof(ui32)

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -15,7 +15,7 @@ class TTableBucketSpiller;
 const ui64 BitsForNumberOfBuckets = 5; // 2^5 = 32
 const ui64 BucketsMask = (0x00000001 << BitsForNumberOfBuckets)  - 1;
 const ui64 NumberOfBuckets = (0x00000001 << BitsForNumberOfBuckets);  // Number of hashed keys buckets to distribute incoming tables tuples
-const ui64 DefaultTuplesNum = 100; // Default initial number of tuples in one bucket to allocate memory
+const ui64 DefaultTuplesNum = 101; // Default initial number of tuples in one bucket to allocate memory
 const ui64 DefaultTupleBytes = 64; // Default size of all columns in table row for estimations
 const ui64 HashSize = 1; // Using ui64 hash size
 const ui64 SpillingSizeLimit = 1_MB; // Don't try to spill if net effect is lower than this size
@@ -241,7 +241,7 @@ class TTable {
     inline bool HasJoinedTupleId(TTable* joinedTable, ui32& tupleId2);
 
     // Adds keys to KeysHashTable, return true if added, false if equal key already added
-    inline bool AddKeysToHashTable(KeysHashTable& t, ui64* keys);
+    inline bool AddKeysToHashTable(KeysHashTable& t, ui64* keys, NYql::NUdf::TUnboxedValue * iColumns);
 
     ui64 TotalPacked = 0; // Total number of packed tuples
     ui64 TotalUnpacked = 0; // Total number of unpacked tuples

--- a/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -71,6 +71,8 @@ struct TTableBucket {
     std::set<ui32> AllLeftMatchedIds;  // All row ids of left join table which have matching rows in right table. To process streaming join mode.
     std::set<ui32> AllRightMatchedIds; // All row ids of right join table which matching rows in left table. To process streaming join mode. 
 
+    std::vector<ui64, TMKQLAllocator<ui64>> JoinSlots;  // Hashtable
+    ui64 NSlots = 0;  // Hashtable
  };
 
  struct TTableBucketStats {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Backports:
e5ae52da + 2d3caea : фикс для интерфейсных колонок (неправильно проверялись на равенство)
98a74bef : улучшение производительности (при некоторых условиях получалось `O(n/[большая константа]*m)` вместо `O(n + m)`, при росте размера табличек это начинало играть роль, начиная где-то с tpc h s100)
774401f + 153df909 + e9a7b28: добавление блумфильтров (производительность)
419b953 - улучшение производительности/памяти для LEFT* JOIN с более короткой (но большой!) табличкой слева (пример - TPC H q13)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
