### PR TITLE
Public api to return node id in the describe table call

### DIFF
--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -327,6 +327,8 @@ message PartitionStats {
     uint64 rows_estimate = 1;
     // Approximate size of shard (bytes)
     uint64 store_size = 2;
+    // id of node that serve shard key range
+    uint32 leader_node_id = 3;
 }
 
 message TableStats {
@@ -781,6 +783,8 @@ message DescribeTableRequest {
     bool include_partition_stats = 7;
     // Includes set_val settings for sequences
     bool include_set_val = 8;
+    // Includes shard -> node id maping (required include_partition_stats)
+    bool include_shard_nodes_info = 9;
 }
 
 message DescribeTableResponse {


### PR DESCRIPTION
Motivation:
Network is limited, we need to reduce amount of transfers between nodes.

One of problem:
Session actor has no knowledge about key range distribution (data shard locations). Which means we have to transfer data between data shard and kqp executor to perform read or write.

![image](https://github.com/user-attachments/assets/26ea05d8-e203-4f0c-b695-471a453feaf5)


Workaround:
Provide estimation about keyRange -> nodeId distribution to use session (which means executor and other kqp components) created on the same node where located corresponding data shard.