### PR TITLE
Automatically account lockout after some attempts to login with wrong password

### DIFF
--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -57,6 +57,7 @@ message TAuthConfig {
     optional bool EnableLoginAuthentication = 81 [default = true];
     optional string NodeRegistrationToken = 82 [default = "root@builtin", (Ydb.sensitive) = true];
     optional TPasswordComplexity PasswordComplexity = 83;
+    optional TAccountLockout AccountLockout = 84;
 }
 
 message TUserRegistryConfig {
@@ -132,4 +133,9 @@ message TPasswordComplexity {
     optional uint32 MinSpecialCharsCount = 5;
     optional string SpecialChars = 6;
     optional bool CanContainUsername = 7;
+}
+
+message TAccountLockout {
+    optional uint32 AttemptThreshold = 1 [default = 4];
+    optional string AttemptResetDuration = 2 [default = "1h"];
 }

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -108,7 +108,8 @@ private:
         }
         case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD:
         case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY: {
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNSPECIFIED: {
             Result->Record.SetError(loginResponse.Error);
             break;
         }
@@ -153,7 +154,8 @@ private:
             break;
         }
         case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY: {
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNSPECIFIED: {
             Result->Record.SetError(loginResponse.Error);
             break;
         }

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -8,13 +8,14 @@ namespace NSchemeShard {
 
 using namespace NTabletFlatExecutor;
 
-struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
+struct TSchemeShard::TTxLogin : TTransactionBase<TSchemeShard> {
     TEvSchemeShard::TEvLogin::TPtr Request;
     TPathId SubDomainPathId;
     bool NeedPublishOnComplete = false;
+    THolder<TEvSchemeShard::TEvLoginResult> Result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
 
     TTxLogin(TSelf *self, TEvSchemeShard::TEvLogin::TPtr &ev)
-        : TRwTxBase(self)
+        : TTransactionBase<TSchemeShard>(self)
         , Request(std::move(ev))
     {}
 
@@ -34,10 +35,11 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
             };
     }
 
-    void DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-                    "TTxLogin DoExecute"
+                    "TTxLogin Execute"
                     << " at schemeshard: " << Self->TabletID());
+        NIceDb::TNiceDb db(txc.DB);
         if (Self->LoginProvider.IsItTimeToRotateKeys()) {
             LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxLogin RotateKeys at schemeshard: " << Self->TabletID());
             std::vector<ui64> keysExpired;
@@ -50,7 +52,6 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
             domainPtr->UpdateSecurityState(Self->LoginProvider.GetSecurityState());
             domainPtr->IncSecurityStateVersion();
 
-            NIceDb::TNiceDb db(txc.DB);
 
             Self->PersistSubDomainSecurityStateVersion(db, SubDomainPathId, *domainPtr);
 
@@ -65,39 +66,139 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
                 }
             }
 
-            NeedPublishOnComplete = true;
+            NeedPublishOnComplete = true; // Сохранение значения после перезапуска транзакции
         }
+
+        return LoginAttempt(db, ctx);
     }
 
-    void DoComplete(const TActorContext &ctx) override {
+    void Complete(const TActorContext &ctx) override {
         if (NeedPublishOnComplete) {
             Self->PublishToSchemeBoard(TTxId(), {SubDomainPathId}, ctx);
         }
 
-        THolder<TEvSchemeShard::TEvLoginResult> result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
-        const auto& loginRequest = GetLoginRequest();
-        if (loginRequest.ExternalAuth || AppData(ctx)->AuthConfig.GetEnableLoginAuthentication()) {
-            NLogin::TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
-            if (loginResponse.Error) {
-                result->Record.SetError(loginResponse.Error);
-            }
-            if (loginResponse.Token) {
-                result->Record.SetToken(loginResponse.Token);
-                result->Record.SetSanitizedToken(loginResponse.SanitizedToken);
-            }
-
-        } else {
-            result->Record.SetError("Login authentication is disabled");
-        }
-
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-                    "TTxLogin DoComplete"
-                    << ", result: " << result->Record.ShortDebugString()
+                    "TTxLogin Complete"
+                    << ", result: " << Result->Record.ShortDebugString()
                     << ", at schemeshard: " << Self->TabletID());
 
-        ctx.Send(Request->Sender, std::move(result), 0, Request->Cookie);
+        ctx.Send(Request->Sender, std::move(Result), 0, Request->Cookie);
     }
 
