### PR TITLE
Skipping unneeded DataShards during object storage listing

### DIFF
--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -3,6 +3,8 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/public/api/protos/draft/ydb_object_storage.pb.h>
 #include <ydb/public/api/grpc/draft/ydb_object_storage_v1.grpc.pb.h>
+#include <ydb/core/tablet_flat/shared_sausagecache.h>
+#include <ydb/core/tx/datashard/datashard.h>
 #include <grpc++/client_context.h>
 #include <grpc++/create_channel.h>
 
@@ -101,39 +103,37 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
                 }}
                 PartitionConfig {
                     ExecutorCacheSize: 100
+                    CompactionPolicy {
+                        InMemSizeToSnapshot: 2000
+                        InMemStepsToSnapshot: 1
+                        InMemForceStepsToSnapshot: 50
+                        InMemForceSizeToSnapshot: 16777216
+                        InMemCompactionBrokerQueue: 0
+                        ReadAheadHiThreshold: 1048576
+                        ReadAheadLoThreshold: 16384
+                        MinDataPageSize: 300
+                        SnapBrokerQueue: 0
 
-                                        CompactionPolicy {
-                                                InMemSizeToSnapshot: 2000
-                                                InMemStepsToSnapshot: 1
-                                                InMemForceStepsToSnapshot: 50
-                                                InMemForceSizeToSnapshot: 16777216
-                                                InMemCompactionBrokerQueue: 0
-                                                ReadAheadHiThreshold: 1048576
-                                                ReadAheadLoThreshold: 16384
-                                                MinDataPageSize: 300
-                                                SnapBrokerQueue: 0
+                        LogOverheadSizeToSnapshot: 16777216
+                        LogOverheadCountToSnapshot: 500
+                        DroppedRowsPercentToCompact: 146
 
-                                                LogOverheadSizeToSnapshot: 16777216
-                                                LogOverheadCountToSnapshot: 500
-                                                DroppedRowsPercentToCompact: 146
-
-                                                Generation {
-                                                  GenerationId: 0
-                                                  SizeToCompact: 0
-                                                  CountToCompact: 2000
-                                                  ForceCountToCompact: 4000
-                                                  ForceSizeToCompact: 100000000
-                                                  #CompactionBrokerQueue: 4294967295
-                                                  KeepInCache: false
-                                                  ResourceBrokerTask: "compaction_gen1"
-                                                  ExtraCompactionPercent: 100
-                                                  ExtraCompactionMinSize: 16384
-                                                  ExtraCompactionExpPercent: 110
-                                                  ExtraCompactionExpMaxSize: 0
-                                                  UpliftPartSize: 0
-                                                }
-                                        }
-
+                        Generation {
+                            GenerationId: 0
+                            SizeToCompact: 0
+                            CountToCompact: 2000
+                            ForceCountToCompact: 4000
+                            ForceSizeToCompact: 100000000
+                            #CompactionBrokerQueue: 4294967295
+                            KeepInCache: false
+                            ResourceBrokerTask: "compaction_gen1"
+                            ExtraCompactionPercent: 100
+                            ExtraCompactionMinSize: 16384
+                            ExtraCompactionExpPercent: 110
+                            ExtraCompactionExpMaxSize: 0
+                            UpliftPartSize: 0
+                        }
+                    }
                 }
             )");
     }
@@ -306,8 +306,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     TString DoS3Listing(ui16 grpcPort, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter, const TString& startAfter,
                     TString continuationToken,
                     const TVector<TString>& columnsToReturn, ui32 maxKeys,
-                    TVector<TString>& commonPrefixes, TVector<TString>& contents, std::optional<Ydb::ObjectStorage::ListingRequest_EMatchType> filter = {}, bool useOldFilter = false)
-    {
+                    TVector<TString>& commonPrefixes, TVector<TString>& contents, std::optional<Ydb::ObjectStorage::ListingRequest_EMatchType> filter = {}, bool useOldFilter = false) {
         std::shared_ptr<grpc::Channel> channel;
         TStringBuilder endpoint;
         endpoint << "localhost:" <<  grpcPort;
@@ -511,8 +510,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
     }
 
     void TestS3Listing(TFlatMsgBusClient& annoyingClient, ui64 bucket, const TString& pathPrefix, const TString& pathDelimiter,
-                       ui32 maxKeys, const TVector<TString>& columnsToReturn)
-    {
+                       ui32 maxKeys, const TVector<TString>& columnsToReturn) {
         Cout << Endl << "---------------------------------------" << Endl
              << "Bucket" << bucket << " : " << pathPrefix << Endl;
 
@@ -544,7 +542,6 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         PrepareS3Data(annoyingClient);
 
         cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::MSGBUS_REQUEST, NActors::NLog::PRI_DEBUG);
