### PR TITLE
Set default MaxNumOfSlowDisks for HDD to 1

### DIFF
--- a/ydb/core/blobstorage/common/immediate_control_defaults.cpp
+++ b/ydb/core/blobstorage/common/immediate_control_defaults.cpp
@@ -11,4 +11,7 @@ TControlWrapper PredictedDelayMultiplierDefaultControl =
 TControlWrapper MaxNumOfSlowDisksDefaultControl =
         TControlWrapper(DefaultMaxNumOfSlowDisks, 1, 2);
 
+TControlWrapper MaxNumOfSlowDisksHDDDefaultControl =
+        TControlWrapper(DefaultMaxNumOfSlowDisksHDD, 1, 2);
+
 } // namespace NKikimr

--- a/ydb/core/blobstorage/common/immediate_control_defaults.h
+++ b/ydb/core/blobstorage/common/immediate_control_defaults.h
@@ -11,8 +11,10 @@ constexpr bool DefaultEnableVPatch = false;
 constexpr float DefaultSlowDiskThreshold = 2;
 constexpr float DefaultPredictedDelayMultiplier = 1;
 constexpr ui32 DefaultMaxNumOfSlowDisks = 2;
+constexpr ui32 DefaultMaxNumOfSlowDisksHDD = 1;
 
 extern TControlWrapper SlowDiskThresholdDefaultControl;
 extern TControlWrapper PredictedDelayMultiplierDefaultControl;
 extern TControlWrapper MaxNumOfSlowDisksDefaultControl;
+extern TControlWrapper MaxNumOfSlowDisksHDDDefaultControl;
 }

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -842,7 +842,10 @@ struct TBlobStorageProxyControlWrappers {
     // Acceleration parameters
     DEVICE_TYPE_SEPECIFIC_MEMORIZABLE_CONTROLS(SlowDiskThreshold);
     DEVICE_TYPE_SEPECIFIC_MEMORIZABLE_CONTROLS(PredictedDelayMultiplier);
-    DEVICE_TYPE_SEPECIFIC_MEMORIZABLE_CONTROLS(MaxNumOfSlowDisks);
+
+    TMemorizableControlWrapper MaxNumOfSlowDisks = MaxNumOfSlowDisksDefaultControl;
+    TMemorizableControlWrapper MaxNumOfSlowDisksHDD = MaxNumOfSlowDisksHDDDefaultControl;
+    TMemorizableControlWrapper MaxNumOfSlowDisksSSD = MaxNumOfSlowDisksDefaultControl;
 
 #undef DEVICE_TYPE_SEPECIFIC_MEMORIZABLE_CONTROLS
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -188,7 +188,7 @@ namespace NKikimr::NStorage {
             , PredictedDelayMultiplierHDD(std::round(DefaultPredictedDelayMultiplier * 1000), 0, 1'000'000)
             , PredictedDelayMultiplierSSD(std::round(DefaultPredictedDelayMultiplier * 1000), 0, 1'000'000)
             , MaxNumOfSlowDisks(DefaultMaxNumOfSlowDisks, 1, 2)
-            , MaxNumOfSlowDisksHDD(DefaultMaxNumOfSlowDisks, 1, 2)
+            , MaxNumOfSlowDisksHDD(DefaultMaxNumOfSlowDisksHDD, 1, 2)
             , MaxNumOfSlowDisksSSD(DefaultMaxNumOfSlowDisks, 1, 2)
         {
             Y_ABORT_UNLESS(Cfg->BlobStorageConfig.GetServiceSet().AvailabilityDomainsSize() <= 1);

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1349,7 +1349,7 @@ message TImmediateControlsConfig {
             Description: "Maximum number of slow disks, which DSProxy can skip with Accelerations, option for HDD",
             MinValue: 1,
             MaxValue: 2,
-            DefaultValue: 2 }];
+            DefaultValue: 1 }];
 
         optional uint64 SlowDiskThresholdSSD = 9 [(ControlOptions) = {
             Description: "The minimum ratio of slowest and second slowest disks, required to accelerate, promille, option for SSD",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Set default MaxNumOfSlowDisks setting for HDD to 1 to disable double accelerations for HDD by default.

### Changelog category <!-- remove all except one -->

* Reverting feature

