### PR TITLE
Add volatile transactions to datashard internal ui

### DIFF
--- a/ydb/core/cms/ui/datashard_info.js
+++ b/ydb/core/cms/ui/datashard_info.js
@@ -105,6 +105,7 @@ function onDataShardInfoLoaded(data) {
     $('#tablet-info-state').text(info.State + (info.IsActive ? ' (active)' : ' (inactive)'));
     $('#tablet-info-shared-blobs').text(info.HasSharedBlobs);
     $('#tablet-info-change-sender').html('<a href="app?TabletID=' + TabletId + '&page=change-sender">Viewer</a>');
+    $('#tablet-info-volatile-txs').html(`<a href="app?TabletID=${TabletId}&page=volatile-txs">Viewer</a>`);
 
     var activities = data.Activities;
     if (activities) {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1205,10 +1205,24 @@ message TEvGetRSInfoResponse {
         optional uint64 SeqNo = 6;
     }
 
+    message TExpectation {
+        optional uint64 Source = 1;
+        optional uint64 TxId = 2;
+        optional uint64 Step = 3;
+    }
+
+    message TPipe {
+        optional uint64 Destination = 1;
+        optional uint64 OutReadSets = 2;
+        optional bool Subscribed = 3;
+    }
+
     optional TStatus Status = 1;
     repeated TOutRSInfo OutReadSets = 2;
     repeated TRSAckInfo OutRSAcks = 3;
     repeated TRSAckInfo DelayedRSAcks = 4;
+    repeated TExpectation Expectations = 5;
+    repeated TPipe Pipes = 6;
 }
 
 message TEvGetDataHistogramRequest {

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -2223,12 +2223,12 @@ bool TDataShard::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TAc
 
     if (const auto& action = cgi.Get("action")) {
         if (action == "cleanup-borrowed-parts") {
-            Execute(CreateTxMonitoringCleanupBorrowedParts(this, ev), ctx);
+            HandleMonCleanupBorrowedParts(ev);
             return true;
         }
 
         if (action == "reset-schema-version") {
-            Execute(CreateTxMonitoringResetSchemaVersion(this, ev), ctx);
+            HandleMonResetSchemaVersion(ev);
             return true;
         }
 
@@ -2254,13 +2254,16 @@ bool TDataShard::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TAc
                 ctx.Send(ev->Sender, new NMon::TEvRemoteHttpInfoRes("Change sender is not running"));
                 return true;
             }
+        } else if (page == "volatile-txs") {
+            HandleMonVolatileTxs(ev);
+            return true;
         } else {
             ctx.Send(ev->Sender, new NMon::TEvRemoteBinaryInfoRes(NMonitoring::HTTPNOTFOUND));
             return true;
         }
     }
 
-    Execute(CreateTxMonitoring(this, ev), ctx);
+    HandleMonIndexPage(ev);
     return true;
 }
 
@@ -4181,60 +4184,6 @@ void TDataShard::Handle(TEvSchemeShard::TEvDescribeSchemeResult::TPtr ev, const 
     Execute(new TTxStoreTablePath(this, pathId, rec.GetPath()), ctx);
 }
 
