### PR TITLE
Views: if exists / if not exists for DDL

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/view/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/view/manager.cpp
@@ -60,6 +60,7 @@ void FillCreateViewProposal(NKikimrSchemeOp::TModifyScheme& modifyScheme,
     const auto pathPair = SplitPathByDb(settings.GetObjectId(), context.GetDatabase());
     modifyScheme.SetWorkingDir(pathPair.first);
     modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpCreateView);
+    modifyScheme.SetFailedOnAlreadyExists(!settings.GetExistingOk());
 
     auto& viewDesc = *modifyScheme.MutableCreateView();
     viewDesc.SetName(pathPair.second);
@@ -77,6 +78,7 @@ void FillDropViewProposal(NKikimrSchemeOp::TModifyScheme& modifyScheme,
     const auto pathPair = SplitPathByObjectId(settings.GetObjectId());
     modifyScheme.SetWorkingDir(pathPair.first);
     modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpDropView);
+    modifyScheme.SetSuccessOnNotExist(settings.GetMissingOk());
 
     auto& drop = *modifyScheme.MutableDrop();
     drop.SetName(pathPair.second);
@@ -84,9 +86,12 @@ void FillDropViewProposal(NKikimrSchemeOp::TModifyScheme& modifyScheme,
 
 NThreading::TFuture<TYqlConclusionStatus> SendSchemeRequest(TEvTxUserProxy::TEvProposeTransaction* request,
                                                             TActorSystem* actorSystem,
-                                                            bool failOnAlreadyExists) {
+                                                            bool failedOnAlreadyExists,
+                                                            bool successOnNotExist) {
     const auto promiseScheme = NThreading::NewPromise<NKqp::TSchemeOpRequestHandler::TResult>();
-    IActor* const requestHandler = new TSchemeOpRequestHandler(request, promiseScheme, failOnAlreadyExists);
+    IActor* const requestHandler = new TSchemeOpRequestHandler(
+        request, promiseScheme, failedOnAlreadyExists, successOnNotExist
+    );
     actorSystem->Register(requestHandler);
     return promiseScheme.GetFuture().Apply([](const NThreading::TFuture<NKqp::TSchemeOpRequestHandler::TResult>& opResult) {
         if (opResult.HasValue()) {
@@ -109,7 +114,12 @@ NThreading::TFuture<TYqlConclusionStatus> CreateView(const NYql::TCreateObjectSe
     auto& schemeTx = *proposal->Record.MutableTransaction()->MutableModifyScheme();
     FillCreateViewProposal(schemeTx, settings, context.GetExternalData());
 
-    return SendSchemeRequest(proposal.Release(), context.GetExternalData().GetActorSystem(), true);
+    return SendSchemeRequest(
+        proposal.Release(),
+        context.GetExternalData().GetActorSystem(),
+        schemeTx.GetFailedOnAlreadyExists(),
+        schemeTx.GetSuccessOnNotExist()
+    );
 }
 
 NThreading::TFuture<TYqlConclusionStatus> DropView(const NYql::TDropObjectSettings& settings,
@@ -122,7 +132,12 @@ NThreading::TFuture<TYqlConclusionStatus> DropView(const NYql::TDropObjectSettin
     auto& schemeTx = *proposal->Record.MutableTransaction()->MutableModifyScheme();
     FillDropViewProposal(schemeTx, settings);
 
-    return SendSchemeRequest(proposal.Release(), context.GetExternalData().GetActorSystem(), false);
+    return SendSchemeRequest(
+        proposal.Release(),
+        context.GetExternalData().GetActorSystem(),
+        schemeTx.GetFailedOnAlreadyExists(),
+        schemeTx.GetSuccessOnNotExist()
+    );
 }
 
 void PrepareCreateView(NKqpProto::TKqpSchemeOperation& schemeOperation,
@@ -214,10 +229,10 @@ NThreading::TFuture<TYqlConclusionStatus> TViewManager::ExecutePrepared(const NK
     switch (schemeOperation.GetOperationCase()) {
         case NKqpProto::TKqpSchemeOperation::kCreateView:
             schemeTx.CopyFrom(schemeOperation.GetCreateView());
-            return SendSchemeRequest(proposal.Release(), context.GetActorSystem(), true);
+            break;
         case NKqpProto::TKqpSchemeOperation::kDropView:
             schemeTx.CopyFrom(schemeOperation.GetDropView());
-            return SendSchemeRequest(proposal.Release(), context.GetActorSystem(), false);
+            break;
         default:
             return NThreading::MakeFuture(TYqlConclusionStatus::Fail(
                     TStringBuilder()
@@ -226,6 +241,12 @@ NThreading::TFuture<TYqlConclusionStatus> TViewManager::ExecutePrepared(const NK
                 )
             );
     }
+    return SendSchemeRequest(
+        proposal.Release(),
+        context.GetActorSystem(),
+        schemeTx.GetFailedOnAlreadyExists(),
+        schemeTx.GetSuccessOnNotExist()
+    );
 }
 
 }

--- a/ydb/library/yql/sql/v1/SQLv1.g.in
+++ b/ydb/library/yql/sql/v1/SQLv1.g.in
@@ -601,12 +601,12 @@ alter_external_data_source_action:
 
 drop_external_data_source_stmt: DROP EXTERNAL DATA SOURCE (IF EXISTS)? object_ref;
 
-create_view_stmt: CREATE VIEW object_ref
+create_view_stmt: CREATE VIEW (IF NOT EXISTS)? object_ref
     create_object_features?
     AS select_stmt
 ;
 
-drop_view_stmt: DROP VIEW object_ref;
+drop_view_stmt: DROP VIEW (IF EXISTS)? object_ref;
 
 upsert_object_stmt: UPSERT OBJECT object_ref
     LPAREN TYPE object_type_ref RPAREN

--- a/ydb/library/yql/sql/v1/SQLv1Antlr4.g.in
+++ b/ydb/library/yql/sql/v1/SQLv1Antlr4.g.in
@@ -600,12 +600,12 @@ alter_external_data_source_action:
 
 drop_external_data_source_stmt: DROP EXTERNAL DATA SOURCE (IF EXISTS)? object_ref;
 
-create_view_stmt: CREATE VIEW object_ref
+create_view_stmt: CREATE VIEW (IF NOT EXISTS)? object_ref
     create_object_features?
     AS select_stmt
 ;
 
-drop_view_stmt: DROP VIEW object_ref;
+drop_view_stmt: DROP VIEW (IF EXISTS)? object_ref;
 
 upsert_object_stmt: UPSERT OBJECT object_ref
     LPAREN TYPE object_type_ref RPAREN

--- a/ydb/library/yql/sql/v1/format/sql_format_ut.h
+++ b/ydb/library/yql/sql/v1/format/sql_format_ut.h
@@ -1538,9 +1538,16 @@ Y_UNIT_TEST(ObfuscatePragma) {
 }
 
 Y_UNIT_TEST(CreateView) {
-    TCases cases = {
-        {"creAte vIEw iF nOt EXistS TheView wiTh (security_invoker = trUE) As SELect 1",
-            "CREATE VIEW IF NOT EXISTS TheView WITH (security_invoker = TRUE) AS\nSELECT\n\t1;\n"},
+    TCases cases = {{
+            "creAte vIEw TheView As SELect 1",
+            "CREATE VIEW TheView AS\nSELECT\n\t1;\n"
+        }, {
+            "creAte vIEw If Not ExIsTs TheView As SELect 1",
+            "CREATE VIEW IF NOT EXISTS TheView AS\nSELECT\n\t1;\n"
+        }, {
+            "creAte vIEw TheView wiTh (option = tRuE) As SELect 1",
+            "CREATE VIEW TheView WITH (option = TRUE) AS\nSELECT\n\t1;\n"
+        }
     };
 
     TSetup setup;
@@ -1548,9 +1555,13 @@ Y_UNIT_TEST(CreateView) {
 }
 
 Y_UNIT_TEST(DropView) {
-    TCases cases = {
-        {"dRop viEW iF EXistS theVIEW",
-            "DROP VIEW IF EXISTS theVIEW;\n"},
+    TCases cases = {{
+            "dRop viEW theVIEW",
+            "DROP VIEW theVIEW;\n"
+        }, {
+            "dRop viEW iF EXistS theVIEW",
+            "DROP VIEW IF EXISTS theVIEW;\n"
+        }
     };
 
     TSetup setup;

--- a/ydb/library/yql/sql/v1/format/sql_format_ut.h
+++ b/ydb/library/yql/sql/v1/format/sql_format_ut.h
@@ -1539,8 +1539,8 @@ Y_UNIT_TEST(ObfuscatePragma) {
 
 Y_UNIT_TEST(CreateView) {
     TCases cases = {
-        {"creAte vIEw TheView wiTh (security_invoker = trUE) As SELect 1",
-            "CREATE VIEW TheView WITH (security_invoker = TRUE) AS\nSELECT\n\t1;\n"},
+        {"creAte vIEw iF nOt EXistS TheView wiTh (security_invoker = trUE) As SELect 1",
+            "CREATE VIEW IF NOT EXISTS TheView WITH (security_invoker = TRUE) AS\nSELECT\n\t1;\n"},
     };
 
     TSetup setup;
@@ -1549,8 +1549,8 @@ Y_UNIT_TEST(CreateView) {
 
 Y_UNIT_TEST(DropView) {
     TCases cases = {
-        {"dRop viEW theVIEW",
-            "DROP VIEW theVIEW;\n"},
+        {"dRop viEW iF EXistS theVIEW",
+            "DROP VIEW IF EXISTS theVIEW;\n"},
     };
 
     TSetup setup;

--- a/ydb/library/yql/sql/v1/sql_query.cpp
+++ b/ydb/library/yql/sql/v1/sql_query.cpp
@@ -1226,11 +1226,11 @@ bool TSqlQuery::Statement(TVector<TNodePtr>& blocks, const TRule_sql_stmt_core& 
             break;
         }
         case TRule_sql_stmt_core::kAltSqlStmtCore42: {
-            // create_view_stmt: CREATE VIEW name WITH (k = v, ...) AS select_stmt;
+            // create_view_stmt: CREATE VIEW (IF NOT EXISTS)? name (WITH (k = v, ...))? AS select_stmt;
             auto& node = core.GetAlt_sql_stmt_core42().GetRule_create_view_stmt1();
             TObjectOperatorContext context(Ctx.Scoped);
-            if (node.GetRule_object_ref3().HasBlock1()) {
-                if (!ClusterExpr(node.GetRule_object_ref3().GetBlock1().GetRule_cluster_expr1(),
+            if (node.GetRule_object_ref4().HasBlock1()) {
+                if (!ClusterExpr(node.GetRule_object_ref4().GetBlock1().GetRule_cluster_expr1(),
                                  false,
                                  context.ServiceId,
                                  context.Cluster)) {
@@ -1238,34 +1238,36 @@ bool TSqlQuery::Statement(TVector<TNodePtr>& blocks, const TRule_sql_stmt_core& 
                 }
             }
 
+            const bool existingOk = node.HasBlock3();
+
             std::map<TString, TDeferredAtom> features;
-            if (node.HasBlock4()) {
-                if (!ParseObjectFeatures(features, node.GetBlock4().GetRule_create_object_features1().GetRule_object_features2())) {
+            if (node.HasBlock5()) {
+                if (!ParseObjectFeatures(features, node.GetBlock5().GetRule_create_object_features1().GetRule_object_features2())) {
                     return false;
                 }
             }
-            if (!ParseViewQuery(features, node.GetRule_select_stmt6())) {
+            if (!ParseViewQuery(features, node.GetRule_select_stmt7())) {
                 return false;
             }
 
-            const TString objectId = Id(node.GetRule_object_ref3().GetRule_id_or_at2(), *this).second;
+            const TString objectId = Id(node.GetRule_object_ref4().GetRule_id_or_at2(), *this).second;
             constexpr const char* TypeId = "VIEW";
             AddStatementToBlocks(blocks,
                                  BuildCreateObjectOperation(Ctx.Pos(),
                                                             BuildTablePath(Ctx.GetPrefixPath(context.ServiceId, context.Cluster), objectId),
                                                             TypeId,
-                                                            false,
+                                                            existingOk,
                                                             false,
                                                             std::move(features),
                                                             context));
             break;
         }
         case TRule_sql_stmt_core::kAltSqlStmtCore43: {
-            // drop_view_stmt: DROP VIEW name;
+            // drop_view_stmt: DROP VIEW (IF EXISTS)? name;
             auto& node = core.GetAlt_sql_stmt_core43().GetRule_drop_view_stmt1();
             TObjectOperatorContext context(Ctx.Scoped);
-            if (node.GetRule_object_ref3().HasBlock1()) {
-                if (!ClusterExpr(node.GetRule_object_ref3().GetBlock1().GetRule_cluster_expr1(),
+            if (node.GetRule_object_ref4().HasBlock1()) {
+                if (!ClusterExpr(node.GetRule_object_ref4().GetBlock1().GetRule_cluster_expr1(),
                                  false,
                                  context.ServiceId,
                                  context.Cluster)) {
@@ -1273,13 +1275,15 @@ bool TSqlQuery::Statement(TVector<TNodePtr>& blocks, const TRule_sql_stmt_core& 
                 }
             }
 
-            const TString objectId = Id(node.GetRule_object_ref3().GetRule_id_or_at2(), *this).second;
+            const bool missingOk = node.HasBlock3();
+
+            const TString objectId = Id(node.GetRule_object_ref4().GetRule_id_or_at2(), *this).second;
             constexpr const char* TypeId = "VIEW";
             AddStatementToBlocks(blocks,
                                  BuildDropObjectOperation(Ctx.Pos(),
                                                           BuildTablePath(Ctx.GetPrefixPath(context.ServiceId, context.Cluster), objectId),
                                                           TypeId,
-                                                          false,
+                                                          missingOk,
                                                           {},
                                                           context));
             break;

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6716,13 +6716,26 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
     }
 
-    Y_UNIT_TEST(CreateViewIfNotExistsGrammarSupport) {
-        NYql::TAstParseResult res = SqlToYql(R"(
+    Y_UNIT_TEST(CreateViewIfNotExists) {
+        constexpr const char* name = "TheView";
+        NYql::TAstParseResult res = SqlToYql(std::format(R"(
                 USE plato;
-                CREATE VIEW IF NOT EXISTS TheView WITH (security_invoker = TRUE) AS SELECT 1;
-            )"
-        );
+                CREATE VIEW IF NOT EXISTS {} WITH (security_invoker = TRUE) AS SELECT 1;
+            )", name
+        ));
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
+
+        TVerifyLineFunc verifyLine = [&](const TString& word, const TString& line) {
+            if (word == "Write!") {
+                UNIT_ASSERT_STRING_CONTAINS(line, name);
+                UNIT_ASSERT_STRING_CONTAINS(line, "createObjectIfNotExists");
+            }
+        };
+
+        TWordCountHive elementStat = { {"Write!"} };
+        VerifyProgram(res, elementStat, verifyLine);
+
+        UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
 
     Y_UNIT_TEST(CreateViewFromTable) {
@@ -6804,13 +6817,26 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
 
-    Y_UNIT_TEST(DropViewIfExistsGrammarSupport) {
-        NYql::TAstParseResult res = SqlToYql(R"(
+    Y_UNIT_TEST(DropViewIfExists) {
+        constexpr const char* name = "TheView";
+        NYql::TAstParseResult res = SqlToYql(std::format(R"(
                 USE plato;
-                DROP VIEW IF EXISTS TheView;
-            )"
-        );
+                DROP VIEW IF EXISTS {};
+            )", name
+        ));
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
+
+        TVerifyLineFunc verifyLine = [&](const TString& word, const TString& line) {
+            if (word == "Write!") {
+                UNIT_ASSERT_STRING_CONTAINS(line, name);
+                UNIT_ASSERT_STRING_CONTAINS(line, "dropObjectIfExists");
+            }
+        };
+
+        TWordCountHive elementStat = { {"Write!"} };
+        VerifyProgram(res, elementStat, verifyLine);
+
+        UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
 
     Y_UNIT_TEST(CreateViewWithTablePrefix) {

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -6716,6 +6716,15 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
     }
 
+    Y_UNIT_TEST(CreateViewIfNotExistsGrammarSupport) {
+        NYql::TAstParseResult res = SqlToYql(R"(
+                USE plato;
+                CREATE VIEW IF NOT EXISTS TheView WITH (security_invoker = TRUE) AS SELECT 1;
+            )"
+        );
+        UNIT_ASSERT_C(res.Root, res.Issues.ToString());
+    }
+
     Y_UNIT_TEST(CreateViewFromTable) {
         constexpr const char* path = "/PathPrefix/TheView";
         constexpr const char* query = R"(
@@ -6793,6 +6802,15 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         VerifyProgram(res, elementStat, verifyLine);
 
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
+    }
+
+    Y_UNIT_TEST(DropViewIfExistsGrammarSupport) {
+        NYql::TAstParseResult res = SqlToYql(R"(
+                USE plato;
+                DROP VIEW IF EXISTS TheView;
+            )"
+        );
+        UNIT_ASSERT_C(res.Root, res.Issues.ToString());
     }
 
     Y_UNIT_TEST(CreateViewWithTablePrefix) {

--- a/ydb/library/yql/sql/v1/sql_ut.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut.cpp
@@ -2533,8 +2533,8 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
         const auto result = SqlToYql(R"(USE plato;
             CREATE TABLE table (
                 pk INT32 NOT NULL,
-                col String, 
-                INDEX idx GLOBAL USING vector_kmeans_tree 
+                col String,
+                INDEX idx GLOBAL USING vector_kmeans_tree
                     ON (col) COVER (col)
                     WITH (distance=cosine, vector_type=float, vector_dimension=1024,),
                 PRIMARY KEY (pk))
@@ -2543,11 +2543,11 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
     }
 
     Y_UNIT_TEST(AlterTableAddIndexVector) {
-        const auto result = SqlToYql(R"(USE plato; 
-            ALTER TABLE table ADD INDEX idx 
-                GLOBAL USING vector_kmeans_tree 
+        const auto result = SqlToYql(R"(USE plato;
+            ALTER TABLE table ADD INDEX idx
+                GLOBAL USING vector_kmeans_tree
                 ON (col) COVER (col)
-                WITH (distance=cosine, vector_type="float", vector_dimension=1024) 
+                WITH (distance=cosine, vector_type="float", vector_dimension=1024)
                 )");
         UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
     }
@@ -2558,11 +2558,11 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
     }
 
     Y_UNIT_TEST(AlterTableAddIndexMissedParameter) {
-        ExpectFailWithError(R"(USE plato; 
-            ALTER TABLE table ADD INDEX idx 
-                GLOBAL USING vector_kmeans_tree 
+        ExpectFailWithError(R"(USE plato;
+            ALTER TABLE table ADD INDEX idx
+                GLOBAL USING vector_kmeans_tree
                 ON (col)
-                WITH (distance=cosine, vector_type=float) 
+                WITH (distance=cosine, vector_type=float)
                 )",
             "<main>:5:52: Error: vector_dimension should be set\n");
     }
@@ -2790,7 +2790,7 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
             auto req = Sprintf(reqTpl, key.c_str(), value.c_str());
             auto res = SqlToYql(req);
             UNIT_ASSERT(res.Root);
-            
+
             TVerifyLineFunc verifyLine = [&key, &value](const TString& word, const TString& line) {
                 if (word == "Write") {
                     UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("MyReplication"));
@@ -6838,7 +6838,7 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
-    
+
     Y_UNIT_TEST(YtAlternativeSchemaSyntax) {
         NYql::TAstParseResult res = SqlToYql(R"(
             SELECT * FROM plato.Input WITH schema(y Int32, x String not null);
@@ -6907,7 +6907,7 @@ Y_UNIT_TEST_SUITE(CompactNamedExprs) {
             pragma CompactNamedExprs;
             pragma ValidateUnusedExprs;
 
-            define subquery $x() as 
+            define subquery $x() as
                 select count(1, 2);
             end define;
             select 1;
@@ -6930,7 +6930,7 @@ Y_UNIT_TEST_SUITE(CompactNamedExprs) {
             pragma CompactNamedExprs;
             pragma DisableValidateUnusedExprs;
 
-            define subquery $x() as 
+            define subquery $x() as
                 select count(1, 2);
             end define;
             select 1;

--- a/ydb/library/yql/sql/v1/sql_ut_antlr4.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut_antlr4.cpp
@@ -2533,8 +2533,8 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
         const auto result = SqlToYql(R"(USE plato;
             CREATE TABLE table (
                 pk INT32 NOT NULL,
-                col String, 
-                INDEX idx GLOBAL USING vector_kmeans_tree 
+                col String,
+                INDEX idx GLOBAL USING vector_kmeans_tree
                     ON (col) COVER (col)
                     WITH (distance=cosine, vector_type=float, vector_dimension=1024,),
                 PRIMARY KEY (pk))
@@ -2543,11 +2543,11 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
     }
 
     Y_UNIT_TEST(AlterTableAddIndexVector) {
-        const auto result = SqlToYql(R"(USE plato; 
-            ALTER TABLE table ADD INDEX idx 
-                GLOBAL USING vector_kmeans_tree 
+        const auto result = SqlToYql(R"(USE plato;
+            ALTER TABLE table ADD INDEX idx
+                GLOBAL USING vector_kmeans_tree
                 ON (col) COVER (col)
-                WITH (distance=cosine, vector_type="float", vector_dimension=1024) 
+                WITH (distance=cosine, vector_type="float", vector_dimension=1024)
                 )");
         UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
     }
@@ -2558,11 +2558,11 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
     }
 
     Y_UNIT_TEST(AlterTableAddIndexMissedParameter) {
-        ExpectFailWithError(R"(USE plato; 
-            ALTER TABLE table ADD INDEX idx 
-                GLOBAL USING vector_kmeans_tree 
+        ExpectFailWithError(R"(USE plato;
+            ALTER TABLE table ADD INDEX idx
+                GLOBAL USING vector_kmeans_tree
                 ON (col)
-                WITH (distance=cosine, vector_type=float) 
+                WITH (distance=cosine, vector_type=float)
                 )",
             "<main>:5:52: Error: vector_dimension should be set\n");
     }
@@ -2790,7 +2790,7 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
             auto req = Sprintf(reqTpl, key.c_str(), value.c_str());
             auto res = SqlToYql(req);
             UNIT_ASSERT(res.Root);
-            
+
             TVerifyLineFunc verifyLine = [&key, &value](const TString& word, const TString& line) {
                 if (word == "Write") {
                     UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("MyReplication"));
@@ -6835,7 +6835,7 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
     }
-    
+
     Y_UNIT_TEST(YtAlternativeSchemaSyntax) {
         NYql::TAstParseResult res = SqlToYql(R"(
             SELECT * FROM plato.Input WITH schema(y Int32, x String not null);
@@ -6904,7 +6904,7 @@ Y_UNIT_TEST_SUITE(CompactNamedExprs) {
             pragma CompactNamedExprs;
             pragma ValidateUnusedExprs;
 
-            define subquery $x() as 
+            define subquery $x() as
                 select count(1, 2);
             end define;
             select 1;
@@ -6927,7 +6927,7 @@ Y_UNIT_TEST_SUITE(CompactNamedExprs) {
             pragma CompactNamedExprs;
             pragma DisableValidateUnusedExprs;
 
-            define subquery $x() as 
+            define subquery $x() as
                 select count(1, 2);
             end define;
             select 1;

--- a/ydb/library/yql/sql/v1/sql_ut_antlr4.cpp
+++ b/ydb/library/yql/sql/v1/sql_ut_antlr4.cpp
@@ -6713,6 +6713,15 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         UNIT_ASSERT_C(res.Root, res.Issues.ToString());
     }
 
+    Y_UNIT_TEST(CreateViewIfNotExistsGrammarSupport) {
+        NYql::TAstParseResult res = SqlToYql(R"(
+                USE plato;
+                CREATE VIEW IF NOT EXISTS TheView WITH (security_invoker = TRUE) AS SELECT 1;
+            )"
+        );
+        UNIT_ASSERT_C(res.Root, res.Issues.ToString());
+    }
+
     Y_UNIT_TEST(CreateViewFromTable) {
         constexpr const char* path = "/PathPrefix/TheView";
         constexpr const char* query = R"(
@@ -6790,6 +6799,15 @@ Y_UNIT_TEST_SUITE(TViewSyntaxTest) {
         VerifyProgram(res, elementStat, verifyLine);
 
         UNIT_ASSERT_VALUES_EQUAL(elementStat["Write!"], 1);
+    }
+
+    Y_UNIT_TEST(DropViewIfExistsGrammarSupport) {
+        NYql::TAstParseResult res = SqlToYql(R"(
+                USE plato;
+                DROP VIEW IF EXISTS TheView;
+            )"
+        );
+        UNIT_ASSERT_C(res.Root, res.Issues.ToString());
     }
 
     Y_UNIT_TEST(CreateViewWithTablePrefix) {


### PR DESCRIPTION
### Description

```sql
CREATE VIEW IF NOT EXISTS ...;
DROP VIEW IF EXISTS ...;
```

Introduce `IF ...` modifiers for the VIEW DDL to not produce errors if the object already exists / does not exist.

### Context

We would like VIEW users to be able to batch create views with scripts (which should not produce errors during the execution) like the following one:

```sql
CREATE OR REPLACE VIEW first_view ...;
CREATE OR REPLACE VIEW second_view ...;
CREATE OR REPLACE VIEW third_view ...;
...
```

However, CREATE OR REPLACE VIEW is a bit harder to implement (it needs to drop the view and recreate it in one transaction + update the server side query cache ☆) than the simple alternative:
```sql
DROP VIEW IF EXISTS first_view;
CREATE VIEW first_view ...;

DROP VIEW IF EXISTS second_view;
CREATE VIEW second_view ...;
...
```

<details>
<summary>☆</summary>

Ideally the server side query cache entry for the queries referencing the view-to-be-dropped should be deleted in the same transaction as the view. However, this feature is not easy to implement (see this [PR](https://github.com/ydb-platform/ydb/pull/1960) for more info). I suppose the query cache update lag would be less of an issue for the scripts using `DROP VIEW` + `CREATE VIEW` rather than a single `CREATE OR REPLACE VIEW`, because the later is expected to be atomic.
</details>