### PR TITLE
Validate blob size 0 on puts in DSProxy and VDisk

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1538,15 +1538,15 @@ struct TEvBlobStorage {
             REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(&patchedId, sizeof(patchedId));
             REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(diffs.Get(), sizeof(*diffs.Get()) * diffCount);
 
-            Y_VERIFY_S(originalId, "EvPatch invalid: LogoBlobId must have non-zero tablet field,"
+            Y_VERIFY_S(originalId, "EvPatch invalid: original LogoBlobId must have non-zero tablet field,"
                     << " OriginalId# " << originalId);
-            Y_VERIFY_S(patchedId, "EvPatch invalid: LogoBlobId must have non-zero tablet field,"
+            Y_VERIFY_S(patchedId, "EvPatch invalid: patched LogoBlobId must have non-zero tablet field,"
                     << " PatchedId# " << patchedId);
             Y_VERIFY_S(originalId != patchedId, "EvPatch invalid: OriginalId and PatchedId mustn't be equal"
                     << " OriginalId# " << originalId
                     << " PatchedId# " << patchedId);
             Y_VERIFY_S(originalId.BlobSize() == patchedId.BlobSize(),
-                    "EvPatch invalid: LogoBlobId must have non-zero tablet field,"
+                    "EvPatch invalid: original and patched size must be equal,"
                     << " OriginalId# " << originalId
                     << " PatchedId# " << patchedId);
 

--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1545,6 +1545,10 @@ struct TEvBlobStorage {
             Y_VERIFY_S(originalId != patchedId, "EvPatch invalid: OriginalId and PatchedId mustn't be equal"
                     << " OriginalId# " << originalId
                     << " PatchedId# " << patchedId);
+            Y_VERIFY_S(patchedId.BlobSize(),
+                    "EvPatch invalid: LogoBlobId must have non-zero size field,"
+                    << " OriginalId# " << originalId
+                    << " PatchedId# " << patchedId);
             Y_VERIFY_S(originalId.BlobSize() == patchedId.BlobSize(),
                     "EvPatch invalid: original and patched size must be equal,"
                     << " OriginalId# " << originalId

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -151,6 +151,29 @@ namespace NKikimr {
         EnsureMonitoring(true);
         const ui64 bytes = ev->Get()->Buffer.size();
         Mon->CountPutEvent(bytes);
+
+        auto replyError = [&](TString errorReason) {
+            std::unique_ptr<TEvBlobStorage::TEvPutResult> result(
+                    new TEvBlobStorage::TEvPutResult(NKikimrProto::ERROR, ev->Get()->Id, 0, GroupId, 0.f));
+            result->ErrorReason = errorReason;
+            result->ExecutionRelay = std::move(ev->Get()->ExecutionRelay);
+            LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BS_PROXY,
+                    "HandleNormal ev# " << ev->Get()->Print(false)
+                    << " result# " << result->Print(false)
+                    << " Marker# DSP54");
+            Send(ev->Sender, result.release(), 0, ev->Cookie);
+        };
+
+        // Make sure blob size is greater than 0
+        if (ev->Get()->Id.BlobSize() == 0) {
+            TStringStream str;
+            str << "Blob size must be greater than 0, LogoBlobId# " << ev->Get()->Id
+                << " Group# " << GroupId
+                << " Marker# DSP55";
+            replyError(str.Str());
+            return;
+        }
+
         // Make sure actual data size matches one in the logoblobid.
         if (bytes != ev->Get()->Id.BlobSize()) {
             TStringStream str;
@@ -158,15 +181,7 @@ namespace NKikimr {
                 << " does not match LogoBlobId# " << ev->Get()->Id
                 << " Group# " << GroupId
                 << " Marker# DSP53";
-            std::unique_ptr<TEvBlobStorage::TEvPutResult> result(
-                    new TEvBlobStorage::TEvPutResult(NKikimrProto::ERROR, ev->Get()->Id, 0, GroupId, 0.f));
-            result->ErrorReason = str.Str();
-            result->ExecutionRelay = std::move(ev->Get()->ExecutionRelay);
-            LOG_ERROR_S(*TlsActivationContext, NKikimrServices::BS_PROXY,
-                    "HandleNormal ev# " << ev->Get()->Print(false)
-                    << " result# " << result->Print(false)
-                    << " Marker# DSP54");
-            Send(ev->Sender, result.release(), 0, ev->Cookie);
+            replyError(str.Str());
             return;
         }
 

--- a/ydb/core/blobstorage/ut_blobstorage/incorrect_queries.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/incorrect_queries.cpp
@@ -303,19 +303,6 @@ Y_UNIT_TEST_SUITE(IncorrectQueries) {
         SendGet(env, test, vdiskId, blobId, "");
     }
 
-    Y_UNIT_TEST(EmptyTest) {
-        TEnvironmentSetup env(true, GetErasureTypeByString("none"));
-        TTestInfo test = InitTest(env);
-
-        constexpr ui32 size = 0;
-        TLogoBlobID blobId(1, 1, 0, 0, size, 0, 1);
-        SendPut(env, test, blobId, NKikimrProto::OK, size);
-        const TString data("");
-        auto vdiskId = test.Info->GetVDiskId(0);
-        SendGet(env, test, vdiskId, blobId, data);
-    }
-
-
     Y_UNIT_TEST(ProtobufBlob) {
         TEnvironmentSetup env(true, GetErasureTypeByString("none"));
         TTestInfo test = InitTest(env);

--- a/ydb/core/blobstorage/ut_blobstorage/put.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/put.cpp
@@ -59,7 +59,7 @@ Y_UNIT_TEST_SUITE(Put) {
         TestBlobSize(10);
     }
 
-    Y_UNIT_TEST(TestSinglePutPartSize0) {
+    Y_UNIT_TEST(TestVPutBlobSize0) {
         TestCtx ctx;
         ctx.Initialize();
 
@@ -74,7 +74,7 @@ Y_UNIT_TEST_SUITE(Put) {
         UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrProto::ERROR);
     }
 
-    Y_UNIT_TEST(TestMultiPutPartSize0) {
+    Y_UNIT_TEST(TestVMultiPutBlobSize0) {
         TestCtx ctx;
         ctx.Initialize();
         auto ev = std::make_unique<TEvBlobStorage::TEvVMultiPut>(ctx.VDiskId, TInstant::Max(),

--- a/ydb/core/blobstorage/ut_blobstorage/put.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/put.cpp
@@ -1,0 +1,98 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/common.h>
+
+Y_UNIT_TEST_SUITE(Put) {
+    struct TestCtx {
+        TestCtx()
+            : Env(new TEnvironmentSetup({
+                .Erasure = TBlobStorageGroupType::ErasureMirror3dc,
+            }))
+        {}
+    
+        void Initialize() {
+            Env->CreateBoxAndPool(1, 1);
+            Env->Sim(TDuration::Minutes(1));
+
+            auto groups = Env->GetGroups();
+            auto groupInfo = Env->GetGroupInfo(groups.front());
+            GroupId = groupInfo->GroupID;
+
+            Edge = Env->Runtime->AllocateEdgeActor(1);
+            VDiskId = groupInfo->GetVDiskId(0);
+            VDiskActorId = groupInfo->GetActorId(0);
+        }
+
+        std::shared_ptr<TEnvironmentSetup> Env;
+
+        TGroupId GroupId;
+        TActorId Edge;
+        TVDiskID VDiskId;
+        TActorId VDiskActorId;
+    };
+
+    void TestBlobSize(ui32 putsCount, ui32 blobSize = 0) {
+        TestCtx ctx;
+        ctx.Initialize();
+
+        for (ui32 i = 0; i < putsCount; ++i) {
+            TLogoBlobID blobId(100, 1, 1, 0, blobSize, i);
+            TString data;
+
+            std::unique_ptr<IEventBase> ev = std::make_unique<TEvBlobStorage::TEvPut>(blobId, data, TInstant::Max());
+            ctx.Env->Runtime->WrapInActorContext(ctx.Edge, [&] {
+                SendToBSProxy(ctx.Edge, ctx.GroupId.GetRawId(), ev.release());
+            });
+        }
+
+        for (ui32 i = 0; i < putsCount; ++i) {
+            auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(ctx.Edge, false, TInstant::Max());
+            UNIT_ASSERT(res);
+            UNIT_ASSERT(res->Get()->Status == NKikimrProto::ERROR);
+        }
+    }
+
+    Y_UNIT_TEST(TestSinglePutBlobSize0) {
+        TestBlobSize(1);
+    }
+
+    Y_UNIT_TEST(TestMultiPutBlobSize0) {
+        TestBlobSize(10);
+    }
+
+    Y_UNIT_TEST(TestSinglePutPartSize0) {
+        TestCtx ctx;
+        ctx.Initialize();
+
+        TLogoBlobID partId(100, 1, 1, 0, /*blobSize=*/0, 0, /*partId=*/1);
+        TString data;
+        auto ev = std::make_unique<TEvBlobStorage::TEvVPut>(partId, TRope(data), ctx.VDiskId, false, nullptr, TInstant::Max(),
+                    NKikimrBlobStorage::EPutHandleClass::TabletLog);
+        ctx.Env->Runtime->Send(new IEventHandle(ctx.VDiskActorId, ctx.Edge, ev.release()), ctx.VDiskActorId.NodeId());
+
+        auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvVPutResult>(ctx.Edge, false, TInstant::Max());
+        UNIT_ASSERT(res);
+        UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrProto::ERROR);
+    }
+
+    Y_UNIT_TEST(TestMultiPutPartSize0) {
+        TestCtx ctx;
+        ctx.Initialize();
+        auto ev = std::make_unique<TEvBlobStorage::TEvVMultiPut>(ctx.VDiskId, TInstant::Max(),
+                NKikimrBlobStorage::EPutHandleClass::TabletLog, false);
+        ui32 vputsCount = 10;
+
+        for (ui32 i = 0; i < vputsCount; ++i) {
+            TLogoBlobID partId(100, 1, 1, 0, /*blobSize=*/0, i, /*partId=*/1);
+            TString data;
+            ev->AddVPut(partId, TRcBuf(data), nullptr, nullptr, {});
+        }
+        ctx.Env->Runtime->Send(new IEventHandle(ctx.VDiskActorId, ctx.Edge, ev.release()), ctx.VDiskActorId.NodeId());
+
+        auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvVMultiPutResult>(ctx.Edge, false, TInstant::Max());
+        UNIT_ASSERT(res);
+        UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrProto::OK);
+        for (ui32 i = 0; i < vputsCount; ++i) {
+            UNIT_ASSERT(res->Get()->Record.GetItems(i).GetStatus() == NKikimrProto::ERROR);
+        }
+    }
+}

--- a/ydb/core/blobstorage/ut_blobstorage/validation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/validation.cpp
@@ -111,19 +111,4 @@ Y_UNIT_TEST_SUITE(RequestValidation) {
         UNIT_ASSERT(res);
         UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrProto::ERROR);
     }
-
-    Y_UNIT_TEST(TestVPatchSize0) {
-        TestCtx ctx;
-        ctx.Initialize();
-        TLogoBlobID oldId(100, 1, 1, 0, /*blobSize=*/100, 0, /*partId=*/1);
-        TLogoBlobID newId(100, 1, 1, 0, /*blobSize=*/0, 1, /*partId=*/1);
-
-        auto ev = std::make_unique<TEvBlobStorage::TEvVPatchStart>(oldId, newId, ctx.VDiskId, TInstant::Max(), 0, false);
-        
-        ctx.Env->Runtime->Send(new IEventHandle(ctx.VDiskActorId, ctx.Edge, ev.release()), ctx.VDiskActorId.NodeId());
-
-        auto res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvVPatchResult>(ctx.Edge, false, TInstant::Max());
-        UNIT_ASSERT(res);
-        UNIT_ASSERT(res->Get()->Record.GetStatus() == NKikimrProto::ERROR);
-    }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -38,7 +38,6 @@ SRCS(
     monitoring.cpp
     multiget.cpp
     patch.cpp
-    put.cpp
     recovery.cpp
     sanitize_groups.cpp
     scrub_fast.cpp
@@ -46,6 +45,7 @@ SRCS(
     space_check.cpp
     sync.cpp
     ut_helpers.cpp
+    validation.cpp
 )
 
 PEERDIR(

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -38,6 +38,7 @@ SRCS(
     monitoring.cpp
     multiget.cpp
     patch.cpp
+    put.cpp
     recovery.cpp
     sanitize_groups.cpp
     scrub_fast.cpp

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -514,8 +514,8 @@ namespace NKikimr {
                 return {NKikimrProto::ERROR, "buffer size mismatch"};
             }
 
-            if (blobPartSize == 0) {
-                LOG_ERROR_S(ctx, BS_VDISK_PUT, VCtx->VDiskLogPrefix << evPrefix << ": part size cannot be 0;"
+            if (id.BlobSize() == 0) {
+                LOG_ERROR_S(ctx, BS_VDISK_PUT, VCtx->VDiskLogPrefix << evPrefix << ": blob size cannot be 0;"
                         << " id# " << id
                         << " Marker# BSVS44");
                 return {NKikimrProto::ERROR, "part size is 0"};

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -243,6 +243,13 @@ namespace NKikimr {
         void Handle(TEvBlobStorage::TEvVMovedPatch::TPtr &ev, const TActorContext &ctx) {
             LOG_DEBUG_S(ctx, BS_VDISK_PATCH, VCtx->VDiskLogPrefix << "TEvVMovedPatch: receive request;"
                     << " Event# " << ev->Get()->ToString());
+
+            TLogoBlobID patchedBlobId = LogoBlobIDFromLogoBlobID(ev->Get()->Record.GetPatchedBlobId());
+            if (patchedBlobId.BlobSize() == 0) {
+                ReplyError(NKikimrProto::ERROR, "Blob size must be non-zero", ev, ctx, TAppData::TimeProvider->Now());
+                return;
+            }
+
             if (!CheckIfWriteAllowed(ev, ctx)) {
                 LOG_DEBUG_S(ctx, BS_VDISK_PATCH, VCtx->VDiskLogPrefix << "TEvVMovedPatch: is not allowed;"
                         << " Event# " << ev->Get()->ToString());

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -514,6 +514,13 @@ namespace NKikimr {
                 return {NKikimrProto::ERROR, "buffer size mismatch"};
             }
 
+            if (blobPartSize == 0) {
+                LOG_ERROR_S(ctx, BS_VDISK_PUT, VCtx->VDiskLogPrefix << evPrefix << ": part size cannot be 0;"
+                        << " id# " << id
+                        << " Marker# BSVS44");
+                return {NKikimrProto::ERROR, "part size is 0"};
+            }
+
             if (bufSize > Config->MaxLogoBlobDataSize) {
                 LOG_ERROR_S(ctx, BS_VDISK_PUT, VCtx->VDiskLogPrefix << evPrefix << ": data is too large;"
                         << " id# " << id


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Now Put requests with blobs of 0 size are validated and rejected with ERROR status

### Changelog category <!-- remove all except one -->

* Improvement
