### PR TITLE
Remove user removes their ACL

### DIFF
--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -327,7 +327,7 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT(result->Token->IsExist("group1"));
         UNIT_ASSERT_VALUES_EQUAL(result->Token->GetGroupSIDs().size(), 2);
 
-        provider.RemoveUser({.User = "user1"});
+        provider.RemoveUser("user1");
 
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvUpdateLoginSecurityState(provider.GetSecurityState())), 0);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -225,8 +225,10 @@ public:
                     context.OnComplete.PublishToSchemeBoard(OperationId, parent->PathId);
                 }
             }
-            // TODO: publish only changed paths
-            context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
+            NACLib::TACL effectiveACL(path->CachedEffectiveACL.GetForSelf());
+            if (effectiveACL.HasAccess(user)) {
+                context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
+            }
         }
 
         context.OnComplete.UpdateTenants(std::move(subTree));

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -227,6 +227,9 @@ public:
             }
             NACLib::TACL effectiveACL(path->CachedEffectiveACL.GetForSelf());
             if (effectiveACL.HasAccess(user)) {
+                // publish paths from which the user's access is being removed
+                // user access could have been granted directly (ACL, handled by `acl.TryRemoveAccess(user)` above)
+                // or it might have been inherited from a parent (effective ACL)
                 context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
             }
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -225,12 +225,10 @@ public:
                     context.OnComplete.PublishToSchemeBoard(OperationId, parent->PathId);
                 }
             }
-            if (!path->IsMigrated()) {
-                context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
-            }
+            // TODO: publish only changed paths
+            context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
         }
 
-        // Note: it seems useless to update only the affected paths as we may update database's root
         context.OnComplete.UpdateTenants(std::move(subTree));
         db.Table<Schema::LoginSids>().Key(user).Delete();
         for (const TString& group : removeUserResponse.TouchedGroups) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -213,7 +213,7 @@ public:
         for (auto pathId : subTree) {
             TPathElement::TPtr path = context.SS->PathsById.at(pathId);
             NACLib::TACL acl(path->ACL);
-            if (acl.RemoveAccess(user)) {
+            if (acl.TryRemoveAccess(user)) {
                 ++path->ACLVersion;
                 path->ACL = acl.SerializeAsString();
                 context.SS->PersistACL(db, path);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
@@ -65,9 +65,7 @@ public:
             context.SS->PersistACL(db, path.Base());
 
             for (const auto& pathId : subTree) {
-                if (!context.SS->PathsById.at(pathId)->IsMigrated()) {
-                    context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
-                }
+                context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
             }
 
             affectedPaths.insert(subTree.begin(), subTree.end());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
@@ -65,10 +65,9 @@ public:
             context.SS->PersistACL(db, path.Base());
 
             for (const auto& pathId : subTree) {
-                if (context.SS->PathsById.at(pathId)->IsMigrated()) {
-                    continue;
+                if (!context.SS->PathsById.at(pathId)->IsMigrated()) {
+                    context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
                 }
-                context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
             }
 
             affectedPaths.insert(subTree.begin(), subTree.end());

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1971,6 +1971,19 @@ namespace NSchemeShardUT_Private {
         TestModificationResults(runtime, txId, expectedResults);
     }
 
+    void CreateAlterLoginRemoveUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TVector<TExpectedResult>& expectedResults) {
+        auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
+        auto transaction = modifyTx->Record.AddTransaction();
+        transaction->SetWorkingDir(database);
+        transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpAlterLogin);
+
+        auto removeUser = transaction->MutableAlterLogin()->MutableRemoveUser();
+        removeUser->SetUser(user);
+
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
     void AlterLoginAddGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& member, const TString& group, const TVector<TExpectedResult>& expectedResults) {
         auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
         auto transaction = modifyTx->Record.AddTransaction();

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -526,6 +526,10 @@ namespace NSchemeShardUT_Private {
     void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, 
         const TString& user, const TString& password,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+    
+    void CreateAlterLoginRemoveUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, 
+        const TString& user,
+        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 
     void AlterLoginAddGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database, 
         const TString& member, const TString& group, 

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -1271,29 +1271,25 @@ void CheckRight(const NKikimrScheme::TEvDescribeSchemeResult& record, const TStr
 
 TCheckFunc HasRight(const TString& right) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
-        CheckRight(record, right, true, true);
+        CheckRight(record, right, true, false);
     };
 }
 
 TCheckFunc HasNoRight(const TString& right) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
-        CheckRight(record, right, false, true);
+        CheckRight(record, right, false, false);
     };
-}
-
-void CheckEffectiveRight(const NKikimrScheme::TEvDescribeSchemeResult& record, const TString& right, bool mustHave) {
-    CheckRight(record, right, mustHave, true);
 }
 
 TCheckFunc HasEffectiveRight(const TString& right) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
-        CheckEffectiveRight(record, right, true);
+        CheckRight(record, right, true, true);
     };
 }
 
 TCheckFunc HasNoEffectiveRight(const TString& right) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
