### PR TITLE
Add escaping for serialized pg types in viewer

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_db_mon.cpp
+++ b/ydb/core/tablet_flat/flat_executor_db_mon.cpp
@@ -238,7 +238,7 @@ public:
                                         }
                                         case NScheme::NTypeIds::Pg: {
                                             auto convert = NPg::PgNativeTextFromNativeBinary(tuple.Columns[i].AsBuf(), tuple.Types[i].GetPgTypeDesc());
-                                            str << (!convert.Error ? convert.Str : *convert.Error);
+                                            str << EncodeHtmlPcdata(!convert.Error ? convert.Str : *convert.Error);
                                             break;
                                         }
                                         default:

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -181,7 +181,7 @@ public:
         case NScheme::NTypeIds::Pg: {
             NScheme::TTypeInfo typeInfo = NKikimr::NScheme::TypeInfoFromProto(type.GetTypeId(), type.GetTypeInfo());
             auto convert = NPg::PgNativeTextFromNativeBinary(cell.AsBuf(),typeInfo.GetPgTypeDesc());
-            return !convert.Error ? convert.Str : *convert.Error;
+            return TStringBuilder() << '"' << (!convert.Error ? convert.Str : *convert.Error) << '"';;
         }        
         case NScheme::NTypeIds::DyNumber:        return "DyNumber";
         case NScheme::NTypeIds::Uuid:            return "Uuid";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add escaping for serialized pg types in viewer (followup to https://github.com/ydb-platform/ydb/pull/10752)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
