### PR TITLE
avoid allocating data on TTypeEnv when making cell vectors (#12552)

### DIFF
--- a/ydb/core/engine/mkql_keys.cpp
+++ b/ydb/core/engine/mkql_keys.cpp
@@ -252,8 +252,10 @@ THolder<TKeyDesc> ExtractEraseRow(TCallable& callable, const TTypeEnvironment& e
 #define MAKE_PRIMITIVE_TYPE_CELL(type, layout) \
     case NUdf::TDataType<type>::Id: return MakeCell<layout>(value);
 
-TCell MakeCell(NScheme::TTypeInfo type, const NUdf::TUnboxedValuePod& value,
-    const TTypeEnvironment& env, bool copy,
+
+template<typename TStringBackend>
+TCell MakeCellImpl(NScheme::TTypeInfo type, const NUdf::TUnboxedValuePod& value,
+    const TStringBackend& env, bool copy,
     i32 typmod, TMaybe<TString>* error)
 {
     if (!value)
@@ -300,6 +302,21 @@ TCell MakeCell(NScheme::TTypeInfo type, const NUdf::TUnboxedValuePod& value,
     std::memcpy(val.Data(), ref.Data(), ref.Size());
     return TCell(val.Data(), val.Size());
 }
+
+TCell MakeCell(NScheme::TTypeInfo type, const NUdf::TUnboxedValuePod& value,
+    const TTypeEnvironment& env, bool copy,
+    i32 typmod, TMaybe<TString>* error)
+{
+    return MakeCellImpl(type, value, env, copy, typmod, error);
+}
+
+TCell MakeCell(NScheme::TTypeInfo type, const NUdf::TUnboxedValuePod& value,
+    const TStringProviderBackend& env, bool copy,
+    i32 typmod, TMaybe<TString>* error)
+{
+    return MakeCellImpl(type, value, env, copy, typmod, error);
+}
+
 
 #undef MAKE_PRIMITIVE_TYPE_CELL
 

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -218,12 +218,15 @@ public:
     virtual ~TKqpLookupRows() {}
 
     void AddInputRow(NUdf::TUnboxedValue inputRow) final {
+        NMiniKQL::TStringProviderBackend backend;
         std::vector<TCell> keyCells(LookupKeyColumns.size());
         for (size_t colId = 0; colId < LookupKeyColumns.size(); ++colId) {
             const auto* lookupKeyColumn = LookupKeyColumns[colId];
             YQL_ENSURE(lookupKeyColumn->KeyOrder < static_cast<i64>(keyCells.size()));
+            // when making a cell we don't really need to make a copy of data, because
+            // TOwnedCellVec will make its' own copy.
             keyCells[lookupKeyColumn->KeyOrder] = MakeCell(lookupKeyColumn->PType,
-                inputRow.GetElement(colId), TypeEnv, /* copy */ true);
+                inputRow.GetElement(colId), backend, /* copy */ false);
         }
 
         if (keyCells.size() < KeyColumns.size()) {
@@ -500,13 +503,16 @@ public:
     void AddInputRow(NUdf::TUnboxedValue inputRow) final {
         auto joinKey = inputRow.GetElement(0);
         std::vector<TCell> joinKeyCells(LookupKeyColumns.size());
+        NMiniKQL::TStringProviderBackend backend;
 
         if (joinKey.HasValue()) {
             for (size_t colId = 0; colId < LookupKeyColumns.size(); ++colId) {
                 const auto* joinKeyColumn = LookupKeyColumns[colId];
                 YQL_ENSURE(joinKeyColumn->KeyOrder < static_cast<i64>(joinKeyCells.size()));
+                // when making a cell we don't really need to make a copy of data, because
+                // TOwnedCellVec will make its' own copy.
                 joinKeyCells[joinKeyColumn->KeyOrder] = MakeCell(joinKeyColumn->PType,
-                    joinKey.GetElement(colId), TypeEnv, true);
+                    joinKey.GetElement(colId), backend,  /* copy */ false);
             }
         }
 


### PR DESCRIPTION
### Changelog entry 

avoid allocating data on TTypeEnv when making cell vectors (#12552)

### Changelog category 

* Not for changelog (changelog entry is not required)

### Additional information

...
