### PR TITLE
AvgWriteBytes and transactions

### DIFF
--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -961,6 +961,10 @@ private:
                            TEvKeyValue::TEvRequest* request,
                            const TActorContext& ctx);
     ui32 RenameTmpCmdWrites(TEvKeyValue::TEvRequest* request);
+
+    void UpdateAvgWriteBytes(ui64 size, const TInstant& now);
+
+    size_t WriteNewSizeFromSupportivePartitions = 0;
 };
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -499,6 +499,7 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
             ui64 seqNo = std::max(info.SeqNo, it->second.SeqNo);
             SourceIdStorage.RegisterSourceId(sourceId, it->second.Updated(seqNo, info.Offset, now));
         }
+        SourceIdCounter.Use(sourceId, now);
     }
     TxSourceIdForPostPersist.clear();
 
@@ -528,23 +529,23 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
     UpdateAfterWriteCounters(true);
 
     //All ok
-    for (auto& avg : AvgWriteBytes) {
-        avg.Update(WriteNewSize, now);
-    }
+    UpdateAvgWriteBytes(WriteNewSize, now);
+    UpdateAvgWriteBytes(WriteNewSizeFromSupportivePartitions, now);
+
     for (auto& avg : AvgQuotaBytes) {
         avg.Update(WriteNewSize, now);
+        avg.Update(WriteNewSizeFromSupportivePartitions, now);
     }
 
-    LOG_DEBUG_S(
-        ctx, NKikimrServices::PERSQUEUE,
-        "TPartition::HandleWriteResponse writeNewSize# " << WriteNewSize;
-    );
+    PQ_LOG_D("TPartition::HandleWriteResponse " <<
+             "writeNewSize# " << WriteNewSize <<
+             " WriteNewSizeFromSupportivePartitions# " << WriteNewSizeFromSupportivePartitions);
 
     if (SupportivePartitionTimeLag) {
         SupportivePartitionTimeLag->UpdateTimestamp(now.MilliSeconds());
     }
 
-    auto writeNewSizeFull = WriteNewSizeFull;
+    auto writeNewSizeFull = WriteNewSizeFull + WriteNewSizeFromSupportivePartitions;
 
     WriteCycleSize = 0;
     WriteNewSize = 0;
@@ -554,12 +555,13 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
     WriteNewSizeUncompressedFull = 0;
     WriteNewMessages = 0;
     WriteNewMessagesInternal = 0;
+    WriteNewSizeFromSupportivePartitions = 0;
     UpdateWriteBufferIsFullState(now);
 
     AnswerCurrentWrites(ctx);
     SyncMemoryStateWithKVState(ctx);
 
