### PR TITLE
WIP: ForceFalse flag

### DIFF
--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -819,6 +819,7 @@ struct TEvPQ {
         ui64 TxId;
         TVector<NKikimrPQ::TPartitionOperation> Operations;
         TActorId SupportivePartitionActor;
+        bool ForceFalse = false;
     };
 
     struct TEvTxCalcPredicateResult : public TEventLocal<TEvTxCalcPredicateResult, EvTxCalcPredicateResult> {

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2087,6 +2087,11 @@ bool TPartition::ExecUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t, 
 
 TPartition::EProcessResult TPartition::BeginTransaction(const TEvPQ::TEvTxCalcPredicate& tx, TMaybe<bool>& predicate)
 {
+    if (tx.ForceFalse) {
+        predicate = false;
+        return EProcessResult::Continue;
+    }
+
     const auto& ctx = ActorContext();
     THashSet<TString> consumers;
     bool ok = true;

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -4096,13 +4096,17 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
         const TTxWriteInfo& writeInfo = TxWrites.at(writeId);
 
         for (auto& [originalPartitionId, partitionId] : writeInfo.Partitions) {
-            Y_ABORT_UNLESS(Partitions.contains(partitionId));
-            const TPartitionInfo& partition = Partitions.at(partitionId);
-
             auto& event = events[originalPartitionId];
             if (!event) {
                 event = std::make_unique<TEvPQ::TEvTxCalcPredicate>(tx.Step, tx.TxId);
             }
+
+            if (!Partitions.contains(partitionId)) {
+                event->ForceFalse = true;
+                continue;
+            }
+
+            const TPartitionInfo& partition = Partitions.at(partitionId);
 
             event->SupportivePartitionActor = partition.Actor;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed the error:
Replaced the `Y_ABORT_UNLESS` checks with the `ForceFalse` flag. Instead of an abnormal termination, the program returns `ABORTED`.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
