### PR TITLE
auditlog: fix logging for unsuccessful ldap logins

### DIFF
--- a/ydb/core/grpc_services/audit_logins.cpp
+++ b/ydb/core/grpc_services/audit_logins.cpp
@@ -1,0 +1,59 @@
+#include "defs.h"
+
+#include <ydb/core/util/address_classifier.h>
+#include <ydb/core/audit/audit_log.h>
+
+#include <ydb/public/api/protos/ydb_auth.pb.h>
+
+#include "base/base.h"
+#include "audit_logins.h"
+
+namespace NKikimr {
+namespace NGRpcService {
+
+void AuditLogLogin(IAuditCtx* ctx, const TString& database, const Ydb::Auth::LoginRequest& request, const Ydb::Auth::LoginResponse& response, const TString& errorDetails)
+{
+    static const TString GrpcLoginComponentName = "grpc-login";
+    static const TString LoginOperationName = "LOGIN";
+
+    //NOTE: EmptyValue couldn't be an empty string as AUDIT_PART() skips parts with an empty values
+    static const TString EmptyValue = "{none}";
+
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(ctx->GetPeerName());
+
+    auto status = response.operation().status();
+    TString detailed_status;
+    TString reason;
+    if (status != Ydb::StatusIds::SUCCESS) {
+        detailed_status = Ydb::StatusIds::StatusCode_Name(status);
+        if (response.operation().issues_size() > 0) {
+            reason = response.operation().issues(0).message();
+        }
+        if (errorDetails) {
+            if (!reason.empty()) {
+                reason += ": ";
+            }
+            reason += errorDetails;
+        }
+    }
+
+    // NOTE: audit field set here must be in sync with ydb/core/security/login_page.cpp, AuditLogWebUILogout()
+    AUDIT_LOG(
+        AUDIT_PART("component", GrpcLoginComponentName)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EmptyValue))
+        AUDIT_PART("database", (!database.empty() ? database : EmptyValue))
+        AUDIT_PART("operation", LoginOperationName)
+        AUDIT_PART("status", (status == Ydb::StatusIds::SUCCESS ? TString("SUCCESS") : TString("ERROR")))
+        AUDIT_PART("detailed_status", detailed_status, status != Ydb::StatusIds::SUCCESS)
+        AUDIT_PART("reason", reason, status != Ydb::StatusIds::SUCCESS)
+
+        // Login
+        AUDIT_PART("login_user", (!request.user().empty() ? request.user() : EmptyValue))
+
+        //TODO: (?) it is possible to show masked version of the resulting token here
+    );
+}
+
+}
+}
+

--- a/ydb/core/grpc_services/audit_logins.h
+++ b/ydb/core/grpc_services/audit_logins.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "defs.h"
+
+namespace Ydb::Auth {
+
+class LoginRequest;
+class LoginResponse;
+
+}
+
+namespace NKikimr::NGRpcService {
+
+class IAuditCtx;
+
+// logins log
+void AuditLogLogin(IAuditCtx* ctx, const TString& database, const Ydb::Auth::LoginRequest& request, const Ydb::Auth::LoginResponse& response, const TString& errorDetails);
+
+} // namespace NKikimr::NGRpcService

--- a/ydb/core/grpc_services/rpc_login.cpp
+++ b/ydb/core/grpc_services/rpc_login.cpp
@@ -1,5 +1,6 @@
 #include "grpc_request_proxy.h"
 #include "service_auth.h"
+#include "audit_logins.h"
 
 #include "rpc_request_base.h"
 
@@ -28,8 +29,6 @@ private:
 public:
     using TRpcRequestActor::TRpcRequestActor;
 
-    THolder<TEvSchemeShard::TEvLoginResult> Result;
-    Ydb::StatusIds_StatusCode Status = Ydb::StatusIds::SUCCESS;
     TDuration Timeout = TDuration::MilliSeconds(60000);
     TActorId PipeClient;
 
@@ -50,8 +49,7 @@ public:
     }
 
     void HandleTimeout() {
-        Status = Ydb::StatusIds::TIMEOUT;
-        ReplyAndPassAway();
+        ReplyErrorAndPassAway(Ydb::StatusIds::TIMEOUT, "Login timeout");
     }
 
     void HandleNavigate(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
@@ -68,42 +66,39 @@ public:
                 return;
             }
         }
-        Status = Ydb::StatusIds::SCHEME_ERROR;
-        ReplyAndPassAway();
+        ReplyErrorAndPassAway(Ydb::StatusIds::SCHEME_ERROR, "No database found");
     }
 
     void Handle(TEvLdapAuthProvider::TEvAuthenticateResponse::TPtr& ev) {
-        TEvLdapAuthProvider::TEvAuthenticateResponse* response = ev->Get();
-        if (response->Status == TEvLdapAuthProvider::EStatus::SUCCESS) {
+        const TEvLdapAuthProvider::TEvAuthenticateResponse& response = *ev->Get();
+        if (response.Status == TEvLdapAuthProvider::EStatus::SUCCESS) {
             Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(CreateNavigateKeySetRequest(PathToDatabase).Release()));
         } else {
-            TResponse loginResponse;
-            Ydb::Operations::Operation& operation = *loginResponse.mutable_operation();
-            Ydb::Issue::IssueMessage* issue = operation.add_issues();
-            issue->set_message(response->Error.Message);
-            Status = ConvertLdapStatus(response->Status);
-            issue->set_issue_code(Status);
-            operation.set_ready(true);
-            operation.set_status(Status);
-            Reply(loginResponse);
+            ReplyErrorAndPassAway(ConvertLdapStatus(response.Status), response.Error.Message, response.Error.LogMessage);
         }
     }
 
     void HandleResult(TEvSchemeShard::TEvLoginResult::TPtr& ev) {
-        Status = Ydb::StatusIds::SUCCESS;
-        Result = ev->Release();
-        ReplyAndPassAway();
+        const NKikimrScheme::TEvLoginResult& loginResult = ev->Get()->Record;
+        if (loginResult.error()) {
+            // explicit error takes precedence
+            ReplyErrorAndPassAway(Ydb::StatusIds::UNAUTHORIZED, loginResult.error(), /*loginResult.details()*/ TString());
+        } else if (loginResult.token().empty()) {
+            // empty token is still an error
+            ReplyErrorAndPassAway(Ydb::StatusIds::INTERNAL_ERROR, "Failed to produce a token");
+        } else {
+            // success = token + no errors
+            ReplyAndPassAway(loginResult.token());
+        }
     }
 
     void HandleUndelivered(TEvents::TEvUndelivered::TPtr&) {
-        Status = Ydb::StatusIds::UNAVAILABLE;
-        ReplyAndPassAway();
+        ReplyErrorAndPassAway(Ydb::StatusIds::UNAVAILABLE, "SchemeShard is unreachable");
     }
 
     void HandleConnect(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
         if (ev->Get()->Status != NKikimrProto::OK) {
-            Status = Ydb::StatusIds::UNAVAILABLE;
-            ReplyAndPassAway();
+            ReplyErrorAndPassAway(Ydb::StatusIds::UNAVAILABLE, "SchemeShard is unavailable");
         }
     }
 
