### PR TITLE
Node TNodeLocation processing to NodeWarden in order to reduce CPU consumption

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -91,24 +91,6 @@ struct TEvLatencyReport : public TEventLocal<TEvLatencyReport, TEvBlobStorage::E
     {}
 };
 
-struct TNodeLayoutInfo : TThrRefBase {
-    // indexed by NodeId
-    TNodeLocation SelfLocation;
-    TVector<TNodeLocation> LocationPerOrderNumber;
-
-    TNodeLayoutInfo(const TNodeLocation& selfLocation, const TIntrusivePtr<TBlobStorageGroupInfo>& info,
-            std::unordered_map<ui32, TNodeLocation>& map)
-        : SelfLocation(selfLocation)
-        , LocationPerOrderNumber(info->GetTotalVDisksNum())
-    {
-        for (ui32 i = 0; i < LocationPerOrderNumber.size(); ++i) {
-            LocationPerOrderNumber[i] = map[info->GetActorId(i).NodeId()];
-        }
-    }
-};
-
-using TNodeLayoutInfoPtr = TIntrusivePtr<TNodeLayoutInfo>;
-
 inline TStoragePoolCounters::EHandleClass HandleClassToHandleClass(NKikimrBlobStorage::EGetHandleClass handleClass) {
     switch (handleClass) {
         case NKikimrBlobStorage::FastRead:
@@ -545,7 +527,7 @@ struct TBlobStorageProxyParameters {
     TBlobStorageProxyControlWrappers Controls;
 };
 
-IActor* CreateBlobStorageGroupProxyConfigured(TIntrusivePtr<TBlobStorageGroupInfo>&& info,
+IActor* CreateBlobStorageGroupProxyConfigured(TIntrusivePtr<TBlobStorageGroupInfo>&& info, TNodeLayoutInfoPtr nodeLayoutInfo,
     bool forceWaitAllDrives, TIntrusivePtr<TDsProxyNodeMon> &nodeMon,
     TIntrusivePtr<TStoragePoolCounters>&& storagePoolCounters, const TBlobStorageProxyParameters& params);
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.cpp
@@ -4,9 +4,9 @@ namespace NKikimr {
 
     std::atomic<TMonotonic> TBlobStorageGroupProxy::ThrottlingTimestamp;
 
-    TBlobStorageGroupProxy::TBlobStorageGroupProxy(TIntrusivePtr<TBlobStorageGroupInfo>&& info, bool forceWaitAllDrives,
-            TIntrusivePtr<TDsProxyNodeMon> &nodeMon, TIntrusivePtr<TStoragePoolCounters>&& storagePoolCounters, 
-            const TBlobStorageProxyParameters& params)
+    TBlobStorageGroupProxy::TBlobStorageGroupProxy(TIntrusivePtr<TBlobStorageGroupInfo>&& info,
+            TNodeLayoutInfoPtr nodeLayoutInfo, bool forceWaitAllDrives, TIntrusivePtr<TDsProxyNodeMon> &nodeMon,
+            TIntrusivePtr<TStoragePoolCounters>&& storagePoolCounters, const TBlobStorageProxyParameters& params)
         : GroupId(info->GroupID)
         , Info(std::move(info))
         , Topology(Info->PickTopology())
@@ -15,10 +15,11 @@ namespace NKikimr {
         , IsEjected(false)
         , ForceWaitAllDrives(forceWaitAllDrives)
         , UseActorSystemTimeInBSQueue(params.UseActorSystemTimeInBSQueue)
+        , NodeLayoutInfo(std::move(nodeLayoutInfo))
         , Controls(std::move(params.Controls))
     {}
 
-    TBlobStorageGroupProxy::TBlobStorageGroupProxy(ui32 groupId, bool isEjected,TIntrusivePtr<TDsProxyNodeMon> &nodeMon,
+    TBlobStorageGroupProxy::TBlobStorageGroupProxy(ui32 groupId, bool isEjected, TIntrusivePtr<TDsProxyNodeMon> &nodeMon,
             const TBlobStorageProxyParameters& params)
         : GroupId(TGroupId::FromValue(groupId))
         , NodeMon(nodeMon)
@@ -39,11 +40,12 @@ namespace NKikimr {
         );
     }
 
-    IActor* CreateBlobStorageGroupProxyConfigured(TIntrusivePtr<TBlobStorageGroupInfo>&& info, bool forceWaitAllDrives,
+    IActor* CreateBlobStorageGroupProxyConfigured(TIntrusivePtr<TBlobStorageGroupInfo>&& info,
+            TNodeLayoutInfoPtr nodeLayoutInfo, bool forceWaitAllDrives,
             TIntrusivePtr<TDsProxyNodeMon> &nodeMon, TIntrusivePtr<TStoragePoolCounters>&& storagePoolCounters,
             const TBlobStorageProxyParameters& params) {
         Y_ABORT_UNLESS(info);
-        return new TBlobStorageGroupProxy(std::move(info), forceWaitAllDrives, nodeMon,
+        return new TBlobStorageGroupProxy(std::move(info), std::move(nodeLayoutInfo), forceWaitAllDrives, nodeMon,
                 std::move(storagePoolCounters), params);
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
@@ -180,7 +180,8 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
     std::optional<TCypherKey> CypherKey;
 
     void Handle(TEvBlobStorage::TEvConfigureProxy::TPtr ev);
-    void ApplyGroupInfo(TIntrusivePtr<TBlobStorageGroupInfo>&& info, TIntrusivePtr<TStoragePoolCounters>&& counters);
+    void ApplyGroupInfo(TIntrusivePtr<TBlobStorageGroupInfo>&& info, TNodeLayoutInfoPtr nodeLayoutInfo,
+        TIntrusivePtr<TStoragePoolCounters>&& counters);
 
     void WakeupUnconfigured(TEvConfigureQueryTimeout::TPtr ev);
 
@@ -319,16 +320,14 @@ public:
         return NKikimrServices::TActivity::BS_PROXY_ACTOR;
     }
 
-    TBlobStorageGroupProxy(TIntrusivePtr<TBlobStorageGroupInfo>&& info, bool forceWaitAllDrives,
-            TIntrusivePtr<TDsProxyNodeMon> &nodeMon, TIntrusivePtr<TStoragePoolCounters>&& storagePoolCounters,
-            const TBlobStorageProxyParameters& params);
+    TBlobStorageGroupProxy(TIntrusivePtr<TBlobStorageGroupInfo>&& info, TNodeLayoutInfoPtr nodeLayoutInfo,
+        bool forceWaitAllDrives, TIntrusivePtr<TDsProxyNodeMon> &nodeMon,
+        TIntrusivePtr<TStoragePoolCounters>&& storagePoolCounters, const TBlobStorageProxyParameters& params);
 
     TBlobStorageGroupProxy(ui32 groupId, bool isEjected, TIntrusivePtr<TDsProxyNodeMon> &nodeMon,
-            const TBlobStorageProxyParameters& params);
+        const TBlobStorageProxyParameters& params);
 
     void Bootstrap();
-
-    void Handle(TEvInterconnect::TEvNodesInfo::TPtr& ev);
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Configuration process
@@ -358,7 +357,6 @@ public:
         hFunc(TEvBlobStorage::TEvBunchOfEvents, Handle);
         hFunc(TEvTimeStats, Handle);
         cFunc(TEvents::TSystem::Poison, PassAway);
-        hFunc(TEvInterconnect::TEvNodesInfo, Handle);
         hFunc(TEvBlobStorage::TEvConfigureProxy, Handle);
         hFunc(TEvProxyQueueState, Handle);
         cFunc(EvUpdateResponsiveness, HandleUpdateResponsiveness);

--- a/ydb/core/blobstorage/dsproxy/ut/dsproxy_env_mock_ut.h
+++ b/ydb/core/blobstorage/dsproxy/ut/dsproxy_env_mock_ut.h
@@ -81,7 +81,7 @@ struct TDSProxyEnv {
         TIntrusivePtr<TStoragePoolCounters> storagePoolCounters = perPoolCounters.GetPoolCounters("pool_name");
         TControlWrapper enablePutBatching(DefaultEnablePutBatching, false, true);
         TControlWrapper enableVPatch(DefaultEnableVPatch, false, true);
-        IActor *dsproxy = CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(Info), true, nodeMon,
+        IActor *dsproxy = CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(Info), nullptr, true, nodeMon,
             std::move(storagePoolCounters), TBlobStorageProxyParameters{
                     .Controls = TBlobStorageProxyControlWrappers{
                         .EnablePutBatching = enablePutBatching,

--- a/ydb/core/blobstorage/dsproxy/ut_fat/dsproxy_ut.cpp
+++ b/ydb/core/blobstorage/dsproxy/ut_fat/dsproxy_ut.cpp
@@ -4230,7 +4230,7 @@ public:
         TIntrusivePtr<TStoragePoolCounters> storagePoolCounters = perPoolCounters.GetPoolCounters("pool_name");
         TControlWrapper enablePutBatching(args.EnablePutBatching, false, true);
         TControlWrapper enableVPatch(DefaultEnableVPatch, false, true);
-        std::unique_ptr<IActor> proxyActor{CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(bsInfo), false,
+        std::unique_ptr<IActor> proxyActor{CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(bsInfo), nullptr, false,
                 dsProxyNodeMon, TIntrusivePtr(storagePoolCounters),
                 TBlobStorageProxyParameters{
                     .Controls = TBlobStorageProxyControlWrappers{

--- a/ydb/core/blobstorage/dsproxy/ut_ftol/dsproxy_fault_tolerance_ut_runtime.h
+++ b/ydb/core/blobstorage/dsproxy/ut_ftol/dsproxy_fault_tolerance_ut_runtime.h
@@ -87,7 +87,7 @@ public:
         TIntrusivePtr<TStoragePoolCounters> storagePoolCounters = perPoolCounters.GetPoolCounters("pool_name");
         TControlWrapper enablePutBatching(DefaultEnablePutBatching, false, true);
         TControlWrapper enableVPatch(DefaultEnableVPatch, false, true);
-        IActor *dsproxy = CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(GroupInfo), false, nodeMon,
+        IActor *dsproxy = CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(GroupInfo), nullptr, false, nodeMon,
             std::move(storagePoolCounters), TBlobStorageProxyParameters{
                 .Controls = TBlobStorageProxyControlWrappers{
                     .EnablePutBatching = enablePutBatching,

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -471,6 +471,7 @@ namespace NKikimr::NStorage {
             bool ProposeRequestPending = false; // if true, then we have sent ProposeKey request and waiting for the group
             TActorId GroupResolver; // resolver actor id
             TIntrusiveList<TVDiskRecord, TGroupRelationTag> VDisksOfGroup;
+            TNodeLayoutInfoPtr NodeLayoutInfo;
         };
 
         std::unordered_map<ui32, TGroupRecord> Groups;
@@ -478,6 +479,7 @@ namespace NKikimr::NStorage {
         using TGroupPendingQueue = THashMap<ui32, std::deque<std::tuple<TMonotonic, std::unique_ptr<IEventHandle>>>>;
         TGroupPendingQueue GroupPendingQueue;
         std::set<std::tuple<TMonotonic, TGroupPendingQueue::value_type*>> TimeoutToQueue;
+        THashMap<ui32, TNodeLocation> NodeLocationMap;
 
         // this function returns group info if possible, or otherwise starts requesting group info and/or proposing key
         // if needed
@@ -517,6 +519,7 @@ namespace NKikimr::NStorage {
         void Bootstrap();
         void HandleReadCache();
         void Handle(TEvInterconnect::TEvNodeInfo::TPtr ev);
+        void Handle(TEvInterconnect::TEvNodesInfo::TPtr ev);
         void Handle(NPDisk::TEvSlayResult::TPtr ev);
         void Handle(TEvRegisterPDiskLoadActor::TPtr ev);
         void Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpdate::TPtr ev);

--- a/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
@@ -45,8 +45,8 @@ void TNodeWarden::StartLocalProxy(ui32 groupId) {
                 case NKikimrBlobStorage::TGroupDecommitStatus::IN_PROGRESS:
                     // create proxy that will be used by blob depot agent to fetch underlying data
                     proxyActorId = as->Register(CreateBlobStorageGroupProxyConfigured(
-                        TIntrusivePtr<TBlobStorageGroupInfo>(info), false, DsProxyNodeMon, getCounters(info),
-                        TBlobStorageProxyParameters{
+                        TIntrusivePtr<TBlobStorageGroupInfo>(info), group.NodeLayoutInfo, false, DsProxyNodeMon,
+                        getCounters(info), TBlobStorageProxyParameters{
                             .UseActorSystemTimeInBSQueue = Cfg->UseActorSystemTimeInBSQueue,
                             .Controls = TBlobStorageProxyControlWrappers{
                                 .EnablePutBatching = EnablePutBatching,
@@ -68,8 +68,8 @@ void TNodeWarden::StartLocalProxy(ui32 groupId) {
             }
         } else {
             // create proxy with configuration
-            proxy.reset(CreateBlobStorageGroupProxyConfigured(TIntrusivePtr<TBlobStorageGroupInfo>(info), false, 
-                DsProxyNodeMon, getCounters(info), TBlobStorageProxyParameters{
+            proxy.reset(CreateBlobStorageGroupProxyConfigured(TIntrusivePtr<TBlobStorageGroupInfo>(info),
+                group.NodeLayoutInfo, false, DsProxyNodeMon, getCounters(info), TBlobStorageProxyParameters{
                         .UseActorSystemTimeInBSQueue = Cfg->UseActorSystemTimeInBSQueue,
                         .Controls = TBlobStorageProxyControlWrappers{
                             .EnablePutBatching = EnablePutBatching,

--- a/ydb/core/blobstorage/ut_group/main.cpp
+++ b/ydb/core/blobstorage/ut_group/main.cpp
@@ -331,7 +331,7 @@ public:
 
         // update group info for proxy
         runtime.Send(new IEventHandle(MakeBlobStorageProxyID(Info->GroupID), TActorId(),
-            new TEvBlobStorage::TEvConfigureProxy(Info, StoragePoolCounters)), 1);
+            new TEvBlobStorage::TEvConfigureProxy(Info, nullptr, StoragePoolCounters)), 1);
     }
 
     void Slay(TTestActorSystem& runtime, TDiskRecord& disk) {
@@ -409,7 +409,7 @@ private:
         StoragePoolCounters = MakeIntrusive<TStoragePoolCounters>(proxy, TString(), NPDisk::DEVICE_TYPE_SSD);
         TControlWrapper enablePutBatching(DefaultEnablePutBatching, false, true);
         TControlWrapper enableVPatch(DefaultEnableVPatch, false, true);
-        std::unique_ptr<IActor> proxyActor{CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(Info), false, mon,
+        std::unique_ptr<IActor> proxyActor{CreateBlobStorageGroupProxyConfigured(TIntrusivePtr(Info), nullptr, false, mon,
                 TIntrusivePtr(StoragePoolCounters), TBlobStorageProxyParameters{
                     .Controls = TBlobStorageProxyControlWrappers{
                         .EnablePutBatching = enablePutBatching,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Node TNodeLocation processing to NodeWarden in order to reduce CPU consumption

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

NodeLocation calculation has been moved from multiple (hundreds or thousands) DS proxies into single NodeWarden.
