### PR TITLE
Fix TComputeActorAsyncInputHelperSync destruction

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -203,14 +203,17 @@ protected:
     }
 
     ~TDqComputeActorBase() override {
-        if (Terminated)
+        if (Terminated) {
             return;
+        }
         Free();
     }
 
     void Free() {
         auto guard = BindAllocator();
-        if (!guard) return;
+        if (!guard) {
+            return;
+        }
 #define CLEANUP(what) decltype(what) what##_; what.swap(what##_);
         CLEANUP(InputChannelsMap);
         CLEANUP(SourcesMap);

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -526,10 +526,8 @@ protected:
                 }
             }
 
-            {
-                // free MKQL memory then destroy TaskRunner and Allocator
-                Free();
-            }
+            // free MKQL memory then destroy TaskRunner and Allocator
+            Free();
         }
 
         if (RuntimeSettings.TerminateHandler) {


### PR DESCRIPTION
`TDqComputeActorBase` contains map to `TComputeActorAsyncInputHelperSync`, `TComputeActorAsyncInputHelperSync` contains `TDqAsyncInputBuffer`, `TDqAsyncInputBuffer` contains `TList<TUnboxedValueBatch>`, which in turn uses mkql allocator during destruction.
In must be destroyed with bound mkql allocator.
In certain cases, `TDqComputeActorBase::Terminate` is not called, and maps are destroyed in `~TDqComputeActorBase()`, without bound allocator.

Fixes
https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/11743390109/ya-x86-64-asan/try_1/artifacts/logs/ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/with_offset_ranges_mode_ut/test-results/unittest/testing_out_stuff/RetryPolicy.TWriteSession_SeqNoShift.err

Note: this is only workaround.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
