### PR TITLE
Backport fixes

### DIFF
--- a/ydb/library/yql/providers/yt/provider/yql_yt_datasink_type_ann.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_datasink_type_ann.cpp
@@ -948,6 +948,10 @@ private:
             if (auto setting = NYql::GetSetting(GetOutputOp(out.Cast()).Output().Item(FromString<ui32>(out.Cast().OutIndex().Value())).Settings().Ref(), EYtSettingType::ColumnGroups)) {
                 inputColGroupSpec = setting->Tail().Content();
             }
+        } else if (auto outTable = path.Table().Maybe<TYtOutTable>()) {
+            if (auto setting = NYql::GetSetting(outTable.Cast().Settings().Ref(), EYtSettingType::ColumnGroups)) {
+                inputColGroupSpec = setting->Tail().Content();
+            }
         }
 
         if (outGroup != inputColGroupSpec) {

--- a/ydb/library/yql/providers/yt/provider/yql_yt_datasource_constraints.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_datasource_constraints.cpp
@@ -165,13 +165,19 @@ public:
             input.Ptr()->CopyConstraints(section.Ref());
         } else {
             TMultiConstraintNode::TMapType multiItems;
+            bool allEmpty = true;
             for (ui32 index = 0; index < read.Input().Size(); ++index) {
                 auto section = read.Input().Item(index);
                 if (!section.Ref().GetConstraint<TEmptyConstraintNode>()) {
                     multiItems.push_back(std::make_pair(index, section.Ref().GetConstraintSet()));
+                    allEmpty = false;
                 }
             }
-            input.Ptr()->AddConstraint(ctx.MakeConstraint<TMultiConstraintNode>(std::move(multiItems)));
+            if (!multiItems.empty()) {
+                input.Ptr()->AddConstraint(ctx.MakeConstraint<TMultiConstraintNode>(std::move(multiItems)));
+            } else if (allEmpty) {
+                input.Ptr()->AddConstraint(ctx.MakeConstraint<TEmptyConstraintNode>());
+            }
         }
         return TStatus::Ok;
     }

--- a/ydb/library/yql/providers/yt/provider/yql_yt_physical_finalizing.cpp
+++ b/ydb/library/yql/providers/yt/provider/yql_yt_physical_finalizing.cpp
@@ -2821,11 +2821,18 @@ private:
             for (size_t outIndex = 0; outIndex < usage.UsedByMerges.size(); ++outIndex) {
                 for (auto merge: usage.UsedByMerges[outIndex]) {
                     const TColumnUsage& mergeUsage = colUsages.at(merge);
-                    usage.FullUsage[outIndex] = usage.FullUsage[outIndex] || mergeUsage.FullUsage.at(0);
-                    usage.PublishUsage[outIndex].insert(mergeUsage.PublishUsage.at(0).cbegin(), mergeUsage.PublishUsage.at(0).cend());
-                    auto& cu = usage.ColumnUsage[outIndex];
-                    for (const auto& p: mergeUsage.ColumnUsage.at(0)) {
-                        cu[p.first].insert(p.second.cbegin(), p.second.cend());
+                    if (TYtCopy::Match(merge)) {
+                        usage.FullUsage[outIndex] = mergeUsage.FullUsage.at(0);
+                        usage.PublishUsage[outIndex] = mergeUsage.PublishUsage.at(0);
+                        usage.ColumnUsage[outIndex] = mergeUsage.ColumnUsage.at(0);
+                        break; // Don't process others. YtCopy enforces exact the same column groups
+                    } else {
+                        usage.FullUsage[outIndex] = usage.FullUsage[outIndex] || mergeUsage.FullUsage.at(0);
+                        usage.PublishUsage[outIndex].insert(mergeUsage.PublishUsage.at(0).cbegin(), mergeUsage.PublishUsage.at(0).cend());
+                        auto& cu = usage.ColumnUsage[outIndex];
+                        for (const auto& p: mergeUsage.ColumnUsage.at(0)) {
+                            cu[p.first].insert(p.second.cbegin(), p.second.cend());
+                        }
                     }
                 }
             }

--- a/ydb/library/yql/tests/sql/dq_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/dq_file/part1/canondata/result.json
@@ -2531,6 +2531,28 @@
         }
     ],
     "test.test[produce-reduce_lambda_presort_twin_list-default.txt-Results]": [],
