### PR TITLE
oidc impersonation

### DIFF
--- a/ydb/mvp/oidc_proxy/context.cpp
+++ b/ydb/mvp/oidc_proxy/context.cpp
@@ -7,8 +7,7 @@
 #include "oidc_settings.h"
 #include "context.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 TContext::TContext(const TInitializer& initializer)
     : State(initializer.State)
@@ -94,5 +93,4 @@ TStringBuf TContext::GetRequestedUrl(const NHttp::THttpIncomingRequestPtr& reque
     return requestedUrl;
 }
 
-} // NOIDC
-} // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/context.h
+++ b/ydb/mvp/oidc_proxy/context.h
@@ -10,8 +10,7 @@ using THttpIncomingRequestPtr = TIntrusivePtr<THttpIncomingRequest>;
 
 }
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 class TContext {
 public:
@@ -45,5 +44,4 @@ private:
     TString GenerateCookie(const TString& key) const;
 };
 
-} // NOIDC
-} // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/mvp.cpp
+++ b/ydb/mvp/oidc_proxy/mvp.cpp
@@ -28,8 +28,7 @@
 
 NActors::IActor* CreateMemProfiler();
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 namespace {
 
@@ -418,5 +417,4 @@ THolder<NActors::TActorSystemSetup> TMVP::BuildActorSystemSetup(int argc, char**
 
 TAtomic TMVP::Quit = false;
 
-} // NOIDC
-} // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/mvp.cpp
+++ b/ydb/mvp/oidc_proxy/mvp.cpp
@@ -233,6 +233,7 @@ void TMVP::TryGetOidcOptionsFromConfig(const YAML::Node& config) {
     OpenIdConnectSettings.AuthUrlPath = oidc["auth_url_path"].as<std::string>(OpenIdConnectSettings.DEFAULT_AUTH_URL_PATH);
     OpenIdConnectSettings.TokenUrlPath = oidc["token_url_path"].as<std::string>(OpenIdConnectSettings.DEFAULT_TOKEN_URL_PATH);
     OpenIdConnectSettings.ExchangeUrlPath = oidc["exchange_url_path"].as<std::string>(OpenIdConnectSettings.DEFAULT_EXCHANGE_URL_PATH);
+    OpenIdConnectSettings.ImpersonateUrlPath = oidc["impersonate_url_path"].as<std::string>(OpenIdConnectSettings.DEFAULT_IMPERSONATE_URL_PATH);
     Cout << "Started processing allowed_proxy_hosts..." << Endl;
     for (const std::string& host : oidc["allowed_proxy_hosts"].as<std::vector<std::string>>()) {
         Cout << host << " added to allowed_proxy_hosts" << Endl;

--- a/ydb/mvp/oidc_proxy/mvp.h
+++ b/ydb/mvp/oidc_proxy/mvp.h
@@ -12,8 +12,7 @@
 #include <contrib/libs/yaml-cpp/include/yaml-cpp/yaml.h>
 #include "oidc_settings.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 const TString& GetEServiceName(NActors::NLog::EComponent component);
 
@@ -72,5 +71,4 @@ public:
     int Shutdown();
 };
 
-} // namespace NOIDC
-} // namespace NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_client.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_client.cpp
@@ -15,6 +15,18 @@ void InitOIDC(NActors::TActorSystem& actorSystem,
                      );
 
     actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
+                         "/impersonate/start",
+                         actorSystem.Register(new THandlerImpersonateStart(httpProxyId, settings))
+                         )
+                     );
+
+    actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
+                         "/impersonate/stop",
+                         actorSystem.Register(new THandlerImpersonateStop(httpProxyId, settings))
+                         )
+                     );
+
+    actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
                         "/",
                         actorSystem.Register(new TProtectedPageHandler(httpProxyId, settings))
                         )

--- a/ydb/mvp/oidc_proxy/oidc_client.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_client.cpp
@@ -4,8 +4,9 @@
 #include "oidc_impersonate_start_page_nebius.h"
 #include "oidc_impersonate_stop_page_nebius.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
+
+using namespace NActors;
 
 void InitOIDC(NActors::TActorSystem& actorSystem,
               const NActors::TActorId& httpProxyId,
@@ -37,5 +38,4 @@ void InitOIDC(NActors::TActorSystem& actorSystem,
                     );
 }
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_client.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_client.cpp
@@ -1,6 +1,8 @@
 #include "oidc_client.h"
 #include "oidc_protected_page_handler.h"
 #include "oidc_session_create_handler.h"
+#include "oidc_impersonate_start_page_nebius.h"
+#include "oidc_impersonate_stop_page_nebius.h"
 
 namespace NMVP {
 namespace NOIDC {
@@ -14,17 +16,19 @@ void InitOIDC(NActors::TActorSystem& actorSystem,
                          )
                      );
 
-    actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
-                         "/impersonate/start",
-                         actorSystem.Register(new THandlerImpersonateStart(httpProxyId, settings))
-                         )
-                     );
+    if (settings.AccessServiceType == NMvp::nebius_v1) {
+        actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
+                            "/impersonate/start",
+                            actorSystem.Register(new TImpersonateStartPageHandler(httpProxyId, settings))
+                            )
+                        );
 
-    actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
-                         "/impersonate/stop",
-                         actorSystem.Register(new THandlerImpersonateStop(httpProxyId, settings))
-                         )
-                     );
+        actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
+                            "/impersonate/stop",
+                            actorSystem.Register(new TImpersonateStopPageHandler(httpProxyId, settings))
+                            )
+                        );
+    }
 
     actorSystem.Send(httpProxyId, new NHttp::TEvHttpProxy::TEvRegisterHandler(
                         "/",

--- a/ydb/mvp/oidc_proxy/oidc_client.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_client.cpp
@@ -6,8 +6,6 @@
 
 namespace NMVP::NOIDC {
 
-using namespace NActors;
-
 void InitOIDC(NActors::TActorSystem& actorSystem,
               const NActors::TActorId& httpProxyId,
               const TOpenIdConnectSettings& settings) {

--- a/ydb/mvp/oidc_proxy/oidc_client.h
+++ b/ydb/mvp/oidc_proxy/oidc_client.h
@@ -5,12 +5,10 @@ class TActorSystem;
 struct TActorId;
 
 }  // NActors
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 struct TOpenIdConnectSettings;
 
 void InitOIDC(NActors::TActorSystem& actorSystem, const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings);
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
@@ -1,4 +1,5 @@
 #include <library/cpp/string_utils/base64/base64.h>
+#include <library/cpp/string_utils/quote/quote.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/library/security/util.h>
 #include <ydb/mvp/core/mvp_log.h>
@@ -7,13 +8,12 @@
 #include "oidc_session_create.h"
 #include "oidc_impersonate_start_page_nebius.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 THandlerImpersonateStart::THandlerImpersonateStart(const NActors::TActorId& sender,
-                                                const NHttp::THttpIncomingRequestPtr& request,
-                                                const NActors::TActorId& httpProxyId,
-                                                const TOpenIdConnectSettings& settings)
+                                                   const NHttp::THttpIncomingRequestPtr& request,
+                                                   const NActors::TActorId& httpProxyId,
+                                                   const TOpenIdConnectSettings& settings)
     : Sender(sender)
     , Request(request)
     , HttpProxyId(httpProxyId)
@@ -21,7 +21,8 @@ THandlerImpersonateStart::THandlerImpersonateStart(const NActors::TActorId& send
 {}
 
 void THandlerImpersonateStart::Bootstrap(const NActors::TActorContext& ctx) {
-    LOG_DEBUG_S(ctx, EService::MVP, "Start impersonation process");
+    BLOG_D("Start impersonation process");
+
     NHttp::TUrlParameters urlParameters(Request->URL);
     TString serviceAccountId = urlParameters["service_account_id"];
 
@@ -31,32 +32,26 @@ void THandlerImpersonateStart::Bootstrap(const NActors::TActorContext& ctx) {
     TString sessionCookieName = CreateNameSessionCookie(Settings.ClientId);
     TStringBuf sessionCookieValue = cookies.Get(sessionCookieName);
     if (!sessionCookieValue.Empty()) {
-        LOG_DEBUG_S(ctx, EService::MVP, "Using session cookie (" << sessionCookieName << ": " << NKikimr::MaskTicket(sessionCookieValue) << ")");
+        BLOG_D("Using session cookie (" << sessionCookieName << ": " << NKikimr::MaskTicket(sessionCookieValue) << ")");
     }
+    TString sessionToken = DecodeToken(sessionCookieValue);
+    TStringBuf impersonatedCookieValue = GetCookie(cookies, CreateNameImpersonatedCookie(Settings.ClientId));
 
-    TString sessionToken = DecodeToken(sessionCookieValue, ctx);
-
-    TString jsonError;
     if (sessionToken.empty()) {
-        jsonError = "Wrong impersonate parameter: session cookie not found";
-    } else if (serviceAccountId.empty()) {
-        jsonError = "Wrong impersonate parameter: account_id not found";
+        return ReplyBadRequestAndDie("Wrong impersonate parameter: session cookie not found", ctx);
+    }
+    if (!impersonatedCookieValue.empty()) {
+        return ReplyBadRequestAndDie("Wrong impersonate parameter: impersonated cookie already exists", ctx);
+    }
+    if (serviceAccountId.empty()) {
+        return ReplyBadRequestAndDie("Wrong impersonate parameter: service_account_id not found", ctx);
     }
 
-    if (jsonError) {
-        NHttp::THeadersBuilder responseHeaders;
-        responseHeaders.Set("Content-Type", "text/plain");
-        SetCORS(Request, &responseHeaders);
-        NHttp::THttpOutgoingResponsePtr httpResponse = Request->CreateResponse("400", "Bad Request", responseHeaders, jsonError);
-        ctx.Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
-        Die(ctx);
-    } else {
-        RequestImpersonatedToken(sessionToken, serviceAccountId, ctx);
-    }
+    RequestImpersonatedToken(sessionToken, serviceAccountId, ctx);
 }
 
 void THandlerImpersonateStart::RequestImpersonatedToken(const TString& sessionToken, const TString& serviceAccountId, const NActors::TActorContext& ctx) {
-    LOG_DEBUG_S(ctx, EService::MVP, "Request impersonated token");
+    BLOG_D("Request impersonated token");
     NHttp::THttpOutgoingRequestPtr httpRequest = NHttp::THttpOutgoingRequest::CreateRequestPost(Settings.GetImpersonateEndpointURL());
     httpRequest->Set<&NHttp::THttpRequest::ContentType>("application/x-www-form-urlencoded");
 
@@ -70,7 +65,9 @@ void THandlerImpersonateStart::RequestImpersonatedToken(const TString& sessionTo
     TStringBuilder body;
     body << "session=" << sessionToken
          << "&service_account_id=" << serviceAccountId;
-    httpRequest->Set<&NHttp::THttpRequest::Body>(body);
+    TString bodyStr = body;
+    CGIEscape(bodyStr);
+    httpRequest->Set<&NHttp::THttpRequest::Body>(bodyStr);
 
     ctx.Send(HttpProxyId, new NHttp::TEvHttpProxy::TEvHttpOutgoingRequest(httpRequest));
     Become(&THandlerImpersonateStart::StateWork);
@@ -79,24 +76,22 @@ void THandlerImpersonateStart::RequestImpersonatedToken(const TString& sessionTo
 void THandlerImpersonateStart::ProcessImpersonatedToken(const TString& impersonatedToken, const NActors::TActorContext& ctx) {
     TString impersonatedCookieName = CreateNameImpersonatedCookie(Settings.ClientId);
     TString impersonatedCookieValue = Base64Encode(impersonatedToken);
-    LOG_DEBUG_S(ctx, EService::MVP, "Set impersonated cookie: (" << impersonatedCookieName << ": " << NKikimr::MaskTicket(impersonatedCookieValue) << ")");
+    BLOG_D("Set impersonated cookie: (" << impersonatedCookieName << ": " << NKikimr::MaskTicket(impersonatedCookieValue) << ")");
 
     NHttp::THeadersBuilder responseHeaders;
     responseHeaders.Set("Set-Cookie", CreateSecureCookie(impersonatedCookieName, impersonatedCookieValue));
     SetCORS(Request, &responseHeaders);
-    NHttp::THttpOutgoingResponsePtr httpResponse;
-    httpResponse = Request->CreateResponse("200", "OK", responseHeaders);
-    ctx.Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
-    Die(ctx);
+    NHttp::THttpOutgoingResponsePtr httpResponse = Request->CreateResponse("200", "OK", responseHeaders);
+    ReplyAndDie(httpResponse, ctx);
 }
 
 void THandlerImpersonateStart::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx) {
     NHttp::THttpOutgoingResponsePtr httpResponse;
     if (event->Get()->Error.empty() && event->Get()->Response) {
         NHttp::THttpIncomingResponsePtr response = event->Get()->Response;
-        LOG_DEBUG_S(ctx, EService::MVP, "Incoming response from authorization server: " << response->Status);
+        BLOG_D("Incoming response from authorization server: " << response->Status);
         if (response->Status == "200") {
-            TStringBuf jsonError;
+            TStringBuf errorMessage;
             NJson::TJsonValue jsonValue;
             NJson::TJsonReaderConfig jsonConfig;
             if (NJson::ReadJsonTree(response->Body, &jsonConfig, &jsonValue)) {
@@ -106,15 +101,15 @@ void THandlerImpersonateStart::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRespon
                     ProcessImpersonatedToken(impersonatedToken, ctx);
                     return;
                 } else {
-                    jsonError = "Wrong OIDC provider response: impersonated token not found";
+                    errorMessage = "Wrong OIDC provider response: impersonated token not found";
                 }
             } else {
-                jsonError =  "Wrong OIDC response";
+                errorMessage =  "Wrong OIDC response";
             }
             NHttp::THeadersBuilder responseHeaders;
             responseHeaders.Set("Content-Type", "text/plain");
             SetCORS(Request, &responseHeaders);
-            httpResponse = Request->CreateResponse("400", "Bad Request", responseHeaders, jsonError);
+            return ReplyAndDie(Request->CreateResponse("400", "Bad Request", responseHeaders, errorMessage), ctx);
         } else {
             NHttp::THeadersBuilder responseHeaders;
             NHttp::THeaders headers(response->Headers);
@@ -122,16 +117,27 @@ void THandlerImpersonateStart::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRespon
                 responseHeaders.Set("Content-Type", headers.Get("Content-Type"));
             }
             SetCORS(Request, &responseHeaders);
-            httpResponse = Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body);
+            return ReplyAndDie(Request->CreateResponse(response->Status, response->Message, responseHeaders, response->Body), ctx);
         }
     } else {
         NHttp::THeadersBuilder responseHeaders;
         responseHeaders.Set("Content-Type", "text/plain");
         SetCORS(Request, &responseHeaders);
-        httpResponse = Request->CreateResponse("400", "Bad Request", responseHeaders, event->Get()->Error);
+        return ReplyAndDie(Request->CreateResponse("400", "Bad Request", responseHeaders, event->Get()->Error), ctx);
     }
+}
+
+void THandlerImpersonateStart::ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx) {
     ctx.Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
     Die(ctx);
+}
+
+void THandlerImpersonateStart::ReplyBadRequestAndDie(const TString& errorMessage, const NActors::TActorContext& ctx) {
+    NHttp::THeadersBuilder responseHeaders;
+    responseHeaders.Set("Content-Type", "text/plain");
+    SetCORS(Request, &responseHeaders);
+    NHttp::THttpOutgoingResponsePtr httpResponse = Request->CreateResponse("400", "Bad Request", responseHeaders, errorMessage);
+    ReplyAndDie(httpResponse, ctx);
 }
 
 TImpersonateStartPageHandler::TImpersonateStartPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings)
