### PR TITLE
Move distconf settings a level up in the configuration and add explicit enabled flag

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -339,7 +339,7 @@ namespace NKikimr::NStorage {
 
         struct TExConfigError : yexception {};
 
-        void GenerateFirstConfig(NKikimrBlobStorage::TStorageConfig *config, const TString& selfAssemblyUUID);
+        std::optional<TString> GenerateFirstConfig(NKikimrBlobStorage::TStorageConfig *config, const TString& selfAssemblyUUID);
 
         void AllocateStaticGroup(NKikimrBlobStorage::TStorageConfig *config, ui32 groupId, ui32 groupGeneration,
             TBlobStorageGroupType gtype, const NKikimrBlobStorage::TGroupGeometry& geometry,

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
@@ -155,7 +155,7 @@ namespace NKikimr::NStorage {
                     return AdvanceGeneration();
 
                 case TQuery::kFetchStorageConfig:
-                    return FetchStorageConfig();
+                    return FetchStorageConfig(record.GetFetchStorageConfig().GetManual());
 
                 case TQuery::kReplaceStorageConfig:
                     return ReplaceStorageConfig(record.GetReplaceStorageConfig().GetYAML());
@@ -373,10 +373,10 @@ namespace NKikimr::NStorage {
             }
             const auto& ss = bsConfig.GetServiceSet();
 
-            if (!bsConfig.HasAutoconfigSettings()) {
-                return FinishWithError(TResult::ERROR, "no AutoconfigSettings defined");
+            if (!config.HasSelfManagementConfig() || !config.GetSelfManagementConfig().GetEnabled()) {
+                return FinishWithError(TResult::ERROR, "self-management is not enabled");
             }
-            const auto& settings = bsConfig.GetAutoconfigSettings();
+            const auto& smConfig = config.GetSelfManagementConfig();
 
             THashMap<TVDiskIdShort, NBsController::TPDiskId> replacedDisks;
             NBsController::TGroupMapper::TForbiddenPDisks forbid;
@@ -405,8 +405,8 @@ namespace NKikimr::NStorage {
                     try {
                         Self->AllocateStaticGroup(&config, vdiskId.GroupID.GetRawId(), vdiskId.GroupGeneration + 1,
                             TBlobStorageGroupType((TBlobStorageGroupType::EErasureSpecies)group.GetErasureSpecies()),
-                            settings.GetGeometry(), settings.GetPDiskFilter(),
-                            settings.HasPDiskType() ? std::make_optional(settings.GetPDiskType()) : std::nullopt,
+                            smConfig.GetGeometry(), smConfig.GetPDiskFilter(),
+                            smConfig.HasPDiskType() ? std::make_optional(smConfig.GetPDiskType()) : std::nullopt,
                             replacedDisks, forbid, maxSlotSize,
                             &BaseConfig.value(), cmd.GetConvertToDonor(), cmd.GetIgnoreVSlotQuotaCheck(),
                             cmd.GetIsSelfHealReasonDecommit());
@@ -625,7 +625,7 @@ namespace NKikimr::NStorage {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Storage configuration YAML manipulation
 
-        void FetchStorageConfig() {
+        void FetchStorageConfig(bool manual) {
             if (!Self->StorageConfig) {
                 FinishWithError(TResult::ERROR, "no agreed StorageConfig");
             } else if (!Self->StorageConfig->HasStorageConfigCompressedYAML()) {
@@ -634,7 +634,13 @@ namespace NKikimr::NStorage {
                 auto ev = PrepareResult(TResult::OK, std::nullopt);
                 auto *record = &ev->Record;
                 TStringInput ss(Self->StorageConfig->GetStorageConfigCompressedYAML());
-                record->MutableFetchStorageConfig()->SetYAML(TZstdDecompress(&ss).ReadAll());
+                TString config = TZstdDecompress(&ss).ReadAll();
+
+                if (manual) {
+                    // add BlobStorageConfig, NameserviceConfig, DomainsConfig
+                }
+
+                record->MutableFetchStorageConfig()->SetYAML(config);
                 Finish(Sender, SelfId(), ev.release(), 0, Cookie);
             }
         }

--- a/ydb/core/blobstorage/nodewarden/node_warden.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden.h
@@ -21,6 +21,7 @@ namespace NKikimr {
         NKikimrConfig::TBlobStorageConfig BlobStorageConfig;
         NKikimrConfig::TStaticNameserviceConfig NameserviceConfig;
         std::optional<NKikimrConfig::TDomainsConfig> DomainsConfig;
+        std::optional<NKikimrConfig::TSelfManagementConfig> SelfManagementConfig;
         TIntrusivePtr<IPDiskServiceFactory> PDiskServiceFactory;
         TIntrusivePtr<TAllVDiskKinds> AllVDiskKinds;
         TIntrusivePtr<NPDisk::TDriveModelDb> AllDriveModels;

--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -589,9 +589,9 @@ void LoadYamlConfig(TConfigRefs refs, const TString& yamlConfigFile, NKikimrConf
 
     const TString yamlConfigString = protoConfigFileProvider.GetProtoFromFile(yamlConfigFile, errorCollector);
 
-    if (appConfig.HasBlobStorageConfig() && appConfig.GetBlobStorageConfig().HasAutoconfigSettings()) {
-        auto *proto = appConfig.MutableBlobStorageConfig()->MutableAutoconfigSettings();
-        proto->SetInitialConfigYaml(yamlConfigString);
+    if (appConfig.HasSelfManagementConfig() && appConfig.GetSelfManagementConfig().GetEnabled()) {
+        // fill in InitialConfigYaml only when self-management through distconf is enabled
+        appConfig.MutableSelfManagementConfig()->SetInitialConfigYaml(yamlConfigString);
     }
 
     /*

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -945,6 +945,9 @@ void TBSNodeWardenInitializer::InitializeServices(NActors::TActorSystemSetup* se
     if (Config.HasDomainsConfig()) {
         nodeWardenConfig->DomainsConfig.emplace(Config.GetDomainsConfig());
     }
+    if (Config.HasSelfManagementConfig()) {
+        nodeWardenConfig->SelfManagementConfig.emplace(Config.GetSelfManagementConfig());
+    }
 
     ObtainTenantKey(&nodeWardenConfig->TenantKey, Config.GetKeyConfig());
     ObtainStaticKey(&nodeWardenConfig->StaticKey);

--- a/ydb/core/grpc_services/rpc_bsconfig.cpp
+++ b/ydb/core/grpc_services/rpc_bsconfig.cpp
@@ -109,11 +109,7 @@ public:
         } catch (const std::exception&) {
             return false; // assuming no distconf enabled in this config
         }
-        if (!newConfig.HasBlobStorageConfig()) {
-            return false;
-        }
-        const NKikimrConfig::TBlobStorageConfig& bsConfig = newConfig.GetBlobStorageConfig();
-        return bsConfig.HasAutoconfigSettings();
+        return newConfig.HasSelfManagementConfig() && newConfig.GetSelfManagementConfig().GetEnabled();
     }
 };
 

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -155,14 +155,14 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
         } else {
             Y_FAIL("no storage configuration provided");
         }
+    }
 
-        if (bsConfig.HasAutoconfigSettings()) {
-            // assuming that in autoconfig mode HostRecords are managed by the distconf; we need to apply it here to
-            // avoid race with box autoconfiguration and node list change
-            HostRecords = std::make_shared<THostRecordMap::element_type>(StorageConfig);
-            if (SelfHealId) {
-                Send(SelfHealId, new TEvPrivate::TEvUpdateHostRecords(HostRecords));
-            }
+    if (StorageConfig.HasSelfManagementConfig() && StorageConfig.GetSelfManagementConfig().GetEnabled()) {
+        // assuming that in autoconfig mode HostRecords are managed by the distconf; we need to apply it here to
+        // avoid race with box autoconfiguration and node list change
+        HostRecords = std::make_shared<THostRecordMap::element_type>(StorageConfig);
+        if (SelfHealId) {
+            Send(SelfHealId, new TEvPrivate::TEvUpdateHostRecords(HostRecords));
         }
     }
 
@@ -188,19 +188,13 @@ void TBlobStorageController::Handle(TEvents::TEvUndelivered::TPtr ev) {
 }
 
 void TBlobStorageController::ApplyStorageConfig() {
-    if (!StorageConfig.HasBlobStorageConfig()) {
+    if (!StorageConfig.HasBlobStorageConfig() || // this would be strange
+            !StorageConfig.HasSelfManagementConfig() ||
+            !StorageConfig.GetSelfManagementConfig().GetEnabled() ||
+            !StorageConfig.GetSelfManagementConfig().GetAutomaticBoxManagement()) {
         return;
     }
     const auto& bsConfig = StorageConfig.GetBlobStorageConfig();
-
-    if (!bsConfig.HasAutoconfigSettings()) {
-        return;
-    }
-    const auto& autoconfigSettings = bsConfig.GetAutoconfigSettings();
-
-    if (autoconfigSettings.HasAutomaticBoxManagement() && !autoconfigSettings.GetAutomaticBoxManagement()) {
-        return;
-    }
 
     if (Boxes.size() > 1) {
         return;

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -141,7 +141,8 @@ void TDynamicNameserver::Bootstrap(const TActorContext &ctx)
 void TDynamicNameserver::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     Y_ABORT_UNLESS(ev->Get()->Config);
     const auto& config = *ev->Get()->Config;
-    if (config.GetBlobStorageConfig().HasAutoconfigSettings()) {
+    if (config.HasSelfManagementConfig() && config.GetSelfManagementConfig().GetEnabled()) {
+        // self-management through distconf is enabled and we are operating based on their tables, so apply them now
         auto newStaticConfig = BuildNameserverTable(config);
         if (StaticConfig->StaticNodeTable != newStaticConfig->StaticNodeTable) {
             StaticConfig = std::move(newStaticConfig);

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -28,8 +28,10 @@ message TStorageConfig { // contents of storage metadata
     repeated TNodeIdentifier AllNodes = 5; // set of all known nodes
     string ClusterUUID = 6; // cluster GUID as provided in nameservice config
     string SelfAssemblyUUID = 7; // self-assembly UUID generated when config is first created
-    TStorageConfig PrevConfig = 8; // previous version of StorageConfig (if any)
     optional bytes StorageConfigCompressedYAML = 12; // compressed stored storage config YAML (if stored)
+    NKikimrConfig.TSelfManagementConfig SelfManagementConfig = 13;
+
+    TStorageConfig PrevConfig = 100; // previous version of StorageConfig (if any)
 }
 
 message TPDiskMetadataRecord {
@@ -188,8 +190,9 @@ message TEvNodeConfigInvokeOnRoot {
     message TAdvanceGeneration
     {}
 
-    message TFetchStorageConfig
-    {}
+    message TFetchStorageConfig {
+        bool Manual = 1; // when set to true, distconf returns conventional configuration
+    }
 
     message TReplaceStorageConfig {
         string YAML = 1;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -276,27 +276,7 @@ message TBlobStorageConfig {
     optional bool CachePDisks = 4 [default = true];
     optional bool CacheVDisks = 5 [default = true];
 
-    // Automatic configuration: when not filled in, then the autoconfig feature is disabled. When multiple nodes are
-    // negotiating about this feature, the disabled one overrides others.
-    message TAutoconfigSettings {
-        // subset of DefineStoragePool command
-        optional string ErasureSpecies = 1;
-        optional NKikimrBlobStorage.TGroupGeometry Geometry = 2;
-        repeated NKikimrBlobStorage.TPDiskFilter PDiskFilter = 3;
-        optional NKikimrBlobStorage.EPDiskType PDiskType = 7;
-
-        // some extra settings
-        optional bool AutomaticBoxManagement = 4; // invoke BSC DefineHostConfig/DefineBox automatically (true when unset)
-        optional bool AutomaticBootstrap = 9; // whether bootstrap should be performed automatically; PROHIBITED for production
-
-        // generation of the distconf section; when set, one can automatically apply in-filesystem config
-        optional uint64 Generation = 8;
-
-        // internally-used field with initial config.yaml loaded on the start
-        optional bytes InitialConfigYaml = 10;
-    }
-
-    optional TAutoconfigSettings AutoconfigSettings = 6;
+    reserved 6; // AutoconfigSettings previously here
 
     message TVDiskPerformanceConfig {
         optional NKikimrBlobStorage.EPDiskType PDiskType = 1;
@@ -335,6 +315,27 @@ message TBlobStorageConfig {
     repeated NKikimrBlobStorage.TDefineHostConfig DefineHostConfig = 10;
     optional NKikimrBlobStorage.TDefineBox DefineBox = 11;
  }
+
+message TSelfManagementConfig {
+    // whether the self management is enabled (through distconf)? (mandatory field)
+    optional bool Enabled = 1;
+
+    // generation of the config; when set, one can automatically apply in-filesystem config
+    optional uint64 Generation = 2;
+
+    // internally-used field with initial config.yaml loaded on the start (for the bootstrap process); not filled by the user
+    optional bytes InitialConfigYaml = 3;
+
+    // subset of DefineStoragePool command
+    optional string ErasureSpecies = 11;
+    optional NKikimrBlobStorage.TGroupGeometry Geometry = 12;
+    repeated NKikimrBlobStorage.TPDiskFilter PDiskFilter = 13;
+    optional NKikimrBlobStorage.EPDiskType PDiskType = 14;
+
+    // some extra settings
+    optional bool AutomaticBoxManagement = 21 [default = true]; // invoke BSC DefineHostConfig/DefineBox automatically
+    optional bool AutomaticBootstrap = 22; // whether bootstrap should be performed automatically; PROHIBITED for production
+}
 
 message TBlobStorageFormatConfig {
     message TDrive {
@@ -2120,6 +2121,7 @@ message TAppConfig {
     optional NKikimrReplication.TReplicationDefaults ReplicationConfig = 83;
     optional TShutdownConfig ShutdownConfig = 84;
     optional TPrioritiesQueueConfig CompPrioritiesConfig = 85;
+    optional TSelfManagementConfig SelfManagementConfig = 86;
 
     repeated TNamedConfig NamedConfigs = 100;
     optional string ClusterYamlConfig = 101;

--- a/ydb/library/yaml_config/yaml_config_parser_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser_ut.cpp
@@ -92,7 +92,7 @@ pdisk_key_config:
     }
 
     Y_UNIT_TEST(AllowDefaultHostConfigId) {
-        TString config = "{blob_storage_config: {autoconfig_settings: {erasure_species: block-4-2, pdisk_type: NVME}}, "
+        TString config = "{self_management_config: {enabled: true, erasure_species: block-4-2, pdisk_type: NVME}, "
             "host_configs: [{nvme: [disk1, disk2]}], hosts: [{host: fqdn1}, {host: fqdn2}]}";
         NKikimrConfig::TAppConfig cfg = Parse(config, true);
         UNIT_ASSERT(cfg.HasBlobStorageConfig());
@@ -106,9 +106,9 @@ pdisk_key_config:
     }
 
     Y_UNIT_TEST(IncorrectHostConfigIdFails) {
-        TString config1 = "{blob_storage_config: {autoconfig_settings: {erasure_species: block-4-2, pdisk_type: NVME}}, "
+        TString config1 = "{self_management_config: {enabled: true, erasure_species: block-4-2, pdisk_type: NVME}, "
             "host_configs: [{nvme: [disk1, disk2]}], hosts: [{host: fqdn1, host_config_id: 2}, {host: fqdn2}]}";
-        TString config2 = "{blob_storage_config: {autoconfig_settings: {erasure_species: block-4-2, pdisk_type: NVME}}, "
+        TString config2 = "{self_management_config: {enabled: true, erasure_species: block-4-2, pdisk_type: NVME}, "
             "host_configs: [{host_config_id: 1, nvme: [disk1, disk2]}], hosts: [{host: fqdn1, host_config_id: 2}, "
             "{host: fqdn2}]}";
         UNIT_CHECK_GENERATED_EXCEPTION(Parse(config1, false), yexception);
@@ -116,7 +116,7 @@ pdisk_key_config:
     }
 
     Y_UNIT_TEST(NoMixedHostConfigIds) {
-        TString config = "{blob_storage_config: {autoconfig_settings: {erasure_species: block-4-2, pdisk_type: NVME}}, "
+        TString config = "{self_management_config: {enabled: true, erasure_species: block-4-2, pdisk_type: NVME}, "
             "host_configs: [{nvme: [disk1, disk2]}, {host_config_id: 2}], hosts: [{host: fqdn1, host_config_id: 2}, "
             "{host: fqdn2, host_config_id: 2}]}";
         UNIT_CHECK_GENERATED_EXCEPTION(Parse(config, false), yexception);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Move distconf settings a level up in the configuration and add explicit enabled flag

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Autoconfig now can be enabled at top-level in SelfManagementConfig section.