-    if (SplitMergeEnabled(Config)) {
+    if (SplitMergeEnabled(Config) && !IsSupportive()) {
         SplitMergeAvgWriteBytes->Update(writeNewSizeFull, now);
         auto needScaling = CheckScaleStatus(ctx);
         ChangeScaleStatusIfNeeded(needScaling);
@@ -575,6 +577,13 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
     ProcessHasDataRequests(ctx);
 
     ProcessTimestampsForNewData(prevEndOffset, ctx);
+}
+
+void TPartition::UpdateAvgWriteBytes(ui64 size, const TInstant& now)
+{
+    for (auto& avg : AvgWriteBytes) {
+        avg.Update(size, now);
+    }
 }
 
 NKikimrPQ::EScaleStatus TPartition::CheckScaleStatus(const TActorContext& ctx) {

--- a/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
@@ -62,18 +62,22 @@ void DoRequest(NActors::TTestActorRuntime& runtime, ui64& txId, NKikimrSchemeOp:
     Sleep(TDuration::Seconds(1));
 }
 
-void SplitPartition(TTopicSdkTestSetup& setup, ui64& txId, const ui32 partition, TString boundary) {
+void SplitPartition(TTopicSdkTestSetup& setup, ui64& txId, const ui32 partition, const TString& boundary) {
     SplitPartition(setup.GetRuntime(), txId, partition, boundary);
 }
 
-void SplitPartition(NActors::TTestActorRuntime& runtime, ui64& txId, const ui32 partition, TString boundary) {
+void SplitPartition(NActors::TTestActorRuntime& runtime, ui64& txId, const TString& topicName, const ui32 partition, const TString& boundary) {
     ::NKikimrSchemeOp::TPersQueueGroupDescription scheme;
-    scheme.SetName(TEST_TOPIC);
+    scheme.SetName(topicName);
     auto* split = scheme.AddSplit();
     split->SetPartition(partition);
     split->SetSplitBoundary(boundary);
 
     DoRequest(runtime, txId, scheme);
+}
+
+void SplitPartition(NActors::TTestActorRuntime& runtime, ui64& txId, const ui32 partition, const TString& boundary) {
+    SplitPartition(runtime, txId, TEST_TOPIC, partition, boundary);
 }
 
 void MergePartition(TTopicSdkTestSetup& setup, ui64& txId, const ui32 partitionLeft, const ui32 partitionRight) {

--- a/ydb/core/persqueue/ut/common/autoscaling_ut_common.h
+++ b/ydb/core/persqueue/ut/common/autoscaling_ut_common.h
@@ -20,8 +20,9 @@ TEvTx* CreateRequest(ui64 txId, NKikimrSchemeOp::TModifyScheme&& tx);
 void DoRequest(TTopicSdkTestSetup& setup, ui64& txId, NKikimrSchemeOp::TPersQueueGroupDescription& scheme);
 void DoRequest(NActors::TTestActorRuntime& runtime, ui64& txId, NKikimrSchemeOp::TPersQueueGroupDescription& scheme);
 
-void SplitPartition(TTopicSdkTestSetup& setup, ui64& txId, const ui32 partition, TString boundary);
-void SplitPartition(NActors::TTestActorRuntime& runtime, ui64& txId, const ui32 partition, TString boundary);
+void SplitPartition(TTopicSdkTestSetup& setup, ui64& txId, const ui32 partition, const TString& boundary);
+void SplitPartition(NActors::TTestActorRuntime& runtime, ui64& txId, const ui32 partition, const TString& boundary);
+void SplitPartition(NActors::TTestActorRuntime& runtime, ui64& txId, const TString& topicName, const ui32 partition, const TString& boundary);
 
 void MergePartition(TTopicSdkTestSetup& setup, ui64& txId, const ui32 partitionLeft, const ui32 partitionRight);
 

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -3,21 +3,25 @@
 #include <ydb/public/sdk/cpp/client/ydb_topic/topic.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/ut_utils/ut_utils.h>
+
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/keyvalue/keyvalue_events.h>
 #include <ydb/core/persqueue/key.h>
 #include <ydb/core/persqueue/blob.h>
-
+#include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/tx/long_tx_service/public/events.h>
 
-#include <library/cpp/logger/stream.h>
+#include <ydb/core/persqueue/ut/common/autoscaling_ut_common.h>
 
+#include <library/cpp/logger/stream.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NYdb::NTopic::NTests {
 
 const auto TEST_MESSAGE_GROUP_ID_1 = TEST_MESSAGE_GROUP_ID + "_1";
 const auto TEST_MESSAGE_GROUP_ID_2 = TEST_MESSAGE_GROUP_ID + "_2";
+const auto TEST_MESSAGE_GROUP_ID_3 = TEST_MESSAGE_GROUP_ID + "_3";
+const auto TEST_MESSAGE_GROUP_ID_4 = TEST_MESSAGE_GROUP_ID + "_4";
 
 Y_UNIT_TEST_SUITE(TxUsage) {
 
@@ -67,10 +71,17 @@ protected:
                      const TString& consumer = TEST_CONSUMER,
                      size_t partitionCount = 1,
                      std::optional<size_t> maxPartitionCount = std::nullopt);
-    void DescribeTopic(const TString& path);
+    TTopicDescription DescribeTopic(const TString& path);
 
-    void AddConsumer(const TString& path,
+    void AddConsumer(const TString& topicPath,
                      const TVector<TString>& consumers);
+    void AlterAutoPartitioning(const TString& topicPath,
+                               ui64 minActivePartitions,
+                               ui64 maxActivePartitions,
+                               EAutoPartitioningStrategy strategy,
+                               TDuration stabilizationWindow,
+                               ui64 downUtilizationPercent,
+                               ui64 upUtilizationPercent);
 
     void WriteToTopicWithInvalidTxId(bool invalidTxId);
 
@@ -166,6 +177,30 @@ protected:
     void CheckTabletKeys(const TString& topicName);
     void DumpPQTabletKeys(const TString& topicName);
 
+    NTable::TDataQueryResult ExecuteDataQuery(NTable::TSession session, const TString& query, const NTable::TTxControl& control);
+
+    void Read_Exactly_N_Messages_From_Topic(const TString& topicPath,
+                                            const TString& consumerName,
+                                            size_t count);
+
+    struct TAvgWriteBytes {
+        ui64 PerSec = 0;
+        ui64 PerMin = 0;
+        ui64 PerHour = 0;
+        ui64 PerDay = 0;
+    };
+
+    TAvgWriteBytes GetAvgWriteBytes(const TString& topicPath,
+                                    ui32 partitionId);
+
+    void CheckAvgWriteBytes(const TString& topicPath,
+                            ui32 partitionId,
+                            size_t minSize, size_t maxSize);
+
+    void SplitPartition(const TString& topicPath,
+                        ui32 partitionId,
+                        const TString& boundary);
+
 private:
     template<class E>
     E ReadEvent(TTopicReadSessionPtr reader, NTable::TTransaction& tx);
@@ -194,6 +229,8 @@ private:
 
     THashMap<std::pair<TString, TString>, TTopicWriteSessionContext> TopicWriteSessions;
     THashMap<TString, TTopicReadSessionPtr> TopicReadSessions;
+
+    ui64 SchemaTxId = 1000;
 };
 
 TFixture::TTableRecord::TTableRecord(const TString& key, const TString& value) :
@@ -206,6 +243,7 @@ void TFixture::SetUp(NUnitTest::TTestContext&)
 {
     NKikimr::Tests::TServerSettings settings = TTopicSdkTestSetup::MakeServerSettings();
     settings.SetEnableTopicServiceTx(true);
+    settings.SetEnableTopicSplitMerge(true);
     settings.SetEnablePQConfigTransactionsAtSchemeShard(true);
 
     Setup = std::make_unique<TTopicSdkTestSetup>(TEST_CASE_NAME, settings);
@@ -354,12 +392,13 @@ void TFixture::CreateTopic(const TString& path,
     Setup->CreateTopic(path, consumer, partitionCount, maxPartitionCount);
 }
 
+
 void TFixture::DescribeTopic(const TString& path)
 {
     Setup->DescribeTopic(path);
 }
 
-void TFixture::AddConsumer(const TString& path,
+void TFixture::AddConsumer(const TString& topicPath,
                            const TVector<TString>& consumers)
 {
     NTopic::TTopicClient client(GetDriver());
@@ -369,8 +408,41 @@ void TFixture::AddConsumer(const TString& path,
         settings.BeginAddConsumer(consumer);
     }
 
-    auto result = client.AlterTopic(path, settings).GetValueSync();
+    auto result = client.AlterTopic(topicPath, settings).GetValueSync();
     UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+}
+
+void TFixture::AlterAutoPartitioning(const TString& topicPath,
+                                     ui64 minActivePartitions,
+                                     ui64 maxActivePartitions,
+                                     EAutoPartitioningStrategy strategy,
+                                     TDuration stabilizationWindow,
+                                     ui64 downUtilizationPercent,
+                                     ui64 upUtilizationPercent)
+{
+    NTopic::TTopicClient client(GetDriver());
+    NTopic::TAlterTopicSettings settings;
+
+    settings
+        .BeginAlterPartitioningSettings()
+            .MinActivePartitions(minActivePartitions)
+            .MaxActivePartitions(maxActivePartitions)
+            .BeginAlterAutoPartitioningSettings()
+                .Strategy(strategy)
+                .StabilizationWindow(stabilizationWindow)
+                .DownUtilizationPercent(downUtilizationPercent)
+                .UpUtilizationPercent(upUtilizationPercent)
+            .EndAlterAutoPartitioningSettings()
+        .EndAlterTopicPartitioningSettings()
+        ;
+
+    auto result = client.AlterTopic(topicPath, settings).GetValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+}
+
+TTopicDescription TFixture::DescribeTopic(const TString& path)
+{
+    return Setup->DescribeTopic(path);
 }
 
 const TDriver& TFixture::GetDriver() const
@@ -936,6 +1008,48 @@ void TFixture::RestartLongTxService()
                      0,
                      true);
     }
+}
+
+void TFixture::Read_Exactly_N_Messages_From_Topic(const TString& topicPath,
+                                                  const TString& consumerName,
+                                                  size_t limit)
+{
+    size_t count = 0;
+
+    while (count < limit) {
+        auto messages = ReadFromTopic(topicPath, consumerName, TDuration::Seconds(2));
+        count += messages.size();
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(count, limit);
+}
+
+auto TFixture::GetAvgWriteBytes(const TString& topicName,
+                                ui32 partitionId) -> TAvgWriteBytes
+{
+    auto& runtime = Setup->GetRuntime();
+    TActorId edge = runtime.AllocateEdgeActor();
+    ui64 tabletId = GetTopicTabletId(edge, "/Root/" + topicName, partitionId);
+
+    runtime.SendToPipe(tabletId, edge, new NKikimr::TEvPersQueue::TEvStatus());
+    auto response = runtime.GrabEdgeEvent<NKikimr::TEvPersQueue::TEvStatusResponse>();
+
+    UNIT_ASSERT_VALUES_EQUAL(tabletId, response->Record.GetTabletId());
+
+    TAvgWriteBytes result;
+
+    for (size_t i = 0; i < response->Record.PartResultSize(); ++i) {
+        const auto& partition = response->Record.GetPartResult(i);
+        if (partition.GetPartition() == static_cast<int>(partitionId)) {
+            result.PerSec = partition.GetAvgWriteSpeedPerSec();
+            result.PerMin = partition.GetAvgWriteSpeedPerMin();
+            result.PerHour = partition.GetAvgWriteSpeedPerHour();
+            result.PerDay = partition.GetAvgWriteSpeedPerDay();
+            break;
+        }
+    }
+
+    return result;
 }
 
 Y_UNIT_TEST_F(WriteToTopic_Demo_1, TFixture)
@@ -2134,6 +2248,245 @@ Y_UNIT_TEST_F(ReadRuleGeneration, TFixture)
     // And they wanted to continue reading their messages
     messages = ReadFromTopic(TEST_TOPIC, "consumer-1", TDuration::Seconds(2));
     UNIT_ASSERT_VALUES_EQUAL(messages.size(), 1);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_40, TFixture)
+{
+    // The recording stream will run into a quota. Before the commit, the client will receive confirmations
+    // for some of the messages. The `CommitTx` call will wait for the rest.
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    CommitTx(tx, EStatus::SUCCESS);
+
+    Read_Exactly_N_Messages_From_Topic("topic_A", TEST_CONSUMER, 100);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_41, TFixture)
+{
+    // If the recording session does not wait for confirmations, the commit will fail
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    CloseTopicWriteSession("topic_A", TEST_MESSAGE_GROUP_ID, true); // force close
+
+    CommitTx(tx, EStatus::SESSION_EXPIRED);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_42, TFixture)
+{
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    CloseTopicWriteSession("topic_A", TEST_MESSAGE_GROUP_ID); // gracefully close
+
+    CommitTx(tx, EStatus::SUCCESS);
+
+    Read_Exactly_N_Messages_From_Topic("topic_A", TEST_CONSUMER, 100);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_43, TFixture)
+{
+    // The recording stream will run into a quota. Before the commit, the client will receive confirmations
+    // for some of the messages. The `ExecuteDataQuery` call will wait for the rest.
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+    NTable::TTransaction tx = BeginTx(tableSession);
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::Tx(tx).CommitTx(true));
+
+    Read_Exactly_N_Messages_From_Topic("topic_A", TEST_CONSUMER, 100);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_44, TFixture)
+{
+    CreateTopic("topic_A", TEST_CONSUMER);
+
+    NTable::TSession tableSession = CreateTableSession();
+
+    auto result = ExecuteDataQuery(tableSession, "SELECT 1", NTable::TTxControl::BeginTx());
+
+    NTable::TTransaction tx = *result.GetTransaction();
+
+    for (size_t k = 0; k < 100; ++k) {
+        WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID, TString(1'000'000, 'a'), &tx);
+    }
+
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID);
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(60));
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 0);
+
+    ExecuteDataQuery(tableSession, "SELECT 2", NTable::TTxControl::Tx(tx).CommitTx(true));
+
+    Read_Exactly_N_Messages_From_Topic("topic_A", TEST_CONSUMER, 100);
+}
+
+void TFixture::CheckAvgWriteBytes(const TString& topicPath,
+                                  ui32 partitionId,
+                                  size_t minSize, size_t maxSize)
+{
+#define UNIT_ASSERT_AVGWRITEBYTES(v, minSize, maxSize) \
+    UNIT_ASSERT_LE_C(minSize, v, ", actual " << minSize << " > " << v); \
+    UNIT_ASSERT_LE_C(v, maxSize, ", actual " << v << " > " << maxSize);
+
+    auto avgWriteBytes = GetAvgWriteBytes(topicPath, partitionId);
+
+    UNIT_ASSERT_AVGWRITEBYTES(avgWriteBytes.PerSec, minSize, maxSize);
+    UNIT_ASSERT_AVGWRITEBYTES(avgWriteBytes.PerMin, minSize, maxSize);
+    UNIT_ASSERT_AVGWRITEBYTES(avgWriteBytes.PerHour, minSize, maxSize);
+    UNIT_ASSERT_AVGWRITEBYTES(avgWriteBytes.PerDay, minSize, maxSize);
+
+#undef UNIT_ASSERT_AVGWRITEBYTES
+}
+
+void TFixture::SplitPartition(const TString& topicName,
+                              ui32 partitionId,
+                              const TString& boundary)
+{
+    NKikimr::NPQ::NTest::SplitPartition(Setup->GetRuntime(),
+                                        ++SchemaTxId,
+                                        topicName,
+                                        partitionId,
+                                        boundary);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_45, TFixture)
+{
+    // Writing to a topic in a transaction affects the `AvgWriteBytes` indicator
+    CreateTopic("topic_A", TEST_CONSUMER, 2);
+
+    auto session = CreateTableSession();
+    auto tx = BeginTx(session);
+
+    TString message(1'000, 'x');
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, &tx, 0);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, &tx, 0);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, message, &tx, 1);
+
+    CommitTx(tx, EStatus::SUCCESS);
+
+    size_t minSize = (message.size() + TEST_MESSAGE_GROUP_ID_1.size()) * 2;
+    size_t maxSize = minSize + 200;
+
+    CheckAvgWriteBytes("topic_A", 0, minSize, maxSize);
+
+    minSize = (message.size() + TEST_MESSAGE_GROUP_ID_2.size());
+    maxSize = minSize + 200;
+
+    CheckAvgWriteBytes("topic_A", 1, minSize, maxSize);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_46, TFixture)
+{
+    // The `split` operation of the topic partition affects the writing in the transaction.
+    // The transaction commit should fail with an error
+    CreateTopic("topic_A", TEST_CONSUMER, 2, 10);
+
+    auto session = CreateTableSession();
+    auto tx = BeginTx(session);
+
+    TString message(1'000, 'x');
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, &tx, 0);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, &tx, 0);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, message, &tx, 1);
+
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID_2);
+
+    SplitPartition("topic_A", 1, "\xC0");
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, message, &tx, 1);
+
+    CommitTx(tx, EStatus::ABORTED);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_47, TFixture)
+{
+    // The `split` operation of the topic partition does not affect the reading in the transaction.
+    CreateTopic("topic_A", TEST_CONSUMER, 2, 10);
+
+    TString message(1'000, 'x');
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, nullptr, 0);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, nullptr, 0);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, message, nullptr, 1);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, message, nullptr, 1);
+
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID_1);
+    WaitForAcks("topic_A", TEST_MESSAGE_GROUP_ID_2);
+
+    SplitPartition("topic_A", 1, "\xC0");
+
+    auto session = CreateTableSession();
+    auto tx = BeginTx(session);
+
+    auto messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2), &tx, 0);
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
+
+    CloseTopicReadSession("topic_A", TEST_CONSUMER);
+
+    messages = ReadFromTopic("topic_A", TEST_CONSUMER, TDuration::Seconds(2), &tx, 1);
+    UNIT_ASSERT_VALUES_EQUAL(messages.size(), 2);
+
+    CommitTx(tx, EStatus::SUCCESS);
+}
+
+Y_UNIT_TEST_F(WriteToTopic_Demo_48, TFixture)
+{
+    // the commit of a transaction affects the split of the partition
+    CreateTopic("topic_A", TEST_CONSUMER, 2, 10);
+    AlterAutoPartitioning("topic_A", 2, 10, EAutoPartitioningStrategy::ScaleUp, TDuration::Seconds(2), 1, 2);
+
+    auto session = CreateTableSession();
+    auto tx = BeginTx(session);
+
+    TString message(1_MB, 'x');
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, &tx, 0);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_1, message, &tx, 0);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_3, message, &tx, 0);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_3, message, &tx, 0);
+
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, message, &tx, 1);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_2, message, &tx, 1);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_4, message, &tx, 1);
+    WriteToTopic("topic_A", TEST_MESSAGE_GROUP_ID_4, message, &tx, 1);
+
+    CommitTx(tx, EStatus::SUCCESS);
+
+    Sleep(TDuration::Seconds(5));
+
+    auto topicDescription = DescribeTopic("topic_A");
+
+    UNIT_ASSERT_GT(topicDescription.GetTotalPartitionsCount(), 2);
 }
 
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.cpp
@@ -52,7 +52,7 @@ void TTopicSdkTestSetup::CreateTopic(const TString& path, const TString& consume
     Server.WaitInit(path);
 }
 
