### PR TITLE
24-3: Add `ListNodes` cache in `DynamicNameserver` (#12694)

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -19,10 +19,11 @@ namespace NKikimr::NStorage {
         STLOG(PRI_DEBUG, BS_NODE, NWDC00, "Bootstrap");
 
         auto ns = NNodeBroker::BuildNameserverTable(Cfg->NameserviceConfig);
-        auto ev = std::make_unique<TEvInterconnect::TEvNodesInfo>();
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
         for (const auto& [nodeId, item] : ns->StaticNodeTable) {
-            ev->Nodes.emplace_back(nodeId, item.Address, item.Host, item.ResolveHost, item.Port, item.Location);
+            nodes->emplace_back(nodeId, item.Address, item.Host, item.ResolveHost, item.Port, item.Location);
         }
+        auto ev = std::make_unique<TEvInterconnect::TEvNodesInfo>(nodes);
         Send(SelfId(), ev.release());
 
         // and subscribe for the node list too

--- a/ydb/core/fq/libs/actors/nodes_manager.cpp
+++ b/ydb/core/fq/libs/actors/nodes_manager.cpp
@@ -259,14 +259,13 @@ private:
     void HandleResponse(NFq::TEvInternalService::TEvHealthCheckResponse::TPtr& ev) {
         try {
             const auto& status = ev->Get()->Status.GetStatus();
-            THolder<TEvInterconnect::TEvNodesInfo> nameServiceUpdateReq(new TEvInterconnect::TEvNodesInfo());
             if (!ev->Get()->Status.IsSuccess()) {
                 ythrow yexception() <<  status << '\n' << ev->Get()->Status.GetIssues().ToString();
             }
             const auto& res = ev->Get()->Result;
 
-            auto& nodesInfo = nameServiceUpdateReq->Nodes;
-            nodesInfo.reserve(res.nodes().size());
+            auto nodesInfo = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodesInfo->reserve(res.nodes().size());
 
             Peers.clear();
             std::set<ui32> nodeIds; // may be not unique
@@ -281,7 +280,7 @@ private:
                   node.active_workers(), node.memory_limit(), node.memory_allocated(), node.data_center()});
 
                 if (node.interconnect_port()) {
-                    nodesInfo.emplace_back(TEvInterconnect::TNodeInfo{
+                    nodesInfo->emplace_back(TEvInterconnect::TNodeInfo{
                         node.node_id(),
                         node.node_address(),
                         node.hostname(), // host
@@ -297,8 +296,9 @@ private:
             ServiceCounters.Counters->GetCounter("PeerCount", false)->Set(Peers.size());
             ServiceCounters.Counters->GetCounter("NodesHealthCheckOk", true)->Inc();
 
-            LOG_T("Send NodeInfo with size: " << nodesInfo.size() << " to DynamicNameserver");
-            if (!nodesInfo.empty()) {
+            LOG_T("Send NodeInfo with size: " << nodesInfo->size() << " to DynamicNameserver");
+            if (!nodesInfo->empty()) {
+                THolder<TEvInterconnect::TEvNodesInfo> nameServiceUpdateReq(new TEvInterconnect::TEvNodesInfo(nodesInfo));
                 Send(GetNameserviceActorId(), nameServiceUpdateReq.Release());
             }
         } catch (yexception &e) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1412,9 +1412,9 @@ public:
         TNodeId NodeId;
         TNodeLocation Location;
 
-        THostRecord(TEvInterconnect::TNodeInfo&& nodeInfo)
+        THostRecord(const TEvInterconnect::TNodeInfo& nodeInfo)
             : NodeId(nodeInfo.NodeId)
-            , Location(std::move(nodeInfo.Location))
+            , Location(nodeInfo.Location)
         {}
     };
 
@@ -1423,11 +1423,13 @@ public:
         THashMap<TNodeId, THostId> NodeIdToHostId;
 
     public:
+        THostRecordMapImpl() = default;
+
         THostRecordMapImpl(TEvInterconnect::TEvNodesInfo *msg) {
-            for (TEvInterconnect::TNodeInfo& nodeInfo : msg->Nodes) {
+            for (const TEvInterconnect::TNodeInfo& nodeInfo : msg->Nodes) {
                 const THostId hostId(nodeInfo.Host, nodeInfo.Port);
                 NodeIdToHostId.emplace(nodeInfo.NodeId, hostId);
-                HostIdToRecord.emplace(hostId, std::move(nodeInfo));
+                HostIdToRecord.emplace(hostId, nodeInfo);
             }
         }
 
@@ -1805,8 +1807,7 @@ public:
 
     // For test purposes, required for self heal actor
     void CreateEmptyHostRecordsMap() {
-        TEvInterconnect::TEvNodesInfo nodes;
-        HostRecords = std::make_shared<THostRecordMapImpl>(&nodes);
+        HostRecords = std::make_shared<THostRecordMapImpl>();
     }
 
     ui64 NextConfigTxSeqNo = 1;

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -47,10 +47,11 @@ void TestHeavy(const ui32 v, ui32 numWorkers) {
     options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, numWorkers);
     runtime.DispatchEvents(options);
     for (const auto& a : cc) {
-        THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
         for (auto i = 1; i <= NODES; ++i) {
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(i, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(i, "::", "localhost", "localhost", 1234, TNodeLocation()));
         }
+        THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
         runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
     }
 
@@ -727,10 +728,11 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
         options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
         runtime.DispatchEvents(options);
         for (const auto& a : cc) {
-            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
             runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
         }
 
@@ -827,10 +829,11 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
         options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
         runtime.DispatchEvents(options);
         for (const auto& a : cc) {
-            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
             runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
         }
 
@@ -903,10 +906,11 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
         options.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
         runtime.DispatchEvents(options);
         for (const auto& a : cc) {
-            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>();
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
-            nodesInfo->Nodes.emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(1, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(2, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            nodes->emplace_back(TEvInterconnect::TNodeInfo(3, "::", "localhost", "localhost", 1234, TNodeLocation()));
+            THolder<TEvInterconnect::TEvNodesInfo> nodesInfo = MakeHolder<TEvInterconnect::TEvNodesInfo>(nodes);
             runtime.Send(new NActors::IEventHandle(a, edge, nodesInfo.Release()), 0, true);
         }
 

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -251,14 +251,19 @@ Y_UNIT_TEST_SUITE(Viewer) {
     };
 
     void ChangeListNodes(TEvInterconnect::TEvNodesInfo::TPtr* ev, int nodesTotal) {
-        auto& nodes = (*ev)->Get()->Nodes;
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*ev)->Get()->Nodes);
 
-        auto sample = nodes[0];
-        nodes.clear();
+        auto sample = *nodes->begin();
+        nodes->clear();
 
         for (int nodeId = 0; nodeId < nodesTotal; nodeId++) {
-            nodes.emplace_back(sample);
+            nodes->emplace_back(sample);
         }
+
+        auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
+            new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
+        );
+        ev->Swap(newEv);
     }
 
     void ChangeTabletStateResponse(TEvWhiteboard::TEvTabletStateResponse::TPtr* ev, int tabletsTotal, int& tabletId, int& nodeId) {
@@ -722,7 +727,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 2);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];
@@ -801,7 +806,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 3);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];
@@ -884,7 +889,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 3);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];
@@ -970,7 +975,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 }
                 case TEvInterconnect::EvNodesInfo: {
                     auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
-                    TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
+                    const TVector<TEvInterconnect::TNodeInfo> &nodes = (*x)->Get()->Nodes;
                     UNIT_ASSERT_EQUAL(nodes.size(), 4);
                     staticNodeId = nodes[0];
                     sharedDynNodeId = nodes[1];

--- a/ydb/library/actors/core/interconnect.h
+++ b/ydb/library/actors/core/interconnect.h
@@ -2,6 +2,7 @@
 
 #include "events.h"
 #include "event_local.h"
+#include <ydb/library/actors/util/intrusive_vector.h>
 #include <ydb/library/actors/protos/interconnect.pb.h>
 #include <util/string/cast.h>
 #include <util/string/builder.h>
@@ -224,7 +225,13 @@ namespace NActors {
         };
 
         struct TEvNodesInfo: public TEventLocal<TEvNodesInfo, EvNodesInfo> {
-            TVector<TNodeInfo> Nodes;
+            TIntrusiveVector<TNodeInfo>::TConstPtr NodesPtr;
+            const TVector<TNodeInfo>& Nodes;
+
+            TEvNodesInfo(TIntrusiveVector<TNodeInfo>::TConstPtr nodesPtr)
+                : NodesPtr(nodesPtr)
+                , Nodes(*nodesPtr)
+            {}
 
             const TNodeInfo* GetNodeInfo(ui32 nodeId) const {
                 for (const auto& x : Nodes) {

--- a/ydb/library/actors/interconnect/interconnect_nameserver_base.h
+++ b/ydb/library/actors/interconnect/interconnect_nameserver_base.h
@@ -55,15 +55,14 @@ namespace NActors {
 
         void Handle(TEvInterconnect::TEvListNodes::TPtr& ev,
                     const TActorContext& ctx) {
-            THolder<TEvInterconnect::TEvNodesInfo>
-                reply(new TEvInterconnect::TEvNodesInfo());
-            reply->Nodes.reserve(NodeTable.size());
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+            nodes->reserve(NodeTable.size());
             for (const auto& pr : NodeTable) {
-                reply->Nodes.emplace_back(pr.first,
-                                          pr.second.Address, pr.second.Host, pr.second.ResolveHost,
-                                          pr.second.Port, pr.second.Location);
+                nodes->emplace_back(pr.first,
+                                    pr.second.Address, pr.second.Host, pr.second.ResolveHost,
+                                    pr.second.Port, pr.second.Location);
             }
-            ctx.Send(ev->Sender, reply.Release());
+            ctx.Send(ev->Sender, new TEvInterconnect::TEvNodesInfo(nodes));
         }
 
         void Handle(TEvInterconnect::TEvGetNode::TPtr& ev,

--- a/ydb/library/actors/util/intrusive_vector.h
+++ b/ydb/library/actors/util/intrusive_vector.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <util/generic/ptr.h>
+#include <util/generic/vector.h>
+
+template<typename T>
+class TIntrusiveVector : public TVector<T>, public TThrRefBase {
+public:
+    using TVector<T>::TVector;
+
+    using TPtr = TIntrusivePtr<TIntrusiveVector<T>>;
+    using TConstPtr = TIntrusiveConstPtr<TIntrusiveVector<T>>;
+
+    TIntrusiveVector(const TVector<T>& other) : TVector<T>(other) {}
+    TIntrusiveVector(TVector<T>&& other) : TVector<T>(std::move(other)) {}
+};

--- a/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
+++ b/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
@@ -166,10 +166,8 @@ namespace NYql::NDqs {
 
         void ReplyListNodes(const NActors::TActorId sender, const TActorContext& ctx)
         {
-            THolder<TEvInterconnect::TEvNodesInfo>
-                reply(new TEvInterconnect::TEvNodesInfo());
-            reply->Nodes = GetNodesInfo();
-            ctx.Send(sender, reply.Release());
+            auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>(GetNodesInfo());
+            ctx.Send(sender, new TEvInterconnect::TEvNodesInfo(nodes));
         }
 
         void Handle(TEvInterconnect::TEvListNodes::TPtr& ev,

--- a/ydb/library/yql/providers/dq/global_worker_manager/service_node_pinger.cpp
+++ b/ydb/library/yql/providers/dq/global_worker_manager/service_node_pinger.cpp
@@ -154,15 +154,14 @@ private:
 
         auto& resp = ev->Get()->Response;
 
-        THolder<TEvInterconnect::TEvNodesInfo>
-            reply(new TEvInterconnect::TEvNodesInfo());
-        reply->Nodes.reserve(resp.GetNodes().size());
         if (resp.GetEpoch()) {
             RuntimeData->Epoch = resp.GetEpoch();
         }
 
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>();
+        nodes->reserve(resp.GetNodes().size());
         for (auto& node : resp.GetNodes()) {
-            reply->Nodes.emplace_back(
+            nodes->emplace_back(
                 node.GetNodeId(),
                 node.GetAddress(),
                 node.GetAddress(),
@@ -170,6 +169,7 @@ private:
                 node.GetPort(),
                 NActors::TNodeLocation());
         }
+        THolder<TEvInterconnect::TEvNodesInfo> reply(new TEvInterconnect::TEvNodesInfo(nodes));
 
         TVector<TResourceFile> downloadList;
         for (auto& file : resp.GetDownloadList()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add caching for `ListNodes` request in `DynamicNameserver`

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

Prior to this change, the entire node list was copied for every `ListNodes` request. This change adds caching of the node list, which is now distributed by pointer. The node list is re-cached when changes are made.
