### PR TITLE
mute unstable tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -24,6 +24,35 @@ ydb/core/kqp/ut/olap KqpOlapBlobsSharing.TableReshardingConsistency64
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.TableReshardingModuloN
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.UpsertWhileSplitTest
 ydb/core/kqp/ut/olap KqpOlapStatistics.StatsUsageWithTTL
+ydb/core/kqp/ut/olap KqpOlapWrite.TierDraftsGCWithRestart
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap [*/*] chunk chunk
 ydb/core/kqp/ut/query KqpLimits.ComputeActorMemoryAllocationFailureQueryService
 ydb/core/kqp/ut/query KqpLimits.QueryExecTimeoutCancel
 ydb/core/kqp/ut/query KqpStats.SysViewClientLost
@@ -52,6 +81,20 @@ ydb/library/actors/http/ut HttpProxy.TooLongHeader
 ydb/library/actors/http/ut sole chunk chunk
 ydb/library/actors/http/ut sole+chunk+chunk
 ydb/library/actors/interconnect/ut_huge_cluster HugeCluster.AllToAll
+ydb/library/actors/interconnect/ut_huge_cluster sole chunk chunk
+ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server test.py.test_select_positive[constant-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server test.py.test_select_positive[primitives-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server test.py.test_select_positive[primitives-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[constant-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[constant-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[count_rows-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[count_rows-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[primitives-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[primitives-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[pushdown0-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[pushdown0-kqprun]
+ydb/library/yql/providers/generic/connector/tests/datasource/oracle test.py.test_select_positive[PRIMITIVES-dqrun]
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[pushdown-kqprun]
 ydb/library/yql/providers/generic/connector/tests/join test.py.test_join[join_ch_ch-dqrun]
 ydb/library/yql/tests/sql/hybrid_file/part1 test.py.test[in-in_noansi_join--Debug]
 ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/with_offset_ranges_mode_ut [*/*] chunk chunk
@@ -80,10 +123,15 @@ ydb/services/ydb/table_split_ut YdbTableSplit.SplitByLoadWithReadsMultipleSplits
 ydb/services/ydb/table_split_ut [*/*] chunk chunk
 ydb/tests/fq/control_plane_storage [*/*] chunk chunk
 ydb/tests/fq/control_plane_storage [*/*]+chunk+chunk
+ydb/tests/fq/generic/analytics test_join.py.TestJoinAnalytics.test_simple[v1-2-fq_client0-mvp_external_ydb_endpoint0]
+ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_simple[v1-fq_client0-mvp_external_ydb_endpoint0]
+ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-0-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-1-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-2-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-3-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-4-True-3-fq_client0-mvp_external_ydb_endpoint0]
+ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-5-True-3-fq_client0-mvp_external_ydb_endpoint0]
+ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-6-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/mem_alloc sole chunk chunk
 ydb/tests/fq/mem_alloc sole+chunk+chunk
 ydb/tests/fq/mem_alloc test_alloc_default.py.TestAlloc.test_hard_limit[kikimr0]

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -16,6 +16,8 @@ ydb/core/keyvalue/ut_trace TKeyValueTracingTest.ReadHuge
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.ReadSmall
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.WriteHuge
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.WriteSmall
+ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.Select
+ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.UpsertEvWrite
 ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestAggregation
 ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestFilterCompare
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.BlobsSharingSplit1_1_clean_with_restarts
@@ -25,33 +27,6 @@ ydb/core/kqp/ut/olap KqpOlapBlobsSharing.TableReshardingModuloN
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.UpsertWhileSplitTest
 ydb/core/kqp/ut/olap KqpOlapStatistics.StatsUsageWithTTL
 ydb/core/kqp/ut/olap KqpOlapWrite.TierDraftsGCWithRestart
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
-ydb/core/kqp/ut/olap [*/*] chunk chunk
 ydb/core/kqp/ut/olap [*/*] chunk chunk
 ydb/core/kqp/ut/query KqpLimits.ComputeActorMemoryAllocationFailureQueryService
 ydb/core/kqp/ut/query KqpLimits.QueryExecTimeoutCancel
@@ -124,6 +99,7 @@ ydb/services/ydb/table_split_ut [*/*] chunk chunk
 ydb/tests/fq/control_plane_storage [*/*] chunk chunk
 ydb/tests/fq/control_plane_storage [*/*]+chunk+chunk
 ydb/tests/fq/generic/analytics test_join.py.TestJoinAnalytics.test_simple[v1-2-fq_client0-mvp_external_ydb_endpoint0]
+ydb/tests/fq/generic/streaming sole chunk chunk
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_simple[v1-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-0-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-1-True-3-fq_client0-mvp_external_ydb_endpoint0]


