### PR TITLE
Add feature flag to enable drive serial numbers discovery

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -226,6 +226,10 @@ void TNodeWarden::RemoveDrivesWithBadSerialsAndReport(TVector<NPDisk::TDriveData
 }
 
 TVector<NPDisk::TDriveData> TNodeWarden::ListLocalDrives() {
+    if (!AppData()->FeatureFlags.GetEnableDriveSerialsDiscovery()) {
+        return {};
+    }
+
     TStringStream details;
     TVector<NPDisk::TDriveData> drives = ListDevicesWithPartlabel(details);
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -174,4 +174,5 @@ message TFeatureFlags {
     optional bool EnableWritePortionsOnInsert = 149 [default = false];
     optional bool EnableFollowerStats = 150 [default = false];
     optional bool EnableTopicAutopartitioningForReplication = 151 [default = false];
+    optional bool EnableDriveSerialsDiscovery = 152 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add feature flag to enable drive serial numbers discovery

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Drive discovery can be controlled with feature flag from now on.
