### PR TITLE
Remove asan sqs from PR

### DIFF
--- a/ydb/tests/functional/sqs/large/ya.make
+++ b/ydb/tests/functional/sqs/large/ya.make
@@ -7,7 +7,7 @@ TEST_SRCS(
     test_leader_start_inflight.py
 )
 
-IF (SANITIZER_TYPE == "thread")
+IF (SANITIZER_TYPE)
     TIMEOUT(2400)
     SIZE(LARGE)
     TAG(ya:fat)

--- a/ydb/tests/functional/sqs/merge_split_common_table/fifo/ya.make
+++ b/ydb/tests/functional/sqs/merge_split_common_table/fifo/ya.make
@@ -8,10 +8,6 @@ TEST_SRCS(
 )
 
 IF (SANITIZER_TYPE)
-    REQUIREMENTS(ram:32 cpu:4)
-ENDIF()
-
-IF (SANITIZER_TYPE == "thread")
     TIMEOUT(2400)
     SIZE(LARGE)
     TAG(ya:fat)

--- a/ydb/tests/functional/sqs/merge_split_common_table/std/ya.make
+++ b/ydb/tests/functional/sqs/merge_split_common_table/std/ya.make
@@ -6,14 +6,11 @@ TEST_SRCS(
     test.py
 )
 
-IF (SANITIZER_TYPE)
-    REQUIREMENTS(ram:32 cpu:4)
-ENDIF()
-
 IF (SANITIZER_TYPE == "thread")
     TIMEOUT(2400)
     SIZE(LARGE)
     TAG(ya:fat)
+    REQUIREMENTS(ram:32 cpu:4)
 ELSE()
     TIMEOUT(600)
     SIZE(MEDIUM)

--- a/ydb/tests/functional/sqs/multinode/ya.make
+++ b/ydb/tests/functional/sqs/multinode/ya.make
@@ -7,7 +7,7 @@ TEST_SRCS(
     test_recompiles_requests.py
 )
 
-IF (SANITIZER_TYPE == "thread")
+IF (SANITIZER_TYPE)
     TIMEOUT(2400)
     SIZE(LARGE)
     TAG(ya:fat)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Mark some sqs tests as large, because of huge RAM consumption (and OOM in PRs). [See RAM consumption](https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/Postcommit_asan/11453862863/ya-x86-64-asan/try_1/summary_report.txt)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
