### PR TITLE
Throw exception instead of calling exit(1) in TBasicServicesInitializer

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -446,8 +446,8 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
             try {
                 return TFileInput(*path).ReadAll();
             } catch (const std::exception& ex) {
-                Cerr << "failed to read " << name << " file '" << *path << "': " << ex.what() << Endl;
-                exit(1);
+                ythrow yexception()
+                    << "failed to read " << name << " file '" << *path << "': " << ex.what();
             }
         }
         return TString();
@@ -743,9 +743,9 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                     auto listener = new TInterconnectListenerTCP(
                         address, node.second.second, icCommon);
                     if (int err = listener->Bind()) {
-                        Cerr << "Failed to set up IC listener on port " << node.second.second
-                            << " errno# " << err << " (" << strerror(err) << ")" << Endl;
-                        exit(1);
+                        ythrow yexception()
+                            << "Failed to set up IC listener on port " << node.second.second
+                            << " errno# " << err << " (" << strerror(err) << ")";
                     }
                     setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(false), TActorSetupCmd(listener,
                         TMailboxType::ReadAsFilled, interconnectPoolId));
@@ -763,9 +763,9 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                 }
                 auto listener = new TInterconnectListenerTCP(address, info.GetPort(), icCommon);
                 if (int err = listener->Bind()) {
-                    Cerr << "Failed to set up IC listener on port " << info.GetPort()
-                        << " errno# " << err << " (" << strerror(err) << ")" << Endl;
-                    exit(1);
+                    ythrow yexception()
+                        << "Failed to set up IC listener on port " << info.GetPort()
+                        << " errno# " << err << " (" << strerror(err) << ")";
                 }
                 setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(true), TActorSetupCmd(listener,
                     TMailboxType::ReadAsFilled, interconnectPoolId));
@@ -779,9 +779,9 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                         icCommon->TechnicalSelfHostName = nodesManagerConfig.GetHost();
                         auto listener = new TInterconnectListenerTCP({}, nodesManagerConfig.GetPort(), icCommon);
                         if (int err = listener->Bind()) {
-                            Cerr << "Failed to set up IC listener on port " << nodesManagerConfig.GetPort()
-                                << " errno# " << err << " (" << strerror(err) << ")" << Endl;
-                            exit(1);
+                            ythrow yexception()
+                                << "Failed to set up IC listener on port " << nodesManagerConfig.GetPort()
+                                << " errno# " << err << " (" << strerror(err) << ")";
                         }
                         setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(true), TActorSetupCmd(listener,
                             TMailboxType::ReadAsFilled, interconnectPoolId));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Objects with thread storage duration are guaranteed to be destroyed **only** for the thread which calls exit.
Therefore there is no guarantee that destruction will happen for objects associated with other threads.
This may cause the [blockstore-server](https://github.com/ydb-platform/nbs/tree/main/cloud/blockstore/apps/server)  to crash as described below:
```
VERIFY failed (2024-11-06T16:40:28.177019Z):
 
  cloud/storage/core/libs/grpc/init.cpp:29
 
  ~TGrpcState(): requirement AtomicGet(Counter) == 0 failed
 
 
Core was generated by `/usr/bin/blockstore-server --temporary-server --server-port 9771 --secure-serve'.
#0 0x00007fb7366d100b in raise () from /lib/x86_64-linux-gnu/libc.so.6
[Current thread is 491 (LWP 1258357)]
 
Thread 491 (LWP 1258357):
#0 raise () from /lib/x86_64-linux-gnu/libc.so.6
#1 abort () from /lib/x86_64-linux-gnu/libc.so.6
#2 NPrivate::InternalPanicImpl (line=<optimized out>, function=0x55da62d049f3 "~TGrpcState", expr=<optimized out>, file=..., errorMessage=0x55da638902c9 <NULL_STRING_REPR+9> "", errorMessageSize=0) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/system/yassert.cpp +90
#3 NPrivate::Panic (file=..., line=29, function=0x55da62d049f3 "~TGrpcState", expr=0x55da62b799dc "AtomicGet(Counter) == 0", format=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/system/yassert.cpp +55
#4 NCloud::(anonymous namespace)::TGrpcState::~TGrpcState (this=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/storage/core/libs/grpc/init.cpp +29
#5 NPrivate::Destroyer<NCloud::(anonymous namespace)::TGrpcState> (ptr=<optimized out>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/generic/singleton.h +23
#6 (anonymous namespace)::TAtExit::Finish (this=0x55da807b5c40 <(anonymous namespace)::atExitMem>) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/system/atexit.cpp +56
#7 (anonymous namespace)::OnExit () at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/util/system/atexit.cpp +93
#8 ?? () from /lib/x86_64-linux-gnu/libc.so.6
#9 exit () from /lib/x86_64-linux-gnu/libc.so.6
#10 NKikimr::NKikimrServicesInitializers::TBasicServicesInitializer::InitializeServices (this=0x149f3e32b930, setup=0x149f3e0c0000, appData=0x149f3ee01340) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp +828
#11 NKikimr::TServiceInitializersList::InitializeServices (this=<optimized out>, setup=0x149f3e0c0000, appData=0x149f3ee01340) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/core/driver_lib/run/service_initializer.cpp +13
#12 NKikimr::TKikimrRunner::InitializeActorSystem (this=0x149f3fa4c600, runConfig=..., serviceInitializers=..., servicesMask=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/contrib/ydb/core/driver_lib/run/run.cpp +1279
#13 NCloud::NBlockStore::NStorage::TActorSystem::Init (this=0x149f3fa4c600) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/init/common/actorsystem.cpp +60
#14 NCloud::NBlockStore::NStorage::CreateActorSystem (sArgs=...) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/storage/init/server/actorsystem.cpp +576
#15 NCloud::NBlockStore::NServer::TBootstrapYdb::InitKikimrService (this=0x7ffc1f153b00) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/daemon/ydb/bootstrap.cpp +571
#16 NCloud::NBlockStore::NServer::TBootstrapBase::Init (this=0x7ffc1f153b00) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/blockstore/libs/daemon/common/bootstrap.cpp +225
#17 NCloud::DoMain<NCloud::NBlockStore::NServer::TBootstrapYdb> (bootstrap=..., argc=59, argv=0x7ffc1f1540c8) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/storage/core/libs/daemon/app.h +36
#18 main (argc=59, argv=0x7ffc1f1540c8) at /opt/buildagent/work/4ec98910e7de170b/__FUSE/mount_path/cloud/nbs_internal/blockstore/daemon/main.cpp +135
...
```

### Changelog category <!-- remove all except one -->

* Bugfix 


### Additional information

...
