### PR TITLE
Fixed CBO Level 1 and Level 2

### DIFF
--- a/ydb/library/yql/dq/opt/dq_cbo_ut.cpp
+++ b/ydb/library/yql/dq/opt/dq_cbo_ut.cpp
@@ -227,7 +227,7 @@ void _DqOptimizeEquiJoinWithCosts(const std::function<IOptimizerNew*()>& optFact
         auto rel = std::make_shared<TRelOptimizerNode>(TString(label), stats);
         rels.push_back(rel);
     };
-    auto res = DqOptimizeEquiJoinWithCosts(equiJoin, ctx, typeCtx, 1, *opt, providerCollect);
+    auto res = DqOptimizeEquiJoinWithCosts(equiJoin, ctx, typeCtx, 2, *opt, providerCollect);
     UNIT_ASSERT(equiJoin.Ptr() != res.Ptr());
     UNIT_ASSERT(equiJoin.Ptr()->ChildrenSize() == res.Ptr()->ChildrenSize());
     UNIT_ASSERT(equiJoin.Maybe<TCoEquiJoin>());

--- a/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join_cost_based.cpp
@@ -335,7 +335,7 @@ TExprBase DqOptimizeEquiJoinWithCosts(
     int& equiJoinCounter,
     const TOptimizerHints& hints
 ) {
-    if (optLevel == 0) {
+    if (optLevel <= 1) {
         return node;
     }
 

--- a/ydb/library/yql/dq/opt/dq_opt_stat.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_stat.cpp
@@ -549,8 +549,10 @@ void InferStatisticsForAsList(const TExprNode::TPtr& input, TTypeAnnotationConte
     if (input->ChildrenSize() && input->Child(0)->IsCallable("AsStruct")) {
         nAttrs = input->Child(0)->ChildrenSize();
     }
-    typeCtx->SetStats(input.Get(), std::make_shared<TOptimizerStatistics>(
-        EStatisticsType::BaseTable, nRows, nAttrs, nRows*nAttrs, 0.0));
+    auto outputStats = std::make_shared<TOptimizerStatistics>(
+        EStatisticsType::BaseTable, nRows, nAttrs, nRows*nAttrs, 0.0);
+    outputStats->StorageType = EStorageType::RowStorage;
+    typeCtx->SetStats(input.Get(), outputStats);
 }
 
 /***
@@ -571,6 +573,7 @@ bool InferStatisticsForListParam(const TExprNode::TPtr& input, TTypeAnnotationCo
             int nRows = 100;
             int nAttrs = maybeStructType.Cast().Ptr()->ChildrenSize();
             auto resStats = std::make_shared<TOptimizerStatistics>(EStatisticsType::BaseTable, nRows, nAttrs, nRows*nAttrs, 0.0);
+            resStats->StorageType = EStorageType::RowStorage;
             typeCtx->SetStats(input.Get(), resStats);
         }
     }

--- a/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
+++ b/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
@@ -291,7 +291,7 @@ protected:
                 rels.push_back(rel);
             };
 
-            return DqOptimizeEquiJoinWithCosts(node, ctx, TypesCtx, 1, *opt, providerCollect);
+            return DqOptimizeEquiJoinWithCosts(node, ctx, TypesCtx, 2, *opt, providerCollect);
         } else {
             return node;
         }


### PR DESCRIPTION
### Changelog entry 
CBO at Level 2 was activated when some tables in the queries were not Data Shard tables, and this included AS_Table constructs and parameters. 
CBO at Level 1 was broken due to a missing commit

...

### Changelog category <!-- remove all except one -->

* Bugfix 


### Additional information

...
