### PR TITLE
Single line backport to put Physical Stage IDs to plans

### DIFF
--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -2746,6 +2746,7 @@ TString AddExecStatsToTxPlan(const TString& txPlanJson, const NYql::NDqProto::TD
                     stats["UseLlvm"] = "undefined";
                 }
 
+                stats["PhysicalStageId"] = (*stat)->GetStageId();
                 stats["Tasks"] = (*stat)->GetTotalTasksCount();
 
                 stats["StageDurationUs"] = (*stat)->GetStageDurationUs();


### PR DESCRIPTION
For easier plan comparison/analyze between version, runs, etc.

Copied from #6904

Other parts of PR for dev/test purposes and aren't needed to be merged into stable