### PR TITLE
Support migration from conventional config to distconf

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -442,18 +442,13 @@ namespace NKikimr::NStorage {
         }
         const auto& bsConfig = config.GetBlobStorageConfig();
 
-        if (!bsConfig.HasAutoconfigSettings()) {
+        if (!bsConfig.HasDefineBox()) {
             return;
         }
-        const auto& autoconfigSettings = bsConfig.GetAutoconfigSettings();
-
-        if (!autoconfigSettings.HasDefineBox()) {
-            return;
-        }
-        const auto& defineBox = autoconfigSettings.GetDefineBox();
+        const auto& defineBox = bsConfig.GetDefineBox();
 
         THashMap<ui64, const NKikimrBlobStorage::TDefineHostConfig*> defineHostConfigMap;
-        for (const auto& defineHostConfig : autoconfigSettings.GetDefineHostConfig()) {
+        for (const auto& defineHostConfig : bsConfig.GetDefineHostConfig()) {
             defineHostConfigMap.emplace(defineHostConfig.GetHostConfigId(), &defineHostConfig);
         }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -46,7 +46,7 @@ namespace NKikimr::NStorage {
     }
 
     void TDistributedConfigKeeper::SwitchToError(const TString& reason) {
-        STLOG(PRI_ERROR, BS_NODE, NWDC38, "SwitchToError", (RootState, RootState), (Reason, reason));
+        STLOG(PRI_NOTICE, BS_NODE, NWDC38, "SwitchToError", (RootState, RootState), (Reason, reason));
         if (Scepter) {
             UnbecomeRoot();
         }
@@ -163,6 +163,11 @@ namespace NKikimr::NStorage {
 
         STLOG(PRI_DEBUG, BS_NODE, NWDC31, "ProcessCollectConfigs", (RootState, RootState), (NodeQuorum, nodeQuorum),
             (ConfigQuorum, configQuorum), (Res, *res));
+
+        if (nodeQuorum && !configQuorum) {
+            // check if there is quorum of no-distconf config along the cluster
+        }
+
         if (!nodeQuorum || !configQuorum) {
             return "no quorum for CollectConfigs";
         }
@@ -327,14 +332,8 @@ namespace NKikimr::NStorage {
         NKikimrBlobStorage::TStorageConfig *configToPropose = nullptr;
         std::optional<NKikimrBlobStorage::TStorageConfig> propositionBase;
 
-        bool canPropose = false;
-        if (StorageConfig->HasBlobStorageConfig()) {
-            if (const auto& bsConfig = StorageConfig->GetBlobStorageConfig(); bsConfig.HasAutoconfigSettings()) {
-                if (const auto& settings = bsConfig.GetAutoconfigSettings(); settings.HasDefineBox()) {
-                    canPropose = true;
-                }
-            }
-        }
+        auto& sc = *StorageConfig;
+        const bool canPropose = sc.HasBlobStorageConfig() && sc.GetBlobStorageConfig().HasDefineBox();
 
         STLOG(PRI_DEBUG, BS_NODE, NWDC59, "ProcessCollectConfigs", (BaseConfig, baseConfig),
             (PersistedConfig, persistedConfig), (ProposedConfig, proposedConfig), (CanPropose, canPropose));
@@ -378,12 +377,12 @@ namespace NKikimr::NStorage {
             }
             UpdateFingerprint(configToPropose);
 
-            const bool error = StorageConfig && configToPropose->GetGeneration() <= StorageConfig->GetGeneration();
+            const bool error = configToPropose->GetGeneration() <= sc.GetGeneration();
 
             STLOG(error ? PRI_ERROR : PRI_INFO, BS_NODE, NWDC60, "ProcessCollectConfigs proposing config",
                 (ConfigToPropose, *configToPropose),
                 (PropositionBase, propositionBase),
-                (StorageConfig, StorageConfig),
+                (StorageConfig, sc),
                 (BaseConfig, static_cast<bool>(baseConfig)),
                 (PersistedConfig, static_cast<bool>(persistedConfig)),
                 (ProposedConfig, static_cast<bool>(proposedConfig)),

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -392,6 +392,9 @@ void TNodeWarden::Bootstrap() {
 
     // fill in a base storage config (from the file)
     NKikimrConfig::TAppConfig appConfig;
+    if (Cfg->DomainsConfig) {
+        appConfig.MutableDomainsConfig()->CopyFrom(*Cfg->DomainsConfig);
+    }
     appConfig.MutableBlobStorageConfig()->CopyFrom(Cfg->BlobStorageConfig);
     appConfig.MutableNameserviceConfig()->CopyFrom(Cfg->NameserviceConfig);
     TString errorReason;
@@ -1014,11 +1017,26 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
         const auto& ssFrom = bsFrom.GetServiceSet();
         auto *ssTo = bsTo->MutableServiceSet();
 
-        ssTo->MutableAvailabilityDomains()->CopyFrom(ssFrom.GetAvailabilityDomains());
+        // update availability domains if set
+        if (ssFrom.AvailabilityDomainsSize()) {
+            ssTo->MutableAvailabilityDomains()->CopyFrom(ssFrom.GetAvailabilityDomains());
+        }
+
+        // replace replication broker configuration
         if (ssFrom.HasReplBrokerConfig()) {
             ssTo->MutableReplBrokerConfig()->CopyFrom(ssFrom.GetReplBrokerConfig());
+        } else {
+            ssTo->ClearReplBrokerConfig();
         }
-        if (!ssTo->PDisksSize() && !ssTo->VDisksSize() && !ssTo->GroupsSize()) {
+
+        const auto hasStaticGroupInfo = [](const NKikimrBlobStorage::TNodeWardenServiceSet& ss) {
+            return ss.PDisksSize() && ss.VDisksSize() && ss.GroupsSize();
+        };
+
+        // update static group information unless distconf is enabled
+        if (!hasStaticGroupInfo(ssFrom) && bsFrom.HasAutoconfigSettings()) {
+            // distconf enabled, keep it as is
+        } else if (!hasStaticGroupInfo(*ssTo)) {
             ssTo->MutablePDisks()->CopyFrom(ssFrom.GetPDisks());
             ssTo->MutableVDisks()->CopyFrom(ssFrom.GetVDisks());
             ssTo->MutableGroups()->CopyFrom(ssFrom.GetGroups());
@@ -1031,16 +1049,16 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
             };
 
             auto pdiskKey = [](const auto *item) {
-                return TStringBuilder() << "PDisk NodeId# " << item->GetNodeID() << " PDiskId# " << item->GetPDiskID();
+                return TStringBuilder() << "PDisk [" << item->GetNodeID() << ':' << item->GetPDiskID() << ']';
             };
 
             auto vdiskKey = [](const auto *item) {
-                return TStringBuilder() << "VDisk NodeId# " << item->GetNodeID() << " PDiskId# " << item->GetPDiskID()
-                    << " VDiskSlotId# " << item->GetVDiskSlotID();
+                return TStringBuilder() << "VSlot [" << item->GetNodeID() << ':' << item->GetPDiskID() << ':'
+                    << item->GetVDiskSlotID() << ']';
             };
 
             auto groupKey = [](const auto *item) {
-                return TStringBuilder() << "group GroupId# " << item->GetGroupID();
+                return TStringBuilder() << "group " << item->GetGroupID();
             };
 
             auto duplicateKey = [&](auto&& key) { return error(std::move(key), "duplicate key in existing StorageConfig"); };
@@ -1064,7 +1082,13 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
                 }
             }
             if (!pdiskMap.empty()) {
-                *errorReason = "some PDisks were added in newly provided configuration";
+                TStringStream err;
+                err << "some static PDisks were removed in newly provided configuration:";
+                for (const auto& [id, _] : pdiskMap) {
+                    const auto& [nodeId, pdiskId] = id;
+                    err << " [" << nodeId << ':' << pdiskId << ']';
+                }
+                *errorReason = std::move(err.Str());
                 return false;
             }
 
@@ -1096,7 +1120,13 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
                 }
             }
             if (!vdiskMap.empty()) {
-                *errorReason = "some VDisks were added in newly provided configuration";
+                TStringStream err;
+                err << "some static VDisks were removed in newly provided configuration:";
+                for (const auto& [id, _] : vdiskMap) {
+                    const auto& [nodeId, pdiskId, vdiskSlotId] = id;
+                    err << " [" << nodeId << ':' << pdiskId << ':' << vdiskSlotId << ']';
+                }
+                *errorReason = std::move(err.Str());
                 return false;
             }
 
@@ -1116,11 +1146,19 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
                 }
             }
             if (!groupMap.empty()) {
-                *errorReason = "some groups were added in newly provided configuration";
+                *errorReason = "some static groups were removed in newly provided configuration";
                 return false;
             }
         }
     }
