### PR TITLE
Simply request all pages in Scan from Shared Cache

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -558,7 +558,6 @@ class TExecutor
     void Handle(TEvents::TEvFlushLog::TPtr &ev);
     void Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr&);
     void Handle(NSharedCache::TEvResult::TPtr &ev);
-    void Handle(NSharedCache::TEvRequest::TPtr &ev);
     void Handle(NSharedCache::TEvUpdated::TPtr &ev);
     void Handle(NResourceBroker::TEvResourceBroker::TEvResourceAllocated::TPtr&);
     void Handle(NOps::TEvScanStat::TPtr &ev, const TActorContext &ctx);

--- a/ydb/core/tablet_flat/flat_scan_actor.h
+++ b/ydb/core/tablet_flat/flat_scan_actor.h
@@ -484,13 +484,7 @@ namespace NOps {
                     if (auto logl = Logger->Log(ELnLev::Debug))
                         logl << NFmt::Do(*this) << " " << NFmt::Do(*req);
 
-                    const auto label = req->PageCollection->Label();
-                    if (PrivateCollections.contains(label)) {
-                        Send(MakeSharedPageCacheId(), new NSharedCache::TEvRequest(Args.ReadPrio, req, SelfId()));
-                        ForwardedSharedRequests = true;
-                    } else {
-                        SendToOwner(new NSharedCache::TEvRequest(Args.ReadPrio, req, Owner), true);
-                    }
+                    Send(MakeSharedPageCacheId(), new NSharedCache::TEvRequest(Args.ReadPrio, req, SelfId()));
                 }
 
                 if (ready == NTable::EReady::Page)
@@ -574,7 +568,6 @@ namespace NOps {
                 MakeSharedPageCacheId(),
                 new NSharedCache::TEvRequest(Args.ReadPrio, std::move(msg->Request), SelfId()),
                 ev->Flags, ev->Cookie);
-            ForwardedSharedRequests = true;
         }
 
         void Handle(NBlockIO::TEvStat::TPtr& ev) noexcept
@@ -595,13 +588,6 @@ namespace NOps {
 
             auto* partStore = partView.As<TPartStore>();
             Y_ABORT_UNLESS(partStore);
-
-            for (auto& cache : partStore->PageCollections) {
-                PrivateCollections.insert(cache->Id);
-            }
-            if (auto& cache = partStore->Pseudo) {
-                PrivateCollections.insert(cache->Id);
-            }
 
             Cache->AddCold(partView);
 
@@ -699,10 +685,7 @@ namespace NOps {
                 Send(pr.second, new TEvents::TEvPoison);
             }
 
-            if (ForwardedSharedRequests) {
-                Send(MakeSharedPageCacheId(), new NSharedCache::TEvUnregister);
-            }
-
+            Send(MakeSharedPageCacheId(), new NSharedCache::TEvUnregister);
             PassAway();
         }
 
@@ -738,13 +721,11 @@ namespace NOps {
 
         THashMap<TLogoBlobID, TActorId> ColdPartLoaders;
         THashMap<TLogoBlobID, TPartView> ColdPartLoaded;
-        THashSet<TLogoBlobID> PrivateCollections;
 
         TLoadBlobQueue BlobQueue;
         TDeque<TBlobQueueRequest> BlobQueueRequests;
         ui64 BlobQueueRequestsOffset = 0;
 
-        bool ForwardedSharedRequests = false;
         bool ContinueInFly = false;
 
         const NHPTimer::STime MaxCyclesPerIteration;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

It seems that request pages from private cache logic was left since private cache stored some additional pages

`ForwardedSharedRequests` is also quite useless as scan usually needs some pages