@@ -118,28 +113,46 @@ public:
         }
     }
 
-    void ReplyAndPassAway() {
+    void ReplyAndPassAway(const TString& resultToken) {
+        TResponse response;
+
+        Ydb::Operations::Operation& operation = *response.mutable_operation();
+        operation.set_ready(true);
+        operation.set_status(Ydb::StatusIds::SUCCESS);
+        // Pack result to google::protobuf::Any
+        {
+            Ydb::Auth::LoginResult result;
+            result.set_token(resultToken);
+            operation.mutable_result()->PackFrom(result);
+        }
+
+        AuditLogLogin(Request.Get(), PathToDatabase, *GetProtoRequest(), response, /* errorDetails */ TString());
+
+        return CleanupAndReply(response);
+    }
+
+    void ReplyErrorAndPassAway(const Ydb::StatusIds_StatusCode status, const TString& error, const TString& reason = "") {
+        TResponse response;
+
+        Ydb::Operations::Operation& operation = *response.mutable_operation();
+        operation.set_ready(true);
+        operation.set_status(status);
+        if (error) {
+            Ydb::Issue::IssueMessage* issue = operation.add_issues();
+            issue->set_issue_code(status);
+            issue->set_message(error);
+        }
+
+        AuditLogLogin(Request.Get(), PathToDatabase, *GetProtoRequest(), response, reason);
+
+        return CleanupAndReply(response);
+    }
+
+    void CleanupAndReply(const TResponse& response) {
         if (PipeClient) {
             NTabletPipe::CloseClient(SelfId(), PipeClient);
         }
-        TResponse response;
-        Ydb::Operations::Operation& operation = *response.mutable_operation();
-        if (Result) {
-            const NKikimrScheme::TEvLoginResult& record = Result->Record;
-            if (record.error()) {
-                Ydb::Issue::IssueMessage* issue = operation.add_issues();
-                issue->set_message(record.error());
-                issue->set_issue_code(Ydb::StatusIds::UNAUTHORIZED);
-                Status = Ydb::StatusIds::UNAUTHORIZED;
-            }
-            if (record.token()) {
-                Ydb::Auth::LoginResult result;
-                result.set_token(record.token());
-                operation.mutable_result()->PackFrom(result);
-            }
-        }
-        operation.set_ready(true);
-        operation.set_status(Status);
+
         return Reply(response);
     }
 

--- a/ydb/core/grpc_services/ya.make
+++ b/ydb/core/grpc_services/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     audit_log.cpp
     audit_dml_operations.cpp
+    audit_logins.cpp
     db_metadata_cache.h
     grpc_endpoint_publish_actor.cpp
     grpc_helper.cpp

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -181,6 +181,7 @@ private:
             if (!NKikimrLdap::IsSuccess(result)) {
                 TStringBuilder logErrorMessage;
                 logErrorMessage << "Could not start TLS. " << NKikimrLdap::ErrorToString(result);
+                LDAP_LOG_D(logErrorMessage);
                 TEvLdapAuthProvider::TError error {
                     .Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)
                 };
@@ -197,6 +198,7 @@ private:
             TStringBuilder logErrorMessage;
             logErrorMessage << "Could not perform initial LDAP bind for dn " << Settings.GetBindDn() << " on server " + UrisCreator.GetUris() << ". "
                             << NKikimrLdap::ErrorToString(result);
+            LDAP_LOG_D(logErrorMessage);
             TEvLdapAuthProvider::TError error {
                 .Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)
             };
@@ -220,6 +222,7 @@ private:
             if (!NKikimrLdap::IsSuccess(result)) {
                 TStringBuilder logErrorMessage;
                 logErrorMessage << "Could not set LDAP ca file \"" << caCertificateFile + "\": " << NKikimrLdap::ErrorToString(result);
+                LDAP_LOG_D(logErrorMessage);
                 NKikimrLdap::Unbind(*ld);
                 return {{NKikimrLdap::ErrorToStatus(result),
                         {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)}}};
@@ -231,6 +234,7 @@ private:
         if (!NKikimrLdap::IsSuccess(result)) {
             TStringBuilder logErrorMessage;
             logErrorMessage << "Could not initialize LDAP connection for uris: " << UrisCreator.GetUris() << ". " << NKikimrLdap::LdapError(*ld);
+            LDAP_LOG_D(logErrorMessage);
             return {{TEvLdapAuthProvider::EStatus::UNAVAILABLE,
                     {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = false}}};
         }
@@ -240,6 +244,7 @@ private:
             NKikimrLdap::Unbind(*ld);
             TStringBuilder logErrorMessage;
             logErrorMessage << "Could not set LDAP protocol version: " << NKikimrLdap::ErrorToString(result);
+            LDAP_LOG_D(logErrorMessage);
             return {{NKikimrLdap::ErrorToStatus(result),
                     {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)}}};
         }
@@ -251,6 +256,7 @@ private:
                 NKikimrLdap::Unbind(*ld);
                 TStringBuilder logErrorMessage;
                 logErrorMessage << "Could not set require certificate option: " << NKikimrLdap::ErrorToString(result);
+                LDAP_LOG_D(logErrorMessage);
                 return {{NKikimrLdap::ErrorToStatus(result),
                         {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)}}};
             }
@@ -265,12 +271,14 @@ private:
             TStringBuilder logErrorMessage;
             logErrorMessage << "Could not get dn for the first entry matching " << FilterCreator.GetFilter(request.Login)
                             << " on server " << UrisCreator.GetUris() << ". " << NKikimrLdap::LdapError(*request.Ld);
+            LDAP_LOG_D(logErrorMessage);
             return {{TEvLdapAuthProvider::EStatus::UNAUTHORIZED,
                     {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = false}}};
         }
         if (request.Password.empty()) {
             TStringBuilder logErrorMessage;
             logErrorMessage << "LDAP login failed for user " << TString(dn) << ". Empty password";
+            LDAP_LOG_D(logErrorMessage);
             NKikimrLdap::MemFree(dn);
             return {{.Status = TEvLdapAuthProvider::EStatus::UNAUTHORIZED, .Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = false}}};
         }
@@ -281,6 +289,7 @@ private:
             TStringBuilder logErrorMessage;
             logErrorMessage << "LDAP login failed for user " << TString(dn) << " on server " << UrisCreator.GetUris() << ". "
                             << NKikimrLdap::ErrorToString((result));
+            LDAP_LOG_D(logErrorMessage);
             error.Message = ERROR_MESSAGE;
             error.LogMessage = logErrorMessage;
             error.Retryable = NKikimrLdap::IsRetryableError(result);
@@ -311,6 +320,7 @@ private:
                             << NKikimrLdap::ErrorToString(result);
             response.Status = NKikimrLdap::ErrorToStatus(result);
             response.Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)};
+            LDAP_LOG_D(logErrorMessage);
             return response;
         }
         const int countEntries = NKikimrLdap::CountEntries(request.Ld, searchMessage);
@@ -326,6 +336,7 @@ private:
             response.Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = false};
             response.Status = TEvLdapAuthProvider::EStatus::UNAUTHORIZED;
             NKikimrLdap::MsgFree(searchMessage);
+            LDAP_LOG_D(logErrorMessage);
             return response;
         }
         response.SearchMessage = searchMessage;

