### PR TITLE
Replace SessionPool with QuerySessionPool in serverless/test_serverless.py

### DIFF
--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -106,7 +106,9 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
             PRIMARY KEY (id)
             );
             """
-            session.execute(create_table_query)
+
+            session.execute_with_retries(create_table_query)
+
             # session.create_table(
             #     path,
             #     ydb.TableDescription()
@@ -133,7 +135,7 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
 
         def drop_table(session, path):
             drop_table_query = f"DROP TABLE `{path}`;"
-            session.execute(drop_table_query)
+            session.execute_with_retries(drop_table_query)
             # session.drop_table(
             #     path
             # )
@@ -174,7 +176,7 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
             PRIMARY KEY (id)
             );
             """
-            session.execute(create_table_query)
+            session.execute_with_retries(create_table_query)
             # session.create_table(
             #     path,
             #     ydb.TableDescription()
@@ -211,7 +213,7 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
 
         def drop_table(session, path):
             drop_table_query = f"DROP TABLE `{path}`;"
-            session.execute(drop_table_query)
+            session.execute_with_retries(drop_table_query)
             # session.drop_table(
             #     path
             # )
@@ -248,7 +250,7 @@ def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_e
             PRIMARY KEY (id)
             );
             """
-        session.execute(create_table_query)
+        session.execute_with_retries(create_table_query)
         # session.create_table(
         #     path,
         #     ydb.TableDescription()
@@ -308,7 +310,11 @@ def test_create_table_with_alter_quotas(ydb_hostel_db, ydb_serverless_db, ydb_en
             PRIMARY KEY (id)
             );
             """
-        session.execute(create_table_query)
+
+
+        session.execute_with_retries(create_table_query)
+
+
         # session.create_table(
         #     path,
         #     ydb.TableDescription()
@@ -357,7 +363,7 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
             PRIMARY KEY (id)
             );
             """
-        session.execute(create_table_query)
+        session.execute_with_retries(create_table_query)
         # session.create_table(
         #     path,
         #     ydb.TableDescription()
@@ -631,7 +637,7 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
             PRIMARY KEY (id)
             );
             """
-            session.execute(create_table_query)
+            session.execute_with_retries(create_table_query)
             # session.create_table(
             #     path,
             #     ydb.TableDescription()
@@ -646,7 +652,7 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
 
         def drop_table(session, path):
             drop_table_query = f"DROP TABLE `{path}`;"
-            session.execute(drop_table_query)
+            session.execute_with_retries(drop_table_query)
             # session.drop_table(
             #     path
             # )
@@ -678,7 +684,7 @@ def test_seamless_migration_to_exclusive_nodes(ydb_serverless_db_with_exclusive_
     PRIMARY KEY (id)
     );
     """
-    session.execute(create_table_query)
+    session.execute_with_retries(create_table_query)
     # session.create_table(
     #     path,
     #     ydb.TableDescription()

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -107,7 +107,11 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
             );
             """
 
-            session.execute_with_retries(create_table_query)
+            with session.transaction().execute(
+                create_table_query,
+                commit_tx=True,
+            ) as _:
+                pass
 
             # session.create_table(
             #     path,
@@ -135,7 +139,12 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
 
         def drop_table(session, path):
             drop_table_query = f"DROP TABLE `{path}`;"
-            session.execute_with_retries(drop_table_query)
+            with session.transaction().execute(
+                drop_table_query,
+                commit_tx=True,
+            ) as _:
+                pass
+            
             # session.drop_table(
             #     path
             # )
@@ -176,7 +185,13 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
             PRIMARY KEY (id)
             );
             """
-            session.execute_with_retries(create_table_query)
+
+            with session.transaction().execute(
+                create_table_query,
+                commit_tx=True,
+            ) as _:
+                pass
+
             # session.create_table(
             #     path,
             #     ydb.TableDescription()
@@ -213,7 +228,12 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
 
         def drop_table(session, path):
             drop_table_query = f"DROP TABLE `{path}`;"
-            session.execute_with_retries(drop_table_query)
+            with session.transaction().execute(
+                drop_table_query,
+                commit_tx=True,
+            ) as _:
+                pass
+
             # session.drop_table(
             #     path
             # )
@@ -250,7 +270,14 @@ def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_e
             PRIMARY KEY (id)
             );
             """
