### PR TITLE
ChaCha AVX512 runtime dispatch improvement

### DIFF
--- a/ydb/core/blobstorage/crypto/chacha_512/chacha_512.h
+++ b/ydb/core/blobstorage/crypto/chacha_512/chacha_512.h
@@ -11,7 +11,6 @@
 #define CHACHA_ROUNDS 8
 #endif
 
-#ifdef __AVX512F__
 typedef unsigned vec128 __attribute__ ((vector_size (16)));
 #define XOR128(a,b)	(vec128)_mm_xor_si128((__m128i)a, (__m128i)b)
 #define LOAD128(m)	(vec128)_mm_loadu_si128((__m128i*)(m))
@@ -116,7 +115,8 @@ typedef long long __m512i __attribute__ ((__vector_size__ (64), __may_alias__));
             _mm512_mask_mov_epi32(_mm512_permutexvar_epi64(_mm512_set_epi64(3,2,1,0,7,6,5,4), (__m512i)(v1)), 0xff0f,	\
             _mm512_mask_mov_epi32(_mm512_permutexvar_epi64(_mm512_set_epi64(5,4,3,2,1,0,7,6), (__m512i)(v0)), 0xfff0,	\
             (__m512i)(v3))))));
-#endif
+
+void XorAVX512(void* destination, const void* a, const void* b, ui32 size);
 
 class ChaCha512
 {
@@ -141,8 +141,7 @@ public:
 private:
     void EncipherImpl(const ui8* plaintext, ui8* ciphertext, size_t len);
 
-#ifdef __AVX512F__
     vec512 q0_, q1_, q2_, q3_;
-#endif
+    
     ui8 rounds_;
 };

--- a/ydb/core/blobstorage/crypto/chacha_512/ya.make
+++ b/ydb/core/blobstorage/crypto/chacha_512/ya.make
@@ -1,0 +1,13 @@
+LIBRARY()
+
+
+IF (NOT OS_WINDOWS AND NOT ARCH_ARM64)
+    SRCS(
+        chacha_512.cpp
+    )
+    CFLAGS(
+        -mavx512f
+    )
+ENDIF()
+
+END()

--- a/ydb/core/blobstorage/crypto/chacha_512_ut.cpp
+++ b/ydb/core/blobstorage/crypto/chacha_512_ut.cpp
@@ -1,15 +1,14 @@
 #include <util/random/fast.h>
 
-#include "chacha_512.h"
 #include "chacha_vec.h"
 #include "secured_block.h"
+
+#include <ydb/core/blobstorage/crypto/chacha_512/chacha_512.h>
 #include <ydb/core/blobstorage/crypto/ut/ut_helpers.h>
 #include <ydb/core/blobstorage/crypto/ut/chacha_test_vectors.h>
 
 
-Y_UNIT_TEST_SUITE(TChaCha512)
-{
-#ifdef __AVX512F__
+Y_UNIT_TEST_SUITE(TChaCha512) {
     void RunTest(int rounds, const ui8 key[KEY_SIZE], const ui8 iv[IV_SIZE],
             const ui8 expected[][DATA_SIZE])
     {
@@ -178,5 +177,4 @@ Y_UNIT_TEST_SUITE(TChaCha512)
             UNIT_ASSERT_ARRAYS_EQUAL(bufOrig.Data(), bufOutNew.Data(), size);
         }
     }
-#endif
 }

--- a/ydb/core/blobstorage/crypto/crypto.cpp
+++ b/ydb/core/blobstorage/crypto/crypto.cpp
@@ -164,28 +164,23 @@ template class TT1ha0HasherBase<ET1haFunc::T1HA0_AVX2>;
 ////////////////////////////////////////////////////////////////////////////
 #define CYPHER_ROUNDS 8
 
+#if (defined(_win_) || defined(_arm64_))
+const bool TStreamCypher::HasAVX512 = false;
+#else
 const bool TStreamCypher::HasAVX512 = NX86::HaveAVX512F();
+#endif
 
 Y_FORCE_INLINE void TStreamCypher::Encipher(const ui8* plaintext, ui8* ciphertext, size_t len) { 
-#ifdef __AVX512F__
     std::visit([&](auto&& chacha) {
         chacha.Encipher(plaintext, ciphertext, len);
     }, *Cypher);
-#else
-    Cypher->Encipher(plaintext, ciphertext, len);
-#endif
 }
 
 Y_FORCE_INLINE void TStreamCypher::SetKeyAndIV(const ui64 blockIdx) {
-#ifdef __AVX512F__
     std::visit([&](auto&& chacha) {
         chacha.SetKey((ui8*)&Key[0], sizeof(Key));
         chacha.SetIV((ui8*)&Nonce, (ui8*)&blockIdx);
     }, *Cypher);
-#else
-    Cypher->SetKey((ui8*)&Key[0], sizeof(Key));
-    Cypher->SetIV((ui8*)&Nonce, (ui8*)&blockIdx);
-#endif
 }
 
 TStreamCypher::TStreamCypher()
@@ -195,7 +190,6 @@ TStreamCypher::TStreamCypher()
 #if ENABLE_ENCRYPTION
     memset(Key, 0, sizeof(Key));
 
