### PR TITLE
Unmute stable tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -59,7 +59,6 @@ ydb/core/kqp/ut/service [*/*]+chunk+chunk
 ydb/core/mind/hive/ut THiveTest.TestHiveBalancerNodeRestarts
 ydb/core/persqueue/ut TPQTest.TestReadAndDeleteConsumer
 ydb/core/persqueue/ut [*/*] chunk chunk
-ydb/core/persqueue/ut/ut_with_sdk TopicAutoscaling.CDC_Write
 ydb/core/quoter/ut QuoterWithKesusTest.PrefetchCoefficient
 ydb/core/tx/datashard/ut_incremental_backup IncrementalBackup.ComplexRestoreBackupCollection+WithIncremental
 ydb/core/tx/schemeshard/ut_move_reboots TSchemeShardMoveRebootsTest.WithData
@@ -76,15 +75,11 @@ ydb/library/actors/http/ut sole chunk chunk
 ydb/library/actors/http/ut sole+chunk+chunk
 ydb/library/actors/interconnect/ut_huge_cluster HugeCluster.AllToAll
 ydb/library/actors/interconnect/ut_huge_cluster sole chunk chunk
-ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2_COL1_HTTP-dqrun]
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*] chunk chunk
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*]+chunk+chunk
 ydb/services/datastreams/ut DataStreams.TestPutRecordsCornerCases
-ydb/services/datastreams/ut DataStreams.TestReservedConsumersMetering
-ydb/services/datastreams/ut DataStreams.TestReservedStorageMetering
 ydb/services/keyvalue/ut sole chunk chunk
 ydb/services/keyvalue/ut sole+chunk+chunk
-ydb/services/persqueue_v1/ut TPersQueueTest.DirectReadCleanCache
 ydb/services/persqueue_v1/ut TPersQueueTest.DirectReadNotCached
 ydb/services/persqueue_v1/ut [*/*] chunk chunk
 ydb/services/persqueue_v1/ut [*/*]+chunk+chunk
@@ -115,7 +110,6 @@ ydb/tests/fq/multi_plane [test_dispatch.py]+chunk+chunk
 ydb/tests/fq/multi_plane [test_retry.py] chunk chunk
 ydb/tests/fq/multi_plane [test_retry.py]+chunk+chunk
 ydb/tests/fq/multi_plane [test_retry_high_rate.py] chunk chunk
-ydb/tests/fq/multi_plane test_retry.py.TestRetry.test_low_rate[kikimr0]
 ydb/tests/fq/s3 [test_format_setting.py] chunk chunk
 ydb/tests/fq/yds [*/*] chunk chunk
 ydb/tests/fq/yds [*/*]+chunk+chunk
@@ -135,7 +129,6 @@ ydb/tests/functional/serializable sole chunk chunk
 ydb/tests/functional/serializable test.py.test_local
 ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--false]
 ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--true]
-ydb/tests/functional/tenants test_dynamic_tenants.py.test_create_and_drop_tenants[enable_alter_database_create_hive_first--false]
 ydb/tests/functional/tenants test_dynamic_tenants.py.test_create_and_drop_the_same_tenant2[enable_alter_database_create_hive_first--false]
 ydb/tests/functional/tenants test_dynamic_tenants.py.test_create_and_drop_the_same_tenant2[enable_alter_database_create_hive_first--true]
 ydb/tests/functional/tenants test_tenants.py.TestTenants.test_create_drop_create_table3[enable_alter_database_create_hive_first--false]

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -75,6 +75,7 @@ ydb/library/actors/http/ut sole chunk chunk
 ydb/library/actors/http/ut sole+chunk+chunk
 ydb/library/actors/interconnect/ut_huge_cluster HugeCluster.AllToAll
 ydb/library/actors/interconnect/ut_huge_cluster sole chunk chunk
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2_COL1_HTTP-dqrun]
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*] chunk chunk
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*]+chunk+chunk
 ydb/services/datastreams/ut DataStreams.TestPutRecordsCornerCases


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

**Unmuted stable 5**

ydb/services/datastreams/ut DataStreams.TestReservedConsumersMetering # owner TEAM:@ydb-platform/Topics success_rate 100%, state Muted Stable days in state 17
ydb/services/datastreams/ut DataStreams.TestReservedStorageMetering # owner TEAM:@ydb-platform/Topics success_rate 100%, state Muted Stable days in state 17
ydb/services/persqueue_v1/ut TPersQueueTest.DirectReadCleanCache # owner TEAM:@ydb-platform/Topics success_rate 100%, state Muted Stable days in state 14
ydb/tests/fq/multi_plane test_retry.py.TestRetry.test_low_rate[kikimr0] # owner TEAM:@ydb-platform/fq success_rate 100%, state Muted Stable days in state 17
ydb/tests/functional/tenants test_dynamic_tenants.py.test_create_and_drop_tenants[enable_alter_database_create_hive_first--false] # owner TEAM:@ydb-platform/system-infra success_rate 100%, state Muted Stable days in state 17

**Deleted 1**
ydb/core/persqueue/ut/ut_with_sdk TopicAutoscaling.CDC_Write # owner TEAM:@ydb-platform/Topics success_rate 0%, state no_runs days in state 17



### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
