### PR TITLE
Fix disconnected proxies unexpectedly registering in kesus

### DIFF
--- a/ydb/core/kesus/tablet/tablet_impl.h
+++ b/ydb/core/kesus/tablet/tablet_impl.h
@@ -91,6 +91,7 @@ private:
     struct TProxyInfo {
         TActorId ActorID;
         ui64 Generation = 0;
+        TActorId InterconnectSession;
         THashSet<ui64> AttachedSessions;
     };
 

--- a/ydb/core/kesus/tablet/ut_helpers.cpp
+++ b/ydb/core/kesus/tablet/ut_helpers.cpp
@@ -188,9 +188,14 @@ void TTestContext::SyncProxy(const TActorId& proxy, ui64 generation, bool useTra
     ExpectEdgeEvent<TEvKesus::TEvDummyResponse>(proxy, cookie);
 }
 
-NKikimrKesus::TEvRegisterProxyResult TTestContext::RegisterProxy(const TActorId& proxy, ui64 generation) {
+ui64 TTestContext::SendRegisterProxy(const TActorId& proxy, ui64 generation) {
     ui64 cookie = RandomNumber<ui64>();
     SendFromProxy(proxy, generation, new TEvKesus::TEvRegisterProxy("", generation), cookie);
+    return cookie;
+}
+
+NKikimrKesus::TEvRegisterProxyResult TTestContext::RegisterProxy(const TActorId& proxy, ui64 generation) {
+    ui64 cookie = SendRegisterProxy(proxy, generation);
     auto result = ExpectEdgeEvent<TEvKesus::TEvRegisterProxyResult>(proxy, cookie);
     UNIT_ASSERT_VALUES_EQUAL(result->Record.GetProxyGeneration(), generation);
     return result->Record;

--- a/ydb/core/kesus/tablet/ut_helpers.h
+++ b/ydb/core/kesus/tablet/ut_helpers.h
@@ -82,6 +82,7 @@ struct TTestContext {
     void SyncProxy(const TActorId& proxy, ui64 generation, bool useTransactions = false);
 
     // Registers a proxy/generation pair with the tablet
+    ui64 SendRegisterProxy(const TActorId& proxy, ui64 generation);
     NKikimrKesus::TEvRegisterProxyResult RegisterProxy(const TActorId& proxy, ui64 generation);
     void MustRegisterProxy(const TActorId& proxy, ui64 generation, Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix disconnected proxies unexpectedly registering in coordination service.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

It was possible for coordination service proxies to successfully register in the kesus tablet after they disconnect, which caused a state mismatch and incorrect registration result handling. Sending registration replies over the same interconnect session avoids the problem: proxy does not receive an unexpected reply, and tablet promptly detects a disconnected proxy.