### PR TITLE
Add IsSystem flag to filestore config; support __filestore_space_limit_ssd_system limit in SchemeShard

### DIFF
--- a/ydb/core/protos/filestore_config.proto
+++ b/ydb/core/protos/filestore_config.proto
@@ -52,6 +52,9 @@ message TConfig {
     optional uint32 PerformanceProfileMaxWriteCostMultiplier = 45;
     optional uint32 PerformanceProfileMaxPostponedTime = 46;
     optional uint32 PerformanceProfileMaxPostponedCount = 47;
+
+    // Indicates that filestore does not belong to user directly, but used for system needs
+    optional bool IsSystem = 48;
 }
 
 message TUpdateConfig {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2313,6 +2313,7 @@ struct TFileStoreInfo : public TSimpleRefCount<TFileStoreInfo> {
             const auto alterSpace = GetFileStoreSpace(*AlterConfig);
             space.SSD = Max(space.SSD, alterSpace.SSD);
             space.HDD = Max(space.HDD, alterSpace.HDD);
+            space.SSDSystem = Max(space.SSDSystem, alterSpace.SSDSystem);
         }
 
         return space;
@@ -2326,7 +2327,11 @@ private:
         TFileStoreSpace space;
         switch (config.GetStorageMediaKind()) {
             case 1: // STORAGE_MEDIA_SSD
-                space.SSD += blockCount * blockSize;
+                if (config.GetIsSystem()) {
+                    space.SSDSystem += blockCount * blockSize;
+                } else {
+                    space.SSD += blockCount * blockSize;
+                }
                 break;
             case 2: // STORAGE_MEDIA_HYBRID
             case 3: // STORAGE_MEDIA_HDD

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -324,6 +324,7 @@ void TPathElement::ApplySpecialAttributes() {
     VolumeSpaceSSDSystem.Limit = Max<ui64>();
     FileStoreSpaceSSD.Limit = Max<ui64>();
     FileStoreSpaceHDD.Limit = Max<ui64>();
+    FileStoreSpaceSSDSystem.Limit = Max<ui64>();
     ExtraPathSymbolsAllowed = TString();
     DocumentApiVersion = 0;
     AsyncReplication = NJson::TJsonValue();
@@ -350,6 +351,9 @@ void TPathElement::ApplySpecialAttributes() {
                 break;
             case EAttribute::FILESTORE_SPACE_LIMIT_HDD:
                 HandleAttributeValue(value, FileStoreSpaceHDD.Limit);
+                break;
+            case EAttribute::FILESTORE_SPACE_LIMIT_SSD_SYSTEM:
+                HandleAttributeValue(value, FileStoreSpaceSSDSystem.Limit);
                 break;
             case EAttribute::EXTRA_PATH_SYMBOLS_ALLOWED:
                 HandleAttributeValue(value, ExtraPathSymbolsAllowed);
@@ -411,16 +415,19 @@ bool TPathElement::CheckVolumeSpaceChange(TVolumeSpace newSpace, TVolumeSpace ol
 void TPathElement::ChangeFileStoreSpaceBegin(TFileStoreSpace newSpace, TFileStoreSpace oldSpace) {
     UpdateSpaceBegin(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD);
     UpdateSpaceBegin(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD);
+    UpdateSpaceBegin(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
 }
 
 void TPathElement::ChangeFileStoreSpaceCommit(TFileStoreSpace newSpace, TFileStoreSpace oldSpace) {
     UpdateSpaceCommit(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD);
     UpdateSpaceCommit(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD);
+    UpdateSpaceCommit(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
 }
 
 bool TPathElement::CheckFileStoreSpaceChange(TFileStoreSpace newSpace, TFileStoreSpace oldSpace, TString& errStr) {
     return (CheckSpaceChanged(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD, errStr, "filestore", " (ssd)") &&
-            CheckSpaceChanged(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD, errStr, "filestore", " (hdd)"));
+            CheckSpaceChanged(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD, errStr, "filestore", " (hdd)") &&
+            CheckSpaceChanged(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem, errStr, "filestore", " (ssd_system)"));
 }
 
 void TPathElement::SetAsyncReplica(bool value) {
@@ -439,6 +446,7 @@ bool TPathElement::HasRuntimeAttrs() const {
             VolumeSpaceSSDSystem.Allocated > 0 ||
             FileStoreSpaceSSD.Allocated > 0 ||
             FileStoreSpaceHDD.Allocated > 0 ||
+            FileStoreSpaceSSDSystem.Allocated > 0 ||
             IsAsyncReplica);
 }
 
@@ -463,6 +471,7 @@ void TPathElement::SerializeRuntimeAttrs(
     // filestore
     process(FileStoreSpaceSSD, "__filestore_space_allocated_ssd");
     process(FileStoreSpaceHDD, "__filestore_space_allocated_hdd");
+    process(FileStoreSpaceSSDSystem, "__filestore_space_allocated_ssd_system");
 
     if (IsAsyncReplica) {
         auto* attr = userAttrs->Add();

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -26,6 +26,7 @@ struct TVolumeSpace {
 struct TFileStoreSpace {
     ui64 SSD = 0;
     ui64 HDD = 0;
+    ui64 SSDSystem = 0;
 };
 
 struct TSpaceLimits {
@@ -78,6 +79,7 @@ struct TPathElement : TSimpleRefCount<TPathElement> {
     TSpaceLimits VolumeSpaceSSDSystem;
     TSpaceLimits FileStoreSpaceSSD;
     TSpaceLimits FileStoreSpaceHDD;
+    TSpaceLimits FileStoreSpaceSSDSystem;
     ui64 DocumentApiVersion = 0;
     NJson::TJsonValue AsyncReplication;
     bool IsAsyncReplica = false;

--- a/ydb/core/tx/schemeshard/user_attributes.cpp
+++ b/ydb/core/tx/schemeshard/user_attributes.cpp
@@ -53,6 +53,7 @@ inline bool IsValidPathName_WeakCheck(const TString& name) {
                 HANDLE_ATTR(VOLUME_SPACE_LIMIT_SSD_SYSTEM);
                 HANDLE_ATTR(FILESTORE_SPACE_LIMIT_SSD);
                 HANDLE_ATTR(FILESTORE_SPACE_LIMIT_HDD);
+                HANDLE_ATTR(FILESTORE_SPACE_LIMIT_SSD_SYSTEM);
                 HANDLE_ATTR(EXTRA_PATH_SYMBOLS_ALLOWED);
                 HANDLE_ATTR(DOCUMENT_API_VERSION);
                 HANDLE_ATTR(ASYNC_REPLICATION);
@@ -130,6 +131,7 @@ inline bool IsValidPathName_WeakCheck(const TString& name) {
             case EAttribute::VOLUME_SPACE_LIMIT_SSD_SYSTEM:
             case EAttribute::FILESTORE_SPACE_LIMIT_SSD:
             case EAttribute::FILESTORE_SPACE_LIMIT_HDD:
+            case EAttribute::FILESTORE_SPACE_LIMIT_SSD_SYSTEM:
                 return CheckValueUint64(name, value, errStr);
             case EAttribute::EXTRA_PATH_SYMBOLS_ALLOWED:
                 return CheckValueStringWeak(name, value, errStr);
@@ -175,6 +177,7 @@ inline bool IsValidPathName_WeakCheck(const TString& name) {
             case EAttribute::VOLUME_SPACE_LIMIT_SSD_SYSTEM:
             case EAttribute::FILESTORE_SPACE_LIMIT_SSD:
             case EAttribute::FILESTORE_SPACE_LIMIT_HDD:
+            case EAttribute::FILESTORE_SPACE_LIMIT_SSD_SYSTEM:
             case EAttribute::EXTRA_PATH_SYMBOLS_ALLOWED:
                 return true;
             case EAttribute::DOCUMENT_API_VERSION:

--- a/ydb/core/tx/schemeshard/user_attributes.h
+++ b/ydb/core/tx/schemeshard/user_attributes.h
@@ -15,6 +15,7 @@ constexpr TStringBuf ATTR_VOLUME_SPACE_LIMIT_SSD_NONREPL = "__volume_space_limit
 constexpr TStringBuf ATTR_VOLUME_SPACE_LIMIT_SSD_SYSTEM = "__volume_space_limit_ssd_system";
 constexpr TStringBuf ATTR_FILESTORE_SPACE_LIMIT_SSD = "__filestore_space_limit_ssd";
 constexpr TStringBuf ATTR_FILESTORE_SPACE_LIMIT_HDD = "__filestore_space_limit_hdd";
+constexpr TStringBuf ATTR_FILESTORE_SPACE_LIMIT_SSD_SYSTEM = "__filestore_space_limit_ssd_system";
 constexpr TStringBuf ATTR_EXTRA_PATH_SYMBOLS_ALLOWED = "__extra_path_symbols_allowed";
 constexpr TStringBuf ATTR_DOCUMENT_API_VERSION = "__document_api_version";
 constexpr TStringBuf ATTR_ASYNC_REPLICATION = "__async_replication";
@@ -36,6 +37,7 @@ enum class EAttribute {
     FILESTORE_SPACE_LIMIT_HDD,
     ASYNC_REPLICA,
     INCREMENTAL_BACKUP,
+    FILESTORE_SPACE_LIMIT_SSD_SYSTEM,
 };
 
 enum class EUserAttributesOp {

--- a/ydb/core/tx/schemeshard/ut_filestore_reboots/ut_filestore_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_filestore_reboots/ut_filestore_reboots.cpp
@@ -47,8 +47,11 @@ void InitAlterFileStoreConfig(NKikimrFileStore::TConfig& vc, bool channels = fal
     }
 }
 
-void CheckLimits(ui64 correctType, ui64 incorrectType) {
-    const TString typeStr = correctType == 1 ? "ssd" : "hdd";
+void CheckLimits(ui64 correctType, ui64 incorrectType, bool isSystem = false) {
+    const TString typeStr =
+        correctType == 1 ?
+            (isSystem ? "ssd_system" : "ssd") :
+            "hdd";
 
     TTestBasicRuntime runtime;
     TTestEnv env(runtime);
@@ -72,6 +75,7 @@ void CheckLimits(ui64 correctType, ui64 incorrectType) {
     vc.SetBlockSize(4_KB);
     vc.SetBlocksCount(100500);
     vc.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
+    vc.SetIsSystem(isSystem);
 
     vdescr.SetName("FSOther");
     TestCreateFileStore(runtime, ++txId, "/MyRoot", vdescr.DebugString());
@@ -352,8 +356,10 @@ Y_UNIT_TEST_SUITE(TFileStoreWithReboots) {
     }
 
     Y_UNIT_TEST(CheckFileStoreSSDLimits) {
-        CheckLimits(1, 3);  // ssd, hdd
-        CheckLimits(1, 2);  // ssd, hybrid
+        CheckLimits(1, 3, false); // ssd, hdd
+        CheckLimits(1, 3, true);  // ssd_system, hdd
+        CheckLimits(1, 2, false); // ssd, hybrid
+        CheckLimits(1, 2, true);  // ssd_system, hybrid
     }
 
     Y_UNIT_TEST(CheckFileStoreHDDLimits) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
We are going to use newly introduced `IsSystem` flag for filestore shards in order to have separate accounting for them.
Shards should be considered as system entities and should not be accounted as regular 'user-created' filestores.

...

* New feature

### Additional information

This feature is implemented by analogy with existing `__volume_space_limit_ssd_system`
...
