### PR TITLE
`--upload-batch-bytes` when it is set to maximum returns `Too much data` in `ydb tools restore`

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,6 +1,6 @@
 * Fixed a bug in TPC-H tables schema where the `partsupp` table had incorrect list of key columns
 * Enhanced parallelism of data restoring in `ydb tools restore`
-* Fixed a bug that `--upload-batch-bytes` when it is set to maximum returns `Too much data` in `ydb tools restore`
+* Fixed a bug where `ydb tools restore` was failing with `Too much data` if `--upload-batch-bytes` option value was set exactly to it's maximum possible value (16MiB)
 
 ## 2.16.0 ##
 

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,7 +1,5 @@
 * Fixed a bug in TPC-H tables schema where the `partsupp` table had incorrect list of key columns
-
 * Enhanced parallelism of data restoring in `ydb tools restore`
-
 * Fixed a bug that `--upload-batch-bytes` when it is set to maximum returns `Too much data` in `ydb tools restore`
 
 ## 2.16.0 ##

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Enhanced parallelism of data restoring in `ydb tools restore`
 
+* Fixed a bug that `--upload-batch-bytes` when it is set to maximum returns `Too much data` in `ydb tools restore`
+
 ## 2.16.0 ##
 
 * Improved throughput of `ydb import file csv` command. It is now approximately x3 times faster

--- a/ydb/public/lib/ydb_cli/dump/restore_import_data.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_import_data.cpp
@@ -912,7 +912,7 @@ public:
     }
 
     bool Push(NPrivate::TBatch&& data) override {
-        if (data.size() >= TRestoreSettings::MaxBytesPerRequest) {
+        if (data.size() > TRestoreSettings::MaxBytesPerRequest) {
             LOG_E("Too much data: " << data.GetLocation());
             return false;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed a bug where `ydb tools restore` was failing with `Too much data` if `--upload-batch-bytes` option value was set exactly to it's maximum possible value (16MiB)

### Changelog category <!-- remove all except one -->

* Bugfix