+private:
+    bool LoginAttempt(NIceDb::TNiceDb& db, const TActorContext& ctx) {
+        const auto& loginRequest = GetLoginRequest();
+        if (!loginRequest.ExternalAuth && !AppData(ctx)->AuthConfig.GetEnableLoginAuthentication()) {
+            Result->Record.SetError("Login authentication is disabled");
+            return true;
+        }
+        if (loginRequest.ExternalAuth) {
+            return HandleExternalAuth(loginRequest);
+        }
+        return HandleLoginAuth(loginRequest, db, ctx);
+    }
+
+    bool HandleExternalAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest) {
+        const NLogin::TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
+        switch (loginResponse.Status) {
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
+            SetSuccessResult(loginResponse);
+            break;
+        }
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY: {
+            Result->Record.SetError(loginResponse.Error);
+            break;
+        }
+        }
+        return true;
+    }
+
+    void SetSuccessResult(const NLogin::TLoginProvider::TLoginUserResponse& loginResponse) {
+        Result->Record.SetToken(loginResponse.Token);
+        Result->Record.SetSanitizedToken(loginResponse.SanitizedToken);
+    }
+
+    bool HandleLoginAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db, const TActorContext& ctx) {
+        auto row = db.Table<Schema::LoginSids>().Key(loginRequest.User).Select();
+        if (!row.IsReady()) {
+            return false;
+        }
+        if (!row.IsValid()) {
+            Result->Record.SetError(TStringBuilder() << "Cannot find user: " << loginRequest.User);
+            return true;
+        }
+        const size_t failedAttemptCount = row.GetValueOrDefault<Schema::LoginSids::FailedAttemptCount>();
+        if (CheckAccountLockout(failedAttemptCount, ctx)) {
+            TInstant lastFailedAttempt = TInstant::FromValue(row.GetValue<Schema::LoginSids::LastFailedAttempt>());
+            if (ShouldUnlockAccount(lastFailedAttempt, ctx)) {
+                UnlockAccount(loginRequest, db);
+            } else {
+                Result->Record.SetError(TStringBuilder() << "User " << loginRequest.User << " is locked out");
+                return true;
+            }
+        }
+        const NLogin::TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
+        switch (loginResponse.Status) {
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
+            HandleLoginAuthSuccess(loginRequest, loginResponse, db);
+            break;
+        }
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD: {
+            HandleLoginAuthInvalidPassword(loginRequest, loginResponse, failedAttemptCount, db);
+            break;
+        }
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY: {
+            Result->Record.SetError(loginResponse.Error);
+            break;
+        }
+        }
+        return true;
+    }
+
+    bool CheckAccountLockout(size_t failedAttemptCount, const TActorContext& ctx) const {
+        const auto& accountLockout = AppData(ctx)->AuthConfig.GetAccountLockout();
+        if (failedAttemptCount >= accountLockout.GetAttemptThreshold()) {
+            return true;
+        }
+        return false;
+    }
+
+    bool ShouldUnlockAccount(const TInstant& lastFailedAttempt, const TActorContext& ctx) {
+        const auto& accountLockout = AppData(ctx)->AuthConfig.GetAccountLockout();
+        if (accountLockout.GetAttemptResetDuration().empty()) {
+            return false;
+        }
+        TDuration attemptResetDuration;
+        if(TDuration::TryParse(accountLockout.GetAttemptResetDuration(), attemptResetDuration)) {
+            if (attemptResetDuration.Seconds() == 0) {
+                return false;
+            }
+            return lastFailedAttempt + attemptResetDuration < TAppData::TimeProvider->Now();
+        }
+        return false;
+    }
+
+    void UnlockAccount(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db) {
+        ResetFailedAttemptCount(loginRequest, db);
+    }
+
+    void ResetFailedAttemptCount(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db) const {
+        db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::FailedAttemptCount>(Schema::LoginSids::FailedAttemptCount::Default);
+    }
+
+    void HandleLoginAuthSuccess(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& loginResponse, NIceDb::TNiceDb& db) {
+        SetSuccessResult(loginResponse);
+        db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastSuccessfulAttempt, Schema::LoginSids::FailedAttemptCount>(TAppData::TimeProvider->Now().MicroSeconds(), Schema::LoginSids::FailedAttemptCount::Default);
+    }
+
+    void HandleLoginAuthInvalidPassword(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& loginResponse, size_t failedAttemptCount, NIceDb::TNiceDb& db) {
+        Cerr << "+++: " << failedAttemptCount << Endl;
+        db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastFailedAttempt, Schema::LoginSids::FailedAttemptCount>(TAppData::TimeProvider->Now().MicroSeconds(), failedAttemptCount + 1);
+        Result->Record.SetError(loginResponse.Error);
+    }
 };
 
 NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxLogin(TEvSchemeShard::TEvLogin::TPtr &ev) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4441,7 +4441,6 @@ TActorId TSchemeShard::TPipeClientFactory::CreateClient(const TActorContext& ctx
 TSchemeShard::TAccountLockout::TAccountLockout(const ::NKikimrProto::TAccountLockout& accountLockout)
     : AttemptThreshold(accountLockout.GetAttemptThreshold())
 {
-    Cerr << "+++++accountLockout.GetAttemptResetDuration(): " << accountLockout.GetAttemptResetDuration() << Endl;
     AttemptResetDuration = TDuration::Zero();
     if (accountLockout.GetAttemptResetDuration().empty()) {
         return;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4438,6 +4438,21 @@ TActorId TSchemeShard::TPipeClientFactory::CreateClient(const TActorContext& ctx
     return clientId;
 }
 
+TSchemeShard::TAccountLockout::TAccountLockout(const ::NKikimrProto::TAccountLockout& accountLockout)
+    : AttemptThreshold(accountLockout.GetAttemptThreshold())
+{
+    Cerr << "+++++accountLockout.GetAttemptResetDuration(): " << accountLockout.GetAttemptResetDuration() << Endl;
+    AttemptResetDuration = TDuration::Zero();
+    if (accountLockout.GetAttemptResetDuration().empty()) {
+        return;
+    }
+    if (TDuration::TryParse(accountLockout.GetAttemptResetDuration(), AttemptResetDuration)) {
+        if (AttemptResetDuration.Seconds() == 0) {
+            AttemptResetDuration = TDuration::Zero();
+        }
+    }
+}
+
 TSchemeShard::TSchemeShard(const TActorId &tablet, TTabletStorageInfo *info)
     : TActor(&TThis::StateInit)
     , TTabletExecutedFlat(info, tablet, new NMiniKQL::TMiniKQLFactory)
@@ -4476,6 +4491,7 @@ TSchemeShard::TSchemeShard(const TActorId &tablet, TTabletStorageInfo *info)
         .SpecialChars = AppData()->AuthConfig.GetPasswordComplexity().GetSpecialChars(),
         .CanContainUsername = AppData()->AuthConfig.GetPasswordComplexity().GetCanContainUsername()
     }))
