### PR TITLE
Try to preserve in-memory state (locks in particular) across restarts

### DIFF
--- a/ydb/core/protos/counters_datashard.proto
+++ b/ydb/core/protos/counters_datashard.proto
@@ -527,4 +527,5 @@ enum ETxTypes {
     TXTYPE_PLAN_PREDICTED_TXS = 81                        [(TxTypeOpts) = {Name: "TxPlanPredictedTxs"}];
     TXTYPE_WRITE = 82                                     [(TxTypeOpts) = {Name: "TxWrite"}];
     TXTYPE_REMOVE_SCHEMA_SNAPSHOTS = 83                   [(TxTypeOpts) = {Name: "TxRemoveSchemaSnapshots"}];
+    TXTYPE_INIT_RESTORED = 84                             [(TxTypeOpts) = {Name: "TxInitRestored"}];
 }

--- a/ydb/core/protos/datashard_config.proto
+++ b/ydb/core/protos/datashard_config.proto
@@ -25,4 +25,5 @@ message TDataShardConfig {
     optional bool DisabledOnSchemeShard = 19 [default = false];
     optional uint64 IncrementalRestoreReadAheadLo = 20 [default = 524288];
     optional uint64 IncrementalRestoreReadAheadHi = 21 [default = 1048576];
+    optional uint64 InMemoryStateMigrationTimeoutMs = 24 [default = 1000];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -181,4 +181,6 @@ message TFeatureFlags {
     optional bool ForceDistconfDisable = 156 [default = false];
     optional bool EnableScaleRecommender = 157 [default = false];
     optional bool EnableVDiskThrottling = 158 [default = false];
+    optional bool EnableDataShardInMemoryStateMigration = 159 [default = true];
+    optional bool EnableDataShardInMemoryStateMigrationAcrossGenerations = 160 [default = false];
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2144,3 +2144,118 @@ message TSerializedEvent {
     // TEventSerializationInfo::IsExtendedFormat flag
     optional bool IsExtendedFormat = 2;
 }
+
+// In-memory variables that are important to restore between shard generations
+message TInMemoryVars {
+    optional NKikimrProto.TRowVersion ImmediateWriteEdge = 1;
+    optional NKikimrProto.TRowVersion ImmediateWriteEdgeReplied = 2;
+    optional NKikimrProto.TRowVersion UnprotectedReadEdge = 3;
+}
+
+// In-memory locks
+message TInMemoryLockInfo {
+    optional uint64 LockId = 1;
+    optional uint32 LockNodeId = 2;
+    optional uint32 Generation = 3;
+    optional uint32 Counter = 4;
+    optional uint64 CreateTs = 5;
+    optional uint64 Flags = 6;
+    optional NKikimrProto.TRowVersion BreakVersion = 7;
+    repeated NKikimrProto.TPathID ReadTables = 8;
+    repeated NKikimrProto.TPathID WriteTables = 9;
+}
+
+// In-memory ranges associated with the lock
+// Note: whole shard locks will have whole table read/write ranges
+message TInMemoryLockRange {
+    optional uint64 LockId = 1;
+    optional NKikimrProto.TPathID TableId = 2;
+    optional uint64 Flags = 3;
+    optional bytes Data = 4;
+}
+
+// In-memory conflicts between locks
+message TInMemoryLockConflict {
+    // When this lock is committed
+    optional uint64 LockId = 1;
+    // It must break another lock with the specified id
+    optional uint64 ConflictId = 2;
+}
+
+// In-memory volatile dependencies
+// This specifies that to commit this lock we must use a volatile transaction
+// that must have a dependency on the specified TxId.
+message TInMemoryLockVolatileDependency {
+    optional uint64 LockId = 1;
+    optional uint64 TxId = 2;
+}
+
+// In-memory prepared volatile transactions, i.e. those we have accepted for
+// execution and may be planned and executed later. This includes planned and
+// acknowledged transactions that haven't executed yet (including those that
+// have not been committed yet?)
+message TInMemoryPreparedVolatileTx {
+    optional uint64 TxId = 1;
+    optional NActorsProto.TActorId Source = 2;
+    optional uint64 Cookie = 3;
+    optional uint64 Type = 4;
+    optional bytes Body = 5;
+    optional uint64 Flags = 6;
+    // This is Min/Max step of a prepared transactions, mostly used for deadline cleanup
+    optional uint64 MinStep = 7;
+    optional uint64 MaxStep = 8;
+    // Specified when the transaction has been planned already (including predictions)
+    optional uint64 PredictedStep = 9;
+    optional uint64 Step = 10;
+}
+
+// In-memory waiting volatile transactions, i.e. those that have not been
+// decided yet (at least persistently), and for which we need to send a
+// result when they eventually commit or abort. This is matched against
+// transactions that are restored from disk.
+message TInMemoryWaitingVolatileTx {
+    optional uint64 TxId = 1;
+    optional NActorsProto.TActorId Source = 2;
+    optional uint64 Cookie = 3;
+    optional uint64 Type = 4;
+}
+
+// Partial in-memory state of the datashard
+message TInMemoryState {
+    optional TInMemoryVars Vars = 1;
+    repeated TInMemoryLockInfo Locks = 2;
+    repeated TInMemoryLockRange LockRanges = 3;
+    repeated TInMemoryLockConflict LockConflicts = 4;
+    repeated TInMemoryLockVolatileDependency LockVolatileDependencies = 5;
+    repeated TInMemoryPreparedVolatileTx PreparedVolatileTxs = 6;
+    repeated TInMemoryWaitingVolatileTx WaitingVolatileTxs = 7;
+}
+
+// Internal continuation token, may change between versions
+message TInMemoryStateContinuationToken {
+    // Index to continue from
+    optional uint64 NextIndex = 1;
+}
+
+// Sent to the state actor by new generations
+message TEvInMemoryStateRequest {
+    // Generation of the new tablet
+    optional uint32 Generation = 1;
+
+    // Continuation token to get the next response
+    optional bytes ContinuationToken = 2;
+}
+
+// Sent by the state actor to new generations
+message TEvInMemoryStateResponse {
+    // Partial serialized TInMemoryState chunk
+    optional uint32 SerializedStatePayloadIndex = 1;
+
+    // Optional checkpoint offsets within the chunk. The protobuf message may
+    // be parsed cleanly up to these offsets without the need to concatenate
+    // subsequent chunks.
+    repeated uint32 SerializedStateCheckpoints = 2 [packed = true];
+
+    // Will be set for incomplete replies
+    optional bytes ContinuationToken = 3;
+}

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -1,6 +1,7 @@
 #include "datashard_impl.h"
 #include "datashard_txs.h"
 #include "datashard_locks_db.h"
+#include "memory_state_migration.h"
 #include "probes.h"
 
 #include <ydb/core/base/interconnect_channels.h>
@@ -174,6 +175,15 @@ TDataShard::TDataShard(const TActorId &tablet, TTabletStorageInfo *info)
     RegisterDataShardProbes();
 }
 
+TDataShard::~TDataShard() {
+    if (InMemoryRestoreActor) {
+        InMemoryRestoreActor->OnTabletDestroyed();
+    }
+    if (InMemoryStateActor) {
+        InMemoryStateActor->OnTabletDestroyed();
+    }
+}
+
 void TDataShard::OnDetach(const TActorContext &ctx) {
     Cleanup(ctx);
     LOG_INFO_S(ctx, NKikimrServices::TX_DATASHARD, "OnDetach: " << TabletID());
@@ -265,6 +275,13 @@ void TDataShard::Cleanup(const TActorContext& ctx) {
 }
 
 void TDataShard::Die(const TActorContext& ctx) {
+    if (InMemoryRestoreActor) {
+        InMemoryRestoreActor->OnTabletDead();
+    }
+    if (InMemoryStateActor) {
+        InMemoryStateActor->OnTabletDead();
+    }
+
     NTabletPipe::CloseAndForgetClient(SelfId(), SchemeShardPipe);
     NTabletPipe::CloseAndForgetClient(SelfId(), StateReportPipe);
     NTabletPipe::CloseAndForgetClient(SelfId(), DbStatsReportPipe);
@@ -1620,6 +1637,29 @@ void TDataShard::PersistSys(NIceDb::TNiceDb& db, ui64 key, bool value) const {
     db.Table<Schema::Sys>().Key(key).Update(NIceDb::TUpdate<Schema::Sys::Uint64>(value ? 1 : 0));
 }
 
+void TDataShard::PersistSys(NIceDb::TNiceDb& db, ui64 key, const TActorId& value) const {
+    char buf[sizeof(ui64) * 2];
+    WriteUnaligned<ui64>(buf, value.RawX1());
+    WriteUnaligned<ui64>(buf + sizeof(ui64), value.RawX2());
+    db.Table<Schema::Sys>().Key(key).Update(NIceDb::TUpdate<Schema::Sys::Bytes>(TString(buf, sizeof(ui64) * 2)));
+}
+
+bool TDataShard::SysGetActorId(NIceDb::TNiceDb& db, ui64 key, TActorId& value) {
+    auto rowset = db.Table<Schema::Sys>().Key(key).Select<Schema::Sys::Bytes>();
+    if (!rowset.IsReady()) {
+        return false;
+    }
+    if (rowset.IsValid()) {
+        TString buf = rowset.GetValue<Schema::Sys::Bytes>();
+        Y_ABORT_UNLESS(buf.size() == sizeof(ui64) * 2, "Unexpected TActorId value size %" PRISZT, buf.size());
+        const char* data = buf.data();
+        ui64 x1 = ReadUnaligned<ui64>(data);
+        ui64 x2 = ReadUnaligned<ui64>(data + sizeof(ui64));
+        value = TActorId(x1, x2);
+    }
+    return true;
+}
+
 void TDataShard::PersistUserTable(NIceDb::TNiceDb& db, ui64 tableId, const TUserTable& tableInfo) {
     db.Table<Schema::UserTables>().Key(tableId).Update(
         NIceDb::TUpdate<Schema::UserTables::LocalTid>(tableInfo.LocalTid),
@@ -2484,11 +2524,18 @@ void TDataShard::SendImmediateWriteResult(
     const ui64 step = version.Step;
     const ui64 observedStep = GetMaxObservedStep();
     if (step <= observedStep) {
-        SnapshotManager.PromoteImmediateWriteEdgeReplied(version);
-        if (!sessionId) {
-            Send(target, event, 0, cookie, span.GetTraceId());
+        // We avoid sending replies that would have promoted the replied edge
+        // when it's frozen. This prevents us replying and causing the next
+        // generation to potentially keep reading stale data.
+        if (Y_LIKELY(!InMemoryVarsFrozen) || version <= SnapshotManager.GetImmediateWriteEdgeReplied()) {
+            SnapshotManager.PromoteImmediateWriteEdgeReplied(version);
+            if (!sessionId) {
+                Send(target, event, 0, cookie, span.GetTraceId());
+            } else {
+                SendViaSession(sessionId, target, SelfId(), event, 0, cookie, span.GetTraceId());
+            }
         } else {
-            SendViaSession(sessionId, target, SelfId(), event, 0, cookie, span.GetTraceId());
+            span.EndError("Dropped");
         }
         return;
     }
@@ -2627,13 +2674,20 @@ void TDataShard::SendAfterMediatorStepActivate(ui64 mediatorStep, const TActorCo
         }
 
         if (step <= mediatorStep) {
-            if (it->second.Span) {
-                it->second.Span.Attribute("ActivateStep", std::to_string(mediatorStep));
+            // We avoid sending replies that would have promoted the replied edge
+            // when it's frozen. This prevents us replying and causing the next
+            // generation to potentially keep reading stale data.
+            if (Y_LIKELY(!InMemoryVarsFrozen) || it->first <= SnapshotManager.GetImmediateWriteEdgeReplied()) {
+                if (it->second.Span) {
+                    it->second.Span.Attribute("ActivateStep", std::to_string(mediatorStep));
+                }
+                SnapshotManager.PromoteImmediateWriteEdgeReplied(it->first);
+                SendViaSession(it->second.SessionId,
+                    it->second.Target, SelfId(), it->second.Event.Release(),
+                    0, it->second.Cookie, it->second.Span.GetTraceId());
+            } else {
+                it->second.Span.EndError("Dropped");
             }
-            SnapshotManager.PromoteImmediateWriteEdgeReplied(it->first);
-            SendViaSession(it->second.SessionId,
-                it->second.Target, SelfId(), it->second.Event.Release(),
-                0, it->second.Cookie, it->second.Span.GetTraceId());
             it = MediatorDelayedReplies.erase(it);
             continue;
         }
@@ -2690,6 +2744,12 @@ bool TDataShard::NeedMediatorStateRestored() const {
     if (!ProcessingParams) {
         // Without processing params there's nothing to restore
         // This includes the first boot before tables are initialized
+        return false;
+    }
+
+    if (InMemoryVarsRestored) {
+        // We have migrated in-memory vars from previous generations
+        // We don't need mediator state for correctness
         return false;
     }
 

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -342,6 +342,10 @@ namespace TEvDataShard {
         EvReadScanStarted,
         EvReadScanFinished,
 
+        // Used to transfer in-memory state between generations
+        EvInMemoryStateRequest,
+        EvInMemoryStateResponse,
+
         EvEnd
     };
 
@@ -1768,6 +1772,29 @@ namespace TEvDataShard {
             Record.SetStatus(status);
             Record.SetErrorDescription(error);
         }
+    };
+
+    struct TEvInMemoryStateRequest
+        : public TEventPB<TEvInMemoryStateRequest,
+                          NKikimrTxDataShard::TEvInMemoryStateRequest,
+                          EvInMemoryStateRequest>
+    {
+        TEvInMemoryStateRequest() = default;
+
+        explicit TEvInMemoryStateRequest(ui32 generation, const TString& continuationToken = {}) {
+            Record.SetGeneration(generation);
+            if (!continuationToken.empty()) {
+                Record.SetContinuationToken(continuationToken);
+            }
+        }
+    };
+
+    struct TEvInMemoryStateResponse
+        : public TEventPB<TEvInMemoryStateResponse,
+                          NKikimrTxDataShard::TEvInMemoryStateResponse,
+                          EvInMemoryStateResponse>
+    {
+        TEvInMemoryStateResponse() = default;
     };
 };
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -156,6 +156,9 @@ struct TSetupSysLocks;
 
 class TNeedGlobalTxId : public yexception {};
 
+class IDataShardInMemoryRestoreActor;
+class IDataShardInMemoryStateActor;
+
 ///
 class TDataShard
     : public TActor<TDataShard>
@@ -164,6 +167,7 @@ class TDataShard
     class TTxStopGuard;
     class TTxGetShardState;
     class TTxInit;
+    class TTxInitRestored;
     class TTxInitSchema;
     class TTxInitSchemaDefaults;
     class TTxPlanStep;
@@ -253,6 +257,8 @@ class TDataShard
     void HandleMonCleanupBorrowedParts(NMon::TEvRemoteHttpInfo::TPtr& ev);
     void HandleMonResetSchemaVersion(NMon::TEvRemoteHttpInfo::TPtr& ev);
 
+    friend class TDataShardInMemoryRestoreActor;
+    friend class TDataShardInMemoryStateActor;
     friend class TDataShardMiniKQLFactory;
     friend class TDataTransactionProcessor;
     friend class TSchemeTransactionProcessor;
@@ -1147,6 +1153,10 @@ class TDataShard
             SysMvcc_FollowerReadEdgeTxId = 43,
             SysMvcc_FollowerReadEdgeRepeatable = 44,
 
+            // Last known in-memory state actor
+            Sys_InMemoryStateActorId = 45,
+            Sys_InMemoryStateGeneration = 46,
+
             // reserved
             SysPipeline_Flags = 1000,
             SysPipeline_LimitActiveTx,
@@ -1208,6 +1218,8 @@ class TDataShard
             value = rowset.GetValue<Schema::Sys::Bytes>();
         return true;
     }
+
+    static bool SysGetActorId(NIceDb::TNiceDb& db, ui64 key, TActorId& value);
 
     template <typename TEvHandle>
     void ForwardEventToOperation(TAutoPtr<TEvHandle> ev, const TActorContext &ctx) {
@@ -1428,6 +1440,7 @@ class TDataShard
     void PersistSys(NIceDb::TNiceDb& db, ui64 key, ui64 value) const;
     void PersistSys(NIceDb::TNiceDb& db, ui64 key, ui32 value) const;
     void PersistSys(NIceDb::TNiceDb& db, ui64 key, bool value) const;
+    void PersistSys(NIceDb::TNiceDb& db, ui64 key, const TActorId& value) const;
     void PersistUserTable(NIceDb::TNiceDb& db, ui64 tableId, const TUserTable& tableInfo);
     void PersistUserTableFullCompactionTs(NIceDb::TNiceDb& db, ui64 tableId, ui64 ts);
     void PersistMoveUserTable(NIceDb::TNiceDb& db, ui64 prevTableId, ui64 tableId, const TUserTable& tableInfo);
@@ -1438,6 +1451,7 @@ class TDataShard
     bool CheckMediatorAuthorisation(ui64 mediatorId);
 
     NTabletFlatExecutor::ITransaction* CreateTxInit();
+    NTabletFlatExecutor::ITransaction* CreateTxInitRestored();
     NTabletFlatExecutor::ITransaction* CreateTxInitSchema();
     NTabletFlatExecutor::ITransaction* CreateTxInitSchemaDefaults();
     NTabletFlatExecutor::ITransaction* CreateTxSchemaChanged(TEvDataShard::TEvSchemaChangedResult::TPtr& ev);
@@ -1456,6 +1470,7 @@ public:
     }
 
     TDataShard(const TActorId &tablet, TTabletStorageInfo *info);
+    ~TDataShard();
 
 
     void PrepareAndSaveOutReadSets(ui64 step,
@@ -2684,6 +2699,30 @@ private:
     TS3UploadsManager S3Uploads;
     TS3DownloadsManager S3Downloads;
 
+    // Initial state
+    struct TInitialState {
+        TVector<IDataShardChangeCollector::TChange> ChangeRecords;
+    };
+    std::optional<TInitialState> InitialState;
+
+    // In-memory state transfer support
+    IDataShardInMemoryRestoreActor* InMemoryRestoreActor = nullptr;
+    IDataShardInMemoryStateActor* InMemoryStateActor = nullptr;
+    TActorId InMemoryStateActorId;
+    TActorId InMemoryStatePrevActorId;
+    ui64 InMemoryStatePrevGeneration = 0;
+
+    void StartInMemoryRestoreActor();
+    void OnInMemoryStateRestored();
+    bool StartInMemoryStateActor();
+
+    struct TPreservedInMemoryState {
+        TVector<TString> Chunks;
+        TVector<size_t> Checkpoints;
+    };
+
+    TPreservedInMemoryState PreserveInMemoryState();
+
     struct TMediatorDelayedReply {
         TActorId Target;
         THolder<IEventBase> Event;
@@ -2719,6 +2758,9 @@ private:
     TVector<THolder<IEventHandle>> MediatorStateWaitingMsgs;
     bool MediatorStateWaiting = false;
     bool MediatorStateRestoreTxPending = false;
+
+    bool InMemoryVarsRestored = false;
+    bool InMemoryVarsFrozen = false;
 
     bool IcbRegistered = false;
 

--- a/ydb/core/tx/datashard/datashard_snapshots.cpp
+++ b/ydb/core/tx/datashard/datashard_snapshots.cpp
@@ -303,6 +303,12 @@ bool TSnapshotManager::PromoteImmediateWriteEdgeReplied(const TRowVersion& versi
     return false;
 }
 
+void TSnapshotManager::RestoreImmediateWriteEdge(const TRowVersion& version, const TRowVersion& replied) {
+    // Note: ImmediateWriteEdge is persistent, we must not overwrite it
+    Y_UNUSED(version);
+    ImmediateWriteEdgeReplied = replied;
+}
+
 TRowVersion TSnapshotManager::GetUnprotectedReadEdge() const {
     return UnprotectedReadEdge;
 }
@@ -314,6 +320,10 @@ bool TSnapshotManager::PromoteUnprotectedReadEdge(const TRowVersion& version) {
     }
 
     return false;
+}
+
+void TSnapshotManager::RestoreUnprotectedReadEdge(const TRowVersion& version) {
+    UnprotectedReadEdge = version;
 }
 
 std::pair<TRowVersion, bool> TSnapshotManager::GetFollowerReadEdge() const {

--- a/ydb/core/tx/datashard/datashard_snapshots.h
+++ b/ydb/core/tx/datashard/datashard_snapshots.h
@@ -138,9 +138,11 @@ public:
     void SetImmediateWriteEdge(NIceDb::TNiceDb& db, const TRowVersion& version);
     bool PromoteImmediateWriteEdge(const TRowVersion& version, TTransactionContext& txc);
     bool PromoteImmediateWriteEdgeReplied(const TRowVersion& version);
+    void RestoreImmediateWriteEdge(const TRowVersion& version, const TRowVersion& replied);
 
     TRowVersion GetUnprotectedReadEdge() const;
     bool PromoteUnprotectedReadEdge(const TRowVersion& version);
+    void RestoreUnprotectedReadEdge(const TRowVersion& version);
 
     std::pair<TRowVersion, bool> GetFollowerReadEdge() const;
     bool PromoteFollowerReadEdge(const TRowVersion& version, bool repeatable, TTransactionContext& txc);

--- a/ydb/core/tx/datashard/datashard_txs.h
+++ b/ydb/core/tx/datashard/datashard_txs.h
@@ -38,19 +38,6 @@ private:
     THolder<TEvDataShard::TEvGetShardStateResult> Result;
 };
 
-class TDataShard::TTxInit : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
-public:
-    TTxInit(TDataShard* ds);
-    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override;
-    void Complete(const TActorContext &ctx) override;
-    TTxType GetTxType() const override { return TXTYPE_INIT; }
-private:
-    bool CreateScheme(TTransactionContext &txc);
-    bool ReadEverything(TTransactionContext &txc);
-private:
-    TVector<IDataShardChangeCollector::TChange> ChangeRecords;
-};
-
 class TDataShard::TTxPlanStep : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
 public:
     TTxPlanStep(TDataShard *self, TEvTxProcessing::TEvPlanStep::TPtr ev);

--- a/ydb/core/tx/datashard/datashard_ut_init.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_init.cpp
@@ -60,7 +60,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardTestInit) {
         CreateTestBootstrapper(runtime, CreateTestTabletInfo(TTestTxConfig::TxTablet0, TTabletTypes::DataShard), &CreateDataShard);
 
         TDispatchOptions options;
-        options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot));
+        options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvTabletActive));
         runtime.DispatchEvents(options);
 
         Y_UNUSED(sender);

--- a/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
@@ -5151,6 +5151,564 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         }
     }
 
