### PR TITLE
Enable duplicating logs to stderr

### DIFF
--- a/ydb/core/log_backend/log_backend_build.cpp
+++ b/ydb/core/log_backend/log_backend_build.cpp
@@ -12,6 +12,13 @@ TAutoPtr<TLogBackend> TLogBackendBuildHelper::CreateLogBackendFromLogConfig(cons
     } else if (logConfig.HasBackendFileName()) {
         logBackend = NActors::CreateFileBackend(logConfig.GetBackendFileName());
     }
+
+    if (logBackend && logConfig.GetSysLogToStdErr()) {
+        logBackend = NActors::CreateCompositeLogBackend(
+            {logBackend, NActors::CreateStderrBackend()}
+        );
+    }
+
     return logBackend;
 }
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -381,7 +381,7 @@ message TLogConfig {
     optional bool UseLocalTimestamps = 9 [default = false];
     optional string BackendFileName = 10;
     optional string SysLogService = 11;
-    optional bool SysLogToStdErr = 12; // writes logs to stderr as well as in syslog
+    optional bool SysLogToStdErr = 12; // writes logs to stderr as well as in syslog/file
     optional TUAClientConfig UAClientConfig = 13;
     optional uint64 TimeThresholdMs = 14 [default = 1000];
     optional bool IgnoreUnknownComponents = 15 [default = true];


### PR DESCRIPTION
### Changelog entry
Now with the `SysLogToStdErr` option from `TLogConfig` enabled, logs are duplicated in stderr.

### Changelog category

* Improvement

### Additional information
This option `SysLogToStdErr` existed but was not used in any way before. This functionality is necessary to write logs both to a local file and to stderr (in order to support cloud logging in kubernetes)