### PR TITLE
Remove TString nullptr ctor usages

### DIFF
--- a/ydb/core/blobstorage/dsproxy/ut_fat/dsproxy_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut_fat/dsproxy_ut.cpp
@@ -3071,7 +3071,7 @@ class TTestBlobStorageProxyBasic1 : public TTestBlobStorageProxy {
                 break;
             case 230:
                 if (Env->ShouldBeUndiscoverable) {
-                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, nullptr);
+                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, "");
                 } else {
                     TEST_RESPONSE(MessageDiscoverResult, OK, 1, testData2);
                 }
@@ -3080,7 +3080,7 @@ class TTestBlobStorageProxyBasic1 : public TTestBlobStorageProxy {
                 break;
             case 240:
                 if (Env->ShouldBeUndiscoverable) {
-                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, 0);
+                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, "");
                 } else {
                     TEST_RESPONSE(MessageDiscoverResult, OK, 1, "");
                 }
@@ -3089,7 +3089,7 @@ class TTestBlobStorageProxyBasic1 : public TTestBlobStorageProxy {
                 break;
             case 250:
                 if (Env->ShouldBeUndiscoverable) {
-                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, 0);
+                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, "");
                 } else {
                     TEST_RESPONSE(MessageDiscoverResult, NODATA, 0, "");
                 }
@@ -3098,7 +3098,7 @@ class TTestBlobStorageProxyBasic1 : public TTestBlobStorageProxy {
                 break;
             case 260:
                 if (Env->ShouldBeUndiscoverable) {
-                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, 0);
+                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, "");
                 } else {
                     TEST_RESPONSE(MessageDiscoverResult, OK, 1, testData2);
                 }
@@ -3107,7 +3107,7 @@ class TTestBlobStorageProxyBasic1 : public TTestBlobStorageProxy {
                 break;
             case 270:
                 if (Env->ShouldBeUndiscoverable) {
-                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, 0);
+                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, "");
                 } else {
                     TEST_RESPONSE(MessageDiscoverResult, OK, 1, "");
                 }
@@ -3117,7 +3117,7 @@ class TTestBlobStorageProxyBasic1 : public TTestBlobStorageProxy {
             case 280:
             {
                 if (Env->ShouldBeUndiscoverable) {
-                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, 0);
+                    TEST_RESPONSE(MessageDiscoverResult, ERROR, 0, "");
                 } else {
                     TEST_RESPONSE(MessageDiscoverResult, NODATA, 0, "");
                 }

--- a/ydb/core/client/object_storage_listing_ut.cpp
+++ b/ydb/core/client/object_storage_listing_ut.cpp
@@ -285,7 +285,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         endpoint << "localhost:" << grpcPort;
         std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(endpoint, grpc::InsecureChannelCredentials());
         auto stub = Ydb::ObjectStorage::V1::ObjectStorageService::NewStub(channel);
-        
+
         TAutoPtr<Ydb::ObjectStorage::ListingRequest> request = new Ydb::ObjectStorage::ListingRequest();
         request->Setpath_column_prefix(pathPrefix);
         request->Settable_name(table);
@@ -427,7 +427,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         grpc::Status status = stub->List(&rcontext, *request, &response);
 
         UNIT_ASSERT_VALUES_EQUAL(response.status(), Ydb::StatusIds::SUCCESS);
-        
+
         commonPrefixes.clear();
         contents.clear();
 
@@ -437,7 +437,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
                 commonPrefixes.emplace_back(row);
             }
         }
