### PR TITLE
Tests `TxUsage::WriteToTopic_Invalid_*`

### DIFF
--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2277,7 +2277,7 @@ public:
     }
 
     void HandleFinalCleanup(TEvKqp::TEvQueryRequest::TPtr& ev) {
-        ReplyProcessError(ev, Ydb::StatusIds::BAD_SESSION, "Session is under shutdown");
+        ReplyProcessError(ev->Sender, ev->Cookie, Ydb::StatusIds::BAD_SESSION, "Session is under shutdown");
     }
 
     STFUNC(ReadyState) {

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2276,6 +2276,10 @@ public:
         PassAway();
     }
 
+    void HandleFinalCleanup(TEvKqp::TEvQueryRequest::TPtr& ev) {
+        ReplyProcessError(ev, Ydb::StatusIds::BAD_SESSION, "Session is under shutdown");
+    }
+
     STFUNC(ReadyState) {
         try {
             switch (ev->GetTypeRewrite()) {
@@ -2407,6 +2411,7 @@ public:
                 hFunc(TEvents::TEvUndelivered, HandleNoop);
                 hFunc(TEvKqpSnapshot::TEvCreateSnapshotResponse, Handle);
                 hFunc(NWorkload::TEvContinueRequest, HandleNoop);
+                hFunc(TEvKqp::TEvQueryRequest, HandleFinalCleanup);
             }
         } catch (const yexception& ex) {
             InternalError(ex.what());

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -490,10 +490,15 @@ Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
     WriteToTopicWithInvalidTxId(false);
 }
 
-Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
+Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
 {
-    WriteToTopicWithInvalidTxId(true);
+    WriteToTopicWithInvalidTxId(false);
 }
+
+//Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
+//{
+//    WriteToTopicWithInvalidTxId(true);
+//}
 
 Y_UNIT_TEST_F(WriteToTopic_Two_WriteSession, TFixture)
 {

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -490,11 +490,6 @@ Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
     WriteToTopicWithInvalidTxId(false);
 }
 
-Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
-{
-    WriteToTopicWithInvalidTxId(false);
-}
-
 //Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
 //{
 //    WriteToTopicWithInvalidTxId(true);

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -490,10 +490,10 @@ Y_UNIT_TEST_F(WriteToTopic_Invalid_Session, TFixture)
     WriteToTopicWithInvalidTxId(false);
 }
 
-//Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
-//{
-//    WriteToTopicWithInvalidTxId(true);
-//}
+Y_UNIT_TEST_F(WriteToTopic_Invalid_Tx, TFixture)
+{
+    WriteToTopicWithInvalidTxId(true);
+}
 
 Y_UNIT_TEST_F(WriteToTopic_Two_WriteSession, TFixture)
 {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Changes from PR #11920

The client may not receive a response to the first write operation in the transaction.

A race between actors. The actor of the KQP session is transferred to the `FinalCleanupState`. In this composition, he does not respond to the `TEvQueryRequest` message from the `TPartitionWriter` actor.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
