### PR TITLE
Audit log: No permission to connect to the database

### DIFF
--- a/ydb/core/grpc_services/audit_log.cpp
+++ b/ydb/core/grpc_services/audit_log.cpp
@@ -35,6 +35,31 @@ void AuditLogConn(const IRequestProxyCtx* ctx, const TString& database, const TS
     );
 }
 
+void AuditLogAccessDenied(const IRequestProxyCtx* ctx, const TString& database, const TString& userSID, const TString& sanitizedToken)
+{
+    static const TString GrpcConnComponentName = "grpc-access-denied";
+
+    const TString remoteAddress = NKikimr::NAddressClassifier::ExtractAddress(ctx->GetPeerName());
+
+    AUDIT_LOG(
+        AUDIT_PART("component", GrpcConnComponentName)
+
+        AUDIT_PART("remote_address", remoteAddress)
+        AUDIT_PART("subject", userSID)
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EmptyValue))
+        AUDIT_PART("database", database)
+        AUDIT_PART("operation", ctx->GetRequestName())
+    );
+
+    LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER, "AUDIT: "
+        << "User has no permission to perform query on this database " << database 
+        << ", subject " << userSID
+        << ", sanitized_token " << (!sanitizedToken.empty() ? sanitizedToken : EmptyValue)
+        << ", operation " << ctx->GetRequestName()
+        << ", remote_address " << remoteAddress
+    );
+}
+
 void AuditLog(ui32 status, const TAuditLogParts& parts)
 {
     static const TString GrpcProxyComponentName = "grpc-proxy";

--- a/ydb/core/grpc_services/audit_log.h
+++ b/ydb/core/grpc_services/audit_log.h
@@ -9,12 +9,12 @@ class IRequestCtxMtSafe;
 
 // grpc "connections" log
 void AuditLogConn(const IRequestProxyCtx* reqCtx, const TString& database, const TString& userSID, const TString& sanitizedToken);
-void AuditLogAccessDenied(const IRequestProxyCtx* reqCtx, const TString& database, const TString& userSID, const TString& sanitizedToken);
 
 using TAuditLogParts = TVector<std::pair<TString, TString>>;
 
 // grpc "operations" log
 void AuditLog(ui32 status, const TAuditLogParts& parts);
+void AuditLogConnectDbAccessDenied(const IRequestProxyCtx* reqCtx, const TString& database, const TString& userSID, const TString& sanitizedToken);
 
 }
 }

--- a/ydb/core/grpc_services/audit_log.h
+++ b/ydb/core/grpc_services/audit_log.h
@@ -9,6 +9,7 @@ class IRequestCtxMtSafe;
 
 // grpc "connections" log
 void AuditLogConn(const IRequestProxyCtx* reqCtx, const TString& database, const TString& userSID, const TString& sanitizedToken);
+void AuditLogAccessDenied(const IRequestProxyCtx* reqCtx, const TString& database, const TString& userSID, const TString& sanitizedToken);
 
 using TAuditLogParts = TVector<std::pair<TString, TString>>;
 

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -562,9 +562,10 @@ private:
         }
 
         const TString error = "No permission to connect to the database";
-        LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER, "AUDIT: "
+        LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER, 
+            "AUDIT: "
             << error
-            << ", database: " << CheckedDatabaseName_
+            << ": " << CheckedDatabaseName_
             << ", user: " << TBase::GetUserSID()
             << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName()
         );

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -563,8 +563,7 @@ private:
 
         const TString error = "No permission to connect to the database";
         LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER, 
-            "AUDIT: "
-            << error
+            error
             << ": " << CheckedDatabaseName_
             << ", user: " << TBase::GetUserSID()
             << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName()

--- a/ydb/services/ydb/ydb_login_ut.cpp
+++ b/ydb/services/ydb/ydb_login_ut.cpp
@@ -169,7 +169,7 @@ Y_UNIT_TEST_SUITE(TGRpcAuthentication) {
         UNIT_ASSERT_NO_EXCEPTION(token = loginProvider->GetAuthInfo());
         UNIT_ASSERT(!token.empty());
         
-        loginConnection.TestConnectRight(token, "Access denied");
+        loginConnection.TestConnectRight(token, "No permission to connect to the database");
 
         loginConnection.Stop();
     }

--- a/ydb/services/ydb/ydb_login_ut.cpp
+++ b/ydb/services/ydb/ydb_login_ut.cpp
@@ -169,7 +169,7 @@ Y_UNIT_TEST_SUITE(TGRpcAuthentication) {
         UNIT_ASSERT_NO_EXCEPTION(token = loginProvider->GetAuthInfo());
         UNIT_ASSERT(!token.empty());
         
-        loginConnection.TestConnectRight(token, "User has no permission");
+        loginConnection.TestConnectRight(token, "Access denied");
 
         loginConnection.Stop();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

When a user tries to connect without the necessary permissions, this error is returned:

```
Status: UNAUTHORIZED
Issues: 
<<main>: Error: User has no permission to perform query on this database, database: /Domain 0/testdb, user: bigpig1-no access@ldap, from ip: ipv4:10.131.0.31:34736, code: 200000
<main>: Error: Endpoint list is empty for database /Domain0/testdb, cluster endpoint bigpig1:2135.
```

In this case, nothing is written to the console log.

What has been fixed:
1. The user does not need to see such a detailed error, it is enough to say “Access Denied”
2. A detailed message should be recorded in the audit log

The result console message is:
```
Status: UNAUTHORIZED
Issues:
<main>: Error: No permission to connect to the databased, code: 200000
<main>: Error: Endpoint list is empty for database /local, cluster endpoint localhost:19140.
```

### Changelog category <!-- remove all except one -->

* Bugfix 


### Additional information

...
