### PR TITLE
Change sha1 algorithm to sha256 on self signed certificate and fingerprints

### DIFF
--- a/ydb/core/security/certificate_check/cert_auth_processor.cpp
+++ b/ydb/core/security/certificate_check/cert_auth_processor.cpp
@@ -152,9 +152,9 @@ TVector<TString> X509CertificateReader::ReadSubjectDns(const X509Ptr& x509, cons
 }
 
 TString X509CertificateReader::GetFingerprint(const X509Ptr& x509) {
-    static constexpr size_t FINGERPRINT_LENGTH = SHA_DIGEST_LENGTH;
+    static constexpr size_t FINGERPRINT_LENGTH = SHA256_DIGEST_LENGTH;
     unsigned char fingerprint[FINGERPRINT_LENGTH];
-    if (X509_digest(x509.get(), EVP_sha1(), fingerprint, nullptr) <= 0) {
+    if (X509_digest(x509.get(), EVP_sha256(), fingerprint, nullptr) <= 0) {
         return "";
     }
     return HexEncode(fingerprint, FINGERPRINT_LENGTH);

--- a/ydb/core/security/certificate_check/cert_auth_utils.cpp
+++ b/ydb/core/security/certificate_check/cert_auth_utils.cpp
@@ -246,7 +246,7 @@ X509Ptr GenerateSelfSignedCertificate(PKeyPtr& pkey, const TProps& props) {
 
 
     /* Actually sign the certificate with our key. */
-    errNo = X509_sign(x509.get(), pkey.get(), EVP_sha1());
+    errNo = X509_sign(x509.get(), pkey.get(), EVP_sha256());
     CHECK(errNo, "Error signing certificate.");
 
     return std::move(x509);
@@ -438,7 +438,7 @@ X509Ptr SignRequest(X509REQPtr& request, X509Ptr& rootCert, PKeyPtr& rootKey, co
     }
 
     /* Actually sign the certificate with our key. */
-    errNo = X509_sign(x509.get(), rootKey.get(), EVP_sha1());
+    errNo = X509_sign(x509.get(), rootKey.get(), EVP_sha256());
     CHECK(errNo, "Error signing certificate.");
 
     pktmp = nullptr;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Change algorithm for create fingerprints of certificates from sha1 to sha256

### Changelog category <!-- remove all except one -->

* Improvement


### Additional information

...
