### PR TITLE
Prepare test to migration

### DIFF
--- a/ydb/tests/fq/s3/test_insert.py
+++ b/ydb/tests/fq/s3/test_insert.py
@@ -13,6 +13,8 @@ import ydb.public.api.protos.draft.fq_pb2 as fq
 import ydb.tests.fq.s3.s3_helpers as s3_helpers
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1, yq_all
 
+from moto import __version__ as moto_version
+from packaging.version import Version
 
 class TestS3(object):
     def create_bucket_and_upload_file(self, filename, s3, kikimr):
@@ -435,7 +437,8 @@ class TestS3(object):
         )
 
         bucket = resource.Bucket("error_bucket")
-        bucket.create(ACL='')
+        acl = '' if Version(moto_version) < Version("4.0.5") else 'public-write'
+        bucket.create(ACL=acl)
         bucket.objects.all().delete()
 
         kikimr.control_plane.wait_bootstrap(1)
@@ -462,18 +465,26 @@ class TestS3(object):
         )
 
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
-        start_at = time.time()
-        while True:
-            result = client.describe_query(query_id).result
-            assert result.query.meta.status in [
-                fq.QueryMeta.STARTING,
-                fq.QueryMeta.RUNNING,
-            ], "Query is not RUNNING anymore"
-            issues = result.query.transient_issue
-            if "500 Internal Server Error" in str(issues):
-                break
-            assert time.time() - start_at < 20, "Timeout waiting for transient issue in " + str(issues)
-            time.sleep(0.5)
+        if Version(moto_version) < Version("4.0.5"):
+            start_at = time.time()
+            while True:
+                result = client.describe_query(query_id).result
+                assert result.query.meta.status in [
+                    fq.QueryMeta.STARTING,
+                    fq.QueryMeta.RUNNING,
+                ], "Query is not RUNNING anymore"
+                issues = result.query.transient_issue
+                if "500 Internal Server Error" in str(issues):
+                    break
+                assert time.time() - start_at < 20, "Timeout waiting for transient issue in " + str(issues)
+                time.sleep(0.5)
+        else:
+            # Available since moto version 4.0.5+
+            client.wait_query_status(query_id, fq.QueryMeta.FAILED)
+            msg = client.describe_query(query_id).result.query.issue
+            assert 'HTTP error code: 403' in str(msg)
+            assert 'Query failed with code EXTERNAL_ERROR' in str(msg)
+
         client.abort_query(query_id)
         client.wait_query(query_id)
 

--- a/ydb/tests/fq/s3/test_insert.py
+++ b/ydb/tests/fq/s3/test_insert.py
@@ -16,6 +16,7 @@ from ydb.tests.tools.fq_runner.kikimr_utils import yq_v1, yq_all
 from moto import __version__ as moto_version
 from packaging.version import Version
 
+
 class TestS3(object):
     def create_bucket_and_upload_file(self, filename, s3, kikimr):
         s3_helpers.create_bucket_and_upload_file(filename, s3.s3_url, "fbucket", "ydb/tests/fq/s3/test_format_data")

--- a/ydb/tests/fq/s3/ya.make
+++ b/ydb/tests/fq/s3/ya.make
@@ -6,6 +6,7 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/fq_runner/ydb_runner_with_datastreams.in
 
 PEERDIR(
     contrib/python/boto3
+    contrib/python/moto
     contrib/python/pyarrow
     library/python/testing/recipe
     library/python/testing/yatest_common


### PR DESCRIPTION
This PR is a preparation for the migration to moto version 4.0.8. 

The main change is related to the expected internal behavior of the moto library. Previously, the test would pass if the S3 ACL was empty, but now it will wait for an internal server error. This behavior is related to a bug that has been fixed in the [external commit](https://github.com/getmoto/moto/commit/58a313d29410ed650f04ff990baaa383a71b719e#diff-a14f7ca014b23638947c5f417dacb9a4d59eef3aee9a8041e2c855e8587643cdR1160) (link to commit).

As an alternative, we can set the ACL to 'public-write'. This will allow us to write data to S3 without any problems, but it will trigger an error during the next read.

P.S. ACL='public-write' is not implemented in the upstream version of the moto library, but our version has been patched.