### PR TITLE
change some event scopes from `struct` to `namespace`

### DIFF
--- a/ydb/core/base/hive.h
+++ b/ydb/core/base/hive.h
@@ -9,7 +9,7 @@
 #include <util/stream/str.h>
 
 namespace NKikimr {
-    struct TEvHive {
+    namespace TEvHive {
         enum EEv {
             // requests
             EvBootTablet = EventSpaceBegin(TKikimrEvents::ES_HIVE),
@@ -888,7 +888,7 @@ namespace NKikimr {
                 Record.MutableDomainKey()->CopyFrom(domainKey);
             }
         };
-        
+
         struct TEvResponseScaleRecommendation : TEventPB<TEvResponseScaleRecommendation,
             NKikimrHive::TEvResponseScaleRecommendation, EvResponseScaleRecommendation> {};
     };

--- a/ydb/core/blob_depot/events.h
+++ b/ydb/core/blob_depot/events.h
@@ -6,7 +6,7 @@
 
 namespace NKikimr {
 
-    struct TEvBlobDepot {
+    namespace TEvBlobDepot {
         enum {
             EvApplyConfig = EventSpaceBegin(TKikimrEvents::ES_BLOB_DEPOT),
             EvApplyConfigResult,

--- a/ydb/core/blockstore/core/blockstore.h
+++ b/ydb/core/blockstore/core/blockstore.h
@@ -7,7 +7,7 @@
 
 namespace NKikimr {
 
-struct TEvBlockStore {
+namespace TEvBlockStore {
     enum EEv {
         EvBegin = EventSpaceBegin(TKikimrEvents::ES_BLOCKSTORE) + 1011,
 

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -26,7 +26,7 @@
 
 namespace NKikimr::NCms {
 
-using NConsole::TEvConsole;
+namespace TEvConsole = NConsole::TEvConsole;
 using NTabletFlatExecutor::TTabletExecutedFlat;
 using NTabletFlatExecutor::ITransaction;
 using NTabletFlatExecutor::TTransactionBase;

--- a/ydb/core/cms/console/configs_dispatcher.h
+++ b/ydb/core/cms/console/configs_dispatcher.h
@@ -28,7 +28,7 @@ namespace NKikimr::NConsole {
  * ConfigId filled in and request Cookie used for response).
  */
 
-struct TEvConfigsDispatcher {
+namespace TEvConfigsDispatcher {
     enum EEv {
         EvSetConfigSubscriptionRequest = EventSpaceBegin(TKikimrEvents::ES_CONFIGS_DISPATCHER),
         EvSetConfigSubscriptionResponse,

--- a/ydb/core/cms/console/console.h
+++ b/ydb/core/cms/console/console.h
@@ -12,7 +12,7 @@
 
 namespace NKikimr::NConsole {
 
-struct TEvConsole {
+namespace TEvConsole {
     enum EEv {
         // requests
         EvCreateTenantRequest = EventSpaceBegin(TKikimrEvents::ES_CONSOLE),

--- a/ydb/core/cms/console/console_tenants_manager.h
+++ b/ydb/core/cms/console/console_tenants_manager.h
@@ -33,7 +33,7 @@ using NTabletFlatExecutor::TTabletExecutedFlat;
 using NTabletFlatExecutor::ITransaction;
 using NTabletFlatExecutor::TTransactionBase;
 using NTabletFlatExecutor::TTransactionContext;
-using NSchemeShard::TEvSchemeShard;
+namespace TEvSchemeShard = NSchemeShard::TEvSchemeShard;
 using NTenantSlotBroker::TEvTenantSlotBroker;
 using NTenantSlotBroker::TSlotDescription;
 using ::NMonitoring::TDynamicCounterPtr;

--- a/ydb/core/filestore/core/filestore.h
+++ b/ydb/core/filestore/core/filestore.h
@@ -7,7 +7,7 @@
 
 namespace NKikimr {
 
-struct TEvFileStore {
+namespace TEvFileStore {
     enum EEv {
         EvBegin = EventSpaceBegin(TKikimrEvents::ES_FILESTORE),
 

--- a/ydb/core/kesus/tablet/events.h
+++ b/ydb/core/kesus/tablet/events.h
@@ -13,7 +13,7 @@ namespace NKesus {
 TString CanonizeQuoterResourcePath(const TVector<TString>& path);
 TString CanonizeQuoterResourcePath(const TString& path);
 
-struct TEvKesus {
+namespace TEvKesus {
     enum EEv {
         EvBegin = EventSpaceBegin(TKikimrEvents::ES_KESUS),
 
@@ -488,15 +488,15 @@ struct TEvKesus {
         }
     };
 
-    struct TEvDeleteQuoterResource : public TEventPB<TEvDeleteQuoterResource, NKikimrKesus::TEvDeleteQuoterResource, EvDeleteQuoterResource> {       
+    struct TEvDeleteQuoterResource : public TEventPB<TEvDeleteQuoterResource, NKikimrKesus::TEvDeleteQuoterResource, EvDeleteQuoterResource> {
         using TBaseEvent = TEventPB<TEvDeleteQuoterResource, NKikimrKesus::TEvDeleteQuoterResource, EvDeleteQuoterResource>;
         using TBaseEvent::TBaseEvent;
     };
 
     struct TEvDeleteQuoterResourceResult : public TEventPB<TEvDeleteQuoterResourceResult, NKikimrKesus::TEvDeleteQuoterResourceResult, EvDeleteQuoterResourceResult> {
         using TBaseEvent = TEventPB<TEvDeleteQuoterResourceResult, NKikimrKesus::TEvDeleteQuoterResourceResult, EvDeleteQuoterResourceResult>;
-        using TBaseEvent::TBaseEvent;        
-        
+        using TBaseEvent::TBaseEvent;
+
         TEvDeleteQuoterResourceResult() = default;
 
         TEvDeleteQuoterResourceResult(Ydb::StatusIds::StatusCode status, const TString& reason) {

--- a/ydb/core/mind/node_broker_impl.h
+++ b/ydb/core/mind/node_broker_impl.h
@@ -23,7 +23,7 @@ using NTabletFlatExecutor::TTabletExecutedFlat;
 using NTabletFlatExecutor::ITransaction;
 using NTabletFlatExecutor::TTransactionBase;
 using NTabletFlatExecutor::TTransactionContext;
-using NConsole::TEvConsole;
+namespace TEvConsole = NConsole::TEvConsole;
 using NConsole::ITxExecutor;
 using NConsole::TTxProcessor;
 
@@ -56,7 +56,7 @@ public:
         struct TEvUpdateEpoch : public TEventLocal<TEvUpdateEpoch, EvUpdateEpoch> {};
 
         struct TEvResolvedRegistrationRequest : public TEventLocal<TEvResolvedRegistrationRequest, EvResolvedRegistrationRequest> {
-            
+
             TEvResolvedRegistrationRequest(
                     TEvNodeBroker::TEvRegistrationRequest::TPtr request,
                     NActors::TScopeId scopeId,

--- a/ydb/core/mind/tenant_slot_broker_impl.h
+++ b/ydb/core/mind/tenant_slot_broker_impl.h
@@ -171,7 +171,7 @@ struct THash<NKikimr::NTenantSlotBroker::TSlotDescription> {
 namespace NKikimr {
 namespace NTenantSlotBroker {
 
-using NConsole::TEvConsole;
+namespace TEvConsole = NConsole::TEvConsole;
 using NTabletFlatExecutor::TTabletExecutedFlat;
 using NTabletFlatExecutor::ITransaction;
 using NTabletFlatExecutor::TTransactionBase;

--- a/ydb/core/persqueue/events/global.h
+++ b/ydb/core/persqueue/events/global.h
@@ -14,7 +14,7 @@
 
 namespace NKikimr {
 
-struct TEvPersQueue {
+namespace TEvPersQueue {
     enum EEv {
         EvRequest = EventSpaceBegin(TKikimrEvents::ES_PQ),
         EvUpdateConfig, //change config for all partitions and count of partitions

--- a/ydb/core/persqueue/read_balancer.h
+++ b/ydb/core/persqueue/read_balancer.h
@@ -270,7 +270,7 @@ private:
     ui64 StatsReportRound;
 
     std::deque<TAutoPtr<TEvPersQueue::TEvRegisterReadSession>> RegisterEvents;
-    std::deque<TAutoPtr<TEvPersQueue::TEvPersQueue::TEvUpdateBalancerConfig>> UpdateEvents;
+    std::deque<TAutoPtr<TEvPersQueue::TEvUpdateBalancerConfig>> UpdateEvents;
 
     TActorId FindSubDomainPathIdActor;
 

--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -41,7 +41,7 @@
 namespace NKikimr {
 namespace NQuoter {
 
-using NKesus::TEvKesus;
+namespace TEvKesus = NKesus::TEvKesus;
 
 class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
     struct TResourceState {

--- a/ydb/core/tx/columnshard/columnshard.h
+++ b/ydb/core/tx/columnshard/columnshard.h
@@ -56,7 +56,7 @@ inline Ydb::StatusIds::StatusCode ConvertToYdbStatus(NKikimrTxColumnShard::EResu
 }
 }
 
-struct TEvColumnShard {
+namespace TEvColumnShard {
     enum EEv {
         EvProposeTransaction = EventSpaceBegin(TKikimrEvents::ES_TX_COLUMNSHARD),
         EvCancelTransactionProposal,

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -192,7 +192,7 @@ namespace NTxDataShard {
     using NDataShard::TTxFlags;
 }
 
-struct TEvDataShard {
+namespace TEvDataShard {
     enum EEv {
         EvProposeTransaction = EventSpaceBegin(TKikimrEvents::ES_TX_DATASHARD),
         EvCancelTransactionProposal,

--- a/ydb/core/tx/replication/controller/public_events.h
+++ b/ydb/core/tx/replication/controller/public_events.h
@@ -7,7 +7,7 @@
 
 namespace NKikimr::NReplication {
 
-struct TEvController {
+namespace TEvController {
     enum EEv {
         EvCreateReplication = EventSpaceBegin(TKikimrEvents::ES_REPLICATION_CONTROLLER),
         EvCreateReplicationResult,
@@ -21,7 +21,7 @@ struct TEvController {
         EvEnd,
     };
 
-    static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_REPLICATION_CONTROLLER), 
+    static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_REPLICATION_CONTROLLER),
         "expect EvEnd < EventSpaceEnd(TKikimrEvents::ES_REPLICATION_CONTROLLER)");
 
     struct TEvCreateReplication

--- a/ydb/core/tx/schemeshard/schemeshard.h
+++ b/ydb/core/tx/schemeshard/schemeshard.h
@@ -51,7 +51,7 @@ public:
     }
 };
 
-struct TEvSchemeShard {
+namespace TEvSchemeShard {
     enum EEv {
         EvModifySchemeTransaction = EventSpaceBegin(TKikimrEvents::ES_FLAT_TX_SCHEMESHARD),  // 271122432
         EvModifySchemeTransactionResult = EvModifySchemeTransaction + 1 * 512,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.h
@@ -74,8 +74,8 @@
     action(TEvBlobDepot::TEvApplyConfigResult,            NSchemeShard::TXTYPE_BLOB_DEPOT_CONFIG_RESULT) \
 \
     action(TEvPrivate::TEvOperationPlan,                   NSchemeShard::TXTYPE_PLAN_STEP)                             \
-    action(TEvPrivate::TEvPrivate::TEvCompletePublication, NSchemeShard::TXTYPE_NOTIFY_OPERATION_COMPLETE_PUBLICATION) \
-    action(TEvPrivate::TEvPrivate::TEvCompleteBarrier,     NSchemeShard::TXTYPE_NOTIFY_OPERATION_COMPLETE_BARRIER)     \
+    action(TEvPrivate::TEvCompletePublication, NSchemeShard::TXTYPE_NOTIFY_OPERATION_COMPLETE_PUBLICATION) \
+    action(TEvPrivate::TEvCompleteBarrier,     NSchemeShard::TXTYPE_NOTIFY_OPERATION_COMPLETE_BARRIER)     \
 \
     action(TEvPersQueue::TEvProposeTransactionAttachResult, NSchemeShard::TXTYPE_PERSQUEUE_PROPOSE_ATTACH_RESULT)
 

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -6,7 +6,7 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
-struct TEvPrivate {
+namespace TEvPrivate {
     enum EEv {
         EvProgressOperation = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
         EvOperationPlanStep,

--- a/ydb/core/tx/sequenceshard/public/events.h
+++ b/ydb/core/tx/sequenceshard/public/events.h
@@ -7,7 +7,7 @@
 namespace NKikimr {
 namespace NSequenceShard {
 
-    struct TEvSequenceShard {
+    namespace TEvSequenceShard {
         enum EEv {
             EvMarkSchemeShardPipe = EventSpaceBegin(TKikimrEvents::ES_SEQUENCESHARD),
             EvCreateSequence,

--- a/ydb/core/tx/tx.h
+++ b/ydb/core/tx/tx.h
@@ -240,7 +240,7 @@ struct TTestTxConfig {
     static constexpr ui64 UseLessId = 0xFFFFFFFFFFFFFFF;
 };
 
-struct TEvSubDomain {
+namespace TEvSubDomain {
     enum EEv {
         EvConfigure = EventSpaceBegin(TKikimrEvents::ES_SUB_DOMAIN),
         EvConfigureStatus,

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -8,7 +8,7 @@
 namespace NKikimr::NViewer {
 
 using namespace NActors;
-using NSchemeShard::TEvSchemeShard;
+namespace TEvSchemeShard = NSchemeShard::TEvSchemeShard;
 using TNavigate = NSchemeCache::TSchemeCacheNavigate;
 
 class TJsonDescribe : public TViewerPipeClient {

--- a/ydb/core/viewer/viewer_hotkeys.h
+++ b/ydb/core/viewer/viewer_hotkeys.h
@@ -6,7 +6,7 @@
 namespace NKikimr::NViewer {
 
 using namespace NActors;
-using NSchemeShard::TEvSchemeShard;
+namespace TEvSchemeShard = NSchemeShard::TEvSchemeShard;
 
 class TJsonHotkeys : public TViewerPipeClient {
     static const bool WithRetry = false;


### PR DESCRIPTION
Change event scopes from struct to namespace.

Only for those components, which events are used by schemeshard and in scheme operations.

When event classes are declared as inner classes of a `struct`, it is impossible to make forward declarations of those classes (without refactoring all those definitions in a very specific way). Changing event scope from `struct` to `namespace` enables easy forwarding of its event classes. And that is just a renaming and not a refactoring (no nontrivial changes).

Scopes changed:
* `TEvBlobDepot`
* `TEvBlockStore`
* `TEvColumnShard`
* `TEvConfigsDispatcher`
* `TEvConsole`
* `TEvDataShard`
* `TEvFileStore`
* `TEvHive`
* `TEvKesus`
* `TEvPersQueue`
* `TEvSchemeShard`
* `TEvSequenceShard`
* `TEvSubDomain`

This is part of "improve schemeshard operation build-time" effort (#10633).

### Changelog category

* Not for changelog