+
+    // copy define box
+    if (bsFrom.HasDefineBox()) {
+        bsTo->MutableDefineBox()->CopyFrom(bsFrom.GetDefineBox());
+    } else {
+        bsTo->ClearDefineBox();
+    }
+    bsTo->MutableDefineHostConfig()->CopyFrom(bsFrom.GetDefineHostConfig());
 
     // copy nameservice-related things
     if (!appConfig.HasNameserviceConfig()) {
@@ -1148,7 +1186,47 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
     // and copy ClusterUUID from there too
     config->SetClusterUUID(nsFrom.GetClusterUUID());
 
-    // TODO(alexvru): apply SS, SSB, SB configs from there too
+    if (appConfig.HasDomainsConfig()) {
+        const auto& domains = appConfig.GetDomainsConfig();
+
+        // we expect strictly one domain
+        if (domains.DomainSize() == 1) {
+            const auto& domain = domains.GetDomain(0);
+
+            auto updateConfig = [&](bool needMerge, auto *to, const auto& from) {
+                if (needMerge) {
+                    char prefix[TActorId::MaxServiceIDLength] = {0};
+                    auto toInfo = BuildStateStorageInfo(prefix, *to);
+                    auto fromInfo = BuildStateStorageInfo(prefix, from);
+                    if (toInfo->NToSelect != fromInfo->NToSelect) {
+                        *errorReason = "NToSelect differs";
+                        return false;
+                    } else if (toInfo->SelectAllReplicas() != fromInfo->SelectAllReplicas()) {
+                        *errorReason = "StateStorage rings differ";
+                        return false;
+                    }
+                }
+
+                to->CopyFrom(from);
+                return true;
+            };
+
+            // find state storage setup for that domain
+            for (const auto& ss : domains.GetStateStorage()) {
+                if (domain.SSIdSize() == 1 && ss.GetSSId() == domain.GetSSId(0)) {
+                    const bool hadStateStorageConfig = config->HasStateStorageConfig();
+                    const bool hadStateStorageBoardConfig = config->HasStateStorageBoardConfig();
+                    const bool hadSchemeBoardConfig = config->HasSchemeBoardConfig();
+                    if (!updateConfig(hadStateStorageConfig, config->MutableStateStorageConfig(), ss) ||
+                            !updateConfig(hadStateStorageBoardConfig, config->MutableStateStorageBoardConfig(), ss) ||
+                            !updateConfig(hadSchemeBoardConfig, config->MutableSchemeBoardConfig(), ss)) {
+                        return false;
+                    }
+                    break;
+                }
+            }
+        }
+    }
 
     return true;
 }

