### PR TITLE
Remove passing part pages on part switch

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -2362,7 +2362,7 @@ void TExecutor::CommitTransactionLog(TAutoPtr<TSeat> seat, TPageCollectionTxEnv 
                 auto *bySwitchAux = aux.AddBySwitchAux();
 
                 TPageCollectionProtoHelper::Snap(snap, loaned->PartComponents, partSwitch.TableId, CompactionLogic->BorrowedPartLevel());
-                TPageCollectionProtoHelper(true, false).Do(bySwitchAux->AddHotBundles(), loaned->PartComponents);
+                TPageCollectionProtoHelper(true).Do(bySwitchAux->AddHotBundles(), loaned->PartComponents);
 
                 auto body = proto.SerializeAsString();
                 auto glob = CommitManager->Turns.One(commit->Refs, std::move(body), true);
@@ -3474,7 +3474,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
             const auto &newPart = result.Part;
 
             TPageCollectionProtoHelper::Snap(snap, newPart, tableId, logicResult.Changes.NewPartsLevel);
-            TPageCollectionProtoHelper(true, false).Do(bySwitchAux->AddHotBundles(), newPart);
+            TPageCollectionProtoHelper(true).Do(bySwitchAux->AddHotBundles(), newPart);
         }
     }
 
@@ -3772,14 +3772,14 @@ TString TExecutor::BorrowSnapshot(ui32 table, const TTableSnapshotContext &snap,
     for (const auto &partView : subset->Flatten) {
         auto *x = proto.AddParts();
 
-        TPageCollectionProtoHelper(false, false).Do(x->MutableBundle(), partView);
+        TPageCollectionProtoHelper(false).Do(x->MutableBundle(), partView);
         snap.Impl->Borrowed(Step(), table, partView->Label, loaner);
     }
 
     for (const auto &part : subset->ColdParts) {
         auto *x = proto.AddParts();
 
-        TPageCollectionProtoHelper(false, false).Do(x->MutableBundle(), part);
+        TPageCollectionProtoHelper(false).Do(x->MutableBundle(), part);
         snap.Impl->Borrowed(Step(), table, part->Label, loaner);
     }
 

--- a/ydb/core/tablet_flat/flat_executor.proto
+++ b/ydb/core/tablet_flat/flat_executor.proto
@@ -15,11 +15,6 @@ message TLargeGlobId {
 }
 
 message TPageCollection {
-    message TPage {
-        required uint32 Id = 1;
-        required bytes Body = 2;
-    }
-
     repeated NKikimrProto.TLogoBlobID MetaId = 1; // Replaced by TLargeGlobId
 
     optional TLargeGlobId LargeGlobId = 6;
@@ -30,7 +25,7 @@ message TPageCollection {
     // packed page collection is called HotBundle.
 
     optional bytes Meta = 2;
-    repeated TPage Pages = 5;
+    reserved 5; // Pages
 }
 
 message TBundle {

--- a/ydb/core/tablet_flat/flat_part_loader.h
+++ b/ydb/core/tablet_flat/flat_part_loader.h
@@ -89,7 +89,7 @@ namespace NTable {
                     if (type != EPage::FlatIndex) {
                         // hack: saving flat index to private cache will break sticky logic
                         // keep it in shared cache only for now
-                        Cache->Fill(std::move(loaded), NeedIn(type));
+                        Cache->Fill(loaded.PageId, std::move(loaded.Page), NeedIn(type));
                     }
                 }
             }

--- a/ydb/core/tablet_flat/flat_part_outset.h
+++ b/ydb/core/tablet_flat/flat_part_outset.h
@@ -2,7 +2,6 @@
 
 #include "defs.h"
 #include "flat_sausage_packet.h"
-#include "flat_sausage_fetch.h"
 
 namespace NKikimr {
 namespace NTable {
@@ -12,7 +11,6 @@ namespace NTable {
         NPageCollection::TLargeGlobId LargeGlobId;
         // loaded meta page
         TIntrusiveConstPtr<NPageCollection::TPageCollection> Packet;
-        TVector<NPageCollection::TLoadedPage> Sticky;
 
         void ParsePacket(TSharedData meta);
     };

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -154,9 +154,6 @@ public:
 
         for (auto &one: components) {
             caches.emplace_back(new TCache(std::move(one.Packet)));
-
-            for (auto &page: one.Sticky)
-                caches.back()->Fill(page, true);
         }
 
         return caches;

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -130,10 +130,6 @@ public:
             return page;
         }
 
-        void Fill(const NPageCollection::TLoadedPage &paged, bool sticky = false) noexcept {
-            EnsurePage(paged.PageId)->Fill(paged.Data, sticky);
-        }
-
         void Fill(ui32 pageId, TSharedPageRef page, bool sticky) noexcept {
             EnsurePage(pageId)->Fill(std::move(page), sticky);
         }

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -134,10 +134,6 @@ public:
             EnsurePage(paged.PageId)->Fill(paged.Data, sticky);
         }
 
-        void Fill(NSharedCache::TEvResult::TLoaded&& loaded, bool sticky = false) noexcept {
-            EnsurePage(loaded.PageId)->Fill(std::move(loaded.Page), sticky);
-        }
-
         void Fill(ui32 pageId, TSharedPageRef page, bool sticky) noexcept {
             EnsurePage(pageId)->Fill(std::move(page), sticky);
         }

--- a/ydb/core/tablet_flat/flat_store_hotdog.h
+++ b/ydb/core/tablet_flat/flat_store_hotdog.h
@@ -23,15 +23,13 @@ namespace NTabletFlatExecutor {
         using TColdPart = NTable::TColdPart;
         using TPartComponents = NTable::TPartComponents;
         using TBundle = NKikimrExecutorFlat::TBundle;
-        using TPages = TArrayRef<const NPageCollection::TLoadedPage>;
         using TScreen = NTable::TScreen;
         using TSlices = NTable::TSlices;
 
         TPageCollectionProtoHelper() = delete;
 
-        TPageCollectionProtoHelper(bool meta, bool pages)
+        TPageCollectionProtoHelper(bool meta)
             : PutMeta(meta)
-            , PutPages(pages)
         {
 
         }
@@ -51,12 +49,10 @@ namespace NTabletFlatExecutor {
         void Bundle(
                 NKikimrExecutorFlat::TPageCollection *pageCollectionProto,
                 const TLargeGlobId &largeGlobId,
-                const NPageCollection::TPageCollection *pack,
-                TPages pages);
+                const NPageCollection::TPageCollection *pack);
 
     private:
         const bool PutMeta = false;     /* Save page collection metablob in bundle  */
-        const bool PutPages = false;    /* Save special pages within bundle */
     };
 }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

As a second step of removing Private Cache Share Body logic, remove pages passing from protobufs