-        session.execute_with_retries(create_table_query)
+
+        with session.transaction().execute(
+            create_table_query,
+            commit_tx=True,
+        ) as _:
+            pass
+
+
         # session.create_table(
         #     path,
         #     ydb.TableDescription()
@@ -312,7 +339,11 @@ def test_create_table_with_alter_quotas(ydb_hostel_db, ydb_serverless_db, ydb_en
             """
 
 
-        session.execute_with_retries(create_table_query)
+        with session.transaction().execute(
+            create_table_query,
+            commit_tx=True,
+        ) as _:
+            pass
 
 
         # session.create_table(
@@ -363,7 +394,14 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
             PRIMARY KEY (id)
             );
             """
-        session.execute_with_retries(create_table_query)
+        
+        with session.transaction().execute(
+            create_table_query,
+            commit_tx=True,
+        ) as _:
+            pass
+
+
         # session.create_table(
         #     path,
         #     ydb.TableDescription()
@@ -637,7 +675,13 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
             PRIMARY KEY (id)
             );
             """
-            session.execute_with_retries(create_table_query)
+            with session.transaction().execute(
+                create_table_query,
+                commit_tx=True,
+            ) as _:
+                pass
+
+
             # session.create_table(
             #     path,
             #     ydb.TableDescription()
@@ -652,7 +696,11 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
 
         def drop_table(session, path):
             drop_table_query = f"DROP TABLE `{path}`;"
-            session.execute_with_retries(drop_table_query)
+            with session.transaction().execute(
+                drop_table_query,
+                commit_tx=True,
+            ) as _:
+                pass
             # session.drop_table(
             #     path
             # )
@@ -684,7 +732,13 @@ def test_seamless_migration_to_exclusive_nodes(ydb_serverless_db_with_exclusive_
     PRIMARY KEY (id)
     );
     """
-    session.execute_with_retries(create_table_query)
+    with session.transaction().execute(
+        create_table_query,
+        commit_tx=True,
+    ) as _:
+        pass
+
+    
     # session.create_table(
     #     path,
     #     ydb.TableDescription()

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -94,33 +94,7 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
     driver.scheme_client.make_directory(os.path.join(database, "dirA1"))
     driver.scheme_client.make_directory(os.path.join(database, "dirA1", "dirB1"))
 
-    # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
-        # def create_table(session, path):
-        #     create_table_query = f"""
-        #     CREATE TABLE `{path}`
-        #     (
-        #     id UInt64,
-        #     value_string Utf8,
-        #     value_num UInt64,
-        #     PRIMARY KEY (id)
-        #     );
-        #     """
-
-        #     with session.transaction().execute(
-        #         create_table_query,
-        #         commit_tx=True,
-        #     ) as _:
-        #         pass
-
-        #     # session.create_table(
-        #     #     path,
-        #     #     ydb.TableDescription()
-        #     #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-        #     #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     #     .with_primary_key('id')
-        #     # )
         
         pool.execute_with_retries(
             f"""
@@ -144,20 +118,6 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
             );
             """
         )
-        # pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
-        # pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table1"))
-
-        # def write_some_data(session, path):
-        #     session.transaction().execute(
-        #         """
-        #         UPSERT INTO `{}` (id, value_string, value_num)
-        #                    VALUES (1u, "Ok", 0u),
-        #                           (2u, "Also_Ok", 0u),
-        #                           (3u, "And_Ok_With_Locks", 0u);
-        #                           """.format(path),
-        #         commit_tx=True)
-
-        # pool.retry_operation_sync(write_some_data, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
         pool.execute_with_retries(
             f"""UPSERT INTO `{os.path.join(database, "dirA1", "dirB1", "table")}` (id, value_string, value_num)
@@ -166,21 +126,9 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
                                   (3u, "And_Ok_With_Locks", 0u);"""
         )
 
-        # def drop_table(session, path):
-        #     drop_table_query = f"DROP TABLE `{path}`;"
-        #     with session.transaction().execute(
-        #         drop_table_query,
-        #         commit_tx=True,
-        #     ) as _:
-        #         pass
-            
-        #     # session.drop_table(
-        #     #     path
-        #     # )
         pool.execute_with_retries(
             f"DROP TABLE `{os.path.join(database, "dirA1", "dirB1", "table")}`;"
         )