@@ -144,5 +150,4 @@ void TImpersonateStartPageHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRe
     ctx.Register(new THandlerImpersonateStart(event->Sender, event->Get()->Request, HttpProxyId, Settings));
 }
 
-} // NOIDC
-} // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.cpp
@@ -20,17 +20,6 @@ THandlerImpersonateStart::THandlerImpersonateStart(const NActors::TActorId& send
     , Settings(settings)
 {}
 
-TString THandlerImpersonateStart::DecodeToken(const TStringBuf& cookie, const NActors::TActorContext& ctx) {
-    TString token;
-    try {
-        Base64StrictDecode(cookie, token);
-    } catch (std::exception& e) {
-        LOG_DEBUG_S(ctx, EService::MVP, "Base64Decode " << cookie << " cookie: " << e.what());
-        token.clear();
-    }
-    return token;
-}
-
 void THandlerImpersonateStart::Bootstrap(const NActors::TActorContext& ctx) {
     LOG_DEBUG_S(ctx, EService::MVP, "Start impersonation process");
     NHttp::TUrlParameters urlParameters(Request->URL);

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/generic/strbuf.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/http/http.h>
+#include <ydb/library/actors/http/http_proxy.h>
+#include "oidc_settings.h"
+#include "context.h"
+
+namespace NMVP {
+namespace NOIDC {
+
+class THandlerImpersonateStart : public NActors::TActorBootstrapped<THandlerImpersonateStart> {
+private:
+    using TBase = NActors::TActorBootstrapped<THandlerImpersonateStart>;
+
+protected:
+    const NActors::TActorId Sender;
+    const NHttp::THttpIncomingRequestPtr Request;
+    NActors::TActorId HttpProxyId;
+    const TOpenIdConnectSettings Settings;
+    TContext Context;
+
+public:
+    THandlerImpersonateStart(const NActors::TActorId& sender,
+                          const NHttp::THttpIncomingRequestPtr& request,
+                          const NActors::TActorId& httpProxyId,
+                          const TOpenIdConnectSettings& settings);
+
+    virtual void RequestSessionToken(const TString&, const NActors::TActorContext&) = 0;
+    virtual void ProcessSessionToken(const TString& accessToken, const NActors::TActorContext&) = 0;
+
+    void Bootstrap(const NActors::TActorContext& ctx);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx);
+
+protected:
+    TString ChangeSameSiteFieldInSessionCookie(const TString& cookie);
+    void RetryRequestToProtectedResourceAndDie(const NActors::TActorContext& ctx);
+    void RetryRequestToProtectedResourceAndDie(NHttp::THeadersBuilder* responseHeaders, const NActors::TActorContext& ctx);
+
+private:
+    void SendUnknownErrorResponseAndDie(const NActors::TActorContext& ctx);
+};
+
+}  // NOIDC
+}  // NMVP

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
@@ -21,8 +21,8 @@ public:
                              const NHttp::THttpIncomingRequestPtr& request,
                              const NActors::TActorId& httpProxyId,
                              const TOpenIdConnectSettings& settings);
-    void Bootstrap(const NActors::TActorContext& ctx);
-    void RequestImpersonatedToken(TString&, TString&, const NActors::TActorContext&);
+    void Bootstrap();
+    void RequestImpersonatedToken(TString&, TString&);
     void ProcessImpersonatedToken(const TString& impersonatedToken);
     void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event);
     void ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse);
@@ -43,11 +43,11 @@ class TImpersonateStartPageHandler : public NActors::TActor<TImpersonateStartPag
 
 public:
     TImpersonateStartPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings);
-    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event);
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
             cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
@@ -23,15 +23,15 @@ public:
                              const NActors::TActorId& httpProxyId,
                              const TOpenIdConnectSettings& settings);
     void Bootstrap(const NActors::TActorContext& ctx);
-    void RequestImpersonatedToken(const TString&, const TString&, const NActors::TActorContext&);
-    void ProcessImpersonatedToken(const TString& impersonatedToken, const NActors::TActorContext& ctx);
-    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx);
-    void ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx);
-    void ReplyBadRequestAndDie(const TString& errorMessage, const NActors::TActorContext& ctx);
+    void RequestImpersonatedToken(TString&, TString&, const NActors::TActorContext&);
+    void ProcessImpersonatedToken(const TString& impersonatedToken);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event);
+    void ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse);
+    void ReplyBadRequestAndPassAway(const TString& errorMessage);
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
@@ -15,10 +15,8 @@ protected:
     const NHttp::THttpIncomingRequestPtr Request;
     NActors::TActorId HttpProxyId;
     const TOpenIdConnectSettings Settings;
-    TContext Context;
 
 public:
