### PR TITLE
Build preset in test report "copy run command"

### DIFF
--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -284,13 +284,15 @@ def render_testlist_html(rows, fn, build_preset):
     for current_status in status_for_history:
         status_test.get(current_status,[]).sort(key=lambda val: (-val.count_of_passed, val.full_name))
 
-    buid_preset_params = '--build "relwithdebinfo"'
+    buid_preset_params = ''
     if build_preset == 'release-asan' :
         buid_preset_params = '--build "release" --sanitize="address" -DDEBUGINFO_LINES_ONLY'
     elif  build_preset == 'release-msan':
         buid_preset_params = '--build "release" --sanitize="memory" -DDEBUGINFO_LINES_ONLY'
     elif build_preset == 'release-tsan':   
         buid_preset_params = '--build "release" --sanitize="thread" -DDEBUGINFO_LINES_ONLY'
+    elif build_preset == 'relwithdebinfo':
+       buid_preset_params = '--build "relwithdebinfo"'
         
     content = env.get_template("summary.html").render(
         status_order=status_order,

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -291,8 +291,6 @@ def render_testlist_html(rows, fn, build_preset):
         buid_preset_params = '--build "release" --sanitize="memory" -DDEBUGINFO_LINES_ONLY'
     elif build_preset == 'release-tsan':   
         buid_preset_params = '--build "release" --sanitize="thread" -DDEBUGINFO_LINES_ONLY'
-    elif build_preset == 'release-clang14': 
-        buid_preset_params = '--build "release" --target-platform="CLANG14-LINUX-X86_64" -DLLD_VERSION=16 -DSTRIP -DDEBUGINFO_LINES_ONLY'
         
     content = env.get_template("summary.html").render(
         status_order=status_order,

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -289,6 +289,7 @@ def render_testlist_html(rows, fn, build_preset):
         tests=status_test,
         has_any_log=has_any_log,
         history=history,
+        build_preset=build_preset
     )
 
     with open(fn, "w") as fp:

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -287,7 +287,7 @@ def render_testlist_html(rows, fn, build_preset):
     buid_preset_params = '--build unknown_build_type'
     if build_preset == 'release-asan' :
         buid_preset_params = '--build "release" --sanitize="address" -DDEBUGINFO_LINES_ONLY'
-    elif  build_preset == 'release-msan':
+    elif build_preset == 'release-msan':
         buid_preset_params = '--build "release" --sanitize="memory" -DDEBUGINFO_LINES_ONLY'
     elif build_preset == 'release-tsan':   
         buid_preset_params = '--build "release" --sanitize="thread" -DDEBUGINFO_LINES_ONLY'

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -292,7 +292,7 @@ def render_testlist_html(rows, fn, build_preset):
     elif build_preset == 'release-tsan':   
         buid_preset_params = '--build "release" --sanitize="thread" -DDEBUGINFO_LINES_ONLY'
     elif build_preset == 'relwithdebinfo':
-       buid_preset_params = '--build "relwithdebinfo"'
+        buid_preset_params = '--build "relwithdebinfo"'
         
     content = env.get_template("summary.html").render(
         status_order=status_order,

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -284,12 +284,22 @@ def render_testlist_html(rows, fn, build_preset):
     for current_status in status_for_history:
         status_test.get(current_status,[]).sort(key=lambda val: (-val.count_of_passed, val.full_name))
 
+    buid_preset_params = '--build "relwithdebinfo"'
+    if build_preset == 'release-asan' :
+        buid_preset_params = '--build "release" --sanitize="address" -DDEBUGINFO_LINES_ONLY'
+    elif  build_preset == 'release-msan':
+        buid_preset_params = '--build "release" --sanitize="memory" -DDEBUGINFO_LINES_ONLY'
+    elif build_preset == 'release-tsan':   
+        buid_preset_params = '--build "release" --sanitize="thread" -DDEBUGINFO_LINES_ONLY'
+    elif build_preset == 'release-clang14': 
+        buid_preset_params = '--build "release" --target-platform="CLANG14-LINUX-X86_64" -DLLD_VERSION=16 -DSTRIP -DDEBUGINFO_LINES_ONLY'
+        
     content = env.get_template("summary.html").render(
         status_order=status_order,
         tests=status_test,
         has_any_log=has_any_log,
         history=history,
-        build_preset=build_preset
+        build_preset=buid_preset_params
     )
 
     with open(fn, "w") as fp:

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -284,7 +284,7 @@ def render_testlist_html(rows, fn, build_preset):
     for current_status in status_for_history:
         status_test.get(current_status,[]).sort(key=lambda val: (-val.count_of_passed, val.full_name))
 
-    buid_preset_params = '-r'
+    buid_preset_params = '--build unknown_build_type'
     if build_preset == 'release-asan' :
         buid_preset_params = '--build "release" --sanitize="address" -DDEBUGINFO_LINES_ONLY'
     elif  build_preset == 'release-msan':

--- a/.github/scripts/tests/generate-summary.py
+++ b/.github/scripts/tests/generate-summary.py
@@ -284,7 +284,7 @@ def render_testlist_html(rows, fn, build_preset):
     for current_status in status_for_history:
         status_test.get(current_status,[]).sort(key=lambda val: (-val.count_of_passed, val.full_name))
 
-    buid_preset_params = ''
+    buid_preset_params = '-r'
     if build_preset == 'release-asan' :
         buid_preset_params = '--build "release" --sanitize="address" -DDEBUGINFO_LINES_ONLY'
     elif  build_preset == 'release-msan':

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -306,7 +306,7 @@
             testName = namePieces[0] + '.' + namePieces[1] + '::' + namePieces.slice(2).join('::');
         }
 
-        const cmdArg = `./ya make -ttt --build "{{ build_preset }}" -k -F '${testName}' ${path}`;
+        const cmdArg = `./ya make -ttt {{ build_preset }} -k -F '${testName}' ${path}`;
 
         console.log(cmdArg);
 

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -291,7 +291,7 @@
     function copyTestNameToClipboard(text) {
         const full_name = text.trim();
         let pieces 
-        if (full_name.includes('.py/'))
+        if (full_name.includes('.py.'))
         {
             pieces = /(.+)\/(.*py.*[^\/]+)$/.exec(full_name);
         } else

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -306,7 +306,7 @@
             testName = namePieces[0] + '.' + namePieces[1] + '::' + namePieces.slice(2).join('::');
         }
 
-        const cmdArg = `./ya make -ttt --build relwithdebinfo -k -F '${testName}' ${path}`;
+        const cmdArg = `./ya make -ttt --build "{{ build_preset }}" -k -F '${testName}' ${path}`;
 
         console.log(cmdArg);
 

--- a/.github/scripts/tests/templates/summary.html
+++ b/.github/scripts/tests/templates/summary.html
@@ -290,7 +290,14 @@
 
     function copyTestNameToClipboard(text) {
         const full_name = text.trim();
-        const pieces = /(.+)\/([^$]+)$/.exec(full_name);
+        let pieces 
+        if (full_name.includes('.py/'))
+        {
+            pieces = /(.+)\/(.*py.*[^\/]+)$/.exec(full_name);
+        } else
+        {
+            pieces = /(.+)\/([^$]+)$/.exec(full_name);
+        }
 
         if (!pieces) {
             console.error("Unable to split path/test name from %o", full_name);
@@ -306,7 +313,7 @@
             testName = namePieces[0] + '.' + namePieces[1] + '::' + namePieces.slice(2).join('::');
         }
 
-        const cmdArg = `./ya make -ttt {{ build_preset }} -k -F '${testName}' ${path}`;
+        const cmdArg = `./ya make -ttt {{ build_preset }} -F '${testName}' ${path}`;
 
         console.log(cmdArg);
 

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -254,7 +254,6 @@ void TColumnShard::Handle(NActors::TEvents::TEvWakeup::TPtr& ev, const TActorCon
     }
 }
 
-
 void TColumnShard::Handle(TEvMediatorTimecast::TEvRegisterTabletResult::TPtr& ev, const TActorContext&) {
     const auto* msg = ev->Get();
     Y_ABORT_UNLESS(msg->TabletId == TabletID());

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -239,6 +239,7 @@ void TColumnShard::Handle(TEvPrivate::TEvPeriodicWakeup::TPtr& ev, const TActorC
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvPrivate::TEvPeriodicWakeup")("tablet_id", TabletID());
         SendWaitPlanStep(GetOutdatedStep());
 
+
         SendPeriodicStats();
         EnqueueBackgroundActivities();
         ctx.Schedule(PeriodicWakeupActivationPeriod, new TEvPrivate::TEvPeriodicWakeup());

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -239,7 +239,6 @@ void TColumnShard::Handle(TEvPrivate::TEvPeriodicWakeup::TPtr& ev, const TActorC
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvPrivate::TEvPeriodicWakeup")("tablet_id", TabletID());
         SendWaitPlanStep(GetOutdatedStep());
 
-
         SendPeriodicStats();
         EnqueueBackgroundActivities();
         ctx.Schedule(PeriodicWakeupActivationPeriod, new TEvPrivate::TEvPeriodicWakeup());

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -254,6 +254,7 @@ void TColumnShard::Handle(NActors::TEvents::TEvWakeup::TPtr& ev, const TActorCon
     }
 }
 
+
 void TColumnShard::Handle(TEvMediatorTimecast::TEvRegisterTabletResult::TPtr& ev, const TActorContext&) {
     const auto* msg = ev->Get();
     Y_ABORT_UNLESS(msg->TabletId == TabletID());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

**Before**:
- same comand for all build presets
- ```./ya make -ttt --build relwithdebinfo -k -F 'TBlobStorageProxyTest::TestBlock' ydb/core/blobstorage/dsproxy/ut_fat```

**Now**:
- depends on build preset
- ``` ./ya make -ttt --build "release" --sanitize="address" -DDEBUGINFO_LINES_ONLY -k -F 'TopicSessionTests::SecondSessionWithoutOffsetsAfterSessionConnected' ydb/core/fq/libs/row_dispatcher/ut```
- ``` ./ya make -ttt --build "relwithdebinfo" -k -F 'TSentinelUnstableTests::BSControllerCantChangeStatus' ydb/core/cms/ut_sentinel_unstable```


and  **fixed issue**
for test with slash inside testname like
``` 
'ydb/tests/functional/suite_tests/test_postgres.py.TestPGSQL.test_sql_suite[plan-jointest/join0.test]
```

we got broken command
```
./ya make -ttt --build relwithdebinfo -k -F 'join0::test]' ydb/tests/functional/suite_tests/test_postgres.py.TestPGSQL.test_sql_suite[plan-jointest
```
fixed, result now
```
./ya make -ttt --build "relwithdebinfo" -F 'test_postgres.py::TestPGSQL::test_sql_suite[plan-jointest/join0::test]' ydb/tests/functional/suite_tests
```
### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
