### PR TITLE
Mark core/health_check as MEDIUM test (because asan timing out)

### DIFF
--- a/ydb/core/health_check/ut/ya.make
+++ b/ydb/core/health_check/ut/ya.make
@@ -2,7 +2,7 @@ UNITTEST_FOR(ydb/core/health_check)
 
 FORK_SUBTESTS()
 
-SIZE(SMALL)
+SIZE(MEDIUM)
 
 PEERDIR(
     ydb/core/testlib/default


### PR DESCRIPTION
Test is timing out with asan 

See https://github.com/ydb-platform/ydb/pull/10045#issuecomment-2441319698 