### PR TITLE
Print location in error messages

### DIFF
--- a/ydb/public/lib/ydb_cli/dump/restore_compat.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_compat.cpp
@@ -46,23 +46,23 @@ public:
         Begin();
     }
 
-    bool Fits(const TString& line) const override {
+    EStatus Check(const NPrivate::TLine& line) const override {
         if (RowsPerRequest > 0 && (Rows + 1) > RowsPerRequest) {
-            return Rows == 0;
+            return Rows == 0 ? OK : FULL;
         }
 
         if (BytesPerRequest > 0 && (Bytes + RecordSize(line)) > BytesPerRequest) {
-            return Bytes == 0;
+            return Bytes == 0 ? OK : FULL;
         }
 
         if (RequestUnitsPerRequest > 0 && CalcRequestUnits(RequestUnitsX2 + RecordRequestUnitsX2(line)) > RequestUnitsPerRequest) {
-            return RequestUnitsX2 == 0;
+            return RequestUnitsX2 == 0 ? OK : FULL;
         }
 
-        return true;
+        return OK;
     }
 
-    void Feed(TString&& line) override {
+    void Feed(NPrivate::TLine&& line) override {
         AddLine(line);
 
         ++Rows;
@@ -90,7 +90,7 @@ public:
         return false;
     }
 
-    TString GetData(bool) override {
+    NPrivate::TBatch GetData(bool) override {
         Rows = 0;
         Bytes = 0;
         RequestUnitsX2 = 0;
@@ -133,7 +133,7 @@ public:
         Uploader = MakeHolder<TUploader>(opts, TableClient, Accumulator->GetQueryString());
     }
 
-    bool Push(TString&&) override {
+    bool Push(NPrivate::TBatch&&) override {
         bool ok;
 
         if (UseBulkUpsert) {

--- a/ydb/public/lib/ydb_cli/dump/restore_import_data.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_import_data.h
@@ -10,7 +10,8 @@ namespace NDump {
 NPrivate::IDataAccumulator* CreateImportDataAccumulator(
     const NTable::TTableDescription& dumpedDesc,
     const NTable::TTableDescription& actualDesc,
-    const TRestoreSettings& settings);
+    const TRestoreSettings& settings,
+    const std::shared_ptr<TLog>& log);
 
 NPrivate::IDataWriter* CreateImportDataWriter(
     const TString& path,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

`tools restore`: print location in error messages.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

<details>
<summary>Example</summary>

```
2024-10-25T18:18:33.506781Z :ERROR: Empty token: /home/ilnaz/dump/table/data_01.csv:1 
2024-10-25T18:39:48.477066Z :DEBUG: Partitioning of "/root/db/table" has been changed while importing: /home/ilnaz/dump/table/data_10.csv:503192-503285, /home/ilnaz/dump/table/data_11.csv:1-1529
```

</details>