### PR TITLE
Higher timeout for dread_cache_service

### DIFF
--- a/ydb/core/persqueue/dread_cache_service/ut/ya.make
+++ b/ydb/core/persqueue/dread_cache_service/ut/ya.make
@@ -3,7 +3,6 @@ UNITTEST_FOR(ydb/core/persqueue)
 FORK_SUBTESTS()
 
 SIZE(MEDIUM)
-TIMEOUT(300)
 
 PEERDIR(
     ydb/core/persqueue/ut/common

--- a/ydb/core/persqueue/dread_cache_service/ut/ya.make
+++ b/ydb/core/persqueue/dread_cache_service/ut/ya.make
@@ -2,14 +2,8 @@ UNITTEST_FOR(ydb/core/persqueue)
 
 FORK_SUBTESTS()
 
-IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
-    SIZE(LARGE)
-    TAG(ya:fat)
-    TIMEOUT(300)
-ELSE()
-    SIZE(MEDIUM)
-    TIMEOUT(60)
-ENDIF()
+SIZE(MEDIUM)
+TIMEOUT(300)
 
 PEERDIR(
     ydb/core/persqueue/ut/common


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

See: https://github.com/ydb-platform/ydb/pull/10045#issuecomment-2443734644

Looks like 10 min (default timeout) is OK

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