-        
+
         if (response.has_contents()) {
             auto &files = response.contents();
             for (auto row : files.rows()) {
@@ -468,7 +468,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
 
         TVector<TString> commonPrefixes;
         TVector<TString> contents;
-        DoS3Listing(GRPC_PORT, bucket, pathPrefix, pathDelimiter, startAfter, nullptr, columnsToReturn, maxKeys, commonPrefixes, contents);
+        DoS3Listing(GRPC_PORT, bucket, pathPrefix, pathDelimiter, startAfter, "", columnsToReturn, maxKeys, commonPrefixes, contents);
 
         UNIT_ASSERT_VALUES_EQUAL(expectedCommonPrefixes.size(), commonPrefixes.size());
         ui32 i = 0;
@@ -600,7 +600,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         return response;
     }
 
-    Ydb::ObjectStorage::ListingResponse TestS3ListingRequest(const TVector<TString>& prefixColumns, 
+    Ydb::ObjectStorage::ListingResponse TestS3ListingRequest(const TVector<TString>& prefixColumns,
                     const TString& pathPrefix, const TString& pathDelimiter,
                     const TString& startAfter, const TVector<TString>& columnsToReturn, ui32 maxKeys,
                     Ydb::StatusIds_StatusCode expectedStatus = Ydb::StatusIds::SUCCESS,
@@ -854,7 +854,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         TVector<TString> contents;
 
         auto continuationToken = DoS3Listing(GRPC_PORT, 750, "foo/", "/", "", "", {}, 1, commonPrefixes, contents);
-        
+
         UNIT_ASSERT(continuationToken);
         UNIT_ASSERT_EQUAL(1, contents.size());
         UNIT_ASSERT_EQUAL(0, commonPrefixes.size());
@@ -947,7 +947,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         {
             TVector<TString> folders;
             TVector<TString> files;
-            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", nullptr, nullptr, {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_EQUAL);
+            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", "", "", {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_EQUAL);
 
             TVector<TString> expectedFolders = {"/Photos/games/", "/Photos/inner/", "/Photos/test/", "/Photos/test3/", "/Photos/test5/", "/Photos/test6/"};
             TVector<TString> expectedFiles = {"/Photos/a.jpg", "/Photos/c.jpg"};
@@ -959,11 +959,11 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         {
             TVector<TString> folders;
             TVector<TString> files;
-            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", nullptr, nullptr, {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_NOT_EQUAL);
+            DoS3Listing(GRPC_PORT, 100, "/Photos/", "/", "", "", {}, 1000, folders, files, Ydb::ObjectStorage::ListingRequest_EMatchType_NOT_EQUAL);
 
             TVector<TString> expectedFolders = {"/Photos/folder/", "/Photos/inner/", "/Photos/test/", "/Photos/test2/", "/Photos/test3/", "/Photos/test4/", "/Photos/test5/", "/Photos/test6/"};
             TVector<TString> expectedFiles = {"/Photos/b.jpg"};
-            
+
             UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
             UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
         }
@@ -1071,7 +1071,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(expectedFolders, folders);
         UNIT_ASSERT_VALUES_EQUAL(expectedFiles, files);
-        // Three partitions, second should be skipped, because it's next prefix of /Photos/ (/Photos0) exceeds 
+        // Three partitions, second should be skipped, because it's next prefix of /Photos/ (/Photos0) exceeds
         // the range of second partition. Third (last) partition will always be checked.
         UNIT_ASSERT_EQUAL(2, count);
     }
@@ -1142,7 +1142,7 @@ Y_UNIT_TEST_SUITE(TObjectStorageListingTest) {
         UNIT_ASSERT_VALUES_EQUAL(resultSet.rows(0).items(2).low_128(), 975580256289238738);
         UNIT_ASSERT_VALUES_EQUAL(resultSet.rows(0).items(2).high_128(), 192747);
         UNIT_ASSERT_VALUES_EQUAL(resultSet.rows(0).items(3).low_128(), 123321000000);
-    }    
+    }
 }
 
 }}

--- a/ydb/core/tablet_flat/ut/ut_db_iface.cpp
+++ b/ydb/core/tablet_flat/ut/ut_db_iface.cpp
@@ -787,7 +787,7 @@ Y_UNIT_TEST_SUITE(DBase) {
                 stream << cache->DumpRanges();
                 return stream.Str();
             } else {
-                return nullptr;
+                return "";
             }
         };
 
@@ -860,7 +860,7 @@ Y_UNIT_TEST_SUITE(DBase) {
                 stream << cache->DumpRanges();
                 return stream.Str();
             } else {
-                return nullptr;
+                return "";
             }
         };
 

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -693,7 +693,7 @@ Y_UNIT_TEST_SUITE(TPart) {
             {1, prefix + "baaaa"}, // -> (1, "b")
             {1, prefix + "bab"},
             {1, prefix + "caa"},
-            
+
             {2, prefix + "aaa"}, // -> (2, null)
             {2, prefix + "bbb"},
             {2, prefix + "ccc"},
@@ -726,13 +726,13 @@ Y_UNIT_TEST_SUITE(TPart) {
             UNIT_ASSERT_VALUES_EQUAL(cmp.Compare(*IndexTools::GetFlatLastRecord(*part), TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(2u, prefix + "cxz"))), 0);
         }
 
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 0)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 0)),
             TSerializedCellVec::Serialize(part->IndexPages.HasBTree() ? TVector<TCell>() : TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(1u, prefix + "aaa"))));
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 1)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 1)),
             TSerializedCellVec::Serialize(TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(1u, prefix + "b"))));
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 2)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 2)),
             TSerializedCellVec::Serialize(TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(2u, nullptr))));
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 3)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*part, 3)),
             TSerializedCellVec::Serialize(TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(2u, prefix + "ccx"))));
     }
 
@@ -753,7 +753,7 @@ Y_UNIT_TEST_SUITE(TPart) {
             {1, "baaaa"}, // -> (1, "b")
             {1, "bab"},
             {1, "caa"},
-            
+
             {2, "aaa"}, // -> (2, null)
             {2, "bbb"},
             {2, "ccc"},
@@ -788,7 +788,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         Cerr << DumpPart(*fullPart, 2) << Endl;
 
         UNIT_ASSERT_GT(fullPart->IndexesRawSize, cutPart->IndexesRawSize);
-        
+
         if (cutPart->IndexPages.HasFlat()) {
             const NPage::TCompare<NPage::TFlatIndex::TRecord> cmp(cutPart->Scheme->Groups[0].ColsKeyIdx, *(*lay).Keys);
             UNIT_ASSERT_VALUES_EQUAL(cmp.Compare(*IndexTools::GetFlatRecord(*cutPart, 0), TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(1u, "aaa"))), 0);
@@ -798,13 +798,13 @@ Y_UNIT_TEST_SUITE(TPart) {
             UNIT_ASSERT_VALUES_EQUAL(cmp.Compare(*IndexTools::GetFlatLastRecord(*cutPart), TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(2u, "cxz"))), 0);
         }
 
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 0)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 0)),
             TSerializedCellVec::Serialize(cutPart->IndexPages.HasBTree() ? TVector<TCell>() : TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(1u, "aaa"))));
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 1)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 1)),
             TSerializedCellVec::Serialize(TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(1u, "b"))));
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 2)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 2)),
             TSerializedCellVec::Serialize(TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(2u, nullptr))));
