### PR TITLE
Fix paths in uig.sh helper

### DIFF
--- a/ydb/library/yql/tools/yqlrun/uig.sh
+++ b/ydb/library/yql/tools/yqlrun/uig.sh
@@ -8,7 +8,7 @@
 #
 
 SCRIPT_DIR="$(dirname $(readlink -f "$0"))"
-UDFS_DIR="${SCRIPT_DIR}/../../udfs;${SCRIPT_DIR}/../../../../../../yql/essentials/udfs"
+UDFS_DIR="${SCRIPT_DIR}/../../udfs;${SCRIPT_DIR}/../../../../../yql/essentials/udfs"
 if [ -d "${SCRIPT_DIR}/../../../../../../yql/udfs" ]; then
 UDFS_DIR="${UDFS_DIR};${SCRIPT_DIR}/../../../../../../yql/udfs"
 fi
@@ -20,7 +20,7 @@ fi
 
 ASSETS_DIR=${SCRIPT_DIR}/http/www
 MOUNTS_CFG=${SCRIPT_DIR}/mounts.txt
-GATEWAYS_CFG=${SCRIPT_DIR}/../../cfg/tests/gateways.conf
+GATEWAYS_CFG=${SCRIPT_DIR}/../../../../../yql/essentials/cfg/tests/gateways.conf
 
 PORT=${1:-3000}
 

--- a/ydb/library/yql/tools/yqlrun/uig.sh
+++ b/ydb/library/yql/tools/yqlrun/uig.sh
@@ -8,7 +8,7 @@
 #
 
 SCRIPT_DIR="$(dirname $(readlink -f "$0"))"
-UDFS_DIR="${SKRIPT_DIR}/../../udfs;${SCRIPT_DIR}/../../../../../../yql/essentials/udfs"
+UDFS_DIR="${SCRIPT_DIR}/../../udfs;${SCRIPT_DIR}/../../../../../../yql/essentials/udfs"
 if [ -d "${SCRIPT_DIR}/../../../../../../yql/udfs" ]; then
 UDFS_DIR="${UDFS_DIR};${SCRIPT_DIR}/../../../../../../yql/udfs"
 fi


### PR DESCRIPTION
This patchset fixes several typos to make all relative paths, being used in `uig.sh`, valid inside GitHub source tree.

Follows up #11690

### Changelog category

* Bugfix 
* Not for changelog (changelog entry is not required)