--- a/ydb/core/security/login_page.cpp
+++ b/ydb/core/security/login_page.cpp
@@ -8,29 +8,30 @@
 
 #include <ydb/core/util/address_classifier.h>
 #include <ydb/core/audit/audit_log.h>
-#include <ydb/core/base/tablet_pipe.h>
-#include <ydb/core/tx/scheme_cache/scheme_cache.h>
-#include <ydb/core/tx/schemeshard/schemeshard.h>
-#include <ydb/core/security/ldap_auth_provider/ldap_auth_provider.h>
+
+#include <ydb/core/base/ticket_parser.h>
+#include <ydb/core/grpc_services/base/base.h>
+#include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/public/api/grpc/ydb_auth_v1.grpc.pb.h>
 
 #include <ydb/library/login/login.h>
 #include <ydb/library/security/util.h>
 
+#include <util/datetime/base.h>  // for ToInstant
+
+
 namespace {
 
-using namespace NActors;
 using namespace NKikimr;
-using namespace NSchemeShard;
-using namespace NMonitoring;
 
 void AuditLogWebUILogout(const NHttp::THttpIncomingRequest& request, const TString& userSID) {
     static const TString WebLoginComponentName = "web-login";
     static const TString LogoutOperationName = "LOGOUT";
     static const TString EmptyValue = "{none}";
 
-    auto remoteAddress = NKikimr::NAddressClassifier::ExtractAddress(request.Address->ToString());
+    auto remoteAddress = NAddressClassifier::ExtractAddress(request.Address->ToString());
 
-    // NOTE: audit field set here must be in sync with ydb/core/tx/schemeshard/schemeshard_audit_log.h, AuditLogLogin()
+    // NOTE: audit field set here must be in sync with ydb/core/grpc_services/audit_logins.cpp, AuditLogLogin()
     AUDIT_LOG(
         AUDIT_PART("component", WebLoginComponentName)
         AUDIT_PART("remote_address", (!remoteAddress.empty() ? remoteAddress : EmptyValue))
@@ -41,7 +42,38 @@ void AuditLogWebUILogout(const NHttp::THttpIncomingRequest& request, const TStri
     );
 }
 
-using THttpResponsePtr = THolder<NMon::IEvHttpInfoRes>;
+struct TEvPrivate {
+    enum EEv {
+        EvLoginResponse = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+        EvEnd
+    };
+
+    static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+
+    struct TEvLoginResponse : NActors::TEventLocal<TEvLoginResponse, EvLoginResponse> {
+        Ydb::Auth::LoginResponse LoginResponse;
+
+        TEvLoginResponse(const Ydb::Auth::LoginResponse& loginResponse)
+            : LoginResponse(loginResponse)
+        {}
+    };
+};
+
+void SendLoginRequest(const TString& database, const TString& user, const TString& password, const TActorContext& recipientCtx) {
+    Ydb::Auth::LoginRequest request;
+    request.set_user(user);
+    request.set_password(password);
+
+    auto* actorSystem = recipientCtx.ActorSystem();
+    auto recipientId = recipientCtx.SelfID;
+
+    using TEvLoginRequest = NGRpcService::TGRpcRequestWrapperNoAuth<NGRpcService::TRpcServices::EvLogin, Ydb::Auth::LoginRequest, Ydb::Auth::LoginResponse>;
+
+    auto rpcFuture = NRpcService::DoLocalRpc<TEvLoginRequest>(std::move(request), database, {}, actorSystem);
+    rpcFuture.Subscribe([actorSystem, recipientId](const auto& future) {
+        actorSystem->Send(recipientId, new TEvPrivate::TEvLoginResponse(future.GetValueSync()));
+    });
+}
 
 class TLoginRequest : public NActors::TActorBootstrapped<TLoginRequest> {
 public:
@@ -60,11 +92,8 @@ public:
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvents::TEvPoisonPill, HandlePoisonPill);
-            hFunc(TEvTabletPipe::TEvClientConnected, HandleConnect);
-            hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleNavigate);
-            hFunc(TEvSchemeShard::TEvLoginResult, HandleResult);
-            hFunc(TEvLdapAuthProvider::TEvAuthenticateResponse, Handle);
             cFunc(TEvents::TSystem::Wakeup, HandleTimeout);
+            hFunc(TEvPrivate::TEvLoginResponse, HandleLoginResponse);
         }
     }
 
@@ -91,11 +120,10 @@ public:
             return ReplyErrorAndPassAway("400", "Bad Request", "Invalid JSON data");
         }
 
-        TString login;
         TString password;
         NJson::TJsonValue* jsonUser;
         if (postData.GetValuePointer("user", &jsonUser)) {
-            login = jsonUser->GetStringRobust();
+            User = jsonUser->GetStringRobust();
         } else {
             return ReplyErrorAndPassAway("400", "Bad Request", "User must be specified");
         }
@@ -111,83 +139,30 @@ public:
             Database = postData["database"].GetStringRobust();
         }
 
-        AuthCredentials = PrepareCredentials(login, password, AppData()->AuthConfig);
-        if (AuthCredentials.AuthType == TAuthCredentials::EAuthType::Ldap) {
-            ALOG_DEBUG(NActorsServices::HTTP, "Login: Requesting LDAP provider for user " << AuthCredentials.Login);
-            Send(MakeLdapAuthProviderID(), new TEvLdapAuthProvider::TEvAuthenticateRequest(AuthCredentials.Login, AuthCredentials.Password));
-        } else {
-            RequestLoginProvider();
-        }
+        SendLoginRequest(Database, User, password, ActorContext());
+
         Become(&TThis::StateWork, Timeout, new TEvents::TEvWakeup());
     }
 
-    static NTabletPipe::TClientConfig GetPipeClientConfig() {
-        NTabletPipe::TClientConfig clientConfig;
-        clientConfig.RetryPolicy = {.RetryLimitCount = 3};
-        return clientConfig;
-    }
 
