### PR TITLE
Try to fix msan for blobstorage unit tests

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -224,13 +224,13 @@ namespace NKikimr {
         bool UseActorSystemTimeInBSQueue = false;
 
         ///////////// BALANCING SETTINGS ////////////////////
-        bool BalancingEnableSend;
-        bool BalancingEnableDelete;
+        bool BalancingEnableSend = false;
+        bool BalancingEnableDelete = false;
         TDuration BalancingJobGranularity;
-        bool BalancingBalanceOnlyHugeBlobs;
-        ui64 BalancingBatchSize;
-        ui64 BalancingMaxToSendPerEpoch;
-        ui64 BalancingMaxToDeletePerEpoch;
+        bool BalancingBalanceOnlyHugeBlobs = false;
+        ui64 BalancingBatchSize = 0;
+        ui64 BalancingMaxToSendPerEpoch = 0;
+        ui64 BalancingMaxToDeletePerEpoch = 0;
         TDuration BalancingReadBatchTimeout;
         TDuration BalancingSendBatchTimeout;
         TDuration BalancingRequestBlobsOnMainTimeout;


### PR DESCRIPTION
### Changelog category

* Not for changelog


### Additional information

```
    #0 0x10c192d1 in void std::__y1::allocator<NKikimr::THull>::construct[abi:ne180000]<NKikimr::THull, TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr>>&, std::__y1::shared_ptr<NKikimr::TPDiskCtx>&, std::__y1::shared_ptr<NKikimr::THugeBlobCtx>&, unsigned int&, NKikimr::TGuardedActorID&, bool&, NKikimr::THullDbRecovery, NActors::TActorSystem* const&, bool&, NKikimr::TGuardedActorID&>(NKikimr::THull*, TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr>>&, std::__y1::shared_ptr<NKikimr::TPDiskCtx>&, std::__y1::shared_ptr<NKikimr::THugeBlobCtx>&, unsigned int&, NKikimr::TGuardedActorID&, bool&, NKikimr::THullDbRecovery&&, NActors::TActorSystem* const&, bool&, NKikimr::TGuardedActorID&) /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:167:28
    #1 0x10bf074a in construct<NKikimr::THull, TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr> > &, std::__y1::shared_ptr<NKikimr::TPDiskCtx> &, std::__y1::shared_ptr<NKikimr::THugeBlobCtx> &, unsigned int &, NKikimr::TGuardedActorID &, bool &, NKikimr::THullDbRecovery, NActors::TActorSystem *const &, bool &, NKikimr::TGuardedActorID &, void> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator_traits.h:296:13
    #2 0x10bf074a in __shared_ptr_emplace<TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr> > &, std::__y1::shared_ptr<NKikimr::TPDiskCtx> &, std::__y1::shared_ptr<NKikimr::THugeBlobCtx> &, unsigned int &, NKikimr::TGuardedActorID &, bool &, NKikimr::THullDbRecovery, NActors::TActorSystem *const &, bool &, NKikimr::TGuardedActorID &, std::__y1::allocator<NKikimr::THull>, 0> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:330:9
    #3 0x10bf074a in allocate_shared<NKikimr::THull, std::__y1::allocator<NKikimr::THull>, TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr> > &, std::__y1::shared_ptr<NKikimr::TPDiskCtx> &, std::__y1::shared_ptr<NKikimr::THugeBlobCtx> &, unsigned int &, NKikimr::TGuardedActorID &, bool &, NKikimr::THullDbRecovery, NActors::TActorSystem *const &, bool &, NKikimr::TGuardedActorID &, void> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:1051:53
    #4 0x10bf074a in make_shared<NKikimr::THull, TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr> > &, std::__y1::shared_ptr<NKikimr::TPDiskCtx> &, std::__y1::shared_ptr<NKikimr::THugeBlobCtx> &, unsigned int &, NKikimr::TGuardedActorID &, bool &, NKikimr::THullDbRecovery, NActors::TActorSystem *const &, bool &, NKikimr::TGuardedActorID &, void> /-S/contrib/libs/cxxsupp/libcxx/include/__memory/shared_ptr.h:1060:12
    #5 0x10bf074a in NKikimr::TSkeleton::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::TEvBlobStorage::TEvLocalRecoveryDone>, TDelete>&, NActors::TActorContext const&) /-S/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp:1946:24
    #6 0x10bec915 in NKikimr::TSkeleton::StateLocalRecovery(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp:2639:9
    #7 0xc3e21e2 in NActors::TGenericExecutorThread::Execute(NActors::TMailbox*, bool) /-S/ydb/library/actors/core/executor_thread.cpp:248:28
    #8 0xc3eb234 in NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(NActors::TMailbox*, bool) const /-S/ydb/library/actors/core/executor_thread.cpp:425:39
    #9 0xc3ea667 in NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) /-S/ydb/library/actors/core/executor_thread.cpp:479:13
    #10 0xc3ec79f in NActors::TExecutorThread::ThreadProc() /-S/ydb/library/actors/core/executor_thread.cpp:510:9
    #11 0xb43d6f3 in (anonymous namespace)::TPosixThread::ThreadProxy(void*) /-S/util/system/thread.cpp:244:20
    #12 0x7fa5194b6ac2  (/lib/x86_64-linux-gnu/libc.so.6+0x94ac2) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #13 0x7fa51954884f  (/lib/x86_64-linux-gnu/libc.so.6+0x12684f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
SUMMARY: MemorySanitizer: use-of-uninitialized-value /-S/contrib/libs/cxxsupp/libcxx/include/__memory/allocator.h:167:28 in void std::__y1::allocator<NKikimr::THull>::construct[abi:ne180000]<NKikimr::THull, TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr>>&, std::__y1::shared_ptr<NKikimr::TPDiskCtx>&, std::__y1::shared_ptr<NKikimr::THugeBlobCtx>&, unsigned int&, NKikimr::TGuardedActorID&, bool&, NKikimr::THullDbRecovery, NActors::TActorSystem* const&, bool&, NKikimr::TGuardedActorID&>(NKikimr::THull*, TIntrusivePtr<NKikimr::TLsnMngr, TDefaultIntrusivePtrOps<NKikimr::TLsnMngr>>&, std::__y1::shared_ptr<NKikimr::TPDiskCtx>&, std::__y1::shared_ptr<NKikimr::THugeBlobCtx>&, unsigned int&, NKikimr::TGuardedActorID&, bool&, NKikimr::THullDbRecovery&&, NActors::TActorSystem* const&, bool&, NKikimr::TGuardedActorID&)
Exiting
```