### PR TITLE
[stable-24-3] remove clang14

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -203,7 +203,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_preset: ["relwithdebinfo", "release-asan", "release-clang14"]
+        build_preset: ["relwithdebinfo", "release-asan"]
     runs-on: [ self-hosted, auto-provisioned, "${{ format('build-preset-{0}', matrix.build_preset) }}" ]
     name: Build and test ${{ matrix.build_preset }}
     steps:
@@ -247,7 +247,7 @@ jobs:
             https://api.github.com/repos/${{github.repository}}/commits/${{github.event.pull_request.head.sha}}/status | \
             jq -cr '.statuses | .[] | select(.state=="success") | select(.context | startswith("build_")) | .context' | \
             wc -l )
-          if [[ $successbuilds == "3" ]];then
+          if [[ $successbuilds == "2" ]];then
             integrated_status="success"
           else
             integrated_status="failure"


### PR DESCRIPTION
Because it is not working properly in cherry-picks

In the other hand nobody needs clang14

See problems in 
https://github.com/ydb-platform/ydb/pull/12292
https://github.com/ydb-platform/ydb/pull/12316 