--- a/ydb/core/grpc_services/rpc_bsconfig.cpp
+++ b/ydb/core/grpc_services/rpc_bsconfig.cpp
@@ -101,6 +101,20 @@ public:
     void FillDistconfResult(NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult& /*record*/,
             Ydb::BSConfig::ReplaceStorageConfigResult& /*result*/)
     {}
+
+    bool IsDistconfEnableQuery() const {
+        NKikimrConfig::TAppConfig newConfig;
+        try {
+            newConfig = NYaml::Parse(GetProtoRequest()->yaml_config());
+        } catch (const std::exception&) {
+            return false; // assuming no distconf enabled in this config
+        }
+        if (!newConfig.HasBlobStorageConfig()) {
+            return false;
+        }
+        const NKikimrConfig::TBlobStorageConfig& bsConfig = newConfig.GetBlobStorageConfig();
+        return bsConfig.HasAutoconfigSettings();
+    }
 };
 
 class TFetchStorageConfigRequest : public TBSConfigRequestGrpc<TFetchStorageConfigRequest, TEvFetchStorageConfigRequest,
@@ -123,6 +137,10 @@ public:
     void FillDistconfResult(NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult& record,
             Ydb::BSConfig::FetchStorageConfigResult& result) {
         result.set_yaml_config(record.GetFetchStorageConfig().GetYAML());
+    }
+
+    bool IsDistconfEnableQuery() const {
+        return false;
     }
 };
 

