### PR TITLE
Fix LogPrefix initialization in Source/Sink/Transform/Channel helpers

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_input_helper.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_input_helper.h
@@ -15,7 +15,7 @@ constexpr ui32 IssuesBufferSize = 16;
 
 struct TComputeActorAsyncInputHelper {
     TString Type;
-    const TString LogPrefix;
+    const TString& LogPrefix;
     ui64 Index;
     IDqComputeActorAsyncInput* AsyncInput = nullptr;
     NActors::IActor* Actor = nullptr;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_input_helper.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_input_helper.h
@@ -15,7 +15,7 @@ constexpr ui32 IssuesBufferSize = 16;
 
 struct TComputeActorAsyncInputHelper {
     TString Type;
-    const TString& LogPrefix; // CAREFUL: TComputeActorAsyncInputHelper must be destroyed before object that owns referenced LogPrefix
+    TString LogPrefix;
     ui64 Index;
     IDqComputeActorAsyncInput* AsyncInput = nullptr;
     NActors::IActor* Actor = nullptr;
@@ -101,6 +101,10 @@ public:
             return EResumeSource::CAPollAsyncNoSpace; // If there is no free space in buffer, => we have something to process
         }
         return {};
+    }
+
+    void SetLogPrefix(const TString& logPrefix) {
+        LogPrefix = logPrefix;
     }
 };
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_input_helper.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_async_input_helper.h
@@ -15,7 +15,7 @@ constexpr ui32 IssuesBufferSize = 16;
 
 struct TComputeActorAsyncInputHelper {
     TString Type;
-    const TString& LogPrefix;
+    const TString& LogPrefix; // CAREFUL: TComputeActorAsyncInputHelper must be destroyed before object that owns referenced LogPrefix
     ui64 Index;
     IDqComputeActorAsyncInput* AsyncInput = nullptr;
     NActors::IActor* Actor = nullptr;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -176,7 +176,7 @@ protected:
         , FunctionRegistry(functionRegistry)
         , CheckpointingMode(GetTaskCheckpointingMode(Task))
         , State(Task.GetCreateSuspended() ? NDqProto::COMPUTE_STATE_UNKNOWN : NDqProto::COMPUTE_STATE_EXECUTING)
-        , WatermarksTracker(this->SelfId(), TxId, Task.GetId())
+        , WatermarksTracker(LogPrefix)
         , TaskCounters(taskCounters)
         , MetricsReporter(taskCounters)
         , ComputeActorSpan(NKikimr::TWilsonKqp::ComputeActor, std::move(traceId), "ComputeActor")

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -788,7 +788,7 @@ protected:
 
 protected:
     struct TInputChannelInfo {
-        const TString LogPrefix;
+        const TString& LogPrefix;
         ui64 ChannelId;
         ui32 SrcStageId;
         IDqInputChannel::TPtr Channel;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -233,6 +233,17 @@ protected:
             prefixBuilder << "Ctx: " << *RequestContext << ". ";
         }
         LogPrefix = std::move(prefixBuilder);
+
+        WatermarksTracker.SetLogPrefix(LogPrefix);
+        for (auto& [_, info]: InputTransformsMap) {
+            info.SetLogPrefix(LogPrefix);
+        }
+        for (auto& [_, info]: SourcesMap) {
+            info.SetLogPrefix(LogPrefix);
+        }
+        for (auto& [_, info]: InputChannelsMap) {
+            info.SetLogPrefix(LogPrefix);
+        }
     }
 
     void ReportEventElapsedTime() {
@@ -790,7 +801,7 @@ protected:
 
 protected:
     struct TInputChannelInfo {
-        const TString& LogPrefix; // CAREFUL: TInputChannelInfo must be destroyed before object that owns referenced LogPrefix
+        TString LogPrefix;
         ui64 ChannelId;
         ui32 SrcStageId;
         IDqInputChannel::TPtr Channel;
@@ -849,6 +860,10 @@ protected:
             if (Channel) {  // async actor doesn't hold channels, so channel is resumed in task runner actor
                 Channel->Resume();
             }
+        }
+
+        void SetLogPrefix(const TString& logPrefix) {
+            LogPrefix = logPrefix;
         }
     };
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -788,7 +788,7 @@ protected:
 
 protected:
     struct TInputChannelInfo {
-        const TString& LogPrefix;
+        const TString& LogPrefix; // CAREFUL: TInputChannelInfo must be destroyed before object that owns referenced LogPrefix
         ui64 ChannelId;
         ui32 SrcStageId;
         IDqInputChannel::TPtr Channel;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -7,28 +7,24 @@
 #include <algorithm>
 
 #define LOG_T(s) \
-    LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, "SelfId: " << SelfId << ", TxId: " << TxId << ", task: " << TaskId << ". Watermarks. " << s)
+    LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, this->LogPrefix << "Watermarks. " << s)
 #define LOG_D(s) \
-    LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, "SelfId: " << SelfId << ", TxId: " << TxId << ", task: " << TaskId << ". Watermarks. " << s)
+    LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, this->LogPrefix << "Watermarks. " << s)
 #define LOG_I(s) \
