### PR TITLE
fstec: Add rules for password strength

### DIFF
--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -18,6 +18,7 @@
 #include <ydb/core/protos/tenant_pool.pb.h>
 #include <ydb/core/protos/compile_service_config.pb.h>
 #include <ydb/core/protos/cms.pb.h>
+#include <ydb/core/config/validation/validators.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/library/actors/core/log_iface.h>
 #include <ydb/library/yaml_config/yaml_config.h>
@@ -1125,6 +1126,12 @@ public:
         }
 
         TenantName = FillTenantPoolConfig(CommonAppOptions);
+
+        std::vector<TString> errors;
+        EValidationResult result = ValidateConfig(AppConfig, errors);
+        if (result == EValidationResult::Error) {
+            ythrow yexception() << errors.front();
+        }
 
         Logger.Out() << "configured" << Endl;
 

--- a/ydb/core/config/validation/auth_config_validator.cpp
+++ b/ydb/core/config/validation/auth_config_validator.cpp
@@ -13,7 +13,8 @@ EValidationResult ValidatePasswordComplexitySettings(const NKikimrProto::TPasswo
                                      passwordComplexitySettings.GetMinNumbersCount() +
                                      passwordComplexitySettings.GetMinSpecialCharsCount();
     if (passwordComplexitySettings.GetMinLength() < minCountOfRequiredChars) {
-        msg = std::vector<TString>{"Min length of password must be not less than the sum of min count of lower case chars, upper case chars, numbers and special chars"};
+        msg = std::vector<TString>{"password_complexity_settings: Min length of password cannot be less than "
+                                   "total min counts of lower case chars, upper case chars, numbers and special chars"};
         return EValidationResult::Error;
     }
     return EValidationResult::Ok;

--- a/ydb/core/config/validation/auth_config_validator.cpp
+++ b/ydb/core/config/validation/auth_config_validator.cpp
@@ -7,13 +7,13 @@
 namespace NKikimr::NConfig {
 namespace {
 
-EValidationResult ValidatePasswordComplexitySettings(const NKikimrProto::TPasswordComplexitySettings& passwordComplexitySettings, std::vector<TString>&msg) {
-    size_t minCountOfRequiredChars = passwordComplexitySettings.GetMinLowerCaseCount() +
-                                     passwordComplexitySettings.GetMinUpperCaseCount() +
-                                     passwordComplexitySettings.GetMinNumbersCount() +
-                                     passwordComplexitySettings.GetMinSpecialCharsCount();
-    if (passwordComplexitySettings.GetMinLength() < minCountOfRequiredChars) {
-        msg = std::vector<TString>{"password_complexity_settings: Min length of password cannot be less than "
+EValidationResult ValidatePasswordComplexity(const NKikimrProto::TPasswordComplexity& passwordComplexity, std::vector<TString>&msg) {
+    size_t minCountOfRequiredChars = passwordComplexity.GetMinLowerCaseCount() +
+                                     passwordComplexity.GetMinUpperCaseCount() +
+                                     passwordComplexity.GetMinNumbersCount() +
+                                     passwordComplexity.GetMinSpecialCharsCount();
+    if (passwordComplexity.GetMinLength() < minCountOfRequiredChars) {
+        msg = std::vector<TString>{"password_complexity: Min length of password cannot be less than "
                                    "total min counts of lower case chars, upper case chars, numbers and special chars"};
         return EValidationResult::Error;
     }
@@ -23,8 +23,8 @@ EValidationResult ValidatePasswordComplexitySettings(const NKikimrProto::TPasswo
 } // namespace
 
 EValidationResult ValidateAuthConfig(const NKikimrProto::TAuthConfig& authConfig, std::vector<TString>& msg) {
-    EValidationResult validatePasswordComplexitySettingsResult = ValidatePasswordComplexitySettings(authConfig.GetPasswordComplexitySettings(), msg);
-    if (validatePasswordComplexitySettingsResult == EValidationResult::Error) {
+    EValidationResult validatePasswordComplexityResult = ValidatePasswordComplexity(authConfig.GetPasswordComplexity(), msg);
+    if (validatePasswordComplexityResult == EValidationResult::Error) {
         return EValidationResult::Error;
     }
     if (msg.size() > 0) {

--- a/ydb/core/config/validation/auth_config_validator.cpp
+++ b/ydb/core/config/validation/auth_config_validator.cpp
@@ -13,7 +13,7 @@ EValidationResult ValidatePasswordComplexitySettings(const NKikimrProto::TPasswo
                                      passwordComplexitySettings.GetMinNumbersCount() +
                                      passwordComplexitySettings.GetMinSpecialCharsCount();
     if (passwordComplexitySettings.GetMinLength() < minCountOfRequiredChars) {
-        msg = std::vector<TString>{"Min length of password must be no less than sum of min count of lower case chars, upper case chars, numbers and special chars"};
+        msg = std::vector<TString>{"Min length of password must be not less than the sum of min count of lower case chars, upper case chars, numbers and special chars"};
         return EValidationResult::Error;
     }
     return EValidationResult::Ok;

--- a/ydb/core/config/validation/auth_config_validator.cpp
+++ b/ydb/core/config/validation/auth_config_validator.cpp
@@ -1,0 +1,35 @@
+#include <ydb/core/protos/auth.pb.h>
+#include <vector>
+#include <util/generic/string.h>
+#include "validators.h"
+
+
+namespace NKikimr::NConfig {
+namespace {
+
+EValidationResult ValidatePasswordComplexitySettings(const NKikimrProto::TPasswordComplexitySettings& passwordComplexitySettings, std::vector<TString>&msg) {
+    size_t minCountOfRequiredChars = passwordComplexitySettings.GetMinLowerCaseCount() +
+                                     passwordComplexitySettings.GetMinUpperCaseCount() +
+                                     passwordComplexitySettings.GetMinNumbersCount() +
+                                     passwordComplexitySettings.GetMinSpecialCharsCount();
+    if (passwordComplexitySettings.GetMinLength() < minCountOfRequiredChars) {
+        msg = std::vector<TString>{"Min length of password must be no less than sum of min count of lower case chars, upper case chars, numbers and special chars"};
+        return EValidationResult::Error;
+    }
+    return EValidationResult::Ok;
+}
+
+} // namespace
+
+EValidationResult ValidateAuthConfig(const NKikimrProto::TAuthConfig& authConfig, std::vector<TString>& msg) {
+    EValidationResult validatePasswordComplexitySettingsResult = ValidatePasswordComplexitySettings(authConfig.GetPasswordComplexitySettings(), msg);
+    if (validatePasswordComplexitySettingsResult == EValidationResult::Error) {
+        return EValidationResult::Error;
+    }
+    if (msg.size() > 0) {
+        return EValidationResult::Warn;
+    }
+    return EValidationResult::Ok;
+}
+
+} // NKikimr::NConfig

--- a/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
+++ b/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
@@ -6,15 +6,15 @@
 using namespace NKikimr::NConfig;
 
 Y_UNIT_TEST_SUITE(AuthConfigValidation) {
-    Y_UNIT_TEST(AcceptValidPasswordComplexitySettings) {
+    Y_UNIT_TEST(AcceptValidPasswordComplexity) {
         NKikimrProto::TAuthConfig authConfig;
-        NKikimrProto::TPasswordComplexitySettings* validPasswordComplexitySettings = authConfig.MutablePasswordComplexitySettings();
+        NKikimrProto::TPasswordComplexity* validPasswordComplexity = authConfig.MutablePasswordComplexity();
 
-        validPasswordComplexitySettings->SetMinLength(8);
-        validPasswordComplexitySettings->SetMinLowerCaseCount(2);
-        validPasswordComplexitySettings->SetMinUpperCaseCount(2);
-        validPasswordComplexitySettings->SetMinNumbersCount(2);
-        validPasswordComplexitySettings->SetMinSpecialCharsCount(2);
+        validPasswordComplexity->SetMinLength(8);
+        validPasswordComplexity->SetMinLowerCaseCount(2);
+        validPasswordComplexity->SetMinUpperCaseCount(2);
+        validPasswordComplexity->SetMinNumbersCount(2);
+        validPasswordComplexity->SetMinSpecialCharsCount(2);
 
         std::vector<TString> error;
         EValidationResult result = ValidateAuthConfig(authConfig, error);
@@ -22,22 +22,22 @@ Y_UNIT_TEST_SUITE(AuthConfigValidation) {
         UNIT_ASSERT_C(error.empty(), "Should not be errors");
     }
 
-    Y_UNIT_TEST(CannotAcceptInvalidPasswordComplexitySettings) {
+    Y_UNIT_TEST(CannotAcceptInvalidPasswordComplexity) {
         NKikimrProto::TAuthConfig authConfig;
-        NKikimrProto::TPasswordComplexitySettings* invalidPasswordComplexitySettings = authConfig.MutablePasswordComplexitySettings();
+        NKikimrProto::TPasswordComplexity* invalidPasswordComplexity = authConfig.MutablePasswordComplexity();
 
         // 8 < 2 + 2 + 2 + 3
-        invalidPasswordComplexitySettings->SetMinLength(8);
-        invalidPasswordComplexitySettings->SetMinLowerCaseCount(2);
-        invalidPasswordComplexitySettings->SetMinUpperCaseCount(2);
-        invalidPasswordComplexitySettings->SetMinNumbersCount(2);
-        invalidPasswordComplexitySettings->SetMinSpecialCharsCount(3);
+        invalidPasswordComplexity->SetMinLength(8);
+        invalidPasswordComplexity->SetMinLowerCaseCount(2);
+        invalidPasswordComplexity->SetMinUpperCaseCount(2);
+        invalidPasswordComplexity->SetMinNumbersCount(2);
+        invalidPasswordComplexity->SetMinSpecialCharsCount(3);
 
         std::vector<TString> error;
         EValidationResult result = ValidateAuthConfig(authConfig, error);
         UNIT_ASSERT_EQUAL(result, EValidationResult::Error);
         UNIT_ASSERT_VALUES_EQUAL(error.size(), 1);
-        UNIT_ASSERT_STRINGS_EQUAL(error.front(), "password_complexity_settings: Min length of password cannot be less than "
+        UNIT_ASSERT_STRINGS_EQUAL(error.front(), "password_complexity: Min length of password cannot be less than "
                                                  "total min counts of lower case chars, upper case chars, numbers and special chars");
     }
 }

--- a/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
+++ b/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
@@ -37,6 +37,7 @@ Y_UNIT_TEST_SUITE(AuthConfigValidation) {
         EValidationResult result = ValidateAuthConfig(authConfig, error);
         UNIT_ASSERT_EQUAL(result, EValidationResult::Error);
         UNIT_ASSERT_VALUES_EQUAL(error.size(), 1);
-        UNIT_ASSERT_STRINGS_EQUAL(error[0], "Min length of password must be not less than the sum of min count of lower case chars, upper case chars, numbers and special chars");
+        UNIT_ASSERT_STRINGS_EQUAL(error.front(), "password_complexity_settings: Min length of password cannot be less than "
+                                                 "total min counts of lower case chars, upper case chars, numbers and special chars");
     }
 }

--- a/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
+++ b/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
@@ -1,0 +1,42 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <ydb/core/config/validation/validators.h>
+#include <ydb/core/protos/auth.pb.h>
+#include <vector>
+
+using namespace NKikimr::NConfig;
+
+Y_UNIT_TEST_SUITE(AuthConfigValidation) {
+    Y_UNIT_TEST(AcceptValidPasswordComplexitySettings) {
+        NKikimrProto::TAuthConfig authConfig;
+        NKikimrProto::TPasswordComplexitySettings* validPasswordComplexitySettings = authConfig.MutablePasswordComplexitySettings();
+
+        validPasswordComplexitySettings->SetMinLength(8);
+        validPasswordComplexitySettings->SetMinLowerCaseCount(2);
+        validPasswordComplexitySettings->SetMinUpperCaseCount(2);
+        validPasswordComplexitySettings->SetMinNumbersCount(2);
+        validPasswordComplexitySettings->SetMinSpecialCharsCount(2);
+
+        std::vector<TString> error;
+        EValidationResult result = ValidateAuthConfig(authConfig, error);
+        UNIT_ASSERT_EQUAL(result, EValidationResult::Ok);
+        UNIT_ASSERT_C(error.empty(), "Should not be errors");
+    }
+
+    Y_UNIT_TEST(CannotAcceptInvalidPasswordComplexitySettings) {
+        NKikimrProto::TAuthConfig authConfig;
+        NKikimrProto::TPasswordComplexitySettings* invalidPasswordComplexitySettings = authConfig.MutablePasswordComplexitySettings();
+
+        // 8 < 2 + 2 + 2 + 3
+        invalidPasswordComplexitySettings->SetMinLength(8);
+        invalidPasswordComplexitySettings->SetMinLowerCaseCount(2);
+        invalidPasswordComplexitySettings->SetMinUpperCaseCount(2);
+        invalidPasswordComplexitySettings->SetMinNumbersCount(2);
+        invalidPasswordComplexitySettings->SetMinSpecialCharsCount(3);
+
+        std::vector<TString> error;
+        EValidationResult result = ValidateAuthConfig(authConfig, error);
+        UNIT_ASSERT_EQUAL(result, EValidationResult::Error);
+        UNIT_ASSERT_VALUES_EQUAL(error.size(), 1);
+        UNIT_ASSERT_STRINGS_EQUAL(error[0], "Min length of password must be no less than sum of min count of lower case chars, upper case chars, numbers and special chars");
+    }
+}

--- a/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
+++ b/ydb/core/config/validation/auth_config_validator_ut/auth_config_validator_ut.cpp
@@ -37,6 +37,6 @@ Y_UNIT_TEST_SUITE(AuthConfigValidation) {
         EValidationResult result = ValidateAuthConfig(authConfig, error);
         UNIT_ASSERT_EQUAL(result, EValidationResult::Error);
         UNIT_ASSERT_VALUES_EQUAL(error.size(), 1);
-        UNIT_ASSERT_STRINGS_EQUAL(error[0], "Min length of password must be no less than sum of min count of lower case chars, upper case chars, numbers and special chars");
+        UNIT_ASSERT_STRINGS_EQUAL(error[0], "Min length of password must be not less than the sum of min count of lower case chars, upper case chars, numbers and special chars");
     }
 }

--- a/ydb/core/config/validation/auth_config_validator_ut/ya.make
+++ b/ydb/core/config/validation/auth_config_validator_ut/ya.make
@@ -1,0 +1,9 @@
+UNITTEST_FOR(ydb/core/config/validation)
+
+SRC(
+    auth_config_validator_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/config/validation/validators.cpp
+++ b/ydb/core/config/validation/validators.cpp
@@ -161,4 +161,18 @@ EValidationResult ValidateStaticGroup(const NKikimrConfig::TAppConfig& current, 
     return EValidationResult::Ok;
 }
 
+EValidationResult ValidateConfig(const NKikimrConfig::TAppConfig& config, std::vector<TString>& msg) {
+    if (config.HasAuthConfig()) {
+        NKikimr::NConfig::EValidationResult result = NKikimr::NConfig::ValidateAuthConfig(config.GetAuthConfig(), msg);
+        if (result == NKikimr::NConfig::EValidationResult::Error) {
+            return EValidationResult::Error;
+        }
+    }
+    if (msg.size() > 0) {
+        return EValidationResult::Warn;
+    }
+
+    return EValidationResult::Ok;
+}
+
 } // namespace NKikimr::NConfig

--- a/ydb/core/config/validation/validators.h
+++ b/ydb/core/config/validation/validators.h
@@ -4,6 +4,12 @@
 
 #include <vector>
 
+namespace NKikimrProto {
+
+class TAuthConfig;
+
+} // NKikimrProto
+
 namespace NKikimr::NConfig {
 
 enum class EValidationResult {
@@ -30,6 +36,14 @@ struct TVDiskKey {
 EValidationResult ValidateStaticGroup(
     const NKikimrConfig::TAppConfig& current,
     const NKikimrConfig::TAppConfig& proposed,
+    std::vector<TString>& msg);
+
+EValidationResult ValidateAuthConfig(
+    const NKikimrProto::TAuthConfig& authConfig,
+    std::vector<TString>& msg);
+
+EValidationResult ValidateConfig(
+    const NKikimrConfig::TAppConfig& config,
     std::vector<TString>& msg);
 
 } // namespace NKikimr::NConfig

--- a/ydb/core/config/validation/ya.make
+++ b/ydb/core/config/validation/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     validators.h
     validators.cpp
+    auth_config_validator.cpp
 )
 
 PEERDIR(
@@ -13,5 +14,5 @@ END()
 
 RECURSE_FOR_TESTS(
     ut
+    auth_config_validator_ut
 )
-

--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -56,7 +56,7 @@ message TAuthConfig {
     optional string CertificateAuthenticationDomain = 80 [default = "cert"];
     optional bool EnableLoginAuthentication = 81 [default = true];
     optional string NodeRegistrationToken = 82 [default = "root@builtin", (Ydb.sensitive) = true];
-    optional TPasswordComplexitySettings PasswordComplexitySettings = 83;
+    optional TPasswordComplexity PasswordComplexity = 83;
 }
 
 message TUserRegistryConfig {
@@ -124,7 +124,7 @@ message TLdapAuthentication {
     optional TExtendedSettings ExtendedSettings = 12;
 }
 
-message TPasswordComplexitySettings {
+message TPasswordComplexity {
     optional uint32 MinLength = 1;
     optional uint32 MinLowerCaseCount = 2;
     optional uint32 MinUpperCaseCount = 3;

--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -130,6 +130,6 @@ message TPasswordComplexitySettings {
     optional uint32 MinUpperCaseCount = 3;
     optional uint32 MinNumbersCount = 4;
     optional uint32 MinSpecialCharsCount = 5;
-    optional string SpecialChars = 6 [default = "!@#$%^&*()_+{}|<>?="];
+    optional string SpecialChars = 6;
     optional bool CanContainUsername = 7;
 }

--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -125,12 +125,11 @@ message TLdapAuthentication {
 }
 
 message TPasswordCheckerParameters {
-    optional uint32 MinimumLength = 1 [default = 8];
-    optional uint32 MaximumLength = 2 [default = 15];
-    optional bool RestrictLower = 3 [default = true];
-    optional bool RestrictUpper = 4 [default = true];
-    optional bool RestrictNumbers = 5 [default = true];
-    optional bool RestrictSpecial = 6 [default = true];
+    optional uint32 MinimumLength = 1 [default = 0];
+    optional uint32 MaximumLength = 2 [default = 4294967295];
+    optional bool RestrictLower = 3;
+    optional bool RestrictUpper = 4;
+    optional bool RestrictNumbers = 5;
+    optional bool RestrictSpecial = 6;
     optional string SpecialChars = 7 [default = "!@#$%^&*()_+{}|<>?="];
-    optional bool EnableEmptyPassword = 8 [default = true];
 }

--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -56,7 +56,7 @@ message TAuthConfig {
     optional string CertificateAuthenticationDomain = 80 [default = "cert"];
     optional bool EnableLoginAuthentication = 81 [default = true];
     optional string NodeRegistrationToken = 82 [default = "root@builtin", (Ydb.sensitive) = true];
-    optional TPasswordCheckerParameters PasswordCheckerParameters = 83;
+    optional TPasswordComplexitySettings PasswordComplexitySettings = 83;
 }
 
 message TUserRegistryConfig {
@@ -124,12 +124,12 @@ message TLdapAuthentication {
     optional TExtendedSettings ExtendedSettings = 12;
 }
 
-message TPasswordCheckerParameters {
-    optional uint32 MinimumLength = 1 [default = 0];
-    optional uint32 MaximumLength = 2 [default = 4294967295];
-    optional bool RestrictLower = 3;
-    optional bool RestrictUpper = 4;
-    optional bool RestrictNumbers = 5;
-    optional bool RestrictSpecial = 6;
-    optional string SpecialChars = 7 [default = "!@#$%^&*()_+{}|<>?="];
+message TPasswordComplexitySettings {
+    optional uint32 MinLength = 1;
+    optional uint32 MinLowerCaseCount = 2;
+    optional uint32 MinUpperCaseCount = 3;
+    optional uint32 MinNumbersCount = 4;
+    optional uint32 MinSpecialCharsCount = 5;
+    optional string SpecialChars = 6 [default = "!@#$%^&*()_+{}|<>?="];
+    optional bool CanContainUsername = 7;
 }

--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -56,6 +56,7 @@ message TAuthConfig {
     optional string CertificateAuthenticationDomain = 80 [default = "cert"];
     optional bool EnableLoginAuthentication = 81 [default = true];
     optional string NodeRegistrationToken = 82 [default = "root@builtin", (Ydb.sensitive) = true];
+    optional TPasswordCheckerParameters PasswordCheckerParameters = 83;
 }
 
 message TUserRegistryConfig {
@@ -121,4 +122,15 @@ message TLdapAuthentication {
     repeated string Hosts = 10;
     optional string Scheme = 11 [default = "ldap"];
     optional TExtendedSettings ExtendedSettings = 12;
+}
+
+message TPasswordCheckerParameters {
+    optional uint32 MinimumLength = 1 [default = 8];
+    optional uint32 MaximumLength = 2 [default = 15];
+    optional bool RestrictLower = 3 [default = true];
+    optional bool RestrictUpper = 4 [default = true];
+    optional bool RestrictNumbers = 5 [default = true];
+    optional bool RestrictSpecial = 6 [default = true];
+    optional string SpecialChars = 7 [default = "!@#$%^&*()_+{}|<>?="];
+    optional bool EnableEmptyPassword = 8 [default = true];
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4437,14 +4437,14 @@ TSchemeShard::TSchemeShard(const TActorId &tablet, TTabletStorageInfo *info)
             COUNTER_PQ_STATS_WRITTEN,
             COUNTER_PQ_STATS_BATCH_LATENCY)
     , AllowDataColumnForIndexTable(0, 0, 1)
-    , LoginProvider(NLogin::TPasswordComplexitySettings({
-        .MinLength = AppData()->AuthConfig.GetPasswordComplexitySettings().GetMinLength(),
-        .MinLowerCaseCount = AppData()->AuthConfig.GetPasswordComplexitySettings().GetMinLowerCaseCount(),
-        .MinUpperCaseCount = AppData()->AuthConfig.GetPasswordComplexitySettings().GetMinUpperCaseCount(),
-        .MinNumbersCount = AppData()->AuthConfig.GetPasswordComplexitySettings().GetMinNumbersCount(),
-        .MinSpecialCharsCount = AppData()->AuthConfig.GetPasswordComplexitySettings().GetMinSpecialCharsCount(),
-        .SpecialChars = AppData()->AuthConfig.GetPasswordComplexitySettings().GetSpecialChars(),
-        .CanContainUsername = AppData()->AuthConfig.GetPasswordComplexitySettings().GetCanContainUsername()
+    , LoginProvider(NLogin::TPasswordComplexity({
+        .MinLength = AppData()->AuthConfig.GetPasswordComplexity().GetMinLength(),
+        .MinLowerCaseCount = AppData()->AuthConfig.GetPasswordComplexity().GetMinLowerCaseCount(),
+        .MinUpperCaseCount = AppData()->AuthConfig.GetPasswordComplexity().GetMinUpperCaseCount(),
+        .MinNumbersCount = AppData()->AuthConfig.GetPasswordComplexity().GetMinNumbersCount(),
+        .MinSpecialCharsCount = AppData()->AuthConfig.GetPasswordComplexity().GetMinSpecialCharsCount(),
+        .SpecialChars = AppData()->AuthConfig.GetPasswordComplexity().GetSpecialChars(),
+        .CanContainUsername = AppData()->AuthConfig.GetPasswordComplexity().GetCanContainUsername()
     }))
 {
     TabletCountersPtr.Reset(new TProtobufTabletCounters<
@@ -7332,26 +7332,26 @@ void TSchemeShard::ConfigureLoginProvider(
         const ::NKikimrProto::TAuthConfig& config,
         const TActorContext &ctx)
 {
-    const auto& complexitySettings = config.GetPasswordComplexitySettings();
-    NLogin::TPasswordComplexitySettings passwordComplexitySettings({
-        .MinLength = complexitySettings.GetMinLength(),
-        .MinLowerCaseCount = complexitySettings.GetMinLowerCaseCount(),
-        .MinUpperCaseCount = complexitySettings.GetMinUpperCaseCount(),
-        .MinNumbersCount = complexitySettings.GetMinNumbersCount(),
-        .MinSpecialCharsCount = complexitySettings.GetMinSpecialCharsCount(),
-        .SpecialChars = (complexitySettings.GetSpecialChars().empty() ? NLogin::TPasswordComplexitySettings::VALID_SPECIAL_CHARS : complexitySettings.GetSpecialChars()),
-        .CanContainUsername = complexitySettings.GetCanContainUsername()
+    const auto& passwordComplexityConfig = config.GetPasswordComplexity();
+    NLogin::TPasswordComplexity passwordComplexity({
+        .MinLength = passwordComplexityConfig.GetMinLength(),
+        .MinLowerCaseCount = passwordComplexityConfig.GetMinLowerCaseCount(),
+        .MinUpperCaseCount = passwordComplexityConfig.GetMinUpperCaseCount(),
+        .MinNumbersCount = passwordComplexityConfig.GetMinNumbersCount(),
+        .MinSpecialCharsCount = passwordComplexityConfig.GetMinSpecialCharsCount(),
+        .SpecialChars = (passwordComplexityConfig.GetSpecialChars().empty() ? NLogin::TPasswordComplexity::VALID_SPECIAL_CHARS : passwordComplexityConfig.GetSpecialChars()),
+        .CanContainUsername = passwordComplexityConfig.GetCanContainUsername()
     });
-    LoginProvider.UpdatePasswordCheckParameters(passwordComplexitySettings);
+    LoginProvider.UpdatePasswordCheckParameters(passwordComplexity);
 
     LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-                 "PasswordComplexitySettings for LoginProvider configured: MinLength# " << passwordComplexitySettings.MinLength
-                 << ", MinLowerCaseCount# " << passwordComplexitySettings.MinLowerCaseCount
-                 << ", MinUpperCaseCount# " << passwordComplexitySettings.MinUpperCaseCount
-                 << ", MinNumbersCount# " << passwordComplexitySettings.MinNumbersCount
-                 << ", MinSpecialCharsCount# " << passwordComplexitySettings.MinSpecialCharsCount
-                 << ", SpecialChars# " << (complexitySettings.GetSpecialChars().empty() ? NLogin::TPasswordComplexitySettings::VALID_SPECIAL_CHARS : complexitySettings.GetSpecialChars())
-                 << ", CanContainUsername# " << (passwordComplexitySettings.CanContainUsername ? "true" : "false"));
+                 "PasswordComplexity for LoginProvider configured: MinLength# " << passwordComplexity.MinLength
+                 << ", MinLowerCaseCount# " << passwordComplexity.MinLowerCaseCount
+                 << ", MinUpperCaseCount# " << passwordComplexity.MinUpperCaseCount
+                 << ", MinNumbersCount# " << passwordComplexity.MinNumbersCount
+                 << ", MinSpecialCharsCount# " << passwordComplexity.MinSpecialCharsCount
+                 << ", SpecialChars# " << (passwordComplexityConfig.GetSpecialChars().empty() ? NLogin::TPasswordComplexity::VALID_SPECIAL_CHARS : passwordComplexityConfig.GetSpecialChars())
+                 << ", CanContainUsername# " << (passwordComplexity.CanContainUsername ? "true" : "false"));
 }
 
 void TSchemeShard::StartStopCompactionQueues() {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -7339,18 +7339,18 @@ void TSchemeShard::ConfigureLoginProvider(
         .MinUpperCaseCount = complexitySettings.GetMinUpperCaseCount(),
         .MinNumbersCount = complexitySettings.GetMinNumbersCount(),
         .MinSpecialCharsCount = complexitySettings.GetMinSpecialCharsCount(),
-        .SpecialChars = complexitySettings.GetSpecialChars(),
+        .SpecialChars = (complexitySettings.GetSpecialChars().empty() ? NLogin::TPasswordComplexitySettings::VALID_SPECIAL_CHARS : complexitySettings.GetSpecialChars()),
         .CanContainUsername = complexitySettings.GetCanContainUsername()
     });
     LoginProvider.UpdatePasswordCheckParameters(passwordComplexitySettings);
 
     LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-                 "LoginProvider configured: MinLength# " << passwordComplexitySettings.MinLength
+                 "PasswordComplexitySettings for LoginProvider configured: MinLength# " << passwordComplexitySettings.MinLength
                  << ", MinLowerCaseCount# " << passwordComplexitySettings.MinLowerCaseCount
                  << ", MinUpperCaseCount# " << passwordComplexitySettings.MinUpperCaseCount
                  << ", MinNumbersCount# " << passwordComplexitySettings.MinNumbersCount
                  << ", MinSpecialCharsCount# " << passwordComplexitySettings.MinSpecialCharsCount
-                 << ", SpecialChars# " << complexitySettings.GetSpecialChars()
+                 << ", SpecialChars# " << (complexitySettings.GetSpecialChars().empty() ? NLogin::TPasswordComplexitySettings::VALID_SPECIAL_CHARS : complexitySettings.GetSpecialChars())
                  << ", CanContainUsername# " << (passwordComplexitySettings.CanContainUsername ? "true" : "false"));
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -36,7 +36,6 @@
 #include <ydb/core/protos/counters_schemeshard.pb.h>
 #include <ydb/core/protos/filestore_config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
-#include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/sys_view/common/events.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/tablet/pipe_tracker.h>

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -65,6 +65,7 @@
 #include <ydb/core/blob_depot/events.h>
 
 #include <ydb/library/login/login.h>
+#include <ydb/library/login/password_checker/password_checker.h>
 
 #include <util/generic/ptr.h>
 
@@ -1456,6 +1457,7 @@ public:
     void ChangeDiskSpaceSoftQuotaBytes(i64 delta) override;
     void AddDiskSpaceSoftQuotaBytes(EUserFacingStorageType storageType, ui64 addend) override;
 
+    NLogin::TPasswordCheckParameters PasswordCheckParameters;
     NLogin::TLoginProvider LoginProvider;
 
 private:

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -65,7 +65,6 @@
 #include <ydb/core/blob_depot/events.h>
 
 #include <ydb/library/login/login.h>
-#include <ydb/library/login/password_checker/password_checker.h>
 
 #include <util/generic/ptr.h>
 
@@ -1461,7 +1460,6 @@ public:
     void ChangeDiskSpaceSoftQuotaBytes(i64 delta) override;
     void AddDiskSpaceSoftQuotaBytes(EUserFacingStorageType storageType, ui64 addend) override;
 
-    NLogin::TPasswordCheckParameters PasswordCheckParameters;
     NLogin::TLoginProvider LoginProvider;
 
 private:

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -36,6 +36,7 @@
 #include <ydb/core/protos/counters_schemeshard.pb.h>
 #include <ydb/core/protos/filestore_config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/sys_view/common/events.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/tablet/pipe_tracker.h>
@@ -496,6 +497,10 @@ public:
 
     void ConfigureBackgroundCleaningQueue(
         const NKikimrConfig::TBackgroundCleaningConfig& config,
+        const TActorContext &ctx);
+
+    void ConfigureLoginProvider(
+        const ::NKikimrProto::TAuthConfig& config,
         const TActorContext &ctx);
 
     void StartStopCompactionQueues();

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -17,18 +17,18 @@ using namespace NSchemeShardUT_Private;
 
 namespace NSchemeShardUT_Private {
 
-void SetPasswordCheckerParameters(TTestActorRuntime &runtime, ui64 schemeShard, const NLogin::TPasswordComplexitySettings::TInitializer& initializer) {
+void SetPasswordCheckerParameters(TTestActorRuntime &runtime, ui64 schemeShard, const NLogin::TPasswordComplexity::TInitializer& initializer) {
     auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
 
-    ::NKikimrProto::TPasswordComplexitySettings passwordComplexitySettings;
-    passwordComplexitySettings.SetMinLength(initializer.MinLength);
-    passwordComplexitySettings.SetMinLowerCaseCount(initializer.MinLowerCaseCount);
-    passwordComplexitySettings.SetMinUpperCaseCount(initializer.MinUpperCaseCount);
-    passwordComplexitySettings.SetMinNumbersCount(initializer.MinNumbersCount);
-    passwordComplexitySettings.SetMinSpecialCharsCount(initializer.MinSpecialCharsCount);
-    passwordComplexitySettings.SetSpecialChars(initializer.SpecialChars);
-    passwordComplexitySettings.SetCanContainUsername(initializer.CanContainUsername);
-    *request->Record.MutableConfig()->MutableAuthConfig()->MutablePasswordComplexitySettings() = passwordComplexitySettings;
+    ::NKikimrProto::TPasswordComplexity passwordComplexity;
+    passwordComplexity.SetMinLength(initializer.MinLength);
+    passwordComplexity.SetMinLowerCaseCount(initializer.MinLowerCaseCount);
+    passwordComplexity.SetMinUpperCaseCount(initializer.MinUpperCaseCount);
+    passwordComplexity.SetMinNumbersCount(initializer.MinNumbersCount);
+    passwordComplexity.SetMinSpecialCharsCount(initializer.MinSpecialCharsCount);
+    passwordComplexity.SetSpecialChars(initializer.SpecialChars);
+    passwordComplexity.SetCanContainUsername(initializer.CanContainUsername);
+    *request->Record.MutableConfig()->MutableAuthConfig()->MutablePasswordComplexity() = passwordComplexity;
     SetConfig(runtime, schemeShard, std::move(request));
 }
 

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -80,7 +80,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  min length 0
         //  optional: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
         // required: cannot contain username
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
         auto resultLogin = Login(runtime, "user1", "password1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -90,7 +90,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().GetSecurityState().PublicKeysSize() > 0);
 
         // Accept password without lower case symbols
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "PASSWORDU2", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "PASSWORDU2");
          resultLogin = Login(runtime, "user2", "PASSWORDU2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -98,14 +98,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
         //  required: lower case = 3, cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 3});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 lower case character"}});
         // Add lower case symbols to password
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASswORDu3", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASswORDu3");
         resultLogin = Login(runtime, "user3", "PASswORDu3");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without upper case symbols
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user4", "passwordu4", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user4", "passwordu4");
         resultLogin = Login(runtime, "user4", "passwordu4");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -113,15 +113,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
         //  required: upper case = 3, cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 0, .MinUpperCaseCount = 3});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 upper case character"}});
         // Add 3 upper case symbols to password
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "PASswORDu5", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "PASswORDu5");
         resultLogin = Login(runtime, "user5", "PASswORDu5");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept short password
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinUpperCaseCount = 0});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user6", "passwu6", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user6", "passwu6");
         resultLogin = Login(runtime, "user6", "passwu6");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -130,15 +130,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  required: cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 8});
         // Too short password
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed, "Password is too short"}});
         // Password has correct length
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwordu7", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwordu7");
         resultLogin = Login(runtime, "user7", "passwordu7");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without numbers
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 0});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "passWorDueitgh", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "passWorDueitgh");
         resultLogin = Login(runtime, "user8", "passWorDueitgh");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -146,15 +146,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, upper case,special symbols from list !@#$%^&*()_+{}|<>?=
         //  required: numbers = 3, cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 3});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 number"}});
         // Password with numbers
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "pas1swo5rdu9", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "pas1swo5rdu9");
         resultLogin = Login(runtime, "user9", "pas1swo5rdu9");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without special symbols
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 0});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "passWorDu10", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "passWorDu10");
         resultLogin = Login(runtime, "user10", "passWorDu10");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -162,9 +162,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, upper case, numbers
         //  required: special symbols from list !@#$%^&*()_+{}|<>?= , cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinSpecialCharsCount = 3});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 special character"}});
         // Password with special symbols
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11*&%#", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11*&%#");
         resultLogin = Login(runtime, "user11", "passwordu11*&%#");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -172,8 +172,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, upper case, numbers
         //  required: special symbols from list *# , cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.SpecialChars = "*#"}); // Only 2 special symbols are valid
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed}});
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*#", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed, "Password contains unacceptable characters"}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*#");
         resultLogin = Login(runtime, "user12", "passwordu12*#");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
     }

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -17,22 +17,20 @@ using namespace NSchemeShardUT_Private;
 
 namespace NSchemeShardUT_Private {
 
-void SetPasswordCheckerParameters(TTestActorRuntime &runtime, ui64 schemeShard, const NLogin::TPasswordCheckParameters::TInitializer& parameters) {
+void SetPasswordCheckerParameters(TTestActorRuntime &runtime, ui64 schemeShard, const NLogin::TPasswordComplexitySettings::TInitializer& initializer) {
     auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
 
-    ::NKikimrProto::TPasswordCheckerParameters passwordCheckParameters;
-    passwordCheckParameters.SetMinimumLength(parameters.MinPasswordLength);
-    passwordCheckParameters.SetMaximumLength(parameters.MaxPasswordLength);
-    passwordCheckParameters.SetRestrictLower(parameters.NeedLowerCase);
-    passwordCheckParameters.SetRestrictUpper(parameters.NeedUpperCase);
-    passwordCheckParameters.SetRestrictNumbers(parameters.NeedNumbers);
-    passwordCheckParameters.SetRestrictSpecial(parameters.NeedSpecialSymbols);
-    passwordCheckParameters.SetSpecialChars(parameters.SpecialSymbols);
-    *request->Record.MutableConfig()->MutableAuthConfig()->MutablePasswordCheckerParameters() = passwordCheckParameters;
+    ::NKikimrProto::TPasswordComplexitySettings passwordComplexitySettings;
+    passwordComplexitySettings.SetMinLength(initializer.MinLength);
+    passwordComplexitySettings.SetMinLowerCaseCount(initializer.MinLowerCaseCount);
+    passwordComplexitySettings.SetMinUpperCaseCount(initializer.MinUpperCaseCount);
+    passwordComplexitySettings.SetMinNumbersCount(initializer.MinNumbersCount);
+    passwordComplexitySettings.SetMinSpecialCharsCount(initializer.MinSpecialCharsCount);
+    passwordComplexitySettings.SetSpecialChars(initializer.SpecialChars);
+    passwordComplexitySettings.SetCanContainUsername(initializer.CanContainUsername);
+    *request->Record.MutableConfig()->MutableAuthConfig()->MutablePasswordComplexitySettings() = passwordComplexitySettings;
     SetConfig(runtime, schemeShard, std::move(request));
 }
-
-const TString VALID_SPECIAL_SYMBOLS = "!@#$%^&*()_+{}|<>?=";
 
 }  // namespace NSchemeShardUT_Private
 
@@ -79,8 +77,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
         // Password parameters:
-        //  length 0 - 4294967295
+        //  min length 0
         //  optional: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
+        // required: cannot contain username
         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
         auto resultLogin = Login(runtime, "user1", "password1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
@@ -95,10 +94,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
          resultLogin = Login(runtime, "user2", "PASSWORDU2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
-        //  length 0 - 4294967295
+        //  min length 0
         //  optional: upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: lower case
-        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.NeedLowerCase = true, .SpecialSymbols = VALID_SPECIAL_SYMBOLS});
+        //  required: lower case = 3, cannot contain username
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 3});
         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed}});
         // Add lower case symbols to password
         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASswORDu3", {{NKikimrScheme::StatusSuccess}});
@@ -110,89 +109,72 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         resultLogin = Login(runtime, "user4", "passwordu4");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
-        //  length 0 - 4294967295
-        //  optional: numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: lower case, upper case
-        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.NeedLowerCase = true, .NeedUpperCase = true, .SpecialSymbols = VALID_SPECIAL_SYMBOLS});
+        //  min length 0
+        //  optional: lower case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
+        //  required: upper case = 3, cannot contain username
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 0, .MinUpperCaseCount = 3});
         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed}});
