### PR TITLE
Parallel local kmeans in schemeshard

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2195,6 +2195,65 @@ void TIndexBuildInfo::SerializeToProto([[maybe_unused]] TSchemeShard* ss, NKikim
     }
 }
 
+void TIndexBuildInfo::AddParent(const TSerializedTableRange& range, TShardIdx shard) {
+    if (KMeans.Parent == 0) {
+        // For Parent == 0 only single kmeans needed, so there is only two options:
+        // 1. It fits entirely in the single shard => local kmeans for single shard
+        // 2. It doesn't fit entirely in the single shard => global kmeans for all shards
+        return;
+    }
+    const auto to = range.To.GetCells();
+    const auto from = range.From.GetCells();
+    Y_ASSERT(!from.empty());
+    const auto parentTo = to.empty() ? std::numeric_limits<ui32>::max() : to[0].AsValue<ui32>() - (to.size() == 1);
+    Y_ASSERT(parentTo >= 1);
+    const auto parentFrom = from[0].IsNull() ? 1 : from[0].AsValue<ui32>();
+    Y_ASSERT(parentFrom >= 1);
+    Y_ASSERT(parentFrom <= parentTo);
+    // TODO(mbkkt) We can make it more granular
+
+    // if new range is not intersect with other ranges, it's local
+    auto itFrom = Cluster2Shards.lower_bound(parentFrom);
+    if (itFrom == Cluster2Shards.end() || parentTo < itFrom->second.From) {
+        Cluster2Shards.emplace_hint(itFrom, parentTo, TClusterShards{.From = parentFrom, .Local = shard});
+        return;
+    }
+
+    // otherwise, this range is global and we need to merge all intersecting ranges
+    auto itTo = parentTo < itFrom->first ? itFrom : Cluster2Shards.lower_bound(parentTo);
+    if (itTo == Cluster2Shards.end()) {
+        itTo = Cluster2Shards.rbegin().base();
+    }
+    if (itTo->first < parentTo) {
+        const bool needsToReplaceFrom = itFrom == itTo;
+        auto node = Cluster2Shards.extract(itTo);
+        node.key() = parentTo;
+        itTo = Cluster2Shards.insert(Cluster2Shards.end(), std::move(node));
+        itFrom = needsToReplaceFrom ? itTo : itFrom;
+    }
+    auto& [toFrom, toLocal, toGlobal] = itTo->second;
+
+    toFrom = std::min(toFrom, parentFrom);
+    if (toLocal != InvalidShardIdx) {
+        toGlobal.emplace_back(toLocal);
+        toLocal = InvalidShardIdx;
+    }
+    toGlobal.emplace_back(shard);
+
+    while (itFrom != itTo) {
+        const auto& [fromFrom, fromLocal, fromGlobal] = itFrom->second;
+        toFrom = std::min(toFrom, fromFrom);
+        if (fromLocal != InvalidShardIdx) {
+            Y_ASSERT(fromGlobal.empty());
+            toGlobal.emplace_back(fromLocal);
+        } else {
+            Y_ASSERT(!fromGlobal.empty());
+            toGlobal.insert(toGlobal.end(), fromGlobal.begin(), fromGlobal.end());
+        }
+        itFrom = Cluster2Shards.erase(itFrom);
+    }
+}
+
 TColumnFamiliesMerger::TColumnFamiliesMerger(NKikimrSchemeOp::TPartitionConfig &container)
     : Container(container)
     , DeduplicationById(TPartitionConfigMerger::DeduplicateColumnFamiliesById(Container))

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3041,7 +3041,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             Reshuffle,
             Local,
         };
-        ui32 Level = 0;
+        ui32 Level = 1;
 
         ui32 Parent = 0;
         ui32 ParentEnd = 0;  // included
@@ -3049,6 +3049,14 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         EState State = Sample;
 
         ui32 ChildBegin = 1;  // included