-    void RequestSchemeShard(ui64 schemeShardTabletId) {
-        ALOG_DEBUG(NActorsServices::HTTP, "Login: Requesting schemeshard " << schemeShardTabletId << " for user " << AuthCredentials.Login);
-        IActor* pipe = NTabletPipe::CreateClient(SelfId(), schemeShardTabletId, GetPipeClientConfig());
-        PipeClient = RegisterWithSameMailbox(pipe);
-        THolder<TEvSchemeShard::TEvLogin> request = MakeHolder<TEvSchemeShard::TEvLogin>();
-        request.Get()->Record = CreateLoginRequest(AuthCredentials, AppData()->AuthConfig);
-        request.Get()->Record.SetPeerName(Request->Address->ToString());
-        NTabletPipe::SendData(SelfId(), PipeClient, request.Release());
-    }
+    void HandleLoginResponse(TEvPrivate::TEvLoginResponse::TPtr& ev) {
+        const auto& operation = ev->Get()->LoginResponse.operation();
 
-    void HandleNavigate(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-        const NSchemeCache::TSchemeCacheNavigate* response = ev->Get()->Request.Get();
-        if (response->ResultSet.size() == 1) {
-            if (response->ResultSet.front().Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
-                const NSchemeCache::TSchemeCacheNavigate::TEntry& entry = response->ResultSet.front();
-                ui64 schemeShardTabletId = entry.DomainInfo->ExtractSchemeShard();
-                RequestSchemeShard(schemeShardTabletId);
-                return;
+        if (operation.status() == Ydb::StatusIds::SUCCESS) {
+            Ydb::Auth::LoginResult loginResult;
+            operation.result().UnpackTo(&loginResult);
+
+            ReplyCookieAndPassAway(loginResult.token());
+
+        } else {
+            TString error;
+            if (operation.issues_size() > 0) {
+                error = operation.issues(0).message();
             } else {
-                ReplyErrorAndPassAway("503", "Service Unavailable", TStringBuilder()
-                    << "Status " << static_cast<int>(response->ResultSet.front().Status));
+                error = Ydb::StatusIds_StatusCode_Name(operation.status());
             }
-        } else {
-            ReplyErrorAndPassAway("503", "Service Unavailable", "Scheme error");
-        }
-    }
 
-    void Handle(TEvLdapAuthProvider::TEvAuthenticateResponse::TPtr& ev) {
-        TEvLdapAuthProvider::TEvAuthenticateResponse* response = ev->Get();
-        if (response->Status == TEvLdapAuthProvider::EStatus::SUCCESS) {
-            RequestLoginProvider();
-        } else {
-            ReplyErrorAndPassAway("403", "Forbidden", response->Error.Message);
-        }
-    }
-
-    void RequestLoginProvider() {
-        auto *domain = AppData()->DomainsInfo->GetDomain();
-        TString rootDatabase = "/" + domain->Name;
-        ui64 rootSchemeShardTabletId = domain->SchemeRoot;
-        if (!Database.empty() && Database != rootDatabase) {
-            Database = rootDatabase;
-            ALOG_DEBUG(NActorsServices::HTTP, "Login: Requesting schemecache for database " << Database);
-            Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(CreateNavigateKeySetRequest(Database).Release()));
-        } else {
-            Database = rootDatabase;
-            RequestSchemeShard(rootSchemeShardTabletId);
-        }
-    }
-
-    void HandleResult(TEvSchemeShard::TEvLoginResult::TPtr& ev) {
-        if (ev->Get()->Record.GetError()) {
-            ReplyErrorAndPassAway("403", "Forbidden", ev->Get()->Record.GetError());
-        } else {
-            ReplyCookieAndPassAway(ev->Get()->Record.GetToken());
-        }
-    }
-
-    void HandleConnect(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
-        if (ev->Get()->Status != NKikimrProto::OK) {
-            ReplyErrorAndPassAway("503", "Service Unavailable", "SchemeShard is not available");
+            ReplyErrorAndPassAway("403", "Forbidden", error);
         }
     }
 
@@ -220,7 +195,7 @@ public:
     }
 
     void ReplyCookieAndPassAway(const TString& cookie) {
-        ALOG_DEBUG(NActorsServices::HTTP, "Login success for " << AuthCredentials.Login);
+        ALOG_DEBUG(NActorsServices::HTTP, "Login success for " << User);
         NHttp::THeadersBuilder headers;
         SetCORS(headers);
         TDuration maxAge = (ToInstant(NLogin::TLoginProvider::GetTokenExpiresAt(cookie)) - TInstant::Now());
@@ -230,7 +205,7 @@ public:
     }
 
     void ReplyErrorAndPassAway(const TString& status, const TString& message, const TString& error) {
-        ALOG_ERROR(NActorsServices::HTTP, "Login: " << error);
+        ALOG_ERROR(NActorsServices::HTTP, "Login fail for " << User << ": " << error);
         NHttp::THeadersBuilder headers;
         SetCORS(headers);
         headers.Set("Content-Type", "application/json");
@@ -240,20 +215,12 @@ public:
         PassAway();
     }
 
-    void PassAway() override {
-        if (PipeClient) {
-            NTabletPipe::CloseClient(TBase::SelfId(), PipeClient);
-        }
-        TBase::PassAway();
-    }
-
 protected:
     TActorId Sender;
     NHttp::THttpIncomingRequestPtr Request;
     TDuration Timeout = TDuration::Seconds(60);
+    TString User;
     TString Database;
-    TActorId PipeClient;
-    TAuthCredentials AuthCredentials;
 };
 
 class TLogoutRequest : public NActors::TActorBootstrapped<TLogoutRequest> {
@@ -293,7 +260,7 @@ public:
             return ReplyErrorAndPassAway("401", "Unauthorized", "No ydb_session_id cookie");
         }
 
