### PR TITLE
Stop wide combiner state from growing unlimited

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/mkql_rh_hash.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_rh_hash.h
@@ -312,7 +312,6 @@ private:
         try {
             Allocate(newCapacity, newData, newDataEnd);
         } catch (...) {
-            YQL_LOG(INFO) << "TRobinHoodHashBase failed to grow from " << Capacity << " to " << newCapacity << "\n";
             Y_ENSURE(newData == nullptr && newDataEnd == nullptr);
             return false;
         }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_rh_hash.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_rh_hash.h
@@ -301,8 +301,7 @@ private:
         auto newCapacity = GetNewCapacity();
         char *newData, *newDataEnd;
         Allocate(newCapacity, newData, newDataEnd);
-        Y_ENSURE(newDataEnd - newData == newCapacity);
-        PlacementGrow(newData, newCapacity);
+        PlacementGrow(newData, newDataEnd, newCapacity);
     }
 
     // This will not throw exception even if it fails to allocate more memory but instead returns false (if memory is allocated successfully performs grow and returns true)
@@ -318,8 +317,7 @@ private:
             Y_ENSURE(newData == nullptr && newDataEnd == nullptr);
             return false;
         }
-        Y_ENSURE(newDataEnd - newData == newCapacity);
-        PlacementGrow(newData, newCapacity);
+        PlacementGrow(newData, newDataEnd, newCapacity);
         return true;
     }
 
@@ -335,8 +333,7 @@ private:
         return Capacity * growFactor;
     }
 
-    void PlacementGrow(char *newData, ui64 newCapacity) {
-        char *newDataEnd = newData + newCapacity;
+    void PlacementGrow(char *newData, char *newDataEnd, ui64 newCapacity) {
         auto newCapacityShift = 64 - MostSignificantBit(newCapacity);
         Y_DEFER {
             Allocator.deallocate(newData, newDataEnd - newData);

--- a/ydb/library/yql/minikql/comp_nodes/mkql_rh_hash.h
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_rh_hash.h
@@ -7,7 +7,6 @@
 #include <span>
 
 #include <ydb/library/yql/utils/prefetch.h>
-#include <ydb/library/yql/utils/log/log.h>
 
 #include <util/digest/city.h>
 #include <util/generic/scope.h>

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -281,15 +281,15 @@ public:
     }
 
     void GrowStates() {
-        if (IsOutOfMemory < AllowOutOfMemory) {
-            try {
-                States.CheckGrow();
-            } catch (TMemoryLimitExceededException) {
-                YQL_LOG(INFO) << "State failed to grow\n";
-                IsOutOfMemory = true;
-            }
-        } else {
+        try {
             States.CheckGrow();
+        } catch (TMemoryLimitExceededException) {
+            YQL_LOG(INFO) << "State failed to grow";
+            if (IsOutOfMemory < AllowOutOfMemory) {
+                IsOutOfMemory = true;
+            } else {
+                throw;
+            }
         }
     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -282,7 +282,7 @@ public:
 
     void GrowStates() {
         if (IsOutOfMemory < AllowOutOfMemory) {
-            if (!States.UnsafeCheckGrow()) {
+            if (!States.TryCheckGrow()) {
                 IsOutOfMemory = true;
             }
         } else {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -274,7 +274,14 @@ public:
             Tongue = CurrentPage->data() + CurrentPosition;
         }
         Throat = States.GetKey(itInsert) + KeyWidth;
-        if (isNew && !IsOutOfMemory) {
+        if (isNew) {
+            SafeGrow();
+        }
+        return isNew;
+    }
+
+    void SafeGrow() {
+        if (!IsOutOfMemory) {
             try {
                 States.CheckGrow();
             } catch (const TMemoryLimitExceededException& e) {
@@ -282,7 +289,6 @@ public:
                 IsOutOfMemory = true;
             }
         }
-        return isNew;
     }
 
     bool CheckIsOutOfMemory() const {
@@ -848,7 +854,6 @@ private:
     }
 
     bool IsSwitchToSpillingModeCondition() const {
-        return false;
         return !HasMemoryForProcessing() || TlsAllocState->GetMaximumLimitValueReached();
     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -282,7 +282,9 @@ public:
 
     void GrowStates() {
         if (IsOutOfMemory < AllowOutOfMemory) {
-            if (!States.TryCheckGrow()) {
+            try {
+                States.CheckGrow();
+            } catch (TMemoryLimitExceededException) {
                 YQL_LOG(INFO) << "State failed to grow\n";
                 IsOutOfMemory = true;
             }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -279,7 +279,6 @@ public:
         Throat = States.GetKey(itInsert) + KeyWidth;
         if (isNew) {
             if (!States.UnsafeCheckGrow()) {
-                YQL_LOG(INFO) << "State " << (void *)this << " no longer growing\n";
                 // first out of memory is safe because spilling still can help us
                 IsOutOfMemory = true;
             }
@@ -850,7 +849,6 @@ private:
     }
 
     bool IsSwitchToSpillingModeCondition() const {
-        return false;
         return !HasMemoryForProcessing() || TlsAllocState->GetMaximumLimitValueReached();
     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -285,10 +285,10 @@ public:
             States.CheckGrow();
         } catch (TMemoryLimitExceededException) {
             YQL_LOG(INFO) << "State failed to grow";
-            if (IsOutOfMemory < AllowOutOfMemory) {
-                IsOutOfMemory = true;
-            } else {
+            if (IsOutOfMemory || !AllowOutOfMemory) {
                 throw;
+            } else {
+                IsOutOfMemory = true;
             }
         }
     }

--- a/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_wide_combine.cpp
@@ -283,6 +283,7 @@ public:
     void GrowStates() {
         if (IsOutOfMemory < AllowOutOfMemory) {
             if (!States.TryCheckGrow()) {
+                YQL_LOG(INFO) << "State failed to grow\n";
                 IsOutOfMemory = true;
             }
         } else {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

 Stop wide combiner state from growing unlimited and spill it if spilling is enabled

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Until that point TState in WideCombiner could grow indefinitely. Without spilling it will just crash when allocator fails to allocate more memory for hashtable. With spilling it will stop its growth only when allocator reaches yellow zone (after that point spilling can begin). But with large enough hashtable TState can grow from green zone up to memory limit in one go (so spilling will not have a chance to begin).
So after this PR TState now catches exception when trying to grow hashtable and if it fails, state will stop its grow.
Using that we can add another condition for enabling spilling: if state can't grow it will be spilled.