### PR DESCRIPTION
Mute Flaky tests : 24

Created issue 'Mute ydb/core/kqp/ut/olap/KqpOlapWrite.TierDraftsGCWithRestart' for TEAM:@ydb-platform/qp, url https://github.com/ydb-platform/ydb/issues/10922 
Created issue 'Mute ydb/library/actors/interconnect/ut_huge_cluster/sole chunk chunk' for TEAM:@ydb-platform/storage, url https://github.com/ydb-platform/ydb/issues/10923 
Created issue 'Mute ydb/library/yql/providers/generic/connector/tests/datasource/oracle/test.py.test_select_positive[PRIMITIVES-dqrun]' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/10924 
Created issue 'Mute ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server 3 tests' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/10925 
Created issue 'Mute ydb/library/yql/providers/generic/connector/tests/datasource/mysql 8 tests' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/10926 
Created issue 'Mute ydb/library/yql/providers/generic/connector/tests/datasource/ydb/test.py.test_select_positive[pushdown-kqprun]' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/10927 
Created issue 'Mute ydb/tests/fq/generic/analytics/test_join.py.TestJoinAnalytics.test_simple[v1-2-fq_client0-mvp_external_ydb_endpoint0]' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/10928 
Created issue 'Mute ydb/tests/fq/generic/streaming 4 tests' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/10929
Created issue 'Mute ydb/core/kqp/ut/data_integrity 2 tests' for TEAM:@ydb-platform/qp, url https://github.com/ydb-platform/ydb/issues/10933
Created issue 'Mute ydb/tests/fq/generic/streaming/sole chunk chunk' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/10934


Reasons:
```
ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.Select # owner TEAM:@ydb-platform/qp success_rate 91%, state Flaky, days in state 5, pass_count 33, fail count 3
ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.UpsertEvWrite # owner TEAM:@ydb-platform/qp success_rate 91%, state Flaky, days in state 3, pass_count 33, fail count 3
ydb/core/kqp/ut/olap KqpOlapWrite.TierDraftsGCWithRestart # owner TEAM:@ydb-platform/qp success_rate 86%, state Flaky, days in state 4, pass_count 33, fail count 5
ydb/core/kqp/ut/olap [*/*] chunk chunk # owner TEAM:@ydb-platform/qp success_rate 0%, state Flaky, days in state 4, pass_count 0, fail count 4
ydb/library/actors/interconnect/ut_huge_cluster sole chunk chunk # owner TEAM:@ydb-platform/storage success_rate 40%, state Flaky, days in state 11, pass_count 2, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server test.py.test_select_positive[constant-dqrun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 5, pass_count 33, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server test.py.test_select_positive[primitives-dqrun] # owner TEAM:@ydb-platform/fq success_rate 80%, state Flaky, days in state 5, pass_count 32, fail count 8
ydb/library/yql/providers/generic/connector/tests/datasource/ms_sql_server test.py.test_select_positive[primitives-kqprun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 7, pass_count 33, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[constant-dqrun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[constant-kqprun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[count_rows-dqrun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[count_rows-kqprun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[primitives-dqrun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[primitives-kqprun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[pushdown0-dqrun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/mysql test.py.test_select_positive[pushdown0-kqprun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 34, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/oracle test.py.test_select_positive[PRIMITIVES-dqrun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 3, pass_count 33, fail count 3
ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[pushdown-kqprun] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 2, pass_count 33, fail count 3
ydb/tests/fq/generic/analytics test_join.py.TestJoinAnalytics.test_simple[v1-2-fq_client0-mvp_external_ydb_endpoint0] # owner TEAM:@ydb-platform/fq success_rate 91%, state Flaky, days in state 4, pass_count 34, fail count 3
ydb/tests/fq/generic/streaming sole chunk chunk # owner TEAM:@ydb-platform/fq success_rate 0%, state Flaky, days in state 3, pass_count 0, fail count 4
ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_simple[v1-fq_client0-mvp_external_ydb_endpoint0] # owner TEAM:@ydb-platform/fq success_rate 80%, state Flaky, days in state 4, pass_count 34, fail count 8
ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-0-True-3-fq_client0-mvp_external_ydb_endpoint0] # owner TEAM:@ydb-platform/fq success_rate 80%, state Flaky, days in state 4, pass_count 34, fail count 8
ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-5-True-3-fq_client0-mvp_external_ydb_endpoint0] # owner TEAM:@ydb-platform/fq success_rate 89%, state Flaky, days in state 3, pass_count 34, fail count 4
ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-6-True-3-fq_client0-mvp_external_ydb_endpoint0] # owner TEAM:@ydb-platform/fq success_rate 89%, state Flaky, days in state 3, pass_count 34, fail count 4
```


### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