-        Send(NKikimr::MakeTicketParserID(), new NKikimr::TEvTicketParser::TEvAuthorizeTicket({
+        Send(MakeTicketParserID(), new TEvTicketParser::TEvAuthorizeTicket({
             .Database = TString(),
             .Ticket = TString("Login ") + ydbSessionId,
             .PeerName = Request->Address->ToString(),

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -1,7 +1,6 @@
 #include <ydb/library/security/util.h>
 #include <ydb/core/protos/auth.pb.h>
 
-#include "schemeshard_audit_log.h"
 #include "schemeshard_impl.h"
 
 namespace NKikimr {
@@ -85,8 +84,6 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
             if (loginResponse.Token) {
                 result->Record.SetToken(loginResponse.Token);
             }
-
-            AuditLogLogin(Request->Get()->Record, result->Record, Self);
 
         } else {
             result->Record.SetError("Login authentication is disabled");

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
@@ -379,25 +379,4 @@ void AuditLogImportEnd(const TImportInfo& info, TSchemeShard* SS) {
     _AuditLogXxportEnd(info, "IMPORT END", ImportKindSpecificParts(info.Settings), SS);
 }
 
-void AuditLogLogin(const NKikimrScheme::TEvLogin& request, const NKikimrScheme::TEvLoginResult& response, TSchemeShard* SS) {
-    static const TString LoginOperationName = "LOGIN";
-
-    TPath databasePath = TPath::Root(SS);
-    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(request.GetPeerName());
-
-    // NOTE: audit field set here must be in sync with ydb/core/security/login_page.cpp, AuditLogWebUILogout()
-    AUDIT_LOG(
-        AUDIT_PART("component", SchemeshardComponentName)
-        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EmptyValue))
-        AUDIT_PART("database", (!databasePath.PathString().empty() ? databasePath.PathString() : EmptyValue))
-        AUDIT_PART("operation", LoginOperationName)
-        AUDIT_PART("status", TString(response.GetError().empty() ? "SUCCESS" : "ERROR"))
-        AUDIT_PART("reason", response.GetError(), response.HasError())
-
-        // Login
-        AUDIT_PART("login_user", (request.HasUser() ? request.GetUser() : EmptyValue))
-        AUDIT_PART("login_auth_domain", (!request.GetExternalAuth().empty() ? request.GetExternalAuth() : EmptyValue))
-    );
-}
-
 }

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log.h
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log.h
@@ -39,7 +39,4 @@ void AuditLogExportEnd(const TExportInfo& exportInfo, TSchemeShard* SS);
 void AuditLogImportStart(const NKikimrImport::TEvCreateImportRequest& request, const NKikimrImport::TEvCreateImportResponse& response, TSchemeShard* SS);
 void AuditLogImportEnd(const TImportInfo& importInfo, TSchemeShard* SS);
 
-void AuditLogLogin(const NKikimrScheme::TEvLogin& request, const NKikimrScheme::TEvLoginResult& response, TSchemeShard* SS);
-void AuditLogWebUILogout(const NHttp::THttpIncomingRequest& request, const TString& userSID);
-
 }

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -2,11 +2,13 @@
 
 #include <ydb/library/login/login.h>
 #include <ydb/library/actors/http/http_proxy.h>
+#include <ydb/library/testlib/service_mocks/ldap_mock/ldap_simple_server.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/auditlog_helpers.h>
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/security/ticket_parser.h>
 #include <ydb/core/security/login_page.h>
+#include <ydb/core/security/ldap_auth_provider/ldap_auth_provider.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -28,6 +30,7 @@ void TestCreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const
 }  // namespace NSchemeShardUT_Private
 
 Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
+
     Y_UNIT_TEST(BasicLogin) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -62,68 +65,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         UNIT_ASSERT(describe.GetPathDescription().HasDomainDescription());
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().HasSecurityState());
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().GetSecurityState().PublicKeysSize() > 0);
-    }
-
-    Y_UNIT_TEST(AuditLogLoginSuccess) {
-        TTestBasicRuntime runtime;
-        std::vector<std::string> lines;
-        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
-        TTestEnv env(runtime);
-
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
-
-        ui64 txId = 100;
-
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);   // +user creation
-
-        // test body
-        {
-            auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_C(resultLogin.error().empty(), resultLogin);
-        }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);   // +user login
-
-        auto last = FindAuditLine(lines, "operation=LOGIN");
-        UNIT_ASSERT_STRING_CONTAINS(last, "component=schemeshard");
-        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=");  // can't check the value
-        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
-        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
-        UNIT_ASSERT_STRING_CONTAINS(last, "status=SUCCESS");
-        UNIT_ASSERT(!last.contains("reason"));
-        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1");
-        UNIT_ASSERT_STRING_CONTAINS(last, "login_auth_domain={none}");
-    }
-
-    Y_UNIT_TEST(AuditLogLoginFailure) {
-        TTestBasicRuntime runtime;
-        std::vector<std::string> lines;
-        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
-        TTestEnv env(runtime);
-
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
-
-        ui64 txId = 100;
-
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);   // +user creation
-
-        // test body
-        {
-            auto resultLogin = Login(runtime, "user1", "bad_password");
-            UNIT_ASSERT_C(!resultLogin.error().empty(), resultLogin);
-        }
-        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);   // +user login
-
-        auto last = FindAuditLine(lines, "operation=LOGIN");
-        UNIT_ASSERT_STRING_CONTAINS(last, "component=schemeshard");
-        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=");  // can't check the value
-        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
-        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
-        UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
-        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Invalid password");
-        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1");
-        UNIT_ASSERT_STRING_CONTAINS(last, "login_auth_domain={none}");
     }
 }
 
