### PR TITLE
The test `TxUsage:: WriteToTopic_Invalid_*` flashes

### DIFF
--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2389,6 +2389,10 @@ public:
         PassAway();
     }
 
+    void HandleFinalCleanup(TEvKqp::TEvQueryRequest::TPtr& ev) {
+        ReplyProcessError(ev, Ydb::StatusIds::BAD_SESSION, "Session is under shutdown");
+    }
+
     STFUNC(ReadyState) {
         try {
             switch (ev->GetTypeRewrite()) {
@@ -2523,6 +2527,7 @@ public:
                 hFunc(TEvents::TEvUndelivered, HandleNoop);
                 hFunc(TEvKqpSnapshot::TEvCreateSnapshotResponse, Handle);
                 hFunc(NWorkload::TEvContinueRequest, HandleNoop);
+                hFunc(TEvKqp::TEvQueryRequest, HandleFinalCleanup);
             }
         } catch (const yexception& ex) {
             InternalError(ex.what());

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -550,10 +550,10 @@ Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
     WriteToTopicWithInvalidTxId(false);
 }
 
-Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
-{
-    WriteToTopicWithInvalidTxId(true);
-}
+//Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
+//{
+//    WriteToTopicWithInvalidTxId(true);
+//}
 
 Y_UNIT_TEST_F(WriteToTopic_Two_WriteSession, TFixture)
 {

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -545,15 +545,15 @@ Y_UNIT_TEST_F(Offsets_Cannot_Be_Promoted_When_Reading_In_A_Transaction, TFixture
     UNIT_ASSERT_EXCEPTION(ReadMessage(reader, {.Tx = tx, .CommitOffsets = true}), yexception);
 }
 
-//Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
-//{
-//    WriteToTopicWithInvalidTxId(false);
-//}
-//
-//Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
-//{
-//    WriteToTopicWithInvalidTxId(true);
-//}
+Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
+{
+    WriteToTopicWithInvalidTxId(false);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
+{
+    WriteToTopicWithInvalidTxId(true);
+}
 
 Y_UNIT_TEST_F(WriteToTopic_Two_WriteSession, TFixture)
 {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

A race between actors. The actor of the KP session is transferred to the `FinalCleanupState`. In this composition, he does not respond to the `TEvQueryRequest` message from the `TPartitionWriter` actor.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
