### PR TITLE
Enable subqueries inside views

### DIFF
--- a/ydb/core/kqp/ut/view/input/cases/in_subquery/create_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/in_subquery/create_view.sql
@@ -1,0 +1,9 @@
+CREATE VIEW in_subquery WITH (security_invoker = TRUE) AS
+    SELECT
+        *
+    FROM series
+    WHERE series_id IN (
+        SELECT
+            series_id
+        FROM series
+    );

--- a/ydb/core/kqp/ut/view/input/cases/in_subquery/drop_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/in_subquery/drop_view.sql
@@ -1,0 +1,1 @@
+DROP VIEW in_subquery;

--- a/ydb/core/kqp/ut/view/input/cases/in_subquery/etalon_query.sql
+++ b/ydb/core/kqp/ut/view/input/cases/in_subquery/etalon_query.sql
@@ -1,0 +1,12 @@
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM series
+    WHERE series_id IN (
+        SELECT
+            series_id
+        FROM series
+    )
+);

--- a/ydb/core/kqp/ut/view/input/cases/in_subquery/select_from_view.sql
+++ b/ydb/core/kqp/ut/view/input/cases/in_subquery/select_from_view.sql
@@ -1,0 +1,3 @@
+SELECT
+    *
+FROM in_subquery;

--- a/ydb/core/kqp/ut/view/view_ut.cpp
+++ b/ydb/core/kqp/ut/view/view_ut.cpp
@@ -139,10 +139,10 @@ void CompareResults(const NQuery::TExecuteQueryResult& first, const NQuery::TExe
     CompareResults(first.GetResultSets(), second.GetResultSets());
 }
 
-void InitializeTablesAndSecondaryViews(TSession& session) {
+void InitializeTablesAndSecondaryViews(NQuery::TSession& session) {
     const auto inputFolder = ArcadiaFromCurrentLocation(__SOURCE_FILE__, "input");
-    ExecuteDataDefinitionQuery(session, ReadWholeFile(inputFolder + "/create_tables_and_secondary_views.sql"));
-    ExecuteDataModificationQuery(session, ReadWholeFile(inputFolder + "/fill_tables.sql"));
+    ExecuteQuery(session, ReadWholeFile(inputFolder + "/create_tables_and_secondary_views.sql"));
+    ExecuteQuery(session, ReadWholeFile(inputFolder + "/fill_tables.sql"));
 }
 
 }
