### PR TITLE
IGNIETFERRO-2094: do not use a temporary string to construct an empty TStringBuf 

### DIFF
--- a/ydb/core/control/immediate_control_board_actor_ut.cpp
+++ b/ydb/core/control/immediate_control_board_actor_ut.cpp
@@ -275,7 +275,7 @@ struct THttpRequest : NMonitoring::IHttpRequest {
     }
 
     TStringBuf GetPostContent() const override {
-        return TString();
+        return TStringBuf();
     }
 
     HTTP_METHOD GetMethod() const override {

--- a/ydb/core/persqueue/ut/counters_ut.cpp
+++ b/ydb/core/persqueue/ut/counters_ut.cpp
@@ -56,7 +56,7 @@ struct THttpRequest : NMonitoring::IHttpRequest {
     }
 
     TStringBuf GetPostContent() const override {
-        return TString();
+        return TStringBuf();
     }
 
     HTTP_METHOD GetMethod() const override {


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The function returns an empty view that does not point to local memory on the stack, which makes it difficult to track the lifetime of string buffers.
It is also requires less time to directly construct the view.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

IGNIETFERRO-2094