+    , AccountLockout(AppData()->AuthConfig.GetAccountLockout())
 {
     TabletCountersPtr.Reset(new TProtobufTabletCounters<
                             ESimpleCounters_descriptor,
@@ -7162,6 +7178,7 @@ void TSchemeShard::ApplyConsoleConfigs(const NKikimrConfig::TAppConfig& appConfi
 
     if (appConfig.HasAuthConfig()) {
         ConfigureLoginProvider(appConfig.GetAuthConfig(), ctx);
+        ConfigureAccountLockout(appConfig.GetAuthConfig(), ctx);
     }
 
     if (IsSchemeShardConfigured()) {
@@ -7381,6 +7398,17 @@ void TSchemeShard::ConfigureLoginProvider(
                  << ", MinSpecialCharsCount# " << passwordComplexity.MinSpecialCharsCount
                  << ", SpecialChars# " << (passwordComplexityConfig.GetSpecialChars().empty() ? NLogin::TPasswordComplexity::VALID_SPECIAL_CHARS : passwordComplexityConfig.GetSpecialChars())
                  << ", CanContainUsername# " << (passwordComplexity.CanContainUsername ? "true" : "false"));
+}
+
+void TSchemeShard::ConfigureAccountLockout(
+        const ::NKikimrProto::TAuthConfig& config,
+        const TActorContext &ctx)
+{
+    AccountLockout = TAccountLockout(config.GetAccountLockout());
+
+    LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                 "AccountLockout configured: AttemptThreshold# " << AccountLockout.AttemptThreshold
+                 << ", AttemptResetDuration# " << AccountLockout.AttemptResetDuration.ToString());
 }
 
 void TSchemeShard::StartStopCompactionQueues() {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -36,6 +36,7 @@
 #include <ydb/core/protos/counters_schemeshard.pb.h>
 #include <ydb/core/protos/filestore_config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/sys_view/common/events.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/tablet/pipe_tracker.h>
@@ -497,6 +498,10 @@ public:
         const TActorContext &ctx);
 
     void ConfigureLoginProvider(
+        const ::NKikimrProto::TAuthConfig& config,
+        const TActorContext &ctx);
+
+    void ConfigureAccountLockout(
         const ::NKikimrProto::TAuthConfig& config,
         const TActorContext &ctx);
 
@@ -1462,6 +1467,15 @@ public:
     void AddDiskSpaceSoftQuotaBytes(EUserFacingStorageType storageType, ui64 addend) override;
 
     NLogin::TLoginProvider LoginProvider;
+
+    struct TAccountLockout {
+        size_t AttemptThreshold = 4;
+        TDuration AttemptResetDuration = TDuration::Hours(1);
+
+        TAccountLockout(const ::NKikimrProto::TAccountLockout& accountLockout);
+    };
+
+    TAccountLockout AccountLockout;
 
 private:
     void OnDetach(const TActorContext &ctx) override;

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1628,9 +1628,19 @@ struct Schema : NIceDb::Schema {
         struct SidName : Column<1, NScheme::NTypeIds::String> {};
         struct SidType : Column<2, NScheme::NTypeIds::Uint64> { using Type = NLoginProto::ESidType::SidType; };
         struct SidHash : Column<3, NScheme::NTypeIds::String> {};
+        struct LastSuccessfulAttempt : Column<4, NScheme::NTypeIds::Timestamp> {};
+        struct LastFailedAttempt : Column<5, NScheme::NTypeIds::Timestamp> {};
+        struct FailedAttemptCount : Column<6, NScheme::NTypeIds::Uint32> {using Type = ui32; static constexpr Type Default = 0;};
 
         using TKey = TableKey<SidName>;
-        using TColumns = TableColumns<SidName, SidType, SidHash>;
+        using TColumns = TableColumns<
+            SidName,
+            SidType,
+            SidHash,
+            LastSuccessfulAttempt,
+            LastFailedAttempt,
+            FailedAttemptCount
+        >;
     };
 
     struct LoginSidMembers : Table<94> {

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -17,6 +17,7 @@
 #include <ydb/core/util/pb.h>
 #include <ydb/public/api/protos/ydb_export.pb.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
+#include <ydb/core/protos/auth.pb.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -1976,9 +1977,20 @@ namespace NSchemeShardUT_Private {
         auto transaction = modifyTx->Record.AddTransaction();
         transaction->SetWorkingDir(database);
         transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpAlterLogin);
-
         auto removeUser = transaction->MutableAlterLogin()->MutableRemoveUser();
         removeUser->SetUser(user);
+
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
+    void CreateAlterLoginCreateGroup(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& group, const TVector<TExpectedResult>& expectedResults) {
+        auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
+        auto transaction = modifyTx->Record.AddTransaction();
+        transaction->SetWorkingDir(database);
+        transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpAlterLogin);
+        auto createGroup = transaction->MutableAlterLogin()->MutableCreateGroup();
+        createGroup->SetGroup(group);
 
         AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
         TestModificationResults(runtime, txId, expectedResults);
@@ -2010,13 +2022,17 @@ namespace NSchemeShardUT_Private {
 
         AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
         TestModificationResults(runtime, txId, expectedResults);
-    }   
-    
+    }
+
     NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, const TString& user, const TString& password) {
         TActorId sender = runtime.AllocateEdgeActor();
         auto evLogin = new TEvSchemeShard::TEvLogin();
         evLogin->Record.SetUser(user);
         evLogin->Record.SetPassword(password);
+
+        if (auto ldapDomain = runtime.GetAppData().AuthConfig.GetLdapAuthenticationDomain(); user.EndsWith("@" + ldapDomain)) {
+            evLogin->Record.SetExternalAuth(ldapDomain);
+        }
         ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, evLogin);
         TAutoPtr<IEventHandle> handle;
         auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvLoginResult>(handle);

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -523,7 +523,7 @@ namespace NSchemeShardUT_Private {
         TTestActorRuntime& runtime, ui64 schemeShard, ui64 tabletId,
         NKikimrScheme::TEvFindTabletSubDomainPathIdResult::EStatus expected = NKikimrScheme::TEvFindTabletSubDomainPathIdResult::SUCCESS);
 
