### PR TITLE
Fix TArrowBlock::From and its usage

### DIFF
--- a/ydb/library/yql/dq/runtime/dq_input_impl.h
+++ b/ydb/library/yql/dq/runtime/dq_input_impl.h
@@ -120,7 +120,8 @@ public:
             case LEGACY_SIMPLE_BLOCK: {
                 ui64 result = 0;
                 batch.ForEachRow([&](NUdf::TUnboxedValue& value) {
-                    result += NKikimr::NMiniKQL::TArrowBlock::From(value.GetElement(LegacyBlockLengthIndex)).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
+                    const auto& blockLengthValue = value.GetElement(LegacyBlockLengthIndex);
+                    result += NKikimr::NMiniKQL::TArrowBlock::From(blockLengthValue).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
                 });
                 return result;
             }
@@ -128,7 +129,8 @@ public:
                 ui64 result = 0;
                 batch.ForEachRow([&](NUdf::TUnboxedValue& value) {
                     const auto& value0 = value.GetElement(0);
-                    result += NKikimr::NMiniKQL::TArrowBlock::From(value0.GetElement(LegacyBlockLengthIndex)).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
+                    const auto& blockLengthValue = value0.GetElement(LegacyBlockLengthIndex);
+                    result += NKikimr::NMiniKQL::TArrowBlock::From(blockLengthValue).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
                 });
                 return result;
             }

--- a/ydb/library/yql/dq/runtime/dq_input_impl.h
+++ b/ydb/library/yql/dq/runtime/dq_input_impl.h
@@ -127,7 +127,7 @@ public:
             case LEGACY_TUPLED_BLOCK: {
                 ui64 result = 0;
                 batch.ForEachRow([&](NUdf::TUnboxedValue& value) {
-                    auto value0 = value.GetElement(0);
+                    const auto& value0 = value.GetElement(0);
                     result += NKikimr::NMiniKQL::TArrowBlock::From(value0.GetElement(LegacyBlockLengthIndex)).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
                 });
                 return result;

--- a/ydb/library/yql/dq/runtime/dq_input_producer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_producer.cpp
@@ -446,7 +446,7 @@ private:
                         return NUdf::EFetchStatus::Yield;
                     }
                 }
-                NUdf::TUnboxedValue* values = FetchedValues_.Head();
+                const NUdf::TUnboxedValue* values = FetchedValues_.Head();
                 CurrentRow_.clear();
                 for (ui32 i = 0; i < width; ++i) {
                     CurrentRow_.emplace_back(TArrowBlock::From(values[i]).GetDatum());

--- a/ydb/library/yql/minikql/comp_nodes/mkql_apply.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_apply.cpp
@@ -54,7 +54,7 @@ public:
                     state.Args[i] = state.HolderFactory.CreateArrowBlock(arrow::Datum(batch.values[i]));
                 }
 
