### PR TITLE
[CBO] Transitive closure adding conditions to existed edges

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_hypergraph_ut.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_hypergraph_ut.cpp
@@ -423,6 +423,22 @@ Y_UNIT_TEST_SUITE(HypergraphBuild) {
         }
     }
 
+    Y_UNIT_TEST(ManyCondsBetweenJoinForTransitiveClosure) {
+        auto join = Join(Join("A", "B", "A.PUDGE=B.PUDGE,A.DOTA=B.DOTA"), "C", "A.PUDGE=C.PUDGE,A.DOTA=C.DOTA");
+
+        auto graph = MakeJoinHypergraph<TNodeSet64>(join);
+        Cout << graph.String() << Endl;
+
+        auto B = graph.GetNodesByRelNames({"B"});
+        auto C = graph.GetNodesByRelNames({"C"});
+        UNIT_ASSERT(graph.FindEdgeBetween(B, C));
+
+        {
+            auto optimizedJoin = Enumerate(join, TOptimizerHints::Parse("Rows(B C # 0)"));
+            UNIT_ASSERT(HaveSameConditionCount(optimizedJoin, join));
+        }
+    }
+
     auto MakeClique(size_t size) {
         std::shared_ptr<IBaseOptimizerNode> root = Join("R0", "R1", "R0.id=R1.id");
 

--- a/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
+++ b/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
@@ -481,8 +481,21 @@ private:
                     auto iNode = Graph_.GetNodesByRelNames({joinCondById[i].RelName});
                     auto jNode = Graph_.GetNodesByRelNames({joinCondById[j].RelName});
 
-                    if (Graph_.FindEdgeBetween(iNode, jNode)) {
-                        continue; 
+                    if (auto* maybeEdge = Graph_.FindEdgeBetween(iNode, jNode)) {
+                        auto addUniqueKey = [](auto& vector, const auto& key) {
+                            if (std::find(vector.begin(), vector.end(), key) == vector.end()) {
+                                vector.push_back(key);
+                            }
+                        };
+
+                        auto& revEdge = Graph_.GetEdge(maybeEdge->ReversedEdgeId);
+                        addUniqueKey(revEdge.LeftJoinKeys, joinCondById[j]);
+                        addUniqueKey(revEdge.RightJoinKeys, joinCondById[i]);
+
+                        auto& edge = Graph_.GetEdge(revEdge.ReversedEdgeId);
+                        addUniqueKey(edge.LeftJoinKeys, joinCondById[i]);
+                        addUniqueKey(edge.RightJoinKeys, joinCondById[j]);
+                        continue;
                     }
 
                     Graph_.AddEdge(THyperedge(iNode, jNode, InnerJoin, false, false, true, {joinCondById[i]}, {joinCondById[j]}));


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->


* Bugfix 


What could happen? When the edge had been created and we tried to add a condition from the transitive closure to this edge, it would be skipped, so we would miss a condition in the tree, if we choose this edge in the join tree