### PR TITLE
Fix incorrect Uuid serialization for CDC.

### DIFF
--- a/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
+++ b/ydb/core/tx/datashard/change_record_cdc_serializer.cpp
@@ -124,6 +124,15 @@ protected:
         return result;
     }
 
+    static NJson::TJsonValue UuidToJson(const TCell& cell) {
+        TStringStream ss;
+        ui16 dw[8];
+        Y_ABORT_UNLESS(cell.Size() == 16);
+        cell.CopyDataInto((char*)dw);
+        NUuid::UuidToString(dw, ss);
+        return NJson::TJsonValue(ss.Str());
+    }
+
     static NJson::TJsonValue ToJson(const TCell& cell, NScheme::TTypeInfo type) {
         if (cell.IsNull()) {
             return NJson::TJsonValue(NJson::JSON_NULL);
@@ -185,7 +194,7 @@ protected:
         case NScheme::NTypeIds::Pg:
             return NJson::TJsonValue(PgToString(cell.AsBuf(), type));
         case NScheme::NTypeIds::Uuid:
-            return NJson::TJsonValue(NUuid::UuidBytesToString(cell.Data()));
+            return UuidToJson(cell);
         default:
             Y_ABORT("Unexpected type");
         }

--- a/ydb/core/tx/datashard/datashard_ut_change_collector.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_collector.cpp
@@ -276,7 +276,7 @@ private:
                     inserter(name, cell.AsValue<ui32>());
                 } else if constexpr (std::is_same_v<T, TUuidHolder>) {
                     TStringStream ss;
-                    NUuid::UuidBytesToString(cell.Data(), ss);
+                    NUuid::UuidBytesToString(TString(cell.Data(), cell.Size()), ss);
                     inserter(name, TUuidHolder(ss.Str()));
                 }
             }
@@ -854,8 +854,8 @@ Y_UNIT_TEST_SUITE(CdcStreamChangeCollector) {
     }
 
     Y_UNIT_TEST(InsertSingleUuidRow) {
-        Run<TUuidHolder>("/Root/path", UuidTable(), KeysOnly(), "INSERT INTO `/Root/path` (key, value) VALUES (Uuid(\"65df1ec1-a97d-47b2-ae56-3c023da6ee8c\"), 10);", {
-            {"keys_stream", {TStructRecordBase<TUuidHolder>(NTable::ERowOp::Upsert, {{"key", TUuidHolder("65df1ec1-a97d-47b2-ae56-3c023da6ee8c")}})}},
+        Run<TUuidHolder>("/Root/path", UuidTable(), KeysOnly(), "INSERT INTO `/Root/path` (key, value) VALUES (Uuid(\"65df1ec1-0000-47b2-ae56-3c023da6ee8c\"), 10);", {
+            {"keys_stream", {TStructRecordBase<TUuidHolder>(NTable::ERowOp::Upsert, {{"key", TUuidHolder("65df1ec1-0000-47b2-ae56-3c023da6ee8c")}})}},
         });
     }
 

--- a/ydb/public/lib/idx_test/idx_test_data_provider.cpp
+++ b/ydb/public/lib/idx_test/idx_test_data_provider.cpp
@@ -63,6 +63,9 @@ NYdb::TValue CreateOptionalValue(const TColumn& column, const TRandomValueProvid
                 value.OptionalJson(TString(sb));
             }
             break;
+        case EPrimitiveType::Uuid:
+            value.OptionalUuid(TUuidValue(rvp.RandomUi64(), rvp.RandomUi64()));
+            break;
         default:
                 Y_ABORT_UNLESS(false, "unimplemented");
     }
@@ -186,6 +189,9 @@ NYdb::TValue CreateRow(const TVector<TColumn>& columns, const TRandomValueProvid
                     auto sb = TStringBuilder() << "[\"" << Base64Encode(rvp.RandomString()) << "\"]";
                     value.AddMember(col.Name).Json(TString(sb));
                 }
+            break;
+            case EPrimitiveType::Uuid:
+                value.AddMember(col.Name).Uuid(TUuidValue(rvp.RandomUi64(), rvp.RandomUi64()));
             break;
 
             default:

--- a/ydb/public/lib/idx_test/idx_test_data_provider.cpp
+++ b/ydb/public/lib/idx_test/idx_test_data_provider.cpp
@@ -190,9 +190,6 @@ NYdb::TValue CreateRow(const TVector<TColumn>& columns, const TRandomValueProvid
                     value.AddMember(col.Name).Json(TString(sb));
                 }
             break;
-            case EPrimitiveType::Uuid:
-                value.AddMember(col.Name).Uuid(TUuidValue(rvp.RandomUi64(), rvp.RandomUi64()));
-            break;
 
             default:
                 Y_ABORT_UNLESS(false, "unimplemented");

--- a/ydb/tests/functional/replication/main.cpp
+++ b/ydb/tests/functional/replication/main.cpp
@@ -60,9 +60,9 @@ Y_UNIT_TEST_SUITE(Replication)
             {
                 const TString query = "UPSERT INTO ProducerUuidValue (Key,Key2,v01,v02,v03) VALUES"
                     "(1, "
-                      "CAST(\"5b99a330-04ef-4f1a-9b64-ba6d5f44ea00\" as Uuid), "
-                      "CAST(\"5b99a330-04ef-4f1a-9b64-ba6d5f44ea01\" as Uuid), "
-                      "UNWRAP(CAST(\"5b99a330-04ef-4f1a-9b64-ba6d5f44ea02\" as Uuid)), "
+                      "CAST(\"00078af5-0000-0000-6c0b-040000000000\" as Uuid), "
+                      "CAST(\"00078af5-0000-0000-6c0b-040000000001\" as Uuid), "
+                      "UNWRAP(CAST(\"00078af5-0000-0000-6c0b-040000000002\" as Uuid)), "
                       "CAST(\"311111111113.222222223\" as Double) "
                     ");";
                 auto res = s.ExecuteDataQuery(query, TTxControl::BeginTx().CommitTx()).GetValueSync();
@@ -90,9 +90,9 @@ Y_UNIT_TEST_SUITE(Replication)
         UNIT_ASSERT_C(sessionResult.IsSuccess(), sessionResult.GetIssues().ToString());
 
         auto s = sessionResult.GetSession();
-        TUuidValue expectedKey2("5b99a330-04ef-4f1a-9b64-ba6d5f44ea00");
-        TUuidValue expectedV1("5b99a330-04ef-4f1a-9b64-ba6d5f44ea01");
-        TUuidValue expectedV2("5b99a330-04ef-4f1a-9b64-ba6d5f44ea02");
+        TUuidValue expectedKey2("00078af5-0000-0000-6c0b-040000000000");
+        TUuidValue expectedV1("00078af5-0000-0000-6c0b-040000000001");
+        TUuidValue expectedV2("00078af5-0000-0000-6c0b-040000000002");
         double expectedV3 = 311111111113.222222223;
         ui32 attempt = 10;
         while (--attempt) {


### PR DESCRIPTION
TCell stores uuid as binary data therefore it can contains \0 byte.

### Changelog category <!-- remove all except one -->


* Bugfix 


### Additional information

...
