### PR TITLE
Fix vector index billing

### DIFF
--- a/ydb/core/protos/index_builder.proto
+++ b/ydb/core/protos/index_builder.proto
@@ -124,7 +124,6 @@ message TEvUploadSampleKResponse {
     optional Ydb.StatusIds.StatusCode UploadStatus = 2;
     repeated Ydb.Issue.IssueMessage Issues = 3;
 
-    optional uint64 RowsDelta = 4;
-    optional uint64 BytesDelta = 5;
+    optional uint64 UploadRows = 4;
+    optional uint64 UploadBytes = 5;
 }
-

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1500,8 +1500,8 @@ message TEvSampleKResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 4;
     repeated Ydb.Issue.IssueMessage Issues = 5;
 
-    optional uint64 RowsDelta = 6;
-    optional uint64 BytesDelta = 7;
+    optional uint64 ReadRows = 6;
+    optional uint64 ReadBytes = 7;
 
     optional uint64 RequestSeqNoGeneration = 8;
     optional uint64 RequestSeqNoRound = 9;
@@ -1568,12 +1568,14 @@ message TEvLocalKMeansResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 6;
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
-    // TODO(mbkkt) implement slow-path (reliable-path)
-    // optional uint64 RowsDelta = 8;
-    // optional uint64 BytesDelta = 9;
+    optional uint64 UploadRows = 8;
+    optional uint64 UploadBytes = 9;
+    optional uint64 ReadRows = 10;
+    optional uint64 ReadBytes = 11;
 
-    // optional TEvLocalKMeansRequest.EState State = 10;
-    // optional uint32 DoneRounds = 11;
+    // TODO(mbkkt) implement slow-path (reliable-path)
+    // optional TEvLocalKMeansRequest.EState State
+    // optional uint32 DoneRounds
 }
 
 message TEvReshuffleKMeansRequest {
@@ -1617,9 +1619,12 @@ message TEvReshuffleKMeansResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 6;
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
+    optional uint64 UploadRows = 8;
+    optional uint64 UploadBytes = 9;
+    optional uint64 ReadRows = 10;
+    optional uint64 ReadBytes = 11;
+
     // TODO(mbkkt) implement slow-path (reliable-path)
-    // optional uint64 RowsDelta = 8;
-    // optional uint64 BytesDelta = 9;
     // optional last written primary key
 }
 

--- a/ydb/core/tx/datashard/kmeans_helper.cpp
+++ b/ydb/core/tx/datashard/kmeans_helper.cpp
@@ -56,7 +56,7 @@ void AddRowBuild2Build(TBufferData& buffer, ui32 parent, TArrayRef<const TCell> 
 }
 
 void AddRowBuild2Posting(TBufferData& buffer, ui32 parent, TArrayRef<const TCell> key, const NTable::TRowState& row,
-                       ui32 dataPos)
+                         ui32 dataPos)
 {
     std::array<TCell, 1> cells;
     cells[0] = TCell::Make(parent);

--- a/ydb/core/tx/datashard/kmeans_helper.h
+++ b/ydb/core/tx/datashard/kmeans_helper.h
@@ -184,19 +184,12 @@ struct TCalculation: TMetric {
     }
 };
 
-struct TStats {
-    ui64 Rows = 0;
-    ui64 Bytes = 0;
-};
-
 template <typename TMetric>
 ui32 FeedEmbedding(const TCalculation<TMetric>& calculation, std::span<const TString> clusters,
-                   const NTable::TRowState& row, NTable::TPos embeddingPos, TStats& stats)
+                   const NTable::TRowState& row, NTable::TPos embeddingPos)
 {
     Y_ASSERT(embeddingPos < row.Size());
     const auto embedding = row.Get(embeddingPos).AsRef();
-    stats.Rows += 1;
-    stats.Bytes += embedding.size(); // TODO(mbkkt) add some constant overhead?
     if (!calculation.IsExpectedSize(embedding)) {
         return std::numeric_limits<ui32>::max();
     }

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -60,10 +60,10 @@ protected:
 
     TLead Lead;
 
-    // Sample
-    TStats ReadStats;
-    // TODO(mbkkt) Sent or Upload stats?
+    ui64 ReadRows = 0;
+    ui64 ReadBytes = 0;
 
+    // Sample
     ui64 MaxProbability = std::numeric_limits<ui64>::max();
     TReallyFastRng32 Rng;
 
@@ -100,6 +100,9 @@ protected:
     TTags UploadScan;
 
     TUploadStatus UploadStatus;
+
+    ui64 UploadRows = 0;
+    ui64 UploadBytes = 0;
 
     // Response
     TActorId ResponseActorId;
@@ -163,6 +166,10 @@ public:
         }
 
         auto& record = Response->Record;
