### PR TITLE
kqp prepartion changes for vector index

### DIFF
--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -28,7 +28,19 @@ bool Contains(const auto& names, std::string_view str) {
     return std::find(std::begin(names), std::end(names), str) != std::end(names);
 }
 
-constexpr std::string_view ImplTables[] = {ImplTable, NTableVectorKmeansTreeIndex::LevelTable, NTableVectorKmeansTreeIndex::PostingTable};
+constexpr std::string_view ImplTables[] = {
+    ImplTable, NTableVectorKmeansTreeIndex::LevelTable, NTableVectorKmeansTreeIndex::PostingTable,
+};
+
+constexpr std::string_view GlobalSecondaryImplTables[] = {
+    ImplTable,
+};
+static_assert(std::is_sorted(std::begin(GlobalSecondaryImplTables), std::end(GlobalSecondaryImplTables)));
+
+constexpr std::string_view GlobalKMeansTreeImplTables[] = {
+    NTableVectorKmeansTreeIndex::LevelTable, NTableVectorKmeansTreeIndex::PostingTable,
+};
+static_assert(std::is_sorted(std::begin(GlobalKMeansTreeImplTables), std::end(GlobalKMeansTreeImplTables)));
 
 }
 
@@ -142,11 +154,11 @@ bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType indexType, const TTableColumn
     return true;
 }
 