-        # pool.retry_operation_sync(drop_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
 
 def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, ydb_endpoint, metering_file_path, ydb_private_client):
@@ -204,7 +152,6 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
     driver.scheme_client.make_directory(os.path.join(database, "dirA1"))
     driver.scheme_client.make_directory(os.path.join(database, "dirA1", "dirB1"))
 
-    # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
             create_table_query = f"""
@@ -223,14 +170,6 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
             ) as _:
                 pass
 
-            # session.create_table(
-            #     path,
-            #     ydb.TableDescription()
-            #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-            #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-            #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-            #     .with_primary_key('id')
-            # )
 
         pool.execute_with_retries(
             f"""
@@ -254,18 +193,6 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
             );
             """
         )
-        # pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
-        # pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table1"))
-
-        # def write_some_data(session, path):
-        #     session.transaction().execute(
-        #         """
-        #         UPSERT INTO `{}` (id, value_string, value_num)
-        #                    VALUES (1u, "Ok", 0u),
-        #                           (2u, "Also_Ok", 0u),
-        #                           (3u, "And_Ok_With_Locks", 0u);
-        #                           """.format(path),
-        #         commit_tx=True)
 
         pool.execute_with_retries(
             f"""UPSERT INTO `{os.path.join(database, "dirA1", "dirB1", "table")}` (id, value_string, value_num)
@@ -274,7 +201,6 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
                                   (3u, "And_Ok_With_Locks", 0u);"""
         )
         
-        # pool.retry_operation_sync(write_some_data, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
         ydb_private_client.add_config_item("FeatureFlags { AllowServerlessStorageBillingForSchemeShard: true }")
         while True:
@@ -286,24 +212,12 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
                 logger.info(" wait data in metering file %s", metering_file_path)
                 time.sleep(15)
 
-        # def drop_table(session, path):
-        #     drop_table_query = f"DROP TABLE `{path}`;"
-        #     with session.transaction().execute(
-        #         drop_table_query,
-        #         commit_tx=True,
-        #     ) as _:
-        #         pass
-
-            # session.drop_table(
-            #     path
-            # )
 
         
         
         pool.execute_with_retries(
             f"DROP TABLE `{os.path.join(database, "dirA1", "dirB1", "table")}`;"
         )
-        # pool.retry_operation_sync(drop_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
 
 def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_endpoint):
@@ -324,37 +238,7 @@ def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_e
 
     driver.scheme_client.make_directory(os.path.join(database, "dirA0"))
 
-    # def create_table(session, path):
-    #     logger.debug("creating table %s", path)
-    #     create_table_query = f"""
-    #         CREATE TABLE `{path}`
-    #         (
-    #         id UInt64,
-    #         value_string Utf8,
-    #         value_num UInt64,
-    #         PRIMARY KEY (id)
-    #         );
-    #         """
-
-    #     with session.transaction().execute(
-    #         create_table_query,
-    #         commit_tx=True,
-    #     ) as _:
-    #         pass
-
-
-        # session.create_table(
-        #     path,
-        #     ydb.TableDescription()
-        #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-        #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     .with_primary_key('id')
-        # )
-
-    # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
-        # pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA0", "table"))
         pool.execute_with_retries(
             f"""
             CREATE TABLE `{os.path.join(database, "dirA0", "table")}`
@@ -392,8 +276,6 @@ def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_e
                     );
                     """
                 )
-                # create_table(session, os.path.join(database, "dirA0", "table2"))
-                # create_table(session, os.path.join(database, "dirA0", "table3"))
             assert "exceeded a limit" in str(excinfo.value)
 
 
