### PR TITLE
Batching for upload test results

### DIFF
--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -242,18 +242,17 @@ def main():
             })
         print(f'upserting runs: {len(prepared_for_upload_rows)} rows')
         if prepared_for_upload_rows:
-
             batch_rows_for_upload_size = 1000
-            for start in range(0, len(prepared_for_upload_rows), batch_rows_for_upload_size):
-                batch_rows_for_upload = prepared_for_upload_rows[start:start + batch_rows_for_upload_size]
-                with ydb.SessionPool(driver) as pool:
-                    create_tables(pool, test_table_name)
+            with ydb.SessionPool(driver) as pool:
+                create_tables(pool, test_table_name)
+                for start in range(0, len(prepared_for_upload_rows), batch_rows_for_upload_size):
+                    batch_rows_for_upload = prepared_for_upload_rows[start:start + batch_rows_for_upload_size]     
                     bulk_upsert(driver.table_client, full_path,
                             batch_rows_for_upload)
                 
             print('tests uploaded')
         else:
-            print('nothing to upsert')
+            print('nothing to upload')
 
        
 

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -239,6 +239,7 @@ void TColumnShard::Handle(TEvPrivate::TEvPeriodicWakeup::TPtr& ev, const TActorC
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvPrivate::TEvPeriodicWakeup")("tablet_id", TabletID());
         SendWaitPlanStep(GetOutdatedStep());
 
+
         SendPeriodicStats();
         EnqueueBackgroundActivities();
         ctx.Schedule(PeriodicWakeupActivationPeriod, new TEvPrivate::TEvPeriodicWakeup());

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -239,7 +239,6 @@ void TColumnShard::Handle(TEvPrivate::TEvPeriodicWakeup::TPtr& ev, const TActorC
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "TEvPrivate::TEvPeriodicWakeup")("tablet_id", TabletID());
         SendWaitPlanStep(GetOutdatedStep());
 
-
         SendPeriodicStats();
         EnqueueBackgroundActivities();
         ctx.Schedule(PeriodicWakeupActivationPeriod, new TEvPrivate::TEvPeriodicWakeup());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

In asan, msan and tsan test runs faced with issue

**Asan** :
```
	debug_error_string = "UNKNOWN:Error received from peer  ***created_time:"2024-12-20T07:00:24.812682876+00:00", grpc_status:8, 
grpc_message:"CLIENT: Sent message larger than max (68044368 vs. 64000000)"***"
>
+ result='upserting runs: 31664 rows
```
=> x1,06 size 148394093 vs. 64000000

**Msan** (very large error messages)
```
	debug_error_string = "UNKNOWN:Error received from peer  ***created_time:"2024-12-20T04:45:30.016096641+00:00", grpc_status:8, 
grpc_message:"CLIENT: Sent message larger than max (148394093 vs. 64000000)"***"
>
+ result='upserting runs: 10183 rows
```
=> x2,3 size 148394093 vs. 64000000

**So 1000 rows shoud be about 20% of maximum**

testing in msan here https://github.com/ydb-platform/ydb/pull/12843

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
