### PR TITLE
Change priority for rule NonOptimalTableContent

### DIFF
--- a/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt.cpp
+++ b/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt.cpp
@@ -56,6 +56,7 @@ TYtPhysicalOptProposalTransformer::TYtPhysicalOptProposalTransformer(TYtState::T
     AddHandler(0, &TYtDqWrite::Match, HNDL(YtDqWrite));
     AddHandler(0, &TYtDqProcessWrite::Match, HNDL(YtDqProcessWrite));
     AddHandler(0, &TYtEquiJoin::Match, HNDL(EarlyMergeJoin));
+    AddHandler(0, &TYtOutputOpBase::Match, HNDL(TableContentWithSettings));
     AddHandler(0, &TYtOutputOpBase::Match, HNDL(NonOptimalTableContent));
 
     if (!State_->Configuration->DisableFuseOperations.Get().GetOrElse(DEFAULT_DISABLE_FUSE_OPERATIONS)) {
@@ -69,7 +70,6 @@ TYtPhysicalOptProposalTransformer::TYtPhysicalOptProposalTransformer(TYtState::T
     AddHandler(1, Names({TYtMap::CallableName(), TYtMapReduce::CallableName()}), HNDL(WeakFields));
     AddHandler(1, &TYtTransientOpBase::Match, HNDL(BypassMerge));
     AddHandler(1, &TYtPublish::Match, HNDL(BypassMergeBeforePublish));
-    AddHandler(1, &TYtOutputOpBase::Match, HNDL(TableContentWithSettings));
     AddHandler(1, &TCoRight::Match, HNDL(ReadWithSettings));
     AddHandler(1, &TYtTransientOpBase::Match, HNDL(PushDownKeyExtract));
     AddHandler(1, &TYtTransientOpBase::Match, HNDL(TransientOpWithSettings));

--- a/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt.cpp
+++ b/ydb/library/yql/providers/yt/provider/phy_opt/yql_yt_phy_opt.cpp
@@ -56,6 +56,7 @@ TYtPhysicalOptProposalTransformer::TYtPhysicalOptProposalTransformer(TYtState::T
     AddHandler(0, &TYtDqWrite::Match, HNDL(YtDqWrite));
     AddHandler(0, &TYtDqProcessWrite::Match, HNDL(YtDqProcessWrite));
     AddHandler(0, &TYtEquiJoin::Match, HNDL(EarlyMergeJoin));
+    AddHandler(0, &TYtOutputOpBase::Match, HNDL(NonOptimalTableContent));
 
     if (!State_->Configuration->DisableFuseOperations.Get().GetOrElse(DEFAULT_DISABLE_FUSE_OPERATIONS)) {
         AddHandler(1, &TYtMap::Match, HNDL(FuseInnerMap));
@@ -69,7 +70,6 @@ TYtPhysicalOptProposalTransformer::TYtPhysicalOptProposalTransformer(TYtState::T
     AddHandler(1, &TYtTransientOpBase::Match, HNDL(BypassMerge));
     AddHandler(1, &TYtPublish::Match, HNDL(BypassMergeBeforePublish));
     AddHandler(1, &TYtOutputOpBase::Match, HNDL(TableContentWithSettings));
-    AddHandler(1, &TYtOutputOpBase::Match, HNDL(NonOptimalTableContent));
     AddHandler(1, &TCoRight::Match, HNDL(ReadWithSettings));
     AddHandler(1, &TYtTransientOpBase::Match, HNDL(PushDownKeyExtract));
     AddHandler(1, &TYtTransientOpBase::Match, HNDL(TransientOpWithSettings));


### PR DESCRIPTION
Removes sync barrier between YtMerge operations, issue YT-22833

In canondata tests, add a YtMerge phase to test samping/table_content

Plan Debug before: https://paste.yandex-team.ru/1286e11a-9801-4307-af72-1a34d6eed335
Plan Debug after: https://paste.yandex-team.ru/2f8781b6-b5b0-4a45-8b41-fed18cb8ca99
Plan Debug diff: https://paste.yandex-team.ru/1a76aa5d-8371-404c-a458-959cbe509921