### PR TITLE
fix clusterName and node_type in UA meta session (cherry-pick to stable 24-3-13-hotfix)

### DIFF
--- a/ydb/core/log_backend/log_backend.cpp
+++ b/ydb/core/log_backend/log_backend.cpp
@@ -10,18 +10,20 @@ TAutoPtr<TLogBackend> CreateLogBackendWithUnifiedAgent(
 {
     if (runConfig.AppConfig.HasLogConfig()) {
         const auto& logConfig = runConfig.AppConfig.GetLogConfig();
+        const auto& dnConfig = runConfig.AppConfig.GetDynamicNameserviceConfig();
         TAutoPtr<TLogBackend> logBackend = TLogBackendBuildHelper::CreateLogBackendFromLogConfig(logConfig);
         if (logConfig.HasUAClientConfig()) {
             const auto& uaClientConfig = logConfig.GetUAClientConfig();
             auto uaCounters = GetServiceCounters(counters, "utils")->GetSubgroup("subsystem", "ua_client");
             auto logName = uaClientConfig.GetLogName();
+            auto maxStaticNodeId = dnConfig.GetMaxStaticNodeId();
             TAutoPtr<TLogBackend> uaLogBackend = TLogBackendBuildHelper::CreateLogBackendFromUAClientConfig(
                 uaClientConfig,
                 uaCounters,
                 logName,
-                runConfig.TenantName == "" ? "static" : "slot",
+                runConfig.NodeId <= maxStaticNodeId ? "static" : "slot",
                 runConfig.TenantName,
-                runConfig.ClusterName
+                logConfig.HasClusterName() ? logConfig.GetClusterName() : ""
             );
             logBackend = logBackend ? NActors::CreateCompositeLogBackend({logBackend, uaLogBackend}) : uaLogBackend;
         }
@@ -54,18 +56,20 @@ TAutoPtr<TLogBackend> CreateMeteringLogBackendWithUnifiedAgent(
 
     if (meteringConfig.GetUnifiedAgentEnable() && runConfig.AppConfig.HasLogConfig() && runConfig.AppConfig.GetLogConfig().HasUAClientConfig()) {
         const auto& logConfig = runConfig.AppConfig.GetLogConfig();
+        const auto& dnConfig = runConfig.AppConfig.GetDynamicNameserviceConfig();
         const auto& uaClientConfig = logConfig.GetUAClientConfig();
         auto uaCounters = GetServiceCounters(counters, "utils")->GetSubgroup("subsystem", "ua_client");
         auto logName = meteringConfig.HasLogName()
             ? meteringConfig.GetLogName()
             : uaClientConfig.GetLogName();
+        auto maxStaticNodeId = dnConfig.GetMaxStaticNodeId();
         TAutoPtr<TLogBackend> uaLogBackend = TLogBackendBuildHelper::CreateLogBackendFromUAClientConfig(
             uaClientConfig,
             uaCounters,
             logName,
-            runConfig.TenantName == "" ? "static" : "slot",
+            runConfig.NodeId <= maxStaticNodeId ? "static" : "slot",
             runConfig.TenantName,
-            runConfig.ClusterName
+            logConfig.HasClusterName() ? logConfig.GetClusterName() : ""
         );
         logBackend = logBackend ? NActors::CreateCompositeLogBackend({logBackend, uaLogBackend}) : uaLogBackend;
     }
@@ -109,18 +113,20 @@ TAutoPtr<TLogBackend> CreateAuditLogUnifiedAgentBackend(
     const auto& auditConfig = runConfig.AppConfig.GetAuditConfig();
     if (auditConfig.HasUnifiedAgentBackend() && runConfig.AppConfig.HasLogConfig() && runConfig.AppConfig.GetLogConfig().HasUAClientConfig()) {
         const auto& logConfig = runConfig.AppConfig.GetLogConfig();
+        const auto& dnConfig = runConfig.AppConfig.GetDynamicNameserviceConfig();
         const auto& uaClientConfig = logConfig.GetUAClientConfig();
         auto uaCounters = GetServiceCounters(counters, "utils")->GetSubgroup("subsystem", "ua_client");
         auto logName = runConfig.AppConfig.GetAuditConfig().GetUnifiedAgentBackend().HasLogName()
             ? runConfig.AppConfig.GetAuditConfig().GetUnifiedAgentBackend().GetLogName()
             : uaClientConfig.GetLogName();
+        auto maxStaticNodeId = dnConfig.GetMaxStaticNodeId();
         logBackend = TLogBackendBuildHelper::CreateLogBackendFromUAClientConfig(
             uaClientConfig,
             uaCounters,
             logName,
-            runConfig.TenantName == "" ? "static" : "slot",
+            runConfig.NodeId <= maxStaticNodeId ? "static" : "slot",
             runConfig.TenantName,
-            runConfig.ClusterName
+            logConfig.HasClusterName() ? logConfig.GetClusterName() : ""
         );
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

https://github.com/ydb-platform/ydb/pull/11240

- human readable `cluster_name` property from `logConfig` (instead of `runConfig` with uuid format)
- fix `node_type` session meta property value

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
