### PR TITLE
viewer handler `/operation/get` doesn't return stats

### DIFF
--- a/ydb/core/viewer/json_local_rpc.h
+++ b/ydb/core/viewer/json_local_rpc.h
@@ -151,7 +151,7 @@ public:
                         response.operation().result().UnpackTo(&rs);
                         result->Message = std::move(rs);
                     } else if constexpr (std::is_same_v<TProtoResult, Ydb::Operations::Operation>) {
-                        result->Message = std::move(*reinterpret_cast<const TProtoResult*>(&response.operation()));
+                        result->Message = std::move(response.operation());
                     }
                 }
                 NYql::TIssues issues;

--- a/ydb/core/viewer/json_local_rpc.h
+++ b/ydb/core/viewer/json_local_rpc.h
@@ -146,9 +146,13 @@ public:
             auto result = MakeHolder<TEvLocalRpcPrivate::TEvGrpcRequestResult<TProtoResult>>();
             if constexpr (TRpcEv::IsOp) {
                 if (response.operation().ready() && response.operation().status() == Ydb::StatusIds::SUCCESS) {
-                    TProtoResult rs;
-                    response.operation().result().UnpackTo(&rs);
-                    result->Message = std::move(rs);
+                    if (response.operation().has_result()) {
+                        TProtoResult rs;
+                        response.operation().result().UnpackTo(&rs);
+                        result->Message = std::move(rs);
+                    } else if constexpr (std::is_same_v<TProtoResult, Ydb::Operations::Operation>) {
+                        result->Message = std::move(*reinterpret_cast<const TProtoResult*>(&response.operation()));
+                    }
                 }
                 NYql::TIssues issues;
                 NYql::IssuesFromMessage(response.operation().issues(), issues);

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1838,11 +1838,11 @@ Y_UNIT_TEST_SUITE(Viewer) {
 
     TString PostExecuteScript(TKeepAliveHttpClient& httpClient, TString query) {
         TStringStream requestBody;
-        requestBody
-            << "{ \"database\": \"/Root\","
-            << " \"script_content\": {"
-                << " \"text\": \"" << query << "\"},"
-            << " \"exec_mode\": \"EXEC_MODE_EXECUTE\" }";
+        requestBody << R"json({
+            "database": "/Root",
+            "script_content": { "text": ")json" << query << R"json(" },
+            "exec_mode": "EXEC_MODE_EXECUTE",
+            "stats_mode": "STATS_MODE_FULL" })json";
         TStringStream responseStream;
         TKeepAliveHttpClient::THeaders headers;
         headers["Content-Type"] = "application/json";
@@ -1867,6 +1867,22 @@ Y_UNIT_TEST_SUITE(Viewer) {
                                                             << "&database=%2FRoot", &responseStream, headers);
         const TString response = responseStream.ReadAll();
         UNIT_ASSERT_EQUAL_C(statusCode, HTTP_OK, statusCode << ": " << response);
+
+        return response;
+    }
+
+    TString ListOperations(TKeepAliveHttpClient& httpClient) {
+        TStringStream requestBody;
+        TStringStream responseStream;
+        TKeepAliveHttpClient::THeaders headers;
+        headers["Content-Type"] = "application/json";
+        headers["Authorization"] = "test_ydb_token";
+        const TKeepAliveHttpClient::THttpCode statusCode = httpClient.DoGet(TStringBuilder()
+                                                            << "/operation/list?timeout=600000&kind=scriptexec"
+                                                            << "&database=%2FRoot", &responseStream, headers);
+        const TString response = responseStream.ReadAll();
+        UNIT_ASSERT_EQUAL_C(statusCode, HTTP_OK, statusCode << ": " << response);
+
         return response;
     }
 
@@ -1927,6 +1943,14 @@ Y_UNIT_TEST_SUITE(Viewer) {
         response = GetOperation(httpClient, id);
         NJson::ReadJsonTree(response, &jsonCfg, &json, /* throwOnError = */ true);
         UNIT_ASSERT_EQUAL_C(json["issues"].GetArray().size(), 0, response);
+        UNIT_ASSERT_C(json.GetMap().contains("metadata"), response);
+        UNIT_ASSERT_C(json["metadata"].GetMap().contains("exec_stats"), response);
+        UNIT_ASSERT_C(json["metadata"].GetMap().at("exec_stats").GetMap().contains("process_cpu_time_us"), response);
+
+        response = ListOperations(httpClient);
+        NJson::ReadJsonTree(response, &jsonCfg, &json, /* throwOnError = */ true);
+        UNIT_ASSERT_EQUAL_C(json["operations"].GetArray().size(), 1, response);
+        UNIT_ASSERT_EQUAL_C(json["operations"].GetArray()[0]["id"], id, response);
 
         response = GetFetchScript(httpClient, id);
         NJson::ReadJsonTree(response, &jsonCfg, &json, /* throwOnError = */ true);


### PR DESCRIPTION
### Changelog entry

Changed `GetOperationResponse` parsing so that `/operation/get` start to return stats if paramater `stats_mode`  is passed.

### Changelog category <!-- remove all except one -->

* Bugfix
