### PR TITLE
Support lightweight alias actor ids for actors

### DIFF
--- a/ydb/core/tx/replication/ydb_proxy/partition_end_watcher_ut.cpp
+++ b/ydb/core/tx/replication/ydb_proxy/partition_end_watcher_ut.cpp
@@ -38,6 +38,14 @@ Y_UNIT_TEST_SUITE(PartitionEndWatcher) {
             Y_ABORT("Unexpected");
         }
 
+        TActorId RegisterAlias() noexcept {
+            Y_ABORT("Unexpected");
+        }
+
+        void UnregisterAlias(const TActorId&) noexcept {
+            Y_ABORT("Unexpected");
+        }
+
         ~MockActorOps() {
             for (auto [_, ptr] : Events) {
                 std::unique_ptr<IEventBase> p;

--- a/ydb/core/util/actorsys_test/testactorsys.cpp
+++ b/ydb/core/util/actorsys_test/testactorsys.cpp
@@ -125,6 +125,14 @@ public:
         return Context->Register(actor, parentId, PoolId, mailbox->Hint, NodeId);
     }
 
+    TActorId RegisterAlias(TMailbox* mailbox, IActor* actor) override {
+        return Context->RegisterAlias(mailbox->Hint, actor, PoolId, NodeId);
+    }
+
+    void UnregisterAlias(TMailbox* mailbox, const TActorId& actorId) override {
+        return Context->UnregisterAlias(mailbox->Hint, actorId, PoolId, NodeId);
+    }
+
     void Prepare(TActorSystem* /*actorSystem*/, NSchedulerQueue::TReader** /*scheduleReaders*/, ui32* /*scheduleSz*/) override {
     }
 

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -145,6 +145,14 @@ namespace NActors {
         return TlsActivationContext->ExecutorThread.RegisterActor(actor, &TlsActivationContext->Mailbox, SelfActorId);
     }
 
+    TActorId IActor::RegisterAlias() noexcept {
+        return TlsActivationContext->ExecutorThread.RegisterAlias(&TlsActivationContext->Mailbox, this);
+    }
+
+    void IActor::UnregisterAlias(const TActorId& actorId) noexcept {
+        return TlsActivationContext->ExecutorThread.UnregisterAlias(&TlsActivationContext->Mailbox, actorId);
+    }
+
     TActorId TActivationContext::InterconnectProxy(ui32 destinationNodeId) {
         return TlsActivationContext->ExecutorThread.ActorSystem->InterconnectProxy(destinationNodeId);
     }
@@ -339,6 +347,14 @@ namespace NActors {
             TlsThreadContext->SendingType = previousType;
             return id;
         }
+    }
+
+    TActorId TGenericExecutorThread::RegisterAlias(TMailbox* mailbox, IActor* actor) {
+        return Ctx.Executor->RegisterAlias(mailbox, actor);
+    }
+
+    void TGenericExecutorThread::UnregisterAlias(TMailbox* mailbox, const TActorId& actorId) {
+        Ctx.Executor->UnregisterAlias(mailbox, actorId);
     }
 
     template bool TActivationContext::Send<ESendingType::Common>(TAutoPtr<IEventHandle> ev);

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -11,6 +11,8 @@
 #include <util/system/tls.h>
 #include <util/generic/noncopyable.h>
 
