### PR TITLE
Fix bugs in progress bar working with import benchmarks

### DIFF
--- a/ydb/library/workload/abstract/workload_query_generator.h
+++ b/ydb/library/workload/abstract/workload_query_generator.h
@@ -72,7 +72,10 @@ public:
             TString Schema;
         };
 
-        using TDataType = std::variant<NYdb::TValue, TCsv, TArrow>;
+        struct TSkip {
+        };
+
+        using TDataType = std::variant<NYdb::TValue, TCsv, TArrow, TSkip>;
 
         template<class T>
         TDataPortion(const TString& table, T&& data, ui64 size)

--- a/ydb/library/workload/clickbench/data_generator.cpp
+++ b/ydb/library/workload/clickbench/data_generator.cpp
@@ -30,7 +30,7 @@ TBulkDataGeneratorList TClickbenchWorkloadDataInitializerGenerator::DoGetBulkIni
 }
 
 TClickbenchWorkloadDataInitializerGenerator::TDataGenerartor::TDataGenerartor(const TClickbenchWorkloadDataInitializerGenerator& owner)
-    : IBulkDataGenerator("hits", 99997497)
+    : IBulkDataGenerator("hits", DataSetSize)
     , Owner(owner)
 {
     if (Owner.GetDataFiles().IsDirectory()) {

--- a/ydb/library/workload/clickbench/data_generator.h
+++ b/ydb/library/workload/clickbench/data_generator.h
@@ -36,12 +36,12 @@ private:
         class TTsvFile;
         class TCsvFile;
         void AddFile(const TFsPath& path);
-        static ui64 CalcSize(const TClickbenchWorkloadDataInitializerGenerator& owner);
 
     private:
         const TClickbenchWorkloadDataInitializerGenerator& Owner;
         TVector<TFile::TPtr> Files;
         TAdaptiveLock Lock;
+        bool FirstPortion = true;
     };
 };
 

--- a/ydb/library/workload/clickbench/data_generator.h
+++ b/ydb/library/workload/clickbench/data_generator.h
@@ -42,6 +42,7 @@ private:
         TVector<TFile::TPtr> Files;
         TAdaptiveLock Lock;
         bool FirstPortion = true;
+        static constexpr ui64 DataSetSize = 99997497;
     };
 };
 

--- a/ydb/library/workload/tpcds/data_generator.cpp
+++ b/ydb/library/workload/tpcds/data_generator.cpp
@@ -63,12 +63,10 @@ TTpcdsWorkloadDataInitializerGenerator::TBulkDataGenerator::TPositions TTpcdsWor
     split_work(tableNum, &result.FirstRow, &result.Count);
     if (useState && owner.StateProcessor && owner.StateProcessor->GetState().contains(tdef->name)) {
         result.Position = owner.StateProcessor->GetState().at(tdef->name).Position;
-        result.Count -= std::min<i64>(result.Count, result.Position);
 
         //this magic is needed for SCD to work correctly. See setSCDKeys in ydb/library/benchmarks/gen/tpcds-dbgen/scd.c
         while (result.Position && !allowedModules.contains((result.FirstRow + result.Position) % 6)) {
             --result.Position;
-            ++result.Count;
         }
     }
     //this magic is needed for SCD to work correctly. See setSCDKeys in ydb/library/benchmarks/gen/tpcds-dbgen/scd.c
@@ -129,12 +127,11 @@ TTpcdsWorkloadDataInitializerGenerator::TBulkDataGenerator::TBulkDataGenerator(c
     : IBulkDataGenerator(getTdefsByNumber(tableNum)->name, CalcCountToGenerate(owner, tableNum, true).Count)
     , TableNum(tableNum)
     , Owner(owner)
-    , TableSize(CalcCountToGenerate(owner, tableNum, false).Count)
 {}
 
 TTpcdsWorkloadDataInitializerGenerator::TBulkDataGenerator::TDataPortions TTpcdsWorkloadDataInitializerGenerator::TBulkDataGenerator::GenerateDataPortion() {
     TDataPortions result;
-    if (TableSize == 0) {
+    if (GetSize() == 0) {
         return result;
     }
     TContexts ctxs;
@@ -149,6 +146,11 @@ TTpcdsWorkloadDataInitializerGenerator::TBulkDataGenerator::TDataPortions TTpcds
     auto positions = CalcCountToGenerate(Owner, TableNum, !Generated);
     if (!Generated) {
         Generated = positions.Position;
+        result.push_back(MakeIntrusive<TDataPortion>(
+            GetFullTableName(tdef->name),
+            TDataPortion::TSkip(),
+            Generated
+        ));
         if (const ui32 toSkip = positions.FirstRow + positions.Position - 1) {
             row_skip(TableNum, toSkip);
             if (tdef->flags & FL_PARENT) {
@@ -159,7 +161,7 @@ TTpcdsWorkloadDataInitializerGenerator::TBulkDataGenerator::TDataPortions TTpcds
             resetCountCount();
         }
     }
-    const auto count = TableSize > Generated ? std::min(ui64(TableSize - Generated), Owner.Params.BulkSize) : 0;
+    const auto count = GetSize() > Generated ? std::min(ui64(GetSize() - Generated), Owner.Params.BulkSize) : 0;
     if (!count) {
         return result;
     }

--- a/ydb/library/workload/tpcds/data_generator.h
+++ b/ydb/library/workload/tpcds/data_generator.h
@@ -70,7 +70,6 @@ public:
         };
         static TPositions CalcCountToGenerate(const TTpcdsWorkloadDataInitializerGenerator& owner, int tableNum, bool useState);
         const TTpcdsWorkloadDataInitializerGenerator& Owner;
-        ui64 TableSize;
     };
 };
 

--- a/ydb/library/workload/tpch/data_generator.h
+++ b/ydb/library/workload/tpch/data_generator.h
@@ -56,9 +56,8 @@ public:
 
     private:
         TString GetFullTableName(const char* table) const;
-        static ui64 CalcCountToGenerate(const TTpchWorkloadDataInitializerGenerator& owner, int tableNum, bool useState);
+        static ui64 CalcCountToGenerate(const TTpchWorkloadDataInitializerGenerator& owner, int tableNum);
         const TTpchWorkloadDataInitializerGenerator& Owner;
-        ui64 TableSize;
     };
 
 };


### PR DESCRIPTION
Fixed two bugs:
* Sometimes line with full progressbar duplicates.
* Size of tables in progressbar reduced when not empty state used.

Now it works fine.