-        CheckEffectiveRight(record, right, false);
+        CheckRight(record, right, false, true);
     };
 }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -1263,7 +1263,7 @@ void CheckRight(const NKikimrScheme::TEvDescribeSchemeResult& record, const TStr
             }
         }
 
-        UNIT_ASSERT_C(!(has ^ mustHave), "" << (mustHave ? "no " : "") << "ace found"
+        UNIT_ASSERT_C(!(has ^ mustHave), "" << record.GetPath() << " " << (mustHave ? "no " : "") << "ace found"
             << ", got " << src.ShortDebugString()
             << ", required " << required.ShortDebugString());
     }

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -217,7 +217,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
             AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
             TestModificationResults(runtime, txId, TVector<TExpectedResult>{{
-                missingOk ? NKikimrScheme::StatusSuccess : NKikimrScheme::StatusPreconditionFailed
+                missingOk ? NKikimrScheme::StatusSuccess : NKikimrScheme::StatusPreconditionFailed,
+                missingOk ? "" : "User not found"
             }});
         }
     }
@@ -244,7 +245,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Dir1").DebugString() << Endl;
 
         CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user1",
-            TVector<TExpectedResult>{{NKikimrScheme::StatusPreconditionFailed}});
+            TVector<TExpectedResult>{{NKikimrScheme::StatusPreconditionFailed, "User user1 owns /MyRoot/Dir1/DirSub1 and can't be removed"}});
         
         // check user still exists and has their rights:
         {
@@ -272,7 +273,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestEnv env(runtime);
         runtime.GetAppData().AuthConfig.SetEnableLoginAuthentication(false);
         ui64 txId = 100;
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusPreconditionFailed}});
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusPreconditionFailed, "Login authentication is disabled"}});
         auto resultLogin = Login(runtime, "user1", "password1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Login authentication is disabled");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -121,24 +121,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             {NLs::HasNoRight("+U:user1"), NLs::HasEffectiveRight("+U:user1")});
         TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub2"),
             {NLs::HasRight("+U:user1"), NLs::HasEffectiveRight("+U:user1")});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir2"),
-            {NLs::HasNoRight("+U:user1"), NLs::HasEffectiveRight("+U:user1")});
-
-        // Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Dir1").DebugString() << Endl;
 
         CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user1");
 
+        // Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Dir1/DirSub2").DebugString() << Endl;
         // Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Dir1").DebugString() << Endl;
 
