### PR TITLE
Switch off the ColumnStatistics feature flag for tenant tests

### DIFF
--- a/ydb/core/cms/console/feature_flags_configurator_ut.cpp
+++ b/ydb/core/cms/console/feature_flags_configurator_ut.cpp
@@ -131,7 +131,8 @@ Y_UNIT_TEST_SUITE(FeatureFlagsConfiguratorTest) {
         WaitForUpdate(runtime); // initial update
 
         CompareFeatureFlags(runtime,
-            "EnableExternalHive: false\n");
+            "EnableExternalHive: false\n"
+            "EnableColumnStatistics: false\n");
 
         auto sender = runtime.AllocateEdgeActor();
         runtime.Send(new IEventHandle(MakeFeatureFlagsServiceID(), sender, new TEvFeatureFlags::TEvSubscribe()));

--- a/ydb/core/testlib/tenant_runtime.cpp
+++ b/ydb/core/testlib/tenant_runtime.cpp
@@ -1160,6 +1160,7 @@ TTenantTestRuntime::TTenantTestRuntime(const TTenantTestConfig &config,
     , Extension(extension)
 {
     Extension.MutableFeatureFlags()->SetEnableExternalHive(false);
+    Extension.MutableFeatureFlags()->SetEnableColumnStatistics(false);
     Setup(createTenantPools);
 }
 


### PR DESCRIPTION
### Changelog entry

Disabling the ColumnStatistics feature flag for ConsoleTests. Since TFakeHive does not work with DataShard type tablets.

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