-//        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
 
         TestS3Listing(annoyingClient, 50, "", "", 10, {});
         TestS3Listing(annoyingClient, 50, "", "/", 7, {});
@@ -626,7 +623,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         }
     }
 
-    void TestS3ListingRequest(const TVector<TString>& prefixColumns, 
+    void TestS3ListingRequest(const TVector<TString>& prefixColumns,
                     const TString& pathPrefix, const TString& pathDelimiter,
                     const TString& startAfter, const TVector<TString>& columnsToReturn, ui32 maxKeys,
                     Ydb::StatusIds_StatusCode expectedStatus = Ydb::StatusIds::SUCCESS,
@@ -725,7 +722,6 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         PrepareS3Data(annoyingClient);
 
         cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::MSGBUS_REQUEST, NActors::NLog::PRI_DEBUG);
-//        cleverServer.GetRuntime()->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_DEBUG);
 
         TestS3ListingRequest({"100", "Bucket100"}, "/", "/", "", {"Path"}, 10,
             Ydb::StatusIds::SUCCESS,
@@ -973,7 +969,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/inner2/c.jpg", 1, 10, "", "Table", false);
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/xyz.io", 1, 10, "", "Table", false);
         S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/yyyyy.txt", 1, 10, "", "Table", false);
-        
+
         {
             TVector<TString> folders;
             TVector<TString> files;
@@ -1009,6 +1005,113 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
             UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
             UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
         }
+    }
+
+    Y_UNIT_TEST(TestSkipShards) {
+        TPortManager pm;
+        ui16 port = pm.GetPort(2134);
+        TServerSettings serverSettings(port);
+
+        TStringStream ss;
+
+        serverSettings.SetLogBackend(new TStreamLogBackend(&ss));
+
+        TServer cleverServer = TServer(serverSettings);
+        GRPC_PORT = pm.GetPort(2135);
+        cleverServer.EnableGRpc(GRPC_PORT);
+
+        TFlatMsgBusClient annoyingClient(port);
+
+        annoyingClient.InitRoot();
+        annoyingClient.MkDir("/dc-1", "Dir");
+        annoyingClient.CreateTable("/dc-1/Dir",
+            R"(Name: "Table"
+                Columns { Name: "Hash"      Type: "Uint64"}
+                Columns { Name: "Name"      Type: "Utf8"}
+                Columns { Name: "Path"      Type: "Utf8"}
+                Columns { Name: "Version"   Type: "Uint64"}
+                Columns { Name: "Timestamp" Type: "Uint64"}
+                Columns { Name: "Data"      Type: "String"}
+                Columns { Name: "ExtraData" Type: "String"}
+                Columns { Name: "Int32Data" Type: "Int32"}
+                Columns { Name: "Unused1"   Type: "Uint32"}
+                Columns { Name: "SomeBool"  Type: "Bool"}
+                KeyColumnNames: [
+                    "Hash",
+                    "Name",
+                    "Path",
+                    "Version"
+                    ]
+                SplitBoundary { KeyPrefix {
+                    Tuple { Optional { Uint64 : 100 }}
+                    Tuple { Optional { Text : 'Bucket100' }}
+                    Tuple { Optional { Text : '/Photos/test5/inner/inner2/a.jpg' }}
+                }}
+                SplitBoundary { KeyPrefix {
+                    Tuple { Optional { Uint64 : 100 }}
+                    Tuple { Optional { Text : 'Bucket100' }}
+                    Tuple { Optional { Text : '/Photos/test6/a.jpg' }}
+                }}
+            )");
+
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/c.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/folder/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/folder/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/games/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/inner/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/inner/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test/inner/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test/inner/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test2/inner/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test2/inner/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test3/inner/inner2/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test3/inner/inner2/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test4/inner/inner2/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test4/inner/inner2/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test5/inner/inner2/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test5/inner/inner2/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test5/inner/inner2/c.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test5/inner/inner2/d.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test5/inner/inner2/e.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/inner2/a.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/inner2/b.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/inner/inner2/c.jpg", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/xyz.io", 1, 10, "", "Table");
+        S3WriteRow(annoyingClient, 100, "Bucket100", "/Photos/test6/yyyyy.txt", 1, 10, "", "Table");
+
+        const auto& runtime = cleverServer.GetRuntime();
+
+        runtime->SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_DEBUG);
+
+        TVector<TString> folders;
+        TVector<TString> files;
+        DoS3Listing(GRPC_PORT, 100, "/", "/", nullptr, nullptr, {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_EQUAL);
+
+        TVector<TString> expectedFolders = {"/Photos/"};
+        TVector<TString> expectedFiles = {};
+
+        TString log = ss.Str();
+        TString sub = "S3 Listing: start at key";
+
+        int count = 0;
+        size_t pos = log.find(sub);
+
+        while (pos != TString::npos) {
+            ++count;
+            pos = log.find(sub, pos + sub.length());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
+        UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
+        // Three partitions, second should be skipped, because it's next prefix of /Photos/ (/Photos0) exceeds
+        // the range of second partition. Third (last) partition will always be checked.
+        UNIT_ASSERT_EQUAL(2, count);
     }
 }
 