-        return; // TODO:
-        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
-            {NLs::HasNoEffectiveRight("+U:user1")});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1"),
-            {NLs::HasNoEffectiveRight("+U:user1")});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/SubDir1"),
-            {NLs::HasNoEffectiveRight("+U:user1")});
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/SubDir2"),
-            {NLs::HasNoEffectiveRight("+U:user1")});
+        for (auto path : {"/MyRoot", "/MyRoot/Dir1", "/MyRoot/Dir2", "/MyRoot/Dir1/DirSub1", "/MyRoot/Dir1/DirSub2"}) {
+            TestDescribeResult(DescribePath(runtime, path),
+                {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1")});
+        }
     }
 
     Y_UNIT_TEST(DisableBuiltinAuthMechanism) {

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -131,6 +131,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             TestDescribeResult(DescribePath(runtime, path),
                 {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1")});
         }
+
+        // check login
+        {
+            auto resultLogin = Login(runtime, "user1", "password1");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
+        }
     }
 
     Y_UNIT_TEST(DisableBuiltinAuthMechanism) {

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -1,5 +1,6 @@
 #include <util/string/join.h>
 
+#include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/library/login/login.h>
 #include <ydb/library/login/password_checker/password_checker.h>
 #include <ydb/library/actors/http/http_proxy.h>
@@ -33,6 +34,21 @@ void SetPasswordCheckerParameters(TTestActorRuntime &runtime, ui64 schemeShard, 
 }
 
 }  // namespace NSchemeShardUT_Private
+
+struct TLogStopwatch {
+    TLogStopwatch(TString message)
+        : Message(std::move(message))
+        , Started(TAppData::TimeProvider->Now())
+    {}
+    
+    ~TLogStopwatch() {
+        Cerr << "[STOPWATCH] " << Message << " in " << (TAppData::TimeProvider->Now() - Started).MilliSeconds() << "ms" << Endl;
+    }
+
+private:
+    TString Message;
+    TInstant Started;
+};
 
 Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
@@ -140,53 +156,82 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
     }
 
     Y_UNIT_TEST(RemoveLogin_Many) {
+        const size_t pathsToCreate = 1000;
+        const size_t usersToAdd = 10;
+
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
         runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_NOTICE);
+        runtime.SetDispatchedEventsLimit(100'000'000'000);
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        auto resultLogin = Login(runtime, "user1", "password1");
+        for (auto userId : xrange(usersToAdd)) {
+            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId), "password" + std::to_string(userId));
+        }
+        auto resultLogin = Login(runtime, "user0", "password0");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         
-        NACLib::TDiffACL diffACL;
-        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user1");
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Created " << pathsToCreate << " paths");
 
-        auto stopwatch = TAppData::TimeProvider->Now();
-
-        THashSet<std::pair<TString, TString>> paths;
-        paths.emplace("", "MyRoot");
-        while (paths.size() < 1000) {
-            TString path = "/MyRoot";
-            ui32 index = RandomNumber<ui32>();
-            for (ui32 depth : xrange(15)) {
-                Y_UNUSED(depth);
-                TString dir = "Dir" + std::to_string(index % 3);
-                index /= 3;
-                if (paths.emplace(path, dir).second) {
-                    Cerr << "Create " << (path + "/" + dir) << Endl;
-                    AsyncMkDir(runtime, ++txId, path, dir);
-                    TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
-                }
-
-                path += "/" + dir;
+            NACLib::TDiffACL diffACL;
+            for (auto userId : xrange(usersToAdd)) {
+                diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user" + std::to_string(userId));
             }
+
+            THashSet<TString> paths;
+            paths.emplace("MyRoot");
+            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
+
+            auto evTx = new TEvSchemeShard::TEvModifySchemeTransaction(++txId, TTestTxConfig::SchemeShard);
+
+            // creating a random directories tree:
+            while (paths.size() < pathsToCreate) {
+                TString path = "/MyRoot";
+                ui32 index = RandomNumber<ui32>();
+                for (ui32 depth : xrange(15)) {
+                    Y_UNUSED(depth);
+                    TString dir = "Dir" + std::to_string(index % 3);
+                    index /= 3;
+                    if (paths.size() < pathsToCreate && paths.emplace(path + "/" + dir).second) {
+                        auto transaction = evTx->Record.AddTransaction();
+                        transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpMkDir);
+                        transaction->SetWorkingDir(path);
+                        transaction->MutableMkDir()->SetName(dir);
+                        transaction->MutableModifyACL()->SetDiffACL(diffACL.SerializeAsString());
+                    }
+                    path += "/" + dir;
+                }
+            }
+
+            AsyncSend(runtime, TTestTxConfig::SchemeShard, evTx);
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
         }
 