@@ -177,7 +118,466 @@ NHttp::THttpIncomingRequestPtr MakeLogoutRequest(const TString& cookieName, cons
 
 Y_UNIT_TEST_SUITE(TWebLoginService) {
 
-    Y_UNIT_TEST(Logout) {
+    Y_UNIT_TEST(AuditLogLoginSuccess) {
+        TTestBasicRuntime runtime;
+        std::vector<std::string> lines;
+        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
+        TTestEnv env(runtime);
+
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+
+        ui64 txId = 100;
+
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);   // +user creation
+
+        // test body
+        const auto target = runtime.Register(CreateWebLoginService());
+        const auto edge = runtime.AllocateEdgeActor();
+
+        {
+            runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+                MakeLoginRequest("user1", "password1")
+            )));
+
+            TAutoPtr<IEventHandle> handle;
+            auto responseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+            UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "200");
+            NHttp::THeaders headers(responseEv->Response->Headers);
+            NHttp::TCookies cookies(headers["Set-Cookie"]);
+            UNIT_ASSERT(!cookies["ydb_session_id"].empty());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);  // +user login
+
+        auto last = FindAuditLine(lines, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
+        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=localhost");
+        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
+        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "status=SUCCESS");
+        UNIT_ASSERT(!last.contains("reason"));
+        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1");
+    }
+
+    Y_UNIT_TEST(AuditLogLoginBadPassword) {
+        TTestBasicRuntime runtime;
+        std::vector<std::string> lines;
+        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
+        TTestEnv env(runtime);
+
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+
+        ui64 txId = 100;
+
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);   // +user creation
+
+        // test body
+        const auto target = runtime.Register(CreateWebLoginService());
+        const auto edge = runtime.AllocateEdgeActor();
+
+        TString ydbSessionId;
+        {
+            runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+                MakeLoginRequest("user1", "bad_password")
+            )));
+
+            TAutoPtr<IEventHandle> handle;
+            auto responseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+            UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "403");
+            NJson::TJsonValue body(responseEv->Response->Body);
+            UNIT_ASSERT_STRINGS_EQUAL(body.GetStringRobust(), "{\"error\":\"Invalid password\"}");
+        }
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 3);  // +user login
+
+        auto last = FindAuditLine(lines, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
+        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=localhost");
+        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
+        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
+        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Invalid password");
+        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1");
+    }
+
+    Y_UNIT_TEST(AuditLogLdapLoginSuccess) {
+        TTestBasicRuntime runtime;
+        std::vector<std::string> lines;
+        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
+        // Enable and configure ldap auth
+        runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
+        TTestEnv env(runtime);
+
+        // configure ldap auth
+        auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
+        {
+            auto& appData = runtime.GetAppData();
+            appData.AuthConfig.SetUseBlackBox(false);
+            appData.AuthConfig.SetUseLoginProvider(true);
+            auto& ldapSettings = *appData.AuthConfig.MutableLdapAuthentication();
+            ldapSettings.MutableUseTls()->SetCertRequire(NKikimrProto::TLdapAuthentication::TUseTls::NEVER);
+            ldapSettings.SetPort(ldapPort);
+            ldapSettings.AddHosts("localhost");
+            ldapSettings.SetBaseDn("dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindDn("cn=robouser,dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindPassword("robouserPassword");
+            ldapSettings.SetSearchFilter("uid=$username");
+        }
+
+        // start ldap auth provider service
+        {
+            IActor* ldapAuthProvider = NKikimr::CreateLdapAuthProvider(runtime.GetAppData().AuthConfig.GetLdapAuthentication());
+            TActorId ldapAuthProviderId = runtime.Register(ldapAuthProvider);
+            runtime.RegisterService(MakeLdapAuthProviderID(), ldapAuthProviderId);
+        }
+
+        // start mock ldap server with predefined responses
+        auto ldapResponses = [](const TString& login, const TString& password) -> LdapMock::TLdapMockResponses {
+            return LdapMock::TLdapMockResponses{
+                .BindResponses = {
+                    {
+                        {{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "robouserPassword"}},
+                        {.Status = LdapMock::EStatus::SUCCESS}
+                    },
+                    {
+                        {{.Login = "uid=" + login + ",dc=search,dc=yandex,dc=net", .Password = password}},
+                        {.Status = LdapMock::EStatus::SUCCESS}
+                    },
+                },
+                .SearchResponses = {
+                    {
+                        {{
+                            .BaseDn = "dc=search,dc=yandex,dc=net",
+                            .Scope = 2,
+                            .DerefAliases = 0,
+                            .Filter = {.Type = LdapMock::EFilterType::LDAP_FILTER_EQUALITY, .Attribute = "uid", .Value = login},
+                            .Attributes = {"1.1"},
+                        }},
+                        {
+                            .ResponseEntries = {{.Dn = "uid=" + login + ",dc=search,dc=yandex,dc=net"}},
+                            .ResponseDone = {.Status = LdapMock::EStatus::SUCCESS}
+                        }
+                    },
+                },
+            };
+        };
+        LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("user1", "password1"));
+
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+
+        // test body
+        const auto target = runtime.Register(CreateWebLoginService());
+        const auto edge = runtime.AllocateEdgeActor();
+
+        {
+            runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+                MakeLoginRequest("user1@ldap", "password1")
+            )));
+
+            TAutoPtr<IEventHandle> handle;
+            auto responseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+            UNIT_ASSERT_STRINGS_EQUAL_C(responseEv->Response->Status, "200", responseEv->Response->Body);
+            NHttp::THeaders headers(responseEv->Response->Headers);
+            NHttp::TCookies cookies(headers["Set-Cookie"]);
+            UNIT_ASSERT(!cookies["ydb_session_id"].empty());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+
+        auto last = FindAuditLine(lines, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
+        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=localhost");
+        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
+        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "status=SUCCESS");
+        UNIT_ASSERT(!last.contains("detailed_status"));
+        UNIT_ASSERT(!last.contains("reason"));
+        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1@ldap");
+    }
+
+    Y_UNIT_TEST(AuditLogLdapLoginBadPassword) {
+        TTestBasicRuntime runtime;
+        std::vector<std::string> lines;
+        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
+        // Enable and configure ldap auth
+        runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
+        TTestEnv env(runtime);
+
+        // configure ldap auth
+        auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
+        {
+            auto& appData = runtime.GetAppData();
+            appData.AuthConfig.SetUseBlackBox(false);
+            appData.AuthConfig.SetUseLoginProvider(true);
+            auto& ldapSettings = *appData.AuthConfig.MutableLdapAuthentication();
+            ldapSettings.MutableUseTls()->SetCertRequire(NKikimrProto::TLdapAuthentication::TUseTls::NEVER);
+            ldapSettings.SetPort(ldapPort);
+            ldapSettings.AddHosts("localhost");
+            ldapSettings.SetBaseDn("dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindDn("cn=robouser,dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindPassword("robouserPassword");
+            ldapSettings.SetSearchFilter("uid=$username");
+        }
+
+        // start ldap auth provider service
+        {
+            IActor* ldapAuthProvider = NKikimr::CreateLdapAuthProvider(runtime.GetAppData().AuthConfig.GetLdapAuthentication());
+            TActorId ldapAuthProviderId = runtime.Register(ldapAuthProvider);
+            runtime.RegisterService(MakeLdapAuthProviderID(), ldapAuthProviderId);
+        }
+
+        // start mock ldap server with predefined responses
+        auto ldapResponses = [](const TString& login, const TString& password) -> LdapMock::TLdapMockResponses {
+            return LdapMock::TLdapMockResponses{
+                .BindResponses = {
+                    {
+                        {{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "robouserPassword"}},
+                        {.Status = LdapMock::EStatus::SUCCESS}
+                    },
+                    {
+                        {{.Login = "uid=" + login + ",dc=search,dc=yandex,dc=net", .Password = password}},
+                        {.Status = LdapMock::EStatus::INVALID_CREDENTIALS}
+                    },
+                },
+                .SearchResponses = {
+                    {
+                        {{
+                            .BaseDn = "dc=search,dc=yandex,dc=net",
+                            .Scope = 2,
+                            .DerefAliases = 0,
+                            .Filter = {.Type = LdapMock::EFilterType::LDAP_FILTER_EQUALITY, .Attribute = "uid", .Value = login},
+                            .Attributes = {"1.1"},
+                        }},
+                        {
+                            .ResponseEntries = {{.Dn = "uid=" + login + ",dc=search,dc=yandex,dc=net"}},
+                            .ResponseDone = {.Status = LdapMock::EStatus::SUCCESS}
+                        }
+                    },
+                },
+            };
+        };
+        LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("user1", "bad_password"));
+
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+
+        // test body
+        const auto target = runtime.Register(CreateWebLoginService());
+        const auto edge = runtime.AllocateEdgeActor();
+
+        {
+            runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+                MakeLoginRequest("user1@ldap", "bad_password")
+            )));
+
+            TAutoPtr<IEventHandle> handle;
+            auto responseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+            UNIT_ASSERT_STRINGS_EQUAL_C(responseEv->Response->Status, "403", responseEv->Response->Body);
+            NHttp::THeaders headers(responseEv->Response->Headers);
+            NHttp::TCookies cookies(headers["Set-Cookie"]);
+            UNIT_ASSERT(cookies["ydb_session_id"].empty());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+
+        auto last = FindAuditLine(lines, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
+        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=localhost");
+        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
+        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
+        UNIT_ASSERT_STRING_CONTAINS(last, "detailed_status=UNAUTHORIZED");
+        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP");
+        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1@ldap");
+    }
+
+    Y_UNIT_TEST(AuditLogLdapLoginBadUser) {
+        TTestBasicRuntime runtime;
+        std::vector<std::string> lines;
+        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
+        // Enable and configure ldap auth
+        runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
+        TTestEnv env(runtime);
+
+        // configure ldap auth
+        auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
+        {
+            auto& appData = runtime.GetAppData();
+            appData.AuthConfig.SetUseBlackBox(false);
+            appData.AuthConfig.SetUseLoginProvider(true);
+            auto& ldapSettings = *appData.AuthConfig.MutableLdapAuthentication();
+            ldapSettings.MutableUseTls()->SetCertRequire(NKikimrProto::TLdapAuthentication::TUseTls::NEVER);
+            ldapSettings.SetPort(ldapPort);
+            ldapSettings.AddHosts("localhost");
+            ldapSettings.SetBaseDn("dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindDn("cn=robouser,dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindPassword("robouserPassword");
+            ldapSettings.SetSearchFilter("uid=$username");
+        }
+
+        // start ldap auth provider service
+        {
+            IActor* ldapAuthProvider = NKikimr::CreateLdapAuthProvider(runtime.GetAppData().AuthConfig.GetLdapAuthentication());
+            TActorId ldapAuthProviderId = runtime.Register(ldapAuthProvider);
+            runtime.RegisterService(MakeLdapAuthProviderID(), ldapAuthProviderId);
+        }
+
+        // start mock ldap server with predefined responses
+        auto ldapResponses = [](const TString& login, const TString& password) -> LdapMock::TLdapMockResponses {
+            return LdapMock::TLdapMockResponses{
+                .BindResponses = {
+                    {
+                        {{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "robouserPassword"}},
+                        {.Status = LdapMock::EStatus::SUCCESS}
+                    },
+                    {
+                        {{.Login = "uid=" + login + ",dc=search,dc=yandex,dc=net", .Password = password}},
+                        {.Status = LdapMock::EStatus::INVALID_CREDENTIALS}
+                    },
+                },
+                .SearchResponses = {
+                    {
+                        {{
+                            .BaseDn = "dc=search,dc=yandex,dc=net",
+                            .Scope = 2,
+                            .DerefAliases = 0,
+                            .Filter = {.Type = LdapMock::EFilterType::LDAP_FILTER_EQUALITY, .Attribute = "uid", .Value = login},
+                            .Attributes = {"1.1"},
+                        }},
+                        {
+                            .ResponseEntries = {},
+                            .ResponseDone = {.Status = LdapMock::EStatus::SUCCESS}
+                        }
+                    },
+                },
+            };
+        };
+        LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("bad_user", "password1"));
+
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+
+        // test body
+        const auto target = runtime.Register(CreateWebLoginService());
+        const auto edge = runtime.AllocateEdgeActor();
+
+        {
+            runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+                MakeLoginRequest("bad_user@ldap", "password1")
+            )));
+
+            TAutoPtr<IEventHandle> handle;
+            auto responseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+            UNIT_ASSERT_STRINGS_EQUAL_C(responseEv->Response->Status, "403", responseEv->Response->Body);
+            NHttp::THeaders headers(responseEv->Response->Headers);
+            NHttp::TCookies cookies(headers["Set-Cookie"]);
+            UNIT_ASSERT(cookies["ydb_session_id"].empty());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+
+        auto last = FindAuditLine(lines, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
+        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=localhost");
+        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
+        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
+        UNIT_ASSERT_STRING_CONTAINS(last, "detailed_status=UNAUTHORIZED");
+        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP");
+        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=bad_user@ldap");
+    }
+
+    // LDAP response to bad BindDn or BindPassword is the same, so this test covers the both cases.
+    Y_UNIT_TEST(AuditLogLdapLoginBadBind) {
+        TTestBasicRuntime runtime;
+        std::vector<std::string> lines;
+        runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
+        // Enable and configure ldap auth
+        runtime.SetLogPriority(NKikimrServices::LDAP_AUTH_PROVIDER, NActors::NLog::PRI_DEBUG);
+        TTestEnv env(runtime);
+
+        // configure ldap auth
+        auto ldapPort = runtime.GetPortManager().GetPort();  // randomized port
+        {
+            auto& appData = runtime.GetAppData();
+            appData.AuthConfig.SetUseBlackBox(false);
+            appData.AuthConfig.SetUseLoginProvider(true);
+            auto& ldapSettings = *appData.AuthConfig.MutableLdapAuthentication();
+            ldapSettings.MutableUseTls()->SetCertRequire(NKikimrProto::TLdapAuthentication::TUseTls::NEVER);
+            ldapSettings.SetPort(ldapPort);
+            ldapSettings.AddHosts("localhost");
+            ldapSettings.SetBaseDn("dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindDn("cn=robouser,dc=search,dc=yandex,dc=net");
+            ldapSettings.SetBindPassword("robouserPassword");
+            ldapSettings.SetSearchFilter("uid=$username");
+        }
+
+        // start ldap auth provider service
+        {
+            IActor* ldapAuthProvider = NKikimr::CreateLdapAuthProvider(runtime.GetAppData().AuthConfig.GetLdapAuthentication());
+            TActorId ldapAuthProviderId = runtime.Register(ldapAuthProvider);
+            runtime.RegisterService(MakeLdapAuthProviderID(), ldapAuthProviderId);
+        }
+
+        // start mock ldap server with predefined responses
+        auto ldapResponses = [](const TString& login, const TString& password) -> LdapMock::TLdapMockResponses {
+            return LdapMock::TLdapMockResponses{
+                .BindResponses = {
+                    {
+                        {{.Login = "cn=robouser,dc=search,dc=yandex,dc=net", .Password = "robouserPassword"}},
+                        {.Status = LdapMock::EStatus::INVALID_CREDENTIALS}
+                    },
+                    {
+                        {{.Login = "uid=" + login + ",dc=search,dc=yandex,dc=net", .Password = password}},
+                        {.Status = LdapMock::EStatus::SUCCESS}
+                    },
+                },
+                .SearchResponses = {
+                    {
+                        {{
+                            .BaseDn = "dc=search,dc=yandex,dc=net",
+                            .Scope = 2,
+                            .DerefAliases = 0,
+                            .Filter = {.Type = LdapMock::EFilterType::LDAP_FILTER_EQUALITY, .Attribute = "uid", .Value = login},
+                            .Attributes = {"1.1"},
+                        }},
+                        {
+                            .ResponseEntries = {{.Dn = "uid=" + login + ",dc=search,dc=yandex,dc=net"}},
+                            .ResponseDone = {.Status = LdapMock::EStatus::SUCCESS}
+                        }
+                    },
+                },
+            };
+        };
+        LdapMock::TLdapSimpleServer ldapServer(ldapPort, ldapResponses("user1", "password1"));
+
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 1);   // alter root subdomain
+
+        // test body
+        const auto target = runtime.Register(CreateWebLoginService());
+        const auto edge = runtime.AllocateEdgeActor();
+
+        {
+            runtime.Send(new IEventHandle(target, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(
+                MakeLoginRequest("user1@ldap", "password1")
+            )));
+
+            TAutoPtr<IEventHandle> handle;
+            auto responseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+            UNIT_ASSERT_STRINGS_EQUAL_C(responseEv->Response->Status, "403", responseEv->Response->Body);
+            NHttp::THeaders headers(responseEv->Response->Headers);
+            NHttp::TCookies cookies(headers["Set-Cookie"]);
+            UNIT_ASSERT(cookies["ydb_session_id"].empty());
+        }
+        UNIT_ASSERT_VALUES_EQUAL(lines.size(), 2);  // +user login
+
+        auto last = FindAuditLine(lines, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "component=grpc-login");
+        UNIT_ASSERT_STRING_CONTAINS(last, "remote_address=localhost");
+        UNIT_ASSERT_STRING_CONTAINS(last, "database=/MyRoot");
+        UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
+        UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
+        UNIT_ASSERT_STRING_CONTAINS(last, "detailed_status=UNAUTHORIZED");
+        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP");
+        UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1@ldap");
+    }
+
+    Y_UNIT_TEST(AuditLogLogout) {
         TTestBasicRuntime runtime;
         std::vector<std::string> lines;
         runtime.AuditLogBackends = std::move(CreateTestAuditLogBackends(lines));
@@ -264,6 +664,10 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             TAutoPtr<IEventHandle> handle;
             auto responseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
             UNIT_ASSERT_STRINGS_EQUAL(responseEv->Response->Status, "200");
+            {
+                NHttp::THeaders headers(responseEv->Response->Headers);
+                UNIT_ASSERT_STRINGS_EQUAL(headers["Set-Cookie"], "ydb_session_id=; Max-Age=0");
+            }
 
             UNIT_ASSERT_VALUES_EQUAL(lines.size(), 4);  // +user web logout
 

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -384,7 +384,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
         UNIT_ASSERT_STRING_CONTAINS(last, "detailed_status=UNAUTHORIZED");
-        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP");
+        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP: LDAP login failed for user uid=user1,dc=search,dc=yandex,dc=net on server ldap://localhost:");
         UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1@ldap");
     }
 