--- a/ydb/core/grpc_services/rpc_bsconfig_base.h
+++ b/ydb/core/grpc_services/rpc_bsconfig_base.h
@@ -178,7 +178,7 @@ protected:
 
     void Handle(TEvNodeWardenStorageConfig::TPtr ev) {
         auto *self = Self();
-        if (ev->Get()->Config->GetGeneration()) { // distconf
+        if (ev->Get()->Config->GetGeneration() || self->IsDistconfEnableQuery()) { // distconf (will be) enabled
             auto ev = std::make_unique<NStorage::TEvNodeConfigInvokeOnRoot>();
             self->FillDistconfQuery(*ev);
             self->Send(MakeBlobStorageNodeWardenID(self->SelfId().NodeId()), ev.release());

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -230,13 +230,13 @@ void TBlobStorageController::ApplyStorageConfig() {
     auto ev = std::make_unique<TEvBlobStorage::TEvControllerConfigRequest>();
     auto& r = ev->Record;
     auto *request = r.MutableRequest();
-    for (const auto& hostConfig : autoconfigSettings.GetDefineHostConfig()) {
+    for (const auto& hostConfig : bsConfig.GetDefineHostConfig()) {
         auto *cmd = request->AddCommand();
         cmd->MutableDefineHostConfig()->CopyFrom(hostConfig);
     }
     auto *cmd = request->AddCommand();
     auto *defineBox = cmd->MutableDefineBox();
-    defineBox->CopyFrom(autoconfigSettings.GetDefineBox());
+    defineBox->CopyFrom(bsConfig.GetDefineBox());
     defineBox->SetBoxId(1);
     for (auto& host : *defineBox->MutableHost()) {
         const ui32 nodeId = host.GetEnforcedNodeId();

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -289,10 +289,6 @@ message TBlobStorageConfig {
         optional bool AutomaticBoxManagement = 4; // invoke BSC DefineHostConfig/DefineBox automatically (true when unset)
         optional bool AutomaticBootstrap = 9; // whether bootstrap should be performed automatically; PROHIBITED for production
 
-        // filled in by config parser, not by user; required for automatic static group creation
-        repeated NKikimrBlobStorage.TDefineHostConfig DefineHostConfig = 5;
-        optional NKikimrBlobStorage.TDefineBox DefineBox = 6;
-
         // generation of the distconf section; when set, one can automatically apply in-filesystem config
         optional uint64 Generation = 8;
 
@@ -334,6 +330,10 @@ message TBlobStorageConfig {
     reserved 7;  // TCostMetricsSettings, moved to ICB
     optional TVDiskPerformanceSettings VDiskPerformanceSettings = 8;
     optional TVDiskBalancingConfig VDiskBalancingConfig = 9;
+
+    // filled in by config parser, not by user; required for correct distconf operation
+    repeated NKikimrBlobStorage.TDefineHostConfig DefineHostConfig = 10;
+    optional NKikimrBlobStorage.TDefineBox DefineBox = 11;
  }
 
 message TBlobStorageFormatConfig {

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/block-4-2.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/block-4-2.yaml.result.json
@@ -651,6 +651,62 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":4
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":5
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":6
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":7
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":8
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
@@ -638,6 +638,46 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"SectorMap:1:64",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"SectorMap:2:64",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"SectorMap:3:64",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes.yaml.result.json
@@ -639,6 +639,46 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-9-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-9-nodes.yaml.result.json
@@ -713,6 +713,66 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":4
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":5
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":6
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":7
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":8
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":9
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/simple.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/simple.yaml.result.json
@@ -656,6 +656,61 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/kikimr_nvme_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/kikimr_nvme_02",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/kikimr_nvme_03",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/kikimr_nvme_04",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "EnforcedNodeId":1
+              },
+              {
+                "EnforcedNodeId":2
+              },
+              {
+                "EnforcedNodeId":3
+              },
+              {
+                "EnforcedNodeId":4
+              },
+              {
+                "EnforcedNodeId":5
+              },
+              {
+                "EnforcedNodeId":6
+              },
+              {
+                "EnforcedNodeId":7
+              },
+              {
+                "EnforcedNodeId":8
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-in-memory.yaml.result.json
@@ -307,6 +307,30 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"SectorMap:1:64",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-with-file.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-with-file.yaml.result.json
@@ -307,6 +307,30 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/tmp/pdisk.data",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/block-4-2.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/block-4-2.yaml.result.json
@@ -600,6 +600,62 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":4
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":5
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":6
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":7
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":8
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/disk.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/disk.yaml.result.json
@@ -252,6 +252,30 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"ydb.data",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/drive.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/drive.yaml.result.json
@@ -252,6 +252,30 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"DRIVE_PATH_PLACEHOLDER",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-distconf.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-distconf.yaml.result.json
@@ -215,103 +215,81 @@
               1
             ]
         },
-      "AutoconfigSettings":
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
+                  "Type":"SSD"
+                }
+              ]
+          },
+          {
+            "HostConfigId":2,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
+                  "Type":"SSD"
+                }
+              ]
+          },
+          {
+            "HostConfigId":3,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
         {
-          "ErasureSpecies":"mirror-3-dc",
-          "Geometry":
-            {
-              "RealmLevelBegin":10,
-              "RealmLevelEnd":20,
-              "DomainLevelBegin":10,
-              "DomainLevelEnd":256
-            },
-          "PDiskFilter":
-            [
-              {
-                "Property":
-                  [
-                    {
-                      "Type":"SSD"
-                    }
-                  ]
-              }
-            ],
-          "DefineHostConfig":
+          "BoxId":1,
+          "Host":
             [
               {
                 "HostConfigId":1,
-                "Drive":
-                  [
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
-                      "Type":"SSD"
-                    },
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
-                      "Type":"SSD"
-                    },
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
-                      "Type":"SSD"
-                    }
-                  ]
+                "EnforcedNodeId":1
               },
               {
                 "HostConfigId":2,
-                "Drive":
-                  [
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
-                      "Type":"SSD"
-                    },
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
-                      "Type":"SSD"
-                    },
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
-                      "Type":"SSD"
-                    }
-                  ]
+                "EnforcedNodeId":2
               },
               {
                 "HostConfigId":3,
-                "Drive":
-                  [
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
-                      "Type":"SSD"
-                    },
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
-                      "Type":"SSD"
-                    },
-                    {
-                      "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
-                      "Type":"SSD"
-                    }
-                  ]
+                "EnforcedNodeId":3
               }
