### PR TITLE
ci: add an "external" label for issues that were opened by external users

### DIFF
--- a/.github/workflows/label_external_issues.yml
+++ b/.github/workflows/label_external_issues.yml
@@ -1,0 +1,22 @@
+name: Label issue from external users
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-external-issues:
+    name: Label issue from external user
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    if: ${{ !contains(fromJson('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.issue.author_association) }}
+    steps:
+      - name: add external label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['external']
+            })


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