-    TString DecodeToken(const TStringBuf& cookie, const NActors::TActorContext& ctx);
     THandlerImpersonateStart(const NActors::TActorId& sender,
                              const NHttp::THttpIncomingRequestPtr& request,
                              const NActors::TActorId& httpProxyId,

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_start_page_nebius.h
@@ -2,10 +2,9 @@
 
 #include "oidc_settings.h"
 #include "context.h"
+#include <ydb/library/actors/core/events.h>
 
 namespace NMVP::NOIDC {
-
-using namespace NActors;
 
 class THandlerImpersonateStart : public NActors::TActorBootstrapped<THandlerImpersonateStart> {
 private:
@@ -32,7 +31,6 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };
@@ -50,7 +48,7 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
+            cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
@@ -22,9 +22,7 @@ void THandlerImpersonateStop::Bootstrap() {
     responseHeaders.Set("Set-Cookie", ClearSecureCookie(impersonatedCookieName));
     SetCORS(Request, &responseHeaders);
 
-    NHttp::THttpOutgoingResponsePtr httpResponse;
-    httpResponse = Request->CreateResponse("200", "OK", responseHeaders);
-    ReplyAndPassAway(std::move(httpResponse));
+    ReplyAndPassAway(Request->CreateResponse("200", "OK", responseHeaders));
 }
 
 void THandlerImpersonateStop::ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse) {
@@ -38,8 +36,8 @@ TImpersonateStopPageHandler::TImpersonateStopPageHandler(const NActors::TActorId
     , Settings(settings)
 {}
 
-void TImpersonateStopPageHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx) {
-    ctx.Register(new THandlerImpersonateStop(event->Sender, event->Get()->Request, HttpProxyId, Settings));
+void TImpersonateStopPageHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event) {
+    Register(new THandlerImpersonateStop(event->Sender, event->Get()->Request, HttpProxyId, Settings));
 }
 
 } // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
@@ -15,7 +15,7 @@ THandlerImpersonateStop::THandlerImpersonateStop(const NActors::TActorId& sender
     , Settings(settings)
 {}
 
-void THandlerImpersonateStop::Bootstrap(const NActors::TActorContext& ctx) {
+void THandlerImpersonateStop::Bootstrap() {
     TString impersonatedCookieName = CreateNameImpersonatedCookie(Settings.ClientId);
     BLOG_D("Clear impersonated cookie: (" << impersonatedCookieName << ")");
 
@@ -25,12 +25,12 @@ void THandlerImpersonateStop::Bootstrap(const NActors::TActorContext& ctx) {
 
     NHttp::THttpOutgoingResponsePtr httpResponse;
     httpResponse = Request->CreateResponse("200", "OK", responseHeaders);
-    ReplyAndDie(httpResponse, ctx);
+    ReplyAndPassAway(httpResponse);
 }
 
-void THandlerImpersonateStop::ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx) {
-    ctx.Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
-    Die(ctx);
+void THandlerImpersonateStop::ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse) {
+    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
+    PassAway();
 }
 
 TImpersonateStopPageHandler::TImpersonateStopPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings)

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
@@ -1,0 +1,34 @@
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/string_utils/base64/base64.h>
+#include <ydb/library/actors/http/http.h>
+#include <ydb/mvp/core/mvp_log.h>
+#include "openid_connect.h"
+#include "oidc_session_create.h"
+#include "oidc_settings.h"
+
+namespace NMVP {
+namespace NOIDC {
+
+THandlerImpersonateStop::THandlerSessionCreate(const NActors::TActorId& sender,
+                                             const NHttp::THttpIncomingRequestPtr& request,
+                                             const NActors::TActorId& httpProxyId,
+                                             const TOpenIdConnectSettings& settings)
+    : Sender(sender)
+    , Request(request)
+    , HttpProxyId(httpProxyId)
+    , Settings(settings)
+{}
+
+void THandlerImpersonateStop::Bootstrap(const NActors::TActorContext& ctx) {
+    NHttp::THeadersBuilder responseHeaders;responseHeaders
+    SetCORS(Request, &responseHeaders);
+    responseHeaders.Set("Set-Cookie", CreateSecureCookie(Settings.ClientId, sessionToken));
+
+    NHttp::THttpOutgoingResponsePtr httpResponse;
+    httpResponse = Request->CreateResponse("200", "OK", responseHeaders);
+    ctx.Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
+    Die(ctx);
+}
+
+} // NOIDC
+} // NMVP

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.cpp
@@ -1,7 +1,6 @@
 #include "openid_connect.h"
 #include "oidc_session_create.h"
 #include "oidc_impersonate_stop_page_nebius.h"
-#include <ydb/library/actors/core/events.h>
 
 namespace NMVP::NOIDC {
 
@@ -25,11 +24,11 @@ void THandlerImpersonateStop::Bootstrap() {
 
     NHttp::THttpOutgoingResponsePtr httpResponse;
     httpResponse = Request->CreateResponse("200", "OK", responseHeaders);
-    ReplyAndPassAway(httpResponse);
+    ReplyAndPassAway(std::move(httpResponse));
 }
 
 void THandlerImpersonateStop::ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse) {
-    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
+    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(std::move(httpResponse)));
     PassAway();
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/generic/strbuf.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/http/http.h>
+#include <ydb/library/actors/http/http_proxy.h>
+#include "oidc_settings.h"
+#include "context.h"
+
+namespace NMVP {
+namespace NOIDC {
+
+class THandlerImpersonateStop : public NActors::TActorBootstrapped<THandlerImpersonateStop> {
+private:
+    using TBase = NActors::TActorBootstrapped<THandlerImpersonateStop>;
+
+protected:
+    const NActors::TActorId Sender;
+    const NHttp::THttpIncomingRequestPtr Request;
+    NActors::TActorId HttpProxyId;
+    const TOpenIdConnectSettings Settings;
+    TContext Context;
+
+public:
+    THandlerImpersonateStop(const NActors::TActorId& sender,
+                          const NHttp::THttpIncomingRequestPtr& request,
+                          const NActors::TActorId& httpProxyId,
+                          const TOpenIdConnectSettings& settings);
+
+    void Bootstrap(const NActors::TActorContext& ctx);
+};
+
+}  // NOIDC
+}  // NMVP

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
@@ -15,7 +15,6 @@ protected:
     const NHttp::THttpIncomingRequestPtr Request;
     NActors::TActorId HttpProxyId;
     const TOpenIdConnectSettings Settings;
-    TContext Context;
 
 public:
     THandlerImpersonateStop(const NActors::TActorId& sender,

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
@@ -3,8 +3,9 @@
 #include "oidc_settings.h"
 #include "context.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
+
+using namespace NActors;
 
 class THandlerImpersonateStop : public NActors::TActorBootstrapped<THandlerImpersonateStop> {
 private:
@@ -23,6 +24,7 @@ public:
                             const TOpenIdConnectSettings& settings);
 
     void Bootstrap(const NActors::TActorContext& ctx);
+    void ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx);
 };
 
 class TImpersonateStopPageHandler : public NActors::TActor<TImpersonateStopPageHandler> {
@@ -38,9 +40,9 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
@@ -23,8 +23,8 @@ public:
                             const NActors::TActorId& httpProxyId,
                             const TOpenIdConnectSettings& settings);
 
-    void Bootstrap(const NActors::TActorContext& ctx);
-    void ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx);
+    void Bootstrap();
+    void ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse);
 };
 
 class TImpersonateStopPageHandler : public NActors::TActor<TImpersonateStopPageHandler> {

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
@@ -2,10 +2,9 @@
 
 #include "oidc_settings.h"
 #include "context.h"
+#include <ydb/library/actors/core/events.h>
 
 namespace NMVP::NOIDC {
-
-using namespace NActors;
 
 class THandlerImpersonateStop : public NActors::TActorBootstrapped<THandlerImpersonateStop> {
 private:
@@ -40,7 +39,7 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
+            cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
@@ -1,11 +1,5 @@
 #pragma once
 
-#include <util/generic/string.h>
-#include <util/generic/strbuf.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorid.h>
-#include <ydb/library/actors/http/http.h>
-#include <ydb/library/actors/http/http_proxy.h>
 #include "oidc_settings.h"
 #include "context.h"
 
@@ -25,11 +19,28 @@ protected:
 
 public:
     THandlerImpersonateStop(const NActors::TActorId& sender,
-                          const NHttp::THttpIncomingRequestPtr& request,
-                          const NActors::TActorId& httpProxyId,
-                          const TOpenIdConnectSettings& settings);
+                            const NHttp::THttpIncomingRequestPtr& request,
+                            const NActors::TActorId& httpProxyId,
+                            const TOpenIdConnectSettings& settings);
 
     void Bootstrap(const NActors::TActorContext& ctx);
+};
+
+class TImpersonateStopPageHandler : public NActors::TActor<TImpersonateStopPageHandler> {
+    using TBase = NActors::TActor<TImpersonateStopPageHandler>;
+
+    const NActors::TActorId HttpProxyId;
+    const TOpenIdConnectSettings Settings;
+
+public:
+    TImpersonateStopPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx);
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+        }
+    }
 };
 
 }  // NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_impersonate_stop_page_nebius.h
@@ -34,11 +34,11 @@ class TImpersonateStopPageHandler : public NActors::TActor<TImpersonateStopPageH
 
 public:
     TImpersonateStopPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings);
-    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event);
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
             cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
@@ -227,7 +227,7 @@ NHttp::THttpOutgoingResponsePtr THandlerSessionServiceCheck::CreateResponseForNo
 }
 
 void THandlerSessionServiceCheck::ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse) {
-    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
+    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(std::move(httpResponse)));
     PassAway();
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.cpp
@@ -33,7 +33,7 @@ void THandlerSessionServiceCheck::Bootstrap(const NActors::TActorContext& ctx) {
 
 void THandlerSessionServiceCheck::HandleProxy(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event) {
     if (event->Get()->Response != nullptr) {
-        NHttp::THttpIncomingResponsePtr response = event->Get()->Response;
+        NHttp::THttpIncomingResponsePtr response = std::move(event->Get()->Response);
         BLOG_D("Incoming response for protected resource: " << response->Status);
         if (NeedSendSecureHttpRequest(response)) {
             return SendSecureHttpRequest(response);

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.h
@@ -8,8 +8,7 @@
 #include <ydb/library/actors/http/http_proxy.h>
 #include "oidc_settings.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 class THandlerSessionServiceCheck : public NActors::TActorBootstrapped<THandlerSessionServiceCheck> {
 protected:
@@ -17,9 +16,9 @@ protected:
 
     const NActors::TActorId Sender;
     const NHttp::THttpIncomingRequestPtr Request;
-    NActors::TActorId HttpProxyId;
+    const NActors::TActorId HttpProxyId;
     const TOpenIdConnectSettings Settings;
-    TString ProtectedPageUrl;
+    const TString ProtectedPageUrl;
     TString RequestedPageScheme;
 
     const static inline TStringBuf IAM_TOKEN_SCHEME = "Bearer ";
@@ -42,6 +41,7 @@ protected:
 
     bool CheckRequestedHost();
     void ForwardRequestHeaders(NHttp::THttpOutgoingRequestPtr& request) const;
+    void ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx);
 
     static bool IsAuthorizedRequest(TStringBuf authHeader);
     static TString FixReferenceInHtml(TStringBuf html, TStringBuf host, TStringBuf findStr);
@@ -55,5 +55,4 @@ private:
     NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const TString& errorMessage);
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_protected_page.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page.h
@@ -32,16 +32,16 @@ public:
                                 const TOpenIdConnectSettings& settings);
 
     virtual void Bootstrap(const NActors::TActorContext& ctx);
-    void HandleProxy(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx);
+    void HandleProxy(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event);
 
 protected:
     virtual void StartOidcProcess(const NActors::TActorContext& ctx) = 0;
-    virtual void ForwardUserRequest(TStringBuf authHeader, const NActors::TActorContext& ctx, bool secure = false);
+    virtual void ForwardUserRequest(TStringBuf authHeader, bool secure = false);
     virtual bool NeedSendSecureHttpRequest(const NHttp::THttpIncomingResponsePtr& response) const = 0;
 
     bool CheckRequestedHost();
     void ForwardRequestHeaders(NHttp::THttpOutgoingRequestPtr& request) const;
-    void ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx);
+    void ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse);
 
     static bool IsAuthorizedRequest(TStringBuf authHeader);
     static TString FixReferenceInHtml(TStringBuf html, TStringBuf host, TStringBuf findStr);
