### PR TITLE
Don't use GetRawData for logging

### DIFF
--- a/ydb/core/fq/libs/compute/ydb/control_plane/monitoring_rest_client_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/monitoring_rest_client_actor.cpp
@@ -56,7 +56,7 @@ public:
                 .Build()
         );
         auto ticket = CredentialsProvider->GetAuthInfo();
-        LOG_D(httpRequest->GetRawData() << " using ticket " << NKikimr::MaskTicket(ticket));
+        LOG_D(httpRequest->GetObfuscatedData() << " using ticket " << NKikimr::MaskTicket(ticket));
         httpRequest->Set("Authorization", ticket);
 
         auto httpSenderId = Register(NYql::NDq::CreateHttpSenderActor(SelfId(), HttpProxyId, NYql::NDq::THttpSenderRetryPolicy::GetNoRetryPolicy()));
@@ -83,7 +83,7 @@ public:
             forwardResponse->Issues.AddIssue(error);
             Send(request->Sender, forwardResponse.release(), 0, request->Cookie);
             return;
-        }        
+        }
 
         try {
             NJson::TJsonReaderConfig jsonConfig;

--- a/ydb/library/actors/http/http.h
+++ b/ydb/library/actors/http/http.h
@@ -199,11 +199,13 @@ public:
 
 template <typename HeaderType, typename BufferType>
 class THttpBase : public HeaderType, public BufferType {
-public:
+protected:
+    // Returns raw, non-obfuscated data
     TStringBuf GetRawData() const {
         return TStringBuf(BufferType::Data(), BufferType::Size());
     }
 
+public:
     TString GetObfuscatedData() const {
         THeaders headers(HeaderType::Headers);
         TStringBuf authorization(headers["Authorization"]);

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
@@ -53,7 +53,7 @@ void THandlerSessionServiceCheck::HandleProxy(NHttp::TEvHttpProxy::TEvHttpIncomi
         }
     } else {
         static constexpr size_t MAX_LOGGED_SIZE = 1024;
-        LOG_DEBUG_S(ctx, EService::MVP, "Can not process request to protected resource:\n" << event->Get()->Request->GetRawData().substr(0, MAX_LOGGED_SIZE));
+        LOG_DEBUG_S(ctx, EService::MVP, "Can not process request to protected resource:\n" << event->Get()->Request->GetObfuscatedData().substr(0, MAX_LOGGED_SIZE));
         httpResponse = CreateResponseForNotExistingResponseFromProtectedResource(event->Get()->GetError());
     }
     ctx.Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));


### PR DESCRIPTION
### Changelog entry
https://nebius.atlassian.net/browse/NBYDB-475
don't use `GetRawData` for logging

### Changelog category
Improvement

### Additional information
Log example
```
2024-10-15T12:04:29.815256Z :MVP DEBUG: Can not process request to protected resource:
2024-10-15T12:04:29.815276Z :HTTP DEBUG: (#20,[2a13:5947:3:1009:2200:2604:9fae:f203]:39070) <- (400 Bad Request)
***
authorization: <obfuscated>
```