### PR TITLE
Fix a bug in YQL node creation for indexImplTable table settings

### DIFF
--- a/ydb/core/kqp/provider/ut/ya.make
+++ b/ydb/core/kqp/provider/ut/ya.make
@@ -8,7 +8,9 @@ SRCS(
 
 PEERDIR(
     ydb/core/kqp/ut/common
+    ydb/library/yql/ast
     ydb/library/yql/sql/pg_dummy
+    ydb/library/yql/sql/v1
     library/cpp/testing/gmock_in_unittest
 )
 

--- a/ydb/core/kqp/provider/yql_kikimr_provider_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_ut.cpp
@@ -1,8 +1,60 @@
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
+#include <ydb/library/yql/ast/yql_expr.h>
+#include <ydb/library/yql/sql/v1/source.h>
+#include <ydb/library/yql/sql/v1/context.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NYql {
+
+namespace {
+
+using namespace NSQLTranslationV1;
+
+TContext CreateDefaultParserContext(NYql::TIssues& issues) {
+    NSQLTranslation::TTranslationSettings settings;
+    settings.DefaultCluster = "/Cluster";
+    settings.AssumeYdbOnClusterWithSlash = true;
+
+    return TContext(settings, {}, issues);
+}
+
+TAstNode* CreateAlterTable(TContext& parserContext, const TString& tableName, const TAlterTableParameters& params) {
+    TTableRef tableRef(tableName, parserContext.Scoped->CurrService, parserContext.Scoped->CurrCluster, {});
+    {
+        TDeferredAtom tableAtom(parserContext.Pos(), tableName);
+        tableRef.Keys = BuildTableKey(parserContext.Pos(), tableRef.Service, tableRef.Cluster, tableAtom, {});
+    }
+
+    auto alterTableNode = BuildAlterTable(parserContext.Pos(), tableRef, params, parserContext.Scoped);
+    UNIT_ASSERT_C(alterTableNode, parserContext.Issues.ToString());
+    UNIT_ASSERT_C(alterTableNode->Init(parserContext, nullptr), parserContext.Issues.ToString());
+    TAstNode* alterTableAst = alterTableNode->Translate(parserContext);
+    UNIT_ASSERT_C(alterTableAst, parserContext.Issues.ToString());
+
+    UNIT_ASSERT_C(alterTableAst->IsList()
+        && alterTableAst->GetChildrenCount() > 1
+        && alterTableAst->GetChild(1)->IsList()
+        && alterTableAst->GetChild(1)->GetChildrenCount() > 1
+        && alterTableAst->GetChild(1)->GetChild(1),
+        alterTableAst->ToString()
+    );
+    // this child represents the world
+    return alterTableAst->GetChild(1)->GetChild(1);
+}
+
+void Find(const TAstNode* node, const std::function<bool(const TAstNode*)>& predicate) {
+    if (predicate(node)) {
+        return;
+    }
+    if (node->IsList()) {
+        for (auto* child : node->GetChildren()) {
+            Find(child, predicate);
+        }
+    }
+}
+
+}
 
 Y_UNIT_TEST_SUITE(KikimrProvider) {
     Y_UNIT_TEST(TestFillAuthPropertiesNone) {
@@ -168,6 +220,87 @@ Y_UNIT_TEST_SUITE(KikimrProvider) {
             UNIT_ASSERT(it != properties.end());
             UNIT_ASSERT_VALUES_EQUAL(it->second, "region");
         }
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndexWithTableSettings) {
+        NYql::TIssues issues;
+        auto parserContext = CreateDefaultParserContext(issues);
+
+        TAlterTableParameters params;
+        {
+            NSQLTranslationV1::TIndexDescription indexDescription(TIdentifier(parserContext.Pos(), "index"));
+            indexDescription.TableSettings.MinPartitions = new TLiteralNumberNode<i32>(parserContext.Pos(), "Int32", "12345");
+            indexDescription.TableSettings.MaxPartitions = new TLiteralNumberNode<i32>(parserContext.Pos(), "Int32", "54321");
+            params.AddIndexes.emplace_back(std::move(indexDescription));
+        }
+
+        TString tableName = "table";
+        auto* alterTableAst = CreateAlterTable(parserContext, tableName, params);
+
+        TString tableSettingsAst;
+        Find(alterTableAst, [&tableSettingsAst](const TAstNode* node) {
+            if (node->IsList()
+                && node->GetChildrenCount() == 2
+                && node->GetChild(0)->ToString() == "'tableSettings"
+            ) {
+                tableSettingsAst = node->GetChild(1)->ToString();
+                return true;
+            }
+            return false;
+        });
+        UNIT_ASSERT_STRINGS_EQUAL_C(
+            tableSettingsAst, R"('('('minPartitions (Int32 '"12345")) '('maxPartitions (Int32 '"54321"))))",
+            alterTableAst->ToString()
+        );
+
+        TExprContext exprContext;
+        TExprNode::TPtr alterTableExpr;
+        UNIT_ASSERT_C(CompileExpr(*alterTableAst, alterTableExpr, exprContext, nullptr, nullptr),
+            exprContext.IssueManager.GetIssues().ToString()
+        );
+
+        UNIT_ASSERT_GT_C(alterTableExpr->ChildrenSize(), 4, alterTableExpr->Dump());
+        const auto* writeSettingsNode = alterTableExpr->Child(4);
+        std::optional<NCommon::TWriteTableSettings> writeSettings;
+        try {
+            writeSettings = NCommon::ParseWriteTableSettings(NNodes::TExprList(writeSettingsNode), exprContext);
+        } catch (...) {
+            UNIT_FAIL(CurrentExceptionMessage());
+        }
+
+        TKikimrKey key(exprContext);
+        UNIT_ASSERT_C(key.Extract(*alterTableExpr->Child(2)), alterTableExpr->Child(2)->Dump());
+        UNIT_ASSERT_STRINGS_EQUAL(key.GetTablePath(), tableName);
+        UNIT_ASSERT(writeSettings->AlterActions);
+        UNIT_ASSERT(!writeSettings->AlterActions.Cast().Empty());
+
+        auto alterActions = TExprNode::TPtr(writeSettings->AlterActions.MutableRaw());
+        TString tableSettingsExpr;
+        VisitExpr(alterActions, [&tableSettingsExpr](const TExprNode::TPtr& node) {
+            if (node->IsList()
+                && node->ChildrenSize() == 2
+                && node->Child(0)->IsAtom("tableSettings")
+            ) {
+                tableSettingsExpr = node->Child(1)->Dump();
+                return false;
+            }
+            return true;
+        });
+        UNIT_ASSERT_STRINGS_EQUAL(
+            Strip(Collapse(tableSettingsExpr)),
+            Strip(Collapse(TString(
+            R"(
+                #37 [List]
+                 #32 [List]
+                  #29 [Atom] <minPartitions>
+                  #31 [Callable] <Int32>
+                   #30 [Atom] <12345>
+                 #36 [List]
+                  #33 [Atom] <maxPartitions>
+                  #35 [Callable] <Int32>
+                   #34 [Atom] <54321>
+            )"
+        ))));
     }
 }
 