-void TTopicSdkTestSetup::DescribeTopic(const TString& path)
+TTopicDescription TTopicSdkTestSetup::DescribeTopic(const TString& path)
 {
     TTopicClient client(MakeDriver());
 
@@ -62,6 +62,8 @@ void TTopicSdkTestSetup::DescribeTopic(const TString& path)
 
     auto status = client.DescribeTopic(path, settings).GetValueSync();
     UNIT_ASSERT(status.IsSuccess());
+
+    return status.GetTopicDescription();
 }
 
 TString TTopicSdkTestSetup::GetEndpoint() const {

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.h
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/ut_utils/topic_sdk_test_setup.h
@@ -21,7 +21,7 @@ public:
     void CreateTopicWithAutoscale(const TString& path = TEST_TOPIC, const TString& consumer = TEST_CONSUMER, size_t partitionCount = 1,
                      size_t maxPartitionCount = 100);
 
-    void DescribeTopic(const TString& path = TEST_TOPIC);
+    TTopicDescription DescribeTopic(const TString& path = TEST_TOPIC);
 
     TString GetEndpoint() const;
     TString GetTopicPath(const TString& name = TEST_TOPIC) const;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Сhanges from PR #12220

When a transaction is committed, the value of the `AvgWriteBytes` metric changes. This, in turn, can lead to a split of the partition.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