@@ -49,7 +49,7 @@ protected:
 
 private:
     NHttp::THeadersBuilder GetResponseHeaders(const NHttp::THttpIncomingResponsePtr& response);
-    void SendSecureHttpRequest(const NHttp::THttpIncomingResponsePtr& response, const NActors::TActorContext& ctx);
+    void SendSecureHttpRequest(const NHttp::THttpIncomingResponsePtr& response);
     TString GetFixedLocationHeader(TStringBuf location);
     NHttp::THttpOutgoingResponsePtr CreateResponseForbiddenHost();
     NHttp::THttpOutgoingResponsePtr CreateResponseForNotExistingResponseFromProtectedResource(const TString& errorMessage);

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_handler.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_handler.cpp
@@ -2,8 +2,7 @@
 #include "oidc_protected_page_nebius.h"
 #include "oidc_protected_page_yandex.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 TProtectedPageHandler::TProtectedPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings)
     : TBase(&TProtectedPageHandler::StateWork)
@@ -22,5 +21,4 @@ void TProtectedPageHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::
     }
 }
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_handler.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_handler.cpp
@@ -10,13 +10,13 @@ TProtectedPageHandler::TProtectedPageHandler(const NActors::TActorId& httpProxyI
     , Settings(settings)
 {}
 
-void TProtectedPageHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx) {
+void TProtectedPageHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event) {
     switch (Settings.AccessServiceType) {
         case NMvp::yandex_v2:
-            ctx.Register(new THandlerSessionServiceCheckYandex(event->Sender, event->Get()->Request, HttpProxyId, Settings));
+            Register(new THandlerSessionServiceCheckYandex(event->Sender, event->Get()->Request, HttpProxyId, Settings));
             break;
         case NMvp::nebius_v1:
-            ctx.Register(new THandlerSessionServiceCheckNebius(event->Sender, event->Get()->Request, HttpProxyId, Settings));
+            Register(new THandlerSessionServiceCheckNebius(event->Sender, event->Get()->Request, HttpProxyId, Settings));
             break;
     }
 }

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_handler.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_handler.h
@@ -5,8 +5,9 @@
 #include <ydb/library/actors/http/http_proxy.h>
 #include "oidc_settings.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
+
+using namespace NActors;
 
 class TProtectedPageHandler : public NActors::TActor<TProtectedPageHandler> {
     using TBase = NActors::TActor<TProtectedPageHandler>;
@@ -21,9 +22,9 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_handler.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_handler.h
@@ -16,11 +16,11 @@ class TProtectedPageHandler : public NActors::TActor<TProtectedPageHandler> {
 
 public:
     TProtectedPageHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings);
-    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event);
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
             cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_handler.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_handler.h
@@ -1,13 +1,12 @@
 #pragma once
 
+#include "oidc_settings.h"
 #include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/http/http_proxy.h>
-#include "oidc_settings.h"
 
 namespace NMVP::NOIDC {
-
-using namespace NActors;
 
 class TProtectedPageHandler : public NActors::TActor<TProtectedPageHandler> {
     using TBase = NActors::TActor<TProtectedPageHandler>;
@@ -22,7 +21,7 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
+            cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
@@ -24,29 +24,29 @@ public:
                                       const NActors::TActorId& httpProxyId,
                                       const TOpenIdConnectSettings& settings);
     void StartOidcProcess(const NActors::TActorContext& ctx) override;
-    void HandleExchange(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx);
+    void HandleExchange(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event);
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleProxy);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleProxy);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 
     STFUNC(StateExchange) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleExchange);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleExchange);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 
 private:
     void SendTokenExchangeRequest(const TStringBuilder& body, const ETokenExchangeType exchangeType, const NActors::TActorContext& ctx);
-    void ExchangeSessionToken(const TString& sessionToken, const NActors::TActorContext& ctx);
-    void ExchangeImpersonatedToken(const TString& sessionToken, const TString& impersonatedToken, const NActors::TActorContext& ctx);
-    void ClearImpersonatedCookie(const NActors::TActorContext& ctx);
-    void RequestAuthorizationCode(const NActors::TActorContext& ctx);
-    void ForwardUserRequest(TStringBuf authHeader, const NActors::TActorContext& ctx, bool secure = false) override;
+    void ExchangeSessionToken(TString& sessionToken, const NActors::TActorContext& ctx);
+    void ExchangeImpersonatedToken(TString& sessionToken, TString& impersonatedToken, const NActors::TActorContext& ctx);
+    void ClearImpersonatedCookie();
+    void RequestAuthorizationCode();
+    void ForwardUserRequest(TStringBuf authHeader, bool secure = false) override;
     bool NeedSendSecureHttpRequest(const NHttp::THttpIncomingResponsePtr& response) const override;
 };
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
@@ -23,7 +23,6 @@ public:
                                       const NActors::TActorId& httpProxyId,
                                       const TOpenIdConnectSettings& settings);
     TStringBuf GetCookie(const NHttp::TCookies& cookies, const TString& cookieName, const NActors::TActorContext& ctx);
-    TString DecodeToken(const TStringBuf& cookie, const NActors::TActorContext& ctx);
     void StartOidcProcess(const NActors::TActorContext& ctx) override;
     void HandleExchange(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx);
 
@@ -40,7 +39,7 @@ public:
     }
 
 private:
-
+    void SendTokenExchangeRequest(const TStringBuilder& body, const ETokenExchangeType exchangeType, const NActors::TActorContext& ctx);
     void ExchangeSessionToken(const TString sessionToken, const NActors::TActorContext& ctx);
     void ExchangeImpersonatedToken(const TString sessionToken, const TString impersonatedToken, const NActors::TActorContext& ctx);
     void ClearImpersonatedCookie(const NActors::TActorContext& ctx);

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
@@ -4,8 +4,6 @@
 
 namespace NMVP::NOIDC {
 
-using namespace NActors;
-
 class THandlerSessionServiceCheckNebius : public THandlerSessionServiceCheck {
 private:
     using TBase = THandlerSessionServiceCheck;
@@ -29,19 +27,17 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleProxy);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 
     STFUNC(StateExchange) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleExchange);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 
 private:
-    void SendTokenExchangeRequest(const TStringBuilder& body, const ETokenExchangeType exchangeType, const NActors::TActorContext& ctx);
+    void SendTokenExchangeRequest(const TCgiParameters& body, const ETokenExchangeType exchangeType, const NActors::TActorContext& ctx);
     void ExchangeSessionToken(TString& sessionToken, const NActors::TActorContext& ctx);
     void ExchangeImpersonatedToken(TString& sessionToken, TString& impersonatedToken, const NActors::TActorContext& ctx);
     void ClearImpersonatedCookie();

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
@@ -9,12 +9,21 @@ class THandlerSessionServiceCheckNebius : public THandlerSessionServiceCheck {
 private:
     using TBase = THandlerSessionServiceCheck;
 
+protected:
+    enum class ETokenExchangeType {
+        SessionToken,
+        ImpersonatedToken
+    };
+
+    ETokenExchangeType tokenExchangeType = ETokenExchangeType::SessionToken;
+
 public:
     THandlerSessionServiceCheckNebius(const NActors::TActorId& sender,
                                       const NHttp::THttpIncomingRequestPtr& request,
                                       const NActors::TActorId& httpProxyId,
                                       const TOpenIdConnectSettings& settings);
-
+    TStringBuf GetCookie(const NHttp::TCookies& cookies, const TString& cookieName, const NActors::TActorContext& ctx);
+    TString DecodeToken(const TStringBuf& cookie, const NActors::TActorContext& ctx);
     void StartOidcProcess(const NActors::TActorContext& ctx) override;
     void HandleExchange(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx);
 
@@ -33,6 +42,8 @@ public:
 private:
 
     void ExchangeSessionToken(const TString sessionToken, const NActors::TActorContext& ctx);
+    void ExchangeImpersonatedToken(const TString sessionToken, const TString impersonatedToken, const NActors::TActorContext& ctx);
+    void ClearImpersonatedCookie(const NActors::TActorContext& ctx);
     void RequestAuthorizationCode(const NActors::TActorContext& ctx);
     void ForwardUserRequest(TStringBuf authHeader, const NActors::TActorContext& ctx, bool secure = false) override;
     bool NeedSendSecureHttpRequest(const NHttp::THttpIncomingResponsePtr& response) const override;

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_nebius.h
@@ -37,9 +37,9 @@ public:
     }
 
 private:
-    void SendTokenExchangeRequest(const TCgiParameters& body, const ETokenExchangeType exchangeType, const NActors::TActorContext& ctx);
-    void ExchangeSessionToken(TString& sessionToken, const NActors::TActorContext& ctx);
-    void ExchangeImpersonatedToken(TString& sessionToken, TString& impersonatedToken, const NActors::TActorContext& ctx);
+    void SendTokenExchangeRequest(const TCgiParameters& body, const ETokenExchangeType exchangeType);
+    void ExchangeSessionToken(const TString& sessionToken);
+    void ExchangeImpersonatedToken(const TString& sessionToken, const TString& impersonatedToken);
     void ClearImpersonatedCookie();
     void RequestAuthorizationCode();
     void ForwardUserRequest(TStringBuf authHeader, bool secure = false) override;

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.cpp
@@ -21,21 +21,21 @@ void THandlerSessionServiceCheckYandex::Bootstrap(const NActors::TActorContext& 
     Become(&THandlerSessionServiceCheckYandex::StateWork);
 }
 
