### PR TITLE
Fix Typo in go sdk documentation

### DIFF
--- a/ydb/docs/ru/core/dev/example-app/go/index.md
+++ b/ydb/docs/ru/core/dev/example-app/go/index.md
@@ -53,7 +53,7 @@ token := "t1.9euelZrOy8aVmZKJm5HGjceMkMeVj-..."
 db, err := ydb.Open(ctx, dsn,
 //  yc.WithInternalCA(), // используем сертификаты Яндекс Облака
   ydb.WithAccessTokenCredentials(token), // аутентификация с помощью токена
-//  ydb.WithAnonimousCredentials(), // анонимная аутентификация (например, в docker ydb)
+//  ydb.WithAnonymousCredentials(), // анонимная аутентификация (например, в docker ydb)
 //  yc.WithMetadataCredentials(token), // аутентификация изнутри виртуальной машины в Яндекс Облаке или из Яндекс Функции
 //  yc.WithServiceAccountKeyFileCredentials("~/.ydb/sa.json"), // аутентификация в Яндекс Облаке с помощью файла сервисного аккаунта
 //  environ.WithEnvironCredentials(ctx), // аутентификация с использованием переменных окружения


### PR DESCRIPTION
fix typo in go sdk documentation
issue https://github.com/ydb-platform/ydb/issues/12626


