### PR TITLE
Refactor harness

### DIFF
--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -13,7 +13,7 @@ from six.moves.urllib.parse import urlparse
 import yatest
 
 from ydb.library.yql.providers.common.proto.gateways_config_pb2 import TGenericConnectorConfig
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.harness.daemon import Daemon
@@ -375,7 +375,7 @@ def deploy(arguments):
         **optionals
     )
 
-    cluster = kikimr_cluster_factory(configuration)
+    cluster = KiKiMR(configuration)
     cluster.start()
 
     info = {'nodes': {}}

--- a/ydb/tests/functional/api/test_crud.py
+++ b/ydb/tests/functional/api/test_crud.py
@@ -5,7 +5,7 @@ import random
 
 from hamcrest import assert_that, equal_to, raises
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class TestCreateAndUpsertWithRepetitions(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver = ydb.Driver(
             ydb.DriverConfig(
@@ -73,7 +73,7 @@ class TestCreateAndUpsertWithRepetitions(object):
 class TestCRUDOperations(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(load_udfs=True))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(load_udfs=True))
         cls.cluster.start()
         cls.driver = ydb.Driver(
             ydb.DriverConfig(
@@ -134,7 +134,7 @@ class TestCRUDOperations(object):
 class TestSelect(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(load_udfs=True))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(load_udfs=True))
         cls.cluster.start()
         cls.driver = ydb.Driver(
             ydb.DriverConfig(
@@ -189,7 +189,7 @@ class TestSelect(object):
 class TestClientTimeouts(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver_config = ydb.DriverConfig(
             database='/Root', endpoint="%s:%s" % (
@@ -242,7 +242,7 @@ class TestManySelectsInRow(object):
     """
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver = ydb.Driver(
             ydb.DriverConfig(

--- a/ydb/tests/functional/api/test_discovery.py
+++ b/ydb/tests/functional/api/test_discovery.py
@@ -6,7 +6,7 @@ import logging
 
 from hamcrest import assert_that, is_, not_
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common import types
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -23,7 +23,7 @@ class TestDiscoveryExtEndpoint(object):
         cls.ext_port_2 = conf.port_allocator.get_node_port_allocator(1).ext_port
         conf.clone_grpc_as_ext_endpoint(cls.ext_port_1, "extserv1")
         conf.clone_grpc_as_ext_endpoint(cls.ext_port_2, "extserv2")
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             configurator=conf
         )
         cls.cluster.start()
@@ -112,7 +112,7 @@ class TestDiscoveryExtEndpoint(object):
 class AbstractTestDiscoveryFaultInjection(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.database_name = '/Root/database'
         cls.logger = logger.getChild(cls.__name__)
@@ -214,7 +214,7 @@ class TestDiscoveryFaultInjectionSlotStop(AbstractTestDiscoveryFaultInjection):
 class TestMirror3DCDiscovery(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(erasure=types.Erasure.MIRROR_3_DC, use_in_memory_pdisks=False))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(erasure=types.Erasure.MIRROR_3_DC, use_in_memory_pdisks=False))
         cls.cluster.start()
 
     @classmethod

--- a/ydb/tests/functional/api/test_execute_scheme.py
+++ b/ydb/tests/functional/api/test_execute_scheme.py
@@ -2,7 +2,7 @@
 import logging
 from hamcrest import assert_that, raises
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 logger = logging.getLogger(__name__)
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class TestExecuteSchemeOperations(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver_config = ydb.DriverConfig(
             "%s:%s" % (cls.cluster.nodes[1].host, cls.cluster.nodes[1].port), database='/Root')

--- a/ydb/tests/functional/api/test_indexes.py
+++ b/ydb/tests/functional/api/test_indexes.py
@@ -3,7 +3,7 @@ import logging
 
 from hamcrest import assert_that, is_
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 logger = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class TestSecondaryIndexes(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.logger = logger.getChild(cls.__name__)
         cls.driver = ydb.Driver(

--- a/ydb/tests/functional/api/test_insert.py
+++ b/ydb/tests/functional/api/test_insert.py
@@ -3,7 +3,7 @@ import logging
 
 from hamcrest import assert_that, raises, equal_to
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class TestInsertOperations(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver_config = ydb.DriverConfig(
             "%s:%s" % (cls.cluster.nodes[1].host, cls.cluster.nodes[1].port), database='/Root')

--- a/ydb/tests/functional/api/test_isolation.py
+++ b/ydb/tests/functional/api/test_isolation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from hamcrest import assert_that, equal_to, raises, contains_string
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 
@@ -12,7 +12,7 @@ class TestTransactionIsolation(object):
     """
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver = ydb.Driver(
             ydb.DriverConfig(

--- a/ydb/tests/functional/api/test_public_api.py
+++ b/ydb/tests/functional/api/test_public_api.py
@@ -14,7 +14,7 @@ import logging
 from datetime import date, datetime
 from ydb.public.api.protos import ydb_table_pb2
 from ydb.public.api.protos import ydb_scheme_pb2
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -90,7 +90,7 @@ storage_policy {
 class Base(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(
                 additional_log_configs={
                     'TENANT_POOL': LogLevels.DEBUG,
@@ -118,7 +118,7 @@ class Base(object):
 class WithTenant(Base):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.database_name = "/Root/tenant"
         cls.cluster.create_database(
@@ -1518,7 +1518,7 @@ class TestDriverCanRecover(Base):
 class TestSelectAfterDropWithRepetitions(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             configurator=KikimrConfigGenerator(
                 additional_log_configs={
                     'TX_PROXY': LogLevels.DEBUG,
@@ -1587,7 +1587,7 @@ class TestSelectAfterDropWithRepetitions(object):
 class TestMetaDataInvalidation(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver = ydb.Driver(ydb.DriverConfig(
             database="/Root",
@@ -1673,7 +1673,7 @@ class TestMetaDataInvalidation(object):
 class TestJsonExample(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver = ydb.Driver(ydb.DriverConfig(
             database="/Root",
@@ -1759,7 +1759,7 @@ class TestJsonExample(object):
 class TestForPotentialDeadlock(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
 
     @classmethod

--- a/ydb/tests/functional/api/test_read_table.py
+++ b/ydb/tests/functional/api/test_read_table.py
@@ -6,7 +6,7 @@ import time
 from hamcrest import assert_that, equal_to, less_than_or_equal_to, is_, none
 from concurrent import futures
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.common.types import TabletTypes
 from ydb.tests.oss.ydb_sdk_import import ydb
 # call this as soon as possible to patch grpc event_handler implementation with additional calls
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class AbstractReadTableTest(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.logger = logger.getChild(cls.__name__)
         cls.driver = ydb.Driver(

--- a/ydb/tests/functional/api/test_session_grace_shutdown.py
+++ b/ydb/tests/functional/api/test_session_grace_shutdown.py
@@ -2,7 +2,7 @@
 import logging
 import time
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 import requests
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class Test(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver_config = ydb.DriverConfig(
             "%s:%s" % (cls.cluster.nodes[1].host, cls.cluster.nodes[1].port), database='/Root')
@@ -55,7 +55,7 @@ class Test(object):
 class TestIdle(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.driver_config = ydb.DriverConfig(
             "%s:%s" % (cls.cluster.nodes[1].host, cls.cluster.nodes[1].port), database='/Root')

--- a/ydb/tests/functional/api/test_session_pool.py
+++ b/ydb/tests/functional/api/test_session_pool.py
@@ -4,7 +4,7 @@ import time
 
 from hamcrest import assert_that, is_, raises
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class TestSessionPool(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.logger = logger.getChild(cls.__name__)
         cls.driver = ydb.Driver(

--- a/ydb/tests/functional/autoconfig/test_actorsystem.py
+++ b/ydb/tests/functional/autoconfig/test_actorsystem.py
@@ -3,7 +3,7 @@
 import sys
 
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 
@@ -17,7 +17,7 @@ def make_test_for_specific_actor_system(node_type, cpu_count):
                 "use_auto_config": True
             }
             configuration = KikimrConfigGenerator(overrided_actor_system_config=actor_system_config)
-            cls.kikimr_cluster = kikimr_cluster_factory(configuration)
+            cls.kikimr_cluster = KiKiMR(configuration)
             cls.kikimr_cluster.start()
 
         @classmethod

--- a/ydb/tests/functional/blobstorage/test_pdisk_format_info.py
+++ b/ydb/tests/functional/blobstorage/test_pdisk_format_info.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from hamcrest import assert_that, equal_to
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.common import msgbus_types
 
 
@@ -12,7 +12,7 @@ class TestPDiskInfo(object):
     """
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
 
     @classmethod

--- a/ydb/tests/functional/blobstorage/test_replication.py
+++ b/ydb/tests/functional/blobstorage/test_replication.py
@@ -5,7 +5,7 @@ from hamcrest import is_
 
 from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.common.wait_for import wait_for_and_assert
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.predicates import blobstorage
 
@@ -15,7 +15,7 @@ TIMEOUT_SECONDS = 480
 
 class TestReplicationAfterNodesRestart(object):
     def __setup_cluster(self, erasure):
-        self.cluster = kikimr_cluster_factory(configurator=KikimrConfigGenerator(erasure=erasure))
+        self.cluster = KiKiMR(configurator=KikimrConfigGenerator(erasure=erasure))
         self.cluster.start()
 
     def teardown_method(self, method=None):

--- a/ydb/tests/functional/blobstorage/test_self_heal.py
+++ b/ydb/tests/functional/blobstorage/test_self_heal.py
@@ -3,7 +3,7 @@
 from hamcrest import is_
 
 from ydb.tests.library.common.wait_for import wait_for_and_assert
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.predicates import blobstorage
 
 
@@ -13,7 +13,7 @@ TIMEOUT_SECONDS = 480
 class TestEnableSelfHeal(object):
     @classmethod
     def setup_class(cls):
-        cls.kikimr_cluster = kikimr_cluster_factory()
+        cls.kikimr_cluster = KiKiMR()
         cls.kikimr_cluster.start()
         cls.client = cls.kikimr_cluster.client
         cls.client.update_self_heal(True)

--- a/ydb/tests/functional/blobstorage/test_tablet_channel_migration.py
+++ b/ydb/tests/functional/blobstorage/test_tablet_channel_migration.py
@@ -3,7 +3,7 @@
 
 from hamcrest import assert_that
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_http_client import HiveClient, SwaggerClient
 from ydb.tests.library.kv.helpers import create_kv_tablets_and_wait_for_start
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
@@ -14,7 +14,7 @@ TIMEOUT_SECONDS = 480
 class TestChannelsOps(object):
     @classmethod
     def setup_class(cls):
-        cls.kikimr_cluster = kikimr_cluster_factory()
+        cls.kikimr_cluster = KiKiMR()
         cls.kikimr_cluster.start()
         cls.client = cls.kikimr_cluster.client
         cls.kv_client = cls.kikimr_cluster.kv_client

--- a/ydb/tests/functional/canonical/test_sql.py
+++ b/ydb/tests/functional/canonical/test_sql.py
@@ -8,7 +8,7 @@ import uuid
 
 import yatest
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.canonical import set_canondata_root, is_oss
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -109,7 +109,7 @@ class BaseCanonicalTest(object):
         set_canondata_root('ydb/tests/functional/canonical/canondata')
 
         cls.database = '/local'
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(
                 load_udfs=True,
                 domain_name='local',

--- a/ydb/tests/functional/cms/test_cms_erasure.py
+++ b/ydb/tests/functional/cms/test_cms_erasure.py
@@ -9,7 +9,7 @@ from ydb.tests.library.common.types import Erasure
 import ydb.tests.library.common.cms as cms
 from ydb.tests.library.harness.kikimr_http_client import SwaggerClient
 from ydb.tests.library.harness.util import LogLevels
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.kv.helpers import create_kv_tablets_and_wait_for_start
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
@@ -29,7 +29,7 @@ class AbstractLocalClusterTest(object):
                                              nodes=nodes_count,
                                              additional_log_configs={'CMS': LogLevels.DEBUG}
                                              )
-        cls.cluster = kikimr_cluster_factory(configurator=configurator)
+        cls.cluster = KiKiMR(configurator=configurator)
         cls.cluster.start()
         # CMS will not let disable state storage
         # nodes for first 2 minutes

--- a/ydb/tests/functional/cms/test_cms_restart.py
+++ b/ydb/tests/functional/cms/test_cms_restart.py
@@ -12,7 +12,7 @@ import ydb.tests.library.common.cms as cms
 from ydb.tests.library.harness.kikimr_http_client import SwaggerClient
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.kv.helpers import create_kv_tablets_and_wait_for_start
 from ydb.tests.library.common.delayed import wait_tablets_are_active
 
@@ -33,7 +33,7 @@ class AbstractLocalClusterTest(object):
                                              use_in_memory_pdisks=False,
                                              additional_log_configs={'CMS': LogLevels.DEBUG},
                                              )
-        cls.cluster = kikimr_cluster_factory(configurator=configurator)
+        cls.cluster = KiKiMR(configurator=configurator)
         cls.cluster.start()
 
         time.sleep(120)

--- a/ydb/tests/functional/cms/test_cms_state_storage.py
+++ b/ydb/tests/functional/cms/test_cms_state_storage.py
@@ -8,7 +8,7 @@ import ydb.tests.library.common.cms as cms
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.library.harness.kikimr_http_client import SwaggerClient
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.kv.helpers import create_kv_tablets_and_wait_for_start
 from ydb.tests.library.common.delayed import wait_tablets_are_active
 
@@ -30,7 +30,7 @@ class AbstractLocalClusterTest(object):
                                              state_storage_rings=list(range(1, 6)),
                                              n_to_select=5,
                                              )
-        cls.cluster = kikimr_cluster_factory(configurator=configurator)
+        cls.cluster = KiKiMR(configurator=configurator)
         cls.cluster.start()
 
         time.sleep(120)

--- a/ydb/tests/functional/compatibility/test_compatibility.py
+++ b/ydb/tests/functional/compatibility/test_compatibility.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import yatest
-from ydb.tests.library.harness.kikimr_cluster import KiKiMR
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.param_constants import kikimr_driver_path
 from ydb.tests.library.common.types import Erasure

--- a/ydb/tests/functional/encryption/test_encryption.py
+++ b/ydb/tests/functional/encryption/test_encryption.py
@@ -8,7 +8,7 @@ import yatest.common
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 from ydb.tests.library.common.types import Erasure
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.msgbus_types import EDriveStatus
 
@@ -73,7 +73,7 @@ class Workload:
 class TestEncryption(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             configurator=KikimrConfigGenerator(
                 use_in_memory_pdisks=True,
                 dynamic_pdisks=[{'user_kind': 0}],

--- a/ydb/tests/functional/hive/test_create_tablets.py
+++ b/ydb/tests/functional/hive/test_create_tablets.py
@@ -4,7 +4,7 @@ from hamcrest import assert_that
 from ydb.tests.library.common.delayed import wait_tablets_are_active
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 from ydb.tests.library.common.types import Erasure, TabletTypes
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.kikimr_http_client import SwaggerClient
 
@@ -17,7 +17,7 @@ class TestHive(object):
     @classmethod
     def setup_class(cls):
         configurator = KikimrConfigGenerator(Erasure.BLOCK_4_2, nodes=8)
-        cls.cluster = kikimr_cluster_factory(configurator=configurator)
+        cls.cluster = KiKiMR(configurator=configurator)
         cls.cluster.start()
         cls.client = cls.cluster.client
         cls.kv_client = cls.cluster.kv_client

--- a/ydb/tests/functional/hive/test_drain.py
+++ b/ydb/tests/functional/hive/test_drain.py
@@ -5,7 +5,7 @@ import yatest
 from ydb.tests.library.common.delayed import wait_tablets_are_active
 from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.harness.kikimr_http_client import SwaggerClient
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.library.harness import param_constants
@@ -20,7 +20,7 @@ TimeoutSeconds = 300
 class TestHive(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(
                 Erasure.BLOCK_4_2,
                 additional_log_configs={

--- a/ydb/tests/functional/hive/test_kill_tablets.py
+++ b/ydb/tests/functional/hive/test_kill_tablets.py
@@ -3,7 +3,7 @@ from hamcrest import assert_that, greater_than, has_length
 
 from ydb.tests.library.common.delayed import wait_tablets_state_by_id
 from ydb.tests.library.common.types import TabletTypes, TabletStates
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_http_client import SwaggerClient
 from ydb.tests.library.matchers.response import is_valid_response_with_field
 from ydb.tests.library.kv.helpers import create_kv_tablets_and_wait_for_start
@@ -15,7 +15,7 @@ NUMBER_OF_TABLETS = 4
 class TestKillTablets(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         host = cls.cluster.nodes[1].host
         mon_port = cls.cluster.nodes[1].mon_port

--- a/ydb/tests/functional/kv_workload/test_kv_workload.py
+++ b/ydb/tests/functional/kv_workload/test_kv_workload.py
@@ -3,7 +3,7 @@ import os
 
 import yatest
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
 
@@ -11,7 +11,7 @@ from ydb.tests.library.common.types import Erasure
 class TestYdbKvWorkload(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(erasure=Erasure.MIRROR_3_DC))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(erasure=Erasure.MIRROR_3_DC))
         cls.cluster.start()
 
     @classmethod

--- a/ydb/tests/functional/large_serializable/test_serializable.py
+++ b/ydb/tests/functional/large_serializable/test_serializable.py
@@ -3,7 +3,7 @@ import sys
 
 import yatest
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
 
@@ -11,7 +11,7 @@ from ydb.tests.library.common.types import Erasure
 class Test(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(erasure=Erasure.MIRROR_3_DC))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(erasure=Erasure.MIRROR_3_DC))
         cls.cluster.start()
 
     @classmethod

--- a/ydb/tests/functional/limits/test_schemeshard_limits.py
+++ b/ydb/tests/functional/limits/test_schemeshard_limits.py
@@ -3,7 +3,7 @@ import os
 import string
 
 from hamcrest import assert_that, raises
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.library.common.types import Erasure
@@ -15,7 +15,7 @@ class Base(object):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(
                 erasure=cls.erasure,
                 additional_log_configs={

--- a/ydb/tests/functional/postgresql/test_postgres.py
+++ b/ydb/tests/functional/postgresql/test_postgres.py
@@ -1,4 +1,4 @@
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 
@@ -58,7 +58,7 @@ def execute_binary(binary_name, cmd, stdin_string=None):
 class BasePostgresTest(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(
+        cls.cluster = KiKiMR(KikimrConfigGenerator(
             additional_log_configs={
                 'LOCAL_PGWIRE': LogLevels.DEBUG,
                 'KQP_YQL': LogLevels.DEBUG,

--- a/ydb/tests/functional/query_cache/test_query_cache.py
+++ b/ydb/tests/functional/query_cache/test_query_cache.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from ydb.tests.oss.ydb_sdk_import import ydb
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 
@@ -26,7 +26,7 @@ class TestQueryCache(object):
     def setup_class(cls):
         cls.config = KikimrConfigGenerator(use_in_memory_pdisks=True)
         cls.config.yaml_config["table_service_config"] = {"compile_query_cache_size": QUERY_CACHE_SIZE}
-        cls.cluster = kikimr_cluster_factory(configurator=cls.config)
+        cls.cluster = KiKiMR(configurator=cls.config)
         cls.cluster.start()
         cls.discovery_endpoint = "%s:%s" % (cls.cluster.nodes[1].host, cls.cluster.nodes[1].grpc_port)
         cls.driver = ydb.Driver(endpoint=cls.discovery_endpoint, database="/Root", credentials=ydb.AnonymousCredentials())

--- a/ydb/tests/functional/restarts/test_restarts.py
+++ b/ydb/tests/functional/restarts/test_restarts.py
@@ -5,7 +5,7 @@ import logging
 
 from ydb.tests.library.common.delayed import wait_tablets_are_active
 from ydb.tests.library.common.types import Erasure
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.kikimr_client import kikimr_client_factory
 from ydb.tests.library.kv.helpers import create_tablets_and_wait_for_start
@@ -21,7 +21,7 @@ class AbstractLocalClusterTest(object):
     @classmethod
     def setup_class(cls):
         configurator = KikimrConfigGenerator(cls.erasure, use_in_memory_pdisks=False)
-        cls.cluster = kikimr_cluster_factory(configurator=configurator)
+        cls.cluster = KiKiMR(configurator=configurator)
         cls.cluster.start()
 
     @classmethod

--- a/ydb/tests/functional/scheme_shard/test_alter_ops.py
+++ b/ydb/tests/functional/scheme_shard/test_alter_ops.py
@@ -8,7 +8,7 @@ from ydb.tests.library.common.msgbus_types import MessageBusStatus
 from ydb.tests.library.common.protobuf_ss import CreatePath, AlterTableRequest, CreateTableRequest
 from ydb.tests.library.common.protobuf_ss import TPartitionConfig, SchemeDescribeRequest
 from ydb.tests.library.common.types import PType
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.matchers.response_matchers import ProtobufWithStatusMatcher
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -16,7 +16,7 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 class TestSchemeShardAlterTest(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
 
         host = cls.cluster.nodes[1].host

--- a/ydb/tests/functional/scheme_shard/test_copy_ops.py
+++ b/ydb/tests/functional/scheme_shard/test_copy_ops.py
@@ -4,14 +4,14 @@ import os
 from hamcrest import assert_that, has_length, has_property, equal_to
 
 from ydb.tests.library.common.protobuf_ss import SchemeDescribeRequest
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 
 class TestSchemeShardCopyOps(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
 
         host = cls.cluster.nodes[1].host

--- a/ydb/tests/functional/scheme_shard/test_scheme_shard_operations.py
+++ b/ydb/tests/functional/scheme_shard/test_scheme_shard_operations.py
@@ -2,14 +2,14 @@
 import os
 
 from hamcrest import assert_that, raises
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 
 class TestSchemeShardSimpleOps(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
 
         host = cls.cluster.nodes[1].host

--- a/ydb/tests/functional/scheme_tests/tablet_scheme_tests.py
+++ b/ydb/tests/functional/scheme_tests/tablet_scheme_tests.py
@@ -9,7 +9,7 @@ import yatest
 
 from ydb.tests.library.common.local_db_scheme import get_scheme
 from ydb.tests.library.common.types import TabletTypes
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.kv.helpers import create_tablets_and_wait_for_start
 from ydb.tests.oss.canonical import set_canondata_root
 
@@ -51,7 +51,7 @@ class TestTabletSchemes(object):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.client = cls.cluster.client
         cls.shard_index = itertools.count(start=1)

--- a/ydb/tests/functional/script_execution/test_update_script_tables.py
+++ b/ydb/tests/functional/script_execution/test_update_script_tables.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -26,7 +26,7 @@ class TestUpdateScriptTablesYdb(object):
     @classmethod
     def setup_class(cls):
         cls.config = KikimrConfigGenerator(extra_feature_flags=["enable_script_execution_operations"])
-        cls.cluster = kikimr_cluster_factory(configurator=cls.config)
+        cls.cluster = KiKiMR(configurator=cls.config)
         cls.cluster.start()
         cls.driver = ydb.Driver(ydb.DriverConfig(
             database="/Root",

--- a/ydb/tests/functional/suite_tests/test_base.py
+++ b/ydb/tests/functional/suite_tests/test_base.py
@@ -16,7 +16,7 @@ from hamcrest import assert_that, is_, equal_to, raises, none
 import yatest
 from yatest.common import source_path, test_source_path
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.ydb_sdk_import import ydb
 from ydb.tests.oss.canonical import set_canondata_root
@@ -243,7 +243,7 @@ def format_as_table(data):
 class BaseSuiteRunner(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(
                 load_udfs=True,
                 use_in_memory_pdisks=True,

--- a/ydb/tests/functional/tenants/test_db_counters.py
+++ b/ydb/tests/functional/tenants/test_db_counters.py
@@ -12,7 +12,7 @@ from hamcrest import assert_that, equal_to, greater_than, not_none
 from ydb.core.protos import config_pb2
 from ydb.tests.library.common.msgbus_types import MessageBusStatus
 from ydb.tests.library.common.protobuf_ss import AlterTableRequest
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.library.harness.ydb_fixtures import ydb_database_ctx
@@ -38,7 +38,7 @@ def get_db_counters(mon_port, service):
 class BaseDbCounters(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(
                 additional_log_configs={
                     'SYSTEM_VIEWS': LogLevels.DEBUG

--- a/ydb/tests/functional/tenants/test_publish_into_schemeboard_with_common_ssring.py
+++ b/ydb/tests/functional/tenants/test_publish_into_schemeboard_with_common_ssring.py
@@ -4,7 +4,7 @@ import logging
 
 from ydb.tests.oss.ydb_sdk_import import ydb
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.library.common.types import Erasure
@@ -28,7 +28,7 @@ class TestOn3DC(object):
                 'SCHEME_BOARD_REPLICA': LogLevels.DEBUG,
             }
         )
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             config_generator
         )
         cls.cluster.start()

--- a/ydb/tests/functional/tenants/test_storage_config.py
+++ b/ydb/tests/functional/tenants/test_storage_config.py
@@ -6,7 +6,7 @@ import pytest
 from hamcrest import assert_that, equal_to, has_item, has_properties
 
 from ydb.tests.library.common.local_db_scheme import get_scheme
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.library.predicates.executor import external_blobs_is_present
@@ -33,7 +33,7 @@ class TBaseTenant(object):
     @classmethod
     def setup_class(cls):
         configurator = KikimrConfigGenerator(additional_log_configs=cls.LOG_SETTINGS)
-        cls.kikimr = kikimr_cluster_factory(configurator)
+        cls.kikimr = KiKiMR(configurator)
         cls.kikimr.start()
         cls.tenant_path = cls.__create_tenant('common_tenant', ('hdd', 'hdd1', 'hdd2'))
         cls.driver = ydb.Driver(

--- a/ydb/tests/functional/tenants/test_system_views.py
+++ b/ydb/tests/functional/tenants/test_system_views.py
@@ -11,7 +11,7 @@ from hamcrest import (
     has_properties,
 )
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class BaseSystemViews(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(
                 additional_log_configs={
                     'SYSTEM_VIEWS': LogLevels.DEBUG

--- a/ydb/tests/functional/ttl/test_ttl.py
+++ b/ydb/tests/functional/ttl/test_ttl.py
@@ -13,7 +13,7 @@ from hamcrest import (
     not_none,
 )
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.oss.ydb_sdk_import import ydb
@@ -24,7 +24,7 @@ class TestTTL(object):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(
+        cls.cluster = KiKiMR(KikimrConfigGenerator(
             additional_log_configs={
                 'FLAT_TX_SCHEMESHARD': LogLevels.DEBUG,
                 'TX_DATASHARD': LogLevels.DEBUG,
@@ -142,7 +142,7 @@ class TestTTLValueSinceUnixEpoch(TestTTL):
 class TestTTLAlterSettings(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator())
+        cls.cluster = KiKiMR(KikimrConfigGenerator())
         cls.cluster.start()
         cls.endpoint = "%s:%s" % (cls.cluster.nodes[1].host, cls.cluster.nodes[1].port)
         cls.database = '/Root'

--- a/ydb/tests/functional/wardens/test_liveness_wardens.py
+++ b/ydb/tests/functional/wardens/test_liveness_wardens.py
@@ -5,7 +5,7 @@ import ydb
 from hamcrest import is_, empty, has_length, greater_than_or_equal_to
 
 from ydb.tests.library.wardens.factories import hive_liveness_warden_factory, transactions_processing_liveness_warden
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_http_client import HiveClient
 from ydb.tests.library.common.wait_for import wait_for_and_assert
 
@@ -16,7 +16,7 @@ TIMEOUT_SECONDS = 480
 class TestLivenessWarden(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
 
         cls.hive = HiveClient(cls.cluster.nodes[1].host, cls.cluster.nodes[1].mon_port)

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -208,7 +208,7 @@ def is_system_object(object):
 class BaseTestBackupInFiles(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(KikimrConfigGenerator(extra_feature_flags=["enable_resource_pools"]))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(extra_feature_flags=["enable_resource_pools"]))
         cls.cluster.start()
         cls.root_dir = "/Root"
         driver_config = ydb.DriverConfig(

--- a/ydb/tests/functional/ydb_cli/test_ydb_flame_graph.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_flame_graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -71,7 +71,7 @@ class BaseTestFlameGraphServiceWithDatabase(BaseTestFlameGraphService):
     def setup_class(cls):
         set_canondata_root('ydb/tests/functional/ydb_cli/canondata')
 
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.root_dir = "/Root"
         driver_config = ydb.DriverConfig(

--- a/ydb/tests/functional/ydb_cli/test_ydb_impex.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_impex.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -153,7 +153,7 @@ class BaseTestTableService(object):
     def setup_class(cls):
         set_canondata_root('ydb/tests/functional/ydb_cli/canondata')
 
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.root_dir = "/Root"
         driver_config = ydb.DriverConfig(

--- a/ydb/tests/functional/ydb_cli/test_ydb_scripting.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_scripting.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -68,7 +68,7 @@ class BaseTestScriptingServiceWithDatabase(BaseTestScriptingService):
     def setup_class(cls):
         set_canondata_root('ydb/tests/functional/ydb_cli/canondata')
 
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.root_dir = "/Root"
         driver_config = ydb.DriverConfig(

--- a/ydb/tests/functional/ydb_cli/test_ydb_sql.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_sql.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -67,7 +67,7 @@ class BaseTestSqlWithDatabase(BaseTestSql):
     def setup_class(cls):
         set_canondata_root('ydb/tests/functional/ydb_cli/canondata')
 
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.root_dir = "/Root"
         driver_config = ydb.DriverConfig(

--- a/ydb/tests/functional/ydb_cli/test_ydb_table.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_table.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.oss.canonical import set_canondata_root
 from ydb.tests.oss.ydb_sdk_import import ydb
 
@@ -52,7 +52,7 @@ class BaseTestTableService(object):
     def setup_class(cls):
         set_canondata_root('ydb/tests/functional/ydb_cli/canondata')
 
-        cls.cluster = kikimr_cluster_factory()
+        cls.cluster = KiKiMR()
         cls.cluster.start()
         cls.root_dir = "/Root"
         driver_config = ydb.DriverConfig(

--- a/ydb/tests/library/harness/daemon.py
+++ b/ydb/tests/library/harness/daemon.py
@@ -109,8 +109,6 @@ class Daemon(object):
         if self.is_alive():
             return
         stderr_stream = self.__stderr_file
-        if param_constants.kikimr_stderr_to_console():
-            stderr_stream = sys.stderr
         self.__daemon = process.execute(
             self.__command,
             check_exit_code=False,

--- a/ydb/tests/library/harness/kikimr_cluster.py
+++ b/ydb/tests/library/harness/kikimr_cluster.py
@@ -22,6 +22,7 @@ DEFAULT_GRPC_PORT = 2135
 
 
 def kikimr_cluster_factory(configurator=None, config_path=None):
+    # TODO: remove current function, use explicit KiKiMR/ExternalKiKiMRCluster
     logger.info("Starting standalone YDB cluster")
     if config_path is not None:
         return ExternalKiKiMRCluster(config_path)
@@ -29,16 +30,11 @@ def kikimr_cluster_factory(configurator=None, config_path=None):
         return KiKiMR(configurator)
 
 
-def load_yaml(path):
-    with open(path, 'r') as r:
-        data = yaml.safe_load(r.read())
-    return data
-
-
 class ExternalKiKiMRCluster(KiKiMRClusterInterface):
     def __init__(self, config_path, binary_path=None, output_path=None):
         self.__config_path = config_path
-        self.__yaml_config = load_yaml(config_path)
+        with open(config_path, 'r') as r:
+            self.__yaml_config = yaml.safe_load(r.read())
         self.__hosts = [host['name'] for host in self.__yaml_config.get('hosts')]
         self._slots = None
         self.__binary_path = binary_path if binary_path is not None else param_constants.kikimr_driver_path()

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -582,7 +582,16 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
 
 class KikimrExternalNode(daemon.ExternalNodeDaemon, kikimr_node_interface.NodeInterface):
     def __init__(
-            self, node_id, host, port, mon_port, ic_port, mbus_port, configurator=None, slot_id=None):
+            self, 
+            node_id, 
+            host, 
+            port, 
+            mon_port, 
+            ic_port, 
+            mbus_port, 
+            configurator=None, 
+            slot_id=None,
+        ):
         super(KikimrExternalNode, self).__init__(host)
         self.__node_id = node_id
         self.__host = host
@@ -601,11 +610,14 @@ class KikimrExternalNode(daemon.ExternalNodeDaemon, kikimr_node_interface.NodeIn
         self._can_update = None
         self.current_version_idx = 0
         self.versions = [
-            param_constants.kikimr_last_version_deploy_path,
-            param_constants.kikimr_next_version_deploy_path,
+            param_constants.kikimr_binary_deploy_path + "_next",
+            param_constants.kikimr_binary_deploy_path + "_last",
         ]
 
-        self.local_drivers_path = (param_constants.kikimr_driver_path(), param_constants.next_version_kikimr_driver_path())
+        self.local_drivers_path = [
+            param_constants.kikimr_driver_path(), 
+            param_constants.next_version_kikimr_driver_path(),
+        ]
 
     @property
     def can_update(self):

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -582,16 +582,16 @@ class KiKiMR(kikimr_cluster_interface.KiKiMRClusterInterface):
 
 class KikimrExternalNode(daemon.ExternalNodeDaemon, kikimr_node_interface.NodeInterface):
     def __init__(
-            self, 
-            node_id, 
-            host, 
-            port, 
-            mon_port, 
-            ic_port, 
-            mbus_port, 
-            configurator=None, 
+            self,
+            node_id,
+            host,
+            port,
+            mon_port,
+            ic_port,
+            mbus_port,
+            configurator=None,
             slot_id=None,
-        ):
+            ):
         super(KikimrExternalNode, self).__init__(host)
         self.__node_id = node_id
         self.__host = host
@@ -615,7 +615,7 @@ class KikimrExternalNode(daemon.ExternalNodeDaemon, kikimr_node_interface.NodeIn
         ]
 
         self.local_drivers_path = [
-            param_constants.kikimr_driver_path(), 
+            param_constants.kikimr_driver_path(),
             param_constants.next_version_kikimr_driver_path(),
         ]
 

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -605,6 +605,8 @@ class KikimrExternalNode(daemon.ExternalNodeDaemon, kikimr_node_interface.NodeIn
             param_constants.kikimr_next_version_deploy_path,
         ]
 
+        self.local_drivers_path = (param_constants.kikimr_driver_path(), param_constants.next_version_kikimr_driver_path())
+
     @property
     def can_update(self):
         if self._can_update is None:
@@ -723,9 +725,8 @@ mon={mon}""".format(
     def prepare_artifacts(self, cluster_yml):
         self.copy_file_or_dir(
             param_constants.kikimr_configure_binary_path(), param_constants.kikimr_configure_binary_deploy_path)
-        local_drivers_path = (param_constants.kikimr_driver_path(), param_constants.next_version_kikimr_driver_path())
 
-        for version, local_driver in zip(self.versions, local_drivers_path):
+        for version, local_driver in zip(self.versions, self.local_drivers_path):
             self.ssh_command("sudo rm -rf %s" % version)
             if local_driver is not None:
                 self.copy_file_or_dir(

--- a/ydb/tests/library/harness/param_constants.py
+++ b/ydb/tests/library/harness/param_constants.py
@@ -34,10 +34,6 @@ def next_version_kikimr_driver_path():
     return _get_param("kikimr.ci.kikimr_driver_next", None)
 
 
-def kikimr_stderr_to_console():
-    return _get_param("kikimr.ci.stderr_to_console", "false") == "true"
-
-
 def kikimr_driver_path():
     built_binary = _get_param("kikimr.ci.kikimr_driver", None)
     if os.getenv("YDB_DRIVER_BINARY"):

--- a/ydb/tests/library/harness/param_constants.py
+++ b/ydb/tests/library/harness/param_constants.py
@@ -18,8 +18,6 @@ kikimr_binary_deploy_path = '/Berkanavt/kikimr/bin/kikimr'
 kikimr_configure_binary_deploy_path = '/Berkanavt/kikimr/bin/kikimr_configure'
 kikimr_configuration_deploy_path = '/Berkanavt/kikimr/cfg'
 kikimr_cluster_yaml_deploy_path = '/Berkanavt/kikimr/cfg/cluster.yaml'
-kikimr_next_version_deploy_path = '/Berkanavt/kikimr/bin/kikimr_next'
-kikimr_last_version_deploy_path = '/Berkanavt/kikimr/bin/kikimr_last'
 kikimr_home = '/Berkanavt/kikimr'
 
 

--- a/ydb/tests/library/harness/ydb_fixtures.py
+++ b/ydb/tests/library/harness/ydb_fixtures.py
@@ -8,7 +8,7 @@ import pytest
 from ydb import Driver, DriverConfig, SessionPool
 
 from ydb.tests.library.common.types import Erasure
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 
@@ -46,7 +46,7 @@ def ydb_cluster(ydb_configurator, request):
     logger.info("setup ydb_cluster for %s", module_name)
 
     logger.info("setup ydb_cluster as local")
-    cluster = kikimr_cluster_factory(
+    cluster = KiKiMR(
         configurator=ydb_configurator,
     )
     cluster.is_local_test = True

--- a/ydb/tests/library/harness/ydbd_slice.py
+++ b/ydb/tests/library/harness/ydbd_slice.py
@@ -3,12 +3,13 @@
 import itertools
 import logging
 import time
+import yaml
 
 import ydb
 import ydb.tools.ydbd_slice as ydbd_slice
 from ydb.tools.cfg import walle
 
-from .kikimr_cluster import DEFAULT_INTERCONNECT_PORT, DEFAULT_MBUS_PORT, DEFAULT_MON_PORT, DEFAULT_GRPC_PORT, load_yaml
+from .kikimr_cluster import DEFAULT_INTERCONNECT_PORT, DEFAULT_MBUS_PORT, DEFAULT_MON_PORT, DEFAULT_GRPC_PORT
 from .kikimr_runner import KikimrExternalNode
 from .kikimr_cluster_interface import KiKiMRClusterInterface
 
@@ -18,7 +19,8 @@ logger = logging.getLogger(__name__)
 class YdbdSlice(KiKiMRClusterInterface):
     def __init__(self, config_path, binary_path=None):
         kikimr_bin = binary_path
-        self.__yaml_config = load_yaml(config_path)
+        with open(config_path) as f:
+            self.__yaml_config = yaml.safe_load(f.read())
         self.__hosts = [host['name'] for host in self.__yaml_config.get('hosts')]
         ssh_user = "yc-user"
         walle_provider = walle.NopHostsInformationProvider()

--- a/ydb/tests/library/sqs/test_base.py
+++ b/ydb/tests/library/sqs/test_base.py
@@ -13,7 +13,7 @@ from hamcrest import assert_that, equal_to, not_none, none, greater_than, less_t
 
 import yatest
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
 
@@ -333,7 +333,7 @@ class KikimrSqsTestBase(object):
     @classmethod
     def _setup_cluster(cls):
         config_generator = cls._setup_config_generator()
-        cluster = kikimr_cluster_factory(config_generator)
+        cluster = KiKiMR(config_generator)
         cluster.start()
         cls._init_cluster(cluster, config_generator)
         return cluster, config_generator

--- a/ydb/tests/postgres_integrations/library/pytest_integration.py
+++ b/ydb/tests/postgres_integrations/library/pytest_integration.py
@@ -14,7 +14,6 @@ import yatest
 
 import logging
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 
 
@@ -36,7 +35,7 @@ _filter_format_function = Callable[[List[str]], str]
 _filter_formatter: Optional[_filter_format_function] = None
 _tests_folder: Optional[str] = None
 _test_results: Optional[Dict[str, TestCase]] = None
-_kikimr_factory: KiKiMR = kikimr_cluster_factory()
+_kikimr_factory: KiKiMR = KiKiMR()
 _integration_tests: Optional[List[str]] = None
 _skip_tests: Dict[str, str] = dict()  # [test name: reason]
 

--- a/ydb/tests/stability/ydb/test_stability.py
+++ b/ydb/tests/stability/ydb/test_stability.py
@@ -11,7 +11,7 @@ logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
 
 from ydb.tests.library.common.composite_assert import CompositeAssert # noqa
 from ydb.tests.library.harness import param_constants # noqa
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory # noqa
+from ydb.tests.library.harness.kikimr_cluster import ExternalKiKiMRCluster # noqa
 from ydb.tests.library.matchers.collection import is_empty # noqa
 from ydb.tests.library.wardens.factories import safety_warden_factory, liveness_warden_factory # noqa
 
@@ -48,7 +48,7 @@ class TestSetupForStability(object):
         assert cls.slice_name is not None
 
         logger.info('setup_class started for slice = {}'.format(cls.slice_name))
-        cls.kikimr_cluster = kikimr_cluster_factory(config_path=get_slice_directory())
+        cls.kikimr_cluster = ExternalKiKiMRCluster(config_path=get_slice_directory())
         cls._stop_nemesis()
         cls.kikimr_cluster.start()
 
@@ -165,7 +165,7 @@ class TestCheckLivenessAndSafety(object):
         slice_name = get_slice_name()
         logger.info('slice = {}'.format(slice_name))
         assert slice_name is not None
-        kikimr_cluster = kikimr_cluster_factory(config_path=get_slice_directory())
+        kikimr_cluster = ExternalKiKiMRCluster(config_path=get_slice_directory())
         composite_assert = CompositeAssert()
         composite_assert.assert_that(
             safety_warden_factory(kikimr_cluster).list_of_safety_violations(),

--- a/ydb/tests/tools/nemesis/ut/test_disk.py
+++ b/ydb/tests/tools/nemesis/ut/test_disk.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from hamcrest import assert_that, greater_than_or_equal_to
 
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common import types
 from ydb.tests.library.common.wait_for import wait_for
@@ -12,7 +12,7 @@ class TestSafeDiskBreak(object):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = kikimr_cluster_factory(
+        cls.cluster = KiKiMR(
             KikimrConfigGenerator(erasure=types.Erasure.BLOCK_4_2, nodes=9, use_in_memory_pdisks=True))
         cls.cluster.start()
 

--- a/ydb/tests/tools/nemesis/ut/test_tablet.py
+++ b/ydb/tests/tools/nemesis/ut/test_tablet.py
@@ -8,7 +8,7 @@ from ydb.tests.library.common.types import Erasure, TabletTypes, TabletStates
 from ydb.tests.library.harness.util import LogLevels
 from ydb.tests.tools.nemesis.library.tablet import BulkChangeTabletGroupNemesis
 from ydb.tests.tools.nemesis.library.tablet import KillHiveNemesis, KillBsControllerNemesis
-from ydb.tests.library.harness.kikimr_cluster import kikimr_cluster_factory
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.matchers.tablets import all_tablets_are_created
 
@@ -27,7 +27,7 @@ class TestMassiveKills(object):
                 'BS_CONTROLLER': LogLevels.DEBUG,
             }
         )
-        cls.cluster = kikimr_cluster_factory(configurator=cls.configurator)
+        cls.cluster = KiKiMR(configurator=cls.configurator)
         cls.cluster.start()
 
     @classmethod


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- stop using `kikimr_cluster_factory`
- remove `load_yaml` because it useless
- remove `param_constants.kikimr_stderr_to_console` because it is unused