-        // Add upper case symbols to password
+        // Add 3 upper case symbols to password
         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "PASswORDu5", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user5", "PASswORDu5");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
-        // Accept short and long passwords
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user6", "pasSWu6", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user6", "pasSWu6");
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "pasSW12345Word!*&u7", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user7", "pasSW12345Word!*&u7");
+        // Accept short password
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinUpperCaseCount = 0});
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user6", "passwu6", {{NKikimrScheme::StatusSuccess}});
+        resultLogin = Login(runtime, "user6", "passwu6");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
-        //  length 8 - 15
-        //  optional: numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: lower case, upper case
-        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinPasswordLength = 8, .MaxPasswordLength = 15, .NeedLowerCase = true, .NeedUpperCase = true, .SpecialSymbols = VALID_SPECIAL_SYMBOLS});
+        //  min length 8
+        //  optional: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
+        //  required: cannot contain username
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 8});
         // Too short password
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "pasSWu8", {{NKikimrScheme::StatusPreconditionFailed}});
-        // Too long password
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "pasSW12345Word!*&u8", {{NKikimrScheme::StatusPreconditionFailed}});
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed}});
         // Password has correct length
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "PASswORDu8", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user8", "PASswORDu8");
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwordu7", {{NKikimrScheme::StatusSuccess}});
+        resultLogin = Login(runtime, "user7", "passwordu7");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without numbers
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passWorDunine", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user9", "passWorDunine");
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 0});
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "passWorDueitgh", {{NKikimrScheme::StatusSuccess}});
+        resultLogin = Login(runtime, "user8", "passWorDueitgh");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
-        //  length 8 - 15
-        //  optional: special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: lower case, upper case, numbers
-        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinPasswordLength = 8,
-                                                                                         .MaxPasswordLength = 15,
-                                                                                         .NeedLowerCase = true,
-                                                                                         .NeedUpperCase = true,
-                                                                                         .NeedNumbers = true,
-                                                                                         .SpecialSymbols = VALID_SPECIAL_SYMBOLS});
-         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "passWorDuten", {{NKikimrScheme::StatusPreconditionFailed}});
+        //  min length 0
+        //  optional: lower case, upper case,special symbols from list !@#$%^&*()_+{}|<>?=
+        //  required: numbers = 3, cannot contain username
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 3});
+         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed}});
         // Password with numbers
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "PASswORDu10", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user10", "PASswORDu10");
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "pas1swo5rdu9", {{NKikimrScheme::StatusSuccess}});
+        resultLogin = Login(runtime, "user9", "pas1swo5rdu9");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without special symbols
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passWorDu11", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user11", "passWorDu11");
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 0});
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "passWorDu10", {{NKikimrScheme::StatusSuccess}});
+        resultLogin = Login(runtime, "user10", "passWorDu10");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
-        //  length 8 - 15
-        //  required: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinPasswordLength = 8,
-                                                                                         .MaxPasswordLength = 15,
-                                                                                         .NeedLowerCase = true,
-                                                                                         .NeedUpperCase = true,
-                                                                                         .NeedNumbers = true,
-                                                                                         .NeedSpecialSymbols = true,
-                                                                                         .SpecialSymbols = VALID_SPECIAL_SYMBOLS});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passWorDu12", {{NKikimrScheme::StatusPreconditionFailed}});
+        //  min length 0
+        //  optional: lower case, upper case, numbers
+        //  required: special symbols from list !@#$%^&*()_+{}|<>?= , cannot contain username
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinSpecialCharsCount = 3});
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed}});
         // Password with special symbols
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "PASswORDu12*&%#", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user12", "PASswORDu12*&%#");
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11*&%#", {{NKikimrScheme::StatusSuccess}});
+        resultLogin = Login(runtime, "user11", "passwordu11*&%#");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
-        //  length 8 - 15
-        //  required: lower case, upper case, numbers, special symbols from list *#
-        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinPasswordLength = 8,
-                                                                                         .MaxPasswordLength = 15,
-                                                                                         .NeedLowerCase = true,
-                                                                                         .NeedUpperCase = true,
-                                                                                         .NeedNumbers = true,
-                                                                                         .NeedSpecialSymbols = true,
-                                                                                         .SpecialSymbols = "*#"}); // Only 2 special symbols are valid
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user13", "PASswORDu13*&%#", {{NKikimrScheme::StatusPreconditionFailed}});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user13", "PASswORDu12*#", {{NKikimrScheme::StatusSuccess}});
-        resultLogin = Login(runtime, "user13", "PASswORDu12*#");
+        //  min length 0
+        //  optional: lower case, upper case, numbers
+        //  required: special symbols from list *# , cannot contain username
+        SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.SpecialChars = "*#"}); // Only 2 special symbols are valid
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed}});
+        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*#", {{NKikimrScheme::StatusSuccess}});
+        resultLogin = Login(runtime, "user12", "passwordu12*#");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
     }
 }

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -80,7 +80,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  min length 0
         //  optional: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
         // required: cannot contain username
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusSuccess}});
         auto resultLogin = Login(runtime, "user1", "password1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -90,7 +90,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().GetSecurityState().PublicKeysSize() > 0);
 
         // Accept password without lower case symbols
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "PASSWORDU2", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "PASSWORDU2", {{NKikimrScheme::StatusSuccess}});
          resultLogin = Login(runtime, "user2", "PASSWORDU2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -98,14 +98,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
         //  required: lower case = 3, cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 3});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed}});
         // Add lower case symbols to password
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASswORDu3", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASswORDu3", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user3", "PASswORDu3");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without upper case symbols
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user4", "passwordu4", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user4", "passwordu4", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user4", "passwordu4");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -113,15 +113,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
         //  required: upper case = 3, cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 0, .MinUpperCaseCount = 3});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed}});
         // Add 3 upper case symbols to password
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "PASswORDu5", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "PASswORDu5", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user5", "PASswORDu5");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept short password
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinUpperCaseCount = 0});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user6", "passwu6", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user6", "passwu6", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user6", "passwu6");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -130,15 +130,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  required: cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 8});
         // Too short password
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed}});
         // Password has correct length
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwordu7", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwordu7", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user7", "passwordu7");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without numbers
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 0});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "passWorDueitgh", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "passWorDueitgh", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user8", "passWorDueitgh");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -146,15 +146,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, upper case,special symbols from list !@#$%^&*()_+{}|<>?=
         //  required: numbers = 3, cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 3});
