### PR TITLE
packed_tuple: fix runtime autodetect

### DIFF
--- a/ydb/library/yql/minikql/comp_nodes/packed_tuple/packing.h
+++ b/ydb/library/yql/minikql/comp_nodes/packed_tuple/packing.h
@@ -311,13 +311,7 @@ template <class TTraits> struct SIMDPack {
         return TupleOrImpl<Left>(vec) | TupleOrImpl<Right>(vec + Left);
     }
 
-    template <> TSimd<ui8> TupleOrImpl<0>(TSimd<ui8>[]) { std::abort(); }
-
     template <> TSimd<ui8> TupleOrImpl<1>(TSimd<ui8> vec[]) { return vec[0]; }
-
-    template <> TSimd<ui8> TupleOrImpl<2>(TSimd<ui8> vec[]) {
-        return vec[0] | vec[1];
-    }
 
     template <ui8 StoresPerLoad, ui8 Cols>
     static void

--- a/ydb/library/yql/minikql/comp_nodes/packed_tuple/ya.make
+++ b/ydb/library/yql/minikql/comp_nodes/packed_tuple/ya.make
@@ -15,7 +15,6 @@ PEERDIR(
 
 CFLAGS(
     -mprfchw
-    -mavx2
     -DMKQL_DISABLE_CODEGEN
 )
 


### PR DESCRIPTION
it was built with `-mavx2` and breaks on older cpus

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