+    "test.test[produce-reduce_multi_in-empty-Analyze]": [
+        {
+            "checksum": "9ca09e642e32d555ae193ebb53450aa7",
+            "size": 5061,
+            "uri": "https://{canondata_backend}/1937492/a3be8907a794dd8afc1b0615834f797b64dd9927/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Analyze_/plan.txt"
+        }
+    ],
+    "test.test[produce-reduce_multi_in-empty-Debug]": [
+        {
+            "checksum": "5ee56492dc75920918834c1591b2d875",
+            "size": 2287,
+            "uri": "https://{canondata_backend}/1937492/a3be8907a794dd8afc1b0615834f797b64dd9927/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[produce-reduce_multi_in-empty-Plan]": [
+        {
+            "checksum": "9ca09e642e32d555ae193ebb53450aa7",
+            "size": 5061,
+            "uri": "https://{canondata_backend}/1937492/a3be8907a794dd8afc1b0615834f797b64dd9927/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Plan_/plan.txt"
+        }
+    ],
+    "test.test[produce-reduce_multi_in-empty-Results]": [],
     "test.test[produce-reduce_multi_in_keytuple_difftype--Analyze]": [
         {
             "checksum": "f60d354ca933908da1ef3fdfbf613ddc",

--- a/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
+++ b/ydb/library/yql/tests/sql/hybrid_file/part4/canondata/result.json
@@ -2519,6 +2519,20 @@
             "uri": "https://{canondata_backend}/1809005/7e4dc59583cad760822faf30fa4695e365329148/resource.tar.gz#test.test_produce-reduce_lambda-default.txt-Plan_/plan.txt"
         }
     ],
+    "test.test[produce-reduce_multi_in-empty-Debug]": [
+        {
+            "checksum": "81ca9a9b5818c411daa1c3ceeb35c10d",
+            "size": 1546,
+            "uri": "https://{canondata_backend}/1777230/dd70c380673122cd500d799c70016541eabd320a/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Debug_/opt.yql_patched"
+        }
+    ],
+    "test.test[produce-reduce_multi_in-empty-Plan]": [
+        {
+            "checksum": "c6fc2ac654b52d444b9a39e91a5f4421",
+            "size": 2870,
+            "uri": "https://{canondata_backend}/1777230/dd70c380673122cd500d799c70016541eabd320a/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Plan_/plan.txt"
+        }
+    ],
     "test.test[produce-reduce_multi_in_sampling--Debug]": [
         {
             "checksum": "6bdbfe3d776ee5a778da5e6c1d80827a",

--- a/ydb/library/yql/tests/sql/suites/produce/reduce_multi_in-empty.cfg
+++ b/ydb/library/yql/tests/sql/suites/produce/reduce_multi_in-empty.cfg
@@ -1,0 +1,2 @@
+in Input empty.txt
+res result.txt

--- a/ydb/library/yql/tests/sql/yt_native_file/part1/canondata/result.json
+++ b/ydb/library/yql/tests/sql/yt_native_file/part1/canondata/result.json
@@ -2626,6 +2626,27 @@
             "uri": "https://{canondata_backend}/1689644/a1e3734b9bd90d7ee8a597f60d142b79a8980665/resource.tar.gz#test.test_produce-reduce_lambda_presort_twin_list-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[produce-reduce_multi_in-empty-Debug]": [
+        {
+            "checksum": "c7995250466d47dd34cb816ac34cfee9",
+            "size": 1477,
+            "uri": "https://{canondata_backend}/1903280/c00a60b19ed912e070196b77ab74860276ef193c/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Debug_/opt.yql"
+        }
+    ],
+    "test.test[produce-reduce_multi_in-empty-Plan]": [
+        {
+            "checksum": "71b7793dbfeb8423224c943ea3994cd6",
+            "size": 2870,
+            "uri": "https://{canondata_backend}/1903280/c00a60b19ed912e070196b77ab74860276ef193c/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Plan_/plan.txt"
+        }
+    ],
+    "test.test[produce-reduce_multi_in-empty-Results]": [
+        {
+            "checksum": "2004d4c4c75a57ebaaffb58738db4ec0",
+            "size": 1133,
+            "uri": "https://{canondata_backend}/1903280/c00a60b19ed912e070196b77ab74860276ef193c/resource.tar.gz#test.test_produce-reduce_multi_in-empty-Results_/results.txt"
+        }
+    ],
     "test.test[produce-reduce_multi_in_keytuple_difftype--Debug]": [
         {
             "checksum": "7926309a068a6f63f3ec9f62c715dc41",


### PR DESCRIPTION
* Fix `TMultiConstraintNode(): requirement Items_.size() failed` error (#11417)
* [yt provider] Fix column group calculation for YtCopy (#11435)
* [yt provider] Bypass YtCopy before YtLength (#11436)
* [yt provider] Fix `unordered_map::at: key not found` error (#11575)
* [yt provider] Fix YtCopy type annotation check for column groups (#11602)
