### PR TITLE
Fix not allocated vectors when used MovedPatch

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_patch.cpp
@@ -585,6 +585,11 @@ public:
         Become(&TBlobStorageGroupPatchRequest::MovedPatchState);
         IsMovedPatch = true;
         std::optional<ui32> subgroupIdx = 0;
+        ReceivedResponseFlags.resize(VDisks.size(), false);
+        ErrorResponseFlags.resize(VDisks.size(), false);
+        EmptyResponseFlags.resize(VDisks.size(), false);
+        ForceStopFlags.resize(VDisks.size(), false);
+        SlowFlags.resize(VDisks.size(), false);
 
         if (OkVDisksWithParts) {
             ui32 okVDiskIdx = RandomNumber<ui32>(OkVDisksWithParts.size());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

MovedPatch uses some vectors that were allocated only during VPatch.
Now they are also allocated during MovedPatch if they were not initially allocated.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
