### PR TITLE
Add `ListNodes` cache in `DynamicNameserver`

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -19,10 +19,11 @@ namespace NKikimr::NStorage {
         STLOG(PRI_DEBUG, BS_NODE, NWDC00, "Bootstrap");
 
         auto ns = NNodeBroker::BuildNameserverTable(Cfg->NameserviceConfig);
-        auto ev = std::make_unique<TEvInterconnect::TEvNodesInfo>();
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
         for (const auto& [nodeId, item] : ns->StaticNodeTable) {
-            ev->Nodes.emplace_back(nodeId, item.Address, item.Host, item.ResolveHost, item.Port, item.Location);
+            nodes->emplace_back(nodeId, item.Address, item.Host, item.ResolveHost, item.Port, item.Location);
         }
+        auto ev = std::make_unique<TEvInterconnect::TEvNodesInfo>(nodes);
         Send(SelfId(), ev.release());
 
         // and subscribe for the node list too

--- a/ydb/core/fq/libs/actors/nodes_manager.cpp
+++ b/ydb/core/fq/libs/actors/nodes_manager.cpp
@@ -318,14 +318,14 @@ private:
     void HandleResponse(NFq::TEvInternalService::TEvHealthCheckResponse::TPtr& ev) {
         try {
             const auto& status = ev->Get()->Status.GetStatus();
-            THolder<TEvInterconnect::TEvNodesInfo> nameServiceUpdateReq(new TEvInterconnect::TEvNodesInfo());
             if (!ev->Get()->Status.IsSuccess()) {
                 ythrow yexception() <<  status << '\n' << ev->Get()->Status.GetIssues().ToString();
             }
             const auto& res = ev->Get()->Result;
 
-            auto& nodesInfo = nameServiceUpdateReq->Nodes;
-            nodesInfo.reserve(res.nodes().size());
+            auto nodesInfo = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodesInfo->reserve(res.nodes().size());
+            THolder<TEvInterconnect::TEvNodesInfo> nameServiceUpdateReq(new TEvInterconnect::TEvNodesInfo(nodesInfo));
 
             Peers.clear();
             std::set<ui32> nodeIds; // may be not unique
@@ -340,7 +340,7 @@ private:
                   node.active_workers(), node.memory_limit(), node.memory_allocated(), node.data_center()});
 
                 if (node.interconnect_port()) {
-                    nodesInfo.emplace_back(TEvInterconnect::TNodeInfo{
+                    nodesInfo->emplace_back(TEvInterconnect::TNodeInfo{
                         node.node_id(),
                         node.node_address(),
                         node.hostname(), // host
@@ -356,8 +356,8 @@ private:
             ServiceCounters.Counters->GetCounter("PeerCount", false)->Set(Peers.size());
             ServiceCounters.Counters->GetCounter("NodesHealthCheckOk", true)->Inc();
 
-            LOG_T("Send NodeInfo with size: " << nodesInfo.size() << " to DynamicNameserver");
-            if (!nodesInfo.empty()) {
+            LOG_T("Send NodeInfo with size: " << nodesInfo->size() << " to DynamicNameserver");
+            if (!nodesInfo->empty()) {
                 Send(GetNameserviceActorId(), nameServiceUpdateReq.Release());
             }
         } catch (yexception &e) {

--- a/ydb/core/fq/libs/actors/nodes_manager.cpp
+++ b/ydb/core/fq/libs/actors/nodes_manager.cpp
@@ -325,7 +325,6 @@ private:
 
             auto nodesInfo = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
             nodesInfo->reserve(res.nodes().size());
-            THolder<TEvInterconnect::TEvNodesInfo> nameServiceUpdateReq(new TEvInterconnect::TEvNodesInfo(nodesInfo));
 
             Peers.clear();
             std::set<ui32> nodeIds; // may be not unique
@@ -358,6 +357,7 @@ private:
 
             LOG_T("Send NodeInfo with size: " << nodesInfo->size() << " to DynamicNameserver");
             if (!nodesInfo->empty()) {
+                THolder<TEvInterconnect::TEvNodesInfo> nameServiceUpdateReq(new TEvInterconnect::TEvNodesInfo(nodesInfo));
                 Send(GetNameserviceActorId(), nameServiceUpdateReq.Release());
             }
         } catch (yexception &e) {

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -337,11 +337,15 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
     }
 
     void SetLongHostValue(TEvInterconnect::TEvNodesInfo::TPtr* ev) {
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*ev)->Get()->Nodes);
         TString host(1000000, 'a');
-        auto& pbRecord = const_cast<TVector<TEvInterconnect::TNodeInfo>&>((*ev)->Get()->Nodes);
-        for (auto itIssue = pbRecord.begin(); itIssue != pbRecord.end(); ++itIssue) {
-            itIssue->Host = host;
+        for (auto it = nodes->begin(); it != nodes->end(); ++it) {
+            it->Host = host;
         }
+        auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
+            new IEventHandle((*ev)->Sender, (*ev)->Recipient, new TEvInterconnect::TEvNodesInfo(nodes))
+        );
+        ev->Swap(newEv);
     }
 
     Ydb::Monitoring::SelfCheckResult RequestHc(size_t const groupNumber, size_t const vdiscPerGroupNumber, bool const isMergeRecords = false, bool const largeSizeVdisksIssues = false) {

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -338,7 +338,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
     void SetLongHostValue(TEvInterconnect::TEvNodesInfo::TPtr* ev) {
         TString host(1000000, 'a');
-        auto& pbRecord = (*ev)->Get()->Nodes;
+        auto& pbRecord = const_cast<TVector<TEvInterconnect::TNodeInfo>&>((*ev)->Get()->Nodes);
         for (auto itIssue = pbRecord.begin(); itIssue != pbRecord.end(); ++itIssue) {
             itIssue->Host = host;
         }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -343,7 +343,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
             it->Host = host;
         }
         auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
-            new IEventHandle((*ev)->Sender, (*ev)->Recipient, new TEvInterconnect::TEvNodesInfo(nodes))
+            new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
         );
         ev->Swap(newEv);
     }

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1416,7 +1416,7 @@ public:
         TNodeId NodeId;
         TNodeLocation Location;
 
-        THostRecord(TEvInterconnect::TNodeInfo&& nodeInfo)
+        THostRecord(TEvInterconnect::TNodeInfo nodeInfo)
             : NodeId(nodeInfo.NodeId)
             , Location(std::move(nodeInfo.Location))
         {}
@@ -1432,11 +1432,13 @@ public:
         THashMap<TNodeId, THostId> NodeIdToHostId;
 
     public:
+        THostRecordMapImpl() = default;
+
         THostRecordMapImpl(TEvInterconnect::TEvNodesInfo *msg) {
-            for (TEvInterconnect::TNodeInfo& nodeInfo : msg->Nodes) {
+            for (const TEvInterconnect::TNodeInfo& nodeInfo : msg->Nodes) {
                 const THostId hostId(nodeInfo.Host, nodeInfo.Port);
                 NodeIdToHostId.emplace(nodeInfo.NodeId, hostId);
-                HostIdToRecord.emplace(hostId, std::move(nodeInfo));
+                HostIdToRecord.emplace(hostId, nodeInfo);
             }
         }
 
@@ -1824,8 +1826,7 @@ public:
 
     // For test purposes, required for self heal actor
     void CreateEmptyHostRecordsMap() {
-        TEvInterconnect::TEvNodesInfo nodes;
-        HostRecords = std::make_shared<THostRecordMapImpl>(&nodes);
+        HostRecords = std::make_shared<THostRecordMapImpl>();
     }
 
     ui64 NextConfigTxSeqNo = 1;

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1416,9 +1416,9 @@ public:
         TNodeId NodeId;
         TNodeLocation Location;
 
-        THostRecord(TEvInterconnect::TNodeInfo nodeInfo)
+        THostRecord(const TEvInterconnect::TNodeInfo& nodeInfo)
             : NodeId(nodeInfo.NodeId)
-            , Location(std::move(nodeInfo.Location))
+            , Location(nodeInfo.Location)
         {}
 
         THostRecord(const NKikimrBlobStorage::TNodeIdentifier& node)

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -69,7 +69,7 @@ void TDynamicNodeResolverBase::Handle(TEvNodeBroker::TEvResolvedNode::TPtr &ev, 
         // Reset proxy if node expired.
         if (exists) {
             ResetInterconnectProxyConfig(NodeId, ctx);
-            *NeedUpdateListNodesCache = true; // node was erased
+            ListNodesCache->Invalidate(); // node was erased
         }
         ReplyWithErrorAndDie(ctx);
         return;
@@ -77,7 +77,7 @@ void TDynamicNodeResolverBase::Handle(TEvNodeBroker::TEvResolvedNode::TPtr &ev, 
 
     TDynamicConfig::TDynamicNodeInfo node(rec.GetNode());
     if (!exists || !oldNode.EqualExceptExpire(node)) {
-        *NeedUpdateListNodesCache = true;
+        ListNodesCache->Invalidate();
     }
 
     // If ID is re-used by another node then proxy has to be reset.
@@ -150,7 +150,7 @@ void TDynamicNameserver::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
         auto newStaticConfig = BuildNameserverTable(config);
         if (StaticConfig->StaticNodeTable != newStaticConfig->StaticNodeTable) {
             StaticConfig = std::move(newStaticConfig);
-            *NeedUpdateListNodesCache = true;
+            ListNodesCache->Invalidate();
             for (const auto& subscriber : StaticNodeChangeSubscribers) {
                 TActivationContext::Send(new IEventHandle(SelfId(), subscriber, new TEvInterconnect::TEvListNodes));
             }
@@ -227,37 +227,39 @@ void TDynamicNameserver::ResolveDynamicNode(ui32 nodeId,
         ctx.Send(ev->Sender, reply);
     } else {
         ctx.RegisterWithSameMailbox(new TDynamicNodeResolver(SelfId(), nodeId, DynamicConfigs[domain],
-            NeedUpdateListNodesCache, ev, deadline));
+            ListNodesCache, ev, deadline));
     }
 }
 
 void TDynamicNameserver::SendNodesList(const TActorContext &ctx)
-{
-    if (*NeedUpdateListNodesCache) {
-        auto newListNodesCache = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+{   
+    auto now = ctx.Now();
+    if (ListNodesCache->NeedUpdate(now)) {
+        auto newNodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+        auto newExpire = now;
 
-        auto now = ctx.Now();
         for (const auto &pr : StaticConfig->StaticNodeTable) {
-            newListNodesCache->emplace_back(pr.first,
-                                            pr.second.Address, pr.second.Host, pr.second.ResolveHost,
-                                            pr.second.Port, pr.second.Location, true);
+            newNodes->emplace_back(pr.first,
+                                   pr.second.Address, pr.second.Host, pr.second.ResolveHost,
+                                   pr.second.Port, pr.second.Location, true);
         }
 
         for (auto &config : DynamicConfigs) {
             for (auto &pr : config->DynamicNodes) {
-                if (pr.second.Expire > now)
-                    newListNodesCache->emplace_back(pr.first, pr.second.Address,
-                                                    pr.second.Host, pr.second.ResolveHost,
-                                                    pr.second.Port, pr.second.Location, false);
+                if (pr.second.Expire > now) {
+                    newNodes->emplace_back(pr.first, pr.second.Address,
+                                           pr.second.Host, pr.second.ResolveHost,
+                                           pr.second.Port, pr.second.Location, false);
+                    newExpire = std::min(newExpire, pr.second.Expire);
+                }
             }
         }
 
-        ListNodesCache = newListNodesCache;
-        *NeedUpdateListNodesCache = false;
+        ListNodesCache->Update(newNodes, newExpire);
     }
 
     for (auto &sender : ListNodesQueue) {
-        ctx.Send(sender, new TEvInterconnect::TEvNodesInfo(ListNodesCache));
+        ctx.Send(sender, new TEvInterconnect::TEvNodesInfo(ListNodesCache->GetNodes()));
     }
     ListNodesQueue.clear();
 }
@@ -313,7 +315,7 @@ void TDynamicNameserver::UpdateState(const NKikimrNodeBroker::TNodesInfo &rec,
             config->ExpiredNodes.emplace(node.GetNodeId(), info);
         }
 
-        *NeedUpdateListNodesCache = true;
+        ListNodesCache->Invalidate();
         config->Epoch = rec.GetEpoch();
         ctx.Schedule(config->Epoch.End - ctx.Now(),
                      new TEvPrivate::TEvUpdateEpoch(domain, config->Epoch.Id + 1));
@@ -323,7 +325,7 @@ void TDynamicNameserver::UpdateState(const NKikimrNodeBroker::TNodesInfo &rec,
             auto nodeId = node.GetNodeId();
             if (!config->DynamicNodes.contains(nodeId)) {
                 config->DynamicNodes.emplace(nodeId, node);
-                *NeedUpdateListNodesCache = true;
+                ListNodesCache->Invalidate();
             }                
         }
         config->Epoch = rec.GetEpoch();
@@ -412,7 +414,7 @@ void TDynamicNameserver::Handle(TEvInterconnect::TEvGetNode::TPtr &ev, const TAc
         } else {
             const TInstant deadline = ev->Get()->Deadline;
             ctx.RegisterWithSameMailbox(new TDynamicNodeSearcher(SelfId(), nodeId, DynamicConfigs[domain],
-                NeedUpdateListNodesCache, ev.Release(), deadline));
+                ListNodesCache, ev.Release(), deadline));
         }
     }
 }
@@ -471,7 +473,7 @@ void TDynamicNameserver::Handle(NConsole::TEvConsole::TEvConfigNotificationReque
             auto newStaticConfig = BuildNameserverTable(config.GetNameserviceConfig());
             if (StaticConfig->StaticNodeTable != newStaticConfig->StaticNodeTable) {
                 StaticConfig = std::move(newStaticConfig);
-                *NeedUpdateListNodesCache = true;
+                ListNodesCache->Invalidate();
                 for (const auto& subscriber : StaticNodeChangeSubscribers) {
                     TActivationContext::Send(new IEventHandle(SelfId(), subscriber, new TEvInterconnect::TEvListNodes));
                 }
@@ -521,6 +523,30 @@ TIntrusivePtr<TTableNameserverSetup> BuildNameserverTable(const NKikimrBlobStora
         );
     }
     return table;
+}
+
+TListNodesCache::TListNodesCache()
+    : Nodes(nullptr)
+    , Expire(TInstant::Zero())
+{}
+
+
+void TListNodesCache::Update(TIntrusiveVector<TEvInterconnect::TNodeInfo>::TConstPtr newNodes, TInstant newExpire) {
+    Nodes = newNodes;
+    Expire = newExpire;
+}
+
+void TListNodesCache::Invalidate() {
+    Nodes = nullptr;
+    Expire = TInstant::Zero();
+}
+
+bool TListNodesCache::NeedUpdate(TInstant now) const {
+    return Nodes == nullptr || now > Expire;
+}
+
+TIntrusiveVector<TEvInterconnect::TNodeInfo>::TConstPtr TListNodesCache::GetNodes() const {
+    return Nodes;
 }
 
 } // NNodeBroker

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -47,10 +47,11 @@ void TestHeavy(const ui32 v, ui32 numWorkers) {
     options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, numWorkers);
     runtime.DispatchEvents(options);
     for (const auto& a : cc) {
-        THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
         for (auto i = 1; i <= NODES; ++i) {
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(i, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(i, "::", "localhost", "localhost", 1234, TNodeLocation()));
         }
+        THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
         runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
     }
 

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -727,10 +727,11 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
         options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
         runtime.DispatchEvents(options);
         for (const auto& a : cc) {
-            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
             runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
         }
 
@@ -827,10 +828,11 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
         options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
         runtime.DispatchEvents(options);
         for (const auto& a : cc) {
-            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
             runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
         }
 
@@ -903,10 +905,11 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
         options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
         runtime.DispatchEvents(options);
         for (const auto& a : cc) {
-            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
             runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
         }
 

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -251,7 +251,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
     };
 
     void ChangeListNodes(TEvInterconnect::TEvNodesInfo::TPtr* ev, int nodesTotal) {
-        auto& nodes = (*ev)->Get()->Nodes;
+        auto& nodes = const_cast<TVector<TEvInterconnect::TNodeInfo>&>((*ev)->Get()->Nodes);
 
         auto sample = nodes[0];
         nodes.clear();

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -261,7 +261,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         }
 
         auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
