### PR TITLE
The value of `PQ/BytesWriteOK` for writing to a transaction (#12337)

### DIFF
--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -452,6 +452,12 @@ void TPartition::SyncMemoryStateWithKVState(const TActorContext& ctx) {
 void TPartition::OnHandleWriteResponse(const TActorContext& ctx)
 {
     KVWriteInProgress = false;
+
+    if (DeletePartitionState == DELETION_IN_PROCESS) {
+        // before deleting an supportive partition, it is necessary to summarize its work
+        HandleWakeup(ctx);
+    }
+
     OnProcessTxsAndUserActsWriteComplete(ctx);
     HandleWriteResponse(ctx);
     ProcessTxsAndUserActs(ctx);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Changes from PR #12337

The partition periodically transmits a set of `PQ/*` indicators to the PQ tablet. This is also done by the service partition for writing to the transaction. If the duration of the transaction is less than the period of transfer of indicators, then part of the data was lost. Now, the service partition transmits the accumulated indicators to the PQ tablet before deletion.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