-        Cerr << "[STOPWATCH] Created " << paths.size() << " paths in " << (TAppData::TimeProvider->Now() - stopwatch).MilliSeconds() << "ms" << Endl;
-        stopwatch = TAppData::TimeProvider->Now();
+        Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot").DebugString() << Endl;
 
-        for (auto& [path, dir] : paths) {
-            AsyncModifyACL(runtime, ++txId, path, dir, diffACL.SerializeAsString(), "");
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Added single root acl");
+            NACLib::TDiffACL diffACL;
+            diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "userX");
+            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
             TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
         }
 
-        Cerr << "[STOPWATCH] Added " << paths.size() << " acls in " << (TAppData::TimeProvider->Now() - stopwatch).MilliSeconds() << "ms" << Endl;
-        stopwatch = TAppData::TimeProvider->Now();
-
-        CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user1");
-
-        Cerr << "[STOPWATCH] Removed user in " << (TAppData::TimeProvider->Now() - stopwatch).MilliSeconds() << "ms" << Endl;
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Removed single root acl");
+            NACLib::TDiffACL diffACL;
+            diffACL.RemoveAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "userX");
+            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
+        }
+    
+        for (auto userId : xrange(usersToAdd))
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Removed user" + std::to_string(userId));
+            CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId));
+        }
     }
 
     Y_UNIT_TEST(DisableBuiltinAuthMechanism) {

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -35,21 +35,6 @@ void SetPasswordCheckerParameters(TTestActorRuntime &runtime, ui64 schemeShard, 
 
 }  // namespace NSchemeShardUT_Private
 
-struct TLogStopwatch {
-    TLogStopwatch(TString message)
-        : Message(std::move(message))
-        , Started(TAppData::TimeProvider->Now())
-    {}
-    
-    ~TLogStopwatch() {
-        Cerr << "[STOPWATCH] " << Message << " in " << (TAppData::TimeProvider->Now() - Started).MilliSeconds() << "ms" << Endl;
-    }
-
-private:
-    TString Message;
-    TInstant Started;
-};
-
 Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
     Y_UNIT_TEST(BasicLogin) {
@@ -224,85 +209,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
                 {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1"), NLs::HasOwner("user2")});
             auto resultLogin = Login(runtime, "user1", "password1");
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
-        }
-    }
-
-    Y_UNIT_TEST(RemoveLogin_Many) {
-        const size_t pathsToCreate = 1000;
-        const size_t usersToAdd = 10;
-
-        TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
-        ui64 txId = 100;
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_NOTICE);
-        runtime.SetDispatchedEventsLimit(100'000'000'000);
-
-        for (auto userId : xrange(usersToAdd)) {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId), "password" + std::to_string(userId));
-        }
-        auto resultLogin = Login(runtime, "user0", "password0");
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-        
-        {
-            TLogStopwatch stopwatch(TStringBuilder() << "Created " << pathsToCreate << " paths");
-
-            NACLib::TDiffACL diffACL;
-            for (auto userId : xrange(usersToAdd)) {
-                diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user" + std::to_string(userId));
-            }
-
-            THashSet<TString> paths;
-            paths.emplace("MyRoot");
-            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
-            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
-
-            auto evTx = new TEvSchemeShard::TEvModifySchemeTransaction(++txId, TTestTxConfig::SchemeShard);
-
-            // creating a random directories tree:
-            while (paths.size() < pathsToCreate) {
-                TString path = "/MyRoot";
-                ui32 index = RandomNumber<ui32>();
-                for (ui32 depth : xrange(15)) {
-                    Y_UNUSED(depth);
-                    TString dir = "Dir" + std::to_string(index % 3);
-                    index /= 3;
-                    if (paths.size() < pathsToCreate && paths.emplace(path + "/" + dir).second) {
-                        auto transaction = evTx->Record.AddTransaction();
-                        transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpMkDir);
-                        transaction->SetWorkingDir(path);
-                        transaction->MutableMkDir()->SetName(dir);
-                        transaction->MutableModifyACL()->SetDiffACL(diffACL.SerializeAsString());
-                    }
-                    path += "/" + dir;
-                }
-            }
-
-            AsyncSend(runtime, TTestTxConfig::SchemeShard, evTx);
-            TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
-        }
-
-        Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot").DebugString() << Endl;
-
-        {
-            TLogStopwatch stopwatch(TStringBuilder() << "Added single root acl");
-            NACLib::TDiffACL diffACL;
-            diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "userX");
-            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
-            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
-        }
-
-        {
-            TLogStopwatch stopwatch(TStringBuilder() << "Removed single root acl");
-            NACLib::TDiffACL diffACL;
-            diffACL.RemoveAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "userX");
-            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
-            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
-        }
-    
-        for (auto userId : xrange(usersToAdd))
-        {
-            TLogStopwatch stopwatch(TStringBuilder() << "Removed user" + std::to_string(userId));
-            CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId));
         }
     }
 

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -120,6 +120,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
         NACLib::TDiffACL diffACL;
         diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user1");
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user2");
         AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
         TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
         AsyncModifyACL(runtime, ++txId, "/MyRoot", "Dir1", diffACL.SerializeAsString(), "");
