### PR TITLE
Enable automatic box management with distconf by default

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -198,7 +198,7 @@ void TBlobStorageController::ApplyStorageConfig() {
     }
     const auto& autoconfigSettings = bsConfig.GetAutoconfigSettings();
 
-    if (!autoconfigSettings.GetAutomaticBoxManagement()) {
+    if (autoconfigSettings.HasAutomaticBoxManagement() && !autoconfigSettings.GetAutomaticBoxManagement()) {
         return;
     }
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -286,7 +286,7 @@ message TBlobStorageConfig {
         optional NKikimrBlobStorage.EPDiskType PDiskType = 7;
 
         // some extra settings
-        optional bool AutomaticBoxManagement = 4; // invoke BSC DefineHostConfig/DefineBox automatically
+        optional bool AutomaticBoxManagement = 4; // invoke BSC DefineHostConfig/DefineBox automatically (true when unset)
         optional bool AutomaticBootstrap = 9; // whether bootstrap should be performed automatically; PROHIBITED for production
 
         // filled in by config parser, not by user; required for automatic static group creation


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Enable automatic box management with distconf by default

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

With unspecified automatic\_box\_management field, it is enabled automatically.
