### PR TITLE
ContinueExecute on non-empty transform

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -427,6 +427,14 @@ protected:
         }
 
         if (status != ERunStatus::Finished) {
+            for (auto& [id, inputTransform] : InputTransformsMap) {
+                if (!inputTransform.Buffer->Empty()) {
+                    ContinueExecute(EResumeSource::CAPendingInput);
+                }
+            }
+        }
+
+        if (status != ERunStatus::Finished) {
             // If the incoming channel's buffer was full at the moment when last ChannelDataAck event had been sent,
             // there will be no attempts to send a new piece of data from the other side of this channel.
             // So, if there is space in the channel buffer (and on previous step is was full), we send ChannelDataAck


### PR DESCRIPTION
Fixes (some) freezes when checkpoint received with data stuck in `InputTransformsMap[].Buffer`.
Checkpoint arrived (on all input channels), there are some data in transform's `TComputeActorAsyncInputHelperSync.Buffer`, but compute don't reads it, so compute state is not saved and checkpoint is not injected into outputs/sink

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