-    void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, 
+    void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user, const TString& password,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
     
@@ -531,15 +531,18 @@ namespace NSchemeShardUT_Private {
         const TString& user,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 
-    void AlterLoginAddGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database, 
-        const TString& member, const TString& group, 
+    void CreateAlterLoginCreateGroup(TTestActorRuntime& runtime, ui64 txId, const TString& database,
+        const TString& group, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+
+    void AlterLoginAddGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database,
+        const TString& member, const TString& group,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 
-    void AlterLoginRemoveGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database, 
-        const TString& member, const TString& group, 
+    void AlterLoginRemoveGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database,
+        const TString& member, const TString& group,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 
-    NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, 
+    NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime,
         const TString& user, const TString& password);
 
     // Mimics data query to a single table with multiple partitions

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -158,7 +158,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // check login
         {
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
         }
 
         // another still has access
@@ -213,7 +213,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // check login
         {
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
         }
 
         // another still has access
@@ -285,7 +285,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),
                 {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1"), NLs::HasOwner("user2")});
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
         }
     }
 

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -415,29 +415,25 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         });
         TTestEnv env(runtime);
         ui64 txId = 100;
-        TString username = "user1";
-        TString password = "password1";
-        TString database = "/MyRoot";
-        CreateAlterLoginCreateUser(runtime, ++txId, database, username, password);
-        TString wrongPassword = "wrongpassword";
-        auto resultLogin = Login(runtime, username, wrongPassword);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        auto resultLogin = Login(runtime, "user1", "wrongpassword1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword3");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword4");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User " << username << " is locked out");
+        resultLogin = Login(runtime, "user1", "wrongpassword5");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 is locked out");
 
         runtime.SimulateSleep(TDuration::Seconds(7));
 
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword6");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, password);
+        resultLogin = Login(runtime, "user1", "password1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-        auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, database);
+        auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
         UNIT_ASSERT(describe.HasPathDescription());
         UNIT_ASSERT(describe.GetPathDescription().HasDomainDescription());
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().HasSecurityState());
@@ -460,30 +456,26 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         });
         TTestEnv env(runtime);
         ui64 txId = 100;