-            new IEventHandle((*ev)->Sender, (*ev)->Recipient, new TEvInterconnect::TEvNodesInfo(nodes))
+            new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
         );
         ev->Swap(newEv);
     }

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -722,7 +722,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 2);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];
@@ -801,7 +801,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 3);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];
@@ -884,7 +884,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 3);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];
@@ -970,7 +970,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 4);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];

--- a/ydb/library/actors/core/interconnect.h
+++ b/ydb/library/actors/core/interconnect.h
@@ -2,6 +2,7 @@
 
 #include "events.h"
 #include "event_local.h"
+#include <ydb/library/actors/util/intrusive_vector.h>
 #include <ydb/library/actors/protos/interconnect.pb.h>
 #include <util/string/cast.h>
 #include <util/string/builder.h>
@@ -118,17 +119,6 @@ namespace NActors {
         friend bool operator >=(const TNodeLocation& x, const TNodeLocation& y) { return x.Compare(y) >= 0; }
     };
 
-    template<typename T>
-    class TIntrusiveVector : public TVector<T>, public TThrRefBase {
-    public:
-        using TPtr = TIntrusivePtr<TIntrusiveVector<T>>;
-        using TConstPtr = TIntrusiveConstPtr<TIntrusiveVector<T>>;
-
-        TIntrusiveVector() = default;
-        TIntrusiveVector(const TVector<T>& other) : TVector<T>(other) {}
-        TIntrusiveVector(TVector<T>&& other) : TVector<T>(std::move(other)) {}
-    };
-
     struct TEvInterconnect {
         enum EEv {
             EvForward = EventSpaceBegin(TEvents::ES_INTERCONNECT),
@@ -238,9 +228,7 @@ namespace NActors {
             TEvNodesInfo(TIntrusiveVector<TNodeInfo>::TConstPtr nodesPtr)
                 : NodesPtr(nodesPtr)
                 , Nodes(*nodesPtr)
-            {
-                Y_ABORT_UNLESS(NodesPtr);
-            }
+            {}
 
             const TNodeInfo* GetNodeInfo(ui32 nodeId) const {
                 for (const auto& x : Nodes) {

--- a/ydb/library/actors/interconnect/interconnect_nameserver_base.h
+++ b/ydb/library/actors/interconnect/interconnect_nameserver_base.h
@@ -55,15 +55,14 @@ namespace NActors {
 
         void Handle(TEvInterconnect::TEvListNodes::TPtr& ev,
                     const TActorContext& ctx) {
-            THolder<TEvInterconnect::TEvNodesInfo>
-                reply(new TEvInterconnect::TEvNodesInfo());
-            reply->Nodes.reserve(NodeTable.size());
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->reserve(NodeTable.size());
             for (const auto& pr : NodeTable) {
-                reply->Nodes.emplace_back(pr.first,
-                                          pr.second.Address, pr.second.Host, pr.second.ResolveHost,
-                                          pr.second.Port, pr.second.Location);
+                nodes->emplace_back(pr.first,
+                                    pr.second.Address, pr.second.Host, pr.second.ResolveHost,
+                                    pr.second.Port, pr.second.Location);
             }
-            ctx.Send(ev->Sender, reply.Release());
+            ctx.Send(ev->Sender, new TEvInterconnect::TEvNodesInfo(nodes));
         }
 
         void Handle(TEvInterconnect::TEvGetNode::TPtr& ev,

--- a/ydb/library/actors/util/intrusive_vector.h
+++ b/ydb/library/actors/util/intrusive_vector.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <util/generic/ptr.h>
+#include <util/generic/vector.h>
+
+template<typename T>
+class TIntrusiveVector : public TVector<T>, public TThrRefBase {
+public:
+    using TVector<T>::TVector;
+
+    using TPtr = TIntrusivePtr<TIntrusiveVector<T>>;
+    using TConstPtr = TIntrusiveConstPtr<TIntrusiveVector<T>>;
+
+    TIntrusiveVector(const TVector<T>& other) : TVector<T>(other) {}
+    TIntrusiveVector(TVector<T>&& other) : TVector<T>(std::move(other)) {}
+};

--- a/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
+++ b/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
@@ -166,10 +166,8 @@ namespace NYql::NDqs {
 
         void ReplyListNodes(const NActors::TActorId sender, const TActorContext& ctx)
         {
-            THolder<TEvInterconnect::TEvNodesInfo>
-                reply(new TEvInterconnect::TEvNodesInfo());
-            reply->Nodes = GetNodesInfo();
-            ctx.Send(sender, reply.Release());
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>(GetNodesInfo());
+            ctx.Send(sender, new TEvInterconnect::TEvNodesInfo(nodes));
         }
 
         void Handle(TEvInterconnect::TEvListNodes::TPtr& ev,

--- a/ydb/library/yql/providers/dq/global_worker_manager/service_node_pinger.cpp
+++ b/ydb/library/yql/providers/dq/global_worker_manager/service_node_pinger.cpp
@@ -154,15 +154,14 @@ private:
 
         auto& resp = ev->Get()->Response;
 
-        THolder<TEvInterconnect::TEvNodesInfo>
-            reply(new TEvInterconnect::TEvNodesInfo());
-        reply->Nodes.reserve(resp.GetNodes().size());
         if (resp.GetEpoch()) {
             RuntimeData->Epoch = resp.GetEpoch();
         }
 
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+        nodes->reserve(resp.GetNodes().size());
         for (auto& node : resp.GetNodes()) {
-            reply->Nodes.emplace_back(
+            nodes->emplace_back(
                 node.GetNodeId(),
                 node.GetAddress(),
                 node.GetAddress(),
@@ -170,6 +169,7 @@ private:
                 node.GetPort(),
                 NActors::TNodeLocation());
         }
+        THolder<TEvInterconnect::TEvNodesInfo> reply(new TEvInterconnect::TEvNodesInfo(nodes));
 
         TVector<TResourceFile> downloadList;
         for (auto& file : resp.GetDownloadList()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add caching for `ListNodes` request in `DynamicNameserver`

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

Prior to this change, the entire node list was copied for every `ListNodes` request. This change adds caching of the node list, which is now distributed by pointer. The node list is re-cached when changes are made.
