### PR TITLE
preserve suid bit fix for old docker versions

### DIFF
--- a/ydb/deploy/docker/Dockerfile
+++ b/ydb/deploy/docker/Dockerfile
@@ -25,6 +25,14 @@ COPY --chmod=0644 /liblibaio-dynamic.so /lib/liblibaio-dynamic.so
 # Base image with google brekpad assets
 ###
 FROM ${BREAKPAD_INIT_IMAGE}:${BREAKPAD_INIT_IMAGE_TAG} AS breakpad_init
+
+
+FROM base AS breakpad-setuid
+COPY --from=breakpad_init /usr/lib/libbreakpad_init.so /usr/lib/libbreakpad_init.so
+# workaround for old docker versions
+# https://github.com/moby/buildkit/issues/3920
+RUN /usr/bin/chmod 4644 /usr/lib/libbreakpad_init.so
+
 FROM base AS base-breakpad
 RUN \
     apt-get -yqq update && \
@@ -34,11 +42,12 @@ ENV LD_PRELOAD=libbreakpad_init.so
 ENV BREAKPAD_MINIDUMPS_PATH=/opt/ydb/volumes/coredumps
 ENV BREAKPAD_MINIDUMPS_SCRIPT=/opt/ydb/bin/minidump_script.py
 # breakpad binaries
-COPY --chmod=4644 --from=breakpad_init /usr/lib/libbreakpad_init.so /usr/lib/libbreakpad_init.so
 COPY --chmod=0755 --from=breakpad_init /usr/bin/minidump_stackwalk /usr/bin/minidump_stackwalk
 COPY --chmod=0755 --from=breakpad_init /usr/bin/minidump-2-core /usr/bin/minidump-2-core
 # minidump callback script
 COPY --chmod=0755 --chown=ydb /minidump_script.py /opt/ydb/bin/minidump_script.py
+# minidump init library
+COPY --link --from=breakpad-setuid /usr/lib/libbreakpad_init.so /usr/lib/libbreakpad_init.so
 
 FROM base AS ydbd-setcap
 COPY --chmod=0755 --chown=ydb /ydbd /opt/ydb/bin/ydbd


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- preserve suid bit for docker that uses buildkit version < 0.13.0 (https://github.com/moby/buildkit/issues/3920)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
