### PR TITLE
VIEW: local backup (ydb tools dump and restore)

### DIFF
--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -2,18 +2,22 @@
 #include "db_iterator.h"
 #include "util.h"
 
+#include <ydb/public/api/protos/draft/ydb_view.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/lib/ydb_cli/common/recursive_remove.h>
 #include <ydb/public/lib/ydb_cli/common/retry_func.h>
 #include <ydb/public/lib/ydb_cli/dump/files/files.h>
 #include <ydb/public/lib/ydb_cli/dump/util/util.h>
+#include <ydb/public/lib/ydb_cli/dump/util/view_utils.h>
 #include <ydb/public/lib/yson_value/ydb_yson_value.h>
+#include <ydb/public/sdk/cpp/client/draft/ydb_view.h>
 #include <ydb/public/sdk/cpp/client/ydb_proto/accessor.h>
 #include <ydb/public/sdk/cpp/client/ydb_driver/driver.h>
 #include <ydb/public/sdk/cpp/client/ydb_result/result.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/topic.h>
 #include <ydb/public/sdk/cpp/client/ydb_value/value.h>
+#include <yql/essentials/sql/v1/format/sql_format.h>
 
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 #include <library/cpp/regex/pcre/regexp.h>
@@ -25,6 +29,7 @@
 #include <util/folder/pathsplit.h>
 #include <util/generic/ptr.h>
 #include <util/generic/yexception.h>
+#include <util/stream/file.h>
 #include <util/stream/format.h>
 #include <util/stream/mem.h>
 #include <util/stream/null.h>
@@ -33,6 +38,8 @@
 #include <util/string/printf.h>
 #include <util/system/file.h>
 #include <util/system/fs.h>