--- a/ydb/library/yql/sql/v1/query.cpp
+++ b/ydb/library/yql/sql/v1/query.cpp
@@ -320,10 +320,10 @@ static INode::TPtr CreateIndexDesc(const TIndexDescription& index, ETableSetting
         node.Q(node.Y(node.Q("dataColumns"), node.Q(dataColumns)))
     );
     if (index.TableSettings.IsSet()) {
-        const auto& tableSettings = node.Y(
+        const auto& tableSettings = node.Q(node.Y(
             node.Q("tableSettings"),
             node.Q(CreateTableSettings(index.TableSettings, parsingMode, node))
-        );
+        ));
         indexNode = node.L(indexNode, tableSettings);
     }
     if (const auto* indexSettingsPtr = std::get_if<TVectorIndexSettings>(&index.IndexSettings)) {


### PR DESCRIPTION
Ticket:
- https://github.com/ydb-platform/ydb/issues/7644

Forgot to quote the tableSettings node that is created while parsing `CREATE TABLE` with an index definition or `ALTER TABLE ADD INDEX` with indexImplTable settings. It is not possible to issue this commands via YQL, because the relevant grammar is not implemented yet, so it is not possible for users to catch this bug.

For those, who are curios if the test does in fact catch the bug, here is the [log](https://gist.github.com/jepett0/1ddecdbe929ffb914497adf7f584019f) of the test after I have reverted the fix:
<details>
<summary>test failure</summary>

```text
(CompileExpr(*alterTableAst, alterTableExpr, exprContext, nullptr, nullptr)) <main>: Error: First item in list is not an atom, did you forget quote?
```

</details>