### PR TITLE
Fix a reversed MissingConfig counter in coordinator

### DIFF
--- a/ydb/core/tx/coordinator/coordinator__configure.cpp
+++ b/ydb/core/tx/coordinator/coordinator__configure.cpp
@@ -123,7 +123,7 @@ struct TTxCoordinator::TTxConfigure : public TTransactionBase<TTxCoordinator> {
         if (ConfigurationApplied) {
             Self->Execute(Self->CreateTxInit(), ctx);
         } else {
-            Self->SetCounter(COUNTER_MISSING_CONFIG, Self->Config.HaveProcessingParams ? 1 : 0);
+            Self->SetCounter(COUNTER_MISSING_CONFIG, Self->Config.HaveProcessingParams ? 0 : 1);
             if (Self->Config.HaveProcessingParams) {
                 Self->SubscribeToSiblings();
             }

--- a/ydb/core/tx/coordinator/coordinator__init.cpp
+++ b/ydb/core/tx/coordinator/coordinator__init.cpp
@@ -124,7 +124,7 @@ struct TTxCoordinator::TTxInit : public TTransactionBase<TTxCoordinator> {
             Self->Config.Resolution = PlanResolution;
             Self->Config.ReducedResolution = ReducedResolution;
             Self->Config.HaveProcessingParams = HaveProcessingParams;
-            Self->SetCounter(COUNTER_MISSING_CONFIG, HaveProcessingParams ? 1 : 0);
+            Self->SetCounter(COUNTER_MISSING_CONFIG, HaveProcessingParams ? 0 : 1);
 
             if (LastBlockedActor && LastPlanned < LastBlockedStep) {
                 Self->RestoreState(LastBlockedActor, LastBlockedStep);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

We planned to use the MissingConfig counter to see if any old coordinators had trouble restoring their historically missing configuration. Unfortunately it turned out that the counter was reversed and thus didn't help.

Fixes #4487.