+#include <library/cpp/containers/absl_flat_hash/flat_hash_set.h>
+
 namespace NActors {
     class TActorSystem;
     class TMailboxTable;
@@ -270,6 +272,9 @@ namespace NActors {
 
         virtual TActorId Register(IActor*, TMailboxType::EType mailboxType = TMailboxType::HTSwap, ui32 poolId = Max<ui32>()) const noexcept = 0;
         virtual TActorId RegisterWithSameMailbox(IActor*) const noexcept = 0;
+
+        virtual TActorId RegisterAlias() noexcept = 0;
+        virtual void UnregisterAlias(const TActorId& actorId) noexcept = 0;
     };
 
     class TDecorator;
@@ -352,6 +357,11 @@ namespace NActors {
         i64 ElapsedTicks;
         friend void DoActorInit(TActorSystem*, IActor*, const TActorId&, const TActorId&);
         friend class TDecorator;
+
+    private:
+        // actor aliases
+        absl::flat_hash_set<ui64> Aliases;
+        friend class TMailbox;
 
     private: // stuck actor monitoring
         TMonotonic LastReceiveTimestamp;
@@ -599,6 +609,9 @@ namespace NActors {
         // This method of registration can be useful if multiple actors share
         // some memory.
         TActorId RegisterWithSameMailbox(IActor* actor) const noexcept final;
+
+        TActorId RegisterAlias() noexcept final;
+        void UnregisterAlias(const TActorId& actorId) noexcept final;
 
         std::pair<ui32, ui32> CountMailboxEvents(ui32 maxTraverse = Max<ui32>()) const;
 

--- a/ydb/library/actors/core/executor_pool.h
+++ b/ydb/library/actors/core/executor_pool.h
@@ -105,6 +105,9 @@ namespace NActors {
         virtual TActorId Register(IActor* actor, TMailboxCache& cache, ui64 revolvingCounter, const TActorId& parentId) = 0;
         virtual TActorId Register(IActor* actor, TMailbox* mailbox, const TActorId& parentId) = 0;
 
+        virtual TActorId RegisterAlias(TMailbox* mailbox, IActor* actor) = 0;
+        virtual void UnregisterAlias(TMailbox* mailbox, const TActorId& actorId) = 0;
+
         virtual void GetCurrentStats(TExecutorPoolStats& poolStats, TVector<TExecutorThreadStats>& statsCopy) const {
             // TODO: make pure virtual and override everywhere
             Y_UNUSED(poolStats);

--- a/ydb/library/actors/core/executor_pool_base.h
+++ b/ydb/library/actors/core/executor_pool_base.h
@@ -42,6 +42,8 @@ namespace NActors {
         TActorId Register(IActor* actor, TMailboxType::EType mailboxType, ui64 revolvingWriteCounter, const TActorId& parentId) override;
         TActorId Register(IActor* actor, TMailboxCache& cache, ui64 revolvingWriteCounter, const TActorId& parentId) override;
         TActorId Register(IActor* actor, TMailbox* mailbox, const TActorId& parentId) override;
+        TActorId RegisterAlias(TMailbox* mailbox, IActor* actor) override;
+        void UnregisterAlias(TMailbox* mailbox, const TActorId& actorId) override;
         bool Cleanup() override;
     };
 

--- a/ydb/library/actors/core/executor_thread.h
+++ b/ydb/library/actors/core/executor_thread.h
@@ -59,6 +59,9 @@ namespace NActors {
         void DropUnregistered();
         const std::vector<THolder<IActor>>& GetUnregistered() const { return DyingActors; }
 
+        TActorId RegisterAlias(TMailbox* mailbox, IActor* actor);
+        void UnregisterAlias(TMailbox* mailbox, const TActorId& actorId);
+
         void Schedule(TInstant deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie = nullptr);
         void Schedule(TMonotonic deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie = nullptr);
         void Schedule(TDuration delta, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie = nullptr);

--- a/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
+++ b/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
@@ -134,6 +134,8 @@ Y_UNIT_TEST_SUITE(HarmonizerTests) {
         TActorId Register(IActor* /*actor*/, TMailboxType::EType /*mailboxType*/, ui64 /*revolvingCounter*/, const TActorId& /*parentId*/) override { return TActorId(); }
         TActorId Register(IActor* /*actor*/, TMailboxCache& /*cache*/, ui64 /*revolvingCounter*/, const TActorId& /*parentId*/) override { return TActorId(); }
         TActorId Register(IActor* /*actor*/, TMailbox* /*mailbox*/, const TActorId& /*parentId*/) override { return TActorId(); }
+        TActorId RegisterAlias(TMailbox*, IActor*) override { return TActorId(); }
+        void UnregisterAlias(TMailbox*, const TActorId&) override {}
 
         TAffinity* Affinity() const override { return nullptr; }
 

--- a/ydb/library/actors/core/mailbox_lockfree.h
+++ b/ydb/library/actors/core/mailbox_lockfree.h
@@ -52,6 +52,7 @@ namespace NActors {
         };
 
         struct TActorMap : public absl::flat_hash_map<ui64, IActor*> {
+            absl::flat_hash_map<ui64, IActor*> Aliases;
             TMailboxStats Stats;
         };
 
@@ -100,6 +101,10 @@ namespace NActors {
         IActor* FindActor(ui64 localActorId) noexcept;
         void AttachActor(ui64 localActorId, IActor* actor) noexcept;
         IActor* DetachActor(ui64 localActorId) noexcept;
+
+        IActor* FindAlias(ui64 localActorId) noexcept;
+        void AttachAlias(ui64 localActorId, IActor* actor) noexcept;
+        IActor* DetachAlias(ui64 localActorId) noexcept;
 
         void EnableStats();
         void AddElapsedCycles(ui64);
@@ -182,6 +187,7 @@ namespace NActors {
         void Unlock(IExecutorPool* pool, NHPTimer::STime now, ui64& revolvingCounter);
 
     private:
+        void EnsureActorMap();
         void OnPreProcessed(IEventHandle* head, IEventHandle* tail) noexcept;
         void AppendPreProcessed(IEventHandle* head, IEventHandle* tail) noexcept;
         void PrependPreProcessed(IEventHandle* head, IEventHandle* tail) noexcept;

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -305,6 +305,7 @@ namespace NActors {
             const TActorId& parentid = TActorId());
         TActorId Register(IActor *actor, ui32 nodeIndex, ui32 poolId, TMailbox *mailbox,
             const TActorId& parentid = TActorId());
+        TActorId RegisterAlias(TMailbox* mailbox, IActor* actor, ui32 nodeIndex, ui32 poolId);
         TActorId RegisterService(const TActorId& serviceId, const TActorId& actorId, ui32 nodeIndex = 0);
         TActorId AllocateEdgeActor(ui32 nodeIndex = 0);
         TEventsList CaptureEvents();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Support lightweight alias actor ids for actors, which work similarly to proxy actors registered in the same mailbox rewriting events for the primary actor, but are much cheaper. I plan to use this for implementing tablet pipes and this will help avoid extra hops when delivering requests to tablets.