### PR TITLE
update followers in 24-3

### DIFF
--- a/ydb/core/mind/hive/data_center_info.h
+++ b/ydb/core/mind/hive/data_center_info.h
@@ -1,0 +1,21 @@
+#include "hive.h"
+#include "hive_events.h"
+
+namespace NKikimr {
+namespace NHive {
+
+struct TDataCenterInfo {
+    using TFullFollowerGroupId = std::pair<TTabletId, TFollowerGroupId>;
+    using TFollowerIter = TList<TFollowerTabletInfo>::iterator; // list iterators are not invalidated
+
+    std::unordered_set<TNodeId> RegisteredNodes;
+    bool UpdateScheduled = false;
+    std::unordered_map<TFullFollowerGroupId, std::vector<TFollowerIter>> Followers;
+
+    bool IsRegistered() const {
+        return !RegisteredNodes.empty();
+    }
+};
+
+} // NHive
+} // NKikimr

--- a/ydb/core/mind/hive/follower_group.h
+++ b/ydb/core/mind/hive/follower_group.h
@@ -67,6 +67,17 @@ struct TFollowerGroup {
         }
     }
 
+    ui32 GetFollowerCountForDataCenter(const TDataCenterId& dc) const {
+        if (!FollowerCountPerDataCenter) {
+            return 0;
+        }
+        if (NodeFilter.IsAllowedDataCenter(dc)) {
+            return FollowerCount;
+        } else {
+            return 0;
+        }
+    }
+
     void SetFollowerCount(ui32 followerCount) {
         FollowerCount = followerCount;
     }

--- a/ydb/core/mind/hive/hive.cpp
+++ b/ydb/core/mind/hive/hive.cpp
@@ -82,11 +82,11 @@ NMetrics::EResource GetDominantResourceType(const TResourceNormalizedValues& nor
 }
 
 TNodeFilter::TNodeFilter(const THive& hive)
-    : Hive(hive)
+    : Hive(&hive)
 {}
 
 TArrayRef<const TSubDomainKey> TNodeFilter::GetEffectiveAllowedDomains() const {
-    const auto* objectDomainInfo = Hive.FindDomain(ObjectDomain);
+    const auto* objectDomainInfo = Hive->FindDomain(ObjectDomain);
 
     if (!objectDomainInfo) {
         return {AllowedDomains.begin(), AllowedDomains.end()};
@@ -98,6 +98,13 @@ TArrayRef<const TSubDomainKey> TNodeFilter::GetEffectiveAllowedDomains() const {
         case ENodeSelectionPolicy::PreferObjectDomain:
             return {&ObjectDomain, 1};
     }
+}
+
+bool TNodeFilter::IsAllowedDataCenter(TDataCenterId dc) const {
+    if (AllowedDataCenters.empty()) {
+        return true;
+    }
+    return std::find(AllowedDataCenters.begin(), AllowedDataCenters.end(), dc) != AllowedDataCenters.end();
 }
 
 template <typename K, typename V>

--- a/ydb/core/mind/hive/hive.h
+++ b/ydb/core/mind/hive/hive.h
@@ -323,11 +323,13 @@ struct TNodeFilter {
     TSubDomainKey ObjectDomain;
     TTabletTypes::EType TabletType = TTabletTypes::TypeInvalid;
 
-    const THive& Hive;
+    const THive* Hive;
 
     explicit TNodeFilter(const THive& hive);
 
     TArrayRef<const TSubDomainKey> GetEffectiveAllowedDomains() const;
+
+    bool IsAllowedDataCenter(TDataCenterId dc) const;
 };
 
 } // NHive

--- a/ydb/core/mind/hive/hive.h
+++ b/ydb/core/mind/hive/hive.h
@@ -332,6 +332,46 @@ struct TNodeFilter {
     bool IsAllowedDataCenter(TDataCenterId dc) const;
 };
 
+struct TFollowerUpdates {
+    enum class EAction {
+        Create,
+        Update,
+        Delete,
+    };
+
+    struct TUpdate {
+        EAction Action;
+        TFullTabletId TabletId;
+        TFollowerGroupId GroupId;
+        TDataCenterId DataCenter;
+    };
+
+    std::deque<TUpdate> Updates;
+
+    bool Empty() const {
+        return Updates.empty();
+    }
+
+    void Create(TFullTabletId leaderTablet, TFollowerGroupId group, TDataCenterId dc) {
+        Updates.emplace_back(EAction::Create, leaderTablet, group, dc);
+    }
+
+    void Update(TFullTabletId tablet, TDataCenterId dc) {
+        Updates.emplace_back(EAction::Update, tablet, 0, dc);
+    }
+
+    void Delete(TFullTabletId tablet, TFollowerGroupId group, TDataCenterId dc) {
+        Updates.emplace_back(EAction::Delete, tablet, group, dc);
+    }
+
+    TUpdate Pop() {
+        TUpdate update = Updates.front();
+        Updates.pop_front();
+        return update;
+    }
+};
+
+
 } // NHive
 } // NKikimr
 

--- a/ydb/core/mind/hive/hive_events.h
+++ b/ydb/core/mind/hive/hive_events.h
@@ -35,6 +35,7 @@ struct TEvPrivate {
         EvCanMoveTablets,
         EvRefreshScaleRecommendation,
         EvUpdateDataCenterFollowers,
+        EvUpdateFollowers,
         EvEnd
     };
 
@@ -129,6 +130,9 @@ struct TEvPrivate {
         TDataCenterId DataCenter;
 
         TEvUpdateDataCenterFollowers(TDataCenterId dataCenter) : DataCenter(dataCenter) {};
+    };
+
+    struct TEvUpdateFollowers : TEventLocal<TEvUpdateFollowers, EvUpdateFollowers> {
     };
 };
 

--- a/ydb/core/mind/hive/hive_events.h
+++ b/ydb/core/mind/hive/hive_events.h
@@ -34,6 +34,7 @@ struct TEvPrivate {
         EvDeleteNode,
         EvCanMoveTablets,
         EvRefreshScaleRecommendation,
+        EvUpdateDataCenterFollowers,
         EvEnd
     };
 
@@ -123,6 +124,12 @@ struct TEvPrivate {
     struct TEvCanMoveTablets : TEventLocal<TEvCanMoveTablets, EvCanMoveTablets> {};
 
     struct TEvRefreshScaleRecommendation : TEventLocal<TEvRefreshScaleRecommendation, EvRefreshScaleRecommendation> {};
+
+    struct TEvUpdateDataCenterFollowers : TEventLocal<TEvUpdateDataCenterFollowers, EvUpdateDataCenterFollowers> {
+        TDataCenterId DataCenter;
+
+        TEvUpdateDataCenterFollowers(TDataCenterId dataCenter) : DataCenter(dataCenter) {};
+    };
 };
 
 } // NHive

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -3044,13 +3044,10 @@ void THive::ProcessEvent(std::unique_ptr<IEventHandle> event) {
         hFunc(TEvHive::TEvUpdateDomain, Handle);
         hFunc(TEvPrivate::TEvDeleteNode, Handle);
         hFunc(TEvHive::TEvRequestTabletDistribution, Handle);
-<<<<<<< HEAD
         hFunc(TEvHive::TEvRequestScaleRecommendation, Handle);
         hFunc(TEvPrivate::TEvRefreshScaleRecommendation, Handle);
         hFunc(TEvHive::TEvConfigureScaleRecommender, Handle);
-=======
         hFunc(TEvPrivate::TEvUpdateDataCenterFollowers, Handle);
->>>>>>> 093fd1f56c1... actually tie per-dc-followers to dc (#8069)
     }
 }
 