-void THandlerSessionServiceCheckYandex::Handle(TEvPrivate::TEvCheckSessionResponse::TPtr event, const NActors::TActorContext& ctx) {
+void THandlerSessionServiceCheckYandex::Handle(TEvPrivate::TEvCheckSessionResponse::TPtr event) {
     BLOG_D("SessionService.Check(): OK");
     auto response = event->Get()->Response;
     const auto& iamToken = response.iam_token();
     const TString authHeader = IAM_TOKEN_SCHEME + iamToken.iam_token();
-    ForwardUserRequest(authHeader, ctx);
+    ForwardUserRequest(authHeader);
 }
 
-void THandlerSessionServiceCheckYandex::Handle(TEvPrivate::TEvErrorResponse::TPtr event, const NActors::TActorContext& ctx) {
+void THandlerSessionServiceCheckYandex::Handle(TEvPrivate::TEvErrorResponse::TPtr event) {
     BLOG_D("SessionService.Check(): " << event->Get()->Status);
     NHttp::THttpOutgoingResponsePtr httpResponse;
     if (event->Get()->Status == "400") {
-        return ReplyAndDie(GetHttpOutgoingResponsePtr(Request, Settings), ctx);
+        return ReplyAndPassAway(GetHttpOutgoingResponsePtr(Request, Settings));
     } else {
-        return ReplyAndDie(Request->CreateResponse( event->Get()->Status, event->Get()->Message, "text/plain", event->Get()->Details), ctx);
+        return ReplyAndPassAway(Request->CreateResponse( event->Get()->Status, event->Get()->Message, "text/plain", event->Get()->Details));
     }
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.h
@@ -3,8 +3,9 @@
 #include "openid_connect.h"
 #include "oidc_protected_page.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
+
+using namespace NActors;
 
 class THandlerSessionServiceCheckYandex : public THandlerSessionServiceCheck {
 private:
@@ -27,6 +28,7 @@ public:
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleProxy);
             HFunc(TEvPrivate::TEvCheckSessionResponse, Handle);
             HFunc(TEvPrivate::TEvErrorResponse, Handle);
+            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 
@@ -35,5 +37,4 @@ private:
     bool NeedSendSecureHttpRequest(const NHttp::THttpIncomingResponsePtr& response) const override;
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.h
@@ -20,14 +20,14 @@ public:
 
     void Bootstrap(const NActors::TActorContext& ctx) override;
 
-    void Handle(TEvPrivate::TEvCheckSessionResponse::TPtr event, const NActors::TActorContext& ctx);
-    void Handle(TEvPrivate::TEvErrorResponse::TPtr event, const NActors::TActorContext& ctx);
+    void Handle(TEvPrivate::TEvCheckSessionResponse::TPtr event);
+    void Handle(TEvPrivate::TEvErrorResponse::TPtr event);
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleProxy);
-            HFunc(TEvPrivate::TEvCheckSessionResponse, Handle);
-            HFunc(TEvPrivate::TEvErrorResponse, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleProxy);
+            hFunc(TEvPrivate::TEvCheckSessionResponse, Handle);
+            hFunc(TEvPrivate::TEvErrorResponse, Handle);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }

--- a/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.h
+++ b/ydb/mvp/oidc_proxy/oidc_protected_page_yandex.h
@@ -5,8 +5,6 @@
 
 namespace NMVP::NOIDC {
 
-using namespace NActors;
-
 class THandlerSessionServiceCheckYandex : public THandlerSessionServiceCheck {
 private:
     using TBase = THandlerSessionServiceCheck;
@@ -28,7 +26,6 @@ public:
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, HandleProxy);
             hFunc(TEvPrivate::TEvCheckSessionResponse, Handle);
             hFunc(TEvPrivate::TEvErrorResponse, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -8,6 +8,8 @@
 #include <ydb/mvp/core/mvp_test_runtime.h>
 #include "oidc_protected_page_handler.h"
 #include "oidc_session_create_handler.h"
+#include "oidc_impersonate_start_page_nebius.h"
+#include "oidc_impersonate_stop_page_nebius.h"
 #include "oidc_settings.h"
 #include "openid_connect.h"
 #include "context.h"
@@ -1125,5 +1127,274 @@ Y_UNIT_TEST_SUITE(Mvp) {
         NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
         UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "400");
         UNIT_ASSERT_STRING_CONTAINS(outgoingResponseEv->Response->Body, "Unknown error has occurred. Please open the page again");
+    }
+
+    Y_UNIT_TEST(OidcImpersonationStartFlow) {
+        TPortManager tp;
+        ui16 sessionServicePort = tp.GetPort(8655);
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        TOpenIdConnectSettings settings {
+            .ClientId = "client_id",
+            .SessionServiceEndpoint = "localhost:" + ToString(sessionServicePort),
+            .AuthorizationServerAddress = "https://auth.test.net",
+            .ClientSecret = "0123456789abcdef",
+            .AccessServiceType = NMvp::nebius_v1
+        };
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+
+        TSessionServiceMock sessionServiceMock;
+        sessionServiceMock.AllowedAccessTokens.insert("valid_access_token");
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(settings.SessionServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&sessionServiceMock);
+        std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
+
+        const NActors::TActorId impersonateStart = runtime.Register(new TImpersonateStartPageHandler(edge, settings));
+        const TString hostProxy = "oidcproxy.net";
+        TStringBuilder request;
+        request << "GET /impersonate/start?service_account_id=serviceaccount-e0tydb-dev HTTP/1.1\r\n"
+                << "Host: " + hostProxy + "\r\n"
+                << "Cookie: " << CreateNameSessionCookie(settings.ClientId) + "=" + Base64Encode("session_cookie") + "\r\n\r\n";
+
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        EatWholeString(incomingRequest, request);
+        incomingRequest->Endpoint->Secure = true;
+        runtime.Send(new IEventHandle(impersonateStart, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->Host, "auth.test.net");
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->URL, "/oauth2/impersonation/impersonate");
+        UNIT_ASSERT_EQUAL(outgoingRequestEv->Request->Secure, true);
+        NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
+        TString okResponseBody {"{\"impersonation\": \"impersonation_token\"}"};
+        EatWholeString(incomingResponse, "HTTP/1.1 200 OK\r\n"
+                                         "Connection: close\r\n"
+                                         "Content-Type: text/html\r\n"
+                                         "Content-Length: " + ToString(okResponseBody.size()) + "\r\n\r\n" + okResponseBody);
+        runtime.Send(new IEventHandle(handle->Sender, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(outgoingRequestEv->Request, incomingResponse)));
+
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "200");
+        const NHttp::THeaders impersonatePageHeaders(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(impersonatePageHeaders.Has("Set-Cookie"));
+        TStringBuf impersonatedCookie = impersonatePageHeaders.Get("Set-Cookie");
+        TString expectedCookie = CreateSecureCookie(CreateNameImpersonatedCookie(settings.ClientId), Base64Encode("impersonation_token"));
+        UNIT_ASSERT_STRINGS_EQUAL(impersonatedCookie, expectedCookie);
+    }
+
+    Y_UNIT_TEST(OidcImpersonationStartNeedServiceAccountId) {
+        TPortManager tp;
+        ui16 sessionServicePort = tp.GetPort(8655);
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        TOpenIdConnectSettings settings {
+            .ClientId = "client_id",
+            .SessionServiceEndpoint = "localhost:" + ToString(sessionServicePort),
+            .AuthorizationServerAddress = "https://auth.test.net",
+            .ClientSecret = "0123456789abcdef",
+            .AccessServiceType = NMvp::nebius_v1
+        };
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+
+        TSessionServiceMock sessionServiceMock;
+        sessionServiceMock.AllowedAccessTokens.insert("valid_access_token");
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(settings.SessionServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&sessionServiceMock);
+        std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
+
+        const NActors::TActorId impersonateStart = runtime.Register(new TImpersonateStartPageHandler(edge, settings));
+        const TString hostProxy = "oidcproxy.net";
+        TStringBuilder request;
+        request << "GET /impersonate/start HTTP/1.1\r\n"
+                << "Host: " + hostProxy + "\r\n"
+                << "Cookie: " << CreateNameSessionCookie(settings.ClientId) + "=" + Base64Encode("session_cookie") + "\r\n\r\n";
+
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        EatWholeString(incomingRequest, request);
+        incomingRequest->Endpoint->Secure = true;
+        runtime.Send(new IEventHandle(impersonateStart, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "400");
+        const NHttp::THeaders impersonatePageHeaders(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(!impersonatePageHeaders.Has("Set-Cookie"));
+    }
+
+    Y_UNIT_TEST(OidcImpersonationStopFlow) {
+        TPortManager tp;
+        ui16 sessionServicePort = tp.GetPort(8655);
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        TOpenIdConnectSettings settings {
+            .ClientId = "client_id",
+            .SessionServiceEndpoint = "localhost:" + ToString(sessionServicePort),
+            .AuthorizationServerAddress = "https://auth.test.net",
+            .ClientSecret = "0123456789abcdef",
+            .AccessServiceType = NMvp::nebius_v1
+        };
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+
+        TSessionServiceMock sessionServiceMock;
+        sessionServiceMock.AllowedAccessTokens.insert("valid_access_token");
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(settings.SessionServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&sessionServiceMock);
+        std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
+
+        const NActors::TActorId impersonateStop = runtime.Register(new TImpersonateStopPageHandler(edge, settings));
+        const TString hostProxy = "oidcproxy.net";
+        TStringBuilder request;
+        request << "GET /impersonate/start HTTP/1.1\r\n"
+                << "Host: " + hostProxy + "\r\n"
+                << "Cookie: " << CreateNameImpersonatedCookie(settings.ClientId) + "=" + Base64Encode("impersonated_cookie") + "\r\n\r\n";
+
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        EatWholeString(incomingRequest, request);
+        incomingRequest->Endpoint->Secure = true;
+        runtime.Send(new IEventHandle(impersonateStop, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "200");
+        const NHttp::THeaders impersonatePageHeaders(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(impersonatePageHeaders.Has("Set-Cookie"));
+        TStringBuf impersonatedCookie = impersonatePageHeaders.Get("Set-Cookie");
+        TString expectedCookie = ClearSecureCookie(CreateNameImpersonatedCookie(settings.ClientId));
+        UNIT_ASSERT_STRINGS_EQUAL(impersonatedCookie, expectedCookie);
+    }
+
+    Y_UNIT_TEST(OidcImpersonatedAccessToProtectedResource) {
+        TPortManager tp;
+        ui16 sessionServicePort = tp.GetPort(8655);
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        const TString allowedProxyHost {"ydb.viewer.page"};
+        TOpenIdConnectSettings settings {
+            .ClientId = "client_id",
+            .SessionServiceEndpoint = "localhost:" + ToString(sessionServicePort),
+            .AuthorizationServerAddress = "https://auth.test.net",
+            .ClientSecret = "0123456789abcdef",
+            .AllowedProxyHosts = {allowedProxyHost},
+            .AccessServiceType = NMvp::nebius_v1
+        };
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+        TSessionServiceMock sessionServiceMock;
+        sessionServiceMock.AllowedAccessTokens.insert("valid_access_token");
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(settings.SessionServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&sessionServiceMock);
+        std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
+
+        const NActors::TActorId impersonateStart = runtime.Register(new TProtectedPageHandler(edge, settings));
+        const TString hostProxy = "oidcproxy.net";
+        const TString protectedPage = "/" + allowedProxyHost + "/counters";
+        TStringBuilder request;
+        request << "GET " << protectedPage << " HTTP/1.1\r\n"
+                << "Host: " << hostProxy << "\r\n"
+                << "Referer: https://" << hostProxy << protectedPage << "\r\n"
+                << "Cookie: " << CreateNameSessionCookie(settings.ClientId) << "=" << Base64Encode("session_cookie") << "; "
+                << CreateNameImpersonatedCookie(settings.ClientId) << "=" << Base64Encode("impersonated_cookie") << "\r\n\r\n";
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        EatWholeString(incomingRequest, request);
+        incomingRequest->Endpoint->Secure = true;
+        runtime.Send(new IEventHandle(impersonateStart, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->Host, "auth.test.net");
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->URL, "/oauth2/session/exchange");
+
+        UNIT_ASSERT_EQUAL(outgoingRequestEv->Request->Secure, true);
+        NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
+        TString okResponseBody {"{\"access_token\": \"access_token\"}"};
+        EatWholeString(incomingResponse, "HTTP/1.1 200 OK\r\n"
+                                         "Connection: close\r\n"
+                                         "Content-Type: text/html\r\n"
+                                         "Content-Length: " + ToString(okResponseBody.size()) + "\r\n\r\n" + okResponseBody);
+        runtime.Send(new IEventHandle(handle->Sender, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(outgoingRequestEv->Request, incomingResponse)));
+
+        outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->Host, allowedProxyHost);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->URL, "/counters");
+        UNIT_ASSERT_STRING_CONTAINS(outgoingRequestEv->Request->Headers, "Authorization: Bearer access_token");
+        UNIT_ASSERT_EQUAL(outgoingRequestEv->Request->Secure, false);
+        incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
+        okResponseBody = "this is test";
+        EatWholeString(incomingResponse, "HTTP/1.1 200 OK\r\n"
+                                         "Connection: close\r\n"
+                                         "Content-Type: text/html\r\n"
+                                         "Content-Length: " + ToString(okResponseBody.size()) + "\r\n\r\n" + okResponseBody);
+
+        runtime.Send(new IEventHandle(handle->Sender, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(outgoingRequestEv->Request, incomingResponse)));
+        auto outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "200");
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Body, "this is test");
+    }
+
+    Y_UNIT_TEST(OidcImpersonatedAccessNotAuthorized) {
+        TPortManager tp;
+        ui16 sessionServicePort = tp.GetPort(8655);
+        TMvpTestRuntime runtime;
+        runtime.Initialize();
+
+        const TString allowedProxyHost {"ydb.viewer.page"};
+        TOpenIdConnectSettings settings {
+            .ClientId = "client_id",
+            .SessionServiceEndpoint = "localhost:" + ToString(sessionServicePort),
+            .AuthorizationServerAddress = "https://auth.test.net",
+            .ClientSecret = "0123456789abcdef",
+            .AllowedProxyHosts = {allowedProxyHost},
+            .AccessServiceType = NMvp::nebius_v1
+        };
+
+        const NActors::TActorId edge = runtime.AllocateEdgeActor();
+        TSessionServiceMock sessionServiceMock;
+        sessionServiceMock.AllowedAccessTokens.insert("valid_access_token");
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(settings.SessionServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&sessionServiceMock);
+        std::unique_ptr<grpc::Server> sessionServer(builder.BuildAndStart());
+
+        const NActors::TActorId impersonateStart = runtime.Register(new TProtectedPageHandler(edge, settings));
+        const TString hostProxy = "oidcproxy.net";
+        const TString protectedPage = "/" + allowedProxyHost + "/counters";
+        TStringBuilder request;
+        request << "GET " << protectedPage << " HTTP/1.1\r\n"
+                << "Host: " << hostProxy << "\r\n"
+                << "Referer: https://" << hostProxy << protectedPage << "\r\n"
+                << "Cookie: " << CreateNameSessionCookie(settings.ClientId) << "=" << Base64Encode("session_cookie") << "; "
+                << CreateNameImpersonatedCookie(settings.ClientId) << "=" << Base64Encode("impersonated_cookie") << "\r\n\r\n";
+        NHttp::THttpIncomingRequestPtr incomingRequest = new NHttp::THttpIncomingRequest();
+        EatWholeString(incomingRequest, request);
+        incomingRequest->Endpoint->Secure = true;
+        runtime.Send(new IEventHandle(impersonateStart, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(incomingRequest)));
+
+        TAutoPtr<IEventHandle> handle;
+        auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->Host, "auth.test.net");
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingRequestEv->Request->URL, "/oauth2/session/exchange");
+
+        UNIT_ASSERT_EQUAL(outgoingRequestEv->Request->Secure, true);
+        NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
+        TString okResponseBody {"{\"error\": \"bad_token\"}"};
+        EatWholeString(incomingResponse, "HTTP/1.1 401 OK\r\n"
+                                         "Connection: close\r\n"
+                                         "Content-Type: text/html\r\n"
+                                         "Content-Length: " + ToString(okResponseBody.size()) + "\r\n\r\n" + okResponseBody);
+        runtime.Send(new IEventHandle(handle->Sender, edge, new NHttp::TEvHttpProxy::TEvHttpIncomingResponse(outgoingRequestEv->Request, incomingResponse)));
+
+        auto outgoingResponseEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        UNIT_ASSERT_STRINGS_EQUAL(outgoingResponseEv->Response->Status, "307");
+        const NHttp::THeaders headers(outgoingResponseEv->Response->Headers);
+        UNIT_ASSERT(headers.Has("Location"));
+        TStringBuf location = headers.Get("Location");
+        UNIT_ASSERT_STRINGS_EQUAL(location, protectedPage);
     }
 }

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -641,8 +641,8 @@ Y_UNIT_TEST_SUITE(Mvp) {
 
         auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
         const TStringBuf& body = outgoingRequestEv->Request->Body;
-        UNIT_ASSERT_STRING_CONTAINS(body, "code=code_template");
-        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type=authorization_code");
+        UNIT_ASSERT_STRING_CONTAINS(body, "code%3Dcode_template");
+        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type%3Dauthorization_code");
 
         const TString authorizationServerResponse = R"___({"access_token":"access_token_value","token_type":"bearer","expires_in":43199,"scope":"openid","id_token":"id_token_value"})___";
         NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
@@ -793,8 +793,8 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TAutoPtr<IEventHandle> handle;
         auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
         const TStringBuf& body = outgoingRequestEv->Request->Body;
-        UNIT_ASSERT_STRING_CONTAINS(body, "code=code_template");
-        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type=authorization_code");
+        UNIT_ASSERT_STRING_CONTAINS(body, "code%3Dcode_template");
+        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type%3Dauthorization_code");
 
         const TString authorizationServerResponse = R"___({"access_token":"access_token_value","token_type":"bearer","expires_in":43199,"scope":"openid","id_token":"id_token_value"})___";
         NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
@@ -848,8 +848,8 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TAutoPtr<IEventHandle> handle;
         auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
         const TStringBuf& body = outgoingRequestEv->Request->Body;
-        UNIT_ASSERT_STRING_CONTAINS(body, "code=code_template");
-        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type=authorization_code");
+        UNIT_ASSERT_STRING_CONTAINS(body, "code%3Dcode_template");
+        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type%3Dauthorization_code");
 
         const TString authorizationServerResponse = R"___({"access_token":"invalid_access_token","token_type":"bearer","expires_in":43199,"scope":"openid","id_token":"id_token_value"})___";
         NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);
