### PR TITLE
use canonized storage path as tier id

### DIFF
--- a/util/generic/strbase.h
+++ b/util/generic/strbase.h
@@ -310,20 +310,71 @@ public:
 #endif
 
     template <typename TDerived2, typename TTraits2>
-    friend constexpr std::strong_ordering operator<=>(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
-        return compare(s1, s2) <=> 0;
+    friend constexpr bool operator<(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
+        return compare(s1, s2) < 0;
     }
 
-    friend constexpr std::strong_ordering operator<=>(const TSelf& s1, TStringView s2) noexcept {
-        return compare(s1, s2) <=> 0;
+    friend constexpr bool operator<(const TSelf& s1, TStringView s2) noexcept {
+        return compare(s1, s2) < 0;
     }
 
-    friend constexpr std::strong_ordering operator<=>(const TSelf& s, const TCharType* pc) noexcept {
-        return compare(s, pc) <=> 0;
+    friend constexpr bool operator<(const TSelf& s, const TCharType* pc) noexcept {
+        return compare(s, pc) < 0;
     }
 
-    friend constexpr std::strong_ordering operator<=>(const TCharType* pc, const TSelf& s) noexcept {
-        return compare(pc, s) <=> 0;
+    friend constexpr bool operator<(const TCharType* pc, const TSelf& s) noexcept {
+        return compare(pc, s) < 0;
+    }
+
+    template <typename TDerived2, typename TTraits2>
+    friend constexpr bool operator<=(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
+        return compare(s1, s2) <= 0;
+    }
+
+    friend constexpr bool operator<=(const TSelf& s1, TStringView s2) noexcept {
+        return compare(s1, s2) <= 0;
+    }
+
+    friend constexpr bool operator<=(const TSelf& s, const TCharType* pc) noexcept {
+        return compare(s, pc) <= 0;
+    }
+
+    friend constexpr bool operator<=(const TCharType* pc, const TSelf& s) noexcept {
+        return compare(pc, s) <= 0;
+    }
+
+    template <typename TDerived2, typename TTraits2>
+    friend constexpr bool operator>(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
+        return compare(s1, s2) > 0;
+    }
+
+    friend constexpr bool operator>(const TSelf& s1, TStringView s2) noexcept {
+        return compare(s1, s2) > 0;
+    }
+
+    friend constexpr bool operator>(const TSelf& s, const TCharType* pc) noexcept {
+        return compare(s, pc) > 0;
+    }
+
+    friend constexpr bool operator>(const TCharType* pc, const TSelf& s) noexcept {
+        return compare(pc, s) > 0;
+    }
+
+    template <typename TDerived2, typename TTraits2>
+    friend constexpr bool operator>=(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
+        return compare(s1, s2) >= 0;
+    }
+
+    friend constexpr bool operator>=(const TSelf& s1, TStringView s2) noexcept {
+        return compare(s1, s2) >= 0;
+    }
+
+    friend constexpr bool operator>=(const TSelf& s, const TCharType* pc) noexcept {
+        return compare(s, pc) >= 0;
+    }
+
+    friend constexpr bool operator>=(const TCharType* pc, const TSelf& s) noexcept {
+        return compare(pc, s) >= 0;
     }
 
     // ~~ Read access ~~

--- a/util/generic/strbase.h
+++ b/util/generic/strbase.h
@@ -310,71 +310,20 @@ public:
 #endif
 
     template <typename TDerived2, typename TTraits2>
-    friend constexpr bool operator<(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
-        return compare(s1, s2) < 0;
+    friend constexpr std::weak_ordering operator<=>(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
+        return compare(s1, s2) <=> 0;
     }
 
-    friend constexpr bool operator<(const TSelf& s1, TStringView s2) noexcept {
-        return compare(s1, s2) < 0;
+    friend constexpr std::weak_ordering operator<=>(const TSelf& s1, TStringView s2) noexcept {
+        return compare(s1, s2) <=> 0;
     }
 
-    friend constexpr bool operator<(const TSelf& s, const TCharType* pc) noexcept {
-        return compare(s, pc) < 0;
+    friend constexpr std::weak_ordering operator<=>(const TSelf& s, const TCharType* pc) noexcept {
+        return compare(s, pc) <=> 0;
     }
 
-    friend constexpr bool operator<(const TCharType* pc, const TSelf& s) noexcept {
-        return compare(pc, s) < 0;
-    }
-
-    template <typename TDerived2, typename TTraits2>
-    friend constexpr bool operator<=(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
-        return compare(s1, s2) <= 0;
-    }
-
-    friend constexpr bool operator<=(const TSelf& s1, TStringView s2) noexcept {
-        return compare(s1, s2) <= 0;
-    }
-
-    friend constexpr bool operator<=(const TSelf& s, const TCharType* pc) noexcept {
-        return compare(s, pc) <= 0;
-    }
-
-    friend constexpr bool operator<=(const TCharType* pc, const TSelf& s) noexcept {
-        return compare(pc, s) <= 0;
-    }
-
-    template <typename TDerived2, typename TTraits2>
-    friend constexpr bool operator>(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
-        return compare(s1, s2) > 0;
-    }
-
-    friend constexpr bool operator>(const TSelf& s1, TStringView s2) noexcept {
-        return compare(s1, s2) > 0;
-    }
-
-    friend constexpr bool operator>(const TSelf& s, const TCharType* pc) noexcept {
-        return compare(s, pc) > 0;
-    }
-
-    friend constexpr bool operator>(const TCharType* pc, const TSelf& s) noexcept {
-        return compare(pc, s) > 0;
-    }
-
-    template <typename TDerived2, typename TTraits2>
-    friend constexpr bool operator>=(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
-        return compare(s1, s2) >= 0;
-    }
-
-    friend constexpr bool operator>=(const TSelf& s1, TStringView s2) noexcept {
-        return compare(s1, s2) >= 0;
-    }
-
-    friend constexpr bool operator>=(const TSelf& s, const TCharType* pc) noexcept {
-        return compare(s, pc) >= 0;
-    }
-
-    friend constexpr bool operator>=(const TCharType* pc, const TSelf& s) noexcept {
-        return compare(pc, s) >= 0;
+    friend constexpr std::weak_ordering operator<=>(const TCharType* pc, const TSelf& s) noexcept {
+        return compare(pc, s) <=> 0;
     }
 
     // ~~ Read access ~~

--- a/util/generic/strbase.h
+++ b/util/generic/strbase.h
@@ -310,19 +310,19 @@ public:
 #endif
 
     template <typename TDerived2, typename TTraits2>
-    friend constexpr std::weak_ordering operator<=>(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
+    friend constexpr std::strong_ordering operator<=>(const TSelf& s1, const TStringBase<TDerived2, TChar, TTraits2>& s2) noexcept {
         return compare(s1, s2) <=> 0;
     }
 
-    friend constexpr std::weak_ordering operator<=>(const TSelf& s1, TStringView s2) noexcept {
+    friend constexpr std::strong_ordering operator<=>(const TSelf& s1, TStringView s2) noexcept {
         return compare(s1, s2) <=> 0;
     }
 
-    friend constexpr std::weak_ordering operator<=>(const TSelf& s, const TCharType* pc) noexcept {
+    friend constexpr std::strong_ordering operator<=>(const TSelf& s, const TCharType* pc) noexcept {
         return compare(s, pc) <=> 0;
     }
 
-    friend constexpr std::weak_ordering operator<=>(const TCharType* pc, const TSelf& s) noexcept {
+    friend constexpr std::strong_ordering operator<=>(const TCharType* pc, const TSelf& s) noexcept {
         return compare(pc, s) <=> 0;
     }
 

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -71,7 +71,7 @@ public:
             UNIT_ASSERT_GT(columnRawBytes, 0);
         }
 
-        TestHelper->SetTiering("/Root/olapStore/olapTable", "/Root/tier1", "timestamp");
+        TestHelper->SetTiering("/Root/olapStore/olapTable", GetTierPathOverride(), "timestamp");
         csController->WaitActualization(TDuration::Seconds(5));
 
         {

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -68,7 +68,7 @@ public:
             UNIT_ASSERT_GT(columnRawBytes, 0);
         }
 
-        TestHelper->SetTiering("/Root/olapStore/olapTable", "/Root/tier1", "timestamp");
+        TestHelper->SetTiering("/Root/olapStore/olapTable", "Root/tier1", "timestamp");
         csController->WaitActualization(TDuration::Seconds(5));
 
         {

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -19,6 +19,9 @@ protected:
 
 protected:
     virtual void UnevictAll() = 0;
+    virtual TString GetTierPathOverride() const {
+        return "/Root/tier1";
+    }
 
 public:
     void RunTest() {
@@ -68,7 +71,7 @@ public:
             UNIT_ASSERT_GT(columnRawBytes, 0);
         }
 
-        TestHelper->SetTiering("/Root/olapStore/olapTable", "Root/tier1", "timestamp");
+        TestHelper->SetTiering("/Root/olapStore/olapTable", "/Root/tier1", "timestamp");
         csController->WaitActualization(TDuration::Seconds(5));
 
         {
@@ -118,6 +121,13 @@ class TTestEvictionResetTiering : public TTestEvictionBase {
     }
 };
 
+class TTestEvictionWithStrippedEdsPath : public TTestEvictionResetTiering  {
+    private:
+    TString GetTierPathOverride() const {
+        return "Root/tier1";
+    }
+};
+
 class TTestEvictionIncreaseDuration : public TTestEvictionBase {
     private:
     void UnevictAll() {
@@ -135,6 +145,10 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
 
     Y_UNIT_TEST(EvictionIncreaseDuration) {
         TTestEvictionIncreaseDuration().RunTest();
+    }
+
+    Y_UNIT_TEST(EvictionWithStrippedEdsPath) {
+        TTestEvictionWithStrippedEdsPath().RunTest();
     }
 
     Y_UNIT_TEST(TieringValidation) {

--- a/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<NKikimr::NOlap::IBlobsStorageOperator> IStoragesManager::GetOper
 void IStoragesManager::OnTieringModified(const std::shared_ptr<NColumnShard::ITiersManager>& tiers) {
     AFL_VERIFY(tiers);
     for (auto&& i : tiers->GetManagers()) {
-        GetOperatorGuarantee(i.first)->OnTieringModified(tiers);
+        GetOperatorGuarantee(i.first.GetPath())->OnTieringModified(tiers);
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<NKikimr::NOlap::IBlobsStorageOperator> IStoragesManager::GetOper
 void IStoragesManager::OnTieringModified(const std::shared_ptr<NColumnShard::ITiersManager>& tiers) {
     AFL_VERIFY(tiers);
     for (auto&& i : tiers->GetManagers()) {
-        GetOperatorGuarantee(i.first.GetPath())->OnTieringModified(tiers);
+        GetOperatorGuarantee(i.first.ToString())->OnTieringModified(tiers);
     }
 }
 

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -111,7 +111,7 @@ void TColumnShard::OnActivateExecutor(const TActorContext& ctx) {
     Tiers->Start(Tiers);
     if (const auto& tiersSnapshot = NYDBTest::TControllers::GetColumnShardController()->GetOverrideTierConfigs(); !tiersSnapshot.empty()) {
         for (const auto& [id, tier] : tiersSnapshot) {
-            Tiers->UpdateTierConfig(tier, CanonizePath(id), false);
+            Tiers->UpdateTierConfig(tier, NTiers::TExternalStorageId(id), false);
         }
     }
     BackgroundSessionsManager = std::make_shared<NOlap::NBackground::TSessionsManager>(
@@ -134,7 +134,7 @@ void TColumnShard::OnActivateExecutor(const TActorContext& ctx) {
 void TColumnShard::Handle(TEvPrivate::TEvTieringModified::TPtr& /*ev*/, const TActorContext& /*ctx*/) {
     if (const auto& tiersSnapshot = NYDBTest::TControllers::GetColumnShardController()->GetOverrideTierConfigs(); !tiersSnapshot.empty()) {
         for (const auto& [id, tier] : tiersSnapshot) {
-            Tiers->UpdateTierConfig(tier, CanonizePath(id), false);
+            Tiers->UpdateTierConfig(tier, NTiers::TExternalStorageId(id), false);
         }
     }
 

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -409,7 +409,7 @@ void TColumnShard::RunEnsureTable(const NKikimrTxColumnShard::TCreateTable& tabl
     }
 
     {
-        THashSet<TString> usedTiers;
+        THashSet<NTiers::TExternalStorageId> usedTiers;
         TTableInfo table(pathId);
         if (tableProto.HasTtlSettings()) {
             const auto& ttlSettings = tableProto.GetTtlSettings();
@@ -455,7 +455,7 @@ void TColumnShard::RunAlterTable(const NKikimrTxColumnShard::TAlterTable& alterP
         schema = alterProto.GetSchema();
     }
 
-    THashSet<TString> usedTiers;
+    THashSet<NTiers::TExternalStorageId> usedTiers;
     if (alterProto.HasTtlSettings()) {
         const auto& ttlSettings = alterProto.GetTtlSettings();
         *tableVerProto.MutableTtlSettings() = ttlSettings;
@@ -1592,10 +1592,10 @@ void TColumnShard::Handle(NOlap::NBlobOperations::NEvents::TEvDeleteSharedBlobs:
     Execute(new TTxRemoveSharedBlobs(this, blobs, NActors::ActorIdFromProto(ev->Get()->Record.GetSourceActorId()), ev->Get()->Record.GetStorageId()), ctx);
 }
 
-void TColumnShard::ActivateTiering(const ui64 pathId, const THashSet<TString>& usedTiers) {
+void TColumnShard::ActivateTiering(const ui64 pathId, const THashSet<NTiers::TExternalStorageId>& usedTiers) {
     AFL_VERIFY(Tiers);
     if (!usedTiers.empty()) {
-        AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("event", "activate_tiering")("path_id", pathId)("tiers", JoinStrings(usedTiers.begin(), usedTiers.end(), ","));
+        AFL_INFO(NKikimrServices::TX_COLUMNSHARD)("event", "activate_tiering")("path_id", pathId)("tier_count", usedTiers.size());
         Tiers->EnablePathId(pathId, usedTiers);
     } else {
         Tiers->DisablePathId(pathId);

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -330,7 +330,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
         putStatus.OnYellowChannels(Executor());
     }
 
-    void ActivateTiering(const ui64 pathId, const THashSet<TString>& usedTiers);
+    void ActivateTiering(const ui64 pathId, const THashSet<NTiers::TExternalStorageId>& usedTiers);
     void OnTieringModified(const std::optional<ui64> pathId = {});
 
     std::shared_ptr<TAtomicCounter> TabletActivityImpl = std::make_shared<TAtomicCounter>(0);

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
@@ -28,7 +28,7 @@ TTiering::TTieringContext TTiering::GetTierToMove(const std::shared_ptr<arrow::S
         if (skipEviction && tierInfo.GetExternalStorageId()) {
             continue;
         }
-        TString tierName = tierInfo.GetExternalStorageId() ? tierInfo.GetExternalStorageId()->GetPath() : NTiering::NCommon::DeleteTierName;
+        const TString tierName = tierInfo.GetExternalStorageId() ? tierInfo.GetExternalStorageId()->GetPath() : NTiering::NCommon::DeleteTierName;
         auto mpiOpt = tierInfo.ScalarToInstant(max);
         Y_ABORT_UNLESS(mpiOpt);
         const TInstant maxTieringPortionInstant = *mpiOpt;

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
@@ -28,7 +28,7 @@ TTiering::TTieringContext TTiering::GetTierToMove(const std::shared_ptr<arrow::S
         if (skipEviction && tierInfo.GetExternalStorageId()) {
             continue;
         }
-        const TString tierName = tierInfo.GetExternalStorageId() ? tierInfo.GetExternalStorageId()->GetPath() : NTiering::NCommon::DeleteTierName;
+        const TString tierName = tierInfo.GetExternalStorageId() ? tierInfo.GetExternalStorageId()->GetConfigPath() : NTiering::NCommon::DeleteTierName;
         auto mpiOpt = tierInfo.ScalarToInstant(max);
         Y_ABORT_UNLESS(mpiOpt);
         const TInstant maxTieringPortionInstant = *mpiOpt;

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
@@ -25,10 +25,10 @@ TTiering::TTieringContext TTiering::GetTierToMove(const std::shared_ptr<arrow::S
     std::optional<TDuration> nextTierDuration;
     for (auto& tierRef : GetOrderedTiers()) {
         auto& tierInfo = tierRef.Get();
-        if (skipEviction && tierInfo.GetStorageId()) {
+        if (skipEviction && tierInfo.GetExternalStorageId()) {
             continue;
         }
-        TString tierName = tierInfo.GetStorageId() ? tierInfo.GetStorageId()->GetPath() : NTiering::NCommon::DeleteTierName;
+        TString tierName = tierInfo.GetExternalStorageId() ? tierInfo.GetExternalStorageId()->GetPath() : NTiering::NCommon::DeleteTierName;
         auto mpiOpt = tierInfo.ScalarToInstant(max);
         Y_ABORT_UNLESS(mpiOpt);
         const TInstant maxTieringPortionInstant = *mpiOpt;

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.cpp
@@ -25,17 +25,18 @@ TTiering::TTieringContext TTiering::GetTierToMove(const std::shared_ptr<arrow::S
     std::optional<TDuration> nextTierDuration;
     for (auto& tierRef : GetOrderedTiers()) {
         auto& tierInfo = tierRef.Get();
-        if (skipEviction && tierInfo.GetName() != NTiering::NCommon::DeleteTierName) {
+        if (skipEviction && tierInfo.GetStorageId()) {
             continue;
         }
+        TString tierName = tierInfo.GetStorageId() ? tierInfo.GetStorageId()->GetPath() : NTiering::NCommon::DeleteTierName;
         auto mpiOpt = tierInfo.ScalarToInstant(max);
         Y_ABORT_UNLESS(mpiOpt);
         const TInstant maxTieringPortionInstant = *mpiOpt;
         const TDuration dWaitLocal = maxTieringPortionInstant - tierInfo.GetEvictInstant(now);
         if (!dWaitLocal) {
-            return TTieringContext(tierInfo.GetName(), tierInfo.GetEvictInstant(now) - maxTieringPortionInstant, nextTierName, nextTierDuration);
+            return TTieringContext(tierName, tierInfo.GetEvictInstant(now) - maxTieringPortionInstant, nextTierName, nextTierDuration);
         } else {
-            nextTierName = tierInfo.GetName();
+            nextTierName = tierName;
             nextTierDuration = dWaitLocal;
         }
     }

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
@@ -73,7 +73,7 @@ public:
 
     TString GetDebugString() const {
         TStringBuilder sb;
-        sb << "storage=" << (ExternalStorageId ? ExternalStorageId->GetPath() : "") << ";duration=" << EvictDuration << ";column=" << EvictColumnName
+        sb << "storage=" << (ExternalStorageId ? ExternalStorageId->GetConfigPath() : "") << ";duration=" << EvictDuration << ";column=" << EvictColumnName
            << ";serializer=";
         if (Serializer) {
             sb << Serializer->DebugString();

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
@@ -5,6 +5,7 @@
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
 #include <ydb/core/tx/columnshard/common/scalars.h>
+#include <ydb/core/tx/tiering/tier/identifier.h>
 
 #include <ydb/library/formats/arrow/common/validation.h>
 
@@ -16,7 +17,7 @@ namespace NKikimr::NOlap {
 
 class TTierInfo {
 private:
-    YDB_READONLY_DEF(TString, Name);
+    YDB_READONLY_DEF(std::optional<NColumnShard::NTiers::TExternalStorageId>, StorageId);
     YDB_READONLY_DEF(TString, EvictColumnName);
     YDB_READONLY_DEF(TDuration, EvictDuration);
 
@@ -27,12 +28,12 @@ public:
         return NTiering::NCommon::DeleteTierName;
     }
 
-    TTierInfo(const TString& tierName, TDuration evictDuration, const TString& column, ui32 unitsInSecond = 0)
-        : Name(tierName)
+    TTierInfo(const std::optional<NColumnShard::NTiers::TExternalStorageId>& storage, TDuration evictDuration, const TString& column,
+        ui32 unitsInSecond = 0)
+        : StorageId(storage)
         , EvictColumnName(column)
         , EvictDuration(evictDuration)
         , TtlUnitsInSecond(unitsInSecond) {
-        Y_ABORT_UNLESS(!!Name);
         Y_ABORT_UNLESS(!!EvictColumnName);
     }
 
@@ -72,7 +73,8 @@ public:
 
     TString GetDebugString() const {
         TStringBuilder sb;
-        sb << "name=" << Name << ";duration=" << EvictDuration << ";column=" << EvictColumnName << ";serializer=";
+        sb << "storage=" << (StorageId ? StorageId->GetPath() : "") << ";duration=" << EvictDuration << ";column=" << EvictColumnName
+           << ";serializer=";
         if (Serializer) {
             sb << Serializer->DebugString();
         } else {
@@ -95,19 +97,19 @@ public:
         if (Info->GetEvictDuration() > b.Info->GetEvictDuration()) {
             return true;
         } else if (Info->GetEvictDuration() == b.Info->GetEvictDuration()) {
-            if (Info->GetName() == NTiering::NCommon::DeleteTierName) {
+            if (!Info->GetStorageId()) {
                 return true;
-            } else if (b.Info->GetName() == NTiering::NCommon::DeleteTierName) {
+            } else if (!b.Info->GetStorageId()) {
                 return false;
             }
-            return Info->GetName() > b.Info->GetName(); // add stability: smaller name is hotter
+            return *Info->GetStorageId() > *b.Info->GetStorageId();   // add stability: smaller name is hotter
         }
         return false;
     }
 
     bool operator == (const TTierRef& b) const {
         return Info->GetEvictDuration() == b.Info->GetEvictDuration()
-            && Info->GetName() == b.Info->GetName();
+            && Info->GetStorageId() == b.Info->GetStorageId();
     }
 
     const TTierInfo& Get() const {
@@ -124,8 +126,7 @@ private:
 
 class TTiering {
     using TProto = NKikimrSchemeOp::TColumnDataLifeCycle::TTtl;
-    using TTiersMap = THashMap<TString, std::shared_ptr<TTierInfo>>;
-    TTiersMap TierByName;
+    using TTiersMap = THashMap<NColumnShard::NTiers::TExternalStorageId, std::shared_ptr<TTierInfo>>;
     TSet<TTierRef> OrderedTiers;
     std::optional<TString> TTLColumnName;
 public:
@@ -169,18 +170,6 @@ public:
 
     TTieringContext GetTierToMove(const std::shared_ptr<arrow::Scalar>& max, const TInstant now, const bool skipEviction) const;
 
-    const TTiersMap& GetTierByName() const {
-        return TierByName;
-    }
-
-    std::shared_ptr<TTierInfo> GetTierByName(const TString& name) const {
-        auto it = TierByName.find(name);
-        if (it == TierByName.end()) {
-            return nullptr;
-        }
-        return it->second;
-    }
-
     const TSet<TTierRef>& GetOrderedTiers() const {
         return OrderedTiers;
     }
@@ -203,18 +192,8 @@ public:
             return false;
         }
 
-        TierByName.emplace(tier->GetName(), tier);
         OrderedTiers.emplace(tier);
         return true;
-    }
-
-    std::optional<NArrow::NSerialization::TSerializerContainer> GetSerializer(const TString& name) const {
-        auto it = TierByName.find(name);
-        if (it != TierByName.end()) {
-            Y_ABORT_UNLESS(!name.empty());
-            return it->second->GetSerializer();
-        }
-        return {};
     }
 
     TConclusionStatus DeserializeFromProto(const TProto& serialized) {
@@ -264,24 +243,26 @@ public:
 
     TString GetDebugString() const {
         TStringBuilder sb;
+        sb << "[";
         for (auto&& i : OrderedTiers) {
             sb << i.Get().GetDebugString() << "; ";
         }
+        sb << "]";
         return sb;
     }
 
-    THashSet<TString> GetUsedTiers() const {
-        THashSet<TString> tiers;
-        for (const auto& [name, info] : TierByName) {
-            if (name != NTiering::NCommon::DeleteTierName) {
-                tiers.emplace(name);
+    THashSet<NColumnShard::NTiers::TExternalStorageId> GetUsedTiers() const {
+        THashSet<NColumnShard::NTiers::TExternalStorageId> tiers;
+        for (const auto& tier : OrderedTiers) {
+            if (const auto& storageId = tier.Get().GetStorageId()) {
+                tiers.emplace(*storageId);
             }
         }
         return tiers;
     }
 
-    static THashSet<TString> GetUsedTiers(const TProto& ttlSettings) {
-        THashSet<TString> usedTiers;
+    static THashSet<NColumnShard::NTiers::TExternalStorageId> GetUsedTiers(const TProto& ttlSettings) {
+        THashSet<NColumnShard::NTiers::TExternalStorageId> usedTiers;
         for (const auto& tier : ttlSettings.GetTiers()) {
             if (tier.HasEvictToExternalStorage()) {
                 usedTiers.emplace(CanonizePath(tier.GetEvictToExternalStorage().GetStorage()));

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
@@ -73,8 +73,8 @@ public:
 
     TString GetDebugString() const {
         TStringBuilder sb;
-        sb << "storage=" << (ExternalStorageId ? ExternalStorageId->GetConfigPath() : "") << ";duration=" << EvictDuration << ";column=" << EvictColumnName
-           << ";serializer=";
+        sb << "storage=" << (ExternalStorageId ? ExternalStorageId->GetConfigPath() : NTiering::NCommon::DeleteTierName)
+           << ";duration=" << EvictDuration << ";column=" << EvictColumnName << ";serializer=";
         if (Serializer) {
             sb << Serializer->DebugString();
         } else {

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/ya.make
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/ya.make
@@ -7,6 +7,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow/serializer
+    ydb/core/tx/tiering/tier
 )
 
 END()

--- a/ydb/core/tx/tiering/abstract/manager.cpp
+++ b/ydb/core/tx/tiering/abstract/manager.cpp
@@ -3,7 +3,7 @@
 
 namespace NKikimr::NColumnShard {
 
-const NTiers::TManager& ITiersManager::GetManagerVerified(const TString& tierId) const {
+const NTiers::TManager& ITiersManager::GetManagerVerified(const NTiers::TExternalStorageId& tierId) const {
     auto* result = GetManagerOptional(tierId);
     AFL_VERIFY(result)("tier_id", tierId);
     return *result;

--- a/ydb/core/tx/tiering/abstract/manager.h
+++ b/ydb/core/tx/tiering/abstract/manager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <util/generic/string.h>
 #include <map>
+#include <ydb/core/tx/tiering/tier/identifier.h>
 
 namespace NKikimr::NColumnShard {
 namespace NTiers {
@@ -9,9 +10,9 @@ class TManager;
 
 class ITiersManager {
 public:
-    const NTiers::TManager& GetManagerVerified(const TString& tierId) const;
-    virtual const NTiers::TManager* GetManagerOptional(const TString& tierId) const = 0;
-    virtual const std::map<TString, NTiers::TManager>& GetManagers() const = 0;
+    const NTiers::TManager& GetManagerVerified(const NTiers::TExternalStorageId& tierId) const;
+    virtual const NTiers::TManager* GetManagerOptional(const NTiers::TExternalStorageId& tierId) const = 0;
+    virtual const std::map<NTiers::TExternalStorageId, NTiers::TManager>& GetManagers() const = 0;
     virtual ~ITiersManager() = default;
 };
 

--- a/ydb/core/tx/tiering/abstract/ya.make
+++ b/ydb/core/tx/tiering/abstract/ya.make
@@ -6,6 +6,7 @@ SRCS(
 
 PEERDIR(
     ydb/library/actors/core
+    ydb/core/tx/tiering/tier
 )
 
 END()

--- a/ydb/core/tx/tiering/manager.cpp
+++ b/ydb/core/tx/tiering/manager.cpp
@@ -338,7 +338,7 @@ TString TTiersManager::DebugString() {
         for (const auto& [pathId, tiers] : UsedTiers) {
             sb << pathId << ":{";
             for (const auto& tierRef : tiers) {
-                sb << tierRef.GetTier() << ";";
+                sb << tierRef.GetTierId() << ";";
             }
             sb << "}";
         }

--- a/ydb/core/tx/tiering/manager.cpp
+++ b/ydb/core/tx/tiering/manager.cpp
@@ -3,6 +3,7 @@
 
 #include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/tiering/fetcher.h>
+#include <ydb/core/tx/tiering/tier/identifier.h>
 
 #include <ydb/library/table_creator/table_creator.h>
 #include <ydb/services/metadata/secret/fetcher.h>
@@ -18,7 +19,7 @@ private:
 
     std::shared_ptr<TTiersManager> Owner;
     IRetryPolicy::TPtr RetryPolicy;
-    THashMap<TString, IRetryPolicy::IRetryState::TPtr> RetryStateByObject;
+    THashMap<NTiers::TExternalStorageId, IRetryPolicy::IRetryState::TPtr> RetryStateByObject;
     NMetadata::NFetcher::ISnapshotsFetcher::TPtr SecretsFetcher;
     TActorId TiersFetcher;
 
@@ -27,29 +28,23 @@ private:
         return NMetadata::NProvider::MakeServiceId(SelfId().NodeId());
     }
 
-    void OnInvalidTierConfig(const TString& path) {
-        if (!Owner->TierRefCount.contains(path)) {
-            ResetRetryState(path);
+    void OnTierFetchingError(const NTiers::TExternalStorageId& tier) {
+        if (!Owner->TierRefCount.contains(tier)) {
+            ResetRetryState(tier);
             return;
         }
         AFL_DEBUG(NKikimrServices::TX_TIERING)("component", "tiers_manager")("event", "retry_watch_objects");
-        auto findRetryState = RetryStateByObject.find(path);
+        auto findRetryState = RetryStateByObject.find(tier);
         if (!findRetryState) {
-            findRetryState = RetryStateByObject.emplace(path, RetryPolicy->CreateRetryState()).first;
+            findRetryState = RetryStateByObject.emplace(tier, RetryPolicy->CreateRetryState()).first;
         }
         auto retryDelay = findRetryState->second->GetNextRetryDelay();
-        AFL_VERIFY(retryDelay)("object", path);
-        ActorContext().Schedule(*retryDelay, std::make_unique<IEventHandle>(SelfId(), TiersFetcher, new NTiers::TEvWatchSchemeObject(std::vector<TString>({ path }))));
+        AFL_VERIFY(retryDelay)("object", tier.GetPath());
+        ActorContext().Schedule(*retryDelay, std::make_unique<IEventHandle>(SelfId(), TiersFetcher, new NTiers::TEvWatchSchemeObject(std::vector<TString>({ tier.GetPath() }))));
     }
 
-    void ResetRetryState(const TString& path) {
-        RetryStateByObject.erase(path);
-    }
-
-    void OnFetchingFailure(const TString& path) {
-        if (Owner->TierRefCount.contains(path)) {
-            OnInvalidTierConfig(path);
-        }
+    void ResetRetryState(const NTiers::TExternalStorageId& tier) {
+        RetryStateByObject.erase(tier);
     }
 
     STATEFN(StateMain) {
@@ -82,33 +77,33 @@ private:
 
     void Handle(NTiers::TEvNotifySchemeObjectUpdated::TPtr& ev) {
         AFL_DEBUG(NKikimrServices::TX_TIERING)("component", "tiering_manager")("event", "object_updated")("path", ev->Get()->GetObjectPath());
-        const TString& objectPath = ev->Get()->GetObjectPath();
+        const NTiers::TExternalStorageId tierId(ev->Get()->GetObjectPath());
         const auto& description = ev->Get()->GetDescription();
-        ResetRetryState(objectPath);
+        ResetRetryState(tierId);
         if (description.GetSelf().GetPathType() == NKikimrSchemeOp::EPathTypeExternalDataSource) {
             NTiers::TTierConfig tier;
             if (const auto status = tier.DeserializeFromProto(description.GetExternalDataSourceDescription()); status.IsFail()) {
                 AFL_WARN(NKikimrServices::TX_TIERING)("event", "fetched_invalid_tier_settings")("error", status.GetErrorMessage());
-                OnInvalidTierConfig(objectPath);
+                OnTierFetchingError(tierId);
                 return;
             }
-            Owner->UpdateTierConfig(tier, objectPath);
+            Owner->UpdateTierConfig(tier, tierId);
         } else {
-            AFL_WARN(false)("error", "invalid_object_type")("type", static_cast<ui64>(description.GetSelf().GetPathType()))("path", objectPath);
-            OnInvalidTierConfig(objectPath);
+            AFL_WARN(false)("error", "invalid_object_type")("type", static_cast<ui64>(description.GetSelf().GetPathType()))("path", tierId.GetPath());
+            OnTierFetchingError(tierId);
         }
     }
 
     void Handle(NTiers::TEvNotifySchemeObjectDeleted::TPtr& ev) {
         AFL_DEBUG(NKikimrServices::TX_TIERING)("component", "tiering_manager")("event", "object_deleted")("name", ev->Get()->GetObjectPath());
-        OnInvalidTierConfig(ev->Get()->GetObjectPath());
+        OnTierFetchingError(ev->Get()->GetObjectPath());
     }
 
     void Handle(NTiers::TEvSchemeObjectResolutionFailed::TPtr& ev) {
         const TString objectPath = ev->Get()->GetObjectPath();
         AFL_WARN(NKikimrServices::TX_TIERING)("event", "object_resolution_failed")("path", objectPath)(
             "reason", static_cast<ui64>(ev->Get()->GetReason()));
-        OnInvalidTierConfig(objectPath);
+        OnTierFetchingError(objectPath);
     }
 
     void Handle(NTiers::TEvWatchSchemeObject::TPtr& ev) {
@@ -141,7 +136,7 @@ public:
 namespace NTiers {
 
 TManager& TManager::Restart(const TTierConfig& config, std::shared_ptr<NMetadata::NSecret::TSnapshot> secrets) {
-    ALS_DEBUG(NKikimrServices::TX_TIERING) << "Restarting tier '" << TierName << "' at tablet " << TabletId;
+    ALS_DEBUG(NKikimrServices::TX_TIERING) << "Restarting tier '" << TierId.GetPath() << "' at tablet " << TabletId;
     Stop();
     Start(config, secrets);
     return *this;
@@ -149,26 +144,26 @@ TManager& TManager::Restart(const TTierConfig& config, std::shared_ptr<NMetadata
 
 bool TManager::Stop() {
     S3Settings.reset();
-    ALS_DEBUG(NKikimrServices::TX_TIERING) << "Tier '" << TierName << "' stopped at tablet " << TabletId;
+    ALS_DEBUG(NKikimrServices::TX_TIERING) << "Tier '" << TierId.GetPath() << "' stopped at tablet " << TabletId;
     return true;
 }
 
 bool TManager::Start(const TTierConfig& config, std::shared_ptr<NMetadata::NSecret::TSnapshot> secrets) {
-    AFL_VERIFY(!S3Settings)("tier", TierName)("event", "already started");
+    AFL_VERIFY(!S3Settings)("tier", TierId.GetPath())("event", "already started");
     auto patchedConfig = config.GetPatchedConfig(secrets);
     if (patchedConfig.IsFail()) {
         AFL_ERROR(NKikimrServices::TX_TIERING)("error", "cannot_read_secrets")("reason", patchedConfig.GetErrorMessage());
         return false;
     }
     S3Settings = patchedConfig.DetachResult();
-    ALS_DEBUG(NKikimrServices::TX_TIERING) << "Tier '" << TierName << "' started at tablet " << TabletId;
+    ALS_DEBUG(NKikimrServices::TX_TIERING) << "Tier '" << TierId.GetPath() << "' started at tablet " << TabletId;
     return true;
 }
 
-TManager::TManager(const ui64 tabletId, const NActors::TActorId& tabletActorId, const TString& tierName)
+TManager::TManager(const ui64 tabletId, const NActors::TActorId& tabletActorId, const TExternalStorageId& tierName)
     : TabletId(tabletId)
     , TabletActorId(tabletActorId)
-    , TierName(tierName) {
+    , TierId(tierName) {
 }
 
 NArrow::NSerialization::TSerializerContainer ConvertCompression(const NKikimrSchemeOp::TCompressionOptions& compressionProto) {
@@ -184,30 +179,30 @@ NArrow::NSerialization::TSerializerContainer ConvertCompression(const NKikimrSch
 }
 }
 
-TTiersManager::TTierRefGuard::TTierRefGuard(const TString& tierName, TTiersManager& owner)
-    : TierName(tierName)
+TTiersManager::TTierRefGuard::TTierRefGuard(const NTiers::TExternalStorageId& tierId, TTiersManager& owner)
+    : TierId(tierId)
     , Owner(&owner) {
-    if (!Owner->TierRefCount.contains(TierName)) {
-        Owner->RegisterTier(tierName);
+    if (!Owner->TierRefCount.contains(TierId)) {
+        Owner->RegisterTier(tierId);
     }
-    ++Owner->TierRefCount[TierName];
+    ++Owner->TierRefCount[TierId];
 }
 
 TTiersManager::TTierRefGuard::~TTierRefGuard() {
     if (Owner) {
-        auto findTier = Owner->TierRefCount.FindPtr(TierName);
+        auto findTier = Owner->TierRefCount.FindPtr(TierId);
         AFL_VERIFY(findTier);
         --*findTier;
         if (!*findTier) {
-            AFL_VERIFY(Owner->TierRefCount.erase(TierName));
-            Owner->UnregisterTier(TierName);
+            AFL_VERIFY(Owner->TierRefCount.erase(TierId));
+            Owner->UnregisterTier(TierId);
         }
     }
 }
 
 void TTiersManager::OnConfigsUpdated(bool notifyShard) {
-    for (auto& [tierName, manager] : Managers) {
-        auto* findTierConfig = TierConfigs.FindPtr(tierName);
+    for (auto& [tierId, manager] : Managers) {
+        auto* findTierConfig = TierConfigs.FindPtr(tierId);
         if (Secrets && findTierConfig) {
             if (manager.IsReady()) {
                 manager.Restart(*findTierConfig, Secrets);
@@ -215,7 +210,7 @@ void TTiersManager::OnConfigsUpdated(bool notifyShard) {
                 manager.Start(*findTierConfig, Secrets);
             }
         } else {
-            AFL_DEBUG(NKikimrServices::TX_TIERING)("event", "skip_tier_manager_reloading")("tier", tierName)("has_secrets", !!Secrets)(
+            AFL_DEBUG(NKikimrServices::TX_TIERING)("event", "skip_tier_manager_reloading")("tier", tierId.GetPath())("has_secrets", !!Secrets)(
                 "found_tier_config", !!findTierConfig);
         }
     }
@@ -227,21 +222,21 @@ void TTiersManager::OnConfigsUpdated(bool notifyShard) {
     AFL_DEBUG(NKikimrServices::TX_TIERING)("event", "configs_updated")("configs", DebugString());
 }
 
-void TTiersManager::RegisterTier(const TString& name) {
-    auto emplaced = Managers.emplace(name, NTiers::TManager(TabletId, TabletActorId, name));
+void TTiersManager::RegisterTier(const NTiers::TExternalStorageId& tierId) {
+    auto emplaced = Managers.emplace(tierId, NTiers::TManager(TabletId, TabletActorId, tierId));
     AFL_VERIFY(emplaced.second);
 
-    auto* findConfig = TierConfigs.FindPtr(name);
+    auto* findConfig = TierConfigs.FindPtr(tierId);
     if (Secrets && findConfig) {
         emplaced.first->second.Start(*findConfig, Secrets);
     } else {
-        AFL_DEBUG(NKikimrServices::TX_TIERING)("event", "skip_tier_manager_start")("tier", name)("has_secrets", !!Secrets)(
+        AFL_DEBUG(NKikimrServices::TX_TIERING)("event", "skip_tier_manager_start")("tier", tierId.GetPath())("has_secrets", !!Secrets)(
             "found_tier_config", !!findConfig);
     }
 }
 
-void TTiersManager::UnregisterTier(const TString& name) {
-    auto findManager = Managers.find(name);
+void TTiersManager::UnregisterTier(const NTiers::TExternalStorageId& tierId) {
+    auto findManager = Managers.find(tierId);
     AFL_VERIFY(findManager != Managers.end());
     findManager->second.Stop();
     Managers.erase(findManager);
@@ -268,7 +263,7 @@ TTiersManager& TTiersManager::Stop(const bool needStopActor) {
     return *this;
 }
 
-const NTiers::TManager* TTiersManager::GetManagerOptional(const TString& tierId) const {
+const NTiers::TManager* TTiersManager::GetManagerOptional(const NTiers::TExternalStorageId& tierId) const {
     auto it = Managers.find(tierId);
     if (it != Managers.end()) {
         return &it->second;
@@ -277,17 +272,16 @@ const NTiers::TManager* TTiersManager::GetManagerOptional(const TString& tierId)
     }
 }
 
-void TTiersManager::EnablePathId(const ui64 pathId, const THashSet<TString>& usedTiers) {
+void TTiersManager::EnablePathId(const ui64 pathId, const THashSet<NTiers::TExternalStorageId>& usedTiers) {
     AFL_VERIFY(Actor)("error", "tiers_manager_is_not_started");
     auto& tierRefs = UsedTiers[pathId];
     tierRefs.clear();
-    for (const TString& tierName : usedTiers) {
-        AFL_VERIFY(tierName == CanonizePath(tierName))("current", tierName)("canonized", CanonizePath(tierName));
-        tierRefs.emplace_back(tierName, *this);
-        if (!TierConfigs.contains(tierName)) {
+    for (const NTiers::TExternalStorageId& tierId : usedTiers) {
+        tierRefs.emplace_back(tierId, *this);
+        if (!TierConfigs.contains(tierId)) {
             const auto& actorContext = NActors::TActivationContext::AsActorContext();
             AFL_VERIFY(&actorContext)("error", "no_actor_context");
-            actorContext.Send(Actor->SelfId(), new NTiers::TEvWatchSchemeObject({ tierName }));
+            actorContext.Send(Actor->SelfId(), new NTiers::TEvWatchSchemeObject({ tierId.GetPath() }));
         }
     }
     OnConfigsUpdated(false);
@@ -305,10 +299,9 @@ void TTiersManager::UpdateSecretsSnapshot(std::shared_ptr<NMetadata::NSecret::TS
     OnConfigsUpdated();
 }
 
-void TTiersManager::UpdateTierConfig(const NTiers::TTierConfig& config, const TString& tierName, const bool notifyShard) {
-    AFL_INFO(NKikimrServices::TX_TIERING)("event", "update_tier_config")("name", tierName)("tablet", TabletId);
-    AFL_VERIFY(tierName == CanonizePath(tierName))("current", tierName)("canonized", CanonizePath(tierName));
-    TierConfigs[tierName] = config;
+void TTiersManager::UpdateTierConfig(const NTiers::TTierConfig& config, const NTiers::TExternalStorageId& tierId, const bool notifyShard) {
+    AFL_INFO(NKikimrServices::TX_TIERING)("event", "update_tier_config")("name", tierId.GetPath())("tablet", TabletId);
+    TierConfigs[tierId] = config;
     OnConfigsUpdated(notifyShard);
 }
 
@@ -334,8 +327,8 @@ TString TTiersManager::DebugString() {
     sb << "TIERS=";
     if (TierConfigs) {
         sb << "{";
-        for (const auto& [name, config] : TierConfigs) {
-            sb << name << ";";
+        for (const auto& [id, config] : TierConfigs) {
+            sb << id.GetPath() << ";";
         }
         sb << "}";
     }
@@ -345,7 +338,7 @@ TString TTiersManager::DebugString() {
         for (const auto& [pathId, tiers] : UsedTiers) {
             sb << pathId << ":{";
             for (const auto& tierRef : tiers) {
-                sb << tierRef.GetTierName() << ";";
+                sb << tierRef.GetTier().GetPath() << ";";
             }
             sb << "}";
         }

--- a/ydb/core/tx/tiering/manager.h
+++ b/ydb/core/tx/tiering/manager.h
@@ -53,7 +53,7 @@ private:
         TTiersManager* Owner;
 
     public:
-        const NTiers::TExternalStorageId& GetTier() const {
+        const NTiers::TExternalStorageId& GetTierId() const {
             return TierId;
         }
 

--- a/ydb/core/tx/tiering/manager.h
+++ b/ydb/core/tx/tiering/manager.h
@@ -4,6 +4,7 @@
 #include "abstract/manager.h"
 
 #include <ydb/core/formats/arrow/serializer/abstract.h>
+#include <ydb/core/tx/tiering/tier/identifier.h>
 #include <ydb/core/tx/tiering/tier/object.h>
 
 #include <ydb/public/sdk/cpp/client/ydb_types/s3_settings.h>
@@ -23,7 +24,7 @@ class TManager {
 private:
     ui64 TabletId = 0;
     NActors::TActorId TabletActorId;
-    TString TierName;
+    TExternalStorageId TierId;
     NActors::TActorId StorageActorId;
     std::optional<NKikimrSchemeOp::TS3Settings> S3Settings;
 public:
@@ -32,7 +33,7 @@ public:
         return *S3Settings;
     }
 
-    TManager(const ui64 tabletId, const NActors::TActorId& tabletActorId, const TString& tierName);
+    TManager(const ui64 tabletId, const NActors::TActorId& tabletActorId, const TExternalStorageId& tierId);
 
     bool IsReady() const {
         return !!S3Settings;
@@ -48,21 +49,25 @@ private:
     friend class TTierRef;
     class TTierRefGuard: public TMoveOnly {
     private:
-        YDB_READONLY_DEF(TString, TierName);
+        NTiers::TExternalStorageId TierId;
         TTiersManager* Owner;
 
     public:
-        TTierRefGuard(const TString& tierName, TTiersManager& owner);
+        const NTiers::TExternalStorageId& GetTier() const {
+            return TierId;
+        }
+
+        TTierRefGuard(const NTiers::TExternalStorageId& tierId, TTiersManager& owner);
         ~TTierRefGuard();
 
         TTierRefGuard(TTierRefGuard&& other)
-            : TierName(other.TierName)
+            : TierId(other.TierId)
             , Owner(other.Owner) {
             other.Owner = nullptr;
         }
         TTierRefGuard& operator=(TTierRefGuard&& other) {
             std::swap(Owner, other.Owner);
-            std::swap(TierName, other.TierName);
+            std::swap(TierId, other.TierId);
             return *this;
         }
     };
@@ -70,7 +75,7 @@ private:
 private:
     class TActor;
     friend class TActor;
-    using TManagers = std::map<TString, NTiers::TManager>;
+    using TManagers = std::map<NTiers::TExternalStorageId, NTiers::TManager>;
 
     ui64 TabletId = 0;
     const TActorId TabletActorId;
@@ -78,19 +83,19 @@ private:
     IActor* Actor = nullptr;
     TManagers Managers;
 
-    using TTierRefCount = THashMap<TString, TPositiveControlInteger>;
+    using TTierRefCount = THashMap<NTiers::TExternalStorageId, TPositiveControlInteger>;
     using TTierRefsByPathId = THashMap<ui64, std::vector<TTierRefGuard>>;
     YDB_READONLY_DEF(TTierRefCount, TierRefCount);
     YDB_READONLY_DEF(TTierRefsByPathId, UsedTiers);
 
-    using TTierByName = THashMap<TString, NTiers::TTierConfig>;
-    YDB_READONLY_DEF(TTierByName, TierConfigs);
+    using TTierById = THashMap<NTiers::TExternalStorageId, NTiers::TTierConfig>;
+    YDB_READONLY_DEF(TTierById, TierConfigs);
     YDB_READONLY_DEF(std::shared_ptr<NMetadata::NSecret::TSnapshot>, Secrets);
 
 private:
     void OnConfigsUpdated(bool notifyShard = true);
-    void RegisterTier(const TString& name);
-    void UnregisterTier(const TString& name);
+    void RegisterTier(const NTiers::TExternalStorageId& name);
+    void UnregisterTier(const NTiers::TExternalStorageId& name);
 
 public:
     TTiersManager(const ui64 tabletId, const TActorId& tabletActorId, std::function<void(const TActorContext& ctx)> shardCallback = {})
@@ -100,21 +105,21 @@ public:
         , Secrets(std::make_shared<NMetadata::NSecret::TSnapshot>(TInstant::Zero())) {
     }
     TActorId GetActorId() const;
-    void EnablePathId(const ui64 pathId, const THashSet<TString>& usedTiers);
+    void EnablePathId(const ui64 pathId, const THashSet<NTiers::TExternalStorageId>& usedTiers);
     void DisablePathId(const ui64 pathId);
 
     void UpdateSecretsSnapshot(std::shared_ptr<NMetadata::NSecret::TSnapshot> secrets);
-    void UpdateTierConfig(const NTiers::TTierConfig& config, const TString& tierName, const bool notifyShard = true);
+    void UpdateTierConfig(const NTiers::TTierConfig& config, const NTiers::TExternalStorageId& tierId, const bool notifyShard = true);
     bool AreConfigsComplete() const;
 
     TString DebugString();
 
     TTiersManager& Start(std::shared_ptr<TTiersManager> ownerPtr);
     TTiersManager& Stop(const bool needStopActor);
-    virtual const std::map<TString, NTiers::TManager>& GetManagers() const override {
+    virtual const std::map<NTiers::TExternalStorageId, NTiers::TManager>& GetManagers() const override {
         return Managers;
     }
-    virtual const NTiers::TManager* GetManagerOptional(const TString& tierId) const override;
+    virtual const NTiers::TManager* GetManagerOptional(const NTiers::TExternalStorageId& tierId) const override;
 };
 
 }

--- a/ydb/core/tx/tiering/tier/identifier.cpp
+++ b/ydb/core/tx/tiering/tier/identifier.cpp
@@ -1,0 +1,3 @@
+#include "identifier.h"
+
+namespace NKikimr::NColumnShard::NTiers {}

--- a/ydb/core/tx/tiering/tier/identifier.h
+++ b/ydb/core/tx/tiering/tier/identifier.h
@@ -22,7 +22,13 @@ public:
     }
 
     std::strong_ordering operator<=>(const TExternalStorageId& other) const {
-        return ConfigPath <=> other.ConfigPath;
+        if (ConfigPath < other.ConfigPath) {
+            return std::strong_ordering::less;
+        }
+        if (ConfigPath > other.ConfigPath) {
+            return std::strong_ordering::greater;
+        }
+        return std::strong_ordering::equal;
     }
     bool operator==(const TExternalStorageId& other) const {
         return ConfigPath == other.ConfigPath;

--- a/ydb/core/tx/tiering/tier/identifier.h
+++ b/ydb/core/tx/tiering/tier/identifier.h
@@ -10,21 +10,22 @@ namespace NKikimr::NColumnShard::NTiers {
 
 class TExternalStorageId {
 private:
-    YDB_READONLY_DEF(TString, Path);
+    YDB_READONLY_DEF(TString, ConfigPath);
 
 public:
     TExternalStorageId(const TString& path)
-        : Path(CanonizePath(path)) {
+        : ConfigPath(CanonizePath(path)) {
     }
 
-    bool operator<(const TExternalStorageId& other) const {
-        return Path < other.Path;
+    TString ToString() const {
+        return ConfigPath;
     }
-    bool operator>(const TExternalStorageId& other) const {
-        return Path > other.Path;
+
+    std::strong_ordering operator<=>(const TExternalStorageId& other) const {
+        return ConfigPath <=> other.ConfigPath;
     }
     bool operator==(const TExternalStorageId& other) const {
-        return Path == other.Path;
+        return ConfigPath == other.ConfigPath;
     }
 };
 
@@ -33,6 +34,6 @@ public:
 template <>
 struct THash<NKikimr::NColumnShard::NTiers::TExternalStorageId> {
     inline ui64 operator()(const NKikimr::NColumnShard::NTiers::TExternalStorageId& x) const noexcept {
-        return THash<TString>()(x.GetPath());
+        return THash<TString>()(x.ToString());
     }
 };

--- a/ydb/core/tx/tiering/tier/identifier.h
+++ b/ydb/core/tx/tiering/tier/identifier.h
@@ -20,6 +20,9 @@ public:
     TString ToString() const {
         return ConfigPath;
     }
+    friend IOutputStream& operator<<(IOutputStream& out, const TExternalStorageId& storageId) {
+        return out << storageId.ToString();
+    }
 
     std::strong_ordering operator<=>(const TExternalStorageId& other) const {
         if (ConfigPath < other.ConfigPath) {

--- a/ydb/core/tx/tiering/tier/identifier.h
+++ b/ydb/core/tx/tiering/tier/identifier.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <ydb/core/base/path.h>
+
+#include <ydb/library/accessor/accessor.h>
+
+#include <util/str_stl.h>
+
+namespace NKikimr::NColumnShard::NTiers {
+
+class TExternalStorageId {
+private:
+    YDB_READONLY_DEF(TString, Path);
+
+public:
+    TExternalStorageId(const TString& path)
+        : Path(CanonizePath(path)) {
+    }
+
+    bool operator<(const TExternalStorageId& other) const {
+        return Path < other.Path;
+    }
+    bool operator>(const TExternalStorageId& other) const {
+        return Path > other.Path;
+    }
+    bool operator==(const TExternalStorageId& other) const {
+        return Path == other.Path;
+    }
+};
+
+}   // namespace NKikimr::NColumnShard::NTiers
+
+template <>
+struct THash<NKikimr::NColumnShard::NTiers::TExternalStorageId> {
+    inline ui64 operator()(const NKikimr::NColumnShard::NTiers::TExternalStorageId& x) const noexcept {
+        return THash<TString>()(x.GetPath());
+    }
+};

--- a/ydb/core/tx/tiering/tier/ya.make
+++ b/ydb/core/tx/tiering/tier/ya.make
@@ -3,9 +3,11 @@ LIBRARY()
 SRCS(
     object.cpp
     s3_uri.cpp
+    identifier.cpp
 )
 
 PEERDIR(
+    ydb/core/base
     ydb/library/conclusion
     ydb/services/metadata/secret/accessor
     contrib/restricted/aws/aws-crt-cpp

--- a/ydb/core/tx/tiering/ut/ut_tiers.cpp
+++ b/ydb/core/tx/tiering/ut/ut_tiers.cpp
@@ -150,7 +150,7 @@ Y_UNIT_TEST_SUITE(ColumnShardTiers) {
     class TTestCSEmulator: public NActors::TActorBootstrapped<TTestCSEmulator> {
     private:
         using TBase = NActors::TActorBootstrapped<TTestCSEmulator>;
-        THashSet<TString> ExpectedTiers;
+        THashSet<NTiers::TExternalStorageId> ExpectedTiers;
         TInstant Start;
         std::shared_ptr<TTiersManager> Manager;
 
@@ -180,7 +180,7 @@ Y_UNIT_TEST_SUITE(ColumnShardTiers) {
             return notFoundTiers.empty();
         }
 
-        const THashMap<TString, NTiers::TTierConfig>& GetTierConfigs() {
+        const THashMap<NTiers::TExternalStorageId, NTiers::TTierConfig>& GetTierConfigs() {
             return Manager->GetTierConfigs();
         }
 
@@ -193,8 +193,14 @@ Y_UNIT_TEST_SUITE(ColumnShardTiers) {
             Manager->EnablePathId(0, ExpectedTiers);
         }
 
-        TTestCSEmulator(THashSet<TString> expectedTiers)
+        TTestCSEmulator(THashSet<NTiers::TExternalStorageId> expectedTiers)
             : ExpectedTiers(std::move(expectedTiers)) {
+        }
+
+        TTestCSEmulator(const std::initializer_list<TString>& expectedTiers) {
+            for (const auto& tier : expectedTiers) {
+                ExpectedTiers.emplace(tier);
+            }
         }
     };
 

--- a/ydb/core/tx/tiering/ut/ut_tiers.cpp
+++ b/ydb/core/tx/tiering/ut/ut_tiers.cpp
@@ -257,7 +257,7 @@ Y_UNIT_TEST_SUITE(ColumnShardTiers) {
                 TTestCSEmulator* emulator = new TTestCSEmulator({ "/Root/tier1", "/Root/tier2" });
                 runtime.Register(emulator);
                 emulator->CheckRuntime(runtime);
-                UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at("/Root/tier1").GetProtoConfig().GetBucket(), "abc");
+                UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at(NTiers::TExternalStorageId("/Root/tier1")).GetProtoConfig().GetBucket(), "abc");
             }
             Cerr << "Initialization finished" << Endl;
             {
@@ -313,7 +313,7 @@ Y_UNIT_TEST_SUITE(ColumnShardTiers) {
             TTestCSEmulator* emulator = new TTestCSEmulator({ "/Root/tier1" });
             runtime.Register(emulator);
             emulator->CheckRuntime(runtime);
-            UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at("/Root/tier1").GetProtoConfig().GetBucket(), "abc1");
+            UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at(NTiers::TExternalStorageId("/Root/tier1")).GetProtoConfig().GetBucket(), "abc1");
         }
 
         lHelper.CreateExternalDataSource("/Root/tier2", "http://fake.fake/abc2");
@@ -321,8 +321,8 @@ Y_UNIT_TEST_SUITE(ColumnShardTiers) {
             TTestCSEmulator* emulator = new TTestCSEmulator({ "/Root/tier1", "/Root/tier2" });
             runtime.Register(emulator);
             emulator->CheckRuntime(runtime);
-            UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at("/Root/tier1").GetProtoConfig().GetBucket(), "abc1");
-            UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at("/Root/tier2").GetProtoConfig().GetBucket(), "abc2");
+            UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at(NTiers::TExternalStorageId("/Root/tier1")).GetProtoConfig().GetBucket(), "abc1");
+            UNIT_ASSERT_EQUAL(emulator->GetTierConfigs().at(NTiers::TExternalStorageId("/Root/tier2")).GetProtoConfig().GetBucket(), "abc2");
         }
 
         lHelper.CreateTestOlapTable("olapTable");
@@ -438,7 +438,7 @@ Y_UNIT_TEST_SUITE(ColumnShardTiers) {
             TTestCSEmulator* emulator = new TTestCSEmulator({ "/Root/tier1", "/Root/tier2" });
             runtime.Register(emulator);
             emulator->CheckRuntime(runtime);
-            UNIT_ASSERT_VALUES_EQUAL(emulator->GetTierConfigs().at("/Root/tier1").GetProtoConfig().GetEndpoint(), TierEndpoint);
+            UNIT_ASSERT_VALUES_EQUAL(emulator->GetTierConfigs().at(NTiers::TExternalStorageId("/Root/tier1")).GetProtoConfig().GetEndpoint(), TierEndpoint);
         }
 
         lHelper.CreateTestOlapTable("olapTable", 2);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Canonize storage path in CS Tiers

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Один путь до схемного объекта может описываться строками с разным количеством слешей. Чтобы CS корректно идентифицировал тир по пути в произвольном формате, в качестве id тиров используются канонизированные пути.