### PR TITLE
Add YDB CLI folders to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,3 +47,6 @@
 /ydb/core/formats/arrow @ydb-platform/cs
 /ydb/core/tx/columnshard @ydb-platform/cs
 
+/ydb/apps/ydb @ydb-platform/cli
+/ydb/public/lib/ydb_cli @ydb-platform/cli
+


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Additional information
Add YDB CLI folders to CODEOWNERS so that @ydb-platform/cli command would be required to review changes in these folders