-void TDataShard::Handle(TEvDataShard::TEvGetInfoRequest::TPtr &ev,
-                               const TActorContext &ctx)
-{
-    Execute(CreateTxGetInfo(this, ev), ctx);
-}
-
-void TDataShard::Handle(TEvDataShard::TEvListOperationsRequest::TPtr &ev,
-                               const TActorContext &ctx)
-{
-    Execute(CreateTxListOperations(this, ev), ctx);
-}
-
-void TDataShard::Handle(TEvDataShard::TEvGetOperationRequest::TPtr &ev,
-                               const TActorContext &ctx)
-{
-    Execute(CreateTxGetOperation(this, ev), ctx);
-}
-
-void TDataShard::Handle(TEvDataShard::TEvGetDataHistogramRequest::TPtr &ev,
-                               const TActorContext &ctx)
-{
-    auto *response = new TEvDataShard::TEvGetDataHistogramResponse;
-    response->Record.MutableStatus()->SetCode(Ydb::StatusIds::SUCCESS);
-    const auto& rec = ev->Get()->Record;
-
-    if (rec.GetCollectKeySampleMs() > 0) {
-        EnableKeyAccessSampling(ctx,
-            AppData(ctx)->TimeProvider->Now() + TDuration::MilliSeconds(rec.GetCollectKeySampleMs()));
-    }
-
-    if (rec.GetActualData()) {
-        if (CurrentKeySampler == DisabledKeySampler) {
-            // datashard stores expired stats
-            ctx.Send(ev->Sender, response);
-            return;
-        }
-    }
-
-    for (const auto &pr : TableInfos) {
-        const auto &tinfo = *pr.second;
-        const NTable::TStats &stats = tinfo.Stats.DataStats;
-
-        auto &hist = *response->Record.AddTableHistograms();
-        hist.SetTableName(pr.second->Name);
-        for (ui32 ki : tinfo.KeyColumnIds)
-            hist.AddKeyNames(tinfo.Columns.FindPtr(ki)->Name);
-        SerializeHistogram(tinfo, stats.DataSizeHistogram, *hist.MutableSizeHistogram());
-        SerializeHistogram(tinfo, stats.RowCountHistogram, *hist.MutableCountHistogram());
-        SerializeKeySample(tinfo, tinfo.Stats.AccessStats, *hist.MutableKeyAccessSample());
-    }
-
-    ctx.Send(ev->Sender, response);
-}
-
 void TDataShard::Handle(TEvDataShard::TEvGetReadTableSinkStateRequest::TPtr &ev,
                                const TActorContext &ctx)
 {
@@ -4327,60 +4276,6 @@ void TDataShard::Handle(TEvDataShard::TEvGetReadTableStreamStateRequest::TPtr &e
     TActiveTransaction *tx = dynamic_cast<TActiveTransaction*>(op.Get());
     Y_VERIFY_S(tx, "cannot cast operation of kind " << op->GetKind());
     ctx.Send(ev->Forward(tx->GetStreamSink()));
-}
-
-void TDataShard::Handle(TEvDataShard::TEvGetRSInfoRequest::TPtr &ev,
-                               const TActorContext &ctx)
-{
-    auto *response = new TEvDataShard::TEvGetRSInfoResponse;
-    response->Record.MutableStatus()->SetCode(Ydb::StatusIds::SUCCESS);
-
-    for (auto &pr : OutReadSets.CurrentReadSets) {
-        auto &rs = *response->Record.AddOutReadSets();
-        rs.SetTxId(pr.second.TxId);
-        rs.SetOrigin(pr.second.Origin);
-        rs.SetSource(pr.second.From);
-        rs.SetDestination(pr.second.To);
-        rs.SetSeqNo(pr.first);
-    }
-
-    for (auto &p : OutReadSets.ReadSetAcks) {
-        auto &rec = p->Record;
-        auto &ack = *response->Record.AddOutRSAcks();
-        ack.SetTxId(rec.GetTxId());
-        ack.SetStep(rec.GetStep());
-        ack.SetOrigin(rec.GetTabletConsumer());
-        ack.SetSource(rec.GetTabletSource());
-        ack.SetDestination(rec.GetTabletDest());
-        ack.SetSeqNo(rec.GetSeqno());
-    }
-
-    for (auto &pr : Pipeline.GetDelayedAcks()) {
-        for (auto &ack : pr.second) {
-            auto *ev = ack->CastAsLocal<TEvTxProcessing::TEvReadSetAck>();
-            if (ev) {
-                auto &rec = ev->Record;
-                auto &ack = *response->Record.AddDelayedRSAcks();
-                ack.SetTxId(rec.GetTxId());
-                ack.SetStep(rec.GetStep());
-                ack.SetOrigin(rec.GetTabletConsumer());
-                ack.SetSource(rec.GetTabletSource());
-                ack.SetDestination(rec.GetTabletDest());
-                ack.SetSeqNo(rec.GetSeqno());
-            }
-        }
-    }
-
-    ctx.Send(ev->Sender, response);
-}
-
-void TDataShard::Handle(TEvDataShard::TEvGetSlowOpProfilesRequest::TPtr &ev,
-                               const TActorContext &ctx)
-{
-    auto *response = new TEvDataShard::TEvGetSlowOpProfilesResponse;
-    response->Record.MutableStatus()->SetCode(Ydb::StatusIds::SUCCESS);
-    Pipeline.FillStoredExecutionProfiles(response->Record);
-    ctx.Send(ev->Sender, response);
 }
 
 void TDataShard::Handle(TEvDataShard::TEvRefreshVolatileSnapshotRequest::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/tx/datashard/datashard__cleanup_borrowed.cpp
+++ b/ydb/core/tx/datashard/datashard__cleanup_borrowed.cpp
@@ -255,11 +255,8 @@ private:
     bool DryRun = true;
 };
 
-ITransaction* TDataShard::CreateTxMonitoringCleanupBorrowedParts(
-        TDataShard* self,
-        NMon::TEvRemoteHttpInfo::TPtr ev)
-{
-    return new TTxMonitoringCleanupBorrowedParts(self, ev);
+void TDataShard::HandleMonCleanupBorrowedParts(NMon::TEvRemoteHttpInfo::TPtr& ev) {
+    Execute(new TTxMonitoringCleanupBorrowedParts(this, ev));
 }
 
 }

--- a/ydb/core/tx/datashard/datashard__mon_reset_schema_version.cpp
+++ b/ydb/core/tx/datashard/datashard__mon_reset_schema_version.cpp
@@ -54,11 +54,8 @@ private:
     size_t Updates = 0;
 };
 