-         TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed}});
         // Password with numbers
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "pas1swo5rdu9", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "pas1swo5rdu9", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user9", "pas1swo5rdu9");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         // Accept password without special symbols
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 0});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "passWorDu10", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "passWorDu10", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user10", "passWorDu10");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -162,9 +162,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, upper case, numbers
         //  required: special symbols from list !@#$%^&*()_+{}|<>?= , cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinSpecialCharsCount = 3});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed}});
         // Password with special symbols
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11*&%#", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11*&%#", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user11", "passwordu11*&%#");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         // Password parameters:
@@ -172,8 +172,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         //  optional: lower case, upper case, numbers
         //  required: special symbols from list *# , cannot contain username
         SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.SpecialChars = "*#"}); // Only 2 special symbols are valid
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed}});
-        TestCreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*#", {{NKikimrScheme::StatusSuccess}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*#", {{NKikimrScheme::StatusSuccess}});
         resultLogin = Login(runtime, "user12", "passwordu12*#");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
     }

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -37,12 +37,12 @@ struct TLoginProvider::TImpl {
 
 TLoginProvider::TLoginProvider()
     : Impl(new TImpl())
-    , PasswordChecker(TPasswordComplexitySettings())
+    , PasswordChecker(TPasswordComplexity())
 {}
 
-TLoginProvider::TLoginProvider(const TPasswordComplexitySettings& passwordComplexitySettings)
+TLoginProvider::TLoginProvider(const TPasswordComplexity& passwordComplexity)
     : Impl(new TImpl())
-    , PasswordChecker(passwordComplexitySettings)
+    , PasswordChecker(passwordComplexity)
 {}
 
 TLoginProvider::~TLoginProvider()
@@ -680,8 +680,8 @@ TString TLoginProvider::SanitizeJwtToken(const TString& token) {
     return TStringBuilder() << TStringBuf(token).SubString(0, signaturePos) << ".**"; // <token>.**
 }
 
-void TLoginProvider::UpdatePasswordCheckParameters(const TPasswordComplexitySettings& passwordCheckParameters) {
-    PasswordChecker.Update(passwordCheckParameters);
+void TLoginProvider::UpdatePasswordCheckParameters(const TPasswordComplexity& passwordComplexity) {
+    PasswordChecker.Update(passwordComplexity);
 }
 
 }

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -37,12 +37,12 @@ struct TLoginProvider::TImpl {
 
 TLoginProvider::TLoginProvider()
     : Impl(new TImpl())
-    , PasswordChecker(TPasswordCheckParameters())
+    , PasswordChecker(TPasswordComplexitySettings())
 {}
 
-TLoginProvider::TLoginProvider(const TPasswordCheckParameters& passwordCheckParameters)
+TLoginProvider::TLoginProvider(const TPasswordComplexitySettings& passwordComplexitySettings)
     : Impl(new TImpl())
-    , PasswordChecker(passwordCheckParameters)
+    , PasswordChecker(passwordComplexitySettings)
 {}
 
 TLoginProvider::~TLoginProvider()
@@ -680,7 +680,7 @@ TString TLoginProvider::SanitizeJwtToken(const TString& token) {
     return TStringBuilder() << TStringBuf(token).SubString(0, signaturePos) << ".**"; // <token>.**
 }
 
-void TLoginProvider::UpdatePasswordCheckParameters(const TPasswordCheckParameters& passwordCheckParameters) {
+void TLoginProvider::UpdatePasswordCheckParameters(const TPasswordComplexitySettings& passwordCheckParameters) {
     PasswordChecker.Update(passwordCheckParameters);
 }
 

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -174,10 +174,10 @@ public:
     TRenameGroupResponse RenameGroup(const TRenameGroupRequest& request);
     TRemoveGroupResponse RemoveGroup(const TRemoveGroupRequest& request);
 
-    void UpdatePasswordCheckParameters(const TPasswordComplexitySettings& passwordComplexitySettings);
+    void UpdatePasswordCheckParameters(const TPasswordComplexity& passwordComplexity);
 
     TLoginProvider();
-    TLoginProvider(const TPasswordComplexitySettings& passwordComplexitySettings);
+    TLoginProvider(const TPasswordComplexity& passwordComplexity);
     ~TLoginProvider();
 
     std::vector<TString> GetGroupsMembership(const TString& member);

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -174,10 +174,10 @@ public:
     TRenameGroupResponse RenameGroup(const TRenameGroupRequest& request);
     TRemoveGroupResponse RemoveGroup(const TRemoveGroupRequest& request);
 
-    void UpdatePasswordCheckParameters(const TPasswordCheckParameters& passwordCheckParameters);
+    void UpdatePasswordCheckParameters(const TPasswordComplexitySettings& passwordComplexitySettings);
 
     TLoginProvider();
-    TLoginProvider(const TPasswordCheckParameters& passwordCheckParameters);
+    TLoginProvider(const TPasswordComplexitySettings& passwordComplexitySettings);
     ~TLoginProvider();
 
     std::vector<TString> GetGroupsMembership(const TString& member);

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -7,6 +7,7 @@
 #include <deque>
 #include <util/generic/string.h>
 #include <ydb/library/login/protos/login.pb.h>
+#include <ydb/library/login/password_checker/password_checker.h>
 
 namespace NLogin {
 
@@ -174,6 +175,7 @@ public:
     TRemoveGroupResponse RemoveGroup(const TRemoveGroupRequest& request);
 
     TLoginProvider();
+    TLoginProvider(const TPasswordCheckParameters& passwordCheckParameters);
     ~TLoginProvider();
 
     std::vector<TString> GetGroupsMembership(const TString& member);
@@ -188,6 +190,8 @@ private:
 
     struct TImpl;
     THolder<TImpl> Impl;
+
+    TPasswordChecker PasswordChecker;
 };
 
 }

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -174,6 +174,8 @@ public:
     TRenameGroupResponse RenameGroup(const TRenameGroupRequest& request);
     TRemoveGroupResponse RemoveGroup(const TRemoveGroupRequest& request);
 
+    void UpdatePasswordCheckParameters(const TPasswordCheckParameters& passwordCheckParameters);
+
     TLoginProvider();
     TLoginProvider(const TPasswordCheckParameters& passwordCheckParameters);
     ~TLoginProvider();

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -80,6 +80,71 @@ Y_UNIT_TEST_SUITE(Login) {
         UNIT_ASSERT_VALUES_EQUAL(response3.Error, "Wrong audience");
     }
 
+    Y_UNIT_TEST(TestModifyUser) {
+        TLoginProvider provider;
+        provider.Audience = "test_audience1";
+        provider.RotateKeys();
+        TLoginProvider::TCreateUserRequest createUser1Request {
+            .User = "user1",
+            .Password = "password1"
+        };
+        auto createUser1Response = provider.CreateUser(createUser1Request);
+        UNIT_ASSERT(!createUser1Response.Error);
+        TLoginProvider::TLoginUserRequest loginUser1Request1 {
+            .User = createUser1Request.User,
+            .Password = createUser1Request.Password
+        };
+        auto loginUser1Response1 = provider.LoginUser(loginUser1Request1);
+        UNIT_ASSERT_VALUES_EQUAL(loginUser1Response1.Error, "");
+        TLoginProvider::TValidateTokenRequest validateUser1TokenRequest1 {
+            .Token = loginUser1Response1.Token
+        };
+        auto validateUser1TokenResponse1 = provider.ValidateToken(validateUser1TokenRequest1);
+        UNIT_ASSERT_VALUES_EQUAL(validateUser1TokenResponse1.Error, "");
+        UNIT_ASSERT(validateUser1TokenResponse1.User == createUser1Request.User);
+
+        TPasswordComplexity passwordComplexity({
+            .MinLength = 8,
+            .MinLowerCaseCount = 2,
+            .MinUpperCaseCount = 2,
+            .MinNumbersCount = 2,
+            .MinSpecialCharsCount = 2,
+            .SpecialChars = TPasswordComplexity::VALID_SPECIAL_CHARS
+        });
+
+        provider.UpdatePasswordCheckParameters(passwordComplexity);
+
+        TLoginProvider::TModifyUserRequest modifyUser1RequestBad {
+            .User = createUser1Request.User,
+            .Password = "UserPassword1"
+        };
+
+        TLoginProvider::TBasicResponse modifyUser1ResponseBad = provider.ModifyUser(modifyUser1RequestBad);
+        UNIT_ASSERT(!modifyUser1ResponseBad.Error.empty());
+        UNIT_ASSERT_STRINGS_EQUAL(modifyUser1ResponseBad.Error, "Incorrect password format: should contain at least 2 number, should contain at least 2 special character");
+
+        TLoginProvider::TModifyUserRequest modifyUser1Request {
+            .User = createUser1Request.User,
+            .Password = "paS*sw1oR#d7"
+        };
+
+        TLoginProvider::TBasicResponse modifyUser1Response = provider.ModifyUser(modifyUser1Request);
+        UNIT_ASSERT_VALUES_EQUAL(modifyUser1Response.Error, "");
+
+        TLoginProvider::TLoginUserRequest loginUser1Request2  = {
+            .User = modifyUser1Request.User,
+            .Password = modifyUser1Request.Password
+        };
+        TLoginProvider::TLoginUserResponse loginUser1Response2 = provider.LoginUser(loginUser1Request2);
+        UNIT_ASSERT_VALUES_EQUAL(loginUser1Response2.Error, "");
+        TLoginProvider::TValidateTokenRequest validateUser1TokenRequest2  = {
+            .Token = loginUser1Response2.Token
+        };
+        TLoginProvider::TValidateTokenResponse validateUser1TokenResponse2 = provider.ValidateToken(validateUser1TokenRequest2);
+        UNIT_ASSERT_VALUES_EQUAL(validateUser1TokenResponse2.Error, "");
+        UNIT_ASSERT(validateUser1TokenResponse2.User == createUser1Request.User);
+    }
+
     Y_UNIT_TEST(TestGroups) {
         TLoginProvider provider;
         provider.Audience = "test_audience1";

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -9,8 +9,7 @@ Y_UNIT_TEST_SUITE(Login) {
     void none() {}
 
     Y_UNIT_TEST(TestSuccessfulLogin1) {
-        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
-        TLoginProvider provider(passwordCheckParameters);
+        TLoginProvider provider;
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
@@ -31,8 +30,7 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestFailedLogin1) {
-        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
-        TLoginProvider provider(passwordCheckParameters);
+        TLoginProvider provider;
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
         request1.User = "user1";
@@ -47,8 +45,7 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestFailedLogin2) {
-        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
-        TLoginProvider provider(passwordCheckParameters);
+        TLoginProvider provider;
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
         request1.User = "user1";
@@ -63,8 +60,7 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestFailedLogin3) {
-        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
-        TLoginProvider provider(passwordCheckParameters);
+        TLoginProvider provider;
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
@@ -85,12 +81,11 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestGroups) {
-        TPasswordCheckParameters passwordCheckParameters; // Empty password is enabled by default
-        TLoginProvider provider(passwordCheckParameters);
+        TLoginProvider provider;
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         {
-            auto response1 = provider.CreateUser({.User = "user1"}); // Empty password
+            auto response1 = provider.CreateUser({.User = "user1"});
             UNIT_ASSERT(!response1.Error);
         }
         {
@@ -226,8 +221,7 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestTokenWithGroups) {
-        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
-        TLoginProvider provider(passwordCheckParameters);
+        TLoginProvider provider;
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         {
@@ -254,8 +248,7 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestCreateTokenForExternalAuth) {
-        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
-        TLoginProvider provider(passwordCheckParameters);
+        TLoginProvider provider;
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -1,5 +1,6 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/generic/algorithm.h>
+#include <ydb/library/login/password_checker/password_checker.h>
 #include "login.h"
 
 using namespace NLogin;
@@ -8,7 +9,8 @@ Y_UNIT_TEST_SUITE(Login) {
     void none() {}
 
     Y_UNIT_TEST(TestSuccessfulLogin1) {
-        TLoginProvider provider;
+        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
+        TLoginProvider provider(passwordCheckParameters);
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
@@ -29,7 +31,8 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestFailedLogin1) {
-        TLoginProvider provider;
+        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
+        TLoginProvider provider(passwordCheckParameters);
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
         request1.User = "user1";
@@ -44,7 +47,8 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestFailedLogin2) {
-        TLoginProvider provider;
+        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
+        TLoginProvider provider(passwordCheckParameters);
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
         request1.User = "user1";
@@ -59,7 +63,8 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestFailedLogin3) {
-        TLoginProvider provider;
+        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
+        TLoginProvider provider(passwordCheckParameters);
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;
@@ -80,11 +85,12 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestGroups) {
-        TLoginProvider provider;
+        TPasswordCheckParameters passwordCheckParameters; // Empty password is enabled by default
+        TLoginProvider provider(passwordCheckParameters);
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         {
-            auto response1 = provider.CreateUser({.User = "user1"});
+            auto response1 = provider.CreateUser({.User = "user1"}); // Empty password
             UNIT_ASSERT(!response1.Error);
         }
         {
@@ -220,7 +226,8 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestTokenWithGroups) {
-        TLoginProvider provider;
+        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
+        TLoginProvider provider(passwordCheckParameters);
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         {
@@ -247,7 +254,8 @@ Y_UNIT_TEST_SUITE(Login) {
     }
 
     Y_UNIT_TEST(TestCreateTokenForExternalAuth) {
-        TLoginProvider provider;
+        TPasswordCheckParameters passwordCheckParameters({.NeedUpperCase = false, .NeedSpecialSymbols = false});
+        TLoginProvider provider(passwordCheckParameters);
         provider.Audience = "test_audience1";
         provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request1;

--- a/ydb/library/login/password_checker/password_checker.cpp
+++ b/ydb/library/login/password_checker/password_checker.cpp
@@ -51,6 +51,39 @@ bool TPasswordCheckParameters::IsSpecialSymbolValid(char symbol) const {
     return SpecialSymbols.contains(symbol);
 }
 
+void TPasswordCheckParameters::SetMinPasswordLength(ui32 length) {
+    MinPasswordLength = length;
+}
+
+void TPasswordCheckParameters::SetMaxPasswordLength(ui32 length) {
+    MaxPasswordLength = length;
+}
+
+void TPasswordCheckParameters::SetLowerCaseUse(bool flag) {
+    NeedLowerCase = flag;
+}
+
+void TPasswordCheckParameters::SetUpperCaseUse(bool flag) {
+    NeedUpperCase = flag;
+}
+
+void TPasswordCheckParameters::SetNumbersUse(bool flag) {
+    NeedNumbers = flag;
+}
+
+void TPasswordCheckParameters::SetSpecialSymbolsUse(bool flag) {
+    NeedSpecialSymbols = flag;
+}
+
+void TPasswordCheckParameters::SetSpecialSymbols(const TString& specialSymbols) {
+    SpecialSymbols.clear();
+    for (const char symbol : specialSymbols) {
+        if (VALID_SPECIAL_SYMBOLS.contains(symbol)) {
+            SpecialSymbols.insert(symbol);
+        }
+    }
+}
+
 const std::unordered_set<char> TPasswordCheckParameters::VALID_SPECIAL_SYMBOLS = {'!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '{', '}', '|', '<', '>', '?', '='};
 
 void TPasswordChecker::TFlagsStore::SetLowerCase(bool flag) {
@@ -151,6 +184,10 @@ TPasswordChecker::TResult TPasswordChecker::Check(const TString& username, const
         return {.Success = false, .Error = errorMessage};
     }
     return {.Success = true};
+}
+
+void TPasswordChecker::Update(const TPasswordCheckParameters& checkParameters) {
+    CheckParameters = checkParameters;
 }
 
 } // NLogin

--- a/ydb/library/login/password_checker/password_checker.cpp
+++ b/ydb/library/login/password_checker/password_checker.cpp
@@ -1,0 +1,161 @@
+#include <cctype>
+#include <util/string/builder.h>
+#include "password_checker.h"
+
+namespace NLogin {
+
+TPasswordCheckParameters::TPasswordCheckParameters()
+    : SpecialSymbols(VALID_SPECIAL_SYMBOLS)
+{}
+
+TPasswordCheckParameters::TPasswordCheckParameters(const TInitializer& initializer)
+    : MinPasswordLength(initializer.MinPasswordLength)
+    , MaxPasswordLength(initializer.MaxPasswordLength)
+    , NeedLowerCase(initializer.NeedLowerCase)
+    , NeedUpperCase(initializer.NeedUpperCase)
+    , NeedNumbers(initializer.NeedNumbers)
+    , NeedSpecialSymbols(initializer.NeedSpecialSymbols)
+    , EnableEmptyPassword((MinPasswordLength == 0 ? true : initializer.EnableEmptyPassword))
+{
+    for (const char symbol : initializer.SpecialSymbols) {
+        if (VALID_SPECIAL_SYMBOLS.contains(symbol)) {
+            SpecialSymbols.insert(symbol);
+        }
+    }
+}
+
+ui32 TPasswordCheckParameters::GetMinPasswordLength() const {
+    return MinPasswordLength;
+}
+
+ui32 TPasswordCheckParameters::GetMaxPasswordLength() const {
+    return MaxPasswordLength;
+}
+
+bool TPasswordCheckParameters::NeedLowerCaseUse() const {
+    return NeedLowerCase;
+}
+
+bool TPasswordCheckParameters::NeedUpperCaseUse() const {
+    return NeedUpperCase;
+}
+
+bool TPasswordCheckParameters::NeedNumbersUse() const {
+    return NeedNumbers;
+}
+
+bool TPasswordCheckParameters::NeedSpecialSymbolsUse() const {
+    return NeedSpecialSymbols;
+}
+
+bool TPasswordCheckParameters::IsEmptyPasswordEnable() const {
+    return EnableEmptyPassword;
+}
+
+bool TPasswordCheckParameters::IsSpecialSymbolValid(char symbol) const {
+    return SpecialSymbols.contains(symbol);
+}
+
+const std::unordered_set<char> TPasswordCheckParameters::VALID_SPECIAL_SYMBOLS = {'!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '{', '}', '|', '<', '>', '?', '='};
+
+void TPasswordChecker::TFlagsStore::SetLowerCase(bool flag) {
+    LowerCase = flag;
+}
+
+void TPasswordChecker::TFlagsStore::SetUpperCase(bool flag) {
+    UpperCase = flag;
+}
+
+void TPasswordChecker::TFlagsStore::SetNumber(bool flag) {
+    Number = flag;
+}
+
+void TPasswordChecker::TFlagsStore::SetSpecialSymbol(bool flag) {
+    SpecialSymbol = flag;
+}
+
+bool TPasswordChecker::TFlagsStore::HasLowerCase() const {
+    return LowerCase;
+}
+
+bool TPasswordChecker::TFlagsStore::HasUpperCase() const {
+    return UpperCase;
+}
+
+bool TPasswordChecker::TFlagsStore::HasNumber() const {
+    return Number;
+}
+
+bool TPasswordChecker::TFlagsStore::HasSpecialSymbol() const {
+    return SpecialSymbol;
+}
+
+TPasswordChecker::TPasswordChecker(const TPasswordCheckParameters& checkParameters)
+    : CheckParameters(checkParameters)
+{}
+
+TPasswordChecker::TResult TPasswordChecker::Check(const TString& username, const TString& password) const {
+    if (CheckParameters.IsEmptyPasswordEnable() && password.empty()) {
+        return {.Success = true};
+    }
+    if (password.length() < CheckParameters.GetMinPasswordLength()) {
+        return {.Success = false, .Error = "Password is too short"};
+    }
+    if (password.length() > CheckParameters.GetMaxPasswordLength()) {
+        return {.Success = false, .Error = "Password is too long"};
+    }
+    if (password.Contains(username)) {
+        return {.Success = false, .Error = "Password must not contain user name"};
+    }
+
+    TFlagsStore passwordFlags;
+    for (const char& symbol : password) {
+        if (std::islower(static_cast<unsigned char>(symbol))) {
+            passwordFlags.SetLowerCase(true);
+        } else if (std::isupper(static_cast<unsigned char>(symbol))) {
+            passwordFlags.SetUpperCase(true);
+        } else if (std::isdigit(static_cast<unsigned char>(symbol))) {
+            passwordFlags.SetNumber(true);
+        } else if (CheckParameters.IsSpecialSymbolValid(symbol)) {
+            passwordFlags.SetSpecialSymbol(true);
+        } else {
+            return {.Success = false, .Error = "Password contains unacceptable characters"};
+        }
+    }
+
+    TStringBuilder errorMessage;
+    errorMessage << "Incorrect password format: ";
+    bool hasError = false;
+    if (!passwordFlags.HasLowerCase() && CheckParameters.NeedLowerCaseUse()) {
+        errorMessage << "lower case character is missing";
+        hasError = true;
+    }
+    if (!passwordFlags.HasUpperCase() && CheckParameters.NeedUpperCaseUse()) {
+        if (hasError) {
+            errorMessage << ", ";
+        }
+        errorMessage << "upper case character is missing";
+        hasError = true;
+    }
+    if (!passwordFlags.HasNumber() && CheckParameters.NeedNumbersUse()) {
+        if (hasError) {
+            errorMessage << ", ";
+        }
+        errorMessage << "number is missing";
+        hasError = true;
+    }
+    if (!passwordFlags.HasSpecialSymbol() && CheckParameters.NeedSpecialSymbolsUse()) {
+        if (hasError) {
+            errorMessage << ", ";
+        }
+        errorMessage << "special character is missing";
+        hasError = true;
+    }
+
+    if (hasError) {
+        return {.Success = false, .Error = errorMessage};
+    }
+    return {.Success = true};
+}
+
+} // NLogin

--- a/ydb/library/login/password_checker/password_checker.cpp
+++ b/ydb/library/login/password_checker/password_checker.cpp
@@ -15,7 +15,6 @@ TPasswordCheckParameters::TPasswordCheckParameters(const TInitializer& initializ
     , NeedUpperCase(initializer.NeedUpperCase)
     , NeedNumbers(initializer.NeedNumbers)
     , NeedSpecialSymbols(initializer.NeedSpecialSymbols)
-    , EnableEmptyPassword((MinPasswordLength == 0 ? true : initializer.EnableEmptyPassword))
 {
     for (const char symbol : initializer.SpecialSymbols) {
         if (VALID_SPECIAL_SYMBOLS.contains(symbol)) {
@@ -46,10 +45,6 @@ bool TPasswordCheckParameters::NeedNumbersUse() const {
 
 bool TPasswordCheckParameters::NeedSpecialSymbolsUse() const {
     return NeedSpecialSymbols;
-}
-
-bool TPasswordCheckParameters::IsEmptyPasswordEnable() const {
-    return EnableEmptyPassword;
 }
 
 bool TPasswordCheckParameters::IsSpecialSymbolValid(char symbol) const {
@@ -95,7 +90,7 @@ TPasswordChecker::TPasswordChecker(const TPasswordCheckParameters& checkParamete
 {}
 
 TPasswordChecker::TResult TPasswordChecker::Check(const TString& username, const TString& password) const {
-    if (CheckParameters.IsEmptyPasswordEnable() && password.empty()) {
+    if (password.empty() && CheckParameters.GetMinPasswordLength() == 0) {
         return {.Success = true};
     }
     if (password.length() < CheckParameters.GetMinPasswordLength()) {

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -6,7 +6,7 @@
 
 namespace NLogin {
 
-class TPasswordComplexitySettings {
+class TPasswordComplexity {
 public:
     struct TInitializer {
         size_t MinLength = 0;
@@ -28,8 +28,8 @@ public:
     std::unordered_set<char> SpecialChars;
     bool CanContainUsername = false;
 
-    TPasswordComplexitySettings();
-    TPasswordComplexitySettings(const TInitializer& initializer);
+    TPasswordComplexity();
+    TPasswordComplexity(const TInitializer& initializer);
 
     bool IsSpecialCharValid(char ch) const;
 };
@@ -49,10 +49,10 @@ private:
         size_t NumbersCount = 0;
         size_t SpecialCharsCount = 0;
 
-        const TPasswordComplexitySettings& ComplexitySettings;
+        const TPasswordComplexity& PasswordComplexity;
 
     public:
-        TComplexityState(const TPasswordComplexitySettings& complexitySettings);
+        TComplexityState(const TPasswordComplexity& passwordComplexity);
 
         void IncLowerCaseCount();
         void IncUpperCaseCount();
@@ -66,12 +66,12 @@ private:
     };
 
 private:
-    TPasswordComplexitySettings ComplexitySettings;
+    TPasswordComplexity PasswordComplexity;
 
 public:
-    TPasswordChecker(const TPasswordComplexitySettings& complexitySettings);
+    TPasswordChecker(const TPasswordComplexity& passwordComplexity);
     TResult Check(const TString& username, const TString& password) const;
-    void Update(const TPasswordComplexitySettings& checkParameters);
+    void Update(const TPasswordComplexity& passwordComplexity);
 };
 
 } // NLogin

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -2,53 +2,36 @@
 
 #include <util/system/types.h>
 #include <util/generic/string.h>
-#include <limits>
 #include <unordered_set>
 
 namespace NLogin {
 
-class TPasswordCheckParameters {
+class TPasswordComplexitySettings {
 public:
     struct TInitializer {
-        ui32 MinPasswordLength = 0;
-        ui32 MaxPasswordLength = std::numeric_limits<ui32>::max();
-        bool NeedLowerCase = false;
-        bool NeedUpperCase = false;
-        bool NeedNumbers = false;
-        bool NeedSpecialSymbols = false;
-        TString SpecialSymbols;
+        size_t MinLength = 0;
+        size_t MinLowerCaseCount = 0;
+        size_t MinUpperCaseCount = 0;
+        size_t MinNumbersCount = 0;
+        size_t MinSpecialCharsCount = 0;
+        TString SpecialChars = VALID_SPECIAL_CHARS;
+        bool CanContainUsername = false;
     };
 
-    static const std::unordered_set<char> VALID_SPECIAL_SYMBOLS;
+    static const TString VALID_SPECIAL_CHARS;
 
-private:
-    ui32 MinPasswordLength = 0;
-    ui32 MaxPasswordLength = std::numeric_limits<ui32>::max();
-    bool NeedLowerCase = false;
-    bool NeedUpperCase = false;
-    bool NeedNumbers = false;
-    bool NeedSpecialSymbols = false;
-    std::unordered_set<char> SpecialSymbols;
+    size_t MinLength = 0;
+    size_t MinLowerCaseCount = 0;
+    size_t MinUpperCaseCount = 0;
+    size_t MinNumbersCount = 0;
+    size_t MinSpecialCharsCount = 0;
+    std::unordered_set<char> SpecialChars;
+    bool CanContainUsername = false;
 
-public:
-    TPasswordCheckParameters();
-    TPasswordCheckParameters(const TInitializer& initializer);
+    TPasswordComplexitySettings();
+    TPasswordComplexitySettings(const TInitializer& initializer);
 
-    ui32 GetMinPasswordLength() const;
-    ui32 GetMaxPasswordLength() const;
-    bool NeedLowerCaseUse() const;
-    bool NeedUpperCaseUse() const;
-    bool NeedNumbersUse() const;
-    bool NeedSpecialSymbolsUse() const;
-    bool IsSpecialSymbolValid(char symbol) const;
-
-    void SetMinPasswordLength(ui32 length);
-    void SetMaxPasswordLength(ui32 length);
-    void SetLowerCaseUse(bool flag);
-    void SetUpperCaseUse(bool flag);
-    void SetNumbersUse(bool flag);
-    void SetSpecialSymbolsUse(bool flag);
-    void SetSpecialSymbols(const TString& specialSymbols);
+    bool IsSpecialCharValid(char ch) const;
 };
 
 class TPasswordChecker {
@@ -59,32 +42,36 @@ public:
     };
 
 private:
-    class TFlagsStore {
+    class TComplexityState {
     private:
-        bool LowerCase = false;
-        bool UpperCase = false;
-        bool Number = false;
-        bool SpecialSymbol = false;
+        size_t LowerCaseCount = 0;
+        size_t UpperCaseCount = 0;
+        size_t NumbersCount = 0;
+        size_t SpecialCharsCount = 0;
+
+        const TPasswordComplexitySettings& ComplexitySettings;
 
     public:
-        void SetLowerCase(bool flag);
-        void SetUpperCase(bool flag);
-        void SetNumber(bool flag);
-        void SetSpecialSymbol(bool flag);
+        TComplexityState(const TPasswordComplexitySettings& complexitySettings);
 
-        bool HasLowerCase() const;
-        bool HasUpperCase() const;
-        bool HasNumber() const;
-        bool HasSpecialSymbol() const;
+        void IncLowerCaseCount();
+        void IncUpperCaseCount();
+        void IncNumbersCount();
+        void IncSpecialCharsCount();
+
+        bool CheckLowerCaseCount() const;
+        bool CheckUpperCaseCount() const;
+        bool CheckNumbersCount() const;
+        bool CheckSpecialCharsCount() const;
     };
 
 private:
-    TPasswordCheckParameters CheckParameters;
+    TPasswordComplexitySettings ComplexitySettings;
 
 public:
-    TPasswordChecker(const TPasswordCheckParameters& checkParameters);
+    TPasswordChecker(const TPasswordComplexitySettings& complexitySettings);
     TResult Check(const TString& username, const TString& password) const;
-    void Update(const TPasswordCheckParameters& checkParameters);
+    void Update(const TPasswordComplexitySettings& checkParameters);
 };
 
 } // NLogin

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <util/system/types.h>
+#include <util/generic/string.h>
+#include <unordered_set>
+
+namespace NLogin {
+
+class TPasswordCheckParameters {
+public:
+    struct TInitializer {
+        ui32 MinPasswordLength = 8;
+        ui32 MaxPasswordLength = 16;
+        bool NeedLowerCase = true;
+        bool NeedUpperCase = true;
+        bool NeedNumbers = true;
+        bool NeedSpecialSymbols = true;
+        std::unordered_set<char> SpecialSymbols = VALID_SPECIAL_SYMBOLS;
+        bool EnableEmptyPassword = true;
+    };
+
+private:
+    static const std::unordered_set<char> VALID_SPECIAL_SYMBOLS;
+
+    ui32 MinPasswordLength = 8;
+    ui32 MaxPasswordLength = 16;
+    bool NeedLowerCase = true;
+    bool NeedUpperCase = true;
+    bool NeedNumbers = true;
+    bool NeedSpecialSymbols = true;
+    std::unordered_set<char> SpecialSymbols;
+    bool EnableEmptyPassword = true;
+
+public:
+    TPasswordCheckParameters();
+    TPasswordCheckParameters(const TInitializer& initializer);
+
+    ui32 GetMinPasswordLength() const;
+    ui32 GetMaxPasswordLength() const;
+    bool NeedLowerCaseUse() const;
+    bool NeedUpperCaseUse() const;
+    bool NeedNumbersUse() const;
+    bool NeedSpecialSymbolsUse() const;
+    bool IsEmptyPasswordEnable() const;
+    bool IsSpecialSymbolValid(char symbol) const;
+};
+
+class TPasswordChecker {
+public:
+    struct TResult {
+        bool Success = true;
+        TString Error;
+    };
+
+private:
+    class TFlagsStore {
+    private:
+        bool LowerCase = false;
+        bool UpperCase = false;
+        bool Number = false;
+        bool SpecialSymbol = false;
+
+    public:
+        void SetLowerCase(bool flag);
+        void SetUpperCase(bool flag);
+        void SetNumber(bool flag);
+        void SetSpecialSymbol(bool flag);
+
+        bool HasLowerCase() const;
+        bool HasUpperCase() const;
+        bool HasNumber() const;
+        bool HasSpecialSymbol() const;
+    };
+
+private:
+    TPasswordCheckParameters CheckParameters;
+
+public:
+    TPasswordChecker(const TPasswordCheckParameters& checkParameters);
+    TResult Check(const TString& username, const TString& password) const;
+};
+
+} // NLogin

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -15,7 +15,7 @@ public:
         bool NeedUpperCase = true;
         bool NeedNumbers = true;
         bool NeedSpecialSymbols = true;
-        std::unordered_set<char> SpecialSymbols = VALID_SPECIAL_SYMBOLS;
+        TString SpecialSymbols;
         bool EnableEmptyPassword = true;
     };
 

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -10,7 +10,7 @@ class TPasswordCheckParameters {
 public:
     struct TInitializer {
         ui32 MinPasswordLength = 8;
-        ui32 MaxPasswordLength = 16;
+        ui32 MaxPasswordLength = 15;
         bool NeedLowerCase = true;
         bool NeedUpperCase = true;
         bool NeedNumbers = true;
@@ -23,7 +23,7 @@ private:
     static const std::unordered_set<char> VALID_SPECIAL_SYMBOLS;
 
     ui32 MinPasswordLength = 8;
-    ui32 MaxPasswordLength = 16;
+    ui32 MaxPasswordLength = 15;
     bool NeedLowerCase = true;
     bool NeedUpperCase = true;
     bool NeedNumbers = true;

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -19,9 +19,9 @@ public:
         TString SpecialSymbols;
     };
 
-private:
     static const std::unordered_set<char> VALID_SPECIAL_SYMBOLS;
 
+private:
     ui32 MinPasswordLength = 0;
     ui32 MaxPasswordLength = std::numeric_limits<ui32>::max();
     bool NeedLowerCase = false;
@@ -41,6 +41,14 @@ public:
     bool NeedNumbersUse() const;
     bool NeedSpecialSymbolsUse() const;
     bool IsSpecialSymbolValid(char symbol) const;
+
+    void SetMinPasswordLength(ui32 length);
+    void SetMaxPasswordLength(ui32 length);
+    void SetLowerCaseUse(bool flag);
+    void SetUpperCaseUse(bool flag);
+    void SetNumbersUse(bool flag);
+    void SetSpecialSymbolsUse(bool flag);
+    void SetSpecialSymbols(const TString& specialSymbols);
 };
 
 class TPasswordChecker {
@@ -76,6 +84,7 @@ private:
 public:
     TPasswordChecker(const TPasswordCheckParameters& checkParameters);
     TResult Check(const TString& username, const TString& password) const;
+    void Update(const TPasswordCheckParameters& checkParameters);
 };
 
 } // NLogin

--- a/ydb/library/login/password_checker/password_checker.h
+++ b/ydb/library/login/password_checker/password_checker.h
@@ -2,6 +2,7 @@
 
 #include <util/system/types.h>
 #include <util/generic/string.h>
+#include <limits>
 #include <unordered_set>
 
 namespace NLogin {
@@ -9,27 +10,25 @@ namespace NLogin {
 class TPasswordCheckParameters {
 public:
     struct TInitializer {
-        ui32 MinPasswordLength = 8;
-        ui32 MaxPasswordLength = 15;
-        bool NeedLowerCase = true;
-        bool NeedUpperCase = true;
-        bool NeedNumbers = true;
-        bool NeedSpecialSymbols = true;
+        ui32 MinPasswordLength = 0;
+        ui32 MaxPasswordLength = std::numeric_limits<ui32>::max();
+        bool NeedLowerCase = false;
+        bool NeedUpperCase = false;
+        bool NeedNumbers = false;
+        bool NeedSpecialSymbols = false;
         TString SpecialSymbols;
-        bool EnableEmptyPassword = true;
     };
 
 private:
     static const std::unordered_set<char> VALID_SPECIAL_SYMBOLS;
 
-    ui32 MinPasswordLength = 8;
-    ui32 MaxPasswordLength = 15;
-    bool NeedLowerCase = true;
-    bool NeedUpperCase = true;
-    bool NeedNumbers = true;
-    bool NeedSpecialSymbols = true;
+    ui32 MinPasswordLength = 0;
+    ui32 MaxPasswordLength = std::numeric_limits<ui32>::max();
+    bool NeedLowerCase = false;
+    bool NeedUpperCase = false;
+    bool NeedNumbers = false;
+    bool NeedSpecialSymbols = false;
     std::unordered_set<char> SpecialSymbols;
-    bool EnableEmptyPassword = true;
 
 public:
     TPasswordCheckParameters();
@@ -41,7 +40,6 @@ public:
     bool NeedUpperCaseUse() const;
     bool NeedNumbersUse() const;
     bool NeedSpecialSymbolsUse() const;
-    bool IsEmptyPasswordEnable() const;
     bool IsSpecialSymbolValid(char symbol) const;
 };
 

--- a/ydb/library/login/password_checker/password_checker_ut.cpp
+++ b/ydb/library/login/password_checker/password_checker_ut.cpp
@@ -1,6 +1,5 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/string/builder.h>
-#include <unordered_set>
 #include "password_checker.h"
 
 using namespace NLogin;
@@ -8,16 +7,16 @@ using namespace NLogin;
 Y_UNIT_TEST_SUITE(PasswordChecker) {
 
     Y_UNIT_TEST(CheckCorrectPasswordWithMaxComplexity) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinLength = 8,
             .MinLowerCaseCount = 2,
             .MinUpperCaseCount = 2,
             .MinNumbersCount = 2,
             .MinSpecialCharsCount = 2,
-            .SpecialChars = TPasswordComplexitySettings::VALID_SPECIAL_CHARS,
+            .SpecialChars = TPasswordComplexity::VALID_SPECIAL_CHARS,
             .CanContainUsername = false
         });
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "qwer%Bs7*S4";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
@@ -26,8 +25,8 @@ Y_UNIT_TEST_SUITE(PasswordChecker) {
     }
 
     Y_UNIT_TEST(CannotAcceptTooShortPassword) {
-        TPasswordComplexitySettings complexitySettings({.MinLength = 8});
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordComplexity passwordComplexity({.MinLength = 8});
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "abcd"; // Short password
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
@@ -36,8 +35,8 @@ Y_UNIT_TEST_SUITE(PasswordChecker) {
     }
 
     Y_UNIT_TEST(PasswordCannotContainUsername) {
-        TPasswordComplexitySettings complexitySettings({.CanContainUsername = false});
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordComplexity passwordComplexity({.CanContainUsername = false});
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "123testuserqqq";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
@@ -46,64 +45,64 @@ Y_UNIT_TEST_SUITE(PasswordChecker) {
     }
 
     Y_UNIT_TEST(CannotAcceptPasswordWithoutLowerCaseCharacters) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinLowerCaseCount = 4
         });
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "12345$*QWERTY";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
         UNIT_ASSERT_C(!result.Success, "Must be error");
         UNIT_ASSERT_STRINGS_EQUAL(result.Error, TStringBuilder() << "Incorrect password format: should contain at least "
-                                                                 << complexitySettings.MinLowerCaseCount
+                                                                 << passwordComplexity.MinLowerCaseCount
                                                                  << " lower case character");
     }
 
     Y_UNIT_TEST(CannotAcceptPasswordWithoutUpperCaseCharacters) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinUpperCaseCount = 4
         });
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "12345$*qwerty";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
         UNIT_ASSERT_C(!result.Success, "Must be error");
         UNIT_ASSERT_STRINGS_EQUAL(result.Error, TStringBuilder() << "Incorrect password format: should contain at least "
-                                                                 << complexitySettings.MinUpperCaseCount
+                                                                 << passwordComplexity.MinUpperCaseCount
                                                                  << " upper case character");
     }
 
     Y_UNIT_TEST(CannotAcceptPasswordWithoutNumbers) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinNumbersCount = 4
         });
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "ASDF$*qwerty";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
         UNIT_ASSERT_C(!result.Success, "Must be error");
         UNIT_ASSERT_STRINGS_EQUAL(result.Error, TStringBuilder() << "Incorrect password format: should contain at least "
-                                                                 << complexitySettings.MinNumbersCount
+                                                                 << passwordComplexity.MinNumbersCount
                                                                  << " number");
     }
 
     Y_UNIT_TEST(CannotAcceptPasswordWithoutSpecialCharacters) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinSpecialCharsCount = 4
         });
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "ASDF42qwerty";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
         UNIT_ASSERT_C(!result.Success, "Must be error");
         UNIT_ASSERT_STRINGS_EQUAL(result.Error, TStringBuilder() << "Incorrect password format: should contain at least "
-                                                                 << complexitySettings.MinSpecialCharsCount
+                                                                 << passwordComplexity.MinSpecialCharsCount
                                                                  << " special character");
     }
 
     Y_UNIT_TEST(CannotAcceptPasswordWithInvalidCharacters) {
-        TPasswordComplexitySettings complexitySettings;
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordComplexity passwordComplexity;
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "ASDF42*qwerty~~"; // ~ is invalid character
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
@@ -112,28 +111,28 @@ Y_UNIT_TEST_SUITE(PasswordChecker) {
     }
 
     Y_UNIT_TEST(CannotAcceptPasswordWithoutLowerCaseAndSpecialCharacters) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinLowerCaseCount = 2, .MinSpecialCharsCount = 2
         });
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "ASDF42Q6S7D8";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
         UNIT_ASSERT_C(!result.Success, "Must be error");
         UNIT_ASSERT_STRINGS_EQUAL(result.Error, TStringBuilder() << "Incorrect password format: should contain at least "
-                                                                 << complexitySettings.MinLowerCaseCount
+                                                                 << passwordComplexity.MinLowerCaseCount
                                                                  << " lower case character, should contain at least "
-                                                                 << complexitySettings.MinSpecialCharsCount
+                                                                 << passwordComplexity.MinSpecialCharsCount
                                                                  << " special character");
     }
 
     Y_UNIT_TEST(AcceptPasswordWithCustomSpecialCharactersList) {
         TString customSpecialCharacters = "!&*"; // Only 3 special symbols are accepted
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinSpecialCharsCount = 2,
             .SpecialChars = customSpecialCharacters
         });
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString correctPassword = "pass45!WOR*d";
         TPasswordChecker::TResult result = passwordChecker.Check(username, correctPassword);
@@ -146,10 +145,10 @@ Y_UNIT_TEST_SUITE(PasswordChecker) {
     }
 
     Y_UNIT_TEST(AcceptEmptyPassword) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinLength = 0
         }); // Enable empty password by set MinLength as 0
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
@@ -158,10 +157,10 @@ Y_UNIT_TEST_SUITE(PasswordChecker) {
     }
 
     Y_UNIT_TEST(CannotAcceptEmptyPassword) {
-        TPasswordComplexitySettings complexitySettings({
+        TPasswordComplexity passwordComplexity({
             .MinLength = 8
         }); // Disable empty password, min length is 8
-        TPasswordChecker passwordChecker(complexitySettings);
+        TPasswordChecker passwordChecker(passwordComplexity);
         TString username = "testuser";
         TString password = "";
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);

--- a/ydb/library/login/password_checker/password_checker_ut.cpp
+++ b/ydb/library/login/password_checker/password_checker_ut.cpp
@@ -1,0 +1,160 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <unordered_set>
+#include "password_checker.h"
+
+using namespace NLogin;
+
+Y_UNIT_TEST_SUITE(PasswordChecker) {
+
+    Y_UNIT_TEST(CheckCorrectPassword) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        // Correct password has:
+        //  lower case
+        //  upper case
+        //  numbers
+        //  special symbols from list !@#$%^&*()_+{}|<>?=
+        //  length from 8 to 16 characters
+        TString password = "qwer%Bs7*S";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(result.Success, "Must not be error");
+        UNIT_ASSERT(result.Error.empty());
+    }
+
+    Y_UNIT_TEST(CannotAcceptTooShortPassword) {
+        TPasswordCheckParameters checkParameters({.MinPasswordLength = 8});
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "abcd"; // Short password
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Password is too short");
+    }
+
+    Y_UNIT_TEST(CannotAcceptTooLongPassword) {
+        TPasswordCheckParameters checkParameters({.MaxPasswordLength = 10});
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "abcd123456789"; // Long password
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Password is too long");
+    }
+
+    Y_UNIT_TEST(PasswordCannotContainUsername) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "123testuserqqq";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Password must not contain user name");
+    }
+
+    Y_UNIT_TEST(CannotAcceptPasswordWithoutLowerCaseCharacters) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "12345$*QWERTY";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Incorrect password format: lower case character is missing");
+    }
+
+    Y_UNIT_TEST(CannotAcceptPasswordWithoutUpperCaseCharacters) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "12345$*qwerty";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Incorrect password format: upper case character is missing");
+    }
+
+    Y_UNIT_TEST(CannotAcceptPasswordWithoutNumbers) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "ASDF$*qwerty";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Incorrect password format: number is missing");
+    }
+
+    Y_UNIT_TEST(CannotAcceptPasswordWithoutSpecialSymbols) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "ASDF42qwerty";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Incorrect password format: special character is missing");
+    }
+
+    Y_UNIT_TEST(CannotAcceptPasswordWithInvalidCharacters) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "ASDF42*qwerty~~";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Password contains unacceptable characters");
+    }
+
+    Y_UNIT_TEST(CannotAcceptPasswordWithoutLowerCaseAndSpecialSymbols) {
+        TPasswordCheckParameters checkParameters;
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "ASDF42Q6S7D8";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Incorrect password format: lower case character is missing, special character is missing");
+    }
+
+    Y_UNIT_TEST(AcceptPasswordWithCustomSpecialSymbolsList) {
+        std::unordered_set<char> customSpecialSymbols {'!', '&', '*'}; // Only 3 special symbols are accepted
+        TPasswordCheckParameters checkParameters({.SpecialSymbols = customSpecialSymbols});
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString correctPassword = "pass45!WOR*d";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, correctPassword);
+        UNIT_ASSERT_C(result.Success, "Must not be error");
+        UNIT_ASSERT(result.Error.empty());
+
+        result = passwordChecker.Check(username, "pass45!WOR$d"); // '$' incorrect symbol
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Password contains unacceptable characters");
+    }
+
+    Y_UNIT_TEST(AcceptEmptyPasswordByEnableSpecialFlag) {
+        TPasswordCheckParameters checkParameters({.EnableEmptyPassword = true}); // Enable empty password, min length is 8
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(result.Success, "Must not be error");
+        UNIT_ASSERT(result.Error.empty());
+    }
+
+    Y_UNIT_TEST(AcceptEmptyPasswordBySetMinPasswordLengthAsZero) {
+        TPasswordCheckParameters checkParameters({.MinPasswordLength = 0, .EnableEmptyPassword = false}); // Enable empty password by set MinPasswordLength as 0
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(result.Success, "Must not be error");
+        UNIT_ASSERT(result.Error.empty());
+    }
+
+    Y_UNIT_TEST(CannotAcceptEmptyPassword) {
+        TPasswordCheckParameters checkParameters({.EnableEmptyPassword = false}); // Disable empty password, min length is 8
+        TPasswordChecker passwordChecker(checkParameters);
+        TString username = "testuser";
+        TString password = "";
+        TPasswordChecker::TResult result = passwordChecker.Check(username, password);
+        UNIT_ASSERT_C(!result.Success, "Must be error");
+        UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Password is too short");
+    }
+
+}

--- a/ydb/library/login/password_checker/password_checker_ut.cpp
+++ b/ydb/library/login/password_checker/password_checker_ut.cpp
@@ -102,7 +102,7 @@ Y_UNIT_TEST_SUITE(PasswordChecker) {
         TPasswordCheckParameters checkParameters({.SpecialSymbols = VALID_SPECIAL_SYMBOLS});
         TPasswordChecker passwordChecker(checkParameters);
         TString username = "testuser";
-        TString password = "ASDF42*qwerty~~";
+        TString password = "ASDF42*qwerty~~"; // ~ is invalid character
         TPasswordChecker::TResult result = passwordChecker.Check(username, password);
         UNIT_ASSERT_C(!result.Success, "Must be error");
         UNIT_ASSERT_STRINGS_EQUAL(result.Error, "Password contains unacceptable characters");

--- a/ydb/library/login/password_checker/ut/ya.make
+++ b/ydb/library/login/password_checker/ut/ya.make
@@ -1,0 +1,9 @@
+UNITTEST_FOR(ydb/library/login/password_checker)
+
+PEERDIR()
+
+SRCS(
+    password_checker_ut.cpp
+)
+
+END()

--- a/ydb/library/login/password_checker/ya.make
+++ b/ydb/library/login/password_checker/ya.make
@@ -1,0 +1,13 @@
+LIBRARY()
+
+PEERDIR()
+
+SRCS(
+    password_checker.cpp
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/library/login/ya.make
+++ b/ydb/library/login/ya.make
@@ -7,6 +7,7 @@ PEERDIR(
     library/cpp/json
     library/cpp/string_utils/base64
     ydb/library/login/protos
+    ydb/library/login/password_checker
 )
 
 SRCS(
@@ -18,4 +19,8 @@ END()
 
 RECURSE_FOR_TESTS(
     ut
+)
+
+RECURSE(
+    password_checker
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Added the ability to check users' passwords whenever they are set with `CREATE USER` and `ALTER USER`
Were added following checks:
- Minimum password length
- Passwords must include a lowercase character
- Passwords must include an uppercase character
- Passwords must include a number
- Passwords must include a special character from list `!@#$%^&*()_+{}|<>?=`
All checks can be enabled or disabled over configuration

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
