### PR TITLE
Refactor computation pattern cache

### DIFF
--- a/ydb/core/kqp/compile_service/kqp_compile_computation_pattern_service.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_computation_pattern_service.cpp
@@ -62,7 +62,7 @@ private:
             timer.Reset();
 
             patternToCompile.Entry->Pattern->Compile({}, nullptr);
-            patternCache->NotifyPatternCompiled(patternToCompile.SerializedProgram, patternToCompile.Entry);
+            patternCache->NotifyPatternCompiled(patternToCompile.SerializedProgram);
             patternToCompile.Entry = nullptr;
 
             Counters->CompiledComputationPatterns->Inc();

--- a/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache.cpp
@@ -1,204 +1,6 @@
-#include "mkql_computation_pattern_cache.h"
-
-#include <util/generic/intrlist.h>
+#include "mkql_computation_pattern_cache_impl.h"
 
 namespace NKikimr::NMiniKQL {
-
-class TComputationPatternLRUCache::TLRUPatternCacheImpl
-{
-public:
-    TLRUPatternCacheImpl(size_t maxPatternsSize,
-        size_t maxPatternsSizeBytes,
-        size_t maxCompiledPatternsSize,
-        size_t maxCompiledPatternsSizeBytes)
-        : MaxPatternsSize(maxPatternsSize)
-        , MaxPatternsSizeBytes(maxPatternsSizeBytes)
-        , MaxCompiledPatternsSize(maxCompiledPatternsSize)
-        , MaxCompiledPatternsSizeBytes(maxCompiledPatternsSizeBytes)
-    {}
-
-    size_t PatternsSize() const {
-        return SerializedProgramToPatternCacheHolder.size();
-    }
-
-    size_t PatternsSizeInBytes() const {
-        return CurrentPatternsSizeBytes;
-    }
-
-    size_t CompiledPatternsSize() const {
-        return CurrentCompiledPatternsSize;
-    }
-
-    size_t PatternsCompiledCodeSizeInBytes() const {
-        return CurrentPatternsCompiledCodeSizeInBytes;
-    }
-
-    std::shared_ptr<TPatternCacheEntry>* Find(const TString& serializedProgram) {
-        auto it = SerializedProgramToPatternCacheHolder.find(serializedProgram);
-        if (it == SerializedProgramToPatternCacheHolder.end()) {
-            return nullptr;
-        }
-
-        PromoteEntry(&it->second);
-
-        return &it->second.Entry;
-    }
-
-    void Insert(const TString& serializedProgram, std::shared_ptr<TPatternCacheEntry>& entry) {
-        auto [it, inserted] = SerializedProgramToPatternCacheHolder.emplace(std::piecewise_construct,
-            std::forward_as_tuple(serializedProgram),
-            std::forward_as_tuple(serializedProgram, entry));
-
-        if (!inserted) {
-            RemoveEntryFromLists(&it->second);
-        }
-
-        entry->UpdateSizeForCache();
-
-        /// New item is inserted, insert it in the back of both LRU lists and recalculate sizes
-        CurrentPatternsSizeBytes += entry->SizeForCache;
-        LRUPatternList.PushBack(&it->second);
-
-        if (entry->Pattern->IsCompiled()) {
-            ++CurrentCompiledPatternsSize;
-            CurrentPatternsCompiledCodeSizeInBytes += entry->Pattern->CompiledCodeSize();
-            LRUCompiledPatternList.PushBack(&it->second);
-        }
-
-        entry->IsInCache.store(true);
-        ClearIfNeeded();
-    }
-
-    void NotifyPatternCompiled(const TString & serializedProgram, std::shared_ptr<TPatternCacheEntry>& entry) {
-        auto it = SerializedProgramToPatternCacheHolder.find(serializedProgram);
-        if (it == SerializedProgramToPatternCacheHolder.end()) {
-            return;
-        }
-
-        Y_ASSERT(entry->Pattern->IsCompiled());
-
-        Y_ASSERT(!it->second.LinkedInCompiledPatternLRUList());
-        PromoteEntry(&it->second);
-
-        ++CurrentCompiledPatternsSize;
-        CurrentPatternsCompiledCodeSizeInBytes += entry->Pattern->CompiledCodeSize();
-        LRUCompiledPatternList.PushBack(&it->second);
-
-        ClearIfNeeded();
-    }
-
-    void Clear() {
-        CurrentPatternsSizeBytes = 0;
-        CurrentCompiledPatternsSize = 0;
-        CurrentPatternsCompiledCodeSizeInBytes = 0;
-
-        SerializedProgramToPatternCacheHolder.clear();
-        for (auto & holder : LRUPatternList) {
-            holder.Entry->IsInCache.store(false);
-        }
-
-        LRUPatternList.Clear();
-        LRUCompiledPatternList.Clear();
-    }
-private:
-    struct TPatternLRUListTag {};
-    struct TCompiledPatternLRUListTag {};
-
-    /** Cache holder is used to store serialized program and pattern cache entry in intrusive LRU lists.
-      * Most recently accessed items are in back of the lists, least recently accessed items are in front of the lists.
-      */
-    struct TPatternCacheHolder : public TIntrusiveListItem<TPatternCacheHolder, TPatternLRUListTag>, TIntrusiveListItem<TPatternCacheHolder, TCompiledPatternLRUListTag> {
-        TPatternCacheHolder(TString serializedProgram, std::shared_ptr<TPatternCacheEntry> entry)
-            : SerializedProgram(std::move(serializedProgram))
-            , Entry(std::move(entry))
-        {}
-
-        bool LinkedInPatternLRUList() const {
-            return !TIntrusiveListItem<TPatternCacheHolder, TPatternLRUListTag>::Empty();
-        }
-
-        bool LinkedInCompiledPatternLRUList() const {
-            return !TIntrusiveListItem<TPatternCacheHolder, TCompiledPatternLRUListTag>::Empty();
-        }
-
-        TString SerializedProgram;
-        std::shared_ptr<TPatternCacheEntry> Entry;
-    };
-
-    void PromoteEntry(TPatternCacheHolder* holder) {
-        Y_ASSERT(holder->LinkedInPatternLRUList());
-        LRUPatternList.Remove(holder);
-        LRUPatternList.PushBack(holder);
-
-        if (!holder->LinkedInCompiledPatternLRUList()) {
-            return;
-        }
-
-        LRUCompiledPatternList.Remove(holder);
-        LRUCompiledPatternList.PushBack(holder);
-    }
-
-    void RemoveEntryFromLists(TPatternCacheHolder* holder) {
-        Y_ASSERT(holder->LinkedInPatternLRUList());
-        LRUPatternList.Remove(holder);
-
-        Y_ASSERT(holder->Entry->SizeForCache <= CurrentPatternsSizeBytes);
-        CurrentPatternsSizeBytes -= holder->Entry->SizeForCache;
-
-        if (!holder->LinkedInCompiledPatternLRUList()) {
-            return;
-        }
-
-        Y_ASSERT(CurrentCompiledPatternsSize > 0);
-        --CurrentCompiledPatternsSize;
-
-        size_t patternCompiledCodeSize = holder->Entry->Pattern->CompiledCodeSize();
-        Y_ASSERT(patternCompiledCodeSize <= CurrentPatternsCompiledCodeSizeInBytes);
-        CurrentPatternsCompiledCodeSizeInBytes -= patternCompiledCodeSize;
-
-        LRUCompiledPatternList.Remove(holder);
-
-        holder->Entry->IsInCache.store(false);
-    }
-
-    void ClearIfNeeded() {
-        /// Remove from pattern LRU list and compiled pattern LRU list
-        while (SerializedProgramToPatternCacheHolder.size() > MaxPatternsSize || CurrentPatternsSizeBytes > MaxPatternsSizeBytes) {
-            TPatternCacheHolder* holder = LRUPatternList.Front();
-            RemoveEntryFromLists(holder);
-            SerializedProgramToPatternCacheHolder.erase(holder->SerializedProgram);
-        }
-
-        /// Only remove from compiled pattern LRU list
-        while (CurrentCompiledPatternsSize > MaxCompiledPatternsSize || CurrentPatternsCompiledCodeSizeInBytes > MaxCompiledPatternsSizeBytes) {
-            TPatternCacheHolder* holder = LRUCompiledPatternList.PopFront();
-
-            Y_ASSERT(CurrentCompiledPatternsSize > 0);
-            --CurrentCompiledPatternsSize;
-
-            auto & pattern = holder->Entry->Pattern;
-            size_t patternCompiledSize = pattern->CompiledCodeSize();
-            Y_ASSERT(patternCompiledSize <= CurrentPatternsCompiledCodeSizeInBytes);
-            CurrentPatternsCompiledCodeSizeInBytes -= patternCompiledSize;
-
-            pattern->RemoveCompiledCode();
-            holder->Entry->AccessTimes.store(0);
-        }
-    }
-
-    const size_t MaxPatternsSize;
-    const size_t MaxPatternsSizeBytes;
-    const size_t MaxCompiledPatternsSize;
-    const size_t MaxCompiledPatternsSizeBytes;
-
-    size_t CurrentPatternsSizeBytes = 0;
-    size_t CurrentCompiledPatternsSize = 0;
-    size_t CurrentPatternsCompiledCodeSizeInBytes = 0;
-
-    THashMap<TString, TPatternCacheHolder> SerializedProgramToPatternCacheHolder;
-    TIntrusiveList<TPatternCacheHolder, TPatternLRUListTag> LRUPatternList;
-    TIntrusiveList<TPatternCacheHolder, TCompiledPatternLRUListTag> LRUCompiledPatternList;
-};
 
 TComputationPatternLRUCache::TComputationPatternLRUCache(const TComputationPatternLRUCache::Config& configuration, NMonitoring::TDynamicCounterPtr counters)
     : Cache(std::make_unique<TLRUPatternCacheImpl>(CacheMaxElementsSize, configuration.MaxSizeBytes, CacheMaxElementsSize, configuration.MaxCompiledSizeBytes))
@@ -228,10 +30,10 @@ std::shared_ptr<TPatternCacheEntry> TComputationPatternLRUCache::Find(const TStr
     if (auto it = Cache->Find(serializedProgram)) {
         ++*Hits;
 
-        if ((*it)->Pattern->IsCompiled())
+        if (it->Pattern->IsCompiled())
             ++*HitsCompiled;
 
-        return *it;
+        return it;
     }
 
     ++*Misses;
@@ -242,8 +44,8 @@ TComputationPatternLRUCache::TTicket TComputationPatternLRUCache::FindOrSubscrib
     std::lock_guard lock(Mutex);
     if (auto it = Cache->Find(serializedProgram)) {
         ++*Hits;
-        AccessPattern(serializedProgram, *it);
-        return TTicket(serializedProgram, false, NThreading::MakeFuture<std::shared_ptr<TPatternCacheEntry>>(*it), nullptr);
+        AccessPattern(serializedProgram, it);
+        return TTicket(serializedProgram, false, NThreading::MakeFuture<std::shared_ptr<TPatternCacheEntry>>(it), nullptr);
     }
 
     auto [notifyIt, isNew] = Notify.emplace(serializedProgram, Nothing());
@@ -269,7 +71,7 @@ void TComputationPatternLRUCache::EmplacePattern(const TString& serializedProgra
 
     {
         std::lock_guard<std::mutex> lock(Mutex);
-        Cache->Insert(serializedProgram, patternWithEnv);
+        Cache->InsertOrUpdate(serializedProgram, patternWithEnv);
 
         auto notifyIt = Notify.find(serializedProgram);
         if (notifyIt != Notify.end()) {
@@ -280,7 +82,7 @@ void TComputationPatternLRUCache::EmplacePattern(const TString& serializedProgra
         *SizeItems = Cache->PatternsSize();
         *SizeBytes = Cache->PatternsSizeInBytes();
         *SizeCompiledItems = Cache->CompiledPatternsSize();
-        *SizeCompiledBytes = Cache->PatternsCompiledCodeSizeInBytes();
+        *SizeCompiledBytes = Cache->CompiledPatternsSizeInBytes();
     }
 
     if (subscribers) {
@@ -290,9 +92,9 @@ void TComputationPatternLRUCache::EmplacePattern(const TString& serializedProgra
     }
 }
 
-void TComputationPatternLRUCache::NotifyPatternCompiled(const TString& serializedProgram, std::shared_ptr<TPatternCacheEntry> patternWithEnv) {
+void TComputationPatternLRUCache::NotifyPatternCompiled(const TString& serializedProgram) {
     std::lock_guard lock(Mutex);
-    Cache->NotifyPatternCompiled(serializedProgram, patternWithEnv);
+    Cache->NotifyPatternCompiled(serializedProgram);
 }
 
 size_t TComputationPatternLRUCache::GetSize() const {

--- a/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache.h
@@ -131,7 +131,7 @@ public:
 
     void EmplacePattern(const TString& serializedProgram, std::shared_ptr<TPatternCacheEntry> patternWithEnv);
 
-    void NotifyPatternCompiled(const TString& serializedProgram, std::shared_ptr<TPatternCacheEntry> patternWithEnv);
+    void NotifyPatternCompiled(const TString& serializedProgram);
 
     size_t GetSize() const;
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_impl.h
@@ -158,8 +158,6 @@ public:
         }
 
         entry->IsInCache = true;
-
-        // TODO: don't forget to make cleanup on PushBack()
     }
 
     void NotifyPatternCompiled(const TString& serializedProgram) {
@@ -198,15 +196,11 @@ private:
 
     void OnPatternExpiredCallback(const TCacheEntry& entry) {
         Y_ENSURE(ProgramToEntryMap_.erase(*entry.first));
-        if (!LRUCompiledPatternList_.Has(entry)) {
-            return;
-        }
-
-        // TODO: no removal of compiled code here, why?
-        LRUCompiledPatternList_.Remove(entry);
-
-        // TODO: why set this member only if was compiled? Is it symmetrical?
         entry.second->IsInCache = false;
+        if (LRUCompiledPatternList_.Has(entry)) {
+            LRUCompiledPatternList_.Remove(entry);
+            OnCompiledPatternExpiredCallback(entry);
+        }
     }
 
     void OnCompiledPatternExpiredCallback(const TCacheEntry& entry) {

--- a/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_impl.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include "mkql_computation_pattern_cache.h"
+
+using namespace std::placeholders;
+
+namespace NKikimr::NMiniKQL {
+
+class TComputationPatternLRUCache::TLRUPatternCacheImpl {
+private:
+    template <class T, class THash>
+    class TLRUList {
+        using OnExpiredCallbackFn = std::function<void(const T&)>;
+        using SizeInBytesFn = std::function<size_t(const T&)>;
+
+    public:
+        explicit TLRUList(size_t maxSize, size_t maxSizeInBytes, SizeInBytesFn sizeInBytes, OnExpiredCallbackFn onExpiredCallback)
+        : MaxSize_(maxSize)
+        , MaxSizeInBytes_(maxSizeInBytes)
+        , GetSizeInBytes_(sizeInBytes)
+        , OnExpiredCallback_(onExpiredCallback)
+        {}
+
+        size_t Size() const {
+            return List_.size();
+        }
+
+        size_t SizeInBytes() const {
+            return SizeInBytes_;
+        }
+
+        bool Has(const T& item) const {
+            return Iterators_.contains(item);
+        }
+
+        void PushBack(const T& item) {
+            auto it = Iterators_.find(item);
+            Y_ENSURE(it == Iterators_.end());
+            List_.push_back(item);
+            Iterators_.emplace(item, std::prev(List_.end()));
+            SizeInBytes_ += GetSizeInBytes_(item);
+
+            while (Size() > MaxSize_ || SizeInBytes() > MaxSizeInBytes_) {
+                auto&& expired = std::move(List_.front());
+                Remove(expired);
+                List_.pop_front();
+
+                OnExpiredCallback_(expired);
+            }
+        }
+
+        void Touch(const T& item) {
+            auto it = Iterators_.find(item);
+            Y_ENSURE(it != Iterators_.end());
+            List_.erase(it->second);
+            List_.push_back(it->first);
+            it->second = std::prev(List_.end());
+        }
+
+        void Remove(const T& item) {
+            auto it = Iterators_.find(item);
+            Y_ENSURE(it != Iterators_.end());
+
+            auto size = GetSizeInBytes_(item);
+            Y_ENSURE(size <= SizeInBytes_);
+
+            List_.erase(it->second);
+            Iterators_.erase(it);
+            SizeInBytes_ -= size;
+        }
+
+        void Clear() {
+            List_.clear();
+            Iterators_.clear();
+            SizeInBytes_ = 0;
+        }
+
+    private:
+        const size_t MaxSize_, MaxSizeInBytes_;
+
+        SizeInBytesFn GetSizeInBytes_;
+        OnExpiredCallbackFn OnExpiredCallback_;
+
+        TList<T> List_;
+        THashMap<T, typename TList<T>::iterator, THash> Iterators_;
+        size_t SizeInBytes_ = 0;
+    };
+
+public:
+    TLRUPatternCacheImpl(
+        size_t maxPatternsSize,
+        size_t maxPatternsSizeInBytes,
+        size_t maxCompiledPatternsSize,
+        size_t maxCompiledPatternsSizeInBytes)
+        : LRUPatternList_(maxPatternsSize, maxPatternsSizeInBytes,
+            [](const TCacheEntry& entry) {
+                return entry.second->SizeForCache;
+            },
+            std::bind(&TLRUPatternCacheImpl::OnPatternExpiredCallback, this, _1))
+        , LRUCompiledPatternList_(maxCompiledPatternsSize, maxCompiledPatternsSizeInBytes,
+            [](const TCacheEntry& entry) {
+                return entry.second->Pattern->CompiledCodeSize();
+            },
+            std::bind(&TLRUPatternCacheImpl::OnCompiledPatternExpiredCallback, this, _1))
+    {}
+
+    size_t PatternsSize() const {
+        return ProgramToEntryMap_.size();
+    }
+
+    size_t PatternsSizeInBytes() const {
+        return LRUPatternList_.SizeInBytes();
+    }
+
+    size_t CompiledPatternsSize() const {
+        return LRUCompiledPatternList_.Size();
+    }
+
+    size_t CompiledPatternsSizeInBytes() const {
+        return LRUCompiledPatternList_.SizeInBytes();
+    }
+
+    std::shared_ptr<TPatternCacheEntry> Find(const TString& serializedProgram) {
+        auto it = ProgramToEntryMap_.find(serializedProgram);
+        if (it == ProgramToEntryMap_.end()) {
+            return {};
+        }
+
+        LRUPatternList_.Touch(it->second);
+        if (LRUCompiledPatternList_.Has(it->second)) {
+            LRUCompiledPatternList_.Touch(it->second);
+        }
+
+        return it->second.second;
+    }
+
+    void InsertOrUpdate(const TString& serializedProgram, const std::shared_ptr<TPatternCacheEntry>& newEntry) {
+        auto [it, isNew] = ProgramToEntryMap_.emplace(std::piecewise_construct,
+            std::forward_as_tuple(serializedProgram),
+            std::forward_as_tuple(std::make_shared<TString>(serializedProgram), newEntry));
+
+        // TODO: what to do if new and old entries are different?
+        auto entry = it->second.second;
+
+        if (!isNew) {
+            // Remove entry from lists to update sizes in bytes later.
+            LRUPatternList_.Remove(it->second);
+            if (LRUCompiledPatternList_.Has(it->second)) {
+                LRUCompiledPatternList_.Remove(it->second);
+            }
+        }
+
+        entry->UpdateSizeForCache();
+        LRUPatternList_.PushBack(it->second);
+
+        if (entry->Pattern->IsCompiled()) {
+            LRUCompiledPatternList_.PushBack(it->second);
+        }
+
+        entry->IsInCache = true;
+
+        // TODO: don't forget to make cleanup on PushBack()
+    }
+
+    void NotifyPatternCompiled(const TString& serializedProgram) {
+        auto it = ProgramToEntryMap_.find(serializedProgram);
+        if (it == ProgramToEntryMap_.end()) {
+            return;
+        }
+
+        auto entry = it->second.second;
+
+        Y_ENSURE(entry->Pattern->IsCompiled());
+        Y_ENSURE(!LRUCompiledPatternList_.Has(it->second));
+
+        LRUPatternList_.Touch(it->second);
+        LRUCompiledPatternList_.PushBack(it->second);
+    }
+
+    void Clear() {
+        for (auto& [_, entry] : ProgramToEntryMap_) {
+            entry.second->IsInCache = false;
+        }
+        ProgramToEntryMap_.clear();
+
+        LRUPatternList_.Clear();
+        LRUCompiledPatternList_.Clear();
+    }
+
+private:
+    using TCacheEntry = std::pair<std::shared_ptr<TString>, std::shared_ptr<TPatternCacheEntry>>;
+
+    struct TCacheEntryHash {
+        size_t operator()(const TCacheEntry& entry) const {
+            return THash<TString>()(*entry.first);
+        }
+    };
+
+    void OnPatternExpiredCallback(const TCacheEntry& entry) {
+        Y_ENSURE(ProgramToEntryMap_.erase(*entry.first));
+        if (!LRUCompiledPatternList_.Has(entry)) {
+            return;
+        }
+
+        // TODO: no removal of compiled code here, why?
+        LRUCompiledPatternList_.Remove(entry);
+
+        // TODO: why set this member only if was compiled? Is it symmetrical?
+        entry.second->IsInCache = false;
+    }
+
+    void OnCompiledPatternExpiredCallback(const TCacheEntry& entry) {
+        entry.second->Pattern->RemoveCompiledCode();
+        entry.second->AccessTimes = 0;
+    }
+
+    THashMap<TString, TCacheEntry> ProgramToEntryMap_;
+    TLRUList<TCacheEntry, TCacheEntryHash> LRUPatternList_, LRUCompiledPatternList_;
+};
+
+} // namespace NKikimr::NMiniKQL

--- a/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_impl.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_pattern_cache_impl.h
@@ -34,17 +34,14 @@ private:
         }
 
         void PushBack(const T& item) {
-            auto it = Iterators_.find(item);
-            Y_ENSURE(it == Iterators_.end());
+            Y_ENSURE(!Iterators_.contains(item));
             List_.push_back(item);
             Iterators_.emplace(item, std::prev(List_.end()));
             SizeInBytes_ += GetSizeInBytes_(item);
 
             while (Size() > MaxSize_ || SizeInBytes() > MaxSizeInBytes_) {
-                auto&& expired = std::move(List_.front());
+                auto expired = List_.front();
                 Remove(expired);
-                List_.pop_front();
-
                 OnExpiredCallback_(expired);
             }
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The previous implementation was prone to errors with external intrusive list size,
i.e. double notification about compiled pattern.

### Changelog category <!-- remove all except one -->

* Bugfix