@@ -478,11 +478,11 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
         UNIT_ASSERT_STRING_CONTAINS(last, "detailed_status=UNAUTHORIZED");
-        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP");
+        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP: LDAP user bad_user does not exist. LDAP search for filter uid=bad_user on server ldap://localhost:");
         UNIT_ASSERT_STRING_CONTAINS(last, "login_user=bad_user@ldap");
     }
 
-    // LDAP response to bad BindDn or BindPassword is the same, so this test covers the both cases.
+    // LDAP responses to bad BindDn or bad BindPassword are the same, so this test covers the both cases.
     Y_UNIT_TEST(AuditLogLdapLoginBadBind) {
         TTestBasicRuntime runtime;
         std::vector<std::string> lines;
@@ -573,7 +573,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         UNIT_ASSERT_STRING_CONTAINS(last, "operation=LOGIN");
         UNIT_ASSERT_STRING_CONTAINS(last, "status=ERROR");
         UNIT_ASSERT_STRING_CONTAINS(last, "detailed_status=UNAUTHORIZED");
-        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP");
+        UNIT_ASSERT_STRING_CONTAINS(last, "reason=Could not login via LDAP: Could not perform initial LDAP bind for dn cn=robouser,dc=search,dc=yandex,dc=net on server ldap://localhost:");
         UNIT_ASSERT_STRING_CONTAINS(last, "login_user=user1@ldap");
     }
 

