### PR TITLE
Calculate disconnections in last hour

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
@@ -565,6 +565,19 @@ namespace NActors {
         void HandleTerminate();
 
         void PassAway() override;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Disconnection management
+
+        static constexpr size_t NumDisconnectsSize = 60;
+        std::array<ui32, NumDisconnectsSize> NumDisconnects;
+        size_t NumDisconnectsIndex = 0;
+        ui32 NumDisconnectsInLastHour = 0;
+        ui64 FirstDisconnectWindowMinutes = 0;
+
+        void RegisterDisconnect();
+        ui32 GetDisconnectCountInLastHour();
+        void ShiftDisconnectWindow(TMonotonic now);
     };
 
 }

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -542,6 +542,7 @@ namespace NActors {
             CloseOnIdleWatchdog.Disarm();
             LostConnectionWatchdog.Rearm(SelfId());
             Proxy->Metrics->SetConnected(0);
+            Proxy->RegisterDisconnect();
             LOG_INFO(*TlsActivationContext, NActorsServices::INTERCONNECT_STATUS, "[%u] disconnected", Proxy->PeerNodeId);
         }
         if (XdcSocket) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Calculate disconnections in last hour

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Interconnect proxy now counts number of disconnections happened in the last hour with one-minute resolution.
