### PR TITLE
Remove yatest_common from ydb

### DIFF
--- a/ydb/library/yaml_config/ut_transform/test_transform.py
+++ b/ydb/library/yaml_config/ut_transform/test_transform.py
@@ -2,7 +2,6 @@
 #
 import yatest
 import pytest
-from ydb.tests.library.common import yatest_common
 
 import json
 import logging
@@ -15,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def bin_from_env(name):
     if os.getenv(name):
-        return yatest_common.binary_path(os.getenv(name))
+        return yatest.common.binary_path(os.getenv(name))
     raise RuntimeError(f'{name} enviroment variable is not specified')
 
 
@@ -35,7 +34,7 @@ class TestYamlConfigTransformations(object):
     @classmethod
     def execute(cls, binary, stdin=None, args=[]):
         try:
-            execution = yatest_common.execute(
+            execution = yatest.common.execute(
                 [binary] + args,
                 stdin=stdin,
             )
@@ -50,7 +49,7 @@ class TestYamlConfigTransformations(object):
         result_path = os.path.join(out_path, result_filename)
         with open(result_path, "w") as f:
             f.write(output_result)
-        return yatest_common.canonical_file(str(result_path), diff_tool=json_diff_bin(), local=True, universal_lines=True)
+        return yatest.common.canonical_file(str(result_path), diff_tool=json_diff_bin(), local=True, universal_lines=True)
 
     def cleanup_errors(self, errors):
         return re.sub(r'address -> 0x[a-zA-Z0-9]+', 'address -> REDACTED', errors)
@@ -65,7 +64,7 @@ class TestYamlConfigTransformations(object):
                         success, result = self.execute(stdin=f, binary=binary, args=args)
                         if not success:
                             result = json.dumps({"error": True, "stderr": self.cleanup_errors(result)})
-                        results[entry.name] = self.canonical_result(result, entry.name, yatest_common.output_path())
+                        results[entry.name] = self.canonical_result(result, entry.name, yatest.common.output_path())
         return [results[key] for key in sorted(results.keys(), reverse=True)]
 
     @pytest.mark.parametrize('binary', [('dump', dump_bin()), ('dump_ds_init', dump_ds_init_bin())], ids=lambda binary: binary[0])

--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -94,7 +94,7 @@ def write_file(args, suffix, content):
         write_file_flushed(os.path.join(args.ydb_working_dir, suffix), content)
         return
 
-    write_file_flushed(os.path.join(yatest.commmon.output_path(suffix)), content)
+    write_file_flushed(os.path.join(yatest.common.output_path(suffix)), content)
 
     try:
         write_file_flushed(suffix, content)
@@ -107,7 +107,7 @@ def read_file(args, suffix):
         with open(os.path.join(args.ydb_working_dir, suffix), 'r') as fd:
             return fd.read()
 
-    with open(os.path.join(yatest.commmon.output_path(suffix)), 'r') as fd:
+    with open(os.path.join(yatest.common.output_path(suffix)), 'r') as fd:
         return fd.read()
 
 
@@ -223,7 +223,7 @@ class Recipe(object):
         if self.arguments.ydb_working_dir:
             self.data_path = self.arguments.ydb_working_dir
             return self.data_path
-        self.data_path = yatest.commmon.output_path(self.data_path_template % random_string())
+        self.data_path = yatest.common.output_path(self.data_path_template % random_string())
         return ensure_path_exists(self.data_path)
 
 

--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -10,8 +10,9 @@ import typing  # noqa: F401
 import sys
 from six.moves.urllib.parse import urlparse
 
+import yatest
+
 from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
@@ -56,7 +57,7 @@ def parse_erasure(args):
 
 
 def driver_path_packages(package_path):
-    return yatest_common.build_path(
+    return yatest.commmon.build_path(
         "{}/Berkanavt/kikimr/bin/kikimr".format(
             package_path
         )
@@ -64,7 +65,7 @@ def driver_path_packages(package_path):
 
 
 def udfs_path_packages(package_path):
-    return yatest_common.build_path(
+    return yatest.commmon.build_path(
         "{}/Berkanavt/kikimr/libs".format(
             package_path
         )
@@ -93,7 +94,7 @@ def write_file(args, suffix, content):
         write_file_flushed(os.path.join(args.ydb_working_dir, suffix), content)
         return
 
-    write_file_flushed(os.path.join(yatest_common.output_path(suffix)), content)
+    write_file_flushed(os.path.join(yatest.commmon.output_path(suffix)), content)
 
     try:
         write_file_flushed(suffix, content)
@@ -106,7 +107,7 @@ def read_file(args, suffix):
         with open(os.path.join(args.ydb_working_dir, suffix), 'r') as fd:
             return fd.read()
 
-    with open(os.path.join(yatest_common.output_path(suffix)), 'r') as fd:
+    with open(os.path.join(yatest.commmon.output_path(suffix)), 'r') as fd:
         return fd.read()
 
 
@@ -222,7 +223,7 @@ class Recipe(object):
         if self.arguments.ydb_working_dir:
             self.data_path = self.arguments.ydb_working_dir
             return self.data_path
-        self.data_path = yatest_common.output_path(self.data_path_template % random_string())
+        self.data_path = yatest.commmon.output_path(self.data_path_template % random_string())
         return ensure_path_exists(self.data_path)
 
 

--- a/ydb/tests/acceptance/test_slice.py
+++ b/ydb/tests/acceptance/test_slice.py
@@ -1,8 +1,9 @@
 import os
 import sys
 
+import yatest
+
 import ydb
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.ydbd_slice import YdbdSlice
 
 
@@ -13,8 +14,8 @@ class TestWithSlice(object):
     @classmethod
     def setup_class(cls):
         cls.cluster = YdbdSlice(
-            config_path=yatest_common.source_path(os.environ["YDB_CLUSTER_YAML"]),
-            binary_path=yatest_common.binary_path(os.environ["YDB_DRIVER_BINARY"])
+            config_path=yatest.common.source_path(os.environ["YDB_CLUSTER_YAML"]),
+            binary_path=yatest.common.binary_path(os.environ["YDB_DRIVER_BINARY"])
         )
         cls.cluster.start()
 
@@ -42,12 +43,12 @@ class TestWithSlice(object):
                     )
 
     def test_serializable(self):
-        yatest_common.execute(
+        yatest.common.execute(
             [
-                yatest_common.binary_path('ydb/tests/tools/ydb_serializable/ydb_serializable'),
+                yatest.common.binary_path('ydb/tests/tools/ydb_serializable/ydb_serializable'),
                 '--endpoint=%s:%d' % (self.cluster.nodes[1].host, self.cluster.nodes[1].grpc_port),
                 '--database=%s' % self.cluster.db_path,
-                '--output-path=%s' % yatest_common.output_path(),
+                '--output-path=%s' % yatest.common.output_path(),
                 '--iterations=25',
                 '--processes=1'
             ],

--- a/ydb/tests/fq/mem_alloc/test_alloc_default.py
+++ b/ydb/tests/fq/mem_alloc/test_alloc_default.py
@@ -7,8 +7,6 @@ import pytest
 import six
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.fq_client import FederatedQueryClient

--- a/ydb/tests/fq/mem_alloc/test_alloc_default.py
+++ b/ydb/tests/fq/mem_alloc/test_alloc_default.py
@@ -7,8 +7,9 @@ import pytest
 import six
 import time
 
+import yatest
+
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.fq_runner.fq_client import FederatedQueryClient
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
@@ -54,8 +55,8 @@ def kikimr(request):
 
 def wait_until(
     predicate,
-    wait_time=yatest_common.plain_or_under_sanitizer(10, 50),
-    wait_step=yatest_common.plain_or_under_sanitizer(0.5, 2),
+    wait_time=yatest.common.plain_or_under_sanitizer(10, 50),
+    wait_step=yatest.common.plain_or_under_sanitizer(0.5, 2),
 ):
     deadline = time.time() + wait_time
     while time.time() < deadline:

--- a/ydb/tests/fq/mem_alloc/test_alloc_default.py
+++ b/ydb/tests/fq/mem_alloc/test_alloc_default.py
@@ -9,6 +9,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.fq_client import FederatedQueryClient
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
@@ -55,8 +56,8 @@ def kikimr(request):
 
 def wait_until(
     predicate,
-    wait_time=yatest.common.plain_or_under_sanitizer(10, 50),
-    wait_step=yatest.common.plain_or_under_sanitizer(0.5, 2),
+    wait_time=plain_or_under_sanitizer(10, 50),
+    wait_step=plain_or_under_sanitizer(0.5, 2),
 ):
     deadline = time.time() + wait_time
     while time.time() < deadline:

--- a/ydb/tests/fq/mem_alloc/test_scheduling.py
+++ b/ydb/tests/fq/mem_alloc/test_scheduling.py
@@ -6,8 +6,6 @@ import os
 import pytest
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.fq_client import FederatedQueryClient
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr

--- a/ydb/tests/fq/mem_alloc/test_scheduling.py
+++ b/ydb/tests/fq/mem_alloc/test_scheduling.py
@@ -6,7 +6,8 @@ import os
 import pytest
 import time
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
+
 from ydb.tests.tools.fq_runner.fq_client import FederatedQueryClient
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
@@ -18,8 +19,8 @@ M = 1024 * 1024
 G = 1024 * 1024 * 1024
 DEFAULT_LIMIT = 8 * G
 DEFAULT_DELTA = 30 * M
-DEFAULT_WAIT_TIME = yatest_common.plain_or_under_sanitizer(10, 50)
-LONG_WAIT_TIME = yatest_common.plain_or_under_sanitizer(60, 300)
+DEFAULT_WAIT_TIME = yatest.common.plain_or_under_sanitizer(10, 50)
+LONG_WAIT_TIME = yatest.common.plain_or_under_sanitizer(60, 300)
 
 
 @pytest.fixture
@@ -37,7 +38,7 @@ def kikimr(request):
     kikimr.stop()
 
 
-def wait_until(predicate, wait_time=DEFAULT_WAIT_TIME, wait_step=yatest_common.plain_or_under_sanitizer(0.5, 2)):
+def wait_until(predicate, wait_time=DEFAULT_WAIT_TIME, wait_step=yatest.common.plain_or_under_sanitizer(0.5, 2)):
     deadline = time.time() + wait_time
     while time.time() < deadline:
         if predicate():

--- a/ydb/tests/fq/mem_alloc/test_scheduling.py
+++ b/ydb/tests/fq/mem_alloc/test_scheduling.py
@@ -8,6 +8,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.fq_client import FederatedQueryClient
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
@@ -19,8 +20,8 @@ M = 1024 * 1024
 G = 1024 * 1024 * 1024
 DEFAULT_LIMIT = 8 * G
 DEFAULT_DELTA = 30 * M
-DEFAULT_WAIT_TIME = yatest.common.plain_or_under_sanitizer(10, 50)
-LONG_WAIT_TIME = yatest.common.plain_or_under_sanitizer(60, 300)
+DEFAULT_WAIT_TIME = plain_or_under_sanitizer(10, 50)
+LONG_WAIT_TIME = plain_or_under_sanitizer(60, 300)
 
 
 @pytest.fixture
@@ -38,7 +39,7 @@ def kikimr(request):
     kikimr.stop()
 
 
-def wait_until(predicate, wait_time=DEFAULT_WAIT_TIME, wait_step=yatest.common.plain_or_under_sanitizer(0.5, 2)):
+def wait_until(predicate, wait_time=DEFAULT_WAIT_TIME, wait_step=plain_or_under_sanitizer(0.5, 2)):
     deadline = time.time() + wait_time
     while time.time() < deadline:
         if predicate():

--- a/ydb/tests/fq/restarts/test_insert_restarts.py
+++ b/ydb/tests/fq/restarts/test_insert_restarts.py
@@ -6,9 +6,10 @@ import boto3
 import pytest
 import time
 
+import yatest
+
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_all
 
 
@@ -71,7 +72,7 @@ class TestS3(object):
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
 
         # Checking insert query
-        timeout = yatest_common.plain_or_under_sanitizer(250, 250 * 5)
+        timeout = yatest.common.plain_or_under_sanitizer(250, 250 * 5)
         start = time.time()
         deadline = start + timeout
         while True:

--- a/ydb/tests/fq/restarts/test_insert_restarts.py
+++ b/ydb/tests/fq/restarts/test_insert_restarts.py
@@ -6,8 +6,6 @@ import boto3
 import pytest
 import time
 
-import yatest
-
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer

--- a/ydb/tests/fq/restarts/test_insert_restarts.py
+++ b/ydb/tests/fq/restarts/test_insert_restarts.py
@@ -10,6 +10,7 @@ import yatest
 
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_all
 
 
@@ -72,7 +73,7 @@ class TestS3(object):
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
 
         # Checking insert query
-        timeout = yatest.common.plain_or_under_sanitizer(250, 250 * 5)
+        timeout = plain_or_under_sanitizer(250, 250 * 5)
         start = time.time()
         deadline = start + timeout
         while True:

--- a/ydb/tests/fq/s3/s3_helpers.py
+++ b/ydb/tests/fq/s3/s3_helpers.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 import boto3
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 
 @dataclass
@@ -20,4 +20,4 @@ def create_bucket_and_upload_file(filename, s3_url, bucket_name, base_path):
     bucket.objects.all().delete()
 
     s3_client = boto3.client("s3", endpoint_url=s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key")
-    s3_client.upload_file(yatest_common.source_path("{}/{}".format(base_path, filename)), bucket_name, filename)
+    s3_client.upload_file(yatest.common.source_path("{}/{}".format(base_path, filename)), bucket_name, filename)

--- a/ydb/tests/fq/s3/test_format_setting.py
+++ b/ydb/tests/fq/s3/test_format_setting.py
@@ -18,7 +18,6 @@ import ydb.public.api.protos.draft.fq_pb2 as fq
 
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_all, yq_v2
 import ydb.tests.fq.s3.s3_helpers as s3_helpers
-import ydb.tests.library.common.yatest_common as yatest_common
 
 from datetime import datetime
 from google.protobuf import struct_pb2
@@ -1060,8 +1059,8 @@ Pear;15;33'''
 
         table = pa.Table.from_arrays(data, schema=schema)
         filename = 'test_parquet_converters_to_timestamp.parquet'
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         kikimr.control_plane.wait_bootstrap(1)
         storage_connection_name = unique_prefix + "hcpp"
@@ -1096,8 +1095,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('us'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1116,8 +1115,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.string())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1136,8 +1135,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.utf8())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1156,8 +1155,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('s'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1176,8 +1175,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('ns'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1196,8 +1195,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1216,8 +1215,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1236,8 +1235,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.int32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1269,8 +1268,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.int64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1302,8 +1301,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.int64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1335,8 +1334,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.int64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1368,8 +1367,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1401,8 +1400,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1421,8 +1420,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1454,8 +1453,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1487,8 +1486,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint16())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         sql = f'''
             SELECT
@@ -1521,8 +1520,8 @@ Pear;15;33'''
 
         table = pa.Table.from_arrays(data, schema=schema)
         filename = 'test_parquet_converters_to_datetime.parquet'
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         kikimr.control_plane.wait_bootstrap(1)
         storage_connection_name = unique_prefix + "hcpp"
@@ -1555,8 +1554,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('us'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.FAILED)
@@ -1573,8 +1572,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('s'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.FAILED)
@@ -1591,8 +1590,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('ns'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.FAILED)
@@ -1609,8 +1608,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1629,8 +1628,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1648,8 +1647,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.int32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1667,8 +1666,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.int64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1684,8 +1683,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1703,8 +1702,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1722,8 +1721,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.uint16())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1744,8 +1743,8 @@ Pear;15;33'''
 
         table = pa.Table.from_arrays(data, schema=schema)
         filename = 'test_parquet_converters_to_string.parquet'
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         kikimr.control_plane.wait_bootstrap(1)
         storage_connection_name = unique_prefix + "hcpp"
@@ -1780,8 +1779,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('us'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1800,8 +1799,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('s'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1820,8 +1819,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('ns'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1840,8 +1839,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1860,8 +1859,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1882,8 +1881,8 @@ Pear;15;33'''
 
         table = pa.Table.from_arrays(data, schema=schema)
         filename = 'test_parquet_converters_to_utf8.parquet'
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         kikimr.control_plane.wait_bootstrap(1)
         storage_connection_name = unique_prefix + "hcpp"
@@ -1918,8 +1917,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('us'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1938,8 +1937,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('s'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1958,8 +1957,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.timestamp('ns'))])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1978,8 +1977,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date64())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -1998,8 +1997,8 @@ Pear;15;33'''
         schema = pa.schema([('fruit', pa.string()), ('ts', pa.date32())])
 
         table = pa.Table.from_arrays(data, schema=schema)
-        pq.write_table(table, yatest_common.work_path(filename))
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename))
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
@@ -2026,8 +2025,8 @@ Pear;15;33'''
 
         table = pa.Table.from_arrays(data, schema=schema)
         filename = 'test_s3_push_down_parquet.parquet'
-        pq.write_table(table, yatest_common.work_path(filename), row_group_size=2)
-        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest_common.work_path())
+        pq.write_table(table, yatest.common.work_path(filename), row_group_size=2)
+        s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", yatest.common.work_path())
 
         kikimr.control_plane.wait_bootstrap(1)
         storage_connection_name = unique_prefix + "hcpp"

--- a/ydb/tests/fq/s3/test_s3_0.py
+++ b/ydb/tests/fq/s3/test_s3_0.py
@@ -9,6 +9,7 @@ import time
 import yatest
 import ydb.public.api.protos.draft.fq_pb2 as fq
 import ydb.public.api.protos.ydb_value_pb2 as ydb
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1, yq_v2, yq_all
 from google.protobuf.struct_pb2 import NullValue
@@ -1092,13 +1093,13 @@ Pear,15,33'''
 
         # Check that checkpointing is finished
         def wait_checkpoints(require_query_is_on=False):
-            deadline = time.time() + yatest.common.plain_or_under_sanitizer(300, 900)
+            deadline = time.time() + plain_or_under_sanitizer(300, 900)
             while True:
                 completed = kikimr.control_plane.get_completed_checkpoints(query_id, require_query_is_on)
                 if completed >= 3:
                     break
                 assert time.time() < deadline, "Completed: {}".format(completed)
-                time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
+                time.sleep(plain_or_under_sanitizer(0.5, 2))
 
         logging.debug("Wait checkpoints")
         wait_checkpoints(True)

--- a/ydb/tests/fq/s3/test_s3_0.py
+++ b/ydb/tests/fq/s3/test_s3_0.py
@@ -6,7 +6,6 @@ import logging
 import os
 import pytest
 import time
-import yatest
 import ydb.public.api.protos.draft.fq_pb2 as fq
 import ydb.public.api.protos.ydb_value_pb2 as ydb
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer

--- a/ydb/tests/fq/s3/test_s3_0.py
+++ b/ydb/tests/fq/s3/test_s3_0.py
@@ -6,9 +6,9 @@ import logging
 import os
 import pytest
 import time
+import yatest
 import ydb.public.api.protos.draft.fq_pb2 as fq
 import ydb.public.api.protos.ydb_value_pb2 as ydb
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1, yq_v2, yq_all
 from google.protobuf.struct_pb2 import NullValue
@@ -1092,13 +1092,13 @@ Pear,15,33'''
 
         # Check that checkpointing is finished
         def wait_checkpoints(require_query_is_on=False):
-            deadline = time.time() + yatest_common.plain_or_under_sanitizer(300, 900)
+            deadline = time.time() + yatest.common.plain_or_under_sanitizer(300, 900)
             while True:
                 completed = kikimr.control_plane.get_completed_checkpoints(query_id, require_query_is_on)
                 if completed >= 3:
                     break
                 assert time.time() < deadline, "Completed: {}".format(completed)
-                time.sleep(yatest_common.plain_or_under_sanitizer(0.5, 2))
+                time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
 
         logging.debug("Wait checkpoints")
         wait_checkpoints(True)

--- a/ydb/tests/fq/yds/test_continue_mode.py
+++ b/ydb/tests/fq/yds/test_continue_mode.py
@@ -5,8 +5,9 @@ import os
 import pytest
 import time
 
+import yatest
+
 import ydb.public.api.protos.draft.fq_pb2 as fq
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.fq_runner.fq_client import StreamingDisposition
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
@@ -129,7 +130,7 @@ class TestContinueMode(TestYdsBase):
             streaming_disposition=StreamingDisposition.from_last_checkpoint(True),
         )
         client.wait_query_status(query_id, fq.QueryMeta.RUNNING)
-        transient_issues_deadline = time.time() + yatest_common.plain_or_under_sanitizer(60, 300)
+        transient_issues_deadline = time.time() + yatest.common.plain_or_under_sanitizer(60, 300)
         msg = "Topic `continue_2_input` is not found in previous query. Query will use fresh offsets for its partitions"
         while True:
             if assert_has_issues(msg, True, transient_issues_deadline):

--- a/ydb/tests/fq/yds/test_continue_mode.py
+++ b/ydb/tests/fq/yds/test_continue_mode.py
@@ -8,6 +8,7 @@ import time
 import yatest
 
 import ydb.public.api.protos.draft.fq_pb2 as fq
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.fq_client import StreamingDisposition
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
@@ -130,7 +131,7 @@ class TestContinueMode(TestYdsBase):
             streaming_disposition=StreamingDisposition.from_last_checkpoint(True),
         )
         client.wait_query_status(query_id, fq.QueryMeta.RUNNING)
-        transient_issues_deadline = time.time() + yatest.common.plain_or_under_sanitizer(60, 300)
+        transient_issues_deadline = time.time() + plain_or_under_sanitizer(60, 300)
         msg = "Topic `continue_2_input` is not found in previous query. Query will use fresh offsets for its partitions"
         while True:
             if assert_has_issues(msg, True, transient_issues_deadline):

--- a/ydb/tests/fq/yds/test_continue_mode.py
+++ b/ydb/tests/fq/yds/test_continue_mode.py
@@ -5,8 +5,6 @@ import os
 import pytest
 import time
 
-import yatest
-
 import ydb.public.api.protos.draft.fq_pb2 as fq
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.fq_client import StreamingDisposition

--- a/ydb/tests/fq/yds/test_mem_alloc.py
+++ b/ydb/tests/fq/yds/test_mem_alloc.py
@@ -7,8 +7,6 @@ import os
 import pytest
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase

--- a/ydb/tests/fq/yds/test_mem_alloc.py
+++ b/ydb/tests/fq/yds/test_mem_alloc.py
@@ -7,7 +7,8 @@ import os
 import pytest
 import time
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
+
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 
@@ -71,7 +72,7 @@ class TestMemAlloc(TestYdsBase):
         time.sleep(2)  # Workaround race between write and read "from now". Remove when YQ-589 will be done.
         for i in range(1):
             self.write_stream([format(i, "0x")])
-        time.sleep(yatest_common.plain_or_under_sanitizer(15, 60))
+        time.sleep(yatest.common.plain_or_under_sanitizer(15, 60))
 
         client.abort_query(query_id)
         client.wait_query_status(query_id, fq.QueryMeta.ABORTED_BY_USER)

--- a/ydb/tests/fq/yds/test_mem_alloc.py
+++ b/ydb/tests/fq/yds/test_mem_alloc.py
@@ -9,6 +9,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 
@@ -72,7 +73,7 @@ class TestMemAlloc(TestYdsBase):
         time.sleep(2)  # Workaround race between write and read "from now". Remove when YQ-589 will be done.
         for i in range(1):
             self.write_stream([format(i, "0x")])
-        time.sleep(yatest.common.plain_or_under_sanitizer(15, 60))
+        time.sleep(plain_or_under_sanitizer(15, 60))
 
         client.abort_query(query_id)
         client.wait_query_status(query_id, fq.QueryMeta.ABORTED_BY_USER)

--- a/ydb/tests/fq/yds/test_metrics_cleanup.py
+++ b/ydb/tests/fq/yds/test_metrics_cleanup.py
@@ -4,7 +4,8 @@
 import os
 import time
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
+
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 
@@ -19,7 +20,7 @@ class TestCleanup(TestYdsBase):
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
 
         assert kikimr.compute_plane.get_task_count(1, query_id) == 0
-        deadline = time.time() + yatest_common.plain_or_under_sanitizer(120, 500)
+        deadline = time.time() + yatest.common.plain_or_under_sanitizer(120, 500)
         while True:
             value = kikimr.compute_plane.get_sensors(1, "yq").find_sensor(
                 {"query_id": query_id, "subsystem": "task_controller", "Stage": "Total", "sensor": "Tasks"}

--- a/ydb/tests/fq/yds/test_metrics_cleanup.py
+++ b/ydb/tests/fq/yds/test_metrics_cleanup.py
@@ -6,6 +6,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 
@@ -20,7 +21,7 @@ class TestCleanup(TestYdsBase):
         client.wait_query_status(query_id, fq.QueryMeta.COMPLETED)
 
         assert kikimr.compute_plane.get_task_count(1, query_id) == 0
-        deadline = time.time() + yatest.common.plain_or_under_sanitizer(120, 500)
+        deadline = time.time() + plain_or_under_sanitizer(120, 500)
         while True:
             value = kikimr.compute_plane.get_sensors(1, "yq").find_sensor(
                 {"query_id": query_id, "subsystem": "task_controller", "Stage": "Total", "sensor": "Tasks"}

--- a/ydb/tests/fq/yds/test_metrics_cleanup.py
+++ b/ydb/tests/fq/yds/test_metrics_cleanup.py
@@ -4,8 +4,6 @@
 import os
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase

--- a/ydb/tests/fq/yds/test_read_rules_deletion.py
+++ b/ydb/tests/fq/yds/test_read_rules_deletion.py
@@ -6,6 +6,7 @@ import pytest
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 
@@ -58,7 +59,7 @@ class TestReadRulesDeletion(TestYdsBase):
 
         client.abort_query(query_id)
         client.wait_query_status(
-            query_id, fq.QueryMeta.ABORTED_BY_USER, timeout=yatest.common.plain_or_under_sanitizer(60, 300)
+            query_id, fq.QueryMeta.ABORTED_BY_USER, timeout=plain_or_under_sanitizer(60, 300)
         )
 
         # Assert that all read rules were removed after query stops

--- a/ydb/tests/fq/yds/test_read_rules_deletion.py
+++ b/ydb/tests/fq/yds/test_read_rules_deletion.py
@@ -4,8 +4,6 @@
 import os
 import pytest
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase

--- a/ydb/tests/fq/yds/test_read_rules_deletion.py
+++ b/ydb/tests/fq/yds/test_read_rules_deletion.py
@@ -4,11 +4,12 @@
 import os
 import pytest
 
+import yatest
+
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 
 from ydb.tests.tools.datastreams_helpers.control_plane import list_read_rules
-import ydb.tests.library.common.yatest_common as yatest_common
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
 
@@ -57,7 +58,7 @@ class TestReadRulesDeletion(TestYdsBase):
 
         client.abort_query(query_id)
         client.wait_query_status(
-            query_id, fq.QueryMeta.ABORTED_BY_USER, timeout=yatest_common.plain_or_under_sanitizer(60, 300)
+            query_id, fq.QueryMeta.ABORTED_BY_USER, timeout=yatest.common.plain_or_under_sanitizer(60, 300)
         )
 
         # Assert that all read rules were removed after query stops

--- a/ydb/tests/fq/yds/test_recovery.py
+++ b/ydb/tests/fq/yds/test_recovery.py
@@ -55,7 +55,7 @@ class TestRecovery(TestYdsBase):
                 return node_index
         assert False, "No active graphs found"
 
-    def dump_workers(self, worker_count, ca_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
+    def dump_workers(self, worker_count, ca_count, wait_time=plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + wait_time
         while True:
             wcs = 0
@@ -339,9 +339,9 @@ class TestRecovery(TestYdsBase):
             "--duration",
             "30s",
             "--sleep-min",
-            yatest.common.plain_or_under_sanitizer("10ms", "50ms"),
+            plain_or_under_sanitizer("10ms", "50ms"),
             "--sleep-max",
-            yatest.common.plain_or_under_sanitizer("100ms", "500ms"),
+            plain_or_under_sanitizer("100ms", "500ms"),
             "--reschedule-min",
             "10ms",
             "--reschedule-max",
@@ -404,7 +404,7 @@ class TestRecovery(TestYdsBase):
         client.wait_query_status(query_id, fq.QueryMeta.RUNNING)
 
         # Checkpointing must be finished
-        deadline = time.time() + yatest.common.plain_or_under_sanitizer(300, 900)
+        deadline = time.time() + plain_or_under_sanitizer(300, 900)
         while True:
             status = client.describe_query(query_id).result.query.meta.status
             assert status == fq.QueryMeta.RUNNING, "Unexpected status " + fq.QueryMeta.ComputeStatus.Name(status)
@@ -412,7 +412,7 @@ class TestRecovery(TestYdsBase):
             if completed >= 5:
                 break
             assert time.time() < deadline, "Completed: {}".format(completed)
-            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(plain_or_under_sanitizer(0.5, 2))
 
         close_ic_sessions_future.wait()
 

--- a/ydb/tests/fq/yds/test_recovery.py
+++ b/ydb/tests/fq/yds/test_recovery.py
@@ -11,7 +11,6 @@ import random
 import yatest
 
 from ydb.tests.library.harness import param_constants
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
 from ydb.tests.tools.fq_runner.kikimr_runner import TenantConfig
@@ -56,7 +55,7 @@ class TestRecovery(TestYdsBase):
                 return node_index
         assert False, "No active graphs found"
 
-    def dump_workers(self, worker_count, ca_count, wait_time=yatest_common.plain_or_under_sanitizer(30, 150)):
+    def dump_workers(self, worker_count, ca_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + wait_time
         while True:
             wcs = 0
@@ -340,9 +339,9 @@ class TestRecovery(TestYdsBase):
             "--duration",
             "30s",
             "--sleep-min",
-            yatest_common.plain_or_under_sanitizer("10ms", "50ms"),
+            yatest.common.plain_or_under_sanitizer("10ms", "50ms"),
             "--sleep-max",
-            yatest_common.plain_or_under_sanitizer("100ms", "500ms"),
+            yatest.common.plain_or_under_sanitizer("100ms", "500ms"),
             "--reschedule-min",
             "10ms",
             "--reschedule-max",
@@ -405,7 +404,7 @@ class TestRecovery(TestYdsBase):
         client.wait_query_status(query_id, fq.QueryMeta.RUNNING)
 
         # Checkpointing must be finished
-        deadline = time.time() + yatest_common.plain_or_under_sanitizer(300, 900)
+        deadline = time.time() + yatest.common.plain_or_under_sanitizer(300, 900)
         while True:
             status = client.describe_query(query_id).result.query.meta.status
             assert status == fq.QueryMeta.RUNNING, "Unexpected status " + fq.QueryMeta.ComputeStatus.Name(status)
@@ -413,7 +412,7 @@ class TestRecovery(TestYdsBase):
             if completed >= 5:
                 break
             assert time.time() < deadline, "Completed: {}".format(completed)
-            time.sleep(yatest_common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
 
         close_ic_sessions_future.wait()
 

--- a/ydb/tests/fq/yds/test_recovery.py
+++ b/ydb/tests/fq/yds/test_recovery.py
@@ -10,6 +10,7 @@ import random
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.library.harness import param_constants
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig

--- a/ydb/tests/fq/yds/test_recovery_match_recognize.py
+++ b/ydb/tests/fq/yds/test_recovery_match_recognize.py
@@ -6,7 +6,8 @@ import logging
 import os
 import time
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
+
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
 from ydb.tests.tools.fq_runner.kikimr_runner import TenantConfig
@@ -35,7 +36,7 @@ class TestRecoveryMatchRecognize(TestYdsBase):
         # for retry
         cls.retry_conf = retry.RetryConf().upto(seconds=30).waiting(0.1)
 
-    def dump_workers(self, kikimr, worker_count, ca_count, wait_time=yatest_common.plain_or_under_sanitizer(30, 150)):
+    def dump_workers(self, kikimr, worker_count, ca_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + wait_time
         while True:
             wcs = 0

--- a/ydb/tests/fq/yds/test_recovery_match_recognize.py
+++ b/ydb/tests/fq/yds/test_recovery_match_recognize.py
@@ -8,6 +8,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
 from ydb.tests.tools.fq_runner.kikimr_runner import TenantConfig
@@ -36,7 +37,7 @@ class TestRecoveryMatchRecognize(TestYdsBase):
         # for retry
         cls.retry_conf = retry.RetryConf().upto(seconds=30).waiting(0.1)
 
-    def dump_workers(self, kikimr, worker_count, ca_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
+    def dump_workers(self, kikimr, worker_count, ca_count, wait_time=plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + wait_time
         while True:
             wcs = 0

--- a/ydb/tests/fq/yds/test_recovery_match_recognize.py
+++ b/ydb/tests/fq/yds/test_recovery_match_recognize.py
@@ -6,8 +6,6 @@ import logging
 import os
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig

--- a/ydb/tests/fq/yds/test_recovery_mz.py
+++ b/ydb/tests/fq/yds/test_recovery_mz.py
@@ -8,6 +8,7 @@ import random
 import os
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
 from ydb.tests.tools.fq_runner.kikimr_runner import TenantConfig

--- a/ydb/tests/fq/yds/test_recovery_mz.py
+++ b/ydb/tests/fq/yds/test_recovery_mz.py
@@ -8,7 +8,6 @@ import random
 import os
 import yatest
 
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimrConfig
 from ydb.tests.tools.fq_runner.kikimr_runner import TenantConfig
@@ -56,7 +55,7 @@ class TestRecovery(TestYdsBase):
                 return node_index
         assert False, "No active graphs found"
 
-    def dump_workers(self, worker_count, ca_count, wait_time=yatest_common.plain_or_under_sanitizer(30, 150)):
+    def dump_workers(self, worker_count, ca_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + wait_time
         while True:
             wcs = 0

--- a/ydb/tests/fq/yds/test_recovery_mz.py
+++ b/ydb/tests/fq/yds/test_recovery_mz.py
@@ -55,7 +55,7 @@ class TestRecovery(TestYdsBase):
                 return node_index
         assert False, "No active graphs found"
 
-    def dump_workers(self, worker_count, ca_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
+    def dump_workers(self, worker_count, ca_count, wait_time=plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + wait_time
         while True:
             wcs = 0

--- a/ydb/tests/fq/yds/test_restart_query.py
+++ b/ydb/tests/fq/yds/test_restart_query.py
@@ -5,8 +5,9 @@ import os
 import pytest
 import time
 
+import yatest
+
 import ydb.public.api.protos.draft.fq_pb2 as fq
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.control_plane import delete_stream
@@ -59,7 +60,7 @@ class TestRestartQuery(TestYdsBase):
             ), f'Text "{text}" is expected to be found in transient issues, but was not found. Describe query result:\n{describe_result}'
             return False
 
-        deadline = time.time() + yatest_common.plain_or_under_sanitizer(60, 300)
+        deadline = time.time() + yatest.common.plain_or_under_sanitizer(60, 300)
         while not assert_has_transient_issues("SCHEME_ERROR", deadline):
             time.sleep(0.3)
 

--- a/ydb/tests/fq/yds/test_restart_query.py
+++ b/ydb/tests/fq/yds/test_restart_query.py
@@ -5,8 +5,6 @@ import os
 import pytest
 import time
 
-import yatest
-
 import ydb.public.api.protos.draft.fq_pb2 as fq
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase

--- a/ydb/tests/fq/yds/test_restart_query.py
+++ b/ydb/tests/fq/yds/test_restart_query.py
@@ -8,6 +8,7 @@ import time
 import yatest
 
 import ydb.public.api.protos.draft.fq_pb2 as fq
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 from ydb.tests.tools.datastreams_helpers.control_plane import delete_stream
@@ -60,7 +61,7 @@ class TestRestartQuery(TestYdsBase):
             ), f'Text "{text}" is expected to be found in transient issues, but was not found. Describe query result:\n{describe_result}'
             return False
 
-        deadline = time.time() + yatest.common.plain_or_under_sanitizer(60, 300)
+        deadline = time.time() + plain_or_under_sanitizer(60, 300)
         while not assert_has_transient_issues("SCHEME_ERROR", deadline):
             time.sleep(0.3)
 

--- a/ydb/tests/fq/yds/test_select_timings.py
+++ b/ydb/tests/fq/yds/test_select_timings.py
@@ -5,9 +5,10 @@ import pytest
 import os
 import time
 
+import yatest
+
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
-import ydb.tests.library.common.yatest_common as yatest_common
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
 
@@ -54,7 +55,7 @@ class TestSelectTimings(TestYdsBase):
             assert meta.finished_at.seconds == 0, "Must not set finished_at"
 
         # will wait 30 sec for lease expiration, reduce timeout when is congifurable
-        wait_query_timeout = yatest_common.plain_or_under_sanitizer(120, 300)
+        wait_query_timeout = yatest.common.plain_or_under_sanitizer(120, 300)
         if success:
             time.sleep(2)  # Workaround race between write and read "from now". Remove when YQ-589 will be done.
             self.write_stream(["Message"])

--- a/ydb/tests/fq/yds/test_select_timings.py
+++ b/ydb/tests/fq/yds/test_select_timings.py
@@ -7,6 +7,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 import ydb.public.api.protos.draft.fq_pb2 as fq
@@ -55,7 +56,7 @@ class TestSelectTimings(TestYdsBase):
             assert meta.finished_at.seconds == 0, "Must not set finished_at"
 
         # will wait 30 sec for lease expiration, reduce timeout when is congifurable
-        wait_query_timeout = yatest.common.plain_or_under_sanitizer(120, 300)
+        wait_query_timeout = plain_or_under_sanitizer(120, 300)
         if success:
             time.sleep(2)  # Workaround race between write and read "from now". Remove when YQ-589 will be done.
             self.write_stream(["Message"])

--- a/ydb/tests/fq/yds/test_select_timings.py
+++ b/ydb/tests/fq/yds/test_select_timings.py
@@ -5,8 +5,6 @@ import pytest
 import os
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1

--- a/ydb/tests/fq/yds/test_stop.py
+++ b/ydb/tests/fq/yds/test_stop.py
@@ -6,8 +6,6 @@ import os
 import pytest
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1

--- a/ydb/tests/fq/yds/test_stop.py
+++ b/ydb/tests/fq/yds/test_stop.py
@@ -8,6 +8,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 
@@ -58,7 +59,7 @@ class TestStop(TestYdsBase):
         messages = ["A", "B"]
         self.write_stream(messages)
 
-        deadline = time.time() + yatest.common.plain_or_under_sanitizer(30, 150)
+        deadline = time.time() + plain_or_under_sanitizer(30, 150)
         while True:
             if time.time() > deadline:
                 break

--- a/ydb/tests/fq/yds/test_stop.py
+++ b/ydb/tests/fq/yds/test_stop.py
@@ -6,10 +6,11 @@ import os
 import pytest
 import time
 
+import yatest
+
 from ydb.tests.tools.datastreams_helpers.test_yds_base import TestYdsBase
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1
 
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.tests.tools.datastreams_helpers.control_plane import create_read_rule, list_read_rules
 
 import ydb.public.api.protos.draft.fq_pb2 as fq
@@ -57,7 +58,7 @@ class TestStop(TestYdsBase):
         messages = ["A", "B"]
         self.write_stream(messages)
 
-        deadline = time.time() + yatest_common.plain_or_under_sanitizer(30, 150)
+        deadline = time.time() + yatest.common.plain_or_under_sanitizer(30, 150)
         while True:
             if time.time() > deadline:
                 break

--- a/ydb/tests/functional/canonical/test_sql.py
+++ b/ydb/tests/functional/canonical/test_sql.py
@@ -6,7 +6,8 @@ import decimal
 import functools
 import uuid
 
-from ydb.tests.library.common import yatest_common
+import yatest
+
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.canonical import set_canondata_root, is_oss
@@ -36,7 +37,7 @@ mute_sdk_loggers()
 
 
 def find_files(data_folder, ext):
-    resources_root = yatest_common.source_path(data_folder)
+    resources_root = yatest.common.source_path(data_folder)
     directories = [resources_root]
     files = []
     while len(directories) > 0:
@@ -63,7 +64,7 @@ def get_queries(data_folder):
 
 
 def canonical_filename(query, suffix):
-    return os.path.join(yatest_common.output_path(), query.replace('/', '_') + suffix)
+    return os.path.join(yatest.common.output_path(), query.replace('/', '_') + suffix)
 
 
 def write_output_file(data, filename):
@@ -201,7 +202,7 @@ class BaseCanonicalTest(object):
 
     @classmethod
     def read_data_rows(cls, s):
-        f_path = yatest_common.source_path(os.path.join(cls.data_folder, s))
+        f_path = yatest.common.source_path(os.path.join(cls.data_folder, s))
         with open(f_path, 'r') as r:
             return json.loads(r.read())
 
@@ -268,7 +269,7 @@ class BaseCanonicalTest(object):
 
     @classmethod
     def read_query_text(cls, query_name):
-        with open(yatest_common.source_path(os.path.join(cls.data_folder, query_name)), 'r') as reader:
+        with open(yatest.common.source_path(os.path.join(cls.data_folder, query_name)), 'r') as reader:
             return reader.read()
 
     @staticmethod
@@ -277,7 +278,7 @@ class BaseCanonicalTest(object):
 
     @staticmethod
     def canonical_results(query, results):
-        return yatest_common.canonical_file(
+        return yatest.common.canonical_file(
             local=True,
             universal_lines=True,
             path=write_output_file(
@@ -297,7 +298,7 @@ class BaseCanonicalTest(object):
 
     @staticmethod
     def canonical_plan(query, query_plan):
-        return yatest_common.canonical_file(
+        return yatest.common.canonical_file(
             local=True,
             universal_lines=True,
             path=write_output_file(
@@ -395,7 +396,7 @@ class BaseCanonicalTest(object):
     def read_config(self, query_name):
         dr = os.path.dirname(query_name)
         fl = os.path.basename(query_name)
-        cfg_json = yatest_common.source_path(os.path.join(self.data_folder, dr, 'test_config.json'))
+        cfg_json = yatest.common.source_path(os.path.join(self.data_folder, dr, 'test_config.json'))
         if not os.path.exists(cfg_json):
             return {}
         cfg = json.loads(self.read_query_text(cfg_json))

--- a/ydb/tests/functional/compatibility/test_compatibility.py
+++ b/ydb/tests/functional/compatibility/test_compatibility.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from ydb.tests.library.common import yatest_common
+import yatest
 from ydb.tests.library.harness.kikimr_cluster import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.param_constants import kikimr_driver_path
@@ -10,7 +10,7 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 class TestCompatibility(object):
     @classmethod
     def setup_class(cls):
-        last_stable_path = yatest_common.binary_path("ydb/tests/library/compatibility/ydbd-last-stable")
+        last_stable_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-last-stable")
         binary_paths = [kikimr_driver_path(), last_stable_path]
         cls.cluster = KiKiMR(KikimrConfigGenerator(erasure=Erasure.MIRROR_3_DC, binary_paths=binary_paths))
         cls.cluster.start()

--- a/ydb/tests/functional/kv_workload/test_kv_workload.py
+++ b/ydb/tests/functional/kv_workload/test_kv_workload.py
@@ -50,7 +50,7 @@ class TestYdbKvWorkload(object):
                 "--seconds", "100",
                 "--threads", "10",
 
-                "  223", "5",
+                "--cols", "5",
                 "--len", "200",
                 "--int-cols", "2",
                 "--key-cols", "3"

--- a/ydb/tests/functional/kv_workload/test_kv_workload.py
+++ b/ydb/tests/functional/kv_workload/test_kv_workload.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 
-from ydb.tests.library.common import yatest_common
+import yatest
+
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
@@ -18,9 +19,9 @@ class TestYdbKvWorkload(object):
         cls.cluster.stop()
 
     def test(self):
-        yatest_common.execute(
+        yatest.common.execute(
             [
-                yatest_common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
                 "--verbose",
                 "--endpoint", "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
                 "--database=/Root",
@@ -38,9 +39,9 @@ class TestYdbKvWorkload(object):
             wait=True
         )
 
-        yatest_common.execute(
+        yatest.common.execute(
             [
-                yatest_common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
                 "--verbose",
                 "--endpoint", "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
                 "--database=/Root",
@@ -49,7 +50,7 @@ class TestYdbKvWorkload(object):
                 "--seconds", "100",
                 "--threads", "10",
 
-                "--cols", "5",
+                "  223", "5",
                 "--len", "200",
                 "--int-cols", "2",
                 "--key-cols", "3"

--- a/ydb/tests/functional/large_serializable/test_serializable.py
+++ b/ydb/tests/functional/large_serializable/test_serializable.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from ydb.tests.library.common import yatest_common
+import yatest
+
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
@@ -18,12 +19,12 @@ class Test(object):
         cls.cluster.stop()
 
     def test(self):
-        yatest_common.execute(
+        yatest.common.execute(
             [
-                yatest_common.binary_path('ydb/tests/tools/ydb_serializable/ydb_serializable'),
+                yatest.common.binary_path('ydb/tests/tools/ydb_serializable/ydb_serializable'),
                 '--endpoint=localhost:%d' % self.cluster.nodes[1].grpc_port,
                 '--database=/Root',
-                '--output-path=%s' % yatest_common.output_path(),
+                '--output-path=%s' % yatest.common.output_path(),
                 '--iterations=25',
                 '--processes=2'
             ],

--- a/ydb/tests/functional/postgresql/test_postgres.py
+++ b/ydb/tests/functional/postgresql/test_postgres.py
@@ -1,4 +1,3 @@
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
@@ -17,12 +16,12 @@ DATA_PATH = os.path.join(arcadia_root, yatest.common.test_source_path('cases'))
 
 
 def get_unique_path_case(sub_folder, file):
-    test_name = yatest_common.context.test_name or ""
+    test_name = yatest.common.context.test_name or ""
     test_name = test_name.replace(':', '_')
     lb, rb = re.escape('['), re.escape(']')
     test_case = re.search(lb + '(.+?)' + rb, test_name)
     assert test_case
-    dirpath = os.path.join(yatest_common.output_path(), test_case.group(1), sub_folder)
+    dirpath = os.path.join(yatest.common.output_path(), test_case.group(1), sub_folder)
     if not os.path.exists(dirpath):
         os.makedirs(dirpath, exist_ok=True)
     return os.path.join(dirpath, file)
@@ -39,7 +38,7 @@ def get_ids():
 
 
 def psql_binary_path():
-    return yatest_common.binary_path('ydb/tests/functional/postgresql/psql/psql')
+    return yatest.common.binary_path('ydb/tests/functional/postgresql/psql/psql')
 
 
 def execute_binary(binary_name, cmd, stdin_string=None):

--- a/ydb/tests/functional/scheme_tests/tablet_scheme_tests.py
+++ b/ydb/tests/functional/scheme_tests/tablet_scheme_tests.py
@@ -5,7 +5,8 @@ import os
 import pytest
 import json
 
-from ydb.tests.library.common import yatest_common
+import yatest
+
 from ydb.tests.library.common.local_db_scheme import get_scheme
 from ydb.tests.library.common.types import TabletTypes
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
@@ -14,7 +15,7 @@ from ydb.tests.oss.canonical import set_canondata_root
 
 
 def write_canonical_file(tablet, content):
-    fn = os.path.join(yatest_common.output_path(), tablet + '.schema')
+    fn = os.path.join(yatest.common.output_path(), tablet + '.schema')
     with open(fn, 'w') as w:
         w.write(
             json.dumps(
@@ -81,7 +82,7 @@ class TestTabletSchemes(object):
         scheme = get_scheme(self.client, self.get_tablet_id(tablet_type))
         scheme = [element.data for element in scheme]
         return {
-            'schema': yatest_common.canonical_file(
+            'schema': yatest.common.canonical_file(
                 local=True,
                 universal_lines=True,
                 path=write_canonical_file(

--- a/ydb/tests/functional/sqs/cloud/test_common.py
+++ b/ydb/tests/functional/sqs/cloud/test_common.py
@@ -7,7 +7,7 @@ import time
 import uuid
 
 import pytest
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 from hamcrest import assert_that, equal_to, not_none, raises, greater_than
 from ydb.tests.library.sqs.test_base import KikimrSqsTestBase, IS_FIFO_PARAMS, TABLES_FORMAT_PARAMS
@@ -161,12 +161,12 @@ class TestCommonSqsYandexCloudMode(get_test_with_sqs_tenant_installation(CommonT
         config_generator.yaml_config['sqs_config']['account_settings_defaults'] = {'max_queues_count': 40}
         config_generator.yaml_config['sqs_config']['background_metrics_update_time_ms'] = 1000
 
-        cls.event_output_file = yatest_common.output_path("events-%s.txt" % random.randint(1, 10000000))
+        cls.event_output_file = yatest.common.output_path("events-%s.txt" % random.randint(1, 10000000))
         config_generator.yaml_config['sqs_config']['yc_search_events_config'] = {
             'enable_yc_search': True,
             'output_file_name': cls.event_output_file,
         }
-        temp_token_file = yatest_common.work_path("tokenfile")
+        temp_token_file = yatest.common.work_path("tokenfile")
         with open(temp_token_file, "w") as fl:
             fl.write("root@builtin")
 

--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
@@ -10,7 +10,7 @@ import time
 import uuid
 
 import pytest
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 import ydb
 from hamcrest import assert_that, equal_to, not_none, has_item, has_items, is_not, contains_string
@@ -36,12 +36,12 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(KikimrSqsTest
         config_generator.yaml_config['sqs_config']['account_settings_defaults'] = {'max_queues_count': 40}
         config_generator.yaml_config['sqs_config']['background_metrics_update_time_ms'] = 1000
 
-        cls.event_output_file = yatest_common.output_path("events-%s.txt" % random.randint(1, 10000000))
+        cls.event_output_file = yatest.common.output_path("events-%s.txt" % random.randint(1, 10000000))
         config_generator.yaml_config['sqs_config']['yc_search_events_config'] = {
             'enable_yc_search': True,
             'output_file_name': cls.event_output_file,
         }
-        temp_token_file = yatest_common.work_path("tokenfile")
+        temp_token_file = yatest.common.work_path("tokenfile")
         with open(temp_token_file, "w") as fl:
             fl.write("root@builtin")
 

--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_queue_counters.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_queue_counters.py
@@ -4,7 +4,7 @@ import random
 import logging
 import uuid
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 from ydb.tests.library.sqs.test_base import KikimrSqsTestBase, get_test_with_sqs_tenant_installation
 
@@ -19,12 +19,12 @@ class TestYmqQueueCounters(get_test_with_sqs_tenant_installation(KikimrSqsTestBa
         config_generator.yaml_config['sqs_config']['account_settings_defaults'] = {'max_queues_count': 40}
         config_generator.yaml_config['sqs_config']['background_metrics_update_time_ms'] = 1000
 
-        cls.event_output_file = yatest_common.output_path("events-%s.txt" % random.randint(1, 10000000))
+        cls.event_output_file = yatest.common.output_path("events-%s.txt" % random.randint(1, 10000000))
         config_generator.yaml_config['sqs_config']['yc_search_events_config'] = {
             'enable_yc_search': True,
             'output_file_name': cls.event_output_file,
         }
-        temp_token_file = yatest_common.work_path("tokenfile")
+        temp_token_file = yatest.common.work_path("tokenfile")
         with open(temp_token_file, "w") as fl:
             fl.write("root@builtin")
 

--- a/ydb/tests/functional/sqs/common/test_acl.py
+++ b/ydb/tests/functional/sqs/common/test_acl.py
@@ -6,7 +6,7 @@ import time
 import pytest
 from hamcrest import assert_that, none, is_not, is_, raises
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 from ydb.tests.library.sqs.test_base import KikimrSqsTestBase, get_sqs_client_path, get_test_with_sqs_installation_by_path, get_test_with_sqs_tenant_installation
 from ydb.tests.library.sqs.test_base import TABLES_FORMAT_PARAMS
@@ -30,8 +30,8 @@ class SqsACLTest(KikimrSqsTestBase):
         while retries_count:
             logging.debug("Running {}".format(' '.join(cmd)))
             try:
-                yatest_common.execute(cmd)
-            except yatest_common.ExecutionError as ex:
+                yatest.common.execute(cmd)
+            except yatest.common.ExecutionError as ex:
                 logging.debug("Modify permissions failed: {}. Retrying".format(ex))
                 retries_count -= 1
                 time.sleep(3)
@@ -49,8 +49,8 @@ class SqsACLTest(KikimrSqsTestBase):
         while retries_count:
             logging.debug("Running {}".format(' '.join(cmd)))
             try:
-                execute = yatest_common.execute(cmd)
-            except yatest_common.ExecutionError as ex:
+                execute = yatest.common.execute(cmd)
+            except yatest.common.ExecutionError as ex:
                 logging.debug("List permissions failed: {}. Retrying".format(ex))
                 retries_count -= 1
                 time.sleep(3)

--- a/ydb/tests/functional/suite_tests/test_base.py
+++ b/ydb/tests/functional/suite_tests/test_base.py
@@ -13,7 +13,7 @@ import enum
 from concurrent import futures
 
 from hamcrest import assert_that, is_, equal_to, raises, none
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 from yatest.common import source_path, test_source_path
 
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
@@ -199,10 +199,10 @@ def wrap_rows(rows):
 
 
 def write_canonical_response(response, file):
-    output_path = os.path.join(yatest_common.output_path(), file)
+    output_path = os.path.join(yatest.common.output_path(), file)
     with open(output_path, 'w') as w:
         w.write(json.dumps(response, indent=4, sort_keys=True))
-    return yatest_common.canonical_file(
+    return yatest.common.canonical_file(
         local=True,
         universal_lines=True,
         path=output_path
@@ -420,13 +420,13 @@ class BaseSuiteRunner(object):
         yql_text = "--!syntax_v1\n" + yql_text + "\n\n"
         result = self.execute_scan_query(yql_text)
         file_name = statement.suite_name.split('/')[1] + '.out'
-        output_path = os.path.join(yatest_common.output_path(), file_name)
+        output_path = os.path.join(yatest.common.output_path(), file_name)
         with open(output_path, 'a+') as w:
             w.write(yql_text)
             w.write(format_as_table(result))
             w.write("\n\n")
 
-        self.files[file_name] = yatest_common.canonical_file(
+        self.files[file_name] = yatest.common.canonical_file(
             path=output_path,
             local=True,
             universal_lines=True,

--- a/ydb/tests/functional/tpc/test_generator.py
+++ b/ydb/tests/functional/tpc/test_generator.py
@@ -9,7 +9,8 @@ import pytest
 import json
 import random
 
-from ydb.tests.library.common import yatest_common
+import yatest
+
 from ydb.tests.oss.canonical import set_canondata_root
 from threading import Thread
 
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 def ydb_bin():
     if os.getenv('YDB_CLI_BINARY'):
-        return yatest_common.binary_path(os.getenv('YDB_CLI_BINARY'))
+        return yatest.common.binary_path(os.getenv('YDB_CLI_BINARY'))
     raise RuntimeError('YDB_CLI_BINARY enviroment variable is not specified')
 
 
@@ -28,7 +29,7 @@ class TpcGeneratorBase(object):
 
     @classmethod
     def execute_generator(cls, output_path, scale=1, import_args=[], generator_args=[]):
-        return yatest_common.execute(
+        return yatest.common.execute(
             [
                 ydb_bin(),
                 '--endpoint', 'grpc://localhost',
@@ -46,7 +47,7 @@ class TpcGeneratorBase(object):
     def canonical_result(output_result, tmp_path):
         with open(tmp_path, 'w') as f:
             f.write(output_result)
-        return yatest_common.canonical_file(tmp_path, local=True, universal_lines=True)
+        return yatest.common.canonical_file(tmp_path, local=True, universal_lines=True)
 
     @staticmethod
     def calc_hashes(files: str | list[str]):

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -10,12 +9,14 @@ import os
 import logging
 import pytest
 
+import yatest
+
 logger = logging.getLogger(__name__)
 
 
 def backup_bin():
     if os.getenv("YDB_CLI_BINARY"):
-        return yatest_common.binary_path(os.getenv("YDB_CLI_BINARY"))
+        return yatest.common.binary_path(os.getenv("YDB_CLI_BINARY"))
     raise RuntimeError("YDB_CLI_BINARY enviroment variable is not specified")
 
 
@@ -34,7 +35,7 @@ def upsert_simple(session, full_path):
 
 
 def output_path(*args):
-    path = os.path.join(yatest_common.output_path(), *args)
+    path = os.path.join(yatest.common.output_path(), *args)
     os.makedirs(path, exist_ok=False)
     return path
 
@@ -229,7 +230,7 @@ class BaseTestBackupInFiles(object):
     def create_backup(cls, path, expected_dirs, check_data, additional_args=[]):
         _, name = os.path.split(path)
         backup_files_dir = output_path(cls.test_name, "backup_files_dir_" + path.replace("/", "_"))
-        execution = yatest_common.execute(
+        execution = yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -482,7 +483,7 @@ class TestSingleBackupRestore(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, 'test_single_table_with_data_backup_restore' + postfix, "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -514,7 +515,7 @@ class TestSingleBackupRestore(BaseTestBackupInFiles):
         ]
         if use_bulk_upsert:
             restore_cmd.append("--bulk-upsert")
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             [child.name for child in self.driver.scheme_client.list_directory("/Root").children],
@@ -545,7 +546,7 @@ class TestBackupRestoreInRoot(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, 'test_single_table_with_data_backup_restore', "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -566,7 +567,7 @@ class TestBackupRestoreInRoot(BaseTestBackupInFiles):
         )
 
         # Restore table
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -600,7 +601,7 @@ class TestBackupRestoreInRootSchemeOnly(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, 'test_single_table_with_data_backup_restore', "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -622,7 +623,7 @@ class TestBackupRestoreInRootSchemeOnly(BaseTestBackupInFiles):
         )
 
         # Restore table
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -655,7 +656,7 @@ class TestIncompleteBackup(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -680,7 +681,7 @@ class TestIncompleteBackup(BaseTestBackupInFiles):
         open(os.path.join(backup_files_dir, "table", "incomplete"), "w").close()
 
         # Restore table and check that it fails without restoring anything
-        execution = yatest_common.execute(
+        execution = yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -705,7 +706,7 @@ class TestIncompleteBackup(BaseTestBackupInFiles):
             is_(["table"])
         )
 
-        execution = yatest_common.execute(
+        execution = yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -771,7 +772,7 @@ class TestAlterBackupRestore(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, 'test_single_table_with_data_backup_restore', "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -792,7 +793,7 @@ class TestAlterBackupRestore(BaseTestBackupInFiles):
         )
 
         # Restore table
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -829,7 +830,7 @@ class TestPermissionsBackupRestoreSingleTable(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, "test_single_table", "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -859,7 +860,7 @@ class TestPermissionsBackupRestoreSingleTable(BaseTestBackupInFiles):
             "--path", "/Root/restored",
             "--input", backup_files_dir
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             self.scheme_listdir("/Root"),
@@ -889,7 +890,7 @@ class TestPermissionsBackupRestoreFolderWithTable(BaseTestBackupInFiles):
 
         # Backup folder with table
         backup_files_dir = output_path(self.test_name, "test_folder_with_table", "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -915,7 +916,7 @@ class TestPermissionsBackupRestoreFolderWithTable(BaseTestBackupInFiles):
             "--path", "/Root/restored",
             "--input", backup_files_dir
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             self.scheme_listdir("/Root"),
@@ -945,7 +946,7 @@ class TestPermissionsBackupRestoreDontOverwriteOnAlreadyExisting(BaseTestBackupI
 
         # Backup folder with table
         backup_files_dir = output_path(self.test_name, "test_dont_overwrite_on_already_existing", "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -989,7 +990,7 @@ class TestPermissionsBackupRestoreDontOverwriteOnAlreadyExisting(BaseTestBackupI
             "--path", "/Root",
             "--input", backup_files_dir
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
         assert_that(
             self.scheme_listdir("/Root"),
             is_(["folder"])
@@ -1005,7 +1006,7 @@ class TestPermissionsBackupRestoreDontOverwriteOnAlreadyExisting(BaseTestBackupI
             "--path", "/Root/restored",
             "--input", backup_files_dir
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             self.scheme_listdir("/Root"),
@@ -1044,7 +1045,7 @@ class TestPermissionsBackupRestoreSchemeOnly(BaseTestBackupInFiles):
 
         # Backup folder with table
         backup_files_dir = output_path(self.test_name, "test_scheme_only", "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -1071,7 +1072,7 @@ class TestPermissionsBackupRestoreSchemeOnly(BaseTestBackupInFiles):
             "--path", "/Root/restored",
             "--input", backup_files_dir,
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             self.scheme_listdir("/Root"),
@@ -1095,7 +1096,7 @@ class TestPermissionsBackupRestoreEmptyDir(BaseTestBackupInFiles):
 
         # Backup folder
         backup_files_dir = output_path(self.test_name, "test_empty_dir", "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -1121,7 +1122,7 @@ class TestPermissionsBackupRestoreEmptyDir(BaseTestBackupInFiles):
             "--path", "/Root/restored",
             "--input", backup_files_dir
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             self.scheme_listdir("/Root"),
@@ -1145,7 +1146,7 @@ class TestRestoreACLOption(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, "test_single_table", "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -1176,7 +1177,7 @@ class TestRestoreACLOption(BaseTestBackupInFiles):
             "--input", backup_files_dir,
             "--restore-acl", "false"
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             self.scheme_listdir("/Root"),
@@ -1212,7 +1213,7 @@ class TestRestoreNoData(BaseTestBackupInFiles):
 
         # Backup table
         backup_files_dir = output_path(self.test_name, "test_single_table", "backup_files_dir")
-        yatest_common.execute(
+        yatest.common.execute(
             [
                 backup_bin(),
                 "--verbose",
@@ -1243,7 +1244,7 @@ class TestRestoreNoData(BaseTestBackupInFiles):
             "--input", backup_files_dir,
             "--restore-data", "false",
         ]
-        yatest_common.execute(restore_cmd)
+        yatest.common.execute(restore_cmd)
 
         assert_that(
             self.scheme_listdir("/Root"),

--- a/ydb/tests/functional/ydb_cli/test_ydb_flame_graph.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_flame_graph.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -9,12 +8,14 @@ import os
 import logging
 import pathlib
 
+import yatest
+
 logger = logging.getLogger(__name__)
 
 
 def ydb_bin():
     if os.getenv("YDB_CLI_BINARY"):
-        return yatest_common.binary_path(os.getenv("YDB_CLI_BINARY"))
+        return yatest.common.binary_path(os.getenv("YDB_CLI_BINARY"))
     raise RuntimeError("YDB_CLI_BINARY enviroment variable is not specified")
 
 
@@ -50,7 +51,7 @@ class BaseTestFlameGraphService(object):
     @classmethod
     def execute_ydb_cli_command(cls, args, stdin=None):
         try:
-            execution = yatest_common.execute([ydb_bin()] + args, stdin=stdin)
+            execution = yatest.common.execute([ydb_bin()] + args, stdin=stdin)
             result = execution.std_out.decode('utf-8') + '\n' + execution.std_err.decode('utf-8')
         except Exception as exc:
             result = str(exc)
@@ -62,7 +63,7 @@ class BaseTestFlameGraphService(object):
         output_file_name = "result.output"
         with open(output_file_name, "w") as f:
             f.write(output_result.decode('utf-8'))
-        return yatest_common.canonical_file(output_file_name, local=True, universal_lines=True)
+        return yatest.common.canonical_file(output_file_name, local=True, universal_lines=True)
 
 
 class BaseTestFlameGraphServiceWithDatabase(BaseTestFlameGraphService):

--- a/ydb/tests/functional/ydb_cli/test_ydb_impex.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_impex.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -9,6 +8,8 @@ import pytest
 import logging
 import pyarrow as pa
 import pyarrow.parquet as pq
+
+import yatest
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +124,7 @@ ONLY_CSV_TSV_PARAMS = [("csv", []), ("csv", ["--newline-delimited"]), ("tsv", []
 
 def ydb_bin():
     if os.getenv("YDB_CLI_BINARY"):
-        return yatest_common.binary_path(os.getenv("YDB_CLI_BINARY"))
+        return yatest.common.binary_path(os.getenv("YDB_CLI_BINARY"))
     raise RuntimeError("YDB_CLI_BINARY enviroment variable is not specified")
 
 
@@ -168,7 +169,7 @@ class BaseTestTableService(object):
 
     @classmethod
     def execute_ydb_cli_command(cls, args, stdin=None, stdout=None):
-        execution = yatest_common.execute(
+        execution = yatest.common.execute(
             [
                 ydb_bin(),
                 "--endpoint", "grpc://localhost:%d" % cls.cluster.nodes[1].grpc_port,
@@ -273,13 +274,13 @@ class TestImpex(BaseTestTableService):
         query = "SELECT `key`, `id`, `value` FROM `{}` ORDER BY `key`".format(self.table_path)
         output_file_name = str(self.tmp_path / "result.output")
         self.execute_ydb_cli_command(["table", "query", "execute", "-q", query, "-t", "scan", "--format", format], stdout=output_file_name)
-        return yatest_common.canonical_file(output_file_name, local=True, universal_lines=True)
+        return yatest.common.canonical_file(output_file_name, local=True, universal_lines=True)
 
     def validate_gen_data(self):
         query = "SELECT count(*) FROM `{}`".format(self.table_path)
         output_file_name = str(self.tmp_path / "result.output")
         self.execute_ydb_cli_command(["table", "query", "execute", "-q", query, "-t", "scan"], stdout=output_file_name)
-        return yatest_common.canonical_file(output_file_name, local=True, universal_lines=True)
+        return yatest.common.canonical_file(output_file_name, local=True, universal_lines=True)
 
     @pytest.mark.parametrize("ftype,additional_args", ALL_PARAMS)
     def test_simple(self, tmp_path, request, table_type, ftype, additional_args):

--- a/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_scheme.py
@@ -2,7 +2,8 @@ import json
 import os
 import pytest
 
-from ydb.tests.library.common import yatest_common
+import yatest
+
 from ydb.tests.oss.canonical import set_canondata_root
 
 CLUSTER_CONFIG = dict(extra_feature_flags=["enable_views"], extra_grpc_services=["view"])
@@ -10,7 +11,7 @@ CLUSTER_CONFIG = dict(extra_feature_flags=["enable_views"], extra_grpc_services=
 
 def bin_from_env(var):
     if os.getenv(var):
-        return yatest_common.binary_path(os.getenv(var))
+        return yatest.common.binary_path(os.getenv(var))
     raise RuntimeError(f"{var} environment variable is not specified")
 
 
@@ -22,11 +23,11 @@ def canonical_result(output_result, tmp_path):
     output_path = tmp_path / "result.output"
     with output_path.open("w") as f:
         f.write(output_result)
-    return yatest_common.canonical_file(output_path, local=True, universal_lines=True)
+    return yatest.common.canonical_file(output_path, local=True, universal_lines=True)
 
 
 def execute_ydb_cli_command(node, database, args, stdin=None):
-    execution = yatest_common.execute(
+    execution = yatest.common.execute(
         [ydb_bin(), "--endpoint", f"grpc://{node.host}:{node.grpc_port}", "--database", database] + args, stdin=stdin
     )
     return execution.std_out.decode("utf-8")

--- a/ydb/tests/functional/ydb_cli/test_ydb_scripting.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_scripting.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -9,13 +8,15 @@ import os
 import logging
 import pytest
 
+import yatest
+
 
 logger = logging.getLogger(__name__)
 
 
 def ydb_bin():
     if os.getenv("YDB_CLI_BINARY"):
-        return yatest_common.binary_path(os.getenv("YDB_CLI_BINARY"))
+        return yatest.common.binary_path(os.getenv("YDB_CLI_BINARY"))
     raise RuntimeError("YDB_CLI_BINARY enviroment variable is not specified")
 
 
@@ -50,7 +51,7 @@ def create_table_with_data(session, path):
 class BaseTestScriptingService(object):
     @classmethod
     def execute_ydb_cli_command(cls, args, stdin=None, env=None):
-        execution = yatest_common.execute([ydb_bin()] + args, stdin=stdin, env=env)
+        execution = yatest.common.execute([ydb_bin()] + args, stdin=stdin, env=env)
         result = execution.std_out
         logger.debug("std_out:\n" + result.decode('utf-8'))
         return result
@@ -59,7 +60,7 @@ class BaseTestScriptingService(object):
     def canonical_result(output_result, tmp_path):
         with (tmp_path / "result.output").open("w") as f:
             f.write(output_result.decode('utf-8'))
-        return yatest_common.canonical_file(str(tmp_path / "result.output"), local=True, universal_lines=True)
+        return yatest.common.canonical_file(str(tmp_path / "result.output"), local=True, universal_lines=True)
 
 
 class BaseTestScriptingServiceWithDatabase(BaseTestScriptingService):

--- a/ydb/tests/functional/ydb_cli/test_ydb_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_sql.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -9,13 +8,14 @@ import os
 import logging
 import pytest
 
+import yatest
 
 logger = logging.getLogger(__name__)
 
 
 def ydb_bin():
     if os.getenv("YDB_CLI_BINARY"):
-        return yatest_common.binary_path(os.getenv("YDB_CLI_BINARY"))
+        return yatest.common.binary_path(os.getenv("YDB_CLI_BINARY"))
     raise RuntimeError("YDB_CLI_BINARY enviroment variable is not specified")
 
 
@@ -50,7 +50,7 @@ def create_table_with_data(session, path):
 class BaseTestSql(object):
     @classmethod
     def execute_ydb_cli_command(cls, args, stdin=None, env=None):
-        execution = yatest_common.execute([ydb_bin()] + args, stdin=stdin, env=env)
+        execution = yatest.common.execute([ydb_bin()] + args, stdin=stdin, env=env)
         result = execution.std_out
         logger.debug("std_out:\n" + result.decode('utf-8'))
         return result
@@ -59,7 +59,7 @@ class BaseTestSql(object):
     def canonical_result(output_result, tmp_path):
         with (tmp_path / "result.output").open("w") as f:
             f.write(output_result.decode('utf-8'))
-        return yatest_common.canonical_file(str(tmp_path / "result.output"), local=True, universal_lines=True)
+        return yatest.common.canonical_file(str(tmp_path / "result.output"), local=True, universal_lines=True)
 
 
 class BaseTestSqlWithDatabase(BaseTestSql):

--- a/ydb/tests/functional/ydb_cli/test_ydb_table.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_table.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.common import yatest_common
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -9,13 +8,14 @@ import os
 import logging
 import pytest
 
+import yatest
 
 logger = logging.getLogger(__name__)
 
 
 def ydb_bin():
     if os.getenv("YDB_CLI_BINARY"):
-        return yatest_common.binary_path(os.getenv("YDB_CLI_BINARY"))
+        return yatest.common.binary_path(os.getenv("YDB_CLI_BINARY"))
     raise RuntimeError("YDB_CLI_BINARY enviroment variable is not specified")
 
 
@@ -68,7 +68,7 @@ class BaseTestTableService(object):
 
     @classmethod
     def execute_ydb_cli_command(cls, args, stdin=None):
-        execution = yatest_common.execute(
+        execution = yatest.common.execute(
             [
                 ydb_bin(),
                 "--endpoint", "grpc://localhost:%d" % cls.cluster.nodes[1].grpc_port,
@@ -85,7 +85,7 @@ class BaseTestTableService(object):
     def canonical_result(output_result, tmp_path):
         with (tmp_path / "result.output").open("w") as f:
             f.write(output_result.decode('utf-8'))
-        return yatest_common.canonical_file(str(tmp_path / "result.output"), local=True, universal_lines=True)
+        return yatest.common.canonical_file(str(tmp_path / "result.output"), local=True, universal_lines=True)
 
 
 class TestExecuteQueryWithParams(BaseTestTableService):

--- a/ydb/tests/library/common/helpers.py
+++ b/ydb/tests/library/common/helpers.py
@@ -3,6 +3,7 @@
 
 import yatest.common
 
+
 def unpack_list(list_of_tuples_of_tuples_and_values):
     """
     >>> unpack_list([((1, 2), 3), ((5, 6), 7)])
@@ -61,6 +62,7 @@ def wrap_in_list(item):
         return item
     else:
         return [item]
+
 
 def plain_or_under_sanitizer(plain, sanitized):
     """

--- a/ydb/tests/library/common/helpers.py
+++ b/ydb/tests/library/common/helpers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import yatest.common
 
 def unpack_list(list_of_tuples_of_tuples_and_values):
     """
@@ -60,3 +61,12 @@ def wrap_in_list(item):
         return item
     else:
         return [item]
+
+def plain_or_under_sanitizer(plain, sanitized):
+    """
+    Meant to be used in test code for constants (timeouts, etc)
+    See also arcadia/util/system/sanitizers.h
+
+    :return: plain if no sanitizer enabled or sanitized otherwise
+    """
+    return plain if not yatest.common.context.sanitize else sanitized

--- a/ydb/tests/library/common/yatest_common.py
+++ b/ydb/tests/library/common/yatest_common.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# TODO (2024): remove this file, it is not needed. See KIKIMR-16114 for details
 import os
 
 import yatest.common as ya_common

--- a/ydb/tests/library/harness/daemon.py
+++ b/ydb/tests/library/harness/daemon.py
@@ -53,6 +53,14 @@ class SeveralDaemonErrors(RuntimeError):
         super(SeveralDaemonErrors, self).__init__("\n".join(str(x) for x in exceptions))
 
 
+def _work_path(name):
+    # TODO: remove yatest dependency from harness
+    try:
+        return yatest.common.work_path(name)
+    except yatest.common.NoRuntimeFormed:
+        return name
+
+
 class Daemon(object):
     """Local process executed as process in current host"""
     def __init__(
@@ -60,8 +68,8 @@ class Daemon(object):
         command,
         cwd,
         timeout,
-        stdout_file=yatest.common.work_path('stdout'),
-        stderr_file=yatest.common.work_path('stderr'),
+        stdout_file=_work_path('stdout'),
+        stderr_file=_work_path('stderr'),
         stderr_on_error_lines=0,
         core_pattern=None,
     ):

--- a/ydb/tests/library/harness/daemon.py
+++ b/ydb/tests/library/harness/daemon.py
@@ -6,11 +6,11 @@ import signal
 import sys
 import subprocess
 
+import yatest
 from yatest.common import process
 import six
 
 from ydb.tests.library.common.wait_for import wait_for
-from ydb.tests.library.common import yatest_common
 from . import param_constants
 
 
@@ -60,8 +60,8 @@ class Daemon(object):
         command,
         cwd,
         timeout,
-        stdout_file=yatest_common.work_path('stdout'),
-        stderr_file=yatest_common.work_path('stderr'),
+        stdout_file=yatest.common.work_path('stdout'),
+        stderr_file=yatest.common.work_path('stderr'),
         stderr_on_error_lines=0,
         core_pattern=None,
     ):

--- a/ydb/tests/library/harness/kikimr_cluster.py
+++ b/ydb/tests/library/harness/kikimr_cluster.py
@@ -7,13 +7,14 @@ import time
 import pprint
 from concurrent import futures
 
-import ydb.tests.library.common.yatest_common as yatest_common
 import ydb
 
 from . import param_constants
 from .kikimr_runner import KiKiMR, KikimrExternalNode
 from .kikimr_cluster_interface import KiKiMRClusterInterface
 import yaml
+
+import yatest
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ DEFAULT_GRPC_PORT = 2135
 
 
 def kikimr_cluster_factory(configurator=None, config_path=None):
-    logger.info("All test params = {}".format(pprint.pformat(yatest_common.get_param_dict_copy())))
+    logger.info("All test params = {}".format(pprint.pformat(yatest.common.get_param_dict_copy())))
     logger.info("Starting standalone YDB cluster")
     if config_path is not None:
         return ExternalKiKiMRCluster(config_path)

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -11,7 +11,8 @@ import yaml
 from google.protobuf.text_format import Parse
 from importlib_resources import read_binary
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
+
 from ydb.core.protos import config_pb2
 from ydb.tests.library.common.types import Erasure
 
@@ -180,7 +181,7 @@ class KikimrConfigGenerator(object):
         self.__grpc_tls_cert = None
         self._pdisks_info = []
         if self.__grpc_ssl_enable:
-            self.__grpc_tls_data_path = grpc_tls_data_path or yatest_common.output_path()
+            self.__grpc_tls_data_path = grpc_tls_data_path or yatest.common.output_path()
             cert_pem, key_pem = tls_tools.generate_selfsigned_cert(_get_fqdn())
             self.__grpc_tls_ca = cert_pem
             self.__grpc_tls_key = key_pem
@@ -225,7 +226,7 @@ class KikimrConfigGenerator(object):
 
         self.__dynamic_pdisks = dynamic_pdisks
 
-        self.__output_path = output_path or yatest_common.output_path()
+        self.__output_path = output_path or yatest.common.output_path()
         self.node_kind = node_kind
         self.yq_tenant = yq_tenant
         self.dc_mapping = dc_mapping
@@ -477,7 +478,7 @@ class KikimrConfigGenerator(object):
             return path
 
         def get_cwd_for_test(output_path):
-            test_name = yatest_common.context.test_name or ""
+            test_name = yatest.common.context.test_name or ""
             test_name = test_name.replace(':', '_')
             return os.path.join(output_path, test_name)
 
@@ -495,7 +496,7 @@ class KikimrConfigGenerator(object):
             return path
 
         def get_cwd_for_test(output_path):
-            test_name = yatest_common.context.test_name or ""
+            test_name = yatest.common.context.test_name or ""
             test_name = test_name.replace(':', '_')
             return os.path.join(output_path, test_name)
 
@@ -564,7 +565,7 @@ class KikimrConfigGenerator(object):
     def get_yql_udfs_to_load(self):
         if not self.__load_udfs:
             return []
-        udfs_path = self.__udfs_path or yatest_common.build_path("yql/udfs")
+        udfs_path = self.__udfs_path or yatest.common.build_path("yql/udfs")
         result = []
         for dirpath, dnames, fnames in os.walk(udfs_path):
             is_loaded = False

--- a/ydb/tests/library/harness/kikimr_port_allocator.py
+++ b/ydb/tests/library/harness/kikimr_port_allocator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import abc
 import os
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 
 class KikimrNodePortAllocatorInterface(object):
@@ -140,7 +140,7 @@ class KikimrPortManagerNodePortAllocator(KikimrNodePortAllocatorInterface):
 class KikimrPortManagerPortAllocator(KikimrPortAllocatorInterface):
     def __init__(self, port_manager=None):
         super(KikimrPortManagerPortAllocator, self).__init__()
-        self.__port_manager = yatest_common.PortManager() if port_manager is None else port_manager
+        self.__port_manager = yatest.common.PortManager() if port_manager is None else port_manager
         self.__nodes_allocators = []
         self.__slots_allocators = []
 

--- a/ydb/tests/library/harness/kikimr_port_allocator.py
+++ b/ydb/tests/library/harness/kikimr_port_allocator.py
@@ -2,6 +2,7 @@
 import abc
 import os
 import yatest
+import yatest.common.network
 
 
 class KikimrNodePortAllocatorInterface(object):
@@ -140,7 +141,7 @@ class KikimrPortManagerNodePortAllocator(KikimrNodePortAllocatorInterface):
 class KikimrPortManagerPortAllocator(KikimrPortAllocatorInterface):
     def __init__(self, port_manager=None):
         super(KikimrPortManagerPortAllocator, self).__init__()
-        self.__port_manager = yatest.common.PortManager() if port_manager is None else port_manager
+        self.__port_manager = yatest.common.network.PortManager() if port_manager is None else port_manager
         self.__nodes_allocators = []
         self.__slots_allocators = []
 

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -26,7 +26,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_unique_path_for_current_test(output_path, sub_folder):
-    test_name = yatest.common.context.test_name or ""
+    # TODO: remove yatest dependency from harness
+    try:
+        test_name = yatest.common.context.test_name
+    except AttributeError:
+        test_name = ""
     test_name = test_name.replace(':', '_')
 
     return os.path.join(output_path, test_name, sub_folder)

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -8,7 +8,7 @@ import itertools
 from importlib_resources import read_binary
 from google.protobuf import text_format
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 from ydb.tests.library.common.wait_for import wait_for
 from . import daemon
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_unique_path_for_current_test(output_path, sub_folder):
-    test_name = yatest_common.context.test_name or ""
+    test_name = yatest.common.context.test_name or ""
     test_name = test_name.replace(':', '_')
 
     return os.path.join(output_path, test_name, sub_folder)
@@ -279,8 +279,8 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
 
         logger.debug("Executing command = {}".format(full_command))
         try:
-            return yatest_common.execute(full_command)
-        except yatest_common.ExecutionError as e:
+            return yatest.common.execute(full_command)
+        except yatest.common.ExecutionError as e:
             logger.exception("KiKiMR command '{cmd}' failed with error: {e}\n\tstdout: {out}\n\tstderr: {err}".format(
                 cmd=" ".join(str(x) for x in full_command),
                 e=str(e),
@@ -516,7 +516,7 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         self._bs_config_invoke(request)
 
     def _bs_config_invoke(self, request):
-        timeout = yatest_common.plain_or_under_sanitizer(120, 240)
+        timeout = yatest.common.plain_or_under_sanitizer(120, 240)
         sleep = 5
         retries, success = timeout / sleep, False
         while retries > 0 and not success:
@@ -569,7 +569,7 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         def predicate():
             return blobstorage_controller_has_started_on_some_node(monitors)
 
-        timeout_seconds = yatest_common.plain_or_under_sanitizer(120, 240)
+        timeout_seconds = yatest.common.plain_or_under_sanitizer(120, 240)
         bs_controller_started = wait_for(
             predicate=predicate, timeout_seconds=timeout_seconds, step_seconds=1.0, multiply=1.3
         )

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -10,6 +10,7 @@ from google.protobuf import text_format
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.library.common.wait_for import wait_for
 from . import daemon
 from . import param_constants
@@ -516,7 +517,7 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         self._bs_config_invoke(request)
 
     def _bs_config_invoke(self, request):
-        timeout = yatest.common.plain_or_under_sanitizer(120, 240)
+        timeout = plain_or_under_sanitizer(120, 240)
         sleep = 5
         retries, success = timeout / sleep, False
         while retries > 0 and not success:
@@ -569,7 +570,7 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
         def predicate():
             return blobstorage_controller_has_started_on_some_node(monitors)
 
-        timeout_seconds = yatest.common.plain_or_under_sanitizer(120, 240)
+        timeout_seconds = plain_or_under_sanitizer(120, 240)
         bs_controller_started = wait_for(
             predicate=predicate, timeout_seconds=timeout_seconds, step_seconds=1.0, multiply=1.3
         )

--- a/ydb/tests/library/harness/param_constants.py
+++ b/ydb/tests/library/harness/param_constants.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import os
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 
-config_name = yatest_common.get_param("kikimr.ci.cluster_name", None)
-ssh_username = yatest_common.get_param("kikimr.ci.ssh_username", os.getenv('NEMESIS_USER', 'robot-nemesis'))
-deploy_cluster = yatest_common.get_bool_param("kikimr.ci.deploy_cluster", False)
-use_packages = yatest_common.get_bool_param('kikimr.ci.packages', True)
+config_name = yatest.common.get_param("kikimr.ci.cluster_name", None)
+ssh_username = yatest.common.get_param("kikimr.ci.ssh_username", os.getenv('NEMESIS_USER', 'robot-nemesis'))
+deploy_cluster = yatest.common.get_bool_param("kikimr.ci.deploy_cluster", False)
+use_packages = yatest.common.get_bool_param('kikimr.ci.packages', True)
 
-log_level = int(yatest_common.get_param('kikimr.ci.driver.log_level', 5))
+log_level = int(yatest.common.get_param('kikimr.ci.driver.log_level', 5))
 
 kikimr_binary_deploy_path = '/Berkanavt/kikimr/bin/kikimr'
 kikimr_configure_binary_deploy_path = '/Berkanavt/kikimr/bin/kikimr_configure'
@@ -28,22 +28,22 @@ def generate_configs_cmd(configs_type="", deploy_path=None):
 
 
 def next_version_kikimr_driver_path():
-    return yatest_common.get_param("kikimr.ci.kikimr_driver_next", None)
+    return yatest.common.get_param("kikimr.ci.kikimr_driver_next", None)
 
 
 def kikimr_stderr_to_console():
-    return yatest_common.get_bool_param("kikimr.ci.stderr_to_console", False)
+    return yatest.common.get_bool_param("kikimr.ci.stderr_to_console", False)
 
 
 def kikimr_driver_path():
-    built_binary = yatest_common.get_param("kikimr.ci.kikimr_driver", None)
+    built_binary = yatest.common.get_param("kikimr.ci.kikimr_driver", None)
     if os.getenv("YDB_DRIVER_BINARY"):
-        return yatest_common.binary_path(os.getenv("YDB_DRIVER_BINARY"))
+        return yatest.common.binary_path(os.getenv("YDB_DRIVER_BINARY"))
 
     if built_binary is None:
-        return yatest_common.binary_path("kikimr/driver/kikimr")
+        return yatest.common.binary_path("kikimr/driver/kikimr")
     return built_binary
 
 
 def kikimr_configure_binary_path():
-    return yatest_common.binary_path("ydb/tools/cfg/bin/ydb_configure")
+    return yatest.common.binary_path("ydb/tools/cfg/bin/ydb_configure")

--- a/ydb/tests/library/harness/param_constants.py
+++ b/ydb/tests/library/harness/param_constants.py
@@ -3,12 +3,20 @@ import os
 import yatest
 
 
-config_name = yatest.common.get_param("kikimr.ci.cluster_name", None)
-ssh_username = yatest.common.get_param("kikimr.ci.ssh_username", os.getenv('NEMESIS_USER', 'robot-nemesis'))
-deploy_cluster = yatest.common.get_param("kikimr.ci.deploy_cluster", "true") == "true"
-use_packages = yatest.common.get_param('kikimr.ci.packages', "false") == "true"
+def _get_param(name, default):
+    # TODO: remove yatest dependency from harness
+    try:
+        return yatest.common.get_param(name, default)
+    except yatest.common.NoRuntimeFormed:
+        return default
 
-log_level = int(yatest.common.get_param('kikimr.ci.driver.log_level', 5))
+
+config_name = _get_param("kikimr.ci.cluster_name", None)
+ssh_username = _get_param("kikimr.ci.ssh_username", os.getenv('NEMESIS_USER', 'robot-nemesis'))
+deploy_cluster = _get_param("kikimr.ci.deploy_cluster", "true") == "true"
+use_packages = _get_param('kikimr.ci.packages', "false") == "true"
+
+log_level = int(_get_param('kikimr.ci.driver.log_level', 5))
 
 kikimr_binary_deploy_path = '/Berkanavt/kikimr/bin/kikimr'
 kikimr_configure_binary_deploy_path = '/Berkanavt/kikimr/bin/kikimr_configure'
@@ -28,15 +36,15 @@ def generate_configs_cmd(configs_type="", deploy_path=None):
 
 
 def next_version_kikimr_driver_path():
-    return yatest.common.get_param("kikimr.ci.kikimr_driver_next", None)
+    return _get_param("kikimr.ci.kikimr_driver_next", None)
 
 
 def kikimr_stderr_to_console():
-    return yatest.common.get_param("kikimr.ci.stderr_to_console", "false") == "true"
+    return _get_param("kikimr.ci.stderr_to_console", "false") == "true"
 
 
 def kikimr_driver_path():
-    built_binary = yatest.common.get_param("kikimr.ci.kikimr_driver", None)
+    built_binary = _get_param("kikimr.ci.kikimr_driver", None)
     if os.getenv("YDB_DRIVER_BINARY"):
         return yatest.common.binary_path(os.getenv("YDB_DRIVER_BINARY"))
 

--- a/ydb/tests/library/harness/param_constants.py
+++ b/ydb/tests/library/harness/param_constants.py
@@ -5,8 +5,8 @@ import yatest
 
 config_name = yatest.common.get_param("kikimr.ci.cluster_name", None)
 ssh_username = yatest.common.get_param("kikimr.ci.ssh_username", os.getenv('NEMESIS_USER', 'robot-nemesis'))
-deploy_cluster = yatest.common.get_bool_param("kikimr.ci.deploy_cluster", False)
-use_packages = yatest.common.get_bool_param('kikimr.ci.packages', True)
+deploy_cluster = yatest.common.get_param("kikimr.ci.deploy_cluster", "true") == "true"
+use_packages = yatest.common.get_param('kikimr.ci.packages', "false") == "true"
 
 log_level = int(yatest.common.get_param('kikimr.ci.driver.log_level', 5))
 
@@ -32,7 +32,7 @@ def next_version_kikimr_driver_path():
 
 
 def kikimr_stderr_to_console():
-    return yatest.common.get_bool_param("kikimr.ci.stderr_to_console", False)
+    return yatest.common.get_param("kikimr.ci.stderr_to_console", "false") == "true"
 
 
 def kikimr_driver_path():

--- a/ydb/tests/library/sqs/test_base.py
+++ b/ydb/tests/library/sqs/test_base.py
@@ -11,7 +11,7 @@ import re
 import socket
 from hamcrest import assert_that, equal_to, not_none, none, greater_than, less_than_or_equal_to, any_of, not_
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
@@ -71,7 +71,7 @@ HAS_QUEUES_PARAMS = {
 
 def get_sqs_client_path():
     if os.getenv("SQS_CLIENT_BINARY"):
-        return yatest_common.binary_path(os.getenv("SQS_CLIENT_BINARY"))
+        return yatest.common.binary_path(os.getenv("SQS_CLIENT_BINARY"))
     raise RuntimeError("SQS_CLIENT_BINARY enviroment variable is not specified")
 
 
@@ -328,7 +328,7 @@ class KikimrSqsTestBase(object):
             '-s', 'localhost',
             '-p', str(grpc_port)
         ]
-        yatest_common.execute(cmd)
+        yatest.common.execute(cmd)
 
     @classmethod
     def _setup_cluster(cls):
@@ -348,8 +348,8 @@ class KikimrSqsTestBase(object):
         while retries_count:
             logging.debug("Running {}".format(' '.join(cmd)))
             try:
-                yatest_common.execute(cmd)
-            except yatest_common.ExecutionError as ex:
+                yatest.common.execute(cmd)
+            except yatest.common.ExecutionError as ex:
                 logging.debug("Create user failed: {}. Retrying".format(ex))
                 retries_count -= 1
                 time.sleep(3)
@@ -434,10 +434,10 @@ class KikimrSqsTestBase(object):
                         '--partitions', '1',
                         '--queue-name', queue_name,
                     ] + self._sqs_server_opts
-                    execute = yatest_common.execute(cmd)
+                    execute = yatest.common.execute(cmd)
                     self.queue_url = execute.std_out
                     self.queue_url = self.queue_url.strip()
-            except (RuntimeError, yatest_common.ExecutionError) as ex:
+            except (RuntimeError, yatest.common.ExecutionError) as ex:
                 logging.debug("Got error: {}. Retrying creation request".format(ex))
                 if retries:
                     time.sleep(1)  # Sleep before next retry

--- a/ydb/tests/stability/ydb/test_stability.py
+++ b/ydb/tests/stability/ydb/test_stability.py
@@ -12,7 +12,8 @@ from ydb.tests.library.harness import param_constants # noqa
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory # noqa
 from ydb.tests.library.matchers.collection import is_empty # noqa
 from ydb.tests.library.wardens.factories import safety_warden_factory, liveness_warden_factory # noqa
-from ydb.tests.library.common import yatest_common # noqa
+
+import yatest
 
 logger = logging.getLogger('ydb.connection')
 logger.setLevel(logging.CRITICAL)
@@ -32,7 +33,7 @@ class ImmutableProperty(object):
 
 
 def read_table_profile():
-    with open(yatest_common.source_path('ydb/tests/stability/resources/tbl_profile.txt'), 'r') as reader:
+    with open(yatest.common.source_path('ydb/tests/stability/resources/tbl_profile.txt'), 'r') as reader:
         return reader.read()
 
 
@@ -43,10 +44,10 @@ def get_slice_directory(slice_name):
 class TestSetupForStability(object):
     stress_binaries_deploy_path = '/Berkanavt/nemesis/bin/'
     artifacts = (
-        yatest_common.binary_path('ydb/tests/tools/nemesis/driver/nemesis'),
-        yatest_common.binary_path('ydb/tools/simple_queue/simple_queue'),
-        yatest_common.binary_path('ydb/tools/olap_workload/olap_workload'),
-        yatest_common.binary_path('ydb/tools/statistics_workload/statistics_workload'),
+        yatest.common.binary_path('ydb/tests/tools/nemesis/driver/nemesis'),
+        yatest.common.binary_path('ydb/tools/simple_queue/simple_queue'),
+        yatest.common.binary_path('ydb/tools/olap_workload/olap_workload'),
+        yatest.common.binary_path('ydb/tools/statistics_workload/statistics_workload'),
     )
 
     @classmethod

--- a/ydb/tests/stability/ydb/test_stability.py
+++ b/ydb/tests/stability/ydb/test_stability.py
@@ -4,6 +4,8 @@ import time
 import logging
 import sys
 
+import yatest
+
 logging.getLogger().setLevel(logging.DEBUG)
 logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
 
@@ -12,8 +14,6 @@ from ydb.tests.library.harness import param_constants # noqa
 from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory # noqa
 from ydb.tests.library.matchers.collection import is_empty # noqa
 from ydb.tests.library.wardens.factories import safety_warden_factory, liveness_warden_factory # noqa
-
-import yatest
 
 logger = logging.getLogger('ydb.connection')
 logger.setLevel(logging.CRITICAL)

--- a/ydb/tests/tools/datastreams_helpers/data_plane.py
+++ b/ydb/tests/tools/datastreams_helpers/data_plane.py
@@ -8,13 +8,12 @@ import uuid
 
 import yatest.common
 
-import ydb.tests.library.common.yatest_common as yatest_common
 from ydb.public.api.grpc.draft import ydb_datastreams_v1_pb2_grpc
 from ydb.public.api.protos.draft import datastreams_pb2
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 
 
-READ_TOOL_TIMEOUT = yatest_common.plain_or_under_sanitizer(30, 300)
+READ_TOOL_TIMEOUT = yatest.common.plain_or_under_sanitizer(30, 300)
 
 
 def write_stream(path, data, partition_key=None):

--- a/ydb/tests/tools/datastreams_helpers/data_plane.py
+++ b/ydb/tests/tools/datastreams_helpers/data_plane.py
@@ -8,12 +8,13 @@ import uuid
 
 import yatest.common
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.public.api.grpc.draft import ydb_datastreams_v1_pb2_grpc
 from ydb.public.api.protos.draft import datastreams_pb2
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 
 
-READ_TOOL_TIMEOUT = yatest.common.plain_or_under_sanitizer(30, 300)
+READ_TOOL_TIMEOUT = plain_or_under_sanitizer(30, 300)
 
 
 def write_stream(path, data, partition_key=None):

--- a/ydb/tests/tools/datastreams_helpers/test_yds_base.py
+++ b/ydb/tests/tools/datastreams_helpers/test_yds_base.py
@@ -5,6 +5,7 @@ import time
 
 import yatest
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.control_plane import create_stream, create_read_rule
 from ydb.tests.tools.datastreams_helpers.data_plane import write_stream, read_stream
 
@@ -30,7 +31,7 @@ class TestYdsBase(object):
         topic = topic_path if topic_path else self.output_topic
         return read_stream(topic, messages_count, commit_after_processing, self.consumer_name)
 
-    def wait_until(self, predicate, wait_time=yatest.common.plain_or_under_sanitizer(10, 50)):
+    def wait_until(self, predicate, wait_time=plain_or_under_sanitizer(10, 50)):
         deadline = time.time() + wait_time
         while time.time() < deadline:
             if predicate():

--- a/ydb/tests/tools/datastreams_helpers/test_yds_base.py
+++ b/ydb/tests/tools/datastreams_helpers/test_yds_base.py
@@ -3,7 +3,8 @@
 
 import time
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
+
 from ydb.tests.tools.datastreams_helpers.control_plane import create_stream, create_read_rule
 from ydb.tests.tools.datastreams_helpers.data_plane import write_stream, read_stream
 
@@ -29,7 +30,7 @@ class TestYdsBase(object):
         topic = topic_path if topic_path else self.output_topic
         return read_stream(topic, messages_count, commit_after_processing, self.consumer_name)
 
-    def wait_until(self, predicate, wait_time=yatest_common.plain_or_under_sanitizer(10, 50)):
+    def wait_until(self, predicate, wait_time=yatest.common.plain_or_under_sanitizer(10, 50)):
         deadline = time.time() + wait_time
         while time.time() < deadline:
             if predicate():

--- a/ydb/tests/tools/datastreams_helpers/test_yds_base.py
+++ b/ydb/tests/tools/datastreams_helpers/test_yds_base.py
@@ -3,8 +3,6 @@
 
 import time
 
-import yatest
-
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.datastreams_helpers.control_plane import create_stream, create_read_rule
 from ydb.tests.tools.datastreams_helpers.data_plane import write_stream, read_stream

--- a/ydb/tests/tools/fq_runner/fq_client.py
+++ b/ydb/tests/tools/fq_runner/fq_client.py
@@ -12,7 +12,7 @@ import library.python.retry as retry
 from ydb.public.api.grpc.draft.fq_v1_pb2_grpc import FederatedQueryServiceStub
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
-import ydb.tests.library.common.yatest_common as yatest_common
+import yatest
 
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -22,7 +22,7 @@ from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 final_statuses = [fq.QueryMeta.COMPLETED, fq.QueryMeta.FAILED, fq.QueryMeta.ABORTED_BY_SYSTEM,
                   fq.QueryMeta.ABORTED_BY_USER, fq.QueryMeta.PAUSED]
 
-CONTROL_PLANE_REQUEST_TIMEOUT = yatest_common.plain_or_under_sanitizer(30.0, 60.0)
+CONTROL_PLANE_REQUEST_TIMEOUT = yatest.common.plain_or_under_sanitizer(30.0, 60.0)
 
 
 class FederatedQueryException(Exception):
@@ -282,7 +282,7 @@ class FederatedQueryClient(object):
         return result.status
 
     # TODO: merge wait_query() and wait_query_status
-    def wait_query(self, query_id, timeout=yatest_common.plain_or_under_sanitizer(40, 200), statuses=final_statuses):
+    def wait_query(self, query_id, timeout=yatest.common.plain_or_under_sanitizer(40, 200), statuses=final_statuses):
         start = time.time()
         deadline = start + timeout
         while True:
@@ -300,10 +300,10 @@ class FederatedQueryClient(object):
                     response.result.query.issue,
                     response.result.query.transient_issue
                 )
-            time.sleep(yatest_common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
 
     # Wait query status or one of statuses in list
-    def wait_query_status(self, query_id, expected_status, timeout=yatest_common.plain_or_under_sanitizer(60, 150)):
+    def wait_query_status(self, query_id, expected_status, timeout=yatest.common.plain_or_under_sanitizer(60, 150)):
         statuses = expected_status if isinstance(expected_status, list) else [expected_status]
         return self.wait_query(query_id, timeout, statuses=statuses).query.meta.status
 

--- a/ydb/tests/tools/fq_runner/fq_client.py
+++ b/ydb/tests/tools/fq_runner/fq_client.py
@@ -12,8 +12,6 @@ import library.python.retry as retry
 from ydb.public.api.grpc.draft.fq_v1_pb2_grpc import FederatedQueryServiceStub
 import ydb.public.api.protos.draft.fq_pb2 as fq
 
-import yatest
-
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
 

--- a/ydb/tests/tools/fq_runner/fq_client.py
+++ b/ydb/tests/tools/fq_runner/fq_client.py
@@ -17,12 +17,13 @@ import yatest
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
 
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_runner import StreamingOverKikimr
 
 final_statuses = [fq.QueryMeta.COMPLETED, fq.QueryMeta.FAILED, fq.QueryMeta.ABORTED_BY_SYSTEM,
                   fq.QueryMeta.ABORTED_BY_USER, fq.QueryMeta.PAUSED]
 
-CONTROL_PLANE_REQUEST_TIMEOUT = yatest.common.plain_or_under_sanitizer(30.0, 60.0)
+CONTROL_PLANE_REQUEST_TIMEOUT = plain_or_under_sanitizer(30.0, 60.0)
 
 
 class FederatedQueryException(Exception):
@@ -282,7 +283,7 @@ class FederatedQueryClient(object):
         return result.status
 
     # TODO: merge wait_query() and wait_query_status
-    def wait_query(self, query_id, timeout=yatest.common.plain_or_under_sanitizer(40, 200), statuses=final_statuses):
+    def wait_query(self, query_id, timeout=plain_or_under_sanitizer(40, 200), statuses=final_statuses):
         start = time.time()
         deadline = start + timeout
         while True:
@@ -300,10 +301,10 @@ class FederatedQueryClient(object):
                     response.result.query.issue,
                     response.result.query.transient_issue
                 )
-            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(plain_or_under_sanitizer(0.5, 2))
 
     # Wait query status or one of statuses in list
-    def wait_query_status(self, query_id, expected_status, timeout=yatest.common.plain_or_under_sanitizer(60, 150)):
+    def wait_query_status(self, query_id, expected_status, timeout=plain_or_under_sanitizer(60, 150)):
         statuses = expected_status if isinstance(expected_status, list) else [expected_status]
         return self.wait_query(query_id, timeout, statuses=statuses).query.meta.status
 

--- a/ydb/tests/tools/fq_runner/kikimr_runner.py
+++ b/ydb/tests/tools/fq_runner/kikimr_runner.py
@@ -15,7 +15,6 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.kikimr_port_allocator import KikimrPortManagerPortAllocator
 from ydb.tests.library.harness.util import LogLevels
-import ydb.tests.library.common.yatest_common as yatest_common
 
 from ydb.library.yql.providers.common.proto import gateways_config_pb2
 
@@ -215,14 +214,14 @@ class BaseTenant(abc.ABC):
             {"subsystem": "worker_manager", "sensor": "ActiveWorkers"})
         return result if result is not None else 0
 
-    def wait_worker_count(self, node_index, activity, expected_count, timeout=yatest_common.plain_or_under_sanitizer(30, 150)):
+    def wait_worker_count(self, node_index, activity, expected_count, timeout=yatest.common.plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + timeout
         while True:
             count = self.get_actor_count(node_index, activity)
             if count >= expected_count:
                 break
             assert time.time() < deadline, "Wait actor count failed"
-            time.sleep(yatest_common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
         pass
 
     def get_mkql_limit(self, node_index):
@@ -267,7 +266,7 @@ class BaseTenant(abc.ABC):
                 self.wait_bootstrap(n)
             assert self.get_actor_count(n, "GRPC_PROXY") > 0, "Node {} died".format(n)
 
-    def wait_bootstrap(self, node_index=None, wait_time=yatest_common.plain_or_under_sanitizer(90, 400)):
+    def wait_bootstrap(self, node_index=None, wait_time=yatest.common.plain_or_under_sanitizer(90, 400)):
         if node_index is None:
             for n in self.kikimr_cluster.nodes:
                 self.wait_bootstrap(n, wait_time)
@@ -280,13 +279,13 @@ class BaseTenant(abc.ABC):
                     if self.get_actor_count(node_index, "GRPC_PROXY") == 0:
                         continue
                 except Exception:
-                    time.sleep(yatest_common.plain_or_under_sanitizer(0.3, 2))
+                    time.sleep(yatest.common.plain_or_under_sanitizer(0.3, 2))
                     continue
                 break
             self.bootstraped_nodes.add(node_index)
             logging.debug("Node {} has been bootstrapped".format(node_index))
 
-    def wait_discovery(self, node_index=None, wait_time=yatest_common.plain_or_under_sanitizer(30, 150)):
+    def wait_discovery(self, node_index=None, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
         if node_index is None:
             for n in self.kikimr_cluster.nodes:
                 self.wait_discovery(n, wait_time)
@@ -301,12 +300,12 @@ class BaseTenant(abc.ABC):
                     if peer_count is None or peer_count < self.node_count:
                         continue
                 except Exception:
-                    time.sleep(yatest_common.plain_or_under_sanitizer(0.3, 2))
+                    time.sleep(yatest.common.plain_or_under_sanitizer(0.3, 2))
                     continue
                 break
             logging.debug("Node {} discovery finished".format(node_index))
 
-    def wait_workers(self, worker_count, wait_time=yatest_common.plain_or_under_sanitizer(30, 150)):
+    def wait_workers(self, worker_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
         ca_count = worker_count * 2  # we count 2x CAs
         deadline = time.time() + wait_time
         while True:
@@ -357,7 +356,7 @@ class BaseTenant(abc.ABC):
                                                       expect_counters_exist=expect_counters_exist)
 
     def wait_completed_checkpoints(self, query_id, checkpoints_count,
-                                   timeout=yatest_common.plain_or_under_sanitizer(30, 150),
+                                   timeout=yatest.common.plain_or_under_sanitizer(30, 150),
                                    expect_counters_exist=False):
         deadline = time.time() + timeout
         while True:
@@ -365,9 +364,9 @@ class BaseTenant(abc.ABC):
             if completed >= checkpoints_count:
                 break
             assert time.time() < deadline, "Wait zero checkpoint failed, actual completed: " + str(completed)
-            time.sleep(yatest_common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
 
-    def wait_zero_checkpoint(self, query_id, timeout=yatest_common.plain_or_under_sanitizer(30, 150),
+    def wait_zero_checkpoint(self, query_id, timeout=yatest.common.plain_or_under_sanitizer(30, 150),
                              expect_counters_exist=False):
         self.wait_completed_checkpoints(query_id, 1, timeout, expect_counters_exist)
 

--- a/ydb/tests/tools/fq_runner/kikimr_runner.py
+++ b/ydb/tests/tools/fq_runner/kikimr_runner.py
@@ -11,6 +11,7 @@ import time
 import ydb
 
 import yatest.common
+from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.kikimr_port_allocator import KikimrPortManagerPortAllocator
@@ -214,14 +215,14 @@ class BaseTenant(abc.ABC):
             {"subsystem": "worker_manager", "sensor": "ActiveWorkers"})
         return result if result is not None else 0
 
-    def wait_worker_count(self, node_index, activity, expected_count, timeout=yatest.common.plain_or_under_sanitizer(30, 150)):
+    def wait_worker_count(self, node_index, activity, expected_count, timeout=plain_or_under_sanitizer(30, 150)):
         deadline = time.time() + timeout
         while True:
             count = self.get_actor_count(node_index, activity)
             if count >= expected_count:
                 break
             assert time.time() < deadline, "Wait actor count failed"
-            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(plain_or_under_sanitizer(0.5, 2))
         pass
 
     def get_mkql_limit(self, node_index):
@@ -266,7 +267,7 @@ class BaseTenant(abc.ABC):
                 self.wait_bootstrap(n)
             assert self.get_actor_count(n, "GRPC_PROXY") > 0, "Node {} died".format(n)
 
-    def wait_bootstrap(self, node_index=None, wait_time=yatest.common.plain_or_under_sanitizer(90, 400)):
+    def wait_bootstrap(self, node_index=None, wait_time=plain_or_under_sanitizer(90, 400)):
         if node_index is None:
             for n in self.kikimr_cluster.nodes:
                 self.wait_bootstrap(n, wait_time)
@@ -279,13 +280,13 @@ class BaseTenant(abc.ABC):
                     if self.get_actor_count(node_index, "GRPC_PROXY") == 0:
                         continue
                 except Exception:
-                    time.sleep(yatest.common.plain_or_under_sanitizer(0.3, 2))
+                    time.sleep(plain_or_under_sanitizer(0.3, 2))
                     continue
                 break
             self.bootstraped_nodes.add(node_index)
             logging.debug("Node {} has been bootstrapped".format(node_index))
 
-    def wait_discovery(self, node_index=None, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
+    def wait_discovery(self, node_index=None, wait_time=plain_or_under_sanitizer(30, 150)):
         if node_index is None:
             for n in self.kikimr_cluster.nodes:
                 self.wait_discovery(n, wait_time)
@@ -300,12 +301,12 @@ class BaseTenant(abc.ABC):
                     if peer_count is None or peer_count < self.node_count:
                         continue
                 except Exception:
-                    time.sleep(yatest.common.plain_or_under_sanitizer(0.3, 2))
+                    time.sleep(plain_or_under_sanitizer(0.3, 2))
                     continue
                 break
             logging.debug("Node {} discovery finished".format(node_index))
 
-    def wait_workers(self, worker_count, wait_time=yatest.common.plain_or_under_sanitizer(30, 150)):
+    def wait_workers(self, worker_count, wait_time=plain_or_under_sanitizer(30, 150)):
         ca_count = worker_count * 2  # we count 2x CAs
         deadline = time.time() + wait_time
         while True:
@@ -356,7 +357,7 @@ class BaseTenant(abc.ABC):
                                                       expect_counters_exist=expect_counters_exist)
 
     def wait_completed_checkpoints(self, query_id, checkpoints_count,
-                                   timeout=yatest.common.plain_or_under_sanitizer(30, 150),
+                                   timeout=plain_or_under_sanitizer(30, 150),
                                    expect_counters_exist=False):
         deadline = time.time() + timeout
         while True:
@@ -364,9 +365,9 @@ class BaseTenant(abc.ABC):
             if completed >= checkpoints_count:
                 break
             assert time.time() < deadline, "Wait zero checkpoint failed, actual completed: " + str(completed)
-            time.sleep(yatest.common.plain_or_under_sanitizer(0.5, 2))
+            time.sleep(plain_or_under_sanitizer(0.5, 2))
 
-    def wait_zero_checkpoint(self, query_id, timeout=yatest.common.plain_or_under_sanitizer(30, 150),
+    def wait_zero_checkpoint(self, query_id, timeout=plain_or_under_sanitizer(30, 150),
                              expect_counters_exist=False):
         self.wait_completed_checkpoints(query_id, 1, timeout, expect_counters_exist)
 

--- a/ydb/tests/tools/kqprun/recipe/__main__.py
+++ b/ydb/tests/tools/kqprun/recipe/__main__.py
@@ -5,7 +5,7 @@ import os
 from library.python.testing.recipe import declare_recipe, set_env
 from library.recipes import common as recipes_common
 from yatest.common.network import PortManager
-from ydb.tests.library.common import yatest_common
+import yatest
 
 
 PID_FILENAME = "kqprun_daemon.pid"
@@ -14,7 +14,7 @@ INITIALIZATION_IMEOUT_RATIO = 2
 
 
 def is_kqprun_daemon_ready() -> bool:
-    with open(yatest_common.output_path("kqprun_daemon.out.log"), "r") as outFile:
+    with open(yatest.common.output_path("kqprun_daemon.out.log"), "r") as outFile:
         return "Initialization finished" in outFile.read()
 
 
@@ -26,9 +26,9 @@ def build_start_comand(argv: list[str], grpc_port: int) -> tuple[int, list[str]]
     parsed, _ = parser.parse_known_args(argv)
 
     cmd = [
-        yatest_common.binary_path(KQPRUN_PATH),
-        "--log-file", yatest_common.output_path("kqprun_daemon.ydb.log"),
-        "--app-config", yatest_common.source_path(parsed.config),
+        yatest.common.binary_path(KQPRUN_PATH),
+        "--log-file", yatest.common.output_path("kqprun_daemon.ydb.log"),
+        "--app-config", yatest.common.source_path(parsed.config),
         "--grpc", str(grpc_port),
         "--timeout", str(parsed.timeout_ms)
     ]
@@ -39,7 +39,7 @@ def build_start_comand(argv: list[str], grpc_port: int) -> tuple[int, list[str]]
 
     for query in parsed.query:
         cmd.append("--script-query")
-        cmd.append(yatest_common.source_path(query))
+        cmd.append(yatest.common.source_path(query))
 
     return (parsed.timeout_ms, cmd)
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- remove yatest_common usage (not needed anymore)
- fix some harness usage of yatest_common (catching vanilla yatest exceptions)

Also see comments in PR

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

See https://st.yandex-team.ru/KIKIMR-16114