--- a/ydb/core/tx/schemeshard/ut_login/ya.make
+++ b/ydb/core/tx/schemeshard/ut_login/ya.make
@@ -19,6 +19,7 @@ PEERDIR(
     ydb/core/tx
     ydb/core/tx/schemeshard/ut_helpers
     ydb/library/login
+    ydb/library/testlib/service_mocks/ldap_mock
     ydb/library/yql/public/udf/service/exception_policy
 )
 

--- a/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
+++ b/ydb/library/testlib/service_mocks/ldap_mock/ldap_message_processor.cpp
@@ -160,6 +160,7 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
 
     if (length == 0) {
         responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        Cerr << "LDAP_MOCK: ExtendedRequest, protocol error, length 1 is zero" << Endl;
         return {responseOpData};
     }
 
@@ -170,6 +171,8 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     EStatus status = EStatus::PROTOCOL_ERROR;
     if (oidValue == LDAP_EXOP_START_TLS) {
         status = EStatus::SUCCESS;
+    } else {
+        Cerr << "LDAP_MOCK: ExtendedRequest, protocol error, oidValue != LDAP_EXOP_START_TLS" << Endl;
     }
 
     responseOpData.Data = CreateExtendedResponse({.Status = status}, oidValue, "");
@@ -187,18 +190,21 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
 
     if (length == 0) {
         responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        Cerr << "LDAP_MOCK: BindRequest, protocol error, length 1 is zero" << Endl;
         return {responseOpData};
     }
 
     int version = GetInt();
     if (version > 127) {
         responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        Cerr << "LDAP_MOCK: BindRequest, protocol error, version > 127" << Endl;
         return {responseOpData};
     }
 
     unsigned char elementType = GetByte();
     if (elementType != EElementType::STRING) {
         responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        Cerr << "LDAP_MOCK: BindRequest, protocol error, login is not a string" << Endl;
         return {responseOpData};
     }
 
@@ -216,6 +222,7 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
 
     if (it == responses.end()) {
         responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        Cerr << "LDAP_MOCK: BindRequest, protocol error, unexpected request, not matched any of provided to mock" << Endl;
         return {responseOpData};
     }
 
@@ -231,14 +238,16 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
 
     size_t length = GetLength();
     if (length == 0) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "length 1 is zero"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, length 1 is zero" << Endl;
         return {responseOpData};
     }
 
     // Extract BaseDn
     unsigned char elementType = GetByte();
     if (elementType != EElementType::STRING) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "BaseDn is not a string type"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, BaseDn is not a string type" << Endl;
         return {responseOpData};
     }
 
@@ -247,12 +256,14 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     // Extract scope
     elementType = GetByte();
     if (elementType != EElementType::ENUMERATED) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "Scope is not an enum type"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, Scope is not an enum type" << Endl;
         return {responseOpData};
     }
     length = GetLength();
     if (length == 0) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "length 2 is zero"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, length 2 is zero" << Endl;
         return {responseOpData};
     }
     requestInfo.Scope = GetByte();
@@ -260,12 +271,14 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     // Extract derefAliases
     elementType = GetByte();
     if (elementType != EElementType::ENUMERATED) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "DerefAliases is not en enum"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, DerefAliases is not en enum" << Endl;
         return {responseOpData};
     }
     length = GetLength();
     if (length == 0) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "length 3 is zero"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, length 3 is zero" << Endl;
         return {responseOpData};
     }
     requestInfo.DerefAliases = GetByte();
@@ -281,12 +294,14 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     // Extract typesOnly
     elementType = GetByte();
     if (elementType != EElementType::BOOL) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "TypesOnly is not bool"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, TypesOnly is not bool" << Endl;
         return {responseOpData};
     }
     length = GetLength();
     if (length == 0) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "length 4 is zero"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, length 4 is zero" << Endl;
         return {responseOpData};
     }
     requestInfo.TypesOnly = GetByte();
@@ -296,7 +311,8 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     // Extract Attributes
     elementType = GetByte();
     if (elementType != EElementType::SEQUENCE) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "Attributes is not a sequence"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, Attributes is not a sequence" << Endl;
         return {responseOpData};
     }
     length = GetLength();
@@ -304,7 +320,8 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     while (ReadBytes < limit) {
         elementType = GetByte();
         if (elementType != EElementType::STRING) {
-            responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+            responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "Attribute is not a string"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, Attribute is not a string" << Endl;
             return {responseOpData};
         }
         requestInfo.Attributes.push_back(GetString());
@@ -316,7 +333,8 @@ std::vector<TLdapRequestProcessor::TProtocolOpData> TLdapRequestProcessor::Proce
     });
 
     if (it == responses.end()) {
-        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR});
+        responseOpData.Data = CreateResponse({.Status = EStatus::PROTOCOL_ERROR, .DiagnosticMsg = "unexpected request, not matched any of provided to mock"});
+        Cerr << "LDAP_MOCK: SearchRequest, protocol error, unexpected request, not matched any of provided to mock" << Endl;
         return {responseOpData};
     }
 


### PR DESCRIPTION
Move audit logging of login operations from schemeshard to grpc service auth (`AuthService`).
Update web-login service login to utilize `AuthService.Login`.
Establish `AuthService` as the sole gateway and audit point for all login operations.

Dependencies:
- https://github.com/ydb-platform/ydb/pull/7060
- https://github.com/ydb-platform/ydb/pull/11403
- https://github.com/ydb-platform/ydb/pull/11404

### Changelog entry

Fix audit log not recording unsuccessful ldap logins.

### Changelog category

* Bugfix 

