### PR TITLE
24-3-11: Revert "Stop writing indexImplTables' split boundaries to backups" + a test

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.cpp
@@ -76,6 +76,7 @@ static NKikimrSchemeOp::TPathDescription GetTableDescription(TSchemeShard* ss, c
     opts.SetReturnPartitioningInfo(false);
     opts.SetReturnPartitionConfig(true);
     opts.SetReturnBoundaries(true);
+    opts.SetReturnIndexTableBoundaries(true);
 
     auto desc = DescribePath(ss, TlsActivationContext->AsActorContext(), pathId, opts);
     auto record = desc->GetRecord();


### PR DESCRIPTION
Tickets:
- CLOUDINC-4212
- https://github.com/ydb-platform/ydb/issues/10663

Backport from stable-24-3:
- https://github.com/ydb-platform/ydb/pull/10791