@@ -444,18 +326,8 @@ def test_create_table_with_alter_quotas(ydb_hostel_db, ydb_serverless_db, ydb_en
             pass
 
 
-        # session.create_table(
-        #     path,
-        #     ydb.TableDescription()
-        #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-        #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     .with_primary_key('id')
-        # )
 
-    # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
-        # pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA0", "table"))
         pool.execute_with_retries(
             f"""
             CREATE TABLE `{os.path.join(database, "dirA0", "table")}`
@@ -493,8 +365,6 @@ def test_create_table_with_alter_quotas(ydb_hostel_db, ydb_serverless_db, ydb_en
                     );
                     """
                 )
-                # create_table(session, os.path.join(database, "dirA0", "table2"))
-                # create_table(session, os.path.join(database, "dirA0", "table3"))
             assert "exceeded a limit" in str(excinfo.value)
 
 
@@ -513,34 +383,6 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
 
     driver = ydb.Driver(driver_config)
     driver.wait(120)
-
-    # def create_table(session, path):
-    #     logger.debug("creating table %s", path)
-    #     create_table_query = f"""
-    #         CREATE TABLE `{path}`
-    #         (
-    #         id UInt64,
-    #         value_string Utf8,
-    #         value_num UInt64,
-    #         PRIMARY KEY (id)
-    #         );
-    #         """
-        
-    #     with session.transaction().execute(
-    #         create_table_query,
-    #         commit_tx=True,
-    #     ) as _:
-    #         pass
-
-
-        # session.create_table(
-        #     path,
-        #     ydb.TableDescription()
-        #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-        #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-        #     .with_primary_key('id')
-        # )
 
     sessions = []
 
@@ -655,10 +497,8 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
         yield driver.table_client.async_bulk_upsert(path, rows, column_types)
 
     driver.scheme_client.make_directory(os.path.join(database, "dirA0"))
-    # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
         path = os.path.join(database, "dirA0", "table")
-        # pool.retry_operation_sync(create_table, None, path)
         pool.execute_with_retries(
             f"""
             CREATE TABLE `{path}`
@@ -807,48 +647,9 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
     dir_path = os.path.join(database, "dir")
     driver.scheme_client.make_directory(dir_path)
 
-    # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
-        # def create_table(session, path):
-        #     create_table_query = f"""
-        #     CREATE TABLE `{path}`
-        #     (
-        #     id UInt64,
-        #     PRIMARY KEY (id)
-        #     );
-        #     """
-        #     with session.transaction().execute(
-        #         create_table_query,
-        #         commit_tx=True,
-        #     ) as _:
-        #         pass
-
-
-            # session.create_table(
-            #     path,
-            #     ydb.TableDescription()
-            #     .with_column(ydb.Column("id", ydb.OptionalType(ydb.DataType.Uint64)))
-            #     .with_primary_key("id")
-            # )
-
-        # def write_some_data(session, path):
-        #     session.transaction().execute(
-        #         f"UPSERT INTO `{path}` (id) VALUES (1), (2), (3);",
-        #         commit_tx=True)
-
-        # def drop_table(session, path):
-        #     drop_table_query = f"DROP TABLE `{path}`;"
-        #     with session.transaction().execute(
-        #         drop_table_query,
-        #         commit_tx=True,
-        #     ) as _:
-        #         pass
-            # session.drop_table(
-            #     path
-            # )
 
         table_path = os.path.join(dir_path, "create_table_with_exclusive_nodes_table")
-        # pool.retry_operation_sync(create_table, None, table_path)
         pool.execute_with_retries(
             f"""
             CREATE TABLE `{table_path}`
@@ -860,11 +661,9 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
             );
             """
         )
-        # pool.retry_operation_sync(write_some_data, None, table_path)
         pool.execute_with_retries(
             f"UPSERT INTO `{table_path}` (id) VALUES (1), (2), (3);"
         )
-        # pool.retry_operation_sync(drop_table, None, table_path)
         pool.execute_with_retries(
             f"DROP TABLE `{table_path}`;"
         )
@@ -898,12 +697,6 @@ def test_seamless_migration_to_exclusive_nodes(ydb_serverless_db_with_exclusive_
         pass
 
     
-    # session.create_table(
-    #     path,
-    #     ydb.TableDescription()
-    #     .with_column(ydb.Column("id", ydb.OptionalType(ydb.DataType.Uint64)))
-    #     .with_primary_key("id")
-    # )
 
     session.transaction().execute(
         f"UPSERT INTO `{path}` (id) VALUES (1), (2), (3);",

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -98,7 +98,7 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
     with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
             create_table_query = f"""
-            CREATE TABLE {path}
+            CREATE TABLE `{path}`
             (
             id UInt64,
             value_string Utf8,
@@ -132,7 +132,7 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
         pool.retry_operation_sync(write_some_data, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
         def drop_table(session, path):
-            drop_table_query = f"DROP TABLE {path};"
+            drop_table_query = f"DROP TABLE `{path}`;"
             session.execute(drop_table_query)
             # session.drop_table(
             #     path
@@ -166,7 +166,7 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
     with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
             create_table_query = f"""
-            CREATE TABLE {path}
+            CREATE TABLE `{path}`
             (
             id UInt64,
             value_string Utf8,
@@ -210,7 +210,7 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
                 time.sleep(15)
 
         def drop_table(session, path):
-            drop_table_query = f"DROP TABLE {path};"
+            drop_table_query = f"DROP TABLE `{path}`;"
             session.execute(drop_table_query)
             # session.drop_table(
             #     path
@@ -240,7 +240,7 @@ def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_e
     def create_table(session, path):
         logger.debug("creating table %s", path)
         create_table_query = f"""
-            CREATE TABLE {path}
+            CREATE TABLE `{path}`
             (
             id UInt64,
             value_string Utf8,
@@ -300,7 +300,7 @@ def test_create_table_with_alter_quotas(ydb_hostel_db, ydb_serverless_db, ydb_en
     def create_table(session, path):
         logger.debug("creating table %s", path)
         create_table_query = f"""
-            CREATE TABLE {path}
+            CREATE TABLE `{path}`
             (
             id UInt64,
             value_string Utf8,
@@ -349,7 +349,7 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
     def create_table(session, path):
         logger.debug("creating table %s", path)
         create_table_query = f"""
-            CREATE TABLE {path}
+            CREATE TABLE `{path}`
             (
             id UInt64,
             value_string Utf8,
@@ -625,7 +625,7 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
     with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
             create_table_query = f"""
-            CREATE TABLE {path}
+            CREATE TABLE `{path}`
             (
             id UInt64,
             PRIMARY KEY (id)
@@ -645,7 +645,7 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
                 commit_tx=True)
 
         def drop_table(session, path):
-            drop_table_query = f"DROP TABLE {path};"
+            drop_table_query = f"DROP TABLE `{path}`;"
             session.execute(drop_table_query)
             # session.drop_table(
             #     path
@@ -672,7 +672,7 @@ def test_seamless_migration_to_exclusive_nodes(ydb_serverless_db_with_exclusive_
     session = driver.table_client.session().create()
     path = os.path.join(database, "seamless_migration_table")
     create_table_query = f"""
-    CREATE TABLE {path}
+    CREATE TABLE `{path}`
     (
     id UInt64,
     PRIMARY KEY (id)

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -94,7 +94,8 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
     driver.scheme_client.make_directory(os.path.join(database, "dirA1"))
     driver.scheme_client.make_directory(os.path.join(database, "dirA1", "dirB1"))
 
-    with ydb.SessionPool(driver) as pool:
+    # with ydb.SessionPool(driver) as pool:
+    with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
             session.create_table(
                 path,
@@ -149,7 +150,8 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
     driver.scheme_client.make_directory(os.path.join(database, "dirA1"))
     driver.scheme_client.make_directory(os.path.join(database, "dirA1", "dirB1"))
 
-    with ydb.SessionPool(driver) as pool:
+    # with ydb.SessionPool(driver) as pool:
+    with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
             session.create_table(
                 path,
@@ -222,7 +224,8 @@ def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_e
             .with_primary_key('id')
         )
 
-    with ydb.SessionPool(driver) as pool:
+    # with ydb.SessionPool(driver) as pool:
+    with ydb.QuerySessionPool(driver) as pool:
         pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA0", "table"))
 
         with pool.checkout() as session:
@@ -271,7 +274,8 @@ def test_create_table_with_alter_quotas(ydb_hostel_db, ydb_serverless_db, ydb_en
             .with_primary_key('id')
         )
 
-    with ydb.SessionPool(driver) as pool:
+    # with ydb.SessionPool(driver) as pool:
+    with ydb.QuerySessionPool(driver) as pool:
         pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA0", "table"))
 
         with pool.checkout() as session:
@@ -422,7 +426,8 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
         yield driver.table_client.async_bulk_upsert(path, rows, column_types)
 
     driver.scheme_client.make_directory(os.path.join(database, "dirA0"))
-    with ydb.SessionPool(driver) as pool:
+    # with ydb.SessionPool(driver) as pool:
+    with ydb.QuerySessionPool(driver) as pool:
         path = os.path.join(database, "dirA0", "table")
         pool.retry_operation_sync(create_table, None, path)
 
@@ -562,7 +567,8 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
     dir_path = os.path.join(database, "dir")
     driver.scheme_client.make_directory(dir_path)
 
-    with ydb.SessionPool(driver) as pool:
+    # with ydb.SessionPool(driver) as pool:
+    with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
             session.create_table(
                 path,

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -97,14 +97,24 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
     # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
-            session.create_table(
-                path,
-                ydb.TableDescription()
-                .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-                .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-                .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-                .with_primary_key('id')
-            )
+            create_table_query = f"""
+            CREATE TABLE {path}
+            (
+            id UInt64,
+            value_string Utf8,
+            value_num UInt64,
+            PRIMARY KEY (id)
+            );
+            """
+            session.execute(create_table_query)
+            # session.create_table(
+            #     path,
+            #     ydb.TableDescription()
+            #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
+            #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
+            #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
+            #     .with_primary_key('id')
+            # )
 
         pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
         pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table1"))
@@ -122,9 +132,11 @@ def test_create_table(ydb_hostel_db, ydb_serverless_db, ydb_endpoint):
         pool.retry_operation_sync(write_some_data, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
         def drop_table(session, path):
-            session.drop_table(
-                path
-            )
+            drop_table_query = f"DROP TABLE {path};"
+            session.execute(drop_table_query)
+            # session.drop_table(
+            #     path
+            # )
 
         pool.retry_operation_sync(drop_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
@@ -153,14 +165,24 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
     # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
-            session.create_table(
-                path,
-                ydb.TableDescription()
-                .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-                .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-                .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-                .with_primary_key('id')
-            )
+            create_table_query = f"""
+            CREATE TABLE {path}
+            (
+            id UInt64,
+            value_string Utf8,
+            value_num UInt64,
+            PRIMARY KEY (id)
+            );
+            """
+            session.execute(create_table_query)
+            # session.create_table(
+            #     path,
+            #     ydb.TableDescription()
+            #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
+            #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
+            #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
+            #     .with_primary_key('id')
+            # )
 
         pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
         pool.retry_operation_sync(create_table, None, os.path.join(database, "dirA1", "dirB1", "table1"))
@@ -188,9 +210,11 @@ def test_turn_on_serverless_storage_billing(ydb_hostel_db, ydb_serverless_db, yd
                 time.sleep(15)
 
         def drop_table(session, path):
-            session.drop_table(
-                path
-            )
+            drop_table_query = f"DROP TABLE {path};"
+            session.execute(drop_table_query)
+            # session.drop_table(
+            #     path
+            # )
 
         pool.retry_operation_sync(drop_table, None, os.path.join(database, "dirA1", "dirB1", "table"))
 
@@ -215,14 +239,24 @@ def test_create_table_with_quotas(ydb_hostel_db, ydb_quoted_serverless_db, ydb_e
 
     def create_table(session, path):
         logger.debug("creating table %s", path)
-        session.create_table(
-            path,
-            ydb.TableDescription()
-            .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-            .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-            .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-            .with_primary_key('id')
-        )
+        create_table_query = f"""
+            CREATE TABLE {path}
+            (
+            id UInt64,
+            value_string Utf8,
+            value_num UInt64,
+            PRIMARY KEY (id)
+            );
+            """
+        session.execute(create_table_query)
+        # session.create_table(
+        #     path,
+        #     ydb.TableDescription()
+        #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
+        #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
+        #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
+        #     .with_primary_key('id')
+        # )
 
     # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
@@ -265,14 +299,24 @@ def test_create_table_with_alter_quotas(ydb_hostel_db, ydb_serverless_db, ydb_en
 
     def create_table(session, path):
         logger.debug("creating table %s", path)
-        session.create_table(
-            path,
-            ydb.TableDescription()
-            .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-            .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-            .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-            .with_primary_key('id')
-        )
+        create_table_query = f"""
+            CREATE TABLE {path}
+            (
+            id UInt64,
+            value_string Utf8,
+            value_num UInt64,
+            PRIMARY KEY (id)
+            );
+            """
+        session.execute(create_table_query)
+        # session.create_table(
+        #     path,
+        #     ydb.TableDescription()
+        #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
+        #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
+        #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
+        #     .with_primary_key('id')
+        # )
 
     # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
@@ -304,14 +348,24 @@ def test_database_with_disk_quotas(ydb_hostel_db, ydb_disk_quoted_serverless_db,
 
     def create_table(session, path):
         logger.debug("creating table %s", path)
-        session.create_table(
-            path,
-            ydb.TableDescription()
-            .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
-            .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
-            .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
-            .with_primary_key('id')
-        )
+        create_table_query = f"""
+            CREATE TABLE {path}
+            (
+            id UInt64,
+            value_string Utf8,
+            value_num UInt64,
+            PRIMARY KEY (id)
+            );
+            """
+        session.execute(create_table_query)
+        # session.create_table(
+        #     path,
+        #     ydb.TableDescription()
+        #     .with_column(ydb.Column('id', ydb.OptionalType(ydb.DataType.Uint64)))
+        #     .with_column(ydb.Column('value_string', ydb.OptionalType(ydb.DataType.Utf8)))
+        #     .with_column(ydb.Column('value_num', ydb.OptionalType(ydb.DataType.Uint64)))
+        #     .with_primary_key('id')
+        # )
 
     sessions = []
 
@@ -570,12 +624,20 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
     # with ydb.SessionPool(driver) as pool:
     with ydb.QuerySessionPool(driver) as pool:
         def create_table(session, path):
-            session.create_table(
-                path,
-                ydb.TableDescription()
-                .with_column(ydb.Column("id", ydb.OptionalType(ydb.DataType.Uint64)))
-                .with_primary_key("id")
-            )
+            create_table_query = f"""
+            CREATE TABLE {path}
+            (
+            id UInt64,
+            PRIMARY KEY (id)
+            );
+            """
+            session.execute(create_table_query)
+            # session.create_table(
+            #     path,
+            #     ydb.TableDescription()
+            #     .with_column(ydb.Column("id", ydb.OptionalType(ydb.DataType.Uint64)))
+            #     .with_primary_key("id")
+            # )
 
         def write_some_data(session, path):
             session.transaction().execute(
@@ -583,9 +645,11 @@ def test_create_table_using_exclusive_nodes(ydb_serverless_db_with_exclusive_nod
                 commit_tx=True)
 
         def drop_table(session, path):
-            session.drop_table(
-                path
-            )
+            drop_table_query = f"DROP TABLE {path};"
+            session.execute(drop_table_query)
+            # session.drop_table(
+            #     path
+            # )
 
         table_path = os.path.join(dir_path, "create_table_with_exclusive_nodes_table")
         pool.retry_operation_sync(create_table, None, table_path)
@@ -607,12 +671,20 @@ def test_seamless_migration_to_exclusive_nodes(ydb_serverless_db_with_exclusive_
 
     session = driver.table_client.session().create()
     path = os.path.join(database, "seamless_migration_table")
-    session.create_table(
-        path,
-        ydb.TableDescription()
-        .with_column(ydb.Column("id", ydb.OptionalType(ydb.DataType.Uint64)))
-        .with_primary_key("id")
-    )
+    create_table_query = f"""
+    CREATE TABLE {path}
+    (
+    id UInt64,
+    PRIMARY KEY (id)
+    );
+    """
+    session.execute(create_table_query)
+    # session.create_table(
+    #     path,
+    #     ydb.TableDescription()
+    #     .with_column(ydb.Column("id", ydb.OptionalType(ydb.DataType.Uint64)))
+    #     .with_primary_key("id")
+    # )
 
     session.transaction().execute(
         f"UPSERT INTO `{path}` (id) VALUES (1), (2), (3);",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Additional information
Try to replace `SessionPool` with new `QuerySessionPool` in python test (`ydb/tests/functional/serverless/test_serverless.py`)