@@ -914,8 +914,9 @@ Y_UNIT_TEST_SUITE(Mvp) {
         TAutoPtr<IEventHandle> handle;
         auto outgoingRequestEv = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingRequest>(handle);
         const TStringBuf& body = outgoingRequestEv->Request->Body;
-        UNIT_ASSERT_STRING_CONTAINS(body, "code=code_template");
-        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type=authorization_code");
+
+        UNIT_ASSERT_STRING_CONTAINS(body, "code%3Dcode_template");
+        UNIT_ASSERT_STRING_CONTAINS(body, "grant_type%3Dauthorization_code");
 
         const TString authorizationServerResponse = R"___({"access_token":"access_token_value","token_type":"bearer","expires_in":43199,"scope":"openid","id_token":"id_token_value"})___";
         NHttp::THttpIncomingResponsePtr incomingResponse = new NHttp::THttpIncomingResponse(outgoingRequestEv->Request);

--- a/ydb/mvp/oidc_proxy/oidc_session_create.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.cpp
@@ -20,6 +20,7 @@ THandlerSessionCreate::THandlerSessionCreate(const NActors::TActorId& sender,
 {}
 
 void THandlerSessionCreate::Bootstrap(const NActors::TActorContext& ctx) {
+    LOG_DEBUG_S(ctx, NMVP::EService::MVP, "Restore oidc session");
     NHttp::TUrlParameters urlParameters(Request->URL);
     TString code = urlParameters["code"];
     TString state = urlParameters["state"];
@@ -56,6 +57,7 @@ void THandlerSessionCreate::Bootstrap(const NActors::TActorContext& ctx) {
             SendUnknownErrorResponseAndDie(ctx);
         }
     }
+
 }
 
 void THandlerSessionCreate::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx) {

--- a/ydb/mvp/oidc_proxy/oidc_session_create.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.cpp
@@ -93,7 +93,7 @@ void THandlerSessionCreate::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse:
         responseHeaders.Set("Content-Type", "text/plain");
         httpResponse = Request->CreateResponse("400", "Bad Request", responseHeaders, event->Get()->Error);
     }
-    ReplyAndPassAway(httpResponse);
+    ReplyAndPassAway(std::move(httpResponse));
 }
 
 TString THandlerSessionCreate::ChangeSameSiteFieldInSessionCookie(const TString& cookie) {
@@ -142,7 +142,7 @@ void THandlerSessionCreate::SendUnknownErrorResponseAndDie() {
 }
 
 void THandlerSessionCreate::ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse) {
-    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(httpResponse));
+    Send(Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(std::move(httpResponse)));
     PassAway();
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_session_create.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.h
@@ -9,8 +9,7 @@
 #include "oidc_settings.h"
 #include "context.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 class THandlerSessionCreate : public NActors::TActorBootstrapped<THandlerSessionCreate> {
 private:
@@ -19,7 +18,7 @@ private:
 protected:
     const NActors::TActorId Sender;
     const NHttp::THttpIncomingRequestPtr Request;
-    NActors::TActorId HttpProxyId;
+    const NActors::TActorId HttpProxyId;
     const TOpenIdConnectSettings Settings;
     TContext Context;
 
@@ -39,10 +38,10 @@ protected:
     TString ChangeSameSiteFieldInSessionCookie(const TString& cookie);
     void RetryRequestToProtectedResourceAndDie(const NActors::TActorContext& ctx);
     void RetryRequestToProtectedResourceAndDie(NHttp::THeadersBuilder* responseHeaders, const NActors::TActorContext& ctx);
+    void ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx);
 
 private:
     void SendUnknownErrorResponseAndDie(const NActors::TActorContext& ctx);
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_session_create.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.h
@@ -28,7 +28,7 @@ public:
                           const NActors::TActorId& httpProxyId,
                           const TOpenIdConnectSettings& settings);
 
-    virtual void RequestSessionToken(const TString&, const NActors::TActorContext&) = 0;
+    virtual void RequestSessionToken(TString&, const NActors::TActorContext&) = 0;
     virtual void ProcessSessionToken(const TString& accessToken, const NActors::TActorContext&) = 0;
 
     void Bootstrap(const NActors::TActorContext& ctx);
@@ -36,12 +36,12 @@ public:
 
 protected:
     TString ChangeSameSiteFieldInSessionCookie(const TString& cookie);
