### PR TITLE
[yt provider] Fix `unordered_map::at: key not found` error

### DIFF
--- a/ydb/library/yql/providers/yt/provider/yql_yt_physical_finalizing.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_physical_finalizing.cpp
@@ -2759,7 +2759,7 @@ private:
         std::vector<std::vector<const TExprNode*>> UsedByMerges;
     };
 
-    void GatherColumnUsage(EColumnGroupMode mode, const TExprNode* writer, const TOpDeps::mapped_type& readers, TColumnUsage& usage, TNodeMap<size_t>& uniquePaths) {
+    void GatherColumnUsage(EColumnGroupMode mode, const TExprNode* writer, const TOpDeps::mapped_type& readers, const TOpDeps& opDeps, TColumnUsage& usage, TNodeMap<size_t>& uniquePaths) {
         for (const auto& outTable: GetRealOperation(TExprBase(writer)).Output()) {
             usage.OutTypes.push_back(outTable.Ref().GetTypeAnn()->Cast<TListExprType>()->GetItemType()->Cast<TStructExprType>());
         }
@@ -2790,11 +2790,17 @@ private:
             } else if (auto maybeMerge = TMaybeNode<TYtMerge>(std::get<0>(item)); maybeMerge && AllOf(maybeMerge.Cast().Input().Item(0).Paths(),
                 [](const TYtPath& path) { return path.Ref().GetTypeAnn()->Equals(*path.Table().Ref().GetTypeAnn()); })) {
 
-                usage.UsedByMerges[outIndex].push_back(std::get<0>(item));
+                // YtMerge may have no usage in the graph (only via Left!)
+                if (opDeps.contains(std::get<0>(item))) {
+                    usage.UsedByMerges[outIndex].push_back(std::get<0>(item));
+                }
 
             } else if (TYtCopy::Match(std::get<0>(item))) {
 
-                usage.UsedByMerges[outIndex].push_back(std::get<0>(item));
+                // YtCopy may have no usage in the graph (only via Left!)
+                if (opDeps.contains(std::get<0>(item))) {
+                    usage.UsedByMerges[outIndex].push_back(std::get<0>(item));
+                }
 
             } else if (EColumnGroupMode::Single == mode) {
                 usage.FullUsage[outIndex] = true;
@@ -2845,7 +2851,7 @@ private:
             TColumnUsage& usage = colUsages[writer];
             usage.GenerateGroups = true;
 
-            GatherColumnUsage(mode, writer, readers, usage, uniquePaths);
+            GatherColumnUsage(mode, writer, readers, opDeps, usage, uniquePaths);
             bool hasMergeDep = false;
             for (const auto& item: usage.UsedByMerges) {
                 hasMergeDep = hasMergeDep || !item.empty();
@@ -2863,7 +2869,7 @@ private:
                 if (res.second) { // Not processed before
                     TColumnUsage& usage = res.first->second;
                     usage.GenerateGroups = TYtCopy::Match(merge); // Maybe we need to rewrite YtCopy to YtMerge
-                    GatherColumnUsage(mode, merge, opDeps.at(merge), usage, uniquePaths);
+                    GatherColumnUsage(mode, merge, opDeps.at(merge), opDeps, usage, uniquePaths);
                     bool hasMergeDep = false;
                     for (const auto& item: usage.UsedByMerges) {
                         hasMergeDep = hasMergeDep || !item.empty();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Error appears during column groups calculation, when YtMerge! operation is used only in Left! (as result of empty join optimization for example)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
