### PR TITLE
Store flag AuthorizeByCertificate to local db of node broker

### DIFF
--- a/ydb/core/mind/node_broker.cpp
+++ b/ydb/core/mind/node_broker.cpp
@@ -199,7 +199,7 @@ void TNodeBroker::AddNode(const TNodeInfo &info)
     FreeIds.Reset(info.NodeId);
     if (info.SlotIndex.has_value()) {
         SlotIndexesPools[info.ServicedSubDomain].Acquire(info.SlotIndex.value());
-    }    
+    }
 
     if (info.Expire > Epoch.Start) {
         LOG_DEBUG_S(TActorContext::AsActorContext(), NKikimrServices::NODE_BROKER,
@@ -564,7 +564,8 @@ void TNodeBroker::DbAddNode(const TNodeInfo &node,
                 << " lease=" << node.Lease
                 << " expire=" << node.ExpirationString()
                 << " servicedsubdomain=" << node.ServicedSubDomain
-                << " slotindex= " << node.SlotIndex);
+                << " slotindex=" << node.SlotIndex
+                << " authorizedbycertificate=" << (node.AuthorizedByCertificate ? "true" : "false"));
 
     NIceDb::TNiceDb db(txc.DB);
     using T = Schema::Nodes;
@@ -576,7 +577,8 @@ void TNodeBroker::DbAddNode(const TNodeInfo &node,
         .Update<T::Lease>(node.Lease)
         .Update<T::Expire>(node.Expire.GetValue())
         .Update<T::Location>(node.Location.GetSerializedLocation())
-        .Update<T::ServicedSubDomain>(node.ServicedSubDomain);
+        .Update<T::ServicedSubDomain>(node.ServicedSubDomain)
+        .Update<T::AuthorizedByCertificate>(node.AuthorizedByCertificate);
 
     if (node.SlotIndex.has_value()) {
         db.Table<T>().Key(node.NodeId)
@@ -729,7 +731,8 @@ bool TNodeBroker::DbLoadState(TTransactionContext &txc,
             info.ServicedSubDomain = TSubDomainKey(nodesRowset.GetValueOrDefault<T::ServicedSubDomain>());
             if (nodesRowset.HaveValue<T::SlotIndex>()) {
                 info.SlotIndex = nodesRowset.GetValue<T::SlotIndex>();
-            } 
+            }
+            info.AuthorizedByCertificate = nodesRowset.GetValue<T::AuthorizedByCertificate>();
             AddNode(info);
 
             LOG_DEBUG_S(ctx, NKikimrServices::NODE_BROKER,
@@ -843,9 +846,21 @@ void TNodeBroker::DbUpdateNodeLocation(const TNodeInfo &node,
     db.Table<T>().Key(node.NodeId).Update<T::Location>(node.Location.GetSerializedLocation());
 }
 
+void TNodeBroker::DbUpdateNodeAuthorizedByCertificate(const TNodeInfo &node,
+                                       TTransactionContext &txc)
+{
+    LOG_DEBUG_S(TActorContext::AsActorContext(), NKikimrServices::NODE_BROKER,
+                "Update node " << node.IdString() << " authorizedbycertificate in database"
+                << " authorizedbycertificate=" << (node.AuthorizedByCertificate ? "true" : "false"));
+
+    NIceDb::TNiceDb db(txc.DB);
+    using T = Schema::Nodes;
+    db.Table<T>().Key(node.NodeId).Update<T::AuthorizedByCertificate>(node.AuthorizedByCertificate);
+}
+
 void TNodeBroker::Handle(TEvConsole::TEvConfigNotificationRequest::TPtr &ev,
                          const TActorContext &ctx)
-{   
+{
     const auto& appConfig = ev->Get()->Record.GetConfig();
     if (appConfig.HasFeatureFlags()) {
         EnableStableNodeNames = appConfig.GetFeatureFlags().GetEnableStableNodeNames();

--- a/ydb/core/mind/node_broker__register_node.cpp
+++ b/ydb/core/mind/node_broker__register_node.cpp
@@ -100,8 +100,11 @@ public:
                 Self->DbUpdateNodeLease(node, txc);
                 ExtendLease = true;
             }
-            node.AuthorizedByCertificate = rec.GetAuthorizedByCertificate();
-            
+            if (node.AuthorizedByCertificate != rec.GetAuthorizedByCertificate()) {
+                node.AuthorizedByCertificate = rec.GetAuthorizedByCertificate();
+                Self->DbUpdateNodeAuthorizedByCertificate(node, txc);
+            }
+
             if (Self->EnableStableNodeNames) {
                 if (ServicedSubDomain != node.ServicedSubDomain) {
                     if (node.SlotIndex.has_value()) {
@@ -110,12 +113,12 @@ public:
                     node.ServicedSubDomain = ServicedSubDomain;
                     node.SlotIndex = Self->SlotIndexesPools[node.ServicedSubDomain].AcquireLowestFreeIndex();
                     Self->DbAddNode(node, txc);
-                } else if (!node.SlotIndex.has_value()) {    
+                } else if (!node.SlotIndex.has_value()) {
                     node.SlotIndex = Self->SlotIndexesPools[node.ServicedSubDomain].AcquireLowestFreeIndex();
                     Self->DbAddNode(node, txc);
                 }
             }
-            
+
             Response->Record.MutableStatus()->SetCode(TStatus::OK);
             Self->FillNodeInfo(node, *Response->Record.MutableNode());
 

--- a/ydb/core/mind/node_broker__scheme.h
+++ b/ydb/core/mind/node_broker__scheme.h
@@ -25,6 +25,7 @@ struct Schema : NIceDb::Schema {
         struct Location : Column<12, NScheme::NTypeIds::String> {};
         struct ServicedSubDomain : Column<13, NScheme::NTypeIds::String> { using Type = NKikimrSubDomains::TDomainKey; };
         struct SlotIndex : Column<14, NScheme::NTypeIds::Uint32> {};
+        struct AuthorizedByCertificate : Column<15, NScheme::NTypeIds::Bool> {};
 
         using TKey = TableKey<ID>;
         using TColumns = TableColumns<
@@ -37,7 +38,8 @@ struct Schema : NIceDb::Schema {
             Expire,
             Location,
             ServicedSubDomain,
-            SlotIndex
+            SlotIndex,
+            AuthorizedByCertificate
         >;
     };
 

--- a/ydb/core/mind/node_broker_impl.h
+++ b/ydb/core/mind/node_broker_impl.h
@@ -288,6 +288,8 @@ private:
                            TTransactionContext &txc);
     void DbUpdateNodeLocation(const TNodeInfo &node,
                               TTransactionContext &txc);
+    void DbUpdateNodeAuthorizedByCertificate(const TNodeInfo &node,
+                              TTransactionContext &txc);
 
     void Handle(TEvConsole::TEvConfigNotificationRequest::TPtr &ev,
                 const TActorContext &ctx);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Adding the ability to register dynamic nodes by certificate. We wont to know how node was registered in node broker. Flag AuthorizeByCertificate is used for this goal.

Formerly this flag sent to node broker but did not store in local db and set to default value after node broker restart.

### Changelog category <!-- remove all except one -->

* Bugfix 


### Additional information

...
