### PR TITLE
base: move TCompactionPolicy out of flat_scheme_op.proto

### DIFF
--- a/ydb/core/base/localdb.cpp
+++ b/ydb/core/base/localdb.cpp
@@ -22,14 +22,14 @@ TCompactionPolicy::TBackgroundPolicy::TBackgroundPolicy(ui32 threshold,
     , ResourceBrokerTask(resourceBrokerTask)
 {}
 
-TCompactionPolicy::TBackgroundPolicy::TBackgroundPolicy(const NKikimrSchemeOp::TCompactionPolicy::TBackgroundPolicy &policyPb)
+TCompactionPolicy::TBackgroundPolicy::TBackgroundPolicy(const NKikimrCompaction::TCompactionPolicy::TBackgroundPolicy &policyPb)
     : Threshold(policyPb.HasThreshold() ? policyPb.GetThreshold() : 101)
     , PriorityBase(policyPb.HasPriorityBase() ? policyPb.GetPriorityBase() : 100)
     , TimeFactor(policyPb.HasTimeFactor() ? policyPb.GetTimeFactor() : 1.0)
     , ResourceBrokerTask(policyPb.HasResourceBrokerTask() ? policyPb.GetResourceBrokerTask() : BackgroundCompactionTaskName)
 {}
 
-void TCompactionPolicy::TBackgroundPolicy::Serialize(NKikimrSchemeOp::TCompactionPolicy::TBackgroundPolicy& policyPb) const
+void TCompactionPolicy::TBackgroundPolicy::Serialize(NKikimrCompaction::TCompactionPolicy::TBackgroundPolicy& policyPb) const
 {
     policyPb.SetThreshold(Threshold);
     policyPb.SetPriorityBase(PriorityBase);
@@ -59,7 +59,7 @@ TCompactionPolicy::TGenerationPolicy::TGenerationPolicy(ui64 sizeToCompact,
     , UpliftPartSize(sizeToCompact / countToCompact)
 {}
 
-TCompactionPolicy::TGenerationPolicy::TGenerationPolicy(const NKikimrSchemeOp::TCompactionPolicy::TGenerationPolicy &policyPb)
+TCompactionPolicy::TGenerationPolicy::TGenerationPolicy(const NKikimrCompaction::TCompactionPolicy::TGenerationPolicy &policyPb)
     : SizeToCompact(policyPb.HasSizeToCompact() ? policyPb.GetSizeToCompact() : 0)
     , CountToCompact(policyPb.HasCountToCompact() ? policyPb.GetCountToCompact() : 5)
     , ForceCountToCompact(policyPb.HasForceCountToCompact() ? policyPb.GetForceCountToCompact() : 8)
@@ -78,7 +78,7 @@ TCompactionPolicy::TGenerationPolicy::TGenerationPolicy(const NKikimrSchemeOp::T
         ResourceBrokerTask = LegacyQueueIdToTaskName(CompactionBrokerQueue);
 }
 
-void TCompactionPolicy::TGenerationPolicy::Serialize(NKikimrSchemeOp::TCompactionPolicy::TGenerationPolicy& policyPb) const
+void TCompactionPolicy::TGenerationPolicy::Serialize(NKikimrCompaction::TCompactionPolicy::TGenerationPolicy& policyPb) const
 {
     policyPb.SetSizeToCompact(SizeToCompact);
     policyPb.SetCountToCompact(CountToCompact);
@@ -116,11 +116,11 @@ TCompactionPolicy::TCompactionPolicy()
     , LogOverheadSizeToSnapshot(16 * 1024 * 1024)
     , LogOverheadCountToSnapshot(500)
     , DroppedRowsPercentToCompact(50)
-    , CompactionStrategy(NKikimrSchemeOp::CompactionStrategyUnset)
+    , CompactionStrategy(NKikimrCompaction::CompactionStrategyUnset)
     , KeepEraseMarkers(false)
 {}
 
-TCompactionPolicy::TCompactionPolicy(const NKikimrSchemeOp::TCompactionPolicy& policyPb)
+TCompactionPolicy::TCompactionPolicy(const NKikimrCompaction::TCompactionPolicy& policyPb)
     : InMemSizeToSnapshot(policyPb.HasInMemSizeToSnapshot() ? policyPb.GetInMemSizeToSnapshot() : 4 * 1024 * 1024)
     , InMemStepsToSnapshot(policyPb.HasInMemStepsToSnapshot() ? policyPb.GetInMemStepsToSnapshot() : 300)
     , InMemForceStepsToSnapshot(policyPb.HasInMemForceStepsToSnapshot() ? policyPb.GetInMemForceStepsToSnapshot() : 500)
@@ -161,7 +161,7 @@ TCompactionPolicy::TCompactionPolicy(const NKikimrSchemeOp::TCompactionPolicy& p
     }
 }
 
-void TCompactionPolicy::Serialize(NKikimrSchemeOp::TCompactionPolicy& policyPb) const {
+void TCompactionPolicy::Serialize(NKikimrCompaction::TCompactionPolicy& policyPb) const {
     policyPb.SetInMemSizeToSnapshot(InMemSizeToSnapshot);
     policyPb.SetInMemStepsToSnapshot(InMemStepsToSnapshot);
     policyPb.SetInMemForceStepsToSnapshot(InMemForceStepsToSnapshot);
@@ -182,7 +182,7 @@ void TCompactionPolicy::Serialize(NKikimrSchemeOp::TCompactionPolicy& policyPb) 
     policyPb.SetLogOverheadSizeToSnapshot(LogOverheadSizeToSnapshot);
     policyPb.SetLogOverheadCountToSnapshot(LogOverheadCountToSnapshot);
     policyPb.SetDroppedRowsPercentToCompact(DroppedRowsPercentToCompact);
-    if (CompactionStrategy != NKikimrSchemeOp::CompactionStrategyUnset) {
+    if (CompactionStrategy != NKikimrCompaction::CompactionStrategyUnset) {
         policyPb.SetCompactionStrategy(CompactionStrategy);
     }
     if (KeepEraseMarkers) {

--- a/ydb/core/base/localdb.h
+++ b/ydb/core/base/localdb.h
@@ -3,7 +3,7 @@
 #include <util/generic/map.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/list.h>
-#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/compaction.pb.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
 #include <google/protobuf/util/message_differencer.h>
 
@@ -19,9 +19,9 @@ struct TCompactionPolicy : public TThrRefBase {
 
         TBackgroundPolicy();
         TBackgroundPolicy(ui32 threshold, ui32 priorityBase, double timeFactor, const TString &resourceBrokerTask);
-        TBackgroundPolicy(const NKikimrSchemeOp::TCompactionPolicy::TBackgroundPolicy &policyPb);
+        TBackgroundPolicy(const NKikimrCompaction::TCompactionPolicy::TBackgroundPolicy &policyPb);
 
-        void Serialize(NKikimrSchemeOp::TCompactionPolicy::TBackgroundPolicy& policyPb) const;
+        void Serialize(NKikimrCompaction::TCompactionPolicy::TBackgroundPolicy& policyPb) const;
 
         bool operator ==(const TBackgroundPolicy& p) const {
             return (Threshold == p.Threshold
@@ -50,9 +50,9 @@ struct TCompactionPolicy : public TThrRefBase {
                           ui64 forceSizeToCompact, const TString &resourceBrokerTask,
                           bool keepInCache,
                           const TBackgroundPolicy &backgroundCompactionPolicy = TBackgroundPolicy());
-        TGenerationPolicy(const NKikimrSchemeOp::TCompactionPolicy::TGenerationPolicy &policyPb);
+        TGenerationPolicy(const NKikimrCompaction::TCompactionPolicy::TGenerationPolicy &policyPb);
 
-        void Serialize(NKikimrSchemeOp::TCompactionPolicy::TGenerationPolicy& policyPb) const;
+        void Serialize(NKikimrCompaction::TCompactionPolicy::TGenerationPolicy& policyPb) const;
 
         bool operator ==(const TGenerationPolicy& p) const {
             return SizeToCompact == p.SizeToCompact
@@ -91,16 +91,16 @@ struct TCompactionPolicy : public TThrRefBase {
     ui64 LogOverheadSizeToSnapshot;
     ui32 LogOverheadCountToSnapshot;
     ui32 DroppedRowsPercentToCompact;
-    NKikimrSchemeOp::ECompactionStrategy CompactionStrategy;
-    NKikimrSchemeOp::TCompactionPolicy::TShardPolicy ShardPolicy;
+    NKikimrCompaction::ECompactionStrategy CompactionStrategy;
+    NKikimrCompaction::TCompactionPolicy::TShardPolicy ShardPolicy;
     bool KeepEraseMarkers;
 
     TVector<TGenerationPolicy> Generations;
 
     TCompactionPolicy();
-    explicit TCompactionPolicy(const NKikimrSchemeOp::TCompactionPolicy& policyPb);
+    explicit TCompactionPolicy(const NKikimrCompaction::TCompactionPolicy& policyPb);
 
-    void Serialize(NKikimrSchemeOp::TCompactionPolicy& policyPb) const;
+    void Serialize(NKikimrCompaction::TCompactionPolicy& policyPb) const;
 
     bool operator ==(const TCompactionPolicy& p) const {
         return InMemSizeToSnapshot == p.InMemSizeToSnapshot

--- a/ydb/core/base/localdb_ut.cpp
+++ b/ydb/core/base/localdb_ut.cpp
@@ -7,7 +7,7 @@ namespace NLocalDb {
     Y_UNIT_TEST_SUITE(TLocalDbTest) {
 
         Y_UNIT_TEST(BackupTaskNameChangedAtLoadTime) {
-            NKikimrSchemeOp::TCompactionPolicy policyPb;
+            NKikimrCompaction::TCompactionPolicy policyPb;
             CreateDefaultUserTablePolicy()->Serialize(policyPb);
 
             // We expect default task name to be "scan" at the moment

--- a/ydb/core/cms/console/console__scheme.h
+++ b/ydb/core/cms/console/console__scheme.h
@@ -5,6 +5,8 @@
 #include <ydb/core/scheme/scheme_types_defs.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
 
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
 namespace NKikimr::NConsole {
 
 struct Schema : NIceDb::Schema {

--- a/ydb/core/protos/compaction.proto
+++ b/ydb/core/protos/compaction.proto
@@ -1,0 +1,113 @@
+package NKikimrCompaction;
+option java_package = "ru.yandex.kikimr.proto";
+
+enum ECompactionStrategy {
+    CompactionStrategyUnset = 0;
+    CompactionStrategyGenerational = 1;
+    CompactionStrategySharded = 2; // DEPRECATED: use CompactionStrategyGenerational
+}
+
+message TCompactionPolicy {
+
+    message TBackgroundPolicy {
+        // How much (in %) of forced compaction criteria should be met to submit background task.
+        optional uint32 Threshold = 1 [default = 101]; // no background compaction by default
+        // Base background compaction priority value (less priority means more important task).
+        // Value is used to compute real task priority basing on compaction criteria, time
+        // in queue etc.
+        optional uint32 PriorityBase = 2 [default = 100];
+        // Submitted background task may become more prioritized over time.
+        // New priority is computed as priority /= max(log(elapsed_seconds) * factor, 1);
+        optional double TimeFactor = 3 [default = 1.0];
+        optional uint32 TaskType = 4 [default = 5]; // DEPRECATED
+        optional string ResourceBrokerTask = 5;
+    }
+
+    message TGenerationPolicy {
+        optional uint32 GenerationId = 1;
+        optional uint64 SizeToCompact = 2;
+        optional uint32 CountToCompact = 3;
+        optional uint32 ForceCountToCompact = 4; // OR one of force limits happend
+        optional uint64 ForceSizeToCompact = 5;
+        optional uint32 CompactionBrokerQueue = 6; // DEPRECATED
+        optional bool KeepInCache = 7;
+        optional TBackgroundPolicy BackgroundCompactionPolicy = 8;
+        optional string ResourceBrokerTask = 9;
+        optional uint32 ExtraCompactionPercent = 10;
+        optional uint64 ExtraCompactionMinSize = 11;
+        optional uint32 ExtraCompactionExpPercent = 12;
+        optional uint64 ExtraCompactionExpMaxSize = 13;
+        optional uint64 UpliftPartSize = 14;
+    }
+
+    //NOTE: default values must be in sync with ydb/core/base/localdb.cpp, TShardPolicy
+    message TShardPolicy {
+        // Adjacent shards smaller than this will be merged
+        optional uint64 MinShardSize = 1 [default = 33554432];
+
+        // Shards bigger than this will split in two or more pieces
+        optional uint64 MaxShardSize = 2 [default = 134217728];
+
+        // Slices smaller than this will get prioritized compaction
+        optional uint64 MinSliceSize = 3 [default = 2097152];
+
+        // Level will be compacted when there are more than this number of slices
+        optional uint32 MaxSlicesPerLevel = 4 [default = 256];
+
+        // Shard will be compacted when there are more than this number of levels
+        optional uint32 MaxTotalLevels = 5 [default = 16];
+
+        // Shard will avoid compacting less than this number of levels
+        optional uint32 MinLevelsToCompact = 6 [default = 2];
+
+        // Level will be compacted when it has X% of its data in upper levels
+        optional uint32 NewDataPercentToCompact = 7 [default = 100];
+
+        // Level will be compacted when it has X% of its rows in upper levels
+        optional uint32 NewRowsPercentToCompact = 8 [default = 0];
+
+        // Resource broker task type for compactions
+        optional string ResourceBrokerTask = 9 [default = "compaction_gen1"];
+
+        // Base priority for compaction tasks
+        optional uint32 TaskPriorityBase = 10 [default = 1000];
+
+        // Task priority will be increased for every N levels over the minimum
+        optional uint32 TaskPriorityLevelsBoost = 11 [default = 1];
+
+        // Task priority will be decreased for every N bytes of input
+        optional uint64 TaskPrioritySizePenalty = 12 [default = 4194304];
+
+        // Part data may be reused, unless it would leave this much garbage
+        optional uint32 MaxGarbagePercentToReuse = 13 [default = 20];
+
+        // Minimum slice that that may be reused
+        optional uint64 MinSliceSizeToReuse = 14 [default = 524288];
+    }
+
+    optional uint64 InMemSizeToSnapshot = 1;
+    optional uint32 InMemStepsToSnapshot = 2; // snapshot inmem state when size AND steps from last snapshot passed
+    optional uint32 InMemForceStepsToSnapshot = 3; // OR steps passed
+    optional uint64 InMemForceSizeToSnapshot = 4; // OR size reached
+    optional uint32 InMemCompactionBrokerQueue = 5 [default = 0]; // DEPRECATED
+    optional uint64 ReadAheadHiThreshold = 6 [default = 67108864];
+    optional uint64 ReadAheadLoThreshold = 7 [default = 16777216];
+    optional uint32 MinDataPageSize = 8 [default = 7168];   // 7KB is smallest optimal for 512 byte sectors
+    optional uint32 SnapBrokerQueue = 9 [default = 0]; // DEPRECATED
+    optional uint32 BackupBrokerQueue = 11 [default = 1]; // DEPRECATED
+    optional uint32 DefaultTaskPriority = 12 [default = 5];
+    optional TBackgroundPolicy BackgroundSnapshotPolicy = 13;
+    optional string InMemResourceBrokerTask = 14;
+    optional string SnapshotResourceBrokerTask = 15;
+    optional string BackupResourceBrokerTask = 16;
+    optional uint64 LogOverheadSizeToSnapshot = 17;
+    optional uint32 LogOverheadCountToSnapshot = 18;
+    optional uint32 DroppedRowsPercentToCompact = 19;
+    optional ECompactionStrategy CompactionStrategy = 20 [default = CompactionStrategyUnset];
+    optional TShardPolicy ShardPolicy = 21;
+    optional bool KeepEraseMarkers = 22;
+    optional uint32 MinBTreeIndexNodeSize = 23 [default = 7168];
+    optional uint32 MinBTreeIndexNodeKeys = 24 [default = 6];
+
+    repeated TGenerationPolicy Generation = 10;
+}

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -15,6 +15,7 @@ import "ydb/core/protos/counters_schemeshard.proto";
 import "ydb/core/protos/datashard_config.proto";
 import "ydb/core/protos/drivemodel.proto";
 import "ydb/core/protos/feature_flags.proto";
+import "ydb/core/protos/compaction.proto";
 import "ydb/core/protos/flat_scheme_op.proto";
 import "ydb/core/protos/hive.proto";
 import "ydb/core/protos/http_config.proto";
@@ -230,7 +231,7 @@ message TDomainsConfig {
 
     message TNamedCompactionPolicy {
         optional string Name = 1;
-        optional NKikimrSchemeOp.TCompactionPolicy Policy = 2;
+        optional NKikimrCompaction.TCompactionPolicy Policy = 2;
     }
 
     message TSecurityConfig {
@@ -962,7 +963,7 @@ message TConfigsDispatcherConfig {
 
 message TCompactionPolicy {
     optional string Name = 1;
-    optional NKikimrSchemeOp.TCompactionPolicy CompactionPolicy = 2;
+    optional NKikimrCompaction.TCompactionPolicy CompactionPolicy = 2;
 }
 
 message TExecutionPolicy {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -3,6 +3,7 @@ import "ydb/core/scheme/protos/pathid.proto";
 import "ydb/core/protos/bind_channel_storage_pool.proto";
 import "ydb/core/protos/pqconfig.proto";
 import "ydb/core/protos/replication.proto";
+import "ydb/core/protos/compaction.proto";
 import "ydb/core/protos/table_stats.proto";
 import "ydb/core/protos/tablet.proto";
 import "ydb/core/protos/subdomains.proto";
@@ -131,115 +132,6 @@ message TFamilyDescription {
     optional TStorageConfig StorageConfig = 9;
 }
 
-enum ECompactionStrategy {
-    CompactionStrategyUnset = 0;
-    CompactionStrategyGenerational = 1;
-    CompactionStrategySharded = 2; // DEPRECATED: use CompactionStrategyGenerational
-}
-
-message TCompactionPolicy {
-    message TBackgroundPolicy {
-        // How much (in %) of forced compaction criteria should be met to submit background task.
-        optional uint32 Threshold = 1 [default = 101]; // no background compaction by default
-        // Base background compaction priority value (less priority means more important task).
-        // Value is used to compute real task priority basing on compaction criteria, time
-        // in queue etc.
-        optional uint32 PriorityBase = 2 [default = 100];
-        // Submitted background task may become more prioritized over time.
-        // New priority is computed as priority /= max(log(elapsed_seconds) * factor, 1);
-        optional double TimeFactor = 3 [default = 1.0];
-        optional uint32 TaskType = 4 [default = 5]; // DEPRECATED
-        optional string ResourceBrokerTask = 5;
-    }
-
-    message TGenerationPolicy {
-        optional uint32 GenerationId = 1;
-        optional uint64 SizeToCompact = 2;
-        optional uint32 CountToCompact = 3;
-        optional uint32 ForceCountToCompact = 4; // OR one of force limits happend
-        optional uint64 ForceSizeToCompact = 5;
-        optional uint32 CompactionBrokerQueue = 6; // DEPRECATED
-        optional bool KeepInCache = 7;
-        optional TBackgroundPolicy BackgroundCompactionPolicy = 8;
-        optional string ResourceBrokerTask = 9;
-        optional uint32 ExtraCompactionPercent = 10;
-        optional uint64 ExtraCompactionMinSize = 11;
-        optional uint32 ExtraCompactionExpPercent = 12;
-        optional uint64 ExtraCompactionExpMaxSize = 13;
-        optional uint64 UpliftPartSize = 14;
-    }
-
-    message TShardPolicy {
-        // Adjacent shards smaller than this will be merged
-        optional uint64 MinShardSize = 1 [default = 33554432];
-
-        // Shards bigger than this will split in two or more pieces
-        optional uint64 MaxShardSize = 2 [default = 134217728];
-
-        // Slices smaller than this will get prioritized compaction
-        optional uint64 MinSliceSize = 3 [default = 2097152];
-
-        // Level will be compacted when there are more than this number of slices
-        optional uint32 MaxSlicesPerLevel = 4 [default = 256];
-
-        // Shard will be compacted when there are more than this number of levels
-        optional uint32 MaxTotalLevels = 5 [default = 16];
-
-        // Shard will avoid compacting less than this number of levels
-        optional uint32 MinLevelsToCompact = 6 [default = 2];
-
-        // Level will be compacted when it has X% of its data in upper levels
-        optional uint32 NewDataPercentToCompact = 7 [default = 100];
-
-        // Level will be compacted when it has X% of its rows in upper levels
-        optional uint32 NewRowsPercentToCompact = 8 [default = 0];
-
-        // Resource broker task type for compactions
-        optional string ResourceBrokerTask = 9 [default = "compaction_gen1"];
-
-        // Base priority for compaction tasks
-        optional uint32 TaskPriorityBase = 10 [default = 1000];
-
-        // Task priority will be increased for every N levels over the minimum
-        optional uint32 TaskPriorityLevelsBoost = 11 [default = 1];
-
-        // Task priority will be decreased for every N bytes of input
-        optional uint64 TaskPrioritySizePenalty = 12 [default = 4194304];
-
-        // Part data may be reused, unless it would leave this much garbage
-        optional uint32 MaxGarbagePercentToReuse = 13 [default = 20];
-
-        // Minimum slice that that may be reused
-        optional uint64 MinSliceSizeToReuse = 14 [default = 524288];
-    }
-
-    optional uint64 InMemSizeToSnapshot = 1;
-    optional uint32 InMemStepsToSnapshot = 2; // snapshot inmem state when size AND steps from last snapshot passed
-    optional uint32 InMemForceStepsToSnapshot = 3; // OR steps passed
-    optional uint64 InMemForceSizeToSnapshot = 4; // OR size reached
-    optional uint32 InMemCompactionBrokerQueue = 5 [default = 0]; // DEPRECATED
-    optional uint64 ReadAheadHiThreshold = 6 [default = 67108864];
-    optional uint64 ReadAheadLoThreshold = 7 [default = 16777216];
-    optional uint32 MinDataPageSize = 8 [default = 7168];   // 7KB is smallest optimal for 512 byte sectors
-    optional uint32 SnapBrokerQueue = 9 [default = 0]; // DEPRECATED
-    optional uint32 BackupBrokerQueue = 11 [default = 1]; // DEPRECATED
-    optional uint32 DefaultTaskPriority = 12 [default = 5];
-    optional TBackgroundPolicy BackgroundSnapshotPolicy = 13;
-    optional string InMemResourceBrokerTask = 14;
-    optional string SnapshotResourceBrokerTask = 15;
-    optional string BackupResourceBrokerTask = 16;
-    optional uint64 LogOverheadSizeToSnapshot = 17;
-    optional uint32 LogOverheadCountToSnapshot = 18;
-    optional uint32 DroppedRowsPercentToCompact = 19;
-    optional ECompactionStrategy CompactionStrategy = 20 [default = CompactionStrategyUnset];
-    optional TShardPolicy ShardPolicy = 21;
-    optional bool KeepEraseMarkers = 22;
-    optional uint32 MinBTreeIndexNodeSize = 23 [default = 7168];
-    optional uint32 MinBTreeIndexNodeKeys = 24 [default = 6];
-
-    repeated TGenerationPolicy Generation = 10;
-}
-
 message TFastSplitSettings {
     optional uint64 SizeThreshold = 1;
     optional uint64 RowCountThreshold = 2;
@@ -273,7 +165,7 @@ message TPipelineConfig {
 
 message TPartitionConfig {
     optional string NamedCompactionPolicy = 1; // One of the predefined policies
-    optional TCompactionPolicy CompactionPolicy = 2; // Customized policy
+    optional NKikimrCompaction.TCompactionPolicy CompactionPolicy = 2; // Customized policy
     optional uint64 FollowerCount = 3;
     optional uint64 ExecutorCacheSize = 4; // (DEPRECATED) Cache size for the whole tablet including all user and system tables
     optional bool AllowFollowerPromotion = 5 [default = true]; // if true followers can upgrade to leader, if false followers only handle reads

--- a/ydb/core/protos/scheme_log.proto
+++ b/ydb/core/protos/scheme_log.proto
@@ -1,4 +1,4 @@
-import "ydb/core/protos/flat_scheme_op.proto";
+import "ydb/core/protos/compaction.proto";
 import "ydb/core/scheme/protos/type_info.proto";
 
 package NTabletFlatScheme;
@@ -63,7 +63,7 @@ message TAlterRecord {
     optional bool NotNull = 24 [default = false];
 
     optional uint64 ExecutorCacheSize = 100;
-    optional NKikimrSchemeOp.TCompactionPolicy CompactionPolicy = 101;
+    optional NKikimrCompaction.TCompactionPolicy CompactionPolicy = 101;
     optional bool ExecutorAllowLogBatching = 102;
     optional uint64 ExecutorLogFlushPeriod = 103;
     optional uint32 ExecutorLimitInFlyTx = 104;

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -32,6 +32,7 @@ SRCS(
     change_exchange.proto
     channel_purpose.proto
     cms.proto
+    compaction.proto
     compile_service_config.proto
     config.proto
     config_units.proto

--- a/ydb/core/tablet_flat/flat_boot_switch.h
+++ b/ydb/core/tablet_flat/flat_boot_switch.h
@@ -51,7 +51,7 @@ namespace NBoot {
         };
 
         struct TCompactionChanges {
-            NKikimrSchemeOp::ECompactionStrategy Strategy = NKikimrSchemeOp::CompactionStrategyUnset;
+            NKikimrCompaction::ECompactionStrategy Strategy = NKikimrCompaction::CompactionStrategyUnset;
             THashMap<ui64, TString> KeyValues;
         };
 

--- a/ydb/core/tablet_flat/flat_boot_turns.h
+++ b/ydb/core/tablet_flat/flat_boot_turns.h
@@ -204,7 +204,7 @@ namespace NBoot {
                     auto &snapshot = compaction->Snapshots[front.Table];
 
                     // N.B.: schema is reflected first during commit
-                    if (front.CompactionChanges.Strategy != NKikimrSchemeOp::CompactionStrategyUnset &&
+                    if (front.CompactionChanges.Strategy != NKikimrCompaction::CompactionStrategyUnset &&
                         front.CompactionChanges.Strategy != snapshot.Strategy)
                     {
                         snapshot.State.PartLevels.clear();

--- a/ydb/core/tablet_flat/flat_dbase_apply.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_apply.cpp
@@ -260,7 +260,7 @@ bool TSchemeModifier::AddColumnWithTypeInfo(ui32 tid, const TString &name, ui32 
 
     NScheme::TTypeInfo typeInfo;
     TString pgTypeMod;
-    Y_ABORT_UNLESS((bool)typeInfoProto == NScheme::NTypeIds::IsParametrizedType(type));    
+    Y_ABORT_UNLESS((bool)typeInfoProto == NScheme::NTypeIds::IsParametrizedType(type));
     switch ((NScheme::TTypeId)type) {
     case NScheme::NTypeIds::Pg: {
         auto typeInfoMod = NScheme::TypeInfoModFromProtoColumnType(type, &*typeInfoProto);
@@ -272,11 +272,11 @@ bool TSchemeModifier::AddColumnWithTypeInfo(ui32 tid, const TString &name, ui32 
         auto typeInfoMod = NScheme::TypeInfoModFromProtoColumnType(type, &*typeInfoProto);
         typeInfo = typeInfoMod.TypeInfo;
         break;
-    } 
+    }
     default: {
         typeInfo = NScheme::TTypeInfo(type);
         break;
-    }   
+    }
     }
 
     // We verify ids and types match when column with the same name already exists
@@ -384,7 +384,7 @@ bool TSchemeModifier::SetExecutorResourceProfile(const TString &name)
     return ChangeExecutorSetting(Scheme.Executor.ResourceProfile, name);
 }
 
-bool TSchemeModifier::SetCompactionPolicy(ui32 tid, const NKikimrSchemeOp::TCompactionPolicy &proto)
+bool TSchemeModifier::SetCompactionPolicy(ui32 tid, const NKikimrCompaction::TCompactionPolicy &proto)
 {
     auto *table = Table(tid);
     TIntrusiveConstPtr<TCompactionPolicy> policy(new TCompactionPolicy(proto));

--- a/ydb/core/tablet_flat/flat_dbase_apply.h
+++ b/ydb/core/tablet_flat/flat_dbase_apply.h
@@ -44,7 +44,7 @@ namespace NTable {
         bool SetExecutorLogFlushPeriod(TDuration flushPeriod);
         bool SetExecutorLimitInFlyTx(ui32 limitTxInFly);
         bool SetExecutorResourceProfile(const TString &name);
-        bool SetCompactionPolicy(ui32 tableId, const NKikimrSchemeOp::TCompactionPolicy& newPolicy);
+        bool SetCompactionPolicy(ui32 tableId, const NKikimrCompaction::TCompactionPolicy& newPolicy);
 
         TTable* Table(ui32 tid) const noexcept
         {

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -16,7 +16,7 @@ namespace NTable {
 
 using namespace NTabletFlatScheme;
 
-using NKikimrSchemeOp::ECompactionStrategy;
+using NKikimrCompaction::ECompactionStrategy;
 
 using TCompactionPolicy = NLocalDb::TCompactionPolicy;
 
@@ -128,7 +128,7 @@ public:
         TDuration LogFlushPeriod = TDuration::MicroSeconds(500);
         ui32 LimitInFlyTx = 0;
         TString ResourceProfile = "default";
-        ECompactionStrategy DefaultCompactionStrategy = NKikimrSchemeOp::CompactionStrategyGenerational;
+        ECompactionStrategy DefaultCompactionStrategy = NKikimrCompaction::CompactionStrategyGenerational;
     };
 
     const TTableInfo* GetTableInfo(ui32 id) const { return const_cast<TScheme*>(this)->GetTableInfo(id); }
@@ -172,11 +172,11 @@ public:
     {
         if (auto *table = GetTableInfo(id)) {
             auto strategy = table->CompactionPolicy->CompactionStrategy;
-            if (strategy != NKikimrSchemeOp::CompactionStrategyUnset) {
-                if (strategy == NKikimrSchemeOp::CompactionStrategySharded) {
+            if (strategy != NKikimrCompaction::CompactionStrategyUnset) {
+                if (strategy == NKikimrCompaction::CompactionStrategySharded) {
                     // Sharded strategy doesn't exist anymore
                     // Use the safe generational strategy instead
-                    strategy = NKikimrSchemeOp::CompactionStrategyGenerational;
+                    strategy = NKikimrCompaction::CompactionStrategyGenerational;
                 }
                 return strategy;
             }

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -1710,7 +1710,7 @@ void TExecutor::ExecuteTransaction(TAutoPtr<TSeat> seat, const TActorContext &ct
     Database->Begin(Stamp(), env);
 
     LWTRACK(TransactionExecuteBegin, seat->Self->Orbit, seat->UniqID);
-    
+
     txc.StartExecutionSpan();
     const bool done = seat->Self->Execute(txc, ctx.MakeFor(OwnerActorId));
     txc.FinishExecutionSpan();
@@ -1943,7 +1943,7 @@ void TExecutor::PostponeTransaction(TAutoPtr<TSeat> seat, TPageCollectionTxEnv &
                 }
                 logl << "]";
             }
-            
+
             auto *req = new NPageCollection::TFetch(0, pageCollectionInfo->PageCollection, std::move(pages), pad->GetWaitingTraceId());
 
             loadPages += toLoad.first;
@@ -4661,7 +4661,7 @@ void TExecutor::Handle(TEvPrivate::TEvActivateCompactionChanges::TPtr& ev, const
 void TExecutor::CommitCompactionChanges(
         ui32 tableId,
         const NTable::TCompactionChanges& changes,
-        NKikimrSchemeOp::ECompactionStrategy strategy)
+        NKikimrCompaction::ECompactionStrategy strategy)
 {
     if (!changes.SliceChanges && !changes.StateChanges) {
         // Don't bother unless there's something to do
@@ -4692,7 +4692,7 @@ void TExecutor::CommitCompactionChanges(
 void TExecutor::ApplyCompactionChanges(
         TCompactionChangesCtx& ctx,
         const NTable::TCompactionChanges& changes,
-        NKikimrSchemeOp::ECompactionStrategy strategy)
+        NKikimrCompaction::ECompactionStrategy strategy)
 {
     const ui32 tableId = ctx.Proto.GetTableId();
 

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -615,11 +615,11 @@ class TExecutor
     void CommitCompactionChanges(
             ui32 tableId,
             const NTable::TCompactionChanges& changes,
-            NKikimrSchemeOp::ECompactionStrategy strategy);
+            NKikimrCompaction::ECompactionStrategy strategy);
     void ApplyCompactionChanges(
             TCompactionChangesCtx& ctx,
             const NTable::TCompactionChanges& changes,
-            NKikimrSchemeOp::ECompactionStrategy strategy);
+            NKikimrCompaction::ECompactionStrategy strategy);
 
 public:
     void Describe(IOutputStream &out) const noexcept override

--- a/ydb/core/tablet_flat/flat_executor.proto
+++ b/ydb/core/tablet_flat/flat_executor.proto
@@ -1,6 +1,6 @@
 import "ydb/core/protos/base.proto";
 import "ydb/core/protos/tablet.proto";
-import "ydb/core/protos/flat_scheme_op.proto";
+import "ydb/core/protos/compaction.proto";
 import "ydb/library/actors/protos/actors.proto";
 
 package NKikimrExecutorFlat;
@@ -68,7 +68,7 @@ message TBundleDelta {
 }
 
 message TBundleMove {
-    optional NKikimrProto.TLogoBlobID Label = 1; 
+    optional NKikimrProto.TLogoBlobID Label = 1;
     optional int64 RebasedEpoch = 2;
     optional uint32 SourceTable = 3;
 }
@@ -158,7 +158,7 @@ message TCompactionState {
     }
 
     optional uint32 Table = 1;
-    optional NKikimrSchemeOp.ECompactionStrategy Strategy = 2;
+    optional NKikimrCompaction.ECompactionStrategy Strategy = 2;
     repeated TKeyValue KeyValues = 3; // Key/value mapping (updates or snapshot)
 }
 

--- a/ydb/core/tablet_flat/flat_executor_compaction_logic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_compaction_logic.cpp
@@ -222,7 +222,7 @@ void TCompactionLogic::TriggerSharedPageCacheMemTableCompaction(ui32 table, ui64
                 MemTableMemoryConsumersCollection->CompactionComplete(consumer);
             }
         }
-    }    
+    }
 }
 
 TFinishedCompactionInfo TCompactionLogic::GetFinishedCompactionInfo(ui32 table) {
@@ -261,10 +261,10 @@ TReflectSchemeChangesResult TCompactionLogic::ReflectSchemeChanges()
         table.Policy = info.CompactionPolicy;
 
         auto newStrategyType = scheme.CompactionStrategyFor(info.Id);
-        Y_ABORT_UNLESS(newStrategyType != NKikimrSchemeOp::CompactionStrategyUnset);
+        Y_ABORT_UNLESS(newStrategyType != NKikimrCompaction::CompactionStrategyUnset);
 
         if (table.StrategyType != newStrategyType) {
-            if (table.StrategyType != NKikimrSchemeOp::CompactionStrategyUnset) {
+            if (table.StrategyType != NKikimrCompaction::CompactionStrategyUnset) {
                 result.StrategyChanges.push_back({ info.Id, newStrategyType });
                 StrategyChanging(table);
             }
@@ -335,15 +335,15 @@ void TCompactionLogic::ReflectRemovedRowVersions(ui32 table)
 
 THolder<NTable::ICompactionStrategy> TCompactionLogic::CreateStrategy(
         ui32 tableId,
-        NKikimrSchemeOp::ECompactionStrategy strategy)
+        NKikimrCompaction::ECompactionStrategy strategy)
 {
     switch (strategy) {
-        case NKikimrSchemeOp::CompactionStrategyGenerational:
+        case NKikimrCompaction::CompactionStrategyGenerational:
             return NTable::CreateGenCompactionStrategy(
                     tableId, Backend, Broker, Time, Logger, TaskNameSuffix);
 
         default:
-            Y_ABORT("Unsupported strategy %s", NKikimrSchemeOp::ECompactionStrategy_Name(strategy).c_str());
+            Y_ABORT("Unsupported strategy %s", NKikimrCompaction::ECompactionStrategy_Name(strategy).c_str());
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_compaction_logic.h
+++ b/ydb/core/tablet_flat/flat_executor_compaction_logic.h
@@ -82,7 +82,7 @@ struct TCompactionLogicState {
 
         // This identifies currently active strategy type
         // The default value is used as a marker for uninitialized strategies
-        NKikimrSchemeOp::ECompactionStrategy StrategyType = NKikimrSchemeOp::CompactionStrategyUnset;
+        NKikimrCompaction::ECompactionStrategy StrategyType = NKikimrCompaction::CompactionStrategyUnset;
 
         THolder<NTable::ICompactionStrategy> Strategy;
 
@@ -127,7 +127,7 @@ struct TCompactionLogicState {
         // The default value is used for compatibility, i.e. tablets that did
         // not have any strategy markers in their history are assumed to have
         // used the generational compaction.
-        NKikimrSchemeOp::ECompactionStrategy Strategy = NKikimrSchemeOp::CompactionStrategyGenerational;
+        NKikimrCompaction::ECompactionStrategy Strategy = NKikimrCompaction::CompactionStrategyGenerational;
     };
 
     TMap<ui32, TTableInfo> Tables;
@@ -138,7 +138,7 @@ class TFlatTableScan;
 
 struct TTableCompactionResult {
     NTable::TCompactionChanges Changes;
-    NKikimrSchemeOp::ECompactionStrategy Strategy;
+    NKikimrCompaction::ECompactionStrategy Strategy;
     TVector<TIntrusivePtr<TTableSnapshotContext>> CompleteSnapshots;
     bool MemCompacted = false;
 };
@@ -146,13 +146,13 @@ struct TTableCompactionResult {
 struct TTableCompactionChanges {
     ui32 Table;
     NTable::TCompactionChanges Changes;
-    NKikimrSchemeOp::ECompactionStrategy Strategy;
+    NKikimrCompaction::ECompactionStrategy Strategy;
 };
 
 struct TReflectSchemeChangesResult {
     struct TStrategyChange {
         ui32 Table;
-        NKikimrSchemeOp::ECompactionStrategy Strategy;
+        NKikimrCompaction::ECompactionStrategy Strategy;
     };
 
     TVector<TStrategyChange> StrategyChanges;
@@ -179,7 +179,7 @@ class TCompactionLogic {
 
     bool BeginMemTableCompaction(ui64 taskId, ui32 tableId);
 
-    THolder<NTable::ICompactionStrategy> CreateStrategy(ui32 tableId, NKikimrSchemeOp::ECompactionStrategy);
+    THolder<NTable::ICompactionStrategy> CreateStrategy(ui32 tableId, NKikimrCompaction::ECompactionStrategy);
 
     void StopTable(TCompactionLogicState::TTableInfo &table);
     void StrategyChanging(TCompactionLogicState::TTableInfo &table);

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -666,7 +666,7 @@ namespace Tests {
         {
             // Compaction policy:
             NLocalDb::TCompactionPolicyPtr defaultPolicy = NLocalDb::CreateDefaultUserTablePolicy();
-            NKikimrSchemeOp::TCompactionPolicy defaultflatSchemePolicy;
+            NKikimrCompaction::TCompactionPolicy defaultflatSchemePolicy;
             defaultPolicy->Serialize(defaultflatSchemePolicy);
             auto &defaultCompactionPolicy = *profiles.AddCompactionPolicies();
             defaultCompactionPolicy.SetName("default");
@@ -674,7 +674,7 @@ namespace Tests {
 
             NLocalDb::TCompactionPolicy policy1;
             policy1.Generations.push_back({ 0, 8, 8, 128 * 1024 * 1024, NLocalDb::LegacyQueueIdToTaskName(1), true });
-            NKikimrSchemeOp::TCompactionPolicy flatSchemePolicy1;
+            NKikimrCompaction::TCompactionPolicy flatSchemePolicy1;
             policy1.Serialize(flatSchemePolicy1);
             auto &compactionPolicy1 = *profiles.AddCompactionPolicies();
             compactionPolicy1.SetName("compaction1");
@@ -683,7 +683,7 @@ namespace Tests {
             NLocalDb::TCompactionPolicy policy2;
             policy2.Generations.push_back({ 0, 8, 8, 128 * 1024 * 1024, NLocalDb::LegacyQueueIdToTaskName(1), true });
             policy2.Generations.push_back({ 40 * 1024 * 1024, 5, 16, 512 * 1024 * 1024, NLocalDb::LegacyQueueIdToTaskName(2), false });
-            NKikimrSchemeOp::TCompactionPolicy flatSchemePolicy2;
+            NKikimrCompaction::TCompactionPolicy flatSchemePolicy2;
             policy2.Serialize(flatSchemePolicy2);
             auto &compactionPolicy2 = *profiles.AddCompactionPolicies();
             compactionPolicy2.SetName("compaction2");

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -6,6 +6,8 @@
 #include <ydb/core/tablet_flat/flat_database.h>
 #include <ydb/core/tablet_flat/flat_stat_table.h>
 
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
 #include <util/generic/ptr.h>
 #include <util/generic/hash.h>
 

--- a/ydb/core/tx/schemeshard/schemeshard_identificators.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_identificators.cpp
@@ -1,5 +1,7 @@
 #include "schemeshard_identificators.h"
 
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
 namespace NKikimr::NSchemeShard {
 
 NKikimrSchemeOp::TShardIdx AsProto(const NKikimr::NSchemeShard::TShardIdx& shardIdx) {

--- a/ydb/core/tx/schemeshard/schemeshard_identificators.h
+++ b/ydb/core/tx/schemeshard/schemeshard_identificators.h
@@ -7,6 +7,10 @@
 #include <util/generic/utility.h>
 #include <util/stream/output.h>
 
+namespace NKikimrSchemeOp {
+class TShardIdx;
+}
+
 namespace NKikimr {
 namespace NSchemeShard {
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1436,14 +1436,14 @@ bool TPartitionConfigMerger::VerifyAlterParams(
     return true;
 }
 
-bool TPartitionConfigMerger::VerifyCompactionPolicy(const NKikimrSchemeOp::TCompactionPolicy &policy, TString &err)
+bool TPartitionConfigMerger::VerifyCompactionPolicy(const NKikimrCompaction::TCompactionPolicy &policy, TString &err)
 {
     if (policy.HasCompactionStrategy()) {
         switch (policy.GetCompactionStrategy()) {
-        case NKikimrSchemeOp::CompactionStrategyUnset:
-        case NKikimrSchemeOp::CompactionStrategyGenerational:
+        case NKikimrCompaction::CompactionStrategyUnset:
+        case NKikimrCompaction::CompactionStrategyGenerational:
             break;
-        case NKikimrSchemeOp::CompactionStrategySharded:
+        case NKikimrCompaction::CompactionStrategySharded:
         default:
             err = TStringBuilder()
                     << "Unsupported compaction strategy.";

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -199,7 +199,7 @@ struct TPartitionConfigMerger {
         );
 
     static bool VerifyCompactionPolicy(
-        const NKikimrSchemeOp::TCompactionPolicy& policy,
+        const NKikimrCompaction::TCompactionPolicy& policy,
         TString& err);
 
     static bool VerifyCommandOnFrozenTable(

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -3294,9 +3294,9 @@ tx_meta {
 
 namespace {
 
-NKikimrSchemeOp::TCompactionPolicy DEFAULT_COMPACTION_POLICY;
-NKikimrSchemeOp::TCompactionPolicy COMPACTION_POLICY1;
-NKikimrSchemeOp::TCompactionPolicy COMPACTION_POLICY2;
+NKikimrCompaction::TCompactionPolicy DEFAULT_COMPACTION_POLICY;
+NKikimrCompaction::TCompactionPolicy COMPACTION_POLICY1;
+NKikimrCompaction::TCompactionPolicy COMPACTION_POLICY2;
 NKikimrSchemeOp::TPipelineConfig PIPELINE_CONFIG1;
 NKikimrSchemeOp::TPipelineConfig PIPELINE_CONFIG2;
 NKikimrSchemeOp::TStorageConfig STORAGE_CONFIG1;
@@ -3702,7 +3702,7 @@ void CheckTablePartitions(const TKikimrWithGrpcAndRootSchema &server,
     }
 }
 
-void Apply(const NKikimrSchemeOp::TCompactionPolicy &policy,
+void Apply(const NKikimrCompaction::TCompactionPolicy &policy,
            NKikimrSchemeOp::TTableDescription &description)
 {
     description.MutablePartitionConfig()->MutableCompactionPolicy()->CopyFrom(policy);

--- a/ydb/tests/library/common/protobuf_ss.py
+++ b/ydb/tests/library/common/protobuf_ss.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from os.path import basename, dirname, join
 
 from ydb.core.protos import msgbus_pb2
+from ydb.core.protos import compaction_pb2
 from ydb.core.protos import flat_scheme_op_pb2
 from ydb.tests.library.common.protobuf import AbstractProtobufBuilder, build_protobuf_if_necessary
 
@@ -24,7 +25,7 @@ class TPartitionConfig(AbstractProtobufBuilder):
 
     def __ensure_has_compaction_policy(self):
         if not self.protobuf.HasField('CompactionPolicy'):
-            self.protobuf.CompactionPolicy.CopyFrom(flat_scheme_op_pb2.TCompactionPolicy())
+            self.protobuf.CompactionPolicy.CopyFrom(compaction_pb2.TCompactionPolicy())
             # default values
             self.protobuf.CompactionPolicy.ReadAheadHiThreshold = 67108864
             self.protobuf.CompactionPolicy.ReadAheadLoThreshold = 16777216


### PR DESCRIPTION
Move `TCompactionPolicy` from `flat_scheme_op.proto` to distinct .proto file.

The final goal is to break dependency of `ydb/core/base/` on `flat_scheme_op.pb.h`.
Currently, `flat_scheme_op.proto` contains few fundamental structures essential for `ydb/core/base/`, alongside numerous higher-level components (scheme entities descriptions, scheme operations) that are irrelevant to `ydb/core/base/`'s needs.

This is part of "improve schemeshard operation build-time" effort (#10633).

### Changelog category

* Not for changelog