--- a/ydb/core/grpc_services/rpc_object_storage.cpp
+++ b/ydb/core/grpc_services/rpc_object_storage.cpp
@@ -743,6 +743,19 @@ private:
         }
     }
 
+    static TString NextPrefix(TString p) {
+        while (p) {
+            if (char next = (char)(((unsigned char)p.back()) + 1)) {
+                p.back() = next;
+                break;
+            } else {
+                p.pop_back(); // overflow, move to the next character
+            }
+        }
+
+        return p;
+    }
+
     void MakeShardRequest(ui32 idx, const NActors::TActorContext& ctx) {
         ui64 shardId = KeyRange->GetPartitions()[idx].ShardId;
 
@@ -816,6 +829,51 @@ private:
         }
     }
 
+    bool FindNextShard() {
+        if (CommonPrefixesRows.empty()) {
+            // Just move to the next shard if no folders were found previously.
+            CurrentShardIdx++;
+            return true;
+        }
+
+        TString prefixColumns = PrefixColumns.GetBuffer();
+        TString lastCommonPrefix = NextPrefix(CommonPrefixesRows.back());
+
+        TSerializedCellVec::UnsafeAppendCells({TCell(lastCommonPrefix.Data(), lastCommonPrefix.Size())}, prefixColumns);
+
+        TSerializedCellVec afterLastFolderPrefix;
+        afterLastFolderPrefix.Parse(prefixColumns);
+
+        auto& partitions = KeyRange->GetPartitions();
+        
+        for (CurrentShardIdx++; CurrentShardIdx < partitions.size(); CurrentShardIdx++) {
+            auto& partition = KeyRange->GetPartitions()[CurrentShardIdx];
+
+            auto& range = partition.Range;
+
+            if (range && range->EndKeyPrefix.GetCells().size() > 0) {
+                auto& endKeyPrefix = range->EndKeyPrefix;
+
+                // Check if range's end greater than the lookup key.
+                int cmp = CompareTypedCellVectors(
+                    endKeyPrefix.GetCells().data(),
+                    afterLastFolderPrefix.GetCells().data(),
+                    KeyColumnTypes.data(),
+                    afterLastFolderPrefix.GetCells().size()
+                );
+
+                if (cmp >= 0) {
+                    // Found a shard whose range end is greater than the lookup key.
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void Handle(TEvDataShard::TEvObjectStorageListingResponse::TPtr& ev, const NActors::TActorContext& ctx) {
         const auto& shardResponse = ev->Get()->Record;
 
@@ -845,14 +903,19 @@ private:
             ContentsRows.emplace_back(shardResponse.GetContentsRows(i));
         }
 
-        bool hasMoreShards = CurrentShardIdx + 1 < KeyRange->GetPartitions().size();
+        auto& partitions = KeyRange->GetPartitions();
+        ui32 partitionsSize = partitions.size();
+
+        bool hasMoreShards = CurrentShardIdx + 1 < partitionsSize;
         bool maxKeysExhausted = MaxKeys <= ContentsRows.size() + CommonPrefixesRows.size();
 
         if (hasMoreShards &&
             !maxKeysExhausted &&
-            shardResponse.GetMoreRows())
-        {
-            ++CurrentShardIdx;
+            shardResponse.GetMoreRows()) {
+            if (!FindNextShard()) {
+                ReplySuccess(ctx, (hasMoreShards && shardResponse.GetMoreRows()) || maxKeysExhausted);
+                return;    
+            }
             MakeShardRequest(CurrentShardIdx, ctx);
         } else {
             ReplySuccess(ctx, (hasMoreShards && shardResponse.GetMoreRows()) || maxKeysExhausted);

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -844,7 +844,7 @@ message TEvObjectStorageListingResponse {
     optional uint32 Status = 2;
     optional string ErrorDescription = 3;
     repeated string CommonPrefixesRows = 4;
-    repeated bytes ContentsRows = 5;        // TSerializedCellVec
+    repeated bytes ContentsRows = 5; // TSerializedCellVec
     optional bool MoreRows = 6;
 }
 

--- a/ydb/core/scheme/scheme_tablecell.cpp
+++ b/ydb/core/scheme/scheme_tablecell.cpp
@@ -256,6 +256,45 @@ bool TSerializedCellVec::DoTryParse(const TString& data) {
     return TryDeserializeCellVec(data, Buf, Cells);
 }
 
+bool TSerializedCellVec::UnsafeAppendCells(TConstArrayRef<TCell> cells, TString& serializedCellVec) {
+    if (Y_UNLIKELY(cells.size() == 0)) {
+        return true;
+    }
+
+    if (!serializedCellVec) {
+        TSerializedCellVec::Serialize(serializedCellVec, cells);
+        return true;
+    }
+
+    const char* buf = serializedCellVec.data();
+    const char* bufEnd = serializedCellVec.data() + serializedCellVec.size();
+    const size_t bufSize = bufEnd - buf;
+
+    if (Y_UNLIKELY(bufSize < static_cast<ptrdiff_t>(sizeof(ui16)))) {
+        return false;
+    }
+
+    ui16 cellCount = ReadUnaligned<ui16>(buf);
+    cellCount += cells.size();
+
+    size_t newSize = serializedCellVec.size();
+
+    for (auto& cell : cells) {
+        newSize += sizeof(TCellHeader) + cell.Size();
+    }
+
+    serializedCellVec.ReserveAndResize(newSize);
+
+    char* mutableBuf = serializedCellVec.Detach();
+    char* oldBufEnd = mutableBuf + bufSize;
+
+    WriteUnaligned<ui16>(mutableBuf, cellCount);
+
+    SerializeCellVecBody(cells, oldBufEnd, nullptr);
+
+    return true;
+}
+
 TSerializedCellMatrix::TSerializedCellMatrix(TConstArrayRef<TCell> cells, ui32 rowCount, ui16 colCount)
     : RowCount(rowCount), ColCount(colCount)
 {

--- a/ydb/core/scheme/scheme_tablecell.h
+++ b/ydb/core/scheme/scheme_tablecell.h
@@ -532,6 +532,14 @@ public:
         return Cells;
     }
 
+    explicit operator bool() const
+    {
+        return !Cells.empty();
+    }
+
+    // read headers, assuming the buf is correct and append additional cells at the end
+    static bool UnsafeAppendCells(TConstArrayRef<TCell> cells, TString& serializedCellVec);
+
     static void Serialize(TString& res, TConstArrayRef<TCell> cells);
 
     static TString Serialize(TConstArrayRef<TCell> cells);


### PR DESCRIPTION
(cherry picked from commit 7e0f2fe98362163220a1ebc7f670f4e25ee0478e)