### PR TITLE
fix abort on invalid null value parsing in BinaryJson

### DIFF
--- a/ydb/library/binary_json/ut/entry_ut.cpp
+++ b/ydb/library/binary_json/ut/entry_ut.cpp
@@ -17,6 +17,7 @@ public:
         UNIT_TEST(TestGetContainer);
         UNIT_TEST(TestGetString);
         UNIT_TEST(TestGetNumber);
+        UNIT_TEST(TestInvalidInput);
     UNIT_TEST_SUITE_END();
 
     void TestGetType() {
@@ -91,6 +92,18 @@ public:
             const auto container = reader->GetRootCursor();
 
             UNIT_ASSERT_VALUES_EQUAL(container.GetElement(0).GetNumber(), testCase.second);
+        }
+    }
+
+    void TestInvalidInput() {
+        const TVector<std::pair<TString, TString>> testCases = {
+            {"nul", "N_ATOM_ERROR: Problem while parsing an atom starting with the letter 'n'"},
+        };
+
+        for (const auto& testCase : testCases) {
+            const auto parsingResult = SerializeToBinaryJson(testCase.first);
+            UNIT_ASSERT(parsingResult.IsFail());
+            UNIT_ASSERT_VALUES_EQUAL(parsingResult.GetErrorMessage(), testCase.second);
         }
     }
 };

--- a/ydb/library/binary_json/write.cpp
+++ b/ydb/library/binary_json/write.cpp
@@ -600,7 +600,9 @@ template <typename TOnDemandValue>
         case simdjson::ondemand::json_type::null: {
             auto is_null = value.is_null();
             RETURN_IF_NOT_SUCCESS(is_null.error());
-            Y_ABORT_UNLESS(is_null.value_unsafe());
+            if (!is_null.value_unsafe()) {
+                return simdjson::error_code::N_ATOM_ERROR;
+            }
             callbacks.OnNull();
             break;
         }

--- a/ydb/library/binary_json/write.cpp
+++ b/ydb/library/binary_json/write.cpp
@@ -600,7 +600,7 @@ template <typename TOnDemandValue>
         case simdjson::ondemand::json_type::null: {
             auto is_null = value.is_null();
             RETURN_IF_NOT_SUCCESS(is_null.error());
-            if (!is_null.value_unsafe()) {
+            if (Y_UNLIKELY(!is_null.value_unsafe())) {
                 return simdjson::error_code::N_ATOM_ERROR;
             }
             callbacks.OnNull();


### PR DESCRIPTION
parsing of jsons, such as: `nul` failed with Y_ABORT

logs: http://distbuild-fileproxy-prod-fileproxy-27.sas.yp-c.yandex.net:50001/tmpa0g7_9jx/testing_out_stuff.tar.zstd/fuzz.err
