### PR TITLE
Refactor tracing configurator to be available from actor system threads

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -12,6 +12,7 @@
 
 #include <ydb/core/control/immediate_control_board_impl.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
+#include <ydb/core/jaeger_tracing/sampling_throttling_configurator.h>
 #include <ydb/core/tablet_flat/shared_cache_pages.h>
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/protos/bootstrap.pb.h>
@@ -123,6 +124,7 @@ TAppData::TAppData(
     , MemoryControllerConfig(Impl->MemoryControllerConfig)
     , ReplicationConfig(Impl->ReplicationConfig)
     , KikimrShouldContinue(kikimrShouldContinue)
+    , TracingConfigurator(MakeIntrusive<NJaegerTracing::TSamplingThrottlingConfigurator>(TimeProvider, RandomProvider))
 {}
 
 TAppData::~TAppData()

--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -22,6 +22,9 @@ namespace NKikimr {
     namespace NSharedCache {
         class TSharedCachePages;
     }
+    namespace NJaegerTracing {
+        class TSamplingThrottlingConfigurator;
+    }
 }
 
 namespace NKikimrCms {
@@ -266,6 +269,9 @@ struct TAppData {
     TString ClusterName;
 
     bool YamlConfigEnabled = false;
+
+    // Tracing configurator (look for tracing config in ydb/core/jaeger_tracing/actors_tracing_control)
+    TIntrusivePtr<NKikimr::NJaegerTracing::TSamplingThrottlingConfigurator> TracingConfigurator;
 
     TAppData(
             ui32 sysPoolId, ui32 userPoolId, ui32 ioPoolId, ui32 batchPoolId,

--- a/ydb/core/base/wilson_tracing_control.cpp
+++ b/ydb/core/base/wilson_tracing_control.cpp
@@ -22,7 +22,14 @@ public:
     {}
 
     TSamplingThrottlingControl* GetTracingControlPtr() {
+        if (Y_UNLIKELY(!Control)) {
+            Control = CreateNewTracingControl();
+        }
         return Control.Get();
+    }
+
+    void ResetTracingControl() {
+        Control = nullptr;
     }
 
 private:
@@ -52,6 +59,13 @@ void HandleTracing(NWilson::TTraceId& traceId, const TRequestDiscriminator& disc
     TSamplingThrottlingControl* control = GetTracingControlTls();
     if (Y_LIKELY(control)) {
         control->HandleTracing(traceId, discriminator);
+    }
+}
+
+void ClearTracingControl() {
+    if (TracingControlRawPtr) {
+        TracingControlRawPtr = nullptr;
+        FastTlsSingleton<TSamplingThrottlingControlTlsHolder>()->ResetTracingControl();
     }
 }
 

--- a/ydb/core/base/wilson_tracing_control.cpp
+++ b/ydb/core/base/wilson_tracing_control.cpp
@@ -1,0 +1,35 @@
+#include "wilson_tracing_control.h"
+
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/jaeger_tracing/sampling_throttling_configurator.h>
+#include <ydb/core/jaeger_tracing/sampling_throttling_control.h>
+
+#include <util/system/yassert.h>
+
+namespace NKikimr::NJaegerTracing {
+
+namespace {
+
+TIntrusivePtr<TSamplingThrottlingControl> CreateNewTracingControl() {
+    Y_ASSERT(HasAppData()); // In general we must call this from actor thread
+    if (!HasAppData()) {
+        return nullptr;
+    }
+
+    return AppData()->TracingConfigurator->GetControl();
+}
+
+TSamplingThrottlingControl* GetTracingControlTls() {
+    static thread_local TIntrusivePtr<TSamplingThrottlingControl> Control = CreateNewTracingControl();
+    return Control.Get();
+}
+
+} // namespace
+
+void HandleTracing(NWilson::TTraceId& traceId, const TRequestDiscriminator& discriminator) {
+    if (TSamplingThrottlingControl* control = GetTracingControlTls()) {
+        control->HandleTracing(traceId, discriminator);
+    }
+}
+
+} // namespace NKikimr::NJaegerTracing

--- a/ydb/core/base/wilson_tracing_control.h
+++ b/ydb/core/base/wilson_tracing_control.h
@@ -9,4 +9,8 @@ namespace NKikimr::NJaegerTracing {
 // Can be called from actor system threads.
 void HandleTracing(NWilson::TTraceId& traceId, const TRequestDiscriminator& discriminator);
 
+// For test purposes
+// Clears tracing control TLS variables that depend on AppData
+void ClearTracingControl();
+
 } // namespace NKikimr::NJaegerTracing

--- a/ydb/core/base/wilson_tracing_control.h
+++ b/ydb/core/base/wilson_tracing_control.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <ydb/core/jaeger_tracing/request_discriminator.h>
+#include <ydb/library/actors/wilson/wilson_trace.h>
+
+namespace NKikimr::NJaegerTracing {
+
+// Generate a new trace id (or throttle existing one)
+// with probability according to current configuration and request type.
+// Can be called from actor system threads.
+void HandleTracing(NWilson::TTraceId& traceId, const TRequestDiscriminator& discriminator);
+
+} // namespace NKikimr::NJaegerTracing

--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -11,6 +11,7 @@ SRCS(
     board_replica.cpp
     blobstorage.h
     blobstorage.cpp
+    blobstorage_grouptype.cpp
     channel_profiles.h
     counters.cpp
     counters.h
@@ -72,7 +73,7 @@ SRCS(
     tx_processing.h
     tx_processing.cpp
     user_registry.h
-    blobstorage_grouptype.cpp
+    wilson_tracing_control.cpp
 )
 
 PEERDIR(
@@ -92,6 +93,7 @@ PEERDIR(
     ydb/core/debug
     ydb/core/erasure
     ydb/core/graph/api
+    ydb/core/jaeger_tracing
     ydb/core/protos
     ydb/core/protos/out
     ydb/library/aclib

--- a/ydb/core/cms/console/jaeger_tracing_configurator.h
+++ b/ydb/core/cms/console/jaeger_tracing_configurator.h
@@ -7,7 +7,7 @@
 
 namespace NKikimr::NConsole {
 
-IActor* CreateJaegerTracingConfigurator(NJaegerTracing::TSamplingThrottlingConfigurator tracingConfigurator,
+IActor* CreateJaegerTracingConfigurator(TIntrusivePtr<NJaegerTracing::TSamplingThrottlingConfigurator> tracingConfigurator,
                                                 NKikimrConfig::TTracingConfig cfg);
 
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/jaeger_tracing_configurator_ut.cpp
+++ b/ydb/core/cms/console/jaeger_tracing_configurator_ut.cpp
@@ -52,7 +52,7 @@ TTenantTestConfig DefaultConsoleTestConfig() {
 
 void InitJaegerTracingConfigurator(
     TTenantTestRuntime& runtime,
-    TSamplingThrottlingConfigurator configurator,
+    TIntrusivePtr<TSamplingThrottlingConfigurator> configurator,
     const NKikimrConfig::TTracingConfig& initCfg
 ) {
     runtime.Register(CreateJaegerTracingConfigurator(std::move(configurator), initCfg));
@@ -99,7 +99,7 @@ public:
 
     std::pair<ETraceState, ui8> HandleTracing(bool isExternal, TRequestDiscriminator discriminator) {
         auto& control = RandomChoice(Controls);
-        
+
         NWilson::TTraceId traceId;
         if (isExternal) {
             traceId = NWilson::TTraceId::NewTraceId(TComponentTracingLevels::ProductionVerbose, Max<ui32>());
@@ -125,13 +125,13 @@ private:
     TVector<TIntrusivePtr<TSamplingThrottlingControl>> Controls;
 };
 
-std::pair<TTracingControls, TSamplingThrottlingConfigurator>
+std::pair<TTracingControls, TIntrusivePtr<TSamplingThrottlingConfigurator>>
     CreateSamplingThrottlingConfigurator(size_t n, TIntrusivePtr<ITimeProvider> timeProvider) {
     auto randomProvider = CreateDefaultRandomProvider();
-    TSamplingThrottlingConfigurator configurator(timeProvider, randomProvider);
+    TIntrusivePtr<TSamplingThrottlingConfigurator> configurator = MakeIntrusive<TSamplingThrottlingConfigurator>(timeProvider, randomProvider);
     TVector<TIntrusivePtr<TSamplingThrottlingControl>> controls;
     for (size_t i = 0; i < n; ++i) {
-        controls.emplace_back(configurator.GetControl());
+        controls.emplace_back(configurator->GetControl());
     }
 
     return {TTracingControls(std::move(controls)), std::move(configurator)};

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1633,11 +1633,10 @@ void TGRpcServicesInitializer::InitializeServices(NActors::TActorSystemSetup* se
 
     if (!IsServiceInitialized(setup, NGRpcService::CreateGRpcRequestProxyId(0))) {
         const size_t proxyCount = Config.HasGRpcConfig() ? Config.GetGRpcConfig().GetGRpcProxyCount() : 1UL;
-        NJaegerTracing::TSamplingThrottlingConfigurator tracingConfigurator(appData->TimeProvider, appData->RandomProvider);
         for (size_t i = 0; i < proxyCount; ++i) {
             auto grpcReqProxy = Config.HasGRpcConfig() && Config.GetGRpcConfig().GetSkipSchemeCheck()
                 ? NGRpcService::CreateGRpcRequestProxySimple(Config)
-                : NGRpcService::CreateGRpcRequestProxy(Config, tracingConfigurator.GetControl());
+                : NGRpcService::CreateGRpcRequestProxy(Config);
             setup->LocalServices.push_back(std::pair<TActorId,
                                            TActorSetupCmd>(NGRpcService::CreateGRpcRequestProxyId(i),
                                                            TActorSetupCmd(grpcReqProxy, TMailboxType::ReadAsFilled,
@@ -1646,7 +1645,7 @@ void TGRpcServicesInitializer::InitializeServices(NActors::TActorSystemSetup* se
         setup->LocalServices.push_back(std::pair<TActorId, TActorSetupCmd>(
                 TActorId(),
                 TActorSetupCmd(
-                    NConsole::CreateJaegerTracingConfigurator(std::move(tracingConfigurator), Config.GetTracingConfig()),
+                    NConsole::CreateJaegerTracingConfigurator(appData->TracingConfigurator, Config.GetTracingConfig()),
                     TMailboxType::ReadAsFilled,
                     appData->UserPoolId)));
     }

--- a/ydb/core/grpc_services/grpc_request_proxy.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy.cpp
@@ -6,10 +6,10 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/nameservice.h>
+#include <ydb/core/base/wilson_tracing_control.h>
 #include <ydb/core/cms/console/configs_dispatcher.h>
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/grpc_services/counters/proxy_counters.h>
-#include <ydb/core/jaeger_tracing/sampling_throttling_control.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/tx/scheme_board/scheme_board.h>
 #include <ydb/library/wilson_ids/wilson.h>
@@ -57,9 +57,8 @@ class TGRpcRequestProxyImpl
 {
     using TBase = TActorBootstrapped<TGRpcRequestProxyImpl>;
 public:
-    explicit TGRpcRequestProxyImpl(const NKikimrConfig::TAppConfig& appConfig, TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> tracingControl)
+    explicit TGRpcRequestProxyImpl(const NKikimrConfig::TAppConfig& appConfig)
         : ChannelBufferSize(appConfig.GetTableServiceConfig().GetResourceManager().GetChannelBufferSize())
-        , TracingControl(std::move(tracingControl))
     { }
 
     void Bootstrap(const TActorContext& ctx);
@@ -326,7 +325,6 @@ private:
     bool DynamicNode = false;
     TString RootDatabase;
     IGRpcProxyCounters::TPtr Counters;
-    TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> TracingControl;
 };
 
 void TGRpcRequestProxyImpl::Bootstrap(const TActorContext& ctx) {
@@ -451,7 +449,7 @@ void TGRpcRequestProxyImpl::MaybeStartTracing(IRequestProxyCtx& ctx) {
     if (const auto otelHeader = ctx.GetPeerMetaValues(NYdb::OTEL_TRACE_HEADER)) {
         traceId = NWilson::TTraceId::FromTraceparentHeader(otelHeader.GetRef(), TComponentTracingLevels::ProductionVerbose);
     }
-    TracingControl->HandleTracing(traceId, ctx.GetRequestDiscriminator());
+    NJaegerTracing::HandleTracing(traceId, ctx.GetRequestDiscriminator());
     if (traceId) {
         NWilson::TSpan grpcRequestProxySpan(TWilsonGrpc::RequestProxy, std::move(traceId), "GrpcRequestProxy");
         if (auto database = ctx.GetDatabaseName()) {
@@ -616,8 +614,8 @@ void TGRpcRequestProxyImpl::StateFunc(TAutoPtr<IEventHandle>& ev) {
     }
 }
 
-IActor* CreateGRpcRequestProxy(const NKikimrConfig::TAppConfig& appConfig, TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> tracingControl) {
-    return new TGRpcRequestProxyImpl(appConfig, std::move(tracingControl));
+IActor* CreateGRpcRequestProxy(const NKikimrConfig::TAppConfig& appConfig) {
+    return new TGRpcRequestProxyImpl(appConfig);
 }
 
 } // namespace NGRpcService

--- a/ydb/core/grpc_services/grpc_request_proxy.h
+++ b/ydb/core/grpc_services/grpc_request_proxy.h
@@ -6,7 +6,6 @@
 #include "grpc_request_proxy_handle_methods.h"
 
 #include <ydb/core/base/appdata_fwd.h>
-#include <ydb/core/jaeger_tracing/sampling_throttling_control.h>
 
 #include <ydb/library/actors/core/actor.h>
 
@@ -23,7 +22,7 @@ struct TAppData;
 
 namespace NGRpcService {
 
-IActor* CreateGRpcRequestProxy(const NKikimrConfig::TAppConfig& appConfig, TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> tracingControl);
+IActor* CreateGRpcRequestProxy(const NKikimrConfig::TAppConfig& appConfig);
 IActor* CreateGRpcRequestProxySimple(const NKikimrConfig::TAppConfig& appConfig);
 
 class TGRpcRequestProxy : public TGRpcRequestProxyHandleMethods, public IFacilityProvider {

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -2899,6 +2899,14 @@ Y_UNIT_TEST_SUITE(THiveTest) {
     }
 
     Y_UNIT_TEST(TestReassignUseRelativeSpace) {
+        // TODO: Remove this code after issue https://github.com/ydb-platform/ydb/issues/12255 will be resolved
+        ui64 prevSeed = NActors::DefaultRandomSeed;
+        NActors::DefaultRandomSeed = 42;
+        Y_SCOPE_EXIT(prevSeed) {
+            NActors::DefaultRandomSeed = prevSeed;
+        };
+        // TODO: Remove this code after issue https://github.com/ydb-platform/ydb/issues/12255 will be resolved
+
         TTestBasicRuntime runtime(1, false);
         Setup(runtime, true, 5);
         const ui64 hiveTablet = MakeDefaultHiveID();
@@ -7181,7 +7189,7 @@ Y_UNIT_TEST_SUITE(TScaleRecommenderTest) {
 
     void AssertScaleRecommencation(TTestBasicRuntime& runtime, NKikimrProto::EReplyStatus expectedStatus, ui32 expectedNodes = 0) {
         const auto sender = runtime.AllocateEdgeActor();
-        
+
         const auto hiveId = MakeDefaultHiveID();
         const TSubDomainKey subdomainKey(TTestTxConfig::SchemeShard, 1);
         runtime.SendToPipe(hiveId, sender, new TEvHive::TEvRequestScaleRecommendation(subdomainKey));

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -15,6 +15,7 @@
 #include <ydb/library/actors/core/scheduler_basic.h>
 #include <ydb/library/actors/interconnect/interconnect_impl.h>
 
+#include <ydb/core/base/wilson_tracing_control.h>
 #include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/protos/key.pb.h>
 #include <ydb/core/protos/netclassifier.pb.h>
@@ -101,6 +102,9 @@ namespace NActors {
         SetRegistrationObserverFunc(&TTestActorRuntimeBase::DefaultRegistrationObserver);
 
         CleanupNodes();
+
+        App0 = nullptr;
+        NKikimr::NJaegerTracing::ClearTracingControl();
     }
 
     void TTestActorRuntime::AddAppDataInit(std::function<void(ui32, NKikimr::TAppData&)> callback) {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -364,17 +364,15 @@ namespace Tests {
         grpcRequestProxies.reserve(proxyCount);
 
         auto& appData = Runtime->GetAppData(grpcServiceNodeId);
-        NJaegerTracing::TSamplingThrottlingConfigurator tracingConfigurator(appData.TimeProvider, appData.RandomProvider);
-
         for (size_t i = 0; i < proxyCount; ++i) {
-            auto grpcRequestProxy = NGRpcService::CreateGRpcRequestProxy(*Settings->AppConfig, tracingConfigurator.GetControl());
+            auto grpcRequestProxy = NGRpcService::CreateGRpcRequestProxy(*Settings->AppConfig);
             auto grpcRequestProxyId = system->Register(grpcRequestProxy, TMailboxType::ReadAsFilled, appData.UserPoolId);
             system->RegisterLocalService(NGRpcService::CreateGRpcRequestProxyId(), grpcRequestProxyId);
             grpcRequestProxies.push_back(grpcRequestProxyId);
         }
 
         system->Register(
-            NConsole::CreateJaegerTracingConfigurator(std::move(tracingConfigurator), Settings->AppConfig->GetTracingConfig()),
+            NConsole::CreateJaegerTracingConfigurator(appData.TracingConfigurator, Settings->AppConfig->GetTracingConfig()),
             TMailboxType::ReadAsFilled,
             appData.UserPoolId
         );


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

There are situations when we need to generate a new trace id (or throttle existing one) not only from grpc proxy actor, but in several other places (long living topic session). For this case I refactored tracing configurator so that it can be available from every actor system thread.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