+        record.SetReadRows(ReadRows);
+        record.SetReadBytes(ReadBytes);
+        record.SetUploadRows(UploadRows);
+        record.SetUploadBytes(UploadBytes);
         if (abort != EAbort::None) {
             record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
         } else if (UploadStatus.IsSuccess()) {
@@ -243,6 +250,8 @@ protected:
         UploadStatus.StatusCode = ev->Get()->Status;
         UploadStatus.Issues = ev->Get()->Issues;
         if (UploadStatus.IsSuccess()) {
+            UploadRows += WriteBuf.GetRows();
+            UploadBytes += WriteBuf.GetBytes();
             WriteBuf.Clear();
             if (!ReadBuf.IsEmpty() && ReadBuf.IsReachLimits(Limits)) {
                 ReadBuf.FlushTo(WriteBuf);
@@ -366,6 +375,9 @@ public:
             if (!InitAggregatedClusters()) {
                 // We don't need to do anything,
                 // because this datashard doesn't have valid embeddings for this parent
+                if (UploadStatus.IsNone()) {
+                    UploadStatus.StatusCode = Ydb::StatusIds::SUCCESS;
+                }
                 return EScan::Final;
             }
             ++Round;
@@ -391,6 +403,8 @@ public:
     EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final
     {
         LOG_T("Feed " << Debug());
+        ++ReadRows;
+        ReadBytes += CountBytes(key, row);
         switch (State) {
             case EState::SAMPLE:
                 return FeedSample(row);
@@ -467,8 +481,6 @@ private:
     {
         Y_ASSERT(row.Size() == 1);
         const auto embedding = row.Get(0).AsRef();
-        ReadStats.Rows += 1;
-        ReadStats.Bytes += embedding.size(); // TODO(mbkkt) add some constant overhead?
         if (!this->IsExpectedSize(embedding)) {
             return EScan::Feed;
         }
@@ -495,14 +507,14 @@ private:
     EScan FeedKMeans(const TRow& row) noexcept
     {
         Y_ASSERT(row.Size() == 1);
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, 0, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, 0);
         AggregateToCluster(pos, row.Get(0).Data());
         return EScan::Feed;
     }
 
     EScan FeedUploadMain2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }
@@ -512,7 +524,7 @@ private:
 
     EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }
@@ -522,7 +534,7 @@ private:
 
     EScan FeedUploadBuild2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }
@@ -532,7 +544,7 @@ private:
 
     EScan FeedUploadBuild2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -38,8 +38,8 @@ protected:
 
     TLead Lead;
 
-    TStats ReadStats;
-    // TODO(mbkkt) Sent or Upload stats?
+    ui64 ReadRows = 0;
+    ui64 ReadBytes = 0;
 
     std::vector<TString> Clusters;
 
@@ -62,6 +62,9 @@ protected:
     TTags UploadScan;
 
     TUploadStatus UploadStatus;
+
+    ui64 UploadRows = 0;
+    ui64 UploadBytes = 0;
 
     // Response
     TActorId ResponseActorId;
@@ -138,6 +141,10 @@ public:
         }
 
         auto& record = Response->Record;
+        record.SetReadRows(ReadRows);
+        record.SetReadBytes(ReadBytes);
+        record.SetUploadRows(UploadRows);
+        record.SetUploadBytes(UploadBytes);
         if (abort != EAbort::None) {
             record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
         } else if (UploadStatus.IsSuccess()) {
@@ -218,6 +225,8 @@ protected:
         UploadStatus.StatusCode = ev->Get()->Status;
         UploadStatus.Issues = ev->Get()->Issues;
         if (UploadStatus.IsSuccess()) {
+            UploadRows += WriteBuf.GetRows();
+            UploadBytes += WriteBuf.GetBytes();
             WriteBuf.Clear();
             if (!ReadBuf.IsEmpty() && ReadBuf.IsReachLimits(Limits)) {
                 ReadBuf.FlushTo(WriteBuf);
@@ -282,6 +291,8 @@ public:
     EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final
     {
         LOG_T("Feed " << Debug());
+        ++ReadRows;
+        ReadBytes += CountBytes(key, row);
         switch (UploadState) {
             case EState::UPLOAD_MAIN_TO_BUILD:
                 return FeedUploadMain2Build(key, row);
@@ -299,7 +310,7 @@ public:
 private:
     EScan FeedUploadMain2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }
@@ -309,7 +320,7 @@ private:
 
     EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }
@@ -319,7 +330,7 @@ private:
 
     EScan FeedUploadBuild2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }
@@ -329,7 +340,7 @@ private:
 
     EScan FeedUploadBuild2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
     {
-        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos, ReadStats);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
             return EScan::Feed;
         }

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -44,8 +44,8 @@ protected:
         auto operator<=>(const TProbability&) const noexcept = default;
     };
 
-    ui64 RowsCount = 0;
-    ui64 RowsBytes = 0;
+    ui64 ReadRows = 0;
+    ui64 ReadBytes = 0;
 
     // We are using binary heap, because we don't want to do batch processing here,
     // serialization is more expensive than compare
@@ -116,27 +116,28 @@ public:
 
     EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final {
         LOG_T("Feed key " << DebugPrintPoint(KeyTypes, key, *AppData()->TypeRegistry) << " " << Debug());
-        ++RowsCount;
+        ++ReadRows;
+        ReadBytes += CountBytes(key, row);
 
         const auto probability = GetProbability();
         if (probability > MaxProbability) {
-            // TODO(mbkkt) it's not nice that we need to compute this, probably can be precomputed in TRow
-            RowsBytes += TSerializedCellVec::SerializedSize(*row);
             return EScan::Feed;
         }
 
-        auto serialized = TSerializedCellVec::Serialize(*row);
-        RowsBytes += serialized.size();
-
         if (DataRows.size() < K) {
             MaxRows.push_back({probability, DataRows.size()});
-            DataRows.emplace_back(std::move(serialized));
+            DataRows.emplace_back(TSerializedCellVec::Serialize(*row));
             if (DataRows.size() == K) {
                 std::make_heap(MaxRows.begin(), MaxRows.end());
                 MaxProbability = MaxRows.front().P;
             }
         } else {
-            ReplaceRow(std::move(serialized), probability);
+            // TODO(mbkkt) use tournament tree to make less compare and swaps
+            std::pop_heap(MaxRows.begin(), MaxRows.end());
+            TSerializedCellVec::Serialize(DataRows[MaxRows.back().I], *row);
+            MaxRows.back().P = probability;
+            std::push_heap(MaxRows.begin(), MaxRows.end());
+            MaxProbability = MaxRows.front().P;
         }
 
         if (MaxProbability == 0) {
@@ -147,6 +148,8 @@ public:
 
     TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final {
         Y_ABORT_UNLESS(Response);
+        Response->Record.SetReadRows(ReadRows);
+        Response->Record.SetReadBytes(ReadBytes);
         if (abort == EAbort::None) {
             FillResponse();
         } else {
@@ -187,15 +190,6 @@ private:
         }
     }
 
-    void ReplaceRow(TString&& row, ui64 p) {
-        // TODO(mbkkt) use tournament tree to make less compare and swaps
-        std::pop_heap(MaxRows.begin(), MaxRows.end());
-        DataRows[MaxRows.back().I] = std::move(row);
-        MaxRows.back().P = p;
-        std::push_heap(MaxRows.begin(), MaxRows.end());
-        MaxProbability = MaxRows.front().P;
-    }
-
     void FillResponse() {
         std::sort(MaxRows.begin(), MaxRows.end());
         auto& record = Response->Record;
@@ -203,8 +197,6 @@ private:
             record.AddProbabilities(p);
             record.AddRows(std::move(DataRows[i]));
         }
-        record.SetRowsDelta(RowsCount);
-        record.SetBytesDelta(RowsBytes);
         record.SetStatus(NKikimrIndexBuilder::EBuildStatus::DONE);
     }
 

--- a/ydb/core/tx/datashard/scan_common.cpp
+++ b/ydb/core/tx/datashard/scan_common.cpp
@@ -29,4 +29,15 @@ TColumnsTypes GetAllTypes(const TUserTable& tableInfo) {
     return result;
 }
 
+ui64 CountBytes(TArrayRef<const TCell> key, const NTable::TRowState& row) {
+    ui64 bytes = 0;
+    for (auto& cell : key) {
+        bytes += cell.Size();
+    }
+    for (auto& cell : *row) {
+        bytes += cell.Size();
+    }
+    return bytes;
+}
+
 }

--- a/ydb/core/tx/datashard/scan_common.h
+++ b/ydb/core/tx/datashard/scan_common.h
@@ -80,4 +80,9 @@ using TColumnsTypes = THashMap<TString, NScheme::TTypeInfo>;
 
 TColumnsTypes GetAllTypes(const TUserTable& tableInfo);
 
+// TODO(mbkkt) unfortunately key can have same columns as row
+// I can detect this but maybe better
+// if IScan will provide for us "how much data did we read"?
+ui64 CountBytes(TArrayRef<const TCell> key, const NTable::TRowState& row);
+
 }

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -786,7 +786,6 @@ private:
                             TABLEH() {str << "DebugMessage";}
                             TABLEH() {str << "SeqNo";}
                             TABLEH() {str << "Processed";}
