### PR TITLE
Commit offsets in a transaction and out of a transaction

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_event.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_event.cpp
@@ -249,7 +249,7 @@ TDataReceivedEvent::TDataReceivedEvent(TVector<TMessage> messages, TVector<TComp
 
 void TDataReceivedEvent::Commit() {
     if (ReadInTransaction) {
-        ythrow yexception() << "Offsets cannot be promoted when reading in a transaction";
+        ythrow yexception() << "Offsets cannot be commited explicitly when reading in a transaction";
     }
 
     for (auto [from, to] : OffsetRanges) {

--- a/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_event.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/impl/read_session_event.cpp
@@ -248,6 +248,10 @@ TDataReceivedEvent::TDataReceivedEvent(TVector<TMessage> messages, TVector<TComp
 }
 
 void TDataReceivedEvent::Commit() {
+    if (ReadInTransaction) {
+        ythrow yexception() << "Offsets cannot be promoted when reading in a transaction";
+    }
+
     for (auto [from, to] : OffsetRanges) {
         static_cast<TPartitionStreamImpl<false>*>(PartitionSession.Get())->Commit(from, to);
     }

--- a/ydb/public/sdk/cpp/client/ydb_topic/include/read_events.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/include/read_events.h
@@ -201,6 +201,10 @@ struct TReadSessionEvent {
             return CompressedMessages;
         }
 
+        void SetReadInTransaction() {
+            ReadInTransaction = true;
+        }
+
         //! Commits all messages in batch.
         void Commit();
 
@@ -219,6 +223,7 @@ struct TReadSessionEvent {
         TVector<TMessage> Messages;
         TVector<TCompressedMessage> CompressedMessages;
         std::vector<std::pair<ui64, ui64>> OffsetRanges;
+        bool ReadInTransaction = false;
     };
 
     //! Acknowledgement for commit request.

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -63,7 +63,7 @@ protected:
 
     struct TReadMessageSettings {
         NTable::TTransaction& Tx;
-        bool Commit = false;
+        bool CommitOffsets = false;
         TMaybe<ui64> Offset;
     };
 
@@ -314,7 +314,7 @@ void TFixture::ReadMessage(TTopicReadSessionPtr reader, NTable::TTransaction& tx
 {
     TReadMessageSettings settings {
         .Tx = tx,
-        .Commit = false,
+        .CommitOffsets = false,
         .Offset = offset
     };
     ReadMessage(reader, settings);
@@ -326,7 +326,7 @@ void TFixture::ReadMessage(TTopicReadSessionPtr reader, const TReadMessageSettin
     if (settings.Offset.Defined()) {
         UNIT_ASSERT_VALUES_EQUAL(event.GetMessages()[0].GetOffset(), *settings.Offset);
     }
-    if (settings.Commit) {
+    if (settings.CommitOffsets) {
         event.Commit();
     }
 }
@@ -538,7 +538,7 @@ Y_UNIT_TEST_F(Offsets_Cannot_Be_Promoted_When_Reading_In_A_Transaction, TFixture
     auto reader = CreateReader();
     StartPartitionSession(reader, tx, 0);
 
-    UNIT_ASSERT_EXCEPTION(ReadMessage(reader, {.Tx = tx, .Commit = true}), yexception);
+    UNIT_ASSERT_EXCEPTION(ReadMessage(reader, {.Tx = tx, .CommitOffsets = true}), yexception);
 }
 
 //Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

You cannot simultaneously commit offsets in a transaction and out of a transaction.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