-ITransaction* TDataShard::CreateTxMonitoringResetSchemaVersion(
-        TDataShard* self,
-        NMon::TEvRemoteHttpInfo::TPtr ev)
-{
-    return new TTxMonitoringResetSchemaVersion(self, ev);
+void TDataShard::HandleMonResetSchemaVersion(NMon::TEvRemoteHttpInfo::TPtr& ev) {
+    Execute(new TTxMonitoringResetSchemaVersion(this, ev));
 }
 
 }

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -193,7 +193,6 @@ class TDataShard
     class TTxStoreTablePath;
     class TTxGoOffline;
     class TTxGetTableStats;
-    class TTxMonitoring;
     class TTxMonitoringCleanupBorrowedParts;
     class TTxMonitoringCleanupBorrowedPartsActor;
     class TTxMonitoringResetSchemaVersion;
@@ -204,9 +203,6 @@ class TDataShard
     class TTxRemoveOldInReadSets;
     class TTxReadContinue;
     class TTxReadColumns;
-    class TTxGetInfo;
-    class TTxListOperations;
-    class TTxGetOperation;
     class TTxStoreScanState;
     class TTxRefreshVolatileSnapshot;
     class TTxDiscardVolatileSnapshot;
@@ -250,22 +246,11 @@ class TDataShard
 
     class TTxMediatorStateRestored;
 
-    ITransaction *CreateTxMonitoring(TDataShard *self,
-                                     NMon::TEvRemoteHttpInfo::TPtr ev);
-    ITransaction *CreateTxGetInfo(TDataShard *self,
-                                  TEvDataShard::TEvGetInfoRequest::TPtr ev);
-    ITransaction *CreateTxListOperations(TDataShard *self,
-                                         TEvDataShard::TEvListOperationsRequest::TPtr ev);
-    ITransaction *CreateTxGetOperation(TDataShard *self,
-                                       TEvDataShard::TEvGetOperationRequest::TPtr ev);
-
-    ITransaction *CreateTxMonitoringCleanupBorrowedParts(
-            TDataShard *self,
-            NMon::TEvRemoteHttpInfo::TPtr ev);
-
-    ITransaction *CreateTxMonitoringResetSchemaVersion(
-            TDataShard *self,
-            NMon::TEvRemoteHttpInfo::TPtr ev);
+    void HandleMonIndexPage(NMon::TEvRemoteHttpInfo::TPtr& ev);
+    void HandleMonVolatileTxs(NMon::TEvRemoteHttpInfo::TPtr& ev);
+    void HandleMonVolatileTxs(NMon::TEvRemoteHttpInfo::TPtr& ev, ui64 txId);
+    void HandleMonCleanupBorrowedParts(NMon::TEvRemoteHttpInfo::TPtr& ev);
+    void HandleMonResetSchemaVersion(NMon::TEvRemoteHttpInfo::TPtr& ev);
 
     friend class TDataShardMiniKQLFactory;
     friend class TDataTransactionProcessor;
@@ -1292,15 +1277,15 @@ class TDataShard
     void Handle(TEvDataShard::TEvReadAck::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvReadCancel::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvReadColumnsRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvGetInfoRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvListOperationsRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvGetDataHistogramRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvGetOperationRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvGetInfoRequest::TPtr& ev);