@@ -153,6 +154,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             auto resultLogin = Login(runtime, "user1", "password1");
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
         }
+
+        // another still has access
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1"),
+            {NLs::HasRight("+U:user2"), NLs::HasEffectiveRight("+U:user2")});
     }
 
     Y_UNIT_TEST(RemoveLogin_Many) {

--- a/ydb/core/tx/schemeshard/ut_login/ya.make
+++ b/ydb/core/tx/schemeshard/ut_login/ya.make
@@ -6,9 +6,7 @@ IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
     SIZE(LARGE)
     TAG(ya:fat)
 ELSE()
-    SIZE(LARGE)
-    TAG(ya:fat)
-    TIMEOUT(3600)
+    SIZE(MEDIUM)
 ENDIF()
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_login/ya.make
+++ b/ydb/core/tx/schemeshard/ut_login/ya.make
@@ -6,7 +6,9 @@ IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
     SIZE(LARGE)
     TAG(ya:fat)
 ELSE()
-    SIZE(MEDIUM)
+    SIZE(LARGE)
+    TAG(ya:fat)
+    TIMEOUT(3600)
 ENDIF()
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
+++ b/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
@@ -1,0 +1,104 @@
+#include <ydb/core/protos/schemeshard/operations.pb.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+struct TLogStopwatch {
+    TLogStopwatch(TString message)
+        : Message(std::move(message))
+        , Started(TAppData::TimeProvider->Now())
+    {}
+    
+    ~TLogStopwatch() {
+        Cerr << "[STOPWATCH] " << Message << " in " << (TAppData::TimeProvider->Now() - Started).MilliSeconds() << "ms" << Endl;
+    }
+
+private:
+    TString Message;
+    TInstant Started;
+};
+
+Y_UNIT_TEST_SUITE(TSchemeShardLoginLargeTest) {
+
+    Y_UNIT_TEST(RemoveLogin_Many) {
+        const size_t pathsToCreate = 10'000;
+        const size_t usersToAdd = 200; // 2M ACL rules in total
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_NOTICE);
+        runtime.SetDispatchedEventsLimit(100'000'000'000);
+
+        for (auto userId : xrange(usersToAdd)) {
+            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId), "password" + std::to_string(userId));
+        }
+        auto resultLogin = Login(runtime, "user0", "password0");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
+        
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Created " << pathsToCreate << " paths");
+
+            NACLib::TDiffACL diffACL;
+            for (auto userId : xrange(usersToAdd)) {
+                diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user" + std::to_string(userId));
+            }
+
+            THashSet<TString> paths;
+            paths.emplace("MyRoot");
+            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
+
+            auto evTx = new TEvSchemeShard::TEvModifySchemeTransaction(++txId, TTestTxConfig::SchemeShard);
+
+            // creating a random directories tree:
+            while (paths.size() < pathsToCreate) {
+                TString path = "/MyRoot";
+                ui32 index = RandomNumber<ui32>();
+                for (ui32 depth : xrange(15)) {
+                    Y_UNUSED(depth);
+                    TString dir = "Dir" + std::to_string(index % 3);
+                    index /= 3;
+                    if (paths.size() < pathsToCreate && paths.emplace(path + "/" + dir).second) {
+                        auto transaction = evTx->Record.AddTransaction();
+                        transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpMkDir);
+                        transaction->SetWorkingDir(path);
+                        transaction->MutableMkDir()->SetName(dir);
+                        transaction->MutableModifyACL()->SetDiffACL(diffACL.SerializeAsString());
+                    }
+                    path += "/" + dir;
+                }
+            }
+
+            AsyncSend(runtime, TTestTxConfig::SchemeShard, evTx);
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
+        }
+
+        Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot").DebugString() << Endl;
+
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Added single root acl");
+            NACLib::TDiffACL diffACL;
+            diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "userX");
+            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
+        }
+
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Removed single root acl");
+            NACLib::TDiffACL diffACL;
+            diffACL.RemoveAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "userX");
+            AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), "");
+            TestModificationResult(runtime, txId, NKikimrScheme::StatusSuccess);
+        }
+    
+        for (auto userId : xrange(Min<size_t>(usersToAdd, 3)))
+        {
+            TLogStopwatch stopwatch(TStringBuilder() << "Removed user" + std::to_string(userId));
+            CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId));
+        }
+    }
+
+}

