### PR TITLE
Change step to common step for publishing pachage

### DIFF
--- a/.github/workflows/update_dstool_package.yaml
+++ b/.github/workflows/update_dstool_package.yaml
@@ -12,9 +12,6 @@ jobs:
     name: Update dstool package
     runs-on: ubuntu-latest
 
-    env:
-      name: robot-ydb
-      url: https://pypi.org/p/ydb-dstool
     permissions:
       id-token: write
 

--- a/.github/workflows/update_dstool_package.yaml
+++ b/.github/workflows/update_dstool_package.yaml
@@ -11,6 +11,13 @@ jobs:
   update-dstool:
     name: Update dstool package
     runs-on: ubuntu-latest
+
+    env:
+      name: pypi
+      url: https://pypi.org/p/ydb-dstool
+    permissions:
+      id-token: write
+
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -36,9 +43,4 @@ jobs:
           python -m build
 
       - name: Upload package to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          set -ex
-          python -m twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/update_dstool_package.yaml
+++ b/.github/workflows/update_dstool_package.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      name: pypi
+      name: robot-ydb
       url: https://pypi.org/p/ydb-dstool
     permissions:
       id-token: write

--- a/.github/workflows/update_dstool_package.yaml
+++ b/.github/workflows/update_dstool_package.yaml
@@ -43,4 +43,4 @@ jobs:
           python -m build
 
       - name: Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.8


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed package upload to PyPI by migrating to the standard pypa/gh-action-pypi-publish@release/v1.8 action

This change addresses security concerns and simplifies our CI/CD process by:
1. Implementing PyPI's Trusted Publisher feature
2. Eliminating the need to store and manage a secret token
3. Allowing the action to automatically obtain a temporary token as a trusted publisher

This update improves our security posture and aligns with best practices for Python package publishing.

For more information on Trusted Publishers, see: https://docs.pypi.org/trusted-publishers/

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
