### PR TITLE
Use new SafeEntropyPoolRead which fills entire buffer

### DIFF
--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -11,7 +11,7 @@
 #include <ydb/core/util/testactorsys.h>
 
 #include <ydb/library/pdisk_io/sector_map.h>
-#include <util/random/entropy.h>
+#include <ydb/core/util/random.h>
 
 #include <google/protobuf/text_format.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -62,12 +62,12 @@ void FormatPDiskRandomKeys(TString path, ui32 diskSize, ui32 chunkSize, ui64 gui
     NPDisk::TKey chunkKey;
     NPDisk::TKey logKey;
     NPDisk::TKey sysLogKey;
-    EntropyPool().Read(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
-    EntropyPool().Read(&logKey, sizeof(NKikimr::NPDisk::TKey));
-    EntropyPool().Read(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&logKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
 
     if (!isGuidValid) {
-        EntropyPool().Read(&guid, sizeof(guid));
+        SafeEntropyPoolRead(&guid, sizeof(guid));
     }
 
     NKikimr::FormatPDisk(path, diskSize, 4 << 10, chunkSize,
@@ -751,7 +751,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         VERBOSE_COUT(" Creating PDisk");
         ui64 guid = 1;
         ui64 pDiskCategory = 0;
-        EntropyPool().Read(&guid, sizeof(guid));
+        SafeEntropyPoolRead(&guid, sizeof(guid));
 //        TODO: look why doesn't sernder 1 work
         ui32 pDiskId = CreatePDisk(runtime, 0, tempDir() + "/new_pdisk.dat", guid, 1001, pDiskCategory);
 
@@ -760,7 +760,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         TVDiskID vDiskId;
         ui64 guid2 = guid;
         while (guid2 == guid) {
-            EntropyPool().Read(&guid2, sizeof(guid2));
+            SafeEntropyPoolRead(&guid2, sizeof(guid2));
         }
         ui32 nodeId = runtime.GetNodeId(0);
         TActorId pDiskActorId = MakeBlobStoragePDiskID(nodeId, pDiskId);

--- a/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
@@ -3,7 +3,7 @@
 
 #include <ydb/core/blob_depot/agent/agent.h>
 
-#include <util/random/entropy.h>
+#include <ydb/core/util/random.h>
 
 namespace NKikimr::NStorage {
 
@@ -62,7 +62,7 @@ namespace NKikimr::NStorage {
         ui8 *keyBytes = nullptr;
         ui32 keySizeBytes = 0;
         groupKey.MutableKeyBytes(&keyBytes, &keySizeBytes);
-        EntropyPool().Read(keyBytes, keySizeBytes);
+        SafeEntropyPoolRead(keyBytes, keySizeBytes);
         TString encryptedGroupKey;
         ui32 h = Crc32c(keyBytes, keySizeBytes);
         encryptedGroupKey.resize(keySizeBytes + sizeof(ui32));

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -21,6 +21,7 @@
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/protos/base.pb.h>
+#include <ydb/core/util/random.h>
 #include <ydb/library/services/services.pb.h>
 #include <ydb/library/schlab/mon/mon.h>
 
@@ -30,7 +31,6 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 
 #include <util/generic/algorithm.h>
-#include <util/random/entropy.h>
 #include <util/string/split.h>
 #include <util/system/sanitizers.h>
 
@@ -416,9 +416,9 @@ public:
                     NPDisk::TKey chunkKey;
                     NPDisk::TKey logKey;
                     NPDisk::TKey sysLogKey;
-                    EntropyPool().Read(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
-                    EntropyPool().Read(&logKey, sizeof(NKikimr::NPDisk::TKey));
-                    EntropyPool().Read(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
+                    SafeEntropyPoolRead(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
+                    SafeEntropyPoolRead(&logKey, sizeof(NKikimr::NPDisk::TKey));
+                    SafeEntropyPoolRead(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
                     TPDiskConfig *cfg = actor->Cfg.Get();
 
                     try {
@@ -1085,7 +1085,7 @@ public:
             }
 
             Send(ev->Sender, new TEvBlobStorage::TEvNotifyWardenPDiskRestarted(PCtx->PDiskId, NKikimrProto::EReplyStatus::NOTREADY));
-            
+
             return;
         }
 
@@ -1098,7 +1098,7 @@ public:
             NPDisk::TMainKey newMainKey = ev->Get()->MainKey;
 
             SecureWipeBuffer((ui8*)ev->Get()->MainKey.Keys.data(), sizeof(NPDisk::TKey) * ev->Get()->MainKey.Keys.size());
-            
+
             P_LOG(PRI_NOTICE, BSP01, "Going to restart PDisk since received TEvAskWardenRestartPDiskResult");
 
             const TActorIdentity& thisActorId = SelfId();
@@ -1111,7 +1111,7 @@ public:
             TIntrusivePtr<TPDiskConfig> actorCfg = std::move(Cfg);
 
             auto& newCfg = ev->Get()->Config;
-            
+
             if (newCfg) {
                 Y_VERIFY_S(newCfg->PDiskId == pdiskId,
                         "New config's PDiskId# " << newCfg->PDiskId << " is not equal to real PDiskId# " << pdiskId);
@@ -1126,7 +1126,7 @@ public:
             TGenericExecutorThread& executorThread = actorCtx.ExecutorThread;
 
             PassAway();
-            
+
             CreatePDiskActor(executorThread, counters, actorCfg, newMainKey, pdiskId, poolId, nodeId);
 
             Send(ev->Sender, new TEvBlobStorage::TEvNotifyWardenPDiskRestarted(pdiskId));

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
@@ -9,12 +9,12 @@
 #include "blobstorage_pdisk_ut_helpers.h"
 
 #include <ydb/core/control/immediate_control_board_wrapper.h>
+#include <ydb/core/util/random.h>
 
 #include <library/cpp/deprecated/atomic/atomic.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/folder/dirut.h>
 #include <util/folder/tempdir.h>
-#include <util/random/entropy.h>
 #include <util/string/printf.h>
 #include <util/system/condvar.h>
 #include <util/system/file.h>
@@ -172,7 +172,8 @@ void RunWriteTestWithSectorMap(NSectorMap::EDiskMode diskMode, ui64 diskSize, ui
     TAlignedData writeData(bufferSize);
     TAlignedData readData(bufferSize);
     TSimpleTimer t;
-    EntropyPool().Read(writeData.Get(), writeData.Size());
+
+    SafeEntropyPoolRead(writeData.Get(), writeData.Size());
     Ctest << bufferSize / t.Get().SecondsFloat() / 1e9 << " GB/s" << Endl;
 
     for (ui64 offset : {ui64(0), NSectorMap::SECTOR_SIZE, 7 * NSectorMap::SECTOR_SIZE, diskSize - bufferSize}) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ydb/core/blobstorage/pdisk/mock/pdisk_mock.h>
+#include <ydb/core/util/random.h>
+
 #include "blobstorage_pdisk_ut.h"
 #include "blobstorage_pdisk_ut_defs.h"
 #include "blobstorage_pdisk_data.h"
@@ -42,7 +44,7 @@ public:
     TSettings Settings;
 
     TIntrusivePtr<TPDiskConfig> DefaultPDiskConfig(bool isBad) {
-        EntropyPool().Read(&TestCtx.PDiskGuid, sizeof(TestCtx.PDiskGuid));
+        SafeEntropyPoolRead(&TestCtx.PDiskGuid, sizeof(TestCtx.PDiskGuid));
         ui64 formatGuid = TestCtx.PDiskGuid + static_cast<ui64>(isBad);
         if (Settings.DiskSize) {
             FormatPDiskForTest(TestCtx.Path, formatGuid, Settings.ChunkSize, Settings.DiskSize, false, TestCtx.SectorMap, Settings.SmallDisk);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_helpers.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_helpers.cpp
@@ -4,6 +4,7 @@
 #include "blobstorage_pdisk_ut_helpers.h"
 
 #include <ydb/core/blobstorage/crypto/default.h>
+#include <ydb/core/util/random.h>
 
 #include <util/folder/dirut.h>
 #include <util/generic/ptr.h>
@@ -66,9 +67,9 @@ void FormatPDiskForTest(TString path, ui64 guid, ui32& chunkSize, ui64 diskSize,
     NPDisk::TKey chunkKey;
     NPDisk::TKey logKey;
     NPDisk::TKey sysLogKey;
-    EntropyPool().Read(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
-    EntropyPool().Read(&logKey, sizeof(NKikimr::NPDisk::TKey));
-    EntropyPool().Read(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&logKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
 
     if (enableSmallDiskOptimization) {
         try {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_run.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_run.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/mon/sync_http_mon.h>
 #include <ydb/core/blobstorage/crypto/default.h>
 #include <ydb/library/pdisk_io/aio.h>
+#include <ydb/core/util/random.h>
 
 #include <util/folder/tempdir.h>
 
@@ -69,7 +70,7 @@ void Run(TVector<IActor*> tests, TTestRunConfig runCfg) {
                 MakeDirIfNotExist(databaseDirectory.c_str());
             }
 
-            EntropyPool().Read(&runCfg.TestContext->PDiskGuid, sizeof(runCfg.TestContext->PDiskGuid));
+            SafeEntropyPoolRead(&runCfg.TestContext->PDiskGuid, sizeof(runCfg.TestContext->PDiskGuid));
             if (!runCfg.IsBad) {
                 FormatPDiskForTest(dataPath, runCfg.TestContext->PDiskGuid, runCfg.ChunkSize,
                         runCfg.IsErasureEncodeUserLog, runCfg.TestContext->SectorMap);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_yard.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/blobstorage/crypto/default.h>
 
 #include <ydb/core/testlib/actors/test_runtime.h>
+#include <ydb/core/util/random.h>
 
 namespace NKikimr {
 
@@ -442,7 +443,7 @@ YARD_UNIT_TEST(TestSysLogOverwrite) {
         dataPath = MakePDiskPath((*tc.TempDir)().c_str());
         MakeDirIfNotExist(databaseDirectory.c_str());
     }
-    EntropyPool().Read(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
+    SafeEntropyPoolRead(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
     FormatPDiskForTest(dataPath, tc.PDiskGuid, chunkSize, 2048ull << 20, false, tc.SectorMap);
 
     Run<TTestInit<true, 1>>(&tc, 1, chunkSize, false);
@@ -853,7 +854,7 @@ YARD_UNIT_TEST(TestFormatInfo) {
             MakeDirIfNotExist(databaseDirectory.c_str());
         }
     }
-    EntropyPool().Read(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
+    SafeEntropyPoolRead(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
     FormatPDiskForTest(dataPath, tc.PDiskGuid, chunkSize, 1 << 30, false, tc.SectorMap);
 
     TPDiskInfo info;
@@ -872,7 +873,7 @@ YARD_UNIT_TEST(TestStartingPointReboots) {
         dataPath = MakePDiskPath((*tc.TempDir)().c_str());
         MakeDirIfNotExist(databaseDirectory.c_str());
     }
-    EntropyPool().Read(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
+    SafeEntropyPoolRead(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
     FormatPDiskForTest(dataPath, tc.PDiskGuid, chunkSize, 1 << 30, false, tc.SectorMap);
     for (ui32 i = 0; i < 32; ++i) {
         Run<TTestStartingPointRebootsIteration>(&tc, 1, chunkSize);
@@ -944,7 +945,7 @@ YARD_UNIT_TEST(TestEnormousDisk) {
     ui64 diskSize = 100ull << 40;
 
     TString dataPath;
-    EntropyPool().Read(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
+    SafeEntropyPoolRead(&tc.PDiskGuid, sizeof(tc.PDiskGuid));
     FormatPDiskForTest(dataPath, tc.PDiskGuid, chunkSize, diskSize, false, tc.SectorMap);
 
     Run<TTestInit<true, 1>>(&tc, 1, chunkSize, false);

--- a/ydb/core/blobstorage/ut_blobstorage/balancing.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/balancing.cpp
@@ -463,16 +463,16 @@ struct TTwoPartsOnOneNodeTest {
 Y_UNIT_TEST_SUITE(VDiskBalancing) {
 
     Y_UNIT_TEST(TestStopOneNode_Block42) {
-        TStopOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenData(100)}.RunTest();
+        TStopOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenRandomBuffer(100)}.RunTest();
     }
     Y_UNIT_TEST(TestStopOneNode_Mirror3dc) {
-        TStopOneNodeTest{TTestEnv(9, TBlobStorageGroupType::ErasureMirror3dc), GenData(100)}.RunTest();
+        TStopOneNodeTest{TTestEnv(9, TBlobStorageGroupType::ErasureMirror3dc), GenRandomBuffer(100)}.RunTest();
     }
     Y_UNIT_TEST(TestStopOneNode_Block42_HugeBlob) {
-        TStopOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenData(521_KB * 6)}.RunTest();
+        TStopOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenRandomBuffer(521_KB * 6)}.RunTest();
     }
     Y_UNIT_TEST(TestStopOneNode_Mirror3dc_HugeBlob) {
-        TStopOneNodeTest{TTestEnv(9, TBlobStorageGroupType::ErasureMirror3dc), GenData(521_KB)}.RunTest();
+        TStopOneNodeTest{TTestEnv(9, TBlobStorageGroupType::ErasureMirror3dc), GenRandomBuffer(521_KB)}.RunTest();
     }
 
     Y_UNIT_TEST(TestRandom_Block42) {
@@ -483,13 +483,13 @@ Y_UNIT_TEST_SUITE(VDiskBalancing) {
     }
 
     Y_UNIT_TEST(TwoPartsOnOneNodeTest_Block42) {
-        TTwoPartsOnOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenData(100)}.RunTest();
+        TTwoPartsOnOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenRandomBuffer(100)}.RunTest();
     }
     Y_UNIT_TEST(TwoPartsOnOneNodeTest_Block42_HugeBlob) {
-        TTwoPartsOnOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenData(521_KB * 6)}.RunTest();
+        TTwoPartsOnOneNodeTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenRandomBuffer(521_KB * 6)}.RunTest();
     }
 
     Y_UNIT_TEST(TestDontSendToReadOnlyTest_Block42) {
-        TDontSendToReadOnlyTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenData(100)}.RunTest();
+        TDontSendToReadOnlyTest{TTestEnv(8, TBlobStorageGroupType::Erasure4Plus2Block), GenRandomBuffer(100)}.RunTest();
     }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/balancing.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/balancing.cpp
@@ -1,8 +1,8 @@
 #include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/util/random.h>
 
 #include <library/cpp/iterator/enumerate.h>
 
-#include <util/random/entropy.h>
 
 
 using TPartsLocations = TVector<TVector<ui8>>;
@@ -214,14 +214,6 @@ TLogoBlobID MakeLogoBlobId(ui32 step, ui32 dataSize) {
     return TLogoBlobID(1, 1, step, 0, dataSize, 0);
 }
 
-
-TString GenData(ui32 len) {
-    TString res = TString::Uninitialized(len);
-    EntropyPool().Read(res.Detach(), res.size());
-    return res;
-}
-
-
 struct TStopOneNodeTest {
     TTestEnv Env;
     TString data;
@@ -323,7 +315,7 @@ struct TRandomTest {
 
         for (ui32 step = 0; step < NumIters; ++step) {
             Cerr << "Step = " << step << Endl;
-            data.push_back(GenData(16 + random() % MaxBlobSize));
+            data.push_back(GenRandomBuffer(16 + random() % MaxBlobSize));
 
             if (Env.SendPut(step, data.back()) == NKikimrProto::OK) {
                 successfulSteps.push_back(step);

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_disk.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_disk.cpp
@@ -1,5 +1,5 @@
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.h>
-#include <util/random/entropy.h>
+#include <ydb/core/util/random.h>
 #include "cli.h"
 #include "cli_cmds.h"
 
@@ -164,9 +164,9 @@ public:
     virtual void Parse(TConfig& config) override {
         TClientCommand::Parse(config);
         Path = config.ParseResult->GetFreeArgs()[0];
-        EntropyPool().Read(&ChunkKey, sizeof(NKikimr::NPDisk::TKey));
-        EntropyPool().Read(&LogKey, sizeof(NKikimr::NPDisk::TKey));
-        EntropyPool().Read(&SysLogKey, sizeof(NKikimr::NPDisk::TKey));
+        SafeEntropyPoolRead(&ChunkKey, sizeof(NKikimr::NPDisk::TKey));
+        SafeEntropyPoolRead(&LogKey, sizeof(NKikimr::NPDisk::TKey));
+        SafeEntropyPoolRead(&SysLogKey, sizeof(NKikimr::NPDisk::TKey));
         bool hasMainOption = config.ParseResult->FindLongOptParseResult("main-key");
         bool hasMasterOption = config.ParseResult->FindLongOptParseResult("master-key");
         bool hasKOption = config.ParseResult->FindCharOptParseResult('k');

--- a/ydb/core/mind/ut_fat/blobstorage_node_warden_ut_fat.cpp
+++ b/ydb/core/mind/ut_fat/blobstorage_node_warden_ut_fat.cpp
@@ -15,8 +15,8 @@
 #include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
 #include <ydb/core/mind/bscontroller/bsc.h>
 #include <ydb/core/mind/local.h>
+#include <ydb/core/util/random.h>
 
-#include <util/random/entropy.h>
 #include <util/stream/file.h>
 #include <util/string/printf.h>
 #include <util/string/subst.h>
@@ -74,12 +74,12 @@ void FormatPDisk(TString path, ui64 diskSize, ui32 chunkSize, ui64 guid, bool is
     NPDisk::TKey chunkKey;
     NPDisk::TKey logKey;
     NPDisk::TKey sysLogKey;
-    EntropyPool().Read(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
-    EntropyPool().Read(&logKey, sizeof(NKikimr::NPDisk::TKey));
-    EntropyPool().Read(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&chunkKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&logKey, sizeof(NKikimr::NPDisk::TKey));
+    SafeEntropyPoolRead(&sysLogKey, sizeof(NKikimr::NPDisk::TKey));
 
     if (!isGuidValid) {
-        EntropyPool().Read(&guid, sizeof(guid));
+        SafeEntropyPoolRead(&guid, sizeof(guid));
     }
 
     NKikimr::FormatPDisk(path, diskSize, 4 << 10, chunkSize, guid,

--- a/ydb/core/util/random.cpp
+++ b/ydb/core/util/random.cpp
@@ -1,0 +1,22 @@
+#include <util/random/entropy.h>
+#include <util/stream/input.h>
+
+#include "random.h"
+
+namespace NKikimr {
+
+void SafeEntropyPoolRead(void* buf, size_t len) {
+    auto& pool = EntropyPool();
+    size_t read = 0;
+    while (read < len) {
+        read += pool.Read((char*)buf + read, len - read);
+    }
+}
+
+TString GenRandomBuffer(size_t len) {
+    TString res = TString::Uninitialized(len);
+    SafeEntropyPoolRead(res.Detach(), res.size());
+    return res;
+}
+
+} // namespace NKikimr

--- a/ydb/core/util/random.h
+++ b/ydb/core/util/random.h
@@ -1,0 +1,11 @@
+#include <util/generic/string.h>
+
+#include <stddef.h>
+
+namespace NKikimr {
+
+void SafeEntropyPoolRead(void* buf, size_t len);
+
+TString GenRandomBuffer(size_t len);
+
+} // namespace NKikimr

--- a/ydb/core/util/ya.make
+++ b/ydb/core/util/ya.make
@@ -41,6 +41,7 @@ SRCS(
     proto_duration.h
     queue_inplace.h
     queue_oneone_inplace.h
+    random.cpp
     simple_cache.h
     single_thread_ic_mock.cpp
     single_thread_ic_mock.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

EntropyPool().Read() can generate data partially, and it returns read bytes, so it should be read inside while loop

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