--- a/ydb/core/tx/schemeshard/ut_login_large/ya.make
+++ b/ydb/core/tx/schemeshard/ut_login_large/ya.make
@@ -1,0 +1,20 @@
+UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+FORK_SUBTESTS()
+
+SIZE(LARGE)
+TAG(ya:fat)
+
+PEERDIR(
+    ydb/core/testlib/default
+    ydb/core/tx
+    ydb/core/tx/schemeshard/ut_helpers
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    ut_login_large.cpp
+)
+
+END()

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -26,6 +26,7 @@ RECURSE_FOR_TESTS(
     ut_index_build
     ut_index_build_reboots
     ut_login
+    ut_login_large
     ut_move
     ut_move_reboots
     ut_olap

--- a/ydb/library/aclib/aclib.cpp
+++ b/ydb/library/aclib/aclib.cpp
@@ -390,9 +390,8 @@ bool TACL::RemoveAccess(const NACLib::TSID& sid) {
         return false;
     }
     
-    while (newEnd != ACL->end()) {
-        ACL->RemoveLast();
-    }
+    ACL->erase(newEnd, ACL->end());
+    
     return true;
 }
 

--- a/ydb/library/aclib/aclib.cpp
+++ b/ydb/library/aclib/aclib.cpp
@@ -379,6 +379,23 @@ std::pair<ui32, ui32> TACL::RemoveAccess(const NACLibProto::TACE& filter) {
     return modified;
 }
 
+bool TACL::RemoveAccess(const NACLib::TSID& sid) {
+    auto* ACL = MutableACE();
+    
+    auto newEnd = std::remove_if(ACL->begin(), ACL->end(), [&sid](const NACLibProto::TACE& ace) {
+        return ace.GetSID() == sid;
+    });
+
+    if (newEnd == ACL->end()) {
+        return false;
+    }
+    
+    while (newEnd != ACL->end()) {
+        ACL->RemoveLast();
+    }
+    return true;
+}
+
 void TACL::SortACL() {
     Sort(*(MutableACE()), [](const NACLibProto::TACE& a, const NACLibProto::TACE& b) -> bool { return a.GetAccessType() < b.GetAccessType(); });
 }