-        TString username = "user1";
-        TString password = "password1";
-        TString database = "/MyRoot";
-        CreateAlterLoginCreateUser(runtime, ++txId, database, username, password);
-        TString wrongPassword = "wrongpassword";
-        auto resultLogin = Login(runtime, username, wrongPassword);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        auto resultLogin = Login(runtime, "user1", "wrongpassword1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword3");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
 
         runtime.SimulateSleep(TDuration::Seconds(7));
 
         // FailedAttemptCount should be reset
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword4");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword5");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, wrongPassword);
+        resultLogin = Login(runtime, "user1", "wrongpassword6");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username, password);
+        resultLogin = Login(runtime, "user1", "password1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-        auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, database);
+        auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
         UNIT_ASSERT(describe.HasPathDescription());
         UNIT_ASSERT(describe.GetPathDescription().HasDomainDescription());
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().HasSecurityState());
@@ -506,29 +498,25 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         });
         TTestEnv env(runtime);
         ui64 txId = 100;
-        TString username1 = "user1";
-        TString password1 = "password1";
-        TString database = "/MyRoot";
-        CreateAlterLoginCreateUser(runtime, ++txId, database, username1, password1);
-        TString wrongPassword1 = "wrongpassword1";
-        auto resultLogin = Login(runtime, username1, wrongPassword1);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        auto resultLogin = Login(runtime, "user1", "wrongpassword1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username1, wrongPassword1);
+        resultLogin = Login(runtime, "user1", "wrongpassword2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username1, wrongPassword1);
+        resultLogin = Login(runtime, "user1", "wrongpassword3");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username1, wrongPassword1);
+        resultLogin = Login(runtime, "user1", "wrongpassword4");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username1, wrongPassword1);
+        resultLogin = Login(runtime, "user1", "wrongpassword5");
         // User is locked out after 4 attempts
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User " << username1 << " is locked out");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 is locked out");
 
         runtime.SimulateSleep(TDuration::Seconds(7));
 
         // Unlock user after 5 sec
