### PR TITLE
Disabling EnableColumnStatistics feature flag for test system view

### DIFF
--- a/ydb/tests/functional/tenants/test_system_views.py
+++ b/ydb/tests/functional/tenants/test_system_views.py
@@ -29,6 +29,7 @@ class BaseSystemViews(object):
                 }
             )
         )
+        cls.cluster.config.yaml_config['feature_flags']['enable_column_statistics'] = False
         cls.cluster.start()
 
     @classmethod


### PR DESCRIPTION
### Changelog entry

Due to that the tests expect only one table to exist, it is necessary to disable the automatic creation of the table with column statistics (.metadata/_statistics).

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