-    void RetryRequestToProtectedResourceAndDie(const NActors::TActorContext& ctx);
-    void RetryRequestToProtectedResourceAndDie(NHttp::THeadersBuilder* responseHeaders, const NActors::TActorContext& ctx);
-    void ReplyAndDie(NHttp::THttpOutgoingResponsePtr httpResponse, const NActors::TActorContext& ctx);
+    void RetryRequestToProtectedResourceAndDie();
+    void RetryRequestToProtectedResourceAndDie(NHttp::THeadersBuilder* responseHeaders);
+    void ReplyAndPassAway(NHttp::THttpOutgoingResponsePtr httpResponse);
 
 private:
-    void SendUnknownErrorResponseAndDie(const NActors::TActorContext& ctx);
+    void SendUnknownErrorResponseAndDie();
 };
 
 } // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_session_create.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create.h
@@ -28,10 +28,10 @@ public:
                           const NActors::TActorId& httpProxyId,
                           const TOpenIdConnectSettings& settings);
 
-    virtual void RequestSessionToken(TString&, const NActors::TActorContext&) = 0;
+    virtual void RequestSessionToken(const TString&) = 0;
     virtual void ProcessSessionToken(const TString& accessToken, const NActors::TActorContext&) = 0;
 
-    void Bootstrap(const NActors::TActorContext& ctx);
+    void Bootstrap();
     void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingResponse::TPtr event, const NActors::TActorContext& ctx);
 
 protected:

--- a/ydb/mvp/oidc_proxy/oidc_session_create_handler.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_handler.cpp
@@ -2,8 +2,7 @@
 #include "oidc_session_create_nebius.h"
 #include "oidc_session_create_yandex.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 TSessionCreateHandler::TSessionCreateHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings)
     : TBase(&TSessionCreateHandler::StateWork)
@@ -27,5 +26,4 @@ void TSessionCreateHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::
     ctx.Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
 }
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_session_create_handler.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_handler.cpp
@@ -10,20 +10,20 @@ TSessionCreateHandler::TSessionCreateHandler(const NActors::TActorId& httpProxyI
     , Settings(settings)
 {}
 
-void TSessionCreateHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx) {
+void TSessionCreateHandler::Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event) {
     NHttp::THttpIncomingRequestPtr request = event->Get()->Request;
     if (request->Method == "GET") {
         switch (Settings.AccessServiceType) {
             case NMvp::yandex_v2:
-                ctx.Register(new THandlerSessionCreateYandex(event->Sender, request, HttpProxyId, Settings));
+                Register(new THandlerSessionCreateYandex(event->Sender, request, HttpProxyId, Settings));
                 return;
             case NMvp::nebius_v1:
-                ctx.Register(new THandlerSessionCreateNebius(event->Sender, request, HttpProxyId, Settings));
+                Register(new THandlerSessionCreateNebius(event->Sender, request, HttpProxyId, Settings));
                 return;
         }
     }
     auto response = request->CreateResponseBadRequest();
-    ctx.Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
+    Send(event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
 }
 
 } // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_session_create_handler.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_handler.h
@@ -5,8 +5,9 @@
 #include <ydb/library/actors/http/http_proxy.h>
 #include "oidc_settings.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
+
+using namespace NActors;
 
 class TSessionCreateHandler : public NActors::TActor<TSessionCreateHandler> {
     using TBase = NActors::TActor<TSessionCreateHandler>;
@@ -21,9 +22,9 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_session_create_handler.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_handler.h
@@ -16,11 +16,11 @@ class TSessionCreateHandler : public NActors::TActor<TSessionCreateHandler> {
 
 public:
     TSessionCreateHandler(const NActors::TActorId& httpProxyId, const TOpenIdConnectSettings& settings);
-    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const NActors::TActorContext& ctx);
+    void Handle(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event);
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
             cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }

--- a/ydb/mvp/oidc_proxy/oidc_session_create_handler.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_handler.h
@@ -1,13 +1,12 @@
 #pragma once
 
 #include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/http/http_proxy.h>
 #include "oidc_settings.h"
 
 namespace NMVP::NOIDC {
-
-using namespace NActors;
 
 class TSessionCreateHandler : public NActors::TActor<TSessionCreateHandler> {
     using TBase = NActors::TActor<TSessionCreateHandler>;
@@ -22,7 +21,7 @@ public:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
+            cFunc(NActors::TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };

--- a/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
@@ -14,7 +14,7 @@ public:
                                 const NActors::TActorId& httpProxyId,
                                 const TOpenIdConnectSettings& settings);
 
-    void RequestSessionToken(TString& code, const NActors::TActorContext& ctx) override;
+    void RequestSessionToken(const TString& code) override;
     void ProcessSessionToken(const TString& sessionToken, const NActors::TActorContext& ctx) override;
 
 private:

--- a/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
@@ -16,7 +16,7 @@ public:
                                 const NActors::TActorId& httpProxyId,
                                 const TOpenIdConnectSettings& settings);
 
-    void RequestSessionToken(const TString& code, const NActors::TActorContext& ctx) override;
+    void RequestSessionToken(TString& code, const NActors::TActorContext& ctx) override;
     void ProcessSessionToken(const TString& sessionToken, const NActors::TActorContext& ctx) override;
 
 private:

--- a/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
@@ -2,8 +2,9 @@
 
 #include "oidc_session_create.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
+
+using namespace NActors;
 
 class THandlerSessionCreateNebius : public THandlerSessionCreate {
 private:
@@ -22,9 +23,9 @@ private:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
+            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_nebius.h
@@ -4,8 +4,6 @@
 
 namespace NMVP::NOIDC {
 
-using namespace NActors;
-
 class THandlerSessionCreateNebius : public THandlerSessionCreate {
 private:
     using TBase = THandlerSessionCreate;
@@ -23,7 +21,6 @@ private:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };

--- a/ydb/mvp/oidc_proxy/oidc_session_create_yandex.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_yandex.cpp
@@ -79,7 +79,7 @@ void THandlerSessionCreateYandex::HandleError(TEvPrivate::TEvErrorResponse::TPtr
         responseHeaders.Set("Content-Type", "text/plain");
         SetCORS(Request, &responseHeaders);
         NHttp::THttpOutgoingResponsePtr httpResponse = Request->CreateResponse( event->Get()->Status, event->Get()->Message, responseHeaders, event->Get()->Details);
-        ReplyAndPassAway(httpResponse);
+        ReplyAndPassAway(std::move(httpResponse));
     }
 }
 

--- a/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
@@ -5,8 +5,6 @@
 
 namespace NMVP::NOIDC {
 
-using namespace NActors;
-
 class THandlerSessionCreateYandex : public THandlerSessionCreate {
 private:
     using TBase = THandlerSessionCreate;
@@ -29,7 +27,6 @@ private:
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
             hFunc(TEvPrivate::TEvCreateSessionResponse, HandleCreateSession);
             hFunc(TEvPrivate::TEvErrorResponse, HandleError);
-            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };

--- a/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
@@ -16,7 +16,7 @@ public:
                                 const NActors::TActorId& httpProxyId,
                                 const TOpenIdConnectSettings& settings);
 
-    void RequestSessionToken(TString& code, const NActors::TActorContext& ctx) override;
+    void RequestSessionToken(const TString& code) override;
     void ProcessSessionToken(const TString& sessionToken, const NActors::TActorContext& ctx) override;
     void HandleCreateSession(TEvPrivate::TEvCreateSessionResponse::TPtr event);
     void HandleError(TEvPrivate::TEvErrorResponse::TPtr event);

--- a/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
@@ -3,8 +3,9 @@
 #include "oidc_session_create.h"
 #include "openid_connect.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
+
+using namespace NActors;
 
 class THandlerSessionCreateYandex : public THandlerSessionCreate {
 private:
@@ -28,9 +29,9 @@ private:
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
             HFunc(TEvPrivate::TEvCreateSessionResponse, HandleCreateSession);
             HFunc(TEvPrivate::TEvErrorResponse, HandleError);
+            cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
+++ b/ydb/mvp/oidc_proxy/oidc_session_create_yandex.h
@@ -18,17 +18,17 @@ public:
                                 const NActors::TActorId& httpProxyId,
                                 const TOpenIdConnectSettings& settings);
 
-    void RequestSessionToken(const TString& code, const NActors::TActorContext& ctx) override;
+    void RequestSessionToken(TString& code, const NActors::TActorContext& ctx) override;
     void ProcessSessionToken(const TString& sessionToken, const NActors::TActorContext& ctx) override;
-    void HandleCreateSession(TEvPrivate::TEvCreateSessionResponse::TPtr event, const NActors::TActorContext& ctx);
-    void HandleError(TEvPrivate::TEvErrorResponse::TPtr event, const NActors::TActorContext& ctx);
+    void HandleCreateSession(TEvPrivate::TEvCreateSessionResponse::TPtr event);
+    void HandleError(TEvPrivate::TEvErrorResponse::TPtr event);
 
 private:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NHttp::TEvHttpProxy::TEvHttpIncomingResponse, Handle);
-            HFunc(TEvPrivate::TEvCreateSessionResponse, HandleCreateSession);
-            HFunc(TEvPrivate::TEvErrorResponse, HandleError);
+            hFunc(TEvPrivate::TEvCreateSessionResponse, HandleCreateSession);
+            hFunc(TEvPrivate::TEvErrorResponse, HandleError);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }

--- a/ydb/mvp/oidc_proxy/oidc_settings.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_settings.cpp
@@ -2,8 +2,7 @@
 #include <library/cpp/string_utils/base64/base64.h>
 #include "oidc_settings.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 TString TOpenIdConnectSettings::GetAuthorizationString() const {
     return "Basic " + Base64Encode(ClientId + ":" + ClientSecret);
@@ -25,5 +24,4 @@ TString TOpenIdConnectSettings::GetImpersonateEndpointURL() const {
     return AuthorizationServerAddress + ImpersonateUrlPath;
 }
 
-} // NOIDC
-} // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_settings.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_settings.cpp
@@ -21,5 +21,9 @@ TString TOpenIdConnectSettings::GetExchangeEndpointURL() const {
     return AuthorizationServerAddress + ExchangeUrlPath;
 }
 
+TString TOpenIdConnectSettings::GetImpersonateEndpointURL() const {
+    return AuthorizationServerAddress + ImpersonateUrlPath;
+}
+
 } // NOIDC
 } // NMVP

--- a/ydb/mvp/oidc_proxy/oidc_settings.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_settings.cpp
@@ -1,6 +1,6 @@
-#include <util/generic/string.h>
-#include <library/cpp/string_utils/base64/base64.h>
 #include "oidc_settings.h"
+#include <library/cpp/string_utils/base64/base64.h>
+#include <util/generic/string.h>
 
 namespace NMVP::NOIDC {
 

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -3,8 +3,7 @@
 #include <util/generic/string.h>
 #include <ydb/mvp/core/protos/mvp.pb.h>
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 struct TOpenIdConnectSettings {
     static const inline TString YDB_OIDC_COOKIE = "ydb_oidc_cookie";
@@ -37,5 +36,4 @@ struct TOpenIdConnectSettings {
     TString GetImpersonateEndpointURL() const;
 };
 
-} // NOIDC
-} // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <util/generic/string.h>
 #include <ydb/mvp/core/protos/mvp.pb.h>