-        resultLogin = Login(runtime, username1, password1);
+        resultLogin = Login(runtime, "user1", "password1");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-        auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, database);
+        auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
         UNIT_ASSERT(describe.HasPathDescription());
         UNIT_ASSERT(describe.GetPathDescription().HasDomainDescription());
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().HasSecurityState());
@@ -538,42 +526,39 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         NLogin::TLoginProvider login;
         login.UpdateSecurityState(describe.GetPathDescription().GetDomainDescription().GetSecurityState());
         auto resultValidate = login.ValidateToken({.Token = resultLogin.token()});
-        UNIT_ASSERT_VALUES_EQUAL(resultValidate.User, username1);
+        UNIT_ASSERT_VALUES_EQUAL(resultValidate.User, "user1");
 
         SetAccountLockoutParameters(runtime, TTestTxConfig::SchemeShard, {.AttemptThreshold = 6, .AttemptResetDuration = "10s"});
 
-        TString username2 = "user2";
-        TString password2 = "password2";
-        CreateAlterLoginCreateUser(runtime, ++txId, database, username2, password2);
-        TString wrongPassword2 = "wrongpassword2";
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "password2");
         // Now user2 have 6 attempts to login
-        resultLogin = Login(runtime, username2, wrongPassword2);
+        resultLogin = Login(runtime, "user2", "wrongpassword21");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username2, wrongPassword2);
+        resultLogin = Login(runtime, "user2", "wrongpassword22");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username2, wrongPassword2);
+        resultLogin = Login(runtime, "user2", "wrongpassword23");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username2, wrongPassword2);
+        resultLogin = Login(runtime, "user2", "wrongpassword24");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username2, wrongPassword2);
+        resultLogin = Login(runtime, "user2", "wrongpassword25");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username2, wrongPassword2);
+        resultLogin = Login(runtime, "user2", "wrongpassword26");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, username2, wrongPassword2);
+        resultLogin = Login(runtime, "user2", "wrongpassword27");
         // User is locked out after 6 attempts
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User " << username2 << " is locked out");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user2 is locked out");
 
         // After 7 sec user2 must be locked out
         runtime.SimulateSleep(TDuration::Seconds(7));
-        resultLogin = Login(runtime, username2, wrongPassword2);
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User " << username2 << " is locked out");
+        resultLogin = Login(runtime, "user2", "wrongpassword28");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user2 is locked out");
 
         runtime.SimulateSleep(TDuration::Seconds(5));
 
         // Unlock user after 10 sec
