### PR TITLE
Fix excessive memory usage during index-only non-restoring TEvRange query execution

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_blob_tracker.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_blob_tracker.h
@@ -18,6 +18,9 @@ namespace NKikimr {
         TIngress Ingress;
         bool HasIngress = true;
 
+        bool Keep = false;
+        bool DoNotKeep = false;
+
     public:
         TBlobStatusTracker(const TLogoBlobID& fullId, const TBlobStorageGroupInfo *info)
             : FullId(fullId)
@@ -86,6 +89,13 @@ namespace NKikimr {
                 default:
                     Y_ABORT("unexpected blob status# %s", NKikimrProto::EReplyStatus_Name(status).data());
             }
+
+            if (result.HasKeep()) {
+                Keep |= result.GetKeep();
+            }
+            if (result.HasDoNotKeep()) {
+                DoNotKeep |= result.GetDoNotKeep();
+            }
         }
 
         TBlobStorageGroupInfo::EBlobState GetBlobState(const TBlobStorageGroupInfo *info, bool *lostByIngress) const {
@@ -116,6 +126,10 @@ namespace NKikimr {
             }
 
             return state;
+        }
+
+        std::tuple<bool, bool> GetKeepFlags() const {
+            return {Keep, DoNotKeep};
         }
     };
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -428,7 +428,7 @@ public:
                 x2Count++;
             }
         }
-        PATCH_LOG(PRI_DEBUG, BS_PROXY_PATCH, BPPA23, "VerifyPartPlacement {mirror-3-dc}",
+        PATCH_LOG(PRI_DEBUG, BS_PROXY_PATCH, BPPA00, "VerifyPartPlacement {mirror-3-dc}",
                 (X2Count, x2Count));
         return x2Count >= 2;
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_range.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_range.cpp
@@ -39,12 +39,7 @@ class TBlobStorageGroupRangeRequest : public TBlobStorageGroupRequestActor {
     };
     TVector<TBlobQueryItem> BlobsToGet;
 
-    template<typename TPtr>
-    void SendReply(TPtr& reply) {
-        /*ui32 size = 0;
-        for (const TEvBlobStorage::TEvRangeResult::TResponse& resp : reply->Responses) {
-            size += resp.Buffer.size();
-        }*/
+    void SendReply(std::unique_ptr<TEvBlobStorage::TEvRangeResult> reply) {
         Mon->CountRangeResponseTime(TActivationContext::Monotonic() - RequestStartTime);
         SendResponseAndDie(std::move(reply));
     }
@@ -181,8 +176,12 @@ class TBlobStorageGroupRangeRequest : public TBlobStorageGroupRequestActor {
         }
 
         if (!NumVGetsPending) {
-            for (const auto& item : BlobStatus) {
-                const TBlobStatusTracker& tracker = item.second;
+            std::unique_ptr<TEvBlobStorage::TEvRangeResult> result;
+            if (IsIndexOnly && !MustRestoreFirst) {
+                result.reset(new TEvBlobStorage::TEvRangeResult(NKikimrProto::OK, From, To, Info->GroupID));
+            }
+
+            for (const auto& [blobId, tracker] : BlobStatus) {
                 bool lostByIngress = false;
                 bool requiredToBePresent = false;
                 switch (tracker.GetBlobState(Info.Get(), &lostByIngress)) {
@@ -212,11 +211,22 @@ class TBlobStorageGroupRangeRequest : public TBlobStorageGroupRequestActor {
                         break;
                 }
 
-                BlobsToGet.emplace_back(item.first, requiredToBePresent);
+                if (result) {
+                    const auto& [keep, doNotKeep] = tracker.GetKeepFlags();
+                    result->Responses.emplace_back(blobId, TString(), keep, doNotKeep);
+                } else {
+                    BlobsToGet.emplace_back(blobId, requiredToBePresent);
+                }
             }
 
-            // send request
-            if (BlobsToGet) {
+            if (result) {
+                if (To < From) { // BlobsToGet are kept in ascending order, but we are expected to reply in descending one
+                    auto& r = result->Responses;
+                    std::reverse(r.begin(), r.end());
+                }
+                DSP_LOG_LOG_S(NLog::PRI_INFO, "DSR00", "Result# " << result->Print(false));
+                SendReply(std::move(result));
+            } else if (BlobsToGet) {
                 SendGetRequest();
             } else {
                 // reply with empty set
@@ -236,10 +246,9 @@ class TBlobStorageGroupRangeRequest : public TBlobStorageGroupRequestActor {
         }
         Y_ABORT_UNLESS(query == queries.Get() + queryCount);
 
-        // register query in wilson and send it to DS proxy; issue non-index query when MustRestoreFirst is false to
-        // prevent IndexRestoreGet invocation
+        // register query in wilson and send it to DS proxy
         auto get = std::make_unique<TEvBlobStorage::TEvGet>(queries, queryCount, Deadline,
-                NKikimrBlobStorage::EGetHandleClass::FastRead, MustRestoreFirst, MustRestoreFirst ? IsIndexOnly : false,
+                NKikimrBlobStorage::EGetHandleClass::FastRead, MustRestoreFirst, IsIndexOnly,
                 TEvBlobStorage::TEvGet::TForceBlockTabletData(TabletId, ForceBlockedGeneration));
         get->IsInternal = true;
         get->Decommission = Decommission;
@@ -299,7 +308,7 @@ class TBlobStorageGroupRangeRequest : public TBlobStorageGroupRequestActor {
             std::reverse(result->Responses.begin(), result->Responses.end());
         }
         DSP_LOG_LOG_S(NLog::PRI_INFO, "DSR05", "Result# " << result->Print(false));
-        SendReply(result);
+        SendReply(std::move(result));
     }
 
     void ReplyAndDie(NKikimrProto::EReplyStatus status) override {
@@ -307,7 +316,7 @@ class TBlobStorageGroupRangeRequest : public TBlobStorageGroupRequestActor {
                     status, From, To, Info->GroupID));
         result->ErrorReason = ErrorReason;
         DSP_LOG_LOG_S(NLog::PRI_NOTICE, "DSR06", "Result# " << result->Print(false));
-        SendReply(result);
+        SendReply(std::move(result));
     }
 
     std::unique_ptr<IEventBase> RestartQuery(ui32 counter) override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix excessive memory usage during index-only non-restoring TEvRange query execution

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Previously due to incorrect behaviour TEvRange index-only queries without restoration requested TEvGet with data for
found blobs. It caused uncontrollable and potentially huge memory consumption. With thix fix TEvRange query processor
does not issue TEvGet for found blobs when it operates in non-restoring index-only mode, because all required data is
obtained during VDisk TEvVGet scanning.
