### PR TITLE
Fix parsing multiple csv columns with escaped quotes in `ydb import file csv`

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed a bug in `ydb import file csv` where multiple columns with escaped quotes in the same row were parsed incorrectly
 * Truncate query results output in benchmarks
 
 ## 2.17.0 ##

--- a/ydb/public/lib/ydb_cli/common/csv_parser.cpp
+++ b/ydb/public/lib/ydb_cli/common/csv_parser.cpp
@@ -438,35 +438,30 @@ TValue TCsvParser::BuildList(std::vector<TString>& lines, const TString& filenam
     for (const TType* type : ResultLineTypesSorted) {
         columnTypeParsers.push_back(std::make_unique<TTypeParser>(*type));
     }
+    
     Ydb::Value listValue;
     auto* listItems = listValue.mutable_items();
     listItems->Reserve(lines.size());
     for (auto& line : lines) {
-        std::vector<TStringBuf> fields;
         NCsvFormat::CsvSplitter splitter(line, Delimeter);
         TParseMetadata meta {row, filename};
+        auto* structItems = listItems->Add()->mutable_items();
+        structItems->Reserve(ResultColumnCount);
         auto headerIt = Header.cbegin();
         auto skipIt = SkipBitMap.begin();
+        auto typeParserIt = columnTypeParsers.begin();
         do {
             if (headerIt == Header.cend()) { // SkipBitMap has same size as Header
                 throw FormatError(yexception() << "Header contains less fields than data. Header: \"" << HeaderRow << "\", data: \"" << line << "\"", meta);
             }
             TStringBuf nextField = Consume(splitter, meta, *headerIt);
             if (!*skipIt) {
-                fields.emplace_back(nextField);
+                *structItems->Add() = FieldToValue(*typeParserIt->get(), nextField, NullValue, meta, *headerIt).GetProto();
+                ++typeParserIt;
             }
             ++headerIt;
             ++skipIt;
         } while (splitter.Step());
-        auto* structItems = listItems->Add()->mutable_items();
-        structItems->Reserve(ResultColumnCount);
-        auto typeParserIt = columnTypeParsers.begin();
-        auto fieldIt = fields.begin();
-        auto nameIt = ResultLineNamesSorted.begin();
-        // fields size equals columnTypeParsers size, no need for second end check
-        for (; typeParserIt != columnTypeParsers.end(); ++typeParserIt, ++fieldIt, ++nameIt) {
-            *structItems->Add() = FieldToValue(*typeParserIt->get(), *fieldIt, NullValue, meta, **nameIt).GetProto();
-        }
         if (row.has_value()) {
             ++row.value();
         }
@@ -484,7 +479,6 @@ void TCsvParser::BuildLineType() {
         if (findIt != DestinationTypes->end()) {
             builder.AddMember(colName, findIt->second);
             ResultLineTypesSorted.push_back(&findIt->second);
-            ResultLineNamesSorted.push_back(&colName);
             SkipBitMap.push_back(false);
             ++ResultColumnCount;
         } else {

--- a/ydb/public/lib/ydb_cli/common/csv_parser.h
+++ b/ydb/public/lib/ydb_cli/common/csv_parser.h
@@ -57,7 +57,6 @@ private:
     // Types of columns in a single row in resulting TValue.
     // Column order according to the header, though can have less elements than the Header
     std::vector<const TType*> ResultLineTypesSorted;
-    std::vector<const TString*> ResultLineNamesSorted;
 };
 
 }

--- a/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
@@ -293,4 +293,22 @@ Y_UNIT_TEST_SUITE(YdbCliCsvParserTests) {
             .Build()
         );
     }
+
+    Y_UNIT_TEST(RepeatedEscaping) {
+        CommonTestBuildList(
+            "col1,escaped2,col3,escaped4,col5",
+            {
+                "aa,\"text2.1 \"\"text2.2 escaped\"\" text2.3\",bb,\"text4.1 \"\"text4.2 escaped\"\" text4.3\",5"
+            },
+            TValueBuilder().BeginList()
+                .AddListItem().BeginStruct()
+                    .AddMember("col1").Utf8("aa")
+                    .AddMember("escaped2").Utf8("text2.1 \"text2.2 escaped\" text2.3")
+                    .AddMember("col3").Utf8("bb")
+                    .AddMember("escaped4").Utf8("text4.1 \"text4.2 escaped\" text4.3")
+                    .AddMember("col5").Uint8(6)
+                    .EndStruct()
+                .EndList().Build());
+        // TODO: same tests for BuildParams and BuildValue when NCsvFormat::CsvSplitter will be fixed
+    }
 }

--- a/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/csv_parser_ut.cpp
@@ -306,7 +306,7 @@ Y_UNIT_TEST_SUITE(YdbCliCsvParserTests) {
                     .AddMember("escaped2").Utf8("text2.1 \"text2.2 escaped\" text2.3")
                     .AddMember("col3").Utf8("bb")
                     .AddMember("escaped4").Utf8("text4.1 \"text4.2 escaped\" text4.3")
-                    .AddMember("col5").Uint8(6)
+                    .AddMember("col5").Uint8(5)
                     .EndStruct()
                 .EndList().Build());
         // TODO: same tests for BuildParams and BuildValue when NCsvFormat::CsvSplitter will be fixed


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Bugfix 