-            ],
-          "DefineBox":
-            {
-              "BoxId":1,
-              "Host":
-                [
-                  {
-                    "HostConfigId":1,
-                    "EnforcedNodeId":1
-                  },
-                  {
-                    "HostConfigId":2,
-                    "EnforcedNodeId":2
-                  },
-                  {
-                    "HostConfigId":3,
-                    "EnforcedNodeId":3
-                  }
-                ]
-            }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
@@ -588,6 +588,46 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"SectorMap:1:64",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"SectorMap:2:64",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"SectorMap:3:64",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes.yaml.result.json
@@ -588,6 +588,46 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_03",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-9-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-9-nodes.yaml.result.json
@@ -659,6 +659,66 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_01",
+                  "Type":"SSD"
+                },
+                {
+                  "Path":"/dev/disk/by-partlabel/ydb_disk_ssd_02",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":2
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":3
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":4
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":5
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":6
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":7
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":8
+              },
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":9
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/ram.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/ram.yaml.result.json
@@ -252,6 +252,30 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"SectorMap:1:64",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-in-memory.yaml.result.json
@@ -252,6 +252,30 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"SectorMap:1:64",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-with-file.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-with-file.yaml.result.json
@@ -252,6 +252,30 @@
             [
               1
             ]
+        },
+      "DefineHostConfig":
+        [
+          {
+            "HostConfigId":1,
+            "Drive":
+              [
+                {
+                  "Path":"/tmp/ydb.data",
+                  "Type":"SSD"
+                }
+              ]
+          }
+        ],
+      "DefineBox":
+        {
+          "BoxId":1,
+          "Host":
+            [
+              {
+                "HostConfigId":1,
+                "EnforcedNodeId":1
+              }
+            ]
         }
     },
   "ChannelProfileConfig":

--- a/ydb/library/yaml_config/yaml_config_parser_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser_ut.cpp
@@ -97,13 +97,11 @@ pdisk_key_config:
         NKikimrConfig::TAppConfig cfg = Parse(config, true);
         UNIT_ASSERT(cfg.HasBlobStorageConfig());
         auto& bsConfig = cfg.GetBlobStorageConfig();
-        UNIT_ASSERT(bsConfig.HasAutoconfigSettings());
-        auto& autoconf = bsConfig.GetAutoconfigSettings();
-        UNIT_ASSERT(autoconf.HasDefineBox());
-        UNIT_ASSERT_VALUES_EQUAL(autoconf.DefineHostConfigSize(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(autoconf.GetDefineBox().HostSize(), 2);
-        for (const auto& host : autoconf.GetDefineBox().GetHost()) {
-            UNIT_ASSERT_VALUES_EQUAL(host.GetHostConfigId(), autoconf.GetDefineHostConfig(0).GetHostConfigId());
+        UNIT_ASSERT(bsConfig.HasDefineBox());
+        UNIT_ASSERT_VALUES_EQUAL(bsConfig.DefineHostConfigSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(bsConfig.GetDefineBox().HostSize(), 2);
+        for (const auto& host : bsConfig.GetDefineBox().GetHost()) {
+            UNIT_ASSERT_VALUES_EQUAL(host.GetHostConfigId(), bsConfig.GetDefineHostConfig(0).GetHostConfigId());
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support migration from conventional config to distconf

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Distconf now can be enabled online on clusters having conventional configuration.
