### PR TITLE
Fixed the test `WriteToTopic_Demo_42`

### DIFF
--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -2205,8 +2205,14 @@ Y_UNIT_TEST_F(WriteToTopic_Demo_42, TFixture)
 
     CommitTx(tx, EStatus::SUCCESS);
 
-    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
-    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 100);
+    size_t count = 0;
+
+    while (count < 100) {
+        auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2));
+        count += messages.size();
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(count, 100);
 }
 
 Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The test expects to read N messages from the topic. In the `asan` read configuration, the test cannot read N messages in one request. Added the `Read_Exactly_N_Messages_From_Topic` method.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