-        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 3)), 
+        UNIT_ASSERT_VALUES_EQUAL(TSerializedCellVec::Serialize(IndexTools::GetKey(*cutPart, 3)),
             TSerializedCellVec::Serialize(TRowTool(*lay).KeyCells(*TSchemedCookRow(*lay).Col(2u, "ccx"))));
 
         for (auto r : fullRows) {
@@ -895,7 +895,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         Cerr << DumpPart(*fullPart, 2) << Endl;
 
         UNIT_ASSERT_GT(fullPart->IndexesRawSize, cutPart->IndexesRawSize);
-        
+
         for (auto r : fullRows) {
             cutWrap.Has(*TSchemedCookRow(*lay).Col(r.first, r.second));
             fullWrap.Has(*TSchemedCookRow(*lay).Col(r.first, r.second));
@@ -1004,14 +1004,14 @@ Y_UNIT_TEST_SUITE(TPart) {
 
         Cerr << "======= CUT =======" << Endl;
         Cerr << DumpPart(*cutPart, 2) << Endl;
-        
+
         Cerr << "======= FULL =======" << Endl;
         Cerr << DumpPart(*fullPart, 2) << Endl;
 
         UNIT_ASSERT_GT(fullPart->IndexesRawSize, cutPart->IndexesRawSize);
         UNIT_ASSERT_GT(cutPart->Slices->size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(fullPart->Slices->size(), 1);
-        
+
         for (auto i : xrange(fullRows.size())) {
             auto &r = fullRows[i];
             fullWrap.To(100 + i).Has(*TSchemedCookRow(*lay).Col(r.first, r.second));
@@ -1069,7 +1069,7 @@ Y_UNIT_TEST_SUITE(TPart) {
         auto check = [&] (ui32 testId, TString a, TString b, TString expected) {
             TPartCook cook(lay, conf);
 
-            cook.Add(*TSchemedCookRow(*lay).Col(a == "<NULL>" ? nullptr : a));
+            cook.Add(*TSchemedCookRow(*lay).Col(a == "<NULL>" ? "" : a));
             cook.Add(*TSchemedCookRow(*lay).Col(b));
 
             TCheckIter wrap(cook.Finish(), { });
@@ -1083,73 +1083,73 @@ Y_UNIT_TEST_SUITE(TPart) {
         };
 
         check(0,
-            "cccccc", 
-            "ccccccd", 
+            "cccccc",
+            "ccccccd",
             "ccccccd");
 
         check(1,
-            "cccccc", 
-            "ccccccddd", 
+            "cccccc",
+            "ccccccddd",
             "ccccccd");
 
         check(2,
-            "cccccc", 
-            "cccccd", 
+            "cccccc",
+            "cccccd",
             "cccccd");
 
         check(3,
-            "cccccc", 
-            "cccccddd", 
+            "cccccc",
+            "cccccddd",
             "cccccd");
 
         check(4,
-            "cccccc", 
-            "ccccd", 
+            "cccccc",
+            "ccccd",
             "ccccd");
 
         check(5,
-            "cccccc", 
-            "ccccddd", 
+            "cccccc",
+            "ccccddd",
             "ccccd");
 
         check(6,
-            "cccccc", 
-            "cccd", 
+            "cccccc",
+            "cccd",
             "cccd");
 
         check(7,
-            "cccccc", 
-            "cccddd", 
+            "cccccc",
+            "cccddd",
             "cccd");
 
         check(8,
-            "cccccc", 
-            "d", 
+            "cccccc",
+            "d",
             "d");
 
         check(9,
-            "cccccc", 
-            "ddd", 
+            "cccccc",
+            "ddd",
             "d");
 
         check(10,
-            "", 
-            "d", 
+            "",
+            "d",
             "d");
-        
+
         check(11,
-            "", 
-            "ddd", 
+            "",
+            "ddd",
             "d");
 
         check(12,
-            "<NULL>", 
-            "d", 
+            "<NULL>",
+            "d",
             "d");
-        
+
         check(12,
-            "<NULL>", 
-            "ddd", 
+            "<NULL>",
+            "ddd",
             "d");
 
         check(13,
@@ -1190,8 +1190,8 @@ Y_UNIT_TEST_SUITE(TPart) {
         };
 
         check(0,
-            "cccccc", 
-            "cccddd", 
+            "cccccc",
+            "cccddd",
             "cccd");
 
         check(1,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Additional information
Preparatory PR for removing nullptr_t constructor from TString.