### PR TITLE
Fix runtime feature flags codegen for darwin

### DIFF
--- a/ydb/core/base/generated/codegen/main.cpp
+++ b/ydb/core/base/generated/codegen/main.cpp
@@ -9,6 +9,7 @@
 #include <jinja2cpp/template.h>
 #include <jinja2cpp/value.h>
 #include <jinja2cpp/reflected_value.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -17,10 +18,10 @@ struct TField;
 
 struct TSlot {
     TString Name;
-    size_t Index;
+    uint64_t Index;
     std::vector<const TField*> Fields;
-    ui64 DefaultValue = 0;
-    ui64 RuntimeFlagsMask = 0;
+    uint64_t DefaultValue = 0;
+    uint64_t RuntimeFlagsMask = 0;
 
     TSlot(const TString& name, size_t index)
         : Name(name)
@@ -31,10 +32,10 @@ struct TSlot {
 struct TField {
     TString Name;
     const TSlot* Slot;
-    ui64 HasMask = 0;
-    ui64 ValueMask = 0;
-    ui64 FullMask = 0;
-    ui64 DefaultValue = 0;
+    uint64_t HasMask = 0;
+    uint64_t ValueMask = 0;
+    uint64_t FullMask = 0;
+    uint64_t DefaultValue = 0;
     bool IsRuntime = false;
 
     TField(const TString& name, const TSlot* slot)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

We use jinja2cpp for runtime feature flags codegen, which defines reflection for types like `uint64_t`. Unfortunately 64-bit darwin typedefs those types to `unsigned long long`, which other types like `size_t` and `ui64` typedef to `unsigned long`, which causes compilation failures.

Related to #9748.