### PR TITLE
schemeshard: stop using schemeshard_utils.h as public header

### DIFF
--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_build_stage.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_build_stage.cpp
@@ -4,7 +4,7 @@
 #include <ydb/core/kqp/opt/kqp_opt_impl.h>
 #include <ydb/core/kqp/opt/physical/kqp_opt_phy_impl.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
-#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
+#include <ydb/core/scheme/scheme_tabledefs.h>
 
 #include <ydb/public/lib/scheme_types/scheme_type_id.h>
 
@@ -96,12 +96,12 @@ bool IsLiteralNothing(TExprBase node) {
 
                 return (
                     NKikimr::NScheme::NTypeIds::IsYqlType(typeId)
-                    && NKikimr::NSchemeShard::IsAllowedKeyType(NKikimr::NScheme::TTypeInfo(typeId))
+                    && NKikimr::IsAllowedKeyType(NKikimr::NScheme::TTypeInfo(typeId))
                 );
             }
             case ETypeAnnotationKind::Pg: {
                 auto pgTypeId = type->Cast<TPgExprType>()->GetId();
-                return NKikimr::NSchemeShard::IsAllowedKeyType(
+                return NKikimr::IsAllowedKeyType(
                     NKikimr::NScheme::TTypeInfo(NKikimr::NPg::TypeDescFromPgTypeId(pgTypeId))
                 );
             }
@@ -425,7 +425,7 @@ bool RequireLookupPrecomputeStage(const TKqlLookupTable& lookup) {
                     auto slot = tuple.Value().Ref().GetTypeAnn()->Cast<TDataExprType>()->GetSlot();
                     auto typeId = NUdf::GetDataTypeInfo(slot).TypeId;
                     auto typeInfo = NScheme::TTypeInfo(typeId);
-                    if (NScheme::NTypeIds::IsYqlType(typeId) && NSchemeShard::IsAllowedKeyType(typeInfo)) {
+                    if (NScheme::NTypeIds::IsYqlType(typeId) && NKikimr::IsAllowedKeyType(typeInfo)) {
                         // pass
                     } else {
                         return true;
@@ -434,7 +434,7 @@ bool RequireLookupPrecomputeStage(const TKqlLookupTable& lookup) {
                     Y_ENSURE(tuple.Value().Ref().GetTypeAnn()->GetKind() == NYql::ETypeAnnotationKind::Pg);
                     auto pgTypeId = tuple.Value().Ref().GetTypeAnn()->Cast<TPgExprType>()->GetId();
                     auto typeInfo = NKikimr::NScheme::TTypeInfo(NKikimr::NPg::TypeDescFromPgTypeId(pgTypeId));
-                    if (NKikimr::NSchemeShard::IsAllowedKeyType(typeInfo)) {
+                    if (NKikimr::IsAllowedKeyType(typeInfo)) {
                         // pass
                     } else {
                         return true;

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_source.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_source.cpp
@@ -3,7 +3,6 @@
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/opt/kqp_opt_impl.h>
 #include <ydb/core/kqp/opt/physical/kqp_opt_phy_impl.h>
-#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
 
 #include <ydb/public/lib/scheme_types/scheme_type_id.h>
 

--- a/ydb/core/kqp/opt/physical/ya.make
+++ b/ydb/core/kqp/opt/physical/ya.make
@@ -15,6 +15,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/scheme
     ydb/core/kqp/common
     ydb/core/kqp/opt/physical/effects
     ydb/library/yql/dq/common

--- a/ydb/core/kqp/provider/ya.make
+++ b/ydb/core/kqp/provider/ya.make
@@ -28,6 +28,7 @@ PEERDIR(
     ydb/core/base
     ydb/core/protos
     ydb/core/docapi
+    ydb/core/scheme
     ydb/core/kqp/query_data
     ydb/library/aclib
     ydb/library/aclib/protos

--- a/ydb/core/kqp/provider/yql_kikimr_provider.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.cpp
@@ -2,7 +2,7 @@
 
 #include <yql/essentials/providers/common/proto/gateways_config.pb.h>
 #include <ydb/core/base/path.h>
-#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
+#include <ydb/core/scheme/scheme_tabledefs.h>
 
 #include <yql/essentials/parser/pg_wrapper/interface/type_desc.h>
 #include <yql/essentials/providers/result/provider/yql_result_provider.h>
@@ -574,7 +574,7 @@ void FillLiteralProtoImpl(const NNodes::TCoDataCtor& literal, TProto& proto) {
     auto typeId = NKikimr::NUdf::GetDataTypeInfo(slot).TypeId;
 
     YQL_ENSURE(NKikimr::NScheme::NTypeIds::IsYqlType(typeId));
-    YQL_ENSURE(typeId == NKikimr::NScheme::NTypeIds::Decimal || NKikimr::NSchemeShard::IsAllowedKeyType(NKikimr::NScheme::TTypeInfo(typeId)));
+    YQL_ENSURE(typeId == NKikimr::NScheme::NTypeIds::Decimal || NKikimr::IsAllowedKeyType(NKikimr::NScheme::TTypeInfo(typeId)));
 
     auto& protoType = *proto.MutableType();
     auto& protoValue = *proto.MutableValue();

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -9,7 +9,7 @@
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
 
-#include <ydb/core/tx/schemeshard/schemeshard_utils.h>
+#include <ydb/core/scheme/scheme_tabledefs.h>
 #include <ydb/library/mkql_proto/mkql_proto.h>
 
 #include <yql/essentials/core/dq_integration/yql_dq_integration.h>
@@ -205,7 +205,7 @@ void FillTable(const TKikimrTableMetadata& tableMeta, THashSet<TStringBuf>&& col
         case NScheme::NTypeIds::Decimal: {
             ProtoFromDecimalType(column->TypeInfo.GetDecimalType(), *phyColumn.MutableTypeParam()->MutableDecimal());
             break;
-        }        
+        }
         }
 
     }
@@ -240,7 +240,7 @@ void FillNothingData(const TDataExprType& dataType, NKqpProto::TKqpPhyLiteralVal
     auto typeId = NKikimr::NUdf::GetDataTypeInfo(slot).TypeId;
 
     YQL_ENSURE(NKikimr::NScheme::NTypeIds::IsYqlType(typeId) &&
-        NKikimr::NSchemeShard::IsAllowedKeyType(NKikimr::NScheme::TTypeInfo(typeId)));
+        NKikimr::IsAllowedKeyType(NKikimr::NScheme::TTypeInfo(typeId)));
 
     value.MutableType()->SetKind(NKikimrMiniKQL::Optional);
     auto* toFill = value.MutableType()->MutableOptional()->MutableItem();

--- a/ydb/core/kqp/query_compiler/ya.make
+++ b/ydb/core/kqp/query_compiler/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     ydb/core/formats
     ydb/core/kqp/common
     ydb/core/protos
+    ydb/core/scheme
     ydb/library/mkql_proto
     yql/essentials/core/arrow_kernels/request
     yql/essentials/core/dq_integration

--- a/ydb/core/scheme/scheme_tabledefs.h
+++ b/ydb/core/scheme/scheme_tabledefs.h
@@ -5,8 +5,11 @@
 
 #include <ydb/core/scheme/scheme_pathid.h>
 #include <ydb/core/scheme/protos/key_range.pb.h>
-#include <ydb/core/scheme_types/scheme_types.h>
 #include <ydb/library/aclib/aclib.h>
+#include <ydb/core/scheme_types/scheme_type_info.h>  // for NScheme::TTypeInfo
+#include <ydb/public/lib/scheme_types/scheme_type_id.h>  // for NScheme::NTypeIds
+
+#include <yql/essentials/parser/pg_wrapper/interface/type_desc.h>  // for NPg::TypeDescIsComparable
 
 #include <library/cpp/deprecated/enum_codegen/enum_codegen.h>
 
@@ -15,12 +18,27 @@
 
 namespace NKikimr {
 
-using TSchemaVersion = ui64;
-
 enum class EColumnTypeConstraint {
     Nullable,
     NotNull,
 };
+
+inline bool IsAllowedKeyType(NScheme::TTypeInfo typeInfo) {
+    switch (typeInfo.GetTypeId()) {
+        case NScheme::NTypeIds::Json:
+        case NScheme::NTypeIds::Yson:
+        case NScheme::NTypeIds::Float:
+        case NScheme::NTypeIds::Double:
+        case NScheme::NTypeIds::JsonDocument:
+            return false;
+        case NScheme::NTypeIds::Pg:
+            return NPg::TypeDescIsComparable(typeInfo.GetPgTypeDesc());
+        default:
+            return true;
+    }
+}
+
+using TSchemaVersion = ui64;
 
 // ident for table, must be unique in selected scope
 // for global transactions ownerid is tabletid of owning schemeshard and tableid is counter designated by schemeshard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -5,6 +5,8 @@
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/datashard_config.pb.h>
 
+#include <ydb/core/scheme/scheme_tabledefs.h>  // for IsAllowedKeyType
+
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/mind/hive/hive.h>
 
@@ -119,7 +121,7 @@ bool DoInitPartitioning(TTableInfo::TPtr tableInfo,
     for (ui32 ki : keyColIds) {
         auto type = tableInfo->Columns[ki].PType;
 
-        if (!IsAllowedKeyType(type)) {
+        if (!NKikimr::IsAllowedKeyType(type)) {
             errStr = Sprintf("Column %s has wrong key type %s",
                 tableInfo->Columns[ki].Name.c_str(), NScheme::TypeName(type).c_str());
             return false;

--- a/ydb/core/tx/schemeshard/schemeshard_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.cpp
@@ -606,7 +606,7 @@ bool IsCompatibleKeyTypes(
             }
         }
 
-        if (!NSchemeShard::IsAllowedKeyType(typeInfo)) {
+        if (!NKikimr::IsAllowedKeyType(typeInfo)) {
             explain += TStringBuilder() << "Column '" << keyName << "' has wrong key type " << NScheme::TypeName(typeInfo) << " for being key";
             return false;
         }

--- a/ydb/core/tx/schemeshard/schemeshard_utils.h
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.h
@@ -23,21 +23,6 @@ namespace NSchemeShard {
 
 inline constexpr TStringBuf SYSTEM_COLUMN_PREFIX = "__ydb_";
 
-inline bool IsAllowedKeyType(NScheme::TTypeInfo typeInfo) {
-    switch (typeInfo.GetTypeId()) {
-        case NScheme::NTypeIds::Json:
-        case NScheme::NTypeIds::Yson:
-        case NScheme::NTypeIds::Float:
-        case NScheme::NTypeIds::Double:
-        case NScheme::NTypeIds::JsonDocument:
-            return false;
-        case NScheme::NTypeIds::Pg:
-            return NPg::TypeDescIsComparable(typeInfo.GetPgTypeDesc());
-        default:
-            return true;
-    }
-}
-
 inline bool IsValidColumnName(const TString& name, bool allowSystemColumnNames = false) {
     if (!allowSystemColumnNames && name.StartsWith(SYSTEM_COLUMN_PREFIX)) {
         return false;


### PR DESCRIPTION
Move `IsAllowedKeyType()` out from schemeshard (from `ydb/core/tx/schemeshard/schemeshard_utils.h` to `ydb/core/scheme/scheme_tablerefs.h`).

Stop using private header `schemeshard_utils.h` as public.

This is part of "improve schemeshard operation build-time" effort (#10633).

### Changelog category

* Not for changelog
