### PR TITLE
Reset pipeline in datashard init

### DIFF
--- a/ydb/core/tx/datashard/datashard__init.cpp
+++ b/ydb/core/tx/datashard/datashard__init.cpp
@@ -26,6 +26,7 @@ bool TDataShard::TTxInit::Execute(TTransactionContext& txc, const TActorContext&
         Self->NextSeqno = 1;
         Self->NextChangeRecordOrder = 1;
         Self->LastChangeRecordGroup = 1;
+        Self->Pipeline.Reset();
         Self->TransQueue.Reset();
         Self->SnapshotManager.Reset();
         Self->SchemaSnapshotManager.Reset();

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -42,6 +42,34 @@ TPipeline::~TPipeline()
     }
 }
 
+void TPipeline::Reset() {
+    ImmediateOps.clear();
+    ActiveOps.clear();
+    ActivePlannedOps.clear();
+    DataTxCache.clear();
+    DelayedAcks.clear();
+    LastPlannedTx = {0, 0};
+    LastCompleteTx = {0, 0};
+    UtmostCompleteTx = {0, 0};
+    KeepSchemaStep = 0;
+    LastCleanupTime = 0;
+    SchemaTx = nullptr;
+    ExecuteBlockers.clear();
+    CandidateOps.clear();
+    CandidateUnits.clear();
+    NextActiveOp = {};
+    SlowOpProfiles.clear();
+    ActiveStreamingTxs.clear();
+    PredictedPlan.clear();
+    WaitingSchemeOpsOrder.clear();
+    WaitingSchemeOps.clear();
+    WaitingDataTxOps.clear();
+    CommittingOps.Reset();
+    CompletingOps.clear();
+    WaitingDataReadIterators.clear();
+    WaitingReadIteratorsById.clear();
+}
+
 bool TPipeline::Load(NIceDb::TNiceDb& db) {
     using Schema = TDataShard::Schema;
 

--- a/ydb/core/tx/datashard/datashard_pipeline.h
+++ b/ydb/core/tx/datashard/datashard_pipeline.h
@@ -85,6 +85,7 @@ public:
     TPipeline(TDataShard * self);
     ~TPipeline();
 
+    void Reset();
     bool Load(NIceDb::TNiceDb& db);
     void UpdateConfig(NIceDb::TNiceDb& db, const NKikimrSchemeOp::TPipelineConfig& cfg);
 
@@ -487,6 +488,11 @@ private:
                     << " while TxCounter has active references, possible Add/Remove mismatch");
                 ItemsSet.erase(it);
             }
+        }
+
+        void Reset() {
+            TxIdMap.clear();
+            ItemsSet.clear();
         }
 
         inline bool HasOpsBelow(TRowVersion upperBound) const {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

A datashard could catch VERIFY during restart with scheme transaction inflight

KIKIMR-22195

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

```
VERIFY failed (2024-11-11T15:00:23.255997+0300):
  contrib/ydb/core/tx/datashard/datashard_pipeline.cpp:49
  Load(): requirement !SchemaTx failed
0. /-S/util/system/yassert.cpp:55: NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...) @ 0x556B236FD67B
1. /-S/contrib/ydb/core/tx/datashard/datashard_pipeline.cpp:49: NKikimr::NDataShard::TPipeline::Load(NKikimr::NIceDb::TNiceDb&) @ 0x556B31C29326
2. /-S/contrib/ydb/core/tx/datashard/datashard__init.cpp:227: NKikimr::NDataShard::TDataShard::TTxInit::ReadEverything(NKikimr::NTabletFlatExecutor::TTransactionContext&) @ 0x556B31D80397
3. /-S/contrib/ydb/core/tx/datashard/datashard__init.cpp:43: NKikimr::NDataShard::TDataShard::TTxInit::Execute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) @ 0x556B31D7CDBC
4. /-S/contrib/ydb/core/tablet_flat/flat_executor.cpp:1717: NKikimr::NTabletFlatExecutor::TExecutor::ExecuteTransaction(TAutoPtr<NKikimr::NTabletFlatExecutor::TSeat, TDelete>, NActors::TActorContext const&) @ 0x556B276FF229
5. /-S/contrib/ydb/core/tablet_flat/flat_executor.cpp:2637: NKikimr::NTabletFlatExecutor::TExecutor::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::NTabletFlatExecutor::TExecutor::TEvPrivate::TEvActivateExecution>, TDelete>&, NActors::TActorContext const&) @ 0x556B2770EBFF
6. /-S/contrib/ydb/core/tablet_flat/flat_executor.cpp:3951: NKikimr::NTabletFlatExecutor::TExecutor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0x556B276E7F1C
7. /-S/contrib/ydb/library/actors/core/executor_thread.cpp:251: NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TReadAsFilledMailbox>(NActors::TMailboxTable::TReadAsFilledMailbox*, unsigned int, bool) @ 0x556B23C8C036
8. /-S/contrib/ydb/library/actors/core/executor_thread.cpp:440: NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(unsigned int, bool) const @ 0x556B23C7EBDE
9. /-S/contrib/ydb/library/actors/core/executor_thread.cpp:492: NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) @ 0x556B23C7E41F
10. /-S/contrib/ydb/library/actors/core/executor_thread.cpp:523: NActors::TExecutorThread::ThreadProc() @ 0x556B23C7F804
11. /-S/util/system/thread.cpp:244: (anonymous namespace)::TPosixThread::ThreadProxy(void*) @ 0x556B2370B859
12. ??:0: ?? @ 0x7FBBE7B20608
13. ??:0: ?? @ 0x7FBBE7A40352
```

...
