### PR TITLE
do not convert google datetime to string in schema

### DIFF
--- a/ydb/core/viewer/json/json.cpp
+++ b/ydb/core/viewer/json/json.cpp
@@ -492,9 +492,7 @@ void TProtoToJson::ProtoToJsonSchema(IOutputStream& to, const TJsonSettings& jso
                 to << "{\"type\":\"array\",\"items\":";
             }
             if (fieldDescriptor->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
-                if (fieldDescriptor->message_type()->full_name() == google::protobuf::Timestamp::descriptor()->full_name()) {
-                    to << "{\"type\":\"string\",\"format\":\"date-time\"}";
-                } else if (fieldDescriptor->message_type()->full_name() == google::protobuf::Duration::descriptor()->full_name()) {
+                if (fieldDescriptor->message_type()->full_name() == google::protobuf::Duration::descriptor()->full_name()) {
                     to << "{\"type\":\"string\", \"example\":\"3600s\"}";
                 } else if (fieldDescriptor->message_type()->full_name() == google::protobuf::BoolValue::descriptor()->full_name()) {
                     to << "{\"type\":\"boolean\"}";

--- a/ydb/core/viewer/yaml/yaml.cpp
+++ b/ydb/core/viewer/yaml/yaml.cpp
@@ -60,10 +60,7 @@ YAML::Node TProtoToYaml::ProtoToYamlSchema(const ::google::protobuf::Descriptor*
                 property.reset(property["items"]);
             }
             if (fieldDescriptor->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
-                if (fieldDescriptor->message_type()->full_name() == google::protobuf::Timestamp::descriptor()->full_name()) {
-                    property["type"] = "string";
-                    property["format"] = "date-time";
-                } else if (fieldDescriptor->message_type()->full_name() == google::protobuf::Duration::descriptor()->full_name()) {
+                if (fieldDescriptor->message_type()->full_name() == google::protobuf::Duration::descriptor()->full_name()) {
                     property["type"] = "string";
                     property["example"] = "3600s";
                 } else if (fieldDescriptor->message_type()->full_name() == google::protobuf::BoolValue::descriptor()->full_name()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

do not convert google datetime to string in schema

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)
