### PR TITLE
Add a feature flag controlling separate disk space quotas accounting

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -175,4 +175,5 @@ message TFeatureFlags {
     optional bool EnableFollowerStats = 150 [default = true];
     optional bool EnableTopicAutopartitioningForReplication = 151 [default = false];
     optional bool EnableDriveSerialsDiscovery = 152 [default = false];
+    optional bool EnableSeparateDiskSpaceQuotas = 153 [default = false];
 }

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -37,6 +37,7 @@ EDiskUsageStatus CheckStoragePoolsQuotas(const THashMap<TString, TStoragePoolUsa
     for (const auto& [poolKind, usage] : storagePoolsUsage) {
         if (const auto* quota = storagePoolsQuotas.FindPtr(poolKind)) {
             const auto totalSize = usage.DataSize + usage.IndexSize;
+            // If a quota is equal to zero, then it sets no limit on the disk space usage.
             if (quota->HardQuota && totalSize > quota->HardQuota) {
                 return EDiskUsageStatus::AboveHardQuota;
             }
@@ -152,24 +153,40 @@ bool TSubDomainInfo::CheckDiskSpaceQuotas(IQuotaCounters* counters) {
         return changeSubdomainState(EDiskUsageStatus::BelowSoftQuota);
     }
 
-    ui64 totalUsage = TotalDiskSpaceUsage();
-    const auto storagePoolsUsageStatus = CheckStoragePoolsQuotas(DiskSpaceUsage.StoragePoolsUsage, quotas.StoragePoolsQuotas);
+    if (!AppData()->FeatureFlags.GetEnableSeparateDiskSpaceQuotas()) {
+        // If the feature flag is turned off, then the storage pool quotas are ignored:
+        // they are not accounted for when we make a decision to change the state of the subdomain.
+        ui64 totalUsage = TotalDiskSpaceUsage();
 
-    // Quota being equal to zero is treated as if there is no limit set on disk space usage.
-    const bool overallHardQuotaIsExceeded = quotas.HardQuota && totalUsage > quotas.HardQuota;
-    const bool someStoragePoolHardQuotaIsExceeded = !quotas.StoragePoolsQuotas.empty()
-                                                        && storagePoolsUsageStatus == EDiskUsageStatus::AboveHardQuota;
-    if (overallHardQuotaIsExceeded || someStoragePoolHardQuotaIsExceeded) {
-        return changeSubdomainState(EDiskUsageStatus::AboveHardQuota);
+        // If a quota is equal to zero, then it sets no limit on the disk space usage.
+        const bool isHardQuotaExceeded = quotas.HardQuota && totalUsage > quotas.HardQuota;
+        const bool isTotalUsageBelowSoftQuota = !quotas.SoftQuota || totalUsage < quotas.SoftQuota;
+
+        if (isHardQuotaExceeded) {
+            return changeSubdomainState(EDiskUsageStatus::AboveHardQuota);
+        }
+        if (isTotalUsageBelowSoftQuota) {
+            return changeSubdomainState(EDiskUsageStatus::BelowSoftQuota);
+        }
+    } else {
+        // If the feature flag is turned on, then the overall quota is ignored:
+        // it is not accounted for when we make a decision to change the state of the subdomain.
+        const auto storagePoolsUsageStatus = CheckStoragePoolsQuotas(DiskSpaceUsage.StoragePoolsUsage, quotas.StoragePoolsQuotas);
+
+        const bool isSomeStoragePoolHardQuotaExceeded = !quotas.StoragePoolsQuotas.empty()
+                                                            && storagePoolsUsageStatus == EDiskUsageStatus::AboveHardQuota;
+        const bool isEachStoragePoolUsageBelowSoftQuota = quotas.StoragePoolsQuotas.empty()
+                                                            || storagePoolsUsageStatus == EDiskUsageStatus::BelowSoftQuota;
+
+        if (isSomeStoragePoolHardQuotaExceeded) {
+            return changeSubdomainState(EDiskUsageStatus::AboveHardQuota);
+        }
+        if (isEachStoragePoolUsageBelowSoftQuota) {
+            return changeSubdomainState(EDiskUsageStatus::BelowSoftQuota);
+        }
     }
 
-    const bool totalUsageIsBelowOverallSoftQuota = !quotas.SoftQuota || totalUsage < quotas.SoftQuota;
-    const bool allStoragePoolsUsageIsBelowSoftQuota = quotas.StoragePoolsQuotas.empty()
-                                                          || storagePoolsUsageStatus == EDiskUsageStatus::BelowSoftQuota;
-    if (totalUsageIsBelowOverallSoftQuota && allStoragePoolsUsageIsBelowSoftQuota) {
-        return changeSubdomainState(EDiskUsageStatus::BelowSoftQuota);
-    }
-
+    // made no changes to the state of the subdomain
     return false;
 }
 
@@ -471,7 +488,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
                 if (!featureFlags.EnableParameterizedDecimal && decimalType != NScheme::TDecimalType::Default()){
                     errStr = Sprintf("Type '%s' specified for column '%s', but support for parametrized decimal is disabled (EnableParameterizedDecimal feature flag is off)", col.GetType().data(), colName.data());
                     return nullptr;
-                }   
+                }
                 break;
             }
             case NScheme::NTypeIds::Pg:
@@ -479,7 +496,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
                     errStr = Sprintf("Type '%s' specified for column '%s', but support for pg types is disabled (EnableTablePgTypes feature flag is off)", col.GetType().data(), colName.data());
                     return nullptr;
                 }