-        resultLogin = Login(runtime, username2, password2);
+        resultLogin = Login(runtime, "user2", "password2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-        describe = DescribePath(runtime, TTestTxConfig::SchemeShard, database);
+        describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
         UNIT_ASSERT(describe.HasPathDescription());
         UNIT_ASSERT(describe.GetPathDescription().HasDomainDescription());
         UNIT_ASSERT(describe.GetPathDescription().GetDomainDescription().HasSecurityState());
@@ -582,7 +567,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // check token
         login.UpdateSecurityState(describe.GetPathDescription().GetDomainDescription().GetSecurityState());
         resultValidate = login.ValidateToken({.Token = resultLogin.token()});
-        UNIT_ASSERT_VALUES_EQUAL(resultValidate.User, username2);
+        UNIT_ASSERT_VALUES_EQUAL(resultValidate.User, "user2");
     }
 }
 

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -375,6 +375,7 @@ TLoginProvider::TLoginUserResponse TLoginProvider::LoginUser(const TLoginUserReq
 
     response.Token = TString(encoded_token);
     response.SanitizedToken = SanitizeJwtToken(response.Token);
+    response.Status = TLoginUserResponse::EStatus::SUCCESS;
 
     return response;
 }

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -320,17 +320,20 @@ TLoginProvider::TLoginUserResponse TLoginProvider::LoginUser(const TLoginUserReq
     if (!request.ExternalAuth) {
         auto itUser = Sids.find(request.User);
         if (itUser == Sids.end() || itUser->second.Type != ESidType::USER) {
+            response.Status = TLoginUserResponse::EStatus::INVALID_USER;
             response.Error = "Invalid user";
             return response;
         }
 
         if (!Impl->VerifyHash(request.Password, itUser->second.Hash)) {
+            response.Status = TLoginUserResponse::EStatus::INVALID_PASSWORD;
             response.Error = "Invalid password";
             return response;
         }
     }
 
     if (Keys.empty() || Keys.back().PrivateKey.empty()) {
+        response.Status = TLoginUserResponse::EStatus::UNAVAILABLE_KEY;
         response.Error = "No key to generate token";
         return response;
     }

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -48,8 +48,16 @@ public:
     };
 
     struct TLoginUserResponse : TBasicResponse {
+        enum class EStatus {
+            SUCCESS,
+            INVALID_USER,
+            INVALID_PASSWORD,
+            UNAVAILABLE_KEY
+        };
+
         TString Token;
         TString SanitizedToken; // Token for audit logs
+        EStatus Status = EStatus::SUCCESS;
     };
 
     struct TValidateTokenRequest : TBasicRequest {

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -49,6 +49,7 @@ public:
 
     struct TLoginUserResponse : TBasicResponse {
         enum class EStatus {
+            UNSPECIFIED,
             SUCCESS,
             INVALID_USER,
             INVALID_PASSWORD,
@@ -57,7 +58,7 @@ public:
 
         TString Token;
         TString SanitizedToken; // Token for audit logs
-        EStatus Status = EStatus::SUCCESS;
+        EStatus Status = EStatus::UNSPECIFIED;
     };
 
     struct TValidateTokenRequest : TBasicRequest {

--- a/ydb/services/ydb/ydb_ldap_login_ut.cpp
+++ b/ydb/services/ydb/ydb_ldap_login_ut.cpp
@@ -412,7 +412,7 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         auto factory = CreateLoginCredentialsProviderFactory({.User = login + incorrectLdapDomain, .Password = password});
         TLoginClientConnection loginConnection(InitLdapSettings);
         auto loginProvider = factory->CreateProvider(loginConnection.GetCoreFacility());
-        UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Invalid user");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Cannot find user: ldapuser@ldap.domain");
 
         loginConnection.Stop();
     }

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -6594,6 +6594,21 @@
                 "ColumnId": 3,
                 "ColumnName": "SidHash",
                 "ColumnType": "String"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "LastSuccessfulAttempt",
+                "ColumnType": "Timestamp"
+            },
+            {
+                "ColumnId": 5,
+                "ColumnName": "LastFailedAttempt",
+                "ColumnType": "Timestamp"
+            },
+            {
+                "ColumnId": 6,
+                "ColumnName": "FailedAttemptCount",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -6602,7 +6617,10 @@
                 "Columns": [
                     1,
                     2,
-                    3
+                    3,
+                    4,
+                    5,
+                    6
                 ],
                 "RoomID": 0,
                 "Codec": 0,

--- a/ydb/tests/library/common/types.py
+++ b/ydb/tests/library/common/types.py
@@ -248,6 +248,8 @@ class PType(AbstractTypeEnum):
     Double = _ptype_from(32, float_in(-100, 100), float, proto_field='Double')
     Float = _ptype_from(33, float_in(-100, 100), float, proto_field='Float')
 
+    Timestamp = _ptype_from(50, int_between(0, 2 ** 64 - 1), int, proto_field='Timestamp', min_value=0, max_value=2 ** 64 - 1)
+
     # Rework Pair later
     PairUi64Ui64 = _ptype_from(257, int_between(0, 2 ** 64 - 1), int)
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Automatically account lockout after some attempts to login with wrong password.
User is unlocked after `AttemptResetDuration` time in config. If  `AttemptResetDuration` is 0 then user is locked out permanently

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

...