@@ -3153,13 +3150,10 @@ STFUNC(THive::StateWork) {
         fFunc(TEvPrivate::TEvProcessStorageBalancer::EventType, EnqueueIncomingEvent);
         fFunc(TEvPrivate::TEvDeleteNode::EventType, EnqueueIncomingEvent);
         fFunc(TEvHive::TEvRequestTabletDistribution::EventType, EnqueueIncomingEvent);
-<<<<<<< HEAD
         fFunc(TEvHive::TEvRequestScaleRecommendation::EventType, EnqueueIncomingEvent);
         fFunc(TEvPrivate::TEvRefreshScaleRecommendation::EventType, EnqueueIncomingEvent);
         fFunc(TEvHive::TEvConfigureScaleRecommender::EventType, EnqueueIncomingEvent);
-=======
         fFunc(TEvPrivate::TEvUpdateDataCenterFollowers::EventType, EnqueueIncomingEvent);
->>>>>>> 093fd1f56c1... actually tie per-dc-followers to dc (#8069)
         hFunc(TEvPrivate::TEvProcessIncomingEvent, Handle);
     default:
         if (!HandleDefaultEvents(ev, SelfId())) {
@@ -3460,7 +3454,6 @@ void THive::Handle(TEvHive::TEvRequestTabletDistribution::TPtr& ev) {
     Send(ev->Sender, response.release());
 }
 
-<<<<<<< HEAD
 void THive::MakeScaleRecommendation() {
     BLOG_D("[MSR] Started");
     
@@ -3583,10 +3576,10 @@ void THive::Handle(TEvHive::TEvRequestScaleRecommendation::TPtr& ev) {
 void THive::Handle(TEvHive::TEvConfigureScaleRecommender::TPtr& ev) {
     BLOG_D("Handle TEvHive::TEvConfigureScaleRecommender(" << ev->Get()->Record.ShortDebugString() << ")");
     Execute(CreateConfigureScaleRecommender(ev));
-=======
+}
+
 void THive::Handle(TEvPrivate::TEvUpdateDataCenterFollowers::TPtr& ev) {
     Execute(CreateUpdateDcFollowers(ev->Get()->DataCenter));
->>>>>>> 093fd1f56c1... actually tie per-dc-followers to dc (#8069)
 }
 
 TVector<TNodeId> THive::GetNodesForWhiteboardBroadcast(size_t maxNodesToReturn) {

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -1595,6 +1595,11 @@ void THive::DeleteTablet(TTabletId tabletId) {
             }
             Y_ENSURE_LOG(nt->second.LockedTablets.count(&tablet) == 0, " Deleting tablet found on node " << nt->first << " in locked set");
         }
+        for (const auto& followerGroup : tablet.FollowerGroups) {
+            for (auto& [_, dataCenter] : DataCenters) {
+                dataCenter.Followers.erase({tabletId, followerGroup.Id});
+            }
+        }
         const i64 tabletsTotalDiff = -1 - (tablet.Followers.size());
         UpdateCounterTabletsTotal(tabletsTotalDiff);
         UpdateDomainTabletsTotal(tablet.ObjectDomain, tabletsTotalDiff);

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -209,7 +209,7 @@ TInstant THive::GetAllowedBootingTime() {
     return result;
 }
 
-void THive::ExecuteProcessBootQueue(NIceDb::TNiceDb& db, TSideEffects& sideEffects) {
+void THive::ExecuteProcessBootQueue(NIceDb::TNiceDb&, TSideEffects& sideEffects) {
     TInstant now = TActivationContext::Now();
     if (WarmUp) {
         TInstant allowed = GetAllowedBootingTime();
@@ -261,10 +261,6 @@ void THive::ExecuteProcessBootQueue(NIceDb::TNiceDb& db, TSideEffects& sideEffec
                     }
                     tablet->ActorsToNotifyOnRestart.clear();
                     tablet->InWaitQueue = true;
-                    if (tablet->IsFollower()) {
-                        TLeaderTabletInfo& leader = tablet->GetLeader();
-                        UpdateTabletFollowersNumber(leader, db, sideEffects); // this may delete tablet
-                    }
                     BootQueue.AddToWaitQueue(record); // waiting for new node
                     continue;
                 }
@@ -778,16 +774,11 @@ void THive::Handle(TEvInterconnect::TEvNodeInfo::TPtr &ev) {
 }
 
 void THive::Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev) {
-    THashSet<TDataCenterId> dataCenters;
     for (const TEvInterconnect::TNodeInfo& node : ev->Get()->Nodes) {
         NodesInfo[node.NodeId] = node;
-        dataCenters.insert(node.Location.GetDataCenterId());
-    }
-    dataCenters.erase(0); // remove default data center id if exists
-    if (!dataCenters.empty()) {
-        if (DataCenters != dataCenters.size()) {
-            DataCenters = dataCenters.size();
-            BLOG_D("TEvInterconnect::TEvNodesInfo DataCenters=" << DataCenters << " RegisteredDataCenters=" << RegisteredDataCenters);
+        auto dataCenterId = node.Location.GetDataCenterId();
+        if (dataCenterId != 0) {
+            DataCenters[dataCenterId]; // just create entry in hash map
         }
     }
     Execute(CreateLoadEverything());
@@ -2733,81 +2724,97 @@ void THive::SendReconnect(const TActorId& local) {
 }
 
 ui32 THive::GetDataCenters() {
-    return DataCenters ? DataCenters : 1;
-}
-
-ui32 THive::GetRegisteredDataCenters() {
-    return RegisteredDataCenters ? RegisteredDataCenters : 1;
-}
-
-void THive::UpdateRegisteredDataCenters() {
-    if (RegisteredDataCenters != RegisteredDataCenterNodes.size()) {
-        BLOG_D("THive (UpdateRegisteredDC) DataCenters=" << DataCenters << " RegisteredDataCenters=" << RegisteredDataCenters << "->" << RegisteredDataCenterNodes.size());
-        RegisteredDataCenters = RegisteredDataCenterNodes.size();
-    }
+    return DataCenters.size() ? DataCenters.size() : 1;
 }
 
 void THive::AddRegisteredDataCentersNode(TDataCenterId dataCenterId, TNodeId nodeId) {
+    BLOG_D("AddRegisteredDataCentersNode(" << dataCenterId << ", " << nodeId << ")");
     if (dataCenterId != 0) { // ignore default data center id if exists
-        if (RegisteredDataCenterNodes[dataCenterId].insert(nodeId).second) {
-            if (RegisteredDataCenters != RegisteredDataCenterNodes.size()) {
-                UpdateRegisteredDataCenters();
-            }
+        auto& dataCenter = DataCenters[dataCenterId];
+        bool wasRegistered = dataCenter.IsRegistered();
+        dataCenter.RegisteredNodes.insert(nodeId);
+        if (!wasRegistered && !dataCenter.UpdateScheduled) {
+            dataCenter.UpdateScheduled = true;
+            Schedule(TDuration::Seconds(1), new TEvPrivate::TEvUpdateDataCenterFollowers(dataCenterId));
         }
     }
 }
 
 void THive::RemoveRegisteredDataCentersNode(TDataCenterId dataCenterId, TNodeId nodeId) {
+    BLOG_D("RemoveRegisteredDataCentersNode(" << dataCenterId << ", " << nodeId << ")");
     if (dataCenterId != 0) { // ignore default data center id if exists
-        RegisteredDataCenterNodes[dataCenterId].erase(nodeId);
-        if (RegisteredDataCenterNodes[dataCenterId].size() == 0) {
-            RegisteredDataCenterNodes.erase(dataCenterId);
-        }
-        if (RegisteredDataCenters != RegisteredDataCenterNodes.size()) {
-            UpdateRegisteredDataCenters();
+        auto& dataCenter = DataCenters[dataCenterId];
+        bool wasRegistered = dataCenter.IsRegistered();
+        dataCenter.RegisteredNodes.erase(nodeId);
+        if (wasRegistered && !dataCenter.IsRegistered() && !dataCenter.UpdateScheduled) {
+            dataCenter.UpdateScheduled = true;
+            Schedule(TDuration::Seconds(1), new TEvPrivate::TEvUpdateDataCenterFollowers(dataCenterId));
         }
     }
 }
 
-void THive::UpdateTabletFollowersNumber(TLeaderTabletInfo& tablet, NIceDb::TNiceDb& db, TSideEffects& sideEffects) {
-    BLOG_D("UpdateTabletFollowersNumber Tablet " << tablet.ToString() << " RegisteredDataCenters=" << GetRegisteredDataCenters());
+void THive::CreateTabletFollowers(TLeaderTabletInfo& tablet, NIceDb::TNiceDb& db, TSideEffects& sideEffects) {
+    BLOG_D("CreateTabletFollowers Tablet " << tablet.ToString());
+
+    // In case tablet already has followers (happens if tablet is modified through CreateTablet), delete them
+    // But create new ones before deleting old ones, to avoid issues with reusing ids
+    decltype(tablet.Followers)::iterator oldFollowersIt;
+    if (tablet.Followers.empty()) {
+        oldFollowersIt = tablet.Followers.end();
+    } else {
+        oldFollowersIt = std::prev(tablet.Followers.end());
+    }
+
     for (TFollowerGroup& group : tablet.FollowerGroups) {
-        ui32 followerCount = tablet.GetActualFollowerCount(group.Id);
-        ui32 requiredFollowerCount = group.GetComputedFollowerCount(GetRegisteredDataCenters());
-
-        while (followerCount < requiredFollowerCount) {
-            BLOG_D("UpdateTabletFollowersNumber Tablet " << tablet.ToString() << " is increasing number of followers (" << followerCount << "<" << requiredFollowerCount << ")");
-
-            TFollowerTabletInfo& follower = tablet.AddFollower(group);
-            follower.Statistics.SetLastAliveTimestamp(TlsActivationContext->Now().MilliSeconds());
-            db.Table<Schema::TabletFollowerTablet>().Key(tablet.Id, follower.Id).Update(
-                        NIceDb::TUpdate<Schema::TabletFollowerTablet::GroupID>(follower.FollowerGroup.Id),
-                        NIceDb::TUpdate<Schema::TabletFollowerTablet::FollowerNode>(0),
-                        NIceDb::TUpdate<Schema::TabletFollowerTablet::Statistics>(follower.Statistics));
-            follower.InitTabletMetrics();
-            follower.BecomeStopped();
-            ++followerCount;
-        }
-
-        while (followerCount > requiredFollowerCount) {
-            BLOG_D("UpdateTabletFollowersNumber Tablet " << tablet.ToString() << " is decreasing number of followers (" << followerCount << ">" << requiredFollowerCount << ")");
-
-            auto itFollower = tablet.Followers.rbegin();
-            while (itFollower != tablet.Followers.rend() && itFollower->FollowerGroup.Id != group.Id) {
-                ++itFollower;
+        if (group.FollowerCountPerDataCenter) {
+            for (auto& [dataCenterId, dataCenter] : DataCenters) {
+                if (!dataCenter.IsRegistered()) {
+                    continue;
+                }
+                for (ui32 i = 0; i < group.GetFollowerCountForDataCenter(dataCenterId); ++i) {
+                    TFollowerTabletInfo& follower = tablet.AddFollower(group);
+                    follower.NodeFilter.AllowedDataCenters = {dataCenterId};
+                    follower.Statistics.SetLastAliveTimestamp(TlsActivationContext->Now().MilliSeconds());
+                    db.Table<Schema::TabletFollowerTablet>().Key(tablet.Id, follower.Id).Update(
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::GroupID>(follower.FollowerGroup.Id),
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::FollowerNode>(0),
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::Statistics>(follower.Statistics),
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::DataCenter>(dataCenterId));
+                    follower.InitTabletMetrics();
+                    follower.BecomeStopped();
+                    dataCenter.Followers[{tablet.Id, group.Id}].push_back(std::prev(tablet.Followers.end()));
+                    BLOG_D("Created follower " << follower.GetFullTabletId() << " for dc " << dataCenterId);
+                }
             }
-            if (itFollower == tablet.Followers.rend()) {
-                break;
+        } else {
+            for (ui32 i = 0; i < group.GetRawFollowerCount(); ++i) {
+                TFollowerTabletInfo& follower = tablet.AddFollower(group);
+                follower.Statistics.SetLastAliveTimestamp(TlsActivationContext->Now().MilliSeconds());
+                db.Table<Schema::TabletFollowerTablet>().Key(tablet.Id, follower.Id).Update(
+                            NIceDb::TUpdate<Schema::TabletFollowerTablet::GroupID>(follower.FollowerGroup.Id),
+                            NIceDb::TUpdate<Schema::TabletFollowerTablet::FollowerNode>(0),
+                            NIceDb::TUpdate<Schema::TabletFollowerTablet::Statistics>(follower.Statistics));
+                follower.InitTabletMetrics();
+                follower.BecomeStopped();
+                BLOG_D("Created follower " << follower.GetFullTabletId());
             }
-            TFollowerTabletInfo& follower = *itFollower;
-            db.Table<Schema::TabletFollowerTablet>().Key(tablet.Id, follower.Id).Delete();
-            db.Table<Schema::Metrics>().Key(tablet.Id, follower.Id).Delete();
-            follower.InitiateStop(sideEffects);
-            tablet.Followers.erase(std::prev(itFollower.base()));
-            UpdateCounterTabletsTotal(-1);
-            --followerCount;
+
         }
     }
+
+    if (oldFollowersIt == tablet.Followers.end()) {
+        return;
+    }
+    auto endIt = std::next(oldFollowersIt);
+    for (auto followerIt = tablet.Followers.begin(); followerIt != endIt; ++followerIt) {
+        TFollowerTabletInfo& follower = *followerIt;
+        BLOG_D("Deleting follower " << follower.GetFullTabletId());
+        db.Table<Schema::TabletFollowerTablet>().Key(tablet.Id, follower.Id).Delete();
+        db.Table<Schema::Metrics>().Key(tablet.Id, follower.Id).Delete();
+        follower.InitiateStop(sideEffects);
+        UpdateCounterTabletsTotal(-1);
+    }
+    tablet.Followers.erase(tablet.Followers.begin(), endIt);
 }
 
 TDuration THive::GetBalancerCooldown(EBalancerType balancerType) const {
@@ -3032,9 +3039,13 @@ void THive::ProcessEvent(std::unique_ptr<IEventHandle> event) {
         hFunc(TEvHive::TEvUpdateDomain, Handle);
         hFunc(TEvPrivate::TEvDeleteNode, Handle);
         hFunc(TEvHive::TEvRequestTabletDistribution, Handle);
+<<<<<<< HEAD
         hFunc(TEvHive::TEvRequestScaleRecommendation, Handle);
         hFunc(TEvPrivate::TEvRefreshScaleRecommendation, Handle);
         hFunc(TEvHive::TEvConfigureScaleRecommender, Handle);
+=======
+        hFunc(TEvPrivate::TEvUpdateDataCenterFollowers, Handle);
+>>>>>>> 093fd1f56c1... actually tie per-dc-followers to dc (#8069)
     }
 }
 
@@ -3137,9 +3148,13 @@ STFUNC(THive::StateWork) {
         fFunc(TEvPrivate::TEvProcessStorageBalancer::EventType, EnqueueIncomingEvent);
         fFunc(TEvPrivate::TEvDeleteNode::EventType, EnqueueIncomingEvent);
         fFunc(TEvHive::TEvRequestTabletDistribution::EventType, EnqueueIncomingEvent);
+<<<<<<< HEAD
         fFunc(TEvHive::TEvRequestScaleRecommendation::EventType, EnqueueIncomingEvent);
         fFunc(TEvPrivate::TEvRefreshScaleRecommendation::EventType, EnqueueIncomingEvent);
         fFunc(TEvHive::TEvConfigureScaleRecommender::EventType, EnqueueIncomingEvent);
+=======
+        fFunc(TEvPrivate::TEvUpdateDataCenterFollowers::EventType, EnqueueIncomingEvent);
+>>>>>>> 093fd1f56c1... actually tie per-dc-followers to dc (#8069)
         hFunc(TEvPrivate::TEvProcessIncomingEvent, Handle);
     default:
         if (!HandleDefaultEvents(ev, SelfId())) {
@@ -3440,6 +3455,7 @@ void THive::Handle(TEvHive::TEvRequestTabletDistribution::TPtr& ev) {
     Send(ev->Sender, response.release());
 }
 
+<<<<<<< HEAD
 void THive::MakeScaleRecommendation() {
     BLOG_D("[MSR] Started");
     
@@ -3562,6 +3578,10 @@ void THive::Handle(TEvHive::TEvRequestScaleRecommendation::TPtr& ev) {
 void THive::Handle(TEvHive::TEvConfigureScaleRecommender::TPtr& ev) {
     BLOG_D("Handle TEvHive::TEvConfigureScaleRecommender(" << ev->Get()->Record.ShortDebugString() << ")");
     Execute(CreateConfigureScaleRecommender(ev));
+=======
+void THive::Handle(TEvPrivate::TEvUpdateDataCenterFollowers::TPtr& ev) {
+    Execute(CreateUpdateDcFollowers(ev->Get()->DataCenter));
+>>>>>>> 093fd1f56c1... actually tie per-dc-followers to dc (#8069)
 }
 
 TVector<TNodeId> THive::GetNodesForWhiteboardBroadcast(size_t maxNodesToReturn) {

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -3048,6 +3048,7 @@ void THive::ProcessEvent(std::unique_ptr<IEventHandle> event) {
         hFunc(TEvPrivate::TEvRefreshScaleRecommendation, Handle);
         hFunc(TEvHive::TEvConfigureScaleRecommender, Handle);
         hFunc(TEvPrivate::TEvUpdateDataCenterFollowers, Handle);
+        hFunc(TEvPrivate::TEvUpdateFollowers, Handle);
     }
 }
 
@@ -3154,6 +3155,7 @@ STFUNC(THive::StateWork) {
         fFunc(TEvPrivate::TEvRefreshScaleRecommendation::EventType, EnqueueIncomingEvent);
         fFunc(TEvHive::TEvConfigureScaleRecommender::EventType, EnqueueIncomingEvent);
         fFunc(TEvPrivate::TEvUpdateDataCenterFollowers::EventType, EnqueueIncomingEvent);
+        fFunc(TEvPrivate::TEvUpdateFollowers::EventType, EnqueueIncomingEvent);
         hFunc(TEvPrivate::TEvProcessIncomingEvent, Handle);
     default:
         if (!HandleDefaultEvents(ev, SelfId())) {
@@ -3454,6 +3456,43 @@ void THive::Handle(TEvHive::TEvRequestTabletDistribution::TPtr& ev) {
     Send(ev->Sender, response.release());
 }
 
+void THive::Handle(TEvPrivate::TEvUpdateDataCenterFollowers::TPtr& ev) {
+    auto dataCenterId = ev->Get()->DataCenter;
+    auto& dataCenter = DataCenters[dataCenterId];
+    if (!dataCenter.UpdateScheduled) {
+        return;
+    }
+    dataCenter.UpdateScheduled = false;
+    if (dataCenter.IsRegistered()) {
+        for (auto& [tabletId, tablet] : Tablets) {
+            for (auto& group : tablet.FollowerGroups) {
+                auto& followers = dataCenter.Followers[{tabletId, group.Id}];
+                i64 neededCount = group.GetFollowerCountForDataCenter(dataCenterId);
+                i64 delta = neededCount - std::ssize(followers);
+                for (i64 i = 0; i < delta; ++i) {
+                    BLOG_TRACE("UpdateDataCenterFollowers: Pending create follower for " << tabletId);
+                    PendingFollowerUpdates.Create(tablet.GetFullTabletId(), group.Id, dataCenterId);
+                }
+            }
+        }
+    } else {
+        for (auto& [group, followers] : dataCenter.Followers) {
+            for (auto follower : followers) {
+                BLOG_TRACE("UpdateDataCenterFollowers: Pending delete follower for " << follower->GetFullTabletId());
+                PendingFollowerUpdates.Delete(follower->GetFullTabletId(), group.second, dataCenterId);
+            }
+        }
+    }
+    if (!PendingFollowerUpdates.Empty() && !ProcessFollowerUpdatesScheduled) {
+        Send(SelfId(), new TEvPrivate::TEvUpdateFollowers);
+        ProcessFollowerUpdatesScheduled = true;
+    }
+}
+
+void THive::Handle(TEvPrivate::TEvUpdateFollowers::TPtr&) {
+    Execute(CreateProcessUpdateFollowers());
+}
+
 void THive::MakeScaleRecommendation() {
     BLOG_D("[MSR] Started");
     
@@ -3576,10 +3615,6 @@ void THive::Handle(TEvHive::TEvRequestScaleRecommendation::TPtr& ev) {
 void THive::Handle(TEvHive::TEvConfigureScaleRecommender::TPtr& ev) {
     BLOG_D("Handle TEvHive::TEvConfigureScaleRecommender(" << ev->Get()->Record.ShortDebugString() << ")");
     Execute(CreateConfigureScaleRecommender(ev));
-}
-
-void THive::Handle(TEvPrivate::TEvUpdateDataCenterFollowers::TPtr& ev) {
-    Execute(CreateUpdateDcFollowers(ev->Get()->DataCenter));
 }
 
 TVector<TNodeId> THive::GetNodesForWhiteboardBroadcast(size_t maxNodesToReturn) {

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -577,13 +577,10 @@ protected:
     void Handle(TEvHive::TEvUpdateDomain::TPtr& ev);
     void Handle(TEvPrivate::TEvDeleteNode::TPtr& ev);
     void Handle(TEvHive::TEvRequestTabletDistribution::TPtr& ev);
-<<<<<<< HEAD
     void Handle(TEvHive::TEvRequestScaleRecommendation::TPtr& ev);
     void Handle(TEvPrivate::TEvRefreshScaleRecommendation::TPtr& ev);
     void Handle(TEvHive::TEvConfigureScaleRecommender::TPtr& ev);
-=======
     void Handle(TEvPrivate::TEvUpdateDataCenterFollowers::TPtr& ev);
->>>>>>> 093fd1f56c1... actually tie per-dc-followers to dc (#8069)
 
 protected:
     void RestartPipeTx(ui64 tabletId);

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -240,7 +240,7 @@ protected:
     friend class TTxUpdateTabletGroups;
     friend class TTxMonEvent_TabletAvailability;
     friend class TLoggedMonTransaction;
-    friend class TTxUpdateDcFollowers;
+    friend class TTxProcessUpdateFollowers;
 
     friend class TDeleteTabletActor;
 
@@ -303,6 +303,7 @@ protected:
     ITransaction* CreateRequestTabletOwners(TEvHive::TEvRequestTabletOwners::TPtr event);
     ITransaction* CreateUpdateTabletsObject(TEvHive::TEvUpdateTabletsObject::TPtr event);
     ITransaction* CreateUpdateDomain(TSubDomainKey subdomainKey, TEvHive::TEvUpdateDomain::TPtr event = {});
+    ITransaction* CreateProcessUpdateFollowers();
     ITransaction* CreateDeleteNode(TNodeId nodeId);
     ITransaction* CreateConfigureScaleRecommender(TEvHive::TEvConfigureScaleRecommender::TPtr event);
     ITransaction* CreateUpdateDcFollowers(const TDataCenterId& dc);
@@ -403,6 +404,7 @@ protected:
     bool ProcessPendingOperationsScheduled = false;
     bool LogTabletMovesScheduled = false;
     bool ProcessStorageBalancerScheduled = false;
+    bool ProcessFollowerUpdatesScheduled = false;
     TResourceRawValues TotalRawResourceValues = {};
     TResourceNormalizedValues TotalNormalizedResourceValues = {};
     TInstant LastResourceChangeReaction;
@@ -420,6 +422,7 @@ protected:
     std::vector<TActorId> ActorsWaitingToMoveTablets;
     std::queue<TActorId> NodePingQueue;
     std::unordered_set<TNodeId> NodePingsInProgress;
+    TFollowerUpdates PendingFollowerUpdates;
 
     struct TPendingCreateTablet {
         NKikimrHive::TEvCreateTablet CreateTablet;
@@ -581,6 +584,7 @@ protected:
     void Handle(TEvPrivate::TEvRefreshScaleRecommendation::TPtr& ev);
     void Handle(TEvHive::TEvConfigureScaleRecommender::TPtr& ev);
     void Handle(TEvPrivate::TEvUpdateDataCenterFollowers::TPtr& ev);
+    void Handle(TEvPrivate::TEvUpdateFollowers::TPtr& ev);
 
 protected:
     void RestartPipeTx(ui64 tabletId);

--- a/ydb/core/mind/hive/hive_schema.h
+++ b/ydb/core/mind/hive/hive_schema.h
@@ -151,9 +151,10 @@ struct Schema : NIceDb::Schema {
         struct GroupID : Column<3, Schema::TabletFollowerGroup::GroupID::ColumnType> {};
         struct FollowerNode : Column<4, NScheme::NTypeIds::Uint32> {};
         struct Statistics : Column<5, NScheme::NTypeIds::String> { using Type = NKikimrHive::TTabletStatistics; };
+        struct DataCenter : Column<6, NScheme::NTypeIds::String> {};
 
         using TKey = TableKey<TabletID, FollowerID>;
-        using TColumns = TableColumns<TabletID, GroupID, FollowerID, FollowerNode, Statistics>;
+        using TColumns = TableColumns<TabletID, GroupID, FollowerID, FollowerNode, Statistics, DataCenter>;
     };
 
     struct TabletChannel : Table<2> {

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -3683,6 +3683,13 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         const TActorId hiveActor = CreateTestBootstrapper(runtime, CreateTestTabletInfo(hiveTablet, TTabletTypes::Hive), &CreateDefaultHive);
         runtime.EnableScheduleForActor(hiveActor);
 
+        // wait for creation of nodes
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvStatus, 2);
+            runtime.DispatchEvents(options);
+        }
+
 
         // creating NUM_TABLETS tablets
         TTabletTypes::EType tabletType = TTabletTypes::Dummy;
@@ -3720,7 +3727,13 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         CreateLocal(runtime, 2);
         CreateLocal(runtime, 3);
 
-        // kill all tablets
+        // no need to kill all tablets, hive must update followers on its own
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvTabletStatus);
+            runtime.DispatchEvents(options);
+        }
+        /*
         for (ui64 tabletId : tablets) {
             runtime.Register(CreateTabletKiller(tabletId));
 
@@ -3729,7 +3742,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
              // leader (death, start) + new extra follower
             options.FinalEvents.emplace_back(TDispatchOptions::TFinalEventCondition(TEvLocal::EvTabletStatus, 3));
             runtime.DispatchEvents(options);
-        }
+        }*/
 
         {
             int leaders = 0;
@@ -3755,7 +3768,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
         CreateLocal(runtime, 4);
         CreateLocal(runtime, 5);
 
-        // kill all tablets
+        /*
         for (ui64 tabletId : tablets) {
             runtime.Register(CreateTabletKiller(tabletId));
 
@@ -3763,6 +3776,12 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             TDispatchOptions options;
              // leader (death, start) + new extra follower
             options.FinalEvents.emplace_back(TDispatchOptions::TFinalEventCondition(TEvLocal::EvTabletStatus, 3));
+            runtime.DispatchEvents(options);
+        }
+        */
+        {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvLocal::EvTabletStatus);
             runtime.DispatchEvents(options);
         }
 

--- a/ydb/core/mind/hive/leader_tablet_info.cpp
+++ b/ydb/core/mind/hive/leader_tablet_info.cpp
@@ -144,6 +144,7 @@ TFollowerTabletInfo& TLeaderTabletInfo::AddFollower(TFollowerGroup& followerGrou
     } else {
         follower.Id = followerId;
     }
+    follower.NodeFilter = followerGroup.NodeFilter;
     Hive.UpdateCounterTabletsTotal(+1);
     Hive.UpdateDomainTabletsTotal(ObjectDomain, +1);
     return follower;

--- a/ydb/core/mind/hive/leader_tablet_info.h
+++ b/ydb/core/mind/hive/leader_tablet_info.h
@@ -66,7 +66,6 @@ public:
     TTabletTypes::EType Type;
     TFullObjectId ObjectId;
     TSubDomainKey ObjectDomain;
-    TNodeFilter NodeFilter;
     NKikimrHive::TDataCentersPreference DataCentersPreference;
     TIntrusivePtr<TTabletStorageInfo> TabletStorageInfo;
     TChannelsBindings BoundChannels;
@@ -94,7 +93,6 @@ public:
         , State(ETabletState::Unknown)
         , Type(TTabletTypes::TypeInvalid)
         , ObjectId(0, 0)
-        , NodeFilter(hive)
         , ChannelProfileReassignReason(NKikimrHive::TEvReassignTablet::HIVE_REASSIGN_REASON_NO)
         , KnownGeneration(0)
         , Category(nullptr)

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -238,22 +238,6 @@ bool TNodeInfo::IsAbleToRunTablet(const TTabletInfo& tablet, TTabletDebugState* 
         const TFollowerTabletInfo& follower = tablet.AsFollower();
         const TFollowerGroup& followerGroup = follower.FollowerGroup;
         const TLeaderTabletInfo& leader = follower.LeaderTablet;
-        if (followerGroup.RequireAllDataCenters) {
-            auto dataCenters = Hive.GetRegisteredDataCenters();
-            ui32 maxFollowersPerDataCenter = (followerGroup.GetComputedFollowerCount(Hive.GetDataCenters()) + dataCenters - 1) / dataCenters; // ceil
-            ui32 existingFollowers;
-            if (tablet.IsAlive()) {
-                existingFollowers = leader.GetFollowersAliveOnDataCenterExcludingFollower(Location.GetDataCenterId(), tablet);
-            } else {
-                existingFollowers = leader.GetFollowersAliveOnDataCenter(Location.GetDataCenterId());
-            }
-            if (maxFollowersPerDataCenter <= existingFollowers) {
-                if (debugState) {
-                    debugState->NodesFilledWithDatacenterFollowers++;
-                }
-                return false;
-            }
-        }
         if (followerGroup.RequireDifferentNodes) {
             if (leader.IsSomeoneAliveOnNode(Id)) {
                 if (debugState) {

--- a/ydb/core/mind/hive/node_info.cpp
+++ b/ydb/core/mind/hive/node_info.cpp
@@ -110,13 +110,11 @@ bool TNodeInfo::MatchesFilter(const TNodeFilter& filter, TTabletDebugState* debu
     bool result = false;
 
     for (const auto& candidate : effectiveAllowedDomains) {
-        if (Hive.DomainHasNodes(candidate)) {
-            result = std::find(ServicedDomains.begin(),
-                               ServicedDomains.end(),
-                               candidate) != ServicedDomains.end();
-            if (result) {
-                break;
-            }
+        result = std::find(ServicedDomains.begin(),
+                           ServicedDomains.end(),
+                           candidate) != ServicedDomains.end();
+        if (result) {
+            break;
         }
     }
 

--- a/ydb/core/mind/hive/tablet_info.cpp
+++ b/ydb/core/mind/hive/tablet_info.cpp
@@ -22,6 +22,7 @@ TTabletInfo::TTabletInfo(ETabletRole role, THive& hive)
     , ResourceMetricsAggregates(Hive.GetDefaultResourceMetricsAggregates())
     , Weight(0)
     , BalancerPolicy(EBalancerPolicy::POLICY_BALANCE)
+    , NodeFilter(hive)
 {}
 
 const TLeaderTabletInfo& TTabletInfo::GetLeader() const {
@@ -492,11 +493,7 @@ void TTabletInfo::ActualizeCounter() {
 }
 
 const TNodeFilter& TTabletInfo::GetNodeFilter() const {
-    if (IsLeader()) {
-        return AsLeader().NodeFilter;
-    } else {
-        return AsFollower().FollowerGroup.NodeFilter;
-    }
+    return NodeFilter;
 }
 
 bool TTabletInfo::InitiateStart(TNodeInfo* node) {

--- a/ydb/core/mind/hive/tablet_info.h
+++ b/ydb/core/mind/hive/tablet_info.h
@@ -164,6 +164,7 @@ public:
     TNodeId FailedNodeId = 0; // last time we tried to start the tablet, we failed on this node
     bool InWaitQueue = false;
     TInstant BootTime;
+    TNodeFilter NodeFilter;
 
     TTabletInfo(ETabletRole role, THive& hive);
     TTabletInfo(const TTabletInfo&) = delete;

--- a/ydb/core/mind/hive/tx__load_everything.cpp
+++ b/ydb/core/mind/hive/tx__load_everything.cpp
@@ -34,7 +34,6 @@ public:
         Self->Keeper.Clear();
         Self->Domains.clear();
         Self->BlockedOwners.clear();
-        Self->RegisteredDataCenterNodes.clear();
 
         Self->Domains[Self->RootDomainKey].Path = Self->RootDomainName;
         Self->Domains[Self->RootDomainKey].HiveId = rootHiveId;
@@ -612,6 +611,11 @@ public:
                     TFollowerGroup& followerGroup = tablet->GetFollowerGroup(followerGroupId);
                     TFollowerTabletInfo& follower = tablet->AddFollower(followerGroup, followerId);
                     follower.Statistics = tabletFollowerRowset.GetValueOrDefault<Schema::TabletFollowerTablet::Statistics>();
+                    if (tabletFollowerRowset.HaveValue<Schema::TabletFollowerTablet::DataCenter>()) {
+                        auto dc = tabletFollowerRowset.GetValue<Schema::TabletFollowerTablet::DataCenter>();
+                        follower.NodeFilter.AllowedDataCenters = {dc};
+                        Self->DataCenters[dc].Followers[{tabletId, followerGroup.Id}].push_back(std::prev(tablet->Followers.end()));
+                    }
                     if (nodeId == 0) {
                         follower.BecomeStopped();
                     } else {
@@ -631,6 +635,58 @@ public:
             }
             BLOG_NOTICE("THive::TTxLoadEverything loaded " << numTabletFollowers << " tablet followers ("
                     << numMissingTablets << " for missing tablets)");
+        }
+
+        // Compatability: some per-dc followers do not have their datacenter set - try to set it now
+        for (auto& [tabletId, tablet] : Self->Tablets) {
+            for (auto& group : tablet.FollowerGroups) {
+                if (!group.FollowerCountPerDataCenter) {
+                    continue;
+                }
+                std::map<TDataCenterId, i32> dataCentersToCover; // dc -> need x more followers in dc
+                for (const auto& [dc, _] : Self->DataCenters) {
+                    dataCentersToCover[dc] = group.GetFollowerCountForDataCenter(dc);
+                }
+                auto groupId = group.Id;
+                auto filterGroup = [groupId](auto&& follower) { return follower->FollowerGroup.Id == groupId;};
+                auto groupFollowersIters = std::views::iota(tablet.Followers.begin(), tablet.Followers.end()) | std::views::filter(filterGroup);
+                std::vector<TDataCenterInfo::TFollowerIter> followersWithoutDc;
+                for (auto followerIt : groupFollowersIters) {
+                    auto& allowedDc = followerIt->NodeFilter.AllowedDataCenters;
+                    if (allowedDc.size() == 1) {
+                        --dataCentersToCover[allowedDc.front()];
+                        continue;
+                    }
+                    bool ok = false;
+                    if (followerIt->Node) {
+                        auto dc = followerIt->Node->Location.GetDataCenterId();
+                        auto& cnt = dataCentersToCover[dc];
+                        if (cnt > 0) {
+                            --cnt;
+                            allowedDc = {dc};
+                            Self->DataCenters[dc].Followers[{tabletId, groupId}].push_back(followerIt);
+                            db.Table<Schema::TabletFollowerTablet>().Key(tabletId, followerIt->Id).Update<Schema::TabletFollowerTablet::DataCenter>(dc);
+                            ok = true;
+                        }
+                    }
+                    if (!ok) {
+                        followersWithoutDc.push_back(followerIt);
+                    }
+                }
+                auto dcIt = dataCentersToCover.begin();
+                for (auto follower : followersWithoutDc) {
+                    while (dcIt != dataCentersToCover.end() && dcIt->second <= 0) {
+                        ++dcIt;
+                    }
+                    if (dcIt == dataCentersToCover.end()) {
+                        break;
+                    }
+                    follower->NodeFilter.AllowedDataCenters = {dcIt->first};
+                    Self->DataCenters[dcIt->first].Followers[{tabletId, groupId}].push_back(follower);
+                    db.Table<Schema::TabletFollowerTablet>().Key(follower->GetFullTabletId()).Update<Schema::TabletFollowerTablet::DataCenter>(dcIt->first);
+                    --dcIt->second;
+                }
+            }
         }
 
         {

--- a/ydb/core/mind/hive/tx__sync_tablets.cpp
+++ b/ydb/core/mind/hive/tx__sync_tablets.cpp
@@ -49,6 +49,18 @@ public:
                 tabletsToStop.insert(tablet->GetFullTabletId());
             }
         }
+        auto foundTablet = [&](TTabletInfo* tablet, const TString& state) {
+            auto tabletId = tablet->GetFullTabletId();
+            if (node.MatchesFilter(tablet->NodeFilter)) {
+                BLOG_TRACE("THive::TTxSyncTablets(" << Local << ") confirmed " << state << " tablet " << tabletId);
+                tabletsToStop.erase(tabletId);
+            } else {
+                BLOG_TRACE("THive::TTxSyncTablets(" << Local << ") confirmed " << state << " tablet " << tabletId << ", but it's not allowed to run on this node");
+            }
+            if (tablet->GetLeader().IsBootingSuppressed()) {
+                tablet->InitiateStop(SideEffects);
+            }
+        };
         for (const NKikimrLocal::TEvSyncTablets_TTabletInfo& ti : SyncTablets.GetInbootTablets()) {
             auto tabletId = std::pair<TTabletId, TFollowerId>(ti.GetTabletId(), ti.GetFollowerId());
             TTabletInfo* tablet = Self->FindTablet(tabletId);
@@ -58,11 +70,7 @@ public:
                         tablet->GetLeader().KnownGeneration = ti.GetGeneration();
                     }
                     tablet->BecomeStarting(node.Id);
-                    BLOG_TRACE("THive::TTxSyncTablets(" << Local << ") confirmed starting tablet " << tabletId);
-                    tabletsToStop.erase(tabletId);
-                    if (tablet->GetLeader().IsBootingSuppressed()) {
-                        tablet->InitiateStop(SideEffects);
-                    }
+                    foundTablet(tablet, "starting");
                     continue;
                 }
             } else {
@@ -90,11 +98,7 @@ public:
                                         NIceDb::TUpdate<Schema::TabletFollowerTablet::FollowerNode>(tablet->NodeId));
                         }
                     }
-                    BLOG_TRACE("THive::TTxSyncTablets(" << Local << ") confirmed running tablet " << tabletId);
-                    tabletsToStop.erase(tabletId);
-                    if (tablet->GetLeader().IsBootingSuppressed()) {
-                        tablet->InitiateStop(SideEffects);
-                    }
+                    foundTablet(tablet, "running");
                     continue;
                 } else if (ti.GetBootMode() == NKikimrLocal::EBootMode::BOOT_MODE_FOLLOWER) {
                     SideEffects.Send(Local, new TEvLocal::TEvStopTablet(tabletId)); // the tablet is running somewhere else

--- a/ydb/core/mind/hive/tx__update_dc_followers.cpp
+++ b/ydb/core/mind/hive/tx__update_dc_followers.cpp
@@ -1,0 +1,79 @@
+#include "hive_impl.h"
+#include "hive_log.h"
+
+namespace NKikimr {
+namespace NHive {
+
+class TTxUpdateDcFollowers : public TTransactionBase<THive> {
+    TDataCenterId DataCenterId;
+    TSideEffects SideEffects;
+public:
+    TTxUpdateDcFollowers(const TDataCenterId& dataCenter, THive* hive)
+        : TBase(hive)
+        , DataCenterId(dataCenter)
+    {}
+
+    TTxType GetTxType() const override { return NHive::TXTYPE_UPDATE_DC_FOLLOWERS; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        BLOG_D("THive::TTxUpdateDcFollowers::Execute(" << DataCenterId << ")");
+        SideEffects.Reset(Self->SelfId());
+        NIceDb::TNiceDb db(txc.DB);
+        auto& dataCenter = Self->DataCenters[DataCenterId];
+        if (!dataCenter.UpdateScheduled) {
+            return true;
+        }
+        dataCenter.UpdateScheduled = false;
+        if (dataCenter.IsRegistered()) {
+            for (auto& [tabletId, tablet] : Self->Tablets) {
+                for (auto& group : tablet.FollowerGroups) {
+                    auto& followers = dataCenter.Followers[{tabletId, group.Id}];
+                    auto neededCount = group.GetFollowerCountForDataCenter(DataCenterId);
+                    while (followers.size() < neededCount) {
+                        TFollowerTabletInfo& follower = tablet.AddFollower(group);
+                        follower.NodeFilter.AllowedDataCenters = {DataCenterId};
+                        follower.Statistics.SetLastAliveTimestamp(TlsActivationContext->Now().MilliSeconds());
+                        db.Table<Schema::TabletFollowerTablet>().Key(tabletId, follower.Id).Update(
+                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::GroupID>(follower.FollowerGroup.Id),
+                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::FollowerNode>(0),
+                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::Statistics>(follower.Statistics),
+                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::DataCenter>(DataCenterId));
+                        follower.InitTabletMetrics();
+                        follower.BecomeStopped();
+                        follower.InitiateBoot();
+                        followers.push_back(std::prev(tablet.Followers.end()));
+                        BLOG_D("THive::TTxUpdateDcFollowers::Execute(" << DataCenterId << "): created follower " << follower.GetFullTabletId());
+                    }
+                }
+            }
+        } else {
+            // deleting followers
+            i64 deletedFollowers = 0;
+            for (auto& [_, followers] : dataCenter.Followers) {
+                for (auto follower : followers) {
+                    db.Table<Schema::TabletFollowerTablet>().Key(follower->GetFullTabletId()).Delete();
+                    db.Table<Schema::Metrics>().Key(follower->GetFullTabletId()).Delete();
+                    follower->InitiateStop(SideEffects);
+                    auto& leader = follower->GetLeader();
+                    leader.Followers.erase(follower);
+                    ++deletedFollowers;
+                }
+            }
+            BLOG_D("THive::TTxUpdateDcFollowers::Execute(" << DataCenterId << "): deleted " << deletedFollowers << " followers");
+            Self->UpdateCounterTabletsTotal(-deletedFollowers);
+            dataCenter.Followers.clear();
+        }
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        SideEffects.Complete(ctx);
+    }
+};
+
+ITransaction* THive::CreateUpdateDcFollowers(const TDataCenterId& dc) {
+    return new TTxUpdateDcFollowers(dc, this);
+}
+
+} // NHive
+} // NKikimr

--- a/ydb/core/mind/hive/tx__update_dc_followers.cpp
+++ b/ydb/core/mind/hive/tx__update_dc_followers.cpp
@@ -7,7 +7,7 @@ namespace NHive {
 class TTxProcessUpdateFollowers : public TTransactionBase<THive> {
     TSideEffects SideEffects;
 
-    static constexpr size_t MAX_UPDATES_PROCESSED = 1;
+    static constexpr size_t MAX_UPDATES_PROCESSED = 1000;
 public:
     TTxProcessUpdateFollowers(THive* hive)
         : TBase(hive)

--- a/ydb/core/mind/hive/tx__update_dc_followers.cpp
+++ b/ydb/core/mind/hive/tx__update_dc_followers.cpp
@@ -4,64 +4,87 @@
 namespace NKikimr {
 namespace NHive {
 
-class TTxUpdateDcFollowers : public TTransactionBase<THive> {
-    TDataCenterId DataCenterId;
+class TTxProcessUpdateFollowers : public TTransactionBase<THive> {
     TSideEffects SideEffects;
+
+    static constexpr size_t MAX_UPDATES_PROCESSED = 1;
 public:
-    TTxUpdateDcFollowers(const TDataCenterId& dataCenter, THive* hive)
+    TTxProcessUpdateFollowers(THive* hive)
         : TBase(hive)
-        , DataCenterId(dataCenter)
     {}
 
     TTxType GetTxType() const override { return NHive::TXTYPE_UPDATE_DC_FOLLOWERS; }
 
     bool Execute(TTransactionContext& txc, const TActorContext&) override {
-        BLOG_D("THive::TTxUpdateDcFollowers::Execute(" << DataCenterId << ")");
-        SideEffects.Reset(Self->SelfId());
+        BLOG_D("TTxProcessUpdateFollowers::Execute()");
         NIceDb::TNiceDb db(txc.DB);
-        auto& dataCenter = Self->DataCenters[DataCenterId];
-        if (!dataCenter.UpdateScheduled) {
-            return true;
-        }
-        dataCenter.UpdateScheduled = false;
-        if (dataCenter.IsRegistered()) {
-            for (auto& [tabletId, tablet] : Self->Tablets) {
-                for (auto& group : tablet.FollowerGroups) {
-                    auto& followers = dataCenter.Followers[{tabletId, group.Id}];
-                    auto neededCount = group.GetFollowerCountForDataCenter(DataCenterId);
-                    while (followers.size() < neededCount) {
-                        TFollowerTabletInfo& follower = tablet.AddFollower(group);
-                        follower.NodeFilter.AllowedDataCenters = {DataCenterId};
-                        follower.Statistics.SetLastAliveTimestamp(TlsActivationContext->Now().MilliSeconds());
-                        db.Table<Schema::TabletFollowerTablet>().Key(tabletId, follower.Id).Update(
-                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::GroupID>(follower.FollowerGroup.Id),
-                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::FollowerNode>(0),
-                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::Statistics>(follower.Statistics),
-                                    NIceDb::TUpdate<Schema::TabletFollowerTablet::DataCenter>(DataCenterId));
-                        follower.InitTabletMetrics();
-                        follower.BecomeStopped();
-                        follower.InitiateBoot();
-                        followers.push_back(std::prev(tablet.Followers.end()));
-                        BLOG_D("THive::TTxUpdateDcFollowers::Execute(" << DataCenterId << "): created follower " << follower.GetFullTabletId());
+        SideEffects.Reset(Self->SelfId());
+        for (size_t i = 0; !Self->PendingFollowerUpdates.Empty() && i < MAX_UPDATES_PROCESSED; ++i) {
+            auto op = Self->PendingFollowerUpdates.Pop();
+            TTabletInfo* tablet = Self->FindTablet(op.TabletId);
+            auto& dc = Self->DataCenters[op.DataCenter];
+            if (tablet == nullptr) {
+                continue;
+            }
+            switch (op.Action) {
+                case TFollowerUpdates::EAction::Create:
+                {
+                    if (!dc.IsRegistered()) {
+                        continue;
                     }
+                    TFollowerGroup& group = tablet->AsLeader().GetFollowerGroup(op.GroupId);
+                    auto& followers = dc.Followers[{op.TabletId.first, op.GroupId}];
+                    if (group.GetFollowerCountForDataCenter(op.DataCenter) <= followers.size()) {
+                        continue;
+                    }
+                    TFollowerTabletInfo& follower = tablet->AsLeader().AddFollower(group);
+                    follower.NodeFilter.AllowedDataCenters = {op.DataCenter};
+                    follower.Statistics.SetLastAliveTimestamp(TlsActivationContext->Now().MilliSeconds());
+                    db.Table<Schema::TabletFollowerTablet>().Key(op.TabletId.first, follower.Id).Update(
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::GroupID>(follower.FollowerGroup.Id),
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::FollowerNode>(0),
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::Statistics>(follower.Statistics),
+                                NIceDb::TUpdate<Schema::TabletFollowerTablet::DataCenter>(op.DataCenter));
+                    follower.InitTabletMetrics();
+                    follower.BecomeStopped();
+                    follower.InitiateBoot();
+                    followers.push_back(std::prev(tablet->AsLeader().Followers.end()));
+                    BLOG_D("THive::TTxProcessUpdateFollowers::Execute(): created follower " << follower.GetFullTabletId());
+                    break;
+                }
+                case TFollowerUpdates::EAction::Update:
+                {
+                    // This is updated in memory in LoadEverything
+                    bool exists = db.Table<Schema::TabletFollowerTablet>().Key(op.TabletId).Select().IsValid();
+                    Y_ABORT_UNLESS(exists, "%s", (TStringBuilder() << "trying to update tablet " << op.TabletId).data());
+                    db.Table<Schema::TabletFollowerTablet>().Key(op.TabletId).Update<Schema::TabletFollowerTablet::DataCenter>(op.DataCenter);
+                    break;
+                }
+                case TFollowerUpdates::EAction::Delete:
+                {
+                    if (dc.IsRegistered()) {
+                        continue;
+                    }
+                    db.Table<Schema::TabletFollowerTablet>().Key(op.TabletId).Delete();
+                    db.Table<Schema::Metrics>().Key(op.TabletId).Delete();
+                    tablet->InitiateStop(SideEffects);
+                    auto& followers = dc.Followers[{op.TabletId.first, op.GroupId}]; // Note: there are at most 3 followers here, see TPartitionConfigMerger
+                    auto iter = std::find_if(followers.begin(), followers.end(), [tabletId = op.TabletId](const auto& fw) {
+                        return fw->GetFullTabletId() == tabletId;
+                    });
+                    Y_ABORT_UNLESS(iter != followers.end());
+                    auto& leader = tablet->GetLeader();
+                    leader.Followers.erase(*iter);
+                    followers.erase(iter);
+                    Self->UpdateCounterTabletsTotal(-1);
+                    break;
                 }
             }
+        }
+        if (Self->PendingFollowerUpdates.Empty()) {
+            Self->ProcessFollowerUpdatesScheduled = false;
         } else {
-            // deleting followers
-            i64 deletedFollowers = 0;
-            for (auto& [_, followers] : dataCenter.Followers) {
-                for (auto follower : followers) {
-                    db.Table<Schema::TabletFollowerTablet>().Key(follower->GetFullTabletId()).Delete();
-                    db.Table<Schema::Metrics>().Key(follower->GetFullTabletId()).Delete();
-                    follower->InitiateStop(SideEffects);
-                    auto& leader = follower->GetLeader();
-                    leader.Followers.erase(follower);
-                    ++deletedFollowers;
-                }
-            }
-            BLOG_D("THive::TTxUpdateDcFollowers::Execute(" << DataCenterId << "): deleted " << deletedFollowers << " followers");
-            Self->UpdateCounterTabletsTotal(-deletedFollowers);
-            dataCenter.Followers.clear();
+            SideEffects.Send(Self->SelfId(), new TEvPrivate::TEvUpdateFollowers);
         }
         return true;
     }
@@ -71,8 +94,8 @@ public:
     }
 };
 
-ITransaction* THive::CreateUpdateDcFollowers(const TDataCenterId& dc) {
-    return new TTxUpdateDcFollowers(dc, this);
+ITransaction* THive::CreateProcessUpdateFollowers() {
+    return new TTxProcessUpdateFollowers(this);
 }
 
 } // NHive

--- a/ydb/core/mind/hive/tx__update_tablet_status.cpp
+++ b/ydb/core/mind/hive/tx__update_tablet_status.cpp
@@ -123,7 +123,6 @@ public:
                     db.Table<Schema::Tablet>().Key(TabletId).Update(NIceDb::TUpdate<Schema::Tablet::LeaderNode>(tablet->NodeId),
                                                                     NIceDb::TUpdate<Schema::Tablet::KnownGeneration>(Generation),
                                                                     NIceDb::TUpdate<Schema::Tablet::Statistics>(tablet->Statistics));
-                    Self->UpdateTabletFollowersNumber(leader, db, SideEffects);
                 } else {
                     db.Table<Schema::TabletFollowerTablet>().Key(TabletId, FollowerId).Update(
                                 NIceDb::TUpdate<Schema::TabletFollowerTablet::GroupID>(tablet->AsFollower().FollowerGroup.Id),

--- a/ydb/core/mind/hive/ya.make
+++ b/ydb/core/mind/hive/ya.make
@@ -5,6 +5,7 @@ SRCS(
     balancer.h
     boot_queue.cpp
     boot_queue.h
+    data_center_info.h
     domain_info.cpp
     domain_info.h
     drain.cpp
@@ -77,6 +78,7 @@ SRCS(
     tx__sync_tablets.cpp
     tx__tablet_owners_reply.cpp
     tx__unlock_tablet.cpp
+    tx__update_dc_followers.cpp
     tx__update_domain.cpp
     tx__update_tablet_groups.cpp
     tx__update_tablet_metrics.cpp

--- a/ydb/core/protos/counters_hive.proto
+++ b/ydb/core/protos/counters_hive.proto
@@ -164,5 +164,6 @@ enum ETxTypes {
     TXTYPE_MON_OBJECT_STATS = 63                          [(TxTypeOpts) = {Name: "TxMonObjectStats"}];
     TXTYPE_MON_SUBACTORS = 64                             [(TxTypeOpts) = {Name: "TxMonSubactors"}];
     TXTYPE_MON_TABLET_AVAILABILITY = 65                   [(TxTypeOpts) = {Name: "TxMonTabletAvailability"}];
-    TXTYPE_CONFIGURE_SCALE_RECOMMENDER = 66               [(TxTypeOpts) = {Name: "TxConfigureScaleRecommender"}];
+    TXTYPE_UPDATE_DC_FOLLOWERS = 66                       [(TxTypeOpts) = {Name: "TxUpdateDcFollowers"}];
+    TXTYPE_CONFIGURE_SCALE_RECOMMENDER = 67               [(TxTypeOpts) = {Name: "TxConfigureScaleRecommender"}];
 }

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_hive_/flat_hive.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_hive_/flat_hive.schema
@@ -884,6 +884,11 @@
                 "ColumnId": 5,
                 "ColumnName": "Statistics",
                 "ColumnType": "String"
+            },
+            {
+                "ColumnId": 6,
+                "ColumnName": "DataCenter",
+                "ColumnType": "String"
             }
         ],
         "ColumnsDropped": [],
@@ -894,7 +899,8 @@
                     2,
                     3,
                     4,
-                    5
+                    5,
+                    6
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Make per-dc followers explicitly tied to datacenters. This eliminates problems like followers not appearing in a datacenter after an outage.

### Changelog category <!-- remove all except one -->

* Improvement 

### Additional information

https://github.com/ydb-platform/ydb/pull/8069 + https://github.com/ydb-platform/ydb/pull/12024
