### PR TITLE
Use QueryService by default (`--executer generic`) in `ydb workload kv` and `ydb workload stock` commands

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Use QueryService by default (`--executer generic`) in `ydb workload kv` and `ydb workload stock` commands
 * Use parquet format instead of CSV to fill tables in `ydb workload` benchmarks
 * Made `--consumer` flag in `ydb topic read` command optional. Now if this flag is not specified, reading is performed in no-consumer mode. In this mode partition IDs should be specified with `--partition-ids` option. 
 * Fixed a bug in `ydb import file csv` where multiple columns with escaped quotes in the same row were parsed incorrectly

--- a/ydb/library/workload/kv/kv.cpp
+++ b/ydb/library/workload/kv/kv.cpp
@@ -565,7 +565,7 @@ void TKvWorkloadParams::ConfigureOpts(NLastGetopt::TOpts& opts, const ECommandTy
                 .DefaultValue((ui64)KvWorkloadConstants::MIXED_CHANGE_PARTITIONS_SIZE).StoreResult(&MixedChangePartitionsSize);
             opts.AddLongOption("do-select", "Do SELECT operations")
                 .DefaultValue((ui64)KvWorkloadConstants::MIXED_DO_SELECT).StoreResult(&MixedDoSelect);
-            opts.AddLongOption("do-read-rows", "Do ReadRows operations")
+            opts.AddLongOption("do-read-rows", "Do ReadRows operations. Not available in QueryService (--executer generic)")
                 .DefaultValue((ui64)KvWorkloadConstants::MIXED_DO_READ_ROWS).StoreResult(&MixedDoReadRows);
         }
         break;

--- a/ydb/library/workload/kv/kv.h
+++ b/ydb/library/workload/kv/kv.h
@@ -22,7 +22,7 @@ enum KvWorkloadConstants : ui64 {
     PARTITIONS_BY_LOAD = true,
 
     MIXED_CHANGE_PARTITIONS_SIZE = false,
-    MIXED_DO_READ_ROWS = true,
+    MIXED_DO_READ_ROWS = false,
     MIXED_DO_SELECT = true,
 
     STALE_RO = false,

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -282,6 +282,8 @@ int TWorkloadCommand::RunWorkload(NYdbWorkload::IWorkloadQueryGenerator& workloa
     auto futures = NPar::LocalExecutor().ExecRangeWithFutures([this, &workloadGen, type](int id) {
         try {
             WorkerFn(id, workloadGen, type);
+        } catch (TMisuseException& error) {
+            throw;
         } catch (std::exception& error) {
             Y_FAIL_S(error.what());
         }

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -106,7 +106,7 @@ void TWorkloadCommand::Config(TConfig& config) {
     config.Opts->AddLongOption("window", "Window duration in seconds.")
         .DefaultValue(1).StoreResult(&WindowSec);
     config.Opts->AddLongOption("executer", "Query executer type (data or generic).")
-        .DefaultValue("data").StoreResult(&QueryExecuterType);
+        .DefaultValue("generic").StoreResult(&QueryExecuterType);
 }
 
 void TWorkloadCommand::PrepareForRun(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -282,8 +282,6 @@ int TWorkloadCommand::RunWorkload(NYdbWorkload::IWorkloadQueryGenerator& workloa
     auto futures = NPar::LocalExecutor().ExecRangeWithFutures([this, &workloadGen, type](int id) {
         try {
             WorkerFn(id, workloadGen, type);
-        } catch (TMisuseException& error) {
-            throw;
         } catch (std::exception& error) {
             Y_FAIL_S(error.what());
         }

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -136,7 +136,7 @@ void TWorkloadCommand::PrepareForRun(TConfig& config) {
                                     .MaxActiveSessions(10+Threads));
         QueryClient = std::make_unique<NQuery::TQueryClient>(*Driver, queryClientSettings);
     } else {
-        Y_FAIL_S("Unexpected executor Type: " + QueryExecuterType);
+        throw TMisuseException() << "Unexpected executor Type: " << QueryExecuterType;
     }
 }
 
@@ -187,9 +187,9 @@ void TWorkloadCommand::WorkerFn(int taskId, NYdbWorkload::IWorkloadQueryGenerato
         }
         ++retryCount;
         if (queryInfo.AlterTable) {
-            Y_FAIL_S("Generic query doesn't support alter table.");
+            throw TMisuseException() << "Generic query doesn't support alter table. Use data query (--executer data)";
         } else if (queryInfo.UseReadRows) {
-            Y_FAIL_S("Generic query doesn't support readrows.");
+            throw TMisuseException() << "Generic query doesn't support readrows. Use data query (--executer data)";
         } else {
             auto result = session.ExecuteQuery(queryInfo.Query.c_str(),
                 NYdb::NQuery::TTxControl::BeginTx(NYdb::NQuery::TTxSettings::SerializableRW()).CommitTx(),


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
Use QueryService by default (`--executer generic`) in `ydb workload kv` and `ydb workload stock` commands
