### PR TITLE
Support ad-hoc run sanitize tests in PR

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -213,7 +213,6 @@ jobs:
             timeout: 240
             build_target: "ydb/"
             test_size: small,medium
-            test_type: unittest,py3test,py2test,pytest
           - build_preset: release-asan
             threads_count: 20
             timeout: 240

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -214,7 +214,7 @@ jobs:
             build_target: "ydb/"
             test_size: small,medium
           - build_preset: release-asan
-            threads_count: 20
+            threads_count: 52
             timeout: 240
             build_target: "ydb/"
             test_size: small,medium
@@ -241,27 +241,17 @@ jobs:
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
     - name: Build and test
-      # 1-st block - release-tsan if exist label run-tsan-tests or run-sanitizer-tests
-      # 2-st block - release-msan if exist label run-msan-tests or run-sanitizer-tests
       if: |
-          (
-            (matrix.build_preset == 'release-asan') || 
-            (matrix.build_preset == 'relwithdebinfo') || 
-            (
-              (matrix.build_preset == 'release-tsan' && 
-              contains(github.event.pull_request.labels.*.name, 'run-tsan-tests')) || 
-              contains(github.event.pull_request.labels.*.name, 'run-sanitizer-tests')
-            )
-          ) || 
-          (
-            (matrix.build_preset == 'release-asan') || 
-            (matrix.build_preset == 'relwithdebinfo') || 
-            (
-              (matrix.build_preset == 'release-msan' && 
-              contains(github.event.pull_request.labels.*.name, 'run-msan-tests')) || 
-              contains(github.event.pull_request.labels.*.name, 'run-sanitizer-tests')
-            )
-          )
+          (matrix.build_preset == 'release-asan') || 
+          (matrix.build_preset == 'relwithdebinfo') || 
+            
+            (matrix.build_preset == 'release-tsan' && 
+            contains(github.event.pull_request.labels.*.name, 'run-tsan-tests') || 
+            contains(github.event.pull_request.labels.*.name, 'run-sanitizer-tests')) || 
+            
+            (matrix.build_preset == 'release-msan' && 
+            contains(github.event.pull_request.labels.*.name, 'run-msan-tests') || 
+            contains(github.event.pull_request.labels.*.name, 'run-sanitizer-tests'))
       uses: ./.github/actions/build_and_test_ya
       with:
         build_preset: ${{ matrix.build_preset }}
@@ -271,7 +261,7 @@ jobs:
         test_size: ${{ matrix.test_size }}
         test_threads: ${{ matrix.threads_count }}
         put_build_results_to_cache: true
-        additional_ya_make_args: -DDEBUGINFO_LINES_ONLY #we don't need full symbols in CI checks
+        additional_ya_make_args: -DDEBUGINFO_LINES_ONLY # we don't need full symbols in CI checks
         secs: ${{ format('{{"TESTMO_TOKEN2":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}',
           secrets.TESTMO_TOKEN2, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
         vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -19,6 +19,7 @@ jobs:
   check-running-allowed:
     if: ${{vars.CHECKS_SWITCH != '' && fromJSON(vars.CHECKS_SWITCH).pr_check == true}}
     runs-on: ubuntu-latest
+    timeout-minutes: 600
     outputs:
       result: ${{ steps.check-ownership-membership.outputs.result == 'true' && steps.check-is-mergeable.outputs.result == 'true' }}
       commit_sha: ${{ steps.check-is-mergeable.outputs.commit_sha }}
@@ -206,7 +207,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_preset: ["relwithdebinfo", "release-asan"]
+        include:
+          - build_preset: relwithdebinfo
+            threads_count: 52
+            timeout: 240
+            build_target: "ydb/"
+            test_size: small,medium
+            test_type: unittest,py3test,py2test,pytest
+          - build_preset: release-asan
+            threads_count: 20
+            timeout: 240
+            build_target: "ydb/"
+            test_size: small,medium
+          - build_preset: release-msan
+            threads_count: 20
+            timeout: 480
+            build_target: "ydb/"
+            test_size: small,medium
+          - build_preset: release-tsan
+            threads_count: 20
+            timeout: 600
+            build_target: "ydb/"
+            test_size: small,medium
     runs-on: [ self-hosted, auto-provisioned, "${{ format('build-preset-{0}', matrix.build_preset) }}" ]
     name: Build and test ${{ matrix.build_preset }}
     steps:
@@ -220,21 +242,41 @@ jobs:
       with:
         ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
     - name: Build and test
+      # 1-st block - release-tsan if exist label run-tsan-tests or run-sanitizer-tests
+      # 2-st block - release-msan if exist label run-msan-tests or run-sanitizer-tests
+      if: |
+          (
+            (matrix.build_preset == 'release-asan') || 
+            (matrix.build_preset == 'relwithdebinfo') || 
+            (
+              (matrix.build_preset == 'release-tsan' && 
+              contains(github.event.pull_request.labels.*.name, 'run-tsan-tests')) || 
+              contains(github.event.pull_request.labels.*.name, 'run-sanitizer-tests')
+            )
+          ) || 
+          (
+            (matrix.build_preset == 'release-asan') || 
+            (matrix.build_preset == 'relwithdebinfo') || 
+            (
+              (matrix.build_preset == 'release-msan' && 
+              contains(github.event.pull_request.labels.*.name, 'run-msan-tests')) || 
+              contains(github.event.pull_request.labels.*.name, 'run-sanitizer-tests')
+            )
+          )
       uses: ./.github/actions/build_and_test_ya
       with:
         build_preset: ${{ matrix.build_preset }}
-        build_target: "ydb/"
+        build_target: ${{ matrix.build_target }}
         increment: true
-        run_tests: ${{ contains(fromJSON('["relwithdebinfo", "release-asan"]'), matrix.build_preset) }}
-        test_size: "small,medium"
-        test_threads: 52
+        run_tests: ${{ contains(fromJSON('["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]'), matrix.build_preset) }}
+        test_size: ${{ matrix.test_size }}
+        test_threads: ${{ matrix.threads_count }}
         put_build_results_to_cache: true
-        additional_ya_make_args: -DDEBUGINFO_LINES_ONLY  # we don't need full symbols in CI checks
+        additional_ya_make_args: -DDEBUGINFO_LINES_ONLY #we don't need full symbols in CI checks
         secs: ${{ format('{{"TESTMO_TOKEN2":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}',
           secrets.TESTMO_TOKEN2, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
         vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',
           vars.AWS_BUCKET, vars.AWS_ENDPOINT, vars.REMOTE_CACHE_URL_YA, vars.TESTMO_URL, vars.TESTMO_PROJECT_ID ) }}
-
   update_integrated_status:
     runs-on: ubuntu-latest
     needs: build_and_test
@@ -255,6 +297,3 @@ jobs:
           curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
             -d '{"state":"'$integrated_status'","description":"All checks completed","context":"checks_integrated"}'
-
-
-        


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

If you add label
 - **run-msan-tests** : all pr-checks now will run tests for builds **relwithdebinfo, asan and msan**
 - **run-tsan-tests** : all pr-checks now will run tests for builds **relwithdebinfo, asan and tsan**
- **run-sanitize-tests** : all pr-checks now will run tests for builds **relwithdebinfo, asan, tsan and msan**

Example of usage
- https://github.com/ydb-platform/ydb/pull/12832
- https://github.com/ydb-platform/ydb/pull/12768

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