+    Y_UNIT_TEST(ShardRestartLockBasic) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (2, 22);
+            )"),
+            "<empty>");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 22 } }");
+    }
+
+    Y_UNIT_TEST(ShardRestartWholeShardLockBasic) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        auto prevLimit = TLockLocker::LockRangesLimit();
+        TLockLocker::SetLockRangesLimit(1);
+        Y_DEFER {
+            TLockLocker::SetLockRangesLimit(prevLimit);
+        };
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key in (1, 3)
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (2, 22);
+            )"),
+            "<empty>");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 22 } }");
+    }
+
+    Y_UNIT_TEST(ShardRestartLockUnrelatedUpsert) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key <= 5
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (6, 66);");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (2, 22);
+            )"),
+            "<empty>");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 22 } }, "
+            "{ items { uint32_value: 6 } items { uint32_value: 66 } }");
+    }
+
+    Y_UNIT_TEST(ShardRestartLockBrokenByConflict) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key <= 5
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (3, 33);");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (2, 22);
+            )"),
+            "ERROR: ABORTED");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 3 } items { uint32_value: 33 } }");
+    }
+
+    Y_UNIT_TEST(ShardRestartWholeShardLockBrokenByUpsert) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        auto prevLimit = TLockLocker::LockRangesLimit();
+        TLockLocker::SetLockRangesLimit(1);
+        Y_DEFER {
+            TLockLocker::SetLockRangesLimit(prevLimit);
+        };
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key in (1, 3)
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (6, 66);");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (2, 22);
+            )"),
+            "ERROR: ABORTED");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 6 } items { uint32_value: 66 } }");
+    }
+
+    Y_UNIT_TEST(ShardRestartLockNotBrokenByUncommittedBeforeRead) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionIdWrite, txIdWrite;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionIdWrite, txIdWrite, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (6, 66);
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 6 } items { uint32_value: 66 } }");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key <= 5
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionIdWrite, txIdWrite, R"(
+                SELECT 1;
+            )"),
+            "{ items { int32_value: 1 } }");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (3, 33);
+            )"),
+            "<empty>");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 3 } items { uint32_value: 33 } }, "
+            "{ items { uint32_value: 6 } items { uint32_value: 66 } }");
+    }
+
+    Y_UNIT_TEST(ShardRestartLockBrokenByUncommittedBeforeRead) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionIdWrite, txIdWrite;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionIdWrite, txIdWrite, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (2, 22);
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 22 } }");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key <= 5
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionIdWrite, txIdWrite, R"(
+                SELECT 1;
+            )"),
+            "{ items { int32_value: 1 } }");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (3, 33);
+            )"),
+            "ERROR: ABORTED");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 22 } }");
+    }
+
+
+    Y_UNIT_TEST(ShardRestartLockNotBrokenByUncommittedAfterRead) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key <= 5
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        TString sessionIdWrite, txIdWrite;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionIdWrite, txIdWrite, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (6, 66);
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 6 } items { uint32_value: 66 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionIdWrite, txIdWrite, R"(
+                SELECT 1;
+            )"),
+            "{ items { int32_value: 1 } }");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (3, 33);
+            )"),
+            "<empty>");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 3 } items { uint32_value: 33 } }, "
+            "{ items { uint32_value: 6 } items { uint32_value: 66 } }");
+    }
+
+    Y_UNIT_TEST(ShardRestartLockBrokenByUncommittedAfterRead) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetDomainPlanResolution(100);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key Uint32, value Uint32, PRIMARY KEY (key));
+            )"),
+            "SUCCESS");
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table` (key, value) VALUES (1, 11);");
+
+        TString sessionId, txId;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId, txId, R"(
+                SELECT key, value FROM `/Root/table`
+                WHERE key <= 5
+                ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }");
+
+        TString sessionIdWrite, txIdWrite;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionIdWrite, txIdWrite, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (2, 22);
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 22 } }");
+
+        RebootTablet(runtime, shards.at(0), sender);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionIdWrite, txIdWrite, R"(
+                SELECT 1;
+            )"),
+            "{ items { int32_value: 1 } }");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(
+                UPSERT INTO `Root/table` (key, value) VALUES (3, 33);
+            )"),
+            "ERROR: ABORTED");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { uint32_value: 1 } items { uint32_value: 11 } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 22 } }");
+    }
+
 }
 
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/memory_state_migration.cpp
+++ b/ydb/core/tx/datashard/memory_state_migration.cpp
@@ -1,0 +1,643 @@
+#include "memory_state_migration.h"
+#include "datashard_impl.h"
+
+#include <ydb/core/protos/datashard_config.pb.h>
+
+namespace NKikimr::NDataShard {
+
+static constexpr size_t MAX_DATASHARD_STATE_CHUNK_SIZE = 8_MB;
+
+class TDataShardInMemoryRestoreActor
+    : public IDataShardInMemoryRestoreActor
+    , public TActor<TDataShardInMemoryRestoreActor>
+{
+public:
+    TDataShardInMemoryRestoreActor(TDataShard* owner, const TActorId& prevStateActorId)
+        : TActor(&TThis::StateWork)
+        , Owner(owner)
+        , PrevStateActorId(prevStateActorId)
+    {}
+
+    ~TDataShardInMemoryRestoreActor() {
+        Detach();
+    }
+
+    void Start() {
+        Send(PrevStateActorId,
+            new TEvDataShard::TEvInMemoryStateRequest(Owner->Generation()),
+            IEventHandle::FlagSubscribeOnSession | IEventHandle::FlagTrackDelivery);
+
+        TDuration timeout = TDuration::MilliSeconds(AppData()->DataShardConfig.GetInMemoryStateMigrationTimeoutMs());
+        Schedule(timeout, new TEvents::TEvWakeup);
+    }
+
+private:
+    void PassAway() override {
+        const ui32 nodeId = PrevStateActorId.NodeId();
+        if (nodeId != SelfId().NodeId()) {
+            Send(TActivationContext::InterconnectProxy(nodeId), new TEvents::TEvUnsubscribe);
+        }
+        TActor::PassAway();
+    }
+
+    void Detach() {
+        if (Owner) {
+            Owner->InMemoryRestoreActor = nullptr;
+            Owner = nullptr;
+        }
+    }
+
+    void Restored() {
+        auto* owner = Owner;
+        Y_ABORT_UNLESS(owner);
+
+        if (Locks) {
+            owner->SysLocks.RestoreInMemoryLocks(std::move(Locks));
+        }
+
+        if (Vars) {
+            owner->SnapshotManager.RestoreImmediateWriteEdge(Vars->ImmediateWriteEdge, Vars->ImmediateWriteEdgeReplied);
+            owner->SnapshotManager.RestoreUnprotectedReadEdge(Vars->UnprotectedReadEdge);
+            owner->InMemoryVarsRestored = true;
+        }
+
+        Detach();
+        PassAway();
+
+        owner->OnInMemoryStateRestored();
+    }
+
+    void Failed() {
+        // TODO: cleanup partial state
+        Locks.clear();
+        Restored();
+    }
+
+    void OnTabletDestroyed() override {
+        Detach();
+    }
+
+    void OnTabletDead() override {
+        Detach();
+        PassAway();
+    }
+
+    void Handle(TEvDataShard::TEvInMemoryStateResponse::TPtr& ev) {
+        auto* msg = ev->Get();
+
+        size_t prevSize = Buffer.size();
+        if (msg->Record.HasSerializedStatePayloadIndex()) {
+            TRope payload = msg->GetPayload(msg->Record.GetSerializedStatePayloadIndex());
+            Buffer.Insert(Buffer.End(), std::move(payload));
+        }
+
+        size_t lastOffset = 0;
+        for (size_t offset : msg->Record.GetSerializedStateCheckpoints()) {
+            // These offsets are relative to the start of the new chunk, we make
+            // them relative to the start of our accumulated buffer and then
+            // transform into parseable chunk sizes.
+            offset += prevSize;
+            // Try to fail gracefully instead of crashing on unexpected data
+            if (offset < lastOffset) {
+                LOG_CRIT_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
+                    "Received TEvInMemoryStateResponse with checkpoints that go backwards");
+                Failed();
+                return;
+            }
+            if (Buffer.size() < offset) {
+                LOG_CRIT_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
+                    "Received TEvInMemoryStateResponse with checkpoints that overflow current buffer");
+                Failed();
+                return;
+            }
+
+            if (offset != lastOffset) {
+                Checkpoints.push_back(offset - lastOffset);
+            }
+            lastOffset = offset;
+        }
+
+        if (!msg->Record.HasContinuationToken() && lastOffset < Buffer.size()) {
+            // Make sure we process the last chunk in the same code below
+            Checkpoints.push_back(Buffer.size() - lastOffset);
+        }
+
+        for (size_t chunkSize : Checkpoints) {
+            Y_ABORT_UNLESS(chunkSize <= Buffer.size(), "Unexpected end of buffer");
+
+            NKikimrTxDataShard::TInMemoryState* state = google::protobuf::Arena::CreateMessage<NKikimrTxDataShard::TInMemoryState>(&Arena);
+            {
+                TRopeStream stream(Buffer.Begin(), chunkSize);
+                bool ok = state->ParseFromZeroCopyStream(&stream);
+                if (!ok) {
+                    LOG_CRIT_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
+                        "Received TEvInMemoryStateResponse has a chunk that cannot be parsed");
+                    Failed();
+                    return;
+                }
+            }
+            Buffer.EraseFront(chunkSize);
+
+            if (state->HasVars()) {
+                const auto& protoVars = state->GetVars();
+                if (!Vars) {
+                    Vars.emplace();
+                }
+                if (protoVars.HasImmediateWriteEdge()) {
+                    Vars->ImmediateWriteEdge = TRowVersion::Parse(protoVars.GetImmediateWriteEdge());
+                }
+                if (protoVars.HasImmediateWriteEdgeReplied()) {
+                    Vars->ImmediateWriteEdgeReplied = TRowVersion::Parse(protoVars.GetImmediateWriteEdgeReplied());
+                }
+                if (protoVars.HasUnprotectedReadEdge()) {
+                    Vars->UnprotectedReadEdge = TRowVersion::Parse(protoVars.GetUnprotectedReadEdge());
+                }
+            }
+            for (const auto& protoLock : state->GetLocks()) {
+                auto& row = Locks[protoLock.GetLockId()];
+                row.LockId = protoLock.GetLockId();
+                row.LockNodeId = protoLock.GetLockNodeId();
+                row.Generation = protoLock.GetGeneration();
+                row.Counter = protoLock.GetCounter();
+                row.CreateTs = protoLock.GetCreateTs();
+                row.Flags = protoLock.GetFlags();
+                if (protoLock.HasBreakVersion()) {
+                    row.BreakVersion = TRowVersion::Parse(protoLock.GetBreakVersion());
+                }
+                for (const auto& protoPathId : protoLock.GetReadTables()) {
+                    row.ReadTables.push_back(PathIdFromPathId(protoPathId));
+                }
+                for (const auto& protoPathId : protoLock.GetWriteTables()) {
+                    row.WriteTables.push_back(PathIdFromPathId(protoPathId));
+                }
+            }
+            for (const auto& protoRange : state->GetLockRanges()) {
+                auto* row = Locks.FindPtr(protoRange.GetLockId());
+                if (!row) {
+                    LOG_CRIT_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
+                        "Received lock range for a missing lock " << protoRange.GetLockId());
+                    Failed();
+                    return;
+                }
+                auto& range = row->Ranges.emplace_back();
+                range.TableId = PathIdFromPathId(protoRange.GetTableId());
+                range.Flags = protoRange.GetFlags();
+                range.Data = protoRange.GetData();
+            }
+            for (const auto& protoConflict : state->GetLockConflicts()) {
+                auto* row = Locks.FindPtr(protoConflict.GetLockId());
+                if (!row) {
+                    LOG_CRIT_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
+                        "Received lock conflict for a missing lock " << protoConflict.GetLockId());
+                    Failed();
+                    return;
+                }
+                row->Conflicts.push_back(protoConflict.GetConflictId());
+            }
+            for (const auto& protoVolatileDep : state->GetLockVolatileDependencies()) {
+                auto* row = Locks.FindPtr(protoVolatileDep.GetLockId());
+                if (!row) {
+                    LOG_CRIT_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
+                        "Received volatile dependency for a missing lock " << protoVolatileDep.GetLockId());
+                    Failed();
+                    return;
+                }
+                row->VolatileDependencies.push_back(protoVolatileDep.GetTxId());
+            }
+
+            Arena.Reset();
+        }
+
+        if (msg->Record.HasContinuationToken()) {
+            // Request the next data chunk
+            // Note: we have subscribed in the first request already
+            Send(PrevStateActorId,
+                new TEvDataShard::TEvInMemoryStateRequest(Owner->Generation(), msg->Record.GetContinuationToken()),
+                IEventHandle::FlagTrackDelivery);
+            return;
+        }
+
+        Restored();
+    }
+
+    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr&) {
+        Failed();
+    }
+
+    void Handle(TEvents::TEvUndelivered::TPtr&) {
+        Failed();
+    }
+
+    void Handle(TEvents::TEvWakeup::TPtr&) {
+        Failed();
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvDataShard::TEvInMemoryStateResponse, Handle);
+            hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
+            hFunc(TEvents::TEvUndelivered, Handle);
+            hFunc(TEvents::TEvWakeup, Handle);
+        }
+    }
+
+private:
+    struct TVars {
+        TRowVersion ImmediateWriteEdge;
+        TRowVersion ImmediateWriteEdgeReplied;
+        TRowVersion UnprotectedReadEdge;
+    };
+
+private:
+    TDataShard* Owner;
+    TActorId PrevStateActorId;
+
+    TRope Buffer;
+    TVector<size_t> Checkpoints;
+
+    google::protobuf::Arena Arena;
+    THashMap<ui64, ILocksDb::TLockRow> Locks;
+    std::optional<TVars> Vars;
+};
+
+void TDataShard::StartInMemoryRestoreActor() {
+    if (InMemoryStatePrevActorId &&
+        AppData()->FeatureFlags.GetEnableDataShardInMemoryStateMigration() &&
+        (InMemoryStatePrevGeneration == Generation() - 1 ||
+         AppData()->FeatureFlags.GetEnableDataShardInMemoryStateMigrationAcrossGenerations()))
+    {
+        auto* actor = new TDataShardInMemoryRestoreActor(this, InMemoryStatePrevActorId);
+        InMemoryRestoreActor = actor;
+        RegisterWithSameMailbox(actor);
+        // Note: avoid unnecessary bootstrap round-trip cost on the same mailbox
+        actor->Start();
+        return;
+    }
+
+    OnInMemoryStateRestored();
+}
+
+class TDataShardInMemoryStateActor
+    : public IDataShardInMemoryStateActor
+    , public TActor<TDataShardInMemoryStateActor>
+{
+public:
+    TDataShardInMemoryStateActor(TDataShard* owner, const TActorId& prevStateActorId)
+        : TActor(&TThis::StateWork)
+        , Owner(owner)
+        , PrevStateActorId(prevStateActorId)
+    {}
+
+    ~TDataShardInMemoryStateActor() {
+        Detach();
+    }
+
+    void ConfirmPersistent() override {
+        if (PrevStateActorId) {
+            Send(PrevStateActorId, new TEvents::TEvPoison);
+            PrevStateActorId = {};
+        }
+    }
+
+    void PreserveState() {
+        Y_ABORT_UNLESS(Owner, "Unexpected call from a detached tablet");
+        Y_ABORT_UNLESS(Owner->InMemoryStateActor == this, "Unexpected call while state actor is not attached");
+
+        auto state = Owner->PreserveInMemoryState();
+
+        Chunks.reserve(state.Chunks.size());
+        for (TString& chunk : state.Chunks) {
+            Chunks.emplace_back(std::move(chunk));
+        }
+
+        Checkpoints = std::move(state.Checkpoints);
+
+        size_t size = 0;
+        size_t checkpointIndex = 0;
+        CheckpointsByChunk.reserve(Chunks.size());
+        for (const TRope& chunk : Chunks) {
+            size_t offset = size;
+            size += chunk.size();
+            while (checkpointIndex < Checkpoints.size() && Checkpoints[checkpointIndex] <= size) {
+                // Convert included checkpoint to a relative offset
+                Checkpoints[checkpointIndex] -= offset;
+                checkpointIndex++;
+            }
+            CheckpointsByChunk.push_back(checkpointIndex);
+        }
+    }
+
+    void Detach() {
+        if (Owner) {
+            Owner->InMemoryStateActor = nullptr;
+            Owner = nullptr;
+        }
+    }
+
+    void OnTabletDestroyed() override {
+        // Note: this should only be called on actor system shutdown
+        // We don't preserve state and expect to be destroyed soon
+        Detach();
+
+        // Not strictly necessary, but make sure we ignore all messages and
+        // reply with undelivery notifications, as if this actor doesn't exist.
+        Become(&TThis::StateDead);
+    }
+
+    void OnTabletDead() override {
+        PreserveState();
+        Detach();
+
+        TDuration timeout = TDuration::MilliSeconds(AppData()->DataShardConfig.GetInMemoryStateMigrationTimeoutMs());
+        Schedule(timeout, new TEvents::TEvPoison);
+    }
+
+    void Handle(TEvDataShard::TEvInMemoryStateRequest::TPtr& ev) {
+        auto* msg = ev->Get();
+
+        // Receiving a request implies our address is persistent
+        ConfirmPersistent();
+
+        if (Owner) {
+            // Tablet might not be dead yet, but it will be very soon
+            OnTabletDead();
+        }
+
+        size_t nextIndex = 0;
+        if (msg->Record.HasContinuationToken()) {
+            NKikimrTxDataShard::TInMemoryStateContinuationToken token;
+            bool ok = token.ParseFromString(msg->Record.GetContinuationToken());
+            Y_ABORT_UNLESS(ok, "Cannot parse continuation token");
+            nextIndex = token.GetNextIndex();
+        }
+
+        auto res = std::make_unique<TEvDataShard::TEvInMemoryStateResponse>();
+        if (nextIndex < Chunks.size()) {
+            res->Record.SetSerializedStatePayloadIndex(res->AddPayload(TRope(Chunks[nextIndex])));
+            size_t checkBegin = nextIndex > 0 ? CheckpointsByChunk[nextIndex - 1] : 0;
+            size_t checkEnd = CheckpointsByChunk[nextIndex];
+            for (size_t i = checkBegin; i != checkEnd; ++i) {
+                res->Record.AddSerializedStateCheckpoints(Checkpoints[i]);
+            }
+            ++nextIndex;
+            if (nextIndex < Chunks.size()) {
+                NKikimrTxDataShard::TInMemoryStateContinuationToken token;
+                token.SetNextIndex(nextIndex);
+                bool ok = token.SerializeToString(res->Record.MutableContinuationToken());
+                Y_ABORT_UNLESS(ok, "Cannot serialize continuation token");
+            }
+        }
+
+        Send(ev->Sender, res.release());
+    }
+
+    void HandlePoison() {
+        Detach();
+        PassAway();
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvDataShard::TEvInMemoryStateRequest, Handle);
+            sFunc(TEvents::TEvPoison, HandlePoison);
+        }
+    }
+
+    STFUNC(StateDead) {
+        TActivationContext::Send(IEventHandle::ForwardOnNondelivery(ev, TEvents::TEvUndelivered::ReasonActorUnknown));
+    }
+
+private:
+    TDataShard* Owner;
+    TActorId PrevStateActorId;
+    TVector<TRope> Chunks;
+    TVector<size_t> Checkpoints;
+    TVector<size_t> CheckpointsByChunk;
+};
+
+bool TDataShard::StartInMemoryStateActor() {
+    if (!InMemoryStateActorId && AppData()->FeatureFlags.GetEnableDataShardInMemoryStateMigration()) {
+        auto* actor = new TDataShardInMemoryStateActor(this, InMemoryStatePrevActorId);
+        InMemoryStateActor = actor;
+        InMemoryStateActorId = RegisterWithSameMailbox(actor);
+        return true;
+    }
+
+    return false;
+}
+
+class TDataShardPreservedInMemoryStateOutputStream
+    : public google::protobuf::io::ZeroCopyOutputStream
+{
+public:
+    TDataShardPreservedInMemoryStateOutputStream() = default;
+
+    TDataShardPreservedInMemoryStateOutputStream(const TDataShardPreservedInMemoryStateOutputStream&) = delete;
+    TDataShardPreservedInMemoryStateOutputStream& operator=(const TDataShardPreservedInMemoryStateOutputStream&) = delete;
+
+    void Reserve(size_t size) {
+        while (Reserved < size) {
+            if (ReserveIndex == Buffers.size()) {
+                // Note: new buffer may have some initial capacity
+                Reserved += Buffers.emplace_back().capacity();
+                if (size <= Reserved) {
+                    // Initial capacity is enough
+                    break;
+                }
+            }
+            size_t currentCapacity = Buffers.back().capacity();
+            size_t targetCapacity = FastClp2(currentCapacity + (size - Reserved));
+            if (targetCapacity > MAX_DATASHARD_STATE_CHUNK_SIZE) {
+                targetCapacity = MAX_DATASHARD_STATE_CHUNK_SIZE;
+                Buffers.back().reserve(targetCapacity);
+                Reserved += Buffers.back().capacity() - currentCapacity;
+                ReserveIndex++;
+                continue;
+            }
+            Buffers.back().reserve(targetCapacity);
+            Reserved += Buffers.back().capacity() - currentCapacity;
+        }
+    }
+
+    bool Next(void** data, int* size) override {
+        // Make sure we have at least 16 bytes available
+        if (Reserved == 0) {
+            Reserve(16);
+        }
+
+        // We should have at least 1 byte available
+        Y_ABORT_UNLESS(WriteIndex < Buffers.size());
+        if (Buffers[WriteIndex].size() == Buffers[WriteIndex].capacity()) {
+            ++WriteIndex;
+            Y_ABORT_UNLESS(WriteIndex < Buffers.size());
+        }
+        TString& buffer = Buffers[WriteIndex];
+        Y_ABORT_UNLESS(buffer.size() < buffer.capacity());
+        size_t oldSize = buffer.size();
+        size_t newSize = buffer.capacity();
+        buffer.resize(newSize);
+        Y_ABORT_UNLESS(buffer.capacity() == newSize);
+        Written += newSize - oldSize;
+        Reserved -= newSize - oldSize;
+        *data = buffer.Detach() + oldSize;
+        *size = newSize - oldSize;
+        return true;
+    }
+
+    void BackUp(int count) override {
+        Y_ABORT_UNLESS(count >= 0);
+        Y_ABORT_UNLESS(WriteIndex < Buffers.size());
+        TString& buffer = Buffers[WriteIndex];
+        Y_ABORT_UNLESS(buffer.size() >= (size_t)count);
+        size_t oldCapacity = buffer.capacity();
+        buffer.resize(buffer.size() - (size_t)count);
+        Y_ABORT_UNLESS(buffer.capacity() == oldCapacity);
+        Reserved += count;
+        Written -= count;
+    }
+
+    int64_t ByteCount() const override {
+        return Written;
+    }
+
+    TVector<TString> Finish() {
+        if (WriteIndex + 1 < Buffers.size()) {
+            Buffers.resize(WriteIndex + 1);
+        }
+        if (!Buffers.empty() && Buffers.back().empty()) {
+            Buffers.pop_back();
+        }
+        return std::move(Buffers);
+    }
+
+private:
+    TVector<TString> Buffers;
+    size_t ReserveIndex = 0;
+    size_t Reserved = 0;
+    size_t WriteIndex = 0;
+    size_t Written = 0;
+};
+
+TDataShard::TPreservedInMemoryState TDataShard::PreserveInMemoryState() {
+    TDataShardPreservedInMemoryStateOutputStream stream;
+    TVector<size_t> checkpoints;
+
+    google::protobuf::Arena arena;
+    NKikimrTxDataShard::TInMemoryState* state = google::protobuf::Arena::CreateMessage<NKikimrTxDataShard::TInMemoryState>(&arena);
+    size_t currentStateSize = 0;
+    bool needCheckpoint = false;
+
+    auto flushState = [&]() {
+        stream.Reserve(state->ByteSizeLong());
+        bool ok = state->SerializeToZeroCopyStream(&stream);
+        Y_ABORT_UNLESS(ok, "Unexpected failure to serialize in-memory state");
+    };
+
+    auto resetState = [&]() {
+        arena.Reset();
+        state = google::protobuf::Arena::CreateMessage<NKikimrTxDataShard::TInMemoryState>(&arena);
+        currentStateSize = 0;
+    };
+
+    auto addedMessage = [&](size_t messageSize) {
+        currentStateSize += 1 + google::protobuf::io::CodedOutputStream::VarintSize32(messageSize) + messageSize;
+        if (currentStateSize >= MAX_DATASHARD_STATE_CHUNK_SIZE) {
+            flushState();
+            resetState();
+            needCheckpoint = true;
+        }
+    };
+
+    auto maybeCheckpoint = [&]() {
+        if (needCheckpoint) {
+            if (currentStateSize > 0) {
+                flushState();
+                resetState();
+            }
+            checkpoints.push_back(stream.ByteCount());
+            needCheckpoint = false;
+        }
+    };
+
+    // Serialize important in-memory vars
+    {
+        auto* vars = state->MutableVars();
+        SnapshotManager.GetImmediateWriteEdge().Serialize(*vars->MutableImmediateWriteEdge());
+        SnapshotManager.GetImmediateWriteEdgeReplied().Serialize(*vars->MutableImmediateWriteEdgeReplied());
+        SnapshotManager.GetUnprotectedReadEdge().Serialize(*vars->MutableUnprotectedReadEdge());
+        addedMessage(vars->ByteSizeLong());
+        maybeCheckpoint();
+
+        // Note: we mark in-memory vars as frozen, but it doesn't affect much.
+        // PreserveInMemoryState is called either before destruction or when
+        // a newer generation unexpectedly requests our state. The latter may
+        // only happen after a newer generation has locked the storage and
+        // obtained the tablet lease, so this generation shouldn't be able
+        // to commit anything new or even serve any new read-only requests,
+        // otherwise it would be possible to read stale data.
+        InMemoryVarsFrozen = true;
+    }
+
+    for (const auto& pr : SysLocks.GetLocks()) {
+        const auto& lockInfo = *pr.second;
+        auto* protoLockInfo = state->AddLocks();
+        protoLockInfo->SetLockId(lockInfo.GetLockId());
+        protoLockInfo->SetLockNodeId(lockInfo.GetLockNodeId());
+        protoLockInfo->SetGeneration(lockInfo.GetGeneration());
+        protoLockInfo->SetCounter(lockInfo.GetRawCounter());
+        protoLockInfo->SetCreateTs(lockInfo.GetCreationTime().MicroSeconds());
+        protoLockInfo->SetFlags((ui64)lockInfo.GetFlags());
+        if (const auto& version = lockInfo.GetBreakVersion()) {
+            version->Serialize(*protoLockInfo->MutableBreakVersion());
+        }
+        for (const auto& pathId : lockInfo.GetReadTables()) {
+            PathIdFromPathId(pathId, protoLockInfo->AddReadTables());
+        }
+        for (const auto& pathId : lockInfo.GetWriteTables()) {
+            PathIdFromPathId(pathId, protoLockInfo->AddWriteTables());
+        }
+        addedMessage(protoLockInfo->ByteSizeLong());
+        for (const auto& point : lockInfo.GetPoints()) {
+            auto serialized = point.ToSerializedLockRange();
+            auto* protoRange = state->AddLockRanges();
+            protoRange->SetLockId(lockInfo.GetLockId());
+            PathIdFromPathId(serialized.TableId, protoRange->MutableTableId());
+            protoRange->SetFlags(serialized.Flags);
+            protoRange->SetData(std::move(serialized.Data));
+            addedMessage(protoRange->ByteSizeLong());
+        }
+        for (const auto& range : lockInfo.GetRanges()) {
+            auto serialized = range.ToSerializedLockRange();
+            auto* protoRange = state->AddLockRanges();
+            protoRange->SetLockId(lockInfo.GetLockId());
+            PathIdFromPathId(serialized.TableId, protoRange->MutableTableId());
+            protoRange->SetFlags(serialized.Flags);
+            protoRange->SetData(std::move(serialized.Data));
+            addedMessage(protoRange->ByteSizeLong());
+        }
+        lockInfo.ForAllConflicts(
+            [&](const auto* conflict) {
+                auto* protoConflict = state->AddLockConflicts();
+                protoConflict->SetLockId(lockInfo.GetLockId());
+                protoConflict->SetConflictId(conflict->GetLockId());
+                addedMessage(protoConflict->ByteSizeLong());
+            },
+            ELockConflictFlags::BreakThemOnOurCommit);
+        lockInfo.ForAllVolatileDependencies(
+            [&](ui64 txId) {
+                auto* protoDep = state->AddLockVolatileDependencies();
+                protoDep->SetLockId(lockInfo.GetLockId());
+                protoDep->SetTxId(txId);
+                addedMessage(protoDep->ByteSizeLong());
+            });
+        maybeCheckpoint();
+    }
+
+    if (state->ByteSizeLong()) {
+        flushState();
+    }
+
+    return { stream.Finish(), std::move(checkpoints) };
+}
+
+} // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/memory_state_migration.h
+++ b/ydb/core/tx/datashard/memory_state_migration.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <ydb/library/actors/core/actor.h>
+
+namespace NKikimr::NDataShard {
+
+class TDataShard;
+
+class IDataShardInMemoryRestoreActor {
+protected:
+    IDataShardInMemoryRestoreActor() = default;
+    ~IDataShardInMemoryRestoreActor() = default;
+
+public:
+    /**
+     * Called from tablet destructor. Detaches from tablet and waits for the
+     * eventual destruction (this method should only be called during the
+     * actor system shutdown).
+     */
+    virtual void OnTabletDestroyed() = 0;
+
+    /**
+     * Called when tablet dies. Detaches from tablet and schedules itself for
+     * destruction.
+     */
+    virtual void OnTabletDead() = 0;
+};
+
+class IDataShardInMemoryStateActor {
+protected:
+    IDataShardInMemoryStateActor() = default;
+    ~IDataShardInMemoryStateActor() = default;
+
+public:
+    /**
+     * Confirms that this state actor address is persistent
+     * This is used to notify previous actors that they are no longer needed
+     */
+    virtual void ConfirmPersistent() = 0;
+
+    /**
+     * Called from tablet destructor. Detaches from tablet and waits for the
+     * eventual destruction (this method should only be called during the
+     * actor system shutdown).
+     */
+    virtual void OnTabletDestroyed() = 0;
+
+    /**
+     * Called when tablet dies. Serializes current state, detaches from tablet
+     * and waits to transfer this state to the next generation or timeout.
+     */
+    virtual void OnTabletDead() = 0;
+};
+
+} // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -174,6 +174,7 @@ SRCS(
     local_kmeans.cpp
     make_scan_snapshot_unit.cpp
     make_snapshot_unit.cpp
+    memory_state_migration.cpp
     move_index_unit.cpp
     move_table_unit.cpp
     operation.cpp

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -32,6 +32,64 @@ struct TLockLoggerContext {
 // Logger requires an l-value, so we use an empty static variable
 static TLockLoggerContext LockLoggerContext;
 
+// TPointKey
+
+ILocksDb::TLockRange TPointKey::ToSerializedLockRange() const {
+    ILocksDb::TLockRange range;
+    range.TableId = Table->GetTableId();
+    range.Flags = ui64(ELockRangeFlags::Read | ELockRangeFlags::SerializedPointKey);
+    range.Data = TSerializedCellVec::Serialize(Key);
+    return range;
+}
+
+bool TPointKey::ParseSerializedLockRange(const ILocksDb::TLockRange& range) {
+    if (range.Data) {
+        Key = TOwnedCellVec::Make(TSerializedCellVec(range.Data).GetCells());
+    }
+    return true;
+}
+
+// TRangeKey
+
+ILocksDb::TLockRange TRangeKey::ToSerializedLockRange() const {
+    ILocksDb::TLockRange range;
+    range.TableId = Table->GetTableId();
+    range.Flags = ui64(ELockRangeFlags::Read | ELockRangeFlags::SerializedRangeKey);
+    NKikimrTx::TKeyRange protoRange;
+    if (From) {
+        protoRange.SetFrom(TSerializedCellVec::Serialize(From));
+    }
+    if (To) {
+        protoRange.SetTo(TSerializedCellVec::Serialize(To));
+    }
+    if (InclusiveFrom) {
+        protoRange.SetFromInclusive(true);
+    }
+    if (InclusiveTo) {
+        protoRange.SetToInclusive(true);
+    }
+    bool ok = protoRange.SerializeToString(&range.Data);
+    Y_ABORT_UNLESS(ok, "Unexpected failure to serialize TRangeKey");
+    return range;
+}
+
+bool TRangeKey::ParseSerializedLockRange(const ILocksDb::TLockRange& range) {
+    NKikimrTx::TKeyRange protoRange;
+    bool ok = protoRange.ParseFromString(range.Data);
+    if (!ok) {
+        return false;
+    }
+    if (protoRange.HasFrom()) {
+        From = TOwnedCellVec::Make(TSerializedCellVec(protoRange.GetFrom()).GetCells());
+    }
+    if (protoRange.HasTo()) {
+        To = TOwnedCellVec::Make(TSerializedCellVec(protoRange.GetTo()).GetCells());
+    }
+    InclusiveFrom = protoRange.GetFromInclusive();
+    InclusiveTo = protoRange.GetToInclusive();
+    return true;
+}
+
 // TLockInfo
 
 TLockInfo::TLockInfo(TLockLocker * locker, ui64 lockId, ui32 lockNodeId)
@@ -51,11 +109,23 @@ TLockInfo::TLockInfo(TLockLocker * locker, const ILocksDb::TLockRow& row)
     , Counter(row.Counter)
     , CreationTime(TInstant::MicroSeconds(row.CreateTs))
     , Flags(ELockFlags(row.Flags))
-    , Persistent(true)
 {
-    if (Counter == Max<ui64>()) {
+    if (row.BreakVersion != TRowVersion::Max()) {
+        BreakVersion.emplace(row.BreakVersion);
+    } else if (Counter == Max<ui64>()) {
         BreakVersion.emplace(TRowVersion::Min());
     }
+    if (IsShardLock()) {
+        for (const auto& tableId : row.ReadTables) {
+            if (auto* table = Locker->FindTablePtr(tableId)) {
+                if (ReadTables.insert(tableId).second) {
+                    table->AddShardLock(this);
+                    UnpersistedRanges = true;
+                }
+            }
+        }
+    }
+    // NOTE: we don't restore WriteTables, they must be persistent
 }
 
 TLockInfo::~TLockInfo() {
@@ -69,13 +139,13 @@ TLockInfo::~TLockInfo() {
 }
 
 void TLockInfo::MakeShardLock() {
-    ShardLock = true;
+    Flags |= ELockFlags::WholeShard;
     Points.clear();
     Ranges.clear();
 }
 
 bool TLockInfo::AddShardLock(const TPathId& pathId) {
-    Y_ABORT_UNLESS(ShardLock);
+    Y_ABORT_UNLESS(IsShardLock());
     if (ReadTables.insert(pathId).second) {
         UnpersistedRanges = true;
         return true;
@@ -87,20 +157,20 @@ bool TLockInfo::AddPoint(const TPointKey& point) {
     if (ReadTables.insert(point.Table->GetTableId()).second) {
         UnpersistedRanges = true;
     }
-    if (!ShardLock) {
+    if (!IsShardLock()) {
         Points.emplace_back(point);
     }
-    return !ShardLock;
+    return !IsShardLock();
 }
 
 bool TLockInfo::AddRange(const TRangeKey& range) {
     if (ReadTables.insert(range.Table->GetTableId()).second) {
         UnpersistedRanges = true;
     }
-    if (!ShardLock) {
+    if (!IsShardLock()) {
         Ranges.emplace_back(range);
     }
-    return !ShardLock;
+    return !IsShardLock();
 }
 
 bool TLockInfo::AddWriteLock(const TPathId& pathId) {
@@ -112,7 +182,7 @@ bool TLockInfo::AddWriteLock(const TPathId& pathId) {
 }
 
 void TLockInfo::SetBroken(TRowVersion at) {
-    if (Persistent) {
+    if (IsPersistent()) {
         // Persistent locks always break completely
         at = TRowVersion::Min();
     }
@@ -145,8 +215,8 @@ void TLockInfo::OnRemoved() {
 void TLockInfo::PersistLock(ILocksDb* db) {
     Y_ABORT_UNLESS(!IsPersistent());
     Y_ABORT_UNLESS(db, "Cannot persist lock without a db");
-    db->PersistAddLock(LockId, LockNodeId, Generation, Counter, CreationTime.MicroSeconds(), ui64(Flags));
-    Persistent = true;
+    db->PersistAddLock(LockId, LockNodeId, Generation, Counter, CreationTime.MicroSeconds(), ui64(Flags & ELockFlags::PersistentMask));
+    Flags |= ELockFlags::Persistent;
 
     PersistRanges(db);
     PersistConflicts(db);
@@ -298,6 +368,66 @@ void TLockInfo::CleanupConflicts() {
     }
 }
 
+void TLockInfo::RestoreInMemoryState(const ILocksDb::TLockRow& lockRow) {
+    auto flags = ELockFlags(lockRow.Flags);
+    if (IsShardLock() && !(flags & ELockFlags::WholeShard)) {
+        // Lock was not a shard lock in the previous generation
+        Locker->UndoShardLock(this);
+        Flags &= ~ELockFlags::WholeShard;
+    }
+    Flags |= flags;
+    Generation = lockRow.Generation;
+    Counter = lockRow.Counter;
+    if (lockRow.BreakVersion != TRowVersion::Max()) {
+        BreakVersion.emplace(lockRow.BreakVersion);
+    }
+    if (IsShardLock()) {
+        // NOTE: this code path is currently only used for persistent locks. We
+        // should have restored all read ranges already, since they are
+        // persistent. Unless we failed to commit some read ranges this loop
+        // shouldn't really change anything.
+        for (const auto& tableId : lockRow.ReadTables) {
+            if (auto* table = Locker->FindTablePtr(tableId)) {
+                if (ReadTables.insert(tableId).second) {
+                    table->AddShardLock(this);
+                    UnpersistedRanges = true;
+                }
+            }
+        }
+    }
+    // NOTE: we don't restore WriteTables, they must be persistent
+}
+
+bool TLockInfo::RestoreInMemoryRange(const ILocksDb::TLockRange& rangeRow) {
+    auto flags = ELockRangeFlags(rangeRow.Flags);
+    if (!!(flags & ELockRangeFlags::Read)) {
+        if (auto* table = Locker->FindTablePtr(rangeRow.TableId)) {
+            if (IsShardLock()) {
+                if (AddShardLock(rangeRow.TableId)) {
+                    table->AddShardLock(this);
+                }
+            } else if (!!(flags & ELockRangeFlags::SerializedPointKey)) {
+                TPointKey point;
+                point.Table = table;
+                if (!point.ParseSerializedLockRange(rangeRow)) {
+                    Locker->MakeShardLock(this);
+                    return false;
+                }
+                Locker->AddPointLock(this, point);
+            } else if (!!(flags & ELockRangeFlags::SerializedRangeKey)) {
+                TRangeKey range;
+                range.Table = table;
+                if (!range.ParseSerializedLockRange(rangeRow)) {
+                    Locker->MakeShardLock(this);
+                    return false;
+                }
+                Locker->AddRangeLock(this, range);
+            }
+        }
+    }
+    return true;
+}
+
 void TLockInfo::RestorePersistentRange(const ILocksDb::TLockRange& rangeRow) {
     auto& range = PersistentRanges.emplace_back();
     range.Id = rangeRow.RangeId;
@@ -306,7 +436,7 @@ void TLockInfo::RestorePersistentRange(const ILocksDb::TLockRange& rangeRow) {
 
     if (!!(range.Flags & ELockRangeFlags::Read)) {
         if (ReadTables.insert(range.TableId).second) {
-            ShardLock = true;
+            Flags |= ELockFlags::WholeShard;
             if (auto* table = Locker->FindTablePtr(range.TableId)) {
                 table->AddShardLock(this);
             }
@@ -321,24 +451,30 @@ void TLockInfo::RestorePersistentRange(const ILocksDb::TLockRange& rangeRow) {
     }
 }
 
-void TLockInfo::RestorePersistentConflict(TLockInfo* otherLock) {
-    Y_ABORT_UNLESS(IsPersistent() && otherLock->IsPersistent());
-
+void TLockInfo::RestoreInMemoryConflict(TLockInfo* otherLock) {
     this->ConflictLocks[otherLock] |= ELockConflictFlags::BreakThemOnOurCommit;
     otherLock->ConflictLocks[this] |= ELockConflictFlags::BreakUsOnTheirCommit;
 }
 
+void TLockInfo::RestorePersistentConflict(TLockInfo* otherLock) {
+    Y_ABORT_UNLESS(IsPersistent() && otherLock->IsPersistent());
+    RestoreInMemoryConflict(otherLock);
+}
+
+void TLockInfo::RestoreInMemoryVolatileDependency(ui64 txId) {
+    VolatileDependencies.insert(txId);
+}
+
 void TLockInfo::RestorePersistentVolatileDependency(ui64 txId) {
     Y_ABORT_UNLESS(IsPersistent());
-
-    VolatileDependencies.insert(txId);
+    RestoreInMemoryVolatileDependency(txId);
 }
 
 void TLockInfo::SetFrozen(ILocksDb* db) {
     Y_ABORT_UNLESS(IsPersistent());
     Flags |= ELockFlags::Frozen;
     if (db) {
-        db->PersistLockFlags(LockId, ui64(Flags));
+        db->PersistLockFlags(LockId, ui64(Flags & ELockFlags::PersistentMask));
     }
 }
 
@@ -452,21 +588,21 @@ void TLockLocker::SetTotalRangesLimit(ui64 newLimit) {
     g_TotalRangesLimit.store(newLimit, std::memory_order_relaxed);
 }
 
-void TLockLocker::AddPointLock(const TLockInfo::TPtr& lock, const TPointKey& key) {
+void TLockLocker::AddPointLock(TLockInfo* lock, const TPointKey& key) {
     if (lock->AddPoint(key)) {
-        key.Table->AddPointLock(key, lock.Get());
-        LocksWithRanges.PushBack(lock.Get());
+        key.Table->AddPointLock(key, lock);
+        LocksWithRanges.PushBack(lock);
     } else {
-        key.Table->AddShardLock(lock.Get());
+        key.Table->AddShardLock(lock);
     }
 }
 
-void TLockLocker::AddRangeLock(const TLockInfo::TPtr& lock, const TRangeKey& key) {
+void TLockLocker::AddRangeLock(TLockInfo* lock, const TRangeKey& key) {
     if (lock->AddRange(key)) {
-        key.Table->AddRangeLock(key, lock.Get());
-        LocksWithRanges.PushBack(lock.Get());
+        key.Table->AddRangeLock(key, lock);
+        LocksWithRanges.PushBack(lock);
     } else {
-        key.Table->AddShardLock(lock.Get());
+        key.Table->AddShardLock(lock);
     }
 }
 
@@ -480,6 +616,13 @@ void TLockLocker::MakeShardLock(TLockInfo* lock) {
         for (const TPathId& tableId : lock->GetReadTables()) {
             Tables.at(tableId)->AddShardLock(lock);
         }
+    }
+}
+
+void TLockLocker::UndoShardLock(TLockInfo* lock) {
+    Y_ABORT_UNLESS(lock->IsShardLock());
+    for (const TPathId& tableId : lock->GetReadTables()) {
+        Tables.at(tableId)->RemoveShardLock(lock);
     }
 }
 
@@ -628,6 +771,27 @@ TLockInfo::TPtr TLockLocker::AddLock(const ILocksDb::TLockRow& row) {
         PendingSubscribeLocks.emplace_back(row.LockId, row.LockNodeId);
     }
     return lock;
+}
+
+TLockInfo::TPtr TLockLocker::RestoreInMemoryLock(const ILocksDb::TLockRow& row) {
+    auto it = Locks.find(row.LockId);
+    if (it == Locks.end()) {
+        auto flags = ELockFlags(row.Flags);
+        if (!!(flags & ELockFlags::Persistent)) {
+            // Persistent lock must be restored from storage
+            // Since this lock is missing its commit must have failed
+            return nullptr;
+        }
+        TLockInfo::TPtr lock(new TLockInfo(this, row));
+        Locks[row.LockId] = lock;
+        if (row.LockNodeId) {
+            PendingSubscribeLocks.emplace_back(row.LockId, row.LockNodeId);
+        }
+        return lock;
+    } else {
+        it->second->RestoreInMemoryState(row);
+        return it->second;
+    }
 }
 
 void TLockLocker::RemoveOneLock(ui64 lockTxId, ILocksDb* db) {
@@ -882,10 +1046,10 @@ TVector<TSysLocks::TLock> TSysLocks::ApplyLocks() {
                 Self->IncCounter(COUNTER_LOCKS_WHOLE_SHARD);
             } else {
                 for (const auto& key : Update->PointLocks) {
-                    Locker.AddPointLock(lock, key);
+                    Locker.AddPointLock(lock.Get(), key);
                 }
                 for (const auto& key : Update->RangeLocks) {
-                    Locker.AddRangeLock(lock, key);
+                    Locker.AddRangeLock(lock.Get(), key);
                 }
             }
             if (Update->WriteTables) {
@@ -1264,6 +1428,7 @@ bool TSysLocks::Load(ILocksDb& db) {
     Locker.Clear();
 
     for (auto& lockRow : rows) {
+        lockRow.Flags |= ui64(ELockFlags::Persistent);
         TLockInfo::TPtr lock = Locker.AddLock(lockRow);
         for (auto& rangeRow : lockRow.Ranges) {
             lock->RestorePersistentRange(rangeRow);
@@ -1284,6 +1449,35 @@ bool TSysLocks::Load(ILocksDb& db) {
     }
 
     return true;
+}
+
+void TSysLocks::RestoreInMemoryLocks(THashMap<ui64, ILocksDb::TLockRow>&& rows) {
+    for (auto& pr : rows) {
+        auto& lockRow = pr.second;
+        TLockInfo::TPtr lock = Locker.RestoreInMemoryLock(lockRow);
+        if (lock) {
+            for (auto& rangeRow : lockRow.Ranges) {
+                lock->RestoreInMemoryRange(rangeRow);
+            }
+        }
+    }
+
+    for (auto& pr : rows) {
+        auto& lockRow = pr.second;
+        auto* lock = Locker.FindLockPtr(lockRow.LockId);
+        if (!lock) {
+            // Skip locks that have not been restored
+            continue;
+        }
+        for (ui64 conflictId : lockRow.Conflicts) {
+            if (auto* otherLock = Locker.FindLockPtr(conflictId)) {
+                lock->RestoreInMemoryConflict(otherLock);
+            }
+        }
+        for (ui64 txId : lockRow.VolatileDependencies) {
+            lock->RestoreInMemoryVolatileDependency(txId);
+        }
+    }
 }
 
 

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -25,7 +25,7 @@ protected:
 
 public:
     struct TLockRange {
-        ui64 RangeId;
+        ui64 RangeId = -1;
         TPathId TableId;
         ui64 Flags;
         TString Data;
@@ -42,6 +42,11 @@ public:
         TVector<TLockRange> Ranges;
         TVector<ui64> Conflicts;
         TVector<ui64> VolatileDependencies;
+
+        // In-memory migration only (not persistent)
+        TRowVersion BreakVersion = TRowVersion::Max();
+        TVector<TPathId> ReadTables;
+        TVector<TPathId> WriteTables;
     };
 
     virtual bool Load(TVector<TLockRow>& rows) = 0;
@@ -153,6 +158,9 @@ struct TPointKey {
     TOwnedTableRange ToOwnedTableRange() const {
         return TOwnedTableRange(Key);
     }
+
+    ILocksDb::TLockRange ToSerializedLockRange() const;
+    bool ParseSerializedLockRange(const ILocksDb::TLockRange&);
 };
 
 ///
@@ -166,6 +174,9 @@ struct TRangeKey {
     TOwnedTableRange ToOwnedTableRange() const {
         return TOwnedTableRange(From, InclusiveFrom, To, InclusiveTo);
     }
+
+    ILocksDb::TLockRange ToSerializedLockRange() const;
+    bool ParseSerializedLockRange(const ILocksDb::TLockRange&);
 };
 
 struct TVersionedLockId {
@@ -202,6 +213,9 @@ struct TPendingSubscribeLock {
 enum class ELockFlags : ui64 {
     None = 0,
     Frozen = 1,
+    WholeShard = 2,
+    Persistent = 4,
+    PersistentMask = Frozen,
 };
 
 using ELockFlagsRaw = std::underlying_type<ELockFlags>::type;
@@ -210,6 +224,7 @@ inline ELockFlags operator|(ELockFlags a, ELockFlags b) { return ELockFlags(ELoc
 inline ELockFlags operator&(ELockFlags a, ELockFlags b) { return ELockFlags(ELockFlagsRaw(a) & ELockFlagsRaw(b)); }
 inline ELockFlags& operator|=(ELockFlags& a, ELockFlags b) { return a = a | b; }
 inline ELockFlags& operator&=(ELockFlags& a, ELockFlags b) { return a = a & b; }
+inline ELockFlags operator~(ELockFlags c) { return ELockFlags(~ELockFlagsRaw(c)); }
 inline bool operator!(ELockFlags c) { return ELockFlagsRaw(c) == 0; }
 
 // ELockConflictFlags type safe enum
@@ -226,6 +241,7 @@ inline ELockConflictFlags operator|(ELockConflictFlags a, ELockConflictFlags b) 
 inline ELockConflictFlags operator&(ELockConflictFlags a, ELockConflictFlags b) { return ELockConflictFlags(ELockConflictFlagsRaw(a) & ELockConflictFlagsRaw(b)); }
 inline ELockConflictFlags& operator|=(ELockConflictFlags& a, ELockConflictFlags b) { return a = a | b; }
 inline ELockConflictFlags& operator&=(ELockConflictFlags& a, ELockConflictFlags b) { return a = a & b; }
+inline ELockConflictFlags operator~(ELockConflictFlags c) { return ELockConflictFlags(~ELockConflictFlagsRaw(c)); }
 inline bool operator!(ELockConflictFlags c) { return ELockConflictFlagsRaw(c) == 0; }
 
 // ELockRangeFlags type safe enum
@@ -234,6 +250,8 @@ enum class ELockRangeFlags : ui8 {
     None = 0,
     Read = 1,
     Write = 2,
+    SerializedPointKey = 4,
+    SerializedRangeKey = 8,
 };
 
 using ELockRangeFlagsRaw = std::underlying_type<ELockRangeFlags>::type;
@@ -242,6 +260,7 @@ inline ELockRangeFlags operator|(ELockRangeFlags a, ELockRangeFlags b) { return 
 inline ELockRangeFlags operator&(ELockRangeFlags a, ELockRangeFlags b) { return ELockRangeFlags(ELockRangeFlagsRaw(a) & ELockRangeFlagsRaw(b)); }
 inline ELockRangeFlags& operator|=(ELockRangeFlags& a, ELockRangeFlags b) { return a = a | b; }
 inline ELockRangeFlags& operator&=(ELockRangeFlags& a, ELockRangeFlags b) { return a = a & b; }
+inline ELockRangeFlags operator~(ELockRangeFlags c) { return ELockRangeFlags(~ELockRangeFlagsRaw(c)); }
 inline bool operator!(ELockRangeFlags c) { return ELockRangeFlagsRaw(c) == 0; }
 
 // Tags for various intrusive lists
@@ -298,18 +317,20 @@ public:
     }
 
     ui32 GetGeneration() const { return Generation; }
+    ui64 GetRawCounter() const { return Counter; }
     ui64 GetCounter(const TRowVersion& at = TRowVersion::Max()) const { return !BreakVersion || at < *BreakVersion ? Counter : Max<ui64>(); }
     bool IsBroken(const TRowVersion& at = TRowVersion::Max()) const { return GetCounter(at) == Max<ui64>(); }
+    const std::optional<TRowVersion>& GetBreakVersion() const { return BreakVersion; }
 
     size_t NumPoints() const { return Points.size(); }
     size_t NumRanges() const { return Ranges.size(); }
-    bool IsShardLock() const { return ShardLock; }
+    bool IsShardLock() const { return !!(Flags & ELockFlags::WholeShard); }
     bool IsWriteLock() const { return !WriteTables.empty(); }
-    bool IsPersistent() const { return Persistent; }
+    bool IsPersistent() const { return !!(Flags & ELockFlags::Persistent); }
     bool HasUnpersistedRanges() const { return UnpersistedRanges; }
     //ui64 MemorySize() const { return 1; } // TODO
 
-    bool MayHavePointsAndRanges() const { return !ShardLock && (!BreakVersion || *BreakVersion); }
+    bool MayHavePointsAndRanges() const { return !IsShardLock() && (!BreakVersion || *BreakVersion); }
 
     ui64 GetLockId() const { return LockId; }
     ui32 GetLockNodeId() const { return LockNodeId; }
@@ -335,19 +356,32 @@ public:
     void PersistConflicts(ILocksDb* db);
     void CleanupConflicts();
 
+    void RestoreInMemoryState(const ILocksDb::TLockRow& lockRow);
+    bool RestoreInMemoryRange(const ILocksDb::TLockRange& rangeRow);
     void RestorePersistentRange(const ILocksDb::TLockRange& rangeRow);
+    void RestoreInMemoryConflict(TLockInfo* otherLock);
     void RestorePersistentConflict(TLockInfo* otherLock);
+    void RestoreInMemoryVolatileDependency(ui64 txId);
     void RestorePersistentVolatileDependency(ui64 txId);
 
     template<class TCallback>
-    void ForAllConflicts(TCallback&& callback) {
+    void ForAllConflicts(TCallback&& callback) const {
         for (auto& pr : ConflictLocks) {
             callback(pr.first);
         }
     }
 
     template<class TCallback>
-    void ForAllVolatileDependencies(TCallback&& callback) {
+    void ForAllConflicts(TCallback&& callback, ELockConflictFlags mask) const {
+        for (auto& pr : ConflictLocks) {
+            if (!!(pr.second & mask)) {
+                callback(pr.first);
+            }
+        }
+    }
+
+    template<class TCallback>
+    void ForAllVolatileDependencies(TCallback&& callback) const {
         for (auto& item : VolatileDependencies) {
             callback(item);
         }
@@ -389,8 +423,6 @@ private:
     THashSet<TPathId> WriteTables;
     TVector<TPointKey> Points;
     TVector<TRangeKey> Ranges;
-    bool ShardLock = false;
-    bool Persistent = false;
     bool UnpersistedRanges = false;
     bool InBrokenLocks = false;
 
@@ -538,9 +570,10 @@ public:
         Tables.clear();
     }
 
-    void AddPointLock(const TLockInfo::TPtr& lock, const TPointKey& key);
-    void AddRangeLock(const TLockInfo::TPtr& lock, const TRangeKey& key);
+    void AddPointLock(TLockInfo* lock, const TPointKey& key);
+    void AddRangeLock(TLockInfo* lock, const TRangeKey& key);
     void MakeShardLock(TLockInfo* lock);
+    void UndoShardLock(TLockInfo* lock);
     void AddShardLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables);
     void AddWriteLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksWriteListTag>& writeTables);
 
@@ -665,6 +698,7 @@ private:
 
     TLockInfo::TPtr GetOrAddLock(ui64 lockId, ui32 lockNodeId);
     TLockInfo::TPtr AddLock(const ILocksDb::TLockRow& row);
+    TLockInfo::TPtr RestoreInMemoryLock(const ILocksDb::TLockRow& row);
     void RemoveOneLock(ui64 lockId, ILocksDb* db = nullptr);
 
     void SaveBrokenPersistentLocks(ILocksDb* db);
@@ -905,6 +939,8 @@ public:
     void UpdateCounters(ui64 counter);
 
     bool Load(ILocksDb& db);
+
+    void RestoreInMemoryLocks(THashMap<ui64, ILocksDb::TLockRow>&& rows);
 
     const THashMap<ui64, TLockInfo::TPtr>& GetLocks() const {
         return Locker.GetLocks();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Try to preserve in-memory state (locks in particular) across datashard restarts.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

We now migrate in-memory state and in-memory locks in particular, which should reduce `ABORTED` errors due to lost locks while rebalancing tablets between nodes, and might improve shard startup time due to less waiting for mediator state restore.

Related to #11561.
