### PR TITLE
Fix memory order for tracing control

### DIFF
--- a/ydb/core/jaeger_tracing/sampling_throttling_control.cpp
+++ b/ydb/core/jaeger_tracing/sampling_throttling_control.cpp
@@ -13,8 +13,8 @@ TSamplingThrottlingControl::~TSamplingThrottlingControl() {
 }
 
 void TSamplingThrottlingControl::HandleTracing(NWilson::TTraceId& traceId, const TRequestDiscriminator& discriminator) {
-    if (ImplUpdate.load(std::memory_order_relaxed)) {
-        auto newImpl = std::unique_ptr<TSamplingThrottlingImpl>(ImplUpdate.exchange(nullptr, std::memory_order_relaxed));
+    if (ImplUpdate.load(std::memory_order_acquire)) {
+        auto newImpl = std::unique_ptr<TSamplingThrottlingImpl>(ImplUpdate.exchange(nullptr, std::memory_order_acquire));
         Y_ABORT_UNLESS(newImpl);
         Impl = std::move(newImpl);
     }
@@ -22,7 +22,7 @@ void TSamplingThrottlingControl::HandleTracing(NWilson::TTraceId& traceId, const
 }
 
 void TSamplingThrottlingControl::UpdateImpl(std::unique_ptr<TSamplingThrottlingImpl> newImpl) {
-    std::unique_ptr<TSamplingThrottlingImpl> guard(ImplUpdate.exchange(newImpl.release(), std::memory_order_relaxed));
+    std::unique_ptr<TSamplingThrottlingImpl> guard(ImplUpdate.exchange(newImpl.release(), std::memory_order_acq_rel));
 }
 
 } // namespace NKikimr::NJaegerTracing


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Relaxed memory order that was before allows the effects of constructor of TSamplingThrottlingImpl in UpdateImpl be observed after reading of ImplUpdate in another thread that calls HandleTracing

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
