### PR TITLE
Remove obsolete map from backpressure queue client

### DIFF
--- a/ydb/core/blobstorage/backpressure/defs.h
+++ b/ydb/core/blobstorage/backpressure/defs.h
@@ -17,6 +17,5 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/mailbox.h>
 #include <ydb/library/actors/core/mon.h>
-#include <library/cpp/containers/intrusive_rb_tree/rb_tree.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
 #include <google/protobuf/message.h>

--- a/ydb/core/blobstorage/backpressure/queue.cpp
+++ b/ydb/core/blobstorage/backpressure/queue.cpp
@@ -339,7 +339,6 @@ TBlobStorageQueue::TItemList::iterator TBlobStorageQueue::EraseItem(TItemList& q
     TItemList::iterator nextIter = std::next(it);
     if (Queues.Unused.size() < MaxUnusedItems) {
         Queues.Unused.splice(Queues.Unused.end(), queue, it);
-        it->TSenderNode::UnLink();
         it->Event.Discard();
     } else {
         queue.erase(it);

--- a/ydb/core/blobstorage/backpressure/queue.h
+++ b/ydb/core/blobstorage/backpressure/queue.h
@@ -31,16 +31,7 @@ class TBlobStorageQueue {
         }
     };
 
-    template<typename TDerived>
-    struct TSenderNode : public TRbTreeItem<TSenderNode<TDerived>, TCompare<TActorId>> {
-        const TActorId& GetKey() const {
-            return static_cast<const TDerived&>(*this).Event.GetSender();
-        }
-    };
-
-    struct TItem
-        : public TSenderNode<TItem>
-    {
+    struct TItem {
         EItemQueue Queue;
         TCostModel::TMessageCostEssence CostEssence;
         NWilson::TSpan Span;
@@ -103,10 +94,7 @@ class TBlobStorageQueue {
         {}
     };
 
-    using TSenderMap = TRbTree<TSenderNode<TItem>, TCompare<TActorId>>;
-
     TQueues Queues;
-    TSenderMap SenderToItems;
     THashMap<std::pair<ui64, ui64>, TItemList::iterator> InFlightLookup;
 
     ui64 WindowSize;
@@ -233,7 +221,6 @@ public:
 
         newIt->Iterator = newIt;
         SetItemQueue(*newIt, EItemQueue::Waiting);
-        SenderToItems.Insert(&*newIt);
 
         // count item
         ++*QueueItemsPut;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Remove obsolete map from backpressure queue client

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Obsolete code removal.