-    LOG_INFO_S(*NActors::TlsActivationContext,  NKikimrServices::KQP_COMPUTE, "SelfId: " << SelfId << ", TxId: " << TxId << ", task: " << TaskId << ". Watermarks. " << s)
+    LOG_INFO_S(*NActors::TlsActivationContext,  NKikimrServices::KQP_COMPUTE, this->LogPrefix << "Watermarks. " << s)
 #define LOG_W(s) \
-    LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, "SelfId: " << SelfId << ", TxId: " << TxId << ", task: " << TaskId << ". Watermarks. " << s)
+    LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, this->LogPrefix << "Watermarks. " << s)
 #define LOG_E(s) \
-    LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, "SelfId: " << SelfId << ", TxId: " << TxId << ", task: " << TaskId << ". Watermarks. " << s)
+    LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, this->LogPrefix << "Watermarks. " << s)
 
 namespace NYql::NDq {
 
 using namespace NActors;
 
 TDqComputeActorWatermarks::TDqComputeActorWatermarks(
-    NActors::TActorIdentity selfId,
-    const TTxId txId,
-    ui64 taskId
+    const TString& logPrefix
 )
-    : SelfId(selfId)
-    , TxId(txId)
-    , TaskId(taskId) {
+    : LogPrefix(logPrefix) {
 }
 
 void TDqComputeActorWatermarks::RegisterAsyncInput(ui64 inputId) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.cpp
@@ -162,4 +162,8 @@ void TDqComputeActorWatermarks::PopPendingWatermark() {
     PendingWatermark = Nothing();
 }
 
+void TDqComputeActorWatermarks::SetLogPrefix(const TString& logPrefix) {
+    LogPrefix = logPrefix;
+}
+
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -10,7 +10,6 @@ class TDqComputeActorWatermarks
 {
 public:
     TDqComputeActorWatermarks(const TString& logPrefix);
-    // CAREFUL: logPrefix stored as reference, TDqComputeActorWatermarks must be destroyed before object that owns referenced LogPrefix
 
     void RegisterAsyncInput(ui64 inputId);
     void RegisterInputChannel(ui64 inputId);
@@ -33,12 +32,14 @@ public:
     TMaybe<TInstant> GetPendingWatermark() const;
     void PopPendingWatermark();
 
+    void SetLogPrefix(const TString& logPrefix);
+
 private:
     void RecalcPendingWatermark();
     bool MaybePopPendingWatermark();
 
 private:
-    const TString& LogPrefix;
+    TString LogPrefix;
 
     std::unordered_map<ui64, TMaybe<TInstant>> AsyncInputsWatermarks;
     std::unordered_map<ui64, TMaybe<TInstant>> InputChannelsWatermarks;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_watermarks.h
@@ -9,7 +9,8 @@ namespace NYql::NDq {
 class TDqComputeActorWatermarks
 {
 public:
-    TDqComputeActorWatermarks(NActors::TActorIdentity selfId, const TTxId graphId, ui64 taskId);
+    TDqComputeActorWatermarks(const TString& logPrefix);
+    // CAREFUL: logPrefix stored as reference, TDqComputeActorWatermarks must be destroyed before object that owns referenced LogPrefix
 
     void RegisterAsyncInput(ui64 inputId);
     void RegisterInputChannel(ui64 inputId);
@@ -37,9 +38,7 @@ private:
     bool MaybePopPendingWatermark();
 
 private:
-    const NActors::TActorIdentity SelfId;
-    const TTxId TxId;
-    ui64 TaskId;
+    const TString& LogPrefix;
 
     std::unordered_map<ui64, TMaybe<TInstant>> AsyncInputsWatermarks;
     std::unordered_map<ui64, TMaybe<TInstant>> InputChannelsWatermarks;

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_actor_async_input_helper_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_actor_async_input_helper_ut.cpp
@@ -75,7 +75,7 @@ Y_UNIT_TEST_SUITE(TComputeActorAsyncInputHelperTest) {
         TDummyAsyncInputHelper helper("MyPrefix", 13, NDqProto::EWatermarksMode::WATERMARKS_MODE_DISABLED);
         helper.AsyncInput = &input;
         TDqComputeActorMetrics metrics{NMonitoring::TDynamicCounterPtr{}};
-        TDqComputeActorWatermarks watermarks(NActors::TActorIdentity{NActors::TActorId{}}, TTxId{}, 7);
+        TDqComputeActorWatermarks watermarks("");
         auto result = helper.PollAsyncInput(metrics, watermarks, 20);
         UNIT_ASSERT(result && EResumeSource::CAPollAsync == *result);
     }


### PR DESCRIPTION
[They](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h#L1548) [are](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h#L1557) [created](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h#L1564) in `InitializeTask()` (that is called [from](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_compute_actor.cpp#L45) [constructor](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp#L81)), but `LogPrefix` [assigned](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h#L119) in `CA::Bootstrap()`.
[v1] As all helper/info object are destroyed before CA, change their `LogPrefix` to reference into `CA::LogPrefix`
[v2] Deemed fragile. Move `LogPrefix` assignment into `InitializeTask` instead.
[v3][reverted, does not work] Move `InitializeTask()` into `Bootstap()` (`SelfId` only available after `Bootstrap()`)
[v4] Return to v1 + WatermarkTracker fixes
[v5] Rework to avoid fragile references

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
