### PR TITLE
Don't use random scan cookie for build index

### DIFF
--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -626,7 +626,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
                                                        record.GetColumnBuildSettings(),
                                                        userTable,
                                                        limits),
-                                  ev->Cookie,
+                                  0,
                                   scanOpts);
 
     TScanRecord recCard = {scanId, seqNo};

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -663,7 +663,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
     TScanOptions scanOpts;
     scanOpts.SetSnapshotRowVersion(rowVersion);
     scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
-    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), ev->Cookie, scanOpts);
+    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
     TScanRecord recCard = {scanId, seqNo};
     ScanManager.Set(id, recCard);
 }

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -460,7 +460,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
     TScanOptions scanOpts;
     scanOpts.SetSnapshotRowVersion(rowVersion);
     scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
-    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), ev->Cookie, scanOpts);
+    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
     TScanRecord recCard = {scanId, seqNo};
     ScanManager.Set(id, recCard);
 }

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -351,7 +351,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TAc
                                       record.GetMaxProbability(),
                                       record.GetColumns(),
                                       userTable),
-                                  ev->Cookie,
+                                  0,
                                   scanOpts);
 
     TScanRecord recCard = {scanId, seqNo};


### PR DESCRIPTION
We shouldn't use random cookie for build index scans. Because in such case it's possible that this random id will intersects with real transaction id. So we use invalid zero id. It's allowed because build index scans don't need some external finalize. New build index scan remove old scan from manager because it has newer version
