### PR TITLE
Stable-24-3-11: Remove old restriction: keys with Uint8 column values >127 are currently prohibited (#11886)

### DIFF
--- a/ydb/core/engine/mkql_engine_flat.cpp
+++ b/ydb/core/engine/mkql_engine_flat.cpp
@@ -577,15 +577,6 @@ public:
                 AddError("Validate", __LINE__, "Bad shard program: key size is greater that specified in schema");
                 return false;
             }
-            for (size_t i = 0; i < desc.Range.From.size(); ++i) {
-                if (desc.KeyColumnTypes[i].GetTypeId() != NScheme::NTypeIds::Uint8)
-                    continue;
-                const TCell& c = desc.Range.From[i];
-                if (!c.IsNull() && c.AsValue<ui8>() > 127) {
-                    AddError("Validate", __LINE__, "Bad shard program: keys with Uint8 column values >127 are currently prohibited");
-                    return false;
-                }
-            }
         }
         return true;
     }

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -5218,6 +5218,64 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
             UNIT_ASSERT_VALUES_EQUAL(reads[0]["columns"].GetArraySafe().size(), 1);
         }
     }
+
+    Y_UNIT_TEST(Uint8Index) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            const TString createTableSql = R"(CREATE TABLE `/Root/table` (
+                key Uint8,
+                value Uint8,
+                PRIMARY KEY (key)
+            );)";
+
+            auto result = session.ExecuteSchemeQuery(createTableSql).GetValueSync();
+            UNIT_ASSERT_C(result.GetIssues().Empty(), result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+        }
+
+        {
+            const TString upsertSql(Q_(R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES
+                (0, 1),
+                (10, 11),
+                (100, 101),
+                (200, 201);
+            )"));
+
+            auto result = session.ExecuteDataQuery(upsertSql, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+            UNIT_ASSERT(result.IsSuccess());
+        }
+
+        {
+            const TString createTableSql = R"(ALTER TABLE `/Root/table`
+                ADD INDEX value_index GLOBAL ON (value)
+            )";
+
+            auto result = session.ExecuteSchemeQuery(createTableSql).GetValueSync();
+            UNIT_ASSERT_C(result.GetIssues().Empty(), result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+        }        
+
+        {
+            const auto& yson = ReadTablePartToYson(session, "/Root/table");
+            const TString expected = R"([[[0u];[1u]];[[10u];[11u]];[[100u];[101u]];[[200u];[201u]]])";
+            UNIT_ASSERT_VALUES_EQUAL(yson, expected);
+        }
+
+        {
+            const TString selectSql(Q1_(R"(
+                SELECT * FROM `/Root/table` VIEW value_index WHERE value > 100;
+            )"));
+
+            auto result = session.ExecuteDataQuery(selectSql, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.GetIssues().Empty(), result.GetIssues().ToString());
+            UNIT_ASSERT(result.IsSuccess());
+            UNIT_ASSERT_VALUES_EQUAL(NYdb::FormatResultSetYson(result.GetResultSet(0)), R"([[[100u];[101u]];[[200u];[201u]]])");            
+        }
+    }    
 }
 
 }

--- a/ydb/core/tx/datashard/datashard_change_receiving.cpp
+++ b/ydb/core/tx/datashard/datashard_change_receiving.cpp
@@ -227,14 +227,6 @@ class TDataShard::TTxApplyChangeRecords: public TTransactionBase<TDataShard> {
         for (size_t i = 0; i < tableInfo.KeyColumnTypes.size(); ++i) {
             const auto type = tableInfo.KeyColumnTypes.at(i);
             const auto& cell = KeyCells.GetCells().at(i);
-
-            if (type.GetTypeId() == NScheme::NTypeIds::Uint8 && !cell.IsNull() && cell.AsValue<ui8>() > 127) {
-                AddRecordStatus(ctx, record.GetOrder(), NKikimrChangeExchange::TEvStatus::STATUS_REJECT,
-                    NKikimrChangeExchange::TEvStatus::REASON_SCHEME_ERROR,
-                    "Keys with Uint8 column values >127 are currently prohibited");
-                return false;
-            }
-
             keyBytes += cell.Size();
             Key.emplace_back(cell.AsRef(), type);
         }

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -129,11 +129,6 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         ui64 keyBytes = 0;
         for (const auto& kt : tableInfo.KeyColumnTypes) {
             const TCell& c = keyCells.GetCells()[ki];
-            if (kt.GetTypeId() == NScheme::NTypeIds::Uint8 && !c.IsNull() && c.AsValue<ui8>() > 127) {
-                SetError(NKikimrTxDataShard::TError::BAD_ARGUMENT, "Keys with Uint8 column values >127 are currently prohibited");
-                return true;
-            }
-
             keyBytes += c.Size();
             key.emplace_back(TRawTypeValue(c.AsRef(), kt));
             ++ki;

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -103,13 +103,6 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
         for (size_t ki : xrange(tableInfo.KeyColumnTypes.size())) {
             const auto& kt = tableInfo.KeyColumnTypes[ki];
             const TCell& cell = keyCells.GetCells()[ki];
-
-            if (kt.GetTypeId() == NScheme::NTypeIds::Uint8 && !cell.IsNull() && cell.AsValue<ui8>() > 127) {
-                status = NKikimrTxDataShard::TEvEraseRowsResponse::BAD_REQUEST;
-                error = "Keys with Uint8 column values >127 are currently prohibited";
-                return EStatus::Error;
-            }
-
             keyBytes += cell.Size();
             key.emplace_back(TRawTypeValue(cell.AsRef(), kt));
         }

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -143,11 +143,7 @@ std::tuple<NKikimrTxDataShard::TError::EKind, TString> TValidatedWriteTxOperatio
     {
         ui64 keyBytes = 0;
         for (ui16 keyColIdx = 0; keyColIdx < tableInfo.KeyColumnIds.size(); ++keyColIdx) {
-            const auto& cellType = tableInfo.KeyColumnTypes[keyColIdx];
             const TCell& cell = Matrix.GetCell(rowIdx, keyColIdx);
-            if (cellType.GetTypeId() == NScheme::NTypeIds::Uint8 && !cell.IsNull() && cell.AsValue<ui8>() > 127)
-                return {NKikimrTxDataShard::TError::BAD_ARGUMENT, TStringBuilder() << "Keys with Uint8 column values >127 are currently prohibited"};
-
             keyBytes += cell.IsNull() ? 1 : cell.Size();
         }
 

--- a/ydb/services/ydb/ydb_bulk_upsert_ut.cpp
+++ b/ydb/services/ydb/ydb_bulk_upsert_ut.cpp
@@ -961,10 +961,7 @@ Y_UNIT_TEST_SUITE(YdbTableBulkUpsert) {
         for (ui32 i = 0; i < 256; ++i) {
             {
                 auto res = TestUpsertRow(client, "/Root/ui8", i, 42);
-                if (i <= 127)
-                    UNIT_ASSERT_VALUES_EQUAL(res.GetStatus(), EStatus::SUCCESS);
-                else
-                    UNIT_ASSERT_VALUES_EQUAL(res.GetStatus(), EStatus::BAD_REQUEST);
+                UNIT_ASSERT_VALUES_EQUAL(res.GetStatus(), EStatus::SUCCESS);
             }
 
             {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

KIKIMR-7112

Due to an old comparator error there is restriction Keys with Uint8 column values >127 are currently prohibited.
The comparator error has been fixed long ago. So the restriction should be removed.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
