### PR TITLE
24-3: Allow to describe index table through ydb cli

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_path.cpp
+++ b/ydb/core/grpc_services/rpc_describe_path.cpp
@@ -65,8 +65,12 @@ private:
             return SendProposeRequest(ctx, this->GetProtoRequest()->path());
         }
 
-        if (entry.Kind != TSchemeCacheNavigate::EKind::KindCdcStream) {
-            return SendProposeRequest(ctx, this->GetProtoRequest()->path());
+        switch (entry.Kind) {
+            case TSchemeCacheNavigate::EKind::KindCdcStream:
+            case TSchemeCacheNavigate::EKind::KindIndex:
+                break;
+            default:
+                return SendProposeRequest(ctx, this->GetProtoRequest()->path());
         }
 
         if (!entry.Self || !entry.ListNodeEntry) {
@@ -79,10 +83,10 @@ private:
         }
 
         OverrideName = entry.Self->Info.GetName();
-        const auto& topicName = entry.ListNodeEntry->Children.at(0).Name;
+        const auto& childName = entry.ListNodeEntry->Children.at(0).Name;
 
         return SendProposeRequest(ctx,
-            NKikimr::JoinPath(NKikimr::ChildPath(NKikimr::SplitPath(this->GetProtoRequest()->path()), topicName)));
+            NKikimr::JoinPath(NKikimr::ChildPath(NKikimr::SplitPath(this->GetProtoRequest()->path()), childName)));
     }
 
     void SendProposeRequest(const TActorContext& ctx, const TString& path) {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -4131,6 +4131,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
     Y_UNIT_TEST(DescribeIndexTable) {
         TKikimrRunner kikimr;
         auto db = kikimr.GetTableClient();
+        auto scheme = NYdb::NScheme::TSchemeClient(kikimr.GetDriver(), TCommonClientSettings().Database("/Root"));
         auto session = db.CreateSession().GetValueSync().GetSession();
 
         {
@@ -4146,6 +4147,11 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto desc = scheme.DescribePath("/Root/table/SyncIndex").ExtractValueSync();
+            UNIT_ASSERT_C(desc.IsSuccess(), desc.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(desc.GetEntry().Name, "SyncIndex");
         }
         {
             auto desc = session.DescribeTable("/Root/table/SyncIndex").ExtractValueSync();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

It is now allowed to describe index table using `ydb cli scheme describe <table_path>/<index_name>`.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

https://github.com/ydb-platform/ydb/pull/12103