+    void Handle(TEvDataShard::TEvListOperationsRequest::TPtr& ev);
+    void Handle(TEvDataShard::TEvGetDataHistogramRequest::TPtr& ev);
+    void Handle(TEvDataShard::TEvGetOperationRequest::TPtr& ev);
     void Handle(TEvDataShard::TEvGetReadTableSinkStateRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvGetReadTableScanStateRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvGetReadTableStreamStateRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvGetRSInfoRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvGetSlowOpProfilesRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvGetRSInfoRequest::TPtr& ev);
+    void Handle(TEvDataShard::TEvGetSlowOpProfilesRequest::TPtr& ev);
     void Handle(TEvDataShard::TEvRefreshVolatileSnapshotRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvDiscardVolatileSnapshotRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvMigrateSchemeShardRequest::TPtr& ev, const TActorContext& ctx);
@@ -3117,15 +3102,15 @@ protected:
             HFunc(TEvDataShard::TEvReadCancel, Handle);
             HFunc(TEvDataShard::TEvReadColumnsRequest, Handle);
             HFunc(NEvents::TDataEvents::TEvWrite, Handle);
-            HFunc(TEvDataShard::TEvGetInfoRequest, Handle);
-            HFunc(TEvDataShard::TEvListOperationsRequest, Handle);
-            HFunc(TEvDataShard::TEvGetDataHistogramRequest, Handle);
-            HFunc(TEvDataShard::TEvGetOperationRequest, Handle);
+            hFunc(TEvDataShard::TEvGetInfoRequest, Handle);
+            hFunc(TEvDataShard::TEvListOperationsRequest, Handle);
+            hFunc(TEvDataShard::TEvGetDataHistogramRequest, Handle);
+            hFunc(TEvDataShard::TEvGetOperationRequest, Handle);
             HFunc(TEvDataShard::TEvGetReadTableSinkStateRequest, Handle);
             HFunc(TEvDataShard::TEvGetReadTableScanStateRequest, Handle);
             HFunc(TEvDataShard::TEvGetReadTableStreamStateRequest, Handle);
-            HFunc(TEvDataShard::TEvGetRSInfoRequest, Handle);
-            HFunc(TEvDataShard::TEvGetSlowOpProfilesRequest, Handle);
+            hFunc(TEvDataShard::TEvGetRSInfoRequest, Handle);
+            hFunc(TEvDataShard::TEvGetSlowOpProfilesRequest, Handle);
             HFunc(TEvDataShard::TEvRefreshVolatileSnapshotRequest, Handle);
             HFunc(TEvDataShard::TEvDiscardVolatileSnapshotRequest, Handle);
             HFuncTraced(TEvDataShard::TEvBuildIndexCreateRequest, Handle);

--- a/ydb/core/tx/datashard/ui/index.html
+++ b/ydb/core/tx/datashard/ui/index.html
@@ -93,6 +93,10 @@
                     <td class="ds-info">Change sender</td>
                     <td class="ds-info" id="tablet-info-change-sender">Loading...</td>
                   </tr>
+                  <tr class="ds-info">
+                    <td class="ds-info">Volatile txs</td>
+                    <td class="ds-info" id="tablet-info-volatile-txs">Loading...</td>
+                  </tr>
                 </tbody>
               </table>
               <table class="ds-info">
@@ -300,6 +304,30 @@
               </tr>
             </thead>
             <tbody id="ds-delayed-ack-body">
+            </tbody>
+          </table>
+          <table id="ds-rs-expectations-table" class="tablesorter">
+            <caption class="ds-info">Expectations</caption>
+            <thead>
+              <tr>
+                <th>TxId</th>
+                <th>Step</th>
+                <th>Source</th>
+              </tr>
+            </thead>
+            <tbody id="ds-rs-expectations-body">
+            </tbody>
+          </table>
+          <table id="ds-rs-pipes-table" class="tablesorter">
+            <caption class="ds-info">Pipes</caption>
+            <thead>
+              <tr>
+                <th>Destination</th>
+                <th>OutReadSets</th>
+                <th>Subscribed</th>
+              </tr>
+            </thead>
+            <tbody id="ds-rs-pipes-body">
             </tbody>
           </table>
         </div>

--- a/ydb/core/tx/datashard/volatile_tx.cpp
+++ b/ydb/core/tx/datashard/volatile_tx.cpp
@@ -1,5 +1,6 @@
 #include "volatile_tx.h"
 #include "datashard_impl.h"
