### PR TITLE
Remove explicit codegen in cmake export

### DIFF
--- a/.github/workflows/sync_cmakebuild.yml
+++ b/.github/workflows/sync_cmakebuild.yml
@@ -40,11 +40,7 @@ jobs:
           echo "Merge did not bring any changes, exiting"
           exit
         fi
-        # Generate ydb/core/base/generate with python codegen under ya
-        ./ya make ydb/core/base/generated/
-        ydb/core/base/generated/codegen/codegen ydb/core/base/generated/runtime_feature_flags.h.in ydb/core/base/generated/runtime_feature_flags.h
-        ydb/core/base/generated/codegen/codegen ydb/core/base/generated/runtime_feature_flags.cpp.in ydb/core/base/generated/runtime_feature_flags.cpp
-        # Generate cmakelists using pregenerated ydb/core/base/generated/runtime_feature_flags.*
+        # Generate cmakelists
         ./generate_cmake -k
         echo ${mainsha} > ydb/ci/cmakegen.txt
         git add .

--- a/ydb/core/base/generated/ya.make
+++ b/ydb/core/base/generated/ya.make
@@ -4,44 +4,34 @@ PEERDIR(
     ydb/core/protos
 )
 
-IF (EXPORT_CMAKE)
-    # No Python codegen in cmake, pregenerate from ya to compile
-    SRCS(
+RUN_PROGRAM(
+    ydb/core/base/generated/codegen
+        runtime_feature_flags.h.in
         runtime_feature_flags.h
-        runtime_feature_flags.cpp
-    )
-ELSE()
-    RUN_PROGRAM(
-        ydb/core/base/generated/codegen
-            runtime_feature_flags.h.in
-            runtime_feature_flags.h
-        IN runtime_feature_flags.h.in
-        OUT runtime_feature_flags.h
-        OUTPUT_INCLUDES
-            util/system/types.h
-            atomic
-            tuple
-    )
+    IN runtime_feature_flags.h.in
+    OUT runtime_feature_flags.h
+    OUTPUT_INCLUDES
+        util/system/types.h
+        atomic
+        tuple
+)
 
-    RUN_PROGRAM(
-        ydb/core/base/generated/codegen
-            runtime_feature_flags.cpp.in
-            runtime_feature_flags.cpp
-        IN runtime_feature_flags.cpp.in
-        OUT runtime_feature_flags.cpp
-        OUTPUT_INCLUDES
-            ydb/core/base/generated/runtime_feature_flags.h
-            ydb/core/protos/feature_flags.pb.h
-    )
-ENDIF()
+RUN_PROGRAM(
+    ydb/core/base/generated/codegen
+        runtime_feature_flags.cpp.in
+        runtime_feature_flags.cpp
+    IN runtime_feature_flags.cpp.in
+    OUT runtime_feature_flags.cpp
+    OUTPUT_INCLUDES
+        ydb/core/base/generated/runtime_feature_flags.h
+        ydb/core/protos/feature_flags.pb.h
+)
 
 END()
 
-IF (NOT EXPORT_CMAKE)
-    RECURSE(
-        codegen
-    )
-ENDIF()
+RECURSE(
+    codegen
+)
 
 RECURSE_FOR_TESTS(
     ut


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Codegen was rewritten in C++ so explicit codegen calls should no longer be necessary.