### PR TITLE
Fix sed in fail summary (exclude brackets in content)

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -411,7 +411,7 @@ runs:
             (( \
               cat $CURRENT_REPORT \
               | jq -r '.results[] | select((.status == "FAILED") and (.error_type == "REGULAR") and (.type = "build")) | "path: " + .path + "\n\n" + ."rich-snippet" + "\n\n\n"' \
-              | sed 's/\[\[.*\]\]//' \
+              | sed 's/\[\[[^]]*]\]//g' \
             ) || true) > $CURRENT_PUBLIC_DIR/fail_summary.txt
             echo "Build failed, see the [logs]($YA_MAKE_OUTPUT_URL). Also see [fail summary]($CURRENT_PUBLIC_DIR_URL/fail_summary.txt)" | GITHUB_TOKEN="${{ github.token }}" .github/scripts/tests/comment-pr.py --color red
             break


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

We want 
`1[[2]]3[[4]]5` -> `135`
But it was 
`1[[2]]3[[4]]5` -> `15`

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Additional information