--- a/ydb/library/aclib/aclib.cpp
+++ b/ydb/library/aclib/aclib.cpp
@@ -395,6 +395,16 @@ bool TACL::RemoveAccess(const NACLib::TSID& sid) {
     return true;
 }
 
+bool TACL::HasAccess(const NACLib::TSID& sid) {
+    for (const auto& ace : GetACE()) {
+        if (ace.GetSID() == sid) {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
 void TACL::SortACL() {
     Sort(*(MutableACE()), [](const NACLibProto::TACE& a, const NACLibProto::TACE& b) -> bool { return a.GetAccessType() < b.GetAccessType(); });
 }

--- a/ydb/library/aclib/aclib.cpp
+++ b/ydb/library/aclib/aclib.cpp
@@ -379,7 +379,7 @@ std::pair<ui32, ui32> TACL::RemoveAccess(const NACLibProto::TACE& filter) {
     return modified;
 }
 
-bool TACL::RemoveAccess(const NACLib::TSID& sid) {
+bool TACL::TryRemoveAccess(const NACLib::TSID& sid) {
     auto* ACL = MutableACE();
     
     auto newEnd = std::remove_if(ACL->begin(), ACL->end(), [&sid](const NACLibProto::TACE& ace) {

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -118,6 +118,7 @@ public:
     std::pair<ui32, ui32> RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
     std::pair<ui32, ui32> RemoveAccess(const NACLibProto::TACE& filter);
     bool RemoveAccess(const NACLib::TSID& sid);
+    bool HasAccess(const NACLib::TSID& sid);
     std::pair<ui32, ui32> ClearAccess();
     std::pair<ui32, ui32> ApplyDiff(const NACLibProto::TDiffACL& diffACL);
     NACLibProto::TACL GetImmediateACL() const;

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -117,7 +117,7 @@ public:
     std::pair<ui32, ui32> AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
     std::pair<ui32, ui32> RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
     std::pair<ui32, ui32> RemoveAccess(const NACLibProto::TACE& filter);
-    bool RemoveAccess(const NACLib::TSID& sid);
+    bool TryRemoveAccess(const NACLib::TSID& sid);
     bool HasAccess(const NACLib::TSID& sid);
     std::pair<ui32, ui32> ClearAccess();
     std::pair<ui32, ui32> ApplyDiff(const NACLibProto::TDiffACL& diffACL);

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -117,6 +117,7 @@ public:
     std::pair<ui32, ui32> AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
     std::pair<ui32, ui32> RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
     std::pair<ui32, ui32> RemoveAccess(const NACLibProto::TACE& filter);
+    bool RemoveAccess(const NACLib::TSID& sid);
     std::pair<ui32, ui32> ClearAccess();
     std::pair<ui32, ui32> ApplyDiff(const NACLibProto::TDiffACL& diffACL);
     NACLibProto::TACL GetImmediateACL() const;

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -88,8 +88,8 @@ bool TLoginProvider::CheckSubjectExists(const TString& name, const ESidType::Sid
     return itSidModify != Sids.end() && itSidModify->second.Type == type;
 }
 
-bool TLoginProvider::CheckUserExists(const TString& name) {
-    return CheckSubjectExists(name, ESidType::USER);
+bool TLoginProvider::CheckUserExists(const TString& user) {
+    return CheckSubjectExists(user, ESidType::USER);
 }
 
 TLoginProvider::TBasicResponse TLoginProvider::ModifyUser(const TModifyUserRequest& request) {
@@ -113,24 +113,22 @@ TLoginProvider::TBasicResponse TLoginProvider::ModifyUser(const TModifyUserReque
     return response;
 }
 
-TLoginProvider::TRemoveUserResponse TLoginProvider::RemoveUser(const TRemoveUserRequest& request) {
+TLoginProvider::TRemoveUserResponse TLoginProvider::RemoveUser(const TString& user) {
     TRemoveUserResponse response;
 
-    auto itUserModify = Sids.find(request.User);
+    auto itUserModify = Sids.find(user);
     if (itUserModify == Sids.end() || itUserModify->second.Type != ESidType::USER) {
-        if (!request.MissingOk) {
-            response.Error = "User not found";
-        }
+        response.Error = "User not found";
         return response;
     }
 
-    auto itChildToParentIndex = ChildToParentIndex.find(request.User);
+    auto itChildToParentIndex = ChildToParentIndex.find(user);
     if (itChildToParentIndex != ChildToParentIndex.end()) {
         for (const TString& parent : itChildToParentIndex->second) {
             auto itGroup = Sids.find(parent);
             if (itGroup != Sids.end()) {
                 response.TouchedGroups.emplace_back(itGroup->first);
-                itGroup->second.Members.erase(request.User);
+                itGroup->second.Members.erase(user);
             }
         }
         ChildToParentIndex.erase(itChildToParentIndex);

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -75,11 +75,6 @@ public:
         TString Password;
     };
 
-    struct TRemoveUserRequest : TBasicRequest {
-        TString User;
-        bool MissingOk;
-    };
-
     struct TRemoveUserResponse : TBasicResponse {
         std::vector<TString> TouchedGroups;
     };
@@ -165,8 +160,8 @@ public:
 
     TBasicResponse CreateUser(const TCreateUserRequest& request);
     TBasicResponse ModifyUser(const TModifyUserRequest& request);
-    TRemoveUserResponse RemoveUser(const TRemoveUserRequest& request);
-    bool CheckUserExists(const TString& name);
+    TRemoveUserResponse RemoveUser(const TString& user);
+    bool CheckUserExists(const TString& user);
 
     TBasicResponse CreateGroup(const TCreateGroupRequest& request);
     TBasicResponse AddGroupMembership(const TAddGroupMembershipRequest& request);

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -276,7 +276,7 @@ Y_UNIT_TEST_SUITE(Login) {
             UNIT_ASSERT(Count(groups, "group5") == 1);
         }
         {
-            auto response1 = provider.RemoveUser({.User = "user1"});
+            auto response1 = provider.RemoveUser("user1");
             UNIT_ASSERT(!response1.Error);
         }
         {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->



### Additional information

Test results shows that remove user works as slow as add/remove of a single ACL rule

That seems reasonable as it also involves `ListSubTree` and `PublishToSchemeBoard` of the whole tree  

```
[STOPWATCH] Created 10000 paths in 6849ms
[STOPWATCH] Added single root acl in 7190ms
[STOPWATCH] Removed single root acl in 7340ms
[STOPWATCH] Removed user0 in 7615ms
[STOPWATCH] Removed user1 in 7531ms
[STOPWATCH] Removed user2 in 7558ms
[STOPWATCH] Removed user3 in 7448ms
[STOPWATCH] Removed user4 in 7605ms
[STOPWATCH] Removed user5 in 7404ms
[STOPWATCH] Removed user6 in 7559ms
[STOPWATCH] Removed user7 in 7564ms
[STOPWATCH] Removed user8 in 7603ms
[STOPWATCH] Removed user9 in 7478ms
```

A bit bigger difference for 1000 paths:

```
[STOPWATCH] Created 1000 paths in 528ms
[STOPWATCH] Added single root acl in 152ms
[STOPWATCH] Removed single root acl in 155ms
[STOPWATCH] Removed user0 in 430ms
[STOPWATCH] Removed user1 in 410ms
[STOPWATCH] Removed user2 in 429ms
[STOPWATCH] Removed user3 in 436ms
[STOPWATCH] Removed user4 in 427ms
[STOPWATCH] Removed user5 in 422ms
[STOPWATCH] Removed user6 in 433ms
[STOPWATCH] Removed user7 in 424ms
[STOPWATCH] Removed user8 in 418ms
[STOPWATCH] Removed user9 in 418ms
```