-                            TABLEH() {str << "Billed";}
                         }
                     }
                     for (auto item : info.Shards) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -210,8 +210,8 @@ void TSchemeShard::PersistBuildIndexProcessed(NIceDb::TNiceDb& db, const TIndexB
 
 void TSchemeShard::PersistBuildIndexBilled(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo) {
     db.Table<Schema::IndexBuild>().Key(indexInfo.Id).Update(
-        NIceDb::TUpdate<Schema::IndexBuild::UploadRowsBilled>(indexInfo.Billed.GetUploadRows()),
-        NIceDb::TUpdate<Schema::IndexBuild::UploadBytesBilled>(indexInfo.Billed.GetUploadBytes()),
+        NIceDb::TUpdate<Schema::IndexBuild::RowsBilled>(indexInfo.Billed.GetUploadRows()),
+        NIceDb::TUpdate<Schema::IndexBuild::BytesBilled>(indexInfo.Billed.GetUploadBytes()),
         NIceDb::TUpdate<Schema::IndexBuild::ReadRowsBilled>(indexInfo.Billed.GetReadRows()),
         NIceDb::TUpdate<Schema::IndexBuild::ReadBytesBilled>(indexInfo.Billed.GetReadBytes())
     );
@@ -223,8 +223,8 @@ void TSchemeShard::PersistBuildIndexUploadProgress(NIceDb::TNiceDb& db, TIndexBu
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::Status>(shardStatus.Status),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::Message>(shardStatus.DebugMessage),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadStatus>(shardStatus.UploadStatus),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadRowsProcessed>(shardStatus.Processed.GetUploadRows()),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadBytesProcessed>(shardStatus.Processed.GetUploadBytes()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::RowsProcessed>(shardStatus.Processed.GetUploadRows()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::BytesProcessed>(shardStatus.Processed.GetUploadBytes()),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadRowsProcessed>(shardStatus.Processed.GetReadRows()),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadBytesProcessed>(shardStatus.Processed.GetReadBytes())
     );
@@ -246,8 +246,8 @@ void TSchemeShard::PersistBuildIndexUploadReset(NIceDb::TNiceDb& db, TIndexBuild
     shardStatus.Processed = {};
     db.Table<Schema::IndexBuildShardStatus>().Key(buildId, shardIdx.GetOwnerId(), shardIdx.GetLocalId()).Update(
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::Status>(shardStatus.Status),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadRowsProcessed>(shardStatus.Processed.GetUploadRows()),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadBytesProcessed>(shardStatus.Processed.GetUploadBytes()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::RowsProcessed>(shardStatus.Processed.GetUploadRows()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::BytesProcessed>(shardStatus.Processed.GetUploadBytes()),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadRowsProcessed>(shardStatus.Processed.GetReadRows()),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadBytesProcessed>(shardStatus.Processed.GetReadBytes())
     );

--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -199,11 +199,22 @@ void TSchemeShard::PersistBuildIndexUnlockTxId(NIceDb::TNiceDb& db, const TIndex
         NIceDb::TUpdate<Schema::IndexBuild::UnlockTxId>(indexInfo.UnlockTxId));
 }
 
-void TSchemeShard::PersistBuildIndexBilling(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo) {
+void TSchemeShard::PersistBuildIndexProcessed(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo) {
     db.Table<Schema::IndexBuild>().Key(indexInfo.Id).Update(
-        NIceDb::TUpdate<Schema::IndexBuild::RowsBilled>(indexInfo.Billed.GetRows()),
-        NIceDb::TUpdate<Schema::IndexBuild::BytesBilled>(indexInfo.Billed.GetBytes())
-        );
+        NIceDb::TUpdate<Schema::IndexBuild::UploadRowsProcessed>(indexInfo.Processed.GetUploadRows()),
+        NIceDb::TUpdate<Schema::IndexBuild::UploadBytesProcessed>(indexInfo.Processed.GetUploadBytes()),
+        NIceDb::TUpdate<Schema::IndexBuild::ReadRowsProcessed>(indexInfo.Processed.GetReadRows()),
+        NIceDb::TUpdate<Schema::IndexBuild::ReadBytesProcessed>(indexInfo.Processed.GetReadBytes())
+    );
+}
+
+void TSchemeShard::PersistBuildIndexBilled(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo) {
+    db.Table<Schema::IndexBuild>().Key(indexInfo.Id).Update(
+        NIceDb::TUpdate<Schema::IndexBuild::UploadRowsBilled>(indexInfo.Billed.GetUploadRows()),
+        NIceDb::TUpdate<Schema::IndexBuild::UploadBytesBilled>(indexInfo.Billed.GetUploadBytes()),
+        NIceDb::TUpdate<Schema::IndexBuild::ReadRowsBilled>(indexInfo.Billed.GetReadRows()),
+        NIceDb::TUpdate<Schema::IndexBuild::ReadBytesBilled>(indexInfo.Billed.GetReadBytes())
+    );
 }
 
 void TSchemeShard::PersistBuildIndexUploadProgress(NIceDb::TNiceDb& db, TIndexBuildId buildId, const TShardIdx& shardIdx, const TIndexBuildInfo::TShardStatus& shardStatus) {
@@ -212,8 +223,10 @@ void TSchemeShard::PersistBuildIndexUploadProgress(NIceDb::TNiceDb& db, TIndexBu
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::Status>(shardStatus.Status),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::Message>(shardStatus.DebugMessage),
         NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadStatus>(shardStatus.UploadStatus),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::RowsProcessed>(shardStatus.Processed.GetRows()),
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::BytesProcessed>(shardStatus.Processed.GetBytes())
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadRowsProcessed>(shardStatus.Processed.GetUploadRows()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadBytesProcessed>(shardStatus.Processed.GetUploadBytes()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadRowsProcessed>(shardStatus.Processed.GetReadRows()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadBytesProcessed>(shardStatus.Processed.GetReadBytes())
     );
 }
 
@@ -230,8 +243,13 @@ void TSchemeShard::PersistBuildIndexUploadInitiate(NIceDb::TNiceDb& db, TIndexBu
 
 void TSchemeShard::PersistBuildIndexUploadReset(NIceDb::TNiceDb& db, TIndexBuildId buildId, const TShardIdx& shardIdx, TIndexBuildInfo::TShardStatus& shardStatus) {
     shardStatus.Status = NKikimrIndexBuilder::EBuildStatus::INVALID;
+    shardStatus.Processed = {};
     db.Table<Schema::IndexBuildShardStatus>().Key(buildId, shardIdx.GetOwnerId(), shardIdx.GetLocalId()).Update(
-        NIceDb::TUpdate<Schema::IndexBuildShardStatus::Status>(shardStatus.Status)
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::Status>(shardStatus.Status),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadRowsProcessed>(shardStatus.Processed.GetUploadRows()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::UploadBytesProcessed>(shardStatus.Processed.GetUploadBytes()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadRowsProcessed>(shardStatus.Processed.GetReadRows()),
+        NIceDb::TUpdate<Schema::IndexBuildShardStatus::ReadBytesProcessed>(shardStatus.Processed.GetReadBytes())
     );
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -52,8 +52,8 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplySchedule(const TActorContext& ct
 }
 
 ui64 TSchemeShard::TIndexBuilder::TTxBase::RequestUnits(const TBillingStats& stats) {
-    return TRUCalculator::ReadTable(stats.GetBytes())
-         + TRUCalculator::BulkUpsert(stats.GetBytes(), stats.GetRows());
+    return TRUCalculator::ReadTable(stats.GetReadBytes())
+         + TRUCalculator::BulkUpsert(stats.GetUploadBytes(), stats.GetUploadRows());
 }
 
 void TSchemeShard::TIndexBuilder::TTxBase::RoundPeriod(TInstant& start, TInstant& end) {
@@ -93,8 +93,10 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
         const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(buildId);
         Y_VERIFY_S(buildInfoPtr, "IndexBuilds has no " << buildId);
         auto& buildInfo = *buildInfoPtr->Get();
+        auto& processed = buildInfo.Processed;
+        auto& billed = buildInfo.Billed;
 
-        TBillingStats toBill = buildInfo.Processed - buildInfo.Billed;
+        TBillingStats toBill = processed - billed;
         if (!toBill) {
             continue;
         }
@@ -139,16 +141,16 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
 
         NIceDb::TNiceDb db(txc.DB);
 
-        buildInfo.Billed += toBill;
-        Self->PersistBuildIndexBilling(db, buildInfo);
+        billed += toBill;
+        Self->PersistBuildIndexBilled(db, buildInfo);
 
         ui64 requestUnits = RequestUnits(toBill);
 
         TString id = TStringBuilder()
             << buildId << "-"
             << buildInfo.TablePathId.OwnerId << "-" << buildInfo.TablePathId.LocalPathId << "-"
-            << buildInfo.Billed.GetRows() << "-" << buildInfo.Billed.GetBytes() << "-"
-            << buildInfo.Processed.GetRows() << "-" << buildInfo.Processed.GetBytes();
+            << billed.GetUploadRows() + billed.GetReadRows() << "-" << billed.GetUploadBytes() + billed.GetReadBytes() << "-"
+            << processed.GetUploadRows() + processed.GetReadRows() << "-" << processed.GetUploadBytes() + processed.GetReadBytes();
 
         const TString billRecord = TBillRecord()
             .Id(id)

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -139,18 +139,18 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
             continue;
         }
 
+        TString id = TStringBuilder()
+            << buildId << "-"
+            << buildInfo.TablePathId.OwnerId << "-" << buildInfo.TablePathId.LocalPathId << "-"
+            << billed.GetUploadRows() + billed.GetReadRows() << "-" << billed.GetUploadBytes() + billed.GetReadBytes() << "-"
+            << processed.GetUploadRows() + processed.GetReadRows() << "-" << processed.GetUploadBytes() + processed.GetReadBytes();
+
         NIceDb::TNiceDb db(txc.DB);
 
         billed += toBill;
         Self->PersistBuildIndexBilled(db, buildInfo);
 
         ui64 requestUnits = RequestUnits(toBill);
-
-        TString id = TStringBuilder()
-            << buildId << "-"
-            << buildInfo.TablePathId.OwnerId << "-" << buildInfo.TablePathId.LocalPathId << "-"
-            << billed.GetUploadRows() + billed.GetReadRows() << "-" << billed.GetUploadBytes() + billed.GetReadBytes() << "-"
-            << processed.GetUploadRows() + processed.GetReadRows() << "-" << processed.GetUploadBytes() + processed.GetReadBytes();
 
         const TString billRecord = TBillRecord()
             .Id(id)

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -142,8 +142,10 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
         TString id = TStringBuilder()
             << buildId << "-"
             << buildInfo.TablePathId.OwnerId << "-" << buildInfo.TablePathId.LocalPathId << "-"
-            << billed.GetUploadRows() + billed.GetReadRows() << "-" << billed.GetUploadBytes() + billed.GetReadBytes() << "-"
-            << processed.GetUploadRows() + processed.GetReadRows() << "-" << processed.GetUploadBytes() + processed.GetReadBytes();
+            << billed.GetUploadRows() << "-" << billed.GetReadRows() << "-"
+            << billed.GetUploadBytes() << "-" << billed.GetReadBytes() << "-"
+            << processed.GetUploadRows() << "-" << processed.GetReadRows() << "-"
+            << processed.GetUploadBytes() << "-" << processed.GetReadBytes();
 
         NIceDb::TNiceDb db(txc.DB);
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1320,7 +1320,8 @@ public:
     void PersistBuildIndexUploadProgress(NIceDb::TNiceDb& db, TIndexBuildId buildId, const TShardIdx& shardIdx, const TIndexBuildInfo::TShardStatus& shardStatus);
     void PersistBuildIndexUploadReset(NIceDb::TNiceDb& db, TIndexBuildId buildId, const TShardIdx& shardIdx, TIndexBuildInfo::TShardStatus& shardStatus);
     void PersistBuildIndexUploadReset(NIceDb::TNiceDb& db, TIndexBuildInfo& info);
-    void PersistBuildIndexBilling(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
+    void PersistBuildIndexProcessed(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
+    void PersistBuildIndexBilled(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
 
     void PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -471,7 +471,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
                 if (!featureFlags.EnableParameterizedDecimal && decimalType != NScheme::TDecimalType::Default()){
                     errStr = Sprintf("Type '%s' specified for column '%s', but support for parametrized decimal is disabled (EnableParameterizedDecimal feature flag is off)", col.GetType().data(), colName.data());
                     return nullptr;
-                }   
+                }
                 break;
             }
             case NScheme::NTypeIds::Pg:
@@ -479,7 +479,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
                     errStr = Sprintf("Type '%s' specified for column '%s', but support for pg types is disabled (EnableTablePgTypes feature flag is off)", col.GetType().data(), colName.data());
                     return nullptr;
                 }
-                break;                             
+                break;
             default:
                 break;
             }
@@ -2332,96 +2332,37 @@ bool TTopicInfo::FillKeySchema(const TString& tabletConfig) {
     return FillKeySchema(proto, unused);
 }
 
-TBillingStats::TBillingStats(ui64 rows, ui64 bytes)
-    : Rows(rows)
-    , Bytes(bytes)
+TBillingStats::TBillingStats(ui64 readRows, ui64 readBytes, ui64 uploadRows, ui64 uploadBytes)
+    : UploadRows{uploadRows}
+    , UploadBytes{uploadBytes}
+    , ReadRows{readRows}
+    , ReadBytes{readBytes}
 {
-}
-
-TBillingStats::TBillingStats(const TBillingStats &other)
-    : Rows(other.Rows)
-    , Bytes(other.Bytes)
-{
-}
-
-TBillingStats &TBillingStats::operator =(const TBillingStats &other) {
-    if (this == &other) {
-        return *this;
-    }
-
-    Rows = other.Rows;
-    Bytes = other.Bytes;
-    return *this;
 }
 
 TBillingStats TBillingStats::operator -(const TBillingStats &other) const {
-    Y_ABORT_UNLESS(Rows >= other.Rows);
-    Y_ABORT_UNLESS(Bytes >= other.Bytes);
+    Y_ABORT_UNLESS(UploadRows >= other.UploadRows);
+    Y_ABORT_UNLESS(UploadBytes >= other.UploadBytes);
+    Y_ABORT_UNLESS(ReadRows >= other.ReadRows);
+    Y_ABORT_UNLESS(ReadBytes >= other.ReadBytes);
 
-    return TBillingStats(Rows - other.Rows, Bytes - other.Bytes);
-}
-
-TBillingStats &TBillingStats::operator -=(const TBillingStats &other) {
-    if (this == &other) {
-        Rows = 0;
-        Bytes = 0;
-        return *this;
-    }
-
-    Y_ABORT_UNLESS(Rows >= other.Rows);
-    Y_ABORT_UNLESS(Bytes >= other.Bytes);
-
-    Rows -= other.Rows;
-    Bytes -= other.Bytes;
-    return *this;
+    return {UploadRows - other.UploadRows, UploadBytes - other.UploadBytes,
+            ReadRows - other.ReadRows, ReadBytes - other.ReadBytes};
 }
 
 TBillingStats TBillingStats::operator +(const TBillingStats &other) const {
-    return TBillingStats(Rows + other.Rows, Bytes + other.Bytes);
-}
-
-TBillingStats &TBillingStats::operator +=(const TBillingStats &other) {
-    if (this == &other) {
-        Rows += Rows;
-        Bytes += Bytes;
-        return *this;
-    }
-
-    Rows += other.Rows;
-    Bytes += other.Bytes;
-    return *this;
-}
-
-bool TBillingStats::operator < (const TBillingStats &other) const {
-    return Rows < other.Rows && Bytes < other.Bytes;
-}
-
-bool TBillingStats::operator <= (const TBillingStats &other) const {
-    return Rows <= other.Rows && Bytes <= other.Bytes;
-}
-
-bool TBillingStats::operator ==(const TBillingStats &other) const {
-    return Rows == other.Rows && Bytes == other.Bytes;
+    return {UploadRows + other.UploadRows, UploadBytes + other.UploadBytes,
+            ReadRows + other.ReadRows, ReadBytes + other.ReadBytes};
 }
 
 TString TBillingStats::ToString() const {
     return TStringBuilder()
             << "{"
-            << " rows: " << GetRows()
-            << " bytes: " << GetBytes()
+            << " upload rows: " << UploadRows
+            << ", upload bytes: " << UploadBytes
+            << ", read rows: " << ReadRows
+            << ", read bytes: " << ReadBytes
             << " }";
-}
-
-ui64 TBillingStats::GetRows() const {
-    return Rows;
-}
-
-ui64 TBillingStats::GetBytes() const {
-    return Bytes;
-}
-
-NKikimr::NSchemeShard::TBillingStats::operator bool() const {
-    return Rows || Bytes;
 }
 
 TSequenceInfo::TSequenceInfo(

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2865,31 +2865,48 @@ struct TImportInfo: public TSimpleRefCount<TImportInfo> {
 class TBillingStats {
 public:
     TBillingStats() = default;
-    TBillingStats(ui64 rows, ui64 bytes);
-    TBillingStats(const TBillingStats& other);
+    TBillingStats(const TBillingStats& other) = default;
+    TBillingStats& operator = (const TBillingStats& other) = default;
 
-    TBillingStats& operator = (const TBillingStats& other);
+    TBillingStats(ui64 uploadRows, ui64 uploadBytes, ui64 readRows, ui64 readBytes);
 
     TBillingStats operator - (const TBillingStats& other) const;
-    TBillingStats& operator -= (const TBillingStats& other);
+    TBillingStats& operator -= (const TBillingStats& other) {
+        return *this = *this - other;
+    }
 
     TBillingStats operator + (const TBillingStats& other) const;
-    TBillingStats& operator += (const TBillingStats& other);
+    TBillingStats& operator += (const TBillingStats& other) {
+        return *this = *this + other;
+    }
 
-    bool operator < (const TBillingStats& other) const;
-    bool operator <= (const TBillingStats& other) const;
-    bool operator == (const TBillingStats& other) const;
+    bool operator == (const TBillingStats& other) const = default;
 
-    operator bool () const;
+    explicit operator bool () const {
+        return *this != TBillingStats{};
+    }
 
     TString ToString() const;
 
-    ui64 GetRows() const;
-    ui64 GetBytes() const;
+    ui64 GetUploadRows() const {
+        return UploadRows;
+    }
+    ui64 GetUploadBytes() const {
+        return UploadBytes;
+    }
+
+    ui64 GetReadRows() const {
+        return ReadRows;
+    }
+    ui64 GetReadBytes() const {
+        return ReadBytes;
+    }
 
 private:
-    ui64 Rows = 0;
-    ui64 Bytes = 0;
+    ui64 UploadRows = 0;
+    ui64 UploadBytes = 0;
+    ui64 ReadRows = 0;
+    ui64 ReadBytes = 0;
 };
 
 // TODO(mbkkt) separate it to 3 classes: TBuildColumnsInfo TBuildSecondaryInfo TBuildVectorInfo with single base TBuildInfo
@@ -3394,9 +3411,24 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             row.template GetValueOrDefault<Schema::IndexBuild::AlterMainTableTxDone>(
                 indexInfo->AlterMainTableTxDone);
 
-        indexInfo->Billed = TBillingStats(
-            row.template GetValueOrDefault<Schema::IndexBuild::RowsBilled>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::BytesBilled>(0));
+        auto& billed = indexInfo->Billed;
+        billed = {
+            row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsBilled>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesBilled>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsBilled>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesBilled>(0),
+        };
+        if (billed.GetUploadRows() != 0 && billed.GetReadRows() == 0 && indexInfo->IsFillBuildIndex()) {
+            // old format: assign upload to read
+            billed += {0, 0, billed.GetUploadRows(), billed.GetUploadBytes()};
+        }
+
+        indexInfo->Processed = {
+            row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesProcessed>(0),
+        };
 
         return indexInfo;
     }
@@ -3428,17 +3460,26 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             Schema::IndexBuildShardStatus::UploadStatus>(
             Ydb::StatusIds::STATUS_CODE_UNSPECIFIED);
 
-        shardStatus.Processed = TBillingStats(
-            row.template GetValueOrDefault<
-                Schema::IndexBuildShardStatus::RowsProcessed>(0),
-            row.template GetValueOrDefault<
-                Schema::IndexBuildShardStatus::BytesProcessed>(0));
-
-        Processed += shardStatus.Processed;
+        auto& processed = shardStatus.Processed;
+        processed = {
+            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::UploadRowsProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::UploadBytesProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadRowsProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadBytesProcessed>(0),
+        };
+        if (processed.GetUploadRows() != 0 && processed.GetReadRows() == 0 && IsFillBuildIndex()) {
+            // old format: assign upload to read
+            processed += {0, 0, processed.GetUploadRows(), processed.GetUploadBytes()};
+        }
+        Processed += processed;
     }
 
     bool IsCancellationRequested() const {
         return CancelRequested;
+    }
+
+    bool IsFillBuildIndex() const {
+        return IsBuildSecondaryIndex() || IsBuildColumns();
     }
 
     bool IsBuildSecondaryIndex() const {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3413,8 +3413,8 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
         auto& billed = indexInfo->Billed;
         billed = {
-            row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsBilled>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesBilled>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::RowsBilled>(0),
+            row.template GetValueOrDefault<Schema::IndexBuild::BytesBilled>(0),
             row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsBilled>(0),
             row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesBilled>(0),
         };
@@ -3462,8 +3462,8 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
         auto& processed = shardStatus.Processed;
         processed = {
-            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::UploadRowsProcessed>(0),
-            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::UploadBytesProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::RowsProcessed>(0),
+            row.template GetValueOrDefault<Schema::IndexBuildShardStatus::BytesProcessed>(0),
             row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadRowsProcessed>(0),
             row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadBytesProcessed>(0),
         };

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1316,8 +1316,8 @@ struct Schema : NIceDb::Schema {
 
         struct MaxRetries : Column<27, NScheme::NTypeIds::Uint32> {};
 
-        struct UploadRowsBilled : Column<28, NScheme::NTypeIds::Uint64> {};
-        struct UploadBytesBilled : Column<29, NScheme::NTypeIds::Uint64> {};
+        struct /*Upload*/ RowsBilled : Column<28, NScheme::NTypeIds::Uint64> {};
+        struct /*Upload*/ BytesBilled : Column<29, NScheme::NTypeIds::Uint64> {};
 
         struct BuildKind : Column<30, NScheme::NTypeIds::Uint32> {};
 
@@ -1366,8 +1366,8 @@ struct Schema : NIceDb::Schema {
             UnlockTxDone,
             CancelRequest,
             MaxRetries,
-            UploadRowsBilled,
-            UploadBytesBilled,
+            RowsBilled,
+            BytesBilled,
             BuildKind,
             AlterMainTableTxId,
             AlterMainTableTxStatus,
@@ -1446,8 +1446,8 @@ struct Schema : NIceDb::Schema {
         struct Message : Column<7, NScheme::NTypeIds::Utf8> {};
         struct UploadStatus : Column<8, NScheme::NTypeIds::Uint32> { using Type = Ydb::StatusIds::StatusCode; };
 
-        struct UploadRowsProcessed : Column<9, NScheme::NTypeIds::Uint64> {};
-        struct UploadBytesProcessed : Column<10, NScheme::NTypeIds::Uint64> {};
+        struct /*Upload*/ RowsProcessed : Column<9, NScheme::NTypeIds::Uint64> {};
+        struct /*Upload*/ BytesProcessed : Column<10, NScheme::NTypeIds::Uint64> {};
 
         struct ReadRowsProcessed : Column<11, NScheme::NTypeIds::Uint64> {};
         struct ReadBytesProcessed : Column<12, NScheme::NTypeIds::Uint64> {};
@@ -1462,8 +1462,8 @@ struct Schema : NIceDb::Schema {
             Status,
             Message,
             UploadStatus,
-            UploadRowsProcessed,
-            UploadBytesProcessed,
+            RowsProcessed,
+            BytesProcessed,
             ReadRowsProcessed,
             ReadBytesProcessed
         >;

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1449,8 +1449,8 @@ struct Schema : NIceDb::Schema {
         struct UploadRowsProcessed : Column<9, NScheme::NTypeIds::Uint64> {};
         struct UploadBytesProcessed : Column<10, NScheme::NTypeIds::Uint64> {};
 
-        struct ReadRowsProcessed : Column<10, NScheme::NTypeIds::Uint64> {};
-        struct ReadBytesProcessed : Column<11, NScheme::NTypeIds::Uint64> {};
+        struct ReadRowsProcessed : Column<11, NScheme::NTypeIds::Uint64> {};
+        struct ReadBytesProcessed : Column<12, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<Id, OwnerShardIdx, LocalShardIdx>;
         using TColumns = TableColumns<

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1316,8 +1316,8 @@ struct Schema : NIceDb::Schema {
 
         struct MaxRetries : Column<27, NScheme::NTypeIds::Uint32> {};
 
-        struct RowsBilled : Column<28, NScheme::NTypeIds::Uint64> {};
-        struct BytesBilled : Column<29, NScheme::NTypeIds::Uint64> {};
+        struct UploadRowsBilled : Column<28, NScheme::NTypeIds::Uint64> {};
+        struct UploadBytesBilled : Column<29, NScheme::NTypeIds::Uint64> {};
 
         struct BuildKind : Column<30, NScheme::NTypeIds::Uint32> {};
 
@@ -1327,6 +1327,15 @@ struct Schema : NIceDb::Schema {
 
         // Serialized as string NKikimrSchemeOp::TIndexCreationConfig protobuf.
         struct CreationConfig : Column<34, NScheme::NTypeIds::String> { using Type = TString; };
+
+        struct ReadRowsBilled : Column<35, NScheme::NTypeIds::Uint64> {};
+        struct ReadBytesBilled : Column<36, NScheme::NTypeIds::Uint64> {};
+
+        struct UploadRowsProcessed : Column<37, NScheme::NTypeIds::Uint64> {};
+        struct UploadBytesProcessed : Column<38, NScheme::NTypeIds::Uint64> {};
+
+        struct ReadRowsProcessed : Column<39, NScheme::NTypeIds::Uint64> {};
+        struct ReadBytesProcessed : Column<40, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<
@@ -1357,13 +1366,19 @@ struct Schema : NIceDb::Schema {
             UnlockTxDone,
             CancelRequest,
             MaxRetries,
-            RowsBilled,
-            BytesBilled,
+            UploadRowsBilled,
+            UploadBytesBilled,
             BuildKind,
             AlterMainTableTxId,
             AlterMainTableTxStatus,
             AlterMainTableTxDone,
-            CreationConfig
+            CreationConfig,
+            ReadRowsBilled,
+            ReadBytesBilled,
+            UploadRowsProcessed,
+            UploadBytesProcessed,
+            ReadRowsProcessed,
+            ReadBytesProcessed
         >;
     };
 
@@ -1431,8 +1446,11 @@ struct Schema : NIceDb::Schema {
         struct Message : Column<7, NScheme::NTypeIds::Utf8> {};
         struct UploadStatus : Column<8, NScheme::NTypeIds::Uint32> { using Type = Ydb::StatusIds::StatusCode; };
 
-        struct RowsProcessed : Column<9, NScheme::NTypeIds::Uint64> {};
-        struct BytesProcessed : Column<10, NScheme::NTypeIds::Uint64> {};
+        struct UploadRowsProcessed : Column<9, NScheme::NTypeIds::Uint64> {};
+        struct UploadBytesProcessed : Column<10, NScheme::NTypeIds::Uint64> {};
+
+        struct ReadRowsProcessed : Column<10, NScheme::NTypeIds::Uint64> {};
+        struct ReadBytesProcessed : Column<11, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<Id, OwnerShardIdx, LocalShardIdx>;
         using TColumns = TableColumns<
@@ -1444,8 +1462,10 @@ struct Schema : NIceDb::Schema {
             Status,
             Message,
             UploadStatus,
-            RowsProcessed,
-            BytesProcessed
+            UploadRowsProcessed,
+            UploadBytesProcessed,
+            ReadRowsProcessed,
+            ReadBytesProcessed
         >;
     };
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -299,7 +299,7 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-101-1818-101-1818","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-202-3636","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData + "\n");
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -299,7 +299,7 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-202-3636","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-1818-1818","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData + "\n");
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -128,7 +128,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":2,"quantity":330,"finish":2,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-404-3486-404-3486","cloud_id":"CLOUD_ID_VAL","source_wt":2,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
+        const TString meteringData = R"({"usage":{"start":2,"quantity":330,"finish":2,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-604-3976","cloud_id":"CLOUD_ID_VAL","source_wt":2,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -128,7 +128,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":2,"quantity":330,"finish":2,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-604-3976","cloud_id":"CLOUD_ID_VAL","source_wt":2,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
+        const TString meteringData = R"({"usage":{"start":2,"quantity":330,"finish":2,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-200-404-1290-2686","cloud_id":"CLOUD_ID_VAL","source_wt":2,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
 

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -4805,6 +4805,36 @@
                 "ColumnId": 34,
                 "ColumnName": "CreationConfig",
                 "ColumnType": "String"
+            },
+            {
+                "ColumnId": 35,
+                "ColumnName": "ReadRowsBilled",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 36,
+                "ColumnName": "ReadBytesBilled",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 37,
+                "ColumnName": "UploadRowsProcessed",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 38,
+                "ColumnName": "UploadBytesProcessed",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 39,
+                "ColumnName": "ReadRowsProcessed",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 40,
+                "ColumnName": "ReadBytesProcessed",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -4844,7 +4874,13 @@
                     31,
                     32,
                     33,
-                    34
+                    34,
+                    35,
+                    36,
+                    37,
+                    38,
+                    39,
+                    40
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -5112,6 +5148,16 @@
                 "ColumnId": 10,
                 "ColumnName": "BytesProcessed",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 11,
+                "ColumnName": "ReadRowsProcessed",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "ReadBytesProcessed",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -5127,7 +5173,9 @@
                     7,
                     8,
                     9,
-                    10
+                    10,
+                    11,
+                    12
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
For kmeans tree vector index count of reads almost always not equal to count of uploads.

For common secondary index, they're always equal except fail cases.
