### PR TITLE
Correct mime type for err/out in ya make tests results

### DIFF
--- a/.github/actions/s3cmd/action.yml
+++ b/.github/actions/s3cmd/action.yml
@@ -35,6 +35,13 @@ runs:
         host_base = storage.yandexcloud.net
         host_bucket = %(bucket)s.storage.yandexcloud.net
         EOF
+
+        # specify mime type for correct content-type in s3cmd sync 
+        # we want to .out/.err files treat as text
+        MIME_TYPES_LINE="text/plain                                      out err log"
+        MIME_TYPES_FILE='/etc/mime.types'
+        # add if not exists
+        sudo bash -c "grep -qF -- '$MIME_TYPES_LINE' '$MIME_TYPES_FILE' || echo '$MIME_TYPES_LINE' >> '$MIME_TYPES_FILE'"
       env:
         s3_key_id: ${{ inputs.s3_key_id }}
         s3_secret_access_key: ${{ inputs.s3_key_secret }}

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -148,9 +148,9 @@ runs:
         # specify mime type for correct content-type in s3cmd sync 
         # we want to .out/.err files treat as text
         MIME_TYPES_LINE="text/plain                                      out err log"
-        MIME_TYPES_LINE='/etc/mime.types'
+        MIME_TYPES_FILE='/etc/mime.types'
         # add if not exists
-        sudo 'grep -qF -- "$MIME_TYPES_LINE" "$MIME_TYPES_LINE" || echo "$MIME_TYPES_LINE" >> "$MIME_TYPES_LINE"'
+        sudo bash -c "grep -qF -- '$MIME_TYPES_LINE' '$MIME_TYPES_FILE' || echo '$MIME_TYPES_LINE' >> '$MIME_TYPES_FILE'"
 
     - name: Setup cache
       shell: bash

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -150,7 +150,7 @@ runs:
         MIME_TYPES_LINE="text/plain                                      out err log"
         MIME_TYPES_LINE='/etc/mime.types'
         # add if not exists
-        grep -qF -- "$MIME_TYPES_LINE" "$MIME_TYPES_LINE" || sudo echo "$MIME_TYPES_LINE" >> "$MIME_TYPES_LINE"
+        sudo 'grep -qF -- "$MIME_TYPES_LINE" "$MIME_TYPES_LINE" || echo "$MIME_TYPES_LINE" >> "$MIME_TYPES_LINE"'
 
     - name: Setup cache
       shell: bash

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -150,7 +150,7 @@ runs:
         MIME_TYPES_LINE="text/plain                                      out err log"
         MIME_TYPES_LINE='/etc/mime.types'
         # add if not exists
-        sudo bash -c 'grep -qF -- "$LINE" "$FILE" || echo "$LINE" >> "$FILE"'
+        grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" >> "$FILE"
 
     - name: Setup cache
       shell: bash

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -145,13 +145,6 @@ runs:
           echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> $GITHUB_ENV
         fi
 
-        # specify mime type for correct content-type in s3cmd sync 
-        # we want to .out/.err files treat as text
-        MIME_TYPES_LINE="text/plain                                      out err log"
-        MIME_TYPES_FILE='/etc/mime.types'
-        # add if not exists
-        sudo bash -c "grep -qF -- '$MIME_TYPES_LINE' '$MIME_TYPES_FILE' || echo '$MIME_TYPES_LINE' >> '$MIME_TYPES_FILE'"
-
     - name: Setup cache
       shell: bash
       run: |

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -147,7 +147,7 @@ runs:
 
         # specify mime type for correct content-type in s3cmd sync 
         # we want to .out/.err files treat as text
-        MIME_TYPES_LINE = "text/plain                                      out err log"
+        MIME_TYPES_LINE="text/plain                                      out err log"
         MIME_TYPES_LINE='/etc/mime.types'
         # add if not exists
         sudo bash -c 'grep -qF -- "$LINE" "$FILE" || echo "$LINE" >> "$FILE"'

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -150,7 +150,7 @@ runs:
         MIME_TYPES_LINE="text/plain                                      out err log"
         MIME_TYPES_LINE='/etc/mime.types'
         # add if not exists
-        grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" >> "$FILE"
+        grep -qF -- "$MIME_TYPES_LINE" "$MIME_TYPES_LINE" || sudo echo "$MIME_TYPES_LINE" >> "$MIME_TYPES_LINE"
 
     - name: Setup cache
       shell: bash

--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -145,6 +145,13 @@ runs:
           echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> $GITHUB_ENV
         fi
 
+        # specify mime type for correct content-type in s3cmd sync 
+        # we want to .out/.err files treat as text
+        MIME_TYPES_LINE = "text/plain                                      out err log"
+        MIME_TYPES_LINE='/etc/mime.types'
+        # add if not exists
+        sudo bash -c 'grep -qF -- "$LINE" "$FILE" || echo "$LINE" >> "$FILE"'
+
     - name: Setup cache
       shell: bash
       run: |


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Treat out/err/log extensions as text in s3 sync 

It is needed because browser downloads logs instead just opening in a new tab in html report

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Check: https://github.com/ydb-platform/ydb/pull/10387 
Example: https://github.com/ydb-platform/ydb/pull/10387#issuecomment-2419126228
