### PR TITLE
Explicitly specify codegen binary name in ydb/core/base

### DIFF
--- a/ydb/core/base/generated/codegen/ya.make
+++ b/ydb/core/base/generated/codegen/ya.make
@@ -1,4 +1,4 @@
-PROGRAM()
+PROGRAM(ydb-core-base-generated-codegen)
 
 SRCS(main.cpp)
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Looks like cmake cannot handle multiple binaries named `codegen`.