+#include <library/cpp/resource/resource.h>
 
 namespace NKikimr::NDataShard {
 

--- a/ydb/core/tx/datashard/volatile_tx_mon.cpp
+++ b/ydb/core/tx/datashard/volatile_tx_mon.cpp
@@ -1,0 +1,185 @@
+#include "volatile_tx.h"
+#include "datashard_impl.h"
+#include <ydb/core/change_exchange/change_sender_monitoring.h>
+#include <library/cpp/resource/resource.h>
+#include <util/string/cast.h>
+
+namespace NKikimr::NDataShard {
+
+    void TDataShard::HandleMonVolatileTxs(NMon::TEvRemoteHttpInfo::TPtr& ev) {
+        using namespace NChangeExchange;
+
+        const auto& cgi = ev->Get()->Cgi();
+        if (const auto& str = cgi.Get("TxId")) {
+            ui64 txId;
+            if (!TryFromString(str, txId)) {
+                Send(ev->Sender, new NMon::TEvRemoteBinaryInfoRes(NMonitoring::HTTPNOTFOUND));
+                return;
+            }
+            HandleMonVolatileTxs(ev, txId);
+            return;
+        }
+
+        size_t limit = 1000;
+        if (const auto& str = cgi.Get("limit")) {
+            TryFromString(str, limit);
+        }
+
+        TStringStream html;
+
+        HTML(html) {
+            DIV_CLASS("page-header") {
+                TAG(TH3) {
+                    html << "Volatile Transactions";
+                    SMALL() {
+                        html << "&nbsp;";
+                        html << "<a href=\"app?TabletID=" << TabletID() << "\">";
+                        html << "Back to tablet " << TabletID();
+                        html << "</a>";
+                    }
+                }
+            }
+
+            TABLE_CLASS("table table-sortable") {
+                TABLEHEAD() {
+                    TABLER() {
+                        TABLEH() { html << "TxId"; }
+                        TABLEH() { html << "State"; }
+                        TABLEH() { html << "Version"; }
+                        TABLEH() { html << "CommitOrder"; }
+                        TABLEH() { html << "Participants"; }
+                        TABLEH() { html << "Dependencies"; }
+                        TABLEH() { html << "Flags"; }
+                    }
+                }
+                TABLEBODY() {
+                    std::vector<ui64> txIds;
+                    for (const auto& pr : VolatileTxManager.VolatileTxs) {
+                        txIds.push_back(pr.first);
+                    }
+                    std::sort(txIds.begin(), txIds.end());
+                    if (txIds.size() > limit) {
+                        txIds.resize(limit);
+                    }
+                    for (ui64 txId : txIds) {
+                        const auto& info = VolatileTxManager.VolatileTxs.at(txId);
+                        TABLER() {
+                            TABLED() {
+                                html << "<a href=\"app?TabletID=" << TabletID()
+                                    << "&page=volatile-txs&TxId=" << txId << "\">"
+                                    << txId << "</a>";
+                            }
+                            TABLED() { html << info->State; }
+                            TABLED() { html << info->Version; }
+                            TABLED() { html << info->CommitOrder; }
+                            TABLED() { html << info->Participants.size(); }
+                            TABLED() { html << info->Dependencies.size(); }
+                            TABLED() {
+                                bool empty = true;
+                                if (info->CommitOrdered) {
+                                    html << "O";
+                                    empty = false;
+                                }
+                                if (info->IsArbiter) {
+                                    html << "A";
+                                    empty = false;
+                                }
+                                if (empty) {
+                                    html << "&nbsp;";
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Send(ev->Sender, new NMon::TEvRemoteHttpInfoRes(html.Str()));
+    }
+
+    void TDataShard::HandleMonVolatileTxs(NMon::TEvRemoteHttpInfo::TPtr& ev, ui64 txId) {
+        auto it = VolatileTxManager.VolatileTxs.find(txId);
+        if (it == VolatileTxManager.VolatileTxs.end()) {
+            Send(ev->Sender, new NMon::TEvRemoteBinaryInfoRes(NMonitoring::HTTPNOTFOUND));
+            return;
+        }
+
+        const auto& info = it->second;
+
+        TStringStream html;
+
+        auto containerString = [](const auto& v, const auto& elemConv) -> TString {
+            TStringBuilder b;
+            b << "[";
+            size_t i = 0;
+            for (const auto& e : v) {
+                if (i != 0) {
+                    b << ", ";
+                }
+                b << elemConv(e);
+                ++i;
+            }
+            b << "]";
+            return std::move(b);
+        };
+
+        auto linkToTxId = [&](ui64 txId) -> TString {
+            return TStringBuilder() << "<a href=\"app?TabletID=" << TabletID()
+                << "&page=volatile-txs&TxId=" << txId << "\">" << txId << "</a>";
+        };
+
+        auto linkToTabletId = [&](ui64 tabletId) -> TString {
+            return TStringBuilder() << "<a href=\"../tablets?TabletID=" << tabletId << "\">" << tabletId << "</a>";
+        };
+
+        HTML(html) {
+            DIV_CLASS("page-header") {
+                TAG(TH3) {
+                    html << "Volatile Transaction " << txId;
+                    SMALL() {
+                        html << "&nbsp;";
+                        html << "<a href=\"app?TabletID=" << TabletID() << "&page=volatile-txs\">";
+                        html << "Back to volatile transactions";
+                        html << "</a>";
+                        html << "&nbsp;";
+                        html << "<a href=\"app?TabletID=" << TabletID() << "\">";
+                        html << "Back to tablet " << TabletID();
+                        html << "</a>";
+                    }
+                }
+            }
+
+            PRE() {
+                html << "TxId:                     " << info->TxId
+                    << (info->AddCommitted ? "" : " (not persisted yet)") << "\n";
+                html << "State:                    " << info->State << "\n";
+                html << "Version:                  " << info->Version << "\n";
+                html << "CommitOrder:              " << info->CommitOrder
+                    << (info->CommitOrdered ? " (ordered)" : "") << "\n";
+                html << "CommitTxIds:              " << containerString(info->CommitTxIds, std::identity{}) << "\n";
+                html << "Dependencies:             " << containerString(info->Dependencies, linkToTxId) << "\n";
+                html << "Dependents:               " << containerString(info->Dependents, linkToTxId) << "\n";
+                html << "Participants:             " << containerString(info->Participants, linkToTabletId) << "\n";
+                if (info->ChangeGroup) {
+                    html << "ChangeGroup:              " << *info->ChangeGroup << "\n";
+                }
+                html << "BlockedOperations:        " << containerString(info->BlockedOperations, std::identity{}) << "\n";
+                html << "WaitingRemovalOperations: " << containerString(info->WaitingRemovalOperations, std::identity{}) << "\n";
+                html << "Callbacks:                " << info->Callbacks.size() << "\n";
+                html << "\n";
+                html << "DelayedAcks:              " << info->DelayedAcks.size() << "\n";
+                html << "DelayedConfirmations:     " << containerString(info->DelayedConfirmations, linkToTabletId) << "\n";
+                html << "\n";
+                html << "IsArbiter:                " << (info->IsArbiter ? "true" : "false") << "\n";
+                html << "IsArbiterOnHold:          " << (info->IsArbiterOnHold ? "true" : "false") << "\n";
+                if (info->IsArbiterOnHold) {
+                    html << "ArbiterReadSets:          " << containerString(info->ArbiterReadSets, std::identity{}) << "\n";
+                }
+                html << "Latency:                  " << TDuration::Seconds(1) * info->LatencyTimer.Passed() << "\n";
+            }
+        }
+
+        Send(ev->Sender, new NMon::TEvRemoteHttpInfoRes(html.Str()));
+    }
+
+} // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -215,6 +215,7 @@ SRCS(
     type_serialization.cpp
     upload_stats.cpp
     volatile_tx.cpp
+    volatile_tx_mon.cpp
     wait_for_plan_unit.cpp
     wait_for_stream_clearance_unit.cpp
 )
@@ -227,9 +228,10 @@ GENERATE_ENUM_SERIALIZATION(datashard_s3_upload.h)
 GENERATE_ENUM_SERIALIZATION(execution_unit.h)
 GENERATE_ENUM_SERIALIZATION(execution_unit_kind.h)
 GENERATE_ENUM_SERIALIZATION(operation.h)
+GENERATE_ENUM_SERIALIZATION(volatile_tx.h)
 
 RESOURCE(
-    index.html datashard/index.html
+    ui/index.html datashard/index.html
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Added info on volatile transactions to datashard internal ui.

See #10714.