### PR TITLE
Allow some quiet period before starting TestShard load

### DIFF
--- a/ydb/core/protos/msgbus.proto
+++ b/ydb/core/protos/msgbus.proto
@@ -704,6 +704,7 @@ message TTestShardControlRequest {
         optional uint32 PatchRequestsFractionPPM = 12;
         optional uint32 PutTraceFractionPPM = 13;
         optional uint32 PutTraceVerbosity = 14 [default = 15];
+        optional uint32 SecondsBeforeLoadStart = 15; // number of seconds to wait before starting load
     }
 
     optional uint64 TabletId = 1;

--- a/ydb/core/test_tablet/load_actor_impl.h
+++ b/ydb/core/test_tablet/load_actor_impl.h
@@ -8,7 +8,7 @@
 
 namespace NKikimr::NTestShard {
 
-    class TLoadActor : public TActorBootstrapped<TLoadActor> {
+    class TLoadActor : public TActor<TLoadActor> {
         const ui64 TabletId;
         const ui32 Generation;
         const TActorId Tablet;
@@ -58,14 +58,16 @@ namespace NKikimr::NTestShard {
         TLoadActor(ui64 tabletId, ui32 generation, const TActorId tablet,
             const NKikimrClient::TTestShardControlRequest::TCmdInitialize& settings);
         ~TLoadActor();
+        void Registered(TActorSystem *sys, const TActorId& owner) override;
         void ClearKeys();
-        void Bootstrap(const TActorId& parentId);
+        void Bootstrap();
         void PassAway() override;
         void HandleWakeup();
         void Action();
         void Handle(TEvStateServerStatus::TPtr ev);
 
         STRICT_STFUNC(StateFunc,
+            cFunc(TEvents::TSystem::Bootstrap, Bootstrap);
             hFunc(TEvKeyValue::TEvResponse, Handle);
             hFunc(NMon::TEvRemoteHttpInfo, Handle);
             hFunc(TEvStateServerStatus, Handle);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Allow some quiet period before starting TestShard load

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

This commit allows changeable interval after TestShard bootup before it starts to generate some load.
