### PR TITLE
add error message to bulk-upsert reply when rows are empty

### DIFF
--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -242,6 +242,12 @@ private:
         // For each row in values
         TMemoryPool valueDataPool(256);
         const auto& rows = GetProtoRequest(Request.get())->Getrows().Getvalue().Getitems();
+
+        if (AllRows.empty()) {
+            errorMessage = "No rows to upload";
+            return false;
+        }
+
         for (const auto& r : rows) {
             valueDataPool.Clear();
 
@@ -277,10 +283,7 @@ private:
     }
 
     bool ExtractBatch(TString& errorMessage) override {
-        if (AllRows.empty()) {
-            errorMessage = "No rows to upload";
-            return false;
-        }
+        Y_ABORT_UNLESS(!AllRows.empty());
         Batch = RowsToBatch(AllRows, errorMessage);
         return Batch.get();
     }

--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -278,7 +278,7 @@ private:
 
     bool ExtractBatch(TString& errorMessage) override {
         if (AllRows.empty()) {
-            errorMessage = "Empty rows list";
+            errorMessage = "No rows to upload";
             return false;
         }
         Batch = RowsToBatch(AllRows, errorMessage);

--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -243,7 +243,7 @@ private:
         TMemoryPool valueDataPool(256);
         const auto& rows = GetProtoRequest(Request.get())->Getrows().Getvalue().Getitems();
 
-        if (AllRows.empty()) {
+        if (rows.empty()) {
             errorMessage = "No rows to upload";
             return false;
         }

--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -283,7 +283,6 @@ private:
     }
 
     bool ExtractBatch(TString& errorMessage) override {
-        Y_ABORT_UNLESS(!AllRows.empty());
         Batch = RowsToBatch(AllRows, errorMessage);
         return Batch.get();
     }

--- a/ydb/core/grpc_services/rpc_load_rows.cpp
+++ b/ydb/core/grpc_services/rpc_load_rows.cpp
@@ -277,6 +277,10 @@ private:
     }
 
     bool ExtractBatch(TString& errorMessage) override {
+        if (AllRows.empty()) {
+            errorMessage = "Empty rows list";
+            return false;
+        }
         Batch = RowsToBatch(AllRows, errorMessage);
         return Batch.get();
     }


### PR DESCRIPTION
Раньше bulk-upsert в OLAP-таблицу возвращал пустой текст ошибки, если передать пустой список строк на запись. Теперь пишет, что строк нет.