### PR TITLE
Use node info from labels in configs dispatcher instead of tenant pool

### DIFF
--- a/ydb/core/cms/console/configs_dispatcher.cpp
+++ b/ydb/core/cms/console/configs_dispatcher.cpp
@@ -301,7 +301,13 @@ void TConfigsDispatcher::Bootstrap()
         CurrentConfig,
         0,
         true,
-        1);
+        1,
+        {},
+        {},
+        TNodeInfo{
+            .Tenant = Labels.contains("tenant") ? Labels.at("tenant") : TString(""),
+            .NodeType = Labels.contains("node_type") ? Labels.at("node_type") : TString(""),
+        });
     CommonSubscriptionClient = RegisterWithSameMailbox(commonClient);
 
     Become(&TThis::StateInit);

--- a/ydb/core/cms/console/console_configs_subscriber.h
+++ b/ydb/core/cms/console/console_configs_subscriber.h
@@ -6,7 +6,14 @@
 
 #include <ydb/library/actors/core/actor.h>
 
+#include <optional>
+
 namespace NKikimr::NConsole {
+
+struct TNodeInfo {
+    TString Tenant;
+    TString NodeType;
+};
 
 IActor *CreateConfigsSubscriber(
     const TActorId &ownerId,
@@ -16,6 +23,7 @@ IActor *CreateConfigsSubscriber(
     bool processYaml = false,
     ui64 version = 0,
     const TString &yamlConfig = {},
-    const TMap<ui64, TString> &volatileYamlConfigs = {});
+    const TMap<ui64, TString> &volatileYamlConfigs = {},
+    const std::optional<TNodeInfo> explicitNodeInfo = std::nullopt);
 
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/log_settings_configurator_ut.cpp
+++ b/ydb/core/cms/console/log_settings_configurator_ut.cpp
@@ -263,7 +263,11 @@ Y_UNIT_TEST_SUITE(TLogSettingsConfiguratorTests)
 
     Y_UNIT_TEST(TestRemoveComponentEntries)
     {
-        TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+        NKikimrConfig::TAppConfig ext;
+        auto& label = *ext.AddLabels();
+        label.SetName("tenant");
+        label.SetValue(TENANT1_1_NAME);
+        TTenantTestRuntime runtime(DefaultConsoleTestConfig(), ext);
         auto settings = InitLogSettingsConfigurator(runtime);
         WaitForUpdate(runtime); // initial update
 
@@ -292,7 +296,11 @@ Y_UNIT_TEST_SUITE(TLogSettingsConfiguratorTests)
 
     Y_UNIT_TEST(TestChangeDefaults)
     {
-        TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+        NKikimrConfig::TAppConfig ext;
+        auto& label = *ext.AddLabels();
+        label.SetName("tenant");
+        label.SetValue(TENANT1_1_NAME);
+        TTenantTestRuntime runtime(DefaultConsoleTestConfig(), ext);
         auto settings = InitLogSettingsConfigurator(runtime);
         WaitForUpdate(runtime); // initial update
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