-                break;                             
+                break;
             default:
                 break;
             }

--- a/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
@@ -130,6 +130,7 @@ constexpr const char* EntireDatabaseTag = "entire_database";
 
 NLs::TCheckFunc LsCheckDiskQuotaExceeded(
     const TMap<TString, EDiskUsageStatus>& expectedExceeders,
+    bool enableSeparateQuotasFeatureFlag,
     const TString& debugHint = ""
 ) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
@@ -166,8 +167,19 @@ NLs::TCheckFunc LsCheckDiskQuotaExceeded(
                                              receivedQuotas.data_size_soft_quota()
                                  }
             );
-            
+
             TMap<TString, EDiskUsageStatus> exceeders = CheckStoragePoolsQuotas(parsedUsage, parsedQuotas);
+            if (enableSeparateQuotasFeatureFlag) {
+                // ignore the status of the overall quota
+                exceeders.erase(EntireDatabaseTag);
+            } else {
+                // ignore the statuses of the separate storage pool quotas
+                TMap<TString, EDiskUsageStatus> onlyOverallStatus;
+                if (auto* overallStatus = exceeders.FindPtr(EntireDatabaseTag)) {
+                    onlyOverallStatus.emplace(EntireDatabaseTag, *overallStatus);
+                }
+                std::swap(exceeders, onlyOverallStatus);
+            }
             UNIT_ASSERT_VALUES_EQUAL_C(exceeders, expectedExceeders,
                 debugHint << ", subdomain's disk space usage:\n" << desc.GetDiskSpaceUsage().DebugString()
             );
