### PR TITLE
handle uninitialized tier

### DIFF
--- a/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/actualizer/tiering/tiering.cpp
@@ -178,7 +178,9 @@ void TTieringActualizer::DoExtractTasks(
             for (auto&& p : portions) {
                 const auto& portion = externalContext.GetPortionVerified(p);
                 auto info = BuildActualizationInfo(*portion, tasksContext.GetActualInstant());
-                AFL_VERIFY(info);
+                if (!info) {
+                    continue;
+                }
                 auto portionScheme = portion->GetSchema(VersionedIndex);
                 TPortionEvictionFeatures features(
                     portionScheme, info->GetTargetScheme(), portion->GetTierNameDef(IStoragesManager::DefaultStorageId));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix crashing when tier is uninitialized on CS

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

On indexation, skip eviction to tiers that has not been initialized yet.