### PR TITLE
Make DQ and KQP use both WideStream and WideFlow for WideFromBlocks

### DIFF
--- a/ydb/core/kqp/opt/peephole/kqp_opt_peephole_wide_read.cpp
+++ b/ydb/core/kqp/opt/peephole/kqp_opt_peephole_wide_read.cpp
@@ -59,16 +59,33 @@ TExprBase KqpBuildWideReadTable(const TExprBase& node, TExprContext& ctx, TTypeA
         auto read = maybeRead.Cast();
 
         if (typesCtx.IsBlockEngineEnabled()) {
-            wideRead = Build<TCoWideFromBlocks>(ctx, node.Pos())
-                .Input<TKqpBlockReadOlapTableRanges>()
-                    .Table(read.Table())
-                    .Ranges(read.Ranges())
-                    .Columns(read.Columns())
-                    .Settings(read.Settings())
-                    .ExplainPrompt(read.ExplainPrompt())
-                    .Process(read.Process())
-                    .Build()
-                .Done();
+            if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+                wideRead = Build<TCoWideFromBlocks>(ctx, node.Pos())
+                    .Input<TKqpBlockReadOlapTableRanges>()
+                        .Table(read.Table())
+                        .Ranges(read.Ranges())
+                        .Columns(read.Columns())
+                        .Settings(read.Settings())
+                        .ExplainPrompt(read.ExplainPrompt())
+                        .Process(read.Process())
+                        .Build()
+                    .Done();
+            } else {
+                wideRead = Build<TCoToFlow>(ctx, node.Pos())
+                    .Input<TCoWideFromBlocks>()
+                        .Input<TCoFromFlow>()
+                            .Input<TKqpBlockReadOlapTableRanges>()
+                                .Table(read.Table())
+                                .Ranges(read.Ranges())
+                                .Columns(read.Columns())
+                                .Settings(read.Settings())
+                                .ExplainPrompt(read.ExplainPrompt())
+                                .Process(read.Process())
+                                .Build()
+                            .Build()
+                        .Build()
+                    .Done();
+            }
         } else {
             wideRead = Build<TKqpWideReadOlapTableRanges>(ctx, node.Pos())
                 .Table(read.Table())

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -2536,16 +2536,28 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
             switch (blockChannelsMode) {
                 case NKikimrConfig::TTableServiceConfig_EBlockChannelsMode_BLOCK_CHANNELS_SCALAR:
-                    UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("return (FromFlow (NarrowMap (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+                        UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("return (FromFlow (NarrowMap (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    } else {
+                        UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("return (FromFlow (NarrowMap (ToFlow (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    }
                     break;
                 case NKikimrConfig::TTableServiceConfig_EBlockChannelsMode_BLOCK_CHANNELS_AUTO:
-                    UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(FromFlow (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+                        UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(FromFlow (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    } else {
+                        UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    }
                     UNIT_ASSERT_C(!plan.QueryStats->Getquery_ast().Contains("WideToBlocks"), plan.QueryStats->Getquery_ast());
                     UNIT_ASSERT_EQUAL_C(plan.QueryStats->Getquery_ast().find("WideFromBlocks"), plan.QueryStats->Getquery_ast().rfind("WideFromBlocks"), plan.QueryStats->Getquery_ast());
                     break;
                 case NKikimrConfig::TTableServiceConfig_EBlockChannelsMode_BLOCK_CHANNELS_FORCE:
                     UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(FromFlow (WideSortBlocks"), plan.QueryStats->Getquery_ast());
-                    UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(FromFlow (NarrowMap (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+                        UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(FromFlow (NarrowMap (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    } else {
+                        UNIT_ASSERT_C(plan.QueryStats->Getquery_ast().Contains("(FromFlow (NarrowMap (ToFlow (WideFromBlocks"), plan.QueryStats->Getquery_ast());
+                    }
                     break;
             }
         }

--- a/ydb/library/yql/dq/opt/dq_opt_build.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_build.cpp
@@ -768,10 +768,16 @@ bool CanRebuildForWideBlockChannelOutput(bool forceBlocks, const TDqPhyStage& st
 
     if (!forceBlocks) {
         // ensure that stage has blocks on top level (i.e. FromFlow(WideFromBlocks(...)))
-        if (!stage.Program().Body().Maybe<TCoFromFlow>() ||
-            !stage.Program().Body().Cast<TCoFromFlow>().Input().Maybe<TCoWideFromBlocks>())
-        {
-            return false;
+        if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+            if (!stage.Program().Body().Maybe<TCoFromFlow>() ||
+                !stage.Program().Body().Cast<TCoFromFlow>().Input().Maybe<TCoWideFromBlocks>())
+            {
+                return false;
+            }
+        } else {
+            if (!stage.Program().Body().Maybe<TCoWideFromBlocks>()) {
+                return false;
+            }
         }
     }
 
@@ -826,15 +832,24 @@ TDqPhyStage RebuildStageInputsAsWideBlock(bool forceBlocks, const TDqPhyStage& s
         if (maybeConn && IsSupportedForWideBlocks(maybeConn.Cast()) && CanRebuildForWideBlockChannelOutput(forceBlocks, maybeConn.Cast().Output(), ctx, typesCtx)) {
             ++blockInputs;
             // input will actually be wide block stream - convert it to wide stream first
-            TExprNode::TPtr newArgNode = ctx.Builder(arg.Pos())
-                .Callable("FromFlow")
-                    .Callable(0, "WideFromBlocks")
-                        .Callable(0, "ToFlow")
-                            .Add(0, newArg.Ptr())
+            TExprNode::TPtr newArgNode;
+            if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+                newArgNode = ctx.Builder(arg.Pos())
+                    .Callable("FromFlow")
+                        .Callable(0, "WideFromBlocks")
+                            .Callable(0, "ToFlow")
+                                .Add(0, newArg.Ptr())
+                            .Seal()
                         .Seal()
                     .Seal()
-                .Seal()
-                .Build();
+                    .Build();
+            } else {
+                newArgNode = ctx.Builder(arg.Pos())
+                    .Callable("WideFromBlocks")
+                        .Add(0, newArg.Ptr())
+                    .Seal()
+                    .Build();
+            }
             argsMap.emplace(arg.Raw(), newArgNode);
 
             const TDqConnection& conn = maybeConn.Cast();

--- a/ydb/library/yql/dq/opt/dq_opt_phy.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_phy.cpp
@@ -2946,11 +2946,23 @@ NNodes::TExprBase DqBuildStageWithSourceWrap(NNodes::TExprBase node, TExprContex
         .Build();
 
     if (supportsBlocks) {
-        wideWrap = ctx.Builder(node.Pos())
-            .Callable("WideFromBlocks")
-                .Add(0, wideWrap)
-            .Seal()
-            .Build();
+        if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+            wideWrap = ctx.Builder(node.Pos())
+                .Callable("WideFromBlocks")
+                    .Add(0, wideWrap)
+                .Seal()
+                .Build();
+        } else {
+            wideWrap = ctx.Builder(node.Pos())
+                .Callable("ToFlow")
+                    .Callable(0, "WideFromBlocks")
+                        .Callable(0, "FromFlow")
+                            .Add(0, wideWrap)
+                        .Seal()
+                    .Seal()
+                .Seal()
+                .Build();
+        }
     }
 
     auto narrow = ctx.Builder(node.Pos())

--- a/ydb/library/yql/providers/dq/opt/dqs_opt.cpp
+++ b/ydb/library/yql/providers/dq/opt/dqs_opt.cpp
@@ -94,16 +94,29 @@ namespace NYql::NDqs {
                     }
 
                     YQL_CLOG(INFO, ProviderDq) << "DqsRewritePhyBlockReadOnDqIntegration";
-                    return Build<TCoWideFromBlocks>(ctx, node->Pos())
-                            .Input(
-                                Build<TCoToFlow>(ctx, node->Pos())
+                    if constexpr (!NYql::NBlockStreamIO::WideFromBlocks) {
+                        return Build<TCoWideFromBlocks>(ctx, node->Pos())
+                            .Input(Build<TCoToFlow>(ctx, node->Pos())
                                 .Input(Build<TDqReadBlockWideWrap>(ctx, node->Pos())
-                                                .Input(readWideWrap.Input())
-                                                .Flags(readWideWrap.Flags())
-                                                .Token(readWideWrap.Token())
-                                            .Done().Ptr())
+                                    .Input(readWideWrap.Input())
+                                    .Flags(readWideWrap.Flags())
+                                    .Token(readWideWrap.Token())
+                                    .Done().Ptr())
                                 .Done())
                             .Done().Ptr();
+                    }
+
+                    YQL_ENSURE(NYql::NBlockStreamIO::WideFromBlocks);
+
+                    return Build<TCoToFlow>(ctx, node->Pos())
+                        .Input(Build<TCoWideFromBlocks>(ctx, node->Pos())
+                            .Input(Build<TDqReadBlockWideWrap>(ctx, node->Pos())
+                                .Input(readWideWrap.Input())
+                                .Flags(readWideWrap.Flags())
+                                .Token(readWideWrap.Token())
+                                .Done().Ptr())
+                            .Done())
+                        .Done().Ptr();
                 }, ctx, optSettings);
         });
     }


### PR DESCRIPTION
This patchset follows up the commit [ydb-platform/ydb@88e0ad5](https://github.com/ydb-platform/ydb/commit/88e0ad5): due to incremental migration from WideFlow to WideStream for the whole block pipeline, a static flag was introduced to control the type of the particular block computation node.

As a result of this patchset, DQ and KQP pipelines supports both WideFlow and WideStream types for `WideFromBlocks` computation node I/O, making the further migration for the node seamless.

### Changelog category

* Improvement