### PR TITLE
Use DEBUGINFO_LINES_ONLY param for ydbd binary in breakpad docker tag

### DIFF
--- a/ydb/deploy/docker/README.md
+++ b/ydb/deploy/docker/README.md
@@ -31,7 +31,7 @@ ya package --docker ydb/deploy/docker/release/pkg.json
 
 Used base image and included:
 - ydb cli binary
-- ydbd server strip'ed binary
+- ydbd server strip'ed binary baked with build type `Release`
 
 ### Breakpad
 
@@ -41,10 +41,10 @@ Image with google breakpad assets to collect minidump
 ya package --docker ydb/deploy/docker/breakpad/pkg.json
 ```
 
-Used base image and included:
+Used base breakpad image and included:
 
 - ydb cli binary
-- ydbd server strip'ed binary
+- ydbd server binary baked with build flag `DEBUGINFO_LINES_ONLY`
 
 ### Debug
 
@@ -54,6 +54,8 @@ Image with debug symbols and utils for dev purposes
 ya package --docker ydb/deploy/docker/debug/pkg.json
 ```
 
-Extend breakpad image with:
+Used base breakpad image and included:
 - additional packages with debug utils (dnsutils, telnet, netcat-openbsd, iputils-ping, curl)
+- ydb cli binary
+- ydbd server strip'ed binary baked with build type `Release`
 - debug symbols for ydbd binary

--- a/ydb/deploy/docker/breakpad/pkg.json
+++ b/ydb/deploy/docker/breakpad/pkg.json
@@ -11,9 +11,37 @@
     "docker_repository": "crp2lrlsrs36odlvd8dv",
     "docker_target": "breakpad"
   },
