### PR TITLE
Cache small readsets in memory and improve resending

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -3582,7 +3582,10 @@ void TDataShard::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev, const TActor
 }
 
 void TDataShard::AckRSToDeletedTablet(ui64 tabletId, TPersistentTablet& state, const TActorContext& ctx) {
-    for (ui64 seqno : state.OutReadSets) {
+    auto seqnos = std::move(state.OutReadSets);
+    state.OutReadSets.clear();
+
+    for (ui64 seqno : seqnos) {
         LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "Pipe reset to dead tablet %" PRIu64 " caused ack of readset %" PRIu64
             " at tablet %" PRIu64, tabletId, seqno, TabletID());
 
@@ -3595,7 +3598,6 @@ void TDataShard::AckRSToDeletedTablet(ui64 tabletId, TPersistentTablet& state, c
             PlanQueue.Progress(ctx);
         }
     }
-    state.OutReadSets.clear();
 
     if (OutReadSets.HasExpectations(tabletId)) {
         AbortExpectationsFromDeletedTablet(tabletId, OutReadSets.RemoveExpectations(tabletId));
@@ -3612,12 +3614,10 @@ void TDataShard::AbortExpectationsFromDeletedTablet(ui64 tabletId, THashMap<ui64
 }
 
 void TDataShard::RestartPipeRS(ui64 tabletId, TPersistentTablet& state, const TActorContext& ctx) {
-    for (auto seqno : state.OutReadSets) {
-        if (seqno == Max<ui64>()) {
-            OutReadSets.ResendExpectations(tabletId, ctx);
-            continue;
-        }
+    auto seqnos = std::move(state.OutReadSets);
+    state.OutReadSets.clear();
 
+    for (auto seqno : seqnos) {
         LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "Pipe reset to tablet %" PRIu64 " caused resend of readset %" PRIu64
             " at tablet %" PRIu64, tabletId, seqno, TabletID());
 

--- a/ydb/core/tx/datashard/datashard_outreadset.h
+++ b/ydb/core/tx/datashard/datashard_outreadset.h
@@ -45,6 +45,7 @@ struct TReadSetKey {
 struct TReadSetInfo : TReadSetKey {
     ui64 Step = 0;
     bool OnHold = false;
+    std::optional<TString> Body;
 
     TReadSetInfo() = default;
 
@@ -74,7 +75,7 @@ public:
 
     bool Empty() const { return CurrentReadSets.empty() && Expectations.empty(); }
     bool HasAcks() const { return ! ReadSetAcks.empty(); }
-    bool Has(const TReadSetKey& rsKey) const { return CurrentReadSetInfos.contains(rsKey); }
+    bool Has(const TReadSetKey& rsKey) const { return CurrentReadSetKeys.contains(rsKey); }
 
     ui64 CountReadSets() const { return CurrentReadSets.size(); }
     ui64 CountAcks() const { return ReadSetAcks.size(); }
@@ -109,8 +110,7 @@ private:
 private:
     TDataShard * Self;
     THashMap<ui64, TReadSetInfo> CurrentReadSets;     // SeqNo -> Info
-    THashMap<TReadSetKey, ui64> CurrentReadSetInfos;  // Info -> SeqNo
-    THashSet<ui64> AckedSeqno;
+    THashMap<TReadSetKey, ui64> CurrentReadSetKeys;   // Key -> SeqNo
     TVector<TIntrusivePtr<TEvTxProcessing::TEvReadSetAck>> ReadSetAcks;
     // Target -> TxId -> Step
     THashMap<ui64, THashMap<ui64, ui64>> Expectations;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Various improvements around outgoing readsets:

* Avoid re-reading very small readsets from disk by keeping them in-memory
* Don't re-read large readsets from disk twice after a restart
* Remove readsets from resend sets as soon as acks are received
* Avoid potential quadratic complexity when resending readsets to rapidly restarting tablets

Fixes #10772.