+
+#include <format>
 
 namespace NYdb::NBackup {
 
@@ -411,7 +418,7 @@ Ydb::Table::CreateTableRequest ProtoFromTableDescription(const NTable::TTableDes
 
 NScheme::TSchemeEntry DescribePath(TDriver driver, const TString& fullPath) {
     NScheme::TSchemeClient client(driver);
-    
+
     auto status = NDump::DescribePath(client, fullPath);
     VerifyStatus(status);
 
@@ -496,7 +503,7 @@ void BackupChangefeeds(TDriver driver, const TString& tablePath, const TFsPath& 
 
     for (const auto& changefeedDesc : desc.GetChangefeedDescriptions()) {
         TFsPath changefeedDirPath = CreateDirectory(folderPath, changefeedDesc.GetName());
-        
+
         auto protoChangeFeedDesc = ProtoFromChangefeedDesc(changefeedDesc);
         const auto descTopicResult = DescribeTopic(driver, JoinDatabasePath(tablePath, changefeedDesc.GetName()));
         VerifyStatus(descTopicResult);
@@ -520,13 +527,122 @@ void BackupTable(TDriver driver, const TString& dbPrefix, const TString& backupP
     auto desc = DescribeTable(driver, fullPath);
     auto proto = ProtoFromTableDescription(desc, preservePoolKinds);
     WriteProtoToFile(proto, folderPath, NDump::NFiles::TableScheme());
-  
+
     BackupChangefeeds(driver, JoinDatabasePath(dbPrefix, path), folderPath);
     BackupPermissions(driver, dbPrefix, path, folderPath);
 
     if (!schemaOnly) {
         ReadTable(driver, desc, fullPath, folderPath, ordered);
     }
+}
+
+namespace {
+
+NView::TViewDescription DescribeView(NView::TViewClient& client, const TString& path) {
+    auto status = NConsoleClient::RetryFunction([&]() {
+        return client.DescribeView(path).ExtractValueSync();
+    });
+    VerifyStatus(status);
+    return status.GetViewDescription();
+}
+
+struct TViewQuerySplit {
+    TString ContextRecreation;
+    TString Select;
+};
+
+TViewQuerySplit SplitViewQuery(TStringInput query) {
+    // to do: make the implementation more versatile
+    TViewQuerySplit split;
+
+    TString line;
+    while (query.ReadLine(line)) {
+        (line.StartsWith("--") || line.StartsWith("PRAGMA ")
+            ? split.ContextRecreation
+            : split.Select
+        ) += line;
+    }
+
+    return split;
+}
+
+void ValidateViewQuery(const TString& query, const TString& dbPath, NYql::TIssues& accumulatedIssues) {
+    NYql::TIssues subIssues;
+    if (!NDump::ValidateViewQuery(query, subIssues)) {
+        NYql::TIssue restorabilityIssue(
+            TStringBuilder() << "Restorability of the view: " << dbPath.Quote()
+            << " storing the following query:\n"
+            << query
+            << "\ncannot be guaranteed. For more information, please consult the 'ydb tools dump' documentation."
+        );
+        restorabilityIssue.Severity = NYql::TSeverityIds::S_WARNING;
+        for (const auto& subIssue : subIssues) {
+            restorabilityIssue.AddSubIssue(MakeIntrusive<NYql::TIssue>(subIssue));
+        }
+        accumulatedIssues.AddIssue(std::move(restorabilityIssue));
+    }
+}
+
+TString BuildCreateViewStatement(TStringBuf name, const NView::TViewDescription& description, TStringBuf backupRoot) {
+    auto [contextRecreation, select] = SplitViewQuery(description.GetQueryText());
+
+    const TString query = std::format(
+        "-- backup root: \"{}\"\n"
+        "{}"
+        "CREATE VIEW IF NOT EXISTS `{}` WITH (security_invoker = TRUE) AS\n"
+        "    {};\n",
+        backupRoot.data(),
+        contextRecreation.data(),
+        name.data(),
+        select.data()
+    );
+
+    TString formattedQuery;
+    TString errors;
+    Y_ENSURE(NSQLFormat::SqlFormatSimple(
+        query,
+        formattedQuery,
+        errors
+    ), errors);
+    return formattedQuery;
+}
+
+}
+
+/*!
+The BackupView function retrieves the view's description from the database,
+constructs a corresponding CREATE VIEW statement,
+and writes it to the backup folder designated for this view.
+
+\param dbBackupRoot the root of the backup in the database
+\param dbPathRelativeToBackupRoot the path to the view in the database relative to the backup root
+\param fsBackupDir the path on the file system to write the file with the CREATE VIEW statement to
+\param issues the accumulated backup issues container
+*/
+void BackupView(TDriver driver, const TString& dbBackupRoot, const TString& dbPathRelativeToBackupRoot,
+    const TFsPath& fsBackupDir, NYql::TIssues& issues
+) {
+    Y_ENSURE(!dbPathRelativeToBackupRoot.empty());
+    const auto dbPath = JoinDatabasePath(dbBackupRoot, dbPathRelativeToBackupRoot);
+
+    LOG_I("Backup view " << dbPath.Quote() << " to " << fsBackupDir.GetPath().Quote());
+
+    NView::TViewClient client(driver);
+    auto viewDescription = DescribeView(client, dbPath);
+
+    ValidateViewQuery(viewDescription.GetQueryText(), dbPath, issues);
+
+    const auto fsPath = fsBackupDir.Child(NDump::NFiles::CreateView().FileName);
+    LOG_D("Write view creation query to " << fsPath.GetPath().Quote());
+
+    TFileOutput output(fsPath);
+    output << BuildCreateViewStatement(
+        TFsPath(dbPathRelativeToBackupRoot).GetName(),
+        viewDescription,
+        dbBackupRoot
+    );
+
+    BackupPermissions(driver, dbBackupRoot, dbPathRelativeToBackupRoot, fsBackupDir);
 }
 
 void CreateClusterDirectory(const TDriver& driver, const TString& path, bool rootBackupDir = false) {
@@ -575,7 +691,9 @@ static void MaybeCreateEmptyFile(const TFsPath& folderPath) {
 
 void BackupFolderImpl(TDriver driver, const TString& dbPrefix, const TString& backupPrefix,
         const TFsPath folderPath, const TVector<TRegExMatch>& exclusionPatterns,
-        bool schemaOnly, bool useConsistentCopyTable, bool avoidCopy, bool preservePoolKinds, bool ordered) {
+        bool schemaOnly, bool useConsistentCopyTable, bool avoidCopy, bool preservePoolKinds, bool ordered,
+        NYql::TIssues& issues
+) {
     TFile(folderPath.Child(NDump::NFiles::Incomplete().FileName), CreateAlways);
 
     TMap<TString, TAsyncStatus> copiedTablesStatuses;
@@ -610,6 +728,9 @@ void BackupFolderImpl(TDriver driver, const TString& dbPrefix, const TString& ba
                 } else if (dbIt.IsDir()) {
                     CreateClusterDirectory(driver, JoinDatabasePath(backupPrefix, dbIt.GetRelPath()));
                 }
+            }
+            if (dbIt.IsView()) {
+                BackupView(driver, dbIt.GetTraverseRoot(), dbIt.GetRelPath(), childFolderPath, issues);
             }
             dbIt.Next();
         }
@@ -721,8 +842,14 @@ void BackupFolder(const TDriver& driver, const TString& database, const TString&
             CreateClusterDirectory(driver, tmpDbFolder, true);
         }
 
+        NYql::TIssues issues;
         BackupFolderImpl(driver, dbPrefix, tmpDbFolder, folderPath, exclusionPatterns,
-            schemaOnly, useConsistentCopyTable, avoidCopy, preservePoolKinds, ordered);
+            schemaOnly, useConsistentCopyTable, avoidCopy, preservePoolKinds, ordered, issues
+        );
+
+        if (issues) {
+            Cerr << issues.ToString();
+        }
     } catch (...) {
         if (!schemaOnly && !avoidCopy) {
             RemoveClusterDirectoryRecursive(driver, tmpDbFolder);

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -583,12 +583,12 @@ void ValidateViewQuery(const TString& query, const TString& dbPath, NYql::TIssue
     }
 }
 
-TString BuildCreateViewStatement(TStringBuf name, const NView::TViewDescription& description, TStringBuf backupRoot) {
+TString BuildCreateViewQuery(TStringBuf name, const NView::TViewDescription& description, TStringBuf backupRoot) {
     auto [contextRecreation, select] = SplitViewQuery(description.GetQueryText());
 
     const TString query = std::format(
         "-- backup root: \"{}\"\n"
-        "{}"
+        "{}\n"
         "CREATE VIEW IF NOT EXISTS `{}` WITH (security_invoker = TRUE) AS\n"
         "    {};\n",
         backupRoot.data(),
@@ -636,7 +636,7 @@ void BackupView(TDriver driver, const TString& dbBackupRoot, const TString& dbPa
     LOG_D("Write view creation query to " << fsPath.GetPath().Quote());
 
     TFileOutput output(fsPath);
-    output << BuildCreateViewStatement(
+    output << BuildCreateViewQuery(
         TFsPath(dbPathRelativeToBackupRoot).GetName(),
         viewDescription,
         dbBackupRoot

--- a/ydb/library/backup/db_iterator.h
+++ b/ydb/library/backup/db_iterator.h
@@ -48,7 +48,7 @@ public:
         Y_ENSURE(listResult.IsSuccess(), "Can't list directory, maybe it doesn't exist, dbPath# "
                 << fullPath.Quote());
 
-        if (listResult.GetEntry().Type == NScheme::ESchemeEntryType::Table) {
+        if (IsIn({NScheme::ESchemeEntryType::Table, NScheme::ESchemeEntryType::View}, listResult.GetEntry().Type)) {
             TPathSplitUnix parentPath(fullPath);
             parentPath.pop_back();
             TraverseRoot = parentPath.Reconstruct();
@@ -127,6 +127,10 @@ public:
 
     bool IsTable() const {
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::Table;
+    }
+
+    bool IsView() const {
+        return GetCurrentNode()->Type == NScheme::ESchemeEntryType::View;
     }
 
     bool IsDir() const {

--- a/ydb/library/backup/ya.make
+++ b/ydb/library/backup/ya.make
@@ -6,11 +6,13 @@ PEERDIR(
     library/cpp/regex/pcre
     library/cpp/string_utils/quote
     yql/essentials/types/dynumber
+    yql/essentials/sql/v1/format
     ydb/public/api/protos
     ydb/public/lib/ydb_cli/common
     ydb/public/lib/ydb_cli/dump/util
     ydb/public/lib/yson_value
     ydb/public/lib/ydb_cli/dump/files
+    ydb/public/sdk/cpp/client/draft
     ydb/public/sdk/cpp/client/ydb_driver
     ydb/public/sdk/cpp/client/ydb_proto
     ydb/public/sdk/cpp/client/ydb_result

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
@@ -3,6 +3,7 @@
 #include <ydb/public/lib/json_value/ydb_json_value.h>
 #include <ydb/public/lib/ydb_cli/common/pretty_table.h>
 #include <ydb/public/lib/ydb_cli/common/scheme_printers.h>
+#include <ydb/public/sdk/cpp/client/ydb_query/client.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/topic.h>
 
 #include <util/string/join.h>
@@ -86,8 +87,9 @@ int TCommandRemoveDirectory::Run(TConfig& config) {
     if (Recursive) {
         NTable::TTableClient tableClient(driver);
         NTopic::TTopicClient topicClient(driver);
+        NQuery::TQueryClient queryClient(driver);
         const auto prompt = Prompt.GetOrElse(ERecursiveRemovePrompt::Once);
-        ThrowOnError(RemoveDirectoryRecursive(schemeClient, tableClient, topicClient, Path, prompt, settings));
+        ThrowOnError(RemoveDirectoryRecursive(schemeClient, tableClient, &topicClient, &queryClient, Path, prompt, settings));
     } else {
         if (Prompt) {
             if (!NConsoleClient::Prompt(*Prompt, Path, NScheme::ESchemeEntryType::Directory)) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -397,7 +397,7 @@ void TWorkloadCommandBase::CleanTables(NYdbWorkload::IWorkloadQueryGenerator& wo
         if (DryRun) {
             Cout << "Remove " << fullPath << Endl;
         } else {
-            ThrowOnError(RemovePathRecursive(*SchemeClient, *TableClient, *TopicClient, fullPath, ERecursiveRemovePrompt::Never, settings));
+            ThrowOnError(RemovePathRecursive(*SchemeClient, *TableClient, TopicClient.Get(), QueryClient.Get(), fullPath, ERecursiveRemovePrompt::Never, settings));
         }
         Cout << "Remove path " << path << "...Ok"  << Endl;
     }
@@ -444,7 +444,7 @@ TWorkloadCommandRoot::TWorkloadCommandRoot(const TString& key)
     }
     AddCommand(std::make_unique<TWorkloadCommandClean>(*Params));
 }
-    
+
 void TWorkloadCommandRoot::Config(TConfig& config) {
     TClientCommandTree::Config(config);
     Params->ConfigureOpts(*config.Opts, NYdbWorkload::TWorkloadParams::ECommandType::Root, 0);

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -26,14 +26,14 @@ TStatus RemoveTable(TTableClient& client, const TString& path, const TDropTableS
     });
 }
 
-TStatus RemoveThrowQuery(const TString& entryType, NQuery::TQueryClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
+TStatus DropSchemeObject(const TString& objectType, NQuery::TQueryClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
     return client.RetryQuerySync([&](NQuery::TSession session) {
         const auto executionSettings = NQuery::TExecuteQuerySettings()
             .TraceId(settings.TraceId_)
             .RequestType(settings.RequestType_)
             .Header(settings.Header_)
             .ClientTimeout(settings.ClientTimeout_);
-        const auto query = TStringBuilder() << "DROP " << entryType << " `" << path << "`";
+        const auto query = TStringBuilder() << "DROP " << objectType << " `" << path << "`";
         return session.ExecuteQuery(query, NQuery::TTxControl::NoTx(), executionSettings).ExtractValueSync();
     });
 }
@@ -61,7 +61,7 @@ TStatus RemoveExternalTable(TTableClient& client, const TString& path, const TRe
 }
 
 TStatus RemoveView(NQuery::TQueryClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
-    return RemoveThrowQuery("VIEW", client, path, settings);
+    return DropSchemeObject("VIEW", client, path, settings);
 }
 
 TStatus RemoveTopic(TTopicClient& client, const TString& path, const TDropTopicSettings& settings) {

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -26,6 +26,18 @@ TStatus RemoveTable(TTableClient& client, const TString& path, const TDropTableS
     });
 }
 
+TStatus RemoveThrowQuery(const TString& entryType, NQuery::TQueryClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
+    return client.RetryQuerySync([&](NQuery::TSession session) {
+        const auto executionSettings = NQuery::TExecuteQuerySettings()
+            .TraceId(settings.TraceId_)
+            .RequestType(settings.RequestType_)
+            .Header(settings.Header_)
+            .ClientTimeout(settings.ClientTimeout_);
+        const auto query = TStringBuilder() << "DROP " << entryType << " `" << path << "`";
+        return session.ExecuteQuery(query, NQuery::TTxControl::NoTx(), executionSettings).ExtractValueSync();
+    });
+}
+
 TStatus RemoveThrowQuery(const TString& entry, TTableClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
     // This is temporary solution, safe deleting of columnstore is impossible now
     return client.RetryOperationSync([path, settings, entry](TSession session) {
@@ -46,6 +58,10 @@ TStatus RemoveExternalDataSource(TTableClient& client, const TString& path, cons
 
 TStatus RemoveExternalTable(TTableClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
     return RemoveThrowQuery("EXTERNAL TABLE", client, path, settings);
+}
+
+TStatus RemoveView(NQuery::TQueryClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
+    return RemoveThrowQuery("VIEW", client, path, settings);
 }
 
 TStatus RemoveTopic(TTopicClient& client, const TString& path, const TDropTopicSettings& settings) {
@@ -105,7 +121,7 @@ TStatus Remove(TRemoveFunc<TClient, TSettings> func, TSchemeClient& schemeClient
 }
 
 TStatus Remove(
-    TSchemeClient& schemeClient, TTableClient* tableClient, TTopicClient* topicClient, const ESchemeEntryType type,
+    TSchemeClient& schemeClient, TTableClient* tableClient, TTopicClient* topicClient, NQuery::TQueryClient* queryClient, const ESchemeEntryType type,
     const TString& path, ERecursiveRemovePrompt prompt, const TRemoveDirectorySettings& settings)
 {
     switch (type) {
@@ -125,6 +141,8 @@ TStatus Remove(
         return Remove(&RemoveExternalDataSource, schemeClient, tableClient, type, path, prompt, settings);
     case ESchemeEntryType::ExternalTable:
         return Remove(&RemoveExternalTable, schemeClient, tableClient, type, path, prompt, settings);
+    case ESchemeEntryType::View:
+        return Remove(&RemoveView, schemeClient, queryClient, type, path, prompt, settings);
 
     default:
         return TStatus(EStatus::UNSUPPORTED, MakeIssues(TStringBuilder()
@@ -136,6 +154,7 @@ TStatus RemoveDirectoryRecursive(
         TSchemeClient& schemeClient,
         TTableClient* tableClient,
         TTopicClient* topicClient,
+        NQuery::TQueryClient* queryClient,
         const TString& path,
         ERecursiveRemovePrompt prompt,
         const TRemoveDirectorySettings& settings,
@@ -152,7 +171,7 @@ TStatus RemoveDirectoryRecursive(
             return TStatus(EStatus::SUCCESS, {});
         }
     }
-    
+
     std::unique_ptr<TProgressBar> bar;
     if (createProgressBar) {
         bar = std::make_unique<TProgressBar>(recursiveListResult.Entries.size());
@@ -160,7 +179,7 @@ TStatus RemoveDirectoryRecursive(
     // output order is: Root, Recursive(children)...
     // we need to reverse it to delete recursively
     for (auto it = recursiveListResult.Entries.rbegin(); it != recursiveListResult.Entries.rend(); ++it) {
-        if (auto result = Remove(schemeClient, tableClient, topicClient, it->Type, it->Name, prompt, settings); !result.IsSuccess()) {
+        if (auto result = Remove(schemeClient, tableClient, topicClient, queryClient, it->Type, it->Name, prompt, settings); !result.IsSuccess()) {
             return result;
         }
         if (createProgressBar) {
@@ -179,23 +198,24 @@ TStatus RemoveDirectoryRecursive(
         bool removeSelf,
         bool createProgressBar)
 {
-    return RemoveDirectoryRecursive(schemeClient, &tableClient, nullptr, path, ERecursiveRemovePrompt::Never, settings, removeSelf, createProgressBar);
+    return RemoveDirectoryRecursive(schemeClient, &tableClient, nullptr, nullptr, path, ERecursiveRemovePrompt::Never, settings, removeSelf, createProgressBar);
 }
 
 TStatus RemoveDirectoryRecursive(
         TSchemeClient& schemeClient,
         TTableClient& tableClient,
-        TTopicClient& topicClient,
+        TTopicClient* topicClient,
+        NQuery::TQueryClient* queryClient,
         const TString& path,
         ERecursiveRemovePrompt prompt,
         const TRemoveDirectorySettings& settings,
         bool removeSelf,
         bool createProgressBar)
 {
-    return RemoveDirectoryRecursive(schemeClient, &tableClient, &topicClient, path, prompt, settings, removeSelf, createProgressBar);
+    return RemoveDirectoryRecursive(schemeClient, &tableClient, topicClient, queryClient, path, prompt, settings, removeSelf, createProgressBar);
 }
 
-NYdb::TStatus RemovePathRecursive(NScheme::TSchemeClient& schemeClient, NTable::TTableClient& tableClient, NTopic::TTopicClient& topicClient, const TString& path, ERecursiveRemovePrompt prompt, const TRemovePathRecursiveSettings& settings /*= {}*/, bool createProgressBar /*= true*/) {
+NYdb::TStatus RemovePathRecursive(NScheme::TSchemeClient& schemeClient, NTable::TTableClient& tableClient, NTopic::TTopicClient* topicClient, NQuery::TQueryClient* queryClient, const TString& path, ERecursiveRemovePrompt prompt, const TRemovePathRecursiveSettings& settings /*= {}*/, bool createProgressBar /*= true*/) {
     auto entity = schemeClient.DescribePath(path).ExtractValueSync();
     if (!entity.IsSuccess()) {
         if (settings.NotExistsIsOk_ && entity.GetStatus() == EStatus::SCHEME_ERROR && entity.GetIssues().ToString().find("Path not found") != TString::npos) {
@@ -206,9 +226,9 @@ NYdb::TStatus RemovePathRecursive(NScheme::TSchemeClient& schemeClient, NTable::
     switch (entity.GetEntry().Type) {
     case ESchemeEntryType::Directory:
     case ESchemeEntryType::ColumnStore:
-        return RemoveDirectoryRecursive(schemeClient, tableClient, topicClient, path, prompt, settings, true, createProgressBar);
+        return RemoveDirectoryRecursive(schemeClient, tableClient, topicClient, queryClient, path, prompt, settings, true, createProgressBar);
     default:
-        return Remove(schemeClient, &tableClient, &topicClient, entity.GetEntry().Type, path, prompt, settings);
+        return Remove(schemeClient, &tableClient, topicClient, queryClient, entity.GetEntry().Type, path, prompt, settings);
     }
 }
 }

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.h
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/public/sdk/cpp/client/ydb_query/client.h>
 #include <ydb/public/sdk/cpp/client/ydb_scheme/scheme.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/topic.h>
@@ -29,7 +30,8 @@ TStatus RemoveDirectoryRecursive(
 TStatus RemoveDirectoryRecursive(
     NScheme::TSchemeClient& schemeClient,
     NTable::TTableClient& tableClient,
-    NTopic::TTopicClient& topicClient,
+    NTopic::TTopicClient* topicClient,
+    NQuery::TQueryClient* queryClient,
     const TString& path,
     ERecursiveRemovePrompt prompt,
     const NScheme::TRemoveDirectorySettings& settings = {},
@@ -39,7 +41,8 @@ TStatus RemoveDirectoryRecursive(
 TStatus RemovePathRecursive(
     NScheme::TSchemeClient& schemeClient,
     NTable::TTableClient& tableClient,
-    NTopic::TTopicClient& topicClient,
+    NTopic::TTopicClient* topicClient,
+    NQuery::TQueryClient* queryClient,
     const TString& path,
     ERecursiveRemovePrompt prompt,
     const TRemovePathRecursiveSettings& settings = {},

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -43,6 +43,7 @@ PEERDIR(
     ydb/public/lib/operation_id
     ydb/public/lib/yson_value
     ydb/public/sdk/cpp/client/draft
+    ydb/public/sdk/cpp/client/ydb_query
     ydb/public/sdk/cpp/client/ydb_result
     ydb/public/sdk/cpp/client/ydb_scheme
     ydb/public/sdk/cpp/client/ydb_table

--- a/ydb/public/lib/ydb_cli/dump/files/files.cpp
+++ b/ydb/public/lib/ydb_cli/dump/files/files.cpp
@@ -10,6 +10,7 @@ enum EFilesType {
     INCOMPLETE_DATA,
     INCOMPLETE,
     EMPTY,
+    CREATE_VIEW,
 };
 
 static constexpr TFileInfo FILES_INFO[] = {
@@ -20,6 +21,7 @@ static constexpr TFileInfo FILES_INFO[] = {
     {"incomplete.csv", "incomplete"},
     {"incomplete", "incomplete"},
     {"empty_dir", "empty_dir"},
+    {"create_view.sql", "view"},
 };
 
 const TFileInfo& TableScheme() {
@@ -48,6 +50,10 @@ const TFileInfo& Incomplete() {
 
 const TFileInfo& Empty() {
     return FILES_INFO[EMPTY];
+}
+
+const TFileInfo& CreateView() {
+    return FILES_INFO[CREATE_VIEW];
 }
 
 } // NYdb::NDump::NFiles

--- a/ydb/public/lib/ydb_cli/dump/files/files.h
+++ b/ydb/public/lib/ydb_cli/dump/files/files.h
@@ -14,5 +14,6 @@ const TFileInfo& Topic();
 const TFileInfo& IncompleteData();
 const TFileInfo& Incomplete();
 const TFileInfo& Empty();
+const TFileInfo& CreateView();
 
 } // NYdb::NDump:NFiles

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -159,7 +159,7 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
     }
 
     TString pathPrefix;
-    if (!re2::RE2::PartialMatch(query, R"-(PRAGMA TablePathPrefix = "(\S+)";)-", &pathPrefix)) {
+    if (!re2::RE2::PartialMatch(query, R"(PRAGMA TablePathPrefix = '(\S+)';)", &pathPrefix)) {
         if (!restoreRootIsDatabase) {
             // Initially, the view used the implicit table path prefix, but this is no longer feasible
             // since the restore root is different from the database root.
@@ -172,7 +172,7 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
                 return false;
             }
             query.insert(contextRecreationEnd, TString(
-                std::format("PRAGMA TablePathPrefix = \"{}\";\n", restoreRoot.data())
+                std::format("PRAGMA TablePathPrefix = '{}';\n", restoreRoot.data())
             ));
         }
         return true;
@@ -180,9 +180,9 @@ bool RewriteTablePathPrefix(TString& query, TStringBuf backupRoot, TStringBuf re
 
     pathPrefix = RewriteAbsolutePath(pathPrefix, backupRoot, restoreRoot);
 
-    constexpr TStringBuf pattern = R"(PRAGMA TablePathPrefix = "\S+";)";
+    constexpr TStringBuf pattern = R"(PRAGMA TablePathPrefix = '\S+';)";
     if (!re2::RE2::Replace(&query, pattern,
-        std::format(R"(PRAGMA TablePathPrefix = "{}";)", pathPrefix.c_str())
+        std::format(R"(PRAGMA TablePathPrefix = '{}';)", pathPrefix.c_str())
     )) {
         issues.AddIssue(TStringBuilder() << "query: " << query.Quote()
             << " does not contain the pattern: \"" << pattern << "\""

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -4,6 +4,7 @@
 
 #include <ydb/public/sdk/cpp/client/ydb_import/import.h>
 #include <ydb/public/sdk/cpp/client/ydb_operation/operation.h>
+#include <ydb/public/sdk/cpp/client/ydb_query/client.h>
 #include <ydb/public/sdk/cpp/client/ydb_scheme/scheme.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_topic/topic.h>
@@ -123,15 +124,16 @@ public:
 } // NPrivate
 
 class TRestoreClient {
-    TRestoreResult RestoreFolder(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, const THashSet<TString>& oldEntries);
-    TRestoreResult RestoreEmptyDir(const TFsPath& fsPath, const TString &dbPath, const TRestoreSettings& settings, const THashSet<TString>& oldEntries);
-    TRestoreResult RestoreTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, const THashSet<TString>& oldEntries);
+    TRestoreResult RestoreFolder(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, const THashSet<TString>& oldEntries);
+    TRestoreResult RestoreEmptyDir(const TFsPath& fsPath, const TString &dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
+    TRestoreResult RestoreTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
+    TRestoreResult RestoreView(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting);
 
     TRestoreResult CheckSchema(const TString& dbPath, const NTable::TTableDescription& desc);
     TRestoreResult RestoreData(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, const NTable::TTableDescription& desc);
     TRestoreResult RestoreIndexes(const TString& dbPath, const NTable::TTableDescription& desc);
     TRestoreResult RestoreChangefeeds(const TFsPath& path, const TString& dbPath);
-    TRestoreResult RestorePermissions(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, const THashSet<TString>& oldEntries);
+    TRestoreResult RestorePermissions(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreConsumers(const TString& topicPath, const TVector<NTopic::TConsumer>& consumers);
 
     THolder<NPrivate::IDataWriter> CreateDataWriter(const TString& dbPath, const TRestoreSettings& settings,
@@ -151,7 +153,20 @@ private:
     NScheme::TSchemeClient SchemeClient;
     NTable::TTableClient TableClient;
     NTopic::TTopicClient TopicClient;
+    NQuery::TQueryClient QueryClient;
     std::shared_ptr<TLog> Log;
+
+    struct TRestoreViewCall {
+        TFsPath FsPath;
+        TString DbRestoreRoot;
+        TString DbPathRelativeToRestoreRoot;
+        TRestoreSettings Settings;
+        bool IsAlreadyExisting;
+    };
+    // Views usually depend on other objects.
+    // If the dependency is not created yet, then the view restoration will fail.
+    // We retry failed view creation attempts until either all views are created, or the errors are persistent.
+    TVector<TRestoreViewCall> ViewRestorationCalls;
 
 }; // TRestoreClient
 

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -125,7 +125,7 @@ public:
 
 class TRestoreClient {
     TRestoreResult RestoreFolder(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, const THashSet<TString>& oldEntries);
-    TRestoreResult RestoreEmptyDir(const TFsPath& fsPath, const TString &dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
+    TRestoreResult RestoreEmptyDir(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreView(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting);
 

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.cpp
@@ -1,0 +1,234 @@
+#include "view_utils.h"
+
+#include <yql/essentials/parser/proto_ast/gen/v1/SQLv1Lexer.h>
+#include <yql/essentials/parser/proto_ast/gen/v1_proto_split/SQLv1Parser.pb.main.h>
+#include <yql/essentials/sql/settings/translation_settings.h>
+#include <yql/essentials/sql/v1/format/sql_format.h>
+#include <yql/essentials/sql/v1/proto_parser/proto_parser.h>
+
+#include <library/cpp/protobuf/util/simple_reflection.h>
+
+#include <util/folder/pathsplit.h>
+#include <util/string/builder.h>
+
+using namespace NSQLv1Generated;
+
+namespace {
+
+struct TAbsolutePathRewriter {
+
+    static bool IsAbsolutePath(TStringBuf path) {
+        return path.StartsWith("`/") && path.EndsWith('`');
+    }
+
+    TString RewriteAbsolutePath(const TString& path) const {
+        if (BackupRoot == RestoreRoot) {
+            return path;
+        }
+
+        return TStringBuilder() << '`'
+            << NYdb::NDump::RewriteAbsolutePath(TStringBuf(path.begin() + 1, path.end() - 1), BackupRoot, RestoreRoot)
+            << '`';
+    }
+
+    TString operator()(const TString& path) const {
+        if (IsAbsolutePath(path)) {
+            return RewriteAbsolutePath(path);
+        }
+        return path;
+    }
+
+    TStringBuf BackupRoot;
+    TStringBuf RestoreRoot;
+};
+
+struct TTokenCollector {
+    TTokenCollector(std::function<TString(const TString&)>&& pathRewriter = {}) : PathRewriter(std::move(pathRewriter)) {}
+
+    void operator()(const NProtoBuf::Message& message) {
+        if (const auto* token = dynamic_cast<const TToken*>(&message)) {
+            const auto& value = token->GetValue();
+            if (token->GetId() != NALPDefault::SQLv1LexerTokens::TOKEN_EOF) {
+                if (!Tokens.empty()) {
+                    Tokens << ' ';
+                }
+                Tokens << (IsTableRefDescendent && PathRewriter ? PathRewriter(value) : value);
+            }
+        }
+    }
+
+    TStringBuilder Tokens;
+
+    bool IsTableRefDescendent = false;
+    std::function<TString(const TString&)> PathRewriter;
+};
+
+void VisitAllFields(const NProtoBuf::Message& msg, const std::function<bool(const NProtoBuf::Message&)>& callback) {
+    const auto* descr = msg.GetDescriptor();
+    for (int i = 0; i < descr->field_count(); ++i) {
+        const auto* fd = descr->field(i);
+        NProtoBuf::TConstField field(msg, fd);
+        if (field.IsMessage()) {
+            for (size_t j = 0; j < field.Size(); ++j) {
+                const auto& message = *field.Get<NProtoBuf::Message>(j);
+                if (callback(message)) {
+                    VisitAllFields(message, callback);
+                }
+            }
+        }
+    }
+}
+
+void VisitAllFields(const NProtoBuf::Message& msg, TTokenCollector& callback) {
+    const auto* descr = msg.GetDescriptor();
+    for (int i = 0; i < descr->field_count(); ++i) {
+        const auto* fd = descr->field(i);
+        NProtoBuf::TConstField field(msg, fd);
+        if (field.IsMessage()) {
+            for (size_t j = 0; j < field.Size(); ++j) {
+                const auto& message = *field.Get<NProtoBuf::Message>(j);
+                const auto* tableRef = dynamic_cast<const TRule_table_ref*>(&message);
+                if (tableRef) {
+                    callback.IsTableRefDescendent = true;
+                }
+
+                callback(message);
+                VisitAllFields(message, callback);
+
+                if (tableRef) {
+                    callback.IsTableRefDescendent = false;
+                }
+            }
+        }
+    }
+}
+
+bool Format(const TString& query, TString& formattedQuery, NYql::TIssues& issues) {
+    google::protobuf::Arena arena;
+    NSQLTranslation::TTranslationSettings settings;
+    settings.Arena = &arena;
+
+    auto formatter = NSQLFormat::MakeSqlFormatter(settings);
+    return formatter->Format(query, formattedQuery, issues);
+}
+
+struct TTableRefValidator {
+
+    // returns true if the message is not a table ref and we need to dive deeper to find it
+    bool operator()(const NProtoBuf::Message& message) {
+        const auto* tableRef = dynamic_cast<const TRule_table_ref*>(&message);
+        if (!tableRef) {
+            return true;
+        }
+
+        // implementation note: a better idea might be to create a custom grammar for validation
+        if (tableRef->HasBlock3() && tableRef->GetBlock3().HasAlt1() && tableRef->GetBlock3().GetAlt1().HasRule_table_key1()) {
+            // Table keys are considered save for view backups.
+            return false;
+        }
+
+        // The only kind of table references in views that we really cannot restore are evaluated absolute paths:
+        // $path = "/old_db" || "/t"; select * from $path;
+        // If the view is being restored to a different database (like "/new_db"),
+        // then the saved create view statement will need manual patching to succeed.
+        TTokenCollector tokenCollector;
+        VisitAllFields(*tableRef, tokenCollector);
+        const TString refString = tokenCollector.Tokens;
+
+        Issues.AddIssue(TStringBuilder() << "Please check that the table reference: " << refString.Quote()
+            << " contains no evaluated expressions."
+        );
+        Issues.back().Severity = NYql::TSeverityIds::S_WARNING;
+
+        return false;
+    }
+
+    NYql::TIssues& Issues;
+};
+
+bool ValidateTableRefs(const TRule_sql_query& query, NYql::TIssues& issues) {
+    TTableRefValidator tableRefValidator(issues);
+    VisitAllFields(query, tableRefValidator);
+    return tableRefValidator.Issues.Empty();
+}
+
+TString RewriteTableRefs(const TRule_sql_query& query, TStringBuf backupRoot, TStringBuf restoreRoot) {
+    TAbsolutePathRewriter pathRewriter;
+    pathRewriter.BackupRoot = backupRoot;
+    pathRewriter.RestoreRoot = restoreRoot;
+
+    TTokenCollector tokenCollector(std::move(pathRewriter));
+    VisitAllFields(query, tokenCollector);
+    return tokenCollector.Tokens;
+}
+
+bool SqlToProtoAst(const TString& query, TRule_sql_query& queryProto, NYql::TIssues& issues) {
+    NSQLTranslation::TTranslationSettings settings;
+    if (!NSQLTranslation::ParseTranslationSettings(query, settings, issues)) {
+        return false;
+    }
+    if (settings.SyntaxVersion == 0) {
+        issues.AddIssue("cannot handle YQL syntax version 0");
+        return false;
+    }
+
+    google::protobuf::Arena arena;
+    const auto* parserProto = NSQLTranslationV1::SqlAST(
+        query, "query", issues, 0, settings.AnsiLexer, settings.Antlr4Parser, settings.TestAntlr4, &arena
+    );
+    if (!parserProto) {
+        return false;
+    }
+
+    queryProto = static_cast<const TSQLv1ParserAST&>(*parserProto).GetRule_sql_query();
+    return true;
+}
+
+}
+
+namespace NYdb::NDump {
+
+bool ValidateViewQuery(const TString& query, NYql::TIssues& issues) {
+    TRule_sql_query queryProto;
+    if (!SqlToProtoAst(query, queryProto, issues)) {
+        return false;
+    }
+    return ValidateTableRefs(queryProto, issues);
+}
+
+TString RewriteAbsolutePath(TStringBuf path, TStringBuf backupRoot, TStringBuf restoreRoot) {
+    if (backupRoot == restoreRoot) {
+        return TString(path);
+    }
+
+    TPathSplitUnix pathSplit(path);
+    TPathSplitUnix backupRootSplit(backupRoot);
+
+    size_t matchedParts = 0;
+    while (matchedParts < pathSplit.size() && matchedParts < backupRootSplit.size()
+        && pathSplit[matchedParts] == backupRootSplit[matchedParts]
+    ) {
+        ++matchedParts;
+    }
+
+    TPathSplitUnix restoreRootSplit(restoreRoot);
+    for (size_t unmatchedParts = matchedParts + 1; unmatchedParts <= backupRootSplit.size(); ++unmatchedParts) {
+        restoreRootSplit.AppendComponent("..");
+    }
+    return restoreRootSplit.AppendMany(pathSplit.begin() + matchedParts, pathSplit.end()).Reconstruct();
+}
+
+bool RewriteTableRefs(TString& query, TStringBuf backupRoot, TStringBuf restoreRoot, NYql::TIssues& issues) {
+    TRule_sql_query queryProto;
+    if (!SqlToProtoAst(query, queryProto, issues)) {
+        return false;
+    }
+    const auto rewrittenQuery = ::RewriteTableRefs(queryProto, backupRoot, restoreRoot);
+    // formatting here is necessary for the view to have pretty text inside it after the creation
+    if (!Format(rewrittenQuery, query, issues)) {
+        return false;
+    }
+    return true;
+}
+
+}

--- a/ydb/public/lib/ydb_cli/dump/util/view_utils.h
+++ b/ydb/public/lib/ydb_cli/dump/util/view_utils.h
@@ -1,0 +1,11 @@
+#include <yql/essentials/public/issue/yql_issue.h>
+
+namespace NYdb::NDump {
+
+bool ValidateViewQuery(const TString& query, NYql::TIssues& issues);
+
+TString RewriteAbsolutePath(TStringBuf path, TStringBuf backupRoot, TStringBuf restoreRoot);
+
+bool RewriteTableRefs(TString& scheme, TStringBuf backupRoot, TStringBuf restoreRoot, NYql::TIssues& issues);
+
+}

--- a/ydb/public/lib/ydb_cli/dump/util/ya.make
+++ b/ydb/public/lib/ydb_cli/dump/util/ya.make
@@ -2,13 +2,20 @@ LIBRARY()
 
 SRCS(
     util.cpp
+    view_utils.cpp
 )
 
 PEERDIR(
+    library/cpp/protobuf/util
     ydb/public/lib/ydb_cli/common
     ydb/public/sdk/cpp/client/ydb_scheme
     ydb/public/sdk/cpp/client/ydb_table
     ydb/public/sdk/cpp/client/ydb_types/status
+    yql/essentials/parser/proto_ast/gen/v1
+    yql/essentials/parser/proto_ast/gen/v1_proto_split
+    yql/essentials/sql/settings
+    yql/essentials/sql/v1/format
+    yql/essentials/sql/v1/proto_parser
 )
 
 END()

--- a/ydb/public/lib/ydb_cli/dump/ya.make
+++ b/ydb/public/lib/ydb_cli/dump/ya.make
@@ -9,6 +9,7 @@ SRCS(
 )
 
 PEERDIR(
+    contrib/libs/re2
     library/cpp/bucket_quoter
     library/cpp/logger
     library/cpp/regex/pcre
@@ -19,6 +20,7 @@ PEERDIR(
     ydb/public/lib/ydb_cli/dump/files
     ydb/public/lib/ydb_cli/dump/util
     ydb/public/sdk/cpp/client/ydb_proto
+    ydb/public/sdk/cpp/client/ydb_query
     ydb/public/sdk/cpp/client/ydb_topic
 )
 


### PR DESCRIPTION
[Ticket](https://github.com/ydb-platform/ydb/issues/12113)
[RFC](https://github.com/ydb-platform/ydb-rfc/blob/main/view_backups.md)

Enable Backup and Restore of Views in 'ydb tools dump' and 'ydb tools restore'.

This update adds support for backing up and restoring views using 'ydb tools dump' and 'ydb tools restore'. Previously, the tool only handled tables and directories. Now, when you run 'ydb tools dump', it generates a 'create_view.sql' file for each view, containing the necessary 'CREATE VIEW' statement to recreate it. These files are stored in the backup directory structure, preserving the views' relative locations within the database.

The 'create_view.sql' file format includes:

```sql
-- backup root: <backup root value>
<context recreation query (with TablePathPrefix pragma being the most important statement)>
CREATE VIEW ...
```

During restoration, 'ydb tools restore' uses the backup root to rewrite captured TablePathPrefix and absolute paths in the view queries, ensuring that the relative locations of referenced tables to the views are maintained.