-#ifdef __AVX512F__
     auto* chacha = new std::variant<ChaChaVec, ChaCha512>;
     
     if (HasAVX512) {
@@ -204,9 +198,6 @@ TStreamCypher::TStreamCypher()
         chacha->emplace<ChaChaVec>(CYPHER_ROUNDS);
     }
     Cypher.reset(chacha);
-#else
-    Cypher.reset(new ChaChaVec(CYPHER_ROUNDS));
-#endif
 #else
     Y_UNUSED(Leftover);
     Y_UNUSED(Key);
@@ -303,31 +294,31 @@ void TStreamCypher::EncryptZeroes(void* destination, ui32 size) {
 
 #if ENABLE_ENCRYPTION
 static void Xor(void* destination, const void* a, const void* b, ui32 size) {
+#if (defined(_win_) || defined(_arm64_))
     ui8 *dst = (ui8*)destination;
     const ui8 *srcA = (const ui8*)a;
     const ui8 *srcB = (const ui8*)b;
-
-#ifdef __AVX512F__
-    // Process 64 bytes at a time with AVX-512
-    size_t i;
-    for (i = 0; i + 63 < size; i += 64) {
-        __m512i vA = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(srcA + i));
-        __m512i vB = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(srcB + i));
-        __m512i vXor = _mm512_xor_si512(vA, vB);
-        _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst + i), vXor);
-    }
-
-    // Process remaining bytes
-    for (; i < size; ++i) {
-        dst[i] = srcA[i] ^ srcB[i];
-    }
-#else
     ui8 *endDst = dst + size;
     while (dst != endDst) {
         *dst = *srcA ^ *srcB;
         ++dst;
         ++srcA;
         ++srcB;
+    }
+#else
+    if (NX86::HaveAVX512F()) {
+        XorAVX512(destination, a, b, size);
+    } else {
+        ui8 *dst = (ui8*)destination;
+        const ui8 *srcA = (const ui8*)a;
+        const ui8 *srcB = (const ui8*)b;
+        ui8 *endDst = dst + size;
+        while (dst != endDst) {
+            *dst = *srcA ^ *srcB;
+            ++dst;
+            ++srcA;
+            ++srcB;
+        }
     }
 #endif
 }

--- a/ydb/core/blobstorage/crypto/crypto.h
+++ b/ydb/core/blobstorage/crypto/crypto.h
@@ -8,14 +8,12 @@
 #include <ydb/core/blobstorage/crypto/chacha.h>
 #include <ydb/core/blobstorage/crypto/poly1305.h>
 #define ChaChaVec ChaCha
+#define ChaCha512 ChaCha
 #define Poly1305Vec Poly1305
 #define CHACHA_BPI 1
-#elif __AVX512F__
-#include <ydb/core/blobstorage/crypto/chacha_vec.h>
-#include <ydb/core/blobstorage/crypto/chacha_512.h>
-#include <ydb/core/blobstorage/crypto/poly1305_vec.h>
 #else
 #include <ydb/core/blobstorage/crypto/chacha_vec.h>
+#include <ydb/core/blobstorage/crypto/chacha_512/chacha_512.h>
 #include <ydb/core/blobstorage/crypto/poly1305_vec.h>
 #endif
 
@@ -103,11 +101,7 @@ class TStreamCypher {
     alignas(16) ui8 Leftover[BLOCK_BYTES];
     alignas(16) ui64 Key[4];
     alignas(16) i64 Nonce;
-#ifdef __AVX512F__
     std::unique_ptr<std::variant<ChaChaVec, ChaCha512>> Cypher;
-#else
-    std::unique_ptr<ChaChaVec> Cypher;
-#endif
     ui32 UnusedBytes;
     static const bool HasAVX512;
 public:

--- a/ydb/core/blobstorage/crypto/ut/ya.make
+++ b/ydb/core/blobstorage/crypto/ut/ya.make
@@ -18,4 +18,8 @@ ELSE()
     )
 ENDIF()
 
+PEERDIR(
+    ydb/core/blobstorage/crypto/chacha_512
+)
+
 END()

--- a/ydb/core/blobstorage/crypto/ya.make
+++ b/ydb/core/blobstorage/crypto/ya.make
@@ -7,7 +7,6 @@ IF (NOT OS_WINDOWS AND NOT ARCH_ARM64)
         crypto.h
         poly1305.cpp
         chacha_vec.cpp
-        chacha_512.cpp
         poly1305_vec.cpp
         secured_block.cpp
     )
@@ -24,10 +23,15 @@ ENDIF()
 PEERDIR(
     contrib/libs/t1ha
     library/cpp/sse
+    ydb/core/blobstorage/crypto/chacha_512
     ydb/library/actors/util
 )
 
 END()
+
+RECURSE(
+    chacha_512
+)
 
 RECURSE_FOR_TESTS(
     ut


### PR DESCRIPTION
At the moment, the only way to utilize AVX512 version of ChaCha is to build YDB with `-mavx512f` which removes the possibility to have one binary for any x86 Linux node since not all of them have AVX512F instruction set available. In this PR I move ChaCha AVX512 to a separate "module" so it can be built with -mavx512f without building everything else with -mavx512f. And in the place where ChaCha is used, runtime-dispatch to either non-AVX512F implementation or to AVX512F implementation, if said instruction set is available.

### Changelog category <!-- remove all except one -->

* Improvement