### PR TITLE
fix import to arcadia

### DIFF
--- a/ydb/core/tx/schemeshard/ut_index_build/ya.make
+++ b/ydb/core/tx/schemeshard/ut_index_build/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     ydb/core/testlib/default
     ydb/core/tx
     ydb/core/tx/schemeshard/ut_helpers
+    ydb/public/sdk/cpp/client/ydb_table
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/public/sdk/cpp/client/ydb_table/table.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.cpp
@@ -253,8 +253,7 @@ static void SerializeTo(const TRenameIndex& rename, Ydb::Table::RenameIndexItem&
     proto.set_replace_destination(rename.ReplaceDestination_);
 }
 
-template <typename TProto>
-TExplicitPartitions TExplicitPartitions::FromProto(const TProto& proto) {
+TExplicitPartitions TExplicitPartitions::FromProto(const Ydb::Table::ExplicitPartitions& proto) {
     TExplicitPartitions out;
     for (const auto& splitPoint : proto.split_points()) {
         TValue value(TType(splitPoint.type()), splitPoint.value());
@@ -2365,13 +2364,12 @@ ui64 TIndexDescription::GetSizeBytes() const {
     return SizeBytes_;
 }
 
-template <typename TProto>
-TGlobalIndexSettings TGlobalIndexSettings::FromProto(const TProto& proto) {
-    auto partitionsFromProto = [](const auto& proto) -> TUniformOrExplicitPartitions {
+TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalIndexSettings& proto) {
+    auto partitionsFromProto = [](const Ydb::Table::GlobalIndexSettings& proto) -> TUniformOrExplicitPartitions {
         switch (proto.partitions_case()) {
-        case TProto::kUniformPartitions:
+        case Ydb::Table::GlobalIndexSettings::kUniformPartitions:
             return proto.uniform_partitions();
-        case TProto::kPartitionAtKeys:
+        case Ydb::Table::GlobalIndexSettings::kPartitionAtKeys:
             return TExplicitPartitions::FromProto(proto.partition_at_keys());
         default:
             return {};
@@ -2398,8 +2396,7 @@ void TGlobalIndexSettings::SerializeTo(Ydb::Table::GlobalIndexSettings& settings
     std::visit(std::move(variantVisitor), Partitions);
 }
 
-template <typename TProto>
-TVectorIndexSettings TVectorIndexSettings::FromProto(const TProto& proto) {
+TVectorIndexSettings TVectorIndexSettings::FromProto(const Ydb::Table::VectorIndexSettings& proto) {
     auto covertMetric = [&] {
         switch (proto.metric()) {
         case Ydb::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT:
@@ -2481,8 +2478,7 @@ void TVectorIndexSettings::Out(IOutputStream& o) const {
     o << *this;
 }
 
-template <typename TProto>
-TKMeansTreeSettings TKMeansTreeSettings::FromProto(const TProto& proto) {
+TKMeansTreeSettings TKMeansTreeSettings::FromProto(const Ydb::Table::KMeansTreeSettings& proto) {
     return {
         .Settings = TVectorIndexSettings::FromProto(proto.settings()),
         .Clusters = proto.clusters(),

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -186,9 +186,7 @@ struct TExplicitPartitions {
 
     FLUENT_SETTING_VECTOR(TValue, SplitPoints);
 
-    template <typename TProto>
-    static TExplicitPartitions FromProto(const TProto& proto);
-
+    static TExplicitPartitions FromProto(const Ydb::Table::ExplicitPartitions& proto);
     void SerializeTo(Ydb::Table::ExplicitPartitions& proto) const;
 };
 
@@ -198,9 +196,7 @@ struct TGlobalIndexSettings {
     TPartitioningSettings PartitioningSettings;
     TUniformOrExplicitPartitions Partitions;
 
-    template <typename TProto>
-    static TGlobalIndexSettings FromProto(const TProto& proto);
-
+    static TGlobalIndexSettings FromProto(const Ydb::Table::GlobalIndexSettings& proto);
     void SerializeTo(Ydb::Table::GlobalIndexSettings& proto) const;
 };
 
@@ -227,9 +223,7 @@ public:
     EVectorType VectorType = EVectorType::Unspecified;
     ui32 VectorDimension = 0;
 
-    template <typename TProto>
-    static TVectorIndexSettings FromProto(const TProto& proto);
-
+    static TVectorIndexSettings FromProto(const Ydb::Table::VectorIndexSettings& proto);
     void SerializeTo(Ydb::Table::VectorIndexSettings& settings) const;
 
     void Out(IOutputStream &o) const;
@@ -258,9 +252,7 @@ public:
     ui32 Clusters = 0;
     ui32 Levels = 0;
 
-    template <typename TProto>
-    static TKMeansTreeSettings FromProto(const TProto& proto);
-
+    static TKMeansTreeSettings FromProto(const Ydb::Table::KMeansTreeSettings& proto);
     void SerializeTo(Ydb::Table::KMeansTreeSettings& settings) const;
 
     void Out(IOutputStream &o) const;


### PR DESCRIPTION
Fix a linking error that has been caught during the YDB Import 620. More specifically:
- add missing peerdir to ya.make
- remove templates, because their instantiation was missing and they are not needed and only complicate things