-TVector<TString> GetImplTables(NKikimrSchemeOp::EIndexType indexType) {
+std::span<const std::string_view> GetImplTables(NKikimrSchemeOp::EIndexType indexType) {
     if (indexType == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree) {
-        return { NTableVectorKmeansTreeIndex::LevelTable, NTableVectorKmeansTreeIndex::PostingTable };
+        return GlobalKMeansTreeImplTables;
     } else {
-        return { ImplTable };
+        return GlobalSecondaryImplTables;
     }
 }
 

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -7,6 +7,9 @@
 #include <util/generic/string.h>
 #include <util/string/builder.h>
 
+#include <span>
+#include <string_view>
+
 namespace NKikimr::NTableIndex {
 
 struct TTableColumns {
@@ -24,7 +27,7 @@ inline constexpr const char* ImplTable = "indexImplTable";
 bool IsCompatibleIndex(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index, TString& explain);
 TTableColumns CalcTableImplDescription(NKikimrSchemeOp::EIndexType type, const TTableColumns& table, const TIndexColumns& index);
 
-TVector<TString> GetImplTables(NKikimrSchemeOp::EIndexType indexType);
+std::span<const std::string_view> GetImplTables(NKikimrSchemeOp::EIndexType indexType);
 bool IsImplTable(std::string_view tableName);
 bool IsBuildImplTable(std::string_view tableName);
 

--- a/ydb/core/kqp/host/kqp_type_ann.cpp
+++ b/ydb/core/kqp/host/kqp_type_ann.cpp
@@ -246,7 +246,7 @@ TStatus AnnotateReadTable(const TExprNode::TPtr& node, TExprContext& ctx, const 
     TKikimrTableMetadataPtr meta;
 
     if (readIndex) {
-        meta = table.second->Metadata->GetIndexMetadata(TString(node->Child(TKqlReadTableIndex::idx_Index)->Content())).first;
+        meta = table.second->Metadata->GetIndexMetadata(node->Child(TKqlReadTableIndex::idx_Index)->Content()).first;
         if (!meta) {
             return TStatus::Error;
         }
@@ -560,7 +560,7 @@ TStatus AnnotateLookupTable(const TExprNode::TPtr& node, TExprContext& ctx, cons
         if (!EnsureAtom(*index, ctx)) {
             return TStatus::Error;
         }
-        auto indexMeta = table.second->Metadata->GetIndexMetadata(TString(index->Content())).first;
+        auto indexMeta = table.second->Metadata->GetIndexMetadata(index->Content()).first;
 
         if (!CalcKeyColumnsCount(ctx, node->Pos(), *structType, *table.second, *indexMeta, keyColumnsCount)) {
             return TStatus::Error;

--- a/ydb/core/kqp/host/kqp_type_ann.cpp
+++ b/ydb/core/kqp/host/kqp_type_ann.cpp
@@ -455,7 +455,7 @@ TStatus AnnotateLookupTable(const TExprNode::TPtr& node, TExprContext& ctx, cons
     if (isStreamLookup && !EnsureArgsCount(*node, TKqlStreamLookupIndex::Match(node.Get()) ? 5 : 4, ctx)) {
         return TStatus::Error;
     }
-    
+
     if (!isStreamLookup && !EnsureArgsCount(*node, TKqlLookupIndexBase::Match(node.Get()) ? 4 : 3, ctx)) {
         return TStatus::Error;
     }
@@ -713,7 +713,7 @@ TStatus AnnotateUpsertRows(const TExprNode::TPtr& node, TExprContext& ctx, const
     }
 
     if (TKqlUpsertRowsIndex::Match(node.Get())) {
-        Y_ENSURE(!table.second->Metadata->SecondaryGlobalIndexMetadata.empty());
+        Y_ENSURE(!table.second->Metadata->ImplTables.empty());
     }
 
     auto effectType = MakeKqpEffectType(ctx);
@@ -1683,7 +1683,7 @@ TStatus AnnotateStreamLookupConnection(const TExprNode::TPtr& node, TExprContext
 
     } else if (settings.Strategy == EStreamLookupStrategyType::LookupJoinRows
         || settings.Strategy == EStreamLookupStrategyType::LookupSemiJoinRows) {
-        
+
         if (!EnsureTupleType(node->Pos(), *inputItemType, ctx)) {
             return TStatus::Error;
         }
@@ -1820,7 +1820,7 @@ TStatus AnnotateIndexLookupJoin(const TExprNode::TPtr& node, TExprContext& ctx) 
     } else {
         node->SetTypeAnn(ctx.MakeType<TListExprType>(outputRowType));
     }
-    
+
     return TStatus::Ok;
 }
 

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -893,7 +893,7 @@ TIntrusivePtr<TKikimrTableMetadata> GetIndexMetadata(const TKqlReadTableIndex& r
     const TKikimrTablesData& tables, TStringBuf cluster)
 {
     const auto& tableDesc = GetTableData(tables, cluster, read.Table().Path());
-    const auto& [indexMeta, _ ] = tableDesc.Metadata->GetIndexMetadata(read.Index().StringValue());
+    const auto& [indexMeta, _ ] = tableDesc.Metadata->GetIndexMetadata(read.Index().Value());
     return indexMeta;
 }
 

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -79,7 +79,7 @@ std::pair<TExprBase, TCoAtomList> CreateRowsToReplace(const TExprBase& input,
 
 bool HasIndexesToWrite(const TKikimrTableDescription& tableData) {
     bool hasIndexesToWrite = false;
-    YQL_ENSURE(tableData.Metadata->Indexes.size() == tableData.Metadata->SecondaryGlobalIndexMetadata.size());
+    YQL_ENSURE(tableData.Metadata->Indexes.size() == tableData.Metadata->ImplTables.size());
     for (const auto& index : tableData.Metadata->Indexes) {
         if (index.ItUsedForWrite()) {
             hasIndexesToWrite = true;

--- a/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
+++ b/ydb/core/kqp/opt/kqp_statistics_transformer.cpp
@@ -52,7 +52,7 @@ void InferStatisticsForReadTable(const TExprNode::TPtr& input, TTypeAnnotationCo
     auto keyColumns = inputStats->KeyColumns;
     if (auto indexRead = inputNode.Maybe<TKqlReadTableIndex>()) {
         const auto& tableData = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, indexRead.Cast().Table().Path().Value());
-        const auto& [indexMeta, _] = tableData.Metadata->GetIndexMetadata(indexRead.Cast().Index().StringValue());
+        const auto& [indexMeta, _] = tableData.Metadata->GetIndexMetadata(indexRead.Cast().Index().Value());
 
         keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>(
             new TOptimizerStatistics::TKeyColumns(indexMeta->KeyColumnNames));
@@ -90,15 +90,15 @@ void InferStatisticsForReadTable(const TExprNode::TPtr& input, TTypeAnnotationCo
     double byteSize = nRows * sizePerRow * (nAttrs / (double)inputStats->Ncols);
 
     auto stats = std::make_shared<TOptimizerStatistics>(
-        EStatisticsType::BaseTable, 
-        nRows, 
-        nAttrs, 
-        byteSize, 
-        0.0, 
+        EStatisticsType::BaseTable,
+        nRows,
+        nAttrs,
+        byteSize,
+        0.0,
         keyColumns,
         inputStats->ColumnStatistics,
         inputStats->StorageType);
-    stats->SortColumns = sortedPrefixPtr; 
+    stats->SortColumns = sortedPrefixPtr;
 
     YQL_CLOG(TRACE, CoreDq) << "Infer statistics for read table" << stats->ToString();
 
@@ -177,11 +177,11 @@ void InferStatisticsForKqpTable(const TExprNode::TPtr& input, TTypeAnnotationCon
 
 /**
  * Infer statistic for Kqp steam lookup operator
- * 
+ *
  * In reality we want to compute the number of rows and cost that the lookyup actually performed.
  * But currently we just take the data from the base table, and join cardinality will still work correctly,
  * because it considers joins on PK.
- * 
+ *
  * In the future it would be better to compute the actual cardinality
 */
 void InferStatisticsForSteamLookup(const TExprNode::TPtr& input, TTypeAnnotationContext* typeCtx) {
@@ -198,17 +198,17 @@ void InferStatisticsForSteamLookup(const TExprNode::TPtr& input, TTypeAnnotation
     auto byteSize = tableStats->ByteSize * (nAttrs / (double) tableStats->Ncols) * inputStats->Selectivity;
 
     auto res = std::make_shared<TOptimizerStatistics>(
-        EStatisticsType::BaseTable, 
-        inputStats->Nrows, 
-        nAttrs, 
-        byteSize, 
-        0, 
+        EStatisticsType::BaseTable,
+        inputStats->Nrows,
+        nAttrs,
+        byteSize,
+        0,
         inputStats->KeyColumns,
         inputStats->ColumnStatistics,
         inputStats->StorageType);
     res->SortColumns = inputStats->SortColumns;
 
-    typeCtx->SetStats(input.Get(), res); 
+    typeCtx->SetStats(input.Get(), res);
 
 }
 
@@ -265,7 +265,7 @@ void InferStatisticsForRowsSourceSettings(const TExprNode::TPtr& input, TTypeAnn
     auto keyColumns = inputStats->KeyColumns;
     if (auto indexRead = inputNode.Maybe<TKqlReadTableIndexRanges>()) {
         const auto& tableData = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, indexRead.Cast().Table().Path().Value());
-        const auto& [indexMeta, _] = tableData.Metadata->GetIndexMetadata(indexRead.Cast().Index().StringValue());
+        const auto& [indexMeta, _] = tableData.Metadata->GetIndexMetadata(indexRead.Cast().Index().Value());
 
         keyColumns = TIntrusivePtr<TOptimizerStatistics::TKeyColumns>(
             new TOptimizerStatistics::TKeyColumns(indexMeta->KeyColumnNames));
@@ -294,19 +294,19 @@ void InferStatisticsForRowsSourceSettings(const TExprNode::TPtr& input, TTypeAnn
     double cost = inputStats->Cost;
 
     auto outputStats = std::make_shared<TOptimizerStatistics>(
-        EStatisticsType::BaseTable, 
-        nRows, 
-        nAttrs, 
-        byteSize, 
-        cost, 
-        keyColumns, 
+        EStatisticsType::BaseTable,
+        nRows,
+        nAttrs,
+        byteSize,
+        cost,
+        keyColumns,
         inputStats->ColumnStatistics,
         inputStats->StorageType);
     outputStats->SortColumns = std::move(sortedPrefixPtr);
 
     YQL_CLOG(TRACE, CoreDq) << "Infer statistics for source settings: " << outputStats->ToString();
 
-    typeCtx->SetStats(input.Get(), outputStats); 
+    typeCtx->SetStats(input.Get(), outputStats);
 }
 
 /**
@@ -334,7 +334,7 @@ void InferStatisticsForReadTableIndexRanges(const TExprNode::TPtr& input, TTypeA
     if (!inputStats) {
         return;
     }
-    
+
     TVector<TString> indexColumns;
     for (auto c : indexRanges.Columns()) {
         indexColumns.push_back(c.StringValue());
@@ -360,11 +360,11 @@ void InferStatisticsForReadTableIndexRanges(const TExprNode::TPtr& input, TTypeA
         sortedPrefixPtr = TIntrusivePtr<TOptimizerStatistics::TSortColumns>(new TOptimizerStatistics::TSortColumns(sortedPrefixCols, sortedPrefixAliases));
     }
     auto stats = std::make_shared<TOptimizerStatistics>(
-        inputStats->Type, 
+        inputStats->Type,
         inputStats->Nrows,
-        inputStats->Ncols, 
-        inputStats->ByteSize, 
-        inputStats->Cost, 
+        inputStats->Ncols,
+        inputStats->ByteSize,
+        inputStats->Cost,
         indexColumnsPtr,
         inputStats->ColumnStatistics,
         inputStats->StorageType);
@@ -418,7 +418,7 @@ void InferStatisticsForLookupJoin(const TExprNode::TPtr& input, TTypeAnnotationC
 /***
  * Infer statistics for result binding of a stage
  */
-void InferStatisticsForResultBinding(const TExprNode::TPtr& input, TTypeAnnotationContext* typeCtx, 
+void InferStatisticsForResultBinding(const TExprNode::TPtr& input, TTypeAnnotationContext* typeCtx,
     TVector<TVector<std::shared_ptr<TOptimizerStatistics>>>& txStats) {
 
     auto inputNode = TExprBase(input);
@@ -478,12 +478,12 @@ public:
                 TExprContext dummyCtx;
                 TPositionHandle dummyPos;
 
-                auto rowArg = 
+                auto rowArg =
                     Build<TCoArgument>(dummyCtx, dummyPos)
                         .Name("row")
                     .Done();
 
-                auto member = 
+                auto member =
                         Build<TCoMember>(dummyCtx, dummyPos)
                             .Struct(rowArg)
                             .Name().Build(attr)
@@ -678,7 +678,7 @@ double EstimateRowSize(const TStructExprType& rowType, const TString& format, co
             } else if (compression == "xz") {
                 compressionRatio *= 1.45;
             }
-            result /= compressionRatio; 
+            result /= compressionRatio;
         }
     }
 
@@ -745,7 +745,7 @@ void InferStatisticsForDqSourceWrap(const TExprNode::TPtr& input, TTypeAnnotatio
 
                 if (stats->Ncols == 0 || stats->Ncols > static_cast<int>(rowType->GetSize()) || stats->Nrows == 0 || stats->ByteSize == 0.0 || stats->Cost == 0.0) {
                     auto newSpecific = std::make_shared<TS3ProviderStatistics>(*specific);
-                    
+
                     auto sortColumns = stats->SortColumns;
                     stats = std::make_shared<TOptimizerStatistics>(stats->Type, stats->Nrows, stats->Ncols, stats->ByteSize, stats->Cost, stats->KeyColumns, stats->ColumnStatistics, stats->StorageType, newSpecific);
                     stats->SortColumns = std::move(sortColumns);
@@ -789,7 +789,7 @@ void InferStatisticsForDqSourceWrap(const TExprNode::TPtr& input, TTypeAnnotatio
  * When encountering a KqpPhysicalTx, we save the results of the stage in a vector
  * where it can later be accessed via binding parameters
  */
-void AppendTxStats(const TExprNode::TPtr& input, TTypeAnnotationContext* typeCtx, 
+void AppendTxStats(const TExprNode::TPtr& input, TTypeAnnotationContext* typeCtx,
     TVector<TVector<std::shared_ptr<TOptimizerStatistics>>>& txStats) {
 
     auto inputNode = TExprBase(input);
@@ -854,7 +854,7 @@ bool TKqpStatisticsTransformer::BeforeLambdasSpecific(const TExprNode::TPtr& inp
     }
     else if(TDqSourceWrapBase::Match(input.Get())) {
         InferStatisticsForDqSourceWrap(input, TypeCtx, KqpCtx);
-    } 
+    }
     else if (TKqpOlapFilter::Match(input.Get())) {
         InferStatisticsForOlapFilter(input, TypeCtx);
     }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
@@ -98,7 +98,7 @@ TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(TKqlReadTableBase read, TExprCon
 
     // we don't need to make filter for point selection
     if (!(prefixSize == from.ArgCount() &&
-         prefixSize == to.ArgCount() && 
+         prefixSize == to.ArgCount() &&
          from.template Maybe<TKqlKeyInc>() &&
          to.template Maybe<TKqlKeyInc>()))
     {
@@ -158,7 +158,7 @@ TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(TKqlReadTableRangesBase read, TE
 
     if (auto indexRead = read.template Maybe<TKqlReadTableIndexRanges>()) {
         const auto& tableDesc = GetTableData(*kqpCtx.Tables, kqpCtx.Cluster, read.Table().Path());
-        const auto& [indexMeta, _ ] = tableDesc.Metadata->GetIndexMetadata(indexRead.Index().Cast().StringValue());
+        const auto& [indexMeta, _ ] = tableDesc.Metadata->GetIndexMetadata(indexRead.Index().Cast().Value());
         lookupTable = indexMeta->Name;
         indexName = indexRead.Cast().Index().StringValue();
     } else {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_ranges_predext.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_ranges_predext.cpp
@@ -183,7 +183,7 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
             auto maxKey = calcKey(primaryBuildResult, mainTableDesc.Metadata->KeyColumnNames.size(), false, mainTableDesc);
             for (auto& index : mainTableDesc.Metadata->Indexes) {
                 if (index.Type != TIndexDescription::EType::GlobalAsync && index.State == TIndexDescription::EIndexState::Ready) {
-                    auto& tableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, mainTableDesc.Metadata->GetIndexMetadata(TString(index.Name)).first->Name);
+                    auto& tableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, mainTableDesc.Metadata->GetIndexMetadata(index.Name).first->Name);
 
                     bool uselessIndex = true;
                     for (size_t i = 0; i < mainTableDesc.Metadata->KeyColumnNames.size(); ++i) {
@@ -223,7 +223,7 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
         }
     }
 
-    auto& tableDesc = indexName ? kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, mainTableDesc.Metadata->GetIndexMetadata(TString(indexName.Cast())).first->Name) : mainTableDesc;
+    auto& tableDesc = indexName ? kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, mainTableDesc.Metadata->GetIndexMetadata(indexName.Cast()).first->Name) : mainTableDesc;
 
     auto buildResult = extractor->BuildComputeNode(tableDesc.Metadata->KeyColumnNames, ctx, typesCtx);
 
@@ -444,4 +444,3 @@ TExprBase KqpPushExtractedPredicateToReadTable(TExprBase node, TExprContext& ctx
 }
 
 } // namespace NKikimr::NKqp::NOpt
-

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
@@ -83,18 +83,17 @@ TVector<std::pair<TExprNode::TPtr, const TIndexDescription*>> BuildSecondaryInde
 {
     TVector<std::pair<TExprNode::TPtr, const TIndexDescription*>> secondaryIndexes;
     secondaryIndexes.reserve(table.Metadata->Indexes.size());
-    YQL_ENSURE(table.Metadata->Indexes.size() == table.Metadata->SecondaryGlobalIndexMetadata.size());
+    YQL_ENSURE(table.Metadata->Indexes.size() == table.Metadata->ImplTables.size());
     for (size_t i = 0; i < table.Metadata->Indexes.size(); i++) {
-        const auto& indexMeta = table.Metadata->Indexes[i];
-
-        if (!indexMeta.ItUsedForWrite()) {
+        const auto& index = table.Metadata->Indexes[i];
+        if (!index.ItUsedForWrite()) {
             continue;
         }
 
         // Add index if filter absent
         bool addIndex = filter ? false : true;
 
-        for (const auto& col : indexMeta.KeyColumns) {
+        for (const auto& col : index.KeyColumns) {
 
             if (filter) {
                 // Add index if filter and at least one column present in the filter
@@ -102,7 +101,7 @@ TVector<std::pair<TExprNode::TPtr, const TIndexDescription*>> BuildSecondaryInde
             }
         }
 
-        for (const auto& col : indexMeta.DataColumns) {
+        for (const auto& col : index.DataColumns) {
 
             if (filter) {
                 // Add index if filter and at least one column present in the filter
@@ -110,9 +109,11 @@ TVector<std::pair<TExprNode::TPtr, const TIndexDescription*>> BuildSecondaryInde
             }
         }
 
-        if (indexMeta.KeyColumns && addIndex) {
-            auto indexTable = tableBuilder(*table.Metadata->SecondaryGlobalIndexMetadata[i], pos, ctx).Ptr();
-            secondaryIndexes.emplace_back(std::make_pair(indexTable, &indexMeta));
+        if (index.KeyColumns && addIndex) {
+            auto& implTable = table.Metadata->ImplTables[i];
+            YQL_ENSURE(!implTable->Next);
+            auto indexTable = tableBuilder(*implTable, pos, ctx).Ptr();
+            secondaryIndexes.emplace_back(indexTable, &index);
         }
     }
     return secondaryIndexes;

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_uniq_helper.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_uniq_helper.cpp
@@ -57,8 +57,9 @@ private:
         if (indexId == -1) {
             meta = &mainTableMeta;
         } else {
-            YQL_ENSURE((size_t)indexId < mainTableMeta.SecondaryGlobalIndexMetadata.size());
-            meta = mainTableMeta.SecondaryGlobalIndexMetadata[indexId].Get();
+            YQL_ENSURE((size_t)indexId < mainTableMeta.ImplTables.size());
+            meta = mainTableMeta.ImplTables[indexId].Get();
+            YQL_ENSURE(!meta->Next);
         }
 
         auto inputs = Build<TDqPhyPrecompute>(ctx, pos)
@@ -138,8 +139,9 @@ private:
         if (indexId == -1) {
             meta = &mainTableMeta;
         } else {
-            YQL_ENSURE((size_t)indexId < mainTableMeta.SecondaryGlobalIndexMetadata.size());
-            meta = mainTableMeta.SecondaryGlobalIndexMetadata[indexId].Get();
+            YQL_ENSURE((size_t)indexId < mainTableMeta.ImplTables.size());
+            meta = mainTableMeta.ImplTables[indexId].Get();
+            YQL_ENSURE(!meta->Next);
         }
 
         TVector<TExprBase> inputs;

--- a/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
@@ -336,12 +336,16 @@ public:
                 tableDesc->Metadata = res.Metadata;
 
                 bool sysColumnsEnabled = SessionCtx->Config().SystemColumnsEnabled();
-                YQL_ENSURE(res.Metadata->Indexes.size() == res.Metadata->SecondaryGlobalIndexMetadata.size());
-                for (const auto& indexMeta : res.Metadata->SecondaryGlobalIndexMetadata) {
-                    YQL_ENSURE(indexMeta);
-                    auto& desc = SessionCtx->Tables().GetOrAddTable(indexMeta->Cluster, SessionCtx->GetDatabase(), indexMeta->Name);
-                    desc.Metadata = indexMeta;
-                    desc.Load(ctx, sysColumnsEnabled);
+                YQL_ENSURE(res.Metadata->Indexes.size() == res.Metadata->ImplTables.size());
+                for (auto implTable : res.Metadata->ImplTables) {
+                    YQL_ENSURE(implTable);
+                    do {
+                        auto nextImplTable = implTable->Next;
+                        auto& desc = SessionCtx->Tables().GetOrAddTable(implTable->Cluster, SessionCtx->GetDatabase(), implTable->Name);
+                        desc.Metadata = std::move(implTable);
+                        desc.Load(ctx, sysColumnsEnabled);
+                        implTable = std::move(nextImplTable);
+                    } while (implTable);
                 }
 
                 if (!tableDesc->Load(ctx, sysColumnsEnabled)) {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -468,6 +468,8 @@ struct TViewPersistedData {
 };
 
 struct TKikimrTableMetadata : public TThrRefBase {
+    TIntrusivePtr<TKikimrTableMetadata> Next;
+
     bool DoesExist = false;
     TString Cluster;
     TString Name;
@@ -494,9 +496,9 @@ struct TKikimrTableMetadata : public TThrRefBase {
     TVector<TString> KeyColumnNames;
     TVector<TString> ColumnOrder;
 
-    // Indexes and SecondaryGlobalIndexMetadata must be in same order
+    // Indexes and ImplTables must be in same order
     TVector<TIndexDescription> Indexes;
-    TVector<TIntrusivePtr<TKikimrTableMetadata>> SecondaryGlobalIndexMetadata;
+    TVector<TIntrusivePtr<TKikimrTableMetadata>> ImplTables;
 
     TVector<TColumnFamily> ColumnFamilies;
     TTableSettings TableSettings;
@@ -536,13 +538,23 @@ struct TKikimrTableMetadata : public TThrRefBase {
             orderMap.emplace(col.GetId(), col.GetName());
         }
 
-        Indexes.reserve(message->GetIndexes().size());
-        for(auto& index: message->GetIndexes())
-            Indexes.push_back(TIndexDescription(&index));
+        const auto indexesCount = message->GetIndexes().size();
+        Indexes.reserve(indexesCount);
+        for(auto& index: message->GetIndexes()) {
+            Indexes.emplace_back(&index);
+        }
 
-        SecondaryGlobalIndexMetadata.reserve(message->GetSecondaryGlobalIndexMetadata().size());
-        for(auto& sgim: message->GetSecondaryGlobalIndexMetadata())
-           SecondaryGlobalIndexMetadata.push_back(MakeIntrusive<TKikimrTableMetadata>(&sgim));
+        auto it = message->GetSecondaryGlobalIndexMetadata().begin();
+        ImplTables.reserve(indexesCount);
+        for(int i = 0; i < indexesCount; ++i) {
+            YQL_ENSURE(it != message->GetSecondaryGlobalIndexMetadata().end());
+            auto& implTable = ImplTables.emplace_back(MakeIntrusive<TKikimrTableMetadata>(&*it++));
+            if (Indexes[i].Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+                YQL_ENSURE(it != message->GetSecondaryGlobalIndexMetadata().end());
+                implTable->Next = MakeIntrusive<TKikimrTableMetadata>(&*it++);
+            }
+        }
+        YQL_ENSURE(it == message->GetSecondaryGlobalIndexMetadata().end());
 
         ColumnOrder.reserve(Columns.size());
         for(auto& [_, name]: orderMap) {
@@ -608,8 +620,12 @@ struct TKikimrTableMetadata : public TThrRefBase {
             index.ToMessage(message->AddIndexes());
         }
 
-        for(auto& IndexTableMetadata: SecondaryGlobalIndexMetadata) {
-            IndexTableMetadata->ToMessage(message->AddSecondaryGlobalIndexMetadata());
+        for(auto implTable: ImplTables) {
+            YQL_ENSURE(implTable);
+            do {
+                implTable->ToMessage(message->AddSecondaryGlobalIndexMetadata());
+                implTable = implTable->Next;
+            } while (implTable);
         }
     }
 
@@ -621,12 +637,12 @@ struct TKikimrTableMetadata : public TThrRefBase {
 
     std::pair<TIntrusivePtr<TKikimrTableMetadata>, TIndexDescription::EIndexState> GetIndexMetadata(const TString& indexName) const {
         YQL_ENSURE(Indexes.size(), "GetIndexMetadata called for table without indexes");
-        YQL_ENSURE(Indexes.size() == SecondaryGlobalIndexMetadata.size(), "index metadata has not been loaded yet");
+        YQL_ENSURE(Indexes.size() == ImplTables.size(), "index metadata has not been loaded yet");
         for (size_t i = 0; i < Indexes.size(); i++) {
             if (Indexes[i].Name == indexName) {
-                auto metadata = SecondaryGlobalIndexMetadata[i];
-                YQL_ENSURE(metadata, "unexpected empty metadata for index " << indexName);
-                return {metadata, Indexes[i].State};
+                auto implTable = ImplTables[i];
+                YQL_ENSURE(implTable, "unexpected empty metadata for index " << indexName);
+                return {std::move(implTable), Indexes[i].State};
             }
         }
         return {nullptr, TIndexDescription::EIndexState::Invalid};

--- a/ydb/core/kqp/provider/yql_kikimr_provider.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.cpp
@@ -843,13 +843,14 @@ void TableDescriptionToTableInfoImpl(const TKikimrTableDescription& desc, TYdbOp
                 continue;
             }
 
-            const auto& idxTableDesc = desc.Metadata->SecondaryGlobalIndexMetadata[idxNo];
+            const auto& implTable = *desc.Metadata->ImplTables[idxNo];
+            YQL_ENSURE(!implTable.Next);
 
             auto info = NKqpProto::TKqpTableInfo();
-            info.SetTableName(idxTableDesc->Name);
-            info.MutableTableId()->SetOwnerId(idxTableDesc->PathId.OwnerId());
-            info.MutableTableId()->SetTableId(idxTableDesc->PathId.TableId());
-            info.SetSchemaVersion(idxTableDesc->SchemaVersion);
+            info.SetTableName(implTable.Name);
+            info.MutableTableId()->SetOwnerId(implTable.PathId.OwnerId());
+            info.MutableTableId()->SetTableId(implTable.PathId.TableId());
+            info.SetSchemaVersion(implTable.SchemaVersion);
 
             back_inserter = std::move(info);
             ++back_inserter;

--- a/ydb/tools/query_replay/query_compiler.cpp
+++ b/ydb/tools/query_replay/query_compiler.cpp
@@ -109,8 +109,13 @@ struct TMetadataInfoHolder {
         : TableMetadata(tableMetadata)
     {
         for (auto& [name, ptr] : TableMetadata) {
-            for (auto& secondary : ptr->SecondaryGlobalIndexMetadata) {
-                Indexes.emplace(secondary->Name, secondary);
+            for (auto implTable : ptr->ImplTables) {
+                YQL_ENSURE(implTable);
+                do {
+                    auto nextImplTable = implTable->Next;
+                    Indexes.emplace(implTable->Name, std::move(implTable));
+                    implTable = std::move(nextImplTable);
+                } while (implTable);
             }
         }
     }

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -105,8 +105,13 @@ struct TMetadataInfoHolder {
         : TableMetadata(tableMetadata)
     {
         for (auto& [name, ptr] : TableMetadata) {
-            for (auto& secondary : ptr->SecondaryGlobalIndexMetadata) {
-                Indexes.emplace(secondary->Name, secondary);
+            for (auto implTable : ptr->ImplTables) {
+                YQL_ENSURE(implTable);
+                do {
+                    auto nextImplTable = implTable->Next;
+                    Indexes.emplace(implTable->Name, std::move(implTable));
+                    implTable = std::move(nextImplTable);
+                } while (implTable);
             }
         }
     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Needed for this PR: https://github.com/ydb-platform/ydb/pull/12639
Contains such changes:
* Support multiple index impl tables in kqp
* Make `FROM <table> VIEW <index>` kqp rewrite rules informed about GlobalKMeansTree vector index existence