@@ -582,7 +582,7 @@ Y_UNIT_TEST_SUITE(TSelectFromViewTest) {
     Y_UNIT_TEST(ReadTestCasesFromFiles) {
         TKikimrRunner kikimr;
         EnableViewsFeatureFlag(kikimr);
-        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+        auto session = kikimr.GetQueryClient().GetSession().ExtractValueSync().GetSession();
 
         InitializeTablesAndSecondaryViews(session);
         EnableLogging();
@@ -593,13 +593,13 @@ Y_UNIT_TEST_SUITE(TSelectFromViewTest) {
         TString testcase;
         while (testcase = testcases.Next()) {
             const auto pathPrefix = TStringBuilder() << testcasesFolder << '/' << testcase << '/';
-            ExecuteDataDefinitionQuery(session, ReadWholeFile(pathPrefix + "create_view.sql"));
+            ExecuteQuery(session, ReadWholeFile(pathPrefix + "create_view.sql"));
 
-            const auto etalonResults = ExecuteDataModificationQuery(session, ReadWholeFile(pathPrefix + "etalon_query.sql"));
-            const auto selectFromViewResults = ExecuteDataModificationQuery(session, ReadWholeFile(pathPrefix + "select_from_view.sql"));
+            const auto etalonResults = ExecuteQuery(session, ReadWholeFile(pathPrefix + "etalon_query.sql"));
+            const auto selectFromViewResults = ExecuteQuery(session, ReadWholeFile(pathPrefix + "select_from_view.sql"));
             CompareResults(etalonResults, selectFromViewResults);
 
-            ExecuteDataDefinitionQuery(session, ReadWholeFile(pathPrefix + "drop_view.sql"));
+            ExecuteQuery(session, ReadWholeFile(pathPrefix + "drop_view.sql"));
         }
     }
 

--- a/ydb/library/yql/sql/v1/sql_translation.cpp
+++ b/ydb/library/yql/sql/v1/sql_translation.cpp
@@ -55,48 +55,62 @@ TString CollectTokens(const TRule_select_stmt& selectStatement) {
     return tokenCollector.Tokens;
 }
 
-bool RestoreContext(
-    TContext& ctx, const NSQLTranslation::TTranslationSettings& settings, const TString& contextRestorationQuery
+bool RecreateContext(
+    TContext& ctx, const NSQLTranslation::TTranslationSettings& settings, const TString& recreationQuery
 ) {
-    const TString queryName = "context restoration query";
+    if (!recreationQuery) {
+        return true;
+    }
+    const TString queryName = "context recreation query";
 
     const auto* ast = NSQLTranslationV1::SqlAST(
-        contextRestorationQuery, queryName, ctx.Issues,
+        recreationQuery, queryName, ctx.Issues,
         settings.MaxErrors, settings.AnsiLexer,  settings.Antlr4Parser, settings.TestAntlr4, settings.Arena
     );
     if (!ast) {
         return false;
     }
 
-    TSqlQuery query(ctx, ctx.Settings.Mode, true);
-    auto node = query.Build(static_cast<const TSQLv1ParserAST&>(*ast));
+    TSqlQuery queryTranslator(ctx, ctx.Settings.Mode, true);
+    auto node = queryTranslator.Build(static_cast<const TSQLv1ParserAST&>(*ast));
 
     return node && node->Init(ctx, nullptr) && node->Translate(ctx);
 }
 
 TNodePtr BuildViewSelect(
-    const TRule_select_stmt& selectQuery,
+    const TRule_select_stmt& selectStatement,
     TContext& parentContext,
-    const TString& contextRestorationQuery
+    const TString& contextRecreationQuery
 ) {
-    TContext context(parentContext.Settings, {}, parentContext.Issues);
-    RestoreContext(context, context.Settings, contextRestorationQuery);
+    TIssues issues;
+    TContext context(parentContext.Settings, {}, issues);
+    if (!RecreateContext(context, context.Settings, contextRecreationQuery)) {
+        parentContext.Issues.AddIssues(issues);
+        return nullptr;
+    }
+    issues.Clear();
 
     context.Settings.Mode = NSQLTranslation::ESqlMode::LIMITED_VIEW;
 
-    TSqlSelect select(context, context.Settings.Mode);
-    TPosition pos;
-    auto source = select.Build(selectQuery, pos);
+    TSqlSelect selectTranslator(context, context.Settings.Mode);
+    TPosition pos = parentContext.Pos();
+    auto source = selectTranslator.Build(selectStatement, pos);
     if (!source) {
+        parentContext.Issues.AddIssues(issues);
         return nullptr;
     }
-    return BuildSelectResult(
+    auto node = BuildSelectResult(
         pos,
         std::move(source),
         false,
         false,
         context.Scoped
     );
+    if (!node) {
+        parentContext.Issues.AddIssues(issues);
+        return nullptr;
+    }
+    return node;
 }
 
 }
@@ -4883,7 +4897,7 @@ bool TSqlTranslation::ParseViewQuery(
     const TRule_select_stmt& query
 ) {
     TString queryText = CollectTokens(query);
-    TString contextRestorationQuery;
+    TString contextRecreationQuery;
     {
         const auto& service = Ctx.Scoped->CurrService;
         const auto& cluster = Ctx.Scoped->CurrCluster;
@@ -4891,19 +4905,19 @@ bool TSqlTranslation::ParseViewQuery(
 
         // TO DO: capture all runtime pragmas in a similar fashion.
         if (effectivePathPrefix != Ctx.Settings.PathPrefix) {
-            contextRestorationQuery = TStringBuilder() << "PRAGMA TablePathPrefix = \"" << effectivePathPrefix << "\";\n";
+            contextRecreationQuery = TStringBuilder() << "PRAGMA TablePathPrefix = \"" << effectivePathPrefix << "\";\n";
         }
 
         // TO DO: capture other compilation-affecting statements except USE.
         if (cluster.GetLiteral() && *cluster.GetLiteral() != Ctx.Settings.DefaultCluster) {
-            contextRestorationQuery = TStringBuilder() << "USE " << *cluster.GetLiteral() << ";\n";
+            contextRecreationQuery = TStringBuilder() << "USE " << *cluster.GetLiteral() << ";\n";
         }
     }
-    features["query_text"] = { Ctx.Pos(), contextRestorationQuery + queryText };
+    features["query_text"] = { Ctx.Pos(), contextRecreationQuery + queryText };
 
     // AST is needed for ready-made validation of CREATE VIEW statement.
     // Query is stored as plain text, not AST.
-    const auto viewSelect = BuildViewSelect(query, Ctx, contextRestorationQuery);
+    const auto viewSelect = BuildViewSelect(query, Ctx, contextRecreationQuery);
     if (!viewSelect) {
         return false;
     }

--- a/ydb/library/yql/sql/v1/sql_translation.cpp
+++ b/ydb/library/yql/sql/v1/sql_translation.cpp
@@ -90,6 +90,11 @@ TNodePtr BuildViewSelect(
     }
     issues.Clear();
 
+    // Holds (among other things) subquery references.
+    // These references need to be passed to the parent context
+    // to be able to compile view queries with subqueries.
+    context.PushCurrentBlocks(&parentContext.GetCurrentBlocks());
+
     context.Settings.Mode = NSQLTranslation::ESqlMode::LIMITED_VIEW;
 
     TSqlSelect selectTranslator(context, context.Settings.Mode);


### PR DESCRIPTION
### Ticket

- https://github.com/ydb-platform/ydb/issues/10521

Please see the ticket for the problem description.

### Context

Views store only the text of the query that was used to create them. Nevertheless, we [build](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/sql_translation.cpp#L89) the AST node of the view's select statement to validate it during the parsing of the `CREATE VIEW` statement.

Our goal is to validate view queries as strictly as possible. This means we validate the view query using a parser [context](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/sql_translation.cpp#L82) that closely resembles the one that would be [created](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/core/kqp/provider/rewrite_io_utils.cpp#L30) when the view is queried.

Let's name the three parser contexts that are relevant for views:
1. [Creation](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/sql_translation.cpp#L79) Parser Context. The context in which the `CREATE VIEW` statement is executed.
2. [Validation](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/sql_translation.cpp#L82) Parser Context. Used for view query validation.
3. [Execution](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/core/kqp/provider/rewrite_io_utils.cpp#L30) Parser Context. Used during the execution of a `SELECT` statement from a view.

Using the creation context for validation would allow queries with references to named expressions defined in the creation context to pass validation, which we want to avoid. Unfortunately, implementing this restriction introduces some issues.

### Cause

The view validation context lacks [blocks](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/context.h#L234) to [store](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/sql_expression.cpp#L1501) subquery references. Unlike the TSqlQuery translator, we cannot simply [create](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/sql_query.cpp#L3245) new blocks because the query references we create must be passed back to the parent context for further [translation](https://github.com/ydb-platform/ydb/blob/0cd5c681b5af33ef6ff54a8a01fd1511cb41e0dd/ydb/library/yql/sql/v1/query.cpp#L2913).

The only viable solution I see is to use the blocks from the current parent context within the validation context. This approach has been implemented in this pull request.

### Note
The main commit is:
- 6424ed6ca3257d6b6af71b3dc932d9c9a1f648b4

The others are supplementary.