-  "include": [
-    "ydb/deploy/docker/release/pkg.json"
-  ],
+  "build": {
+    "build_type": "release",
+    "targets": [
+        "ydb/apps/ydbd",
+        "ydb/apps/ydb",
+        "contrib/libs/libiconv/dynamic",
+        "contrib/libs/libidn/dynamic",
+        "contrib/libs/libaio/dynamic"
+    ],
+    "flags": [
+      {
+          "name": "OPENSOURCE",
+          "value": "yes"
+      },
+      {
+          "name": "HARDENING",
+          "value": "yes"
+      },
+      {
+          "name": "CFLAGS",
+          "value": "-fno-omit-frame-pointer"
+      },
+      {
+          "name": "DEBUGINFO_LINES_ONLY",
+          "value": "yes"
+      }
+    ],
+    "target-platforms": [
+      "default-linux-x86_64"
+    ]
+  },
   "data": [
     {
       "source": {
@@ -21,7 +49,103 @@
         "path": "ydb/deploy/docker/breakpad/minidump_script.py"
       },
       "destination": {
-        "path": "/minidump_script.py"
+        "path": "/minidump_script.py",
+        "attributes": {
+          "mode": {
+            "value": "a+x"
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "ydb/deploy/docker/Dockerfile"
+      },
+      "destination": {
+        "path": "/Dockerfile"
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "AUTHORS"
+      },
+      "destination": {
+        "path": "/AUTHORS"
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "LICENSE"
+      },
+      "destination": {
+        "path": "/LICENSE"
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "README.md"
+      },
+      "destination": {
+        "path": "/README.md"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "contrib/libs/libiconv/dynamic/libiconv.so"
+      },
+      "destination": {
+        "path": "/libiconv.so"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "contrib/libs/libidn/dynamic/liblibidn-dynamic.so"
+      },
+      "destination": {
+        "path": "/liblibidn-dynamic.so"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "contrib/libs/libaio/dynamic/liblibaio-dynamic.so"
+      },
+      "destination": {
+        "path": "/liblibaio-dynamic.so"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "ydb/apps/ydbd/ydbd"
+      },
+      "destination": {
+        "path": "/ydbd",
+        "attributes": {
+          "mode": {
+            "value": "a+x"
+          }
+        }
+      }
+    },
+    {
+      "source": {
+          "type": "BUILD_OUTPUT",
+          "path": "ydb/apps/ydb/ydb"
+      },
+      "destination": {
+        "path": "/ydb",
+        "attributes": {
+          "mode": {
+            "value": "a+x"
+          }
+        }
       }
     }
   ]

--- a/ydb/deploy/docker/debug/pkg.json
+++ b/ydb/deploy/docker/debug/pkg.json
@@ -11,8 +11,142 @@
     "docker_repository": "crp2lrlsrs36odlvd8dv",
     "docker_target": "debug"
   },
-  "include": [
-    "ydb/deploy/docker/breakpad/pkg.json"
-  ],
-  "data": []
+  "build": {
+    "build_type": "release",
+    "targets": [
+        "ydb/apps/ydbd",
+        "ydb/apps/ydb",
+        "contrib/libs/libiconv/dynamic",
+        "contrib/libs/libidn/dynamic",
+        "contrib/libs/libaio/dynamic"
+    ],
+    "flags": [
+      {
+          "name": "OPENSOURCE",
+          "value": "yes"
+      },
+      {
+          "name": "HARDENING",
+          "value": "yes"
+      },
+      {
+          "name": "CFLAGS",
+          "value": "-fno-omit-frame-pointer"
+      },
+      {
+          "name": "SPLIT_DWARF_VALUE",
+          "value": "yes"
+      }
+    ],
+    "target-platforms": [
+      "default-linux-x86_64"
+    ]
+  },
+  "data": [
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "ydb/deploy/docker/breakpad/minidump_script.py"
+      },
+      "destination": {
+        "path": "/minidump_script.py",
+        "attributes": {
+          "mode": {
+            "value": "a+x"
+          }
+        }
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "ydb/deploy/docker/Dockerfile"
+      },
+      "destination": {
+        "path": "/Dockerfile"
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "AUTHORS"
+      },
+      "destination": {
+        "path": "/AUTHORS"
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "LICENSE"
+      },
+      "destination": {
+        "path": "/LICENSE"
+      }
+    },
+    {
+      "source": {
+        "type": "ARCADIA",
+        "path": "README.md"
+      },
+      "destination": {
+        "path": "/README.md"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "contrib/libs/libiconv/dynamic/libiconv.so"
+      },
+      "destination": {
+        "path": "/libiconv.so"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "contrib/libs/libidn/dynamic/liblibidn-dynamic.so"
+      },
+      "destination": {
+        "path": "/liblibidn-dynamic.so"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "contrib/libs/libaio/dynamic/liblibaio-dynamic.so"
+      },
+      "destination": {
+        "path": "/liblibaio-dynamic.so"
+      }
+    },
+    {
+      "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "ydb/apps/ydbd/ydbd"
+      },
+      "destination": {
+        "path": "/ydbd",
+        "attributes": {
+          "mode": {
+            "value": "a+x"
+          }
+        }
+      }
+    },
+    {
+      "source": {
+          "type": "BUILD_OUTPUT",
+          "path": "ydb/apps/ydb/ydb"
+      },
+      "destination": {
+        "path": "/ydb",
+        "attributes": {
+          "mode": {
+            "value": "a+x"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/ydb/deploy/docker/release/pkg.json
+++ b/ydb/deploy/docker/release/pkg.json
@@ -122,15 +122,6 @@
     },
     {
       "source": {
-        "type": "BUILD_OUTPUT",
-        "path": "ydb/apps/ydbd/ydbd.debug"
-      },
-      "destination": {
-        "path": "/ydbd.debug"
-      }
-    },
-    {
-      "source": {
           "type": "BUILD_OUTPUT",
           "path": "ydb/apps/ydb/ydb"
       },


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Use `DEBUGINFO_LINES_ONLY` param for ydbd binary in breakpad docker tag
This will allow to extract the correct stacktraces and see lines in coredumps (thanks to @iddqdex)

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
