### PR TITLE
Update breakpad dependencies for docker image

### DIFF
--- a/ydb/deploy/breakpad_init/Dockerfile
+++ b/ydb/deploy/breakpad_init/Dockerfile
@@ -13,7 +13,8 @@ FROM breakpad-base AS breakpad-build
 ARG BREAKPAD_GIT_TAG="v2023.06.01"
 RUN \
     mkdir breakpad && cd breakpad && \
-    fetch breakpad && cd src && git checkout tags/${BREAKPAD_GIT_TAG} && \
+    fetch breakpad && cd src && \
+    git checkout -- . && git checkout tags/${BREAKPAD_GIT_TAG} && \
     ./configure && make
 WORKDIR /breakpad/src
 COPY /breakpad_init.cc /breakpad/breakpad_init.cc

--- a/ydb/deploy/breakpad_init/Dockerfile
+++ b/ydb/deploy/breakpad_init/Dockerfile
@@ -1,24 +1,23 @@
 # syntax=docker/dockerfile:1.4
 ARG BASE_IMAGE="cr.yandex/mirror/ubuntu"
 ARG BASE_IMAGE_TAG="focal"
-ARG BREAKPAD_GIT_TAG="v2022.07.12"
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS breakpad-base
 RUN \
     apt-get -yqq update && \
-    apt-get -yqq install --no-install-recommends git build-essential libz-dev python3 curl && \
+    apt-get -yqq install --no-install-recommends ca-certificates git build-essential libz-dev python3 curl && \
     apt-get clean all && rm -rf /var/lib/apt/lists/*
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 ENV PATH="/depot_tools:${PATH}"
 
 FROM breakpad-base AS breakpad-build
-COPY /breakpad_init.cc /breakpad/breakpad_init.cc
+ARG BREAKPAD_GIT_TAG="v2023.06.01"
 RUN \
-    cd breakpad && \
-    fetch breakpad && \
-    cd src && \
-    git checkout -- . && git checkout tags/${BREAKPAD_GIT_TAG} && \
-    ./configure && make && \
-    g++ -std=c++11 -shared -Wall -o ../libbreakpad_init.so -fPIC ../breakpad_init.cc -Isrc/ -Lsrc/client/linux/ -lbreakpad_client -lpthread
+    mkdir breakpad && cd breakpad && \
+    fetch breakpad && cd src && git checkout tags/${BREAKPAD_GIT_TAG} && \
+    ./configure && make
+WORKDIR /breakpad/src
+COPY /breakpad_init.cc /breakpad/breakpad_init.cc
+RUN g++ -std=c++11 -shared -Wall -o ../libbreakpad_init.so -fPIC ../breakpad_init.cc -Isrc/ -Lsrc/client/linux/ -lbreakpad_client -lpthread
 
 FROM scratch AS breakpad-release
 COPY --link --from=breakpad-build /breakpad/libbreakpad_init.so /usr/lib/libbreakpad_init.so

--- a/ydb/deploy/breakpad_init/README.md
+++ b/ydb/deploy/breakpad_init/README.md
@@ -1,0 +1,23 @@
+# Breakpad Init Library
+
+## Build
+
+```bash
+ya package --docker --docker-build-arg=BREAKPAD_GIT_TAG="v2023.06.01" ydb/deploy/breakpad_init/pkg.json
+```
+
+### Extract file
+
+```bash
+id=$(docker create cr.yandex/crp2lrlsrs36odlvd8dv/breakpad_init:<branch>.<revision> sleep infinity)
+docker cp $id:/usr/lib/libbreakpad_init.so libbreakpad_init.so
+docker rm -v $id
+```
+
+## Usage
+
+1. Copy library to path `/usr/lib/libbreakpad_init.so`
+
+2. Set suid bit on library to execute `chmod 4644 /usr/lib/libbreakpad_init.so`
+
+3. Set environment variable with basename `export LD_PRELOAD=libbreakpad_init.so`

--- a/ydb/deploy/breakpad_init/pkg.json
+++ b/ydb/deploy/breakpad_init/pkg.json
@@ -2,18 +2,15 @@
     "meta": {
       "name": "breakpad_init",
       "maintainer": "ydb <info@ydb.tech>",
-      "description": "Package with breakpad_init",
-      "version": "v2022.07.12.{revision}"
+      "description": "Package with breakpad dynamic library",
+      "version": "{branch}.{revision}"
     },
     "build": {},
     "params": {
       "docker_build_network": "host",
       "docker_registry": "cr.yandex",
       "docker_repository": "crp2lrlsrs36odlvd8dv",
-      "docker_target": "breakpad-release",
-      "docker_build_arg": {
-        "BREAKPAD_GIT_TAG": "v2022.07.12"
-      }
+      "docker_target": "breakpad-release"
     },
     "data": [
       {

--- a/ydb/deploy/docker/Dockerfile
+++ b/ydb/deploy/docker/Dockerfile
@@ -2,7 +2,7 @@
 ARG BASE_IMAGE="cr.yandex/mirror/ubuntu"
 ARG BASE_IMAGE_TAG="focal"
 ARG BREAKPAD_INIT_IMAGE="cr.yandex/crp2lrlsrs36odlvd8dv/breakpad_init"
-ARG BREAKPAD_INIT_IMAGE_TAG="v2022.07.12"
+ARG BREAKPAD_INIT_IMAGE_TAG="v2023.06.01"
 
 ###
 # Base image with required deb packages

--- a/ydb/deploy/docker/breakpad/minidump_script.py
+++ b/ydb/deploy/docker/breakpad/minidump_script.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
             "/opt/ydb/bin/ydbd",
             core_file,
             "-iex=set auto-load safe-path /",
+            "-iex=set print thread-events off",
             "-ex=thread apply all bt",
             "--batch",
             "-q"

--- a/ydb/deploy/docker/debug/pkg.json
+++ b/ydb/deploy/docker/debug/pkg.json
@@ -136,6 +136,15 @@
     },
     {
       "source": {
+        "type": "BUILD_OUTPUT",
+        "path": "ydb/apps/ydbd/ydbd.debug"
+      },
+      "destination": {
+        "path": "/ydbd.debug"
+      }
+    },
+    {
+      "source": {
           "type": "BUILD_OUTPUT",
           "path": "ydb/apps/ydb/ydb"
       },


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

- bump breakpad dependency to `v2023.06.01`
- disable useless thread events from gdb output for stacktrace
- add debug symbols into pkg.json for build docker `debug` image 
- add README.md for `breakpad_init` package

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
