### PR TITLE
Make sure mailboxes in test actorsystems are in a locked state

### DIFF
--- a/ydb/core/util/actorsys_test/testactorsys.h
+++ b/ydb/core/util/actorsys_test/testactorsys.h
@@ -492,9 +492,12 @@ public:
         }
 
         // register actor in mailbox
-        const auto& it = Mailboxes.try_emplace(TMailboxId(nodeId, poolId, mboxId)).first;
+        auto [it, mboxInserted] = Mailboxes.try_emplace(TMailboxId(nodeId, poolId, mboxId));
         TMailboxInfo& mbox = it->second;
         mbox.Hint = mboxId;
+        if (mboxInserted) {
+            mbox.LockFromFree();
+        }
         mbox.AttachActor(ActorLocalId, actor);
 
         // generate actor id

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -928,7 +928,7 @@ namespace NActors {
         RegistrationObserver(*this, parentId ? parentId : CurrentRecipient, actorId);
         DoActorInit(node->ActorSystem.Get(), actor, actorId, parentId ? parentId : CurrentRecipient);
 
-        mailbox->Unlock(node->ExecutorPools[0], GetCycleCountFast(), revolvingCounter);
+        // Note: test actorsystem mailboxes stay permanently locked
 
         return actorId;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Test actorsystems don't schedule mailboxes, so they need to stay in a locked state which is ready for event processing.