### PR TITLE
Unmute stable tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -38,7 +38,6 @@ ydb/core/kqp/ut/olap KqpOlapBlobsSharing.MultipleSplits
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.MultipleSplitsThenMerges
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.MultipleSplitsWithRestartsAfterWait
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.MultipleSplitsWithRestartsWhenWait
-ydb/core/kqp/ut/olap KqpOlapBlobsSharing.SplitEmpty
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.TableReshardingConsistency64
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.TableReshardingModuloN
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.UpsertWhileSplitTest
@@ -56,7 +55,6 @@ ydb/core/kqp/ut/scheme [*/*]+chunk+chunk
 ydb/core/kqp/ut/service KqpService.CloseSessionsWithLoad
 ydb/core/kqp/ut/service [*/*] chunk chunk
 ydb/core/kqp/ut/service [*/*]+chunk+chunk
-ydb/core/mind/hive/ut THiveTest.DrainWithHiveRestart
 ydb/core/persqueue/ut TPQTest.TestReadAndDeleteConsumer
 ydb/core/persqueue/ut [*/*] chunk chunk
 ydb/core/persqueue/ut/ut_with_sdk TopicAutoscaling.CDC_Write
@@ -92,7 +90,6 @@ ydb/public/sdk/cpp/client/ydb_topic/ut [*/*]+chunk+chunk
 ydb/services/datastreams/ut DataStreams.TestPutRecordsCornerCases
 ydb/services/datastreams/ut DataStreams.TestReservedConsumersMetering
 ydb/services/datastreams/ut DataStreams.TestReservedStorageMetering
-ydb/services/keyvalue/ut KeyValueGRPCService.SimpleConcatUnexistedKey
 ydb/services/keyvalue/ut sole chunk chunk
 ydb/services/keyvalue/ut sole+chunk+chunk
 ydb/services/persqueue_v1/ut TPersQueueTest.DirectReadCleanCache
@@ -139,11 +136,9 @@ ydb/tests/fq/yds test_row_dispatcher.py.TestPqRowDispatcher.test_restart_compute
 ydb/tests/fq/yds test_select_limit_db_id.py.TestSelectLimitWithDbId.test_select_same_with_id[v1-mvp_external_ydb_endpoint0]
 ydb/tests/fq/yds test_yds_bindings.py.TestBindings.test_yds_insert[v1]
 ydb/tests/fq/yt/kqp_yt_file/part18 test.py.test[pg-join_brackets2-default.txt]
-ydb/tests/functional/audit test_auditlog.py.test_dml_requests_arent_logged_when_sid_is_expected
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
 ydb/tests/functional/kqp/kqp_query_session KqpQuerySession.NoLocalAttach
 ydb/tests/functional/rename [test_rename.py */*] chunk chunk
-ydb/tests/functional/restarts test_restarts.py.TestRestartSingleBlock42.test_restart_single_node_is_ok
 ydb/tests/functional/serializable test.py.test_local
 ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--false]
 ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--true]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
**Unmuted tests : stable 5 and deleted 0**

ydb/core/kqp/ut/olap KqpOlapBlobsSharing.SplitEmpty # owner TEAM:@ydb-platform/qp success_rate 100%, state Muted Stable days in state 14
ydb/core/mind/hive/ut THiveTest.DrainWithHiveRestart # owner TEAM:@ydb-platform/system-infra success_rate 100%, state Muted Stable days in state 16
ydb/services/keyvalue/ut KeyValueGRPCService.SimpleConcatUnexistedKey # owner Unknown success_rate 100%, state Muted Stable days in state 17
ydb/tests/functional/audit test_auditlog.py.test_dml_requests_arent_logged_when_sid_is_expected # owner TEAM:@ydb-platform/system-infra success_rate 100%, state Muted Stable days in state 16
ydb/tests/functional/restarts test_restarts.py.TestRestartSingleBlock42.test_restart_single_node_is_ok # owner Unknown success_rate 100%, state Muted Stable days in state 16


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
