### PR TITLE
Improve compute nodes database error message

### DIFF
--- a/ydb/core/mind/node_broker__register_node.cpp
+++ b/ydb/core/mind/node_broker__register_node.cpp
@@ -60,7 +60,7 @@ public:
 
         if (rec.HasPath() && ScopeId == NActors::TScopeId()) {
             return Error(TStatus::ERROR,
-                         TStringBuilder() << "Cannot resolve scope id for path " << rec.GetPath(),
+                         TStringBuilder() << "The database hasn't been created and therefore it couldn't be resolved by its path " << rec.GetPath(),
                          ctx);
         }
 

--- a/ydb/core/mind/node_broker__register_node.cpp
+++ b/ydb/core/mind/node_broker__register_node.cpp
@@ -60,7 +60,7 @@ public:
 
         if (rec.HasPath() && ScopeId == NActors::TScopeId()) {
             return Error(TStatus::ERROR,
-                         TStringBuilder() << "The database hasn't been created and therefore it couldn't be resolved by its path " << rec.GetPath(),
+                         TStringBuilder() << "Failed to resolve the database by its path. Perhaps the database " << rec.GetPath() << " does not exist",
                          ctx);
         }
 


### PR DESCRIPTION
When the compute nodes try to start with a missing database and this error is thrown. However, in order to make it clearer for cluster administrators, the error message has been improved so that they know the reason why the error occurred.

Related issue:  https://github.com/ydb-platform/ydb/issues/11057

