### PR TITLE
Implemented split datashard status (wrong shard state)

### DIFF
--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -560,18 +560,12 @@ public:
                     << " ShardID=" << ev->Get()->Record.GetOrigin() << ","
                     << " Sink=" << this->SelfId() << "."
                     << getIssues().ToOneLineString());
-            // TODO: Add new status for splits in datashard. This is tmp solution.
-            if (getIssues().ToOneLineString().Contains("in a pre/offline state assuming this is due to a finished split (wrong shard state)")) {
-                ResetShardRetries(ev->Get()->Record.GetOrigin(), ev->Cookie);
-                RetryResolveTable();
-            } else {
-                RuntimeError(
-                    TStringBuilder() << "Internal error for table `"
-                        << TablePath << "`. "
-                        << getIssues().ToOneLineString(),
-                    NYql::NDqProto::StatusIds::INTERNAL_ERROR,
-                    getIssues());
-            }
+            RuntimeError(
+                TStringBuilder() << "Internal error for table `"
+                    << TablePath << "`. "
+                    << getIssues().ToOneLineString(),
+                NYql::NDqProto::StatusIds::INTERNAL_ERROR,
+                getIssues());
             return;
         }
         case NKikimrDataEvents::TEvWriteResult::STATUS_DISK_SPACE_EXHAUSTED: {

--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -130,6 +130,7 @@ message TEvWriteResult {
         STATUS_SCHEME_CHANGED = 8;
         STATUS_LOCKS_BROKEN = 9;
         STATUS_DISK_SPACE_EXHAUSTED = 10;
+        STATUS_WRONG_SHARD_STATE = 11;
     }
 
     // Status

--- a/ydb/core/tx/data_events/common/error_codes.cpp
+++ b/ydb/core/tx/data_events/common/error_codes.cpp
@@ -26,6 +26,8 @@ TConclusion<NErrorCodes::TOperator::TYdbStatusInfo> TOperator::GetStatusInfo(
         case NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN: {
             return TYdbStatusInfo(Ydb::StatusIds::ABORTED, NYql::TIssuesIds::KIKIMR_LOCKS_INVALIDATED, "Transaction locks invalidated.");
         }
+        case NKikimrDataEvents::TEvWriteResult::STATUS_WRONG_SHARD_STATE:
+            return TYdbStatusInfo(Ydb::StatusIds::PRECONDITION_FAILED, NYql::TIssuesIds::KIKIMR_PRECONDITION_FAILED, "Wrong shard state");
     }
 }
 

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -3054,7 +3054,7 @@ bool TDataShard::CheckDataTxRejectAndReply(const NEvents::TDataEvents::TEvWrite:
                 status = NKikimrDataEvents::TEvWriteResult::STATUS_OVERLOADED;
                 break;
             case NKikimrTxDataShard::TEvProposeTransactionResult::ERROR:
-                if (rejectReasons == ERejectReasons::WrongState) {
+                if ((rejectReasons & ERejectReasons::WrongState) != ERejectReasons::None) {
                     status = NKikimrDataEvents::TEvWriteResult::STATUS_WRONG_SHARD_STATE;
                 } else {
                     status = NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR;

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -3054,7 +3054,11 @@ bool TDataShard::CheckDataTxRejectAndReply(const NEvents::TDataEvents::TEvWrite:
                 status = NKikimrDataEvents::TEvWriteResult::STATUS_OVERLOADED;
                 break;
             case NKikimrTxDataShard::TEvProposeTransactionResult::ERROR:
-                status = NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR;
+                if (rejectStatus == ERejectReasons::WrongState) {
+                    status = NKikimrDataEvents::TEvWriteResult::STATUS_WRONG_SHARD_STATE;
+                } else {
+                    status = NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR;
+                }
                 break;
             default:
                 Y_FAIL_S("Unexpected rejectStatus " << rejectStatus);

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -3054,7 +3054,7 @@ bool TDataShard::CheckDataTxRejectAndReply(const NEvents::TDataEvents::TEvWrite:
                 status = NKikimrDataEvents::TEvWriteResult::STATUS_OVERLOADED;
                 break;
             case NKikimrTxDataShard::TEvProposeTransactionResult::ERROR:
-                if (rejectStatus == ERejectReasons::WrongState) {
+                if (rejectReasons == ERejectReasons::WrongState) {
                     status = NKikimrDataEvents::TEvWriteResult::STATUS_WRONG_SHARD_STATE;
                 } else {
                     status = NKikimrDataEvents::TEvWriteResult::STATUS_INTERNAL_ERROR;


### PR DESCRIPTION
### Changelog entry

New internal error status for EvWriteResult from data_events: wrong shard state.

...

### Changelog category

* Improvement

### Additional information

...
