### PR TITLE
Mute ydb/core/blobstorage/ 4 tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -212,3 +212,4 @@ ydb/core/blobstorage/ut_vdisk TBsVDiskManyPutGet.ManyPutRangeGetCompactionIndexO
 ydb/core/blobstorage/ut_blobstorage/ut_osiris Osiris.block42
 ydb/core/blobstorage/ut_blobstorage/ut_osiris Osiris.mirror3dc
 ydb/core/blobstorage/ut_blobstorage/ut_osiris Osiris.mirror3of4
+ydb/core/blobstorage/ut_mirror3of4 Mirror3of4.ReplicationSmall

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -209,3 +209,6 @@ ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.CreateMultiplePqTablet
 ydb/tests/functional/serializable test.py.test_local
 ydb/core/blobstorage/ut_vdisk TBsVDiskGC.GCPutKeepBarrierSync
 ydb/core/blobstorage/ut_vdisk TBsVDiskManyPutGet.ManyPutRangeGetCompactionIndexOnly
+ydb/core/blobstorage/ut_blobstorage/ut_osiris Osiris.block42
+ydb/core/blobstorage/ut_blobstorage/ut_osiris Osiris.mirror3dc
+ydb/core/blobstorage/ut_blobstorage/ut_osiris Osiris.mirror3of4


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Mute:<!--mute_list_start-->
ydb/core/blobstorage/ut_blobstorage/ut_osiris/Osiris.block42
ydb/core/blobstorage/ut_blobstorage/ut_osiris/Osiris.mirror3dc
ydb/core/blobstorage/ut_blobstorage/ut_osiris/Osiris.mirror3of4<!--mute_list_end-->

 Owner: [TEAM:@ydb-platform/storage](https://github.com/orgs/ydb-platform/teams/storage)

**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**

**Summary history:** in window 2024-10-21 
 Success rate **0%**
Pass:0 Fail:12 Mute:0 Skip:0

**Test run history:** [link](https://datalens.yandex/34xnbsom67hcq?full_name=__in_ydb/core/blobstorage/ut_blobstorage/ut_osiris/Osiris.block42&full_name=__in_ydb/core/blobstorage/ut_blobstorage/ut_osiris/Osiris.mirror3dc&full_name=__in_ydb/core/blobstorage/ut_blobstorage/ut_osiris/Osiris.mirror3of4)


Mute <!--mute_list_start-->
ydb/core/blobstorage/ut_mirror3of4/Mirror3of4.ReplicationSmall<!--mute_list_end-->

 Owner: [TEAM:@ydb-platform/storage](https://github.com/orgs/ydb-platform/teams/storage)

**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**  

**Summary history:** in window 2024-10-20 - 2024-10-21 
 Success rate **86.36363636363636%**
Pass:19 Fail:3 Mute:0 Skip:0
### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