-                const auto ret = Callable_.Run(&state.ValueBuilder, state.Args.data());
+                const auto& ret = Callable_.Run(&state.ValueBuilder, state.Args.data());
                 *res = TArrowBlock::From(ret).GetDatum();
                 return arrow::Status::OK();
             })

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_compress.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_compress.cpp
@@ -544,9 +544,8 @@ private:
         EStep Check(const NUdf::TUnboxedValuePod bitmapValue) {
             Y_ABORT_UNLESS(!IsFinished_);
             Y_ABORT_UNLESS(!InputSize_);
-            const NUdf::TUnboxedValue b(std::move(bitmapValue));
             auto& bitmap = Arrays_.back();
-            bitmap = TArrowBlock::From(b).GetDatum().array();
+            bitmap = TArrowBlock::From(bitmapValue).GetDatum().array();
 
             if (!bitmap->length)
                 return EStep::Skip;

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_skiptake.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_skiptake.cpp
@@ -214,9 +214,8 @@ public:
 #endif
 private:
     static NUdf::TUnboxedValuePod SliceBlock(const THolderFactory& holderFactory, NUdf::TUnboxedValuePod block, const uint64_t offset) {
-        NUdf::TUnboxedValue b(block);
-        auto& datum = TArrowBlock::From(b).GetDatum();
-        return datum.is_scalar() ? b.Release() : holderFactory.CreateArrowBlock(DeepSlice(datum.array(), offset, datum.array()->length - offset));
+        auto& datum = TArrowBlock::From(block).GetDatum();
+        return datum.is_scalar() ? block : holderFactory.CreateArrowBlock(DeepSlice(datum.array(), offset, datum.array()->length - offset));
     }
 
     void RegisterDependencies() const final {
@@ -408,9 +407,8 @@ public:
 #endif
 private:
     static NUdf::TUnboxedValuePod SliceBlock(const THolderFactory& holderFactory, NUdf::TUnboxedValuePod block, const uint64_t offset) {
-        NUdf::TUnboxedValue b(block);
-        auto& datum = TArrowBlock::From(b).GetDatum();
-        return datum.is_scalar() ? b.Release() : holderFactory.CreateArrowBlock(DeepSlice(datum.array(), 0ULL, offset));
+        auto& datum = TArrowBlock::From(block).GetDatum();
+        return datum.is_scalar() ? block : holderFactory.CreateArrowBlock(DeepSlice(datum.array(), 0ULL, offset));
     }
 
     void RegisterDependencies() const final {

--- a/ydb/library/yql/minikql/comp_nodes/mkql_block_skiptake.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_block_skiptake.cpp
@@ -214,7 +214,7 @@ public:
 #endif
 private:
     static NUdf::TUnboxedValuePod SliceBlock(const THolderFactory& holderFactory, NUdf::TUnboxedValuePod block, const uint64_t offset) {
-        auto& datum = TArrowBlock::From(block).GetDatum();
+        const auto& datum = TArrowBlock::From(block).GetDatum();
         return datum.is_scalar() ? block : holderFactory.CreateArrowBlock(DeepSlice(datum.array(), offset, datum.array()->length - offset));
     }
 
@@ -407,7 +407,7 @@ public:
 #endif
 private:
     static NUdf::TUnboxedValuePod SliceBlock(const THolderFactory& holderFactory, NUdf::TUnboxedValuePod block, const uint64_t offset) {
-        auto& datum = TArrowBlock::From(block).GetDatum();
+        const auto& datum = TArrowBlock::From(block).GetDatum();
         return datum.is_scalar() ? block : holderFactory.CreateArrowBlock(DeepSlice(datum.array(), 0ULL, offset));
     }
 

--- a/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
+++ b/ydb/library/yql/minikql/comp_nodes/mkql_blocks.cpp
@@ -475,8 +475,7 @@ private:
         }
 
         void Reset(const NUdf::TUnboxedValuePod block) {
-            const NUdf::TUnboxedValue v(block);
-            const auto& datum = TArrowBlock::From(v).GetDatum();
+            const auto& datum = TArrowBlock::From(block).GetDatum();
             MKQL_ENSURE(datum.is_arraylike(), "Expecting array as FromBlocks argument");
             MKQL_ENSURE(Arrays_.empty(), "Not all input is processed");
             if (datum.is_array()) {
@@ -953,9 +952,8 @@ private:
     }
 
     arrow::Datum DoReplicate(const NUdf::TUnboxedValuePod val, const NUdf::TUnboxedValuePod cnt, TComputationContext& ctx) const {
-        const NUdf::TUnboxedValue v(val), c(cnt);
-        const auto value = TArrowBlock::From(v).GetDatum().scalar();
-        const ui64 count = TArrowBlock::From(c).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
+        const auto value = TArrowBlock::From(val).GetDatum().scalar();
+        const ui64 count = TArrowBlock::From(cnt).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
 
         const auto reader = MakeBlockReader(TTypeInfoHelper(), Type_);
         const auto builder = MakeArrayBuilder(TTypeInfoHelper(), Type_, ctx.ArrowMemoryPool, count, &ctx.Builder->GetPgBuilder());

--- a/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
@@ -18,8 +18,7 @@ extern "C" uint64_t GetBlockCount(const NYql::NUdf::TUnboxedValuePod data) {
 }
 
 extern "C" uint64_t GetBitmapPopCountCount(const NYql::NUdf::TUnboxedValuePod data) {
-    const NYql::NUdf::TUnboxedValue v(data);
-    const auto& arr = NKikimr::NMiniKQL::TArrowBlock::From(v).GetDatum().array();
+    const auto& arr = NKikimr::NMiniKQL::TArrowBlock::From(data).GetDatum().array();
     const size_t len = (size_t)arr->length;
     MKQL_ENSURE(arr->GetNullCount() == 0, "Bitmap block should not have nulls");
     const ui8* src = arr->GetValues<ui8>(1);

--- a/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
@@ -351,7 +351,7 @@ void TBlockState::FillArrays() {
 
     for (size_t i = 0U; i < Deques.size(); ++i) {
         Deques[i].clear();
-        if (const auto value = Values[i]) {
+        if (const auto& value = Values[i]) {
             const auto& datum = TArrowBlock::From(value).GetDatum();
             if (datum.is_scalar()) {
                 return;

--- a/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_block_impl.cpp
@@ -258,7 +258,8 @@ NUdf::TUnboxedValuePod TBlockFuncNode::DoCalculate(TComputationContext& ctx) con
 
     std::vector<arrow::Datum> argDatums;
     for (ui32 i = 0; i < ArgsNodes.size(); ++i) {
-        argDatums.emplace_back(TArrowBlock::From(ArgsNodes[i]->GetValue(ctx)).GetDatum());
+        const auto& value = ArgsNodes[i]->GetValue(ctx);
+        argDatums.emplace_back(TArrowBlock::From(value).GetDatum());
         ARROW_DEBUG_CHECK_DATUM_TYPES(ArgsValuesDescr[i], argDatums.back().descr());
     }
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node.cpp
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node.cpp
@@ -39,7 +39,8 @@ TDatumProvider MakeDatumProvider(const arrow::Datum& datum) {
 
 TDatumProvider MakeDatumProvider(const IComputationNode* node, TComputationContext& ctx) {
     return [node, &ctx]() {
-        return TArrowBlock::From(node->GetValue(ctx)).GetDatum();
+        const auto& value = node->GetValue(ctx);
+        return TArrowBlock::From(value).GetDatum();
     };
 }
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
@@ -582,7 +582,7 @@ public:
     {
     }
 
-    inline static TArrowBlock& From(const NUdf::TUnboxedValue& value) {
+    inline static TArrowBlock& From(NUdf::TUnboxedValuePod& value) {
         return *static_cast<TArrowBlock*>(value.AsRawBoxed());
     }
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
@@ -583,7 +583,7 @@ public:
     }
 
     inline static TArrowBlock& From(const NUdf::TUnboxedValue& value) {
-        return *static_cast<TArrowBlock*>(value.AsBoxed().Get());
+        return *static_cast<TArrowBlock*>(value.AsRawBoxed());
     }
 
     inline arrow::Datum& GetDatum() {

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
@@ -586,6 +586,8 @@ public:
         return *static_cast<TArrowBlock*>(value.AsRawBoxed());
     }
 
+    inline static const TArrowBlock& From(NUdf::TUnboxedValuePod&& value) = delete;
+
     inline const arrow::Datum& GetDatum() const {
         return Datum_;
     }

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
@@ -586,7 +586,15 @@ public:
         return *static_cast<TArrowBlock*>(value.AsRawBoxed());
     }
 
+    inline static const TArrowBlock& From(const NUdf::TUnboxedValuePod& value) {
+        return *static_cast<TArrowBlock*>(value.AsRawBoxed());
+    }
+
     inline arrow::Datum& GetDatum() {
+        return Datum_;
+    }
+
+    inline const arrow::Datum& GetDatum() const {
         return Datum_;
     }
 

--- a/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
+++ b/ydb/library/yql/minikql/computation/mkql_computation_node_holders.h
@@ -582,16 +582,8 @@ public:
     {
     }
 
-    inline static TArrowBlock& From(NUdf::TUnboxedValuePod& value) {
-        return *static_cast<TArrowBlock*>(value.AsRawBoxed());
-    }
-
     inline static const TArrowBlock& From(const NUdf::TUnboxedValuePod& value) {
         return *static_cast<TArrowBlock*>(value.AsRawBoxed());
-    }
-
-    inline arrow::Datum& GetDatum() {
-        return Datum_;
     }
 
     inline const arrow::Datum& GetDatum() const {

--- a/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
+++ b/ydb/library/yql/public/purecalc/io_specs/arrow/spec.cpp
@@ -170,7 +170,8 @@ public:
         OutputItemType batch = Batch_.Get();
         size_t nvalues = DatumToMemberIDMap_.size();
 
-        const auto& sizeDatum = TArrowBlock::From(value.GetElement(BatchLengthID_)).GetDatum();
+        const auto& batchLengthValue = value.GetElement(BatchLengthID_);
+        const auto& sizeDatum = TArrowBlock::From(batchLengthValue).GetDatum();
         Y_ENSURE(sizeDatum.is_scalar());
         const auto& sizeScalar = sizeDatum.scalar();
         const auto& sizeData = arrow::internal::checked_cast<const arrow::UInt64Scalar&>(*sizeScalar);
@@ -179,7 +180,8 @@ public:
         TVector<arrow::Datum> datums(nvalues);
         for (size_t i = 0; i < nvalues; i++) {
             const ui32 id = DatumToMemberIDMap_[i];
-            const auto& datum = TArrowBlock::From(value.GetElement(id)).GetDatum();
+            const auto& memberValue = value.GetElement(id);
+            const auto& datum = TArrowBlock::From(memberValue).GetDatum();
             datums[i] = datum;
             if (datum.is_scalar()) {
                 continue;


### PR DESCRIPTION
This patchset fixes `TArrowBlock::From` routine and its usage all over the code base.

The first commit changes `AsBoxed` to `AsRawBoxed` to remove the creation of refcounted pointer to obtain the `TUnboxedValue` contents. The next patch changes the parameter type from `TUnboxedValue&` to `TUnboxedValuePod&` to respect the unboxed value contents ownership and prevent possible data leaks. All the following patches fix usage of `TArrowBlock::From` method (i.e. `TUnboxedValuePod` ownership, constness in various places, etc). The last patch just drops all non-const `TArrowBlock` methods, since they are required nowhere.

### Changelog category

* Bugfix