+#include <util/generic/string.h>
 
 namespace NMVP::NOIDC {
 

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -9,6 +9,7 @@ namespace NOIDC {
 struct TOpenIdConnectSettings {
     static const inline TString YDB_OIDC_COOKIE = "ydb_oidc_cookie";
     static const inline TString SESSION_COOKIE = "session_cookie";
+    static const inline TString IMPERSONATED_COOKIE = "impersonated_cookie";
 
     static const inline TString DEFAULT_CLIENT_ID = "yc.oauth.ydb-viewer";
     static const inline TString DEFAULT_AUTH_URL_PATH = "/oauth/authorize";

--- a/ydb/mvp/oidc_proxy/oidc_settings.h
+++ b/ydb/mvp/oidc_proxy/oidc_settings.h
@@ -15,6 +15,7 @@ struct TOpenIdConnectSettings {
     static const inline TString DEFAULT_AUTH_URL_PATH = "/oauth/authorize";
     static const inline TString DEFAULT_TOKEN_URL_PATH = "/oauth/token";
     static const inline TString DEFAULT_EXCHANGE_URL_PATH = "/oauth2/session/exchange";
+    static const inline TString DEFAULT_IMPERSONATE_URL_PATH = "/oauth2/impersonation/impersonate";
 
     TString ClientId = DEFAULT_CLIENT_ID;
     TString SessionServiceEndpoint;
@@ -27,11 +28,13 @@ struct TOpenIdConnectSettings {
     TString AuthUrlPath = DEFAULT_AUTH_URL_PATH;
     TString TokenUrlPath = DEFAULT_TOKEN_URL_PATH;
     TString ExchangeUrlPath = DEFAULT_EXCHANGE_URL_PATH;
+    TString ImpersonateUrlPath = DEFAULT_IMPERSONATE_URL_PATH;
 
     TString GetAuthorizationString() const;
     TString GetAuthEndpointURL() const;
     TString GetTokenEndpointURL() const;
     TString GetExchangeEndpointURL() const;
+    TString GetImpersonateEndpointURL() const;
 };
 
 } // NOIDC

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -237,5 +237,16 @@ TCheckStateResult CheckState(const TString& state, const TString& key) {
     return TCheckStateResult();
 }
 
+TString DecodeToken(const TStringBuf& cookie, const NActors::TActorContext& ctx) {
+    TString token;
+    try {
+        Base64StrictDecode(cookie, token);
+    } catch (std::exception& e) {
+        LOG_DEBUG_S(ctx, EService::MVP, "Base64Decode " << cookie << " cookie: " << e.what());
+        token.clear();
+    }
+    return token;
+}
+
 }  // NOIDC
 }  // NMVP

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -127,6 +127,12 @@ TString CreateSecureCookie(const TString& name, const TString& value) {
     return cookieBuilder;
 }
 
+TString ClearSecureCookie(const TString& name) {
+    TStringBuilder cookieBuilder;
+    cookieBuilder << name << "=; Path=/; Secure; HttpOnly; SameSite=None; Partitioned; Max-Age=0";
+    return cookieBuilder;
+}
+
 TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key) {
     TStringBuilder errorMessage;
     errorMessage << "Restore oidc context failed: ";

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -1,15 +1,15 @@
-#include <util/random/random.h>
-#include <util/string/builder.h>
-#include <util/string/hex.h>
-#include <library/cpp/json/json_reader.h>
-#include <library/cpp/string_utils/base64/base64.h>
-#include <ydb/library/security/util.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-#include <openssl/sha.h>
 #include "context.h"
 #include "openid_connect.h"
 #include "oidc_settings.h"
+#include <ydb/library/security/util.h>
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/string_utils/base64/base64.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#include <util/random/random.h>
+#include <util/string/builder.h>
+#include <util/string/hex.h>
 
 namespace NMVP::NOIDC {
 
@@ -242,7 +242,7 @@ TString DecodeToken(const TStringBuf& cookie) {
     try {
         Base64StrictDecode(cookie, token);
     } catch (std::exception& e) {
-        BLOG_D("Base64Decode " << cookie << " cookie: " << e.what());
+        BLOG_D("Base64Decode " << NKikimr::MaskTicket(cookie) << " cookie: " << e.what());
         token.clear();
     }
     return token;

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -111,6 +111,10 @@ TString CreateNameSessionCookie(TStringBuf key) {
     return "__Host_" + TOpenIdConnectSettings::SESSION_COOKIE + "_" + HexEncode(key);
 }
 
+TString CreateNameImpersonatedCookie(TStringBuf key) {
+    return "__Host_" + TOpenIdConnectSettings::IMPERSONATED_COOKIE + "_" + HexEncode(key);
+}
+
 const TString& GetAuthCallbackUrl() {
     static const TString callbackUrl = "/auth/callback";
     return callbackUrl;

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -9,8 +9,7 @@
 #include <ydb/mvp/core/core_ydb.h>
 #include "context.h"
 
-namespace NMVP {
-namespace NOIDC {
+namespace NMVP::NOIDC {
 
 struct TOpenIdConnectSettings;
 
@@ -51,7 +50,8 @@ TString ClearSecureCookie(const TString& name);
 void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder* const headers);
 TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key);
 TCheckStateResult CheckState(const TString& state, const TString& key);
-TString DecodeToken(const TStringBuf& cookie, const NActors::TActorContext& ctx);
+TString DecodeToken(const TStringBuf& cookie);
+TStringBuf GetCookie(const NHttp::TCookies& cookies, const TString& cookieName);
 
 template <typename TSessionService>
 std::unique_ptr<NYdbGrpc::TServiceConnection<TSessionService>> CreateGRpcServiceConnection(const TString& endpoint) {
@@ -145,5 +145,4 @@ struct TEvPrivate {
     };
 };
 
-}  // NOIDC
-}  // NMVP
+} // NMVP::NOIDC

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -9,7 +9,6 @@
 #include <ydb/mvp/core/core_ydb.h>
 #include "context.h"
 
-
 namespace NMVP {
 namespace NOIDC {
 
@@ -52,6 +51,7 @@ TString ClearSecureCookie(const TString& name);
 void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder* const headers);
 TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key);
 TCheckStateResult CheckState(const TString& state, const TString& key);
+TString DecodeToken(const TStringBuf& cookie, const NActors::TActorContext& ctx);
 
 template <typename TSessionService>
 std::unique_ptr<NYdbGrpc::TServiceConnection<TSessionService>> CreateGRpcServiceConnection(const TString& endpoint) {

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -45,8 +45,10 @@ void SetHeader(NYdbGrpc::TCallMeta& meta, const TString& name, const TString& va
 NHttp::THttpOutgoingResponsePtr GetHttpOutgoingResponsePtr(const NHttp::THttpIncomingRequestPtr& request, const TOpenIdConnectSettings& settings);
 TString CreateNameYdbOidcCookie(TStringBuf key, TStringBuf state);
 TString CreateNameSessionCookie(TStringBuf key);
+TString CreateNameImpersonatedCookie(TStringBuf key);
 const TString& GetAuthCallbackUrl();
 TString CreateSecureCookie(const TString& name, const TString& value);
+TString ClearSecureCookie(const TString& name);
 void SetCORS(const NHttp::THttpIncomingRequestPtr& request, NHttp::THeadersBuilder* const headers);
 TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, const TString& key);
 TCheckStateResult CheckState(const TString& state, const TString& key);

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -1,13 +1,13 @@
 #pragma once
-#include <util/generic/string.h>
-#include <util/generic/ptr.h>
-#include <ydb/public/api/client/yc_private/oauth/session_service.grpc.pb.h>
+#include "context.h"
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/library/grpc/client/grpc_client_low.h>
 #include <ydb/mvp/core/core_ydb.h>
-#include "context.h"
+#include <ydb/public/api/client/yc_private/oauth/session_service.grpc.pb.h>
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
 
 namespace NMVP::NOIDC {
 

--- a/ydb/mvp/oidc_proxy/ya.make
+++ b/ydb/mvp/oidc_proxy/ya.make
@@ -10,6 +10,8 @@ SRCS(
     oidc_client.cpp
     openid_connect.cpp
     oidc_settings.cpp
+    oidc_impersonate_start_page_nebius.cpp
+    oidc_impersonate_stop_page_nebius.cpp
     oidc_protected_page_handler.cpp
     oidc_protected_page_yandex.cpp
     oidc_protected_page_nebius.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

https://nebius.atlassian.net/browse/NBYDB-594

oidc impersonation adds impersonated cookie that could be used instead session cookie
to get impersonated cookie session cookie and service-account-id could be used

2 oidc impersonate handler were added
`/impersonate/start` to add impersonated cookie
`/impersonate/stop` to remove impersonated cookie

If request to oidc happens, it checks new impersonated cookie. if exists, oidc uses it for next authentification
If the authentication domain returns a status code of 400 or 401, OIDC performs a redirect with a 307 status code to the same address and clears the impersonated cookie.

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Examples:

1) /impersonate/start
curl -i 'https://oidc.net/impersonate/start?service_account_id=serviceaccount-e0tydb-dev' \
-H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
-H 'cookie: __Host_session_cookie_6D76702D6F6964632D74657374696E67=****' \
--insecure

expected result:
set-cookie: __Host_impersonated_cookie_6D76702D6F6964632D74657374696E67=****; Path=/; Secure; HttpOnly; SameSite=None; Partitioned

2) /impersonate/stop
curl -i 'https://oidc.net/impersonate/start?service_account_id=service-account-name' \
-H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
-H 'cookie: __Host_session_cookie_6D76702D6F6964632D74657374696E67=****' \
--insecure

expected result:
set-cookie: __Host_impersonated_cookie_6D76702D6F6964632D74657374696E67=; Path=/; Secure; HttpOnly; SameSite=None; Partitioned; Max-Age=0

3) impersonate access (just new impersonated cookie here)
curl 'https://oidc.net/storage-status.ydb-global.ik8s-beta.ik8s.man.nbhost.net:8765/viewer/json/describe?database=%2Ftesting%2Fcharlotte&path=%2Ftesting%2Fcharlotte&enums=true&backup=false&private=true&partition_config=false&partition_stats=false&partitioning_info=false&subs=1' \
  -H 'accept: application/json, text/plain, */*' \
  -H 'cookie: __Host_session_cookie_6D76702D6F6964632D74657374696E67=****; __Host_impersonated_cookie_6D76702D6F6964632D74657374696E67=****; _ga_N2V9EEXZGE=GS1.1.1731507944.10.1.1731507976.0.0.0' \
 --insecure
 
If the authentication domain returns a status code of 400 or 401, OIDC performs a redirect with a 307 status code to the same address and clears the impersonated cookie.
...