+
+        TString ToStr() const {
+            return TStringBuilder()
+                << "{ K = " << K
+                << ", Level = " << Level << " / " << Levels
+                << ", Parent = " << Parent << " / " << ParentEnd
+                << ", State = " << State << " }";
+        }
 
         static ui32 BinPow(ui32 k, ui32 l) {
             ui32 r = 1;
@@ -3103,7 +3111,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         }
 
         NKikimrTxDataShard::TEvLocalKMeansRequest::EState GetUpload() const {
-            if (Level == 0) {
+            if (Parent == 0) {
                 if (NeedsAnotherLevel()) {
                     return NKikimrTxDataShard::TEvLocalKMeansRequest::UPLOAD_MAIN_TO_BUILD;
                 } else {
@@ -3122,15 +3130,15 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             using namespace NTableIndex::NTableVectorKmeansTreeIndex;
             TString name = PostingTable;
             if (needsBuildTable || NeedsAnotherLevel()) {
-                name += Level % 2 == 0 ? BuildPostingTableSuffix0 : BuildPostingTableSuffix1;
+                name += Level % 2 != 0 ? BuildPostingTableSuffix0 : BuildPostingTableSuffix1;
             }
             return name;
         }
         TString ReadFrom() const {
-            Y_ASSERT(Level != 0);
+            Y_ASSERT(Parent != 0);
             using namespace NTableIndex::NTableVectorKmeansTreeIndex;
             TString name = PostingTable;
-            name += Level % 2 == 0 ? BuildPostingTableSuffix1 : BuildPostingTableSuffix0;
+            name += Level % 2 != 0 ? BuildPostingTableSuffix1 : BuildPostingTableSuffix0;
             return name;
         }
     };
@@ -3212,7 +3220,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
     TBillingStats Processed;
     TBillingStats Billed;
 
-    struct TSampleK {
+    struct TSample {
         struct TRow {
             ui64 P = 0;
             TString Row;
@@ -3276,8 +3284,26 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             MaxProbability = kth->P;
         }
     };
+    TSample Sample;
 
-    TSampleK Sample;
+    TString KMeansTreeToDebugStr() const {
+        return TStringBuilder()
+            << KMeans.ToStr() << ", "
+            << "{ Rows = " << Sample.Rows.size()
+            << ", Sent = " << Sample.Sent << " }, "
+            << "{ Done = " << DoneShards.size()
+            << ", ToUpload = " << ToUploadShards.size()
+            << ", InProgress = " << InProgressShards.size() << " }";
+    }
+
+    struct TClusterShards {
+        ui32 From = std::numeric_limits<ui32>::max();
+        TShardIdx Local = InvalidShardIdx;
+        std::vector<TShardIdx> Global;
+    };
+    TMap<ui32, TClusterShards> Cluster2Shards;
+
+    void AddParent(const TSerializedTableRange& range, TShardIdx shard);
 
     TIndexBuildInfo(TIndexBuildId id, TString uid)
         : Id(id)
@@ -3470,9 +3496,10 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         TString lastKeyAck =
             row.template GetValue<Schema::IndexBuildShardStatus::LastKeyAck>();
 
+        TSerializedTableRange bound{range};
+        AddParent(bound, shardIdx);
         Shards.emplace(
-            shardIdx, TIndexBuildInfo::TShardStatus(
-                          TSerializedTableRange(range), std::move(lastKeyAck)));
+            shardIdx, TIndexBuildInfo::TShardStatus(std::move(bound), std::move(lastKeyAck)));
         TIndexBuildInfo::TShardStatus &shardStatus = Shards.at(shardIdx);
 
         shardStatus.Status =
@@ -3541,11 +3568,9 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
     float CalcProgressPercent() const {
         if (IsBuildVectorIndex()) {
+            Y_ASSERT(KMeans.Level != 0);
             // TODO(mbkkt) better calculation for vector index
-            if (KMeans.Level == 0) {
-                return 0.0;
-            }
-            return KMeans.Levels * 100. / KMeans.Level;
+            return KMeans.Level * 100.0 / KMeans.Levels;
         }
         if (Shards) {
             float totalShards = Shards.size();

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -129,7 +129,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":2,"quantity":128,"finish":2,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-200-0-1290-0","cloud_id":"CLOUD_ID_VAL","source_wt":2,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
+        const TString meteringData = R"({"usage":{"start":1,"quantity":100,"finish":1,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-0-200-0-1290","cloud_id":"CLOUD_ID_VAL","source_wt":1,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
 


### PR DESCRIPTION
Now we're able to send LocalKMeans request in parallel for parent-ranges that depend on single shard.
It's schemeshard part of parallel kmeans without datashard part.

Also I fix few issues that was detected during tests on slice