### PR TITLE
Audit log json envelope

### DIFF
--- a/ydb/core/audit/audit_log_impl.cpp
+++ b/ydb/core/audit/audit_log_impl.cpp
@@ -73,7 +73,7 @@ void WriteLog(const TString& log, const TVector<THolder<TLogBackend>>& logBacken
                 log.length()
             ));
         } catch (const yexception& e) {
-            LOG_W("WriteLog: unable to write audit log (error: " << e.what() << ")");
+            LOG_E("WriteLog: unable to write audit log (error: " << e.what() << ")");
         }
     }
 }

--- a/ydb/core/log_backend/json_envelope.cpp
+++ b/ydb/core/log_backend/json_envelope.cpp
@@ -8,76 +8,99 @@ const TStringBuf PLACEHOLDER = "%message%";
 
 void TJsonEnvelope::Parse() {
     ReadJsonTree(TemplateString, &Value, true);
-    Parse(&Value);
+    std::vector<TReplace::TPathComponent> path;
+    Parse(Value, path);
 }
 
-void TJsonEnvelope::Parse(NJson::TJsonValue* value) {
-    if (Replace) {
-        return;
-    }
+bool TJsonEnvelope::Parse(const NJson::TJsonValue& value, std::vector<TReplace::TPathComponent>& path) {
+    Y_ASSERT(!Replace);
 
-    switch (value->GetType()) {
+    switch (value.GetType()) {
     case NJson::JSON_STRING: {
-            TReplace replace(value);
-            if (replace.Parse(value->GetStringSafe())) {
-                Replace = std::move(replace);
-            }
-            break;
+        if (auto replacePair = Parse(value.GetStringSafe())) {
+            Replace.emplace(std::move(path), std::move(replacePair->first), std::move(replacePair->second));
+            return true;
         }
+        return false;
+    }
     case NJson::JSON_ARRAY: {
-            for (NJson::TJsonValue& el : value->GetArraySafe()) {
-                Parse(&el);
-                if (Replace) {
-                    break;
-                }
+        const auto& arr = value.GetArraySafe();
+        path.emplace_back(size_t(0));
+        for (size_t i = 0; i < arr.size(); ++i) {
+            path.back() = i;
+            if (Parse(arr[i], path)) {
+                return true;
             }
-            break;
         }
+        path.pop_back();
+        return false;
+    }
     case NJson::JSON_MAP: {
-            for (auto& [key, el] : value->GetMapSafe()) {
-                Parse(&el);
-                if (Replace) {
-                    break;
-                }
+        const auto& map = value.GetMapSafe();
+        path.emplace_back(TString());
+        for (const auto& [key, el] : map) {
+            path.back() = key;
+            if (Parse(el, path)) {
+                return true;
             }
-            break;
         }
+        path.pop_back();
+        return false;
+    }
     default:
-        break;
+        return false;
     }
 }
 
-TString TJsonEnvelope::ApplyJsonEnvelope(const TStringBuf& message) {
+std::optional<std::pair<TString, TString>> TJsonEnvelope::Parse(const TString& stringValue) {
+    std::optional<std::pair<TString, TString>> result;
+    size_t pos = stringValue.find(PLACEHOLDER);
+    if (pos == TString::npos) {
+        return result;
+    }
+
+    TString prefix, suffix;
+    if (pos != 0) {
+        prefix = stringValue.substr(0, pos);
+    }
+    if (pos + PLACEHOLDER.size() < stringValue.size()) {
+        suffix = stringValue.substr(pos + PLACEHOLDER.size());
+    }
+    result.emplace(std::move(prefix), std::move(suffix));
+    return result;
+}
+
+TString TJsonEnvelope::ApplyJsonEnvelope(const TStringBuf& message) const {
     if (!IsUtf(message)) {
         throw std::runtime_error("Attempt to write non utf-8 string");
     }
 
+    const NJson::TJsonValue* value = &Value;
+    NJson::TJsonValue valueCopy;
     if (Replace) {
-        Replace->Apply(message);
+        valueCopy = Value;
+        value = &valueCopy;
+        Replace->Apply(&valueCopy, message);
     }
 
     TStringStream ss;
-    NJson::WriteJson(&ss, &Value, NJson::TJsonWriterConfig().SetValidateUtf8(true));
+    NJson::WriteJson(&ss, value, NJson::TJsonWriterConfig().SetValidateUtf8(true));
     ss << Endl;
     return ss.Str();
 }
 
-bool TJsonEnvelope::TReplace::Parse(const TString& replace) {
-    size_t pos = replace.find(PLACEHOLDER);
-    if (pos == TString::npos) {
-        return false;
+void TJsonEnvelope::TReplace::Apply(NJson::TJsonValue* value, const TStringBuf& message) const {
+    size_t currentEl = 0;
+    while (currentEl < Path.size()) {
+        std::visit(
+            [&](const auto& child) {
+                value = &(*value)[child];
+            },
+            Path[currentEl++]
+        );
     }
 
-    if (pos != 0) {
-        Prefix = replace.substr(0, pos);
-    }
-    if (pos + PLACEHOLDER.size() < replace.size()) {
-        Suffix = replace.substr(pos + PLACEHOLDER.size());
-    }
-    return true;
-}
-
-void TJsonEnvelope::TReplace::Apply(const TStringBuf& message) {
+    Y_ASSERT(value && value->GetType() == NJson::JSON_STRING);
     TString result;
     result.reserve(Prefix.size() + Suffix.size() + message.size());
     if (Prefix) {
@@ -87,7 +110,7 @@ void TJsonEnvelope::TReplace::Apply(const TStringBuf& message) {
     if (Suffix) {
         result += Suffix;
     }
-    *Value = result;
+    *value = result;
 }
 
 } // namespace NKikimr

--- a/ydb/core/log_backend/json_envelope.cpp
+++ b/ydb/core/log_backend/json_envelope.cpp
@@ -1,0 +1,88 @@
+#include "json_envelope.h"
+
+#include <util/charset/utf8.h>
+
+namespace NKikimr {
+
+const TStringBuf PLACEHOLDER = "%message%";
+
+void TJsonEnvelope::Parse() {
+    ReadJsonTree(TemplateString, &Value, true);
+    Parse(&Value);
+}
+
+void TJsonEnvelope::Parse(NJson::TJsonValue* value) {
+    switch (value->GetType()) {
+    case NJson::JSON_STRING: {
+            TReplace replace(value);
+            if (replace.Parse(value->GetStringSafe())) {
+                Replaces.emplace_back(std::move(replace));
+            }
+            break;
+        }
+    case NJson::JSON_ARRAY: {
+            for (NJson::TJsonValue& el : value->GetArraySafe()) {
+                Parse(&el);
+            }
+            break;
+        }
+    case NJson::JSON_MAP: {
+            for (auto& [key, el] : value->GetMapSafe()) {
+                Parse(&el);
+            }
+            break;
+        }
+    default:
+        break;
+    }
+}
+
+TString TJsonEnvelope::ApplyJsonEnvelope(const TStringBuf& message) {
+    if (!IsUtf(message)) {
+        throw std::runtime_error("Attempt to write non utf-8 string");
+    }
+
+    for (TReplace& replace : Replaces) {
+        replace.Apply(message);
+    }
+
+    TStringStream ss;
+    NJson::WriteJson(&ss, &Value, NJson::TJsonWriterConfig().SetValidateUtf8(true));
+    ss << Endl;
+    return ss.Str();
+}
+
+bool TJsonEnvelope::TReplace::Parse(const TString& replace) {
+    size_t pos = replace.find(PLACEHOLDER);
+    if (pos == TString::npos) {
+        return false;
+    }
+
+    if (pos != 0) {
+        ReplaceSequence.emplace_back(replace.substr(0, pos));
+    }
+    while (pos != TString::npos) {
+        ReplaceSequence.emplace_back(); // placeholder
+        if (pos + PLACEHOLDER.size() == replace.size()) {
+            break;
+        }
+        size_t next = replace.find(PLACEHOLDER, pos + PLACEHOLDER.size());
+        ReplaceSequence.emplace_back(replace.substr(pos + PLACEHOLDER.size(), next == TString::npos ? next : next - pos - PLACEHOLDER.size()));
+        pos = next;
+    }
+    return true;
+}
+
+void TJsonEnvelope::TReplace::Apply(const TStringBuf& message) {
+    TString result;
+    for (const TString& replace : ReplaceSequence) {
+        if (replace.empty()) {
+            result += message;
+        } else {
+            result += replace;
+        }
+    }
+    *Value = result;
+}
+
+} // namespace NKikimr

--- a/ydb/core/log_backend/json_envelope.h
+++ b/ydb/core/log_backend/json_envelope.h
@@ -29,7 +29,8 @@ private:
 private:
     struct TReplace {
         NJson::TJsonValue* Value = nullptr;
-        std::vector<TString> ReplaceSequence; // empty string for placeholder
+        TString Prefix;
+        TString Suffix;
 
         TReplace(NJson::TJsonValue* value)
             : Value(value)
@@ -42,7 +43,7 @@ private:
 private:
     TString TemplateString;
     NJson::TJsonValue Value;
-    std::vector<TReplace> Replaces;
+    TMaybe<TReplace> Replace;
 };
 
 } // namespace NKikimr

--- a/ydb/core/log_backend/json_envelope.h
+++ b/ydb/core/log_backend/json_envelope.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
+
+#include <util/generic/string.h>
+
+#include <vector>
+
+namespace NKikimr {
+
+class TJsonEnvelope {
+public:
+    explicit TJsonEnvelope(const TString& templateString)
+        : TemplateString(templateString)
+    {
+        Parse(); // can throw
+    }
+
+    TJsonEnvelope() = delete;
+    TJsonEnvelope(const TJsonEnvelope&) = delete;
+    TJsonEnvelope(TJsonEnvelope&&) = delete;
+
+    TString ApplyJsonEnvelope(const TStringBuf& message);
+
+private:
+    void Parse();
+    void Parse(NJson::TJsonValue* value);
+
+private:
+    struct TReplace {
+        NJson::TJsonValue* Value = nullptr;
+        std::vector<TString> ReplaceSequence; // empty string for placeholder
+
+        TReplace(NJson::TJsonValue* value)
+            : Value(value)
+        {}
+
+        bool Parse(const TString& replace);
+        void Apply(const TStringBuf& message);
+    };
+
+private:
+    TString TemplateString;
+    NJson::TJsonValue Value;
+    std::vector<TReplace> Replaces;
+};
+
+} // namespace NKikimr

--- a/ydb/core/log_backend/json_envelope_ut.cpp
+++ b/ydb/core/log_backend/json_envelope_ut.cpp
@@ -1,0 +1,63 @@
+#include "json_envelope.h"
+
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+
+#define UNIT_ASSERT_JSONS_EQUAL(j1, j2) {                    \
+    const TString js1 = (j1), js2 = (j2);                    \
+    UNIT_ASSERT(!js1.empty());                               \
+    UNIT_ASSERT_C(js1.back() == '\n', js1);                  \
+    NJson::TJsonValue jv1, jv2;                              \
+    UNIT_ASSERT(ReadJsonTree(j1, &jv1));                     \
+    UNIT_ASSERT(ReadJsonTree(j2, &jv2));                     \
+    const TString jsn1 = NJson::WriteJson(&jv1, true, true); \
+    const TString jsn2 = NJson::WriteJson(&jv2, true, true); \
+    UNIT_ASSERT_VALUES_EQUAL(jsn1, jsn2);                    \
+}
+
+Y_UNIT_TEST_SUITE(JsonEnvelopeTest) {
+    Y_UNIT_TEST(Replace) {
+        TJsonEnvelope env(R"json({
+            "a": "b",
+            "m": "abc%message%def - %message%!",
+            "subfield": {
+                "s": "% message %",
+                "t": "%Message%",
+                "m": "%message%",
+                "x": 42,
+                "a": [
+                    42,
+                    "42: %message%"
+                ]
+            }
+        })json");
+
+        UNIT_ASSERT_JSONS_EQUAL(env.ApplyJsonEnvelope("msg"), R"json({"a":"b","m":"abcmsgdef - msg!","subfield":{"s":"% message %","t":"%Message%","m":"msg","x":42,"a":[42,"42: msg"]}})json");
+        UNIT_ASSERT_JSONS_EQUAL(env.ApplyJsonEnvelope("xyz"), R"json({"a":"b","m":"abcxyzdef - xyz!","subfield":{"s":"% message %","t":"%Message%","m":"xyz","x":42,"a":[42,"42: xyz"]}})json");
+    }
+
+    Y_UNIT_TEST(Escape) {
+        TJsonEnvelope env(R"json({
+            "a": "%message%"
+        })json");
+
+        UNIT_ASSERT_JSONS_EQUAL(env.ApplyJsonEnvelope("msg"), R"json({"a":"msg"})json");
+        UNIT_ASSERT_JSONS_EQUAL(env.ApplyJsonEnvelope("\"\n\""), R"json({"a":"\"\n\""})json");
+    }
+
+    Y_UNIT_TEST(BinaryData) {
+        TJsonEnvelope env(R"json({
+            "a": "%message%"
+        })json");
+
+        const ui64 binaryData = 0xABCDEFFF87654321;
+        const TStringBuf data(reinterpret_cast<const char*>(&binaryData), sizeof(binaryData));
+        UNIT_ASSERT_EXCEPTION(env.ApplyJsonEnvelope(data), std::exception);
+        UNIT_ASSERT_JSONS_EQUAL(env.ApplyJsonEnvelope("text"), R"json({"a":"text"})json");
+    }
+}
+
+} // namespace NKikimr

--- a/ydb/core/log_backend/log_backend.cpp
+++ b/ydb/core/log_backend/log_backend.cpp
@@ -1,8 +1,51 @@
 #include "log_backend.h"
+#include "json_envelope.h"
 #include "log_backend_build.h"
 #include <ydb/core/base/counters.h>
 
+#include <util/system/mutex.h>
+
 namespace NKikimr {
+
+class TLogBackendWithJsonEnvelope : public TLogBackend {
+public:
+    TLogBackendWithJsonEnvelope(const TString& jsonEnvelope, THolder<TLogBackend> logBackend)
+        : JsonEnvelope(jsonEnvelope)
+        , LogBackend(std::move(logBackend))
+    {}
+
+    void WriteData(const TLogRecord& rec) override {
+        TString data;
+        TLogRecord record = rec;
+        with_lock (Mutex) {
+            data = JsonEnvelope.ApplyJsonEnvelope(TStringBuf(record.Data, record.Len));
+        }
+        record.Data = data.data();
+        record.Len = data.size();
+        LogBackend->WriteData(record);
+    }
+
+    void ReopenLog() override {
+        LogBackend->ReopenLog();
+    }
+
+    void ReopenLogNoFlush() override {
+        LogBackend->ReopenLogNoFlush();
+    }
+
+    ELogPriority FiltrationLevel() const override {
+        return LogBackend->FiltrationLevel();
+    }
+
+    size_t QueueSize() const override {
+        return LogBackend->QueueSize();
+    }
+
+private:
+    TJsonEnvelope JsonEnvelope;
+    THolder<TLogBackend> LogBackend;
+    TMutex Mutex;
+};
 
 TAutoPtr<TLogBackend> CreateLogBackendWithUnifiedAgent(
         const TKikimrRunConfig& runConfig,
@@ -127,36 +170,46 @@ TAutoPtr<TLogBackend> CreateAuditLogUnifiedAgentBackend(
     return logBackend;
 }
 
+THolder<TLogBackend> MaybeWrapWithJsonEnvelope(THolder<TLogBackend> logBackend, const TString& jsonEnvelope) {
+    if (jsonEnvelope.empty() || !logBackend) {
+        return logBackend;
+    }
+
+    return MakeHolder<TLogBackendWithJsonEnvelope>(jsonEnvelope, std::move(logBackend));
+}
+
 TMap<NKikimrConfig::TAuditConfig::EFormat, TVector<THolder<TLogBackend>>> CreateAuditLogBackends(
         const TKikimrRunConfig& runConfig,
         NMonitoring::TDynamicCounterPtr counters) {
     TMap<NKikimrConfig::TAuditConfig::EFormat, TVector<THolder<TLogBackend>>> logBackends;
-    if (runConfig.AppConfig.HasAuditConfig() && runConfig.AppConfig.GetAuditConfig().HasStderrBackend()) {
-        auto logBackend = NActors::CreateStderrBackend();
-        auto format = runConfig.AppConfig.GetAuditConfig().GetStderrBackend().GetFormat();
-        logBackends[format].push_back(std::move(logBackend));
-    }
 
-    if (runConfig.AppConfig.HasAuditConfig() && runConfig.AppConfig.GetAuditConfig().HasFileBackend()) {
-        auto logBackend = CreateAuditLogFileBackend(runConfig);
-        if (logBackend) {
-            auto format = runConfig.AppConfig.GetAuditConfig().GetFileBackend().GetFormat();
+    if (runConfig.AppConfig.HasAuditConfig()) {
+        const auto& auditConfig = runConfig.AppConfig.GetAuditConfig();
+        if (auditConfig.HasStderrBackend()) {
+            auto logBackend = MaybeWrapWithJsonEnvelope(NActors::CreateStderrBackend(), auditConfig.GetStderrBackend().GetLogJsonEnvelope());
+            auto format = auditConfig.GetStderrBackend().GetFormat();
             logBackends[format].push_back(std::move(logBackend));
         }
-    }
 
-    if (runConfig.AppConfig.HasAuditConfig() && runConfig.AppConfig.GetAuditConfig().HasUnifiedAgentBackend()) {
-        auto logBackend = CreateAuditLogUnifiedAgentBackend(runConfig, counters);
-        if (logBackend) {
-            auto format = runConfig.AppConfig.GetAuditConfig().GetUnifiedAgentBackend().GetFormat();
-            logBackends[format].push_back(std::move(logBackend));
+        if (auditConfig.HasFileBackend()) {
+            auto logBackend = MaybeWrapWithJsonEnvelope(CreateAuditLogFileBackend(runConfig), auditConfig.GetFileBackend().GetLogJsonEnvelope());
+            if (logBackend) {
+                auto format = auditConfig.GetFileBackend().GetFormat();
+                logBackends[format].push_back(std::move(logBackend));
+            }
+        }
+
+        if (auditConfig.HasUnifiedAgentBackend()) {
+            auto logBackend = MaybeWrapWithJsonEnvelope(CreateAuditLogUnifiedAgentBackend(runConfig, counters), auditConfig.GetUnifiedAgentBackend().GetLogJsonEnvelope());
+            if (logBackend) {
+                auto format = auditConfig.GetUnifiedAgentBackend().GetFormat();
+                logBackends[format].push_back(std::move(logBackend));
+            }
         }
     }
-
 
     return logBackends;
 }
 
 
 } // NKikimr
-

--- a/ydb/core/log_backend/log_backend.cpp
+++ b/ydb/core/log_backend/log_backend.cpp
@@ -15,11 +15,8 @@ public:
     {}
 
     void WriteData(const TLogRecord& rec) override {
-        TString data;
         TLogRecord record = rec;
-        with_lock (Mutex) {
-            data = JsonEnvelope.ApplyJsonEnvelope(TStringBuf(record.Data, record.Len));
-        }
+        TString data = JsonEnvelope.ApplyJsonEnvelope(TStringBuf(record.Data, record.Len));
         record.Data = data.data();
         record.Len = data.size();
         LogBackend->WriteData(record);
@@ -42,9 +39,8 @@ public:
     }
 
 private:
-    TJsonEnvelope JsonEnvelope;
-    THolder<TLogBackend> LogBackend;
-    TMutex Mutex;
+    const TJsonEnvelope JsonEnvelope;
+    const THolder<TLogBackend> LogBackend;
 };
 
 TAutoPtr<TLogBackend> CreateLogBackendWithUnifiedAgent(

--- a/ydb/core/log_backend/ut/ya.make
+++ b/ydb/core/log_backend/ut/ya.make
@@ -1,0 +1,7 @@
+UNITTEST_FOR(ydb/core/log_backend)
+
+SRCS(
+    json_envelope_ut.cpp
+)
+
+END()

--- a/ydb/core/log_backend/ya.make
+++ b/ydb/core/log_backend/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    json_envelope.cpp
     log_backend.cpp
     log_backend.h
     log_backend_build.cpp
@@ -15,3 +16,7 @@ PEERDIR(
 YQL_LAST_ABI_VERSION()
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1455,16 +1455,19 @@ message TAuditConfig {
 
     message TStderrBackend {
         optional EFormat Format = 1 [default = JSON];
+        optional string LogJsonEnvelope = 2; // Json template with text field containing %message% placeholder. For example {"my_enveloped_message": "%message%"}. %message% will be replaced with real audit log message
     }
 
     message TFileBackend {
         optional EFormat Format = 1 [default = JSON];
         optional string FilePath = 2;
+        optional string LogJsonEnvelope = 3; // Json template with text field containing %message% placeholder. For example {"my_enveloped_message": "%message%"}. %message% will be replaced with real audit log message
     }
 
     message TUnifiedAgentBackend {
         optional EFormat Format = 1 [default = JSON];
         optional string LogName = 2;
+        optional string LogJsonEnvelope = 3; // Json template with text field containing %message% placeholder. For example {"my_enveloped_message": "%message%"}. %message% will be replaced with real audit log message
     }
 
     optional TStderrBackend StderrBackend = 1;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support the configuration setting to wrap log records into a fixed json envelope, based on the log record nature. To be used when a single-stream unified logs delivery system is in place (like stderr in k8s installations), with all logs streamed there (including audit), and which needs to have some environment-specific information in the message to decide which system to forward a particular record to.

As the first application is for audit logs, the first implementation is also for the audit logs only.

The function is agnostic to the audit logs format, as addresses not the audit system requirements, but the logs delivery and routing system ones.

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
