### PR TITLE
Move TEventPBBase::ToString() implementation out of *.h file

### DIFF
--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -1,6 +1,15 @@
 #include "event_pb.h"
 
 namespace NActors {
+    TString EventPBBaseToString(const TString& header, const TString& dbgStr) {
+        TString res;
+        res.reserve(header.size() + 1 + dbgStr.size());
+        res.append(header);
+        res.append(' ');
+        res.append(dbgStr);
+        return res;
+    }
+
     bool TRopeStream::Next(const void** data, int* size) {
         *data = Iter.ContiguousData();
         *size = Iter.ContiguousSize();

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -19,6 +19,7 @@ namespace NActorsProto {
 } // NActorsProto
 
 namespace NActors {
+    TString EventPBBaseToString(const TString& header, const TString& dbgStr);
 
     class TRopeStream : public NProtoBuf::io::ZeroCopyInputStream {
         TRope::TConstIterator Iter;
@@ -183,9 +184,7 @@ namespace NActors {
         }
 
         TString ToString() const override {
-            TStringStream ss;
-            ss << ToStringHeader() << " " << Record.ShortDebugString();
-            return ss.Str();
+            return EventPBBaseToString(ToStringHeader(), Record.ShortDebugString());
         }
 
         bool IsSerializable() const override {


### PR DESCRIPTION

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