@@ -181,9 +193,9 @@ void CheckQuotaExceedance(TTestActorRuntime& runtime,
                           bool expectExceeded,
                           const TString& debugHint = ""
 ) {
-    TestDescribeResult(DescribePath(runtime, schemeShard, pathToSubdomain),
-                       { LsCheckDiskQuotaExceeded(expectExceeded, debugHint) }
-    );
+    TestDescribeResult(DescribePath(runtime, schemeShard, pathToSubdomain), {
+        LsCheckDiskQuotaExceeded(expectExceeded, debugHint)
+    });
 }
 
 void CheckQuotaExceedance(TTestActorRuntime& runtime,
@@ -192,9 +204,13 @@ void CheckQuotaExceedance(TTestActorRuntime& runtime,
                           const TMap<TString, EDiskUsageStatus>& expectedExceeders,
                           const TString& debugHint = ""
 ) {
-    TestDescribeResult(DescribePath(runtime, schemeShard, pathToSubdomain),
-                       { LsCheckDiskQuotaExceeded(expectedExceeders, debugHint) }
-    );
+    TestDescribeResult(DescribePath(runtime, schemeShard, pathToSubdomain), {
+        LsCheckDiskQuotaExceeded(
+            expectedExceeders,
+            runtime.GetAppData().FeatureFlags.GetEnableSeparateDiskSpaceQuotas(),
+            debugHint
+        )
+    });
 }
 
 TVector<ui64> GetTableShards(TTestActorRuntime& runtime,
@@ -3207,6 +3223,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         opts.EnableTopicDiskSubDomainQuota(false);
 
         TTestEnv env(runtime, opts);
+        runtime.GetAppData().FeatureFlags.SetEnableSeparateDiskSpaceQuotas(false);
+
         ui64 txId = 100;
 
         auto waitForTableStats = [&](ui32 shards) {
@@ -3435,6 +3453,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         runtime.SetLogPriority(NKikimrServices::PERSQUEUE_READ_BALANCER, NLog::PRI_TRACE);
 
         runtime.GetAppData().PQConfig.SetBalancerWakeupIntervalSec(1);
+        runtime.GetAppData().FeatureFlags.SetEnableSeparateDiskSpaceQuotas(false);
 
         ui64 txId = 100;
 
@@ -3482,7 +3501,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
 
         auto stats = NPQ::GetReadBalancerPeriodicTopicStats(runtime, balancerId);
         UNIT_ASSERT_EQUAL_C(false, stats->Record.GetSubDomainOutOfSpace(), "SubDomainOutOfSpace from ReadBalancer");
-        
+
         auto msg = TString(24_MB, '_');
 
         ui32 seqNo = 100;
@@ -3517,7 +3536,9 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
         opts.EnablePersistentPartitionStats(true);
         opts.EnableBackgroundCompaction(false);
         TTestEnv env(runtime, opts);
-        
+
+        runtime.GetAppData().FeatureFlags.SetEnableSeparateDiskSpaceQuotas(true);
+
         NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
         NDataShard::gDbStatsDataSizeResolution = 1;
         NDataShard::gDbStatsRowCountResolution = 1;
@@ -3610,7 +3631,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
         UpdateRow(runtime, "SomeTable", 1, "some_value_for_the_key", shards[0]);
         {
             const auto tableStats = WaitTableStats(runtime, shards[0]).GetTableStats();
-            // channels' usage statistics appears only after a table compaction 
+            // channels' usage statistics appears only after a table compaction
             UNIT_ASSERT_VALUES_EQUAL_C(tableStats.ChannelsSize(), 0, tableStats.DebugString());
         }
         CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", false, DEBUG_HINT);
@@ -3636,7 +3657,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
 
         TTestEnvOptions opts;
         TTestEnv env(runtime, opts);
-        
+
         ui64 txId = 100;
 
         constexpr const char* databaseDescription = R"(
@@ -3688,8 +3709,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
         opts.EnablePersistentPartitionStats(true);
         opts.EnableBackgroundCompaction(false);
         TTestEnv env(runtime, opts);
-        bool bTreeIndex = runtime.GetAppData().FeatureFlags.GetEnableLocalDBBtreeIndex();
-        
+
         NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
         NDataShard::gDbStatsDataSizeResolution = 1;
         NDataShard::gDbStatsRowCountResolution = 1;
@@ -3798,43 +3818,47 @@ Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {
 
         const auto updateAndCheck = [&](ui32 rowsToUpdate,
                                         const TString& value,
-                                        bool compact,
                                         const TMap<TString, EDiskUsageStatus>& expectedExceeders,
                                         const TString& debugHint = ""
         ) {
             for (ui32 i = 0; i < rowsToUpdate; ++i) {
                 UpdateRow(runtime, "SomeTable", i, value, shards[0]);
             }
-            if (compact) {
-                CompactTableAndCheckResult(runtime, shards[0], tableId);
-            }
+            CompactTableAndCheckResult(runtime, shards[0], tableId);
             WaitTableStats(runtime, shards[0]);
             CheckQuotaExceedance(runtime, tenantSchemeShard, "/MyRoot/SomeDatabase", expectedExceeders, debugHint);
         };
 
-        // Warning: calculated empirically, might need an update if the test fails.
-        // The logic of the test expects:
-        // batchSizes[0] <= batchSizes[1] <= batchSizes[2],
-        // because rows are never deleted, only updated.
-        const std::array<ui32, 3> batchSizes = {25, 35, bTreeIndex ? 60u : 50u};
+        // Warning: calculated empirically, might need an update if the test fails!
+        constexpr ui32 lessRows = 37u;
+        const ui32 moreRows = runtime.GetAppData().FeatureFlags.GetEnableLocalDBBtreeIndex() ? 60u : 50u;
 
-        constexpr const char* longText = "this_text_is_very_long_and_takes_a_lot_of_disk_space";
-        constexpr const char* middleLengthText = "this_text_is_significantly_shorter";
+        const TString longText = TString(64, 'a');;
+        const TString mediumText = TString(32, 'a');
+        const TString shortText = TString(16, 'a');
+        const TString tinyText = TString(8, 'a');
 
+        // There are two columns in the table: key and value. Key is stored at the fast storage, value at the large storage.
+        // We can:
+        // - simultaneously increase the consumption of the both storage pools by increasing the number of rows in the table
+        // - increase or decrease the consumption of the large storage by making the value longer / shorter
         // Test scenario:
-        // 1) break only the entire database hard quota, don't break others,
-        updateAndCheck(batchSizes[0], longText, false, {{EntireDatabaseTag, EDiskUsageStatus::AboveHardQuota}}, DEBUG_HINT);
-        updateAndCheck(0, "", true, {}, DEBUG_HINT);
+        // 1) disable separate disk space quotas, write a lot of data to break the overall hard quota
+        // 2) enable separate quotas, a small number of rows (little fast storage consumption), but a long text that breaks the large_kind hard quota
+        // 3) the same small number of rows, but a medium text that gets the large_kind storage consumption in between the soft and the large quotas
+        // 4) the same small number of rows, but a short text that gets the large_kind storage consumption below the soft quota
+        // 5) a bigger number of rows, but a tiny text to break only the fast_kind hard quota
+        runtime.GetAppData().FeatureFlags.SetEnableSeparateDiskSpaceQuotas(false);
+        updateAndCheck(lessRows, longText, {{EntireDatabaseTag, EDiskUsageStatus::AboveHardQuota}}, DEBUG_HINT);
 
-        // 2) break only the large_kind hard quota, don't break other hard quotas,
-        updateAndCheck(batchSizes[1], longText, true,
-            {{"large_kind", EDiskUsageStatus::AboveHardQuota}, {EntireDatabaseTag, EDiskUsageStatus::InBetween}}, DEBUG_HINT
-        );
-        updateAndCheck(batchSizes[1], middleLengthText, true, {{"large_kind", EDiskUsageStatus::InBetween}}, DEBUG_HINT);
-        updateAndCheck(batchSizes[1], "extra_short_text", true, {}, DEBUG_HINT);
+        runtime.GetAppData().FeatureFlags.SetEnableSeparateDiskSpaceQuotas(true);
+        updateAndCheck(lessRows, longText, {{"large_kind", EDiskUsageStatus::AboveHardQuota}}, DEBUG_HINT);
 
-        // 3) break only the fast_kind hard quota, don't break others.
-        updateAndCheck(batchSizes[2], "shortest", true, {{"fast_kind", EDiskUsageStatus::AboveHardQuota}}, DEBUG_HINT);
+        updateAndCheck(lessRows, mediumText, {{"large_kind", EDiskUsageStatus::InBetween}}, DEBUG_HINT);
+
+        updateAndCheck(lessRows, shortText, {}, DEBUG_HINT);
+
+        updateAndCheck(moreRows, tinyText, {{"fast_kind", EDiskUsageStatus::AboveHardQuota}}, DEBUG_HINT);
 
         // step 4: drop the table
         TestDropTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/SomeDatabase", "SomeTable");


### PR DESCRIPTION
- #10839

### Description

We would like to provide an easy way to disable new quotas on databases, which is a feature flag that would:
- disable separate (HDD, SSD) disk usage quotas and enable the overall (legacy) quota accounting if the feature flag is turned off
- enable separate quotas and disable the overall (legacy) quota accounting if the feature flag is turned on

Previously, we have accounted for both: separate quotas and the legacy overall quota simultaneously. However, accounting for both of them seems to have no real use.