### PR TITLE
Fix possible race with NodeDisconnected and incoming messages

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -147,6 +147,10 @@ namespace NActors {
     STATEFN(TInputSessionTCP::WorkingState) {
         std::unique_ptr<IEventBase> termEv;
 
+        if (Context->Terminated) {
+            return PassAway();
+        }
+
         try {
             WorkingStateImpl(ev);
         } catch (const TExReestablishConnection& ex) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -84,6 +84,7 @@ namespace NActors {
         IActor::InvokeOtherActor(*Proxy, &TInterconnectProxyTCP::UnregisterSession, this);
         ShutdownSocket(std::move(reason));
 
+        ReceiveContext->Terminated = true; // prevent further message generation by receiving actor
         for (const auto& kv : Subscribers) {
             Send(kv.first, new TEvInterconnect::TEvNodeDisconnected(Proxy->PeerNodeId), 0, kv.second);
         }

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -100,8 +100,6 @@ namespace NActors {
     };
 
     struct TReceiveContext: public TAtomicRefCount<TReceiveContext> {
-        /* All invokations to these fields should be thread-safe */
-
         ui64 ControlPacketSendTimer = 0;
         ui64 ControlPacketId = 0;
 
@@ -153,6 +151,7 @@ namespace NActors {
         std::array<TPerChannelContext, 16> ChannelArray;
         std::unordered_map<ui16, TPerChannelContext> ChannelMap;
         ui64 LastProcessedSerial = 0;
+        bool Terminated = false;
 
         TReceiveContext() {
             GetTimeFast(&StartTime);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix possible race with NodeDisconnected and incoming messages

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Currently, there was theoretical possibility of incoming messages issued after NodeDisconnected. This fix removes this possibility
by explicitly checking that master session actor has not been terminated yet.
