### PR TITLE
Store flag AuthorizeByCertificate to local db of node broker (#11315)

### DIFF
--- a/ydb/core/mind/node_broker__register_node.cpp
+++ b/ydb/core/mind/node_broker__register_node.cpp
@@ -100,8 +100,11 @@ public:
                 Self->DbUpdateNodeLease(node, txc);
                 ExtendLease = true;
             }
-            node.AuthorizedByCertificate = rec.GetAuthorizedByCertificate();
-            
+            if (node.AuthorizedByCertificate != rec.GetAuthorizedByCertificate()) {
+                node.AuthorizedByCertificate = rec.GetAuthorizedByCertificate();
+                Self->DbUpdateNodeAuthorizedByCertificate(node, txc);
+            }
+
             if (Self->EnableStableNodeNames) {
                 if (ServicedSubDomain != node.ServicedSubDomain) {
                     if (node.SlotIndex.has_value()) {
@@ -110,12 +113,12 @@ public:
                     node.ServicedSubDomain = ServicedSubDomain;
                     node.SlotIndex = Self->SlotIndexesPools[node.ServicedSubDomain].AcquireLowestFreeIndex();
                     Self->DbAddNode(node, txc);
-                } else if (!node.SlotIndex.has_value()) {    
+                } else if (!node.SlotIndex.has_value()) {
                     node.SlotIndex = Self->SlotIndexesPools[node.ServicedSubDomain].AcquireLowestFreeIndex();
                     Self->DbAddNode(node, txc);
                 }
             }
-            
+
             Response->Record.MutableStatus()->SetCode(TStatus::OK);
             Self->FillNodeInfo(node, *Response->Record.MutableNode());
 

--- a/ydb/core/mind/node_broker__scheme.h
+++ b/ydb/core/mind/node_broker__scheme.h
@@ -25,6 +25,7 @@ struct Schema : NIceDb::Schema {
         struct Location : Column<12, NScheme::NTypeIds::String> {};
         struct ServicedSubDomain : Column<13, NScheme::NTypeIds::String> { using Type = NKikimrSubDomains::TDomainKey; };
         struct SlotIndex : Column<14, NScheme::NTypeIds::Uint32> {};
+        struct AuthorizedByCertificate : Column<15, NScheme::NTypeIds::Bool> {};
 
         using TKey = TableKey<ID>;
         using TColumns = TableColumns<
@@ -37,7 +38,8 @@ struct Schema : NIceDb::Schema {
             Expire,
             Location,
             ServicedSubDomain,
-            SlotIndex
+            SlotIndex,
+            AuthorizedByCertificate
         >;
     };
 

--- a/ydb/core/mind/node_broker_impl.h
+++ b/ydb/core/mind/node_broker_impl.h
@@ -288,6 +288,8 @@ private:
                            TTransactionContext &txc);
     void DbUpdateNodeLocation(const TNodeInfo &node,
                               TTransactionContext &txc);
+    void DbUpdateNodeAuthorizedByCertificate(const TNodeInfo &node,
+                              TTransactionContext &txc);
 
     void Handle(TEvConsole::TEvConfigNotificationRequest::TPtr &ev,
                 const TActorContext &ctx);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Adding the ability to register dynamic nodes by certificate. We wont to know how node was registered in node broker. Flag AuthorizeByCertificate is used for this goal.

Formerly this flag sent to node broker but did not store in local db and set to default value after node broker restart.

cherry-pick https://github.com/ydb-platform/ydb/pull/11315

### Changelog category <!-- remove all except one -->

* Bugfix 


### Additional information

...
